### PR TITLE
fopen: ny grafisk profil (TV), gruppfärgning, utökad kommande och historikkontroll

### DIFF
--- a/fopen/index.html
+++ b/fopen/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Färöarna Open 2026</title>
-    <link rel="icon" type="image/png" href="https://enkel.design/fopen/fopen.png">
-<link rel="apple-touch-icon" href="https://enkel.design/fopen/fopen.png">
+    <link rel="icon" type="image/jpeg" href="logo.jpg">
+<link rel="apple-touch-icon" href="logo.jpg">
     <!-- Link our stylesheet -->
   <link rel="stylesheet" href="styles.css">
       
@@ -40,7 +40,7 @@
 <div class="hero-left">
   <img
     class="hero-logo"
-    src="https://enkel.design/fopen/fopen.png"
+    src="logo.jpg"
     alt="Färöarna Open"
   >
   <h1 class="title">Färöarna<br>Open&nbsp;2026</h1>
@@ -52,6 +52,7 @@
                     <div id="menu-dropdown" class="menu-dropdown" hidden>
                         <button id="backup-btn" class="btn menu-item">Backup</button>
                         <button id="import-btn" class="btn menu-item">Importera backup</button>
+                        <button id="auto-results-menu-btn" class="btn menu-item debug">Fyll i resultat (debug)</button>
                         <button id="reset-btn" class="btn menu-item">Nollställ</button>
                     </div>
                 </div>
@@ -113,9 +114,6 @@
                 <div class="marathon-section">
                     <button id="schedule-btn" class="btn btn-primary">Visa spelschema</button>
                     <button id="marathon-btn" class="btn btn-secondary">Visa maratontabell</button>
-                </div>
-                <div class="tournament-actions">
-                    <button id="auto-results" class="btn btn-secondary debug">Fyll i resultat (debug)</button>
                 </div>
             </section>
 

--- a/fopen/main.js
+++ b/fopen/main.js
@@ -507,7 +507,7 @@ function getReadyMatches() {
 }
 
 
