### PR TITLE
Align now-playing and rankings headers; allow full previous meetings display

### DIFF
--- a/fopen/index.html
+++ b/fopen/index.html
@@ -95,7 +95,7 @@
                 <div class="tournament-overview">
                     <!-- Now playing area -->
                     <div id="now-playing" class="now-playing">
-                        <h2>Kör nu</h2>
+                        <h2 class="overview-title">Kör nu</h2>
                         <div id="current-matches" class="current-matches"></div>
                         <div id="upcoming-wrap" class="upcoming-wrap" hidden>
                             <h3 class="upcoming-title">Kommande:</h3>
@@ -104,7 +104,7 @@
                     </div>
                     <!-- Groups rankings area -->
                     <div class="rankings-panel">
-                        <h2 class="rankings-title">Ställningen just nu</h2>
+                        <h2 class="overview-title rankings-title">Ställningen just nu</h2>
                         <div id="groups-rankings" class="groups-rankings"></div>
                     </div>
                 </div>

--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -65,6 +65,13 @@ h2, h3 {
   color: var(--color-primary);
 }
 
+
+.overview-title {
+  margin: 0;
+  font-size: clamp(1.25rem, 1.9vw, 1.9rem);
+  line-height: 1.1;
+}
+
 .container {
   max-width: 1100px;
   width: 100%;
@@ -712,8 +719,6 @@ header.hero {
 
 .rankings-title {
   margin: 0;
-  font-size: clamp(1.25rem, 1.9vw, 1.9rem);
-  line-height: 1.1;
 }
 
 .groups-rankings.groups-count-3 { grid-template-columns: repeat(3, 1fr); }
@@ -1124,7 +1129,7 @@ header.hero {
   /* LEFT: matches */
   body.tournament-fullscreen .now-playing {
     min-height: 0;
-    overflow: hidden;
+    overflow: auto;
     padding: 14px;
     gap: 6px;
   }
@@ -1191,9 +1196,6 @@ header.hero {
     gap: 2px;
   }
 
-  body.tournament-fullscreen .history .history-entry:nth-child(n + 3) {
-    display: none;
-  }
 
   body.tournament-fullscreen .match-inputs {
     gap: 6px;


### PR DESCRIPTION
### Motivation
- Ensure the "Kör nu" and "Ställningen just nu" headings share the same visual baseline and restore the UI's ability to display multiple previous meetings without clipping so match cards can expand when history grows.

### Description
- Add a shared `.overview-title` style in `fopen/styles.css` and apply it to both headings in `fopen/index.html` so they align consistently.
- Remove the fullscreen CSS rule that hid older `.history-entry` rows and change `body.tournament-fullscreen .now-playing` from `overflow: hidden` to `overflow: auto` so historical rows can expand without being clipped.
- Files modified: `fopen/index.html`, `fopen/styles.css`.

### Testing
- No automated tests were run for this static HTML/CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d27444f0608320a641c94047dde71f)