### PR TITLE
Add static ruleset checks and seed-resolution tests for playoff formats

### DIFF
--- a/fopen/index.html
+++ b/fopen/index.html
@@ -116,6 +116,7 @@
          RULESET, MARATHON and HISTORIK on the window object so that
          main.js can access them without using ES module imports. -->
     <script src="data/global-data.js"></script>
+    <script src="logic/playoff-utils.js"></script>
     <!-- Main script for the app -->
     <script src="main.js"></script>
 </body>

--- a/fopen/logic/playoff-utils.js
+++ b/fopen/logic/playoff-utils.js
@@ -1,0 +1,103 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) {
+    module.exports = api;
+  }
+  if (root) {
+    root.PlayoffUtils = api;
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  function computeGoalDiff(entry) {
+    return (entry?.goalsFor || 0) - (entry?.goalsAgainst || 0);
+  }
+
+  function compareBestOfEntries(a, b, sortBy) {
+    for (const criterion of sortBy || []) {
+      if (criterion === 'points') {
+        const diff = (b.points || 0) - (a.points || 0);
+        if (diff !== 0) return diff;
+      }
+      if (criterion === 'goalDiff') {
+        const diff = computeGoalDiff(b) - computeGoalDiff(a);
+        if (diff !== 0) return diff;
+      }
+      if (criterion === 'goalsFor') {
+        const diff = (b.goalsFor || 0) - (a.goalsFor || 0);
+        if (diff !== 0) return diff;
+      }
+      if (criterion === 'fairPlay') {
+        const diff = (a.fairPlay || 0) - (b.fairPlay || 0);
+        if (diff !== 0) return diff;
+      }
+      if (criterion === 'stableSeed') {
+        const diff = String(a.stableSeed).localeCompare(String(b.stableSeed), 'sv');
+        if (diff !== 0) return diff;
+      }
+    }
+
+    return String(a.team || '').localeCompare(String(b.team || ''), 'sv');
+  }
+
+  function resolveBestOfSeed(seedDef, rankedStatsByGroup) {
+    const fromBestOf = seedDef?.fromBestOf;
+    if (!fromBestOf) return null;
+    const candidates = [];
+    const groups = fromBestOf.groups || [];
+    for (const groupLabel of groups) {
+      const ranked = rankedStatsByGroup[groupLabel] || [];
+      const idx = (fromBestOf.rank || 1) - 1;
+      const teamStats = ranked[idx];
+      if (teamStats) {
+        candidates.push({ ...teamStats, stableSeed: `${groupLabel}${fromBestOf.rank}` });
+      }
+    }
+
+    candidates.sort((a, b) => compareBestOfEntries(a, b, fromBestOf.sortBy || []));
+    const pickIndex = (fromBestOf.pick || 1) - 1;
+    return candidates[pickIndex] ? candidates[pickIndex].team : null;
+  }
+
+  function resolveSeedToTeam(seed, playoffSeeds, rankedStatsByGroup) {
+    if (typeof seed !== 'string') return null;
+    const seedDef = playoffSeeds?.[seed];
+    if (seedDef?.from) {
+      const groupLabel = seedDef.from.group;
+      const idx = seedDef.from.rank - 1;
+      return rankedStatsByGroup[groupLabel]?.[idx]?.team || null;
+    }
+
+    if (seedDef?.fromBestOf) {
+      return resolveBestOfSeed(seedDef, rankedStatsByGroup);
+    }
+
+    if (/^[A-Z][0-9]+$/.test(seed)) {
+      const groupLabel = seed.charAt(0);
+      const idx = parseInt(seed.slice(1), 10) - 1;
+      return rankedStatsByGroup[groupLabel]?.[idx]?.team || null;
+    }
+
+    return null;
+  }
+
+  function collectSpecialPlayoffFormats(ruleset) {
+    const flagged = [];
+    for (const format of ruleset.formats || []) {
+      const seeds = format.playoffs?.seeds || {};
+      const fromBestOfSeeds = Object.keys(seeds).filter((seedName) => Boolean(seeds[seedName]?.fromBestOf));
+      if (fromBestOfSeeds.length || Array.isArray(format.playoffs?.groupPlayoffs)) {
+        flagged.push({
+          participants: format.participants,
+          fromBestOfSeeds,
+          hasGroupPlayoffs: Array.isArray(format.playoffs?.groupPlayoffs)
+        });
+      }
+    }
+    return flagged;
+  }
+
+  return {
+    collectSpecialPlayoffFormats,
+    compareBestOfEntries,
+    resolveSeedToTeam
+  };
+});

