### PR TITLE
Fix playoff bracket seed resolution regression after merge

### DIFF
--- a/fopen/main.js
+++ b/fopen/main.js
@@ -945,6 +945,9 @@ function generatePlayoffBracket() {
     return null;
   }
 
+  const playoffSeeds = seedDefs;
+  const rankedStatsByGroup = finalStats;
+
   const rounds = [];
   format.playoffs.rounds.forEach(round => {
     const r = { name: round.name, matches: [] };
@@ -953,8 +956,12 @@ function generatePlayoffBracket() {
       const seed2 = match.away;
       // Resolve group and best-of seeds to concrete teams. Winner references
       // from previous rounds (e.g. numeric refs) remain unresolved until played.
-      const team1 = window.PlayoffUtils.resolveSeedToTeam(seed1, playoffSeeds, rankedStatsByGroup);
-      const team2 = window.PlayoffUtils.resolveSeedToTeam(seed2, playoffSeeds, rankedStatsByGroup);
+      const team1 = window.PlayoffUtils?.resolveSeedToTeam
+        ? window.PlayoffUtils.resolveSeedToTeam(seed1, playoffSeeds, rankedStatsByGroup)
+        : resolveSeed(seed1);
+      const team2 = window.PlayoffUtils?.resolveSeedToTeam
+        ? window.PlayoffUtils.resolveSeedToTeam(seed2, playoffSeeds, rankedStatsByGroup)
+        : resolveSeed(seed2);
       r.matches.push({
         id: match.id,
         homeSeed: seed1,


### PR DESCRIPTION
### Motivation
- A merge introduced a regression in `generatePlayoffBracket` where `playoffSeeds` and `rankedStatsByGroup` were referenced before being defined, which can cause runtime errors when resolving seeds. 
- The code also assumed `window.PlayoffUtils.resolveSeedToTeam` would always be available, which is not true in all contexts and can break bracket generation.

### Description
- Define `playoffSeeds` from `seedDefs` and `rankedStatsByGroup` from `finalStats` before building rounds to ensure values exist when needed in `fopen/main.js`.
- Add a safe fallback so that if `window.PlayoffUtils.resolveSeedToTeam` is unavailable the local `resolveSeed` function is used instead to resolve seeds.
- Changes are implemented in `fopen/main.js` and committed with a concise message fixing the regression.

### Testing
- Ran `node --check fopen/main.js` which completed without errors.
- Ran `node --test fopen/tests/playoff-utils.test.js` and all tests passed (5 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9a01a63c08320abef36863441d61c)