### PR TITLE
Add efficiency toggle to marathon table modal

### DIFF
--- a/fopen/index.html
+++ b/fopen/index.html
@@ -139,6 +139,10 @@
                     <h2>Maratontabell</h2>
                     <button id="close-marathon" class="btn btn-secondary">Stäng</button>
                 </div>
+                <div class="marathon-view-toggle" role="tablist" aria-label="Vy för maratontabellen">
+                    <button id="marathon-view-absolute" class="btn btn-secondary" data-view="absolute" aria-selected="true">Absoluta tal</button>
+                    <button id="marathon-view-efficiency" class="btn btn-secondary" data-view="efficiency" aria-selected="false">Effektiv prestation</button>
+                </div>
                 <div id="marathon-table" class="marathon-table"></div>
             </div>
         </div>

--- a/fopen/main.js
+++ b/fopen/main.js
@@ -100,6 +100,7 @@ function getDefaultState() {
     results: {}, // matchId -> {score1, score2}
     numBoards: 1,
     marathonUpdated: null,
+    marathonView: 'absolute',
     // Use a stable ordering for matches in progress to avoid concurrency issues
     playing: [],
     // List of schedule indices that are currently being played. This is
@@ -118,6 +119,7 @@ function normalizeState(rawState) {
   if (!merged.results || typeof merged.results !== 'object') merged.results = {};
   if (!Array.isArray(merged.playing)) merged.playing = [];
   if (!Array.isArray(merged.playingMatches)) merged.playingMatches = [];
+  if (!['absolute', 'efficiency'].includes(merged.marathonView)) merged.marathonView = 'absolute';
   if (typeof merged.numSlots !== 'number' || Number.isNaN(merged.numSlots)) merged.numSlots = 12;
   if (!['select', 'draw', 'tournament', 'playoff'].includes(merged.stage)) merged.stage = 'select';
   return merged;
@@ -1838,10 +1840,14 @@ function renderMarathonTable() {
   // Render table
   const tableContainer = document.getElementById('marathon-table');
   tableContainer.innerHTML = '';
+  const viewMode = state.marathonView || 'absolute';
   const table = document.createElement('table');
   const thead = document.createElement('thead');
   const trh = document.createElement('tr');
-  ['Plac', 'Nation', 'Matcher', 'Vinster', 'Oavg', 'Förluster', 'Målskillnad', 'Poäng', '∆'].forEach(h => {
+  const headers = viewMode === 'efficiency'
+    ? ['Plac', 'Nation', 'Poäng/match', 'Vinst %', 'Oavg %', 'Förlust %', 'Mål/match', 'Insläppta/match', '∆']
+    : ['Plac', 'Nation', 'Matcher', 'Vinster', 'Oavg', 'Förluster', 'Målskillnad', 'Poäng', '∆'];
+  headers.forEach(h => {
     const th = document.createElement('th');
     th.textContent = h;
     trh.appendChild(th);
@@ -1881,8 +1887,19 @@ function renderMarathonTable() {
     tdNation.appendChild(flagImg);
     tdNation.appendChild(nameSpan);
     tr.appendChild(tdNation);
-    // Matches, wins, draws, losses, goal diff, points
-    const values = [entry.matches, entry.wins, entry.draws, entry.losses, entry.goal_difference, entry.points];
+    // Matches, wins, draws, losses, goal diff, points OR efficiency view values
+    const safeMatches = entry.matches || 0;
+    const ratio = (value) => (safeMatches ? value / safeMatches : 0);
+    const values = viewMode === 'efficiency'
+      ? [
+          ratio(entry.points).toFixed(2),
+          `${(ratio(entry.wins) * 100).toFixed(1)}%`,
+          `${(ratio(entry.draws) * 100).toFixed(1)}%`,
+          `${(ratio(entry.losses) * 100).toFixed(1)}%`,
+          ratio(entry.goalsFor).toFixed(2),
+          ratio(entry.goalsAgainst).toFixed(2)
+        ]
+      : [entry.matches, entry.wins, entry.draws, entry.losses, entry.goal_difference, entry.points];
     values.forEach(val => {
       const td = document.createElement('td');
       td.textContent = val;
@@ -1913,6 +1930,16 @@ function toggleMarathonModal(show) {
   } else {
     modal.hidden = true;
   }
+}
+
+function setMarathonView(view) {
+  state.marathonView = view === 'efficiency' ? 'efficiency' : 'absolute';
+  const absoluteBtn = document.getElementById('marathon-view-absolute');
+  const efficiencyBtn = document.getElementById('marathon-view-efficiency');
+  if (absoluteBtn) absoluteBtn.setAttribute('aria-selected', String(state.marathonView === 'absolute'));
+  if (efficiencyBtn) efficiencyBtn.setAttribute('aria-selected', String(state.marathonView === 'efficiency'));
+  renderMarathonTable();
+  saveState();
 }
 
 function toggleScheduleModal(show) {
@@ -1975,6 +2002,8 @@ function bindEvents() {
   document.getElementById('start-tournament-btn').addEventListener('click', startTournament);
   document.getElementById('marathon-btn').addEventListener('click', () => toggleMarathonModal(true));
   document.getElementById('close-marathon').addEventListener('click', () => toggleMarathonModal(false));
+  document.getElementById('marathon-view-absolute').addEventListener('click', () => setMarathonView('absolute'));
+  document.getElementById('marathon-view-efficiency').addEventListener('click', () => setMarathonView('efficiency'));
   // Schedule button opens the dedicated schedule modal.
   const scheduleBtn = document.getElementById('schedule-btn');
   const closeScheduleBtn = document.getElementById('close-schedule');

--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -941,6 +941,17 @@ header.hero {
   padding-bottom: 0.5rem;
 }
 
+.marathon-view-toggle {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.marathon-view-toggle .btn[aria-selected="true"] {
+  background-color: var(--color-primary);
+  color: #fff;
+}
+
 .marathon-table table {
   width: 100%;
   border-collapse: collapse;


### PR DESCRIPTION
### Motivation
- Provide an alternate "efficiency" view for the marathon standings that shows averages and percentages (e.g. points per match, win/draw/loss % and goals per match) instead of absolute totals.

### Description
- Add a view toggle UI inside the marathon modal with two buttons: `Absoluta tal` and `Effektiv prestation` to switch table modes.
- Persist the selected view in application state via `state.marathonView` and normalize it on load to accept only `absolute` or `efficiency`.
- Update `renderMarathonTable()` to compute and display either absolute columns or efficiency metrics (`points/match`, `win%`, `draw%`, `loss%`, `goals/match`, `goalsAgainst/match`) depending on the selected view.
- Add `setMarathonView()` and wire event listeners for the toggle buttons, and add simple styling for the toggle including an active state.

### Testing
- Ran `node --check fopen/main.js` and the check completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b2cea80c83209e194191e313662d)