### PR TITLE
TURN v1.3.8 r24: Replace prototype props with a brick wall

### DIFF
--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -64,7 +64,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.7 · Build 2026\.07\.20-r23/);
+assert.match(index, /TURN v1\.3\.8 · Build 2026\.07\.20-r24/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -45,9 +45,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.7 · Build 2026\.07\.20-r23/);
-assert.match(index, /drive-pad\.css\?build=20260720-r23/);
-assert.match(index, /gameplay-v2\.css\?build=20260720-r23/);
+assert.match(index, /TURN v1\.3\.8 · Build 2026\.07\.20-r24/);
+assert.match(index, /drive-pad\.css\?build=20260720-r24/);
+assert.match(index, /gameplay-v2\.css\?build=20260720-r24/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -35,7 +35,7 @@ for (const id of expectedIds) {
 
 const brickFiles = (await fs.readdir(path.join(turnDir, 'assets/lot-bricks')))
   .filter((file) => file.endsWith('.glb'));
-assert.equal(brickFiles.length, 9, 'The Lot should ship with nine compact Brick Kit props');
+assert.equal(brickFiles.length, 9, 'The vendored Kenney Brick Kit subset should remain available');
 
 const sedan = catalog.getCarDefinition('sedan');
 const race = catalog.getCarDefinition('race');
@@ -75,9 +75,9 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.7 · Build 2026\.07\.20-r23/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260720-r23/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r23"/, 'r23 must cache-bust the Lot module imported by the current static main graph');
+assert.match(index, /TURN v1\.3\.8 · Build 2026\.07\.20-r24/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260720-r24/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r24"/, 'r24 must cache-bust the Lot module imported by the current static main graph');
 assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');
@@ -109,6 +109,12 @@ assert.doesNotMatch(lotR10, /material\.opacity = 0\.46/, 'The retired translucen
 assert.match(lotR10, /function makeParkingPad\(\) \{\s*return new THREE\.Group\(\);\s*\}/, 'The Lot parking pad must not render a coloured floor fill');
 assert.match(lotR10, /function setParkingPadSelected\(\) \{\}/, 'Selecting a car must not reintroduce the teal parking pad');
 assert.doesNotMatch(lotR10, /new THREE\.PlaneGeometry\(6\.7, 5\.9\)/, 'The retired parking pad fill geometry must stay removed');
+assert.match(lotR10, /lotLoader\.loadAsync\(brickUrl\(1\)\)/, 'The Lot brick wall must use the literal 1x2 brick asset');
+assert.match(lotR10, /new THREE\.InstancedMesh\(geometry, material, bricks\.length\)/, 'The brick wall must remain instanced for older-device performance');
+assert.match(lotR10, /turn-literal-brick-wall/, 'The Lot must include the deliberate brick-wall scenery group');
+assert.match(lotR10, /addBrickWallRun\(bricks/, 'The brick wall must use staggered repeated runs');
+assert.doesNotMatch(lotR10, /const palette = \[0xffd43b, 0xff4fa3, 0x38d9ff, 0x8ce99a, 0x9775fa\]/, 'The retired scattered prototype prop palette must stay removed');
+assert.doesNotMatch(lotR10, /\[-23, 0, -13, 0\]/, 'The retired scattered perimeter prop placement must stay removed');
 assert.match(lotR10, /selectedColor = selection\.color/, 'The Lot must restore the selected native body colour');
 assert.match(lotR10, /selectedSecondaryColor = selection\.secondaryColor/, 'The Lot must restore secondary paint');
 assert.match(lotR10, /lot-viewbox/, 'The Lot must include a dedicated 3D car viewbox');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -38,8 +38,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.7 · Build 2026\.07\.20-r23/);
-assert.match(index, /in-game-menu\.css\?build=20260720-r23/);
+assert.match(index, /TURN v1\.3\.8 · Build 2026\.07\.20-r24/);
+assert.match(index, /in-game-menu\.css\?build=20260720-r24/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Back to Start<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -26,7 +26,7 @@ const css = await fs.readFile(new URL('../../turn/manual-steering.css', import.m
 
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260720-r23/);
+assert.match(index, /manual-steering\.css\?build=20260720-r24/);
 assert.match(css, /--manual-steer-left/);
 assert.match(css, /content: "←"/);
 assert.match(css, /content: "→"/);

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -48,7 +48,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.7 · Build 2026\.07\.20-r23/);
+assert.match(index, /TURN v1\.3\.8 · Build 2026\.07\.20-r24/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -85,7 +85,7 @@ const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, m
   fs.readFile(new URL('../../turn/performance-monitor.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.7 · Build 2026\.07\.20-r23/);
+assert.match(index, /TURN v1\.3\.8 · Build 2026\.07\.20-r24/);
 assert.match(main, /mainSceneOcclusion/);
 assert.match(main, /HUD_UPDATE_INTERVAL_MS = 1000 \/ 30/);
 assert.match(main, /recordPerformanceFrame/);
@@ -104,6 +104,8 @@ assert.doesNotMatch(camera, /state\.position\.clone\(\)/);
 assert.match(cars, /record\.node\.castShadow = !ghost/);
 assert.doesNotMatch(lot, /root\.scale\.lerp\(new THREE\.Vector3/);
 assert.match(lot, /recordPerformanceFrame/);
+assert.match(lot, /new THREE\.InstancedMesh\(geometry, material, bricks\.length\)/, 'The brick wall must stay batched into one instanced draw call');
+assert.doesNotMatch(lot, /Promise\.all\(placements\.map/, 'The retired per-prop scenery loader must stay removed');
 assert.match(monitor, /turn:perf-snapshot/);
 assert.match(monitor, /trackChecksPerQuery/);
 

--- a/turn/garage/lot-r10.js
+++ b/turn/garage/lot-r10.js
@@ -163,7 +163,7 @@ export function showTheLot({ initialSelection } = {}) {
     }
 
     installBrickScenery(lot).catch((error) => {
-      console.warn('TURN: The Lot Brick Kit scenery could not load.', error);
+      console.warn('TURN: The Lot brick wall could not load.', error);
     });
 
     function updateSelectionUi({ refreshViewer = true } = {}) {
@@ -560,82 +560,107 @@ function makeStats(vehicleStats) {
 }
 
 async function installBrickScenery(lot) {
-  // The prototype scattered nine oversized Brick Kit pieces around the whole perimeter.
-  // Keep the same lightweight vendored kit, but assemble three basic pieces into one
-  // deliberate pit-wall backdrop behind the cars so the scenery reads as architecture.
-  const [wallAsset, capAsset, slopeAsset] = await Promise.all([
-    lotLoader.loadAsync(brickUrl(4)),
-    lotLoader.loadAsync(brickUrl(2)),
-    lotLoader.loadAsync(brickUrl(8))
-  ]);
+  // Build a literal brick wall from the vendored Kenney 1x2 brick. Using one
+  // InstancedMesh keeps the entire wall to a single draw call on older devices.
+  const gltf = await lotLoader.loadAsync(brickUrl(1));
+  const sourceMesh = findFirstMesh(gltf.scene);
+  if (!sourceMesh?.geometry) throw new Error('Brick Kit 1x2 mesh is missing.');
 
-  const scenery = new THREE.Group();
-  scenery.name = 'turn-brick-pit-wall';
-  lot.add(scenery);
+  const geometry = sourceMesh.geometry.clone();
+  geometry.computeBoundingBox();
+  const sourceSize = geometry.boundingBox.getSize(new THREE.Vector3());
+  const brickSize = new THREE.Vector3(1.34, 0.5, 0.56);
+  const brickScale = new THREE.Vector3(
+    brickSize.x / Math.max(0.001, sourceSize.x),
+    brickSize.y / Math.max(0.001, sourceSize.y),
+    brickSize.z / Math.max(0.001, sourceSize.z)
+  );
 
-  const wallXs = [-17.1, -10.25, -3.4, 3.4, 10.25, 17.1];
-  const charcoal = 0x25292e;
-  const cream = 0xfcf6e7;
-  const yellow = 0xffd43b;
-
-  for (const x of wallXs) {
-    scenery.add(makeBrickSceneryPiece(wallAsset.scene, {
-      color: charcoal,
-      targetSize: 6.7,
-      position: [x, 0.06, -14.45]
-    }));
-    scenery.add(makeBrickSceneryPiece(capAsset.scene, {
-      color: cream,
-      targetSize: 6.7,
-      position: [x, 1.4, -14.45]
-    }));
-  }
-
-  scenery.add(makeBrickSceneryPiece(slopeAsset.scene, {
-    color: yellow,
-    targetSize: 3.2,
-    position: [-21.65, 0.06, -14.45],
-    rotationY: Math.PI
-  }));
-  scenery.add(makeBrickSceneryPiece(slopeAsset.scene, {
-    color: yellow,
-    targetSize: 3.2,
-    position: [21.65, 0.06, -14.45]
-  }));
-}
-
-function makeBrickSceneryPiece(source, { color, targetSize, position, rotationY = 0 }) {
-  const model = source.clone(true);
-  model.traverse((node) => {
-    if (!node.isMesh || !node.material) return;
-    const materials = Array.isArray(node.material) ? node.material : [node.material];
-    const clones = materials.map((material) => {
-      const clone = material.clone();
-      clone.color?.setHex(color);
-      return clone;
-    });
-    node.material = Array.isArray(node.material) ? clones : clones[0];
-    node.castShadow = false;
-    node.receiveShadow = false;
+  const bricks = [];
+  addBrickWallRun(bricks, {
+    axis: 'x',
+    from: -21.7,
+    to: 21.7,
+    fixed: -15.25,
+    rows: 5,
+    brickSize
   });
-  normalizeProp(model, targetSize);
-  model.position.set(...position);
-  model.rotation.y = rotationY;
-  return model;
+  addBrickWallRun(bricks, {
+    axis: 'z',
+    from: -14.55,
+    to: -9.25,
+    fixed: -22.35,
+    rows: 5,
+    brickSize
+  });
+  addBrickWallRun(bricks, {
+    axis: 'z',
+    from: -14.55,
+    to: -9.25,
+    fixed: 22.35,
+    rows: 5,
+    brickSize
+  });
+
+  const material = new THREE.MeshStandardMaterial({
+    color: 0xffffff,
+    roughness: 0.96,
+    metalness: 0
+  });
+  const wall = new THREE.InstancedMesh(geometry, material, bricks.length);
+  wall.name = 'turn-literal-brick-wall';
+  wall.castShadow = false;
+  wall.receiveShadow = false;
+  wall.instanceMatrix.setUsage(THREE.StaticDrawUsage);
+
+  const brickColors = [0x82483c, 0x925246, 0x754038, 0xa05b4c];
+  const matrix = new THREE.Matrix4();
+  const quaternion = new THREE.Quaternion();
+  const euler = new THREE.Euler();
+
+  bricks.forEach((brick, index) => {
+    euler.set(0, brick.rotationY, 0);
+    quaternion.setFromEuler(euler);
+    matrix.compose(brick.position, quaternion, brickScale);
+    wall.setMatrixAt(index, matrix);
+    wall.setColorAt(index, new THREE.Color(brickColors[brick.colorIndex % brickColors.length]));
+  });
+
+  wall.instanceMatrix.needsUpdate = true;
+  if (wall.instanceColor) wall.instanceColor.needsUpdate = true;
+  lot.add(wall);
 }
 
-function normalizeProp(model, targetSize) {
-  model.updateMatrixWorld(true);
-  const bounds = new THREE.Box3().setFromObject(model);
-  const size = bounds.getSize(new THREE.Vector3());
-  const maxSize = Math.max(0.001, size.x, size.y, size.z);
-  model.scale.setScalar(targetSize / maxSize);
-  model.updateMatrixWorld(true);
-  const nextBounds = new THREE.Box3().setFromObject(model);
-  const center = nextBounds.getCenter(new THREE.Vector3());
-  model.position.x -= center.x;
-  model.position.z -= center.z;
-  model.position.y -= nextBounds.min.y;
+function addBrickWallRun(target, { axis, from, to, fixed, rows, brickSize }) {
+  const brickStep = brickSize.x + 0.08;
+  const rowStep = brickSize.y + 0.06;
+  const runLength = to - from;
+  const columns = Math.floor(runLength / brickStep);
+  const rotationY = axis === 'z' ? Math.PI / 2 : 0;
+
+  for (let row = 0; row < rows; row += 1) {
+    const offset = row % 2 ? brickStep * 0.5 : 0;
+    for (let column = 0; column <= columns; column += 1) {
+      const along = from + column * brickStep + offset;
+      if (along > to) continue;
+      const position = axis === 'x'
+        ? new THREE.Vector3(along, 0.04 + row * rowStep, fixed)
+        : new THREE.Vector3(fixed, 0.04 + row * rowStep, along);
+      target.push({
+        position,
+        rotationY,
+        colorIndex: row * 3 + column
+      });
+    }
+  }
+}
+
+function findFirstMesh(root) {
+  let result = null;
+  root.traverse((node) => {
+    if (!result && node.isMesh) result = node;
+  });
+  return result;
 }
 
 function brickUrl(index) {

--- a/turn/garage/lot-r10.js
+++ b/turn/garage/lot-r10.js
@@ -560,31 +560,68 @@ function makeStats(vehicleStats) {
 }
 
 async function installBrickScenery(lot) {
-  const palette = [0xffd43b, 0xff4fa3, 0x38d9ff, 0x8ce99a, 0x9775fa];
-  const placements = [
-    [-23, 0, -13, 0], [-20, 0, -14, 0.25], [20, 0, -14, -0.2], [23, 0, -12, 0],
-    [-23, 0, 13, 0.3], [-19, 0, 14, 0], [19, 0, 14, 0], [23, 0, 12, -0.3], [0, 0, -15, 0]
-  ];
+  // The prototype scattered nine oversized Brick Kit pieces around the whole perimeter.
+  // Keep the same lightweight vendored kit, but assemble three basic pieces into one
+  // deliberate pit-wall backdrop behind the cars so the scenery reads as architecture.
+  const [wallAsset, capAsset, slopeAsset] = await Promise.all([
+    lotLoader.loadAsync(brickUrl(4)),
+    lotLoader.loadAsync(brickUrl(2)),
+    lotLoader.loadAsync(brickUrl(8))
+  ]);
 
-  await Promise.all(placements.map(async (placement, index) => {
-    const gltf = await lotLoader.loadAsync(brickUrl(index + 1));
-    const model = gltf.scene.clone(true);
-    const color = new THREE.Color(palette[index % palette.length]);
-    model.traverse((node) => {
-      if (!node.isMesh || !node.material) return;
-      const materials = Array.isArray(node.material) ? node.material : [node.material];
-      const clones = materials.map((material) => {
-        const clone = material.clone();
-        clone.color?.lerp(color, 0.72);
-        return clone;
-      });
-      node.material = Array.isArray(node.material) ? clones : clones[0];
-    });
-    normalizeProp(model, 3.2 + (index % 3) * 0.65);
-    model.position.set(placement[0], placement[1], placement[2]);
-    model.rotation.y = placement[3];
-    lot.add(model);
+  const scenery = new THREE.Group();
+  scenery.name = 'turn-brick-pit-wall';
+  lot.add(scenery);
+
+  const wallXs = [-17.1, -10.25, -3.4, 3.4, 10.25, 17.1];
+  const charcoal = 0x25292e;
+  const cream = 0xfcf6e7;
+  const yellow = 0xffd43b;
+
+  for (const x of wallXs) {
+    scenery.add(makeBrickSceneryPiece(wallAsset.scene, {
+      color: charcoal,
+      targetSize: 6.7,
+      position: [x, 0.06, -14.45]
+    }));
+    scenery.add(makeBrickSceneryPiece(capAsset.scene, {
+      color: cream,
+      targetSize: 6.7,
+      position: [x, 1.4, -14.45]
+    }));
+  }
+
+  scenery.add(makeBrickSceneryPiece(slopeAsset.scene, {
+    color: yellow,
+    targetSize: 3.2,
+    position: [-21.65, 0.06, -14.45],
+    rotationY: Math.PI
   }));
+  scenery.add(makeBrickSceneryPiece(slopeAsset.scene, {
+    color: yellow,
+    targetSize: 3.2,
+    position: [21.65, 0.06, -14.45]
+  }));
+}
+
+function makeBrickSceneryPiece(source, { color, targetSize, position, rotationY = 0 }) {
+  const model = source.clone(true);
+  model.traverse((node) => {
+    if (!node.isMesh || !node.material) return;
+    const materials = Array.isArray(node.material) ? node.material : [node.material];
+    const clones = materials.map((material) => {
+      const clone = material.clone();
+      clone.color?.setHex(color);
+      return clone;
+    });
+    node.material = Array.isArray(node.material) ? clones : clones[0];
+    node.castShadow = false;
+    node.receiveShadow = false;
+  });
+  normalizeProp(model, targetSize);
+  model.position.set(...position);
+  model.rotation.y = rotationY;
+  return model;
 }
 
 function normalizeProp(model, targetSize) {

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r23 Lot floor cleanup and dark unselected cars -->
+<!-- TURN r24 Literal brick wall scenery -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,37 +10,37 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.7 · Build 2026.07.20-r23</title>
+  <title>TURN v1.3.8 · Build 2026.07.20-r24</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.7',
-      id: '2026.07.20-r23',
-      cacheKey: '20260720-r23'
+      version: '1.3.8',
+      id: '2026.07.20-r24',
+      cacheKey: '20260720-r24'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260720-r23">
-  <link rel="stylesheet" href="./styles.css?build=20260720-r23">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260720-r23">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260720-r23">
-  <link rel="stylesheet" href="./install-gate.css?build=20260720-r23">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260720-r23">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260720-r23">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260720-r23">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260720-r23">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260720-r23">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260720-r23">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260720-r23">
+  <link rel="manifest" href="./site.webmanifest?build=20260720-r24">
+  <link rel="stylesheet" href="./styles.css?build=20260720-r24">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260720-r24">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260720-r24">
+  <link rel="stylesheet" href="./install-gate.css?build=20260720-r24">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260720-r24">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260720-r24">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260720-r24">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260720-r24">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260720-r24">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260720-r24">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260720-r24">
 
-  <script src="./install-gate.js?build=20260720-r23"></script>
-  <script src="./orientation-compat.js?build=20260720-r23"></script>
+  <script src="./install-gate.js?build=20260720-r24"></script>
+  <script src="./orientation-compat.js?build=20260720-r24"></script>
   <script type="importmap">
     {
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
-        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-r10.js?build=20260720-r23",
+        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-r10.js?build=20260720-r24",
         "./vehicle/car-models.js?build=20260720-r19": "./vehicle/car-models.js?build=20260720-r22"
       }
     }
@@ -54,7 +54,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.7 · Build 2026.07.20-r23</span>
+        <span class="install-kicker">TURN v1.3.8 · Build 2026.07.20-r24</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -82,7 +82,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.7 · Build 2026.07.20-r23</span>
+      <span class="kicker">TURN v1.3.8 · Build 2026.07.20-r24</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -148,6 +148,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260720-r23"></script>
+  <script type="module" src="./app.js?build=20260720-r24"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- removes the nine oversized, scattered prototype Brick Kit props from The Lot
- replaces them with a literal staggered brick wall built from the vendored Kenney 1×2 brick mesh
- runs the wall across the rear of the parking area with short side returns, keeping scenery away from the foreground and UI
- renders the repeated bricks through one `THREE.InstancedMesh` rather than hundreds of separate scene objects
- preserves the r23 floor cleanup, `#313131` unselected cars, and the stable r22 outline implementation
- bumps TURN to **v1.3.8 · Build 2026.07.20-r24** and cache-busts The Lot

## Visual direction

The old prototype scenery took nine unrelated Brick Kit shapes, enlarged each into a standalone object and scattered them around the perimeter. r24 uses the actual `1x2` brick geometry as bricks: staggered courses form one coherent low wall behind the cars, with short returns at the back corners. Brick tones vary subtly between warm dark reds so the wall reads as masonry without competing with the selected car or UI.

## Performance

The full wall is a single `InstancedMesh`, so the repeated brick geometry remains one batched draw call rather than one object/draw call per brick. No new asset pack or runtime animation is added.

## Regression coverage

- garage regression protects the literal 1×2 brick source, instanced construction, removal of the old rainbow prop palette and scattered placements
- performance regression protects the instanced wall and prevents the old per-prop loader from returning
- full existing TURN regression suite will run before merge

No physics, boost behavior, controls, vehicle balance, checkpoints, race state, paint persistence, orientation, outline behavior, or spectator behavior is changed.