### PR TITLE
Improve TV schedule modal layout and add ultra-compact mode

### DIFF
--- a/fopen/main.js
+++ b/fopen/main.js
@@ -1475,8 +1475,10 @@ function updateStandingsUI() {
 // Render schedule at bottom
 function updateScheduleUI() {
   const list = document.getElementById('schedule-modal-list');
+  const modal = document.getElementById('schedule-modal');
   if (!list) return;
   list.innerHTML = '';
+  if (modal) modal.classList.remove('ultra-compact');
   // Bygg varje rad i spelschemat med en tydlig struktur: flagga + nation, resultat,
   // flagga + nation, gruppnamn och en ändra‑knapp. Vinnande lag markeras med
   // fetstil. Gruppnamn hämtas från match.group som sätts i buildSchedule().
@@ -1544,7 +1546,8 @@ function updateScheduleUI() {
       changeBtn = document.createElement('button');
       changeBtn.classList.add('btn', 'btn-secondary', 'change-result');
       changeBtn.textContent = 'Ändra';
-      changeBtn.addEventListener('click', () => {
+      changeBtn.addEventListener('click', (event) => {
+        event.stopPropagation();
         editResult(idx);
       });
     }
@@ -1558,10 +1561,32 @@ function updateScheduleUI() {
     if (changeBtn) item.appendChild(changeBtn);
     list.appendChild(item);
   });
+  enableUltraCompactScheduleIfNeeded();
   // After rendering the schedule, check if the group stage has been completed.
   // This ensures that on page reload the "Gruppspelet är slut" message and button
   // appear if all matches have results.
   checkGroupStageComplete();
+}
+
+function enableUltraCompactScheduleIfNeeded() {
+  const modal = document.getElementById('schedule-modal');
+  const list = document.getElementById('schedule-modal-list');
+  if (!modal || !list) return;
+  if (!document.body.classList.contains('tournament-fullscreen')) return;
+
+  requestAnimationFrame(() => {
+    const listOverflows = list.scrollHeight > list.clientHeight;
+    modal.classList.toggle('ultra-compact', listOverflows);
+    if (!listOverflows) return;
+
+    const rows = list.querySelectorAll('.schedule-item');
+    rows.forEach(row => {
+      row.addEventListener('click', () => {
+        rows.forEach(otherRow => otherRow.classList.remove('expanded'));
+        row.classList.add('expanded');
+      });
+    });
+  });
 }
 
 function editResult(idx) {
@@ -1752,8 +1777,8 @@ function toggleScheduleModal(show) {
   const modal = document.getElementById('schedule-modal');
   if (!modal) return;
   if (show) {
-    updateScheduleUI();
     modal.hidden = false;
+    updateScheduleUI();
   } else {
     modal.hidden = true;
   }

--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -255,6 +255,19 @@ header.hero {
   padding-right: 0.25rem;
 }
 
+#schedule-modal .modal-content {
+  width: min(96vw, 1600px);
+  height: min(92vh, 1200px);
+  max-width: none;
+  max-height: none;
+  overflow: hidden;
+}
+
+#schedule-modal-list {
+  flex: 1;
+  min-height: 0;
+}
+
 /* =========================
    NATION LIST
    ========================= */
@@ -984,14 +997,35 @@ header.hero {
     margin-top: -0.1rem;
   }
 
-  body.tournament-fullscreen #schedule-modal-list {
-    max-height: 21vh;
+  body.tournament-fullscreen #schedule-modal .modal-content {
+    overflow: hidden;
   }
 
-  body.tournament-fullscreen .schedule-item {
+  body.tournament-fullscreen #schedule-modal-list {
+    max-height: none;
+    overflow: visible;
+    padding-right: 0;
+  }
+
+  body.tournament-fullscreen #schedule-modal .schedule-item {
     min-height: 2.2rem;
-    padding: 0.42rem 0.5rem;
-    font-size: 0.86rem;
+    padding: 0.32rem 0.4rem;
+    font-size: 0.78rem;
+    gap: 0.35rem;
+  }
+
+  body.tournament-fullscreen #schedule-modal .schedule-item img.flag {
+    width: 30px;
+    height: 20px;
+  }
+
+  body.tournament-fullscreen #schedule-modal .schedule-group {
+    font-size: 0.72rem;
+  }
+
+  body.tournament-fullscreen #schedule-modal .schedule-item button.change-result {
+    font-size: 0.68rem;
+    padding: 0.18rem 0.36rem;
   }
 }
 
