### PR TITLE
Add schedule CTA before marathon button and wire modal opening

### DIFF
--- a/fopen/index.html
+++ b/fopen/index.html
@@ -107,8 +107,8 @@
                 </div>
                 <!-- Marathon button -->
                 <div class="marathon-section">
+                    <button id="schedule-btn" class="btn btn-primary">Visa spelschema</button>
                     <button id="marathon-btn" class="btn btn-secondary">Visa maratontabell</button>
-                    <button id="schedule-btn" class="btn btn-secondary">Visa spelschema</button>
                 </div>
                 <div class="tournament-actions">
                     <button id="auto-results" class="btn btn-secondary debug">Fyll i resultat (debug)</button>

--- a/fopen/main.js
+++ b/fopen/main.js
@@ -1803,8 +1803,11 @@ function bindEvents() {
   document.getElementById('start-tournament-btn').addEventListener('click', startTournament);
   document.getElementById('marathon-btn').addEventListener('click', () => toggleMarathonModal(true));
   document.getElementById('close-marathon').addEventListener('click', () => toggleMarathonModal(false));
-  document.getElementById('schedule-btn').addEventListener('click', () => toggleScheduleModal(true));
-  document.getElementById('close-schedule').addEventListener('click', () => toggleScheduleModal(false));
+  // Schedule button opens the dedicated schedule modal.
+  const scheduleBtn = document.getElementById('schedule-btn');
+  const closeScheduleBtn = document.getElementById('close-schedule');
+  if (scheduleBtn) scheduleBtn.addEventListener('click', () => toggleScheduleModal(true));
+  if (closeScheduleBtn) closeScheduleBtn.addEventListener('click', () => toggleScheduleModal(false));
   document.getElementById('backup-btn').addEventListener('click', backupState);
   document.getElementById('reset-btn').addEventListener('click', resetState);
   document.getElementById('auto-results').addEventListener('click', autoFillResults);

--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -239,8 +239,10 @@ header.hero {
 
 .marathon-section {
   display: flex;
+  flex-direction: row;
+  align-items: center;
   justify-content: flex-end;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
 .schedule {


### PR DESCRIPTION
### Motivation
- Provide a clear, primary call-to-action for opening the match schedule from the tournament view. 
- Keep the marathon/table button visually distinct as a secondary action. 
- Ensure the buttons render inline and that the schedule modal can be opened/closed reliably from the UI.

### Description
- Inserted a dedicated `#schedule-btn` with text `Visa spelschema` before `#marathon-btn` in `fopen/index.html` and set it to `btn btn-primary`. 
- Kept `#marathon-btn` as `btn btn-secondary` to preserve visual hierarchy. 
- Adjusted `.marathon-section` in `fopen/styles.css` to `display: flex` with `flex-direction: row`, `align-items: center`, and increased `gap` to `0.75rem` so buttons appear inline with proper spacing. 
- Updated `bindEvents()` in `fopen/main.js` to safely bind click listeners for the schedule modal using `document.getElementById('schedule-btn')` and `document.getElementById('close-schedule')` with null checks.

### Testing
- Verified file diffs with `git -C /workspace/webb diff -- fopen/index.html fopen/styles.css fopen/main.js` and inspected relevant lines with `nl`/`sed`, both showing the intended changes (success). 
- Added and committed the changes with `git -C /workspace/webb add ...` and `git -C /workspace/webb commit -m "Add schedule button styling and modal trigger wiring"`, producing a successful commit. 
- Confirmed updated event binding and CSS via file inspection; no automated unit tests were present or run beyond the repository diffs and commit commands.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfa3e9e1108320b5ae79a766d7fbf6)