### PR TITLE
Lägg till Fredrik-citat: JSON-driven rotation, kortkommando och slutmeddelande

### DIFF
--- a/fopen/data/fredrik-citat.json
+++ b/fopen/data/fredrik-citat.json
@@ -1,0 +1,24 @@
+{
+  "quotes": [
+    {
+      "quote": "Prova för fan aldrig något nytt!",
+      "caption": "2025, apropå självmål vid försök till nytt trick."
+    },
+    {
+      "quote": "Varje drag är ett beslut – och varje beslut får konsekvenser.",
+      "caption": "Inför avgörande sista rundan i gruppspelet."
+    },
+    {
+      "quote": "Man behöver inte spela vackert om man spelar rätt.",
+      "caption": "Klassisk turneringsnerv efter ett taktiskt kryss."
+    },
+    {
+      "quote": "Historiken bryr sig inte om ursäkter.",
+      "caption": "Kommentar efter en oväntad skräll mot topplag."
+    }
+  ],
+  "finalMessage": {
+    "quote": "Turneringen är slut – tack för showen!",
+    "caption": "Nu är det dags för eftersnack, statistik och nya planer inför nästa år."
+  }
+}

--- a/fopen/index.html
+++ b/fopen/index.html
@@ -155,5 +155,13 @@
     <script src="data/global-data.js"></script>
     <!-- Main script for the app -->
     <script src="main.js"></script>
+
+    <div id="fredrik-overlay" class="fredrik-overlay" hidden aria-live="polite">
+        <img src="almkvist-citat.PNG" alt="Fredrik" class="fredrik-image">
+        <div class="fredrik-bubble">
+            <p id="fredrik-quote" class="fredrik-quote"></p>
+            <p id="fredrik-caption" class="fredrik-caption"></p>
+        </div>
+    </div>
 </body>
 </html>

--- a/fopen/main.js
+++ b/fopen/main.js
@@ -88,6 +88,9 @@ const DEFAULT_FLAG = 'placeholder_light_gray_block.png';
 
 // State management: we persist state in localStorage under key 'fo-state'
 let state = {};
