### PR TITLE
TURN v1.3.13 r29: Guard race orientation

### DIFF
--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -10,8 +10,8 @@ const [index, app, audio, controls, catalogSource] = await Promise.all([
 ]);
 const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
 
-assert.match(index, /TURN v1\.3\.12 · Build 2026\.07\.21-r28/);
-assert.match(index, /\.\/app\.js\?build=20260721-r28/);
+assert.match(index, /TURN v1\.3\.13 · Build 2026\.07\.21-r29/);
+assert.match(index, /\.\/app\.js\?build=20260721-r29/);
 assert.match(
   index,
   /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r27"/,

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -64,7 +64,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.12 · Build 2026\.07\.21-r28/);
+assert.match(index, /TURN v1\.3\.13 · Build 2026\.07\.21-r29/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -20,9 +20,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.12 · Build 2026\.07\.21-r28/);
-assert.match(index, /drive-pad\.css\?build=20260721-r28/);
-assert.match(index, /gameplay-v2\.css\?build=20260721-r28/);
+assert.match(index, /TURN v1\.3\.13 · Build 2026\.07\.21-r29/);
+assert.match(index, /drive-pad\.css\?build=20260721-r29/);
+assert.match(index, /gameplay-v2\.css\?build=20260721-r29/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -47,9 +47,9 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.12 · Build 2026\.07\.21-r28/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260721-r28/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r28 must preserve the latest Lot module cache redirect');
+assert.match(index, /TURN v1\.3\.13 · Build 2026\.07\.21-r29/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260721-r29/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r29 must preserve the latest Lot module cache redirect');
 assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -26,8 +26,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.12 · Build 2026\.07\.21-r28/);
-assert.match(index, /in-game-menu\.css\?build=20260721-r28/);
+assert.match(index, /TURN v1\.3\.13 · Build 2026\.07\.21-r29/);
+assert.match(index, /in-game-menu\.css\?build=20260721-r29/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Back to Start<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -12,13 +12,44 @@ assert.equal(manualStep(-1), 1, 'manual left should steer the car left');
 assert.equal(manualStep(1), -1, 'manual right should steer the car right');
 assert.equal(manualStep(0), 0, 'centered manual steering should stay centered');
 
-const index = await fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8');
-const css = await fs.readFile(new URL('../../turn/manual-steering.css', import.meta.url), 'utf8');
+const [index, css, orientationGuardCss, orientationCompat, camera] = await Promise.all([
+  fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/manual-steering.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/orientation-guard.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/orientation-compat.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/render/camera.js', import.meta.url), 'utf8')
+]);
+
+assert.match(index, /TURN v1\.3\.13 · Build 2026\.07\.21-r29/);
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260721-r28/);
+assert.match(index, /manual-steering\.css\?build=20260721-r29/);
+assert.match(index, /orientation-guard\.css\?build=20260721-r29/);
+assert.match(index, /orientation-compat\.js\?build=20260721-r29/);
+assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r29 must cache-bust the guarded race camera');
+assert.match(index, /<strong>Rotate to landscape<\/strong>/, 'The pre-race landscape instruction must remain available');
+
 assert.match(css, /--manual-steer-left/);
 assert.match(css, /content: "←"/);
 assert.match(css, /content: "→"/);
 
-console.log('TURN manual steering regression passed.');
+assert.match(orientationGuardCss, /body\.turn-race-active \.rotate-panel/, 'The portrait warning must stay hidden during an active race');
+assert.match(orientationGuardCss, /turn-steering-limit-near/, 'Approaching the steering guard must have visual feedback');
+assert.match(orientationGuardCss, /turn-steering-limit-hard/, 'The hard steering guard must have stronger visual feedback');
+assert.match(orientationGuardCss, /prefers-reduced-motion: reduce/, 'Orientation feedback must respect reduced-motion preferences');
+
+assert.match(orientationCompat, /STEERING_LIMIT_NEAR = 13 \* Math\.PI \/ 180/, 'Steering-limit feedback must begin before the camera guard');
+assert.match(orientationCompat, /STEERING_LIMIT_HARD = 17 \* Math\.PI \/ 180/, 'The stronger warning must arrive just before the 18-degree camera clamp');
+assert.match(orientationCompat, /document\.body\.classList\.toggle\('turn-race-active', gameplayActive\)/, 'Race lifecycle must control the orientation-warning suppression class');
+assert.match(orientationCompat, /gameplayAngle = computedAngle\(\)/, 'The race must freeze its starting motion-axis orientation');
+assert.match(orientationCompat, /return gameplayActive && gameplayAngle != null \? gameplayAngle : computedAngle\(\)/, 'Live viewport flips must not remap steering while racing');
+assert.match(orientationCompat, /orientation\.lock\?\.\('landscape'\)/, 'The race guard must retry the platform landscape lock when supported');
+assert.match(orientationCompat, /navigator\.vibrate\?\.\(pattern\)/, 'Approaching the guard should provide haptic feedback where supported');
+assert.match(orientationCompat, /window\.addEventListener\('turn:ui-state-change'/, 'The guard must follow the actual race lifecycle rather than viewport shape alone');
+
+assert.match(camera, /MAX_SENSOR_CAMERA_ROLL = 18 \* Math\.PI \/ 180/, 'Race camera roll must stop before device over-rotation');
+assert.match(camera, /state\.roll - neutralRoll/, 'Camera horizon roll must be relative to the calibrated steering neutral');
+assert.match(camera, /clamp\(relativeRoll, -MAX_SENSOR_CAMERA_ROLL, MAX_SENSOR_CAMERA_ROLL\)/, 'Camera roll must be hard-clamped at the guard limit');
+assert.doesNotMatch(camera, /camera\.rotateZ\(-state\.roll\)/, 'The camera must never again follow raw sensor roll toward a portrait flip');
+
+console.log('TURN manual steering and race orientation guard regression passed.');

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -34,7 +34,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.12 · Build 2026\.07\.21-r28/);
+assert.match(index, /TURN v1\.3\.13 · Build 2026\.07\.21-r29/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -45,7 +45,7 @@ assert.equal(summary.p95Ms, 50);
 assert.equal(summary.slowPercent, 40);
 assert.ok(Math.abs(summary.fps - 1000 / 30) < 1e-9);
 
-const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, monitor, audio] = await Promise.all([
+const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, monitor, audio, orientationCompat] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/ui/gameplay-controls.js', import.meta.url), 'utf8'),
@@ -57,10 +57,11 @@ const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, m
   fs.readFile(new URL('../../turn/vehicle/car-models.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-r10.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/performance-monitor.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/audio/audio-system.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../../turn/audio/audio-system.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/orientation-compat.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.12 · Build 2026\.07\.21-r28/);
+assert.match(index, /TURN v1\.3\.13 · Build 2026\.07\.21-r29/);
 assert.match(main, /mainSceneOcclusion/);
 assert.match(main, /HUD_UPDATE_INTERVAL_MS = 1000 \/ 30/);
 assert.match(main, /recordPerformanceFrame/);
@@ -82,6 +83,7 @@ assert.match(lot, /recordPerformanceFrame/);
 assert.doesNotMatch(lot, /GLTFLoader|InstancedMesh|installBrickScenery/, 'The clean Lot must not spend asset or draw-call budget on decorative wall scenery');
 assert.match(audio, /AUDIO_UPDATE_INTERVAL_MS = 1000 \/ 30/, 'Audio state must stay capped at 30 Hz');
 assert.doesNotMatch(audio, /requestAnimationFrame|setAnimationLoop|setInterval/, 'New sound cues must not add a second loop');
+assert.doesNotMatch(orientationCompat, /requestAnimationFrame|setAnimationLoop|setInterval/, 'The orientation guard must remain event-driven and add no render loop');
 assert.match(monitor, /turn:perf-snapshot/);
 assert.match(monitor, /trackChecksPerQuery/);
 

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r28 Drift, boost and rival sound design -->
+<!-- TURN r29 Race orientation guard -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,37 +10,39 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.12 · Build 2026.07.21-r28</title>
+  <title>TURN v1.3.13 · Build 2026.07.21-r29</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.12',
-      id: '2026.07.21-r28',
-      cacheKey: '20260721-r28'
+      version: '1.3.13',
+      id: '2026.07.21-r29',
+      cacheKey: '20260721-r29'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260721-r28">
-  <link rel="stylesheet" href="./styles.css?build=20260721-r28">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260721-r28">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260721-r28">
-  <link rel="stylesheet" href="./install-gate.css?build=20260721-r28">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260721-r28">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260721-r28">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260721-r28">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260721-r28">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260721-r28">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260721-r28">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260721-r28">
+  <link rel="manifest" href="./site.webmanifest?build=20260721-r29">
+  <link rel="stylesheet" href="./styles.css?build=20260721-r29">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260721-r29">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260721-r29">
+  <link rel="stylesheet" href="./install-gate.css?build=20260721-r29">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260721-r29">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260721-r29">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260721-r29">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260721-r29">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260721-r29">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260721-r29">
+  <link rel="stylesheet" href="./orientation-guard.css?build=20260721-r29">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260721-r29">
 
-  <script src="./install-gate.js?build=20260721-r28"></script>
-  <script src="./orientation-compat.js?build=20260721-r28"></script>
+  <script src="./install-gate.js?build=20260721-r29"></script>
+  <script src="./orientation-compat.js?build=20260721-r29"></script>
   <script type="importmap">
     {
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-r10.js?build=20260720-r25",
+        "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260721-r29",
         "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260721-r27",
         "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260721-r27",
         "./vehicle/car-models.js?build=20260720-r19": "./vehicle/car-models.js?build=20260720-r22"
@@ -56,7 +58,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.12 · Build 2026.07.21-r28</span>
+        <span class="install-kicker">TURN v1.3.13 · Build 2026.07.21-r29</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -84,7 +86,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.12 · Build 2026.07.21-r28</span>
+      <span class="kicker">TURN v1.3.13 · Build 2026.07.21-r29</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -150,6 +152,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260721-r28"></script>
+  <script type="module" src="./app.js?build=20260721-r29"></script>
 </body>
 </html>

--- a/turn/orientation-compat.js
+++ b/turn/orientation-compat.js
@@ -22,17 +22,32 @@
 
   const SENSOR_OFFSETS = [0, 90, -90];
   const SENSOR_CALIBRATION_SAMPLES = 8;
+  const STEERING_LIMIT_NEAR = 13 * Math.PI / 180;
+  const STEERING_LIMIT_HARD = 17 * Math.PI / 180;
+  const STEERING_LIMIT_CLEAR = 10.5 * Math.PI / 180;
   const sensorScores = new Array(SENSOR_OFFSETS.length).fill(0);
   let sensorSamples = 0;
   let sensorOffset = 0;
   let sensorOffsetLocked = false;
   let lastBaseAngle = null;
+  let gameplayActive = false;
+  let gameplayAngle = null;
+  let lastResolvedRoll = 0;
+  let steeringNeutralRoll = 0;
+  let steeringLimitLevel = 0;
 
   function normalizeDegrees(value) {
     if (!Number.isFinite(value)) return null;
     let degrees = ((value % 360) + 360) % 360;
     if (degrees > 180) degrees -= 360;
     return degrees;
+  }
+
+  function normalizeRadians(value) {
+    let angle = Number(value) || 0;
+    while (angle > Math.PI) angle -= Math.PI * 2;
+    while (angle < -Math.PI) angle += Math.PI * 2;
+    return angle;
   }
 
   function angleIsLandscape(value) {
@@ -90,48 +105,136 @@
     lastBaseAngle = null;
   }
 
-  function observeMotion(event) {
-    if (sensorOffsetLocked) return;
+  function computedAngle() {
+    const baseAngle = resolveBaseAngle(readBrowserAngle());
+    return normalizeDegrees(baseAngle + sensorOffset) ?? 0;
+  }
 
+  function resolvedAngle() {
+    return gameplayActive && gameplayAngle != null ? gameplayAngle : computedAngle();
+  }
+
+  function clearSteeringLimitFeedback() {
+    steeringLimitLevel = 0;
+    document.body.classList.remove('turn-steering-limit-near', 'turn-steering-limit-hard');
+  }
+
+  function pulseHaptic(pattern) {
+    try {
+      navigator.vibrate?.(pattern);
+    } catch (_) {}
+  }
+
+  function updateSteeringLimitFeedback(roll) {
+    if (!gameplayActive) {
+      clearSteeringLimitFeedback();
+      return;
+    }
+
+    const magnitude = Math.abs(normalizeRadians(roll - steeringNeutralRoll));
+    let nextLevel = steeringLimitLevel;
+
+    if (magnitude >= STEERING_LIMIT_HARD) nextLevel = 2;
+    else if (magnitude >= STEERING_LIMIT_NEAR) nextLevel = Math.max(1, nextLevel);
+    else if (magnitude <= STEERING_LIMIT_CLEAR) nextLevel = 0;
+    else if (steeringLimitLevel === 2 && magnitude < STEERING_LIMIT_NEAR) nextLevel = 1;
+
+    if (nextLevel > steeringLimitLevel) {
+      pulseHaptic(nextLevel === 2 ? [18, 26, 28] : 12);
+    }
+
+    steeringLimitLevel = nextLevel;
+    document.body.classList.toggle('turn-steering-limit-near', nextLevel >= 1);
+    document.body.classList.toggle('turn-steering-limit-hard', nextLevel >= 2);
+  }
+
+  function requestLandscapeLock() {
+    try {
+      return Promise.resolve(orientation.lock?.('landscape')).catch(() => false);
+    } catch (_) {
+      return Promise.resolve(false);
+    }
+  }
+
+  function setGameplayActive(active) {
+    const nextActive = Boolean(active);
+    if (nextActive === gameplayActive) return;
+
+    gameplayActive = nextActive;
+    document.body.classList.toggle('turn-race-active', gameplayActive);
+
+    if (gameplayActive) {
+      gameplayAngle = computedAngle();
+      steeringNeutralRoll = lastResolvedRoll;
+      clearSteeringLimitFeedback();
+      void requestLandscapeLock();
+      console.info(`TURN: race orientation guard locked at ${gameplayAngle}°.`);
+    } else {
+      gameplayAngle = null;
+      clearSteeringLimitFeedback();
+    }
+  }
+
+  function observeMotion(event) {
     const gravity = event.accelerationIncludingGravity;
     if (!gravity || gravity.x == null || gravity.y == null) return;
     if (Math.hypot(gravity.x, gravity.y) < 0.8) return;
 
     const baseAngle = resolveBaseAngle(readBrowserAngle());
-    if (lastBaseAngle != null && Math.abs(normalizeDegrees(baseAngle - lastBaseAngle) || 0) >= 90) {
-      resetSensorCalibration();
-    }
-    lastBaseAngle = baseAngle;
 
-    for (let index = 0; index < SENSOR_OFFSETS.length; index += 1) {
-      const candidateAngle = baseAngle + SENSOR_OFFSETS[index];
-      sensorScores[index] += Math.abs(foldedRollForAngle(gravity, candidateAngle));
+    if (!sensorOffsetLocked) {
+      if (
+        !gameplayActive &&
+        lastBaseAngle != null &&
+        Math.abs(normalizeDegrees(baseAngle - lastBaseAngle) || 0) >= 90
+      ) {
+        resetSensorCalibration();
+      }
+      lastBaseAngle = baseAngle;
+
+      for (let index = 0; index < SENSOR_OFFSETS.length; index += 1) {
+        const candidateAngle = baseAngle + SENSOR_OFFSETS[index];
+        sensorScores[index] += Math.abs(foldedRollForAngle(gravity, candidateAngle));
+      }
+
+      sensorSamples += 1;
+      let bestIndex = 0;
+      for (let index = 1; index < sensorScores.length; index += 1) {
+        if (sensorScores[index] < sensorScores[bestIndex]) bestIndex = index;
+      }
+      sensorOffset = SENSOR_OFFSETS[bestIndex];
+
+      if (sensorSamples >= SENSOR_CALIBRATION_SAMPLES) {
+        sensorOffsetLocked = true;
+        console.info(`TURN: motion axis mapping locked at ${sensorOffset >= 0 ? '+' : ''}${sensorOffset}°.`);
+      }
     }
 
-    sensorSamples += 1;
-    let bestIndex = 0;
-    for (let index = 1; index < sensorScores.length; index += 1) {
-      if (sensorScores[index] < sensorScores[bestIndex]) bestIndex = index;
-    }
-    sensorOffset = SENSOR_OFFSETS[bestIndex];
-
-    if (sensorSamples >= SENSOR_CALIBRATION_SAMPLES) {
-      sensorOffsetLocked = true;
-      console.info(`TURN: motion axis mapping locked at ${sensorOffset >= 0 ? '+' : ''}${sensorOffset}°.`);
-    }
-  }
-
-  function resolvedAngle() {
-    const baseAngle = resolveBaseAngle(readBrowserAngle());
-    return normalizeDegrees(baseAngle + sensorOffset) ?? 0;
+    lastResolvedRoll = foldedRollForAngle(gravity, resolvedAngle());
+    updateSteeringLimitFeedback(lastResolvedRoll);
   }
 
   // Register before the game adds its own devicemotion listener. Each sensor event can
   // therefore update the mapping before TURN reads screen.orientation.angle for that frame.
   window.addEventListener('devicemotion', observeMotion, { passive: true });
-  window.addEventListener('orientationchange', resetSensorCalibration, { passive: true });
+  window.addEventListener('orientationchange', () => {
+    if (gameplayActive) {
+      void requestLandscapeLock();
+      return;
+    }
+    resetSensorCalibration();
+  }, { passive: true });
+
+  window.addEventListener('turn:ui-state-change', (event) => {
+    setGameplayActive(Boolean(event.detail?.running));
+  });
+
   document.addEventListener('click', (event) => {
     if (event.target.closest?.('#motionButton')) resetSensorCalibration();
+    if (event.target.closest?.('#calibrateButton') && gameplayActive) {
+      steeringNeutralRoll = lastResolvedRoll;
+      clearSteeringLimitFeedback();
+    }
   });
 
   let installed = false;
@@ -165,7 +268,7 @@
 
   console.info(
     installed
-      ? 'TURN: adaptive motion-axis compatibility enabled.'
+      ? 'TURN: adaptive motion-axis compatibility and race orientation guard enabled.'
       : 'TURN: ScreenOrientation angle could not be shimmed; using browser values as-is.'
   );
 })();

--- a/turn/orientation-guard.css
+++ b/turn/orientation-guard.css
@@ -1,0 +1,44 @@
+body.turn-race-active .rotate-panel {
+  display: none !important;
+}
+
+.hud::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 40;
+  pointer-events: none;
+  border: 0 solid var(--yellow);
+  border-radius: 18px;
+  opacity: 0;
+  box-shadow: inset 0 0 0 rgb(255 212 59 / 0);
+  transition:
+    border-width 110ms ease,
+    opacity 140ms ease,
+    box-shadow 140ms ease;
+}
+
+body.turn-steering-limit-near .hud::before {
+  border-width: 5px;
+  opacity: 0.42;
+  box-shadow: inset 0 0 22px rgb(255 212 59 / 0.2);
+  animation: turn-steering-limit-pulse 520ms ease-out both;
+}
+
+body.turn-steering-limit-hard .hud::before {
+  border-width: 8px;
+  opacity: 0.72;
+  box-shadow: inset 0 0 34px rgb(255 212 59 / 0.34);
+}
+
+@keyframes turn-steering-limit-pulse {
+  0% { opacity: 0; }
+  35% { opacity: 0.66; }
+  100% { opacity: 0.42; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body.turn-steering-limit-near .hud::before {
+    animation: none;
+  }
+}

--- a/turn/render/camera.js
+++ b/turn/render/camera.js
@@ -1,3 +1,5 @@
+const MAX_SENSOR_CAMERA_ROLL = 18 * Math.PI / 180;
+
 export function updateRaceCameraState({
   state,
   camera,
@@ -45,10 +47,22 @@ export function updateRaceCameraState({
   camera.up.set(0, 1, 0);
   camera.lookAt(cameraTarget);
 
-  if (state.sensorMode) camera.rotateZ(-state.roll);
+  if (state.sensorMode) {
+    const neutralRoll = Number.isFinite(state.neutralRoll) ? state.neutralRoll : 0;
+    const relativeRoll = normalizeAngle(state.roll - neutralRoll);
+    const guardedRoll = clamp(relativeRoll, -MAX_SENSOR_CAMERA_ROLL, MAX_SENSOR_CAMERA_ROLL);
+    camera.rotateZ(-guardedRoll);
+  }
 
   camera.fov = lerp(camera.fov, 68 + speedRatio * 14, Math.min(1, dt * 4.5));
   camera.updateProjectionMatrix();
+}
+
+function normalizeAngle(angle) {
+  let value = Number(angle) || 0;
+  while (value > Math.PI) value -= Math.PI * 2;
+  while (value < -Math.PI) value += Math.PI * 2;
+  return value;
 }
 
 function lerp(a, b, t) {


### PR DESCRIPTION
## Summary

- keeps the existing **Rotate to landscape** takeover before gameplay
- suppresses that takeover while a race is active
- clamps sensor-driven race-camera roll to **18° relative to the calibrated neutral**, so the view stops leaning before the phone approaches a portrait flip
- adds subtle yellow edge feedback at **13°** and stronger feedback at **17°**, plus haptics where supported
- freezes TURN's motion-axis orientation to the angle captured when the race starts, so a live viewport orientation change cannot suddenly remap steering
- retries the platform landscape lock on race start / orientation change where supported
- adds no new render loop, timer loop, physics behavior, or steering-strength change
- bumps TURN to **v1.3.13 · Build 2026.07.21-r29**

## Why

The gameplay video showed that full steering is already reached at 14°, but the camera continued following raw phone roll far beyond that point. The world could therefore lean dramatically even though additional device rotation added no steering, encouraging the player toward the point where iOS changed the viewport to portrait and TURN displayed the full-screen orientation warning.

r29 separates those concerns:

- **steering remains exactly as before**
- **camera roll is guarded**
- **approaching the guard gets feedback**
- **the pre-game orientation instruction stays intact**
- **the in-race portrait takeover is removed**

## Regression coverage

The expanded manual-steering/orientation regression protects:

- the 18° camera guard and calibrated-neutral reference
- removal of raw `camera.rotateZ(-state.roll)` behavior
- pre-race landscape instruction remaining present
- in-race rotate-panel suppression
- 13° / 17° feedback thresholds
- race-start motion-axis freezing
- landscape-lock retry behavior
- haptic and reduced-motion support

The performance regression also ensures the orientation guard remains event-driven and adds no animation/timer loop.

No vehicle physics, 14° full-steering threshold, boost behavior, controls, lap/checkpoint logic, race balance, sound design, paint, orientation normalization, outlines, ghosts, or spectator behavior is intentionally changed.