### PR TITLE
docs(make): add Figma Make realisation handoff notes

### DIFF
--- a/make/REALISATION.md
+++ b/make/REALISATION.md
@@ -1,0 +1,23 @@
+# Figma Make realisation status
+
+This repository now contains a full import of the Figma Make export in `make/imports/`.
+
+## What is included
+- Auto-generated screens/components from Figma Make (`make/imports/**`)
+- Token/theme styles (`make/styles/**`, `make/default_shadcn_theme.css`)
+- App shell and interactive flow (`make/app/**`)
+
+## How to continue implementation
+1. Start from `make/app/App.tsx` for app-level flow and state.
+2. Reuse imported mockup screens in `make/imports/` as visual references.
+3. Promote repeated UI patterns from imports into reusable components under `make/app/components/`.
+4. Keep style tokens from `make/styles/theme.css` and `make/styles/tailwind.css` as the source of truth.
+
+## Suggested next integration step
+Map each imported screen to app route/state transitions:
+- `03MinaArenden` -> list view
+- `021SkapaArendeGrunduppgifter` -> step 1
+- `022SkapaArendeLeverantorerLaggTill` and `023SkapaArendeLeverantorerValiderade` -> step 2 states
+- `024SkapaArendeGranska` -> step 3
+- `025SkapaArendeBekraftelse2` -> confirmation
+


### PR DESCRIPTION
## Summary
- Added `make/REALISATION.md` documenting the imported Figma Make project status.
- Listed what has already been imported (`imports`, styles, app shell/components).
- Added clear next-step mapping from imported screens to current app states.

## Why
This creates a concrete handoff guide so the imported Figma Make assets can be systematically realized into the interactive app flow.

## Files
- `make/REALISATION.md`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16d43fcae48320871c875d3e53bd03)