### PR TITLE
TURN v1.3.14 r30: Strengthen landscape lock requests

### DIFF
--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -10,8 +10,8 @@ const [index, app, audio, controls, catalogSource] = await Promise.all([
 ]);
 const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
 
-assert.match(index, /TURN v1\.3\.13 · Build 2026\.07\.21-r29/);
-assert.match(index, /\.\/app\.js\?build=20260721-r29/);
+assert.match(index, /TURN v1\.3\.14 · Build 2026\.07\.21-r30/);
+assert.match(index, /\.\/app\.js\?build=20260721-r30/);
 assert.match(
   index,
   /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r27"/,

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -64,7 +64,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.13 · Build 2026\.07\.21-r29/);
+assert.match(index, /TURN v1\.3\.14 · Build 2026\.07\.21-r30/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -20,9 +20,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.13 · Build 2026\.07\.21-r29/);
-assert.match(index, /drive-pad\.css\?build=20260721-r29/);
-assert.match(index, /gameplay-v2\.css\?build=20260721-r29/);
+assert.match(index, /TURN v1\.3\.14 · Build 2026\.07\.21-r30/);
+assert.match(index, /drive-pad\.css\?build=20260721-r30/);
+assert.match(index, /gameplay-v2\.css\?build=20260721-r30/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -47,9 +47,9 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.13 · Build 2026\.07\.21-r29/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260721-r29/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r29 must preserve the latest Lot module cache redirect');
+assert.match(index, /TURN v1\.3\.14 · Build 2026\.07\.21-r30/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260721-r30/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r30 must preserve the latest Lot module cache redirect');
 assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -26,8 +26,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.13 · Build 2026\.07\.21-r29/);
-assert.match(index, /in-game-menu\.css\?build=20260721-r29/);
+assert.match(index, /TURN v1\.3\.14 · Build 2026\.07\.21-r30/);
+assert.match(index, /in-game-menu\.css\?build=20260721-r30/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Back to Start<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -20,13 +20,13 @@ const [index, css, orientationGuardCss, orientationCompat, camera] = await Promi
   fs.readFile(new URL('../../turn/render/camera.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.13 · Build 2026\.07\.21-r29/);
+assert.match(index, /TURN v1\.3\.14 · Build 2026\.07\.21-r30/);
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260721-r29/);
-assert.match(index, /orientation-guard\.css\?build=20260721-r29/);
-assert.match(index, /orientation-compat\.js\?build=20260721-r29/);
-assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r29 must cache-bust the guarded race camera');
+assert.match(index, /manual-steering\.css\?build=20260721-r30/);
+assert.match(index, /orientation-guard\.css\?build=20260721-r30/);
+assert.match(index, /orientation-compat\.js\?build=20260721-r30/);
+assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r30 must preserve the guarded race camera cache redirect');
 assert.match(index, /<strong>Rotate to landscape<\/strong>/, 'The pre-race landscape instruction must remain available');
 
 assert.match(css, /--manual-steer-left/);
@@ -43,7 +43,13 @@ assert.match(orientationCompat, /STEERING_LIMIT_HARD = 17 \* Math\.PI \/ 180/, '
 assert.match(orientationCompat, /document\.body\.classList\.toggle\('turn-race-active', gameplayActive\)/, 'Race lifecycle must control the orientation-warning suppression class');
 assert.match(orientationCompat, /gameplayAngle = computedAngle\(\)/, 'The race must freeze its starting motion-axis orientation');
 assert.match(orientationCompat, /return gameplayActive && gameplayAngle != null \? gameplayAngle : computedAngle\(\)/, 'Live viewport flips must not remap steering while racing');
-assert.match(orientationCompat, /orientation\.lock\?\.\('landscape'\)/, 'The race guard must retry the platform landscape lock when supported');
+assert.match(orientationCompat, /preferredLandscapeLock = currentLandscapeLockType\(\)/, 'The guard must remember the exact landscape side selected at race start');
+assert.match(orientationCompat, /await orientation\.lock\(type\)/, 'Supported browsers must receive an actual Screen Orientation lock request');
+assert.match(orientationCompat, /return tryOrientationLock\('landscape'\)/, 'Exact-side locking must fall back to generic landscape');
+assert.match(orientationCompat, /globalThis\.__turnRequestLandscapeLock = requestLandscapeLock/, 'The strongest landscape-lock request must be reusable by the runtime');
+assert.match(orientationCompat, /document\.addEventListener\('pointerdown'/, 'User gestures must retry the browser orientation lock');
+assert.match(orientationCompat, /document\.addEventListener\('fullscreenchange'/, 'Entering fullscreen must retry the browser orientation lock');
+assert.match(orientationCompat, /window\.addEventListener\('pageshow'/, 'Returning to the web app must retry the browser orientation lock');
 assert.match(orientationCompat, /navigator\.vibrate\?\.\(pattern\)/, 'Approaching the guard should provide haptic feedback where supported');
 assert.match(orientationCompat, /window\.addEventListener\('turn:ui-state-change'/, 'The guard must follow the actual race lifecycle rather than viewport shape alone');
 

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -34,7 +34,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.13 · Build 2026\.07\.21-r29/);
+assert.match(index, /TURN v1\.3\.14 · Build 2026\.07\.21-r30/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -61,7 +61,7 @@ const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, m
   fs.readFile(new URL('../../turn/orientation-compat.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.13 · Build 2026\.07\.21-r29/);
+assert.match(index, /TURN v1\.3\.14 · Build 2026\.07\.21-r30/);
 assert.match(main, /mainSceneOcclusion/);
 assert.match(main, /HUD_UPDATE_INTERVAL_MS = 1000 \/ 30/);
 assert.match(main, /recordPerformanceFrame/);

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r29 Race orientation guard -->
+<!-- TURN r30 Stronger landscape lock requests -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,32 +10,32 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.13 · Build 2026.07.21-r29</title>
+  <title>TURN v1.3.14 · Build 2026.07.21-r30</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.13',
-      id: '2026.07.21-r29',
-      cacheKey: '20260721-r29'
+      version: '1.3.14',
+      id: '2026.07.21-r30',
+      cacheKey: '20260721-r30'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260721-r29">
-  <link rel="stylesheet" href="./styles.css?build=20260721-r29">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260721-r29">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260721-r29">
-  <link rel="stylesheet" href="./install-gate.css?build=20260721-r29">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260721-r29">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260721-r29">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260721-r29">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260721-r29">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260721-r29">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260721-r29">
-  <link rel="stylesheet" href="./orientation-guard.css?build=20260721-r29">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260721-r29">
+  <link rel="manifest" href="./site.webmanifest?build=20260721-r30">
+  <link rel="stylesheet" href="./styles.css?build=20260721-r30">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260721-r30">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260721-r30">
+  <link rel="stylesheet" href="./install-gate.css?build=20260721-r30">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260721-r30">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260721-r30">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260721-r30">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260721-r30">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260721-r30">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260721-r30">
+  <link rel="stylesheet" href="./orientation-guard.css?build=20260721-r30">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260721-r30">
 
-  <script src="./install-gate.js?build=20260721-r29"></script>
-  <script src="./orientation-compat.js?build=20260721-r29"></script>
+  <script src="./install-gate.js?build=20260721-r30"></script>
+  <script src="./orientation-compat.js?build=20260721-r30"></script>
   <script type="importmap">
     {
       "imports": {
@@ -58,7 +58,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.13 · Build 2026.07.21-r29</span>
+        <span class="install-kicker">TURN v1.3.14 · Build 2026.07.21-r30</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -86,7 +86,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.13 · Build 2026.07.21-r29</span>
+      <span class="kicker">TURN v1.3.14 · Build 2026.07.21-r30</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -152,6 +152,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260721-r29"></script>
+  <script type="module" src="./app.js?build=20260721-r30"></script>
 </body>
 </html>

--- a/turn/orientation-compat.js
+++ b/turn/orientation-compat.js
@@ -32,9 +32,11 @@
   let lastBaseAngle = null;
   let gameplayActive = false;
   let gameplayAngle = null;
+  let preferredLandscapeLock = 'landscape';
   let lastResolvedRoll = 0;
   let steeringNeutralRoll = 0;
   let steeringLimitLevel = 0;
+  let lockUnsupportedReported = false;
 
   function normalizeDegrees(value) {
     if (!Number.isFinite(value)) return null;
@@ -148,13 +150,39 @@
     document.body.classList.toggle('turn-steering-limit-hard', nextLevel >= 2);
   }
 
-  function requestLandscapeLock() {
+  function currentLandscapeLockType() {
+    const type = String(orientation.type || '');
+    if (type === 'landscape-primary' || type === 'landscape-secondary') return type;
+    return 'landscape';
+  }
+
+  async function tryOrientationLock(type) {
+    if (typeof orientation.lock !== 'function') {
+      if (!lockUnsupportedReported) {
+        lockUnsupportedReported = true;
+        console.info('TURN: OS orientation lock is not exposed by this WebKit build; using the in-game guard only.');
+      }
+      return false;
+    }
+
     try {
-      return Promise.resolve(orientation.lock?.('landscape')).catch(() => false);
+      await orientation.lock(type);
+      return true;
     } catch (_) {
-      return Promise.resolve(false);
+      return false;
     }
   }
+
+  async function requestLandscapeLock() {
+    const exactType = preferredLandscapeLock === 'landscape'
+      ? currentLandscapeLockType()
+      : preferredLandscapeLock;
+
+    if (exactType !== 'landscape' && await tryOrientationLock(exactType)) return true;
+    return tryOrientationLock('landscape');
+  }
+
+  globalThis.__turnRequestLandscapeLock = requestLandscapeLock;
 
   function setGameplayActive(active) {
     const nextActive = Boolean(active);
@@ -164,13 +192,15 @@
     document.body.classList.toggle('turn-race-active', gameplayActive);
 
     if (gameplayActive) {
+      preferredLandscapeLock = currentLandscapeLockType();
       gameplayAngle = computedAngle();
       steeringNeutralRoll = lastResolvedRoll;
       clearSteeringLimitFeedback();
       void requestLandscapeLock();
-      console.info(`TURN: race orientation guard locked at ${gameplayAngle}°.`);
+      console.info(`TURN: race orientation guard locked at ${gameplayAngle}° (${preferredLandscapeLock}).`);
     } else {
       gameplayAngle = null;
+      preferredLandscapeLock = 'landscape';
       clearSteeringLimitFeedback();
     }
   }
@@ -214,6 +244,10 @@
     updateSteeringLimitFeedback(lastResolvedRoll);
   }
 
+  function retryGameplayLock() {
+    if (gameplayActive) void requestLandscapeLock();
+  }
+
   // Register before the game adds its own devicemotion listener. Each sensor event can
   // therefore update the mapping before TURN reads screen.orientation.angle for that frame.
   window.addEventListener('devicemotion', observeMotion, { passive: true });
@@ -224,10 +258,25 @@
     }
     resetSensorCalibration();
   }, { passive: true });
+  orientation.addEventListener?.('change', retryGameplayLock, { passive: true });
+  window.addEventListener('pageshow', retryGameplayLock, { passive: true });
+  document.addEventListener('fullscreenchange', retryGameplayLock, { passive: true });
+  document.addEventListener('webkitfullscreenchange', retryGameplayLock, { passive: true });
+  document.addEventListener('visibilitychange', () => {
+    if (!document.hidden) retryGameplayLock();
+  }, { passive: true });
 
   window.addEventListener('turn:ui-state-change', (event) => {
     setGameplayActive(Boolean(event.detail?.running));
   });
+
+  // Safari may only accept an orientation request while processing a user interaction.
+  // Re-request on meaningful gestures so supported WebKit builds get every opportunity
+  // to keep the exact landscape side chosen at race start.
+  document.addEventListener('pointerdown', (event) => {
+    const startsGame = event.target.closest?.('#motionButton, #manualButton');
+    if (gameplayActive || startsGame) void requestLandscapeLock();
+  }, { passive: true, capture: true });
 
   document.addEventListener('click', (event) => {
     if (event.target.closest?.('#motionButton')) resetSensorCalibration();


### PR DESCRIPTION
## Summary

- strengthens TURN's browser-level landscape lock attempts without changing steering or physics
- remembers the exact `landscape-primary` or `landscape-secondary` side available when a race starts
- tries that exact orientation first, then falls back to generic `landscape`
- retries the lock on meaningful user gestures, fullscreen transitions, orientation changes, page restore, and visibility restore
- exposes one shared `__turnRequestLandscapeLock` hook for diagnostics/runtime reuse
- logs clearly when the current WebKit build does not expose `ScreenOrientation.lock()`
- preserves the r29 in-game orientation guard, 18° camera clamp, warning pulse, haptics, and in-race portrait-warning suppression
- bumps TURN to **v1.3.14 · Build 2026.07.21-r30**

## Platform boundary

This is the strongest safe lock request a web app can make. iOS/WebKit can still reject or omit the Screen Orientation locking API, so r30 does not claim to override an OS decision that the browser refuses to expose. A true guaranteed OS-level orientation restriction requires a native iOS container/app configuration.

## Regression coverage

The orientation regression now protects:

- exact landscape-side capture at race start
- actual `ScreenOrientation.lock(type)` calls when supported
- generic landscape fallback
- user-gesture retries
- fullscreen/page-resume retries
- the existing r29 camera and warning guard
- the absence of any extra render/timer loop

No vehicle physics, steering strength, boost behavior, controls, lap/checkpoint logic, race balance, sound design, paint, car orientation normalization, outlines, rivals, or spectator behavior is intentionally changed.