### PR TITLE
Scope schedule modal and compact rows for TV fullscreen (fopen/styles.css)

### DIFF
--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -261,11 +261,17 @@ header.hero {
   max-width: none;
   max-height: none;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 #schedule-modal-list {
   flex: 1;
   min-height: 0;
+}
+
+#schedule-modal .schedule-item {
+  line-height: 1.12;
 }
 
 /* =========================
@@ -1248,8 +1254,8 @@ header.hero {
   }
 
   body.tournament-fullscreen #schedule-modal .modal-content {
-    width: 96vw;
-    height: 92vh;
+    width: min(98vw, 1700px);
+    height: min(96vh, 1280px);
     max-width: none;
     max-height: none;
     overflow: hidden;
@@ -1257,33 +1263,43 @@ header.hero {
 
   body.tournament-fullscreen #schedule-modal-list {
     max-height: none;
-    overflow: visible;
+    overflow: hidden;
     padding-right: 0;
   }
 
   body.tournament-fullscreen #schedule-modal .schedule-item {
-    min-height: 52px;
-    padding: 5px 7px;
-    font-size: 0.84rem;
-    gap: 5px;
+    min-height: 42px;
+    padding: 3px 6px;
+    font-size: 0.76rem;
+    line-height: 1;
+    gap: 4px;
+  }
+
+  body.tournament-fullscreen #schedule-modal .schedule-team {
+    gap: 4px;
   }
 
   body.tournament-fullscreen #schedule-modal .schedule-score {
-    min-width: 76px;
+    min-width: 68px;
   }
 
   body.tournament-fullscreen #schedule-modal .schedule-group {
-    font-size: 0.72rem;
+    font-size: 0.66rem;
   }
 
   body.tournament-fullscreen #schedule-modal .schedule-item img.flag {
-    width: 30px;
-    height: 20px;
+    width: 26px;
+    height: 17px;
   }
 
   body.tournament-fullscreen #schedule-modal .schedule-item button.change-result {
-    font-size: 0.68rem;
-    padding: 2px 6px;
+    font-size: 0.66rem;
+    padding: 2px 5px;
+    min-height: 24px;
+    white-space: nowrap;
+    pointer-events: auto;
+    position: relative;
+    z-index: 1;
   }
 
   /* Toast / latest result */


### PR DESCRIPTION
### Motivation
- Improve the schedule modal layout for TV/fullscreen displays so group-stage matches fit without introducing scroll side-effects to other modals.
- Keep marathon modal scrolling behavior unchanged while making the schedule modal use near-fullscreen sizing in large displays.
- Ensure the `Ändra` (change) button remains clickable in the denser, compact schedule view.

### Description
- Scoped schedule-modal content by adding `display: flex; flex-direction: column;` to `#schedule-modal .modal-content` and a `line-height` rule for `#schedule-modal .schedule-item` so layout and overflow stay contained to the schedule modal.
- In the TV media query (`@media (min-width: 1400px) and (min-height: 760px)`) increased the schedule modal `width`/`height` to `min(98vw, 1700px)` / `min(96vh, 1280px)` and ensured `overflow: hidden` to use near-fullscreen space.
- Compressed schedule rows inside the schedule modal by reducing `min-height`, `padding`, `font-size`, `gap`, flag image sizes, and `schedule-score`/`schedule-group` sizing to allow more rows to display simultaneously.
- Kept the marathon modal intact and reinforced the `change-result` button visibility/clickability by setting `min-height`, `white-space: nowrap`, `pointer-events: auto`, and `z-index: 1` for `#schedule-modal .schedule-item button.change-result`.

### Testing
- No automated tests were run for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfaa1a7bb48320ba07538e751cbd2a)