@@ -1213,29 +1247,43 @@ header.hero {
     margin-top: 0;
   }
 
+  body.tournament-fullscreen #schedule-modal .modal-content {
+    width: 96vw;
+    height: 92vh;
+    max-width: none;
+    max-height: none;
+    overflow: hidden;
+  }
+
   body.tournament-fullscreen #schedule-modal-list {
-    max-height: 24vh;
-    overflow: auto;
+    max-height: none;
+    overflow: visible;
+    padding-right: 0;
   }
 
-  body.tournament-fullscreen .schedule-item {
+  body.tournament-fullscreen #schedule-modal .schedule-item {
     min-height: 52px;
-    padding: 8px 12px;
-    font-size: 0.96rem;
-    gap: 8px;
+    padding: 5px 7px;
+    font-size: 0.84rem;
+    gap: 5px;
   }
 
-  body.tournament-fullscreen .schedule-score {
+  body.tournament-fullscreen #schedule-modal .schedule-score {
     min-width: 76px;
   }
 
-  body.tournament-fullscreen .schedule-group {
-    font-size: 0.82rem;
+  body.tournament-fullscreen #schedule-modal .schedule-group {
+    font-size: 0.72rem;
   }
 
-  body.tournament-fullscreen .schedule-item button.change-result {
-    font-size: 0.8rem;
-    padding: 4px 10px;
+  body.tournament-fullscreen #schedule-modal .schedule-item img.flag {
+    width: 30px;
+    height: 20px;
+  }
+
+  body.tournament-fullscreen #schedule-modal .schedule-item button.change-result {
+    font-size: 0.68rem;
+    padding: 2px 6px;
   }
 
   /* Toast / latest result */
@@ -1243,4 +1291,21 @@ header.hero {
     padding: 14px 24px;
     font-size: 1.2rem;
   }
+}
+
+body.tournament-fullscreen #schedule-modal.ultra-compact .schedule-item {
+  grid-template-columns: auto 1fr auto auto 1fr auto;
+  cursor: pointer;
+}
+
+body.tournament-fullscreen #schedule-modal.ultra-compact .schedule-item button.change-result {
+  display: none;
+}
+
+body.tournament-fullscreen #schedule-modal.ultra-compact .schedule-item.expanded {
+  grid-template-columns: auto 1fr auto auto 1fr auto auto;
+}
+
+body.tournament-fullscreen #schedule-modal.ultra-compact .schedule-item.expanded button.change-result {
+  display: inline-flex;
 }


### PR DESCRIPTION
### Motivation
- Make the schedule modal usable in TV/fullscreen presentation by growing it near full-screen and preventing double-scrolling. 
- Reduce per-row footprint inside the schedule modal so more rows fit on large screens. 
- Add a fallback “ultra-compact” mode when even the compact layout still overflows. 

### Description
- Added dedicated modal sizing for the schedule modal via `#schedule-modal .modal-content` to open near fullscreen (`width: 96vw; height: 92vh`) and set `overflow: hidden`. (`fopen/styles.css`) 
- Removed TV-mode `max-height`/internal scrolling on `#schedule-modal-list` and made it expand/visible in fullscreen so the modal controls overall overflow. (`fopen/styles.css`) 
- Compacted schedule rows only inside the schedule modal in TV/fullscreen: reduced `padding`, `font-size`, `flag` sizes and tightened `gap`, and adjusted the change-button sizing. (`fopen/styles.css`) 
- Added an automatic ultra-compact fallback implemented by: `enableUltraCompactScheduleIfNeeded()` which toggles a `ultra-compact` class when the list still overflows, hides per-row `Ändra` buttons, and lets a row expand (showing its button) when clicked; also stopped propagation on the `Ändra` button to avoid row click conflicts and ensured the overflow check runs after rendering. (`fopen/main.js`) 

### Testing
- Ran `node --check fopen/main.js` to validate the modified JS and the check completed without errors. 
- No automated UI tests exist; changes were limited to `fopen/styles.css` and `fopen/main.js` and validated with the static JS check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfa7d146108320a0dd56fd6116e1c7)