### PR TITLE
fopen: förbättra matchkort-alignment och undvik sidledsscroll i spelschema (fullscreen)

### DIFF
--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -431,7 +431,7 @@ header.hero {
   font-weight: bold;
   font-size: 1rem;
   gap: 0.5rem;
-  margin-bottom: -15px;
+  margin-bottom: 0;
 }
 
 .match-teams span {
@@ -449,8 +449,9 @@ header.hero {
 
 .match-team-left span, .match-team-right span {
   font-family: var(--font-display);
-  font-size: 1.05rem;
+  font-size: clamp(1.5rem, 2.2vw, 2rem);
   font-weight: 600;
+  line-height: 1;
 }
 
 .match-team-right {
@@ -1144,7 +1145,7 @@ header.hero {
 
   body.tournament-fullscreen .match-card {
     width: 100%;
-    min-height: 118px;
+    min-height: 102px;
     padding: 10px 12px;
     gap: 6px;
     border-left-width: 10px;
@@ -1190,7 +1191,7 @@ header.hero {
     gap: 2px;
   }
 
-  body.tournament-fullscreen .history .history-entry:nth-of-type(n + 2) {
+  body.tournament-fullscreen .history .history-entry:nth-child(n + 3) {
     display: none;
   }
 
@@ -1298,7 +1299,8 @@ header.hero {
     columns: 2;
     column-gap: 12px;
     max-height: none;
-    overflow: auto;
+    overflow-y: auto;
+    overflow-x: hidden;
     padding-right: 0;
   }
 
@@ -1308,12 +1310,20 @@ header.hero {
     font-size: 0.79rem;
     line-height: 1;
     gap: 3px;
+    grid-template-columns: auto auto minmax(0, 1fr) auto auto minmax(0, 1fr) auto auto;
     break-inside: avoid;
     margin: 0 0 6px;
   }
 
   body.tournament-fullscreen #schedule-modal .schedule-team {
     gap: 4px;
+    min-width: 0;
+  }
+
+  body.tournament-fullscreen #schedule-modal .schedule-team span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   body.tournament-fullscreen #schedule-modal .schedule-score {


### PR DESCRIPTION
### Motivation
- Matchkortens layout och textstorlek var inte i linje med designmocken vilket påverkade läsbarhet och alignment i "Kör nu"-vyn.
- Spelschemat i fullscreen gav sidledsscroll på grund av breda grid-kolumner och oförträngda lagnamn.
- Historiksektionen visade felaktigt inga tidigare möten p.g.a. en hård selector som dolde för många rader.

### Description
- Åtgärdat alignment genom att ta bort negativ bottenmarginal på `.match-teams` och återställa `margin-bottom` till `0`.
- Ökat team-namnets storlek till en responsiv `clamp()` och satt `line-height` för bättre visuell vikt och placeholder‑paritet.
- Sänkt `min-height` för `.match-card` i fullscreen så att "Kör nu"-ytan får plats utan att bli trång.
- Fixat historik-regression genom att ändra selektorn till `.history-entry:nth-child(n + 3)` och begränsat schedule-modalens horisontella overflow samt lagt till grid-kolumndefinition och ellips-trunkering för långa lagnamn.

### Testing
- Inga automatiserade tester kördes för denna UI/CSS-ändring.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d27099fa888320960888916ef5d9fa)