### PR TITLE
Simplify .skip-match-btn selector and remove explicit color/background in styles.css

### DIFF
--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -407,13 +407,11 @@ header.hero {
   font-size: 0.875rem;
 }
 
-.btn.btn-secondary.skip-match-btn {
+.skip-match-btn {
   margin-left: auto;
   min-width: 32px;
   line-height: 1;
   padding: 0.15rem 0.45rem;
-  background: transparent;
-  color: var(--color-secondary);
 }
 
 


### PR DESCRIPTION
### Motivation
- Reduce specificity and remove hard-coded background and color for the skip match button to allow theme variables and simpler styling by changing the selector in `fopen/styles.css`.

### Description
- Replace `.btn.btn-secondary.skip-match-btn` with a simpler `.skip-match-btn` selector and remove the explicit `background: transparent;` and `color: var(--color-secondary);` rules in `fopen/styles.css`.

### Testing
- Ran project style checks with `stylelint` and a local build verification which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9bbd886c48320968823798e16b837)