### PR TITLE
Force GitHub Pages rebuild for TURN r14

### DIFF
--- a/.github/pages-rebuild-r14.trigger
+++ b/.github/pages-rebuild-r14.trigger
@@ -1,1 +1,1 @@
-TURN r14 Pages rebuild requested at 2026-07-20.
+TURN r14 Pages rebuild requested through PR event at 2026-07-20.

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r14 Drive pad rearm · Pages deployment nudge -->
+<!-- TURN r14 Drive pad rearm · Pages deployment nudge via PR -->
 <html lang="en">
 <head>
   <meta charset="utf-8">


### PR DESCRIPTION
Temporary operational PR to trigger an explicit GitHub Pages rebuild of the current `main` source.

- does not change TURN game code
- requests a Pages build through GitHub's own Pages API
- exists because connector-authored direct pushes did not emit Actions runs
- temporary workflow and trigger files will be removed after the build result is captured