### PR TITLE
TURN v1.3.0 r15: State-aware in-game menu

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -49,5 +49,8 @@ jobs:
       - name: Run unified drive pad and reverse regression
         run: node turn-lab/tests/drive-pad-production.mjs
 
+      - name: Run state-aware in-game menu regression
+        run: node turn-lab/tests/in-game-menu-production.mjs
+
       - name: Verify release architecture
         run: node turn-lab/scripts/check-release.mjs

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -44,8 +44,8 @@ const [index, controls, css, analogGas, spectate] = await Promise.all([
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.2\.1 · Build 2026\.07\.20-r14/);
-assert.match(index, /drive-pad\.css\?build=20260720-r14/);
+assert.match(index, /TURN v1\.3\.0 · Build 2026\.07\.20-r15/);
+assert.match(index, /drive-pad\.css\?build=20260720-r15/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -75,8 +75,8 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.2\.1 · Build 2026\.07\.20-r14/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260720-r14/);
+assert.match(index, /TURN v1\.3\.0 · Build 2026\.07\.20-r15/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260720-r15/);
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');
 assert.match(main, /vehicleTuning: state\.vehicleTuning/, 'Selected handling profile must reach physics');
@@ -102,7 +102,7 @@ assert.match(lotR10Css, /--lot-rail-width/, 'The stats and viewer rail must rese
 const backToLot = await fs.readFile(path.join(turnDir, 'ui/back-to-lot.js'), 'utf8');
 assert.match(main, /openLot: openLotFromRace/, 'Race runtime must expose the Back to the Lot action');
 assert.match(main, /await showTheLot\(/, 'Back to the Lot must reuse the real Lot selector');
-assert.match(backToLot, /Back to the Lot/, 'Race UI must include the Back to the Lot button');
-assert.match(backToLot, /insertAdjacentElement\('afterend'/, 'Back to the Lot button must sit next to Reset Car');
+assert.match(backToLot, /Back to Lot/, 'Race UI must include the Back to Lot button');
+assert.match(backToLot, /back-to-lot-button/, 'Back to Lot must expose its menu hook');
 
 console.log('TURN garage production regression passed.');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import { GAME_MODE } from '../../turn/race/game-state.js';
+import {
+  IN_GAME_MENU_STATE,
+  inGameMenuStateFor,
+  inGameMenuVisibilityFor
+} from '../../turn/ui/in-game-menu-state.js';
+
+assert.equal(inGameMenuStateFor(GAME_MODE.STAGED), IN_GAME_MENU_STATE.STAGED);
+assert.equal(inGameMenuStateFor(GAME_MODE.RACING), IN_GAME_MENU_STATE.RACING);
+assert.equal(inGameMenuStateFor(GAME_MODE.SPECTATING), IN_GAME_MENU_STATE.HIDDEN);
+
+assert.deepEqual(inGameMenuVisibilityFor(GAME_MODE.STAGED), {
+  menuState: IN_GAME_MENU_STATE.STAGED,
+  backToStart: false,
+  startActions: true
+});
+assert.deepEqual(inGameMenuVisibilityFor(GAME_MODE.RACING), {
+  menuState: IN_GAME_MENU_STATE.RACING,
+  backToStart: true,
+  startActions: false
+});
+assert.deepEqual(inGameMenuVisibilityFor(GAME_MODE.SPECTATING), {
+  menuState: IN_GAME_MENU_STATE.HIDDEN,
+  backToStart: false,
+  startActions: false
+});
+
+const [index, app, menu, controls, backToLot, main, css, spectate] = await Promise.all([
+  fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/app.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/ui/in-game-menu.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/ui/gameplay-controls.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/ui/back-to-lot.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/in-game-menu.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
+]);
+
+assert.match(index, /TURN v1\.3\.0 · Build 2026\.07\.20-r15/);
+assert.match(index, /in-game-menu\.css\?build=20260720-r15/);
+assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
+assert.match(index, /id="resetButton"[^>]*>Back to Start<\/button>/);
+assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);
+
+assert.match(menu, /inGameMenuVisibilityFor\(runtime\.state\.mode\)/, 'Menu visibility must follow the explicit game mode');
+assert.doesNotMatch(menu, /state\.speed/, 'Menu visibility must not infer race state from speed');
+assert.match(menu, /backToStartButton\.hidden = !visibility\.backToStart/);
+assert.match(menu, /backToLotButton\.hidden = !visibility\.startActions/);
+assert.match(menu, /recalibrateButton\.hidden = !visibility\.startActions/);
+assert.match(menu, /resetRivalsButton\.hidden = !visibility\.startActions/);
+assert.match(
+  menu,
+  /const buttonOrder = \[\s*backToLotButton,\s*recalibrateButton,\s*resetRivalsButton,\s*spectateButton,\s*backToStartButton\s*\]/,
+  'Start actions must follow the requested order'
+);
+
+assert.match(controls, /Reset Rivals/);
+assert.match(controls, /globalThis\.__turnResetRivals/);
+assert.match(backToLot, /Back to Lot/);
+assert.match(main, /globalThis\.__turnResetRivals = resetRivals/);
+assert.match(spectate, /spectateButton\.hidden = !current\.available/, 'Spectate must remain conditional on a saved rival');
+assert.match(css, /\.utility-group\[data-menu-state="staged"\]/);
+assert.match(css, /\.utility-group\[data-menu-state="racing"\] \.back-to-start-button/);
+assert.match(css, /\.utility-group\[data-menu-state="hidden"\]/);
+
+console.log('TURN state-aware in-game menu regression passed.');

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -26,7 +26,7 @@ const css = await fs.readFile(new URL('../../turn/manual-steering.css', import.m
 
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260720-r14/);
+assert.match(index, /manual-steering\.css\?build=20260720-r15/);
 assert.match(css, /--manual-steer-left/);
 assert.match(css, /content: "←"/);
 assert.match(css, /content: "→"/);

--- a/turn/app.js
+++ b/turn/app.js
@@ -16,4 +16,6 @@ await Promise.all([
   import(withBuild('./ui/back-to-lot.js'))
 ]);
 
+await import(withBuild('./ui/in-game-menu.js'));
+
 console.info(`TURN: ${globalThis.__TURN_BUILD__?.id || 'development'} loaded from the static module graph.`);

--- a/turn/in-game-menu.css
+++ b/turn/in-game-menu.css
@@ -1,0 +1,41 @@
+.utility-group[data-menu-state="staged"] {
+  flex: 1 1 auto;
+  min-width: 0;
+  justify-content: center;
+  align-items: stretch;
+}
+
+.utility-group[data-menu-state="staged"] .utility,
+.utility-group[data-menu-state="racing"] .back-to-start-button {
+  min-height: 50px;
+  padding: 8px clamp(10px, 1.55vw, 18px);
+  border-radius: 14px;
+  white-space: nowrap;
+}
+
+.back-to-lot-button {
+  background: #ff7b54;
+}
+
+.back-to-start-button,
+.recalibrate-button,
+.reset-rivals-button {
+  background: var(--paper);
+}
+
+.utility-group[data-menu-state="hidden"] {
+  display: none;
+}
+
+@media (max-height: 430px) {
+  .utility-group[data-menu-state="staged"] {
+    gap: 7px;
+  }
+
+  .utility-group[data-menu-state="staged"] .utility,
+  .utility-group[data-menu-state="racing"] .back-to-start-button {
+    min-height: 40px;
+    padding: 6px clamp(8px, 1.2vw, 13px);
+    font-size: clamp(0.52rem, 1.18vw, 0.64rem);
+  }
+}

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r14 Drive pad rearm · Pages deployment nudge via PR -->
+<!-- TURN r15 State-aware in-game menu -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,30 +10,31 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.2.1 · Build 2026.07.20-r14</title>
+  <title>TURN v1.3.0 · Build 2026.07.20-r15</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.2.1',
-      id: '2026.07.20-r14',
-      cacheKey: '20260720-r14'
+      version: '1.3.0',
+      id: '2026.07.20-r15',
+      cacheKey: '20260720-r15'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260720-r14">
-  <link rel="stylesheet" href="./styles.css?build=20260720-r14">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260720-r14">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260720-r14">
-  <link rel="stylesheet" href="./install-gate.css?build=20260720-r14">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260720-r14">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260720-r14">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260720-r14">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260720-r14">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260720-r14">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260720-r14">
+  <link rel="manifest" href="./site.webmanifest?build=20260720-r15">
+  <link rel="stylesheet" href="./styles.css?build=20260720-r15">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260720-r15">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260720-r15">
+  <link rel="stylesheet" href="./install-gate.css?build=20260720-r15">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260720-r15">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260720-r15">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260720-r15">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260720-r15">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260720-r15">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260720-r15">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260720-r15">
 
-  <script src="./install-gate.js?build=20260720-r14"></script>
-  <script src="./orientation-compat.js?build=20260720-r14"></script>
+  <script src="./install-gate.js?build=20260720-r15"></script>
+  <script src="./orientation-compat.js?build=20260720-r15"></script>
   <script type="importmap">
     {
       "imports": {
@@ -51,7 +52,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.2.1 · Build 2026.07.20-r14</span>
+        <span class="install-kicker">TURN v1.3.0 · Build 2026.07.20-r15</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -79,7 +80,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.2.1 · Build 2026.07.20-r14</span>
+      <span class="kicker">TURN v1.3.0 · Build 2026.07.20-r15</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -136,8 +137,8 @@
 
   <div class="controls" id="controls" hidden>
     <div class="utility-group">
-      <button class="utility" id="calibrateButton" type="button">Center controls</button>
-      <button class="utility" id="resetButton" type="button">Reset car</button>
+      <button class="utility" id="calibrateButton" type="button">Recalibrate</button>
+      <button class="utility" id="resetButton" type="button">Back to Start</button>
     </div>
     <div class="pedals">
       <button class="pedal brake" id="brakeButton" type="button">Brake</button>
@@ -145,6 +146,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260720-r14"></script>
+  <script type="module" src="./app.js?build=20260720-r15"></script>
 </body>
 </html>

--- a/turn/main.js
+++ b/turn/main.js
@@ -1006,7 +1006,7 @@ function loadGhost() {
 
 globalThis.__turnHasGhosts = () => state.competitorLaps.length > 0;
 
-globalThis.__turnNukeGhosts = () => {
+function resetRivals() {
   state.competitorLaps = [];
   state.bestTime = Infinity;
   state.ghostFrames = [];
@@ -1018,9 +1018,12 @@ globalThis.__turnNukeGhosts = () => {
   for (const car of competitorCars) car.visible = false;
   refreshCompetitorLabels();
   updateHud();
-  showMessage('GHOSTS NUKED', 1800);
-  window.dispatchEvent(new CustomEvent('turn:ghosts-nuked'));
-};
+  showMessage('RIVALS RESET', 1800);
+  window.dispatchEvent(new CustomEvent('turn:rivals-reset'));
+}
+
+globalThis.__turnResetRivals = resetRivals;
+globalThis.__turnNukeGhosts = resetRivals;
 
 function lapFrameAt(lap, time) {
   return replayFrameAt(lap, time);

--- a/turn/ui/back-to-lot.js
+++ b/turn/ui/back-to-lot.js
@@ -19,7 +19,7 @@ function install(runtime) {
   const button = document.createElement('button');
   button.type = 'button';
   button.className = 'utility back-to-lot-button';
-  button.textContent = 'Back to the Lot';
+  button.textContent = 'Back to Lot';
   button.setAttribute('aria-label', 'Back to The Lot and choose another car');
 
   resetButton.insertAdjacentElement('afterend', button);

--- a/turn/ui/gameplay-controls.js
+++ b/turn/ui/gameplay-controls.js
@@ -207,24 +207,24 @@ function installGameplayUi() {
     if (drivePointerId === event.pointerId) releaseDrive(event);
   });
 
-  const nukeButton = document.createElement('button');
-  nukeButton.type = 'button';
-  nukeButton.className = 'utility nuke-ghosts-button';
-  nukeButton.setAttribute('aria-label', 'Nuke saved ghosts');
-  nukeButton.title = 'Nuke saved ghosts';
-  nukeButton.innerHTML = '<span class="mushroom-cloud-icon" aria-hidden="true"><i></i></span>';
-  utilityGroup.appendChild(nukeButton);
+  const resetRivalsButton = document.createElement('button');
+  resetRivalsButton.type = 'button';
+  resetRivalsButton.className = 'utility reset-rivals-button';
+  resetRivalsButton.textContent = 'Reset Rivals';
+  resetRivalsButton.setAttribute('aria-label', 'Reset saved rivals');
+  resetRivalsButton.title = 'Reset saved rivals';
+  utilityGroup.appendChild(resetRivalsButton);
 
   const dialog = document.createElement('dialog');
   dialog.className = 'nuke-dialog';
   dialog.innerHTML = `
     <form method="dialog" class="nuke-dialog-card">
       <div class="nuke-dialog-icon" aria-hidden="true"><span class="mushroom-cloud-icon"><i></i></span></div>
-      <h2>NUKE THE GHOSTS?</h2>
-      <p>Are you sure you want to nuke the ghosts?</p>
+      <h2>RESET RIVALS?</h2>
+      <p>Remove all saved rivals and their lap records?</p>
       <div class="nuke-dialog-actions">
         <button value="cancel" class="nuke-cancel">Cancel</button>
-        <button value="nuke" class="nuke-confirm">Nuke ghosts</button>
+        <button value="nuke" class="nuke-confirm">Reset rivals</button>
       </div>
     </form>`;
   document.body.appendChild(dialog);
@@ -248,7 +248,7 @@ function installGameplayUi() {
     else dialog.removeAttribute('open');
   }
 
-  nukeButton.addEventListener('click', () => {
+  resetRivalsButton.addEventListener('click', () => {
     if (typeof dialog.showModal === 'function') dialog.showModal();
     else dialog.setAttribute('open', '');
   });
@@ -258,7 +258,7 @@ function installGameplayUi() {
     closeNukeDialog();
     effect.hidden = false;
     document.body.classList.add('turn-nuking');
-    window.setTimeout(() => globalThis.__turnNukeGhosts?.(), 360);
+    window.setTimeout(() => globalThis.__turnResetRivals?.(), 360);
     window.setTimeout(() => {
       document.body.classList.remove('turn-nuking');
       effect.hidden = true;

--- a/turn/ui/in-game-menu-state.js
+++ b/turn/ui/in-game-menu-state.js
@@ -1,0 +1,22 @@
+import { GAME_MODE } from '../race/game-state.js';
+
+export const IN_GAME_MENU_STATE = Object.freeze({
+  STAGED: 'staged',
+  RACING: 'racing',
+  HIDDEN: 'hidden'
+});
+
+export function inGameMenuStateFor(mode) {
+  if (mode === GAME_MODE.STAGED) return IN_GAME_MENU_STATE.STAGED;
+  if (mode === GAME_MODE.RACING) return IN_GAME_MENU_STATE.RACING;
+  return IN_GAME_MENU_STATE.HIDDEN;
+}
+
+export function inGameMenuVisibilityFor(mode) {
+  const menuState = inGameMenuStateFor(mode);
+  return Object.freeze({
+    menuState,
+    backToStart: menuState === IN_GAME_MENU_STATE.RACING,
+    startActions: menuState === IN_GAME_MENU_STATE.STAGED
+  });
+}

--- a/turn/ui/in-game-menu.js
+++ b/turn/ui/in-game-menu.js
@@ -1,0 +1,69 @@
+import { IN_GAME_MENU_STATE, inGameMenuVisibilityFor } from './in-game-menu-state.js';
+
+function waitForRuntime() {
+  if (globalThis.__turnRuntime) {
+    install(globalThis.__turnRuntime);
+    return;
+  }
+
+  window.addEventListener('turn:runtime-ready', (event) => {
+    install(event.detail || globalThis.__turnRuntime);
+  }, { once: true });
+}
+
+function install(runtime) {
+  if (!runtime || runtime.__inGameMenuInstalled) return;
+
+  const utilityGroup = document.querySelector('.utility-group');
+  const backToStartButton = document.querySelector('#resetButton');
+  const recalibrateButton = document.querySelector('#calibrateButton');
+  const backToLotButton = document.querySelector('.back-to-lot-button');
+  const resetRivalsButton = document.querySelector('.reset-rivals-button');
+  const spectateButton = document.querySelector('.spectate-button');
+
+  if (!utilityGroup || !backToStartButton || !recalibrateButton || !backToLotButton || !resetRivalsButton || !spectateButton) {
+    requestAnimationFrame(() => install(runtime));
+    return;
+  }
+
+  runtime.__inGameMenuInstalled = true;
+
+  backToStartButton.textContent = 'Back to Start';
+  backToStartButton.setAttribute('aria-label', 'Return to the start');
+  backToStartButton.classList.add('back-to-start-button');
+
+  recalibrateButton.textContent = 'Recalibrate';
+  recalibrateButton.setAttribute('aria-label', 'Recalibrate steering and tilt controls');
+  recalibrateButton.classList.add('recalibrate-button');
+
+  const buttonOrder = [
+    backToLotButton,
+    recalibrateButton,
+    resetRivalsButton,
+    spectateButton,
+    backToStartButton
+  ];
+  for (const button of buttonOrder) utilityGroup.appendChild(button);
+
+  let previousMenuState = null;
+  function syncMenu() {
+    const visibility = inGameMenuVisibilityFor(runtime.state.mode);
+    if (visibility.menuState !== previousMenuState) {
+      utilityGroup.dataset.menuState = visibility.menuState;
+      utilityGroup.setAttribute(
+        'aria-label',
+        visibility.menuState === IN_GAME_MENU_STATE.STAGED ? 'Start actions' : 'Race actions'
+      );
+      backToStartButton.hidden = !visibility.backToStart;
+      backToLotButton.hidden = !visibility.startActions;
+      recalibrateButton.hidden = !visibility.startActions;
+      resetRivalsButton.hidden = !visibility.startActions;
+      previousMenuState = visibility.menuState;
+    }
+    requestAnimationFrame(syncMenu);
+  }
+
+  syncMenu();
+}
+
+waitForRuntime();


### PR DESCRIPTION
## What changed

- During an active race, the utility menu now shows only **Back to Start**.
- At the staged start, it shows **Back to Lot**, **Recalibrate**, **Reset Rivals**, and **Spectate**, in that order.
- Menu visibility follows TURN's explicit `GAME_MODE` state rather than vehicle speed.
- Existing reset, calibration, lot, rival-reset, and spectate actions are preserved; Spectate remains available only when a saved rival exists.
- The former destructive-sounding rival label is now **Reset Rivals**, while keeping its confirmation and visual feedback.
- Release metadata and cache keys are bumped to **TURN v1.3.0 · Build 2026.07.20-r15**.

## Why

The utility actions should match the player's moment: a single quick return action while racing, and the full setup menu only while staged at the start.

## Validation

- Added a production regression for staged, racing, and spectating menu states.
- Updated existing garage, manual-steering, and drive-pad release assertions for r15.
- The GitHub TURN regression workflow runs the full suite on this PR.
