### PR TITLE
Set TV tournament board count default to three

### DIFF
--- a/fopen/main.js
+++ b/fopen/main.js
@@ -108,7 +108,7 @@ function loadState() {
       drawAssignments: {},
       schedule: [],
       results: {}, // matchId -> {score1, score2}
-      numBoards: 1,
+      numBoards: 3,
       marathonUpdated: null,
       // Use a stable ordering for matches in progress to avoid concurrency issues
       playing: [],
@@ -123,6 +123,7 @@ function loadState() {
   if (!state.drawAssignments) state.drawAssignments = {};
   if (!Array.isArray(state.schedule)) state.schedule = [];
   if (!state.results) state.results = {};
+  if (!Number.isInteger(state.numBoards) || state.numBoards < 1) state.numBoards = 3;
   if (!state.playing) state.playing = [];
   if (!Array.isArray(state.playingMatches)) state.playingMatches = [];
   return state;
@@ -445,11 +446,9 @@ function buildSchedule() {
   saveState();
 }
 
-// Prompt user for number of boards and start tournament
+// Start tournament (TV deployment uses fixed 3 boards)
 function startTournament() {
-  let boards = parseInt(prompt('Hur många bord (1–5)?', state.numBoards || 1), 10);
-  if (isNaN(boards) || boards < 1 || boards > 5) boards = 1;
-  state.numBoards = boards;
+  state.numBoards = 3;
   buildSchedule();
   // Initialise group standings with zero values so that groups are displayed even before any matches are played.
   initGroupStandings();
@@ -556,6 +555,9 @@ function updateNowPlaying() {
     const m = state.schedule[idx];
     return m && m.status !== 'completed';
   });
+  if (state.playingMatches.length > state.numBoards) {
+    state.playingMatches = state.playingMatches.slice(0, state.numBoards);
+  }
   // Reset status of all non-completed matches to pending; matches
   // currently in playingMatches will be set to 'playing' later
   state.schedule.forEach((m, i) => {
@@ -1917,7 +1919,7 @@ function resetState() {
     drawAssignments: {},
     schedule: [],
     results: {},
-    numBoards: 1,
+    numBoards: 3,
     marathonUpdated: null,
     playing: [],
     playingMatches: []


### PR DESCRIPTION
### Motivation
- The TV deployment should run with a fixed three-board layout instead of prompting an operator at startup.
- The UI must never show more active "now playing" cards than the configured board count to avoid overflowing the TV view.

### Description
- Set the default `numBoards` to `3` in the initial `state` and in `resetState()` so new and reset sessions use three boards.
- Replace the prompt in `startTournament()` with a fixed `state.numBoards = 3` so the board count is no longer requested from the user.
- Add a guard in `loadState()` to set `state.numBoards = 3` when the loaded value is missing or invalid.
- Trim `state.playingMatches` to `state.numBoards` at the start of `updateNowPlaying()` so the now-playing area never renders more than the configured cards.

### Testing
- Ran `node --check fopen/main.js` and the file passed the syntax check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfaad2801483209bdf7d2e16a329ef)