### PR TITLE
Fix schedule highlight when next match moves into "Kör nu"

### DIFF
--- a/fopen/main.js
+++ b/fopen/main.js
@@ -456,8 +456,8 @@ function startTournament() {
   state.playingMatches = [];
   saveState();
   renderStage();
-  updateScheduleUI();
   updateNowPlaying();
+  updateScheduleUI();
   updateStandingsUI();
 }
 
@@ -718,8 +718,8 @@ function recordResult(scheduleIndex, score1, score2) {
   // Save state
   saveState();
   // Update UI
-  updateScheduleUI();
   updateNowPlaying();
+  updateScheduleUI();
   updateStandingsUI();
   // Check if group stage is complete and update UI accordingly
   checkGroupStageComplete();
@@ -1477,9 +1477,9 @@ function editResult(idx) {
     }
   });
   saveState();
+  updateNowPlaying();
   updateScheduleUI();
   updateStandingsUI();
-  updateNowPlaying();
 }
 
 // Render marathon modal
@@ -1782,8 +1782,8 @@ function autoFillResults() {
   });
   saveState();
   // Refresh UI: schedule, now playing list, and standings
-  updateScheduleUI();
   updateNowPlaying();
+  updateScheduleUI();
   updateStandingsUI();
   // After auto filling results, check if group stage is complete
   checkGroupStageComplete();
@@ -1811,8 +1811,8 @@ function init() {
   renderStage();
   if (state.stage === 'tournament') {
     // Always build the schedule and now playing lists from stored state
-    updateScheduleUI();
     updateNowPlaying();
+    updateScheduleUI();
     // If no group standings exist yet, initialise them so that the rankings
     // table displays even before any games have been played. Without this
     // initialisation, the rankings section would remain blank on page load


### PR DESCRIPTION
### Motivation
- Matches promoted into the "Kör nu" area should be highlighted (yellow) in the Spelschema, but the replacement match sometimes stayed unhighlighted because the schedule was rendered before the now-playing list was updated. 

### Description
- Reordered UI refresh calls so `updateNowPlaying()` runs before `updateScheduleUI()` in all tournament flows to ensure match `status` is set to `playing` prior to rendering. 
- Applied the ordering consistently in the flows: `startTournament()`, `recordResult()`, `editResult()`, `autoFillResults()`, and the tournament branch of `init()`. 
- Ensured `updateStandingsUI()` is called after the now-playing/schedule updates where relevant. 
- Modified file: `fopen/main.js`.

### Testing
- Ran syntax check with `node --check fopen/main.js` which completed successfully. 
- Launched a local server with `python3 -m http.server 8000` and executed a Playwright script that seeds `localStorage` with a tournament state and captures a screenshot to validate the UI behavior. 
- The Playwright-driven verification produced a screenshot artifact showing the promoted match highlighted as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a968deeb5c8320a414fa36f60c2d7b)