### PR TITLE
Compact 4-board /fopen: show only latest meeting and remove 5-board option

### DIFF
--- a/fopen/main.js
+++ b/fopen/main.js
@@ -494,8 +494,8 @@ function buildSchedule() {
 
 // Prompt user for number of boards and start tournament
 function startTournament() {
-  let boards = parseInt(prompt('Hur många bord (1–5)?', state.numBoards || 1), 10);
-  if (isNaN(boards) || boards < 1 || boards > 5) boards = 1;
+  let boards = parseInt(prompt('Hur många bord (1–4)?', state.numBoards || 1), 10);
+  if (isNaN(boards) || boards < 1 || boards > 4) boards = 1;
   state.numBoards = boards;
   buildSchedule();
   // Initialise group standings with zero values so that groups are displayed even before any matches are played.
@@ -676,11 +676,12 @@ function updateNowPlaying() {
     historyContainer.classList.add('history');
     const history = getHistory(match.team1, match.team2);
     if (history.length > 0) {
+      const compactHistoryMode = state.numBoards === 4;
       const title = document.createElement('div');
       title.classList.add('history-title');
-      title.textContent = 'Tidigare möten';
+      title.textContent = compactHistoryMode ? 'Senaste mötet' : 'Tidigare möten';
       historyContainer.appendChild(title);
-      const MAX_HISTORY_ROWS = 3;
+      const MAX_HISTORY_ROWS = compactHistoryMode ? 1 : 3;
       const hasOverflowHistory = history.length > MAX_HISTORY_ROWS;
       history.forEach((entry, entryIndex) => {
         const row = document.createElement('div');
@@ -737,7 +738,7 @@ function updateNowPlaying() {
         const toggleButton = document.createElement('button');
         toggleButton.type = 'button';
         toggleButton.classList.add('history-toggle-btn');
-        toggleButton.textContent = 'Visa mer';
+        toggleButton.textContent = compactHistoryMode ? 'Historik' : 'Visa mer';
         toggleButton.setAttribute('aria-expanded', 'false');
         toggleButton.dataset.expanded = 'false';
         toggleButton.addEventListener('click', () => {
@@ -749,7 +750,11 @@ function updateNowPlaying() {
           const nextExpanded = !isExpanded;
           toggleButton.dataset.expanded = nextExpanded ? 'true' : 'false';
           toggleButton.setAttribute('aria-expanded', nextExpanded ? 'true' : 'false');
-          toggleButton.textContent = isExpanded ? 'Visa mer' : 'Visa mindre';
+          if (compactHistoryMode) {
+            toggleButton.textContent = isExpanded ? 'Historik' : 'Mindre';
+          } else {
+            toggleButton.textContent = isExpanded ? 'Visa mer' : 'Visa mindre';
+          }
         });
         historyContainer.appendChild(toggleButton);
       }


### PR DESCRIPTION
### Motivation
- The /fopen UI is cramped when showing four match cards, so history on each "Kör nu" card should be more compact when 4 boards are selected.
- The five-board option is never used and should be removed from the start prompt to prevent selecting an unsupported layout.

### Description
- Limit the start prompt board selection to `1–4` instead of `1–5` and validate accordingly by updating `startTournament()` in `fopen/main.js`.
- Add a compact history mode when `state.numBoards === 4` that sets the history title to `Senaste mötet` and reduces `MAX_HISTORY_ROWS` to `1` so only the latest meeting shows by default.
- Replace the overflow toggle labels in compact mode to use `Historik` / `Mindre` instead of `Visa mer` / `Visa mindre`, while preserving the original 3-row behavior and labels for 1–3 boards.

### Testing
- Ran `git status` and `git diff` to inspect changes and confirmed the diff shows the updated prompt and compact-history branching, which succeeded.
- Committed the change (`git commit`) to the repository, which succeeded.
- Performed a manual code review of `fopen/main.js` to verify the branching logic and text changes; no automated unit tests exist for this UI change so no additional automated test runs were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a90540c4832094c6d38b80c668db)