### PR TITLE
Introduce tournament overview layout and fullscreen mode with responsive styles

### DIFF
--- a/fopen/index.html
+++ b/fopen/index.html
@@ -90,17 +90,19 @@
 
             <!-- Tournament stage -->
             <section id="tournament-stage" class="stage" hidden>
-                <!-- Now playing area -->
-                <div id="now-playing" class="now-playing">
-                    <h2>Kör nu</h2>
-                    <div id="current-matches" class="current-matches"></div>
-                    <div id="upcoming-wrap" class="upcoming-wrap" hidden>
-                        <h3 class="upcoming-title">Kommande:</h3>
-                        <div id="upcoming-matches" class="upcoming-matches"></div>
+                <div class="tournament-overview">
+                    <!-- Now playing area -->
+                    <div id="now-playing" class="now-playing">
+                        <h2>Kör nu</h2>
+                        <div id="current-matches" class="current-matches"></div>
+                        <div id="upcoming-wrap" class="upcoming-wrap" hidden>
+                            <h3 class="upcoming-title">Kommande:</h3>
+                            <div id="upcoming-matches" class="upcoming-matches"></div>
+                        </div>
                     </div>
+                    <!-- Groups rankings area -->
+                    <div id="groups-rankings" class="groups-rankings"></div>
                 </div>
-                <!-- Groups rankings area -->
-                <div id="groups-rankings" class="groups-rankings"></div>
                 <!-- Marathon button -->
                 <div class="marathon-section">
                     <button id="marathon-btn" class="btn btn-secondary">Visa maratontabell</button>

--- a/fopen/main.js
+++ b/fopen/main.js
@@ -1751,6 +1751,9 @@ function renderStage() {
   const selectStage = document.getElementById('select-stage');
   const drawStage = document.getElementById('draw-stage');
   const tournamentStage = document.getElementById('tournament-stage');
+  const isTournamentStage = state.stage === 'tournament';
+  document.body.classList.toggle('tournament-fullscreen', isTournamentStage);
+
   if (state.stage === 'select') {
     selectStage.hidden = false;
     drawStage.hidden = true;

--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -217,6 +217,41 @@ header.hero {
   display: none !important;
 }
 
+
+#content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.tournament-overview {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
+  gap: 1rem;
+  align-items: stretch;
+}
+
+#tournament-stage {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.marathon-section {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.schedule {
+  min-height: 0;
+}
+
+#schedule-list {
+  max-height: 38vh;
+  overflow: auto;
+  padding-right: 0.25rem;
+}
+
 /* =========================
    NATION LIST
    ========================= */