-function getUpcomingMatches(limit = 3) {
+function getUpcomingMatches(limit = 6) {
   const upcoming = [];
   const playingSet = new Set(state.playingMatches);
   for (let i = 0; i < state.schedule.length; i++) {
@@ -525,7 +525,7 @@ function renderUpcomingMatches() {
   const wrap = document.getElementById('upcoming-wrap');
   const container = document.getElementById('upcoming-matches');
   if (!wrap || !container) return;
-  const upcoming = getUpcomingMatches(3);
+  const upcoming = getUpcomingMatches(6);
   container.innerHTML = '';
   if (!upcoming.length) {
     wrap.hidden = true;
@@ -534,6 +534,7 @@ function renderUpcomingMatches() {
   upcoming.forEach(match => {
     const chip = document.createElement('div');
     chip.classList.add('upcoming-chip');
+    if (match.group) chip.classList.add(`group-${String(match.group).toLowerCase()}`);
 
     const group = document.createElement('span');
     group.classList.add('upcoming-group');
@@ -606,6 +607,7 @@ function updateNowPlaying() {
     if (match.status !== 'completed') match.status = 'playing';
     const card = document.createElement('div');
     card.classList.add('match-card');
+    if (match.group) card.classList.add(`group-${String(match.group).toLowerCase()}`);
     // Insert group label at top of card
     const groupLabel = document.createElement('div');
     groupLabel.classList.add('match-group');
@@ -653,9 +655,15 @@ function updateNowPlaying() {
       title.classList.add('history-title');
       title.textContent = 'Tidigare möten';
       historyContainer.appendChild(title);
-      history.forEach(entry => {
+      const MAX_HISTORY_ROWS = 3;
+      const hasOverflowHistory = history.length > MAX_HISTORY_ROWS;
+      history.forEach((entry, entryIndex) => {
         const row = document.createElement('div');
         row.classList.add('history-entry');
+        if (hasOverflowHistory && entryIndex >= MAX_HISTORY_ROWS) {
+          row.classList.add('history-entry-overflow');
+          row.hidden = true;
+        }
         // Year
         const yearSpan = document.createElement('span');
         yearSpan.classList.add('history-year');
@@ -700,6 +708,22 @@ function updateNowPlaying() {
         row.appendChild(score2Span);
         historyContainer.appendChild(row);
       });
+      if (hasOverflowHistory) {
+        const toggleButton = document.createElement('button');
+        toggleButton.type = 'button';
+        toggleButton.classList.add('history-toggle-btn');
+        toggleButton.textContent = 'Visa mer';
+        toggleButton.addEventListener('click', () => {
+          const hiddenRows = historyContainer.querySelectorAll('.history-entry-overflow');
+          const isExpanded = toggleButton.dataset.expanded === 'true';
+          hiddenRows.forEach(row => {
+            row.hidden = isExpanded;
+          });
+          toggleButton.dataset.expanded = isExpanded ? 'false' : 'true';
+          toggleButton.textContent = isExpanded ? 'Visa mer' : 'Visa mindre';
+        });
+        historyContainer.appendChild(toggleButton);
+      }
     } else {
       // No historic meetings: simply inform that there are no previous meetings.
       historyContainer.textContent = 'Inga möten i historiken.';
@@ -1401,6 +1425,7 @@ function updateStandingsUI() {
     const label = group.label;
     const rankingDiv = document.createElement('div');
     rankingDiv.classList.add('group-ranking');
+    rankingDiv.classList.add(`group-${String(label).toLowerCase()}`);
     const title = document.createElement('h3');
     title.textContent = 'Grupp ' + label;
     rankingDiv.appendChild(title);
@@ -1869,7 +1894,7 @@ function bindEvents() {
   document.getElementById('backup-btn').addEventListener('click', backupState);
   document.getElementById('import-btn').addEventListener('click', importBackupState);
   document.getElementById('reset-btn').addEventListener('click', resetState);
-  document.getElementById('auto-results').addEventListener('click', autoFillResults);
+  document.getElementById('auto-results-menu-btn').addEventListener('click', autoFillResults);
 
   // Return to group stage from playoffs
   // Removed: no playoff stage in this version
@@ -1891,6 +1916,11 @@ function bindEvents() {
       if (!menuDropdown.hasAttribute('hidden') && !menuDropdown.contains(evt.target) && evt.target !== menuToggle) {
         menuDropdown.setAttribute('hidden', '');
       }
+    });
+    menuDropdown.querySelectorAll('button').forEach(btn => {
+      btn.addEventListener('click', () => {
+        menuDropdown.setAttribute('hidden', '');
+      });
     });
   }
   // Event listeners for start playoff modal actions are removed: no playoff stage

--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -1386,3 +1386,113 @@ body.tournament-fullscreen #schedule-modal.ultra-compact .schedule-item.expanded
   body.tournament-fullscreen #schedule-modal-list {
     column-fill: auto;
   }
+}
+
+/* =========================================
+   OPEN 2026 visual refresh
+   ========================================= */
+:root {
+  --bg-deep: #030a1f;
+  --bg-panel: #071534;
+  --text-bright: #eaf1ff;
+}
+
+body {
+  background: radial-gradient(circle at 20% 0%, #0c214f 0%, var(--bg-deep) 55%, #030712 100%);
+  color: var(--text-bright);
+}
+
+body::before { opacity: 0.08; }
+
+.container,
+.stage,
+header.hero,
+.now-playing,
+.group-ranking,
+.modal .modal-content {
+  background: linear-gradient(180deg, rgba(9, 24, 56, 0.94) 0%, rgba(3, 13, 34, 0.96) 100%);
+  border: 1px solid #16386f;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+}
+
+.hero h1.title,
+h2, h3, .overview-title { color: var(--text-bright); }
+.hero-logo { border-radius: 10px; }
+
+.menu-toggle {
+  border: 1px solid #2e4f84;
+  background: #0a1a3b;
+  color: var(--text-bright);
+  border-radius: 12px;
+  min-width: 54px;
+  min-height: 54px;
+  font-size: 1.5rem;
+}
+
+.menu-dropdown {
+  background: #081737;
+  border: 1px solid #22467f;
+  border-radius: 12px;
+  padding: 0.4rem;
+}
+
+.menu-item { width: 100%; justify-content: flex-start; margin-bottom: 0.25rem; }
+
+.match-card { background: linear-gradient(180deg, rgba(8, 23, 53, 0.97) 0%, rgba(4, 15, 37, 0.98) 100%); border-color: #22467a; }
+.match-team-left span, .match-team-right span { color: #f1f5ff; }
+.history { color: #a5b9e0; }
+.history-title { color: #dce8ff; }
+
+.history-toggle-btn {
+  margin-top: 0.15rem;
+  border: 1px solid #365d97;
+  border-radius: 8px;
+  background: #102851;
+  color: #dce8ff;
+  padding: 0.15rem 0.5rem;
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.match-inputs input[type="number"] { background: #061839; color: #fff; border-color: #3863a5; }
+.btn.btn-primary, .btn.btn-secondary { border: 1px solid #3b5f98; border-radius: 10px; font-weight: 700; }
+.btn.btn-primary { background: linear-gradient(180deg, #173f7a 0%, #0b2a5d 100%); }
+.btn.btn-secondary { background: linear-gradient(180deg, #163c73 0%, #09244f 100%); }
+
+.marathon-section { display: grid; grid-template-columns: 1fr 1fr; gap: 0.8rem; }
+
+#schedule-btn, #marathon-btn {
+  width: 100%;
+  justify-content: center;
+  min-height: 58px;
+  font-size: 1.2rem;
+  border-radius: 14px;
+  border: 1px solid #3b67ab;
+  background: linear-gradient(180deg, rgba(17, 47, 95, 0.95) 0%, rgba(8, 26, 56, 0.98) 100%);
+  color: #d9e8ff;
+}
+
+.upcoming-title { color: #b9ceef; }
+.upcoming-chip { background: #081b3e; border-color: #365b94; }
+.group-ranking h3 { margin: 0 0 0.45rem; letter-spacing: 0.04em; text-transform: uppercase; }
+.group-ranking th { background: #0f2a5b; color: #cfe2ff; border-bottom-color: #365c93; }
+.group-ranking td, .group-ranking tr:nth-child(even) td { background: transparent; color: #edf3ff; }
+
+.group-ranking tr.direct td { background-color: rgba(52, 161, 106, 0.3); }
+.group-ranking tr.chance td { background-color: rgba(255, 189, 83, 0.3); }
+
+.group-a { border-color: #3a86ff; }
+.group-b { border-color: #f4b942; }
+.group-c { border-color: #25c281; }
+.group-d { border-color: #b76dff; }
+.group-e { border-color: #f26f78; }
+
+.group-a .match-group, .group-a h3, .upcoming-chip.group-a .upcoming-group { color: #78aefe; }
+.group-b .match-group, .group-b h3, .upcoming-chip.group-b .upcoming-group { color: #f4c96f; }
+.group-c .match-group, .group-c h3, .upcoming-chip.group-c .upcoming-group { color: #5ed4a3; }
+.group-d .match-group, .group-d h3, .upcoming-chip.group-d .upcoming-group { color: #c696ff; }
+.group-e .match-group, .group-e h3, .upcoming-chip.group-e .upcoming-group { color: #f79ba2; }
+
+@media (min-width: 1400px) and (min-height: 760px) {
+  body.tournament-fullscreen .current-matches { overflow: hidden; }
+}


### PR DESCRIPTION
### Motivation
- Uppdatera /fopen till den nya mörka TV‑anpassade grafiska profilen som visas i mockupen och göra UI‑ändringar för 1920×1080 fullscreen.
- Förbättra läsbarhet och överblick genom att visa fler kommande matcher och begränsa visuellt långa historiklistor.
- Förenkla debug‑flödet och minska UI‑störning genom att flytta automatisk resultatfyllning till menyn.
- Lägga in gruppfärgning visuellt samtidigt som befintlig logik för vilka som går vidare (direct/chance) bevaras.

### Description
- Bytte header‑logga och favicon/apple‑touch‑icon till `fopen/logo.jpg` och uppdaterade referenser i `fopen/index.html`.
- Flyttade debugknappen `Fyll i resultat (debug)` från turneringsytan till hamburgermenyn och stänger menyn automatiskt efter val; uppdatering i `fopen/index.html` och `fopen/main.js`.
- Visar fler kommande matcher genom att ändra `getUpcomingMatches(limit)` från `3` till `6` och renderar dessa i UI; ändring i `fopen/main.js`.
- Begränsar historik i matchkort till max 3 rader och lägger till en `Visa mer / Visa mindre`‑knapp för att expandera/kollapsa resterande rader; implementerat i `fopen/main.js`.
- Lägger till gruppspecifika CSS‑klasser på matchkort, upcoming‑chips och grupptabeller (`group-a`, `group-b`, …) så färgkodning kan appliceras; ändring i `fopen/main.js` och `fopen/styles.css`.
- Införde ett merge‑vänligt visuellt override i slutet av `fopen/styles.css` med den nya mörka TV‑profilen, uppdaterade knappstilar för `#schedule-btn`/`#marathon-btn` och gruppfärger A–E.
- Behöll och använde oförändrad kvalificeringslogik för `direct` och `chance` men anpassade endast presentationen via CSS och gruppklasser.

### Testing
- Körda syntaxkontroller med `node --check fopen/main.js` och inga syntaxfel rapporterades.
- Enkel CSS‑sanity kontroll körd med ett litet Python‑skript som räknar `{`/`}` i `fopen/styles.css` och balanseringen verifierades.
- Applikationsfiler uppdaterades och byggbarhet/syntax i repository kontrollerades lokalt utan automatiska testfel.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9155f24dc8320a50a9ce3ebbe0991)