### PR TITLE
Fix five-group standings layout in /fopen

### DIFF
--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -862,7 +862,7 @@ header.hero {
 
 .groups-rankings.groups-count-3 { grid-template-columns: repeat(3, 1fr); }
 .groups-rankings.groups-count-4 { grid-template-columns: repeat(2, 1fr); }
-.groups-rankings.groups-count-5 { grid-template-columns: repeat(3, 1fr); }
+.groups-rankings.groups-count-5 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 
 .group-ranking {
   flex: 1 1 240px;
@@ -1139,6 +1139,10 @@ header.hero {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
+  body.tournament-fullscreen .groups-rankings.groups-count-5 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   body.tournament-fullscreen .group-ranking {
     min-height: 0;
     padding: 0.35rem 0.45rem;
@@ -1396,6 +1400,12 @@ header.hero {
   }
 
   body.tournament-fullscreen .groups-rankings.groups-count-4 {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+  }
+
+  body.tournament-fullscreen .groups-rankings.groups-count-5 {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 12px;


### PR DESCRIPTION
### Motivation
- When the tournament has 21 participants the app creates 5 groups and the previous CSS forced a 3-column grid for `groups-count-5`, which made the standings tables too narrow and broke the intended layout.

### Description
- Changed the base `.groups-rankings.groups-count-5` rule to use two columns (`repeat(2, minmax(0, 1fr))`) in `fopen/styles.css`.
- Added matching `body.tournament-fullscreen` and large-TV/fullscreen breakpoint overrides so `groups-count-5` also renders as two columns at larger breakpoints.
- The change is limited to layout CSS in `fopen/styles.css` and does not alter JavaScript logic.

### Testing
- Verified the CSS diff with `git diff -- fopen/styles.css` and inspected the updated regions using `nl`/`sed` to confirm selectors and values.
- Committed the change with `git commit` and confirmed file status with `git status --short`.
- Attempted automated visual/headless checks (`playwright`/`puppeteer`/Chromium) but those tools are not available in the environment, so no automated screenshot verification was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c36aa4488320b16ee85985a73178)