### PR TITLE
Add fallback seed resolution when PlayoffUtils.resolveSeedToTeam is missing

### DIFF
--- a/fopen/main.js
+++ b/fopen/main.js
@@ -1439,11 +1439,56 @@ function updateStandingsUI() {
 
   const groupStageComplete = isGroupStageComplete();
   const resolvedChanceTeams = new Set();
-  if (groupStageComplete && format?.playoffs?.seeds && window.PlayoffUtils?.resolveSeedToTeam) {
+  if (groupStageComplete && format?.playoffs?.seeds) {
     const rankedStatsByGroup = getSortedGroupStats();
+    const resolveSeedToTeam = window.PlayoffUtils?.resolveSeedToTeam
+      ? window.PlayoffUtils.resolveSeedToTeam
+      : (seedName, playoffSeeds, statsByGroup) => {
+        const seedDef = playoffSeeds?.[seedName];
+        if (seedDef?.from) {
+          const group = seedDef.from.group;
+          const rank = parseInt(seedDef.from.rank, 10);
+          if (!Number.isNaN(rank) && rank > 0) return statsByGroup[group]?.[rank - 1]?.team || null;
+          return null;
+        }
+        if (seedDef?.fromBestOf) {
+          const bestOf = seedDef.fromBestOf;
+          const rank = parseInt(bestOf.rank, 10);
+          const pick = parseInt(bestOf.pick, 10);
+          if (Number.isNaN(rank) || rank < 1 || Number.isNaN(pick) || pick < 1) return null;
+          const candidates = [];
+          (bestOf.groups || []).forEach(group => {
+            const stat = statsByGroup[group]?.[rank - 1];
+            if (!stat) return;
+            candidates.push({
+              ...stat,
+              fairPlay: stat.fairPlay ?? 0,
+              stableSeed: `${group}${rank}`
+            });
+          });
+          candidates.sort((a, b) => {
+            for (const criterion of bestOf.sortBy || []) {
+              if (criterion === 'points' && a.points !== b.points) return b.points - a.points;
+              if (criterion === 'goalDiff') {
+                const gdA = a.goalsFor - a.goalsAgainst;
+                const gdB = b.goalsFor - b.goalsAgainst;
+                if (gdA !== gdB) return gdB - gdA;
+              }
+              if (criterion === 'goalsFor' && a.goalsFor !== b.goalsFor) return b.goalsFor - a.goalsFor;
+              if (criterion === 'fairPlay' && a.fairPlay !== b.fairPlay) return a.fairPlay - b.fairPlay;
+              if (criterion === 'stableSeed' && a.stableSeed !== b.stableSeed) {
+                return a.stableSeed.localeCompare(b.stableSeed, 'sv');
+              }
+            }
+            return a.team.localeCompare(b.team, 'sv');
+          });
+          return candidates[pick - 1]?.team || null;
+        }
+        return null;
+      };
     Object.entries(format.playoffs.seeds).forEach(([seedName, seedDef]) => {
       if (!seedDef.fromBestOf) return;
-      const team = window.PlayoffUtils.resolveSeedToTeam(seedName, format.playoffs.seeds, rankedStatsByGroup);
+      const team = resolveSeedToTeam(seedName, format.playoffs.seeds, rankedStatsByGroup);
       if (team) resolvedChanceTeams.add(team);
     });
   }


### PR DESCRIPTION
### Motivation
- Ensure playoff seed-to-team resolution works even when `window.PlayoffUtils.resolveSeedToTeam` is not present so chance-qualified teams can be resolved from group standings. 
- Support `from` and `fromBestOf` seed definitions and their tie-break sorting so seed inference is robust across formats.

### Description
- Stop requiring `window.PlayoffUtils.resolveSeedToTeam` to exist and add a local `resolveSeedToTeam` fallback used when the global helper is not available. 
- Implement logic to resolve `seedDef.from` by group and rank and `seedDef.fromBestOf` by collecting candidate teams, defaulting `fairPlay` to `0` and adding a `stableSeed` key. 
- Sort candidates according to `bestOf.sortBy` with support for `points`, `goalDiff`, `goalsFor`, `fairPlay`, and `stableSeed`, falling back to locale comparison on team name. 
- Use the resolver to populate `resolvedChanceTeams` from `format.playoffs.seeds` when the group stage is complete. 

### Testing
- Ran the project test suite via `npm test` and all tests passed. 
- Ran lint checks via `npm run lint` and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a99c84835c8320b13baec2c30e8984)