### PR TITLE
Refine tournament-fullscreen and schedule modal styles for compact layouts

### DIFF
--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -261,11 +261,17 @@ header.hero {
   max-width: none;
   max-height: none;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 #schedule-modal-list {
   flex: 1;
   min-height: 0;
+}
+
+#schedule-modal .schedule-item {
+  line-height: 1.12;
 }
 
 /* =========================
@@ -1082,8 +1088,8 @@ header.hero {
     flex: 1;
     min-height: 0;
     display: grid;
-    grid-template-columns: minmax(0, 1.6fr) minmax(420px, 1fr);
-    gap: 18px;
+    grid-template-columns: minmax(0, 1.42fr) minmax(520px, 1.12fr);
+    gap: 14px;
     align-items: stretch;
   }
 
@@ -1091,8 +1097,8 @@ header.hero {
   body.tournament-fullscreen .now-playing {
     min-height: 0;
     overflow: hidden;
-    padding: 18px;
-    gap: 8px;
+    padding: 14px;
+    gap: 6px;
   }
 
   body.tournament-fullscreen .now-playing h2,
@@ -1111,9 +1117,9 @@ header.hero {
 
   body.tournament-fullscreen .match-card {
     width: 100%;
-    min-height: 140px;
-    padding: 14px 16px;
-    gap: 8px;
+    min-height: 118px;
+    padding: 10px 12px;
+    gap: 6px;
     border-left-width: 10px;
   }
 
@@ -1122,21 +1128,25 @@ header.hero {
   }
 
   body.tournament-fullscreen .match-teams {
-    grid-template-columns: 1fr auto 1fr;
-    gap: 12px;
-    font-size: 1.05rem;
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+    gap: 8px;
+    font-size: 0.98rem;
     margin-bottom: 0;
   }
 
   body.tournament-fullscreen .match-team-left,
   body.tournament-fullscreen .match-team-right {
-    gap: 10px;
+    gap: 8px;
+    min-width: 0;
   }
 
   body.tournament-fullscreen .match-team-left span,
   body.tournament-fullscreen .match-team-right span {
-    font-size: 1.3rem;
-    line-height: 1.05;
+    font-size: 1.08rem;
+    line-height: 1.04;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   body.tournament-fullscreen .match-vs {
@@ -1223,13 +1233,13 @@ header.hero {
   }
 
   body.tournament-fullscreen .group-ranking table {
-    font-size: 0.9rem;
-    line-height: 1.2;
+    font-size: 1rem;
+    line-height: 1.24;
   }
 
   body.tournament-fullscreen .group-ranking th,
   body.tournament-fullscreen .group-ranking td {
-    padding: 4px 4px;
+    padding: 5px 5px;
   }
 
   body.tournament-fullscreen .group-ranking .nation-cell {
@@ -1248,42 +1258,58 @@ header.hero {
   }
 
   body.tournament-fullscreen #schedule-modal .modal-content {
-    width: 96vw;
-    height: 92vh;
+    width: min(90vw, 1420px);
+    height: min(96vh, 1280px);
     max-width: none;
     max-height: none;
     overflow: hidden;
   }
 
   body.tournament-fullscreen #schedule-modal-list {
+    display: block;
+    column-count: 2;
+    column-gap: 10px;
     max-height: none;
-    overflow: visible;
+    overflow: hidden;
     padding-right: 0;
   }
 
   body.tournament-fullscreen #schedule-modal .schedule-item {
-    min-height: 52px;
-    padding: 5px 7px;
-    font-size: 0.84rem;
-    gap: 5px;
+    min-height: 36px;
+    padding: 2px 5px;
+    font-size: 0.71rem;
+    line-height: 1;
+    gap: 3px;
+    margin: 0 0 4px;
+    break-inside: avoid;
+    -webkit-column-break-inside: avoid;
+  }
+
+  body.tournament-fullscreen #schedule-modal .schedule-team {
+    gap: 4px;
   }
 
   body.tournament-fullscreen #schedule-modal .schedule-score {
-    min-width: 76px;
+    min-width: 56px;
   }
 
   body.tournament-fullscreen #schedule-modal .schedule-group {
-    font-size: 0.72rem;
+    font-size: 0.6rem;
   }
 
   body.tournament-fullscreen #schedule-modal .schedule-item img.flag {
-    width: 30px;
-    height: 20px;
+    width: 22px;
+    height: 15px;
   }
 
   body.tournament-fullscreen #schedule-modal .schedule-item button.change-result {
-    font-size: 0.68rem;
-    padding: 2px 6px;
+    font-size: 0.6rem;
+    padding: 1px 4px;
+    min-height: 20px;
+    white-space: nowrap;
+    pointer-events: auto;
+    position: relative;
+    z-index: 1;
   }
 
   /* Toast / latest result */

--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -1332,3 +1332,10 @@ body.tournament-fullscreen #schedule-modal.ultra-compact .schedule-item.expanded
 body.tournament-fullscreen #schedule-modal.ultra-compact .schedule-item.expanded button.change-result {
   display: inline-flex;
 }
+
+/* Merge-safe override: fill schedule modal column 1 before column 2 on TV */
+@media (min-width: 1400px) and (min-height: 760px) {
+  body.tournament-fullscreen #schedule-modal-list {
+    column-fill: auto;
+  }
+}

--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -253,6 +253,8 @@ header.hero {
   max-height: 38vh;
   overflow: auto;
   padding-right: 0.25rem;
+  flex: 1;
+  min-height: 0;
 }
 
 #schedule-modal .modal-content {
@@ -263,11 +265,6 @@ header.hero {
   overflow: hidden;
   display: flex;
   flex-direction: column;
-}
-
-#schedule-modal-list {
-  flex: 1;
-  min-height: 0;
 }
 
 #schedule-modal .schedule-item {


### PR DESCRIPTION
### Motivation
- Improve layout density and readability in the tournament fullscreen view and schedule modal so more content fits without inner scrolling. 
- Ensure team names truncate cleanly, schedule items flow into multi-column lists in fullscreen, and interactive controls remain usable in compact modes.

### Description
- Convert `#schedule-modal .modal-content` to a column flex container and add `.schedule-item` line-height tweaks for tighter vertical spacing. 
- Adjust fullscreen overview grid and panel spacing by updating `grid-template-columns`, gaps, paddings, and `match-card` sizing to be more compact. 
- Make team columns fluid with `minmax(0, 1fr)`, add truncation (`white-space: nowrap; overflow: hidden; text-overflow: ellipsis`) for team name spans, and ensure team containers have `min-width: 0`. 
- Rework fullscreen schedule modal to use `column-count: 2` with compact `.schedule-item` sizing, reduced flag sizes, and improved `button.change-result` sizing/interaction (`min-height`, `white-space: nowrap`, `pointer-events`, `z-index`).

### Testing
- Ran `npm run build` and the stylesheet compiled successfully. 
- Ran `npm run test` (unit/CI tests) and all tests passed. 
- Ran `npm run lint:css` and no linting issues were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfaa1a7bb48320ba07538e751cbd2a)