### PR TITLE
Modernisera turneringsvyn för TV och förbättra spelschemalistan

### DIFF
--- a/fopen/index.html
+++ b/fopen/index.html
@@ -103,7 +103,10 @@
                         </div>
                     </div>
                     <!-- Groups rankings area -->
-                    <div id="groups-rankings" class="groups-rankings"></div>
+                    <div class="rankings-panel">
+                        <h2 class="rankings-title">Ställningen just nu</h2>
+                        <div id="groups-rankings" class="groups-rankings"></div>
+                    </div>
                 </div>
                 <!-- Marathon button -->
                 <div class="marathon-section">

--- a/fopen/main.js
+++ b/fopen/main.js
@@ -1491,7 +1491,10 @@ function updateScheduleUI() {
     item.classList.add(match.status);
     if (match.status === 'completed') item.classList.add('completed');
     if (match.skipped) item.classList.add('skipped');
-    // Build columns: flag1, team1, score, flag2, team2, group label, edit button
+    // Build columns: number, flag1, team1, score, flag2, team2, group label, edit button
+    const numberDiv = document.createElement('div');
+    numberDiv.classList.add('schedule-number');
+    numberDiv.textContent = `${idx + 1}.`;
     // Flag for team1
     const leftImg = document.createElement('img');
     leftImg.src = getFlagSrc(match.team1);
@@ -1552,6 +1555,7 @@ function updateScheduleUI() {
       });
     }
     // Append in order to match grid columns
+    item.appendChild(numberDiv);
     item.appendChild(leftImg);
     item.appendChild(leftName);
     item.appendChild(score);

--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -20,9 +20,8 @@
   --shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
 
   /* Fonts */
-  --font-display: 'Teko', 'Barlow Condensed', Impact, sans-serif;
+  --font-display: 'Teko', 'Barlow Condensed', 'Inter', 'Segoe UI', sans-serif;
   --font-body: 'Inter', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
-  --font-display: 'Press Start 2P', 'Teko', monospace;
   /* --font-body: 'Press Start 2P', 'Teko', monospace; */
 
   /* Flag sizing + styling */
@@ -135,6 +134,8 @@ header.hero {
   margin: 0.5rem 0 0;
   font-family: var(--font-display);
   font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
   line-height: 1.05;
   color: var(--color-primary);
 }
@@ -409,7 +410,8 @@ header.hero {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  width: 97%;
+  width: 100%;
+  box-sizing: border-box;
   animation: slideDown 0.6s ease;
   transition: transform 0.5s ease, opacity 0.5s ease;
 }
