### PR TITLE
Add fopen/flags/flags.html listing all flags alphabetically

### DIFF
--- a/fopen/flags/flags.html
+++ b/fopen/flags/flags.html
@@ -1,0 +1,238 @@
+<!doctype html>
+<html lang="sv">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Flags</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 24px; line-height: 1.3; }
+    .flag { margin-bottom: 20px; }
+    h2 { font-size: 1.05rem; margin: 0 0 6px; }
+    img { width: 120px; height: auto; border: 1px solid #ddd; display: block; margin-bottom: 6px; }
+    a { font-size: 0.9rem; color: #0a58ca; word-break: break-all; }
+  </style>
+</head>
+<body>
+  <h1>Flaggor i bokstavsordning</h1>
+  <section class="flag">
+    <h2>Flag of #U00c5land</h2>
+    <img src="Flag_of_#U00c5land.svg" alt="Flag of #U00c5land">
+    <a href="Flag_of_#U00c5land.svg">Flag_of_#U00c5land.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Albania</h2>
+    <img src="Flag_of_Albania.svg" alt="Flag of Albania">
+    <a href="Flag_of_Albania.svg">Flag_of_Albania.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Australia</h2>
+    <img src="Flag_of_Australia.svg" alt="Flag of Australia">
+    <a href="Flag_of_Australia.svg">Flag_of_Australia.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Belgium</h2>
+    <img src="Flag_of_Belgium.svg" alt="Flag of Belgium">
+    <a href="Flag_of_Belgium.svg">Flag_of_Belgium.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Canada</h2>
+    <img src="Flag_of_Canada.svg" alt="Flag of Canada">
+    <a href="Flag_of_Canada.svg">Flag_of_Canada.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Chile</h2>
+    <img src="Flag_of_Chile.svg" alt="Flag of Chile">
+    <a href="Flag_of_Chile.svg">Flag_of_Chile.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Cyprus</h2>
+    <img src="Flag_of_Cyprus.svg" alt="Flag of Cyprus">
+    <a href="Flag_of_Cyprus.svg">Flag_of_Cyprus.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Denmark</h2>
+    <img src="Flag_of_Denmark.svg" alt="Flag of Denmark">
+    <a href="Flag_of_Denmark.svg">Flag_of_Denmark.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of East Germany</h2>
+    <img src="Flag_of_East_Germany.svg" alt="Flag of East Germany">
+    <a href="Flag_of_East_Germany.svg">Flag_of_East_Germany.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of El Salvador</h2>
+    <img src="Flag_of_El_Salvador.svg" alt="Flag of El Salvador">
+    <a href="Flag_of_El_Salvador.svg">Flag_of_El_Salvador.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of England</h2>
+    <img src="Flag_of_England.svg" alt="Flag of England">
+    <a href="Flag_of_England.svg">Flag_of_England.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Finland</h2>
+    <img src="Flag_of_Finland.svg" alt="Flag of Finland">
+    <a href="Flag_of_Finland.svg">Flag_of_Finland.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Greece</h2>
+    <img src="Flag_of_Greece.svg" alt="Flag of Greece">
+    <a href="Flag_of_Greece.svg">Flag_of_Greece.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Iceland</h2>
+    <img src="Flag_of_Iceland.svg" alt="Flag of Iceland">
+    <a href="Flag_of_Iceland.svg">Flag_of_Iceland.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of India</h2>
+    <img src="Flag_of_India.svg" alt="Flag of India">
+    <a href="Flag_of_India.svg">Flag_of_India.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Iran</h2>
+    <img src="Flag_of_Iran.svg" alt="Flag of Iran">
+    <a href="Flag_of_Iran.svg">Flag_of_Iran.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Ireland</h2>
+    <img src="Flag_of_Ireland.svg" alt="Flag of Ireland">
+    <a href="Flag_of_Ireland.svg">Flag_of_Ireland.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Italy</h2>
+    <img src="Flag_of_Italy.svg" alt="Flag of Italy">
+    <a href="Flag_of_Italy.svg">Flag_of_Italy.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Japan</h2>
+    <img src="Flag_of_Japan.svg" alt="Flag of Japan">
+    <a href="Flag_of_Japan.svg">Flag_of_Japan.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Mali</h2>
+    <img src="Flag_of_Mali.svg" alt="Flag of Mali">
+    <a href="Flag_of_Mali.svg">Flag_of_Mali.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Malta</h2>
+    <img src="Flag_of_Malta.svg" alt="Flag of Malta">
+    <a href="Flag_of_Malta.svg">Flag_of_Malta.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Mexico</h2>
+    <img src="Flag_of_Mexico.svg" alt="Flag of Mexico">
+    <a href="Flag_of_Mexico.svg">Flag_of_Mexico.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Nauru</h2>
+    <img src="Flag_of_Nauru.svg" alt="Flag of Nauru">
+    <a href="Flag_of_Nauru.svg">Flag_of_Nauru.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Nepal</h2>
+    <img src="Flag_of_Nepal.svg" alt="Flag of Nepal">
+    <a href="Flag_of_Nepal.svg">Flag_of_Nepal.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of North Korea</h2>
+    <img src="Flag_of_North_Korea.svg" alt="Flag of North Korea">
+    <a href="Flag_of_North_Korea.svg">Flag_of_North_Korea.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Norway</h2>
+    <img src="Flag_of_Norway.svg" alt="Flag of Norway">
+    <a href="Flag_of_Norway.svg">Flag_of_Norway.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Peru</h2>
+    <img src="Flag_of_Peru.svg" alt="Flag of Peru">
+    <a href="Flag_of_Peru.svg">Flag_of_Peru.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Poland</h2>
+    <img src="Flag_of_Poland.svg" alt="Flag of Poland">
+    <a href="Flag_of_Poland.svg">Flag_of_Poland.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Rhodesia (1968#U20131979)</h2>
+    <img src="Flag_of_Rhodesia_(1968#U20131979).svg" alt="Flag of Rhodesia (1968#U20131979)">
+    <a href="Flag_of_Rhodesia_(1968#U20131979).svg">Flag_of_Rhodesia_(1968#U20131979).svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Saint Kitts and Nevis</h2>
+    <img src="Flag_of_Saint_Kitts_and_Nevis.svg" alt="Flag of Saint Kitts and Nevis">
+    <a href="Flag_of_Saint_Kitts_and_Nevis.svg">Flag_of_Saint_Kitts_and_Nevis.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Scotland</h2>
+    <img src="Flag_of_Scotland.svg" alt="Flag of Scotland">
+    <a href="Flag_of_Scotland.svg">Flag_of_Scotland.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Spain</h2>
+    <img src="Flag_of_Spain.svg" alt="Flag of Spain">
+    <a href="Flag_of_Spain.svg">Flag_of_Spain.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Sweden</h2>
+    <img src="Flag_of_Sweden.svg" alt="Flag of Sweden">
+    <a href="Flag_of_Sweden.svg">Flag_of_Sweden.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Switzerland</h2>
+    <img src="Flag_of_Switzerland.svg" alt="Flag of Switzerland">
+    <a href="Flag_of_Switzerland.svg">Flag_of_Switzerland.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of the Faroe Islands</h2>
+    <img src="Flag_of_the_Faroe_Islands.svg" alt="Flag of the Faroe Islands">
+    <a href="Flag_of_the_Faroe_Islands.svg">Flag_of_the_Faroe_Islands.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of the Soviet Union</h2>
+    <img src="Flag_of_the_Soviet_Union.svg" alt="Flag of the Soviet Union">
+    <a href="Flag_of_the_Soviet_Union.svg">Flag_of_the_Soviet_Union.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of the United States</h2>
+    <img src="Flag_of_the_United_States.svg" alt="Flag of the United States">
+    <a href="Flag_of_the_United_States.svg">Flag_of_the_United_States.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Trinidad and Tobago</h2>
+    <img src="Flag_of_Trinidad_and_Tobago.svg" alt="Flag of Trinidad and Tobago">
+    <a href="Flag_of_Trinidad_and_Tobago.svg">Flag_of_Trinidad_and_Tobago.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Tunisia</h2>
+    <img src="Flag_of_Tunisia.svg" alt="Flag of Tunisia">
+    <a href="Flag_of_Tunisia.svg">Flag_of_Tunisia.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Ukraine</h2>
+    <img src="Flag_of_Ukraine.svg" alt="Flag of Ukraine">
+    <a href="Flag_of_Ukraine.svg">Flag_of_Ukraine.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Upper Volta</h2>
+    <img src="Flag_of_Upper_Volta.svg" alt="Flag of Upper Volta">
+    <a href="Flag_of_Upper_Volta.svg">Flag_of_Upper_Volta.svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of West Germany; Flag of Germany (1990#U20131996)</h2>
+    <img src="Flag_of_West_Germany;_Flag_of_Germany_(1990#U20131996).svg" alt="Flag of West Germany; Flag of Germany (1990#U20131996)">
+    <a href="Flag_of_West_Germany;_Flag_of_Germany_(1990#U20131996).svg">Flag_of_West_Germany;_Flag_of_Germany_(1990#U20131996).svg</a>
+  </section>
+  <section class="flag">
+    <h2>Flag of Yugoslavia (1946-1992)</h2>
+    <img src="Flag_of_Yugoslavia_(1946-1992).svg" alt="Flag of Yugoslavia (1946-1992)">
+    <a href="Flag_of_Yugoslavia_(1946-1992).svg">Flag_of_Yugoslavia_(1946-1992).svg</a>
+  </section>
+  <section class="flag">
+    <h2>Tamil Eelam Flag</h2>
+    <img src="Tamil_Eelam_Flag.svg" alt="Tamil Eelam Flag">
+    <a href="Tamil_Eelam_Flag.svg">Tamil_Eelam_Flag.svg</a>
+  </section>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a simple, browsable index page for the SVG flag assets in `fopen/flags` that shows each flag with a compact preview and a direct link, and present them in alphabetical order so they are easy to find.

### Description
- Added `fopen/flags/flags.html`, a static HTML document that lists every `.svg` in the folder sorted case-insensitively, with each flag in a `<section>` containing an `<h2>`, a small `<img>` preview (`width: 120px`) and a clickable relative file link.
- Included minimal CSS for a compact, readable layout and used HTML-escaped titles for headings and alt text.
- The HTML was produced by a short Python generator that enumerates `*.svg` files and writes the generated page into `flags.html`.

### Testing
- Ran the generator with `python - <<'PY' ...` which produced `flags.html` and printed `wrote 44 flags`, confirming all SVGs were included.
- Inspected the generated file with `sed -n '1,120p' fopen/flags/flags.html` to verify structure and sample entries succeeded.
- Enumerated source files with `rg --files /workspace/webb/fopen/flags` to confirm the SVG set used for generation succeeded.
- Prepared PR metadata via the repository PR helper tool to record the change (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f43d74e5108320af818c59e4cd1a17)