### PR TITLE
Fix vertical-only scrolling in /fopen schedule modal

### DIFF
--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -330,7 +330,8 @@ header.hero {
 
 #schedule-modal-list {
   max-height: 38vh;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
   padding-right: 0.25rem;
   flex: 1;
   min-height: 0;
@@ -1131,7 +1132,8 @@ header.hero {
 
   body.tournament-fullscreen #schedule-modal-list {
     max-height: none;
-    overflow: visible;
+    overflow-y: auto;
+    overflow-x: hidden;
     padding-right: 0;
   }
 


### PR DESCRIPTION
### Motivation
- Prevent horizontal scrolling and layout overflow in the "Spelschema och resultat" modal so the schedule/results list only scrolls vertically.

### Description
- Change `#schedule-modal-list` and `body.tournament-fullscreen #schedule-modal-list` in `fopen/styles.css` to use `overflow-y: auto` and `overflow-x: hidden` instead of the previous `overflow`/`visible` settings.

### Testing
- Ran `git diff --check` and it completed with no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed326fe2488320b38539203eeb28a6)