### PR TITLE
TURN v1.0.1 r8 manual steering fix

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -1,16 +1,18 @@
-name: TURN LAB regression suite
+name: TURN regression suite
 
 on:
   pull_request:
     branches:
       - main
     paths:
+      - 'turn/**'
       - 'turn-lab/**'
       - '.github/workflows/turn-lab-tests.yml'
   push:
     branches:
       - main
     paths:
+      - 'turn/**'
       - 'turn-lab/**'
       - '.github/workflows/turn-lab-tests.yml'
 
@@ -30,10 +32,13 @@ jobs:
           node-version: '24'
 
       - name: Syntax-check TURN modules
-        run: find turn-lab -type f \( -name '*.js' -o -name '*.mjs' \) -print0 | xargs -0 -n1 node --check
+        run: find turn turn-lab -type f \( -name '*.js' -o -name '*.mjs' \) -print0 | xargs -0 -n1 node --check
 
       - name: Run race and replay regression tests
         run: node turn-lab/tests/regression.mjs
+
+      - name: Run production manual steering regression
+        run: node turn-lab/tests/manual-steering-production.mjs
 
       - name: Verify release architecture
         run: node turn-lab/scripts/check-release.mjs

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import { updateMotionInputState } from '../../turn/input/motion.js';
+
+function manualStep(manualSteering) {
+  const state = {
+    sensorMode: false,
+    manualSteering,
+    steering: 0,
+    tiltDrive: 0
+  };
+
+  updateMotionInputState({ state, dt: 1, maxSteerRoll: 1 });
+  return state.steering;
+}
+
+// TURN's vehicle yaw convention is opposite to screen-space manual input.
+// A touch/keyboard input on the left must therefore produce positive vehicle steering,
+// while a right input must produce negative vehicle steering.
+assert.equal(manualStep(-1), 1, 'manual left should steer the car left');
+assert.equal(manualStep(1), -1, 'manual right should steer the car right');
+assert.equal(manualStep(0), 0, 'centered manual steering should stay centered');
+
+const index = await fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8');
+const css = await fs.readFile(new URL('../../turn/manual-steering.css', import.meta.url), 'utf8');
+
+assert.match(index, /role="slider"/);
+assert.match(index, /manual-steer-knob/);
+assert.match(index, /manual-steering\.css\?build=20260719-r8/);
+assert.match(css, /--manual-steer-left/);
+assert.match(css, /content: "←"/);
+assert.match(css, /content: "→"/);
+
+console.log('TURN manual steering regression passed.');

--- a/turn/index.html
+++ b/turn/index.html
@@ -9,27 +9,28 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.0.0 · Build 2026.07.19-r7</title>
+  <title>TURN v1.0.1 · Build 2026.07.19-r8</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.0.0',
-      id: '2026.07.19-r7',
-      cacheKey: '20260719-r7'
+      version: '1.0.1',
+      id: '2026.07.19-r8',
+      cacheKey: '20260719-r8'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260719-r7">
-  <link rel="stylesheet" href="./styles.css?build=20260719-r7">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260719-r7">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260719-r7">
-  <link rel="stylesheet" href="./install-gate.css?build=20260719-r7">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260719-r7">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260719-r7">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260719-r7">
+  <link rel="manifest" href="./site.webmanifest?build=20260719-r8">
+  <link rel="stylesheet" href="./styles.css?build=20260719-r8">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260719-r8">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260719-r8">
+  <link rel="stylesheet" href="./install-gate.css?build=20260719-r8">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260719-r8">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260719-r8">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260719-r8">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260719-r8">
 
