### PR TITLE
Stäng schema-modalen med Escape/overlay och lägg till fokushantering

### DIFF
--- a/fopen/main.js
+++ b/fopen/main.js
@@ -1775,12 +1775,16 @@ function toggleMarathonModal(show) {
 
 function toggleScheduleModal(show) {
   const modal = document.getElementById('schedule-modal');
+  const closeScheduleBtn = document.getElementById('close-schedule');
+  const scheduleBtn = document.getElementById('schedule-btn');
   if (!modal) return;
   if (show) {
     modal.hidden = false;
     updateScheduleUI();
+    if (closeScheduleBtn) closeScheduleBtn.focus({ preventScroll: true });
   } else {
     modal.hidden = true;
+    if (scheduleBtn) scheduleBtn.focus({ preventScroll: true });
   }
 }
 
@@ -1831,8 +1835,21 @@ function bindEvents() {
   // Schedule button opens the dedicated schedule modal.
   const scheduleBtn = document.getElementById('schedule-btn');
   const closeScheduleBtn = document.getElementById('close-schedule');
+  const scheduleModal = document.getElementById('schedule-modal');
+  const scheduleModalContent = scheduleModal ? scheduleModal.querySelector('.modal-content') : null;
   if (scheduleBtn) scheduleBtn.addEventListener('click', () => toggleScheduleModal(true));
   if (closeScheduleBtn) closeScheduleBtn.addEventListener('click', () => toggleScheduleModal(false));
+  if (scheduleModal && scheduleModalContent) {
+    scheduleModal.addEventListener('click', evt => {
+      if (evt.target === scheduleModal) toggleScheduleModal(false);
+    });
+  }
+
+  document.addEventListener('keydown', evt => {
+    if (evt.key === 'Escape' && scheduleModal && !scheduleModal.hidden) {
+      toggleScheduleModal(false);
+    }
+  });
   document.getElementById('backup-btn').addEventListener('click', backupState);
   document.getElementById('reset-btn').addEventListener('click', resetState);
   document.getElementById('auto-results').addEventListener('click', autoFillResults);


### PR DESCRIPTION
### Motivation
- Förbättra användbarheten och tillgängligheten för spelschema-modalen genom att stödja tangentbordsstyrning och overlay-stängning.
- Gör det enkelt att snabbt styra modal med tangentbord utan att ändra den primära blå knappen `#schedule-btn`.

### Description
- Vid öppning av modalen sätts fokus på stängknappen `#close-schedule` med `preventScroll` för att undvika oönskad scrollning.
- Vid stängning återställs fokus till `#schedule-btn` med `preventScroll` så att primärknappen förblir huvudtriggern.
- Klick på overlay (klick utanför `.modal-content`) stänger nu `#schedule-modal`.
- Tangenttryck `Escape` stänger också `#schedule-modal` när den är öppen.

### Testing
- `node --check fopen/main.js` — testet kördes och lyckades.
- Det finns inga automatiserade browser-/UI-tester i denna miljö för att köra öppna/stänga-scenarion automatiskt.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfa8fda38c8320af05f42e764530d1)