--- a/fopen/main.js
+++ b/fopen/main.js
@@ -877,34 +877,23 @@ function generatePlayoffBracket() {
   const format = getFormat(state.numSlots);
   if (!format || !format.playoffs || !format.playoffs.rounds) return [];
   // Compute final standings order for each group (sorted by rank)
-  const finalStandings = {};
+  const rankedStatsByGroup = {};
   state.groups.forEach(group => {
     const stats = Object.values(state.groupStandings[group.label]);
     stats.sort(compareStandings);
-    finalStandings[group.label] = stats.map(s => s.team);
+    rankedStatsByGroup[group.label] = stats;
   });
+  const playoffSeeds = format.playoffs.seeds || {};
   const rounds = [];
   format.playoffs.rounds.forEach(round => {
     const r = { name: round.name, matches: [] };
     round.matches.forEach(match => {
       const seed1 = match.home;
       const seed2 = match.away;
-      // Resolve group seeds (e.g. 'A2') to team names.  Seeds referencing
-      // winners of previous matches (e.g. 'V1', '1') remain unresolved (null)
-      let team1 = null;
-      let team2 = null;
-      if (typeof seed1 === 'string' && /^[A-Z][0-9]+$/.test(seed1)) {
-        const g = seed1.charAt(0);
-        const rnk = parseInt(seed1.slice(1), 10);
-        const arr = finalStandings[g];
-        if (arr && arr.length >= rnk) team1 = arr[rnk - 1];
-      }
-      if (typeof seed2 === 'string' && /^[A-Z][0-9]+$/.test(seed2)) {
-        const g = seed2.charAt(0);
-        const rnk = parseInt(seed2.slice(1), 10);
-        const arr = finalStandings[g];
-        if (arr && arr.length >= rnk) team2 = arr[rnk - 1];
-      }
+      // Resolve group and best-of seeds to concrete teams. Winner references
+      // from previous rounds (e.g. numeric refs) remain unresolved until played.
+      const team1 = window.PlayoffUtils.resolveSeedToTeam(seed1, playoffSeeds, rankedStatsByGroup);
+      const team2 = window.PlayoffUtils.resolveSeedToTeam(seed2, playoffSeeds, rankedStatsByGroup);
       r.matches.push({
         id: match.id,
         homeSeed: seed1,
@@ -942,6 +931,11 @@ function generatePlayoffBracket() {
 
 // Start playoffs: generate bracket, set stage to 'playoff' and render the bracket
 function startPlayoffs() {
+  const format = getFormat(state.numSlots);
+  if (format?.playoffs?.groupPlayoffs) {
+    alert('Det här formatet använder gruppslutspel i slutspelet och stöds inte ännu.');
+    return;
+  }
   // Generate the playoff bracket using final group standings
   const bracket = generatePlayoffBracket();
   state.playoffs = bracket;

--- a/fopen/tests/playoff-utils.test.js
+++ b/fopen/tests/playoff-utils.test.js
@@ -1,0 +1,79 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { resolveSeedToTeam, collectSpecialPlayoffFormats } = require('../logic/playoff-utils.js');
+
+const ruleset = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '..', 'data', 'ruleset.json'), 'utf8')
+);
+
+function byParticipants(count) {
+  return ruleset.formats.find((format) => format.participants === count);
+}
+
+function mkGroup(label, pointsByRank) {
+  return pointsByRank.map((points, idx) => ({
+    team: `${label}_T${idx + 1}`,
+    points,
+    goalsFor: 10 - idx,
+    goalsAgainst: idx,
+    fairPlay: idx
+  }));
+}
+
+test('statisk inventering flaggar format med fromBestOf och groupPlayoffs', () => {
+  const flagged = collectSpecialPlayoffFormats(ruleset);
+  assert.deepEqual(flagged.map((item) => item.participants), [12, 13, 15, 21]);
+  assert.equal(flagged.find((item) => item.participants === 21).hasGroupPlayoffs, true);
+});
+
+test('12 lag: W3_* resolvas till faktiska lag', () => {
+  const format = byParticipants(12);
+  const rankedStatsByGroup = {
+    A: mkGroup('A', [8, 6, 5, 1]),
+    B: mkGroup('B', [7, 5, 4, 1]),
+    C: mkGroup('C', [9, 4, 3, 1])
+  };
+
+  const w3_1 = resolveSeedToTeam('W3_1', format.playoffs.seeds, rankedStatsByGroup);
+  const w3_2 = resolveSeedToTeam('W3_2', format.playoffs.seeds, rankedStatsByGroup);
+
+  assert.equal(w3_1, 'A_T3');
+  assert.equal(w3_2, 'B_T3');
+});
+
+test('13 lag: W3_BC resolvas till bästa trean mellan B/C', () => {
+  const format = byParticipants(13);
+  const rankedStatsByGroup = {
+    A: mkGroup('A', [9, 5, 1, 0, 0]),
+    B: mkGroup('B', [7, 4, 6, 2]),
+    C: mkGroup('C', [8, 5, 3, 1])
+  };
+
+  const seed = resolveSeedToTeam('W3_BC', format.playoffs.seeds, rankedStatsByGroup);
+  assert.equal(seed, 'B_T3');
+});
+
+test('15 lag: W3_1 och W3_2 resolvas konsekvent', () => {
+  const format = byParticipants(15);
+  const rankedStatsByGroup = {
+    A: mkGroup('A', [8, 7, 5, 1, 0]),
+    B: mkGroup('B', [9, 6, 4, 1, 0]),
+    C: mkGroup('C', [7, 6, 3, 2, 0])
+  };
+
+  const first = resolveSeedToTeam('W3_1', format.playoffs.seeds, rankedStatsByGroup);
+  const second = resolveSeedToTeam('W3_2', format.playoffs.seeds, rankedStatsByGroup);
+
+  assert.equal(first, 'A_T3');
+  assert.equal(second, 'B_T3');
+});
+
+test('21 lag: X3_* finns för groupPlayoffs-flödet i ruleset', () => {
+  const format = byParticipants(21);
+  assert.ok(format.playoffs.groupPlayoffs?.length > 0);
+  assert.ok(format.playoffs.seeds.X3_1?.fromBestOf);
+  assert.ok(format.playoffs.seeds.X3_2?.fromBestOf);
+});


### PR DESCRIPTION
### Motivation
- Ensure all playoff seed formats in `fopen/data/ruleset.json` are discovered and that best-of/third-place seeds (`W3_*`, `X3_*`) resolve consistently to concrete teams. 
- Avoid silent failures in the UI for formats that require group-playoffs flow before that feature is implemented.

### Description
- Add a shared utility `fopen/logic/playoff-utils.js` that inventories formats with `fromBestOf` and/or `groupPlayoffs` and resolves seed codes (including `fromBestOf`) to team names using ranked group stats via `resolveSeedToTeam`.
- Wire `generatePlayoffBracket()` in `fopen/main.js` to use `PlayoffUtils.resolveSeedToTeam` so best-of seeds are resolved consistently and deterministically from group standings.
- Add a guardrail in `startPlayoffs()` to show a clear unsupported alert when a format uses `playoffs.groupPlayoffs` instead of failing silently.
- Load the new utility before `main.js` by updating `fopen/index.html` and add unit tests `fopen/tests/playoff-utils.test.js` that cover inventory and seed resolution for the 12/13/15/21 participant formats.

### Testing
- Ran `node --test fopen/tests/playoff-utils.test.js` which executes 5 tests validating format discovery and seed resolution for participants 12, 13, 15 and metadata for 21; all tests passed (5/5).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a99d48b76483208e9b5fca8e78222f)