### PR TITLE
Improve backup import to detect nested app-state in uploaded JSON

### DIFF
--- a/fopen/main.js
+++ b/fopen/main.js
@@ -2091,6 +2091,25 @@ function backupState() {
   URL.revokeObjectURL(url);
 }
 
+
+function looksLikeAppState(candidate) {
+  if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return false;
+  return ['stage', 'selectedTeams', 'groups', 'schedule', 'results'].some(k => Object.prototype.hasOwnProperty.call(candidate, k));
+}
+
+function extractStateFromBackup(parsed) {
+  const candidates = [
+    parsed,
+    parsed && parsed.state,
+    parsed && parsed.sourceBackup,
+    parsed && parsed.sourceBackup && parsed.sourceBackup.state,
+    parsed && parsed.backup,
+    parsed && parsed.data && parsed.data.state
+  ];
+  const match = candidates.find(looksLikeAppState);
+  if (!match) throw new Error('Ingen giltig app-state hittades i backupfilen.');
+  return match;
+}
 function importBackupState() {
   const input = document.createElement('input');
   input.type = 'file';
@@ -2101,7 +2120,8 @@ function importBackupState() {
     try {
       const text = await file.text();
       const parsed = JSON.parse(text);
-      const importedState = normalizeState(parsed);
+      const rawState = extractStateFromBackup(parsed);
+      const importedState = normalizeState(rawState);
       localStorage.setItem('fo-state', JSON.stringify(importedState));
       alert('Backup importerad. Sidan laddas om.');
       location.reload();


### PR DESCRIPTION
### Motivation
- Make the backup importer resilient to different JSON backup shapes by locating the app state even when it's nested under various keys.

### Description
- Add `looksLikeAppState` and `extractStateFromBackup` helpers and wire `importBackupState` to extract a nested `state` from multiple candidate paths before calling `normalizeState`.

### Testing
- No automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feec527dd08320976cee618fa70d7a)