+let fredrikConfig = null;
+let fredrikHideTimeout = null;
+let fredrikInterval = null;
 
 function getDefaultState() {
   return {
@@ -105,7 +108,10 @@ function getDefaultState() {
     // List of schedule indices that are currently being played. This is
     // separate from the list of team names and ensures that matches in
     // progress persist in the UI until their results are recorded.
-    playingMatches: []
+    playingMatches: [],
+    fredrikPool: [],
+    fredrikPoolIndex: 0,
+    tournamentFinished: false
   };
 }
 
@@ -118,6 +124,9 @@ function normalizeState(rawState) {
   if (!merged.results || typeof merged.results !== 'object') merged.results = {};
   if (!Array.isArray(merged.playing)) merged.playing = [];
   if (!Array.isArray(merged.playingMatches)) merged.playingMatches = [];
+  if (!Array.isArray(merged.fredrikPool)) merged.fredrikPool = [];
+  if (typeof merged.fredrikPoolIndex !== 'number') merged.fredrikPoolIndex = 0;
+  if (typeof merged.tournamentFinished !== 'boolean') merged.tournamentFinished = false;
   if (typeof merged.numSlots !== 'number' || Number.isNaN(merged.numSlots)) merged.numSlots = 12;
   if (!['select', 'draw', 'tournament', 'playoff'].includes(merged.stage)) merged.stage = 'select';
   return merged;
@@ -147,6 +156,104 @@ function saveState() {
   } catch (e) {
     console.error('Kunde inte spara state', e);
   }
+}
+
+function shuffleArray(items) {
+  const arr = [...items];
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+async function loadFredrikConfig() {
+  if (fredrikConfig) return fredrikConfig;
+  try {
+    const response = await fetch('data/fredrik-citat.json', { cache: 'no-store' });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const parsed = await response.json();
+    const quotes = Array.isArray(parsed.quotes) ? parsed.quotes.filter(q => q?.quote && q?.caption) : [];
+    fredrikConfig = {
+      quotes,
+      finalMessage: parsed.finalMessage || {
+        quote: 'Turneringen är slut. Bra kämpat!',
+        caption: 'Färöarna Open'
+      }
+    };
+  } catch (err) {
+    console.warn('Kunde inte läsa fredrik-citat.json, använder fallback.', err);
+    fredrikConfig = {
+      quotes: [
+        { quote: 'Prova för fan aldrig något nytt!', caption: '2025, apropå självmål vid försök till nytt trick.' }
+      ],
+      finalMessage: {
+        quote: 'Turneringen är slut. Bra kämpat!',
+        caption: 'Färöarna Open'
+      }
+    };
+  }
+  return fredrikConfig;
+}
+
+function getNextFredrikQuote() {
+  const quotes = fredrikConfig?.quotes || [];
+  if (!quotes.length) return null;
+  if (!Array.isArray(state.fredrikPool) || state.fredrikPool.length !== quotes.length) {
+    state.fredrikPool = shuffleArray(quotes.map((_, index) => index));
+    state.fredrikPoolIndex = 0;
+  }
+  if (state.fredrikPoolIndex >= state.fredrikPool.length) {
+    state.fredrikPool = shuffleArray(quotes.map((_, index) => index));
+    state.fredrikPoolIndex = 0;
+  }
+  const quoteIndex = state.fredrikPool[state.fredrikPoolIndex];
+  state.fredrikPoolIndex += 1;
+  return quotes[quoteIndex] || null;
+}
+
+function showFredrikOverlay(message, { persistent = false, durationMs = 9000 } = {}) {
+  const overlay = document.getElementById('fredrik-overlay');
+  const quoteEl = document.getElementById('fredrik-quote');
+  const captionEl = document.getElementById('fredrik-caption');
+  if (!overlay || !quoteEl || !captionEl || !message) return;
+  quoteEl.textContent = message.quote || '';
+  captionEl.textContent = message.caption || '';
+  overlay.hidden = false;
+  clearTimeout(fredrikHideTimeout);
+  if (!persistent) {
+    fredrikHideTimeout = setTimeout(() => {
+      overlay.hidden = true;
+    }, durationMs);
+  }
+}
+
+async function triggerFredrikQuote({ manual = false } = {}) {
+  if (state.stage !== 'tournament' || state.tournamentFinished) return;
+  await loadFredrikConfig();
+  const quote = getNextFredrikQuote();
+  if (!quote) return;
+  showFredrikOverlay(quote, { persistent: false, durationMs: manual ? 12000 : 9000 });
+  saveState();
+}
+
+function stopFredrikRotation() {
+  if (fredrikInterval) {
+    clearInterval(fredrikInterval);
+    fredrikInterval = null;
+  }
+}
+
+async function startFredrikRotation() {
+  stopFredrikRotation();
+  await loadFredrikConfig();
+  if (state.stage !== 'tournament' || state.tournamentFinished) return;
+  fredrikInterval = setInterval(() => {
+    if (state.stage !== 'tournament' || state.tournamentFinished) return;
+    if (Math.random() < 0.35) {
+      triggerFredrikQuote();
+    }
+  }, 75000);
 }
 
 // Debounce autosave status reset
@@ -501,13 +608,17 @@ function startTournament() {
   // Initialise group standings with zero values so that groups are displayed even before any matches are played.
   initGroupStandings();
   state.stage = 'tournament';
+  state.tournamentFinished = false;
   // Clear playing matches list when starting new tournament
   state.playingMatches = [];
+  const overlay = document.getElementById('fredrik-overlay');
+  if (overlay) overlay.hidden = true;
   saveState();
   renderStage();
   updateNowPlaying();
   updateScheduleUI();
   updateStandingsUI();
+  startFredrikRotation();
 }
 
 // Build "Kör nu" according to schedule order with team-collision guard.
@@ -880,6 +991,9 @@ function recordResult(scheduleIndex, score1, score2) {
   updateNowPlaying();
   updateScheduleUI();
   updateStandingsUI();
+  if (Math.random() < 0.32) {
+    triggerFredrikQuote();
+  }
   // Check if group stage is complete and update UI accordingly
   checkGroupStageComplete();
 }
@@ -1114,6 +1228,14 @@ function checkGroupStageComplete() {
   nowPlaying.appendChild(msg);
   // Ensure latest recorded result is reflected in group tables
   updateStandingsUI();
+  state.tournamentFinished = true;
+  stopFredrikRotation();
+  loadFredrikConfig().then(() => {
+    if (fredrikConfig?.finalMessage) {
+      showFredrikOverlay(fredrikConfig.finalMessage, { persistent: true });
+    }
+  });
+  saveState();
 }
 
 // Compute and update group standings after a result
@@ -1901,6 +2023,11 @@ function renderStage() {
     const playoffStage = document.getElementById('playoff-stage');
     if (playoffStage) playoffStage.hidden = false;
   }
+  if (state.stage !== 'tournament') {
+    stopFredrikRotation();
+    const overlay = document.getElementById('fredrik-overlay');
+    if (overlay) overlay.hidden = true;
+  }
 }
 
 // Set up event listeners
@@ -1926,6 +2053,16 @@ function bindEvents() {
   document.addEventListener('keydown', evt => {
     if (evt.key === 'Escape' && scheduleModal && !scheduleModal.hidden) {
       toggleScheduleModal(false);
+      return;
+    }
+    const isTypingTarget = evt.target && (
+      evt.target.tagName === 'INPUT' ||
+      evt.target.tagName === 'TEXTAREA' ||
+      evt.target.isContentEditable
+    );
+    if (!isTypingTarget && evt.key === 'F' && evt.shiftKey) {
+      evt.preventDefault();
+      triggerFredrikQuote({ manual: true });
     }
   });
   document.getElementById('backup-btn').addEventListener('click', backupState);
@@ -2087,6 +2224,17 @@ function init() {
     });
     // Finally, render the standings table UI
     updateStandingsUI();
+    if (state.tournamentFinished || state.schedule.every(match => match.status === 'completed')) {
+      state.tournamentFinished = true;
+      loadFredrikConfig().then(() => {
+        if (fredrikConfig?.finalMessage) {
+          showFredrikOverlay(fredrikConfig.finalMessage, { persistent: true });
+        }
+      });
+      saveState();
+    } else {
+      startFredrikRotation();
+    }
   }
 }
 

