### PR TITLE
Fix non-working "Visa mer" toggle in match history

### DIFF
--- a/fopen/main.js
+++ b/fopen/main.js
@@ -713,13 +713,17 @@ function updateNowPlaying() {
         toggleButton.type = 'button';
         toggleButton.classList.add('history-toggle-btn');
         toggleButton.textContent = 'Visa mer';
+        toggleButton.setAttribute('aria-expanded', 'false');
+        toggleButton.dataset.expanded = 'false';
         toggleButton.addEventListener('click', () => {
           const hiddenRows = historyContainer.querySelectorAll('.history-entry-overflow');
           const isExpanded = toggleButton.dataset.expanded === 'true';
           hiddenRows.forEach(row => {
             row.hidden = isExpanded;
           });
-          toggleButton.dataset.expanded = isExpanded ? 'false' : 'true';
+          const nextExpanded = !isExpanded;
+          toggleButton.dataset.expanded = nextExpanded ? 'true' : 'false';
+          toggleButton.setAttribute('aria-expanded', nextExpanded ? 'true' : 'false');
           toggleButton.textContent = isExpanded ? 'Visa mer' : 'Visa mindre';
         });
         historyContainer.appendChild(toggleButton);

--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -587,6 +587,10 @@ header.hero {
   --score-width: 24px;
   font-size: rem;
 }
+.history-entry[hidden],
+.history-entry-overflow[hidden] {
+  display: none !important;
+}
 .history-entry .history-year {
   font-size: 1.25rem;
   color: var(--color-text-muted);


### PR DESCRIPTION
### Motivation
- The "Visa mer" overflow toggle in match history sometimes appeared to do nothing because hidden rows were not consistently hidden visually and the button had no explicit initial/ARIA state.

### Description
- Initialize the history toggle with `aria-expanded="false"` and `data-expanded="false"` and update `aria-expanded` on click to reflect the current state.
- Compute and store the next expanded state (`nextExpanded`) when toggling so the dataset value is updated consistently.
- Add a CSS fallback rule `.history-entry[hidden], .history-entry-overflow[hidden] { display: none !important; }` to ensure rows with the `hidden` attribute are always visually hidden.

### Testing
- Ran `node --check fopen/main.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea32ba0128832081466177ed539fc6)