### PR TITLE
TURN v1.3.6 r22: Stabilize car outlines and warm The Lot

### DIFF
--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -64,12 +64,18 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.5 · Build 2026\.07\.20-r21/);
+assert.match(index, /TURN v1\.3\.6 · Build 2026\.07\.20-r22/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,
   'The shared model factory must apply the catalog correction'
 );
+assert.match(carModels, /side: THREE\.BackSide/, 'Car outlines must remain inverted back-face shells');
+assert.match(carModels, /depthTest: true/, 'Car outlines must still respect the body depth buffer');
+assert.match(carModels, /depthWrite: false/, 'Car outlines must not write depth and compete with body surfaces');
+assert.match(carModels, /polygonOffset: true/, 'Car outlines must use a depth offset for stable close surface intersections');
+assert.match(carModels, /polygonOffsetFactor: 1/);
+assert.match(carModels, /polygonOffsetUnits: 1/);
 assert.match(lot, /visual\.rotation\.y = Math\.PI/, 'The Lot must map local -Z to the camera-facing direction');
 assert.match(lot, /VIEWER_INITIAL_YAW = Math\.PI - 0\.55/, 'The viewer must start on the normalized front');
 assert.match(main, /playerCar\.rotation\.y = state\.heading \+ Math\.PI/);

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -45,9 +45,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.5 · Build 2026\.07\.20-r21/);
-assert.match(index, /drive-pad\.css\?build=20260720-r21/);
-assert.match(index, /gameplay-v2\.css\?build=20260720-r21/);
+assert.match(index, /TURN v1\.3\.6 · Build 2026\.07\.20-r22/);
+assert.match(index, /drive-pad\.css\?build=20260720-r22/);
+assert.match(index, /gameplay-v2\.css\?build=20260720-r22/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -75,9 +75,10 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.5 · Build 2026\.07\.20-r21/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260720-r21/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r21"/, 'r21 must cache-bust the Lot module imported by the current static main graph');
+assert.match(index, /TURN v1\.3\.6 · Build 2026\.07\.20-r22/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260720-r22/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r22"/, 'r22 must cache-bust the Lot module imported by the current static main graph');
+assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'r22 must cache-bust the shared car model module imported by the current static main graph');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');
 assert.match(main, /vehicleTuning: state\.vehicleTuning/, 'Selected handling profile must reach physics');
@@ -96,11 +97,13 @@ assert.match(carModels, /loadCarSource\(car\.id\)/, 'Car model factory must load
 const lotR10 = await fs.readFile(path.join(turnDir, 'garage/lot-r10.js'), 'utf8');
 const lotR10Css = await fs.readFile(path.join(turnDir, 'garage/lot-r10.css'), 'utf8');
 assert.match(main, /garage\/lot-r10\.js/, 'Production must load the r10 Lot module');
-assert.match(lotR10, /UNSELECTED_COLOR = new THREE\.Color\(0xeeeeee\)/, 'Unselected Lot cars must use the requested light gray presentation');
+assert.match(lotR10, /UNSELECTED_COLOR = new THREE\.Color\(0xfcf6e7\)/, 'Unselected Lot cars must use the requested warm cream presentation');
+assert.match(lotR10, /car-models\.js\?build=20260720-r22/, 'The Lot must load the r22 outline implementation');
 assert.match(lotR10, /if \(selected \|\| record\.outline\)/, 'Unselected Lot cars must preserve their original outline materials');
-assert.match(lotR10, /material\.transparent = false/, 'Unselected Lot car surfaces must be opaque to avoid transparent sorting flicker');
+assert.match(lotR10, /material\.transparent = false/, 'Unselected Lot car surfaces must remain opaque');
 assert.match(lotR10, /material\.opacity = 1/, 'Unselected Lot car surfaces must render at full opacity');
 assert.match(lotR10, /material\.depthWrite = true/, 'Unselected Lot car surfaces must write depth so outlines cannot show through them');
+assert.doesNotMatch(lotR10, /0xeeeeee/, 'The retired cool gray unselected colour must stay removed');
 assert.doesNotMatch(lotR10, /material\.opacity = 0\.46/, 'The retired translucent unselected-car presentation must stay removed');
 assert.match(lotR10, /selectedColor = selection\.color/, 'The Lot must restore the selected native body colour');
 assert.match(lotR10, /selectedSecondaryColor = selection\.secondaryColor/, 'The Lot must restore secondary paint');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -38,8 +38,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.5 · Build 2026\.07\.20-r21/);
-assert.match(index, /in-game-menu\.css\?build=20260720-r21/);
+assert.match(index, /TURN v1\.3\.6 · Build 2026\.07\.20-r22/);
+assert.match(index, /in-game-menu\.css\?build=20260720-r22/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Back to Start<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -26,7 +26,7 @@ const css = await fs.readFile(new URL('../../turn/manual-steering.css', import.m
 
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260720-r21/);
+assert.match(index, /manual-steering\.css\?build=20260720-r22/);
 assert.match(css, /--manual-steer-left/);
 assert.match(css, /content: "←"/);
 assert.match(css, /content: "→"/);

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -48,7 +48,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.5 · Build 2026\.07\.20-r21/);
+assert.match(index, /TURN v1\.3\.6 · Build 2026\.07\.20-r22/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -85,7 +85,7 @@ const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, m
   fs.readFile(new URL('../../turn/performance-monitor.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.5 · Build 2026\.07\.20-r21/);
+assert.match(index, /TURN v1\.3\.6 · Build 2026\.07\.20-r22/);
 assert.match(main, /mainSceneOcclusion/);
 assert.match(main, /HUD_UPDATE_INTERVAL_MS = 1000 \/ 30/);
 assert.match(main, /recordPerformanceFrame/);

--- a/turn/garage/lot-r10.js
+++ b/turn/garage/lot-r10.js
@@ -9,12 +9,12 @@ import {
   normalizeVehicleSecondaryColor,
   normalizeVehicleSelection
 } from '../vehicle/catalog.js?build=20260720-r20';
-import { createCarVisual, recolorCarVisual } from '../vehicle/car-models.js?build=20260720-r20';
+import { createCarVisual, recolorCarVisual } from '../vehicle/car-models.js?build=20260720-r22';
 import { recordPerformanceFrame } from '../performance-monitor.js?build=20260720-r20';
 
 const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
 const lotLoader = new GLTFLoader();
-const UNSELECTED_COLOR = new THREE.Color(0xeeeeee);
+const UNSELECTED_COLOR = new THREE.Color(0xfcf6e7);
 const VIEWER_INITIAL_YAW = Math.PI - 0.55;
 
 export function showTheLot({ initialSelection } = {}) {

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r21 Opaque unselected Lot cars -->
+<!-- TURN r22 Outline depth stability and warm unselected cars -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,37 +10,38 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.5 · Build 2026.07.20-r21</title>
+  <title>TURN v1.3.6 · Build 2026.07.20-r22</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.5',
-      id: '2026.07.20-r21',
-      cacheKey: '20260720-r21'
+      version: '1.3.6',
+      id: '2026.07.20-r22',
+      cacheKey: '20260720-r22'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260720-r21">
-  <link rel="stylesheet" href="./styles.css?build=20260720-r21">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260720-r21">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260720-r21">
-  <link rel="stylesheet" href="./install-gate.css?build=20260720-r21">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260720-r21">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260720-r21">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260720-r21">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260720-r21">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260720-r21">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260720-r21">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260720-r21">
+  <link rel="manifest" href="./site.webmanifest?build=20260720-r22">
+  <link rel="stylesheet" href="./styles.css?build=20260720-r22">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260720-r22">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260720-r22">
+  <link rel="stylesheet" href="./install-gate.css?build=20260720-r22">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260720-r22">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260720-r22">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260720-r22">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260720-r22">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260720-r22">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260720-r22">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260720-r22">
 
-  <script src="./install-gate.js?build=20260720-r21"></script>
-  <script src="./orientation-compat.js?build=20260720-r21"></script>
+  <script src="./install-gate.js?build=20260720-r22"></script>
+  <script src="./orientation-compat.js?build=20260720-r22"></script>
   <script type="importmap">
     {
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
-        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-r10.js?build=20260720-r21"
+        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-r10.js?build=20260720-r22",
+        "./vehicle/car-models.js?build=20260720-r19": "./vehicle/car-models.js?build=20260720-r22"
       }
     }
   </script>
@@ -53,7 +54,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.5 · Build 2026.07.20-r21</span>
+        <span class="install-kicker">TURN v1.3.6 · Build 2026.07.20-r22</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -81,7 +82,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.5 · Build 2026.07.20-r21</span>
+      <span class="kicker">TURN v1.3.6 · Build 2026.07.20-r22</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -147,6 +148,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260720-r21"></script>
+  <script type="module" src="./app.js?build=20260720-r22"></script>
 </body>
 </html>

--- a/turn/vehicle/car-models.js
+++ b/turn/vehicle/car-models.js
@@ -166,8 +166,12 @@ function addOutlines(model) {
         color: 0x08090a,
         side: THREE.BackSide,
         transparent: false,
-        opacity: 0.82,
-        depthWrite: true
+        opacity: 1,
+        depthTest: true,
+        depthWrite: false,
+        polygonOffset: true,
+        polygonOffsetFactor: 1,
+        polygonOffsetUnits: 1
       })
     );
     outline.scale.setScalar(1.035);


### PR DESCRIPTION
## Summary

- changes unselected Lot cars from cool `#eee` to the requested warm `#FCF6E7`
- stabilizes the shared inverted-hull outline material used by selected and unselected cars
- keeps outline depth testing enabled so body surfaces still occlude internal outline geometry
- disables outline depth writes so the enlarged outline shell cannot poison the depth buffer or compete with the car body
- adds a small positive polygon offset to bias the outline behind nearby body surfaces
- bumps TURN to **v1.3.6 · Build 2026.07.20-r22** and cache-busts both the Lot and shared car-model module

## Flicker theory

The remaining flicker is visible even when the car is selected, which makes the old transparent unselected-car treatment an incomplete explanation. The shared outline implementation uses a 3.5% enlarged back-face shell for every model mesh. Those outline shells currently write depth, so at close intersections between enlarged outline geometry and the original car geometry they can intermittently win the depth test as the camera moves.

r22 keeps the same lightweight outline technique but switches it to the more stable depth behavior: `depthTest: true`, `depthWrite: false`, plus polygon offset. This preserves the silhouette while preventing the outline shell from modifying the depth buffer.

## Regression coverage

- all 15 vehicle orientation coverage remains in place
- outline regression now protects back-face rendering, depth testing, disabled depth writes, and polygon offset
- garage regression protects `#FCF6E7`, opaque unselected surfaces, black outlines, and both r22 cache redirects
- full existing TURN regression suite will run before merge

No physics, boost behavior, controls, vehicle balance, checkpoint logic, race state, paint persistence, or spectator behavior is changed.