### PR TITLE
Add standalone playoff app (playoff.html + playoff.js) and link from header

### DIFF
--- a/fopen/index.html
+++ b/fopen/index.html
@@ -53,6 +53,7 @@
                     <div id="menu-dropdown" class="menu-dropdown" hidden>
                         <button id="backup-btn" class="btn menu-item">Backup</button>
                         <button id="import-btn" class="btn menu-item">Importera backup</button>
+                        <a href="playoff.html" class="btn menu-item">Slutspelsappen</a>
                         <button id="auto-results-menu-btn" class="btn menu-item debug">Fyll i resultat (debug)</button>
                         <button id="reset-btn" class="btn menu-item">Nollställ</button>
                     </div>

--- a/fopen/playoff.html
+++ b/fopen/playoff.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Färöarna Open – Slutspel</title>
+  <link rel="icon" type="image/jpeg" href="logo.png">
+  <link rel="stylesheet" href="styles.css" />
+  <style>
+    .playoff-wrap{padding:1rem;max-width:1200px;margin:0 auto}
+    .card{background:#111827;border:1px solid #334155;border-radius:12px;padding:1rem;margin-bottom:1rem}
+    .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:.75rem}
+    .match{border:1px solid #334155;border-radius:10px;padding:.75rem;background:#0b1220}
+    .slot{display:flex;gap:.5rem;align-items:center;margin:.35rem 0}
+    select,input{width:100%;padding:.45rem;border-radius:8px;border:1px solid #475569;background:#0f172a;color:#fff}
+    .status{font-size:.85rem;color:#93c5fd}
+  </style>
+</head>
+<body class="tournament-fullscreen">
+  <div class="playoff-wrap">
+    <header class="hero" style="margin-bottom:1rem;">
+      <div class="hero-left"><img class="hero-logo" src="logo.svg" alt="Färöarna Open"></div>
+      <div class="hero-right"><a class="btn menu-item" href="index.html">Till gruppspelsappen</a></div>
+    </header>
+
+    <section class="card">
+      <h2>1) Välj slutspelsupplägg</h2>
+      <select id="preset"></select>
+      <div class="grid" style="margin-top:.75rem">
+        <button id="load-backup" class="btn btn-secondary">Importera backup-fil</button>
+        <button id="save-export" class="btn btn-primary">Exportera hela turneringen</button>
+      </div>
+      <input id="backup-file" type="file" accept="application/json" hidden>
+      <p class="status" id="meta-status">Ingen backup läst ännu.</p>
+    </section>
+
+    <section class="card">
+      <h2>2) Placera deltagare manuellt</h2>
+      <div id="rounds"></div>
+    </section>
+
+    <section class="card">
+      <h2>3) Slutrapport</h2>
+      <div id="summary">Spela klart semifinaler/final/bronsmatch för att se GULD/SILVER/BRONS.</div>
+    </section>
+  </div>
+  <script src="playoff.js"></script>
+</body>
+</html>