-  <script src="./install-gate.js?build=20260719-r7"></script>
-  <script src="./orientation-compat.js?build=20260719-r7"></script>
+  <script src="./install-gate.js?build=20260719-r8"></script>
+  <script src="./orientation-compat.js?build=20260719-r8"></script>
   <script type="importmap">
     {
       "imports": {
@@ -47,7 +48,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.0.0 · Build 2026.07.19-r7</span>
+        <span class="install-kicker">TURN v1.0.1 · Build 2026.07.19-r8</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -75,7 +76,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.0.0 · Build 2026.07.19-r7</span>
+      <span class="kicker">TURN v1.0.1 · Build 2026.07.19-r8</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Press and drag the gas pedal up for more throttle or down for less. Brake stays on its own button.
@@ -117,7 +118,18 @@
     </div>
   </div>
 
-  <div class="manual-steer" id="manualSteer" hidden></div>
+  <div
+    class="manual-steer"
+    id="manualSteer"
+    role="slider"
+    aria-label="Steering. Drag left or right."
+    aria-valuemin="-100"
+    aria-valuemax="100"
+    aria-valuenow="0"
+    hidden
+  >
+    <span class="manual-steer-knob" aria-hidden="true"></span>
+  </div>
 
   <div class="controls" id="controls" hidden>
     <div class="utility-group">
@@ -130,6 +142,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260719-r7"></script>
+  <script type="module" src="./app.js?build=20260719-r8"></script>
 </body>
 </html>

--- a/turn/input/motion.js
+++ b/turn/input/motion.js
@@ -16,7 +16,9 @@ export function motionPoseFromGravity(event) {
 
 export function updateMotionInputState({ state, dt, maxSteerRoll }) {
   if (!state.sensorMode) {
-    state.steering = lerp(state.steering, state.manualSteering, Math.min(1, dt * 10));
+    // Manual input is expressed in screen space (left = -1, right = +1), while
+    // TURN's vehicle yaw convention uses the opposite sign.
+    state.steering = lerp(state.steering, -state.manualSteering, Math.min(1, dt * 10));
     state.tiltDrive = 0;
     return;
   }

--- a/turn/manual-steering.css
+++ b/turn/manual-steering.css
@@ -1,0 +1,88 @@
+.manual-steer {
+  --manual-steer-left: 50%;
+  position: absolute;
+  left: max(22px, env(safe-area-inset-left));
+  right: auto;
+  top: auto;
+  bottom: max(68px, calc(env(safe-area-inset-bottom) + 56px));
+  z-index: 18;
+  width: clamp(150px, 21vw, 220px);
+  height: clamp(102px, 15vw, 150px);
+  overflow: hidden;
+  border: 5px solid var(--ink);
+  border-radius: 30px;
+  background: var(--yellow);
+  box-shadow: 7px 7px 0 var(--ink);
+  touch-action: none;
+  cursor: ew-resize;
+}
+
+.manual-steer::before,
+.manual-steer::after {
+  position: absolute;
+  top: 50%;
+  z-index: 1;
+  color: var(--ink);
+  font-size: clamp(2.2rem, 5vw, 4rem);
+  font-weight: 1000;
+  line-height: 1;
+  transform: translateY(-54%);
+  pointer-events: none;
+}
+
+.manual-steer::before {
+  content: "←";
+  left: 7%;
+}
+
+.manual-steer::after {
+  content: "→";
+  right: 7%;
+}
+
+.manual-steer-knob {
+  position: absolute;
+  left: var(--manual-steer-left);
+  top: 50%;
+  z-index: 2;
+  width: clamp(66px, 9.5vw, 96px);
+  aspect-ratio: 1;
+  border: 5px solid var(--ink);
+  border-radius: 50%;
+  background: var(--cyan);
+  box-shadow: 5px 7px 0 rgb(8 9 10 / 0.35);
+  transform: translate(-50%, -50%);
+  transition: left 110ms cubic-bezier(0.2, 0.9, 0.25, 1.15), box-shadow 100ms ease;
+  pointer-events: none;
+}
+
+.manual-steer.is-steering .manual-steer-knob {
+  transition: none;
+  box-shadow: 2px 3px 0 rgb(8 9 10 / 0.35);
+}
+
+.manual-steer-knob::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 22%;
+  aspect-ratio: 1;
+  border: 4px solid var(--ink);
+  border-radius: 50%;
+  background: var(--paper);
+  transform: translate(-50%, -50%);
+}
+
+@media (max-height: 430px) {
+  .manual-steer {
+    bottom: max(58px, calc(env(safe-area-inset-bottom) + 50px));
+    width: clamp(145px, 20vw, 190px);
+    height: clamp(96px, 14vw, 126px);
+    border-radius: 26px;
+  }
+
+  .manual-steer-knob {
+    width: clamp(62px, 8.5vw, 82px);
+  }
+}

--- a/turn/ui/gameplay-controls.js
+++ b/turn/ui/gameplay-controls.js
@@ -10,9 +10,45 @@ if (!globalThis.__turnGameplayControlsInstalled) {
 function installGameplayUi() {
   const gasButton = document.querySelector('#gasButton');
   const brakeButton = document.querySelector('#brakeButton');
+  const calibrateButton = document.querySelector('#calibrateButton');
+  const manualSteer = document.querySelector('#manualSteer');
   const utilityGroup = document.querySelector('.utility-group');
   const hud = document.querySelector('#hud');
-  if (!gasButton || !brakeButton || !utilityGroup || !hud) return;
+  if (!gasButton || !brakeButton || !manualSteer || !utilityGroup || !hud) return;
+
+  let manualPointerId = null;
+
+  function setManualSteerVisual(event) {
+    if (manualPointerId !== null && event.pointerId !== manualPointerId) return;
+    const rect = manualSteer.getBoundingClientRect();
+    const x = Math.max(0, Math.min(1, (event.clientX - rect.left) / Math.max(1, rect.width)));
+    const position = x * 2 - 1;
+    manualSteer.style.setProperty('--manual-steer-left', `${50 + position * 28}%`);
+    manualSteer.setAttribute('aria-valuenow', String(Math.round(position * 100)));
+  }
+
+  function centerManualSteerVisual(event) {
+    if (manualPointerId !== null && event?.pointerId != null && event.pointerId !== manualPointerId) return;
+    manualPointerId = null;
+    manualSteer.classList.remove('is-steering');
+    manualSteer.style.setProperty('--manual-steer-left', '50%');
+    manualSteer.setAttribute('aria-valuenow', '0');
+  }
+
+  manualSteer.addEventListener('pointerdown', (event) => {
+    event.preventDefault();
+    manualPointerId = event.pointerId;
+    manualSteer.setPointerCapture?.(event.pointerId);
+    manualSteer.classList.add('is-steering');
+    setManualSteerVisual(event);
+  });
+  manualSteer.addEventListener('pointermove', (event) => {
+    if (manualPointerId === event.pointerId) setManualSteerVisual(event);
+  });
+  manualSteer.addEventListener('pointerup', centerManualSteerVisual);
+  manualSteer.addEventListener('pointercancel', centerManualSteerVisual);
+  manualSteer.addEventListener('lostpointercapture', centerManualSteerVisual);
+  calibrateButton?.addEventListener('click', () => centerManualSteerVisual());
 
   const positionHud = document.createElement('div');
   positionHud.className = 'race-position-hud';
@@ -169,11 +205,15 @@ function installGameplayUi() {
   gasButton.addEventListener('pointerup', releaseBoost);
   gasButton.addEventListener('pointercancel', releaseBoost);
   gasButton.addEventListener('lostpointercapture', releaseBoost);
-  window.addEventListener('blur', () => releaseBoost());
+  window.addEventListener('blur', () => {
+    releaseBoost();
+    centerManualSteerVisual();
+  });
   document.addEventListener('visibilitychange', () => {
     if (document.hidden) {
       releaseBoost();
       endDrift();
+      centerManualSteerVisual();
     }
   });
 


### PR DESCRIPTION
Validated successfully. TURN v1.0.1 build r8 fixes mirrored manual steering, adds the visible joystick-style steering control, and includes a permanent regression check. Syntax, race/replay regressions, manual steering regression, and architecture checks all passed. The branch was fast-forwarded directly to main.