### PR TITLE
fopen: visa falmkvist-bild innan första resultat

### DIFF
--- a/fopen/index.html
+++ b/fopen/index.html
@@ -57,6 +57,10 @@
                         <button id="reset-btn" class="btn menu-item">Nollställ</button>
                     </div>
                 </div>
+        <!-- Pre-results banner shown before first played match -->
+        <div id="pre-results-banner" class="pre-results-banner" hidden>
+          <img src="falmkvist.jpg" alt="Falmkvist" class="pre-results-image">
+        </div>
         <!-- Latest result (toast) is placed here to be vertically centered within the header -->
         <div id="toast" class="toast" hidden></div>
             </div>

--- a/fopen/main.js
+++ b/fopen/main.js
@@ -873,6 +873,7 @@ function recordResult(scheduleIndex, score1, score2) {
   state.results[match.id] = { score1, score2 };
   // Show toast with result and winner information (except after final group match)
   if (!isGroupStageComplete()) showToast(match, score1, score2);
+  else updatePreResultsBanner();
   // Remove teams from playing list
   state.playing = state.playing.filter(team => team !== match.team1 && team !== match.team2);
   // Remove this match from the list of currently playing matches so that it
@@ -889,6 +890,17 @@ function recordResult(scheduleIndex, score1, score2) {
   updateStandingsUI();
   // Check if group stage is complete and update UI accordingly
   checkGroupStageComplete();
+}
+
+
+function updatePreResultsBanner() {
+  const banner = document.getElementById('pre-results-banner');
+  const toast = document.getElementById('toast');
+  if (!banner) return;
+  const inTournament = state.stage === 'tournament';
+  const hasResults = Object.keys(state.results || {}).length > 0;
+  const toastVisible = toast && !toast.hidden;
+  banner.hidden = !(inTournament && !hasResults && !toastVisible);
 }
 
 // Show a toast notification summarising a match result.  The toast displays the
@@ -945,6 +957,7 @@ function showToast(match, score1, score2) {
   toast.classList.remove('show');
   void toast.offsetWidth;
   toast.classList.add('show');
+  updatePreResultsBanner();
 }
 
 // Generate the playoff bracket based on final group standings and ruleset.
@@ -1119,6 +1132,7 @@ function checkGroupStageComplete() {
     toast.hidden = true;
     toast.classList.remove('show');
   }
+  updatePreResultsBanner();
   // Clear existing content
   nowPlaying.innerHTML = '';
   nowPlaying.classList.add('group-stage-complete');
@@ -1930,6 +1944,7 @@ function renderStage() {
     const playoffStage = document.getElementById('playoff-stage');
     if (playoffStage) playoffStage.hidden = false;
   }
+  updatePreResultsBanner();
 }
 
 // Set up event listeners

--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -973,6 +973,25 @@ header.hero {
 .marathon-table tr.participant td { background-color: var(--line-muted); }
 .marathon-table tr.participant:nth-child(even) td { background-color: var(--line-muted-lite); }
 
+
+.pre-results-banner {
+  position: absolute;
+  top: 0.25rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 790;
+  pointer-events: none;
+}
+
+.pre-results-image {
+  display: block;
+  max-width: min(420px, 65vw);
+  width: 100%;
+  height: auto;
+  border-radius: 10px;
+  box-shadow: var(--shadow);
+}
+
 /* =========================
    TOAST (latest result)
    ========================= */


### PR DESCRIPTION
### Motivation
- Visa bilden `falmkvist.jpg` centrerad högst upp i headern när turneringen har startat men innan något resultat registrerats, och ta bort den när "Senaste resultat" (toast) visas eller när första resultatet är inmatat.

### Description
- Lagt till en ny banner i `fopen/index.html` med id `pre-results-banner` som innehåller `falmkvist.jpg` och ligger i samma yta som toasten (`#toast`).
- Lagt till CSS i `fopen/styles.css` för `.pre-results-banner` och `.pre-results-image` för positionering, max-bredd och visuellt utseende så den hamnar centrerad högst upp.
- Lagt till funktionen `updatePreResultsBanner()` i `fopen/main.js` och anropat den från relevanta ställen (`recordResult`, `showToast`, `checkGroupStageComplete` och `renderStage`) så bannern visas endast när `state.stage === 'tournament'`, inga resultat finns (`state.results` tomt) och toasten inte är synlig.

### Testing
- Gjort kodinspektion och grep/visningskontroller med `rg`/`nl` för att verifiera att nya element, CSS-regler och anrop finns på förväntade platser, och dessa kontroller lyckades.
- Visat diff med `git diff -- fopen/index.html fopen/main.js fopen/styles.css` för att granska ändringarna innan commit, vilket också lyckades.
- Ändringarna committades lokalt (`git commit`) utan fel; ingen automatiserad testsvit kördes i detta PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f216805eb8832087369771aa123252)