### PR TITLE
Markera aktuella slutspelsplatser i grupptabeller

### DIFF
--- a/fopen/main.js
+++ b/fopen/main.js
@@ -1343,6 +1343,9 @@ function updateStandingsUI() {
     // direct (green) and chance (yellow) placements. Seeds with `from` map
     // directly to a group and rank; seeds with `fromBestOf` indicate potential
     // qualifiers (best third placements).
+    // Build a quick lookup of current ranked teams per group so seeds that use
+    // fromBestOf can point to the teams currently occupying those best-of slots.
+    const sortedByGroup = getSortedGroupStats();
     Object.entries(format.playoffs.seeds).forEach(([seedName, seedDef]) => {
       if (seedDef.from) {
         const g = seedDef.from.group;
@@ -1350,11 +1353,19 @@ function updateStandingsUI() {
         if (!direct[g]) direct[g] = new Set();
         direct[g].add(r);
       } else if (seedDef.fromBestOf) {
-        const groups = seedDef.fromBestOf.groups;
+        const { groups, rank, pick } = seedDef.fromBestOf;
+        const candidates = [];
         groups.forEach(g => {
-          if (!chance[g]) chance[g] = new Set();
-          chance[g].add(seedDef.fromBestOf.rank);
+          const stats = sortedByGroup[g] || [];
+          const row = stats[rank - 1];
+          if (row) candidates.push({ ...row, __group: g, __rank: rank });
         });
+        candidates.sort(compareStandings);
+        const picked = candidates[(pick || 1) - 1];
+        if (picked) {
+          if (!chance[picked.__group]) chance[picked.__group] = new Set();
+          chance[picked.__group].add(picked.__rank);
+        }
       }
     });
   } else if (format.playoffs && format.playoffs.rounds) {


### PR DESCRIPTION
### Motivation

- Visa i grupptabellerna vilka lag som för närvarande ligger på slutspelsplatser enligt ruleset (t.ex. vid 12 lag: 1:or+2:or gröna och de två bästa 3:orna gula) utan att bygga någon slutspels-UI.

### Description

- Uppdaterade `updateStandingsUI` i `fopen/main.js` så att `playoffs.seeds.fromBestOf` inte längre markerar alla potentiella grupper utan istället beräknas mot den aktuella tabellställningen (`getSortedGroupStats()`).
- För varje `fromBestOf` byggs en kandidatlista från angivna grupper, kandidaterna sorteras med samma `compareStandings`-logik och den konfigurerade `pick` markeras som chansplats (gul) i respektive grupp.
- Befintlig `from`-logik behåller oförändrad beteende och markeras fortfarande som direkt kval (grön).
- Mindre formatändring (ny rad i filslutet) och commit med förändringen.

### Testing

- Körning av `node --check fopen/main.js` kördes och lyckades (syntaktisk kontroll). 
- Försök att köra en headless end-to-end-skript med Playwright för att ta skärmbild misslyckades p.g.a. problem att nå den lokala `http.server` (`ERR_EMPTY_RESPONSE` / kunde inte ansluta), alltså E2E-checken kunde inte verifieras automatiskt.
- Kodändringen är commit:ad (`git commit`) efter patchen (ingen enhetstestsvit finns i repot att köra här).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9de9afab8832089f4ed929f0aca1a)