### PR TITLE
TURN v1.3.11 r27: Give the cars sound character

### DIFF
--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -1,20 +1,22 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [index, app, audio, controls] = await Promise.all([
+const [index, app, audio, controls, catalogSource] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/audio/audio-system.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/ui/gameplay-controls.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../../turn/ui/gameplay-controls.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/vehicle/catalog.js', import.meta.url), 'utf8')
 ]);
+const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
 
-assert.match(index, /TURN v1\.3\.10 · Build 2026\.07\.21-r26/);
-assert.match(index, /\.\/app\.js\?build=20260721-r26/);
+assert.match(index, /TURN v1\.3\.11 · Build 2026\.07\.21-r27/);
+assert.match(index, /\.\/app\.js\?build=20260721-r27/);
 
 assert.match(app, /import\(withBuild\('\.\/audio\/audio-system\.js'\)\)/, 'Production must load the central audio module');
 assert.match(app, /installTurnAudio\(\)/, 'The audio foundation must install before gameplay starts');
 assert.ok(
-  app.indexOf("./audio/audio-system.js") < app.indexOf("./ui/gameplay-controls.js"),
+  app.indexOf('./audio/audio-system.js') < app.indexOf('./ui/gameplay-controls.js'),
   'Audio must install before gameplay controls begin feeding it state'
 );
 
