### PR TITLE
Clickable nation highlighting in schedule modal and improved contrast for labels

### DIFF
--- a/fopen/main.js
+++ b/fopen/main.js
@@ -88,6 +88,7 @@ const DEFAULT_FLAG = 'placeholder_light_gray_block.png';
 
 // State management: we persist state in localStorage under key 'fo-state'
 let state = {};
+let selectedScheduleNation = null;
 
 function getDefaultState() {
   return {
@@ -1617,6 +1618,8 @@ function updateScheduleUI() {
   const list = document.getElementById('schedule-modal-list');
   const modal = document.getElementById('schedule-modal');
   if (!list) return;
+
+  const isHighlightedMatch = (match) => selectedScheduleNation && (match.team1 === selectedScheduleNation || match.team2 === selectedScheduleNation);
   list.innerHTML = '';
   if (modal) modal.classList.remove('ultra-compact');
   // Bygg varje rad i spelschemat med en tydlig struktur: flagga + nation, resultat,
@@ -1629,6 +1632,7 @@ function updateScheduleUI() {
     // still gets the dedicated class.  Pending and playing statuses will
     // receive their own class names (pending, playing).
     item.classList.add(match.status);
+    if (isHighlightedMatch(match)) item.classList.add('highlighted-nation-match');
     if (match.status === 'completed') item.classList.add('completed');
     if (match.skipped) item.classList.add('skipped');
     // Build columns: number, flag1, team1, score, flag2, team2, group label, edit button
@@ -1644,12 +1648,17 @@ function updateScheduleUI() {
     const leftName = document.createElement('div');
     leftName.classList.add('schedule-team');
     const leftNameSpan = document.createElement('span');
+    leftNameSpan.classList.add('schedule-team-name');
     if (match.status === 'completed' && match.score1 > match.score2) {
       leftNameSpan.innerHTML = `<strong>${match.team1}</strong>`;
     } else {
       leftNameSpan.textContent = match.team1;
     }
     leftName.appendChild(leftNameSpan);
+    leftName.addEventListener('click', () => {
+      selectedScheduleNation = selectedScheduleNation === match.team1 ? null : match.team1;
+      updateScheduleUI();
+    });
     // Score
     const score = document.createElement('div');
     score.classList.add('schedule-score');
@@ -1673,12 +1682,17 @@ function updateScheduleUI() {
     const rightName = document.createElement('div');
     rightName.classList.add('schedule-team');
     const rightNameSpan = document.createElement('span');
+    rightNameSpan.classList.add('schedule-team-name');
     if (match.status === 'completed' && match.score2 > match.score1) {
       rightNameSpan.innerHTML = `<strong>${match.team2}</strong>`;
     } else {
       rightNameSpan.textContent = match.team2;
     }
     rightName.appendChild(rightNameSpan);
+    rightName.addEventListener('click', () => {
+      selectedScheduleNation = selectedScheduleNation === match.team2 ? null : match.team2;
+      updateScheduleUI();
+    });
     // Group label
     const groupDiv = document.createElement('div');
     groupDiv.classList.add('schedule-group');
@@ -1948,6 +1962,7 @@ function toggleScheduleModal(show) {
   const scheduleBtn = document.getElementById('schedule-btn');
   if (!modal) return;
   if (show) {
+    selectedScheduleNation = null;
     modal.hidden = false;
     updateScheduleUI();
     if (closeScheduleBtn) closeScheduleBtn.focus({ preventScroll: true });

--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -781,7 +781,7 @@ header.hero {
 
 .schedule-number {
   font-weight: 700;
-  color: #5e6d81;
+  color: var(--text-muted);
   min-width: 2.2ch;
   text-align: right;
 }
@@ -837,13 +837,21 @@ header.hero {
 
 .schedule-group {
   font-size: 0.8rem;
-  color: var(--color-text-muted);
+  color: var(--text-muted);
   white-space: nowrap;
 }
 
 .schedule-item button.change-result {
   padding: 0.25rem 0.5rem;
   font-size: 0.75rem;
+}
+
+.schedule-team-name {
+  cursor: pointer;
+}
+
+.schedule-item.highlighted-nation-match {
+  background: linear-gradient(90deg, rgba(45, 95, 15, 0.72) 0%, rgba(24, 58, 12, 0.84) 100%);
 }
 
 /* =========================


### PR DESCRIPTION
### Motivation
- Make it easy to see all matches for a given nation by allowing the user to click a team name in the “Spelschema och resultat” modal to highlight all matches involving that nation. 
- Keep behavior predictable by resetting any highlighted nation when the schedule modal is opened. 
- Improve legibility by increasing contrast for schedule order numbers and group labels.

### Description
- Added `selectedScheduleNation` state and per-row logic in `updateScheduleUI()` to toggle a `highlighted-nation-match` class for matches where `team1` or `team2` equals the selected nation in `fopen/main.js`.
- Made team name elements clickable and togglable by attaching click handlers that set/clear `selectedScheduleNation` and re-render the schedule in `fopen/main.js`.
- Reset `selectedScheduleNation` when opening the schedule modal by clearing it in `toggleScheduleModal(show)` in `fopen/main.js`.
- Increased contrast by changing `.schedule-number` and `.schedule-group` colors to `var(--text-muted)` and added `.schedule-team-name { cursor: pointer; }` plus a `.schedule-item.highlighted-nation-match` visual style in `fopen/styles.css`.

### Testing
- Performed repository checks and reviewed diffs using `git diff` to verify only `fopen/main.js` and `fopen/styles.css` were modified and the changes are as intended, which succeeded. 
- Committed the changes with `git commit` which completed successfully. 
- Created the PR metadata via the automated `make_pr` step which reported the expected summary and files changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fedf0957a88320800bffea10a1ca71)