### PR TITLE
Auto-collapse history toggles after one minute

### DIFF
--- a/fopen/main.js
+++ b/fopen/main.js
@@ -741,6 +741,20 @@ function updateNowPlaying() {
         toggleButton.textContent = compactHistoryMode ? 'Historik' : 'Visa mer';
         toggleButton.setAttribute('aria-expanded', 'false');
         toggleButton.dataset.expanded = 'false';
+        let autoCollapseTimeoutId = null;
+        const collapseHistoryOverflow = () => {
+          const hiddenRows = historyContainer.querySelectorAll('.history-entry-overflow');
+          hiddenRows.forEach(row => {
+            row.hidden = true;
+          });
+          toggleButton.dataset.expanded = 'false';
+          toggleButton.setAttribute('aria-expanded', 'false');
+          toggleButton.textContent = compactHistoryMode ? 'Historik' : 'Visa mer';
+          if (autoCollapseTimeoutId) {
+            clearTimeout(autoCollapseTimeoutId);
+            autoCollapseTimeoutId = null;
+          }
+        };
         toggleButton.addEventListener('click', () => {
           const hiddenRows = historyContainer.querySelectorAll('.history-entry-overflow');
           const isExpanded = toggleButton.dataset.expanded === 'true';
@@ -754,6 +768,13 @@ function updateNowPlaying() {
             toggleButton.textContent = isExpanded ? 'Historik' : 'Mindre';
           } else {
             toggleButton.textContent = isExpanded ? 'Visa mer' : 'Visa mindre';
+          }
+          if (autoCollapseTimeoutId) {
+            clearTimeout(autoCollapseTimeoutId);
+            autoCollapseTimeoutId = null;
+          }
+          if (nextExpanded) {
+            autoCollapseTimeoutId = setTimeout(collapseHistoryOverflow, 60000);
           }
         });
         historyContainer.appendChild(toggleButton);


### PR DESCRIPTION
### Motivation
- Prevent expanded history rows from remaining open indefinitely by automatically collapsing overflow entries after a short timeout. 
- Ensure stable behavior when users repeatedly toggle the history view by clearing stale timers before setting a new one.

### Description
- Added `autoCollapseTimeoutId` and a `collapseHistoryOverflow` helper to `fopen/main.js` to hide `.history-entry-overflow` rows and reset the toggle state and label. 
- Clear any existing timeout on each toggle and start a new `setTimeout(..., 60000)` when the view is expanded so it auto-collapses after one minute. 
- Preserve existing `aria-expanded` attributes and the localized button labels for both compact and regular modes. 
- Changes applied to `fopen/main.js` (toggle logic around the history overflow button).

### Testing
- Ran the update script that performed the replacement, and it printed `updated` indicating the edit completed successfully. 
- Ran `git diff -- fopen/main.js` to verify the intended changes were applied and the command succeeded. 
- Ran `git commit -m "Auto-collapse history toggles after one minute"` and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2e518c0e0832094346ec731e2393e)