### PR TITLE
Hide latest-result toast and show korv.png when group stage completes

### DIFF
--- a/fopen/main.js
+++ b/fopen/main.js
@@ -603,6 +603,8 @@ function renderUpcomingMatches() {
 function updateNowPlaying() {
   const container = document.getElementById('current-matches');
   container.innerHTML = '';
+  const nowPlayingWrap = document.getElementById('now-playing');
+  if (nowPlayingWrap) nowPlayingWrap.classList.remove('group-stage-complete');
   // Remove invalid/completed/skipped matches from the playingMatches list
   state.playingMatches = state.playingMatches.filter(idx => {
     const m = state.schedule[idx];
@@ -864,8 +866,8 @@ function recordResult(scheduleIndex, score1, score2) {
   match.score2 = score2;
   match.status = 'completed';
   state.results[match.id] = { score1, score2 };
-  // Show toast with result and winner information
-  showToast(match, score1, score2);
+  // Show toast with result and winner information (except after final group match)
+  if (!isGroupStageComplete()) showToast(match, score1, score2);
   // Remove teams from playing list
   state.playing = state.playing.filter(team => team !== match.team1 && team !== match.team2);
   // Remove this match from the list of currently playing matches so that it
@@ -1106,12 +1108,26 @@ function checkGroupStageComplete() {
   if (!allDone) return;
   const nowPlaying = document.getElementById('now-playing');
   if (!nowPlaying) return;
+  // Hide latest result toast when group stage is finished
+  const toast = document.getElementById('toast');
+  if (toast) {
+    toast.hidden = true;
+    toast.classList.remove('show');
+  }
   // Clear existing content
   nowPlaying.innerHTML = '';
+  nowPlaying.classList.add('group-stage-complete');
   // Message indicating group stage completion
   const msg = document.createElement('h2');
   msg.textContent = 'Gruppspelet är slut';
   nowPlaying.appendChild(msg);
+
+  const korvImg = document.createElement('img');
+  korvImg.src = 'korv.png';
+  korvImg.alt = 'Korv';
+  korvImg.className = 'korv-mascot';
+  nowPlaying.appendChild(korvImg);
+
   // Ensure latest recorded result is reflected in group tables
   updateStandingsUI();
 }

--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -673,6 +673,28 @@ header.hero {
   to { transform: translateY(0); opacity: 1; }
 }
 
+
+.now-playing.group-stage-complete {
+  position: relative;
+  overflow: hidden;
+}
+
+.korv-mascot {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  max-width: min(44%, 300px);
+  height: auto;
+  pointer-events: none;
+  animation: korvSlideIn 1.8s ease-out forwards;
+  transform: translateY(100%);
+}
+
+@keyframes korvSlideIn {
+  from { transform: translateY(100%); }
+  to { transform: translateY(0); }
+}
+
 /* =========================
    HISTORY (now-playing)
    ========================= */


### PR DESCRIPTION
### Motivation
- When the group stage finishes we should not show the “Senaste resultat” toast and instead present a friendly mascot image (`korv.png`) anchored bottom-left that slides in from below.

### Description
- Skip showing the toast in `recordResult` by calling `showToast` only if `isGroupStageComplete()` is false (change in `fopen/main.js`).
- When the group stage is detected complete in `checkGroupStageComplete`, hide the toast, replace the now-playing area with the heading `Gruppspelet är slut`, append an `<img src="korv.png">` with class `korv-mascot`, and add a `group-stage-complete` class to the container (changes in `fopen/main.js`).
- Ensure the `group-stage-complete` class is removed when `updateNowPlaying` rerenders normal now-playing cards (change in `fopen/main.js`).
- Add CSS rules for `.now-playing.group-stage-complete` and `.korv-mascot` including `position: absolute; left: 0; bottom: 0;` and a `korvSlideIn` keyframe animation so the image slowly slides in from the bottom (changes in `fopen/styles.css`).

### Testing
- Ran a JS syntax check with `node --check fopen/main.js`, which completed successfully.
- Verified workspace shows the modified files present after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef9f7b19148320bdea8d6143b77e6e)