--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -1638,3 +1638,48 @@ h2, h3, .overview-title { color: var(--text-bright); }
     margin-top: 0.4rem;
   }
 }
+
+.fredrik-overlay {
+  position: fixed;
+  right: 1.2rem;
+  bottom: 1.2rem;
+  z-index: 9999;
+  display: flex;
+  align-items: flex-end;
+  gap: 0.75rem;
+  max-width: min(92vw, 540px);
+  pointer-events: none;
+}
+
+.fredrik-image {
+  width: clamp(90px, 10vw, 140px);
+  height: auto;
+  border-radius: 12px;
+  border: 2px solid var(--line-strong);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
+  background: #fff;
+}
+
+.fredrik-bubble {
+  background: rgba(4, 16, 40, 0.96);
+  color: var(--text-bright);
+  border: 1px solid var(--line-strong);
+  border-radius: 12px;
+  padding: 0.7rem 0.9rem;
+  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.4);
+  max-width: min(70vw, 360px);
+}
+
+.fredrik-quote {
+  margin: 0;
+  font-size: 0.98rem;
+  line-height: 1.3;
+  font-weight: 700;
+}
+
+.fredrik-caption {
+  margin: 0.45rem 0 0;
+  font-size: 0.8rem;
+  line-height: 1.25;
+  color: var(--text-muted);
+}


### PR DESCRIPTION
### Motivation
- Ge arrangören ("Fredrik") möjlighet att dyka upp i UI:t och påminna eller citera tidigare kommentarer med quote+caption som appen hämtar från en extern fil.
- Citat ska roteras så att varje item visas en gång innan repriser, kunna vara obegränsat antal i filen, och det ska gå att framkalla Fredrik manuellt.
- När turneringen är slut ska Fredrik visas permanent med ett förutbestämt slutmeddelande som specificeras i samma JSON.

### Description
- Lagt till datafilen `fopen/data/fredrik-citat.json` som innehåller en `quotes`-array (objekt med `quote` + `caption`) och ett `finalMessage` för slutläge.
- Lagt in en overlay-komponent i `fopen/index.html` med bilden `almkvist-citat.PNG` och element för quote + caption (`#fredrik-overlay`, `#fredrik-quote`, `#fredrik-caption`).
- Stilmallar i `fopen/styles.css` för en icke-blockerande fixed overlay (`.fredrik-overlay`, `.fredrik-image`, `.fredrik-bubble`, `.fredrik-quote`, `.fredrik-caption`).
- Utökad logik i `fopen/main.js`: nya state-fält (`fredrikPool`, `fredrikPoolIndex`, `tournamentFinished`), funktioner för att läsa JSON (`loadFredrikConfig`), slumpa pool (`shuffleArray`), välja nästa citat utan upprepning (`getNextFredrikQuote`), rendera overlay (`showFredrikOverlay`) och hantera rotation (`startFredrikRotation`, `stopFredrikRotation`).
- Integration i turneringsflödet: `startFredrikRotation` startas vid `startTournament`, slumpvisa citat triggas ibland efter resultatregistrering, overlay göms utanför tournament-stage, och `finalMessage` visas permanent när gruppspelet är klart (alla matcher färdiga).
- Manual trigger via kortkommandot `Shift+F` när fokus inte är i ett inmatningsfält, och fallback-citat används om JSON inte kan läsas.
- Citat-poolen sparas i appens state så rotationen fortsätter korrekt efter reload; state sparas i `localStorage` som tidigare.

### Testing
- Körda syntax-/runtidskontroller: `node --check fopen/main.js` — lyckades.
- JSON-validering: `python -m json.tool fopen/data/fredrik-citat.json` — lyckades.
- Inga automatiserade UI‑tester kördes i denna miljö (endast statisk/syntaktisk kontroll ovan).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecdae139848320b342ebeaaed9152a)