### PR TITLE
Lägg till kompakt "Kommande:"-sektion under "Kör nu"

### DIFF
--- a/fopen/index.html
+++ b/fopen/index.html
@@ -74,6 +74,10 @@
                 <div id="now-playing" class="now-playing">
                     <h2>Kör nu</h2>
                     <div id="current-matches" class="current-matches"></div>
+                    <div id="upcoming-wrap" class="upcoming-wrap" hidden>
+                        <h3 class="upcoming-title">Kommande:</h3>
+                        <div id="upcoming-matches" class="upcoming-matches"></div>
+                    </div>
                 </div>
                 <!-- Groups rankings area -->
                 <div id="groups-rankings" class="groups-rankings"></div>

--- a/fopen/main.js
+++ b/fopen/main.js
@@ -263,6 +263,7 @@ function toggleTeamSelection(nation) {
   updateNationCards();
   updateSelectedCounter();
   updateDrawButtonState();
+  renderUpcomingMatches();
   saveState();
 }
 
@@ -491,6 +492,58 @@ function getReadyMatches() {
   return ready;
 }
 
+
+function getUpcomingMatches(limit = 3) {
+  const upcoming = [];
+  const playingSet = new Set(state.playingMatches);
+  for (let i = 0; i < state.schedule.length; i++) {
+    if (playingSet.has(i)) continue;
+    const match = state.schedule[i];
+    if (!match || match.status === 'completed') continue;
+    upcoming.push(match);
+    if (upcoming.length >= limit) break;
+  }
+  return upcoming;
+}
+
+function renderUpcomingMatches() {
+  const wrap = document.getElementById('upcoming-wrap');
+  const container = document.getElementById('upcoming-matches');
+  if (!wrap || !container) return;
+  const upcoming = getUpcomingMatches(3);
+  container.innerHTML = '';
+  if (!upcoming.length) {
+    wrap.hidden = true;
+    return;
+  }
+  upcoming.forEach(match => {
+    const chip = document.createElement('div');
+    chip.classList.add('upcoming-chip');
+
+    const group = document.createElement('span');
+    group.classList.add('upcoming-group');
+    group.textContent = match.group || '—';
+
+    const t1 = document.createElement('img');
+    t1.src = getFlagSrc(match.team1);
+    t1.alt = match.team1;
+    t1.classList.add('flag');
+
+    const sep = document.createElement('span');
+    sep.classList.add('upcoming-sep');
+    sep.textContent = '–';
+
+    const t2 = document.createElement('img');
+    t2.src = getFlagSrc(match.team2);
+    t2.alt = match.team2;
+    t2.classList.add('flag');
+
+    chip.append(group, t1, sep, t2);
+    container.appendChild(chip);
+  });
+  wrap.hidden = false;
+}
+
 // Render now playing area
 function updateNowPlaying() {
   const container = document.getElementById('current-matches');
@@ -669,6 +722,7 @@ function updateNowPlaying() {
     card.appendChild(inputRow);
     container.appendChild(card);
   });
+  renderUpcomingMatches();
   saveState();
 }
 

--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -407,6 +407,59 @@ header.hero {
   font-size: 0.875rem;
 }
 
+
+.upcoming-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+  flex-wrap: wrap;
+}
+
+.upcoming-title {
+  margin: 0;
+  font-size: 0.72rem;
+  line-height: 1;
+}
+
+.upcoming-matches {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.upcoming-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border: 1px solid #b9cbe6;
+  border-radius: 6px;
+  padding: 0.14rem 0.3rem;
+  background: #f6f9ff;
+}
+
+.upcoming-chip .flag {
+  width: 28px;
+  height: 18px;
+  border-radius: 3px;
+}
+
+.upcoming-group {
+  font-size: 0.72rem;
+  line-height: 1;
+  font-weight: 700;
+  color: #8da8c7;
+  text-transform: uppercase;
+}
+
+.upcoming-sep {
+  font-weight: 700;
+  color: var(--color-text-muted);
+  font-size: 0.72rem;
+  line-height: 1;
+}
+
+
 @keyframes slideDown {
   from { transform: translateY(-10px); opacity: 0; }
   to { transform: translateY(0); opacity: 1; }


### PR DESCRIPTION
### Motivation
- Visa de tre nästkommande matcherna under `Kör nu` enligt skiss utan att ta mycket vertikal plats, så användare snabbt ser vad som kommer härnäst.

### Description
- Lagt till markup i `fopen/index.html`: wrapper och container `#upcoming-wrap` / `#upcoming-matches` under `#current-matches` för sektionen `Kommande:`.
- Implementerat i `fopen/main.js` två funktioner `getUpcomingMatches(limit = 3)` och `renderUpcomingMatches()` som väljer nästa 3 icke-spelande/icke-kompletta matcher och renderar dem som kompakta chips, samt anrop av `renderUpcomingMatches()` i `updateNowPlaying()` (och vid team-toggle) så sektionen uppdateras automatiskt.
- Uppdaterat `fopen/styles.css` med kompakta stylar (`.upcoming-wrap`, `.upcoming-chip`, `.upcoming-group`, `.upcoming-sep`) för låg höjd, små flaggor och tät layout; sektionen döljs när inga matcher finns.
- Logiken filtrerar bort matcher som redan är i `state.playingMatches` eller `completed` så endast verkligt kommande matcher visas.

### Testing
- Körbarhetskontroll med `node --check fopen/main.js` kördes och gav inga syntaxfel.
- Startade lokal server (`python -m http.server`) och körde ett automatiserat Playwright-skript som simulerar lottning och start av turnering för att verifiera UI-uppdatering, vilket genererade en screenshot för manuell inspektion.
- Funktionaliteten verifierades manuellt via den servern (sektionen visar upp till tre kommande matcher och döljs när ingen finns).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a96d6b91cc83208229246b3386cb91)