### PR TITLE
Move schedule panel into modal view

### DIFF
--- a/fopen/index.html
+++ b/fopen/index.html
@@ -108,11 +108,7 @@
                 <!-- Marathon button -->
                 <div class="marathon-section">
                     <button id="marathon-btn" class="btn btn-secondary">Visa maratontabell</button>
-                </div>
-                <!-- Full schedule area -->
-                <div id="schedule" class="schedule">
-                <h2>Spelschema och resultat</h2>
-                    <div id="schedule-list"></div>
+                    <button id="schedule-btn" class="btn btn-secondary">Visa spelschema</button>
                 </div>
                 <div class="tournament-actions">
                     <button id="auto-results" class="btn btn-secondary debug">Fyll i resultat (debug)</button>
@@ -129,6 +125,17 @@
                     <button id="close-marathon" class="btn btn-secondary">Stäng</button>
                 </div>
                 <div id="marathon-table" class="marathon-table"></div>
+            </div>
+        </div>
+
+        <!-- Schedule modal -->
+        <div id="schedule-modal" class="modal" hidden>
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h2>Spelschema och resultat</h2>
+                    <button id="close-schedule" class="btn btn-secondary">Stäng</button>
+                </div>
+                <div id="schedule-modal-list" class="schedule-list"></div>
             </div>
         </div>
     </div>

--- a/fopen/main.js
+++ b/fopen/main.js
@@ -1474,7 +1474,8 @@ function updateStandingsUI() {
 
 // Render schedule at bottom
 function updateScheduleUI() {
-  const list = document.getElementById('schedule-list');
+  const list = document.getElementById('schedule-modal-list');
+  if (!list) return;
   list.innerHTML = '';
   // Bygg varje rad i spelschemat med en tydlig struktur: flagga + nation, resultat,
   // flagga + nation, gruppnamn och en ändra‑knapp. Vinnande lag markeras med
@@ -1747,6 +1748,17 @@ function toggleMarathonModal(show) {
   }
 }
 
+function toggleScheduleModal(show) {
+  const modal = document.getElementById('schedule-modal');
+  if (!modal) return;
+  if (show) {
+    updateScheduleUI();
+    modal.hidden = false;
+  } else {
+    modal.hidden = true;
+  }
+}
+
 // Render current stage UI
 function renderStage() {
   const selectStage = document.getElementById('select-stage');
@@ -1791,6 +1803,8 @@ function bindEvents() {
   document.getElementById('start-tournament-btn').addEventListener('click', startTournament);
   document.getElementById('marathon-btn').addEventListener('click', () => toggleMarathonModal(true));
   document.getElementById('close-marathon').addEventListener('click', () => toggleMarathonModal(false));
+  document.getElementById('schedule-btn').addEventListener('click', () => toggleScheduleModal(true));
+  document.getElementById('close-schedule').addEventListener('click', () => toggleScheduleModal(false));
   document.getElementById('backup-btn').addEventListener('click', backupState);
   document.getElementById('reset-btn').addEventListener('click', resetState);
   document.getElementById('auto-results').addEventListener('click', autoFillResults);

--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -240,13 +240,14 @@ header.hero {
 .marathon-section {
   display: flex;
   justify-content: flex-end;
+  gap: 0.5rem;
 }
 
 .schedule {
   min-height: 0;
 }
 
-#schedule-list {
+#schedule-modal-list {
   max-height: 38vh;
   overflow: auto;
   padding-right: 0.25rem;
@@ -981,7 +982,7 @@ header.hero {
     margin-top: -0.1rem;
   }
 
-  body.tournament-fullscreen #schedule-list {
+  body.tournament-fullscreen #schedule-modal-list {
     max-height: 21vh;
   }
 
@@ -1206,7 +1207,7 @@ header.hero {
     margin-top: 0;
   }
 
-  body.tournament-fullscreen #schedule-list {
+  body.tournament-fullscreen #schedule-modal-list {
     max-height: 24vh;
     overflow: auto;
   }


### PR DESCRIPTION
### Motivation
- Replace the permanently visible schedule panel with an on-demand modal so the tournament view can be more compact and the schedule opened separately.
- Keep existing per-match status styling and the existing `Ändra` (edit result) behavior intact while moving rendering into the modal.

### Description
- Removed the fixed `#schedule` panel and added a `Visa spelschema` button in `.marathon-section` which opens a new `#schedule-modal` with header, close button and a `#schedule-modal-list` container (`fopen/index.html`).
- Updated `updateScheduleUI()` to render match rows into `#schedule-modal-list` and added `toggleScheduleModal(show)` to open/close the modal (`fopen/main.js`).
- Wired the `schedule-btn` and `close-schedule` event listeners in `bindEvents()` so the modal is interactive (`fopen/main.js`).
- Adjusted CSS: added spacing for the two action buttons in `.marathon-section` and replaced schedule list selectors to target the modal list including fullscreen variants (`fopen/styles.css`).

### Testing
- Ran `node --check fopen/main.js` and the script reported no syntax errors (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfa2a10d308320af6592bfec07b3ce)