@@ -447,8 +449,8 @@ header.hero {
 
 .match-team-left span, .match-team-right span {
   font-family: var(--font-display);
-  font-size: 1rem;
-  font-weight: normal;
+  font-size: 1.05rem;
+  font-weight: 600;
 }
 
 .match-team-right {
@@ -494,48 +496,48 @@ header.hero {
 .upcoming-wrap {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin-top: 0.25rem;
+  gap: 0.75rem;
+  margin-top: 0.4rem;
   flex-wrap: wrap;
 }
 
 .upcoming-title {
   margin: 0 1rem 0 0;
-  font-size: 1.25rem;
+  font-size: 1.35rem;
   line-height: 1;
 }
 
 .upcoming-matches {
   display: flex;
-  gap: 2rem;
+  gap: 0.9rem;
   flex-wrap: wrap;
 }
 
 .upcoming-chip {
   display: inline-flex;
   align-items: center;
-  gap: .5rem;
+  gap: 0.6rem;
   border: 1px solid #b9cbe6;
-  border-radius: 6px;
-  padding: 0.14rem .5rem;
+  border-radius: 10px;
+  padding: 0.38rem 0.72rem;
   background: #f6f9ff;
   border-left: var(--color-secondary) 3px solid;
 }
 
 .upcoming-chip .flag {
-  width: 42px;
-  height: 28px;
+  width: 52px;
+  height: 34px;
   border-radius: 3px;
 }
 
 .upcoming-group {
   font-family: var(--font-display);
-  font-size: 0.75rem;
-     font-weight: normal;
+  font-size: 0.95rem;
+  font-weight: 600;
   line-height: 1;
   color: #457;
   text-transform: uppercase;
-  margin: 0 0.5rem;
+  margin: 0 0.4rem;
 }
 
 .upcoming-sep {
@@ -617,11 +619,18 @@ header.hero {
   border-radius: var(--border-radius);
   border: 1px solid var(--color-border);
   display: grid;
-  grid-template-columns: auto 1fr auto auto 1fr auto auto;
+  grid-template-columns: auto auto 1fr auto auto 1fr auto auto;
   align-items: center;
   gap: 0.6rem;
   min-height: 3rem;
   font-size: 1.05rem;
+}
+
+.schedule-number {
+  font-weight: 700;
+  color: #5e6d81;
+  min-width: 2.2ch;
+  text-align: right;
 }
 
 .schedule-item.completed {
@@ -691,6 +700,19 @@ header.hero {
   display: grid;
   gap: 1rem;
   grid-auto-flow: row;
+}
+
+.rankings-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  min-height: 0;
+}
+
+.rankings-title {
+  margin: 0;
+  font-size: clamp(1.25rem, 1.9vw, 1.9rem);
+  line-height: 1.1;
 }
 
 .groups-rankings.groups-count-3 { grid-template-columns: repeat(3, 1fr); }
@@ -958,6 +980,10 @@ header.hero {
     gap: 0.65rem;
   }
 
+  body.tournament-fullscreen .rankings-title {
+    font-size: 1.45rem;
+  }
+
   body.tournament-fullscreen .groups-rankings.groups-count-4 {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -1198,13 +1224,14 @@ header.hero {
   }
 
   body.tournament-fullscreen .upcoming-chip {
-    gap: 8px;
-    padding: 4px 10px;
+    gap: 10px;
+    padding: 8px 12px;
+    border-radius: 12px;
   }
 
   body.tournament-fullscreen .upcoming-chip .flag {
-    width: 34px;
-    height: 23px;
+    width: 46px;
+    height: 30px;
   }
 
   body.tournament-fullscreen .upcoming-group {
@@ -1267,21 +1294,22 @@ header.hero {
   }
 
   body.tournament-fullscreen #schedule-modal-list {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 4px 8px;
-    align-content: start;
+    display: block;
+    columns: 2;
+    column-gap: 12px;
     max-height: none;
-    overflow: hidden;
+    overflow: auto;
     padding-right: 0;
   }
 
   body.tournament-fullscreen #schedule-modal .schedule-item {
-    min-height: 36px;
-    padding: 2px 5px;
-    font-size: 0.71rem;
+    min-height: 42px;
+    padding: 4px 7px;
+    font-size: 0.79rem;
     line-height: 1;
     gap: 3px;
+    break-inside: avoid;
+    margin: 0 0 6px;
   }
 
   body.tournament-fullscreen #schedule-modal .schedule-team {
@@ -1293,7 +1321,7 @@ header.hero {
   }
 
   body.tournament-fullscreen #schedule-modal .schedule-group {
-    font-size: 0.66rem;
+    font-size: 0.7rem;
   }
 
   body.tournament-fullscreen #schedule-modal .schedule-item img.flag {
@@ -1319,7 +1347,7 @@ header.hero {
 }
 
 body.tournament-fullscreen #schedule-modal.ultra-compact .schedule-item {
-  grid-template-columns: auto 1fr auto auto 1fr auto;
+  grid-template-columns: auto auto 1fr auto auto 1fr auto;
   cursor: pointer;
 }
 
@@ -1328,7 +1356,7 @@ body.tournament-fullscreen #schedule-modal.ultra-compact .schedule-item button.c
 }
 
 body.tournament-fullscreen #schedule-modal.ultra-compact .schedule-item.expanded {
-  grid-template-columns: auto 1fr auto auto 1fr auto auto;
+  grid-template-columns: auto auto 1fr auto auto 1fr auto auto;
 }
 
 body.tournament-fullscreen #schedule-modal.ultra-compact .schedule-item.expanded button.change-result {


### PR DESCRIPTION
### Motivation
- Göra UI:t mer harmoniskt och läsbart på fullscreen-TV (1920×1080) för åskådare på avstånd genom typografi-, spacing- och layoutförbättringar.
- Tydliggöra aktuell ställning och göra spelschemalistan enklare att följa för speakern/producenten genom numrering och kolumnfylningsbeteende.
- Åtgärda att "Kör nu"-kort blev för breda och förbättra "Kommande"-kortens synlighet och hierarki.

### Description
- Lagt till en dedikerad rankings-panel med rubriken `Ställningen just nu` ovanför grupptabellerna i `fopen/index.html` och style för panelen i `fopen/styles.css`.
- Uppdaterat typografi-variabler för att använda en modernare kombination (`Teko`/`Inter`) och justerat titelvikter/letter-spacing i `fopen/styles.css`.
- Fixat matchkortens bredd/box-modell och ökat tyngd på lagnamn så korten inte blir för breda i `fopen/styles.css` och gjort `match-card` fullbredd med `box-sizing:border-box`.
- Förstorat och luftat upp "Kommande"-chips (större flaggor, padding, radius och fontvikt) i `fopen/styles.css` för bättre TV-läsbarhet.
- Numrerat spelschemarader genom att injicera ett `div.schedule-number` i varje rad i `fopen/main.js` och justerat grid-layouten för raden i `fopen/styles.css` så numret får egen kolumn.
- Förbättrat schedule-modalens fullscreen-layout så listan fylls uppifrån–ner i första kolumnen och sedan i nästa genom att använda `columns: 2` och relaterade TV-tweaks i `fopen/styles.css`.
- Diverse spacing/storleks- och media-query-justeringar för mer enhetligt utseende i TV-läge i `fopen/styles.css`.

### Testing
- Kört syntaxkontroll med `node --check fopen/main.js`, vilket körde utan fel (succeeded).
- Render-beroende förändringar har verifierats genom lokal inspektion av HTML/CSS/JS-struktur (ingen automatisk visuell testkörning utförd).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d26ad1805c8320be542933c21ae56e)