### PR TITLE
TURN v1.3.3 r19: Native paint controls and secondary accents

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Run all-car orientation regression
         run: node turn-lab/tests/car-orientation-production.mjs
 
+      - name: Run native and secondary paint regression
+        run: node turn-lab/tests/native-paint-production.mjs
+
       - name: Run balance and anti-shortcut regression
         run: node turn-lab/tests/balance-and-checkpoints.mjs
 

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -64,7 +64,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.2 · Build 2026\.07\.20-r18/);
+assert.match(index, /TURN v1\.3\.3 · Build 2026\.07\.20-r19/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -44,8 +44,8 @@ const [index, controls, css, analogGas, spectate] = await Promise.all([
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.2 · Build 2026\.07\.20-r18/);
-assert.match(index, /drive-pad\.css\?build=20260720-r18/);
+assert.match(index, /TURN v1\.3\.3 · Build 2026\.07\.20-r19/);
+assert.match(index, /drive-pad\.css\?build=20260720-r19/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -75,17 +75,19 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.2 · Build 2026\.07\.20-r18/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260720-r18/);
+assert.match(index, /TURN v1\.3\.3 · Build 2026\.07\.20-r19/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260720-r19/);
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');
 assert.match(main, /vehicleTuning: state\.vehicleTuning/, 'Selected handling profile must reach physics');
 assert.doesNotMatch(main, /wayne-wu\/webgpu-crowd-simulation/, 'Production must not depend on the old remote Sedan model');
 assert.match(lapSystem, /carId: state\.vehicleId \|\| 'sedan'/, 'Completed laps must remember their car model');
 assert.match(lapSystem, /carColor: state\.vehicleColor \|\| '#ffd43b'/, 'Completed laps must remember their paint colour');
-assert.match(rivalStorage, /version: 3/, 'Rival storage schema must include vehicle metadata version');
+assert.match(lapSystem, /carSecondaryColor: state\.vehicleSecondaryColor \|\| '#f8f9fa'/, 'Completed laps must remember secondary paint');
+assert.match(rivalStorage, /version: 4/, 'Rival storage schema must include secondary paint metadata');
 assert.match(rivalStorage, /normalizeVehicleId\(lap\.carId\)/, 'Loaded rivals must normalize stored car ids');
 assert.match(rivalStorage, /normalizeVehicleColor\(lap\.carColor\)/, 'Loaded rivals must normalize stored car colours');
+assert.match(rivalStorage, /normalizeVehicleSecondaryColor\(lap\.carSecondaryColor\)/, 'Loaded rivals must normalize secondary paint');
 assert.match(controls, /boostDurationSeconds/, 'Boost drain must use the selected car boost tank stat');
 assert.match(catalogSource, /asset: `\.\/assets\/cars\/\$\{id\}\.glb`/, 'Vehicle catalog must point to vendored local car assets');
 assert.match(carModels, /loadCarSource\(car\.id\)/, 'Car model factory must load the catalog-selected vehicle');
@@ -94,7 +96,8 @@ const lotR10 = await fs.readFile(path.join(turnDir, 'garage/lot-r10.js'), 'utf8'
 const lotR10Css = await fs.readFile(path.join(turnDir, 'garage/lot-r10.css'), 'utf8');
 assert.match(main, /garage\/lot-r10\.js/, 'Production must load the r10 Lot module');
 assert.match(lotR10, /MUTED_COLOR/, 'Unselected Lot cars must have a muted visual state');
-assert.match(lotR10, /selectedColor = DEFAULT_VEHICLE_COLOR/, 'Newly selected cars must return to the default yellow paint');
+assert.match(lotR10, /selectedColor = selection\.color/, 'The Lot must restore the selected native body colour');
+assert.match(lotR10, /selectedSecondaryColor = selection\.secondaryColor/, 'The Lot must restore secondary paint');
 assert.match(lotR10, /lot-viewbox/, 'The Lot must include a dedicated 3D car viewbox');
 assert.match(lotR10, /DRAG TO ROTATE/, 'The 3D car viewer must advertise drag rotation');
 assert.match(lotR10Css, /--lot-rail-width/, 'The stats and viewer rail must reserve space beside the parking lot');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -38,8 +38,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.2 · Build 2026\.07\.20-r18/);
-assert.match(index, /in-game-menu\.css\?build=20260720-r18/);
+assert.match(index, /TURN v1\.3\.3 · Build 2026\.07\.20-r19/);
+assert.match(index, /in-game-menu\.css\?build=20260720-r19/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Back to Start<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -26,7 +26,7 @@ const css = await fs.readFile(new URL('../../turn/manual-steering.css', import.m
 
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260720-r18/);
+assert.match(index, /manual-steering\.css\?build=20260720-r19/);
 assert.match(css, /--manual-steer-left/);
 assert.match(css, /content: "←"/);
 assert.match(css, /content: "→"/);

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const catalogSource = await fs.readFile(new URL('../../turn/vehicle/catalog.js', import.meta.url), 'utf8');
+const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
+
+assert.equal(catalog.normalizeVehicleColor('#12AbEf'), '#12abef', 'Native picker colours must not be palette-limited');
+assert.equal(catalog.normalizeVehicleColor('#fff'), catalog.DEFAULT_VEHICLE_COLOR, 'Invalid short hex must use the body fallback');
+assert.equal(
+  catalog.normalizeVehicleSecondaryColor('#654321'),
+  '#654321',
+  'Secondary paint must accept a native picker value'
+);
+assert.deepEqual(
+  catalog.normalizeVehicleSelection({
+    carId: 'sedan-sports',
+    color: '#123456',
+    secondaryColor: '#abcdef'
+  }),
+  { carId: 'sedan-sports', color: '#123456', secondaryColor: '#abcdef' },
+  'Vehicle selection must persist both native colours'
+);
+
+const secondaryCars = catalog.CAR_CATALOG.filter((car) => car.secondaryPaint);
+assert.deepEqual(
+  secondaryCars.map((car) => car.id),
+  ['sedan-sports'],
+  'Only genuinely separate secondary meshes should expose a second picker'
+);
+assert.equal(secondaryCars[0].secondaryPaint.label, 'Spoiler');
+assert.deepEqual(secondaryCars[0].secondaryPaint.meshNames, ['spoiler']);
+
+const sportSedanGlb = await fs.readFile(new URL('../../turn/assets/cars/sedan-sports.glb', import.meta.url));
+const sportSedanJson = readGlbJson(sportSedanGlb);
+const meshNodeNames = (sportSedanJson.nodes || [])
+  .filter((node) => Number.isInteger(node.mesh))
+  .map((node) => String(node.name || '').toLowerCase());
+assert.ok(meshNodeNames.includes('body'), 'Sport Sedan body must remain a separate primary mesh');
+assert.ok(meshNodeNames.includes('spoiler'), 'Sport Sedan spoiler must remain a separate secondary mesh');
+
+const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promise.all([
+  fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-r10.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-r10.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/vehicle/car-models.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/race/lap-system.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
+]);
+
+assert.match(index, /TURN v1\.3\.3 · Build 2026\.07\.20-r19/);
+assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
+assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
+assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');
+assert.match(css, /\.lot-color-input/);
+assert.doesNotMatch(css, /\.lot-color\[aria-pressed=/, 'The retired custom swatch state must be removed');
+assert.match(carModels, /turnSecondaryPaintMaterials/);
+assert.match(carModels, /isSecondaryPaint\(node, car\)/);
+assert.match(main, /vehicleSecondaryColor: initialVehicleSelection\.secondaryColor/);
+assert.match(main, /secondaryColor: state\.vehicleSecondaryColor/);
+assert.match(lapSystem, /carSecondaryColor: state\.vehicleSecondaryColor \|\| '#f8f9fa'/);
+assert.match(rivalStorage, /version: 4/);
+assert.match(rivalStorage, /normalizeVehicleSecondaryColor\(lap\.carSecondaryColor\)/);
+
+console.log('TURN native and secondary paint regression passed.');
+
+function readGlbJson(buffer) {
+  assert.equal(buffer.toString('utf8', 0, 4), 'glTF');
+  let offset = 12;
+  while (offset + 8 <= buffer.length) {
+    const length = buffer.readUInt32LE(offset);
+    const type = buffer.toString('utf8', offset + 4, offset + 8);
+    if (type === 'JSON') {
+      return JSON.parse(buffer.subarray(offset + 8, offset + 8 + length).toString('utf8').trim());
+    }
+    offset += 8 + length;
+  }
+  assert.fail('Sport Sedan has no GLB JSON chunk');
+}

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -85,7 +85,7 @@ const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, m
   fs.readFile(new URL('../../turn/performance-monitor.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.2 · Build 2026\.07\.20-r18/);
+assert.match(index, /TURN v1\.3\.3 · Build 2026\.07\.20-r19/);
 assert.match(main, /mainSceneOcclusion/);
 assert.match(main, /HUD_UPDATE_INTERVAL_MS = 1000 \/ 30/);
 assert.match(main, /recordPerformanceFrame/);

--- a/turn/garage/lot-r10.css
+++ b/turn/garage/lot-r10.css
@@ -236,27 +236,56 @@
 
 .lot-colors {
   display: grid;
-  grid-template-columns: repeat(8, 1fr);
-  gap: 5px;
+  grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
+  gap: 7px;
   margin: 8px 0 10px;
 }
 
-.lot-color {
-  width: 100%;
-  aspect-ratio: 1;
-  min-height: 0;
-  padding: 0;
-  border-width: 2px;
-  border-radius: 50%;
-  background: var(--lot-color);
+.lot-color-control {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 38px;
+  align-items: center;
+  gap: 6px;
+  min-height: 38px;
+  padding: 4px 5px 4px 7px;
+  border: 2px solid var(--ink);
+  border-radius: 10px;
+  background: var(--paper);
   box-shadow: 2px 2px 0 var(--ink);
+  cursor: pointer;
 }
 
-.lot-color[aria-pressed="true"] {
-  outline: 3px solid var(--paper);
-  outline-offset: -6px;
-  transform: translate(-1px, -1px) scale(1.12);
-  box-shadow: 4px 4px 0 var(--ink);
+.lot-color-control > span {
+  overflow: hidden;
+  font-size: 0.45rem;
+  letter-spacing: 0.055em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lot-color-input {
+  width: 38px;
+  height: 28px;
+  min-height: 0;
+  padding: 0;
+  border: 2px solid var(--ink);
+  border-radius: 7px;
+  background: transparent;
+  cursor: pointer;
+}
+
+.lot-color-input::-webkit-color-swatch-wrapper {
+  padding: 2px;
+}
+
+.lot-color-input::-webkit-color-swatch {
+  border: 0;
+  border-radius: 3px;
+}
+
+.lot-color-input:focus-visible {
+  outline: 3px solid var(--cyan);
+  outline-offset: 2px;
 }
 
 .lot-card-actions {

--- a/turn/garage/lot-r10.js
+++ b/turn/garage/lot-r10.js
@@ -2,13 +2,15 @@ import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import {
   CAR_CATALOG,
-  CAR_PALETTE,
   DEFAULT_VEHICLE_COLOR,
+  DEFAULT_VEHICLE_SECONDARY_COLOR,
   getCarDefinition,
+  normalizeVehicleColor,
+  normalizeVehicleSecondaryColor,
   normalizeVehicleSelection
-} from '../vehicle/catalog.js?build=20260720-r18';
-import { createCarVisual, recolorCarVisual } from '../vehicle/car-models.js?build=20260720-r18';
-import { recordPerformanceFrame } from '../performance-monitor.js?build=20260720-r18';
+} from '../vehicle/catalog.js?build=20260720-r19';
+import { createCarVisual, recolorCarVisual } from '../vehicle/car-models.js?build=20260720-r19';
+import { recordPerformanceFrame } from '../performance-monitor.js?build=20260720-r19';
 
 const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
 const lotLoader = new GLTFLoader();
@@ -46,7 +48,7 @@ export function showTheLot({ initialSelection } = {}) {
             <strong></strong>
           </div>
           <div class="lot-stats"></div>
-          <div class="lot-colors" aria-label="Choose car colour"></div>
+          <div class="lot-colors" aria-label="Choose car paint colours"></div>
           <div class="lot-card-actions">
             <button class="lot-view-open" type="button" hidden>VIEW 3D</button>
             <button class="lot-race" type="button">RACE THIS CAR</button>
@@ -102,7 +104,8 @@ export function showTheLot({ initialSelection } = {}) {
     const carRoots = new Map();
     const platforms = new Map();
     let selectedCarId = selection.carId;
-    let selectedColor = DEFAULT_VEHICLE_COLOR;
+    let selectedColor = selection.color;
+    let selectedSecondaryColor = selection.secondaryColor;
     let disposed = false;
     let loadedCars = 0;
 
@@ -130,6 +133,7 @@ export function showTheLot({ initialSelection } = {}) {
       createCarVisual({
         carId: car.id,
         color: DEFAULT_VEHICLE_COLOR,
+        secondaryColor: DEFAULT_VEHICLE_SECONDARY_COLOR,
         targetLength: 5.15,
         outline: true
       }).then((visual) => {
@@ -143,7 +147,12 @@ export function showTheLot({ initialSelection } = {}) {
         rememberMaterialState(visual);
         lot.add(visual);
         carRoots.set(car.id, visual);
-        applyLotCarPresentation(visual, car.id === selectedCarId, selectedColor);
+        applyLotCarPresentation(
+          visual,
+          car.id === selectedCarId,
+          selectedColor,
+          selectedSecondaryColor
+        );
         loadedCars += 1;
         if (loadedCars >= CAR_CATALOG.length) loading.classList.add('is-done');
       }).catch((error) => {
@@ -161,7 +170,26 @@ export function showTheLot({ initialSelection } = {}) {
       const car = getCarDefinition(selectedCarId);
       title.textContent = car.name;
       stats.replaceChildren(...makeStats(car.stats));
-      colors.replaceChildren(...CAR_PALETTE.map((entry) => makeColorButton(entry)));
+      const paintControls = [makeColorInput({
+        label: 'Body',
+        value: selectedColor,
+        onInput(value) {
+          selectedColor = normalizeVehicleColor(value);
+          applySelectedPaint();
+        }
+      })];
+      if (car.secondaryPaint) {
+        paintControls.push(makeColorInput({
+          label: car.secondaryPaint.label,
+          value: selectedSecondaryColor,
+          secondary: true,
+          onInput(value) {
+            selectedSecondaryColor = normalizeVehicleSecondaryColor(value);
+            applySelectedPaint();
+          }
+        }));
+      }
+      colors.replaceChildren(...paintControls);
 
       for (const [carId, platform] of platforms) {
         setParkingPadSelected(platform, carId === selectedCarId);
@@ -170,39 +198,50 @@ export function showTheLot({ initialSelection } = {}) {
       for (const [carId, root] of carRoots) {
         const selected = carId === selectedCarId;
         root.userData.turnLotSelected = selected;
-        applyLotCarPresentation(root, selected, selectedColor);
+        applyLotCarPresentation(root, selected, selectedColor, selectedSecondaryColor);
       }
 
-      if (refreshViewer) void viewer.show(selectedCarId, selectedColor);
+      if (refreshViewer) void viewer.show(selectedCarId, selectedColor, selectedSecondaryColor);
     }
 
     function selectCar(carId) {
       if (!carId) return;
       const changedCar = carId !== selectedCarId;
       selectedCarId = carId;
-      if (changedCar) selectedColor = DEFAULT_VEHICLE_COLOR;
+      if (changedCar) {
+        selectedColor = DEFAULT_VEHICLE_COLOR;
+        selectedSecondaryColor = DEFAULT_VEHICLE_SECONDARY_COLOR;
+      }
       updateSelectionUi();
       navigator.vibrate?.(16);
     }
 
-    function makeColorButton(entry) {
-      const button = document.createElement('button');
-      button.type = 'button';
-      button.className = 'lot-color';
-      button.style.setProperty('--lot-color', entry.value);
-      button.title = entry.name;
-      button.setAttribute('aria-label', entry.name);
-      button.setAttribute('aria-pressed', String(entry.value === selectedColor));
-      button.addEventListener('click', () => {
-        selectedColor = entry.value;
-        const selectedRoot = carRoots.get(selectedCarId);
-        if (selectedRoot) applyLotCarPresentation(selectedRoot, true, selectedColor);
-        viewer.recolor(selectedColor);
-        colors.querySelectorAll('.lot-color').forEach((colorButton) => {
-          colorButton.setAttribute('aria-pressed', String(colorButton === button));
-        });
-      });
-      return button;
+    function makeColorInput({ label, value, secondary = false, onInput }) {
+      const control = document.createElement('label');
+      control.className = 'lot-color-control';
+
+      const name = document.createElement('span');
+      name.textContent = label.toUpperCase();
+
+      const input = document.createElement('input');
+      input.type = 'color';
+      input.className = 'lot-color-input';
+      input.value = secondary
+        ? normalizeVehicleSecondaryColor(value)
+        : normalizeVehicleColor(value);
+      input.setAttribute('aria-label', `Choose ${label.toLowerCase()} colour`);
+      input.addEventListener('input', () => onInput(input.value));
+
+      control.append(name, input);
+      return control;
+    }
+
+    function applySelectedPaint() {
+      const selectedRoot = carRoots.get(selectedCarId);
+      if (selectedRoot) {
+        applyLotCarPresentation(selectedRoot, true, selectedColor, selectedSecondaryColor);
+      }
+      viewer.recolor(selectedColor, selectedSecondaryColor);
     }
 
     renderer.domElement.addEventListener('pointerdown', (event) => {
@@ -230,7 +269,11 @@ export function showTheLot({ initialSelection } = {}) {
       viewer.resize();
     });
 
-    raceButton.addEventListener('click', () => finish({ carId: selectedCarId, color: selectedColor }));
+    raceButton.addEventListener('click', () => finish({
+      carId: selectedCarId,
+      color: selectedColor,
+      secondaryColor: selectedSecondaryColor
+    }));
     backButton.addEventListener('click', () => finish(null));
 
     const resizeObserver = new ResizeObserver(() => resize());
@@ -311,6 +354,8 @@ function createViewer(host) {
 
   let visual = null;
   let generation = 0;
+  let currentColor = DEFAULT_VEHICLE_COLOR;
+  let currentSecondaryColor = DEFAULT_VEHICLE_SECONDARY_COLOR;
   let yaw = VIEWER_INITIAL_YAW;
   let pitch = 0.08;
   let dragging = false;
@@ -348,12 +393,15 @@ function createViewer(host) {
 
   return {
     renderer,
-    async show(carId, color) {
+    async show(carId, color, secondaryColor) {
       const request = ++generation;
+      currentColor = normalizeVehicleColor(color);
+      currentSecondaryColor = normalizeVehicleSecondaryColor(secondaryColor);
       try {
         const next = await createCarVisual({
           carId,
-          color,
+          color: currentColor,
+          secondaryColor: currentSecondaryColor,
           targetLength: 6.4,
           outline: true
         });
@@ -361,14 +409,17 @@ function createViewer(host) {
         if (visual) stage.remove(visual);
         visual = next;
         stage.add(visual);
+        recolorCarVisual(visual, currentColor, currentSecondaryColor);
         yaw = VIEWER_INITIAL_YAW;
         pitch = 0.08;
       } catch (error) {
         console.warn('TURN: selected car could not load in the 3D viewer.', error);
       }
     },
-    recolor(color) {
-      if (visual) recolorCarVisual(visual, color);
+    recolor(color, secondaryColor) {
+      currentColor = normalizeVehicleColor(color);
+      currentSecondaryColor = normalizeVehicleSecondaryColor(secondaryColor);
+      if (visual) recolorCarVisual(visual, currentColor, currentSecondaryColor);
     },
     resize() {
       const rect = host.getBoundingClientRect();
@@ -416,7 +467,7 @@ function rememberMaterialState(root) {
   root.userData.turnLotMaterialState = records;
 }
 
-function applyLotCarPresentation(root, selected, selectedColor) {
+function applyLotCarPresentation(root, selected, selectedColor, selectedSecondaryColor) {
   rememberMaterialState(root);
   const records = root.userData.turnLotMaterialState || [];
 
@@ -438,7 +489,13 @@ function applyLotCarPresentation(root, selected, selectedColor) {
     material.needsUpdate = true;
   }
 
-  if (selected) recolorCarVisual(root, selectedColor || DEFAULT_VEHICLE_COLOR);
+  if (selected) {
+    recolorCarVisual(
+      root,
+      selectedColor || DEFAULT_VEHICLE_COLOR,
+      selectedSecondaryColor || DEFAULT_VEHICLE_SECONDARY_COLOR
+    );
+  }
 }
 
 function makeLotGround(lot) {

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r18 Normalized car orientation -->
+<!-- TURN r19 Native paint controls and secondary accents -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,31 +10,31 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.2 · Build 2026.07.20-r18</title>
+  <title>TURN v1.3.3 · Build 2026.07.20-r19</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.2',
-      id: '2026.07.20-r18',
-      cacheKey: '20260720-r18'
+      version: '1.3.3',
+      id: '2026.07.20-r19',
+      cacheKey: '20260720-r19'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260720-r18">
-  <link rel="stylesheet" href="./styles.css?build=20260720-r18">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260720-r18">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260720-r18">
-  <link rel="stylesheet" href="./install-gate.css?build=20260720-r18">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260720-r18">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260720-r18">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260720-r18">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260720-r18">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260720-r18">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260720-r18">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260720-r18">
+  <link rel="manifest" href="./site.webmanifest?build=20260720-r19">
+  <link rel="stylesheet" href="./styles.css?build=20260720-r19">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260720-r19">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260720-r19">
+  <link rel="stylesheet" href="./install-gate.css?build=20260720-r19">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260720-r19">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260720-r19">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260720-r19">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260720-r19">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260720-r19">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260720-r19">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260720-r19">
 
-  <script src="./install-gate.js?build=20260720-r18"></script>
-  <script src="./orientation-compat.js?build=20260720-r18"></script>
+  <script src="./install-gate.js?build=20260720-r19"></script>
+  <script src="./orientation-compat.js?build=20260720-r19"></script>
   <script type="importmap">
     {
       "imports": {
@@ -52,7 +52,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.2 · Build 2026.07.20-r18</span>
+        <span class="install-kicker">TURN v1.3.3 · Build 2026.07.20-r19</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -80,7 +80,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.2 · Build 2026.07.20-r18</span>
+      <span class="kicker">TURN v1.3.3 · Build 2026.07.20-r19</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -146,6 +146,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260720-r18"></script>
+  <script type="module" src="./app.js?build=20260720-r19"></script>
 </body>
 </html>

--- a/turn/main.js
+++ b/turn/main.js
@@ -2,19 +2,24 @@
 
 import * as THREE from 'three';
 import { installKenneyWorld } from './world-assets.js';
-import { updateRaceCameraState } from './render/camera.js?build=20260720-r18';
-import { updateHudState } from './ui/hud.js?build=20260720-r18';
+import { updateRaceCameraState } from './render/camera.js?build=20260720-r19';
+import { updateHudState } from './ui/hud.js?build=20260720-r19';
 import { motionPoseFromGravity as motionPoseFromGravityState, updateMotionInputState } from './input/motion.js';
-import { updateVehiclePhysicsState } from './vehicle/physics.js?build=20260720-r18';
+import { updateVehiclePhysicsState } from './vehicle/physics.js?build=20260720-r19';
 import { GAME_MODE, installGameModeState, prepareRaceStartState, resetRaceToStage, setGameModeState } from './race/game-state.js';
-import { beginTimedLapState, completeLapState, updateLapProgressState } from './race/lap-system.js';
+import { beginTimedLapState, completeLapState, updateLapProgressState } from './race/lap-system.js?build=20260720-r19';
 import { recordReplayFrame, replayFrameAt } from './race/replay-system.js';
-import { RIVAL_LIMIT, loadRivalsState, saveRivalsState } from './race/rival-storage.js';
-import { createTrackSpatialIndex } from './race/track-spatial-index.js?build=20260720-r18';
-import { showTheLot } from './garage/lot-r10.js?build=20260720-r18';
-import { getCarDefinition, loadVehicleSelection, saveVehicleSelection } from './vehicle/catalog.js?build=20260720-r18';
-import { createCarVisual } from './vehicle/car-models.js?build=20260720-r18';
-import { installPerformanceMonitor, recordPerformanceFrame } from './performance-monitor.js?build=20260720-r18';
+import { RIVAL_LIMIT, loadRivalsState, saveRivalsState } from './race/rival-storage.js?build=20260720-r19';
+import { createTrackSpatialIndex } from './race/track-spatial-index.js?build=20260720-r19';
+import { showTheLot } from './garage/lot-r10.js?build=20260720-r19';
+import {
+  DEFAULT_VEHICLE_SECONDARY_COLOR,
+  getCarDefinition,
+  loadVehicleSelection,
+  saveVehicleSelection
+} from './vehicle/catalog.js?build=20260720-r19';
+import { createCarVisual } from './vehicle/car-models.js?build=20260720-r19';
+import { installPerformanceMonitor, recordPerformanceFrame } from './performance-monitor.js?build=20260720-r19';
 
 const intro = document.querySelector('#intro');
 const hud = document.querySelector('#hud');
@@ -91,6 +96,7 @@ const state = {
   competitorLaps: [],
   vehicleId: initialVehicleSelection.carId,
   vehicleColor: initialVehicleSelection.color,
+  vehicleSecondaryColor: initialVehicleSelection.secondaryColor,
   vehicleTuning: initialVehicleDefinition.tuning,
   lastFrame: performance.now(),
   messageTimer: 0
@@ -445,15 +451,22 @@ const proceduralGhostParts = [...ghostCar.children];
 playerCar.userData.turnProceduralParts = proceduralPlayerParts;
 ghostCar.userData.turnProceduralParts = proceduralGhostParts;
 
-async function installCarVisual(root, { carId, color, ghost = false }) {
-  const key = `${carId}|${color}|${ghost ? 1 : 0}`;
+async function installCarVisual(root, { carId, color, secondaryColor, ghost = false }) {
+  const key = `${carId}|${color}|${secondaryColor}|${ghost ? 1 : 0}`;
   if (root.userData.turnVisualKey === key || root.userData.turnVisualPendingKey === key) return;
 
   const generation = (root.userData.turnVisualGeneration || 0) + 1;
   root.userData.turnVisualGeneration = generation;
   root.userData.turnVisualPendingKey = key;
 
-  const visual = await createCarVisual({ carId, color, ghost, targetLength: 5.5, outline: true });
+  const visual = await createCarVisual({
+    carId,
+    color,
+    secondaryColor,
+    ghost,
+    targetLength: 5.5,
+    outline: true
+  });
   if (root.userData.turnVisualGeneration !== generation) return;
 
   for (const child of [...root.children]) {
@@ -472,6 +485,7 @@ async function applyVehicleSelection(selection) {
   const definition = getCarDefinition(saved.carId);
   state.vehicleId = saved.carId;
   state.vehicleColor = saved.color;
+  state.vehicleSecondaryColor = saved.secondaryColor;
   state.vehicleTuning = definition.tuning;
   globalThis.__turnVehicleTuning = definition.tuning;
 
@@ -479,6 +493,7 @@ async function applyVehicleSelection(selection) {
     await installCarVisual(playerCar, {
       carId: state.vehicleId,
       color: state.vehicleColor,
+      secondaryColor: state.vehicleSecondaryColor,
       ghost: false
     });
   } catch (error) {
@@ -490,6 +505,7 @@ async function applyVehicleSelection(selection) {
 void installCarVisual(playerCar, {
   carId: state.vehicleId,
   color: state.vehicleColor,
+  secondaryColor: state.vehicleSecondaryColor,
   ghost: false
 }).catch((error) => console.warn('TURN: initial selected car failed to load.', error));
 
@@ -527,10 +543,11 @@ function ensureCompetitorCars() {
 async function syncCompetitorVisual(car, lap) {
   const carId = lap.carId || 'sedan';
   const color = lap.carColor || COMPETITOR_MAP_COLORS[competitorCars.indexOf(car)] || '#38d9ff';
+  const secondaryColor = lap.carSecondaryColor || DEFAULT_VEHICLE_SECONDARY_COLOR;
   try {
-    await installCarVisual(car, { carId, color, ghost: true });
+    await installCarVisual(car, { carId, color, secondaryColor, ghost: true });
   } catch (error) {
-    const key = `${carId}|${color}|1`;
+    const key = `${carId}|${color}|${secondaryColor}|1`;
     if (car.userData.turnVisualFailedKey !== key) {
       car.userData.turnVisualFailedKey = key;
       console.warn('TURN: rival car model failed to load, using procedural fallback.', error);
@@ -769,7 +786,11 @@ async function requestMotion() {
 async function chooseVehicleAndStart(fullscreenPromise = Promise.resolve(false)) {
   intro.hidden = true;
   const selection = await showTheLot({
-    initialSelection: { carId: state.vehicleId, color: state.vehicleColor }
+    initialSelection: {
+      carId: state.vehicleId,
+      color: state.vehicleColor,
+      secondaryColor: state.vehicleSecondaryColor
+    }
   });
 
   if (!selection) {
@@ -805,7 +826,11 @@ async function openLotFromRace() {
   publishUiState('lot-open');
 
   const selection = await showTheLot({
-    initialSelection: { carId: state.vehicleId, color: state.vehicleColor }
+    initialSelection: {
+      carId: state.vehicleId,
+      color: state.vehicleColor,
+      secondaryColor: state.vehicleSecondaryColor
+    }
   });
 
   if (!selection) {

--- a/turn/race/lap-system.js
+++ b/turn/race/lap-system.js
@@ -123,6 +123,7 @@ export function completeLapState({
         hitAt: Date.now(),
         carId: state.vehicleId || 'sedan',
         carColor: state.vehicleColor || '#ffd43b',
+        carSecondaryColor: state.vehicleSecondaryColor || '#f8f9fa',
         frames: candidateFrames
       };
 

--- a/turn/race/rival-storage.js
+++ b/turn/race/rival-storage.js
@@ -2,9 +2,11 @@ import { normalizeReplayFrames } from './replay-system.js';
 import {
   DEFAULT_VEHICLE_COLOR,
   DEFAULT_VEHICLE_ID,
+  DEFAULT_VEHICLE_SECONDARY_COLOR,
   normalizeVehicleColor,
-  normalizeVehicleId
-} from '../vehicle/catalog.js';
+  normalizeVehicleId,
+  normalizeVehicleSecondaryColor
+} from '../vehicle/catalog.js?build=20260720-r19';
 
 export const RIVAL_LIMIT = 4;
 
@@ -15,7 +17,7 @@ const LEGACY_RIVAL_COLORS = ['#38d9ff', '#ff4fa3', '#9775fa', '#ff922b'];
 export function saveRivalsState(state) {
   try {
     localStorage.setItem(COMPETITOR_KEY, JSON.stringify({
-      version: 3,
+      version: 4,
       laps: state.competitorLaps
     }));
     return true;
@@ -42,6 +44,7 @@ export function loadRivalsState({ state, samples, findNearestTrack }) {
           hitAt: null,
           carId: DEFAULT_VEHICLE_ID,
           carColor: DEFAULT_VEHICLE_COLOR,
+          carSecondaryColor: DEFAULT_VEHICLE_SECONDARY_COLOR,
           frames: oldGhost.frames
         }];
       }
@@ -59,6 +62,7 @@ export function loadRivalsState({ state, samples, findNearestTrack }) {
         carColor: lap.carColor
           ? normalizeVehicleColor(lap.carColor)
           : LEGACY_RIVAL_COLORS[index % LEGACY_RIVAL_COLORS.length],
+        carSecondaryColor: normalizeVehicleSecondaryColor(lap.carSecondaryColor),
         frames: normalizeReplayFrames(lap.frames, { startSample, findProgress })
       }))
       .sort((a, b) => a.time - b.time)

--- a/turn/vehicle/car-models.js
+++ b/turn/vehicle/car-models.js
@@ -1,6 +1,12 @@
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
-import { getCarDefinition, makeGhostColor, normalizeVehicleColor } from './catalog.js?build=20260720-r18';
+import {
+  DEFAULT_VEHICLE_SECONDARY_COLOR,
+  getCarDefinition,
+  makeGhostColor,
+  normalizeVehicleColor,
+  normalizeVehicleSecondaryColor
+} from './catalog.js?build=20260720-r19';
 
 const loader = new GLTFLoader();
 const sourceCache = new Map();
@@ -14,6 +20,7 @@ export async function preloadCarModels(carIds) {
 export async function createCarVisual({
   carId,
   color,
+  secondaryColor = DEFAULT_VEHICLE_SECONDARY_COLOR,
   ghost = false,
   targetLength = 5.4,
   outline = true
@@ -28,7 +35,9 @@ export async function createCarVisual({
   root.add(model);
 
   const requestedColor = normalizeVehicleColor(color);
+  const requestedSecondaryColor = normalizeVehicleSecondaryColor(secondaryColor);
   const ghostColor = makeGhostColor(requestedColor);
+  const ghostSecondaryColor = makeGhostColor(requestedSecondaryColor);
   const meshRecords = [];
   let explicitPaintCount = 0;
 
@@ -44,6 +53,7 @@ export async function createCarVisual({
         material,
         protected: isProtectedPart(node, material),
         wheel: isWheelPart(node, material),
+        secondaryPaint: isSecondaryPaint(node, car),
         explicitPaint: isExplicitPaint(node, material)
       };
       if (record.explicitPaint && !record.protected) explicitPaintCount += 1;
@@ -51,15 +61,17 @@ export async function createCarVisual({
     });
   });
 
-  const paintMaterials = [];
+  const primaryPaintMaterials = [];
+  const secondaryPaintMaterials = [];
   for (const record of meshRecords) {
     const {
       material,
       protected: protectedPart,
       wheel: wheelPart,
+      secondaryPaint,
       explicitPaint
     } = record;
-    const paintable = !protectedPart && (
+    const paintable = !protectedPart && !secondaryPaint && (
       explicitPaint ||
       (explicitPaintCount === 0 && isFallbackPaintCandidate(material)) ||
       (car.pack !== 'car' && isFallbackPaintCandidate(material))
@@ -70,9 +82,12 @@ export async function createCarVisual({
       // remain visually grounded instead of inheriting white or body paint.
       material.color.setHex(TIRE_COLOR);
       if ('roughness' in material) material.roughness = Math.max(Number(material.roughness) || 0, 0.82);
+    } else if (secondaryPaint && !protectedPart && material.color) {
+      material.color.set(ghost ? ghostSecondaryColor : requestedSecondaryColor);
+      secondaryPaintMaterials.push(material);
     } else if (paintable && material.color) {
       material.color.set(ghost ? ghostColor : requestedColor);
-      paintMaterials.push(material);
+      primaryPaintMaterials.push(material);
     }
 
     // Personal rivals are solid cars. Their identity comes from the lighter body colour,
@@ -95,22 +110,33 @@ export async function createCarVisual({
 
   root.userData.turnCarId = car.id;
   root.userData.turnCarColor = requestedColor;
+  root.userData.turnCarSecondaryColor = requestedSecondaryColor;
   root.userData.turnGhost = ghost;
   root.userData.turnModelYawQuarterTurns = car.modelYawQuarterTurns;
-  root.userData.turnPaintMaterials = paintMaterials;
+  root.userData.turnPrimaryPaintMaterials = primaryPaintMaterials;
+  root.userData.turnSecondaryPaintMaterials = secondaryPaintMaterials;
+  root.userData.turnPaintMaterials = [...primaryPaintMaterials, ...secondaryPaintMaterials];
   root.userData.frontWheelPivots = [];
   root.userData.wheelSpinners = [];
   return root;
 }
 
-export function recolorCarVisual(root, color) {
+export function recolorCarVisual(root, color, secondaryColor = root?.userData?.turnCarSecondaryColor) {
   const normalized = normalizeVehicleColor(color);
+  const normalizedSecondary = normalizeVehicleSecondaryColor(secondaryColor);
   const ghost = Boolean(root?.userData?.turnGhost);
   const displayColor = ghost ? makeGhostColor(normalized) : normalized;
-  for (const material of root?.userData?.turnPaintMaterials || []) {
+  const displaySecondary = ghost ? makeGhostColor(normalizedSecondary) : normalizedSecondary;
+  for (const material of root?.userData?.turnPrimaryPaintMaterials || []) {
     material.color?.set(displayColor);
   }
-  if (root?.userData) root.userData.turnCarColor = normalized;
+  for (const material of root?.userData?.turnSecondaryPaintMaterials || []) {
+    material.color?.set(displaySecondary);
+  }
+  if (root?.userData) {
+    root.userData.turnCarColor = normalized;
+    root.userData.turnCarSecondaryColor = normalizedSecondary;
+  }
 }
 
 async function loadCarSource(carId) {
@@ -175,6 +201,11 @@ function isProtectedPart(node, material) {
 function isWheelPart(node, material) {
   const label = `${node.name || ''} ${material.name || ''}`.toLowerCase();
   return /wheel|tire|tyre|rubber/.test(label);
+}
+
+function isSecondaryPaint(node, car) {
+  const name = String(node?.name || '').toLowerCase();
+  return (car.secondaryPaint?.meshNames || []).includes(name);
 }
 
 function isExplicitPaint(node, material) {

--- a/turn/vehicle/catalog.js
+++ b/turn/vehicle/catalog.js
@@ -1,5 +1,6 @@
 export const DEFAULT_VEHICLE_ID = 'sedan';
 export const DEFAULT_VEHICLE_COLOR = '#ffd43b';
+export const DEFAULT_VEHICLE_SECONDARY_COLOR = '#f8f9fa';
 export const VEHICLE_SELECTION_KEY = 'turn-vehicle-selection-v1';
 export const VEHICLE_STAT_BUDGET = 18;
 
@@ -36,6 +37,15 @@ const RAW_CARS = [
   ['van', 'Van', 'car', { speed: 2, acceleration: 3, control: 3, drift: 5, boostPower: 1, boostDuration: 4 }, 1.08, 0]
 ];
 
+// The current GLBs use one atlas material per mesh. Roofs are part of the body mesh,
+// while Sport Sedan's spoiler is the one safe, separately addressable paint surface.
+const SECONDARY_PAINT_BY_ID = Object.freeze({
+  'sedan-sports': Object.freeze({
+    label: 'Spoiler',
+    meshNames: Object.freeze(['spoiler'])
+  })
+});
+
 export const CAR_CATALOG = Object.freeze(RAW_CARS.map(([
   id,
   name,
@@ -51,11 +61,12 @@ export const CAR_CATALOG = Object.freeze(RAW_CARS.map(([
   stats: Object.freeze({ ...stats }),
   visualScale,
   modelYawQuarterTurns,
+  secondaryPaint: SECONDARY_PAINT_BY_ID[id] || null,
   tuning: Object.freeze(deriveVehicleTuning(stats))
 })));
 
 const CAR_BY_ID = new Map(CAR_CATALOG.map((car) => [car.id, car]));
-const PALETTE_VALUES = new Set(CAR_PALETTE.map((color) => color.value.toLowerCase()));
+const HEX_COLOR_PATTERN = /^#[0-9a-f]{6}$/;
 
 export function getCarDefinition(id) {
   return CAR_BY_ID.get(id) || CAR_BY_ID.get(DEFAULT_VEHICLE_ID);
@@ -67,13 +78,19 @@ export function normalizeVehicleId(id) {
 
 export function normalizeVehicleColor(color) {
   const value = typeof color === 'string' ? color.toLowerCase() : '';
-  return PALETTE_VALUES.has(value) ? value : DEFAULT_VEHICLE_COLOR;
+  return HEX_COLOR_PATTERN.test(value) ? value : DEFAULT_VEHICLE_COLOR;
+}
+
+export function normalizeVehicleSecondaryColor(color) {
+  const value = typeof color === 'string' ? color.toLowerCase() : '';
+  return HEX_COLOR_PATTERN.test(value) ? value : DEFAULT_VEHICLE_SECONDARY_COLOR;
 }
 
 export function normalizeVehicleSelection(selection) {
   return {
     carId: normalizeVehicleId(selection?.carId),
-    color: normalizeVehicleColor(selection?.color)
+    color: normalizeVehicleColor(selection?.color),
+    secondaryColor: normalizeVehicleSecondaryColor(selection?.secondaryColor)
   };
 }
 


### PR DESCRIPTION
## Sammanfattning

- ersätter de egenbyggda färgknapparna i The Lot med webbläsarens/OS:ets `input type="color"`
- accepterar valfri sexsiffrig hex-färg och sparar valet bakåtkompatibelt
- lägger till en separat **SPOILER**-väljare för Sport Sedan, vars spoiler är en egen mesh
- för sekundärfärgen genom bilval, race, varvspöken och sparade rivaler
- migrerar äldre sparade rivaler automatiskt till standardsfärg
- uppdaterar TURN till **v1.3.3 · Build 2026.07.20-r19**

## Modellbegränsning

I de övriga nuvarande GLB-modellerna är tak och chassi samma mesh/material. Därför visas ingen vilseledande sekundärväljare för dem. En takfärg kräver att respektive modell delas upp eller får separat material.

## Verifiering

- full TURN-regressionssvit
- produktionsprov för alla 15 bilmodellers orientering
- nytt produktionsprov för native color input, fri hex-färg, persistence och Sport Sedans separata spoiler-mesh
- drive pad/reverse, in-game menu, garage, checkpoints/balans, arkitektur och prestandabudget
- syntaxkontroll av samtliga JS/MJS-filer samt `git diff --check`

Ingen ändring av fysik, bilbalans eller banlogik.