### PR TITLE
Add robust backup import extraction and regression test

### DIFF
--- a/fopen/import-backup-regression.test.js
+++ b/fopen/import-backup-regression.test.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const vm = require('vm');
+
+const src = fs.readFileSync(require('path').join(__dirname, 'main.js'), 'utf8');
+
+function extractFunction(name) {
+  const start = src.indexOf(`function ${name}(`);
+  if (start < 0) throw new Error(`Missing function: ${name}`);
+  const bodyStart = src.indexOf('{', start);
+  let depth = 0;
+  for (let i = bodyStart; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') {
+      depth--;
+      if (depth === 0) return src.slice(start, i + 1);
+    }
+  }
+  throw new Error(`Unbalanced function: ${name}`);
+}
+
+const snippet = [
+  extractFunction('getDefaultState'),
+  extractFunction('normalizeState'),
+  extractFunction('looksLikeAppState'),
+  extractFunction('extractStateFromBackup')
+].join('\n\n');
+
+const ctx = {};
+vm.createContext(ctx);
+vm.runInContext(snippet, ctx);
+
+const validBackups = [
+  { stage: 'tournament', selectedTeams: ['A'], groups: [], schedule: [], results: {} },
+  { state: { stage: 'draw', selectedTeams: [], groups: [], schedule: [], results: {} } },
+  { sourceBackup: { stage: 'playoff', selectedTeams: [], groups: [], schedule: [], results: {} } },
+  { sourceBackup: { state: { stage: 'select', selectedTeams: [], groups: [], schedule: [], results: {} } } },
+  { backup: { stage: 'tournament', selectedTeams: [], groups: [], schedule: [], results: {} } },
+  { data: { state: { stage: 'draw', selectedTeams: [], groups: [], schedule: [], results: {} } } }
+];
+
+for (const payload of validBackups) {
+  const extracted = ctx.extractStateFromBackup(payload);
+  const normalized = ctx.normalizeState(extracted);
+  if (!normalized || typeof normalized !== 'object') throw new Error('normalizeState failed');
+  if (!['select', 'draw', 'tournament', 'playoff'].includes(normalized.stage)) {
+    throw new Error(`Unexpected stage: ${normalized.stage}`);
+  }
+}
+
+let threw = false;
+try {
+  ctx.extractStateFromBackup({ version: 'x.y.z', meta: {} });
+} catch {
+  threw = true;
+}
+if (!threw) throw new Error('Expected invalid backup to throw');
+
+console.log('import-backup regression tests passed');

--- a/fopen/main.js
+++ b/fopen/main.js
@@ -2091,6 +2091,25 @@ function backupState() {
   URL.revokeObjectURL(url);
 }
 
+
+function looksLikeAppState(candidate) {
+  if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return false;
+  return ['stage', 'selectedTeams', 'groups', 'schedule', 'results'].some(k => Object.prototype.hasOwnProperty.call(candidate, k));
+}
+
+function extractStateFromBackup(parsed) {
+  const candidates = [
+    parsed,
+    parsed && parsed.state,
+    parsed && parsed.sourceBackup,
+    parsed && parsed.sourceBackup && parsed.sourceBackup.state,
+    parsed && parsed.backup,
+    parsed && parsed.data && parsed.data.state
+  ];
+  const match = candidates.find(looksLikeAppState);
+  if (!match) throw new Error('Ingen giltig app-state hittades i backupfilen.');
+  return match;
+}
 function importBackupState() {
   const input = document.createElement('input');
   input.type = 'file';
@@ -2101,7 +2120,11 @@ function importBackupState() {
     try {
       const text = await file.text();
       const parsed = JSON.parse(text);
-      const importedState = normalizeState(parsed);
+      const rawState = extractStateFromBackup(parsed);
+      const importedState = normalizeState(rawState);
+      // Viktigt: uppdatera även minnes-state innan reload. beforeunload sparar
+      // annars om det gamla state:t och kan skriva över den importerade backupen.
+      state = importedState;
       localStorage.setItem('fo-state', JSON.stringify(importedState));
       alert('Backup importerad. Sidan laddas om.');
       location.reload();


### PR DESCRIPTION
### Motivation

- Support importing backups from several different file structures by locating the actual app state inside nested payloads. 
- Prevent the imported backup from being overwritten by the previous in-memory `state` during the reload flow.
- Add an automated regression test to ensure extraction and normalization logic handles multiple backup shapes and invalid inputs.

### Description

- Add `looksLikeAppState` to heuristically detect objects that resemble the app state. 
- Add `extractStateFromBackup` to search common backup payload patterns (`state`, `sourceBackup`, `sourceBackup.state`, `backup`, `data.state`) and throw on missing app state. 
- Update `importBackupState` to call `extractStateFromBackup`, normalize the returned raw state via `normalizeState`, and assign `state = importedState` before writing to `localStorage` and reloading. 
- Add `fopen/import-backup-regression.test.js` which extracts the relevant functions from `main.js` and asserts correct behavior for several valid backup shapes and for an invalid backup case.

### Testing

- Ran the new regression test file `fopen/import-backup-regression.test.js` with `node` and it completed successfully printing the expected success message. 
- No other automated test failures were observed when running the added test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feec527dd08320976cee618fa70d7a)