### PR TITLE
TURN v1.3.4 r20: Preserve Lot outlines and add boost bar feedback

### DIFF
--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -64,7 +64,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.3 · Build 2026\.07\.20-r19/);
+assert.match(index, /TURN v1\.3\.4 · Build 2026\.07\.20-r20/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -36,16 +36,18 @@ class Vec3 {
   }
 }
 
-const [index, controls, css, analogGas, spectate] = await Promise.all([
+const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/ui/gameplay-controls.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/drive-pad.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/gameplay-v2.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/input/analog-gas.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.3 · Build 2026\.07\.20-r19/);
-assert.match(index, /drive-pad\.css\?build=20260720-r19/);
+assert.match(index, /TURN v1\.3\.4 · Build 2026\.07\.20-r20/);
+assert.match(index, /drive-pad\.css\?build=20260720-r20/);
+assert.match(index, /gameplay-v2\.css\?build=20260720-r20/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');
@@ -59,6 +61,19 @@ assert.match(css, /\.drive-pad \{/);
 assert.match(css, /place-items: center/, 'Gas label must be vertically and horizontally centered');
 assert.match(css, /content: "LEAVE"/, 'Boost lock hint must explain that leaving the Boost zone re-arms it');
 assert.match(css, /\.brake-reverse \{/);
+assert.match(
+  gameplayCss,
+  /\.boost-hud\[style\*="--boost-charge: 100\.0%"\]/,
+  'Boost HUD must react when recharge reaches full capacity'
+);
+assert.match(
+  gameplayCss,
+  /\.boost-hud\[style\*="--boost-charge: 0\.0%"\]/,
+  'Boost HUD must react distinctly when the tank becomes empty'
+);
+assert.match(gameplayCss, /@keyframes turn-boost-full-flash/, 'Full boost feedback must have its own animation');
+assert.match(gameplayCss, /@keyframes turn-boost-empty-flash/, 'Empty boost feedback must have a distinct animation');
+assert.match(gameplayCss, /prefers-reduced-motion: reduce/, 'Boost feedback must respect reduced-motion preferences');
 assert.doesNotMatch(analogGas, /pointerdown/, 'Legacy analog gas pointer handling must stay retired');
 assert.doesNotMatch(spectate, /updateBoostZoneHaptic/, 'Spectator UI must not own obsolete gas-zone pointer state');
 

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -57,20 +57,16 @@ assert.match(controls, /boostRequested = nextZone === 'boost'/, 'Boost zone must
 assert.match(controls, /boostRequested && !boostExhausted/, 'Boost must stay locked while the thumb remains in Boost after exhaustion');
 assert.match(controls, /previousZone === 'boost' && nextZone !== 'boost'\) boostExhausted = false/, 'Leaving Boost for Gas or Drift must re-arm Boost without requiring pointer release');
 assert.match(controls, /Brake · Reverse/, 'Separate brake control must advertise reverse');
+assert.match(controls, /becameEmpty = previousBoostCharge > 0\.001 && boostCharge <= 0\.001/, 'Empty feedback must trigger on the actual depletion transition');
+assert.match(controls, /becameFull = previousBoostCharge < 0\.999 && boostCharge >= 0\.999/, 'Full feedback must trigger only when recharge crosses the full threshold');
+assert.match(controls, /flashBoostHud\('is-boost-empty-flash'\)/, 'Empty boost must trigger its distinct HUD feedback class');
+assert.match(controls, /flashBoostHud\('is-boost-full-flash'\)/, 'Full boost must trigger its distinct HUD feedback class');
 assert.match(css, /\.drive-pad \{/);
 assert.match(css, /place-items: center/, 'Gas label must be vertically and horizontally centered');
 assert.match(css, /content: "LEAVE"/, 'Boost lock hint must explain that leaving the Boost zone re-arms it');
 assert.match(css, /\.brake-reverse \{/);
-assert.match(
-  gameplayCss,
-  /\.boost-hud\[style\*="--boost-charge: 100\.0%"\]/,
-  'Boost HUD must react when recharge reaches full capacity'
-);
-assert.match(
-  gameplayCss,
-  /\.boost-hud\[style\*="--boost-charge: 0\.0%"\]/,
-  'Boost HUD must react distinctly when the tank becomes empty'
-);
+assert.match(gameplayCss, /\.boost-hud\.is-boost-full-flash/, 'Boost HUD must visibly react when recharge reaches full capacity');
+assert.match(gameplayCss, /\.boost-hud\.is-boost-empty-flash/, 'Boost HUD must react distinctly when the tank becomes empty');
 assert.match(gameplayCss, /@keyframes turn-boost-full-flash/, 'Full boost feedback must have its own animation');
 assert.match(gameplayCss, /@keyframes turn-boost-empty-flash/, 'Empty boost feedback must have a distinct animation');
 assert.match(gameplayCss, /prefers-reduced-motion: reduce/, 'Boost feedback must respect reduced-motion preferences');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -75,8 +75,8 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.3 · Build 2026\.07\.20-r19/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260720-r19/);
+assert.match(index, /TURN v1\.3\.4 · Build 2026\.07\.20-r20/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260720-r20/);
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');
 assert.match(main, /vehicleTuning: state\.vehicleTuning/, 'Selected handling profile must reach physics');
@@ -96,6 +96,8 @@ const lotR10 = await fs.readFile(path.join(turnDir, 'garage/lot-r10.js'), 'utf8'
 const lotR10Css = await fs.readFile(path.join(turnDir, 'garage/lot-r10.css'), 'utf8');
 assert.match(main, /garage\/lot-r10\.js/, 'Production must load the r10 Lot module');
 assert.match(lotR10, /MUTED_COLOR/, 'Unselected Lot cars must have a muted visual state');
+assert.match(lotR10, /if \(selected \|\| record\.outline\)/, 'Unselected Lot cars must preserve their original outline materials');
+assert.doesNotMatch(lotR10, /record\.outline \? 0\.18/, 'Lot outlines must not become translucent when a car is unselected');
 assert.match(lotR10, /selectedColor = selection\.color/, 'The Lot must restore the selected native body colour');
 assert.match(lotR10, /selectedSecondaryColor = selection\.secondaryColor/, 'The Lot must restore secondary paint');
 assert.match(lotR10, /lot-viewbox/, 'The Lot must include a dedicated 3D car viewbox');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -38,8 +38,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.3 · Build 2026\.07\.20-r19/);
-assert.match(index, /in-game-menu\.css\?build=20260720-r19/);
+assert.match(index, /TURN v1\.3\.4 · Build 2026\.07\.20-r20/);
+assert.match(index, /in-game-menu\.css\?build=20260720-r20/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Back to Start<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -26,7 +26,7 @@ const css = await fs.readFile(new URL('../../turn/manual-steering.css', import.m
 
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260720-r19/);
+assert.match(index, /manual-steering\.css\?build=20260720-r20/);
 assert.match(css, /--manual-steer-left/);
 assert.match(css, /content: "←"/);
 assert.match(css, /content: "→"/);

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -48,7 +48,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.3 · Build 2026\.07\.20-r19/);
+assert.match(index, /TURN v1\.3\.4 · Build 2026\.07\.20-r20/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -85,7 +85,7 @@ const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, m
   fs.readFile(new URL('../../turn/performance-monitor.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.3 · Build 2026\.07\.20-r19/);
+assert.match(index, /TURN v1\.3\.4 · Build 2026\.07\.20-r20/);
 assert.match(main, /mainSceneOcclusion/);
 assert.match(main, /HUD_UPDATE_INTERVAL_MS = 1000 \/ 30/);
 assert.match(main, /recordPerformanceFrame/);

--- a/turn/gameplay-v2.css
+++ b/turn/gameplay-v2.css
@@ -88,19 +88,19 @@
   background: linear-gradient(90deg, #38d9ff, #8ce99a);
 }
 
-.boost-hud[style*="--boost-charge: 100.0%"] {
+.boost-hud.is-boost-full-flash {
   animation: turn-boost-full-flash 520ms cubic-bezier(.16,.82,.24,1);
 }
 
-.boost-hud[style*="--boost-charge: 100.0%"] > div {
+.boost-hud.is-boost-full-flash > div {
   animation: turn-boost-full-bar-flash 520ms ease-out;
 }
 
-.boost-hud[style*="--boost-charge: 0.0%"] {
+.boost-hud.is-boost-empty-flash {
   animation: turn-boost-empty-flash 620ms cubic-bezier(.28,.78,.34,1);
 }
 
-.boost-hud[style*="--boost-charge: 0.0%"] > div {
+.boost-hud.is-boost-empty-flash > div {
   animation: turn-boost-empty-bar-flash 620ms ease-out;
 }
 
@@ -154,8 +154,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .boost-hud[style*="--boost-charge: 100.0%"],
-  .boost-hud[style*="--boost-charge: 0.0%"] {
+  .boost-hud.is-boost-full-flash,
+  .boost-hud.is-boost-empty-flash {
     animation: none;
   }
 }

--- a/turn/gameplay-v2.css
+++ b/turn/gameplay-v2.css
@@ -88,6 +88,78 @@
   background: linear-gradient(90deg, #38d9ff, #8ce99a);
 }
 
+.boost-hud[style*="--boost-charge: 100.0%"] {
+  animation: turn-boost-full-flash 520ms cubic-bezier(.16,.82,.24,1);
+}
+
+.boost-hud[style*="--boost-charge: 100.0%"] > div {
+  animation: turn-boost-full-bar-flash 520ms ease-out;
+}
+
+.boost-hud[style*="--boost-charge: 0.0%"] {
+  animation: turn-boost-empty-flash 620ms cubic-bezier(.28,.78,.34,1);
+}
+
+.boost-hud[style*="--boost-charge: 0.0%"] > div {
+  animation: turn-boost-empty-bar-flash 620ms ease-out;
+}
+
+@keyframes turn-boost-full-flash {
+  0%, 100% { transform: translateX(-50%) rotate(-1deg) scale(1); }
+  24% { transform: translateX(-50%) rotate(2deg) scale(1.2); }
+  52% { transform: translateX(-50%) rotate(-2deg) scale(1.08); }
+  76% { transform: translateX(-50%) rotate(1deg) scale(1.14); }
+}
+
+@keyframes turn-boost-full-bar-flash {
+  0%, 100% {
+    background: rgb(255 248 232 / 0.82);
+    box-shadow: 3px 3px 0 var(--ink);
+  }
+  28%, 72% {
+    background: #fff6a8;
+    box-shadow:
+      3px 3px 0 var(--ink),
+      0 0 0 7px rgb(56 217 255 / 0.5),
+      0 0 22px 10px rgb(255 212 59 / 0.58);
+  }
+  48% {
+    background: #ffffff;
+  }
+}
+
+@keyframes turn-boost-empty-flash {
+  0%, 100% { transform: translateX(-50%) rotate(-1deg); }
+  14% { transform: translateX(calc(-50% - 7px)) rotate(-5deg); }
+  28% { transform: translateX(calc(-50% + 7px)) rotate(4deg); }
+  42% { transform: translateX(calc(-50% - 5px)) rotate(-4deg); }
+  56% { transform: translateX(calc(-50% + 4px)) rotate(3deg); }
+  72% { transform: translateX(calc(-50% - 2px)) rotate(-2deg); }
+}
+
+@keyframes turn-boost-empty-bar-flash {
+  0%, 100% {
+    background: rgb(255 248 232 / 0.82);
+    box-shadow: 3px 3px 0 var(--ink);
+  }
+  18%, 54% {
+    background: #ff5a5f;
+    box-shadow:
+      3px 3px 0 var(--ink),
+      0 0 0 6px rgb(255 90 95 / 0.48);
+  }
+  36%, 72% {
+    background: #fff8e8;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .boost-hud[style*="--boost-charge: 100.0%"],
+  .boost-hud[style*="--boost-charge: 0.0%"] {
+    animation: none;
+  }
+}
+
 .race-position-hud {
   position: absolute;
   left: 38%;

--- a/turn/garage/lot-r10.js
+++ b/turn/garage/lot-r10.js
@@ -8,9 +8,9 @@ import {
   normalizeVehicleColor,
   normalizeVehicleSecondaryColor,
   normalizeVehicleSelection
-} from '../vehicle/catalog.js?build=20260720-r19';
-import { createCarVisual, recolorCarVisual } from '../vehicle/car-models.js?build=20260720-r19';
-import { recordPerformanceFrame } from '../performance-monitor.js?build=20260720-r19';
+} from '../vehicle/catalog.js?build=20260720-r20';
+import { createCarVisual, recolorCarVisual } from '../vehicle/car-models.js?build=20260720-r20';
+import { recordPerformanceFrame } from '../performance-monitor.js?build=20260720-r20';
 
 const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
 const lotLoader = new GLTFLoader();
@@ -473,17 +473,17 @@ function applyLotCarPresentation(root, selected, selectedColor, selectedSecondar
 
   for (const record of records) {
     const { material } = record;
-    if (selected) {
+    if (selected || record.outline) {
       material.transparent = record.transparent;
       material.opacity = record.opacity;
       material.depthWrite = record.depthWrite;
       if (!record.paint && record.color && material.color) material.color.copy(record.color);
     } else {
       material.transparent = true;
-      material.opacity = record.outline ? 0.18 : 0.46;
+      material.opacity = 0.46;
       material.depthWrite = false;
       if (record.color && material.color) {
-        material.color.copy(record.color).lerp(MUTED_COLOR, record.outline ? 0.3 : 0.88);
+        material.color.copy(record.color).lerp(MUTED_COLOR, 0.88);
       }
     }
     material.needsUpdate = true;

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r19 Native paint controls and secondary accents -->
+<!-- TURN r20 Lot outlines and boost bar feedback -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,31 +10,31 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.3 · Build 2026.07.20-r19</title>
+  <title>TURN v1.3.4 · Build 2026.07.20-r20</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.3',
-      id: '2026.07.20-r19',
-      cacheKey: '20260720-r19'
+      version: '1.3.4',
+      id: '2026.07.20-r20',
+      cacheKey: '20260720-r20'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260720-r19">
-  <link rel="stylesheet" href="./styles.css?build=20260720-r19">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260720-r19">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260720-r19">
-  <link rel="stylesheet" href="./install-gate.css?build=20260720-r19">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260720-r19">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260720-r19">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260720-r19">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260720-r19">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260720-r19">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260720-r19">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260720-r19">
+  <link rel="manifest" href="./site.webmanifest?build=20260720-r20">
+  <link rel="stylesheet" href="./styles.css?build=20260720-r20">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260720-r20">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260720-r20">
+  <link rel="stylesheet" href="./install-gate.css?build=20260720-r20">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260720-r20">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260720-r20">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260720-r20">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260720-r20">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260720-r20">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260720-r20">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260720-r20">
 
-  <script src="./install-gate.js?build=20260720-r19"></script>
-  <script src="./orientation-compat.js?build=20260720-r19"></script>
+  <script src="./install-gate.js?build=20260720-r20"></script>
+  <script src="./orientation-compat.js?build=20260720-r20"></script>
   <script type="importmap">
     {
       "imports": {
@@ -52,7 +52,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.3 · Build 2026.07.20-r19</span>
+        <span class="install-kicker">TURN v1.3.4 · Build 2026.07.20-r20</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -80,7 +80,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.3 · Build 2026.07.20-r19</span>
+      <span class="kicker">TURN v1.3.4 · Build 2026.07.20-r20</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -146,6 +146,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260720-r19"></script>
+  <script type="module" src="./app.js?build=20260720-r20"></script>
 </body>
 </html>

--- a/turn/ui/gameplay-controls.js
+++ b/turn/ui/gameplay-controls.js
@@ -128,6 +128,8 @@ function installGameplayUi() {
   let boostRequested = false;
   let boostExhausted = false;
   let boostCharge = 1;
+  let previousBoostCharge = boostCharge;
+  let boostFlashTimer = 0;
   let previousTime = performance.now();
   const TOP_ZONE_SHARE = 0.42;
   const DEFAULT_BOOST_DRAIN_SECONDS = 2.0;
@@ -146,6 +148,17 @@ function installGameplayUi() {
     try {
       navigator.vibrate?.(pattern);
     } catch (_) {}
+  }
+
+  function flashBoostHud(className) {
+    window.clearTimeout(boostFlashTimer);
+    boostHud.classList.remove('is-boost-full-flash', 'is-boost-empty-flash');
+    void boostHud.offsetWidth;
+    boostHud.classList.add(className);
+    boostFlashTimer = window.setTimeout(() => {
+      boostHud.classList.remove(className);
+      boostFlashTimer = 0;
+    }, 700);
   }
 
   function getBoostDrainSeconds() {
@@ -307,6 +320,10 @@ function installGameplayUi() {
       boostCharge = Math.min(1, boostCharge + dt * rechargeMultiplier / BOOST_RECHARGE_SECONDS);
     }
 
+    const becameEmpty = previousBoostCharge > 0.001 && boostCharge <= 0.001;
+    const becameFull = previousBoostCharge < 0.999 && boostCharge >= 0.999;
+    previousBoostCharge = boostCharge;
+
     const boosting = boostRequested && !boostExhausted && boostCharge > 0.001;
     globalThis.__turnBoostActive = boosting;
     globalThis.__turnBoostCharge = boostCharge;
@@ -325,6 +342,8 @@ function installGameplayUi() {
       boostVisualDirty = true;
       return;
     }
+    if (becameEmpty) flashBoostHud('is-boost-empty-flash');
+    else if (becameFull) flashBoostHud('is-boost-full-flash');
     if (!boostVisualDirty && !stateChanged && !visualDue) return;
 
     if (boostVisualDirty || boosting !== publishedBoosting) {


### PR DESCRIPTION
## Summary

- keeps the black outline fully visible on unselected cars in The Lot while retaining the muted/translucent body treatment
- adds a brief celebratory pulse when the boost bar reaches full charge
- adds a visually distinct shake/red flash when the boost tank reaches empty
- respects `prefers-reduced-motion` by removing the movement animation
- bumps TURN to **v1.3.4 · Build 2026.07.20-r20** with fresh top-level asset cache keys

## Implementation notes

The Lot already creates outline geometry for every car. The unselected presentation path was also muting that outline to low opacity and tinting it toward gray. r20 now restores the outline material's original black presentation while only muting the non-outline car materials.

Boost feedback reuses the existing boost update function and charge state. It detects only the two threshold transitions, empty and full, and adds a temporary HUD class for the corresponding CSS animation. This adds no new animation or render loop and allows the empty feedback to finish even though recharge begins immediately afterward.

## Regression coverage

- production garage regression now protects visible outlines for unselected cars
- unified drive-pad regression now protects transition-based full/empty boost feedback and reduced-motion handling
- existing release assertions updated for r20

No physics, boost drain/recharge behavior, boost lockout, brake/reverse behavior, vehicle balance, checkpoint logic, orientation logic, paint persistence, or spectator behavior is intentionally changed.