### PR TITLE
Fixera dubbelräkning av grupptabeller vid omladdning och aktivera Enter för att spara resultat (/fopen)

### DIFF
--- a/fopen/main.js
+++ b/fopen/main.js
@@ -752,6 +752,16 @@ function updateNowPlaying() {
       }
       recordResult(idx, s1, s2);
     });
+    const submitOnEnter = evt => {
+      if (evt.key !== 'Enter') return;
+      const s1 = parseInt(input1.value, 10);
+      const s2 = parseInt(input2.value, 10);
+      if (isNaN(s1) || isNaN(s2)) return;
+      evt.preventDefault();
+      recordResult(idx, s1, s2);
+    };
+    input1.addEventListener('keydown', submitOnEnter);
+    input2.addEventListener('keydown', submitOnEnter);
 
     const skipBtn = document.createElement('button');
     skipBtn.classList.add('btn', 'btn-secondary', 'skip-match-btn');
@@ -2038,14 +2048,9 @@ function init() {
     // Always build the schedule and now playing lists from stored state
     updateNowPlaying();
     updateScheduleUI();
-    // If no group standings exist yet, initialise them so that the rankings
-    // table displays even before any games have been played. Without this
-    // initialisation, the rankings section would remain blank on page load
-    // until at least one match result is recorded. We then recompute
-    // statistics for all completed matches to reflect current results.
-    if (!state.groupStandings) {
-      initGroupStandings();
-    }
+    // Rebuild standings from scratch on every load to avoid double-counting
+    // completed matches when the page is refreshed.
+    initGroupStandings();
     // Recompute standings from scratch based on completed matches. This
     // ensures that standings reflect any results that were entered before
     // reloading the page. Note that updateStandings() will update the


### PR DESCRIPTION
### Motivation
- Det finns en kritisk bugg där grupptabellerna kunde räknas upp dubbelt efter att sidan laddats om, vilket gav felaktiga tabeller; detta måste åtgärdas omedelbart. 
- Användarönskemål att trycka `Enter` i resultatrutan ska motsvara att knappen `Klar` trycks när båda fälten innehåller siffror för snabbare inmatning.

### Description
- Återställer alltid gruppstatistik vid uppstart av tournament-läget genom att kalla `initGroupStandings()` innan full omräkning av redan spelade matcher så att summering inte dubbleras. 
- Lägger till `keydown`-lyssnare på matchinmatningens `input1` och `input2` som vid `Enter` och giltiga siffror anropar `recordResult(...)` för att fungera som knappen `Klar`. 
- Ändringarna gjordes i `fopen/main.js` (uppdaterad init-flöde och matchkortets inmatningslogik).

### Testing
- Körningen `node --check fopen/main.js` kördes och rapporterade inga syntaxfel (godkänd).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2f864cc88320b0d8aa3d32362992)