### PR TITLE
Tighten TV match-card layout and compact history

### DIFF
--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -1058,7 +1058,7 @@ header.hero {
     min-height: 0;
     overflow: hidden;
     padding: 18px;
-    gap: 12px;
+    gap: 8px;
   }
 
   body.tournament-fullscreen .now-playing h2,
@@ -1070,16 +1070,16 @@ header.hero {
   }
 
   body.tournament-fullscreen .current-matches {
-    gap: 12px;
+    gap: 8px;
     overflow: visible; /* 3 cards should fit without inner scroll */
     padding-right: 0;
   }
 
   body.tournament-fullscreen .match-card {
     width: 100%;
-    min-height: 168px;
+    min-height: 140px;
     padding: 14px 16px;
-    gap: 10px;
+    gap: 8px;
     border-left-width: 10px;
   }
 
@@ -1101,7 +1101,7 @@ header.hero {
 
   body.tournament-fullscreen .match-team-left span,
   body.tournament-fullscreen .match-team-right span {
-    font-size: 1.5rem;
+    font-size: 1.3rem;
     line-height: 1.05;
   }
 
@@ -1115,12 +1115,16 @@ header.hero {
   }
 
   body.tournament-fullscreen .history {
-    font-size: 0.82rem;
-    gap: 4px;
+    font-size: 0.76rem;
+    gap: 2px;
+  }
+
+  body.tournament-fullscreen .history .history-entry:nth-of-type(n + 2) {
+    display: none;
   }
 
   body.tournament-fullscreen .match-inputs {
-    gap: 10px;
+    gap: 6px;
     margin-top: 6px;
     padding-top: 10px;
   }


### PR DESCRIPTION
### Motivation
- Reduce vertical footprint of match cards in TV/fullscreen mode so three simultaneous matches leave room for the “Kommande” row. 
- Make team names visually smaller in TV mode to fit tighter layouts. 
- Shorten the history section in TV mode to a single row to avoid pushing the upcoming row off-screen.

### Description
- Reduced TV/fullscreen gaps: `.now-playing` from `12px` to `8px`, `.current-matches` from `12px` to `8px`, and `.match-inputs` from `10px` to `6px`.
- Lowered `.match-card` `min-height` from `168px` to `140px` and reduced internal `gap` from `10px` to `8px`.
- Reduced team name font size in TV mode: `.match-team-left span` / `.match-team-right span` from `1.5rem` to `1.3rem`.
- Compacted history in TV mode by changing `.history` `font-size` to `0.76rem`, reducing `gap` to `2px`, and hiding all history rows after the first with `.history .history-entry:nth-of-type(n + 2) { display: none; }`.
- Preserved `overflow: visible` on `.current-matches` so three cards remain visible and the upcoming (`Kommande`) row can still be shown.

### Testing
- Ran `git diff -- fopen/styles.css` to inspect the CSS changes and confirmed the intended edits were present (succeeded).
- Ran `git status --short` to verify the working tree state showing the modified file (succeeded) and committed the change with `git commit -m "Tighten TV match card layout to keep upcoming row visible"` (succeeded).
- Inspected the resulting file with a ranged file print (`nl -ba fopen/styles.css | sed -n '1048,1145p'`) to confirm live values (succeeded).
- No automated visual/UI test suite is configured for this static layout change, so visual verification in-browser was not performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfa75c0ee08320b22e3617a56368e8)