### PR TITLE
fopen: förbättra färgkontrast och mörk styling i UI

### DIFF
--- a/fopen/index.html
+++ b/fopen/index.html
@@ -146,6 +146,8 @@
         </div>
     </div>
 
+    <div class="copyright-note">©2026 erik@enkel.design</div>
+
         <!-- Toast notification for match results inside header for vertical centering -->
         <!-- Moved inside header to align centrally -->
 

--- a/fopen/main.js
+++ b/fopen/main.js
@@ -869,6 +869,8 @@ function recordResult(scheduleIndex, score1, score2) {
 function showToast(match, score1, score2) {
   const toast = document.getElementById('toast');
   if (!toast) return;
+  toast.classList.remove('group-a', 'group-b', 'group-c', 'group-d', 'group-e');
+  if (match.group) toast.classList.add(`group-${String(match.group).toLowerCase()}`);
   let resultHtml;
   // Generate HTML with flag icons and scores.  A draw shows both teams in neutral colour;
   // otherwise the winner uses the "winner" class and the loser uses the "loser" class.  Flags

--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -1642,3 +1642,101 @@ h2, h3, .overview-title { color: var(--text-bright); }
     margin-top: 0.4rem;
   }
 }
+
+/* =========================================
+   2026-04 visual contrast + tournament polish
+   ========================================= */
+.toast .toast-title {
+  font-family: var(--font-display);
+  font-size: 1.35rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.toast .toast-body {
+  font-family: var(--font-display);
+  font-size: 2rem;
+}
+
+.toast.group-a { border-color: var(--group-a-line); }
+.toast.group-b { border-color: var(--group-b-line); }
+.toast.group-c { border-color: var(--group-c-line); }
+.toast.group-d { border-color: var(--group-d-line); }
+.toast.group-e { border-color: var(--group-e-line); }
+
+.toast.group-a .toast-title { color: var(--group-a-color); }
+.toast.group-b .toast-title { color: var(--group-b-color); }
+.toast.group-c .toast-title { color: var(--group-c-color); }
+.toast.group-d .toast-title { color: var(--group-d-color); }
+.toast.group-e .toast-title { color: var(--group-e-color); }
+
+.history-entry .history-year {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.group-ranking h3,
+.group-ranking th,
+.group-ranking .nation-cell {
+  font-family: var(--font-display);
+}
+
+.group-ranking .nation-cell {
+  font-size: 1.15rem;
+  letter-spacing: 0.02em;
+}
+
+.nation-card,
+.group,
+.group .slot,
+.selected-nations .selected-card {
+  background-color: var(--bg-panel);
+  border-color: var(--line-muted);
+}
+
+.group .slot {
+  border-style: dashed;
+}
+
+.group .slot.filled,
+.group .slot:hover {
+  background-color: var(--bg-panel-soft);
+}
+
+.nation-card .name,
+.nation-card .seed,
+.group header,
+.draw-instructions,
+.controls label,
+.selected-counter,
+#select-hint {
+  color: var(--text-primary);
+}
+
+.nation-card.selected,
+.selected-card.selected-team {
+  border-color: var(--line-strong);
+  box-shadow: 0 0 0 1px rgba(91, 150, 234, 0.5);
+}
+
+.marathon-table .up {
+  color: #5aff7f;
+  text-shadow: 0 0 6px rgba(78, 255, 143, 0.35);
+}
+
+.copyright-note {
+  text-align: right;
+  color: var(--text-dim);
+  font-size: 0.8rem;
+  padding: 0 0.25rem 0.2rem;
+}
+
+@media (min-width: 1400px) and (min-height: 760px) {
+  body.tournament-fullscreen .hero h1.title {
+    display: none;
+  }
+
+  body.tournament-fullscreen .upcoming-wrap .marathon-section {
+    display: none;
+  }
+}


### PR DESCRIPTION
### Motivation
- Förbättra läsbarhet och kontrast i `/fopen`-appen genom en mörk temapassning och färgjusteringar enligt annoterade bilagor.  
- Ge visuell kontext till matchresultat genom att färgsätta toasten efter grupp (A–E).  
- Göra historik- och maratontabellselement tydligare på TV/fullscreen-vyer.

### Description
- Lagt till ett copyright-element i `fopen/index.html` för att visa ägartext längst ner i vyn.  
- Uppdaterat `fopen/main.js` så att `showToast` tar bort tidigare gruppklasser och lägger till dynamisk gruppklass (`group-a` … `group-e`) baserat på `match.group`.  
- Lagt till en samling nya stilregler i `fopen/styles.css` som förfinar toast-typografi och gruppramar, ökar kontrast för årtal i historik, förstärker uppflyttningsindikator i maratontabellen och anpassar bakgrund/ramar för nationkort, slots och rankningstabeller.  
- Justerat fullscreen/TV-beteende så att header-rubriken döljs (endast logga visas) och den extra marathon-knappsektionen i nedersta "kommande"-raden göms.

### Testing
- Körbarhetskontroll: `node --check fopen/main.js` kördes och returnerade utan fel (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb0a1dafd48320b91a7873b59326eb)