### PR TITLE
Add light/dark theme toggle and corresponding styles; remove debug auto-fill menu item

### DIFF
--- a/fopen/index.html
+++ b/fopen/index.html
@@ -52,7 +52,7 @@
                     <div id="menu-dropdown" class="menu-dropdown" hidden>
                         <button id="backup-btn" class="btn menu-item">Backup</button>
                         <button id="import-btn" class="btn menu-item">Importera backup</button>
-                        <button id="auto-results-menu-btn" class="btn menu-item debug">Fyll i resultat (debug)</button>
+                        <button id="theme-toggle-btn" class="btn menu-item" type="button" aria-pressed="false">Ljust läge</button>
                         <button id="reset-btn" class="btn menu-item">Nollställ</button>
                     </div>
                 </div>

--- a/fopen/main.js
+++ b/fopen/main.js
@@ -161,6 +161,43 @@ function updateAutosaveStatus(status) {
   }, 3000);
 }
 
+const THEME_STORAGE_KEY = 'fo-theme';
+const LIGHT_THEME = 'light';
+const DARK_THEME = 'dark';
+
+function applyTheme(theme) {
+  const resolvedTheme = theme === LIGHT_THEME ? LIGHT_THEME : DARK_THEME;
+  document.documentElement.setAttribute('data-theme', resolvedTheme);
+  const themeToggleBtn = document.getElementById('theme-toggle-btn');
+  if (themeToggleBtn) {
+    const isLightTheme = resolvedTheme === LIGHT_THEME;
+    themeToggleBtn.setAttribute('aria-pressed', isLightTheme ? 'true' : 'false');
+    themeToggleBtn.textContent = isLightTheme ? 'Mörkt läge' : 'Ljust läge';
+  }
+}
+
+function initializeTheme() {
+  const savedTheme = localStorage.getItem(THEME_STORAGE_KEY);
+  if (savedTheme === LIGHT_THEME || savedTheme === DARK_THEME) {
+    applyTheme(savedTheme);
+    return;
+  }
+  applyTheme(LIGHT_THEME);
+}
+
+function toggleTheme() {
+  const currentTheme = document.documentElement.getAttribute('data-theme') === LIGHT_THEME ? LIGHT_THEME : DARK_THEME;
+  const nextTheme = currentTheme === LIGHT_THEME ? DARK_THEME : LIGHT_THEME;
+  localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
+  applyTheme(nextTheme);
+}
+
+function bindThemeToggle() {
+  const themeToggleBtn = document.getElementById('theme-toggle-btn');
+  if (!themeToggleBtn) return;
+  themeToggleBtn.addEventListener('click', toggleTheme);
+}
+
 // Utility: sort teams by Swedish name (locale aware)
 function sortTeamsAlphabetical(teams) {
   return [...teams].sort((a, b) => a.localeCompare(b, 'sv'));
@@ -1908,7 +1945,6 @@ function bindEvents() {
   document.getElementById('backup-btn').addEventListener('click', backupState);
   document.getElementById('import-btn').addEventListener('click', importBackupState);
   document.getElementById('reset-btn').addEventListener('click', resetState);
-  document.getElementById('auto-results-menu-btn').addEventListener('click', autoFillResults);
 
   // Return to group stage from playoffs
   // Removed: no playoff stage in this version
@@ -1997,37 +2033,6 @@ function resetState() {
   location.reload();
 }
 
-// Auto fill results for debugging
-function autoFillResults() {
-  state.schedule.forEach((match, idx) => {
-    if (match.status !== 'completed') {
-      const s1 = Math.floor(Math.random() * 6);
-      const s2 = Math.floor(Math.random() * 6);
-      match.score1 = s1;
-      match.score2 = s2;
-      match.status = 'completed';
-      state.results[match.id] = { score1: s1, score2: s2 };
-    }
-  });
-  // Reset standings and recompute
-  state.groupStandings = null;
-  // Initialize empty standings so that ranking tables are visible even before recomputation
-  initGroupStandings();
-  // Recalculate standings based on the completed matches
-  state.schedule.forEach(match => {
-    if (match.status === 'completed') {
-      updateStandings(match);
-    }
-  });
-  saveState();
-  // Refresh UI: schedule, now playing list, and standings
-  updateNowPlaying();
-  updateScheduleUI();
-  updateStandingsUI();
-  // After auto filling results, check if group stage is complete
-  checkGroupStageComplete();
-}
-
 // Update selected items each time we enter draw stage
 function renderDrawStage() {
   updateSelectedNationCards();
@@ -2037,12 +2042,14 @@ function renderDrawStage() {
 
 // Initial bootstrap
 function init() {
+  initializeTheme();
   loadState();
   populateNumSlotsSelect();
   renderNationList();
   updateSelectedCounter();
   updateDrawButtonState();
   bindEvents();
+  bindThemeToggle();
   if (state.stage === 'draw') {
     // Rebuild group assignments from state
     renderDrawStage();

--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -1447,11 +1447,45 @@ body.tournament-fullscreen #schedule-modal.ultra-compact .schedule-item.expanded
   --group-c-line: #25c281;
   --group-d-line: #b76dff;
   --group-e-line: #f26f78;
+  --body-gradient: radial-gradient(circle at 20% 0%, var(--bg-body-top) 0%, var(--bg-deep) 55%, var(--bg-body-bottom) 100%);
+  --brand-gradient: linear-gradient(90deg, rgba(28, 106, 218, 0.98) 0%, rgba(238, 51, 64, 0.88) 18%, rgba(255, 255, 255, 0) 75%);
+  --brand-title-color: #0f2e58;
 }
 
 body {
-  background: radial-gradient(circle at 20% 0%, var(--bg-body-top) 0%, var(--bg-deep) 55%, var(--bg-body-bottom) 100%);
+  background: var(--body-gradient);
   color: var(--text-primary);
+}
+
+:root[data-theme="light"] {
+  --bg-deep: #eceef3;
+  --bg-body-top: #f4f6fb;
+  --bg-body-bottom: #e9ecf4;
+  --bg-panel: #f8faff;
+  --bg-panel-soft: #eff4fb;
+  --bg-panel-elevated: #ebf1fc;
+  --bg-chip: #f3f7ff;
+  --bg-input: #ffffff;
+  --bg-modal: #f7f9fe;
+  --bg-toast: #f7f9fe;
+  --panel-grad-top: rgba(248, 250, 255, 0.96);
+  --panel-grad-bottom: rgba(240, 244, 252, 0.96);
+  --match-grad-top: rgba(248, 250, 255, 0.98);
+  --match-grad-bottom: rgba(239, 243, 252, 0.98);
+  --line-strong: #2a63b4;
+  --line-muted: #9db5da;
+  --line-muted-lite: #c2d3ee;
+  --line-subtle: #d2deef;
+  --text-bright: #0f2e58;
+  --text-primary: #16345c;
+  --text-muted: #35557f;
+  --text-dim: #4e6e97;
+  --btn-bg-top: #2f63ab;
+  --btn-bg-bottom: #1d4e96;
+  --btn-alt-top: #d94452;
+  --btn-alt-bottom: #bf2634;
+  --body-gradient: linear-gradient(180deg, #f3f4f8 0%, #eceef3 100%);
+  --brand-gradient: linear-gradient(90deg, rgba(28, 106, 218, 0.96) 0%, rgba(238, 51, 64, 0.86) 17%, rgba(243, 244, 248, 0) 72%);
 }
 
 body::before { opacity: 0.08; }
@@ -1464,8 +1498,6 @@ header.hero,
 .modal .modal-content {
   background: linear-gradient(180deg, var(--panel-grad-top) 0%, var(--panel-grad-bottom) 100%);
   border: 1px solid var(--line-subtle);
-  background: linear-gradient(180deg, rgba(9, 24, 56, 0.94) 0%, rgba(3, 13, 34, 0.96) 100%);
-  border: 1px solid #16386f;
   box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
 }
 
@@ -1490,6 +1522,16 @@ h2, h3, .overview-title { color: var(--text-bright); }
 }
 
 .menu-item { width: 100%; justify-content: flex-start; margin-bottom: 0.25rem; }
+
+.hero-left {
+  background: var(--brand-gradient);
+  border-radius: 10px;
+  padding: 0.45rem 1.2rem 0.55rem 0.5rem;
+}
+
+.hero h1.title {
+  color: var(--brand-title-color);
+}
 
 .match-card {
   background: linear-gradient(180deg, var(--match-grad-top) 0%, var(--match-grad-bottom) 100%);
@@ -1545,7 +1587,14 @@ h2, h3, .overview-title { color: var(--text-bright); }
   width: 100%;
 }
 
-.upcoming-title { color: var(--text-primary); }
+.upcoming-wrap {
+  background: var(--brand-gradient);
+  border: 1px solid var(--line-strong);
+  border-radius: 12px;
+  padding: 0.55rem 0.9rem;
+}
+
+.upcoming-title { color: var(--brand-title-color); }
 .upcoming-chip { background: var(--bg-chip); border-color: var(--line-strong); }
 .group-ranking h3 { margin: 0 0 0.45rem; letter-spacing: 0.04em; text-transform: uppercase; }
 .group-ranking th {


### PR DESCRIPTION
### Motivation
- Introduce a user-facing theme switch (light/dark) to provide an alternative visual style and persist the choice across sessions.
- Replace a debug-only menu action with a real feature in the hamburger menu to avoid exposing development tools to end users.
- Update CSS variables and component styling to support theming and improve header/branding visuals.

### Description
- Added theme constants and theme management functions (`THEME_STORAGE_KEY`, `applyTheme`, `initializeTheme`, `toggleTheme`, `bindThemeToggle`) and wired theme initialization in `init()` in `fopen/main.js`.
- Added a menu button `theme-toggle-btn` to `fopen/index.html` in place of the debug `auto-results-menu-btn` and bound its click handler to toggle the theme in `bindEvents()`.
- Removed the `autoFillResults` debug function and its registration so the debug fill action is no longer available from the menu.
- Extended `fopen/styles.css` with a light theme ruleset using `:root[data-theme="light"]`, introduced new CSS variables and gradients, and adjusted header and component styles (hero, upcoming wrap, brand colors) to support the new theming system.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea513a458483209a708203779d1f22)