### PR TITLE
TURN v1.3.2 r18: Normalize all car orientations

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Run production garage regression
         run: node turn-lab/tests/garage-production.mjs
 
+      - name: Run all-car orientation regression
+        run: node turn-lab/tests/car-orientation-production.mjs
+
       - name: Run balance and anti-shortcut regression
         run: node turn-lab/tests/balance-and-checkpoints.mjs
 

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const catalogSource = await fs.readFile(new URL('../../turn/vehicle/catalog.js', import.meta.url), 'utf8');
+const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
+
+const expectedQuarterTurns = new Map([
+  ['convertible', 1],
+  ['classic', 1],
+  ['vintage-racer', 2],
+  ['toy-racer', 2],
+  ['monster-truck', 2],
+  ['race-future', 0],
+  ['race', 0],
+  ['sedan-sports', 0],
+  ['sedan', 0],
+  ['suv', 0],
+  ['suv-luxury', 0],
+  ['hatchback-sports', 0],
+  ['truck-flat', 0],
+  ['truck', 0],
+  ['van', 0]
+]);
+
+assert.equal(catalog.CAR_CATALOG.length, expectedQuarterTurns.size);
+
+for (const car of catalog.CAR_CATALOG) {
+  assert.equal(
+    car.modelYawQuarterTurns,
+    expectedQuarterTurns.get(car.id),
+    `${car.name} must keep its verified GLB orientation correction`
+  );
+
+  const glb = await fs.readFile(new URL(`../../turn/assets/cars/${car.id}.glb`, import.meta.url));
+  const json = readGlbJson(glb, car.id);
+  const wheelNodes = (json.nodes || []).filter((node) => /wheel/i.test(node.name || '') && node.translation);
+  const front = averageWheelPosition(wheelNodes.filter((node) => wheelRole(node.name) === 'front'));
+  const back = averageWheelPosition(wheelNodes.filter((node) => wheelRole(node.name) === 'back'));
+  const rawFront = { x: front.x - back.x, z: front.z - back.z };
+  const rawLength = Math.hypot(rawFront.x, rawFront.z);
+  assert.ok(rawLength > 0.1, `${car.name} must expose a usable front/back wheel axis`);
+
+  const correctedFront = rotateYaw(rawFront, car.modelYawQuarterTurns * Math.PI / 2);
+  assert.ok(
+    Math.abs(correctedFront.x) < rawLength * 1e-6 && correctedFront.z > 0,
+    `${car.name} correction must normalize its authored nose to +Z`
+  );
+
+  // createCarVisual points normalized models down local -Z. The Lot and race roots
+  // both add a half-turn, while the viewer adds a three-quarter presentation angle.
+  const factoryFront = rotateYaw(correctedFront, Math.PI);
+  const lotFront = rotateYaw(factoryFront, Math.PI);
+  const raceFront = rotateYaw(factoryFront, Math.PI);
+  const viewerFront = rotateYaw(factoryFront, Math.PI - 0.55);
+  assert.ok(lotFront.z > 0, `${car.name} must face the Lot camera`);
+  assert.ok(raceFront.z > 0, `${car.name} must face the physics heading in a race`);
+  assert.ok(viewerFront.z > 0, `${car.name} must open on a front three-quarter view`);
+}
+
+const [index, carModels, lot, main] = await Promise.all([
+  fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/vehicle/car-models.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-r10.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
+]);
+
+assert.match(index, /TURN v1\.3\.2 · Build 2026\.07\.20-r18/);
+assert.match(
+  carModels,
+  /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,
+  'The shared model factory must apply the catalog correction'
+);
+assert.match(lot, /visual\.rotation\.y = Math\.PI/, 'The Lot must map local -Z to the camera-facing direction');
+assert.match(lot, /VIEWER_INITIAL_YAW = Math\.PI - 0\.55/, 'The viewer must start on the normalized front');
+assert.match(main, /playerCar\.rotation\.y = state\.heading \+ Math\.PI/);
+assert.match(main, /car\.rotation\.y = frame\.h \+ Math\.PI/);
+
+console.log('TURN car orientation regression passed for all 15 models.');
+
+function readGlbJson(buffer, carId) {
+  assert.equal(buffer.toString('utf8', 0, 4), 'glTF', `${carId} must remain a binary glTF`);
+  let offset = 12;
+  while (offset + 8 <= buffer.length) {
+    const length = buffer.readUInt32LE(offset);
+    const type = buffer.toString('utf8', offset + 4, offset + 8);
+    if (type === 'JSON') {
+      return JSON.parse(buffer.subarray(offset + 8, offset + 8 + length).toString('utf8').trim());
+    }
+    offset += 8 + length;
+  }
+  assert.fail(`${carId} has no GLB JSON chunk`);
+}
+
+function wheelRole(name = '') {
+  const label = name.toLowerCase();
+  if (/^wheel-(?:front|f[lr])(?:-|$)/.test(label)) return 'front';
+  if (/^wheel-(?:back|b[lr])(?:-|$)/.test(label)) return 'back';
+  return null;
+}
+
+function averageWheelPosition(nodes) {
+  assert.ok(nodes.length >= 2, 'Each axle must expose at least two named wheels');
+  return nodes.reduce((average, node) => ({
+    x: average.x + node.translation[0] / nodes.length,
+    z: average.z + node.translation[2] / nodes.length
+  }), { x: 0, z: 0 });
+}
+
+function rotateYaw(vector, angle) {
+  const cosine = Math.cos(angle);
+  const sine = Math.sin(angle);
+  return {
+    x: cosine * vector.x + sine * vector.z,
+    z: -sine * vector.x + cosine * vector.z
+  };
+}

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -44,8 +44,8 @@ const [index, controls, css, analogGas, spectate] = await Promise.all([
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.1 · Build 2026\.07\.20-r17/);
-assert.match(index, /drive-pad\.css\?build=20260720-r17/);
+assert.match(index, /TURN v1\.3\.2 · Build 2026\.07\.20-r18/);
+assert.match(index, /drive-pad\.css\?build=20260720-r18/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -75,8 +75,8 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.1 · Build 2026\.07\.20-r17/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260720-r17/);
+assert.match(index, /TURN v1\.3\.2 · Build 2026\.07\.20-r18/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260720-r18/);
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');
 assert.match(main, /vehicleTuning: state\.vehicleTuning/, 'Selected handling profile must reach physics');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -38,8 +38,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.1 · Build 2026\.07\.20-r17/);
