### PR TITLE
TURN v1.3.5 r21: Make unselected Lot cars opaque

### DIFF
--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -64,7 +64,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.4 · Build 2026\.07\.20-r20/);
+assert.match(index, /TURN v1\.3\.5 · Build 2026\.07\.20-r21/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -45,9 +45,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.4 · Build 2026\.07\.20-r20/);
-assert.match(index, /drive-pad\.css\?build=20260720-r20/);
-assert.match(index, /gameplay-v2\.css\?build=20260720-r20/);
+assert.match(index, /TURN v1\.3\.5 · Build 2026\.07\.20-r21/);
+assert.match(index, /drive-pad\.css\?build=20260720-r21/);
+assert.match(index, /gameplay-v2\.css\?build=20260720-r21/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -75,8 +75,9 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.4 · Build 2026\.07\.20-r20/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260720-r20/);
+assert.match(index, /TURN v1\.3\.5 · Build 2026\.07\.20-r21/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260720-r21/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r21"/, 'r21 must cache-bust the Lot module imported by the current static main graph');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');
 assert.match(main, /vehicleTuning: state\.vehicleTuning/, 'Selected handling profile must reach physics');
@@ -95,9 +96,12 @@ assert.match(carModels, /loadCarSource\(car\.id\)/, 'Car model factory must load
 const lotR10 = await fs.readFile(path.join(turnDir, 'garage/lot-r10.js'), 'utf8');
 const lotR10Css = await fs.readFile(path.join(turnDir, 'garage/lot-r10.css'), 'utf8');
 assert.match(main, /garage\/lot-r10\.js/, 'Production must load the r10 Lot module');
-assert.match(lotR10, /MUTED_COLOR/, 'Unselected Lot cars must have a muted visual state');
+assert.match(lotR10, /UNSELECTED_COLOR = new THREE\.Color\(0xeeeeee\)/, 'Unselected Lot cars must use the requested light gray presentation');
 assert.match(lotR10, /if \(selected \|\| record\.outline\)/, 'Unselected Lot cars must preserve their original outline materials');
-assert.doesNotMatch(lotR10, /record\.outline \? 0\.18/, 'Lot outlines must not become translucent when a car is unselected');
+assert.match(lotR10, /material\.transparent = false/, 'Unselected Lot car surfaces must be opaque to avoid transparent sorting flicker');
+assert.match(lotR10, /material\.opacity = 1/, 'Unselected Lot car surfaces must render at full opacity');
+assert.match(lotR10, /material\.depthWrite = true/, 'Unselected Lot car surfaces must write depth so outlines cannot show through them');
+assert.doesNotMatch(lotR10, /material\.opacity = 0\.46/, 'The retired translucent unselected-car presentation must stay removed');
 assert.match(lotR10, /selectedColor = selection\.color/, 'The Lot must restore the selected native body colour');
 assert.match(lotR10, /selectedSecondaryColor = selection\.secondaryColor/, 'The Lot must restore secondary paint');
 assert.match(lotR10, /lot-viewbox/, 'The Lot must include a dedicated 3D car viewbox');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -38,8 +38,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.4 · Build 2026\.07\.20-r20/);
-assert.match(index, /in-game-menu\.css\?build=20260720-r20/);
+assert.match(index, /TURN v1\.3\.5 · Build 2026\.07\.20-r21/);
+assert.match(index, /in-game-menu\.css\?build=20260720-r21/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Back to Start<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -26,7 +26,7 @@ const css = await fs.readFile(new URL('../../turn/manual-steering.css', import.m
 
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260720-r20/);
+assert.match(index, /manual-steering\.css\?build=20260720-r21/);
 assert.match(css, /--manual-steer-left/);
 assert.match(css, /content: "←"/);
 assert.match(css, /content: "→"/);

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -48,7 +48,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.4 · Build 2026\.07\.20-r20/);
+assert.match(index, /TURN v1\.3\.5 · Build 2026\.07\.20-r21/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -85,7 +85,7 @@ const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, m
   fs.readFile(new URL('../../turn/performance-monitor.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.4 · Build 2026\.07\.20-r20/);
+assert.match(index, /TURN v1\.3\.5 · Build 2026\.07\.20-r21/);
 assert.match(main, /mainSceneOcclusion/);
 assert.match(main, /HUD_UPDATE_INTERVAL_MS = 1000 \/ 30/);
 assert.match(main, /recordPerformanceFrame/);

--- a/turn/garage/lot-r10.js
+++ b/turn/garage/lot-r10.js
@@ -14,7 +14,7 @@ import { recordPerformanceFrame } from '../performance-monitor.js?build=20260720
 
 const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
 const lotLoader = new GLTFLoader();
-const MUTED_COLOR = new THREE.Color(0x9da5ab);
+const UNSELECTED_COLOR = new THREE.Color(0xeeeeee);
 const VIEWER_INITIAL_YAW = Math.PI - 0.55;
 
 export function showTheLot({ initialSelection } = {}) {
@@ -479,12 +479,10 @@ function applyLotCarPresentation(root, selected, selectedColor, selectedSecondar
       material.depthWrite = record.depthWrite;
       if (!record.paint && record.color && material.color) material.color.copy(record.color);
     } else {
-      material.transparent = true;
-      material.opacity = 0.46;
-      material.depthWrite = false;
-      if (record.color && material.color) {
-        material.color.copy(record.color).lerp(MUTED_COLOR, 0.88);
-      }
+      material.transparent = false;
+      material.opacity = 1;
+      material.depthWrite = true;
+      if (material.color) material.color.copy(UNSELECTED_COLOR);
     }
     material.needsUpdate = true;
   }

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r20 Lot outlines and boost bar feedback -->
+<!-- TURN r21 Opaque unselected Lot cars -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,36 +10,37 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.4 · Build 2026.07.20-r20</title>
+  <title>TURN v1.3.5 · Build 2026.07.20-r21</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.4',
-      id: '2026.07.20-r20',
-      cacheKey: '20260720-r20'
+      version: '1.3.5',
+      id: '2026.07.20-r21',
+      cacheKey: '20260720-r21'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260720-r20">
-  <link rel="stylesheet" href="./styles.css?build=20260720-r20">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260720-r20">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260720-r20">
-  <link rel="stylesheet" href="./install-gate.css?build=20260720-r20">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260720-r20">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260720-r20">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260720-r20">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260720-r20">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260720-r20">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260720-r20">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260720-r20">
+  <link rel="manifest" href="./site.webmanifest?build=20260720-r21">
+  <link rel="stylesheet" href="./styles.css?build=20260720-r21">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260720-r21">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260720-r21">
+  <link rel="stylesheet" href="./install-gate.css?build=20260720-r21">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260720-r21">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260720-r21">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260720-r21">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260720-r21">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260720-r21">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260720-r21">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260720-r21">
 
-  <script src="./install-gate.js?build=20260720-r20"></script>
-  <script src="./orientation-compat.js?build=20260720-r20"></script>
+  <script src="./install-gate.js?build=20260720-r21"></script>
+  <script src="./orientation-compat.js?build=20260720-r21"></script>
   <script type="importmap">
     {
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
-        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/"
+        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
+        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-r10.js?build=20260720-r21"
       }
     }
   </script>
@@ -52,7 +53,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.4 · Build 2026.07.20-r20</span>
+        <span class="install-kicker">TURN v1.3.5 · Build 2026.07.20-r21</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -80,7 +81,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.4 · Build 2026.07.20-r20</span>
+      <span class="kicker">TURN v1.3.5 · Build 2026.07.20-r21</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -146,6 +147,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260720-r20"></script>
+  <script type="module" src="./app.js?build=20260720-r21"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- replaces the translucent unselected-car treatment in The Lot with an opaque light gray `#eee` presentation
- keeps the black outline fully visible on every car
- restores normal depth writing for unselected car surfaces so outlines and nearby geometry do not sort through translucent layers
- preserves original materials and selected paint when a car becomes selected again
- bumps TURN to **v1.3.5 · Build 2026.07.20-r21**

## Why

r20 correctly preserved black outlines on unselected cars, but the body surfaces still used `transparent = true`, `opacity = 0.46`, and `depthWrite = false`. With enlarged backface outline geometry around nearby transparent meshes, that can produce depth-sorting flicker on mobile GPUs.

r21 removes that transparent sorting path entirely for unselected cars: non-outline surfaces are rendered opaque in `#eee` with depth writing enabled, while outline materials retain their original black presentation.

## Cache handling

The current production `main.js` still statically references the Lot module with its older r19 query string. r21 adds an exact import-map redirect from that existing module specifier to the r21 URL so the changed Lot module is cache-busted without touching the large working game core.

## Regression coverage

The production garage regression now explicitly protects:

- `#eee` unselected presentation
- opaque materials
- full opacity
- depth writing
- persistent black outline materials
- removal of the old `0.46` translucent treatment
- the r21 Lot module cache redirect

No physics, handling, boost behavior, race state, checkpoints, vehicle balance, orientation, paint persistence, or spectator behavior is changed.