### PR TITLE
Add light mode toggle, remove debug auto-fill results, and add brand gradient behind logo and upcoming

### DIFF
--- a/fopen/index.html
+++ b/fopen/index.html
@@ -52,7 +52,7 @@
                     <div id="menu-dropdown" class="menu-dropdown" hidden>
                         <button id="backup-btn" class="btn menu-item">Backup</button>
                         <button id="import-btn" class="btn menu-item">Importera backup</button>
-                        <button id="auto-results-menu-btn" class="btn menu-item debug">Fyll i resultat (debug)</button>
+                        <button id="theme-toggle-btn" class="btn menu-item" type="button" aria-pressed="false">Ljust läge</button>
                         <button id="reset-btn" class="btn menu-item">Nollställ</button>
                     </div>
                 </div>

--- a/fopen/main.js
+++ b/fopen/main.js
@@ -161,6 +161,33 @@ function updateAutosaveStatus(status) {
   }, 3000);
 }
 
+const THEME_STORAGE_KEY = 'fo-theme';
+const LIGHT_THEME = 'light';
+const DARK_THEME = 'dark';
+
+function applyTheme(theme) {
+  const resolvedTheme = theme === LIGHT_THEME ? LIGHT_THEME : DARK_THEME;
+  document.documentElement.setAttribute('data-theme', resolvedTheme);
+  const themeToggleBtn = document.getElementById('theme-toggle-btn');
+  if (themeToggleBtn) {
+    const isLightTheme = resolvedTheme === LIGHT_THEME;
+    themeToggleBtn.setAttribute('aria-pressed', isLightTheme ? 'true' : 'false');
+    themeToggleBtn.textContent = isLightTheme ? 'Mörkt läge' : 'Ljust läge';
+  }
+}
+
+function initializeTheme() {
+  const savedTheme = localStorage.getItem(THEME_STORAGE_KEY);
+  applyTheme(savedTheme === LIGHT_THEME ? LIGHT_THEME : DARK_THEME);
+}
+
+function toggleTheme() {
+  const currentTheme = document.documentElement.getAttribute('data-theme') === LIGHT_THEME ? LIGHT_THEME : DARK_THEME;
+  const nextTheme = currentTheme === LIGHT_THEME ? DARK_THEME : LIGHT_THEME;
+  localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
+  applyTheme(nextTheme);
+}
+
 // Utility: sort teams by Swedish name (locale aware)
 function sortTeamsAlphabetical(teams) {
   return [...teams].sort((a, b) => a.localeCompare(b, 'sv'));
@@ -1908,7 +1935,7 @@ function bindEvents() {
   document.getElementById('backup-btn').addEventListener('click', backupState);
   document.getElementById('import-btn').addEventListener('click', importBackupState);
   document.getElementById('reset-btn').addEventListener('click', resetState);
-  document.getElementById('auto-results-menu-btn').addEventListener('click', autoFillResults);
+  document.getElementById('theme-toggle-btn').addEventListener('click', toggleTheme);
 
   // Return to group stage from playoffs
   // Removed: no playoff stage in this version
@@ -1997,37 +2024,6 @@ function resetState() {
   location.reload();
 }
 
-// Auto fill results for debugging
-function autoFillResults() {
-  state.schedule.forEach((match, idx) => {
-    if (match.status !== 'completed') {
-      const s1 = Math.floor(Math.random() * 6);
-      const s2 = Math.floor(Math.random() * 6);
-      match.score1 = s1;
-      match.score2 = s2;
-      match.status = 'completed';
-      state.results[match.id] = { score1: s1, score2: s2 };
-    }
-  });
-  // Reset standings and recompute
-  state.groupStandings = null;
-  // Initialize empty standings so that ranking tables are visible even before recomputation
-  initGroupStandings();
-  // Recalculate standings based on the completed matches
-  state.schedule.forEach(match => {
-    if (match.status === 'completed') {
-      updateStandings(match);
-    }
-  });
-  saveState();
-  // Refresh UI: schedule, now playing list, and standings
-  updateNowPlaying();
-  updateScheduleUI();
-  updateStandingsUI();
-  // After auto filling results, check if group stage is complete
-  checkGroupStageComplete();
-}
-
 // Update selected items each time we enter draw stage
 function renderDrawStage() {
   updateSelectedNationCards();
@@ -2037,6 +2033,7 @@ function renderDrawStage() {
 
 // Initial bootstrap
 function init() {
+  initializeTheme();
   loadState();
   populateNumSlotsSelect();
   renderNationList();

--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -1447,11 +1447,42 @@ body.tournament-fullscreen #schedule-modal.ultra-compact .schedule-item.expanded
   --group-c-line: #25c281;
   --group-d-line: #b76dff;
   --group-e-line: #f26f78;
+  --brand-gradient: linear-gradient(135deg, rgba(11, 42, 93, 0.95) 0%, rgba(238, 51, 64, 0.92) 100%);
+  --brand-title-color: #f2f6ff;
 }
 
 body {
   background: radial-gradient(circle at 20% 0%, var(--bg-body-top) 0%, var(--bg-deep) 55%, var(--bg-body-bottom) 100%);
   color: var(--text-primary);
+}
+
+:root[data-theme="light"] {
+  --bg-deep: #dce8ff;
+  --bg-body-top: #f6f9ff;
+  --bg-body-bottom: #c9d9ff;
+  --bg-panel: #eff5ff;
+  --bg-panel-soft: #e7f0ff;
+  --bg-panel-elevated: #dde9ff;
+  --bg-chip: #edf4ff;
+  --bg-input: #ffffff;
+  --bg-modal: #f3f8ff;
+  --bg-toast: #edf4ff;
+  --panel-grad-top: rgba(244, 249, 255, 0.96);
+  --panel-grad-bottom: rgba(223, 234, 255, 0.96);
+  --match-grad-top: rgba(241, 247, 255, 0.98);
+  --match-grad-bottom: rgba(220, 234, 255, 0.98);
+  --line-strong: #2d5ea6;
+  --line-muted: #9eb9e6;
+  --line-muted-lite: #b5caed;
+  --line-subtle: #bdd0ef;
+  --text-bright: #0f2e58;
+  --text-primary: #16345c;
+  --text-muted: #35557f;
+  --text-dim: #4e6e97;
+  --btn-bg-top: #2f63ab;
+  --btn-bg-bottom: #1d4e96;
+  --btn-alt-top: #d94452;
+  --btn-alt-bottom: #bf2634;
 }
 
 body::before { opacity: 0.08; }
@@ -1490,6 +1521,16 @@ h2, h3, .overview-title { color: var(--text-bright); }
 }
 
 .menu-item { width: 100%; justify-content: flex-start; margin-bottom: 0.25rem; }
+
+.hero-left {
+  background: var(--brand-gradient);
+  border-radius: 14px;
+  padding: 0.4rem 0.9rem 0.55rem 0.5rem;
+}
+
+.hero h1.title {
+  color: var(--brand-title-color);
+}
 
 .match-card {
   background: linear-gradient(180deg, var(--match-grad-top) 0%, var(--match-grad-bottom) 100%);
@@ -1545,7 +1586,14 @@ h2, h3, .overview-title { color: var(--text-bright); }
   width: 100%;
 }
 
-.upcoming-title { color: var(--text-primary); }
+.upcoming-wrap {
+  background: var(--brand-gradient);
+  border: 1px solid var(--line-strong);
+  border-radius: 12px;
+  padding: 0.55rem 0.8rem;
+}
+
+.upcoming-title { color: var(--brand-title-color); }
 .upcoming-chip { background: var(--bg-chip); border-color: var(--line-strong); }
 .group-ranking h3 { margin: 0 0 0.45rem; letter-spacing: 0.04em; text-transform: uppercase; }
 .group-ranking th {


### PR DESCRIPTION
### Motivation
- Provide a light-mode alternative with an explicit toggle in the hamburger menu and persist the user's choice. 
- Remove the developer-only "Fyll i resultat (debug)" autofill feature to avoid accidental use in production. 
- Keep the logo and logo text colors intact while improving contrast with a branded gradient behind the logo and reuse that gradient behind the "Kommande" area.

### Description
- Replaced the debug menu item with a theme toggle button (`#theme-toggle-btn`) in `fopen/index.html` and wired it to the app menu. 
- Implemented theme persistence and runtime switching in `fopen/main.js` with `applyTheme`, `initializeTheme`, and `toggleTheme`, stored under the `fo-theme` key in `localStorage`, and call `initializeTheme()` during `init()`. 
- Removed the `autoFillResults` function and its menu binding so the "Fyll i resultat (debug)" functionality is no longer present. 
- Added CSS variables `--brand-gradient` and `--brand-title-color`, a `:root[data-theme="light"]` light-mode variant, applied the gradient to `.hero-left` (behind logo/title) and `.upcoming-wrap` in `fopen/styles.css` to preserve logo text colors while improving contrast. 
- Files changed: `fopen/index.html`, `fopen/main.js`, `fopen/styles.css`.

### Testing
- Ran `node --check fopen/main.js` to validate JS syntax and it succeeded. 
- Verified removal of debug feature and menu references using `rg` (no remaining `autoFillResults`/menu entry matches) and the search returned as expected. 
- Confirmed repository changes with `git status` and created a commit for the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea513a458483209a708203779d1f22)