@@ -26,6 +28,32 @@ assert.match(audio, /unlock,\s*update,\s*cue,\s*silence/, 'The shared audio API 
 assert.match(audio, /function installEngineGraph\(/, 'The foundation must provide a continuous engine layer');
 assert.match(audio, /function installDriftGraph\(/, 'The foundation must provide a continuous drift layer');
 assert.match(audio, /function installBoostGraph\(/, 'The foundation must provide a continuous boost layer');
+assert.match(audio, /globalThis\.__turnVehicleTuning\?\.enginePitch/, 'Engine frequency must follow the selected car tuning');
+assert.match(audio, /engineBaseHz = \(52 \+ speedRatio \* 96 \+ throttle \* 24\) \* enginePitch/, 'Per-car pitch must multiply the whole engine baseline');
+
+assert.equal(catalog.getCarDefinition('sedan').tuning.enginePitch, 1, 'Sedan must remain the neutral engine pitch baseline');
+assert.equal(catalog.getCarDefinition('monster-truck').tuning.enginePitch, 0.62, 'Monster Truck must have the lowest deep engine baseline');
+assert.equal(catalog.getCarDefinition('race').tuning.enginePitch, 1.55, 'Race Car must have the highest F1-like engine baseline');
+assert.ok(
+  catalog.getCarDefinition('monster-truck').tuning.enginePitch < catalog.getCarDefinition('truck').tuning.enginePitch,
+  'Monster Truck must sit below the regular Truck in pitch'
+);
+assert.ok(
+  catalog.getCarDefinition('race').tuning.enginePitch > catalog.getCarDefinition('race-future').tuning.enginePitch,
+  'Race Car must remain the highest-pitched racer'
+);
+
+assert.match(audio, /regularSlipLevel = active \? slipIntent \* driftSpeed \* 0\.018 : 0/, 'Ordinary cornering slip must stay very quiet');
+assert.match(audio, /deliberateDriftLevel = active && driftHeld/, 'Holding DRIFT must add a distinct stronger tire layer');
+assert.match(audio, /const skidLevel = active && driftHeld/, 'Skid hiss must only wake up during deliberate DRIFT');
+assert.match(audio, /skidNoise\.buffer = makeNoiseBuffer\(context, 1\.1, 0\.1\)/, 'DRIFT must use a brighter separate skid texture');
+
+assert.match(audio, /case 'garage-open':/, 'The Lot must have a restrained entrance cue');
+assert.match(audio, /case 'car-select':/, 'The Lot car field must have a selection cue');
+assert.match(audio, /case 'paint-select':/, 'Native paint changes must have a small confirmation cue');
+assert.match(audio, /handleLotVisibilityChange/, 'The Lot entrance cue must follow the actual open state');
+assert.match(audio, /handleLotPointerDown/, 'The Lot car field must feed selection sound');
+assert.match(audio, /handleUiChange/, 'The Lot paint picker must feed paint sound');
 assert.match(audio, /case 'boost-start':/, 'Boost activation must have a distinct one-shot cue');
 assert.match(audio, /function handleUiClick\(/, 'UI buttons must receive lightweight procedural feedback');
 
@@ -45,4 +73,4 @@ assert.match(controls, /document\.body\.classList\.contains\('turn-lot-open'\)/,
 assert.match(controls, /driftAmount: runtimeState\?\.driftAmount \|\| 0/, 'Drift sound must follow the real physics drift state');
 assert.match(controls, /boostActive: boosting/, 'Boost sound must follow the post-lockout boost state');
 
-console.log('TURN sound foundation production regression passed.');
+console.log('TURN sound character production regression passed.');

--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -12,6 +12,16 @@ const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogS
 
 assert.match(index, /TURN v1\.3\.11 · Build 2026\.07\.21-r27/);
 assert.match(index, /\.\/app\.js\?build=20260721-r27/);
+assert.match(
+  index,
+  /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r27"/,
+  'The main runtime catalog import must be cache-busted for r27 engine tuning'
+);
+assert.match(
+  index,
+  /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260721-r27"/,
+  'The Lot catalog import must resolve to the same r27 engine tuning'
+);
 
 assert.match(app, /import\(withBuild\('\.\/audio\/audio-system\.js'\)\)/, 'Production must load the central audio module');
 assert.match(app, /installTurnAudio\(\)/, 'The audio foundation must install before gameplay starts');
@@ -31,6 +41,10 @@ assert.match(audio, /function installBoostGraph\(/, 'The foundation must provide
 assert.match(audio, /globalThis\.__turnVehicleTuning\?\.enginePitch/, 'Engine frequency must follow the selected car tuning');
 assert.match(audio, /engineBaseHz = \(52 \+ speedRatio \* 96 \+ throttle \* 24\) \* enginePitch/, 'Per-car pitch must multiply the whole engine baseline');
 
+for (const car of catalog.CAR_CATALOG) {
+  assert.ok(Number.isFinite(car.tuning.enginePitch), `${car.name} must define an engine pitch baseline`);
+  assert.ok(car.tuning.enginePitch >= 0.55 && car.tuning.enginePitch <= 1.7, `${car.name} engine pitch must stay within the supported range`);
+}
 assert.equal(catalog.getCarDefinition('sedan').tuning.enginePitch, 1, 'Sedan must remain the neutral engine pitch baseline');
 assert.equal(catalog.getCarDefinition('monster-truck').tuning.enginePitch, 0.62, 'Monster Truck must have the lowest deep engine baseline');
 assert.equal(catalog.getCarDefinition('race').tuning.enginePitch, 1.55, 'Race Car must have the highest F1-like engine baseline');

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -64,7 +64,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.10 · Build 2026\.07\.21-r26/);
+assert.match(index, /TURN v1\.3\.11 · Build 2026\.07\.21-r27/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -45,9 +45,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.10 · Build 2026\.07\.21-r26/);
-assert.match(index, /drive-pad\.css\?build=20260721-r26/);
-assert.match(index, /gameplay-v2\.css\?build=20260721-r26/);
+assert.match(index, /TURN v1\.3\.11 · Build 2026\.07\.21-r27/);
+assert.match(index, /drive-pad\.css\?build=20260721-r27/);
+assert.match(index, /gameplay-v2\.css\?build=20260721-r27/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -75,9 +75,9 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.10 · Build 2026\.07\.21-r26/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260721-r26/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r26 must preserve the latest Lot module cache redirect');
+assert.match(index, /TURN v1\.3\.11 · Build 2026\.07\.21-r27/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260721-r27/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r27 must preserve the latest Lot module cache redirect');
 assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -38,8 +38,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.10 · Build 2026\.07\.21-r26/);
-assert.match(index, /in-game-menu\.css\?build=20260721-r26/);
+assert.match(index, /TURN v1\.3\.11 · Build 2026\.07\.21-r27/);
+assert.match(index, /in-game-menu\.css\?build=20260721-r27/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Back to Start<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -26,7 +26,7 @@ const css = await fs.readFile(new URL('../../turn/manual-steering.css', import.m
 
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260721-r26/);
+assert.match(index, /manual-steering\.css\?build=20260721-r27/);
 assert.match(css, /--manual-steer-left/);
 assert.match(css, /content: "←"/);
 assert.match(css, /content: "→"/);

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -48,7 +48,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.10 · Build 2026\.07\.21-r26/);
+assert.match(index, /TURN v1\.3\.11 · Build 2026\.07\.21-r27/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -85,7 +85,7 @@ const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, m
   fs.readFile(new URL('../../turn/performance-monitor.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.10 · Build 2026\.07\.21-r26/);
+assert.match(index, /TURN v1\.3\.11 · Build 2026\.07\.21-r27/);
 assert.match(main, /mainSceneOcclusion/);
 assert.match(main, /HUD_UPDATE_INTERVAL_MS = 1000 \/ 30/);
 assert.match(main, /recordPerformanceFrame/);

--- a/turn/audio/audio-system.js
+++ b/turn/audio/audio-system.js
@@ -18,6 +18,7 @@ let boostFilter = null;
 let boostTone = null;
 let lastUpdateAt = -Infinity;
 let lastBoostActive = false;
+let lotOpen = false;
 let installed = false;
 
 export function installTurnAudio() {
@@ -40,10 +41,18 @@ export function installTurnAudio() {
   globalThis.__turnAudio = api;
 
   document.addEventListener('pointerdown', unlockFromGesture, { capture: true, passive: true });
+  document.addEventListener('pointerdown', handleLotPointerDown, { capture: true, passive: true });
   document.addEventListener('keydown', unlockFromGesture, { capture: true });
   document.addEventListener('click', handleUiClick, { capture: true });
+  document.addEventListener('change', handleUiChange, { capture: true });
   document.addEventListener('visibilitychange', handleVisibilityChange, { passive: true });
   window.addEventListener('pagehide', handlePageHide, { passive: true });
+
+  lotOpen = document.body?.classList.contains('turn-lot-open') || false;
+  if (document.body && typeof MutationObserver !== 'undefined') {
+    const lotObserver = new MutationObserver(handleLotVisibilityChange);
+    lotObserver.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+  }
 
   return api;
 }
@@ -75,7 +84,11 @@ export function update(frame = {}, now = performance.now()) {
   const driftAmount = clamp(Number(frame.driftAmount) || 0, 0, 1);
   const driftHeld = Boolean(frame.driftHeld);
   const boostActive = active && Boolean(frame.boostActive);
-  const enginePitch = clamp(Number(frame.enginePitch) || 1, 0.55, 1.7);
+  const enginePitch = clamp(
+    Number(frame.enginePitch ?? globalThis.__turnVehicleTuning?.enginePitch) || 1,
+    0.55,
+    1.7
+  );
   const audioNow = context.currentTime;
 
   const engineLevel = active
@@ -362,6 +375,21 @@ function smooth(param, value, time, timeConstant) {
 function hardMute(param, time) {
   param.cancelScheduledValues(time);
   param.setValueAtTime(0, time);
+}
+
+function handleLotPointerDown(event) {
+  if (!event.target.closest?.('.lot-canvas-host')) return;
+  cue('car-select');
+}
+
+function handleUiChange(event) {
+  if (event.target.matches?.('.lot-color-input')) cue('paint-select');
+}
+
+function handleLotVisibilityChange() {
+  const nextLotOpen = document.body?.classList.contains('turn-lot-open') || false;
+  if (nextLotOpen && !lotOpen) cue('garage-open');
+  lotOpen = nextLotOpen;
 }
 
 function handleUiClick(event) {

--- a/turn/audio/audio-system.js
+++ b/turn/audio/audio-system.js
@@ -11,6 +11,8 @@ let engineLow = null;
 let engineHigh = null;
 let driftGain = null;
 let driftFilter = null;
+let skidGain = null;
+let skidFilter = null;
 let boostGain = null;
 let boostFilter = null;
 let boostTone = null;
@@ -73,24 +75,39 @@ export function update(frame = {}, now = performance.now()) {
   const driftAmount = clamp(Number(frame.driftAmount) || 0, 0, 1);
   const driftHeld = Boolean(frame.driftHeld);
   const boostActive = active && Boolean(frame.boostActive);
+  const enginePitch = clamp(Number(frame.enginePitch) || 1, 0.55, 1.7);
   const audioNow = context.currentTime;
 
   const engineLevel = active
     ? 0.045 + speedRatio * 0.045 + throttle * 0.075
     : 0;
-  const engineBaseHz = 52 + speedRatio * 96 + throttle * 24;
+  const engineBaseHz = (52 + speedRatio * 96 + throttle * 24) * enginePitch;
   smooth(engineGain.gain, engineLevel, audioNow, 0.06);
   smooth(engineLow.frequency, engineBaseHz, audioNow, 0.045);
   smooth(engineHigh.frequency, engineBaseHz * 2.02, audioNow, 0.045);
-  smooth(engineFilter.frequency, 420 + speedRatio * 1450 + throttle * 420, audioNow, 0.06);
+  smooth(
+    engineFilter.frequency,
+    (420 + speedRatio * 1450 + throttle * 420) * (0.82 + enginePitch * 0.18),
+    audioNow,
+    0.06
+  );
 
-  const driftIntent = Math.max(driftAmount, driftHeld ? 0.5 : 0);
-  const driftSpeed = clamp((speed - 10) / 38, 0, 1);
-  const driftLevel = active
-    ? clamp((driftIntent - 0.14) / 0.76, 0, 1) * driftSpeed * 0.19
+  // Ordinary cornering can create a little physics slip, but it should sit far below
+  // the engine. Holding DRIFT adds a stronger tire layer plus a separate high skid hiss.
+  const slipIntent = clamp((driftAmount - 0.12) / 0.88, 0, 1);
+  const driftSpeed = clamp((speed - 10) / 42, 0, 1);
+  const regularSlipLevel = active ? slipIntent * driftSpeed * 0.018 : 0;
+  const deliberateDriftLevel = active && driftHeld
+    ? driftSpeed * (0.018 + slipIntent * 0.032)
     : 0;
-  smooth(driftGain.gain, driftLevel, audioNow, 0.045);
-  smooth(driftFilter.frequency, 920 + speedRatio * 1700, audioNow, 0.07);
+  const driftLevel = regularSlipLevel + deliberateDriftLevel;
+  const skidLevel = active && driftHeld
+    ? driftSpeed * clamp((driftAmount - 0.08) / 0.92, 0, 1) * 0.045
+    : 0;
+  smooth(driftGain.gain, driftLevel, audioNow, 0.05);
+  smooth(driftFilter.frequency, 720 + speedRatio * 1200, audioNow, 0.08);
+  smooth(skidGain.gain, skidLevel, audioNow, 0.045);
+  smooth(skidFilter.frequency, 2500 + speedRatio * 2800, audioNow, 0.055);
 
   const boostLevel = boostActive ? 0.16 : 0;
   smooth(boostGain.gain, boostLevel, audioNow, boostActive ? 0.035 : 0.09);
@@ -101,9 +118,9 @@ export function update(frame = {}, now = performance.now()) {
   lastBoostActive = boostActive;
 }
 
-export function cue(name) {
+export function cue(name, options = {}) {
   void unlock().then((ready) => {
-    if (ready) playCueNow(name);
+    if (ready) playCueNow(name, options);
   });
 }
 
@@ -112,6 +129,7 @@ export function silence() {
   const now = context.currentTime;
   hardMute(engineGain.gain, now);
   hardMute(driftGain.gain, now);
+  hardMute(skidGain.gain, now);
   hardMute(boostGain.gain, now);
   lastBoostActive = false;
 }
@@ -181,16 +199,33 @@ function installDriftGraph() {
 
   driftFilter = context.createBiquadFilter();
   driftFilter.type = 'bandpass';
-  driftFilter.frequency.value = 1200;
-  driftFilter.Q.value = 0.65;
+  driftFilter.frequency.value = 900;
+  driftFilter.Q.value = 0.58;
+
+  skidGain = context.createGain();
+  skidGain.gain.value = 0;
+
+  skidFilter = context.createBiquadFilter();
+  skidFilter.type = 'bandpass';
+  skidFilter.frequency.value = 3200;
+  skidFilter.Q.value = 1.05;
 
   const driftNoise = context.createBufferSource();
-  driftNoise.buffer = makeNoiseBuffer(context, 1.4);
+  driftNoise.buffer = makeNoiseBuffer(context, 1.4, 0.72);
   driftNoise.loop = true;
   driftNoise.connect(driftFilter);
   driftFilter.connect(driftGain);
   driftGain.connect(masterGain);
+
+  const skidNoise = context.createBufferSource();
+  skidNoise.buffer = makeNoiseBuffer(context, 1.1, 0.1);
+  skidNoise.loop = true;
+  skidNoise.connect(skidFilter);
+  skidFilter.connect(skidGain);
+  skidGain.connect(masterGain);
+
   driftNoise.start();
+  skidNoise.start();
 }
 
 function installBoostGraph() {
@@ -226,11 +261,15 @@ function installBoostGraph() {
   boostTone.start();
 }
 
-function playCueNow(name) {
+function playCueNow(name, options = {}) {
   if (!context || context.state !== 'running') return;
   const now = context.currentTime;
 
   switch (name) {
+    case 'garage-open':
+      playTone(260, 390, 0.11, 0.038, 'triangle', now);
+      playTone(430, 620, 0.12, 0.032, 'triangle', now + 0.07);
+      break;
     case 'ui-confirm':
       playTone(420, 610, 0.085, 0.075, 'triangle', now);
       playTone(610, 760, 0.09, 0.06, 'triangle', now + 0.07);
@@ -238,8 +277,14 @@ function playCueNow(name) {
     case 'ui-back':
       playTone(390, 250, 0.12, 0.06, 'triangle', now);
       break;
-    case 'car-select':
-      playTone(230, 340, 0.09, 0.055, 'square', now);
+    case 'car-select': {
+      const pitch = clamp(Number(options.enginePitch) || 1, 0.55, 1.7);
+      playTone(170 * pitch, 310 * pitch, 0.12, 0.052, 'square', now);
+      playNoiseBurst(now, 0.07, 0.022, 320 * pitch, 920 * pitch);
+      break;
+    }
+    case 'paint-select':
+      playTone(560, 760, 0.065, 0.032, 'triangle', now);
       break;
     case 'boost-start':
       playNoiseBurst(now, 0.18, 0.11, 720, 2400);
@@ -294,15 +339,17 @@ function playNoiseBurst(startAt, duration, level, lowHz, highHz) {
   source.stop(endAt + 0.02);
 }
 
-function makeNoiseBuffer(audioContext, seconds) {
+function makeNoiseBuffer(audioContext, seconds, smoothing = 0.72) {
   const frameCount = Math.max(1, Math.ceil(audioContext.sampleRate * seconds));
   const buffer = audioContext.createBuffer(1, frameCount, audioContext.sampleRate);
   const data = buffer.getChannelData(0);
   let previous = 0;
+  const memory = clamp(Number(smoothing) || 0, 0, 0.98);
+  const fresh = 1 - memory;
 
   for (let index = 0; index < frameCount; index += 1) {
     const white = Math.random() * 2 - 1;
-    previous = previous * 0.72 + white * 0.28;
+    previous = previous * memory + white * fresh;
     data[index] = previous;
   }
   return buffer;

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r26 Sound foundation -->
+<!-- TURN r27 Sound character and Lot feedback -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,31 +10,31 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.10 · Build 2026.07.21-r26</title>
+  <title>TURN v1.3.11 · Build 2026.07.21-r27</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.10',
-      id: '2026.07.21-r26',
-      cacheKey: '20260721-r26'
+      version: '1.3.11',
+      id: '2026.07.21-r27',
+      cacheKey: '20260721-r27'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260721-r26">
-  <link rel="stylesheet" href="./styles.css?build=20260721-r26">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260721-r26">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260721-r26">
-  <link rel="stylesheet" href="./install-gate.css?build=20260721-r26">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260721-r26">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260721-r26">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260721-r26">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260721-r26">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260721-r26">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260721-r26">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260721-r26">
+  <link rel="manifest" href="./site.webmanifest?build=20260721-r27">
+  <link rel="stylesheet" href="./styles.css?build=20260721-r27">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260721-r27">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260721-r27">
+  <link rel="stylesheet" href="./install-gate.css?build=20260721-r27">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260721-r27">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260721-r27">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260721-r27">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260721-r27">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260721-r27">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260721-r27">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260721-r27">
 
-  <script src="./install-gate.js?build=20260721-r26"></script>
-  <script src="./orientation-compat.js?build=20260721-r26"></script>
+  <script src="./install-gate.js?build=20260721-r27"></script>
+  <script src="./orientation-compat.js?build=20260721-r27"></script>
   <script type="importmap">
     {
       "imports": {
@@ -54,7 +54,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.10 · Build 2026.07.21-r26</span>
+        <span class="install-kicker">TURN v1.3.11 · Build 2026.07.21-r27</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -82,7 +82,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.10 · Build 2026.07.21-r26</span>
+      <span class="kicker">TURN v1.3.11 · Build 2026.07.21-r27</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -148,6 +148,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260721-r26"></script>
+  <script type="module" src="./app.js?build=20260721-r27"></script>
 </body>
 </html>

--- a/turn/index.html
+++ b/turn/index.html
@@ -41,6 +41,8 @@
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-r10.js?build=20260720-r25",
+        "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260721-r27",
+        "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260721-r27",
         "./vehicle/car-models.js?build=20260720-r19": "./vehicle/car-models.js?build=20260720-r22"
       }
     }

--- a/turn/vehicle/catalog.js
+++ b/turn/vehicle/catalog.js
@@ -19,22 +19,23 @@ export const CAR_PALETTE = Object.freeze([
 // every other vehicle trades strengths for weaknesses instead of becoming a straight upgrade.
 // The vendored packs use three different authored front axes. modelYawQuarterTurns
 // rotates each raw GLB so every car has the same local front before TURN positions it.
+// enginePitch is an audio-only baseline multiplier: heavy vehicles sit lower, race cars higher.
 const RAW_CARS = [
-  ['convertible', 'Convertible', 'prototype', { speed: 4, acceleration: 4, control: 4, drift: 2, boostPower: 3, boostDuration: 1 }, 0.98, 1],
-  ['classic', 'Classic', 'prototype', { speed: 3, acceleration: 2, control: 4, drift: 4, boostPower: 2, boostDuration: 3 }, 1.00, 1],
-  ['vintage-racer', 'Vintage Racer', 'toy', { speed: 5, acceleration: 4, control: 3, drift: 2, boostPower: 3, boostDuration: 1 }, 0.96, 2],
-  ['toy-racer', 'Toy Racer', 'toy', { speed: 4, acceleration: 5, control: 5, drift: 1, boostPower: 2, boostDuration: 1 }, 0.94, 2],
-  ['monster-truck', 'Monster Truck', 'toy', { speed: 2, acceleration: 3, control: 2, drift: 5, boostPower: 2, boostDuration: 4 }, 1.18, 2],
-  ['race-future', 'Future Racer', 'car', { speed: 5, acceleration: 5, control: 3, drift: 1, boostPower: 3, boostDuration: 1 }, 0.96, 0],
-  ['race', 'Race Car', 'car', { speed: 5, acceleration: 4, control: 4, drift: 1, boostPower: 3, boostDuration: 1 }, 0.94, 0],
-  ['sedan-sports', 'Sport Sedan', 'car', { speed: 4, acceleration: 4, control: 4, drift: 2, boostPower: 2, boostDuration: 2 }, 0.98, 0],
-  ['sedan', 'Sedan', 'car', { speed: 3, acceleration: 3, control: 3, drift: 3, boostPower: 3, boostDuration: 3 }, 1.00, 0],
-  ['suv', 'SUV', 'car', { speed: 3, acceleration: 3, control: 3, drift: 4, boostPower: 2, boostDuration: 3 }, 1.05, 0],
-  ['suv-luxury', 'Luxury SUV', 'car', { speed: 3, acceleration: 3, control: 4, drift: 4, boostPower: 2, boostDuration: 2 }, 1.06, 0],
-  ['hatchback-sports', 'Sport Hatch', 'car', { speed: 4, acceleration: 4, control: 5, drift: 2, boostPower: 2, boostDuration: 1 }, 0.96, 0],
-  ['truck-flat', 'Flatbed', 'car', { speed: 2, acceleration: 2, control: 3, drift: 5, boostPower: 2, boostDuration: 4 }, 1.12, 0],
-  ['truck', 'Truck', 'car', { speed: 2, acceleration: 2, control: 3, drift: 5, boostPower: 1, boostDuration: 5 }, 1.12, 0],
-  ['van', 'Van', 'car', { speed: 2, acceleration: 3, control: 3, drift: 5, boostPower: 1, boostDuration: 4 }, 1.08, 0]
+  ['convertible', 'Convertible', 'prototype', { speed: 4, acceleration: 4, control: 4, drift: 2, boostPower: 3, boostDuration: 1 }, 0.98, 1, 1.08],
+  ['classic', 'Classic', 'prototype', { speed: 3, acceleration: 2, control: 4, drift: 4, boostPower: 2, boostDuration: 3 }, 1.00, 1, 0.88],
+  ['vintage-racer', 'Vintage Racer', 'toy', { speed: 5, acceleration: 4, control: 3, drift: 2, boostPower: 3, boostDuration: 1 }, 0.96, 2, 1.28],
+  ['toy-racer', 'Toy Racer', 'toy', { speed: 4, acceleration: 5, control: 5, drift: 1, boostPower: 2, boostDuration: 1 }, 0.94, 2, 1.18],
+  ['monster-truck', 'Monster Truck', 'toy', { speed: 2, acceleration: 3, control: 2, drift: 5, boostPower: 2, boostDuration: 4 }, 1.18, 2, 0.62],
+  ['race-future', 'Future Racer', 'car', { speed: 5, acceleration: 5, control: 3, drift: 1, boostPower: 3, boostDuration: 1 }, 0.96, 0, 1.42],
+  ['race', 'Race Car', 'car', { speed: 5, acceleration: 4, control: 4, drift: 1, boostPower: 3, boostDuration: 1 }, 0.94, 0, 1.55],
+  ['sedan-sports', 'Sport Sedan', 'car', { speed: 4, acceleration: 4, control: 4, drift: 2, boostPower: 2, boostDuration: 2 }, 0.98, 0, 1.12],
+  ['sedan', 'Sedan', 'car', { speed: 3, acceleration: 3, control: 3, drift: 3, boostPower: 3, boostDuration: 3 }, 1.00, 0, 1.00],
+  ['suv', 'SUV', 'car', { speed: 3, acceleration: 3, control: 3, drift: 4, boostPower: 2, boostDuration: 3 }, 1.05, 0, 0.90],
+  ['suv-luxury', 'Luxury SUV', 'car', { speed: 3, acceleration: 3, control: 4, drift: 4, boostPower: 2, boostDuration: 2 }, 1.06, 0, 0.84],
+  ['hatchback-sports', 'Sport Hatch', 'car', { speed: 4, acceleration: 4, control: 5, drift: 2, boostPower: 2, boostDuration: 1 }, 0.96, 0, 1.18],
+  ['truck-flat', 'Flatbed', 'car', { speed: 2, acceleration: 2, control: 3, drift: 5, boostPower: 2, boostDuration: 4 }, 1.12, 0, 0.72],
+  ['truck', 'Truck', 'car', { speed: 2, acceleration: 2, control: 3, drift: 5, boostPower: 1, boostDuration: 5 }, 1.12, 0, 0.68],
+  ['van', 'Van', 'car', { speed: 2, acceleration: 3, control: 3, drift: 5, boostPower: 1, boostDuration: 4 }, 1.08, 0, 0.80]
 ];
 
 // The current GLBs use one atlas material per mesh. Roofs are part of the body mesh,
@@ -52,7 +53,8 @@ export const CAR_CATALOG = Object.freeze(RAW_CARS.map(([
   pack,
   stats,
   visualScale,
-  modelYawQuarterTurns
+  modelYawQuarterTurns,
+  enginePitch
 ]) => Object.freeze({
   id,
   name,
@@ -62,7 +64,10 @@ export const CAR_CATALOG = Object.freeze(RAW_CARS.map(([
   visualScale,
   modelYawQuarterTurns,
   secondaryPaint: SECONDARY_PAINT_BY_ID[id] || null,
-  tuning: Object.freeze(deriveVehicleTuning(stats))
+  tuning: Object.freeze({
+    ...deriveVehicleTuning(stats),
+    enginePitch
+  })
 })));
 
 const CAR_BY_ID = new Map(CAR_CATALOG.map((car) => [car.id, car]));


### PR DESCRIPTION
## Summary

- lowers ordinary cornering/sliding tire noise by roughly an order of magnitude so normal turns sit beneath the engine
- gives deliberate **DRIFT** a stronger tire layer plus a separate brighter skid texture
- adds an explicit engine-pitch baseline for all 15 cars without changing their 18-point balance or driving physics
- ranges engine character from the deep Monster Truck to the high Race Car, with Sedan remaining the neutral baseline
- adds restrained The Lot feedback: a soft entrance cue, a car-field selection chirp, and a paint confirmation sound
- keeps all audio procedural and offline-friendly
- adds catalog import-map cache redirects so PWA installs cannot keep the old pitch-less vehicle catalog
- bumps TURN to **v1.3.11 · Build 2026.07.21-r27**

## Engine pitch character

The pitch multiplier is audio-only and lives alongside each car's existing tuning data. It does not affect acceleration, speed, control, drift, boost, or the 18-point stat budget.

Key anchors:
- Monster Truck: `0.62`
- Truck: `0.68`
- Sedan: `1.00`
- Sport Sedan: `1.12`
- Vintage Racer: `1.28`
- Future Racer: `1.42`
- Race Car: `1.55`

All other vehicles have their own baseline between those anchors.

## Tire sound tuning

The old single tire layer could reach `0.19` during ordinary physics slip, which made normal turning sound much too dramatic. r27 splits the behavior:

- regular slip: max base contribution `0.018`
- deliberate DRIFT: adds a stronger low/mid tire layer
- deliberate DRIFT only: adds a separate high-frequency skid-noise bus

This keeps small natural slides subtle while making the DRIFT control audibly intentional.

## The Lot

The Lot now gets sound without adding ambience or clutter:
- soft cue when The Lot opens
- short selection chirp when interacting with the car field
- tiny confirmation sound when a native paint picker commits a colour
- existing button/UI sounds remain unchanged

## Mobile / performance

- no additional animation loop, interval, network fetch, or audio asset
- continuous audio remains capped at 30 Hz through the existing update path
- the extra skid layer is one persistent procedural noise source with gain/filter modulation
- audio still hard-mutes before mobile AudioContext suspension

## Regression coverage

The sound regression now protects:
- all 15 engine pitch baselines
- Monster Truck as the low anchor, Sedan as neutral, Race Car as the high anchor
- quiet ordinary slip versus DRIFT-only skid enhancement
- The Lot entrance/selection/paint cues
- r27 catalog cache-busting for both historical import URLs
- existing mobile unlock, offline/procedural architecture, loop budget and spectator/Lot race-audio silencing

No driving physics, boost drain/recharge, boost lockout, brake/reverse behavior, vehicle balance, checkpoints, lap logic, paint persistence, orientation, outlines, or spectator behavior is changed.