### PR TITLE
Lägg till stöd för att skippa matcher i "Kör nu"

### DIFF
--- a/fopen/main.js
+++ b/fopen/main.js
@@ -468,6 +468,7 @@ function getReadyMatches() {
   // We'll iterate through schedule sequentially; pick matches that are pending and whose teams have completed all previous matches and are not currently playing
   for (let i = 0; i < state.schedule.length; i++) {
     const match = state.schedule[i];
+    if (match.skipped) continue;
     if (match.status !== 'pending') continue;
     const team1 = match.team1;
     const team2 = match.team2;
@@ -477,7 +478,7 @@ function getReadyMatches() {
     let previousIncomplete = false;
     for (let j = 0; j < i; j++) {
       const m = state.schedule[j];
-      if (m.status !== 'completed') {
+      if (m.status !== 'completed' && !m.skipped) {
         if (m.team1 === team1 || m.team2 === team1 || m.team1 === team2 || m.team2 === team2) {
           previousIncomplete = true;
           break;
@@ -499,6 +500,7 @@ function getUpcomingMatches(limit = 3) {
   for (let i = 0; i < state.schedule.length; i++) {
     if (playingSet.has(i)) continue;
     const match = state.schedule[i];
+    if (match?.skipped) continue;
     if (!match || match.status === 'completed') continue;
     upcoming.push(match);
     if (upcoming.length >= limit) break;
@@ -713,17 +715,46 @@ function updateNowPlaying() {
       }
       recordResult(idx, s1, s2);
     });
+
+    const skipBtn = document.createElement('button');
+    skipBtn.classList.add('btn', 'btn-secondary', 'skip-match-btn');
+    skipBtn.type = 'button';
+    skipBtn.textContent = '↪';
+    skipBtn.title = 'Skippa match';
+    skipBtn.addEventListener('click', () => {
+      skipMatch(idx);
+    });
+
     inputRow.appendChild(input1);
     const dash = document.createElement('span');
     dash.textContent = '-';
     inputRow.appendChild(dash);
     inputRow.appendChild(input2);
     inputRow.appendChild(doneBtn);
+    inputRow.appendChild(skipBtn);
     card.appendChild(inputRow);
     container.appendChild(card);
   });
   renderUpcomingMatches();
   saveState();
+}
+
+function skipMatch(scheduleIndex) {
+  const match = state.schedule[scheduleIndex];
+  if (!match || match.status === 'completed') return;
+  const ok = confirm(
+    'Vill du ersätta den här matchen med nästa i kön?\nFör att sedan mata in resultatet för denna match, använd knappen Ändra i spelschemat.'
+  );
+  if (!ok) return;
+  match.status = 'pending';
+  match.score1 = null;
+  match.score2 = null;
+  match.skipped = true;
+  state.playing = state.playing.filter(team => team !== match.team1 && team !== match.team2);
+  state.playingMatches = state.playingMatches.filter(i => i !== scheduleIndex);
+  saveState();
+  updateNowPlaying();
+  updateScheduleUI();
 }
 
 // Precompute last year each team appeared in historik for fallback messages
@@ -1444,6 +1475,7 @@ function updateScheduleUI() {
     // receive their own class names (pending, playing).
     item.classList.add(match.status);
     if (match.status === 'completed') item.classList.add('completed');
+    if (match.skipped) item.classList.add('skipped');
     // Build columns: flag1, team1, score, flag2, team2, group label, edit button
     // Flag for team1
     const leftImg = document.createElement('img');
@@ -1465,6 +1497,12 @@ function updateScheduleUI() {
     score.classList.add('schedule-score');
     if (match.status === 'completed') {
       score.innerHTML = `<span>${match.score1}</span><span> – </span><span>${match.score2}</span>`;
+    } else if (match.skipped) {
+      const skippedMarker = document.createElement('span');
+      skippedMarker.classList.add('skipped-indicator');
+      skippedMarker.textContent = '!';
+      skippedMarker.title = 'Skippad match. Tryck Ändra för att mata in resultatet.';
+      score.appendChild(skippedMarker);
     } else {
       score.innerHTML = '';
     }
@@ -1489,7 +1527,7 @@ function updateScheduleUI() {
     groupDiv.textContent = match.group ? `Grupp ${match.group}` : '';
     // Change result button (if match completed)
     let changeBtn = null;
-    if (match.status === 'completed') {
+    if (match.status === 'completed' || match.skipped) {
       changeBtn = document.createElement('button');
       changeBtn.classList.add('btn', 'btn-secondary', 'change-result');
       changeBtn.textContent = 'Ändra';
@@ -1523,6 +1561,10 @@ function editResult(idx) {
   state.groupStandings = null;
   match.score1 = newScore1;
   match.score2 = newScore2;
+  match.status = 'completed';
+  delete match.skipped;
+  state.playingMatches = state.playingMatches.filter(i => i !== idx);
+  state.playing = state.playing.filter(team => team !== match.team1 && team !== match.team2);
   state.results[match.id] = { score1: newScore1, score2: newScore2 };
   // Recompute standings from scratch
   state.schedule.forEach(m => {

--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -407,6 +407,13 @@ header.hero {
   font-size: 0.875rem;
 }
 
+.skip-match-btn {
+  margin-left: auto;
+  min-width: 32px;
+  line-height: 1;
+  padding: 0.15rem 0.45rem;
+}
+
 
 .upcoming-wrap {
   display: flex;
@@ -555,6 +562,11 @@ header.hero {
   border-left: 4px solid var(--color-secondary);
 }
 
+.schedule-item.skipped {
+  background-color: #fff3f5;
+  border-left: 4px solid #f03747;
+}
+
 .schedule-team {
   display: flex;
   align-items: center;
@@ -568,6 +580,19 @@ header.hero {
   justify-content: center;
   gap: 0.15rem;
   font-weight: bold;
+}
+
+.skipped-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 2px solid #f03747;
+  color: #f03747;
+  font-weight: 700;
+  font-size: 0.9rem;
 }
 
 .schedule-group {


### PR DESCRIPTION
### Motivation
- Användaren ska kunna skippa en pågående match i "Kör nu" när förhinder uppstår utan att ta bort matchen från spelschemat. 
- En skippad match ska ersättas i spelkön av nästa match i "Kommande" och markeras i spelschemat med en tydlig indikation och möjlighet att mata in resultat i efterhand via `Ändra`.

### Description
- Lagt till en skip-knapp (`↪`) på varje matchkort i `updateNowPlaying()` som anropar ny funktion `skipMatch(scheduleIndex)`. 
- Implementerat `skipMatch()` som markerar `match.skipped = true`, nollställer score-fält, tar bort matchen från `state.playing`/`state.playingMatches` och sparar state samt uppdaterar UI så att nästa match fylls på. 
- Ändrat kö- och visningslogik så att `getReadyMatches()` och `getUpcomingMatches()` hoppar över skippade matcher och att tidigare icke-kompletta matcher ignoreras om de är skippade, så nästa tillgängliga match kan plockas in. 
- Uppdaterat `updateScheduleUI()` så att skippade matcher får klass `skipped`, visar en `!`-indikator med tooltip och fortfarande visar `Ändra`-knappen; uppdaterat `editResult()` så att efterhandsinmatning sätter matchen till `completed`, tar bort `skipped` och uppdaterar ståndings/playing-listor. 
- Lagt till CSS för `.skip-match-btn`, `.schedule-item.skipped` och `.skipped-indicator` för visuell markering.

### Testing
- Syntaxkontroll körd med `node --check fopen/main.js` och utan felmeddelanden (succeeded). 
- Lokalt HTTP-server för visuell verifiering startad med `python3 -m http.server 4173 --bind 0.0.0.0` och UI verifierad med en Playwright-skript som körde och tog en skärmbild (`artifacts/skip-match-feature.png`), vilket visade skip-knapp och skippad markering. 
- Efter ändringar kördes UI-flöden för att skippa match, visa nästa match och mata in resultat via `Ändra`, och dessa automatiska flöden fungerade i manual verifiering (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9851c2d40832099da82969c43bc1b)