### PR TITLE
Lägg till scrollbar i spelschema-modalen och justera radluft

### DIFF
--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -329,8 +329,9 @@ header.hero {
 }
 
 #schedule-modal-list {
-  max-height: 38vh;
-  overflow: auto;
+  max-height: none;
+  overflow-y: auto;
+  overflow-x: hidden;
   padding-right: 0.25rem;
   flex: 1;
   min-height: 0;
@@ -347,7 +348,9 @@ header.hero {
 }
 
 #schedule-modal .schedule-item {
-  line-height: 1.12;
+  line-height: 1.18;
+  padding-block: 0.85rem;
+  gap: 0.48rem;
 }
 
 /* =========================
@@ -1130,8 +1133,9 @@ header.hero {
   }
 
   body.tournament-fullscreen #schedule-modal-list {
-    max-height: none;
-    overflow: visible;
+    max-height: 100%;
+    overflow-y: auto;
+    overflow-x: hidden;
     padding-right: 0;
   }
 


### PR DESCRIPTION
### Motivation
- Spelschema-modalen ska få samma konsekventa vertikala scrollbeteende som maratontabellen så att långa listor blir scrollbara istället för att skjuta ut layouten.
- Horisontell scroll i spelschemat ska undvikas för renare presentation.
- Raderna i spelschemat ska vara lite luftigare men fortfarande kompakta för bättre läsbarhet.

### Description
- Uppdaterade `#schedule-modal-list` i `fopen/styles.css` för att använda `overflow-y: auto` och `overflow-x: hidden` samt `max-height: none` så att listan alltid kan scrollas vertikalt.
- Justerade `.schedule-item` i modalen genom att höja `line-height` och lägga till `padding-block` och `gap` för ökad vertikal luft mellan raderna.
- Säkrade samma scrollbeteende i fullscreen-läget genom att ändra `body.tournament-fullscreen #schedule-modal-list` till `max-height: 100%` och `overflow-y: auto; overflow-x: hidden`.

### Testing
- Körning av `git diff --check` visade inga whitespace- eller patch-problem och kontrollerna passerade.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed2e51ac308320acb3c98eb4fc166f)