### PR TITLE
TURN v1.3.1 r17: Performance headroom and diagnostics

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -52,5 +52,8 @@ jobs:
       - name: Run state-aware in-game menu regression
         run: node turn-lab/tests/in-game-menu-production.mjs
 
+      - name: Run production performance and diagnostics regression
+        run: node turn-lab/tests/performance-production.mjs
+
       - name: Verify release architecture
         run: node turn-lab/scripts/check-release.mjs

--- a/turn-lab/PERFORMANCE.md
+++ b/turn-lab/PERFORMANCE.md
@@ -1,0 +1,24 @@
+# TURN performance checks
+
+TURN's production build exposes diagnostics only when the page is opened with `?perf=1`.
+The overlay reports frame rate, p50/p95 frame interval, frames slower than 33 ms,
+draw calls, triangles, GPU resource counts, device pixel ratio and average track-index
+checks per query. The latest sample is also available through
+`globalThis.__turnGetPerfSnapshot()` and the `turn:perf-snapshot` browser event.
+
+## Target-device pass
+
+Use the same released build and run each scenario for at least 60 seconds after assets
+have loaded:
+
+1. Start line, stationary.
+2. Race with no saved rivals.
+3. Race with four saved rivals.
+4. Sustained drift and boost effects.
+5. The Lot with the 3D viewer open, then closed.
+6. Spectate with four rivals.
+
+Record the final snapshot for each scenario together with the device and OS version.
+For the inclusive-device baseline, include a 9th-generation iPad or comparable hardware.
+Compare p95 frame interval and slow-frame percentage before accepting visual additions;
+an average FPS value alone can hide disruptive spikes.

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -44,8 +44,8 @@ const [index, controls, css, analogGas, spectate] = await Promise.all([
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.0 · Build 2026\.07\.20-r15/);
-assert.match(index, /drive-pad\.css\?build=20260720-r15/);
+assert.match(index, /TURN v1\.3\.1 · Build 2026\.07\.20-r17/);
+assert.match(index, /drive-pad\.css\?build=20260720-r17/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -75,8 +75,8 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.0 · Build 2026\.07\.20-r15/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260720-r15/);
+assert.match(index, /TURN v1\.3\.1 · Build 2026\.07\.20-r17/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260720-r17/);
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');
 assert.match(main, /vehicleTuning: state\.vehicleTuning/, 'Selected handling profile must reach physics');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -38,8 +38,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.0 · Build 2026\.07\.20-r15/);
-assert.match(index, /in-game-menu\.css\?build=20260720-r15/);
+assert.match(index, /TURN v1\.3\.1 · Build 2026\.07\.20-r17/);
+assert.match(index, /in-game-menu\.css\?build=20260720-r17/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Back to Start<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -26,7 +26,7 @@ const css = await fs.readFile(new URL('../../turn/manual-steering.css', import.m
 
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260720-r15/);
+assert.match(index, /manual-steering\.css\?build=20260720-r17/);
 assert.match(css, /--manual-steer-left/);
 assert.match(css, /content: "←"/);
 assert.match(css, /content: "→"/);

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+import {
+  createTrackSpatialIndex,
+  findNearestTrackBruteForce
+} from '../../turn/race/track-spatial-index.js';
+import {
+  performanceModeRequested,
+  summarizeFrameSamples
+} from '../../turn/performance-monitor.js';
+
+const samples = Array.from({ length: 720 }, (_, index) => {
+  const angle = index / 720 * Math.PI * 2;
+  const radiusX = 208 + Math.sin(angle * 2 + 0.35) * 20 + Math.sin(angle * 3 - 0.8) * 9;
+  const radiusZ = 146 + Math.cos(angle * 2 - 0.4) * 14 + Math.sin(angle * 3 + 0.6) * 8;
+  return {
+    point: {
+      x: Math.cos(angle) * radiusX,
+      z: Math.sin(angle) * radiusZ
+    }
+  };
+});
+
+const spatialIndex = createTrackSpatialIndex(samples, { cellSize: 32 });
+let seed = 0x17c0ffee;
+function random() {
+  seed = (seed * 1664525 + 1013904223) >>> 0;
+  return seed / 0x100000000;
+}
+
+for (let query = 0; query < 1200; query += 1) {
+  const position = {
+    x: (random() - 0.5) * 540,
+    z: (random() - 0.5) * 420
+  };
+  const indexed = spatialIndex.find(position);
+  const brute = findNearestTrackBruteForce(samples, position);
+  assert.equal(indexed.index, brute.index, `Spatial query ${query} must preserve the exact nearest sample`);
+  assert.ok(Math.abs(indexed.distance - brute.distance) < 1e-9);
+}
+
+const checksBeforeTrackPass = spatialIndex.getStats();
+for (let index = 0; index < samples.length; index += 1) {
+  spatialIndex.find({
+    x: samples[index].point.x + Math.sin(index) * 3,
+    z: samples[index].point.z + Math.cos(index) * 3
+  });
+}
+const checksAfterTrackPass = spatialIndex.getStats();
+const trackQueries = checksAfterTrackPass.queryCount - checksBeforeTrackPass.queryCount;
+const trackChecks = checksAfterTrackPass.totalChecks - checksBeforeTrackPass.totalChecks;
+assert.ok(
+  trackChecks / trackQueries < 120,
+  'Normal on-track queries should inspect far fewer than all 720 samples'
+);
+
+const fallback = spatialIndex.find({ x: 5000, z: -5000 });
+const fallbackBrute = findNearestTrackBruteForce(samples, { x: 5000, z: -5000 });
+assert.equal(fallback.index, fallbackBrute.index, 'Far teleports must retain the exact full-scan fallback');
+assert.equal(fallback.checks, samples.length);
+
+assert.equal(performanceModeRequested('?perf=1'), true);
+assert.equal(performanceModeRequested('?perf=0'), false);
+assert.equal(performanceModeRequested(''), false);
+
+const summary = summarizeFrameSamples([10, 20, 30, 40, 50]);
+assert.equal(summary.averageMs, 30);
+assert.equal(summary.p50Ms, 30);
+assert.equal(summary.p95Ms, 50);
+assert.equal(summary.slowPercent, 40);
+assert.ok(Math.abs(summary.fps - 1000 / 30) < 1e-9);
+
+const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, monitor] = await Promise.all([
+  fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/ui/gameplay-controls.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/ui/in-game-menu.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/ui/hud.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/vehicle/physics.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/render/camera.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/vehicle/car-models.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-r10.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/performance-monitor.js', import.meta.url), 'utf8')
+]);
+
+assert.match(index, /TURN v1\.3\.1 · Build 2026\.07\.20-r17/);
+assert.match(main, /mainSceneOcclusion/);
+assert.match(main, /HUD_UPDATE_INTERVAL_MS = 1000 \/ 30/);
+assert.match(main, /recordPerformanceFrame/);
+assert.match(main, /createTrackSpatialIndex/);
+assert.match(main, /globalThis\.__turnUpdateGameplayControls\?\.\(now\)/);
+assert.doesNotMatch(controls, /requestAnimationFrame\(updateBoost\)/);
+assert.match(controls, /globalThis\.__turnUpdateGameplayControls = updateBoost/);
+assert.match(controls, /BOOST_VISUAL_INTERVAL_MS = 1000 \/ 30/);
+assert.doesNotMatch(menu, /requestAnimationFrame\(syncMenu\)/);
+assert.match(menu, /turn:ui-state-change/);
+assert.doesNotMatch(spectate, /requestAnimationFrame\(syncUi\)/);
+assert.match(spectate, /turn:ui-state-change/);
+assert.match(hud, /function setText\(/);
+assert.doesNotMatch(physics, /getForward\(\)\.clone\(\)/);
+assert.doesNotMatch(camera, /state\.position\.clone\(\)/);
+assert.match(cars, /record\.node\.castShadow = !ghost/);
+assert.doesNotMatch(lot, /root\.scale\.lerp\(new THREE\.Vector3/);
+assert.match(lot, /recordPerformanceFrame/);
+assert.match(monitor, /turn:perf-snapshot/);
+assert.match(monitor, /trackChecksPerQuery/);
+
+console.log(
+  `TURN production performance and diagnostics regression passed ` +
+  `(${(trackChecks / trackQueries).toFixed(1)} average on-track checks vs 720).`
+);

--- a/turn/garage/lot-r10.js
+++ b/turn/garage/lot-r10.js
@@ -7,7 +7,8 @@ import {
   getCarDefinition,
   normalizeVehicleSelection
 } from '../vehicle/catalog.js';
-import { createCarVisual, recolorCarVisual } from '../vehicle/car-models.js';
+import { createCarVisual, recolorCarVisual } from '../vehicle/car-models.js?build=20260720-r17';
+import { recordPerformanceFrame } from '../performance-monitor.js?build=20260720-r17';
 
 const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
 const lotLoader = new GLTFLoader();
@@ -272,13 +273,18 @@ export function showTheLot({ initialSelection } = {}) {
       for (const root of carRoots.values()) {
         const selected = Boolean(root.userData.turnLotSelected);
         const targetScale = selected ? 1.08 : 1;
-        root.scale.lerp(new THREE.Vector3(targetScale, targetScale, targetScale), 0.12);
+        root.scale.setScalar(THREE.MathUtils.lerp(root.scale.x, targetScale, 0.12));
         root.position.y = selected ? 0.13 + Math.sin(elapsed * 3.1) * 0.07 : 0.08;
       }
       camera.position.x = Math.sin(elapsed * 0.12) * 1.5;
       camera.lookAt(0, 0, -1.5);
       renderer.render(scene, camera);
-      viewer.render(elapsed);
+      const viewerRendered = !viewbox.hidden && viewer.render(elapsed);
+      recordPerformanceFrame(
+        'lot',
+        viewerRendered ? [renderer, viewer.renderer] : renderer,
+        performance.now()
+      );
     });
   });
 }