-assert.match(index, /in-game-menu\.css\?build=20260720-r17/);
+assert.match(index, /TURN v1\.3\.2 · Build 2026\.07\.20-r18/);
+assert.match(index, /in-game-menu\.css\?build=20260720-r18/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Back to Start<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -26,7 +26,7 @@ const css = await fs.readFile(new URL('../../turn/manual-steering.css', import.m
 
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260720-r17/);
+assert.match(index, /manual-steering\.css\?build=20260720-r18/);
 assert.match(css, /--manual-steer-left/);
 assert.match(css, /content: "←"/);
 assert.match(css, /content: "→"/);

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -85,7 +85,7 @@ const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, m
   fs.readFile(new URL('../../turn/performance-monitor.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.1 · Build 2026\.07\.20-r17/);
+assert.match(index, /TURN v1\.3\.2 · Build 2026\.07\.20-r18/);
 assert.match(main, /mainSceneOcclusion/);
 assert.match(main, /HUD_UPDATE_INTERVAL_MS = 1000 \/ 30/);
 assert.match(main, /recordPerformanceFrame/);

--- a/turn/garage/lot-r10.js
+++ b/turn/garage/lot-r10.js
@@ -6,13 +6,14 @@ import {
   DEFAULT_VEHICLE_COLOR,
   getCarDefinition,
   normalizeVehicleSelection
-} from '../vehicle/catalog.js';
-import { createCarVisual, recolorCarVisual } from '../vehicle/car-models.js?build=20260720-r17';
-import { recordPerformanceFrame } from '../performance-monitor.js?build=20260720-r17';
+} from '../vehicle/catalog.js?build=20260720-r18';
+import { createCarVisual, recolorCarVisual } from '../vehicle/car-models.js?build=20260720-r18';
+import { recordPerformanceFrame } from '../performance-monitor.js?build=20260720-r18';
 
 const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
 const lotLoader = new GLTFLoader();
 const MUTED_COLOR = new THREE.Color(0x9da5ab);
+const VIEWER_INITIAL_YAW = Math.PI - 0.55;
 
 export function showTheLot({ initialSelection } = {}) {
   return new Promise((resolve) => {
@@ -310,7 +311,7 @@ function createViewer(host) {
 
   let visual = null;
   let generation = 0;
-  let yaw = -0.55;
+  let yaw = VIEWER_INITIAL_YAW;
   let pitch = 0.08;
   let dragging = false;
   let pointerId = null;
@@ -360,7 +361,7 @@ function createViewer(host) {
         if (visual) stage.remove(visual);
         visual = next;
         stage.add(visual);
-        yaw = -0.55;
+        yaw = VIEWER_INITIAL_YAW;
         pitch = 0.08;
       } catch (error) {
         console.warn('TURN: selected car could not load in the 3D viewer.', error);

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r17 Performance headroom and opt-in diagnostics -->
+<!-- TURN r18 Normalized car orientation -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,31 +10,31 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.1 · Build 2026.07.20-r17</title>
+  <title>TURN v1.3.2 · Build 2026.07.20-r18</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.1',
-      id: '2026.07.20-r17',
-      cacheKey: '20260720-r17'
+      version: '1.3.2',
+      id: '2026.07.20-r18',
+      cacheKey: '20260720-r18'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260720-r17">
-  <link rel="stylesheet" href="./styles.css?build=20260720-r17">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260720-r17">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260720-r17">
-  <link rel="stylesheet" href="./install-gate.css?build=20260720-r17">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260720-r17">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260720-r17">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260720-r17">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260720-r17">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260720-r17">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260720-r17">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260720-r17">
+  <link rel="manifest" href="./site.webmanifest?build=20260720-r18">
+  <link rel="stylesheet" href="./styles.css?build=20260720-r18">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260720-r18">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260720-r18">
+  <link rel="stylesheet" href="./install-gate.css?build=20260720-r18">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260720-r18">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260720-r18">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260720-r18">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260720-r18">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260720-r18">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260720-r18">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260720-r18">
 
-  <script src="./install-gate.js?build=20260720-r17"></script>
-  <script src="./orientation-compat.js?build=20260720-r17"></script>
+  <script src="./install-gate.js?build=20260720-r18"></script>
+  <script src="./orientation-compat.js?build=20260720-r18"></script>
   <script type="importmap">
     {
       "imports": {
@@ -52,7 +52,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.1 · Build 2026.07.20-r17</span>
+        <span class="install-kicker">TURN v1.3.2 · Build 2026.07.20-r18</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -80,7 +80,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.1 · Build 2026.07.20-r17</span>
+      <span class="kicker">TURN v1.3.2 · Build 2026.07.20-r18</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -146,6 +146,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260720-r17"></script>
+  <script type="module" src="./app.js?build=20260720-r18"></script>
 </body>
 </html>

--- a/turn/main.js
+++ b/turn/main.js
@@ -2,19 +2,19 @@
 
 import * as THREE from 'three';
 import { installKenneyWorld } from './world-assets.js';
-import { updateRaceCameraState } from './render/camera.js?build=20260720-r17';
-import { updateHudState } from './ui/hud.js?build=20260720-r17';
+import { updateRaceCameraState } from './render/camera.js?build=20260720-r18';
+import { updateHudState } from './ui/hud.js?build=20260720-r18';
 import { motionPoseFromGravity as motionPoseFromGravityState, updateMotionInputState } from './input/motion.js';
-import { updateVehiclePhysicsState } from './vehicle/physics.js?build=20260720-r17';
+import { updateVehiclePhysicsState } from './vehicle/physics.js?build=20260720-r18';
 import { GAME_MODE, installGameModeState, prepareRaceStartState, resetRaceToStage, setGameModeState } from './race/game-state.js';
 import { beginTimedLapState, completeLapState, updateLapProgressState } from './race/lap-system.js';
 import { recordReplayFrame, replayFrameAt } from './race/replay-system.js';
 import { RIVAL_LIMIT, loadRivalsState, saveRivalsState } from './race/rival-storage.js';
-import { createTrackSpatialIndex } from './race/track-spatial-index.js?build=20260720-r17';
-import { showTheLot } from './garage/lot-r10.js?build=20260720-r17';
-import { getCarDefinition, loadVehicleSelection, saveVehicleSelection } from './vehicle/catalog.js';
-import { createCarVisual } from './vehicle/car-models.js?build=20260720-r17';
-import { installPerformanceMonitor, recordPerformanceFrame } from './performance-monitor.js?build=20260720-r17';
+import { createTrackSpatialIndex } from './race/track-spatial-index.js?build=20260720-r18';
+import { showTheLot } from './garage/lot-r10.js?build=20260720-r18';
+import { getCarDefinition, loadVehicleSelection, saveVehicleSelection } from './vehicle/catalog.js?build=20260720-r18';
+import { createCarVisual } from './vehicle/car-models.js?build=20260720-r18';
+import { installPerformanceMonitor, recordPerformanceFrame } from './performance-monitor.js?build=20260720-r18';
 
 const intro = document.querySelector('#intro');
 const hud = document.querySelector('#hud');

--- a/turn/vehicle/car-models.js
+++ b/turn/vehicle/car-models.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
-import { getCarDefinition, makeGhostColor, normalizeVehicleColor } from './catalog.js';
+import { getCarDefinition, makeGhostColor, normalizeVehicleColor } from './catalog.js?build=20260720-r18';
 
 const loader = new GLTFLoader();
 const sourceCache = new Map();
@@ -22,7 +22,9 @@ export async function createCarVisual({
   const source = await loadCarSource(car.id);
   const root = new THREE.Group();
   const model = source.clone(true);
-  model.rotation.y = Math.PI;
+  // TURN's visual roots point down local -Z. The per-asset quarter turns first
+  // normalize the GLB's authored nose direction, then the shared half-turn aligns it.
+  model.rotation.y = Math.PI + car.modelYawQuarterTurns * Math.PI / 2;
   root.add(model);
 
   const requestedColor = normalizeVehicleColor(color);
@@ -94,6 +96,7 @@ export async function createCarVisual({
   root.userData.turnCarId = car.id;
   root.userData.turnCarColor = requestedColor;
   root.userData.turnGhost = ghost;
+  root.userData.turnModelYawQuarterTurns = car.modelYawQuarterTurns;
   root.userData.turnPaintMaterials = paintMaterials;
   root.userData.frontWheelPivots = [];
   root.userData.wheelSpinners = [];

--- a/turn/vehicle/catalog.js
+++ b/turn/vehicle/catalog.js
@@ -16,31 +16,41 @@ export const CAR_PALETTE = Object.freeze([
 
 // Every car has exactly 18 stat points. The Sedan's 3/3/3/3/3/3 is the neutral baseline;
 // every other vehicle trades strengths for weaknesses instead of becoming a straight upgrade.
+// The vendored packs use three different authored front axes. modelYawQuarterTurns
+// rotates each raw GLB so every car has the same local front before TURN positions it.
 const RAW_CARS = [
-  ['convertible', 'Convertible', 'prototype', { speed: 4, acceleration: 4, control: 4, drift: 2, boostPower: 3, boostDuration: 1 }, 0.98],
-  ['classic', 'Classic', 'prototype', { speed: 3, acceleration: 2, control: 4, drift: 4, boostPower: 2, boostDuration: 3 }, 1.00],
-  ['vintage-racer', 'Vintage Racer', 'toy', { speed: 5, acceleration: 4, control: 3, drift: 2, boostPower: 3, boostDuration: 1 }, 0.96],
-  ['toy-racer', 'Toy Racer', 'toy', { speed: 4, acceleration: 5, control: 5, drift: 1, boostPower: 2, boostDuration: 1 }, 0.94],
-  ['monster-truck', 'Monster Truck', 'toy', { speed: 2, acceleration: 3, control: 2, drift: 5, boostPower: 2, boostDuration: 4 }, 1.18],
-  ['race-future', 'Future Racer', 'car', { speed: 5, acceleration: 5, control: 3, drift: 1, boostPower: 3, boostDuration: 1 }, 0.96],
-  ['race', 'Race Car', 'car', { speed: 5, acceleration: 4, control: 4, drift: 1, boostPower: 3, boostDuration: 1 }, 0.94],
-  ['sedan-sports', 'Sport Sedan', 'car', { speed: 4, acceleration: 4, control: 4, drift: 2, boostPower: 2, boostDuration: 2 }, 0.98],
-  ['sedan', 'Sedan', 'car', { speed: 3, acceleration: 3, control: 3, drift: 3, boostPower: 3, boostDuration: 3 }, 1.00],
-  ['suv', 'SUV', 'car', { speed: 3, acceleration: 3, control: 3, drift: 4, boostPower: 2, boostDuration: 3 }, 1.05],
-  ['suv-luxury', 'Luxury SUV', 'car', { speed: 3, acceleration: 3, control: 4, drift: 4, boostPower: 2, boostDuration: 2 }, 1.06],
-  ['hatchback-sports', 'Sport Hatch', 'car', { speed: 4, acceleration: 4, control: 5, drift: 2, boostPower: 2, boostDuration: 1 }, 0.96],
-  ['truck-flat', 'Flatbed', 'car', { speed: 2, acceleration: 2, control: 3, drift: 5, boostPower: 2, boostDuration: 4 }, 1.12],
-  ['truck', 'Truck', 'car', { speed: 2, acceleration: 2, control: 3, drift: 5, boostPower: 1, boostDuration: 5 }, 1.12],
-  ['van', 'Van', 'car', { speed: 2, acceleration: 3, control: 3, drift: 5, boostPower: 1, boostDuration: 4 }, 1.08]
+  ['convertible', 'Convertible', 'prototype', { speed: 4, acceleration: 4, control: 4, drift: 2, boostPower: 3, boostDuration: 1 }, 0.98, 1],
+  ['classic', 'Classic', 'prototype', { speed: 3, acceleration: 2, control: 4, drift: 4, boostPower: 2, boostDuration: 3 }, 1.00, 1],
+  ['vintage-racer', 'Vintage Racer', 'toy', { speed: 5, acceleration: 4, control: 3, drift: 2, boostPower: 3, boostDuration: 1 }, 0.96, 2],
+  ['toy-racer', 'Toy Racer', 'toy', { speed: 4, acceleration: 5, control: 5, drift: 1, boostPower: 2, boostDuration: 1 }, 0.94, 2],
+  ['monster-truck', 'Monster Truck', 'toy', { speed: 2, acceleration: 3, control: 2, drift: 5, boostPower: 2, boostDuration: 4 }, 1.18, 2],
+  ['race-future', 'Future Racer', 'car', { speed: 5, acceleration: 5, control: 3, drift: 1, boostPower: 3, boostDuration: 1 }, 0.96, 0],
+  ['race', 'Race Car', 'car', { speed: 5, acceleration: 4, control: 4, drift: 1, boostPower: 3, boostDuration: 1 }, 0.94, 0],
+  ['sedan-sports', 'Sport Sedan', 'car', { speed: 4, acceleration: 4, control: 4, drift: 2, boostPower: 2, boostDuration: 2 }, 0.98, 0],
+  ['sedan', 'Sedan', 'car', { speed: 3, acceleration: 3, control: 3, drift: 3, boostPower: 3, boostDuration: 3 }, 1.00, 0],
+  ['suv', 'SUV', 'car', { speed: 3, acceleration: 3, control: 3, drift: 4, boostPower: 2, boostDuration: 3 }, 1.05, 0],
+  ['suv-luxury', 'Luxury SUV', 'car', { speed: 3, acceleration: 3, control: 4, drift: 4, boostPower: 2, boostDuration: 2 }, 1.06, 0],
+  ['hatchback-sports', 'Sport Hatch', 'car', { speed: 4, acceleration: 4, control: 5, drift: 2, boostPower: 2, boostDuration: 1 }, 0.96, 0],
+  ['truck-flat', 'Flatbed', 'car', { speed: 2, acceleration: 2, control: 3, drift: 5, boostPower: 2, boostDuration: 4 }, 1.12, 0],
+  ['truck', 'Truck', 'car', { speed: 2, acceleration: 2, control: 3, drift: 5, boostPower: 1, boostDuration: 5 }, 1.12, 0],
+  ['van', 'Van', 'car', { speed: 2, acceleration: 3, control: 3, drift: 5, boostPower: 1, boostDuration: 4 }, 1.08, 0]
 ];
 
-export const CAR_CATALOG = Object.freeze(RAW_CARS.map(([id, name, pack, stats, visualScale]) => Object.freeze({
+export const CAR_CATALOG = Object.freeze(RAW_CARS.map(([
+  id,
+  name,
+  pack,
+  stats,
+  visualScale,
+  modelYawQuarterTurns
+]) => Object.freeze({
   id,
   name,
   pack,
   asset: `./assets/cars/${id}.glb`,
   stats: Object.freeze({ ...stats }),
   visualScale,
+  modelYawQuarterTurns,
   tuning: Object.freeze(deriveVehicleTuning(stats))
 })));
 


### PR DESCRIPTION
## What changed

- records an explicit yaw correction for every car asset
- normalizes all 15 GLBs in the shared car visual factory
- aligns The Lot, the initial 3D viewer angle, player cars and rivals to the same nose direction
- bumps TURN to v1.3.2 / build r18 with cache-safe catalog and model imports
- adds a production regression that reads the actual wheel-node positions from every GLB

## Root cause

TURN's three vendored model groups use different authored front axes:

- Convertible and Classic: `-X`
- Vintage Racer, Toy Racer and Monster Truck: `-Z`
- the other ten models: `+Z`

The Lot and race renderer assumed one shared axis, so side-facing and rear-facing models stayed wrong in both places.

## Validation

- all 15 raw GLB wheel axes normalize to the same forward direction
- The Lot, race heading and 3D viewer transforms are verified for every model
- the full TURN GitHub Actions-equivalent suite passes
- no physics, handling, stats or balance changes
