### PR TITLE
Förbättra toast-färger och neutral ton vid oavgjort i /fopen

### DIFF
--- a/fopen/main.js
+++ b/fopen/main.js
@@ -941,12 +941,12 @@ function showToast(match, score1, score2) {
   if (score1 === score2) {
     resultHtml = `
       <img src="${getFlagSrc(match.team1)}" alt="${match.team1}" class="flag">
-      <span class="winner">${match.team1}</span>
+      <span class="neutral">${match.team1}</span>
       <span class="score">${score1}</span>
       <span>–</span>
       <span class="score">${score2}</span>
       <img src="${getFlagSrc(match.team2)}" alt="${match.team2}" class="flag">
-      <span class="loser">${match.team2}</span>
+      <span class="neutral">${match.team2}</span>
     `;
   } else {
     let winnerTeam, loserTeam, winnerScore, loserScore;

--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -54,7 +54,7 @@
   --text-primary: #deebff;
   --text-muted: #a9bcde;
   --text-dim: #7f93b8;
-  --success-ring: #9af5b7;
+  --success-ring: #7effad;
   --danger-ring: #7b2f37;
   --draw-ring: #8f99ab;
   --success-text: #dffff0;
@@ -66,7 +66,8 @@
   --btn-alt-bottom: #c92a35;
   --bg-playing-row: #233a0e;
   --bg-skipped-row: #321720;
-  --toast-loser: #ff8d9b;
+  --toast-loser: #e7a1aa;
+  --toast-neutral: #9eb8d9;
   --row-direct-bg: rgba(52, 161, 106, 0.3);
   --row-chance-bg: rgba(255, 189, 83, 0.3);
   --score-win-bg: rgba(60, 130, 80, 0.18);
@@ -1035,6 +1036,7 @@ header.hero {
 .toast .winner { color: var(--color-primary); }
 .toast .loser { color: var(--color-secondary); }
 .toast .score { color: var(--color-text); }
+.toast .neutral { color: var(--toast-neutral); }
 
 .toast .toast-title {
   font-size: 0.7em;
@@ -1787,6 +1789,7 @@ h2, h3, .overview-title { color: var(--text-bright); }
 
 .toast .winner { color: var(--success-ring); }
 .toast .loser { color: var(--toast-loser); }
+.toast .neutral { color: var(--toast-neutral); }
 
 @media (min-width: 1400px) and (min-height: 760px) {
   body.tournament-fullscreen .current-matches { overflow: hidden; }


### PR DESCRIPTION
### Motivation
- Visa båda nationsnamn i senaste-resultat-toast med en neutral färg vid oavgjort så att varken vinst- eller förlustfärg används.
- Göra vinnarens gröna ton något mer mättad för bättre framhävning.
- Ton ner den röda/rosa förlorarfärgen så att förlust inte blir lika dominerande visuellt.

### Description
- Uppdaterade toast-rendering i `showToast` i `fopen/main.js` så att vid oavgjort båda nationernas namn får klassen `neutral` i HTML istället för `winner`/`loser`.
- Justerade färgvariabler i `fopen/styles.css`: ändrat `--success-ring` till en mer mättad grön, ändrat `--toast-loser` till en mindre framträdande rosa/röd och lagt till ny variabel `--toast-neutral` med en omättad ljusblå nyans.
- Lade till CSS-regeln `.toast .neutral` i både grund- och temaöverskrivningsdelarna av `fopen/styles.css` så att neutral färg används konsekvent i toasten.
- Ingen annan beteendeförändring; vinst-/förlust-flödet förblir oförändrat för icke-oavgjorda matcher (`winner`/`loser` klasser används som tidigare).

### Testing
- Inga automatiserade tester kördes för denna förändring.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faffe7dca48320b85387d6c75fd86e)