### PR TITLE
TURN v1.4.0 r16: Permanent Ability Zones

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -52,5 +52,8 @@ jobs:
       - name: Run state-aware in-game menu regression
         run: node turn-lab/tests/in-game-menu-production.mjs
 
+      - name: Run Ability Zones and nitrous regression
+        run: node turn-lab/tests/ability-zones-production.mjs
+
       - name: Verify release architecture
         run: node turn-lab/scripts/check-release.mjs

--- a/turn-lab/tests/ability-zones-production.mjs
+++ b/turn-lab/tests/ability-zones-production.mjs
@@ -1,0 +1,241 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+import {
+  ABILITY_ZONES,
+  ABILITY_ZONE_TYPE,
+  findAbilityZoneAt,
+  zoneSampleIndices
+} from '../../turn/race/ability-zones.js';
+import {
+  NITROUS_POWER_MULTIPLIER,
+  createBoostReservoir,
+  updateBoostReservoir
+} from '../../turn/race/boost-reservoir.js';
+import { updateVehiclePhysicsState } from '../../turn/vehicle/physics.js';
+
+class Vec3 {
+  constructor(x = 0, y = 0, z = 0) {
+    this.x = x;
+    this.y = y;
+    this.z = z;
+  }
+
+  clone() {
+    return new Vec3(this.x, this.y, this.z);
+  }
+
+  dot(other) {
+    return this.x * other.x + this.y * other.y + this.z * other.z;
+  }
+
+  addScaledVector(other, scale) {
+    this.x += other.x * scale;
+    this.y += other.y * scale;
+    this.z += other.z * scale;
+    return this;
+  }
+
+  multiplyScalar(scale) {
+    this.x *= scale;
+    this.y *= scale;
+    this.z *= scale;
+    return this;
+  }
+
+  length() {
+    return Math.hypot(this.x, this.y, this.z);
+  }
+}
+
+const driftZones = ABILITY_ZONES.filter((zone) => zone.type === ABILITY_ZONE_TYPE.DRIFT);
+const boostZones = ABILITY_ZONES.filter((zone) => zone.type === ABILITY_ZONE_TYPE.BOOST);
+
+assert.equal(driftZones.length, 3, 'The permanent circuit must have three authored Drift Zones');
+assert.equal(boostZones.length, 2, 'The permanent circuit must have two authored Boost Zones');
+assert.ok(Object.isFrozen(ABILITY_ZONES), 'Ability Zone placement must be immutable');
+
+for (const zone of ABILITY_ZONES) {
+  assert.ok(zone.laneWidth < 0.4, `${zone.id} must cover only a lane, not the full road`);
+  assert.ok(zone.start >= 0 && zone.start < 1 && zone.end >= 0 && zone.end < 1);
+  assert.ok(zoneSampleIndices(zone, 720).length > 10, `${zone.id} must have a playable length`);
+}
+
+for (const zone of driftZones) {
+  assert.equal(zone.edge, 'outer', `${zone.id} must be authored on a curve's outer edge`);
+  assert.ok(Math.abs(zone.laneCenter) >= 0.3, `${zone.id} must stay near that outer edge`);
+}
+
+for (const zone of boostZones) {
+  assert.equal(zone.straightAfter[0], zone.end, `${zone.id} must lead directly into its straight`);
+  assert.ok(zone.straightAfter[1] - zone.straightAfter[0] >= 0.1, `${zone.id} needs useful road after it`);
+}
+
+const samples = Array.from({ length: 720 }, (_, index) => ({
+  point: new Vec3(index, 0, 0),
+  tangent: new Vec3(1, 0, 0),
+  normal: new Vec3(0, 0, 1)
+}));
+const firstDriftZone = driftZones[0];
+const driftIndex = zoneSampleIndices(firstDriftZone, samples.length)[10];
+const driftLane = firstDriftZone.laneCenter * 27;
+const detectedDriftZone = findAbilityZoneAt({
+  position: new Vec3(driftIndex, 0, driftLane),
+  nearestTrackIndex: driftIndex,
+  samples,
+  trackWidth: 27
+});
+
+assert.equal(detectedDriftZone?.id, firstDriftZone.id, 'Driving through the authored outer lane must enter the Drift Zone');
+assert.equal(
+  findAbilityZoneAt({
+    position: new Vec3(driftIndex, 0, 0),
+    nearestTrackIndex: driftIndex,
+    samples,
+    trackWidth: 27
+  }),
+  null,
+  'The road centre must remain outside a narrow outer-edge Drift Zone'
+);
+
+let fullReservoir = createBoostReservoir(1, 0);
+for (let step = 0; step < 20; step += 1) {
+  fullReservoir = updateBoostReservoir(fullReservoir, {
+    dt: 0.1,
+    requested: true,
+    inBoostZone: true,
+    drainSeconds: 2
+  });
+}
+assert.equal(fullReservoir.charge, 1, 'Using a full bar in a red zone must not create empty space');
+assert.ok(fullReservoir.nitrousCharge > 0.999, 'A well-used full bar must become a full nitrous bar');
+assert.equal(fullReservoir.boostPowerMultiplier, NITROUS_POWER_MULTIPLIER);
+
+let lowReservoir = createBoostReservoir(0.2, 0);
+for (let step = 0; step < 20; step += 1) {
+  lowReservoir = updateBoostReservoir(lowReservoir, {
+    dt: 0.1,
+    requested: true,
+    inBoostZone: true,
+    drainSeconds: 2
+  });
+}
+assert.equal(lowReservoir.charge, 0.2, 'A red zone must preserve existing empty capacity');
+assert.equal(lowReservoir.nitrousCharge, 0.2, 'Only carried charge may be converted to nitrous');
+
+const spentOutside = updateBoostReservoir(lowReservoir, {
+  dt: 0.1,
+  requested: true,
+  inBoostZone: false,
+  drainSeconds: 2
+});
+assert.ok(spentOutside.charge < lowReservoir.charge, 'Stored nitrous must drain normally outside the red zone');
+assert.ok(spentOutside.nitrousCharge < lowReservoir.nitrousCharge, 'Stored nitrous must be spent before ordinary boost');
+assert.ok(spentOutside.nitrousActive, 'Stored nitrous must retain its stronger output outside the zone');
+
+const rechargedOutside = updateBoostReservoir(spentOutside, {
+  dt: 0.1,
+  requested: false,
+  inBoostZone: false,
+  rechargeSeconds: 4.2
+});
+assert.equal(rechargedOutside.nitrousCharge, spentOutside.nitrousCharge, 'Ordinary recharge must not overwrite stored nitrous');
+assert.ok(rechargedOutside.normalCharge > spentOutside.normalCharge, 'Recharge outside the red zone must add ordinary boost');
+
+const normalDrift = makePhysicsState();
+const rewardedDrift = makePhysicsState();
+runPhysics(normalDrift, { driftHeld: true });
+runPhysics(rewardedDrift, {
+  driftHeld: true,
+  driftAssist: {
+    laneError: 3,
+    sample: {
+      tangent: new Vec3(0, 0, 1),
+      normal: new Vec3(1, 0, 0)
+    }
+  }
+});
+assert.ok(rewardedDrift.speed > normalDrift.speed, 'Active blue zones must remove the normal drift speed penalty');
+assert.ok(rewardedDrift.velocity.x > normalDrift.velocity.x, 'Active blue zones must add a light lane-centering pull');
+
+const normalBoost = makePhysicsState();
+const nitrousBoost = makePhysicsState();
+runPhysics(normalBoost, { boostActive: true });
+runPhysics(nitrousBoost, {
+  boostActive: true,
+  boostPowerMultiplier: NITROUS_POWER_MULTIPLIER,
+  boostSpeedMultiplier: 1.12
+});
+assert.ok(nitrousBoost.speed > normalBoost.speed, 'Nitrous must accelerate harder than ordinary boost');
+
+const [index, main, controls, visuals, driveCss, hudCss] = await Promise.all([
+  fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/ui/gameplay-controls.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/render/ability-zones.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/drive-pad.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/gameplay-v2.css', import.meta.url), 'utf8')
+]);
+
+assert.match(index, /TURN v1\.4\.0 · Build 2026\.07\.20-r16/);
+assert.match(main, /installAbilityZoneVisuals/);
+assert.match(main, /findAbilityZoneAt/);
+assert.match(main, /driftAssist/);
+assert.match(controls, /updateBoostReservoir/);
+assert.match(controls, /__turnNitrousCharge/);
+assert.match(visuals, /ZONE_COLORS/);
+assert.match(visuals, /InstancedMesh/, 'Ability Zones need a distinct non-colour road pattern');
+assert.match(driveCss, /--boost-normal/);
+assert.match(driveCss, /#ef3340/);
+assert.match(hudCss, /\.boost-nitrous/);
+
+console.log('TURN Ability Zones and persistent nitrous regression passed.');
+
+function makePhysicsState() {
+  return {
+    position: new Vec3(),
+    velocity: new Vec3(0, 0, 30),
+    touchGas: true,
+    touchBrake: false,
+    throttle: 0,
+    brake: 0,
+    steering: 0.25,
+    driftAmount: 0.4,
+    heading: 0,
+    progress: 0,
+    lastProgress: 0,
+    nearestTrackIndex: 0,
+    trackDistance: 0,
+    offRoad: false,
+    speed: 30
+  };
+}
+
+function runPhysics(state, overrides = {}) {
+  const trackSample = {
+    point: new Vec3(),
+    tangent: new Vec3(0, 0, 1),
+    normal: new Vec3(1, 0, 0)
+  };
+  return updateVehiclePhysicsState({
+    state,
+    dt: 0.1,
+    updateMotionInput: () => {},
+    findNearestTrack: () => ({ index: 0, distance: 0, sample: trackSample }),
+    getForward: () => new Vec3(Math.sin(state.heading), 0, Math.cos(state.heading)),
+    getRight: () => new Vec3(Math.cos(state.heading), 0, -Math.sin(state.heading)),
+    trackWidth: 27,
+    trackSampleCount: 100,
+    maxSpeed: 88,
+    analogGas: 1,
+    vehicleTuning: {
+      accelerationMultiplier: 1,
+      controlMultiplier: 1,
+      driftEngineMultiplier: 0.93,
+      driftDragAdd: 0.085,
+      boostPowerMultiplier: 1,
+      boostSpeedMultiplier: 1.32
+    },
+    ...overrides
+  });
+}

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -44,15 +44,15 @@ const [index, controls, css, analogGas, spectate] = await Promise.all([
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.0 · Build 2026\.07\.20-r15/);
-assert.match(index, /drive-pad\.css\?build=20260720-r15/);
+assert.match(index, /TURN v1\.4\.0 · Build 2026\.07\.20-r16/);
+assert.match(index, /drive-pad\.css\?build=20260720-r16/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');
 assert.match(controls, /globalThis\.__turnAnalogGas = nextZone \? 1 : 0/, 'All three drive zones must keep normal gas engaged');
 assert.match(controls, /globalThis\.__turnDriftHeld = nextZone === 'drift'/, 'Drift zone must add drift to gas');
 assert.match(controls, /boostRequested = nextZone === 'boost'/, 'Boost zone must add boost to gas');
-assert.match(controls, /boostRequested && !boostExhausted/, 'Boost must stay locked while the thumb remains in Boost after exhaustion');
+assert.match(controls, /requested: boostRequested,[\s\S]*locked: boostExhausted/, 'Boost reservoir must respect the touch-sequence exhaustion lock');
 assert.match(controls, /previousZone === 'boost' && nextZone !== 'boost'\) boostExhausted = false/, 'Leaving Boost for Gas or Drift must re-arm Boost without requiring pointer release');
 assert.match(controls, /Brake · Reverse/, 'Separate brake control must advertise reverse');
 assert.match(css, /\.drive-pad \{/);

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -75,8 +75,8 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.0 · Build 2026\.07\.20-r15/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260720-r15/);
+assert.match(index, /TURN v1\.4\.0 · Build 2026\.07\.20-r16/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260720-r16/);
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');
 assert.match(main, /vehicleTuning: state\.vehicleTuning/, 'Selected handling profile must reach physics');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -38,8 +38,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.0 · Build 2026\.07\.20-r15/);
-assert.match(index, /in-game-menu\.css\?build=20260720-r15/);
+assert.match(index, /TURN v1\.4\.0 · Build 2026\.07\.20-r16/);
+assert.match(index, /in-game-menu\.css\?build=20260720-r16/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Back to Start<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -26,7 +26,7 @@ const css = await fs.readFile(new URL('../../turn/manual-steering.css', import.m
 
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260720-r15/);
+assert.match(index, /manual-steering\.css\?build=20260720-r16/);
 assert.match(css, /--manual-steer-left/);
 assert.match(css, /content: "←"/);
 assert.match(css, /content: "→"/);

--- a/turn/drive-pad.css
+++ b/turn/drive-pad.css
@@ -11,6 +11,8 @@
 
 .drive-pad {
   --boost-charge: 100%;
+  --boost-normal: 100%;
+  --boost-nitrous: 0%;
   position: relative;
   height: clamp(150px, 20vw, 210px);
   overflow: hidden;
@@ -68,7 +70,8 @@
   background:
     linear-gradient(
       to top,
-      #ff6b6b 0 var(--boost-charge),
+      #ff922b 0 var(--boost-normal),
+      #ef3340 var(--boost-normal) var(--boost-charge),
       #ffb2aa var(--boost-charge) 100%
     );
 }
@@ -114,7 +117,8 @@
   background:
     linear-gradient(
       to top,
-      #ff3f4a 0 var(--boost-charge),
+      #ff7a1a 0 var(--boost-normal),
+      #f20d4b var(--boost-normal) var(--boost-charge),
       #ff9a8e var(--boost-charge) 100%
     );
 }
@@ -123,6 +127,31 @@
   box-shadow:
     7px 8px 0 var(--ink),
     0 0 0 5px rgb(255 90 95 / 0.28);
+}
+
+.drive-pad.is-boost-zone .drive-boost-zone {
+  box-shadow: inset 0 0 0 6px rgb(255 248 232 / 0.58);
+}
+
+.drive-pad.is-nitrous {
+  box-shadow:
+    7px 8px 0 var(--ink),
+    0 0 0 6px rgb(239 51 64 / 0.42),
+    0 0 24px rgb(255 248 232 / 0.52);
+}
+
+.drive-pad.has-nitrous .drive-boost-zone:not(.is-locked)::after {
+  content: "N₂O";
+  position: absolute;
+  right: 7px;
+  bottom: 6px;
+  padding: 2px 5px;
+  border: 2px solid var(--ink);
+  border-radius: 999px;
+  background: #ef3340;
+  color: #fff8e8;
+  font-size: 0.44rem;
+  letter-spacing: 0.06em;
 }
 
 .drive-boost-zone.is-locked::after {

--- a/turn/gameplay-v2.css
+++ b/turn/gameplay-v2.css
@@ -34,6 +34,8 @@
 
 .boost-hud {
   --boost-charge: 100%;
+  --boost-normal: 100%;
+  --boost-nitrous: 0%;
   position: absolute;
   left: 50%;
   bottom: clamp(92px, 20vh, 150px);
@@ -69,9 +71,20 @@
 .boost-hud i {
   position: absolute;
   inset: 0 auto 0 0;
-  width: var(--boost-charge);
+  width: 0;
+  transition: left 70ms linear, width 70ms linear;
+}
+
+.boost-hud .boost-normal {
+  width: var(--boost-normal);
   background: linear-gradient(90deg, #ff922b, #ff5a5f);
-  transition: width 70ms linear;
+}
+
+.boost-hud .boost-nitrous {
+  left: var(--boost-normal);
+  width: var(--boost-nitrous);
+  background:
+    linear-gradient(90deg, #ef3340, #ff2f75 72%, #fff8e8 100%);
 }
 
 .boost-hud.is-boosting {
@@ -84,7 +97,19 @@
     0 0 0 5px rgb(255 90 95 / 0.28);
 }
 
-.boost-hud.is-drift-charging i {
+.boost-hud.has-nitrous > span {
+  background: #ef3340;
+  color: #fff8e8;
+}
+
+.boost-hud.is-nitrous > div {
+  box-shadow:
+    3px 3px 0 var(--ink),
+    0 0 0 5px rgb(239 51 64 / 0.34),
+    0 0 20px rgb(255 248 232 / 0.58);
+}
+
+.boost-hud.is-drift-charging .boost-normal {
   background: linear-gradient(90deg, #38d9ff, #8ce99a);
 }
 

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r15 State-aware in-game menu -->
+<!-- TURN r16 Permanent Ability Zones and persistent nitrous -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,31 +10,31 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.0 · Build 2026.07.20-r15</title>
+  <title>TURN v1.4.0 · Build 2026.07.20-r16</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.0',
-      id: '2026.07.20-r15',
-      cacheKey: '20260720-r15'
+      version: '1.4.0',
+      id: '2026.07.20-r16',
+      cacheKey: '20260720-r16'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260720-r15">
-  <link rel="stylesheet" href="./styles.css?build=20260720-r15">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260720-r15">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260720-r15">
-  <link rel="stylesheet" href="./install-gate.css?build=20260720-r15">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260720-r15">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260720-r15">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260720-r15">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260720-r15">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260720-r15">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260720-r15">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260720-r15">
+  <link rel="manifest" href="./site.webmanifest?build=20260720-r16">
+  <link rel="stylesheet" href="./styles.css?build=20260720-r16">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260720-r16">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260720-r16">
+  <link rel="stylesheet" href="./install-gate.css?build=20260720-r16">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260720-r16">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260720-r16">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260720-r16">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260720-r16">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260720-r16">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260720-r16">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260720-r16">
 
-  <script src="./install-gate.js?build=20260720-r15"></script>
-  <script src="./orientation-compat.js?build=20260720-r15"></script>
+  <script src="./install-gate.js?build=20260720-r16"></script>
+  <script src="./orientation-compat.js?build=20260720-r16"></script>
   <script type="importmap">
     {
       "imports": {
@@ -52,7 +52,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.0 · Build 2026.07.20-r15</span>
+        <span class="install-kicker">TURN v1.4.0 · Build 2026.07.20-r16</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -80,10 +80,10 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.0 · Build 2026.07.20-r15</span>
+      <span class="kicker">TURN v1.4.0 · Build 2026.07.20-r16</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
-        Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
+        Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control. Blue zones reward an outside-line drift; red zones turn used boost into stored nitrous.
       </p>
       <div class="actions">
         <button id="motionButton" type="button">Enable motion &amp; race</button>
@@ -146,6 +146,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260720-r15"></script>
+  <script type="module" src="./app.js?build=20260720-r16"></script>
 </body>
 </html>

--- a/turn/main.js
+++ b/turn/main.js
@@ -3,9 +3,11 @@
 import * as THREE from 'three';
 import { installKenneyWorld } from './world-assets.js';
 import { updateRaceCameraState } from './render/camera.js';
+import { installAbilityZoneVisuals } from './render/ability-zones.js';
 import { updateHudState } from './ui/hud.js';
 import { motionPoseFromGravity as motionPoseFromGravityState, updateMotionInputState } from './input/motion.js';
-import { updateVehiclePhysicsState } from './vehicle/physics.js';
+import { updateVehiclePhysicsState } from './vehicle/physics.js?build=20260720-r16';
+import { ABILITY_ZONE_TYPE, findAbilityZoneAt } from './race/ability-zones.js';
 import { GAME_MODE, installGameModeState, prepareRaceStartState, resetRaceToStage, setGameModeState } from './race/game-state.js';
 import { beginTimedLapState, completeLapState, updateLapProgressState } from './race/lap-system.js';
 import { recordReplayFrame, replayFrameAt } from './race/replay-system.js';
@@ -90,10 +92,16 @@ const state = {
   vehicleColor: initialVehicleSelection.color,
   vehicleTuning: initialVehicleDefinition.tuning,
   lastFrame: performance.now(),
-  messageTimer: 0
+  messageTimer: 0,
+  abilityZoneId: null,
+  abilityZoneType: null,
+  abilityZoneActive: false
 };
 
 globalThis.__turnVehicleTuning = state.vehicleTuning;
+globalThis.__turnAbilityZoneId = null;
+globalThis.__turnAbilityZoneType = null;
+globalThis.__turnAbilityZoneActive = false;
 
 installGameModeState(state);
 
@@ -411,6 +419,11 @@ function makeCar(color = 0xffd43b, opacity = 1) {
 }
 
 makeRoad();
+const abilityZoneVisuals = installAbilityZoneVisuals({
+  world,
+  samples,
+  trackWidth: TRACK_WIDTH
+});
 makeScenery();
 
 const playerCar = makeCar(0xffd43b, 1);
@@ -602,13 +615,20 @@ function updateDriveEffects(dt) {
     for (const side of [-1, 1]) {
       const position = rear.clone().addScaledVector(right, side * 0.78);
       const velocity = forward.clone().multiplyScalar(-8 - state.speed * 0.08).add(new THREE.Vector3(0, 1.2, 0));
+      const nitrous = Boolean(globalThis.__turnNitrousActive);
+      const particle = flamePool[flameCursor % flamePool.length];
+      particle.material.color.setHex(
+        nitrous
+          ? (flameCursor % 2 ? 0xfff8e8 : 0xef3340)
+          : (flameCursor % 2 ? 0xff922b : 0xffd43b)
+      );
       flameCursor = launchParticle(
         flamePool,
         flameCursor,
         position,
         velocity,
-        0.22,
-        new THREE.Vector3(0.5, 0.48, 1.8),
+        nitrous ? 0.3 : 0.22,
+        nitrous ? new THREE.Vector3(0.62, 0.58, 2.45) : new THREE.Vector3(0.5, 0.48, 1.8),
         0.95
       );
     }
@@ -620,6 +640,11 @@ function updateDriveEffects(dt) {
     for (const side of [-1, 1]) {
       const position = rear.clone().addScaledVector(right, side * 1.28).setY(0.45);
       const velocity = right.clone().multiplyScalar(-side * state.steering * 2.8).add(new THREE.Vector3(0, 2.1, 0));
+      smokePool[smokeCursor % smokePool.length].material.color.setHex(
+        state.abilityZoneActive && state.abilityZoneType === ABILITY_ZONE_TYPE.DRIFT
+          ? 0x8dd7ff
+          : 0xb9c0c7
+      );
       smokeCursor = launchParticle(
         smokePool,
         smokeCursor,
@@ -782,6 +807,15 @@ async function openLotFromRace() {
   globalThis.__turnAnalogGas = 0;
   globalThis.__turnBoostActive = false;
   globalThis.__turnDriftHeld = false;
+  globalThis.__turnAbilityZoneId = null;
+  globalThis.__turnAbilityZoneType = null;
+  globalThis.__turnAbilityZoneActive = false;
+  state.abilityZoneId = null;
+  state.abilityZoneType = null;
+  state.abilityZoneActive = false;
+  document.body.dataset.abilityZone = '';
+  document.body.classList.remove('ability-zone-active');
+  abilityZoneVisuals.update(null);
 
   hud.hidden = true;
   controls.hidden = true;
@@ -948,7 +982,49 @@ function beginTimedLap(now) {
   beginTimedLapState({ state, samples, now, showMessage });
 }
 
+let publishedAbilityZoneType = null;
+let publishedAbilityZoneActive = false;
+
+function resolveCurrentAbilityZone(nearestTrack) {
+  const abilityZone = findAbilityZoneAt({
+    position: state.position,
+    nearestTrackIndex: nearestTrack.index,
+    samples,
+    trackWidth: TRACK_WIDTH
+  });
+  const driftHeld = Boolean(globalThis.__turnDriftHeld);
+  const boostActive = Boolean(globalThis.__turnBoostActive);
+
+  state.abilityZoneId = abilityZone?.id || null;
+  state.abilityZoneType = abilityZone?.type || null;
+  state.abilityZoneActive = Boolean(
+    abilityZone && (
+      (abilityZone.type === ABILITY_ZONE_TYPE.DRIFT && driftHeld) ||
+      (abilityZone.type === ABILITY_ZONE_TYPE.BOOST && boostActive)
+    )
+  );
+
+  globalThis.__turnAbilityZoneId = state.abilityZoneId;
+  globalThis.__turnAbilityZoneType = state.abilityZoneType;
+  globalThis.__turnAbilityZoneActive = state.abilityZoneActive;
+  if (
+    state.abilityZoneType !== publishedAbilityZoneType ||
+    state.abilityZoneActive !== publishedAbilityZoneActive
+  ) {
+    document.body.dataset.abilityZone = state.abilityZoneType || '';
+    document.body.classList.toggle('ability-zone-active', state.abilityZoneActive);
+    publishedAbilityZoneType = state.abilityZoneType;
+    publishedAbilityZoneActive = state.abilityZoneActive;
+  }
+  return abilityZone;
+}
+
 function updatePhysics(dt, now) {
+  const nearestTrackBefore = findNearestTrack(state.position);
+  const abilityZone = resolveCurrentAbilityZone(nearestTrackBefore);
+  const driftAssist = abilityZone?.type === ABILITY_ZONE_TYPE.DRIFT && globalThis.__turnDriftHeld
+    ? abilityZone
+    : null;
   const nearestAfter = updateVehiclePhysicsState({
     state,
     dt,
@@ -961,7 +1037,11 @@ function updatePhysics(dt, now) {
     maxSpeed: MAX_SPEED * state.vehicleTuning.topSpeedMultiplier,
     analogGas: globalThis.__turnAnalogGas || 0,
     boostActive: Boolean(globalThis.__turnBoostActive),
+    boostPowerMultiplier: globalThis.__turnBoostPowerMultiplier || 1,
+    boostSpeedMultiplier: globalThis.__turnBoostSpeedMultiplier || 1,
     driftHeld: Boolean(globalThis.__turnDriftHeld),
+    driftAssist,
+    nearestTrackBefore,
     vehicleTuning: state.vehicleTuning
   });
 
@@ -1082,6 +1162,7 @@ function updateScene(dt) {
   placePlayerCar(dt);
   placeCompetitorCars(dt);
   updateDriveEffects(dt);
+  abilityZoneVisuals.update(state.abilityZoneActive ? state.abilityZoneId : null);
   updateRaceCameraState({
     state,
     camera,

--- a/turn/race/ability-zones.js
+++ b/turn/race/ability-zones.js
@@ -1,0 +1,138 @@
+export const ABILITY_ZONE_TYPE = Object.freeze({
+  DRIFT: 'drift',
+  BOOST: 'boost'
+});
+
+// These positions are authored for TURN's permanent 720-sample circuit.
+// Ratios keep them stable if the visual sampling density changes later.
+export const ABILITY_ZONES = Object.freeze([
+  zone({
+    id: 'drift-east-outer',
+    type: ABILITY_ZONE_TYPE.DRIFT,
+    start: 0.018,
+    end: 0.104,
+    laneCenter: -0.32,
+    laneWidth: 0.24,
+    edge: 'outer'
+  }),
+  zone({
+    id: 'boost-north-straight',
+    type: ABILITY_ZONE_TYPE.BOOST,
+    start: 0.145,
+    end: 0.184,
+    laneCenter: -0.18,
+    laneWidth: 0.26,
+    straightAfter: Object.freeze([0.184, 0.305])
+  }),
+  zone({
+    id: 'drift-northwest-outer',
+    type: ABILITY_ZONE_TYPE.DRIFT,
+    start: 0.313,
+    end: 0.397,
+    laneCenter: -0.32,
+    laneWidth: 0.24,
+    edge: 'outer'
+  }),
+  zone({
+    id: 'drift-west-outer',
+    type: ABILITY_ZONE_TYPE.DRIFT,
+    start: 0.472,
+    end: 0.565,
+    laneCenter: -0.32,
+    laneWidth: 0.24,
+    edge: 'outer'
+  }),
+  zone({
+    id: 'boost-south-straight',
+    type: ABILITY_ZONE_TYPE.BOOST,
+    start: 0.708,
+    end: 0.752,
+    laneCenter: 0.12,
+    laneWidth: 0.26,
+    straightAfter: Object.freeze([0.752, 0.865])
+  })
+]);
+
+function zone(definition) {
+  return Object.freeze(definition);
+}
+
+export function progressInZone(progress, abilityZone) {
+  const value = wrapProgress(progress);
+  const start = wrapProgress(abilityZone.start);
+  const end = wrapProgress(abilityZone.end);
+  return start <= end
+    ? value >= start && value <= end
+    : value >= start || value <= end;
+}
+
+export function zoneSampleIndices(abilityZone, sampleCount) {
+  const count = Math.max(1, Math.floor(sampleCount));
+  const start = Math.round(wrapProgress(abilityZone.start) * count) % count;
+  const end = Math.round(wrapProgress(abilityZone.end) * count) % count;
+  const indices = [];
+  let index = start;
+
+  for (let guard = 0; guard <= count; guard += 1) {
+    indices.push(index);
+    if (index === end) break;
+    index = (index + 1) % count;
+  }
+
+  return indices;
+}
+
+export function findAbilityZoneAt({
+  position,
+  nearestTrackIndex,
+  samples,
+  trackWidth,
+  abilityZones = ABILITY_ZONES
+}) {
+  if (!samples?.length || !position) return null;
+
+  const count = samples.length;
+  const index = modulo(Math.round(nearestTrackIndex || 0), count);
+  const progress = index / count;
+  const sample = samples[index];
+  const laneOffset = signedLaneOffset(position, sample);
+
+  for (const abilityZone of abilityZones) {
+    if (!progressInZone(progress, abilityZone)) continue;
+
+    const targetLaneOffset = abilityZone.laneCenter * trackWidth;
+    const halfWidth = abilityZone.laneWidth * trackWidth * 0.5;
+    const laneError = targetLaneOffset - laneOffset;
+    if (Math.abs(laneError) > halfWidth) continue;
+
+    return Object.freeze({
+      id: abilityZone.id,
+      type: abilityZone.type,
+      definition: abilityZone,
+      sample,
+      index,
+      progress,
+      laneOffset,
+      targetLaneOffset,
+      laneError,
+      halfWidth
+    });
+  }
+
+  return null;
+}
+
+export function signedLaneOffset(position, sample) {
+  const dx = (Number(position.x) || 0) - (Number(sample?.point?.x) || 0);
+  const dz = (Number(position.z) || 0) - (Number(sample?.point?.z) || 0);
+  return dx * (Number(sample?.normal?.x) || 0) + dz * (Number(sample?.normal?.z) || 0);
+}
+
+function wrapProgress(value) {
+  const number = Number(value) || 0;
+  return ((number % 1) + 1) % 1;
+}
+
+function modulo(value, divisor) {
+  return ((value % divisor) + divisor) % divisor;
+}

--- a/turn/race/boost-reservoir.js
+++ b/turn/race/boost-reservoir.js
@@ -1,0 +1,100 @@
+export const NITROUS_POWER_MULTIPLIER = 1.5;
+export const NITROUS_SPEED_MULTIPLIER = 1.12;
+
+const EPSILON = 0.001;
+
+export function createBoostReservoir(charge = 1, nitrousCharge = 0) {
+  return normalizeReservoir({ charge, nitrousCharge });
+}
+
+export function updateBoostReservoir(reservoir, {
+  dt,
+  requested = false,
+  locked = false,
+  inBoostZone = false,
+  driftHeld = false,
+  drainSeconds = 2,
+  rechargeSeconds = 4.2,
+  driftRechargeMultiplier = 2.4
+} = {}) {
+  let { charge, nitrousCharge } = normalizeReservoir(reservoir);
+  const elapsed = clamp(Number(dt) || 0, 0, 0.1);
+  const canBoost = Boolean(requested && !locked && charge > EPSILON);
+  let boosting = canBoost;
+  let exhausted = false;
+  let convertedToNitrous = 0;
+  let nitrousSpent = 0;
+  let boostPowerMultiplier = 1;
+  let boostSpeedMultiplier = 1;
+
+  if (canBoost) {
+    const spendRequest = elapsed / positiveNumber(drainSeconds, 2);
+
+    if (inBoostZone) {
+      // The slice that would normally become empty is retained and changes type.
+      // Existing empty capacity remains empty, so arriving with charge matters.
+      const normalCharge = Math.max(0, charge - nitrousCharge);
+      convertedToNitrous = Math.min(normalCharge, spendRequest);
+      nitrousCharge = Math.min(charge, nitrousCharge + convertedToNitrous);
+      boostPowerMultiplier = NITROUS_POWER_MULTIPLIER;
+      boostSpeedMultiplier = NITROUS_SPEED_MULTIPLIER;
+    } else {
+      const spent = Math.min(charge, spendRequest);
+      nitrousSpent = Math.min(nitrousCharge, spent);
+      const nitrousShare = spent > 0 ? nitrousSpent / spent : 0;
+      charge = Math.max(0, charge - spent);
+      nitrousCharge = Math.max(0, nitrousCharge - nitrousSpent);
+      boostPowerMultiplier = mix(1, NITROUS_POWER_MULTIPLIER, nitrousShare);
+      boostSpeedMultiplier = mix(1, NITROUS_SPEED_MULTIPLIER, nitrousShare);
+
+      if (charge <= EPSILON) {
+        charge = 0;
+        nitrousCharge = 0;
+        boosting = false;
+        exhausted = true;
+      }
+    }
+  } else {
+    const multiplier = driftHeld ? positiveNumber(driftRechargeMultiplier, 2.4) : 1;
+    const recharge = elapsed * multiplier / positiveNumber(rechargeSeconds, 4.2);
+    // Passive recharge is always ordinary boost. A red zone only converts charge
+    // that is actively used there; it never fills pre-existing empty capacity.
+    charge = Math.min(1, charge + recharge);
+  }
+
+  nitrousCharge = Math.min(charge, nitrousCharge);
+  const normalCharge = Math.max(0, charge - nitrousCharge);
+  const nitrousActive = boosting && (inBoostZone || nitrousSpent > 0);
+
+  return Object.freeze({
+    charge,
+    normalCharge,
+    nitrousCharge,
+    boosting,
+    exhausted,
+    nitrousActive,
+    convertedToNitrous,
+    nitrousSpent,
+    boostPowerMultiplier,
+    boostSpeedMultiplier
+  });
+}
+
+function normalizeReservoir(reservoir) {
+  const charge = clamp(Number(reservoir?.charge) || 0, 0, 1);
+  const nitrousCharge = clamp(Number(reservoir?.nitrousCharge) || 0, 0, charge);
+  return Object.freeze({ charge, nitrousCharge });
+}
+
+function positiveNumber(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : fallback;
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function mix(from, to, amount) {
+  return from + (to - from) * clamp(amount, 0, 1);
+}

--- a/turn/render/ability-zones.js
+++ b/turn/render/ability-zones.js
@@ -1,0 +1,140 @@
+import * as THREE from 'three';
+import {
+  ABILITY_ZONES,
+  ABILITY_ZONE_TYPE,
+  zoneSampleIndices
+} from '../race/ability-zones.js';
+
+const ZONE_COLORS = Object.freeze({
+  [ABILITY_ZONE_TYPE.DRIFT]: 0x2f9fe8,
+  [ABILITY_ZONE_TYPE.BOOST]: 0xef3340
+});
+
+export function installAbilityZoneVisuals({ world, samples, trackWidth }) {
+  const root = new THREE.Group();
+  root.name = 'TURN Ability Zones';
+  const visuals = new Map();
+
+  for (const abilityZone of ABILITY_ZONES) {
+    const visual = makeZoneVisual({ abilityZone, samples, trackWidth });
+    root.add(visual.group);
+    visuals.set(abilityZone.id, visual);
+  }
+
+  world.add(root);
+
+  return Object.freeze({
+    root,
+    update(activeZoneId, now = performance.now()) {
+      for (const [zoneId, visual] of visuals) {
+        const active = zoneId === activeZoneId;
+        visual.material.emissiveIntensity = active
+          ? 0.46 + Math.sin(now * 0.014) * 0.16
+          : 0.12;
+        visual.material.opacity = active ? 1 : 0.88;
+        visual.markerMaterial.emissiveIntensity = active ? 0.4 : 0.08;
+      }
+    }
+  });
+}
+
+function makeZoneVisual({ abilityZone, samples, trackWidth }) {
+  const group = new THREE.Group();
+  group.name = abilityZone.id;
+  const width = abilityZone.laneWidth * trackWidth;
+  const laneCenter = abilityZone.laneCenter * trackWidth;
+  const indices = zoneSampleIndices(abilityZone, samples.length);
+
+  const outlineGeometry = makeStripGeometry({
+    indices,
+    samples,
+    laneCenter,
+    width: width + 0.9,
+    height: 0.195
+  });
+  const outline = new THREE.Mesh(
+    outlineGeometry,
+    new THREE.MeshBasicMaterial({ color: 0x08090a, side: THREE.DoubleSide })
+  );
+  outline.receiveShadow = true;
+  group.add(outline);
+
+  const material = new THREE.MeshStandardMaterial({
+    color: ZONE_COLORS[abilityZone.type],
+    emissive: ZONE_COLORS[abilityZone.type],
+    emissiveIntensity: 0.12,
+    roughness: 0.72,
+    metalness: 0,
+    transparent: true,
+    opacity: 0.88,
+    depthWrite: true,
+    side: THREE.DoubleSide
+  });
+  const strip = new THREE.Mesh(
+    makeStripGeometry({ indices, samples, laneCenter, width, height: 0.22 }),
+    material
+  );
+  strip.receiveShadow = true;
+  group.add(strip);
+
+  const markerMaterial = new THREE.MeshStandardMaterial({
+    color: 0xfff8e8,
+    emissive: 0xfff8e8,
+    emissiveIntensity: 0.08,
+    roughness: 0.8
+  });
+  const markerGeometry = new THREE.BoxGeometry(width * 0.72, 0.055, 0.82);
+  const markerCount = Math.max(1, Math.floor(indices.length / 9));
+  const markers = new THREE.InstancedMesh(markerGeometry, markerMaterial, markerCount);
+  const marker = new THREE.Object3D();
+
+  for (let markerIndex = 0; markerIndex < markerCount; markerIndex += 1) {
+    const index = indices[Math.min(indices.length - 1, markerIndex * 9 + 4)];
+    const sample = samples[index];
+    marker.position.copy(sample.point).addScaledVector(sample.normal, laneCenter);
+    marker.position.y = 0.255;
+    const yaw = Math.atan2(sample.tangent.x, sample.tangent.z);
+    marker.rotation.set(
+      0,
+      yaw + (abilityZone.type === ABILITY_ZONE_TYPE.DRIFT ? 0.48 : 0),
+      0
+    );
+    marker.updateMatrix();
+    markers.setMatrixAt(markerIndex, marker.matrix);
+  }
+
+  markers.instanceMatrix.needsUpdate = true;
+  markers.receiveShadow = true;
+  group.add(markers);
+
+  return { group, material, markerMaterial };
+}
+
+function makeStripGeometry({ indices, samples, laneCenter, width, height }) {
+  const positions = [];
+  const triangleIndices = [];
+  const halfWidth = width * 0.5;
+
+  for (const index of indices) {
+    const sample = samples[index];
+    const leftOffset = laneCenter + halfWidth;
+    const rightOffset = laneCenter - halfWidth;
+    const left = sample.point.clone().addScaledVector(sample.normal, leftOffset).setY(height);
+    const right = sample.point.clone().addScaledVector(sample.normal, rightOffset).setY(height);
+    positions.push(left.x, left.y, left.z, right.x, right.y, right.z);
+  }
+
+  for (let segment = 0; segment < indices.length - 1; segment += 1) {
+    const a = segment * 2;
+    const b = a + 1;
+    const c = a + 2;
+    const d = a + 3;
+    triangleIndices.push(a, c, b, b, c, d);
+  }
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  geometry.setIndex(triangleIndices);
+  geometry.computeVertexNormals();
+  return geometry;
+}

--- a/turn/ui/gameplay-controls.js
+++ b/turn/ui/gameplay-controls.js
@@ -1,5 +1,11 @@
+import { createBoostReservoir, updateBoostReservoir } from '../race/boost-reservoir.js';
+
 globalThis.__turnBoostActive = false;
 globalThis.__turnBoostCharge = 1;
+globalThis.__turnNitrousCharge = 0;
+globalThis.__turnNitrousActive = false;
+globalThis.__turnBoostPowerMultiplier = 1;
+globalThis.__turnBoostSpeedMultiplier = 1;
 globalThis.__turnDriftHeld = false;
 
 if (!globalThis.__turnGameplayControlsInstalled) {
@@ -76,8 +82,9 @@ function installGameplayUi() {
 
   const boostHud = document.createElement('div');
   boostHud.className = 'boost-hud';
-  boostHud.innerHTML = '<span>BOOST</span><div><i></i></div>';
+  boostHud.innerHTML = '<span>BOOST</span><div><i class="boost-normal"></i><i class="boost-nitrous"></i></div>';
   hud.appendChild(boostHud);
+  const boostLabel = boostHud.querySelector('span');
 
   const driveStack = document.createElement('div');
   driveStack.className = 'drive-stack';
@@ -87,6 +94,8 @@ function installGameplayUi() {
   drivePad.setAttribute('role', 'group');
   drivePad.setAttribute('aria-label', 'Drive control. Slide between Gas, Drift and Boost.');
   drivePad.style.setProperty('--boost-charge', '100%');
+  drivePad.style.setProperty('--boost-normal', '100%');
+  drivePad.style.setProperty('--boost-nitrous', '0%');
 
   const driveTop = document.createElement('div');
   driveTop.className = 'drive-pad-top';
@@ -120,7 +129,7 @@ function installGameplayUi() {
   let driveZone = null;
   let boostRequested = false;
   let boostExhausted = false;
-  let boostCharge = 1;
+  let boostReservoir = createBoostReservoir(1, 0);
   let previousTime = performance.now();
   const TOP_ZONE_SHARE = 0.42;
   const DEFAULT_BOOST_DRAIN_SECONDS = 2.0;
@@ -189,6 +198,9 @@ function installGameplayUi() {
     boostRequested = false;
     boostExhausted = false;
     globalThis.__turnBoostActive = false;
+    globalThis.__turnNitrousActive = false;
+    globalThis.__turnBoostPowerMultiplier = 1;
+    globalThis.__turnBoostSpeedMultiplier = 1;
     drivePad.classList.remove('is-boosting', 'is-boost-locked');
   }
 
@@ -279,31 +291,58 @@ function installGameplayUi() {
   function updateBoost(now) {
     const dt = Math.min(0.05, Math.max(0, (now - previousTime) / 1000));
     previousTime = now;
-    const active = boostRequested && !boostExhausted && boostCharge > 0.001;
+    const inBoostAbilityZone = globalThis.__turnAbilityZoneType === 'boost';
+    const nextReservoir = updateBoostReservoir(boostReservoir, {
+      dt,
+      requested: boostRequested,
+      locked: boostExhausted,
+      inBoostZone: inBoostAbilityZone,
+      driftHeld: globalThis.__turnDriftHeld,
+      drainSeconds: getBoostDrainSeconds(),
+      rechargeSeconds: BOOST_RECHARGE_SECONDS,
+      driftRechargeMultiplier: DRIFT_RECHARGE_MULTIPLIER
+    });
+    boostReservoir = nextReservoir;
 
-    if (active) {
-      boostCharge = Math.max(0, boostCharge - dt / getBoostDrainSeconds());
-      if (boostCharge <= 0) {
-        boostExhausted = true;
-        safeVibrate([28, 36, 62]);
-      }
-    } else {
-      const rechargeMultiplier = globalThis.__turnDriftHeld ? DRIFT_RECHARGE_MULTIPLIER : 1;
-      boostCharge = Math.min(1, boostCharge + dt * rechargeMultiplier / BOOST_RECHARGE_SECONDS);
+    if (nextReservoir.exhausted && !boostExhausted) {
+      boostExhausted = true;
+      safeVibrate([28, 36, 62]);
     }
 
-    const boosting = boostRequested && !boostExhausted && boostCharge > 0.001;
+    const boosting = nextReservoir.boosting;
     globalThis.__turnBoostActive = boosting;
-    globalThis.__turnBoostCharge = boostCharge;
+    globalThis.__turnBoostCharge = nextReservoir.charge;
+    globalThis.__turnNitrousCharge = nextReservoir.nitrousCharge;
+    globalThis.__turnNitrousActive = nextReservoir.nitrousActive;
+    globalThis.__turnBoostPowerMultiplier = nextReservoir.boostPowerMultiplier;
+    globalThis.__turnBoostSpeedMultiplier = nextReservoir.boostSpeedMultiplier;
     drivePad.classList.toggle('is-boosting', boosting);
+    drivePad.classList.toggle('is-nitrous', nextReservoir.nitrousActive);
+    drivePad.classList.toggle('has-nitrous', nextReservoir.nitrousCharge > 0.001);
+    drivePad.classList.toggle('is-boost-zone', inBoostAbilityZone);
     drivePad.classList.toggle('is-boost-locked', boostRequested && boostExhausted);
     boostZone.classList.toggle('is-locked', boostRequested && boostExhausted);
     boostHud.classList.toggle('is-boosting', boosting);
+    boostHud.classList.toggle('is-nitrous', nextReservoir.nitrousActive);
+    boostHud.classList.toggle('has-nitrous', nextReservoir.nitrousCharge > 0.001);
     boostHud.classList.toggle('is-drift-charging', globalThis.__turnDriftHeld && !boosting);
-    const chargePercent = (boostCharge * 100).toFixed(1) + '%';
+    const chargePercent = (nextReservoir.charge * 100).toFixed(1) + '%';
+    const normalPercent = (nextReservoir.normalCharge * 100).toFixed(1) + '%';
+    const nitrousPercent = (nextReservoir.nitrousCharge * 100).toFixed(1) + '%';
     drivePad.style.setProperty('--boost-charge', chargePercent);
+    drivePad.style.setProperty('--boost-normal', normalPercent);
+    drivePad.style.setProperty('--boost-nitrous', nitrousPercent);
     boostHud.style.setProperty('--boost-charge', chargePercent);
-    boostHud.setAttribute('aria-label', 'Boost ' + Math.round(boostCharge * 100) + ' percent charged');
+    boostHud.style.setProperty('--boost-normal', normalPercent);
+    boostHud.style.setProperty('--boost-nitrous', nitrousPercent);
+    boostLabel.textContent = nextReservoir.nitrousActive
+      ? 'NITROUS'
+      : (nextReservoir.nitrousCharge > 0.001 ? 'BOOST · N₂O' : 'BOOST');
+    boostHud.setAttribute(
+      'aria-label',
+      'Boost ' + Math.round(nextReservoir.charge * 100) + ' percent charged, ' +
+        Math.round(nextReservoir.nitrousCharge * 100) + ' percent nitrous'
+    );
     requestAnimationFrame(updateBoost);
   }
 

--- a/turn/vehicle/physics.js
+++ b/turn/vehicle/physics.js
@@ -10,7 +10,11 @@ export function updateVehiclePhysicsState({
   maxSpeed,
   analogGas = 0,
   boostActive = false,
+  boostPowerMultiplier = 1,
+  boostSpeedMultiplier = 1,
   driftHeld = false,
+  driftAssist = null,
+  nearestTrackBefore = null,
   vehicleTuning = null
 }) {
   updateMotionInput(dt);
@@ -22,7 +26,7 @@ export function updateVehiclePhysicsState({
   state.throttle = Math.max(directGas, state.touchGas ? 1 : 0);
   state.brake = Math.max(directBrake, state.touchBrake ? 1 : 0);
 
-  const nearestBefore = findNearestTrack(state.position);
+  const nearestBefore = nearestTrackBefore || findNearestTrack(state.position);
   state.nearestTrackIndex = nearestBefore.index;
   state.trackDistance = nearestBefore.distance;
   state.offRoad = nearestBefore.distance > trackWidth * 0.58;
@@ -36,13 +40,16 @@ export function updateVehiclePhysicsState({
   const brakingOrReversing = state.brake > 0;
   const driveThrottle = brakingOrReversing ? 0 : state.throttle;
   const effectiveBoostActive = boostActive && !brakingOrReversing;
+  const driftZoneActive = Boolean(driftHeld && driftAssist?.sample?.normal && driftAssist?.sample?.tangent);
+  const effectiveBoostPowerMultiplier = positiveNumber(boostPowerMultiplier, 1);
+  const effectiveBoostSpeedMultiplier = positiveNumber(boostSpeedMultiplier, 1);
 
   const enginePower =
     (state.offRoad ? 36 : 43) *
     tuning.accelerationMultiplier *
-    (driftHeld ? tuning.driftEngineMultiplier : 1);
+    (driftHeld && !driftZoneActive ? tuning.driftEngineMultiplier : 1);
   const boostPower = effectiveBoostActive
-    ? (state.offRoad ? 16 : 36) * tuning.boostPowerMultiplier
+    ? (state.offRoad ? 16 : 36) * tuning.boostPowerMultiplier * effectiveBoostPowerMultiplier
     : 0;
   state.velocity.addScaledVector(
     forward,
@@ -103,6 +110,17 @@ export function updateVehiclePhysicsState({
 
   state.heading = normalizeAngle(state.heading + yawRate * dt);
 
+  if (driftZoneActive) {
+    const targetHeading = Math.atan2(driftAssist.sample.tangent.x, driftAssist.sample.tangent.z);
+    const headingError = clamp(normalizeAngle(targetHeading - state.heading), -0.42, 0.42);
+    state.heading = normalizeAngle(
+      state.heading + headingError * Math.min(1, dt * 0.85)
+    );
+
+    const magneticAcceleration = clamp((Number(driftAssist.laneError) || 0) * 0.75, -5.5, 5.5);
+    state.velocity.addScaledVector(driftAssist.sample.normal, magneticAcceleration * dt);
+  }
+
   const newRight = getRight().clone();
   lateralSpeed = state.velocity.dot(newRight);
 
@@ -127,12 +145,14 @@ export function updateVehiclePhysicsState({
 
   const drag = state.offRoad
     ? 0.34
-    : 0.11 + speed * 0.0009 + (driftHeld ? tuning.driftDragAdd : 0);
+    : 0.11 + speed * 0.0009 + (driftHeld && !driftZoneActive ? tuning.driftDragAdd : 0);
   state.velocity.multiplyScalar(Math.exp(-drag * dt));
 
   const speedLimit = state.offRoad
     ? (effectiveBoostActive ? effectiveMaxSpeed * 0.82 : effectiveMaxSpeed * 0.73)
-    : (effectiveBoostActive ? effectiveMaxSpeed * tuning.boostSpeedMultiplier : effectiveMaxSpeed);
+    : (effectiveBoostActive
+      ? effectiveMaxSpeed * tuning.boostSpeedMultiplier * effectiveBoostSpeedMultiplier
+      : effectiveMaxSpeed);
 
   speed = state.velocity.length();
   if (speed > speedLimit) state.velocity.multiplyScalar(speedLimit / speed);


### PR DESCRIPTION
## Summary

- adds five fixed, hand-authored Ability Zones to the current track
- places narrow blue Drift Zones on the outside line of selected curves
- places narrow red Boost Zones before useful straights
- removes the normal drift speed penalty and adds light line assistance only while actively drifting in a blue zone
- converts the ordinary boost actually spent in a red zone into persistent, stronger nitrous without filling pre-existing empty capacity
- keeps nitrous in the regular boost bar, consumes it before ordinary boost, and makes recharge outside red zones ordinary boost
- distinguishes the zones with both colour and road-marking patterns
- bumps TURN to v1.4.0 / Build 2026.07.20-r16

## Verification

- full TURN regression suite
- real-physics drive pad and reverse tests
- manual steering, garage, checkpoints/balance and in-game menu tests
- new production-level Ability Zones/nitrous tests
- release architecture and syntax checks
- `git diff --check`

All checks pass locally.