### PR TITLE
TURN v1.3.9 r25: Clean up The Lot

### DIFF
--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -64,7 +64,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.8 · Build 2026\.07\.20-r24/);
+assert.match(index, /TURN v1\.3\.9 · Build 2026\.07\.20-r25/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -45,9 +45,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.8 · Build 2026\.07\.20-r24/);
-assert.match(index, /drive-pad\.css\?build=20260720-r24/);
-assert.match(index, /gameplay-v2\.css\?build=20260720-r24/);
+assert.match(index, /TURN v1\.3\.9 · Build 2026\.07\.20-r25/);
+assert.match(index, /drive-pad\.css\?build=20260720-r25/);
+assert.match(index, /gameplay-v2\.css\?build=20260720-r25/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -35,7 +35,7 @@ for (const id of expectedIds) {
 
 const brickFiles = (await fs.readdir(path.join(turnDir, 'assets/lot-bricks')))
   .filter((file) => file.endsWith('.glb'));
-assert.equal(brickFiles.length, 9, 'The vendored Kenney Brick Kit subset should remain available');
+assert.equal(brickFiles.length, 9, 'The vendored Kenney Brick Kit subset should remain available even though The Lot no longer renders it');
 
 const sedan = catalog.getCarDefinition('sedan');
 const race = catalog.getCarDefinition('race');
@@ -75,9 +75,9 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.8 · Build 2026\.07\.20-r24/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260720-r24/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r24"/, 'r24 must cache-bust the Lot module imported by the current static main graph');
+assert.match(index, /TURN v1\.3\.9 · Build 2026\.07\.20-r25/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260720-r25/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r25 must cache-bust the Lot module imported by the current static main graph');
 assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');
@@ -103,18 +103,14 @@ assert.match(lotR10, /if \(selected \|\| record\.outline\)/, 'Unselected Lot car
 assert.match(lotR10, /material\.transparent = false/, 'Unselected Lot car surfaces must remain opaque');
 assert.match(lotR10, /material\.opacity = 1/, 'Unselected Lot car surfaces must render at full opacity');
 assert.match(lotR10, /material\.depthWrite = true/, 'Unselected Lot car surfaces must write depth');
-assert.doesNotMatch(lotR10, /0xfcf6e7/, 'The retired warm cream unselected colour must stay removed');
-assert.doesNotMatch(lotR10, /0xeeeeee/, 'The retired cool gray unselected colour must stay removed');
 assert.doesNotMatch(lotR10, /material\.opacity = 0\.46/, 'The retired translucent unselected-car presentation must stay removed');
 assert.match(lotR10, /function makeParkingPad\(\) \{\s*return new THREE\.Group\(\);\s*\}/, 'The Lot parking pad must not render a coloured floor fill');
 assert.match(lotR10, /function setParkingPadSelected\(\) \{\}/, 'Selecting a car must not reintroduce the teal parking pad');
 assert.doesNotMatch(lotR10, /new THREE\.PlaneGeometry\(6\.7, 5\.9\)/, 'The retired parking pad fill geometry must stay removed');
-assert.match(lotR10, /lotLoader\.loadAsync\(brickUrl\(1\)\)/, 'The Lot brick wall must use the literal 1x2 brick asset');
-assert.match(lotR10, /new THREE\.InstancedMesh\(geometry, material, bricks\.length\)/, 'The brick wall must remain instanced for older-device performance');
-assert.match(lotR10, /turn-literal-brick-wall/, 'The Lot must include the deliberate brick-wall scenery group');
-assert.match(lotR10, /addBrickWallRun\(bricks/, 'The brick wall must use staggered repeated runs');
-assert.doesNotMatch(lotR10, /const palette = \[0xffd43b, 0xff4fa3, 0x38d9ff, 0x8ce99a, 0x9775fa\]/, 'The retired scattered prototype prop palette must stay removed');
-assert.doesNotMatch(lotR10, /\[-23, 0, -13, 0\]/, 'The retired scattered perimeter prop placement must stay removed');
+assert.doesNotMatch(lotR10, /GLTFLoader/, 'The clean Lot must not load decorative scenery assets');
+assert.doesNotMatch(lotR10, /installBrickScenery/, 'The brick wall must remain removed');
+assert.doesNotMatch(lotR10, /InstancedMesh/, 'The retired brick wall geometry must remain removed');
+assert.match(lotR10Css, /word-spacing: 0\.16em/, 'THE LOT must keep the increased word spacing');
 assert.match(lotR10, /selectedColor = selection\.color/, 'The Lot must restore the selected native body colour');
 assert.match(lotR10, /selectedSecondaryColor = selection\.secondaryColor/, 'The Lot must restore secondary paint');
 assert.match(lotR10, /lot-viewbox/, 'The Lot must include a dedicated 3D car viewbox');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -38,8 +38,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.8 · Build 2026\.07\.20-r24/);
-assert.match(index, /in-game-menu\.css\?build=20260720-r24/);
+assert.match(index, /TURN v1\.3\.9 · Build 2026\.07\.20-r25/);
+assert.match(index, /in-game-menu\.css\?build=20260720-r25/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Back to Start<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -26,7 +26,7 @@ const css = await fs.readFile(new URL('../../turn/manual-steering.css', import.m
 
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260720-r24/);
+assert.match(index, /manual-steering\.css\?build=20260720-r25/);
 assert.match(css, /--manual-steer-left/);
 assert.match(css, /content: "←"/);
 assert.match(css, /content: "→"/);

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -48,7 +48,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.8 · Build 2026\.07\.20-r24/);
+assert.match(index, /TURN v1\.3\.9 · Build 2026\.07\.20-r25/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -85,7 +85,7 @@ const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, m
   fs.readFile(new URL('../../turn/performance-monitor.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.8 · Build 2026\.07\.20-r24/);
+assert.match(index, /TURN v1\.3\.9 · Build 2026\.07\.20-r25/);
 assert.match(main, /mainSceneOcclusion/);
 assert.match(main, /HUD_UPDATE_INTERVAL_MS = 1000 \/ 30/);
 assert.match(main, /recordPerformanceFrame/);
@@ -104,8 +104,7 @@ assert.doesNotMatch(camera, /state\.position\.clone\(\)/);
 assert.match(cars, /record\.node\.castShadow = !ghost/);
 assert.doesNotMatch(lot, /root\.scale\.lerp\(new THREE\.Vector3/);
 assert.match(lot, /recordPerformanceFrame/);
-assert.match(lot, /new THREE\.InstancedMesh\(geometry, material, bricks\.length\)/, 'The brick wall must stay batched into one instanced draw call');
-assert.doesNotMatch(lot, /Promise\.all\(placements\.map/, 'The retired per-prop scenery loader must stay removed');
+assert.doesNotMatch(lot, /GLTFLoader|InstancedMesh|installBrickScenery/, 'The clean Lot must not spend asset or draw-call budget on decorative wall scenery');
 assert.match(monitor, /turn:perf-snapshot/);
 assert.match(monitor, /trackChecksPerQuery/);
 

--- a/turn/garage/lot-r10.css
+++ b/turn/garage/lot-r10.css
@@ -45,6 +45,7 @@
   margin-top: 8px;
   font-size: clamp(2.7rem, 8vw, 6.4rem);
   line-height: 0.72;
+  word-spacing: 0.16em;
 }
 
 .lot-heading p {

--- a/turn/garage/lot-r10.js
+++ b/turn/garage/lot-r10.js
@@ -1,5 +1,4 @@
 import * as THREE from 'three';
-import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import {
   CAR_CATALOG,
   DEFAULT_VEHICLE_COLOR,
@@ -12,8 +11,6 @@ import {
 import { createCarVisual, recolorCarVisual } from '../vehicle/car-models.js?build=20260720-r22';
 import { recordPerformanceFrame } from '../performance-monitor.js?build=20260720-r20';
 
-const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
-const lotLoader = new GLTFLoader();
 const UNSELECTED_COLOR = new THREE.Color(0x313131);
 const VIEWER_INITIAL_YAW = Math.PI - 0.55;
 
@@ -161,10 +158,6 @@ export function showTheLot({ initialSelection } = {}) {
         if (loadedCars >= CAR_CATALOG.length) loading.classList.add('is-done');
       });
     }
-
-    installBrickScenery(lot).catch((error) => {
-      console.warn('TURN: The Lot brick wall could not load.', error);
-    });
 
     function updateSelectionUi({ refreshViewer = true } = {}) {
       const car = getCarDefinition(selectedCarId);
@@ -557,114 +550,4 @@ function makeStats(vehicleStats) {
     row.innerHTML = `<span>${label}</span><i>${Array.from({ length: 5 }, (_, index) => `<b class="${index < value ? 'is-full' : ''}"></b>`).join('')}</i>`;
     return row;
   });
-}
-
-async function installBrickScenery(lot) {
-  // Build a literal brick wall from the vendored Kenney 1x2 brick. Using one
-  // InstancedMesh keeps the entire wall to a single draw call on older devices.
-  const gltf = await lotLoader.loadAsync(brickUrl(1));
-  const sourceMesh = findFirstMesh(gltf.scene);
-  if (!sourceMesh?.geometry) throw new Error('Brick Kit 1x2 mesh is missing.');
-
-  const geometry = sourceMesh.geometry.clone();
-  geometry.computeBoundingBox();
-  const sourceSize = geometry.boundingBox.getSize(new THREE.Vector3());
-  const brickSize = new THREE.Vector3(1.34, 0.5, 0.56);
-  const brickScale = new THREE.Vector3(
-    brickSize.x / Math.max(0.001, sourceSize.x),
-    brickSize.y / Math.max(0.001, sourceSize.y),
-    brickSize.z / Math.max(0.001, sourceSize.z)
-  );
-
-  const bricks = [];
-  addBrickWallRun(bricks, {
-    axis: 'x',
-    from: -21.7,
-    to: 21.7,
-    fixed: -15.25,
-    rows: 5,
-    brickSize
-  });
-  addBrickWallRun(bricks, {
-    axis: 'z',
-    from: -14.55,
-    to: -9.25,
-    fixed: -22.35,
-    rows: 5,
-    brickSize
-  });
-  addBrickWallRun(bricks, {
-    axis: 'z',
-    from: -14.55,
-    to: -9.25,
-    fixed: 22.35,
-    rows: 5,
-    brickSize
-  });
-
-  const material = new THREE.MeshStandardMaterial({
-    color: 0xffffff,
-    roughness: 0.96,
-    metalness: 0
-  });
-  const wall = new THREE.InstancedMesh(geometry, material, bricks.length);
-  wall.name = 'turn-literal-brick-wall';
-  wall.castShadow = false;
-  wall.receiveShadow = false;
-  wall.instanceMatrix.setUsage(THREE.StaticDrawUsage);
-
-  const brickColors = [0x82483c, 0x925246, 0x754038, 0xa05b4c];
-  const matrix = new THREE.Matrix4();
-  const quaternion = new THREE.Quaternion();
-  const euler = new THREE.Euler();
-
-  bricks.forEach((brick, index) => {
-    euler.set(0, brick.rotationY, 0);
-    quaternion.setFromEuler(euler);
-    matrix.compose(brick.position, quaternion, brickScale);
-    wall.setMatrixAt(index, matrix);
-    wall.setColorAt(index, new THREE.Color(brickColors[brick.colorIndex % brickColors.length]));
-  });
-
-  wall.instanceMatrix.needsUpdate = true;
-  if (wall.instanceColor) wall.instanceColor.needsUpdate = true;
-  lot.add(wall);
-}
-
-function addBrickWallRun(target, { axis, from, to, fixed, rows, brickSize }) {
-  const brickStep = brickSize.x + 0.08;
-  const rowStep = brickSize.y + 0.06;
-  const runLength = to - from;
-  const columns = Math.floor(runLength / brickStep);
-  const rotationY = axis === 'z' ? Math.PI / 2 : 0;
-
-  for (let row = 0; row < rows; row += 1) {
-    const offset = row % 2 ? brickStep * 0.5 : 0;
-    for (let column = 0; column <= columns; column += 1) {
-      const along = from + column * brickStep + offset;
-      if (along > to) continue;
-      const position = axis === 'x'
-        ? new THREE.Vector3(along, 0.04 + row * rowStep, fixed)
-        : new THREE.Vector3(fixed, 0.04 + row * rowStep, along);
-      target.push({
-        position,
-        rotationY,
-        colorIndex: row * 3 + column
-      });
-    }
-  }
-}
-
-function findFirstMesh(root) {
-  let result = null;
-  root.traverse((node) => {
-    if (!result && node.isMesh) result = node;
-  });
-  return result;
-}
-
-function brickUrl(index) {
-  const url = new URL(`../assets/lot-bricks/brick-prop-${String(index).padStart(2, '0')}.glb`, import.meta.url);
-  if (buildKey) url.searchParams.set('build', buildKey);
-  return url.href;
 }

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r24 Literal brick wall scenery -->
+<!-- TURN r25 Clean Lot and title spacing -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,37 +10,37 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.8 · Build 2026.07.20-r24</title>
+  <title>TURN v1.3.9 · Build 2026.07.20-r25</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.8',
-      id: '2026.07.20-r24',
-      cacheKey: '20260720-r24'
+      version: '1.3.9',
+      id: '2026.07.20-r25',
+      cacheKey: '20260720-r25'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260720-r24">
-  <link rel="stylesheet" href="./styles.css?build=20260720-r24">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260720-r24">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260720-r24">
-  <link rel="stylesheet" href="./install-gate.css?build=20260720-r24">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260720-r24">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260720-r24">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260720-r24">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260720-r24">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260720-r24">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260720-r24">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260720-r24">
+  <link rel="manifest" href="./site.webmanifest?build=20260720-r25">
+  <link rel="stylesheet" href="./styles.css?build=20260720-r25">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260720-r25">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260720-r25">
+  <link rel="stylesheet" href="./install-gate.css?build=20260720-r25">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260720-r25">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260720-r25">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260720-r25">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260720-r25">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260720-r25">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260720-r25">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260720-r25">
 
-  <script src="./install-gate.js?build=20260720-r24"></script>
-  <script src="./orientation-compat.js?build=20260720-r24"></script>
+  <script src="./install-gate.js?build=20260720-r25"></script>
+  <script src="./orientation-compat.js?build=20260720-r25"></script>
   <script type="importmap">
     {
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
-        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-r10.js?build=20260720-r24",
+        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-r10.js?build=20260720-r25",
         "./vehicle/car-models.js?build=20260720-r19": "./vehicle/car-models.js?build=20260720-r22"
       }
     }
@@ -54,7 +54,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.8 · Build 2026.07.20-r24</span>
+        <span class="install-kicker">TURN v1.3.9 · Build 2026.07.20-r25</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -82,7 +82,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.8 · Build 2026.07.20-r24</span>
+      <span class="kicker">TURN v1.3.9 · Build 2026.07.20-r25</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -148,6 +148,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260720-r24"></script>
+  <script type="module" src="./app.js?build=20260720-r25"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- removes the r24 brick wall entirely from The Lot
- removes the now-unused scenery GLTF loader and wall construction code rather than merely hiding the wall
- keeps the clean parking area, `#313131` unselected cars, r22 outline stabilization, and all existing car-selection behavior
- adds a restrained `0.16em` word spacing to **THE LOT** for clearer separation between the words
- bumps TURN to **v1.3.9 · Build 2026.07.20-r25** and cache-busts The Lot CSS/module

## Regression coverage

- garage regression now protects the clean, scenery-free Lot and the title word spacing
- performance regression protects against decorative wall asset loading or draw-call geometry returning
- existing release assertions updated for r25

No physics, boost behavior, controls, vehicle balance, checkpoints, race state, paint persistence, orientation, outlines, or spectator behavior is changed.