### PR TITLE
TURN v1.3.16 r32: Add lap result toast

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Run state-aware in-game menu regression
         run: node turn-lab/tests/in-game-menu-production.mjs
 
+      - name: Run lap result toast regression
+        run: node turn-lab/tests/lap-result-toast-production.mjs
+
       - name: Run production sound foundation regression
         run: node turn-lab/tests/audio-foundation-production.mjs
 

--- a/turn-lab/race/lap-system.js
+++ b/turn-lab/race/lap-system.js
@@ -96,9 +96,16 @@ export function completeLapState({
 }) {
   const finishedTime = (now - state.lapStartedAt) / 1000;
   const validLap = finishedTime > 5 && state.recording.length > 20;
+  let finishingPosition = null;
+  let finishingTotal = null;
 
   if (validLap) {
     const previousBest = state.bestTime;
+    const raceRivals = state.competitorLaps
+      .filter((lap) => Number.isFinite(lap?.time))
+      .slice(0, competitorLimit);
+    finishingPosition = 1 + raceRivals.filter((lap) => lap.time < finishedTime).length;
+    finishingTotal = raceRivals.length + 1;
     let message = 'LAP ' + formatLapTime(finishedTime);
 
     try {
@@ -145,6 +152,11 @@ export function completeLapState({
     }
 
     showMessage?.(message);
+    publishLapResult({
+      position: finishingPosition,
+      total: finishingTotal,
+      time: finishedTime
+    });
   }
 
   state.lapCheckpointIndex = 0;
@@ -154,7 +166,17 @@ export function completeLapState({
   state.lapElapsed = 0;
   state.recording = [];
 
-  return { finishedTime, validLap };
+  return {
+    finishedTime,
+    validLap,
+    position: finishingPosition,
+    total: finishingTotal
+  };
+}
+
+function publishLapResult(detail) {
+  if (typeof globalThis.dispatchEvent !== 'function' || typeof globalThis.CustomEvent !== 'function') return;
+  globalThis.dispatchEvent(new globalThis.CustomEvent('turn:lap-result', { detail }));
 }
 
 function checkpointSampleAt(samples, progress) {

--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -10,8 +10,8 @@ const [index, app, audio, controls, catalogSource] = await Promise.all([
 ]);
 const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
 
-assert.match(index, /TURN v1\.3\.15 · Build 2026\.07\.21-r31/);
-assert.match(index, /\.\/app\.js\?build=20260721-r31/);
+assert.match(index, /TURN v1\.3\.16 · Build 2026\.07\.21-r32/);
+assert.match(index, /\.\/app\.js\?build=20260721-r32/);
 assert.match(
   index,
   /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r27"/,

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -64,7 +64,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.15 · Build 2026\.07\.21-r31/);
+assert.match(index, /TURN v1\.3\.16 · Build 2026\.07\.21-r32/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -20,9 +20,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.15 · Build 2026\.07\.21-r31/);
-assert.match(index, /drive-pad\.css\?build=20260721-r31/);
-assert.match(index, /gameplay-v2\.css\?build=20260721-r31/);
+assert.match(index, /TURN v1\.3\.16 · Build 2026\.07\.21-r32/);
+assert.match(index, /drive-pad\.css\?build=20260721-r32/);
+assert.match(index, /gameplay-v2\.css\?build=20260721-r32/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -47,9 +47,9 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.15 · Build 2026\.07\.21-r31/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260721-r31/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r31 must preserve the latest Lot module cache redirect');
+assert.match(index, /TURN v1\.3\.16 · Build 2026\.07\.21-r32/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260721-r32/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r32 must preserve the latest Lot module cache redirect');
 assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -26,8 +26,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.15 · Build 2026\.07\.21-r31/);
-assert.match(index, /in-game-menu\.css\?build=20260721-r31/);
+assert.match(index, /TURN v1\.3\.16 · Build 2026\.07\.21-r32/);
+assert.match(index, /in-game-menu\.css\?build=20260721-r32/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Back to Start<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import { completeLapState } from '../../turn/race/lap-system.js';
+
+function makeFrames(count = 25) {
+  return Array.from({ length: count }, (_, index) => ({
+    t: index * 0.05,
+    x: index,
+    z: index * 2,
+    h: 0,
+    s: 0,
+    d: 0,
+    p: index / Math.max(1, count - 1)
+  }));
+}
+
+const samples = [{ point: { x: 0, z: 0 }, tangent: { x: 0, z: 1 } }];
+const state = {
+  competitorLaps: [10, 11, 12, 13].map((time) => ({ time, frames: makeFrames() })),
+  recording: makeFrames(),
+  lapStartedAt: 0,
+  lapCheckpointIndex: 12,
+  lapActive: true,
+  lap: 1,
+  lapElapsed: 13.5,
+  bestTime: 10,
+  ghostFrames: [],
+  ghostVisible: true,
+  vehicleId: 'sedan',
+  vehicleColor: '#ffd43b',
+  vehicleSecondaryColor: '#f8f9fa'
+};
+
+const result = completeLapState({
+  state,
+  samples,
+  now: 13500,
+  competitorLimit: 4,
+  saveGhost() {},
+  showMessage() {}
+});
+
+assert.equal(result.validLap, true);
+assert.equal(result.finishedTime, 13.5);
+assert.equal(result.position, 5, 'A lap slower than all four rivals must finish fifth');
+assert.equal(result.total, 5, 'The result must include the player plus the four rivals that actually raced');
+assert.deepEqual(state.competitorLaps.map((lap) => lap.time), [10, 11, 12, 13], 'A fifth-place lap need not replace a saved rival');
+
+const [index, app, lapSystem, toast, css] = await Promise.all([
+  fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/app.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/race/lap-system.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/ui/lap-result-toast.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/lap-result-toast.css', import.meta.url), 'utf8')
+]);
+
+assert.match(index, /TURN v1\.3\.16 · Build 2026\.07\.21-r32/);
+assert.match(index, /lap-result-toast\.css\?build=20260721-r32/);
+assert.match(app, /installLapResultToast\(\)/, 'The toast must install before the game runtime starts');
+assert.match(lapSystem, /turn:lap-result/, 'Valid lap completion must publish one frozen result event');
+assert.match(lapSystem, /raceRivals\.filter\(\(lap\) => lap\.time < finishedTime\)\.length/, 'Finish placement must be calculated against the rivals from the completed race');
+assert.match(toast, /TOAST_VISIBLE_MS = 4000/, 'The result should remain readable for a few seconds');
+assert.match(toast, /LAST LAP/, 'The toast must use the requested result label');
+assert.match(toast, /lap-result-position/, 'The toast must show frozen finishing position');
+assert.match(toast, /lap-result-time/, 'The toast must show the completed lap time');
+assert.match(toast, /aria-live', 'polite'/, 'The result toast should be announced without interrupting gameplay');
+assert.match(css, /background: var\(--yellow\)/, 'The toast must share the yellow finish-result colour');
+assert.match(css, /left: max\(112px/, 'The toast should sit in the lower-left result area rather than cover the racing line');
+assert.match(css, /prefers-reduced-motion: reduce/, 'Toast animation must respect reduced-motion preferences');
+
+console.log('TURN lap result toast production regression passed.');

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -20,13 +20,13 @@ const [index, css, orientationGuardCss, orientationCompat, camera] = await Promi
   fs.readFile(new URL('../../turn/render/camera.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.15 · Build 2026\.07\.21-r31/);
+assert.match(index, /TURN v1\.3\.16 · Build 2026\.07\.21-r32/);
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260721-r31/);
-assert.match(index, /orientation-guard\.css\?build=20260721-r31/);
-assert.match(index, /orientation-compat\.js\?build=20260721-r31/);
-assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r31 must preserve the guarded race camera cache redirect');
+assert.match(index, /manual-steering\.css\?build=20260721-r32/);
+assert.match(index, /orientation-guard\.css\?build=20260721-r32/);
+assert.match(index, /orientation-compat\.js\?build=20260721-r32/);
+assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r32 must preserve the guarded race camera cache redirect');
 assert.match(index, /<strong>Rotate to landscape<\/strong>/, 'The pre-race landscape instruction must remain available');
 
 assert.match(css, /--manual-steer-left/);

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -34,7 +34,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.15 · Build 2026\.07\.21-r31/);
+assert.match(index, /TURN v1\.3\.16 · Build 2026\.07\.21-r32/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -61,7 +61,7 @@ const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, m
   fs.readFile(new URL('../../turn/orientation-compat.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.15 · Build 2026\.07\.21-r31/);
+assert.match(index, /TURN v1\.3\.16 · Build 2026\.07\.21-r32/);
 assert.match(main, /mainSceneOcclusion/);
 assert.match(main, /HUD_UPDATE_INTERVAL_MS = 1000 \/ 30/);
 assert.match(main, /recordPerformanceFrame/);

--- a/turn/app.js
+++ b/turn/app.js
@@ -9,6 +9,9 @@ function withBuild(path) {
 const { installTurnAudio } = await import(withBuild('./audio/audio-system.js'));
 installTurnAudio();
 
+const { installLapResultToast } = await import(withBuild('./ui/lap-result-toast.js'));
+installLapResultToast();
+
 await import(withBuild('./input/analog-gas.js'));
 await import(withBuild('./ui/gameplay-controls.js'));
 await import(withBuild('./main.js'));

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r31 Symmetric landscape lock -->
+<!-- TURN r32 Lap result toast -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,32 +10,33 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.15 · Build 2026.07.21-r31</title>
+  <title>TURN v1.3.16 · Build 2026.07.21-r32</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.15',
-      id: '2026.07.21-r31',
-      cacheKey: '20260721-r31'
+      version: '1.3.16',
+      id: '2026.07.21-r32',
+      cacheKey: '20260721-r32'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260721-r31">
-  <link rel="stylesheet" href="./styles.css?build=20260721-r31">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260721-r31">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260721-r31">
-  <link rel="stylesheet" href="./install-gate.css?build=20260721-r31">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260721-r31">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260721-r31">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260721-r31">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260721-r31">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260721-r31">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260721-r31">
-  <link rel="stylesheet" href="./orientation-guard.css?build=20260721-r31">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260721-r31">
+  <link rel="manifest" href="./site.webmanifest?build=20260721-r32">
+  <link rel="stylesheet" href="./styles.css?build=20260721-r32">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260721-r32">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260721-r32">
+  <link rel="stylesheet" href="./install-gate.css?build=20260721-r32">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260721-r32">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260721-r32">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260721-r32">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260721-r32">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260721-r32">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260721-r32">
+  <link rel="stylesheet" href="./orientation-guard.css?build=20260721-r32">
+  <link rel="stylesheet" href="./lap-result-toast.css?build=20260721-r32">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260721-r32">
 
-  <script src="./install-gate.js?build=20260721-r31"></script>
-  <script src="./orientation-compat.js?build=20260721-r31"></script>
+  <script src="./install-gate.js?build=20260721-r32"></script>
+  <script src="./orientation-compat.js?build=20260721-r32"></script>
   <script type="importmap">
     {
       "imports": {
@@ -58,7 +59,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.15 · Build 2026.07.21-r31</span>
+        <span class="install-kicker">TURN v1.3.16 · Build 2026.07.21-r32</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -86,7 +87,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.15 · Build 2026.07.21-r31</span>
+      <span class="kicker">TURN v1.3.16 · Build 2026.07.21-r32</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -152,6 +153,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260721-r31"></script>
+  <script type="module" src="./app.js?build=20260721-r32"></script>
 </body>
 </html>

--- a/turn/lap-result-toast.css
+++ b/turn/lap-result-toast.css
@@ -1,0 +1,81 @@
+.lap-result-toast {
+  position: absolute;
+  z-index: 36;
+  left: max(112px, calc(env(safe-area-inset-left) + 112px));
+  bottom: max(92px, calc(env(safe-area-inset-bottom) + 92px));
+  width: min(320px, 42vw);
+  padding: 12px 18px 14px;
+  border: 4px solid var(--ink);
+  border-radius: 20px;
+  background: var(--yellow);
+  box-shadow: 7px 7px 0 var(--ink);
+  color: var(--ink);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(14px) scale(0.96);
+  transform-origin: left bottom;
+  transition: opacity 180ms ease, transform 220ms cubic-bezier(0.2, 0.85, 0.3, 1.18);
+}
+
+.lap-result-toast[hidden] {
+  display: none;
+}
+
+.lap-result-toast.is-visible {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.lap-result-toast.is-leaving {
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+}
+
+.lap-result-toast > span {
+  display: block;
+  margin-bottom: 4px;
+  font-size: clamp(0.52rem, 1.35vw, 0.72rem);
+  letter-spacing: 0.07em;
+}
+
+.lap-result-toast > strong {
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+  font-size: clamp(1.05rem, 3.15vw, 1.75rem);
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.lap-result-toast > strong b {
+  font: inherit;
+}
+
+.lap-result-toast > strong i {
+  font-style: normal;
+  font-size: 0.72em;
+}
+
+@media (max-height: 430px) {
+  .lap-result-toast {
+    left: max(96px, calc(env(safe-area-inset-left) + 96px));
+    bottom: max(70px, calc(env(safe-area-inset-bottom) + 70px));
+    width: min(286px, 40vw);
+    padding: 9px 14px 11px;
+    border-width: 3px;
+    border-radius: 16px;
+    box-shadow: 5px 5px 0 var(--ink);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lap-result-toast {
+    transition: opacity 120ms linear;
+    transform: none;
+  }
+
+  .lap-result-toast.is-visible,
+  .lap-result-toast.is-leaving {
+    transform: none;
+  }
+}

--- a/turn/race/lap-system.js
+++ b/turn/race/lap-system.js
@@ -99,9 +99,16 @@ export function completeLapState({
 }) {
   const finishedTime = (now - state.lapStartedAt) / 1000;
   const validLap = finishedTime > 5 && state.recording.length > 20;
+  let finishingPosition = null;
+  let finishingTotal = null;
 
   if (validLap) {
     const previousBest = state.bestTime;
+    const raceRivals = state.competitorLaps
+      .filter((lap) => Number.isFinite(lap?.time))
+      .slice(0, competitorLimit);
+    finishingPosition = 1 + raceRivals.filter((lap) => lap.time < finishedTime).length;
+    finishingTotal = raceRivals.length + 1;
     let message = 'LAP ' + formatLapTime(finishedTime);
 
     try {
@@ -149,6 +156,11 @@ export function completeLapState({
     }
 
     showMessage?.(message);
+    publishLapResult({
+      position: finishingPosition,
+      total: finishingTotal,
+      time: finishedTime
+    });
   }
 
   state.lapCheckpointIndex = 0;
@@ -158,7 +170,17 @@ export function completeLapState({
   state.lapElapsed = 0;
   state.recording = [];
 
-  return { finishedTime, validLap };
+  return {
+    finishedTime,
+    validLap,
+    position: finishingPosition,
+    total: finishingTotal
+  };
+}
+
+function publishLapResult(detail) {
+  if (typeof globalThis.dispatchEvent !== 'function' || typeof globalThis.CustomEvent !== 'function') return;
+  globalThis.dispatchEvent(new globalThis.CustomEvent('turn:lap-result', { detail }));
 }
 
 function checkpointSampleAt(samples, progress) {

--- a/turn/ui/lap-result-toast.js
+++ b/turn/ui/lap-result-toast.js
@@ -1,0 +1,87 @@
+const TOAST_VISIBLE_MS = 4000;
+const TOAST_EXIT_MS = 220;
+
+export function installLapResultToast() {
+  if (globalThis.__turnLapResultToastInstalled) return;
+  globalThis.__turnLapResultToastInstalled = true;
+
+  const hud = document.querySelector('#hud');
+  if (!hud) return;
+
+  const toast = document.createElement('div');
+  toast.className = 'lap-result-toast';
+  toast.hidden = true;
+  toast.setAttribute('role', 'status');
+  toast.setAttribute('aria-live', 'polite');
+  toast.setAttribute('aria-atomic', 'true');
+  toast.innerHTML = `
+    <span>LAST LAP</span>
+    <strong>
+      <b class="lap-result-position">1/1</b>
+      <i aria-hidden="true">•</i>
+      <b class="lap-result-time">0:00.000</b>
+    </strong>
+  `;
+  hud.appendChild(toast);
+
+  const position = toast.querySelector('.lap-result-position');
+  const time = toast.querySelector('.lap-result-time');
+  let hideTimer = 0;
+  let exitTimer = 0;
+
+  function clearTimers() {
+    window.clearTimeout(hideTimer);
+    window.clearTimeout(exitTimer);
+    hideTimer = 0;
+    exitTimer = 0;
+  }
+
+  function hide({ immediate = false } = {}) {
+    clearTimers();
+    if (toast.hidden) return;
+
+    if (immediate) {
+      toast.hidden = true;
+      toast.classList.remove('is-visible', 'is-leaving');
+      return;
+    }
+
+    toast.classList.remove('is-visible');
+    toast.classList.add('is-leaving');
+    exitTimer = window.setTimeout(() => {
+      toast.hidden = true;
+      toast.classList.remove('is-leaving');
+      exitTimer = 0;
+    }, TOAST_EXIT_MS);
+  }
+
+  function show(result) {
+    const place = Number(result?.position);
+    const total = Number(result?.total);
+    const seconds = Number(result?.time);
+    if (!Number.isFinite(place) || !Number.isFinite(total) || !Number.isFinite(seconds)) return;
+
+    clearTimers();
+    position.textContent = `${Math.max(1, Math.round(place))}/${Math.max(1, Math.round(total))}`;
+    time.textContent = formatLapTime(seconds);
+    toast.hidden = false;
+    toast.classList.remove('is-visible', 'is-leaving');
+    void toast.offsetWidth;
+    toast.classList.add('is-visible');
+
+    hideTimer = window.setTimeout(() => hide(), TOAST_VISIBLE_MS);
+  }
+
+  window.addEventListener('turn:lap-result', (event) => show(event.detail));
+  window.addEventListener('turn:ui-state-change', (event) => {
+    if (!event.detail?.running) hide({ immediate: true });
+  });
+}
+
+function formatLapTime(seconds) {
+  if (!Number.isFinite(seconds)) return '--:--.---';
+  const minutes = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60).toString().padStart(2, '0');
+  const ms = Math.floor((seconds % 1) * 1000).toString().padStart(3, '0');
+  return `${minutes}:${secs}.${ms}`;
+}


### PR DESCRIPTION
## Summary

- adds a yellow **LAST LAP** result toast based on the supplied gameplay mockup
- shows frozen finishing position and lap time, e.g. `1/5 • 0:12.115`
- keeps the existing yellow POSITION pop as the instant finish-line feedback
- keeps the toast visible for 4 seconds, then fades it away
- dismisses it immediately when leaving the active race
- calculates finish position against the rivals that actually participated in the completed lap, before the next lap begins or the saved top-four rival list is updated
- correctly supports results such as `5/5` even when the completed lap is too slow to become one of the four saved rivals
- adds a polite live-region announcement and reduced-motion support
- bumps TURN to **v1.3.16 · Build 2026.07.21-r32**

## Architecture

The lap system publishes one `turn:lap-result` event containing the frozen `{ position, total, time }` result. A small dedicated HUD module owns the toast presentation and timing. No physics, controls, position calculation during racing, replay behavior, sound, orientation handling, or rival storage format is changed.

## Regression coverage

A new production regression protects:

- frozen finish placement against the four race rivals
- fifth-place results remaining `5/5` even when not saved as a rival
- the 4-second toast duration
- LAST LAP / position / time presentation
- yellow result styling
- accessibility and reduced-motion behavior

The full existing TURN regression suite is also run before merge.