@@ -340,6 +346,7 @@ function createViewer(host) {
   host.addEventListener('lostpointercapture', stopDrag);
 
   return {
+    renderer,
     async show(carId, color) {
       const request = ++generation;
       try {
@@ -370,12 +377,12 @@ function createViewer(host) {
       renderer.setSize(Math.round(rect.width), Math.round(rect.height), false);
     },
     render(elapsed) {
-      if (host.offsetParent === null) return;
       if (!dragging) yaw += 0.0024;
       stage.rotation.y = yaw;
       stage.rotation.x = pitch;
       if (visual) visual.position.y = Math.sin(elapsed * 2.1) * 0.04;
       renderer.render(scene, camera);
+      return true;
     },
     dispose() {
       generation += 1;

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r15 State-aware in-game menu -->
+<!-- TURN r17 Performance headroom and opt-in diagnostics -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,31 +10,31 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.0 · Build 2026.07.20-r15</title>
+  <title>TURN v1.3.1 · Build 2026.07.20-r17</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.0',
-      id: '2026.07.20-r15',
-      cacheKey: '20260720-r15'
+      version: '1.3.1',
+      id: '2026.07.20-r17',
+      cacheKey: '20260720-r17'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260720-r15">
-  <link rel="stylesheet" href="./styles.css?build=20260720-r15">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260720-r15">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260720-r15">
-  <link rel="stylesheet" href="./install-gate.css?build=20260720-r15">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260720-r15">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260720-r15">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260720-r15">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260720-r15">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260720-r15">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260720-r15">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260720-r15">
+  <link rel="manifest" href="./site.webmanifest?build=20260720-r17">
+  <link rel="stylesheet" href="./styles.css?build=20260720-r17">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260720-r17">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260720-r17">
+  <link rel="stylesheet" href="./install-gate.css?build=20260720-r17">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260720-r17">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260720-r17">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260720-r17">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260720-r17">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260720-r17">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260720-r17">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260720-r17">
 
-  <script src="./install-gate.js?build=20260720-r15"></script>
-  <script src="./orientation-compat.js?build=20260720-r15"></script>
+  <script src="./install-gate.js?build=20260720-r17"></script>
+  <script src="./orientation-compat.js?build=20260720-r17"></script>
   <script type="importmap">
     {
       "imports": {
@@ -52,7 +52,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.0 · Build 2026.07.20-r15</span>
+        <span class="install-kicker">TURN v1.3.1 · Build 2026.07.20-r17</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -80,7 +80,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.0 · Build 2026.07.20-r15</span>
+      <span class="kicker">TURN v1.3.1 · Build 2026.07.20-r17</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -146,6 +146,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260720-r15"></script>
+  <script type="module" src="./app.js?build=20260720-r17"></script>
 </body>
 </html>

--- a/turn/main.js
+++ b/turn/main.js
@@ -2,17 +2,19 @@
 
 import * as THREE from 'three';
 import { installKenneyWorld } from './world-assets.js';
-import { updateRaceCameraState } from './render/camera.js';
-import { updateHudState } from './ui/hud.js';
+import { updateRaceCameraState } from './render/camera.js?build=20260720-r17';
+import { updateHudState } from './ui/hud.js?build=20260720-r17';
 import { motionPoseFromGravity as motionPoseFromGravityState, updateMotionInputState } from './input/motion.js';
-import { updateVehiclePhysicsState } from './vehicle/physics.js';
+import { updateVehiclePhysicsState } from './vehicle/physics.js?build=20260720-r17';
 import { GAME_MODE, installGameModeState, prepareRaceStartState, resetRaceToStage, setGameModeState } from './race/game-state.js';
 import { beginTimedLapState, completeLapState, updateLapProgressState } from './race/lap-system.js';
 import { recordReplayFrame, replayFrameAt } from './race/replay-system.js';
 import { RIVAL_LIMIT, loadRivalsState, saveRivalsState } from './race/rival-storage.js';
-import { showTheLot } from './garage/lot-r10.js';
+import { createTrackSpatialIndex } from './race/track-spatial-index.js?build=20260720-r17';
+import { showTheLot } from './garage/lot-r10.js?build=20260720-r17';
 import { getCarDefinition, loadVehicleSelection, saveVehicleSelection } from './vehicle/catalog.js';
-import { createCarVisual } from './vehicle/car-models.js';
+import { createCarVisual } from './vehicle/car-models.js?build=20260720-r17';
+import { installPerformanceMonitor, recordPerformanceFrame } from './performance-monitor.js?build=20260720-r17';
 
 const intro = document.querySelector('#intro');
 const hud = document.querySelector('#hud');
@@ -34,6 +36,7 @@ const mapCanvas = document.querySelector('#map');
 const mapCtx = mapCanvas.getContext('2d');
 const tiltNeedle = document.querySelector('#tiltNeedle');
 const tiltValue = document.querySelector('#tiltValue');
+const installGate = document.querySelector('#installGate');
 
 const TAU = Math.PI * 2;
 const TRACK_WIDTH = 27;
@@ -97,8 +100,16 @@ globalThis.__turnVehicleTuning = state.vehicleTuning;
 
 installGameModeState(state);
 
+function publishUiState(reason) {
+  window.dispatchEvent(new CustomEvent('turn:ui-state-change', {
+    detail: { reason, mode: state.mode, running: state.running }
+  }));
+}
+
 function setGameMode(mode) {
-  return setGameModeState(state, mode);
+  const result = setGameModeState(state, mode);
+  publishUiState('game-mode');
+  return result;
 }
 
 globalThis.__turnGameModes = GAME_MODE;
@@ -161,6 +172,12 @@ for (let i = 0; i < TRACK_SAMPLES; i += 1) {
   samples.push({ point, tangent, normal, distance: trackLength });
 }
 trackLength += samples[0].point.distanceTo(samples.at(-1).point);
+
+const trackSpatialIndex = createTrackSpatialIndex(samples, { cellSize: 32 });
+installPerformanceMonitor({
+  getMode: () => state.mode,
+  getTrackStats: () => trackSpatialIndex.getStats()
+});
 
 const blackMaterial = new THREE.MeshBasicMaterial({ color: 0x08090a, side: THREE.BackSide });
 
@@ -539,6 +556,7 @@ const smokePool = Array.from({ length: 24 }, () => {
   );
   mesh.visible = false;
   mesh.userData.life = 0;
+  mesh.userData.velocity = new THREE.Vector3();
   world.add(mesh);
   return mesh;
 });
@@ -555,6 +573,7 @@ const flamePool = Array.from({ length: 16 }, (_, index) => {
   );
   mesh.visible = false;
   mesh.userData.life = 0;
+  mesh.userData.velocity = new THREE.Vector3();
   world.add(mesh);
   return mesh;
 });
@@ -563,6 +582,12 @@ let smokeCursor = 0;
 let flameCursor = 0;
 let smokeCooldown = 0;
 let flameCooldown = 0;
+const effectForward = new THREE.Vector3();
+const effectRight = new THREE.Vector3();
+const effectRear = new THREE.Vector3();
+const effectPosition = new THREE.Vector3();
+const effectVelocity = new THREE.Vector3();
+const effectScale = new THREE.Vector3();
 
 function launchParticle(pool, cursor, position, velocity, life, scale, opacity) {
   const particle = pool[cursor % pool.length];
@@ -572,7 +597,7 @@ function launchParticle(pool, cursor, position, velocity, life, scale, opacity) 
   particle.material.opacity = opacity;
   particle.userData.life = life;
   particle.userData.maxLife = life;
-  particle.userData.velocity = velocity.clone();
+  particle.userData.velocity.copy(velocity);
   return cursor + 1;
 }
 
@@ -593,22 +618,23 @@ function updateParticlePool(pool, dt, smoke = false) {
 }
 
 function updateDriveEffects(dt) {
-  const forward = getForward().clone();
-  const right = getRight().clone();
-  const rear = state.position.clone().addScaledVector(forward, -3.2).setY(0.72);
+  effectForward.copy(getForward());
+  effectRight.copy(getRight());
+  effectRear.copy(state.position).addScaledVector(effectForward, -3.2).setY(0.72);
 
   flameCooldown -= dt;
   if (globalThis.__turnBoostActive && state.speed > 4 && flameCooldown <= 0) {
     for (const side of [-1, 1]) {
-      const position = rear.clone().addScaledVector(right, side * 0.78);
-      const velocity = forward.clone().multiplyScalar(-8 - state.speed * 0.08).add(new THREE.Vector3(0, 1.2, 0));
+      effectPosition.copy(effectRear).addScaledVector(effectRight, side * 0.78);
+      effectVelocity.copy(effectForward).multiplyScalar(-8 - state.speed * 0.08);
+      effectVelocity.y += 1.2;
       flameCursor = launchParticle(
         flamePool,
         flameCursor,
-        position,
-        velocity,
+        effectPosition,
+        effectVelocity,
         0.22,
-        new THREE.Vector3(0.5, 0.48, 1.8),
+        effectScale.set(0.5, 0.48, 1.8),
         0.95
       );
     }
@@ -618,15 +644,16 @@ function updateDriveEffects(dt) {
   smokeCooldown -= dt;
   if (globalThis.__turnDriftHeld && state.speed > 13 && Math.abs(state.steering) > 0.08 && smokeCooldown <= 0) {
     for (const side of [-1, 1]) {
-      const position = rear.clone().addScaledVector(right, side * 1.28).setY(0.45);
-      const velocity = right.clone().multiplyScalar(-side * state.steering * 2.8).add(new THREE.Vector3(0, 2.1, 0));
+      effectPosition.copy(effectRear).addScaledVector(effectRight, side * 1.28).setY(0.45);
+      effectVelocity.copy(effectRight).multiplyScalar(-side * state.steering * 2.8);
+      effectVelocity.y += 2.1;
       smokeCursor = launchParticle(
         smokePool,
         smokeCursor,
-        position,
-        velocity,
+        effectPosition,
+        effectVelocity,
         0.72,
-        new THREE.Vector3(0.78, 0.52, 0.78),
+        effectScale.set(0.78, 0.52, 0.78),
         0.42
       );
     }
@@ -665,19 +692,7 @@ function getRight(angle = state.heading) {
 }
 
 function findNearestTrack(position) {
-  let bestIndex = 0;
-  let bestDistanceSq = Infinity;
-  for (let i = 0; i < samples.length; i += 1) {
-    const point = samples[i].point;
-    const dx = position.x - point.x;
-    const dz = position.z - point.z;
-    const distanceSq = dx * dx + dz * dz;
-    if (distanceSq < bestDistanceSq) {
-      bestDistanceSq = distanceSq;
-      bestIndex = i;
-    }
-  }
-  return { index: bestIndex, sample: samples[bestIndex], distance: Math.sqrt(bestDistanceSq) };
+  return trackSpatialIndex.find(position);
 }
 
 function resetCar(showFeedback = true) {
@@ -688,6 +703,7 @@ function resetCar(showFeedback = true) {
     showMessage,
     setRacePosition: globalThis.__turnSetRacePosition
   });
+  publishUiState('race-reset');
 }
 
 function getScreenOrientationAngle() {
@@ -786,6 +802,7 @@ async function openLotFromRace() {
   hud.hidden = true;
   controls.hidden = true;
   manualSteer.hidden = true;
+  publishUiState('lot-open');
 
   const selection = await showTheLot({
     initialSelection: { carId: state.vehicleId, color: state.vehicleColor }
@@ -798,6 +815,7 @@ async function openLotFromRace() {
     controls.hidden = false;
     manualSteer.hidden = state.sensorMode;
     resize();
+    publishUiState('lot-cancelled');
     return false;
   }
 
@@ -814,6 +832,7 @@ async function startGame(fullscreenPromise = Promise.resolve(false)) {
   hud.hidden = false;
   controls.hidden = false;
   manualSteer.hidden = state.sensorMode;
+  publishUiState('race-started');
 
   if (state.sensorMode) {
     window.setTimeout(() => {
@@ -946,6 +965,7 @@ function updateMotionInput(dt) {
 
 function beginTimedLap(now) {
   beginTimedLapState({ state, samples, now, showMessage });
+  publishUiState('lap-started');
 }
 
 function updatePhysics(dt, now) {
@@ -994,6 +1014,7 @@ function completeLap(now) {
       globalThis.__turnLastLapError = error;
     }
   });
+  publishUiState('lap-completed');
 }
 
 function saveGhost() {
@@ -1002,6 +1023,7 @@ function saveGhost() {
 
 function loadGhost() {
   loadRivalsState({ state, samples, findNearestTrack });
+  publishUiState('rivals-loaded');
 }
 
 globalThis.__turnHasGhosts = () => state.competitorLaps.length > 0;
@@ -1020,6 +1042,7 @@ function resetRivals() {
   updateHud();
   showMessage('RIVALS RESET', 1800);
   window.dispatchEvent(new CustomEvent('turn:rivals-reset'));
+  publishUiState('rivals-reset');
 }
 
 globalThis.__turnResetRivals = resetRivals;
@@ -1319,6 +1342,7 @@ const turnRuntime = {
   trackWidth: TRACK_WIDTH,
   maxSpeed: MAX_SPEED,
   trackSampleCount: TRACK_SAMPLES,
+  trackSpatialIndex,
   findNearestTrack,
   getForward,
   getRight,
@@ -1346,11 +1370,31 @@ const turnRuntime = {
 };
 globalThis.__turnRuntime = turnRuntime;
 window.dispatchEvent(new CustomEvent('turn:runtime-ready', { detail: turnRuntime }));
+publishUiState('runtime-ready');
 
 const MAX_PHYSICS_STEP = 1 / 60;
 const MAX_FRAME_CATCHUP = 0.12;
+const HUD_UPDATE_INTERVAL_MS = 1000 / 30;
+let nextHudUpdateAt = 0;
+
+function mainSceneOcclusion() {
+  if (document.body.classList.contains('turn-lot-open')) return 'lot';
+  if (installGate && !installGate.hidden) return 'install gate';
+  return null;
+}
 
 renderer.setAnimationLoop((now) => {
+  globalThis.__turnUpdateGameplayControls?.(now);
+
+  const occlusion = mainSceneOcclusion();
+  if (occlusion) {
+    state.lastFrame = now;
+    if (occlusion !== 'lot') {
+      recordPerformanceFrame(`${occlusion} · paused`, [], now, { rendered: false });
+    }
+    return;
+  }
+
   const frameDt = Math.min(MAX_FRAME_CATCHUP, Math.max(0.001, (now - state.lastFrame) / 1000));
   const frameStart = now - frameDt * 1000;
   state.lastFrame = now;
@@ -1364,7 +1408,10 @@ renderer.setAnimationLoop((now) => {
     }
 
     updateScene(frameDt);
-    updateHud();
+    if (now >= nextHudUpdateAt) {
+      updateHud();
+      nextHudUpdateAt = now + HUD_UPDATE_INTERVAL_MS;
+    }
   } else {
     const preview = samples[Math.floor((now * 0.012) % TRACK_SAMPLES)];
     playerCar.position.copy(preview.point);
@@ -1377,4 +1424,5 @@ renderer.setAnimationLoop((now) => {
   }
 
   renderer.render(scene, camera);
+  recordPerformanceFrame(state.running ? state.mode : 'preview', renderer, now);
 });

--- a/turn/performance-monitor.js
+++ b/turn/performance-monitor.js
@@ -1,0 +1,184 @@
+const SAMPLE_LIMIT = 240;
+const DISPLAY_INTERVAL_MS = 500;
+
+let activeMonitor = null;
+
+export function performanceModeRequested(search = globalThis.location?.search || '') {
+  try {
+    return new URLSearchParams(search).get('perf') === '1';
+  } catch (_) {
+    return false;
+  }
+}
+
+export function summarizeFrameSamples(samples) {
+  const finite = Array.from(samples || []).filter((value) => Number.isFinite(value) && value > 0);
+  if (!finite.length) {
+    return Object.freeze({ fps: 0, averageMs: 0, p50Ms: 0, p95Ms: 0, slowPercent: 0 });
+  }
+
+  const ordered = [...finite].sort((a, b) => a - b);
+  const total = finite.reduce((sum, value) => sum + value, 0);
+  const averageMs = total / finite.length;
+  const slowFrames = finite.filter((value) => value > 1000 / 30).length;
+
+  return Object.freeze({
+    fps: 1000 / averageMs,
+    averageMs,
+    p50Ms: percentile(ordered, 0.5),
+    p95Ms: percentile(ordered, 0.95),
+    slowPercent: slowFrames / finite.length * 100
+  });
+}
+
+export function installPerformanceMonitor({ getMode, getTrackStats } = {}) {
+  if (!performanceModeRequested() || typeof document === 'undefined') return null;
+  if (activeMonitor) return activeMonitor;
+
+  const panel = document.createElement('pre');
+  panel.className = 'turn-performance-monitor';
+  panel.setAttribute('aria-hidden', 'true');
+  panel.style.cssText = [
+    'position:fixed',
+    'z-index:9999',
+    'top:max(6px,env(safe-area-inset-top))',
+    'left:max(6px,env(safe-area-inset-left))',
+    'margin:0',
+    'padding:7px 9px',
+    'border:2px solid #08090a',
+    'border-radius:8px',
+    'background:rgb(8 9 10 / 0.84)',
+    'color:#fff8e8',
+    'font:700 11px/1.35 ui-monospace,SFMono-Regular,Menlo,monospace',
+    'pointer-events:none',
+    'white-space:pre'
+  ].join(';');
+  document.body.appendChild(panel);
+
+  const timelines = new Map();
+  let activeLabel = 'starting';
+  let latestRenderers = [];
+  let lastDisplayAt = 0;
+  let lastTrackStats = getTrackStats?.() || null;
+  let snapshot = Object.freeze({ enabled: true, label: activeLabel });
+
+  activeMonitor = Object.freeze({
+    enabled: true,
+    record(label, renderers, now = performance.now(), { rendered = true } = {}) {
+      activeLabel = label || getMode?.() || 'unknown';
+      latestRenderers = normalizeRenderers(renderers);
+      let timeline = timelines.get(activeLabel);
+      if (!timeline) {
+        timeline = { samples: new Float32Array(SAMPLE_LIMIT), cursor: 0, count: 0, lastAt: null };
+        timelines.set(activeLabel, timeline);
+      }
+
+      if (timeline.lastAt != null && rendered) {
+        const frameMs = now - timeline.lastAt;
+        if (frameMs > 0 && frameMs < 1000) {
+          timeline.samples[timeline.cursor] = frameMs;
+          timeline.cursor = (timeline.cursor + 1) % SAMPLE_LIMIT;
+          timeline.count = Math.min(SAMPLE_LIMIT, timeline.count + 1);
+        }
+      }
+      timeline.lastAt = now;
+
+      if (now - lastDisplayAt < DISPLAY_INTERVAL_MS) return;
+      lastDisplayAt = now;
+      const frames = timeline.count < SAMPLE_LIMIT
+        ? timeline.samples.subarray(0, timeline.count)
+        : timeline.samples;
+      const summary = summarizeFrameSamples(frames);
+      const render = summarizeRenderers(latestRenderers);
+      const track = summarizeTrackChecks(getTrackStats?.(), lastTrackStats);
+      if (track.current) lastTrackStats = track.current;
+
+      snapshot = Object.freeze({
+        enabled: true,
+        label: activeLabel,
+        mode: getMode?.() || null,
+        samples: timeline.count,
+        ...summary,
+        ...render,
+        trackChecksPerQuery: track.average
+      });
+      globalThis.__turnPerfSnapshot = snapshot;
+      panel.textContent = formatSnapshot(snapshot);
+      window.dispatchEvent(new CustomEvent('turn:perf-snapshot', { detail: snapshot }));
+    },
+    getSnapshot() {
+      return snapshot;
+    }
+  });
+
+  globalThis.__turnPerfMonitor = activeMonitor;
+  globalThis.__turnGetPerfSnapshot = () => activeMonitor?.getSnapshot() || null;
+  panel.textContent = 'TURN PERF · collecting…';
+  return activeMonitor;
+}
+
+export function recordPerformanceFrame(label, renderers, now, options) {
+  activeMonitor?.record(label, renderers, now, options);
+}
+
+function normalizeRenderers(renderers) {
+  if (!renderers) return [];
+  return (Array.isArray(renderers) ? renderers : [renderers]).filter(Boolean);
+}
+
+function summarizeRenderers(renderers) {
+  let drawCalls = 0;
+  let triangles = 0;
+  let geometries = 0;
+  let textures = 0;
+  const pixelRatios = [];
+
+  for (const renderer of renderers) {
+    drawCalls += Number(renderer.info?.render?.calls) || 0;
+    triangles += Number(renderer.info?.render?.triangles) || 0;
+    geometries += Number(renderer.info?.memory?.geometries) || 0;
+    textures += Number(renderer.info?.memory?.textures) || 0;
+    const ratio = Number(renderer.getPixelRatio?.());
+    if (Number.isFinite(ratio)) pixelRatios.push(ratio);
+  }
+
+  return {
+    renderers: renderers.length,
+    drawCalls,
+    triangles,
+    geometries,
+    textures,
+    pixelRatio: pixelRatios.length ? Math.max(...pixelRatios) : 0
+  };
+}
+
+function summarizeTrackChecks(current, previous) {
+  if (!current) return { average: 0, current: null };
+  const queries = current.queryCount - (previous?.queryCount || 0);
+  const checks = current.totalChecks - (previous?.totalChecks || 0);
+  return {
+    average: queries > 0 ? checks / queries : 0,
+    current
+  };
+}
+
+function formatSnapshot(snapshot) {
+  return [
+    `TURN PERF · ${snapshot.label}`,
+    `${snapshot.fps.toFixed(1)} fps · p50 ${snapshot.p50Ms.toFixed(1)} · p95 ${snapshot.p95Ms.toFixed(1)} ms`,
+    `${snapshot.drawCalls} calls · ${compactNumber(snapshot.triangles)} tris · ${snapshot.renderers} renderer${snapshot.renderers === 1 ? '' : 's'}`,
+    `${snapshot.geometries} geo · ${snapshot.textures} tex · DPR ${snapshot.pixelRatio.toFixed(2)}`,
+    `track ${snapshot.trackChecksPerQuery.toFixed(1)} checks/query · >33ms ${snapshot.slowPercent.toFixed(1)}%`
+  ].join('\n');
+}
+
+function compactNumber(value) {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}m`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`;
+  return String(Math.round(value));
+}
+
+function percentile(ordered, percentileValue) {
+  const index = Math.min(ordered.length - 1, Math.max(0, Math.ceil(ordered.length * percentileValue) - 1));
+  return ordered[index];
+}

--- a/turn/race/track-spatial-index.js
+++ b/turn/race/track-spatial-index.js
@@ -1,0 +1,178 @@
+const DEFAULT_CELL_SIZE = 32;
+
+export function createTrackSpatialIndex(samples, { cellSize = DEFAULT_CELL_SIZE } = {}) {
+  if (!Array.isArray(samples) || !samples.length) {
+    throw new TypeError('TURN track index needs at least one sample');
+  }
+
+  const size = positiveNumber(cellSize, DEFAULT_CELL_SIZE);
+  const columns = new Map();
+  let minCellX = Infinity;
+  let maxCellX = -Infinity;
+  let minCellZ = Infinity;
+  let maxCellZ = -Infinity;
+  let queryCount = 0;
+  let totalChecks = 0;
+  let maxChecks = 0;
+  let lastChecks = 0;
+
+  for (let index = 0; index < samples.length; index += 1) {
+    const point = samples[index]?.point;
+    if (!point || !Number.isFinite(point.x) || !Number.isFinite(point.z)) {
+      throw new TypeError(`TURN track sample ${index} has no finite point`);
+    }
+
+    const cellX = Math.floor(point.x / size);
+    const cellZ = Math.floor(point.z / size);
+    let column = columns.get(cellX);
+    if (!column) {
+      column = new Map();
+      columns.set(cellX, column);
+    }
+    let bucket = column.get(cellZ);
+    if (!bucket) {
+      bucket = [];
+      column.set(cellZ, bucket);
+    }
+    bucket.push(index);
+    minCellX = Math.min(minCellX, cellX);
+    maxCellX = Math.max(maxCellX, cellX);
+    minCellZ = Math.min(minCellZ, cellZ);
+    maxCellZ = Math.max(maxCellZ, cellZ);
+  }
+
+  function find(position) {
+    const x = Number(position?.x);
+    const z = Number(position?.z);
+    if (!Number.isFinite(x) || !Number.isFinite(z)) {
+      return recordResult(findNearestTrackBruteForce(samples, position));
+    }
+
+    const centerCellX = Math.floor(x / size);
+    const centerCellZ = Math.floor(z / size);
+
+    // Teleports or corrupt replay points outside the indexed world are rare. A full scan
+    // keeps those cases exact without making the common on-track query more complicated.
+    if (
+      centerCellX < minCellX ||
+      centerCellX > maxCellX ||
+      centerCellZ < minCellZ ||
+      centerCellZ > maxCellZ
+    ) {
+      return recordResult(findNearestTrackBruteForce(samples, position));
+    }
+
+    let bestIndex = -1;
+    let bestDistanceSq = Infinity;
+    let checks = 0;
+
+    function inspectCell(cellX, cellZ) {
+      const bucket = columns.get(cellX)?.get(cellZ);
+      if (!bucket) return;
+      for (const index of bucket) {
+        const point = samples[index].point;
+        const dx = x - point.x;
+        const dz = z - point.z;
+        const distanceSq = dx * dx + dz * dz;
+        checks += 1;
+        if (
+          distanceSq < bestDistanceSq ||
+          (distanceSq === bestDistanceSq && (bestIndex < 0 || index < bestIndex))
+        ) {
+          bestDistanceSq = distanceSq;
+          bestIndex = index;
+        }
+      }
+    }
+
+    const maxRadius = Math.max(
+      centerCellX - minCellX,
+      maxCellX - centerCellX,
+      centerCellZ - minCellZ,
+      maxCellZ - centerCellZ
+    );
+
+    for (let radius = 0; radius <= maxRadius; radius += 1) {
+      const minX = centerCellX - radius;
+      const maxX = centerCellX + radius;
+      const minZ = centerCellZ - radius;
+      const maxZ = centerCellZ + radius;
+
+      for (let cellX = minX; cellX <= maxX; cellX += 1) {
+        inspectCell(cellX, minZ);
+        if (radius > 0) inspectCell(cellX, maxZ);
+      }
+      for (let cellZ = minZ + 1; cellZ < maxZ; cellZ += 1) {
+        inspectCell(minX, cellZ);
+        if (radius > 0) inspectCell(maxX, cellZ);
+      }
+
+      if (bestIndex >= 0) {
+        const boundaryDistance = Math.min(
+          x - minX * size,
+          (maxX + 1) * size - x,
+          z - minZ * size,
+          (maxZ + 1) * size - z
+        );
+
+        // Every unsearched cell lies beyond this square. A strict comparison preserves
+        // the brute-force tie rule as well as the exact nearest sample.
+        if (bestDistanceSq < boundaryDistance * boundaryDistance) break;
+      }
+    }
+
+    if (bestIndex < 0) return recordResult(findNearestTrackBruteForce(samples, position));
+    return recordResult({
+      index: bestIndex,
+      sample: samples[bestIndex],
+      distance: Math.sqrt(bestDistanceSq),
+      checks
+    });
+  }
+
+  function recordResult(result) {
+    lastChecks = result.checks;
+    queryCount += 1;
+    totalChecks += result.checks;
+    maxChecks = Math.max(maxChecks, result.checks);
+    return result;
+  }
+
+  return Object.freeze({
+    cellSize: size,
+    find,
+    getStats() {
+      return Object.freeze({ queryCount, totalChecks, maxChecks, lastChecks });
+    }
+  });
+}
+
+export function findNearestTrackBruteForce(samples, position) {
+  let bestIndex = 0;
+  let bestDistanceSq = Infinity;
+  const x = Number(position?.x);
+  const z = Number(position?.z);
+
+  for (let index = 0; index < samples.length; index += 1) {
+    const point = samples[index].point;
+    const dx = x - point.x;
+    const dz = z - point.z;
+    const distanceSq = dx * dx + dz * dz;
+    if (distanceSq < bestDistanceSq) {
+      bestDistanceSq = distanceSq;
+      bestIndex = index;
+    }
+  }
+
+  return {
+    index: bestIndex,
+    sample: samples[bestIndex],
+    distance: Math.sqrt(bestDistanceSq),
+    checks: samples.length
+  };
+}
+
+function positiveNumber(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : fallback;
+}

--- a/turn/render/camera.js
+++ b/turn/render/camera.js
@@ -8,22 +8,40 @@ export function updateRaceCameraState({
   maxSpeed,
   dt
 }) {
-  const forward = getForward().clone();
-  const right = getRight().clone();
+  const forward = getForward();
+  const right = getRight();
   const speedRatio = clamp(state.speed / maxSpeed, 0, 1);
   const lateralVelocity = state.velocity.dot(right);
 
-  const desiredCamera = state.position
-    .clone()
-    .addScaledVector(forward, -(14 + speedRatio * 7))
-    .addScaledVector(right, -lateralVelocity * 0.11);
-  desiredCamera.y = 7.7 + speedRatio * 2.5;
-  cameraPosition.lerp(desiredCamera, 1 - Math.exp(-dt * 6.2));
+  const followDistance = 14 + speedRatio * 7;
+  const lateralOffset = lateralVelocity * 0.11;
+  const cameraResponse = 1 - Math.exp(-dt * 6.2);
+  cameraPosition.x = lerp(
+    cameraPosition.x,
+    state.position.x - forward.x * followDistance - right.x * lateralOffset,
+    cameraResponse
+  );
+  cameraPosition.y = lerp(cameraPosition.y, 7.7 + speedRatio * 2.5, cameraResponse);
+  cameraPosition.z = lerp(
+    cameraPosition.z,
+    state.position.z - forward.z * followDistance - right.z * lateralOffset,
+    cameraResponse
+  );
   camera.position.copy(cameraPosition);
 
-  const desiredTarget = state.position.clone().addScaledVector(forward, 15 + speedRatio * 12);
-  desiredTarget.y = 2.0;
-  cameraTarget.lerp(desiredTarget, 1 - Math.exp(-dt * 8.5));
+  const targetDistance = 15 + speedRatio * 12;
+  const targetResponse = 1 - Math.exp(-dt * 8.5);
+  cameraTarget.x = lerp(
+    cameraTarget.x,
+    state.position.x + forward.x * targetDistance,
+    targetResponse
+  );
+  cameraTarget.y = lerp(cameraTarget.y, 2, targetResponse);
+  cameraTarget.z = lerp(
+    cameraTarget.z,
+    state.position.z + forward.z * targetDistance,
+    targetResponse
+  );
   camera.up.set(0, 1, 0);
   camera.lookAt(cameraTarget);
 

--- a/turn/ui/gameplay-controls.js
+++ b/turn/ui/gameplay-controls.js
@@ -14,6 +14,7 @@ function installGameplayUi() {
   const manualSteer = document.querySelector('#manualSteer');
   const utilityGroup = document.querySelector('.utility-group');
   const hud = document.querySelector('#hud');
+  const controlsRoot = document.querySelector('#controls');
   const pedals = gasButton?.parentElement;
   if (!gasButton || !brakeButton || !manualSteer || !utilityGroup || !hud || !pedals) return;
 
@@ -56,22 +57,28 @@ function installGameplayUi() {
   positionHud.hidden = true;
   positionHud.innerHTML = '<span>POSITION</span><strong>1/1</strong>';
   hud.appendChild(positionHud);
+  const positionValue = positionHud.querySelector('strong');
   let lastPosition = null;
+  let lastPositionTotal = null;
 
   globalThis.__turnSetRacePosition = (position, total) => {
     if (position == null) {
-      positionHud.hidden = true;
+      if (!positionHud.hidden) positionHud.hidden = true;
       lastPosition = null;
+      lastPositionTotal = null;
       return;
     }
-    positionHud.hidden = false;
-    positionHud.querySelector('strong').textContent = position + '/' + total;
+    if (positionHud.hidden) positionHud.hidden = false;
+    if (position !== lastPosition || total !== lastPositionTotal) {
+      positionValue.textContent = position + '/' + total;
+    }
     if (lastPosition !== null && position !== lastPosition) {
       positionHud.classList.remove('position-pop');
       void positionHud.offsetWidth;
       positionHud.classList.add('position-pop');
     }
     lastPosition = position;
+    lastPositionTotal = total;
   };
 
   const boostHud = document.createElement('div');
@@ -126,6 +133,14 @@ function installGameplayUi() {
   const DEFAULT_BOOST_DRAIN_SECONDS = 2.0;
   const BOOST_RECHARGE_SECONDS = 4.2;
   const DRIFT_RECHARGE_MULTIPLIER = 2.4;
+  const BOOST_VISUAL_INTERVAL_MS = 1000 / 30;
+  let lastBoostVisualAt = -Infinity;
+  let boostVisualDirty = true;
+  let publishedBoosting = null;
+  let publishedLocked = null;
+  let publishedDriftCharging = null;
+  let publishedChargePercent = null;
+  let publishedAriaPercent = null;
 
   function safeVibrate(pattern) {
     try {
@@ -295,18 +310,50 @@ function installGameplayUi() {
     const boosting = boostRequested && !boostExhausted && boostCharge > 0.001;
     globalThis.__turnBoostActive = boosting;
     globalThis.__turnBoostCharge = boostCharge;
-    drivePad.classList.toggle('is-boosting', boosting);
-    drivePad.classList.toggle('is-boost-locked', boostRequested && boostExhausted);
-    boostZone.classList.toggle('is-locked', boostRequested && boostExhausted);
-    boostHud.classList.toggle('is-boosting', boosting);
-    boostHud.classList.toggle('is-drift-charging', globalThis.__turnDriftHeld && !boosting);
+    const locked = boostRequested && boostExhausted;
+    const driftCharging = globalThis.__turnDriftHeld && !boosting;
     const chargePercent = (boostCharge * 100).toFixed(1) + '%';
-    drivePad.style.setProperty('--boost-charge', chargePercent);
-    boostHud.style.setProperty('--boost-charge', chargePercent);
-    boostHud.setAttribute('aria-label', 'Boost ' + Math.round(boostCharge * 100) + ' percent charged');
-    requestAnimationFrame(updateBoost);
+    const ariaPercent = Math.round(boostCharge * 100);
+    const controlsVisible = !controlsRoot?.hidden && !document.hidden;
+    const stateChanged =
+      boosting !== publishedBoosting ||
+      locked !== publishedLocked ||
+      driftCharging !== publishedDriftCharging;
+    const visualDue = now - lastBoostVisualAt >= BOOST_VISUAL_INTERVAL_MS;
+
+    if (!controlsVisible) {
+      boostVisualDirty = true;
+      return;
+    }
+    if (!boostVisualDirty && !stateChanged && !visualDue) return;
+
+    if (boostVisualDirty || boosting !== publishedBoosting) {
+      drivePad.classList.toggle('is-boosting', boosting);
+      boostHud.classList.toggle('is-boosting', boosting);
+      publishedBoosting = boosting;
+    }
+    if (boostVisualDirty || locked !== publishedLocked) {
+      drivePad.classList.toggle('is-boost-locked', locked);
+      boostZone.classList.toggle('is-locked', locked);
+      publishedLocked = locked;
+    }
+    if (boostVisualDirty || driftCharging !== publishedDriftCharging) {
+      boostHud.classList.toggle('is-drift-charging', driftCharging);
+      publishedDriftCharging = driftCharging;
+    }
+    if (boostVisualDirty || chargePercent !== publishedChargePercent) {
+      drivePad.style.setProperty('--boost-charge', chargePercent);
+      boostHud.style.setProperty('--boost-charge', chargePercent);
+      publishedChargePercent = chargePercent;
+    }
+    if (boostVisualDirty || ariaPercent !== publishedAriaPercent) {
+      boostHud.setAttribute('aria-label', 'Boost ' + ariaPercent + ' percent charged');
+      publishedAriaPercent = ariaPercent;
+    }
+    boostVisualDirty = false;
+    lastBoostVisualAt = now;
   }
 
   setDriveZone(null, { announce: false });
-  requestAnimationFrame(updateBoost);
+  globalThis.__turnUpdateGameplayControls = updateBoost;
 }

--- a/turn/ui/hud.js
+++ b/turn/ui/hud.js
@@ -17,17 +17,18 @@ export function updateHudState({
   findNearestTrack,
   setRacePosition
 }) {
-  speedEl.textContent = Math.round(state.speed * 3.6);
-  lapEl.textContent = state.lap;
-  lapTimeEl.textContent = formatTime(state.lapElapsed);
-  bestTimeEl.textContent = formatTime(state.bestTime);
+  setText(speedEl, Math.round(state.speed * 3.6));
+  setText(lapEl, state.lap);
+  setText(lapTimeEl, formatTime(state.lapElapsed));
+  setText(bestTimeEl, formatTime(state.bestTime));
 
   const driveDisplay = state.throttle >= state.brake ? state.throttle : -state.brake;
   const drivePercent = Math.round(driveDisplay * 100);
-  tiltNeedle.style.left = `${50 + driveDisplay * 46}%`;
-  if (drivePercent > 2) tiltValue.textContent = `gas ${drivePercent}%`;
-  else if (drivePercent < -2) tiltValue.textContent = `brake ${Math.abs(drivePercent)}%`;
-  else tiltValue.textContent = 'neutral';
+  const needleLeft = `${50 + driveDisplay * 46}%`;
+  if (tiltNeedle.style.left !== needleLeft) tiltNeedle.style.left = needleLeft;
+  if (drivePercent > 2) setText(tiltValue, `gas ${drivePercent}%`);
+  else if (drivePercent < -2) setText(tiltValue, `brake ${Math.abs(drivePercent)}%`);
+  else setText(tiltValue, 'neutral');
 
   drawMap({
     state,
@@ -209,4 +210,9 @@ function formatTime(seconds) {
   const secs = Math.floor(seconds % 60).toString().padStart(2, '0');
   const ms = Math.floor((seconds % 1) * 1000).toString().padStart(3, '0');
   return `${minutes}:${secs}.${ms}`;
+}
+
+function setText(element, value) {
+  const text = String(value);
+  if (element.textContent !== text) element.textContent = text;
 }

--- a/turn/ui/in-game-menu.js
+++ b/turn/ui/in-game-menu.js
@@ -60,9 +60,9 @@ function install(runtime) {
       resetRivalsButton.hidden = !visibility.startActions;
       previousMenuState = visibility.menuState;
     }
-    requestAnimationFrame(syncMenu);
   }
 
+  window.addEventListener('turn:ui-state-change', syncMenu);
   syncMenu();
 }
 

--- a/turn/ui/spectate.js
+++ b/turn/ui/spectate.js
@@ -10,6 +10,12 @@ const spectate = {
   snapshot: null
 };
 
+function notifyUiState(reason) {
+  window.dispatchEvent(new CustomEvent('turn:ui-state-change', {
+    detail: { reason }
+  }));
+}
+
 globalThis.__turnSpectateV3 = spectate;
 
 function waitForRuntime() {
@@ -133,12 +139,14 @@ function installPublicApi(runtime) {
     globalThis.__turnDriftHeld = false;
     playerCar.visible = false;
     runtime.setRacePosition(null, state.competitorLaps.length + 1);
+    notifyUiState('spectate-started');
     return true;
   };
 
   globalThis.__turnNextSpectateV3 = () => {
     if (!spectate.active || !state.competitorLaps.length) return false;
     spectate.index = (spectate.index + 1) % state.competitorLaps.length;
+    notifyUiState('spectate-next');
     return true;
   };
 
@@ -164,6 +172,7 @@ function installPublicApi(runtime) {
       car.visible = false;
       hideCompetitorLabels(car);
     }
+    notifyUiState('spectate-stopped');
     return true;
   };
 }
@@ -212,10 +221,10 @@ function installUi(runtime) {
       recordEl.textContent = current.record || '';
       nextButton.hidden = current.total < 2;
     }
-    requestAnimationFrame(syncUi);
   }
 
-  requestAnimationFrame(syncUi);
+  window.addEventListener('turn:ui-state-change', syncUi);
+  syncUi();
 }
 
 function hideCompetitorLabels(car) {

--- a/turn/vehicle/car-models.js
+++ b/turn/vehicle/car-models.js
@@ -82,7 +82,9 @@ export async function createCarVisual({
       material.needsUpdate = true;
     }
 
-    record.node.castShadow = true;
+    // Rivals remain fully shaded but do not trigger another shadow-map draw for every
+    // GLB mesh. The player's car keeps its grounding shadow.
+    record.node.castShadow = !ghost;
     record.node.receiveShadow = true;
   }
 

--- a/turn/vehicle/physics.js
+++ b/turn/vehicle/physics.js
@@ -15,7 +15,13 @@ export function updateVehiclePhysicsState({
 }) {
   updateMotionInput(dt);
 
-  const tuning = normalizeVehicleTuning(vehicleTuning || globalThis.__turnVehicleTuning);
+  const tuning = vehicleTuning || globalThis.__turnVehicleTuning;
+  const accelerationMultiplier = positiveNumber(tuning?.accelerationMultiplier, 1);
+  const controlMultiplier = positiveNumber(tuning?.controlMultiplier, 1);
+  const driftEngineMultiplier = positiveNumber(tuning?.driftEngineMultiplier, 0.93);
+  const driftDragAdd = nonNegativeNumber(tuning?.driftDragAdd, 0.085);
+  const tuningBoostPowerMultiplier = positiveNumber(tuning?.boostPowerMultiplier, 1);
+  const tuningBoostSpeedMultiplier = positiveNumber(tuning?.boostSpeedMultiplier, 1.32);
   const effectiveMaxSpeed = maxSpeed;
   const directGas = Math.max(0, Number(analogGas) || 0);
   const directBrake = 0;
@@ -27,8 +33,8 @@ export function updateVehiclePhysicsState({
   state.trackDistance = nearestBefore.distance;
   state.offRoad = nearestBefore.distance > trackWidth * 0.58;
 
-  const forward = getForward().clone();
-  const right = getRight().clone();
+  const forward = getForward();
+  const right = getRight();
   let forwardSpeed = state.velocity.dot(forward);
   let lateralSpeed = state.velocity.dot(right);
   let speed = state.velocity.length();
@@ -39,10 +45,10 @@ export function updateVehiclePhysicsState({
 
   const enginePower =
     (state.offRoad ? 36 : 43) *
-    tuning.accelerationMultiplier *
-    (driftHeld ? tuning.driftEngineMultiplier : 1);
+    accelerationMultiplier *
+    (driftHeld ? driftEngineMultiplier : 1);
   const boostPower = effectiveBoostActive
-    ? (state.offRoad ? 16 : 36) * tuning.boostPowerMultiplier
+    ? (state.offRoad ? 16 : 36) * tuningBoostPowerMultiplier
     : 0;
   state.velocity.addScaledVector(
     forward,
@@ -61,7 +67,7 @@ export function updateVehiclePhysicsState({
       );
     } else {
       // Once forward motion is essentially gone, the same held control becomes reverse.
-      const reversePower = (state.offRoad ? 20 : 27) * tuning.accelerationMultiplier;
+      const reversePower = (state.offRoad ? 20 : 27) * accelerationMultiplier;
       state.velocity.addScaledVector(forward, -reversePower * state.brake * dt);
 
       const reverseSpeed = state.velocity.dot(forward);
@@ -98,12 +104,12 @@ export function updateVehiclePhysicsState({
     Math.sign(forwardSpeed || 1) *
     (0.18 + Math.abs(forwardSpeed) * 0.012) *
     steeringAuthority *
-    tuning.controlMultiplier *
+    controlMultiplier *
     (1 + state.driftAmount * 0.65 + (driftHeld ? 0.58 : 0));
 
   state.heading = normalizeAngle(state.heading + yawRate * dt);
 
-  const newRight = getRight().clone();
+  const newRight = getRight();
   lateralSpeed = state.velocity.dot(newRight);
 
   const grip = (
@@ -111,7 +117,7 @@ export function updateVehiclePhysicsState({
       ? lerp(3.4, 1.35, state.driftAmount)
       : lerp(11.5, 1.45, state.driftAmount)
   ) *
-    (0.92 + tuning.controlMultiplier * 0.08) *
+    (0.92 + controlMultiplier * 0.08) *
     (driftHeld ? 0.42 : 1);
 
   const lateralCorrection = 1 - Math.exp(-grip * dt);
@@ -127,12 +133,12 @@ export function updateVehiclePhysicsState({
 
   const drag = state.offRoad
     ? 0.34
-    : 0.11 + speed * 0.0009 + (driftHeld ? tuning.driftDragAdd : 0);
+    : 0.11 + speed * 0.0009 + (driftHeld ? driftDragAdd : 0);
   state.velocity.multiplyScalar(Math.exp(-drag * dt));
 
   const speedLimit = state.offRoad
     ? (effectiveBoostActive ? effectiveMaxSpeed * 0.82 : effectiveMaxSpeed * 0.73)
-    : (effectiveBoostActive ? effectiveMaxSpeed * tuning.boostSpeedMultiplier : effectiveMaxSpeed);
+    : (effectiveBoostActive ? effectiveMaxSpeed * tuningBoostSpeedMultiplier : effectiveMaxSpeed);
 
   speed = state.velocity.length();
   if (speed > speedLimit) state.velocity.multiplyScalar(speedLimit / speed);
@@ -149,17 +155,6 @@ export function updateVehiclePhysicsState({
   state.nearestTrackIndex = nearestAfter.index;
 
   return nearestAfter;
-}
-
-function normalizeVehicleTuning(tuning) {
-  return {
-    accelerationMultiplier: positiveNumber(tuning?.accelerationMultiplier, 1),
-    controlMultiplier: positiveNumber(tuning?.controlMultiplier, 1),
-    driftEngineMultiplier: positiveNumber(tuning?.driftEngineMultiplier, 0.93),
-    driftDragAdd: nonNegativeNumber(tuning?.driftDragAdd, 0.085),
-    boostPowerMultiplier: positiveNumber(tuning?.boostPowerMultiplier, 1),
-    boostSpeedMultiplier: positiveNumber(tuning?.boostSpeedMultiplier, 1.32)
-  };
 }
 
 function positiveNumber(value, fallback) {


### PR DESCRIPTION
## What changed

- pauses the main WebGL renderer while the install gate or The Lot fully covers it
- replaces continuous menu, Spectate and boost UI animation loops with state-driven updates
- caps HUD and boost presentation updates at 30 Hz and skips unchanged DOM writes
- replaces the 720-sample nearest-track scan with an exact spatial index
- removes rival shadow-map draws while retaining player shadows
- reuses hot-path vectors in physics, camera, particles and The Lot
- adds opt-in `?perf=1` diagnostics plus a target-device test matrix

## Why

TURN targets inclusive hardware, including 9th-generation iPads. This pass creates CPU/GPU headroom without changing physics, handling, race rules or visual balance.

The exact spatial search averages 53.8 checks per normal on-track query instead of 720 in the deterministic regression.

## Validation

- full TURN GitHub Actions-equivalent suite passes
- 1,200 deterministic spatial queries exactly match the brute-force result
- far-teleport fallback remains exact
- 5,000-step r15/r17 physics comparison is bit-for-bit identical
- r15/r17 camera hot-path comparison is bit-for-bit identical
- release architecture and diff checks pass
