### PR TITLE
Fix playoff transition UI after completed group stage

### DIFF
--- a/fopen/index.html
+++ b/fopen/index.html
@@ -95,6 +95,12 @@
                 </div>
             </section>
 
+            <!-- Playoff stage -->
+            <section id="playoff-stage" class="stage" hidden>
+                <h2>Slutspel</h2>
+                <div id="playoff-bracket" class="playoff-bracket"></div>
+            </section>
+
         </main>
 
         <!-- Marathon modal -->

--- a/fopen/main.js
+++ b/fopen/main.js
@@ -1100,6 +1100,13 @@ function checkGroupStageComplete() {
   const msg = document.createElement('h2');
   msg.textContent = 'Gruppspelet är slut';
   nowPlaying.appendChild(msg);
+
+  const startBtn = document.createElement('button');
+  startBtn.className = 'btn btn-primary';
+  startBtn.textContent = 'Starta slutspel';
+  startBtn.addEventListener('click', startPlayoffs);
+  nowPlaying.appendChild(startBtn);
+
   // Ensure latest recorded result is reflected in group tables
   updateStandingsUI();
 }
@@ -1988,6 +1995,8 @@ function init() {
     });
     // Finally, render the standings table UI
     updateStandingsUI();
+  } else if (state.stage === 'playoff') {
+    renderPlayoffStage();
   }
 }
 


### PR DESCRIPTION
### Motivation

- The app could not display the playoff view because the `#playoff-stage` container was missing and there was no UI to trigger `startPlayoffs()` when group play finished.
- Reloading into an existing playoff state did not render the bracket, so users could not resume an already-started playoff.

### Description

- Add a dedicated playoff section to `fopen/index.html` containing `#playoff-stage` and `#playoff-bracket` so the playoff UI has a render target.
- Update `checkGroupStageComplete()` in `fopen/main.js` to show a `Starta slutspel` button when all group matches are completed and wire it to `startPlayoffs()`.
- Ensure `init()` calls `renderPlayoffStage()` when `state.stage === 'playoff'` so the bracket is rendered after page reload.
- Modified files: `fopen/index.html` and `fopen/main.js`.

### Testing

- Ran unit tests with `node --test tests/playoff-utils.test.js` from the `fopen` directory, and all tests passed.
- Executed an automated Playwright check against a local static server that loaded the app, simulated a completed group stage and verified the presence of the playoff start button (screenshot artifact generated), and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9a5b06d988320a3388c8ef0bb7958)