### PR TITLE
Fix /fopen backup import for full-tournament export files

### DIFF
--- a/fopen/main.js
+++ b/fopen/main.js
@@ -2101,7 +2101,12 @@ function importBackupState() {
     try {
       const text = await file.text();
       const parsed = JSON.parse(text);
-      const importedState = normalizeState(parsed);
+      // Stöd både rena backup-filer (state direkt i root) och full-exporter
+      // från slutspelet där backup-state ligger i sourceBackup.
+      const rawState = parsed && typeof parsed === 'object' && parsed.sourceBackup && typeof parsed.sourceBackup === 'object'
+        ? parsed.sourceBackup
+        : parsed;
+      const importedState = normalizeState(rawState);
       localStorage.setItem('fo-state', JSON.stringify(importedState));
       alert('Backup importerad. Sidan laddas om.');
       location.reload();


### PR DESCRIPTION
### Motivation
- The import routine in `importBackupState()` only handled backups where the saved `state` was at the root of the file and therefore ignored full-tournament export files that embed the backup under `sourceBackup`, causing imports to appear to succeed but not restore state.

### Description
- Update `fopen/main.js` in `importBackupState()` to detect and prefer `parsed.sourceBackup` when present and object-shaped, falling back to the parsed root object otherwise, before calling `normalizeState()` and writing to `localStorage`.

### Testing
- Run `node --check fopen/main.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feec527dd08320976cee618fa70d7a)