### PR TITLE
Fix nation highlight visibility in schedule/results list

### DIFF
--- a/fopen/main.js
+++ b/fopen/main.js
@@ -1632,7 +1632,8 @@ function updateScheduleUI() {
     // still gets the dedicated class.  Pending and playing statuses will
     // receive their own class names (pending, playing).
     item.classList.add(match.status);
-    if (isHighlightedMatch(match)) item.classList.add('highlighted-nation-match');
+    const isHighlighted = isHighlightedMatch(match);
+    if (isHighlighted) item.classList.add('highlighted-nation-match');
     if (match.status === 'completed') item.classList.add('completed');
     if (match.skipped) item.classList.add('skipped');
     // Build columns: number, flag1, team1, score, flag2, team2, group label, edit button
@@ -1649,6 +1650,7 @@ function updateScheduleUI() {
     leftName.classList.add('schedule-team');
     const leftNameSpan = document.createElement('span');
     leftNameSpan.classList.add('schedule-team-name');
+    if (selectedScheduleNation === match.team1) leftNameSpan.classList.add('selected-nation');
     if (match.status === 'completed' && match.score1 > match.score2) {
       leftNameSpan.innerHTML = `<strong>${match.team1}</strong>`;
     } else {
@@ -1683,6 +1685,7 @@ function updateScheduleUI() {
     rightName.classList.add('schedule-team');
     const rightNameSpan = document.createElement('span');
     rightNameSpan.classList.add('schedule-team-name');
+    if (selectedScheduleNation === match.team2) rightNameSpan.classList.add('selected-nation');
     if (match.status === 'completed' && match.score2 > match.score1) {
       rightNameSpan.innerHTML = `<strong>${match.team2}</strong>`;
     } else {

--- a/fopen/styles.css
+++ b/fopen/styles.css
@@ -855,7 +855,16 @@ header.hero {
 }
 
 .schedule-item.highlighted-nation-match {
-  background-color: var(--color-primary);
+  background-color: color-mix(in srgb, var(--color-primary) 16%, var(--color-surface));
+  border-color: var(--color-primary);
+  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--color-primary) 40%, transparent);
+}
+
+.schedule-team-name.selected-nation {
+  color: var(--color-primary);
+  font-weight: 800;
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 /* =========================


### PR DESCRIPTION
### Motivation
- Recent CSS tweaks made the “click a nation” highlight in the schedule/results list hard to perceive, so selecting a nation looked like it did nothing.
- The intent is to restore clear visual feedback without changing the existing click/toggle behavior.

### Description
- Adjusted `updateScheduleUI()` in `fopen/main.js` to compute `isHighlighted` and add an explicit `selected-nation` class on the matching team name spans so the chosen nation is emphasised even if row styling is subtle.
- Strengthened the row highlight CSS in `fopen/styles.css` by using a tinted `color-mix` background, adding a `border-color` and an inset ring for contrast, and added `.schedule-team-name.selected-nation` rules to bold/underline the selected nation name.
- Changes are visual only; clicking to select/deselect a nation and existing match status classes remain unchanged.

### Testing
- Ran the repository searches to validate locations and usages with `rg -n "selectedScheduleNation|highlighted-nation-match|schedule-team-name" fopen/main.js fopen/styles.css`, which returned the expected hits (success).
- Verified the patch with `git diff -- fopen/main.js fopen/styles.css` to inspect the changes (success).
- Committed the change with `git commit -m "Fix nation highlight visibility in schedule/results list"` (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fee6c7c5548320bda361daa611931d)