### PR TITLE
TURN v1.3.17 r33: Unify lap result feedback

### DIFF
--- a/turn-lab/race/lap-system.js
+++ b/turn-lab/race/lap-system.js
@@ -91,23 +91,23 @@ export function completeLapState({
   now,
   competitorLimit,
   saveGhost,
-  showMessage,
   onError
 }) {
   const finishedTime = (now - state.lapStartedAt) / 1000;
-  const validLap = finishedTime > 5 && state.recording.length > 20;
+  const completedLap = finishedTime > 5;
+  const validLap = completedLap && state.recording.length > 20;
   let finishingPosition = null;
   let finishingTotal = null;
 
-  if (validLap) {
-    const previousBest = state.bestTime;
+  if (completedLap) {
     const raceRivals = state.competitorLaps
       .filter((lap) => Number.isFinite(lap?.time))
       .slice(0, competitorLimit);
     finishingPosition = 1 + raceRivals.filter((lap) => lap.time < finishedTime).length;
     finishingTotal = raceRivals.length + 1;
-    let message = 'LAP ' + formatLapTime(finishedTime);
+  }
 
+  if (validLap) {
     try {
       const candidateFrames = state.recording.map((frame) => ({ ...frame }));
       if (candidateFrames.length) {
@@ -130,28 +130,20 @@ export function completeLapState({
         frames: candidateFrames
       };
 
-      const nextLaps = [...state.competitorLaps, candidate]
+      state.competitorLaps = [...state.competitorLaps, candidate]
         .filter((lap) => Number.isFinite(lap?.time) && Array.isArray(lap?.frames) && lap.frames.length > 20)
         .sort((a, b) => a.time - b.time)
         .slice(0, competitorLimit);
-
-      const rank = nextLaps.indexOf(candidate);
-      state.competitorLaps = nextLaps;
       state.bestTime = state.competitorLaps[0]?.time ?? Infinity;
       state.ghostFrames = state.competitorLaps[0]?.frames ?? [];
       state.ghostVisible = state.competitorLaps.length > 0;
       saveGhost?.();
-
-      if (finishedTime < previousBest) {
-        message = 'NEW BEST ' + formatLapTime(finishedTime);
-      } else if (rank >= 0) {
-        message = 'TOP ' + (rank + 1) + ' LAP ' + formatLapTime(finishedTime);
-      }
     } catch (error) {
       onError?.(error);
     }
+  }
 
-    showMessage?.(message);
+  if (completedLap) {
     publishLapResult({
       position: finishingPosition,
       total: finishingTotal,
@@ -168,6 +160,7 @@ export function completeLapState({
 
   return {
     finishedTime,
+    completedLap,
     validLap,
     position: finishingPosition,
     total: finishingTotal
@@ -182,12 +175,4 @@ function publishLapResult(detail) {
 function checkpointSampleAt(samples, progress) {
   const index = Math.round(progress * samples.length) % samples.length;
   return samples[index];
-}
-
-function formatLapTime(seconds) {
-  if (!Number.isFinite(seconds)) return '--:--.---';
-  const minutes = Math.floor(seconds / 60);
-  const secs = Math.floor(seconds % 60).toString().padStart(2, '0');
-  const ms = Math.floor((seconds % 1) * 1000).toString().padStart(3, '0');
-  return `${minutes}:${secs}.${ms}`;
 }

--- a/turn-lab/race/lap-system.js
+++ b/turn-lab/race/lap-system.js
@@ -91,23 +91,23 @@ export function completeLapState({
   now,
   competitorLimit,
   saveGhost,
+  showMessage,
   onError
 }) {
   const finishedTime = (now - state.lapStartedAt) / 1000;
-  const completedLap = finishedTime > 5;
-  const validLap = completedLap && state.recording.length > 20;
+  const validLap = finishedTime > 5 && state.recording.length > 20;
   let finishingPosition = null;
   let finishingTotal = null;
 
-  if (completedLap) {
+  if (validLap) {
+    const previousBest = state.bestTime;
     const raceRivals = state.competitorLaps
       .filter((lap) => Number.isFinite(lap?.time))
       .slice(0, competitorLimit);
     finishingPosition = 1 + raceRivals.filter((lap) => lap.time < finishedTime).length;
     finishingTotal = raceRivals.length + 1;
-  }
+    let message = 'LAP ' + formatLapTime(finishedTime);
 
-  if (validLap) {
     try {
       const candidateFrames = state.recording.map((frame) => ({ ...frame }));
       if (candidateFrames.length) {
@@ -130,20 +130,28 @@ export function completeLapState({
         frames: candidateFrames
       };
 
-      state.competitorLaps = [...state.competitorLaps, candidate]
+      const nextLaps = [...state.competitorLaps, candidate]
         .filter((lap) => Number.isFinite(lap?.time) && Array.isArray(lap?.frames) && lap.frames.length > 20)
         .sort((a, b) => a.time - b.time)
         .slice(0, competitorLimit);
+
+      const rank = nextLaps.indexOf(candidate);
+      state.competitorLaps = nextLaps;
       state.bestTime = state.competitorLaps[0]?.time ?? Infinity;
       state.ghostFrames = state.competitorLaps[0]?.frames ?? [];
       state.ghostVisible = state.competitorLaps.length > 0;
       saveGhost?.();
+
+      if (finishedTime < previousBest) {
+        message = 'NEW BEST ' + formatLapTime(finishedTime);
+      } else if (rank >= 0) {
+        message = 'TOP ' + (rank + 1) + ' LAP ' + formatLapTime(finishedTime);
+      }
     } catch (error) {
       onError?.(error);
     }
-  }
 
-  if (completedLap) {
+    showMessage?.(message);
     publishLapResult({
       position: finishingPosition,
       total: finishingTotal,
@@ -160,7 +168,6 @@ export function completeLapState({
 
   return {
     finishedTime,
-    completedLap,
     validLap,
     position: finishingPosition,
     total: finishingTotal
@@ -175,4 +182,12 @@ function publishLapResult(detail) {
 function checkpointSampleAt(samples, progress) {
   const index = Math.round(progress * samples.length) % samples.length;
   return samples[index];
+}
+
+function formatLapTime(seconds) {
+  if (!Number.isFinite(seconds)) return '--:--.---';
+  const minutes = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60).toString().padStart(2, '0');
+  const ms = Math.floor((seconds % 1) * 1000).toString().padStart(3, '0');
+  return `${minutes}:${secs}.${ms}`;
 }

--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -10,8 +10,8 @@ const [index, app, audio, controls, catalogSource] = await Promise.all([
 ]);
 const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
 
-assert.match(index, /TURN v1\.3\.16 · Build 2026\.07\.21-r32/);
-assert.match(index, /\.\/app\.js\?build=20260721-r32/);
+assert.match(index, /TURN v1\.3\.17 · Build 2026\.07\.21-r33/);
+assert.match(index, /\.\/app\.js\?build=20260721-r33/);
 assert.match(
   index,
   /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r27"/,

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -64,7 +64,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.16 · Build 2026\.07\.21-r32/);
+assert.match(index, /TURN v1\.3\.17 · Build 2026\.07\.21-r33/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -20,9 +20,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.16 · Build 2026\.07\.21-r32/);
-assert.match(index, /drive-pad\.css\?build=20260721-r32/);
-assert.match(index, /gameplay-v2\.css\?build=20260721-r32/);
+assert.match(index, /TURN v1\.3\.17 · Build 2026\.07\.21-r33/);
+assert.match(index, /drive-pad\.css\?build=20260721-r33/);
+assert.match(index, /gameplay-v2\.css\?build=20260721-r33/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -47,9 +47,9 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.16 · Build 2026\.07\.21-r32/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260721-r32/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r32 must preserve the latest Lot module cache redirect');
+assert.match(index, /TURN v1\.3\.17 · Build 2026\.07\.21-r33/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260721-r33/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r33 must preserve the latest Lot module cache redirect');
 assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -26,8 +26,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.16 · Build 2026\.07\.21-r32/);
-assert.match(index, /in-game-menu\.css\?build=20260721-r32/);
+assert.match(index, /TURN v1\.3\.17 · Build 2026\.07\.21-r33/);
+assert.match(index, /in-game-menu\.css\?build=20260721-r33/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Back to Start<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -14,37 +14,82 @@ function makeFrames(count = 25) {
   }));
 }
 
+function makeState({ recording = makeFrames(), lapElapsed = 13.5 } = {}) {
+  return {
+    competitorLaps: [10, 11, 12, 13].map((time) => ({ time, frames: makeFrames() })),
+    recording,
+    lapStartedAt: 0,
+    lapCheckpointIndex: 12,
+    lapActive: true,
+    lap: 1,
+    lapElapsed,
+    bestTime: 10,
+    ghostFrames: [],
+    ghostVisible: true,
+    vehicleId: 'sedan',
+    vehicleColor: '#ffd43b',
+    vehicleSecondaryColor: '#f8f9fa'
+  };
+}
+
 const samples = [{ point: { x: 0, z: 0 }, tangent: { x: 0, z: 1 } }];
-const state = {
-  competitorLaps: [10, 11, 12, 13].map((time) => ({ time, frames: makeFrames() })),
-  recording: makeFrames(),
-  lapStartedAt: 0,
-  lapCheckpointIndex: 12,
-  lapActive: true,
-  lap: 1,
-  lapElapsed: 13.5,
-  bestTime: 10,
-  ghostFrames: [],
-  ghostVisible: true,
-  vehicleId: 'sedan',
-  vehicleColor: '#ffd43b',
-  vehicleSecondaryColor: '#f8f9fa'
+const originalCustomEvent = globalThis.CustomEvent;
+const originalDispatchEvent = globalThis.dispatchEvent;
+const publishedResults = [];
+
+globalThis.CustomEvent = class TestCustomEvent {
+  constructor(type, options = {}) {
+    this.type = type;
+    this.detail = options.detail;
+  }
+};
+globalThis.dispatchEvent = (event) => {
+  publishedResults.push(event);
+  return true;
 };
 
-const result = completeLapState({
-  state,
-  samples,
-  now: 13500,
-  competitorLimit: 4,
-  saveGhost() {},
-  showMessage() {}
-});
+try {
+  const state = makeState();
+  const result = completeLapState({
+    state,
+    samples,
+    now: 13500,
+    competitorLimit: 4,
+    saveGhost() {}
+  });
 
-assert.equal(result.validLap, true);
-assert.equal(result.finishedTime, 13.5);
-assert.equal(result.position, 5, 'A lap slower than all four rivals must finish fifth');
-assert.equal(result.total, 5, 'The result must include the player plus the four rivals that actually raced');
-assert.deepEqual(state.competitorLaps.map((lap) => lap.time), [10, 11, 12, 13], 'A fifth-place lap need not replace a saved rival');
+  assert.equal(result.completedLap, true);
+  assert.equal(result.validLap, true);
+  assert.equal(result.finishedTime, 13.5);
+  assert.equal(result.position, 5, 'A lap slower than all four rivals must finish fifth');
+  assert.equal(result.total, 5, 'The result must include the player plus the four rivals that actually raced');
+  assert.deepEqual(state.competitorLaps.map((lap) => lap.time), [10, 11, 12, 13], 'A fifth-place lap need not replace a saved rival');
+  assert.equal(publishedResults.at(-1)?.type, 'turn:lap-result');
+  assert.deepEqual(publishedResults.at(-1)?.detail, { position: 5, total: 5, time: 13.5 });
+
+  const shortRecordingState = makeState({ recording: makeFrames(5), lapElapsed: 14 });
+  const shortRecordingResult = completeLapState({
+    state: shortRecordingState,
+    samples,
+    now: 14000,
+    competitorLimit: 4,
+    saveGhost() {
+      assert.fail('A short replay must not be saved as a rival');
+    }
+  });
+
+  assert.equal(shortRecordingResult.completedLap, true, 'A completed race lap is still a result even when its replay cannot be saved');
+  assert.equal(shortRecordingResult.validLap, false, 'Replay eligibility remains separate from result visibility');
+  assert.equal(shortRecordingResult.position, 5);
+  assert.equal(shortRecordingResult.total, 5);
+  assert.deepEqual(shortRecordingState.competitorLaps.map((lap) => lap.time), [10, 11, 12, 13]);
+  assert.deepEqual(publishedResults.at(-1)?.detail, { position: 5, total: 5, time: 14 }, 'Every completed lap must publish the frozen last-lap result');
+} finally {
+  if (originalCustomEvent === undefined) delete globalThis.CustomEvent;
+  else globalThis.CustomEvent = originalCustomEvent;
+  if (originalDispatchEvent === undefined) delete globalThis.dispatchEvent;
+  else globalThis.dispatchEvent = originalDispatchEvent;
+}
 
 const [index, app, lapSystem, toast, css] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
@@ -54,10 +99,14 @@ const [index, app, lapSystem, toast, css] = await Promise.all([
   fs.readFile(new URL('../../turn/lap-result-toast.css', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.16 · Build 2026\.07\.21-r32/);
-assert.match(index, /lap-result-toast\.css\?build=20260721-r32/);
+assert.match(index, /TURN v1\.3\.17 · Build 2026\.07\.21-r33/);
+assert.match(index, /lap-result-toast\.css\?build=20260721-r33/);
 assert.match(app, /installLapResultToast\(\)/, 'The toast must install before the game runtime starts');
-assert.match(lapSystem, /turn:lap-result/, 'Valid lap completion must publish one frozen result event');
+assert.match(lapSystem, /turn:lap-result/, 'Completed lap finish must publish one frozen result event');
+assert.match(lapSystem, /const completedLap = finishedTime > 5/, 'Result visibility must be separated from replay-save eligibility');
+assert.match(lapSystem, /const validLap = completedLap && state\.recording\.length > 20/, 'Ghost saving may still require a usable recording');
+assert.match(lapSystem, /if \(completedLap\) \{\s*publishLapResult/s, 'Every completed lap must publish a result, including last place and unsaved replays');
+assert.doesNotMatch(lapSystem, /TOP ['"] \+|NEW BEST|showMessage\?\.\(message\)/, 'The retired duplicate lap-ranking message must stay removed');
 assert.match(lapSystem, /raceRivals\.filter\(\(lap\) => lap\.time < finishedTime\)\.length/, 'Finish placement must be calculated against the rivals from the completed race');
 assert.match(toast, /TOAST_VISIBLE_MS = 4000/, 'The result should remain readable for a few seconds');
 assert.match(toast, /LAST LAP/, 'The toast must use the requested result label');
@@ -65,7 +114,9 @@ assert.match(toast, /lap-result-position/, 'The toast must show frozen finishing
 assert.match(toast, /lap-result-time/, 'The toast must show the completed lap time');
 assert.match(toast, /aria-live', 'polite'/, 'The result toast should be announced without interrupting gameplay');
 assert.match(css, /background: var\(--yellow\)/, 'The toast must share the yellow finish-result colour');
-assert.match(css, /left: max\(112px/, 'The toast should sit in the lower-left result area rather than cover the racing line');
+assert.match(css, /left: 50%/, 'The last-lap toast must occupy the former central finish-message position');
+assert.match(css, /top: 22%/, 'The last-lap toast must sit where the old TOP X LAP message appeared');
+assert.doesNotMatch(css, /left: max\(112px/, 'The retired lower-left toast placement must stay removed');
 assert.match(css, /prefers-reduced-motion: reduce/, 'Toast animation must respect reduced-motion preferences');
 
-console.log('TURN lap result toast production regression passed.');
+console.log('TURN unified last-lap result toast production regression passed.');

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -20,13 +20,13 @@ const [index, css, orientationGuardCss, orientationCompat, camera] = await Promi
   fs.readFile(new URL('../../turn/render/camera.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.16 · Build 2026\.07\.21-r32/);
+assert.match(index, /TURN v1\.3\.17 · Build 2026\.07\.21-r33/);
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260721-r32/);
-assert.match(index, /orientation-guard\.css\?build=20260721-r32/);
-assert.match(index, /orientation-compat\.js\?build=20260721-r32/);
-assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r32 must preserve the guarded race camera cache redirect');
+assert.match(index, /manual-steering\.css\?build=20260721-r33/);
+assert.match(index, /orientation-guard\.css\?build=20260721-r33/);
+assert.match(index, /orientation-compat\.js\?build=20260721-r33/);
+assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r33 must preserve the guarded race camera cache redirect');
 assert.match(index, /<strong>Rotate to landscape<\/strong>/, 'The pre-race landscape instruction must remain available');
 
 assert.match(css, /--manual-steer-left/);

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -34,7 +34,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.16 · Build 2026\.07\.21-r32/);
+assert.match(index, /TURN v1\.3\.17 · Build 2026\.07\.21-r33/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -61,7 +61,7 @@ const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, m
   fs.readFile(new URL('../../turn/orientation-compat.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.16 · Build 2026\.07\.21-r32/);
+assert.match(index, /TURN v1\.3\.17 · Build 2026\.07\.21-r33/);
 assert.match(main, /mainSceneOcclusion/);
 assert.match(main, /HUD_UPDATE_INTERVAL_MS = 1000 \/ 30/);
 assert.match(main, /recordPerformanceFrame/);

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r32 Lap result toast -->
+<!-- TURN r33 Unified lap result toast -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,33 +10,33 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.16 · Build 2026.07.21-r32</title>
+  <title>TURN v1.3.17 · Build 2026.07.21-r33</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.16',
-      id: '2026.07.21-r32',
-      cacheKey: '20260721-r32'
+      version: '1.3.17',
+      id: '2026.07.21-r33',
+      cacheKey: '20260721-r33'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260721-r32">
-  <link rel="stylesheet" href="./styles.css?build=20260721-r32">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260721-r32">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260721-r32">
-  <link rel="stylesheet" href="./install-gate.css?build=20260721-r32">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260721-r32">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260721-r32">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260721-r32">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260721-r32">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260721-r32">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260721-r32">
-  <link rel="stylesheet" href="./orientation-guard.css?build=20260721-r32">
-  <link rel="stylesheet" href="./lap-result-toast.css?build=20260721-r32">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260721-r32">
+  <link rel="manifest" href="./site.webmanifest?build=20260721-r33">
+  <link rel="stylesheet" href="./styles.css?build=20260721-r33">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260721-r33">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260721-r33">
+  <link rel="stylesheet" href="./install-gate.css?build=20260721-r33">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260721-r33">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260721-r33">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260721-r33">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260721-r33">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260721-r33">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260721-r33">
+  <link rel="stylesheet" href="./orientation-guard.css?build=20260721-r33">
+  <link rel="stylesheet" href="./lap-result-toast.css?build=20260721-r33">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260721-r33">
 
-  <script src="./install-gate.js?build=20260721-r32"></script>
-  <script src="./orientation-compat.js?build=20260721-r32"></script>
+  <script src="./install-gate.js?build=20260721-r33"></script>
+  <script src="./orientation-compat.js?build=20260721-r33"></script>
   <script type="importmap">
     {
       "imports": {
@@ -59,7 +59,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.16 · Build 2026.07.21-r32</span>
+        <span class="install-kicker">TURN v1.3.17 · Build 2026.07.21-r33</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -87,7 +87,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.16 · Build 2026.07.21-r32</span>
+      <span class="kicker">TURN v1.3.17 · Build 2026.07.21-r33</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -153,6 +153,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260721-r32"></script>
+  <script type="module" src="./app.js?build=20260721-r33"></script>
 </body>
 </html>

--- a/turn/lap-result-toast.css
+++ b/turn/lap-result-toast.css
@@ -1,10 +1,10 @@
 .lap-result-toast {
   position: absolute;
   z-index: 36;
-  left: max(112px, calc(env(safe-area-inset-left) + 112px));
-  bottom: max(92px, calc(env(safe-area-inset-bottom) + 92px));
-  width: min(320px, 42vw);
-  padding: 12px 18px 14px;
+  left: 50%;
+  top: 22%;
+  width: min(360px, 48vw);
+  padding: 10px 16px 12px;
   border: 4px solid var(--ink);
   border-radius: 20px;
   background: var(--yellow);
@@ -12,8 +12,8 @@
   color: var(--ink);
   pointer-events: none;
   opacity: 0;
-  transform: translateY(14px) scale(0.96);
-  transform-origin: left bottom;
+  transform: translate(-50%, 14px) scale(0.96);
+  transform-origin: center top;
   transition: opacity 180ms ease, transform 220ms cubic-bezier(0.2, 0.85, 0.3, 1.18);
 }
 
@@ -23,26 +23,28 @@
 
 .lap-result-toast.is-visible {
   opacity: 1;
-  transform: translateY(0) scale(1);
+  transform: translate(-50%, 0) scale(1);
 }
 
 .lap-result-toast.is-leaving {
   opacity: 0;
-  transform: translateY(10px) scale(0.98);
+  transform: translate(-50%, 10px) scale(0.98);
 }
 
 .lap-result-toast > span {
   display: block;
-  margin-bottom: 4px;
-  font-size: clamp(0.52rem, 1.35vw, 0.72rem);
+  margin-bottom: 3px;
+  font-size: clamp(0.5rem, 1.15vw, 0.68rem);
   letter-spacing: 0.07em;
+  text-align: center;
 }
 
 .lap-result-toast > strong {
   display: flex;
   align-items: baseline;
+  justify-content: center;
   gap: 9px;
-  font-size: clamp(1.05rem, 3.15vw, 1.75rem);
+  font-size: clamp(1rem, 2.75vw, 1.55rem);
   line-height: 1;
   white-space: nowrap;
 }
@@ -58,10 +60,9 @@
 
 @media (max-height: 430px) {
   .lap-result-toast {
-    left: max(96px, calc(env(safe-area-inset-left) + 96px));
-    bottom: max(70px, calc(env(safe-area-inset-bottom) + 70px));
-    width: min(286px, 40vw);
-    padding: 9px 14px 11px;
+    top: 17%;
+    width: min(320px, 46vw);
+    padding: 8px 13px 10px;
     border-width: 3px;
     border-radius: 16px;
     box-shadow: 5px 5px 0 var(--ink);
@@ -71,11 +72,11 @@
 @media (prefers-reduced-motion: reduce) {
   .lap-result-toast {
     transition: opacity 120ms linear;
-    transform: none;
+    transform: translateX(-50%);
   }
 
   .lap-result-toast.is-visible,
   .lap-result-toast.is-leaving {
-    transform: none;
+    transform: translateX(-50%);
   }
 }

--- a/turn/race/lap-system.js
+++ b/turn/race/lap-system.js
@@ -94,23 +94,25 @@ export function completeLapState({
   now,
   competitorLimit,
   saveGhost,
-  showMessage,
   onError
 }) {
   const finishedTime = (now - state.lapStartedAt) / 1000;
-  const validLap = finishedTime > 5 && state.recording.length > 20;
+  const completedLap = finishedTime > 5;
+  const validLap = completedLap && state.recording.length > 20;
   let finishingPosition = null;
   let finishingTotal = null;
 
-  if (validLap) {
-    const previousBest = state.bestTime;
+  if (completedLap) {
+    // Freeze the race result before the saved top-four rival list is updated. The last-lap
+    // result is meaningful even when this run is too slow to become a saved rival.
     const raceRivals = state.competitorLaps
       .filter((lap) => Number.isFinite(lap?.time))
       .slice(0, competitorLimit);
     finishingPosition = 1 + raceRivals.filter((lap) => lap.time < finishedTime).length;
     finishingTotal = raceRivals.length + 1;
-    let message = 'LAP ' + formatLapTime(finishedTime);
+  }
 
+  if (validLap) {
     try {
       const candidateFrames = state.recording.map((frame) => ({ ...frame }));
       if (candidateFrames.length) {
@@ -134,28 +136,20 @@ export function completeLapState({
         frames: candidateFrames
       };
 
-      const nextLaps = [...state.competitorLaps, candidate]
+      state.competitorLaps = [...state.competitorLaps, candidate]
         .filter((lap) => Number.isFinite(lap?.time) && Array.isArray(lap?.frames) && lap.frames.length > 20)
         .sort((a, b) => a.time - b.time)
         .slice(0, competitorLimit);
-
-      const rank = nextLaps.indexOf(candidate);
-      state.competitorLaps = nextLaps;
       state.bestTime = state.competitorLaps[0]?.time ?? Infinity;
       state.ghostFrames = state.competitorLaps[0]?.frames ?? [];
       state.ghostVisible = state.competitorLaps.length > 0;
       saveGhost?.();
-
-      if (finishedTime < previousBest) {
-        message = 'NEW BEST ' + formatLapTime(finishedTime);
-      } else if (rank >= 0) {
-        message = 'TOP ' + (rank + 1) + ' LAP ' + formatLapTime(finishedTime);
-      }
     } catch (error) {
       onError?.(error);
     }
+  }
 
-    showMessage?.(message);
+  if (completedLap) {
     publishLapResult({
       position: finishingPosition,
       total: finishingTotal,
@@ -172,6 +166,7 @@ export function completeLapState({
 
   return {
     finishedTime,
+    completedLap,
     validLap,
     position: finishingPosition,
     total: finishingTotal
@@ -186,12 +181,4 @@ function publishLapResult(detail) {
 function checkpointSampleAt(samples, progress) {
   const index = Math.round(progress * samples.length) % samples.length;
   return samples[index];
-}
-
-function formatLapTime(seconds) {
-  if (!Number.isFinite(seconds)) return '--:--.---';
-  const minutes = Math.floor(seconds / 60);
-  const secs = Math.floor(seconds % 60).toString().padStart(2, '0');
-  const ms = Math.floor((seconds % 1) * 1000).toString().padStart(3, '0');
-  return `${minutes}:${secs}.${ms}`;
 }


### PR DESCRIPTION
## Summary

- removes the old finish-line `TOP X LAP` / `NEW BEST` / `LAP` message so it no longer duplicates the new result toast
- moves the **LAST LAP** toast to the former central finish-message position
- keeps the existing yellow POSITION pop as the immediate finish-line feedback
- shows LAST LAP for every completed race lap, including last place
- separates result visibility from ghost/replay save eligibility, so a completed lap still gets a visible result even if its replay cannot be saved
- keeps the four-rival leaderboard and saved-ghost rules unchanged
- bumps TURN to **v1.3.17 · Build 2026.07.21-r33**

## Result semantics

The result toast is now the single source of truth for the completed lap. It freezes placement against the rivals that actually participated before the saved top-four list is updated, so results like `5/5` remain visible even when that lap does not qualify as a saved rival.

## Regression coverage

The lap-result regression now protects:

- normal fifth-place `5/5` results
- completed laps remaining visible even when replay recording is too short to save
- the old duplicate `TOP X LAP` / `NEW BEST` finish message staying removed
- the toast occupying the central former finish-message position
- four-second visibility, accessibility and reduced-motion behavior

No vehicle physics, controls, sound, orientation behavior, checkpoint rules, rival storage format, car tuning, paint, or spectator behavior is changed.