--- a/fopen/playoff.js
+++ b/fopen/playoff.js
@@ -1,0 +1,142 @@
+const PRESETS = {
+  qf_sf_bronze_final: {
+    label: 'Kvartsfinal + Semi + Brons + Final',
+    rounds: [
+      { name: 'Quarterfinals', matches: ['QF1','QF2','QF3','QF4'] },
+      { name: 'Semifinals', matches: ['SF1','SF2'] },
+      { name: 'Bronze', matches: ['BR'] },
+      { name: 'Final', matches: ['F'] }
+    ],
+    links: {
+      QF1:{winner:['SF1','home']}, QF2:{winner:['SF2','home']}, QF3:{winner:['SF1','away']}, QF4:{winner:['SF2','away']},
+      SF1:{winner:['F','home'], loser:['BR','home']}, SF2:{winner:['F','away'], loser:['BR','away']}
+    }
+  },
+  group_sf_bronze_final: {
+    label: 'Slutspelsgrupper + Semi + Brons + Final',
+    rounds: [
+      { name: 'Slutspelsgrupp A', matches: ['GA1','GA2','GA3'] },
+      { name: 'Slutspelsgrupp B', matches: ['GB1','GB2','GB3'] },
+      { name: 'Semifinals', matches: ['SF1','SF2'] },
+      { name: 'Bronze', matches: ['BR'] },
+      { name: 'Final', matches: ['F'] }
+    ],
+    links: { SF1:{winner:['F','home'], loser:['BR','home']}, SF2:{winner:['F','away'], loser:['BR','away']} }
+  }
+};
+
+let backupData = null;
+let teams = [];
+let state = { preset: 'qf_sf_bronze_final', matches: {} };
+
+function init() {
+  const presetEl = document.getElementById('preset');
+  Object.entries(PRESETS).forEach(([key,p]) => {
+    const o=document.createElement('option'); o.value=key; o.textContent=p.label; presetEl.appendChild(o);
+  });
+  presetEl.value = state.preset;
+  presetEl.addEventListener('change', ()=> { state.preset=presetEl.value; buildBracket(); saveState(); });
+
+  document.getElementById('load-backup').addEventListener('click', ()=>document.getElementById('backup-file').click());
+  document.getElementById('backup-file').addEventListener('change', onBackupFile);
+  document.getElementById('save-export').addEventListener('click', exportFullTournament);
+
+  const stored = localStorage.getItem('fo-playoff-state');
+  if (stored) state = JSON.parse(stored);
+  buildBracket();
+}
+
+function saveState(){ localStorage.setItem('fo-playoff-state', JSON.stringify(state)); }
+
+function onBackupFile(e){
+  const file=e.target.files[0]; if(!file) return;
+  const reader=new FileReader();
+  reader.onload=()=>{
+    backupData=JSON.parse(reader.result);
+    teams = extractTeams(backupData);
+    document.getElementById('meta-status').textContent = `Backup inläst (${teams.length} nationer).`;
+    buildBracket();
+  };
+  reader.readAsText(file);
+}
+
+function extractTeams(data){
+  if (Array.isArray(data?.selectedTeams)) return data.selectedTeams;
+  if (Array.isArray(data?.participants)) return data.participants.map(p=>p.nation||p.display_name).filter(Boolean);
+  return [];
+}
+
+function ensureMatch(id){
+  if(!state.matches[id]) state.matches[id]={ home:'', away:'', scoreHome:'', scoreAway:'', winner:'' };
+  return state.matches[id];
+}
+
+function teamSelect(value, onchange){
+  const s=document.createElement('select');
+  const blank=document.createElement('option'); blank.value=''; blank.textContent='— välj lag —'; s.appendChild(blank);
+  teams.forEach(t=>{ const o=document.createElement('option'); o.value=t; o.textContent=t; s.appendChild(o); });
+  s.value=value||''; s.addEventListener('change',()=>onchange(s.value)); return s;
+}
+
+function buildBracket(){
+  const wrap=document.getElementById('rounds'); wrap.innerHTML='';
+  const preset=PRESETS[state.preset];
+  preset.rounds.forEach(r=>{
+    const sec=document.createElement('div'); sec.className='match';
+    const h=document.createElement('h3'); h.textContent=r.name; sec.appendChild(h);
+    r.matches.forEach(id=>{ sec.appendChild(renderMatch(id)); });
+    wrap.appendChild(sec);
+  });
+  updateSummary();
+}
+
+function renderMatch(id){
+  const m=ensureMatch(id); const el=document.createElement('div'); el.className='match';
+  const t=document.createElement('strong'); t.textContent=id; el.appendChild(t);
+  const s1=document.createElement('div'); s1.className='slot'; s1.append('Hemma: ', teamSelect(m.home,v=>{m.home=v; saveState(); buildBracket();}));
+  const s2=document.createElement('div'); s2.className='slot'; s2.append('Borta: ', teamSelect(m.away,v=>{m.away=v; saveState(); buildBracket();}));
+  el.append(s1,s2);
+
+  const rs=document.createElement('div'); rs.className='slot';
+  const a=document.createElement('input'); a.type='number'; a.placeholder='Mål hemma'; a.value=m.scoreHome;
+  const b=document.createElement('input'); b.type='number'; b.placeholder='Mål borta'; b.value=m.scoreAway;
+  const btn=document.createElement('button'); btn.className='btn btn-secondary'; btn.textContent='Spara resultat';
+  btn.onclick=()=>{ m.scoreHome=a.value; m.scoreAway=b.value; resolveMatch(id); saveState(); buildBracket(); };
+  rs.append(a,b,btn); el.appendChild(rs);
+  return el;
+}
+
+function resolveMatch(id){
+  const m=state.matches[id]; if(!(m.home&&m.away)) return;
+  const sh=Number(m.scoreHome), sa=Number(m.scoreAway); if(Number.isNaN(sh)||Number.isNaN(sa)||sh===sa) return;
+  m.winner = sh>sa?m.home:m.away;
+  const loser = sh>sa?m.away:m.home;
+  const link=PRESETS[state.preset].links[id]; if(!link) return;
+  if(link.winner){ const [next,slot]=link.winner; ensureMatch(next)[slot]=m.winner; }
+  if(link.loser){ const [next,slot]=link.loser; ensureMatch(next)[slot]=loser; }
+}
+
+function updateSummary(){
+  const f=state.matches.F, br=state.matches.BR;
+  const sum=document.getElementById('summary');
+  if(!f?.winner || !br?.winner){ sum.textContent='Spela klart semifinaler/final/bronsmatch för att se GULD/SILVER/BRONS.'; return; }
+  const finalLoser = f.winner===f.home?f.away:f.home;
+  sum.innerHTML = `<p><strong>GULD:</strong> ${f.winner}</p><p><strong>SILVER:</strong> ${finalLoser}</p><p><strong>BRONS:</strong> ${br.winner}</p>`;
+}
+
+function exportFullTournament(){
+  const out={
+    version:'tournament-export-v1.1',
+    generatedAt:new Date().toISOString(),
+    sourceBackup:backupData,
+    playoff:{preset:state.preset,matches:state.matches}
+  };
+  if(state.matches.F?.winner && state.matches.BR?.winner){
+    const f=state.matches.F;
+    out.finalStandings={ gold:f.winner, silver:f.winner===f.home?f.away:f.home, bronze:state.matches.BR.winner };
+  }
+  const blob=new Blob([JSON.stringify(out,null,2)],{type:'application/json'});
+  const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download='fopen-full-tournament.json'; a.click();
+}
+
+init();


### PR DESCRIPTION
### Motivation
- Provide a separate UI for constructing and resolving playoff brackets from a saved tournament backup and exporting final standings. 
- Allow manual placement of teams into playoff slots, support common playoff presets, and persist playoff state in the browser.
- Give quick access to the playoff tool from the main app header.

### Description
- Added `playoff.html` which contains the playoff UI with preset selection, import/export controls, manual slot placement, and a summary card. 
- Implemented `playoff.js` which defines presets, parses imported backups to extract teams, persists state to `localStorage`, resolves match winners and propagates winners/losers to linked matches, and exports a full tournament JSON with final standings. 
- Updated `fopen/index.html` header menu to include a "Slutspelsappen" link to the new `playoff.html` page and integrated the existing menu dropdown.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f43a9848248320a304c143bd4bcf99)