### PR TITLE
TURN v1.3.7 r23: Remove Lot selection pad

### DIFF
--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -64,7 +64,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.6 · Build 2026\.07\.20-r22/);
+assert.match(index, /TURN v1\.3\.7 · Build 2026\.07\.20-r23/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -45,9 +45,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.6 · Build 2026\.07\.20-r22/);
-assert.match(index, /drive-pad\.css\?build=20260720-r22/);
-assert.match(index, /gameplay-v2\.css\?build=20260720-r22/);
+assert.match(index, /TURN v1\.3\.7 · Build 2026\.07\.20-r23/);
+assert.match(index, /drive-pad\.css\?build=20260720-r23/);
+assert.match(index, /gameplay-v2\.css\?build=20260720-r23/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -75,10 +75,10 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.6 · Build 2026\.07\.20-r22/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260720-r22/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r22"/, 'r22 must cache-bust the Lot module imported by the current static main graph');
-assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'r22 must cache-bust the shared car model module imported by the current static main graph');
+assert.match(index, /TURN v1\.3\.7 · Build 2026\.07\.20-r23/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260720-r23/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r23"/, 'r23 must cache-bust the Lot module imported by the current static main graph');
+assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');
 assert.match(main, /vehicleTuning: state\.vehicleTuning/, 'Selected handling profile must reach physics');
@@ -97,14 +97,18 @@ assert.match(carModels, /loadCarSource\(car\.id\)/, 'Car model factory must load
 const lotR10 = await fs.readFile(path.join(turnDir, 'garage/lot-r10.js'), 'utf8');
 const lotR10Css = await fs.readFile(path.join(turnDir, 'garage/lot-r10.css'), 'utf8');
 assert.match(main, /garage\/lot-r10\.js/, 'Production must load the r10 Lot module');
-assert.match(lotR10, /UNSELECTED_COLOR = new THREE\.Color\(0xfcf6e7\)/, 'Unselected Lot cars must use the requested warm cream presentation');
-assert.match(lotR10, /car-models\.js\?build=20260720-r22/, 'The Lot must load the r22 outline implementation');
+assert.match(lotR10, /UNSELECTED_COLOR = new THREE\.Color\(0x313131\)/, 'Unselected Lot cars must use #313131');
+assert.match(lotR10, /car-models\.js\?build=20260720-r22/, 'The Lot must keep the r22 outline implementation');
 assert.match(lotR10, /if \(selected \|\| record\.outline\)/, 'Unselected Lot cars must preserve their original outline materials');
 assert.match(lotR10, /material\.transparent = false/, 'Unselected Lot car surfaces must remain opaque');
 assert.match(lotR10, /material\.opacity = 1/, 'Unselected Lot car surfaces must render at full opacity');
-assert.match(lotR10, /material\.depthWrite = true/, 'Unselected Lot car surfaces must write depth so outlines cannot show through them');
+assert.match(lotR10, /material\.depthWrite = true/, 'Unselected Lot car surfaces must write depth');
+assert.doesNotMatch(lotR10, /0xfcf6e7/, 'The retired warm cream unselected colour must stay removed');
 assert.doesNotMatch(lotR10, /0xeeeeee/, 'The retired cool gray unselected colour must stay removed');
 assert.doesNotMatch(lotR10, /material\.opacity = 0\.46/, 'The retired translucent unselected-car presentation must stay removed');
+assert.match(lotR10, /function makeParkingPad\(\) \{\s*return new THREE\.Group\(\);\s*\}/, 'The Lot parking pad must not render a coloured floor fill');
+assert.match(lotR10, /function setParkingPadSelected\(\) \{\}/, 'Selecting a car must not reintroduce the teal parking pad');
+assert.doesNotMatch(lotR10, /new THREE\.PlaneGeometry\(6\.7, 5\.9\)/, 'The retired parking pad fill geometry must stay removed');
 assert.match(lotR10, /selectedColor = selection\.color/, 'The Lot must restore the selected native body colour');
 assert.match(lotR10, /selectedSecondaryColor = selection\.secondaryColor/, 'The Lot must restore secondary paint');
 assert.match(lotR10, /lot-viewbox/, 'The Lot must include a dedicated 3D car viewbox');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -38,8 +38,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.6 · Build 2026\.07\.20-r22/);
-assert.match(index, /in-game-menu\.css\?build=20260720-r22/);
+assert.match(index, /TURN v1\.3\.7 · Build 2026\.07\.20-r23/);
+assert.match(index, /in-game-menu\.css\?build=20260720-r23/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Back to Start<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -26,7 +26,7 @@ const css = await fs.readFile(new URL('../../turn/manual-steering.css', import.m
 
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260720-r22/);
+assert.match(index, /manual-steering\.css\?build=20260720-r23/);
 assert.match(css, /--manual-steer-left/);
 assert.match(css, /content: "←"/);
 assert.match(css, /content: "→"/);

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -48,7 +48,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.6 · Build 2026\.07\.20-r22/);
+assert.match(index, /TURN v1\.3\.7 · Build 2026\.07\.20-r23/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -85,7 +85,7 @@ const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, m
   fs.readFile(new URL('../../turn/performance-monitor.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.6 · Build 2026\.07\.20-r22/);
+assert.match(index, /TURN v1\.3\.7 · Build 2026\.07\.20-r23/);
 assert.match(main, /mainSceneOcclusion/);
 assert.match(main, /HUD_UPDATE_INTERVAL_MS = 1000 \/ 30/);
 assert.match(main, /recordPerformanceFrame/);

--- a/turn/garage/lot-r10.js
+++ b/turn/garage/lot-r10.js
@@ -526,28 +526,11 @@ function makeLotGround(lot) {
   lot.add(centerLine);
 }
 
-function makeParkingPad(selected) {
-  const group = new THREE.Group();
-  const mesh = new THREE.Mesh(
-    new THREE.PlaneGeometry(6.7, 5.9),
-    new THREE.MeshBasicMaterial({
-      color: selected ? 0x38d9ff : 0x61676d,
-      transparent: true,
-      opacity: selected ? 0.5 : 0.22
-    })
-  );
-  mesh.rotation.x = -Math.PI / 2;
-  group.add(mesh);
-  group.userData.turnPadMesh = mesh;
-  return group;
+function makeParkingPad() {
+  return new THREE.Group();
 }
 
-function setParkingPadSelected(platform, selected) {
-  const mesh = platform.userData.turnPadMesh;
-  if (!mesh) return;
-  mesh.material.color.set(selected ? 0x38d9ff : 0x61676d);
-  mesh.material.opacity = selected ? 0.5 : 0.22;
-}
+function setParkingPadSelected() {}
 
 function findCarId(object) {
   let node = object;

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r22 Outline depth stability and warm unselected cars -->
+<!-- TURN r23 Lot floor cleanup and dark unselected cars -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,37 +10,37 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.6 · Build 2026.07.20-r22</title>
+  <title>TURN v1.3.7 · Build 2026.07.20-r23</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.6',
-      id: '2026.07.20-r22',
-      cacheKey: '20260720-r22'
+      version: '1.3.7',
+      id: '2026.07.20-r23',
+      cacheKey: '20260720-r23'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260720-r22">
-  <link rel="stylesheet" href="./styles.css?build=20260720-r22">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260720-r22">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260720-r22">
-  <link rel="stylesheet" href="./install-gate.css?build=20260720-r22">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260720-r22">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260720-r22">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260720-r22">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260720-r22">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260720-r22">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260720-r22">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260720-r22">
+  <link rel="manifest" href="./site.webmanifest?build=20260720-r23">
+  <link rel="stylesheet" href="./styles.css?build=20260720-r23">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260720-r23">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260720-r23">
+  <link rel="stylesheet" href="./install-gate.css?build=20260720-r23">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260720-r23">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260720-r23">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260720-r23">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260720-r23">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260720-r23">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260720-r23">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260720-r23">
 
-  <script src="./install-gate.js?build=20260720-r22"></script>
-  <script src="./orientation-compat.js?build=20260720-r22"></script>
+  <script src="./install-gate.js?build=20260720-r23"></script>
+  <script src="./orientation-compat.js?build=20260720-r23"></script>
   <script type="importmap">
     {
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
-        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-r10.js?build=20260720-r22",
+        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-r10.js?build=20260720-r23",
         "./vehicle/car-models.js?build=20260720-r19": "./vehicle/car-models.js?build=20260720-r22"
       }
     }
@@ -54,7 +54,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.6 · Build 2026.07.20-r22</span>
+        <span class="install-kicker">TURN v1.3.7 · Build 2026.07.20-r23</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -82,7 +82,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.6 · Build 2026.07.20-r22</span>
+      <span class="kicker">TURN v1.3.7 · Build 2026.07.20-r23</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -148,6 +148,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260720-r22"></script>
+  <script type="module" src="./app.js?build=20260720-r23"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- removes the coloured parking-pad floor fill from The Lot, including the teal selected-car rectangle shown in the screenshot
- keeps the existing parking bay lines and all car selection interaction
- preserves the latest direct `main` change that makes unselected cars exactly `#313131`
- keeps the r22 outline-depth stabilization unchanged
- bumps TURN to **v1.3.7 · Build 2026.07.20-r23** and cache-busts the Lot module

## Implementation

The teal area came from `makeParkingPad()`, which created a 6.7 × 5.9 plane under every car and changed the selected plane to cyan at 50% opacity. r23 removes the fill geometry entirely. The selection still has the existing car-scale/bob treatment and the selected car's real paint, so no gameplay or input behavior changes.

## Regression coverage

The production garage regression now explicitly protects:

- unselected cars staying `#313131`
- the parking-pad fill geometry remaining absent
- selection not reintroducing a teal floor pad
- the r23 Lot cache redirect
- the stable r22 outline module remaining in use

No physics, boost behavior, controls, vehicle balance, checkpoints, race state, paint persistence, orientation, outline behavior, or spectator behavior is changed.