@@ -813,4 +848,152 @@ header.hero {
   .hero-right { margin-top: 0.5rem; }
   .nation-list { grid-template-columns: repeat(auto-fill, minmax(90px, 1fr)); }
   .match-teams { font-size: 0.9rem; }
+}
+
+
+@media (min-width: 1000px) and (min-height: 760px) {
+  body.tournament-fullscreen {
+    min-height: 100dvh;
+    overflow: hidden;
+  }
+
+  body.tournament-fullscreen .container {
+    max-width: min(1460px, 100vw);
+    min-height: 100dvh;
+    margin: 0 auto;
+    border-radius: 0;
+    padding: clamp(0.6rem, 1.1vw, 1rem);
+    gap: clamp(0.5rem, 1vh, 0.85rem);
+  }
+
+  body.tournament-fullscreen #content {
+    flex: 1;
+    min-height: 0;
+  }
+
+  body.tournament-fullscreen #tournament-stage {
+    flex: 1;
+    min-height: 0;
+    padding: clamp(0.75rem, 1.2vw, 1rem);
+  }
+
+  body.tournament-fullscreen .hero-logo {
+    height: clamp(68px, 8vh, 84px);
+  }
+
+  body.tournament-fullscreen .hero h1.title {
+    font-size: clamp(1.35rem, 2.4vw, 1.75rem);
+  }
+
+  body.tournament-fullscreen .tournament-overview {
+    flex: 1;
+    min-height: 0;
+    grid-template-columns: minmax(0, 1.45fr) minmax(0, 1fr);
+  }
+
+  body.tournament-fullscreen .now-playing {
+    min-height: 0;
+    overflow: hidden;
+    padding: 0.8rem;
+    gap: 0.35rem;
+  }
+
+  body.tournament-fullscreen .current-matches {
+    gap: 0.4rem;
+    overflow: auto;
+    padding-right: 0.2rem;
+  }
+
+  body.tournament-fullscreen .match-card {
+    width: 100%;
+    padding: 0.45rem 0.5rem;
+    gap: 0.35rem;
+  }
+
+  body.tournament-fullscreen .match-teams {
+    font-size: 0.9rem;
+    margin-bottom: -6px;
+  }
+
+  body.tournament-fullscreen .match-teams span {
+    font-size: 1.05rem;
+    margin: 0 0.35rem;
+  }
+
+  body.tournament-fullscreen .match-inputs {
+    margin-top: 0.35rem;
+    padding-top: 0.35rem;
+  }
+
+  body.tournament-fullscreen .match-inputs input[type="number"] {
+    width: 40px;
+    padding: 0.15rem;
+  }
+
+  body.tournament-fullscreen .groups-rankings {
+    min-height: 0;
+    gap: 0.65rem;
+  }
+
+  body.tournament-fullscreen .groups-rankings.groups-count-4 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  body.tournament-fullscreen .group-ranking {
+    min-height: 0;
+    padding: 0.35rem 0.45rem;
+    overflow: auto;
+  }
+
+  body.tournament-fullscreen .group-ranking table {
+    font-size: 0.76rem;
+  }
+
+  body.tournament-fullscreen .group-ranking th,
+  body.tournament-fullscreen .group-ranking td {
+    padding: 0.18rem 0.2rem;
+  }
+
+  body.tournament-fullscreen .upcoming-wrap {
+    gap: 0.35rem;
+  }
+
+  body.tournament-fullscreen .upcoming-title {
+    margin-right: 0.5rem;
+    font-size: 1rem;
+  }
+
+  body.tournament-fullscreen .upcoming-matches {
+    gap: 0.65rem;
+  }
+
+  body.tournament-fullscreen .upcoming-chip {
+    gap: 0.3rem;
+    padding: 0.1rem 0.35rem;
+  }
+
+  body.tournament-fullscreen .upcoming-chip .flag {
+    width: 34px;
+    height: 23px;
+  }
+
+  body.tournament-fullscreen .marathon-section {
+    margin-top: -0.1rem;
+  }
+
+  body.tournament-fullscreen #schedule-list {
+    max-height: 21vh;
+  }
+
+  body.tournament-fullscreen .schedule-item {
+    min-height: 2.2rem;
+    padding: 0.42rem 0.5rem;
+    font-size: 0.86rem;
+  }
+}
+
+@media (max-width: 999px) {
+  .tournament-overview {
+    grid-template-columns: 1fr;
+  }
 }


### PR DESCRIPTION
### Motivation
- Improve tournament-stage layout by grouping the live matches and group rankings into a unified overview for better visual balance.
- Enable a fullscreen/optimized presentation when viewing the tournament to maximize use of large screens and improve readability of matches and rankings.

### Description
- Wrap the now-playing area and the groups rankings into a new `.tournament-overview` container in `fopen/index.html` to create a two-column layout. 
- Add a `tournament-fullscreen` body class toggle in `renderStage()` in `fopen/main.js` that sets `document.body.classList.toggle('tournament-fullscreen', state.stage === 'tournament')` to enable fullscreen styles when `state.stage` is `tournament`.
- Add new layout and responsive CSS in `fopen/styles.css` including `#content`, `.tournament-overview`, scoped `#tournament-stage` rules, `.marathon-section`, and many `body.tournament-fullscreen` rules inside a large media query to style the fullscreen experience on large viewports, plus a mobile fallback where the overview stacks.
- Adjust schedule list scrolling and match/group sizing constraints to keep the UI usable when the tournament view is expanded.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5c30e46f083209e072d13ef8ba93c)