### PR TITLE
TURN v1.3.12 r28: Redesign drift and boost sound

### DIFF
--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -10,17 +10,17 @@ const [index, app, audio, controls, catalogSource] = await Promise.all([
 ]);
 const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
 
-assert.match(index, /TURN v1\.3\.11 · Build 2026\.07\.21-r27/);
-assert.match(index, /\.\/app\.js\?build=20260721-r27/);
+assert.match(index, /TURN v1\.3\.12 · Build 2026\.07\.21-r28/);
+assert.match(index, /\.\/app\.js\?build=20260721-r28/);
 assert.match(
   index,
   /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r27"/,
-  'The main runtime catalog import must be cache-busted for r27 engine tuning'
+  'The main runtime catalog import must keep the r27 engine tuning cache redirect'
 );
 assert.match(
   index,
   /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260721-r27"/,
-  'The Lot catalog import must resolve to the same r27 engine tuning'
+  'The Lot catalog import must keep the same r27 engine tuning'
 );
 
 assert.match(app, /import\(withBuild\('\.\/audio\/audio-system\.js'\)\)/, 'Production must load the central audio module');
@@ -39,7 +39,8 @@ assert.match(audio, /function installEngineGraph\(/, 'The foundation must provid
 assert.match(audio, /function installDriftGraph\(/, 'The foundation must provide a continuous drift layer');
 assert.match(audio, /function installBoostGraph\(/, 'The foundation must provide a continuous boost layer');
 assert.match(audio, /globalThis\.__turnVehicleTuning\?\.enginePitch/, 'Engine frequency must follow the selected car tuning');
-assert.match(audio, /engineBaseHz = \(52 \+ speedRatio \* 96 \+ throttle \* 24\) \* enginePitch/, 'Per-car pitch must multiply the whole engine baseline');
+assert.match(audio, /engineBaseHz = \(52 \+ speedRatio \* 96 \+ throttle \* 24\) \* enginePitch \* boostEngineLift/, 'Per-car pitch and boost lift must stay connected to the engine bed');
+assert.match(audio, /const boostEngineLift = boostActive \? 1\.055 : 1/, 'Boost must lift the engine subtly rather than replace it');
 
 for (const car of catalog.CAR_CATALOG) {
   assert.ok(Number.isFinite(car.tuning.enginePitch), `${car.name} must define an engine pitch baseline`);
@@ -57,18 +58,32 @@ assert.ok(
   'Race Car must remain the highest-pitched racer'
 );
 
-assert.match(audio, /regularSlipLevel = active \? slipIntent \* driftSpeed \* 0\.018 : 0/, 'Ordinary cornering slip must stay very quiet');
-assert.match(audio, /deliberateDriftLevel = active && driftHeld/, 'Holding DRIFT must add a distinct stronger tire layer');
-assert.match(audio, /const skidLevel = active && driftHeld/, 'Skid hiss must only wake up during deliberate DRIFT');
-assert.match(audio, /skidNoise\.buffer = makeNoiseBuffer\(context, 1\.1, 0\.1\)/, 'DRIFT must use a brighter separate skid texture');
+assert.match(audio, /regularScrubLevel = active \? slipIntent \* driftSpeed \* 0\.0055 : 0/, 'Ordinary cornering scrub must stay nearly subliminal');
+assert.match(audio, /deliberateScrubLevel = active && driftHeld/, 'Holding DRIFT must crossfade in stronger tire scrub');
+assert.match(audio, /const gritLevel = active && driftHeld/, 'Deliberate DRIFT must add a separate low-mid grit layer');
+assert.match(audio, /gritNoise\.buffer = makeNoiseBuffer\(context, 1\.7, 0\.95\)/, 'Drift grit must use heavily smoothed low-frequency noise rather than spray-like hiss');
+assert.match(audio, /skidTone\.type = 'triangle'/, 'Strong drift must use a restrained tonal squeal instead of the retired bright white-noise skid bus');
+assert.doesNotMatch(audio, /skidNoise/, 'The spray-can-like bright skid noise loop must stay removed');
 
-assert.match(audio, /case 'garage-open':/, 'The Lot must have a restrained entrance cue');
-assert.match(audio, /case 'car-select':/, 'The Lot car field must have a selection cue');
-assert.match(audio, /case 'paint-select':/, 'Native paint changes must have a small confirmation cue');
+assert.match(audio, /const boostLevel = boostActive \? 0\.024 : 0/, 'Boost sustain must remain quiet beneath the engine');
+assert.doesNotMatch(audio, /const boostLevel = boostActive \? 0\.16 : 0/, 'The old loud vacuum-like boost sustain must stay removed');
+assert.match(audio, /boostTone\.type = 'sine'/, 'Boost sustain must use a clean turbine-like tone');
+assert.match(audio, /case 'boost-start':/, 'Boost activation must have a layered aggressive one-shot');
+assert.match(audio, /case 'boost-empty':/, 'Boost depletion must have its own cue');
+assert.match(audio, /case 'boost-full':/, 'Boost recharge completion must have its own cue');
+
+assert.match(audio, /RIVAL_NEAR_ENTER_METERS = 10/, 'Nearby-rival sound must use a deliberate entry threshold');
+assert.match(audio, /RIVAL_NEAR_EXIT_METERS = 15/, 'Nearby-rival sound must use hysteresis before it can re-trigger');
+assert.match(audio, /case 'car-near':/, 'A nearby rival must have a restrained proximity cue');
+assert.match(audio, /case 'overtake':/, 'Position gains must have an overtake cue');
+assert.match(audio, /cueAllowed\(name, now\)/, 'Repeatable rival cues must be cooldown-protected');
+
+assert.match(audio, /case 'garage-open':/, 'The Lot must keep its restrained entrance cue');
+assert.match(audio, /case 'car-select':/, 'The Lot car field must keep its selection cue');
+assert.match(audio, /case 'paint-select':/, 'Native paint changes must keep their small confirmation cue');
 assert.match(audio, /handleLotVisibilityChange/, 'The Lot entrance cue must follow the actual open state');
 assert.match(audio, /handleLotPointerDown/, 'The Lot car field must feed selection sound');
 assert.match(audio, /handleUiChange/, 'The Lot paint picker must feed paint sound');
-assert.match(audio, /case 'boost-start':/, 'Boost activation must have a distinct one-shot cue');
 assert.match(audio, /function handleUiClick\(/, 'UI buttons must receive lightweight procedural feedback');
 
 assert.match(audio, /document\.addEventListener\('pointerdown', unlockFromGesture/, 'Touch gestures must unlock audio on mobile');
@@ -86,5 +101,10 @@ assert.match(controls, /runtimeState\?\.mode === runtime\?\.GAME_MODE\?\.SPECTAT
 assert.match(controls, /document\.body\.classList\.contains\('turn-lot-open'\)/, 'Race audio must fade out while The Lot is open');
 assert.match(controls, /driftAmount: runtimeState\?\.driftAmount \|\| 0/, 'Drift sound must follow the real physics drift state');
 assert.match(controls, /boostActive: boosting/, 'Boost sound must follow the post-lockout boost state');
+assert.match(controls, /nearestRivalDistance: nearestRivalDistance\(runtime, active\)/, 'Existing rival positions must feed proximity audio without a new loop');
+assert.match(controls, /globalThis\.__turnAudio\?\.cue\('boost-empty'\)/, 'The exact empty transition must trigger its audio cue');
+assert.match(controls, /globalThis\.__turnAudio\?\.cue\('boost-full'\)/, 'The exact full transition must trigger its audio cue');
+assert.match(controls, /if \(position < lastPosition\)/, 'Only an improved race position may trigger the overtake cue');
+assert.match(controls, /globalThis\.__turnAudio\?\.cue\('overtake'/, 'Position gains must feed the shared overtake cue');
 
-console.log('TURN sound character production regression passed.');
+console.log('TURN drift, boost and rival sound production regression passed.');

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -64,7 +64,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.11 · Build 2026\.07\.21-r27/);
+assert.match(index, /TURN v1\.3\.12 · Build 2026\.07\.21-r28/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -3,37 +3,12 @@ import fs from 'node:fs/promises';
 import { updateVehiclePhysicsState } from '../../turn/vehicle/physics.js';
 
 class Vec3 {
-  constructor(x = 0, y = 0, z = 0) {
-    this.x = x;
-    this.y = y;
-    this.z = z;
-  }
-
-  clone() {
-    return new Vec3(this.x, this.y, this.z);
-  }
-
-  dot(other) {
-    return this.x * other.x + this.y * other.y + this.z * other.z;
-  }
-
-  addScaledVector(other, scale) {
-    this.x += other.x * scale;
-    this.y += other.y * scale;
-    this.z += other.z * scale;
-    return this;
-  }
-
-  multiplyScalar(scale) {
-    this.x *= scale;
-    this.y *= scale;
-    this.z *= scale;
-    return this;
-  }
-
-  length() {
-    return Math.hypot(this.x, this.y, this.z);
-  }
+  constructor(x = 0, y = 0, z = 0) { this.x = x; this.y = y; this.z = z; }
+  clone() { return new Vec3(this.x, this.y, this.z); }
+  dot(other) { return this.x * other.x + this.y * other.y + this.z * other.z; }
+  addScaledVector(other, scale) { this.x += other.x * scale; this.y += other.y * scale; this.z += other.z * scale; return this; }
+  multiplyScalar(scale) { this.x *= scale; this.y *= scale; this.z *= scale; return this; }
+  length() { return Math.hypot(this.x, this.y, this.z); }
 }
 
 const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.all([
@@ -45,9 +20,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.11 · Build 2026\.07\.21-r27/);
-assert.match(index, /drive-pad\.css\?build=20260721-r27/);
-assert.match(index, /gameplay-v2\.css\?build=20260721-r27/);
+assert.match(index, /TURN v1\.3\.12 · Build 2026\.07\.21-r28/);
+assert.match(index, /drive-pad\.css\?build=20260721-r28/);
+assert.match(index, /gameplay-v2\.css\?build=20260721-r28/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');
@@ -77,52 +52,22 @@ const forward = new Vec3(0, 0, 1);
 const right = new Vec3(1, 0, 0);
 const trackSample = { point: new Vec3(), tangent: forward.clone(), normal: right.clone() };
 const state = {
-  position: new Vec3(),
-  velocity: new Vec3(0, 0, 5),
-  touchGas: true,
-  touchBrake: true,
-  throttle: 0,
-  brake: 0,
-  steering: 0,
-  driftAmount: 0,
-  heading: 0,
-  progress: 0,
-  lastProgress: 0,
-  nearestTrackIndex: 0,
-  trackDistance: 0,
-  offRoad: false,
-  speed: 5
+  position: new Vec3(), velocity: new Vec3(0, 0, 5), touchGas: true, touchBrake: true,
+  throttle: 0, brake: 0, steering: 0, driftAmount: 0, heading: 0, progress: 0,
+  lastProgress: 0, nearestTrackIndex: 0, trackDistance: 0, offRoad: false, speed: 5
 };
-
 const physicsArgs = {
-  state,
-  dt: 0.1,
-  updateMotionInput: () => {},
+  state, dt: 0.1, updateMotionInput: () => {},
   findNearestTrack: () => ({ index: 0, distance: 0, sample: trackSample }),
-  getForward: () => forward.clone(),
-  getRight: () => right.clone(),
-  trackWidth: 27,
-  trackSampleCount: 100,
-  maxSpeed: 80,
-  analogGas: 1,
-  boostActive: true,
-  driftHeld: false,
-  vehicleTuning: {
-    accelerationMultiplier: 1,
-    controlMultiplier: 1,
-    driftEngineMultiplier: 0.93,
-    driftDragAdd: 0.085,
-    boostPowerMultiplier: 1,
-    boostSpeedMultiplier: 1.32
-  }
+  getForward: () => forward.clone(), getRight: () => right.clone(),
+  trackWidth: 27, trackSampleCount: 100, maxSpeed: 80, analogGas: 1, boostActive: true, driftHeld: false,
+  vehicleTuning: { accelerationMultiplier: 1, controlMultiplier: 1, driftEngineMultiplier: 0.93, driftDragAdd: 0.085, boostPowerMultiplier: 1, boostSpeedMultiplier: 1.32 }
 };
 
 updateVehiclePhysicsState(physicsArgs);
 assert.ok(state.velocity.z <= 0.001, 'Brake must stop forward motion before reverse begins');
-
 updateVehiclePhysicsState(physicsArgs);
 assert.ok(state.velocity.z < -0.1, 'Holding Brake after stopping must engage reverse');
-
 for (let i = 0; i < 100; i += 1) updateVehiclePhysicsState(physicsArgs);
 assert.ok(state.velocity.z >= -(80 * 0.32 + 0.5), 'Reverse must stay capped well below forward top speed');
 

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -4,43 +4,19 @@ import path from 'node:path';
 
 const root = process.cwd();
 const turnDir = path.join(root, 'turn');
-
 const catalogSource = await fs.readFile(path.join(turnDir, 'vehicle/catalog.js'), 'utf8');
 const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
-
-const expectedIds = [
-  'convertible',
-  'classic',
-  'vintage-racer',
-  'toy-racer',
-  'monster-truck',
-  'race-future',
-  'race',
-  'sedan-sports',
-  'sedan',
-  'suv',
-  'suv-luxury',
-  'hatchback-sports',
-  'truck-flat',
-  'truck',
-  'van'
-];
+const expectedIds = ['convertible','classic','vintage-racer','toy-racer','monster-truck','race-future','race','sedan-sports','sedan','suv','suv-luxury','hatchback-sports','truck-flat','truck','van'];
 
 assert.equal(catalog.CAR_CATALOG.length, 15, 'The Lot must contain exactly 15 cars');
 assert.deepEqual(catalog.CAR_CATALOG.map((car) => car.id), expectedIds, 'The Lot car order changed unexpectedly');
-
-for (const id of expectedIds) {
-  await fs.access(path.join(turnDir, `assets/cars/${id}.glb`));
-}
-
-const brickFiles = (await fs.readdir(path.join(turnDir, 'assets/lot-bricks')))
-  .filter((file) => file.endsWith('.glb'));
+for (const id of expectedIds) await fs.access(path.join(turnDir, `assets/cars/${id}.glb`));
+const brickFiles = (await fs.readdir(path.join(turnDir, 'assets/lot-bricks'))).filter((file) => file.endsWith('.glb'));
 assert.equal(brickFiles.length, 9, 'The vendored Kenney Brick Kit subset should remain available even though The Lot no longer renders it');
 
 const sedan = catalog.getCarDefinition('sedan');
 const race = catalog.getCarDefinition('race');
 const truck = catalog.getCarDefinition('truck');
-
 assert.equal(sedan.tuning.topSpeedMultiplier, 1, 'Sedan top speed must remain the v1.0 baseline');
 assert.equal(sedan.tuning.accelerationMultiplier, 1, 'Sedan acceleration must remain the v1.0 baseline');
 assert.equal(sedan.tuning.controlMultiplier, 1, 'Sedan control must remain the v1.0 baseline');
@@ -49,22 +25,18 @@ assert.equal(sedan.tuning.driftDragAdd, 0.085, 'Sedan drift drag must remain the
 assert.equal(sedan.tuning.boostPowerMultiplier, 1, 'Sedan boost power must remain the v1.0 baseline');
 assert.equal(sedan.tuning.boostSpeedMultiplier, 1.32, 'Sedan boost speed must remain the v1.0 baseline');
 assert.equal(sedan.tuning.boostDurationSeconds, 2, 'Sedan boost tank must remain the v1.0 baseline');
-
 assert.ok(race.tuning.topSpeedMultiplier > sedan.tuning.topSpeedMultiplier, 'Race car should have more top speed than Sedan');
 assert.ok(race.tuning.accelerationMultiplier > sedan.tuning.accelerationMultiplier, 'Race car should accelerate faster than Sedan');
 assert.ok(race.tuning.controlMultiplier > sedan.tuning.controlMultiplier, 'Race car should have more control than Sedan');
 assert.ok(race.tuning.driftDragAdd > sedan.tuning.driftDragAdd, 'Race car should pay a larger speed penalty while drifting');
 assert.ok(race.tuning.boostPowerMultiplier >= sedan.tuning.boostPowerMultiplier, 'Race car boost should not be weaker than Sedan');
 assert.ok(race.tuning.boostDurationSeconds < sedan.tuning.boostDurationSeconds, 'Race car should have a shorter boost tank');
-
 assert.ok(truck.tuning.topSpeedMultiplier < sedan.tuning.topSpeedMultiplier, 'Truck should have less top speed than Sedan');
 assert.ok(truck.tuning.accelerationMultiplier < sedan.tuning.accelerationMultiplier, 'Truck should accelerate slower than Sedan');
 assert.ok(truck.tuning.driftDragAdd < sedan.tuning.driftDragAdd, 'Truck should retain more speed while drifting');
 assert.ok(truck.tuning.boostPowerMultiplier < sedan.tuning.boostPowerMultiplier, 'Truck boost should be weaker than Sedan');
 assert.ok(truck.tuning.boostDurationSeconds > sedan.tuning.boostDurationSeconds, 'Truck should have a longer boost tank');
-
-const lighterGhost = catalog.makeGhostColor('#ff4fa3');
-assert.notEqual(lighterGhost, '#ff4fa3', 'Ghost colour should be a lighter nuance, not the original paint colour');
+assert.notEqual(catalog.makeGhostColor('#ff4fa3'), '#ff4fa3', 'Ghost colour should be a lighter nuance, not the original paint colour');
 
 const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promise.all([
   fs.readFile(path.join(turnDir, 'index.html'), 'utf8'),
@@ -75,9 +47,9 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.11 · Build 2026\.07\.21-r27/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260721-r27/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r27 must preserve the latest Lot module cache redirect');
+assert.match(index, /TURN v1\.3\.12 · Build 2026\.07\.21-r28/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260721-r28/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r28 must preserve the latest Lot module cache redirect');
 assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -11,21 +11,9 @@ assert.equal(inGameMenuStateFor(GAME_MODE.STAGED), IN_GAME_MENU_STATE.STAGED);
 assert.equal(inGameMenuStateFor(GAME_MODE.RACING), IN_GAME_MENU_STATE.RACING);
 assert.equal(inGameMenuStateFor(GAME_MODE.SPECTATING), IN_GAME_MENU_STATE.HIDDEN);
 
-assert.deepEqual(inGameMenuVisibilityFor(GAME_MODE.STAGED), {
-  menuState: IN_GAME_MENU_STATE.STAGED,
-  backToStart: false,
-  startActions: true
-});
-assert.deepEqual(inGameMenuVisibilityFor(GAME_MODE.RACING), {
-  menuState: IN_GAME_MENU_STATE.RACING,
-  backToStart: true,
-  startActions: false
-});
-assert.deepEqual(inGameMenuVisibilityFor(GAME_MODE.SPECTATING), {
-  menuState: IN_GAME_MENU_STATE.HIDDEN,
-  backToStart: false,
-  startActions: false
-});
+assert.deepEqual(inGameMenuVisibilityFor(GAME_MODE.STAGED), { menuState: IN_GAME_MENU_STATE.STAGED, backToStart: false, startActions: true });
+assert.deepEqual(inGameMenuVisibilityFor(GAME_MODE.RACING), { menuState: IN_GAME_MENU_STATE.RACING, backToStart: true, startActions: false });
+assert.deepEqual(inGameMenuVisibilityFor(GAME_MODE.SPECTATING), { menuState: IN_GAME_MENU_STATE.HIDDEN, backToStart: false, startActions: false });
 
 const [index, app, menu, controls, backToLot, main, css, spectate] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
@@ -38,24 +26,18 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.11 · Build 2026\.07\.21-r27/);
-assert.match(index, /in-game-menu\.css\?build=20260721-r27/);
+assert.match(index, /TURN v1\.3\.12 · Build 2026\.07\.21-r28/);
+assert.match(index, /in-game-menu\.css\?build=20260721-r28/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Back to Start<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);
-
 assert.match(menu, /inGameMenuVisibilityFor\(runtime\.state\.mode\)/, 'Menu visibility must follow the explicit game mode');
 assert.doesNotMatch(menu, /state\.speed/, 'Menu visibility must not infer race state from speed');
 assert.match(menu, /backToStartButton\.hidden = !visibility\.backToStart/);
 assert.match(menu, /backToLotButton\.hidden = !visibility\.startActions/);
 assert.match(menu, /recalibrateButton\.hidden = !visibility\.startActions/);
 assert.match(menu, /resetRivalsButton\.hidden = !visibility\.startActions/);
-assert.match(
-  menu,
-  /const buttonOrder = \[\s*backToLotButton,\s*recalibrateButton,\s*resetRivalsButton,\s*spectateButton,\s*backToStartButton\s*\]/,
-  'Start actions must follow the requested order'
-);
-
+assert.match(menu, /const buttonOrder = \[\s*backToLotButton,\s*recalibrateButton,\s*resetRivalsButton,\s*spectateButton,\s*backToStartButton\s*\]/, 'Start actions must follow the requested order');
 assert.match(controls, /Reset Rivals/);
 assert.match(controls, /globalThis\.__turnResetRivals/);
 assert.match(backToLot, /Back to Lot/);

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -3,30 +3,20 @@ import fs from 'node:fs/promises';
 import { updateMotionInputState } from '../../turn/input/motion.js';
 
 function manualStep(manualSteering) {
-  const state = {
-    sensorMode: false,
-    manualSteering,
-    steering: 0,
-    tiltDrive: 0
-  };
-
+  const state = { sensorMode: false, manualSteering, steering: 0, tiltDrive: 0 };
   updateMotionInputState({ state, dt: 1, maxSteerRoll: 1 });
   return state.steering;
 }
 
-// TURN's vehicle yaw convention is opposite to screen-space manual input.
-// A touch/keyboard input on the left must therefore produce positive vehicle steering,
-// while a right input must produce negative vehicle steering.
 assert.equal(manualStep(-1), 1, 'manual left should steer the car left');
 assert.equal(manualStep(1), -1, 'manual right should steer the car right');
 assert.equal(manualStep(0), 0, 'centered manual steering should stay centered');
 
 const index = await fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8');
 const css = await fs.readFile(new URL('../../turn/manual-steering.css', import.meta.url), 'utf8');
-
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260721-r27/);
+assert.match(index, /manual-steering\.css\?build=20260721-r28/);
 assert.match(css, /--manual-steer-left/);
 assert.match(css, /content: "←"/);
 assert.match(css, /content: "→"/);

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -6,35 +6,21 @@ const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogS
 
 assert.equal(catalog.normalizeVehicleColor('#12AbEf'), '#12abef', 'Native picker colours must not be palette-limited');
 assert.equal(catalog.normalizeVehicleColor('#fff'), catalog.DEFAULT_VEHICLE_COLOR, 'Invalid short hex must use the body fallback');
-assert.equal(
-  catalog.normalizeVehicleSecondaryColor('#654321'),
-  '#654321',
-  'Secondary paint must accept a native picker value'
-);
+assert.equal(catalog.normalizeVehicleSecondaryColor('#654321'), '#654321', 'Secondary paint must accept a native picker value');
 assert.deepEqual(
-  catalog.normalizeVehicleSelection({
-    carId: 'sedan-sports',
-    color: '#123456',
-    secondaryColor: '#abcdef'
-  }),
+  catalog.normalizeVehicleSelection({ carId: 'sedan-sports', color: '#123456', secondaryColor: '#abcdef' }),
   { carId: 'sedan-sports', color: '#123456', secondaryColor: '#abcdef' },
   'Vehicle selection must persist both native colours'
 );
 
 const secondaryCars = catalog.CAR_CATALOG.filter((car) => car.secondaryPaint);
-assert.deepEqual(
-  secondaryCars.map((car) => car.id),
-  ['sedan-sports'],
-  'Only genuinely separate secondary meshes should expose a second picker'
-);
+assert.deepEqual(secondaryCars.map((car) => car.id), ['sedan-sports'], 'Only genuinely separate secondary meshes should expose a second picker');
 assert.equal(secondaryCars[0].secondaryPaint.label, 'Spoiler');
 assert.deepEqual(secondaryCars[0].secondaryPaint.meshNames, ['spoiler']);
 
 const sportSedanGlb = await fs.readFile(new URL('../../turn/assets/cars/sedan-sports.glb', import.meta.url));
 const sportSedanJson = readGlbJson(sportSedanGlb);
-const meshNodeNames = (sportSedanJson.nodes || [])
-  .filter((node) => Number.isInteger(node.mesh))
-  .map((node) => String(node.name || '').toLowerCase());
+const meshNodeNames = (sportSedanJson.nodes || []).filter((node) => Number.isInteger(node.mesh)).map((node) => String(node.name || '').toLowerCase());
 assert.ok(meshNodeNames.includes('body'), 'Sport Sedan body must remain a separate primary mesh');
 assert.ok(meshNodeNames.includes('spoiler'), 'Sport Sedan spoiler must remain a separate secondary mesh');
 
@@ -48,7 +34,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.11 · Build 2026\.07\.21-r27/);
+assert.match(index, /TURN v1\.3\.12 · Build 2026\.07\.21-r28/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');
@@ -70,9 +56,7 @@ function readGlbJson(buffer) {
   while (offset + 8 <= buffer.length) {
     const length = buffer.readUInt32LE(offset);
     const type = buffer.toString('utf8', offset + 4, offset + 8);
-    if (type === 'JSON') {
-      return JSON.parse(buffer.subarray(offset + 8, offset + 8 + length).toString('utf8').trim());
-    }
+    if (type === 'JSON') return JSON.parse(buffer.subarray(offset + 8, offset + 8 + length).toString('utf8').trim());
     offset += 8 + length;
   }
   assert.fail('Sport Sedan has no GLB JSON chunk');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -1,39 +1,21 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
-
-import {
-  createTrackSpatialIndex,
-  findNearestTrackBruteForce
-} from '../../turn/race/track-spatial-index.js';
-import {
-  performanceModeRequested,
-  summarizeFrameSamples
-} from '../../turn/performance-monitor.js';
+import { createTrackSpatialIndex, findNearestTrackBruteForce } from '../../turn/race/track-spatial-index.js';
+import { performanceModeRequested, summarizeFrameSamples } from '../../turn/performance-monitor.js';
 
 const samples = Array.from({ length: 720 }, (_, index) => {
   const angle = index / 720 * Math.PI * 2;
   const radiusX = 208 + Math.sin(angle * 2 + 0.35) * 20 + Math.sin(angle * 3 - 0.8) * 9;
   const radiusZ = 146 + Math.cos(angle * 2 - 0.4) * 14 + Math.sin(angle * 3 + 0.6) * 8;
-  return {
-    point: {
-      x: Math.cos(angle) * radiusX,
-      z: Math.sin(angle) * radiusZ
-    }
-  };
+  return { point: { x: Math.cos(angle) * radiusX, z: Math.sin(angle) * radiusZ } };
 });
 
 const spatialIndex = createTrackSpatialIndex(samples, { cellSize: 32 });
 let seed = 0x17c0ffee;
-function random() {
-  seed = (seed * 1664525 + 1013904223) >>> 0;
-  return seed / 0x100000000;
-}
+function random() { seed = (seed * 1664525 + 1013904223) >>> 0; return seed / 0x100000000; }
 
 for (let query = 0; query < 1200; query += 1) {
-  const position = {
-    x: (random() - 0.5) * 540,
-    z: (random() - 0.5) * 420
-  };
+  const position = { x: (random() - 0.5) * 540, z: (random() - 0.5) * 420 };
   const indexed = spatialIndex.find(position);
   const brute = findNearestTrackBruteForce(samples, position);
   assert.equal(indexed.index, brute.index, `Spatial query ${query} must preserve the exact nearest sample`);
@@ -42,28 +24,20 @@ for (let query = 0; query < 1200; query += 1) {
 
 const checksBeforeTrackPass = spatialIndex.getStats();
 for (let index = 0; index < samples.length; index += 1) {
-  spatialIndex.find({
-    x: samples[index].point.x + Math.sin(index) * 3,
-    z: samples[index].point.z + Math.cos(index) * 3
-  });
+  spatialIndex.find({ x: samples[index].point.x + Math.sin(index) * 3, z: samples[index].point.z + Math.cos(index) * 3 });
 }
 const checksAfterTrackPass = spatialIndex.getStats();
 const trackQueries = checksAfterTrackPass.queryCount - checksBeforeTrackPass.queryCount;
 const trackChecks = checksAfterTrackPass.totalChecks - checksBeforeTrackPass.totalChecks;
-assert.ok(
-  trackChecks / trackQueries < 120,
-  'Normal on-track queries should inspect far fewer than all 720 samples'
-);
+assert.ok(trackChecks / trackQueries < 120, 'Normal on-track queries should inspect far fewer than all 720 samples');
 
 const fallback = spatialIndex.find({ x: 5000, z: -5000 });
 const fallbackBrute = findNearestTrackBruteForce(samples, { x: 5000, z: -5000 });
 assert.equal(fallback.index, fallbackBrute.index, 'Far teleports must retain the exact full-scan fallback');
 assert.equal(fallback.checks, samples.length);
-
 assert.equal(performanceModeRequested('?perf=1'), true);
 assert.equal(performanceModeRequested('?perf=0'), false);
 assert.equal(performanceModeRequested(''), false);
-
 const summary = summarizeFrameSamples([10, 20, 30, 40, 50]);
 assert.equal(summary.averageMs, 30);
 assert.equal(summary.p50Ms, 30);
@@ -71,7 +45,7 @@ assert.equal(summary.p95Ms, 50);
 assert.equal(summary.slowPercent, 40);
 assert.ok(Math.abs(summary.fps - 1000 / 30) < 1e-9);
 
-const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, monitor] = await Promise.all([
+const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, monitor, audio] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/ui/gameplay-controls.js', import.meta.url), 'utf8'),
@@ -82,10 +56,11 @@ const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, m
   fs.readFile(new URL('../../turn/render/camera.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/vehicle/car-models.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-r10.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/performance-monitor.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../../turn/performance-monitor.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/audio/audio-system.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.11 · Build 2026\.07\.21-r27/);
+assert.match(index, /TURN v1\.3\.12 · Build 2026\.07\.21-r28/);
 assert.match(main, /mainSceneOcclusion/);
 assert.match(main, /HUD_UPDATE_INTERVAL_MS = 1000 \/ 30/);
 assert.match(main, /recordPerformanceFrame/);
@@ -105,10 +80,9 @@ assert.match(cars, /record\.node\.castShadow = !ghost/);
 assert.doesNotMatch(lot, /root\.scale\.lerp\(new THREE\.Vector3/);
 assert.match(lot, /recordPerformanceFrame/);
 assert.doesNotMatch(lot, /GLTFLoader|InstancedMesh|installBrickScenery/, 'The clean Lot must not spend asset or draw-call budget on decorative wall scenery');
+assert.match(audio, /AUDIO_UPDATE_INTERVAL_MS = 1000 \/ 30/, 'Audio state must stay capped at 30 Hz');
+assert.doesNotMatch(audio, /requestAnimationFrame|setAnimationLoop|setInterval/, 'New sound cues must not add a second loop');
 assert.match(monitor, /turn:perf-snapshot/);
 assert.match(monitor, /trackChecksPerQuery/);
 
-console.log(
-  `TURN production performance and diagnostics regression passed ` +
-  `(${(trackChecks / trackQueries).toFixed(1)} average on-track checks vs 720).`
-);
+console.log(`TURN production performance and diagnostics regression passed (${(trackChecks / trackQueries).toFixed(1)} average on-track checks vs 720).`);

--- a/turn/audio/audio-system.js
+++ b/turn/audio/audio-system.js
@@ -2,6 +2,8 @@ const AudioContextClass = globalThis.AudioContext || globalThis.webkitAudioConte
 
 const AUDIO_UPDATE_INTERVAL_MS = 1000 / 30;
 const MASTER_GAIN = 0.72;
+const RIVAL_NEAR_ENTER_METERS = 10;
+const RIVAL_NEAR_EXIT_METERS = 15;
 
 let context = null;
 let masterGain = null;
@@ -11,15 +13,20 @@ let engineLow = null;
 let engineHigh = null;
 let driftGain = null;
 let driftFilter = null;
+let gritGain = null;
+let gritFilter = null;
 let skidGain = null;
 let skidFilter = null;
+let skidTone = null;
 let boostGain = null;
 let boostFilter = null;
 let boostTone = null;
 let lastUpdateAt = -Infinity;
 let lastBoostActive = false;
+let rivalNearLatched = false;
 let lotOpen = false;
 let installed = false;
+const cueTimes = new Map();
 
 export function installTurnAudio() {
   if (installed) return globalThis.__turnAudio;
@@ -89,12 +96,15 @@ export function update(frame = {}, now = performance.now()) {
     0.55,
     1.7
   );
+  const nearestRivalDistance = Number(frame.nearestRivalDistance);
   const audioNow = context.currentTime;
 
+  // Boost lifts the existing engine slightly instead of replacing it with a loud effect bed.
+  const boostEngineLift = boostActive ? 1.055 : 1;
   const engineLevel = active
     ? 0.045 + speedRatio * 0.045 + throttle * 0.075
     : 0;
-  const engineBaseHz = (52 + speedRatio * 96 + throttle * 24) * enginePitch;
+  const engineBaseHz = (52 + speedRatio * 96 + throttle * 24) * enginePitch * boostEngineLift;
   smooth(engineGain.gain, engineLevel, audioNow, 0.06);
   smooth(engineLow.frequency, engineBaseHz, audioNow, 0.045);
   smooth(engineHigh.frequency, engineBaseHz * 2.02, audioNow, 0.045);
@@ -105,30 +115,40 @@ export function update(frame = {}, now = performance.now()) {
     0.06
   );
 
-  // Ordinary cornering can create a little physics slip, but it should sit far below
-  // the engine. Holding DRIFT adds a stronger tire layer plus a separate high skid hiss.
-  const slipIntent = clamp((driftAmount - 0.12) / 0.88, 0, 1);
+  // Drift should read as traction loss rather than broadband spray. Normal slip is nearly
+  // subliminal; deliberate DRIFT crossfades in tire scrub, low-mid body grit and a small squeal.
+  const slipIntent = clamp((driftAmount - 0.14) / 0.86, 0, 1);
+  const strongSlip = clamp((driftAmount - 0.32) / 0.68, 0, 1);
   const driftSpeed = clamp((speed - 10) / 42, 0, 1);
-  const regularSlipLevel = active ? slipIntent * driftSpeed * 0.018 : 0;
-  const deliberateDriftLevel = active && driftHeld
-    ? driftSpeed * (0.018 + slipIntent * 0.032)
+  const regularScrubLevel = active ? slipIntent * driftSpeed * 0.0055 : 0;
+  const deliberateScrubLevel = active && driftHeld
+    ? driftSpeed * (0.014 + slipIntent * 0.024)
     : 0;
-  const driftLevel = regularSlipLevel + deliberateDriftLevel;
+  const gritLevel = active && driftHeld
+    ? driftSpeed * (0.007 + slipIntent * 0.021)
+    : regularScrubLevel * 0.32;
   const skidLevel = active && driftHeld
-    ? driftSpeed * clamp((driftAmount - 0.08) / 0.92, 0, 1) * 0.045
+    ? driftSpeed * strongSlip * 0.012
     : 0;
-  smooth(driftGain.gain, driftLevel, audioNow, 0.05);
-  smooth(driftFilter.frequency, 720 + speedRatio * 1200, audioNow, 0.08);
-  smooth(skidGain.gain, skidLevel, audioNow, 0.045);
-  smooth(skidFilter.frequency, 2500 + speedRatio * 2800, audioNow, 0.055);
 
-  const boostLevel = boostActive ? 0.16 : 0;
-  smooth(boostGain.gain, boostLevel, audioNow, boostActive ? 0.035 : 0.09);
-  smooth(boostFilter.frequency, 1050 + speedRatio * 1000, audioNow, 0.05);
-  smooth(boostTone.frequency, 82 + speedRatio * 58, audioNow, 0.045);
+  smooth(driftGain.gain, regularScrubLevel + deliberateScrubLevel, audioNow, 0.075);
+  smooth(driftFilter.frequency, 820 + speedRatio * 980 + slipIntent * 260, audioNow, 0.085);
+  smooth(gritGain.gain, gritLevel, audioNow, 0.09);
+  smooth(gritFilter.frequency, 300 + speedRatio * 330 + slipIntent * 180, audioNow, 0.1);
+  smooth(skidGain.gain, skidLevel, audioNow, 0.08);
+  smooth(skidTone.frequency, 720 + speedRatio * 520 + strongSlip * 190, audioNow, 0.07);
+  smooth(skidFilter.frequency, 980 + speedRatio * 520, audioNow, 0.09);
+
+  // The boost sustain is intentionally quiet. Most of the character lives in the start cue.
+  const boostLevel = boostActive ? 0.024 : 0;
+  smooth(boostGain.gain, boostLevel, audioNow, boostActive ? 0.055 : 0.12);
+  smooth(boostFilter.frequency, 1150 + speedRatio * 1450, audioNow, 0.07);
+  smooth(boostTone.frequency, 430 + speedRatio * 430, audioNow, 0.06);
 
   if (boostActive && !lastBoostActive) playCueNow('boost-start');
   lastBoostActive = boostActive;
+
+  updateRivalProximity(active, nearestRivalDistance);
 }
 
 export function cue(name, options = {}) {
@@ -142,9 +162,11 @@ export function silence() {
   const now = context.currentTime;
   hardMute(engineGain.gain, now);
   hardMute(driftGain.gain, now);
+  hardMute(gritGain.gain, now);
   hardMute(skidGain.gain, now);
   hardMute(boostGain.gain, now);
   lastBoostActive = false;
+  rivalNearLatched = false;
 }
 
 function ensureGraph() {
@@ -209,36 +231,49 @@ function installEngineGraph() {
 function installDriftGraph() {
   driftGain = context.createGain();
   driftGain.gain.value = 0;
-
   driftFilter = context.createBiquadFilter();
   driftFilter.type = 'bandpass';
-  driftFilter.frequency.value = 900;
-  driftFilter.Q.value = 0.58;
+  driftFilter.frequency.value = 980;
+  driftFilter.Q.value = 0.72;
+
+  gritGain = context.createGain();
+  gritGain.gain.value = 0;
+  gritFilter = context.createBiquadFilter();
+  gritFilter.type = 'bandpass';
+  gritFilter.frequency.value = 420;
+  gritFilter.Q.value = 0.62;
 
   skidGain = context.createGain();
   skidGain.gain.value = 0;
-
   skidFilter = context.createBiquadFilter();
   skidFilter.type = 'bandpass';
-  skidFilter.frequency.value = 3200;
-  skidFilter.Q.value = 1.05;
+  skidFilter.frequency.value = 1150;
+  skidFilter.Q.value = 1.35;
 
   const driftNoise = context.createBufferSource();
-  driftNoise.buffer = makeNoiseBuffer(context, 1.4, 0.72);
+  driftNoise.buffer = makeNoiseBuffer(context, 1.6, 0.86);
   driftNoise.loop = true;
   driftNoise.connect(driftFilter);
   driftFilter.connect(driftGain);
   driftGain.connect(masterGain);
 
-  const skidNoise = context.createBufferSource();
-  skidNoise.buffer = makeNoiseBuffer(context, 1.1, 0.1);
-  skidNoise.loop = true;
-  skidNoise.connect(skidFilter);
+  const gritNoise = context.createBufferSource();
+  gritNoise.buffer = makeNoiseBuffer(context, 1.7, 0.95);
+  gritNoise.loop = true;
+  gritNoise.connect(gritFilter);
+  gritFilter.connect(gritGain);
+  gritGain.connect(masterGain);
+
+  skidTone = context.createOscillator();
+  skidTone.type = 'triangle';
+  skidTone.frequency.value = 820;
+  skidTone.connect(skidFilter);
   skidFilter.connect(skidGain);
   skidGain.connect(masterGain);
 
   driftNoise.start();
-  skidNoise.start();
+  gritNoise.start();
+  skidTone.start();
 }
 
 function installBoostGraph() {
@@ -247,22 +282,22 @@ function installBoostGraph() {
 
   boostFilter = context.createBiquadFilter();
   boostFilter.type = 'bandpass';
-  boostFilter.frequency.value = 1300;
-  boostFilter.Q.value = 0.45;
+  boostFilter.frequency.value = 1500;
+  boostFilter.Q.value = 1.2;
 
   const boostNoiseMix = context.createGain();
-  boostNoiseMix.gain.value = 0.8;
+  boostNoiseMix.gain.value = 0.12;
   const boostToneMix = context.createGain();
-  boostToneMix.gain.value = 0.28;
+  boostToneMix.gain.value = 0.58;
 
   const boostNoise = context.createBufferSource();
-  boostNoise.buffer = makeNoiseBuffer(context, 1.1);
+  boostNoise.buffer = makeNoiseBuffer(context, 1.3, 0.91);
   boostNoise.loop = true;
   boostNoise.connect(boostNoiseMix);
 
   boostTone = context.createOscillator();
-  boostTone.type = 'triangle';
-  boostTone.frequency.value = 82;
+  boostTone.type = 'sine';
+  boostTone.frequency.value = 430;
   boostTone.connect(boostToneMix);
 
   boostNoiseMix.connect(boostFilter);
@@ -274,9 +309,27 @@ function installBoostGraph() {
   boostTone.start();
 }
 
+function updateRivalProximity(active, distance) {
+  if (!active || !Number.isFinite(distance)) {
+    rivalNearLatched = false;
+    return;
+  }
+
+  if (!rivalNearLatched && distance <= RIVAL_NEAR_ENTER_METERS) {
+    rivalNearLatched = true;
+    playCueNow('car-near', {
+      intensity: clamp(1 - distance / RIVAL_NEAR_ENTER_METERS, 0.25, 1)
+    });
+    return;
+  }
+
+  if (rivalNearLatched && distance >= RIVAL_NEAR_EXIT_METERS) rivalNearLatched = false;
+}
+
 function playCueNow(name, options = {}) {
   if (!context || context.state !== 'running') return;
   const now = context.currentTime;
+  if (!cueAllowed(name, now)) return;
 
   switch (name) {
     case 'garage-open':
@@ -293,21 +346,61 @@ function playCueNow(name, options = {}) {
     case 'car-select': {
       const pitch = clamp(Number(options.enginePitch) || 1, 0.55, 1.7);
       playTone(170 * pitch, 310 * pitch, 0.12, 0.052, 'square', now);
-      playNoiseBurst(now, 0.07, 0.022, 320 * pitch, 920 * pitch);
+      playNoiseBurst(now, 0.07, 0.022, 320 * pitch, 920 * pitch, 0.84);
       break;
     }
     case 'paint-select':
       playTone(560, 760, 0.065, 0.032, 'triangle', now);
       break;
     case 'boost-start':
-      playNoiseBurst(now, 0.18, 0.11, 720, 2400);
-      playTone(92, 180, 0.18, 0.075, 'sawtooth', now);
+      // Spool, pressure punch, then a short whoosh. The quiet sustain takes over underneath.
+      playTone(260, 980, 0.18, 0.038, 'sine', now);
+      playTone(86, 54, 0.085, 0.05, 'triangle', now + 0.015);
+      playNoiseBurst(now + 0.025, 0.23, 0.045, 520, 3200, 0.84);
+      playTone(620, 1080, 0.19, 0.018, 'triangle', now + 0.035);
       break;
+    case 'boost-empty':
+      playTone(860, 230, 0.2, 0.034, 'sine', now);
+      playNoiseBurst(now + 0.025, 0.15, 0.035, 1300, 340, 0.91);
+      playTone(105, 62, 0.09, 0.04, 'triangle', now + 0.045);
+      break;
+    case 'boost-full':
+      playTone(470, 760, 0.08, 0.028, 'triangle', now);
+      playTone(760, 1120, 0.1, 0.021, 'sine', now + 0.07);
+      playNoiseBurst(now + 0.045, 0.07, 0.012, 900, 2100, 0.88);
+      break;
+    case 'overtake': {
+      const places = clamp(Number(options.places) || 1, 1, 4);
+      const lift = 1 + (places - 1) * 0.06;
+      playTone(240 * lift, 590 * lift, 0.16, 0.038, 'triangle', now);
+      playNoiseBurst(now + 0.025, 0.18, 0.028, 420, 1900, 0.88);
+      break;
+    }
+    case 'car-near': {
+      const intensity = clamp(Number(options.intensity) || 0.5, 0.25, 1);
+      playTone(150, 360 + intensity * 140, 0.14, 0.014 + intensity * 0.012, 'triangle', now);
+      playNoiseBurst(now, 0.16, 0.012 + intensity * 0.012, 300, 1200, 0.9);
+      break;
+    }
     case 'ui-tap':
     default:
       playTone(330, 420, 0.055, 0.038, 'triangle', now);
       break;
   }
+}
+
+function cueAllowed(name, now) {
+  const cooldown = name === 'car-near'
+    ? 1.2
+    : name === 'overtake'
+      ? 0.45
+      : 0;
+  if (!cooldown) return true;
+
+  const previous = cueTimes.get(name) ?? -Infinity;
+  if (now - previous < cooldown) return false;
+  cueTimes.set(name, now);
+  return true;
 }
 
 function playTone(startHz, endHz, duration, level, type, startAt) {
@@ -329,17 +422,17 @@ function playTone(startHz, endHz, duration, level, type, startAt) {
   oscillator.stop(endAt + 0.02);
 }
 
-function playNoiseBurst(startAt, duration, level, lowHz, highHz) {
+function playNoiseBurst(startAt, duration, level, lowHz, highHz, smoothing = 0.78) {
   const source = context.createBufferSource();
   const filter = context.createBiquadFilter();
   const gain = context.createGain();
   const endAt = startAt + duration;
 
-  source.buffer = makeNoiseBuffer(context, Math.max(0.2, duration));
+  source.buffer = makeNoiseBuffer(context, Math.max(0.2, duration), smoothing);
   filter.type = 'bandpass';
   filter.Q.value = 0.7;
-  filter.frequency.setValueAtTime(lowHz, startAt);
-  filter.frequency.exponentialRampToValueAtTime(highHz, endAt);
+  filter.frequency.setValueAtTime(Math.max(1, lowHz), startAt);
+  filter.frequency.exponentialRampToValueAtTime(Math.max(1, highHz), endAt);
 
   gain.gain.setValueAtTime(0.0001, startAt);
   gain.gain.exponentialRampToValueAtTime(level, startAt + 0.01);

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r27 Sound character and Lot feedback -->
+<!-- TURN r28 Drift, boost and rival sound design -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,31 +10,31 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.11 · Build 2026.07.21-r27</title>
+  <title>TURN v1.3.12 · Build 2026.07.21-r28</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.11',
-      id: '2026.07.21-r27',
-      cacheKey: '20260721-r27'
+      version: '1.3.12',
+      id: '2026.07.21-r28',
+      cacheKey: '20260721-r28'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260721-r27">
-  <link rel="stylesheet" href="./styles.css?build=20260721-r27">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260721-r27">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260721-r27">
-  <link rel="stylesheet" href="./install-gate.css?build=20260721-r27">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260721-r27">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260721-r27">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260721-r27">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260721-r27">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260721-r27">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260721-r27">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260721-r27">
+  <link rel="manifest" href="./site.webmanifest?build=20260721-r28">
+  <link rel="stylesheet" href="./styles.css?build=20260721-r28">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260721-r28">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260721-r28">
+  <link rel="stylesheet" href="./install-gate.css?build=20260721-r28">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260721-r28">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260721-r28">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260721-r28">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260721-r28">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260721-r28">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260721-r28">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260721-r28">
 
-  <script src="./install-gate.js?build=20260721-r27"></script>
-  <script src="./orientation-compat.js?build=20260721-r27"></script>
+  <script src="./install-gate.js?build=20260721-r28"></script>
+  <script src="./orientation-compat.js?build=20260721-r28"></script>
   <script type="importmap">
     {
       "imports": {
@@ -56,7 +56,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.11 · Build 2026.07.21-r27</span>
+        <span class="install-kicker">TURN v1.3.12 · Build 2026.07.21-r28</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -84,7 +84,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.11 · Build 2026.07.21-r27</span>
+      <span class="kicker">TURN v1.3.12 · Build 2026.07.21-r28</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -150,6 +150,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260721-r27"></script>
+  <script type="module" src="./app.js?build=20260721-r28"></script>
 </body>
 </html>

--- a/turn/ui/gameplay-controls.js
+++ b/turn/ui/gameplay-controls.js
@@ -76,6 +76,9 @@ function installGameplayUi() {
       positionHud.classList.remove('position-pop');
       void positionHud.offsetWidth;
       positionHud.classList.add('position-pop');
+      if (position < lastPosition) {
+        globalThis.__turnAudio?.cue('overtake', { places: lastPosition - position });
+      }
     }
     lastPosition = position;
     lastPositionTotal = total;
@@ -304,6 +307,21 @@ function installGameplayUi() {
     }
   });
 
+  function nearestRivalDistance(runtime, active) {
+    if (!active || !runtime?.state?.lapActive || !runtime?.playerCar?.position) return Infinity;
+    let nearestSquared = Infinity;
+    const player = runtime.playerCar.position;
+
+    for (const car of runtime.competitorCars || []) {
+      if (!car?.visible || !car.position) continue;
+      const dx = car.position.x - player.x;
+      const dz = car.position.z - player.z;
+      nearestSquared = Math.min(nearestSquared, dx * dx + dz * dz);
+    }
+
+    return Number.isFinite(nearestSquared) ? Math.sqrt(nearestSquared) : Infinity;
+  }
+
   function updateAudio(now, boosting) {
     const runtime = globalThis.__turnRuntime;
     const runtimeState = runtime?.state;
@@ -321,7 +339,9 @@ function installGameplayUi() {
       throttle: runtimeState?.throttle || 0,
       driftAmount: runtimeState?.driftAmount || 0,
       driftHeld: Boolean(globalThis.__turnDriftHeld),
-      boostActive: boosting
+      boostActive: boosting,
+      enginePitch: runtimeState?.vehicleTuning?.enginePitch || 1,
+      nearestRivalDistance: nearestRivalDistance(runtime, active)
     }, now);
   }
 
@@ -365,8 +385,13 @@ function installGameplayUi() {
       boostVisualDirty = true;
       return;
     }
-    if (becameEmpty) flashBoostHud('is-boost-empty-flash');
-    else if (becameFull) flashBoostHud('is-boost-full-flash');
+    if (becameEmpty) {
+      globalThis.__turnAudio?.cue('boost-empty');
+      flashBoostHud('is-boost-empty-flash');
+    } else if (becameFull) {
+      globalThis.__turnAudio?.cue('boost-full');
+      flashBoostHud('is-boost-full-flash');
+    }
     if (!boostVisualDirty && !stateChanged && !visualDue) return;
 
     if (boostVisualDirty || boosting !== publishedBoosting) {


### PR DESCRIPTION
## Summary

- redesigns DRIFT so it reads as traction loss rather than bright spray-like noise
- replaces the loud vacuum-like boost bed with a short layered energy burst and a very quiet turbine sustain
- gives active boost a subtle engine-pitch lift so the effect feels connected to the car
- adds distinct boost-empty and boost-full cues on the existing exact charge transitions
- adds an overtake cue only when the player's race position improves
- adds a restrained nearby-rival cue with 10 m entry / 15 m exit hysteresis to avoid chatter
- keeps all sound procedural, offline-friendly, and on the existing 30 Hz audio update path
- bumps TURN to **v1.3.12 · Build 2026.07.21-r28**

## Drift redesign

The r27 bright skid-noise loop could read like an aerosol can. r28 removes that loop entirely and layers:

- very quiet ordinary tire scrub for natural cornering slip
- stronger filtered scrub only while DRIFT is deliberately held
- low-mid smoothed noise for chassis/tire grit
- a restrained tonal squeal only during stronger deliberate slip

All layers crossfade through the existing smoothed Web Audio parameters.

## Boost redesign

The old continuous boost layer could reach `0.16`, which dominated the engine and read like a vacuum cleaner. r28 changes the sustain to `0.024` and moves the character into the activation event:

- rising turbine spool
- short low pressure punch
- filtered whoosh
- brief bright mechanical overtone

While boost is active, the existing engine pitch is lifted by only 5.5%, keeping the power connected to the selected car's own engine character.

## New event cues

- **Boost empty**: descending turbine and pressure cough
- **Boost full**: compact ascending charge confirmation
- **Overtake**: fires only when race position improves
- **Car near**: fires once when a visible rival enters 10 m; it must leave 15 m before re-arming

The proximity check uses the already-existing player and rival root positions and adds no new render/update loop.

## Performance / compatibility

- no new `requestAnimationFrame`, animation loop, interval, fetch, or audio asset
- continuous audio remains capped at 30 Hz
- nearby-rival distance checks cover at most the existing four rivals
- mobile gesture unlock and hard-mute-before-suspend behavior remain unchanged
- no gameplay physics or race logic is changed

## Regression coverage

The sound regression now protects:

- removal of the old bright skid-noise loop
- low ordinary scrub versus deliberate drift layers
- low-mid grit and restrained tonal squeal
- quiet boost sustain and subtle engine lift
- boost start/full/empty cues
- overtake-only-on-position-gain behavior
- nearby-rival hysteresis and cue cooldown
- the existing no-second-loop / offline procedural architecture

No vehicle balance, boost drain/recharge timing, boost lockout, controls, checkpoints, lap logic, paint persistence, orientation, outlines, or spectator behavior is intentionally changed.