### PR TITLE
TURN v1.3.19 r35: Fix Vintage Racer orientation

### DIFF
--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -10,17 +10,17 @@ const [index, app, audio, controls, catalogSource] = await Promise.all([
 ]);
 const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
 
-assert.match(index, /TURN v1\.3\.18 · Build 2026\.07\.21-r34/);
-assert.match(index, /\.\/app\.js\?build=20260721-r34/);
+assert.match(index, /TURN v1\.3\.19 · Build 2026\.07\.21-r35/);
+assert.match(index, /\.\/app\.js\?build=20260721-r35/);
 assert.match(
   index,
-  /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r27"/,
-  'The main runtime catalog import must keep the r27 engine tuning cache redirect'
+  /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r35"/,
+  'The main runtime catalog import must cache-bust the r35 orientation correction'
 );
 assert.match(
   index,
-  /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260721-r27"/,
-  'The Lot catalog import must keep the same r27 engine tuning'
+  /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260721-r35"/,
+  'The Lot catalog import must use the same corrected r35 catalog'
 );
 
 assert.match(app, /import\(withBuild\('\.\/audio\/audio-system\.js'\)\)/, 'Production must load the central audio module');

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -7,7 +7,7 @@ const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogS
 const expectedQuarterTurns = new Map([
   ['convertible', 1],
   ['classic', 1],
-  ['vintage-racer', 2],
+  ['vintage-racer', 0],
   ['toy-racer', 2],
   ['monster-truck', 2],
   ['race-future', 0],
@@ -21,6 +21,10 @@ const expectedQuarterTurns = new Map([
   ['truck', 0],
   ['van', 0]
 ]);
+
+// Vintage Racer's GLB wheel labels describe the axles opposite to the visible body nose.
+// Keep the visual orientation verified by gameplay instead of trusting those labels literally.
+const reversedWheelLabelAxes = new Set(['vintage-racer']);
 
 assert.equal(catalog.CAR_CATALOG.length, expectedQuarterTurns.size);
 
@@ -36,7 +40,10 @@ for (const car of catalog.CAR_CATALOG) {
   const wheelNodes = (json.nodes || []).filter((node) => /wheel/i.test(node.name || '') && node.translation);
   const front = averageWheelPosition(wheelNodes.filter((node) => wheelRole(node.name) === 'front'));
   const back = averageWheelPosition(wheelNodes.filter((node) => wheelRole(node.name) === 'back'));
-  const rawFront = { x: front.x - back.x, z: front.z - back.z };
+  const labelAxis = { x: front.x - back.x, z: front.z - back.z };
+  const rawFront = reversedWheelLabelAxes.has(car.id)
+    ? { x: -labelAxis.x, z: -labelAxis.z }
+    : labelAxis;
   const rawLength = Math.hypot(rawFront.x, rawFront.z);
   assert.ok(rawLength > 0.1, `${car.name} must expose a usable front/back wheel axis`);
 
@@ -64,7 +71,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.18 · Build 2026\.07\.21-r34/);
+assert.match(index, /TURN v1\.3\.19 · Build 2026\.07\.21-r35/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -20,9 +20,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.18 · Build 2026\.07\.21-r34/);
-assert.match(index, /drive-pad\.css\?build=20260721-r34/);
-assert.match(index, /gameplay-v2\.css\?build=20260721-r34/);
+assert.match(index, /TURN v1\.3\.19 · Build 2026\.07\.21-r35/);
+assert.match(index, /drive-pad\.css\?build=20260721-r35/);
+assert.match(index, /gameplay-v2\.css\?build=20260721-r35/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -47,9 +47,10 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.18 · Build 2026\.07\.21-r34/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260721-r34/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r34 must preserve the latest Lot module cache redirect');
+assert.match(index, /TURN v1\.3\.19 · Build 2026\.07\.21-r35/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260721-r35/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r35 must preserve the latest Lot module cache redirect');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r35"/, 'r35 must cache-bust the corrected Vintage Racer orientation');
 assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -26,8 +26,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.18 · Build 2026\.07\.21-r34/);
-assert.match(index, /in-game-menu\.css\?build=20260721-r34/);
+assert.match(index, /TURN v1\.3\.19 · Build 2026\.07\.21-r35/);
+assert.match(index, /in-game-menu\.css\?build=20260721-r35/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Back to Start<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -127,10 +127,10 @@ const [index, app, lapSystem, toast, css] = await Promise.all([
   fs.readFile(new URL('../../turn/lap-result-toast.css', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.18 · Build 2026\.07\.21-r34/);
-assert.match(index, /lap-result-toast\.css\?build=20260721-r34/);
-assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260721-r34"/, 'r34 must cache-bust the production lap system');
-assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260721-r34"/, 'r34 must cache-bust reset gate-history state');
+assert.match(index, /TURN v1\.3\.19 · Build 2026\.07\.21-r35/);
+assert.match(index, /lap-result-toast\.css\?build=20260721-r35/);
+assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260721-r34"/, 'r35 must preserve the reliable r34 production lap system');
+assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260721-r34"/, 'r35 must preserve reset gate-history state');
 assert.match(app, /installLapResultToast\(\)/, 'The toast must install before the game runtime starts');
 assert.match(lapSystem, /turn:lap-result/, 'Completed lap finish must publish one frozen result event');
 assert.match(lapSystem, /const completedLap = finishedTime > 5/, 'Result visibility must be separated from replay-save eligibility');

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -20,13 +20,13 @@ const [index, css, orientationGuardCss, orientationCompat, camera] = await Promi
   fs.readFile(new URL('../../turn/render/camera.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.18 · Build 2026\.07\.21-r34/);
+assert.match(index, /TURN v1\.3\.19 · Build 2026\.07\.21-r35/);
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260721-r34/);
-assert.match(index, /orientation-guard\.css\?build=20260721-r34/);
-assert.match(index, /orientation-compat\.js\?build=20260721-r34/);
-assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r34 must preserve the guarded race camera cache redirect');
+assert.match(index, /manual-steering\.css\?build=20260721-r35/);
+assert.match(index, /orientation-guard\.css\?build=20260721-r35/);
+assert.match(index, /orientation-compat\.js\?build=20260721-r35/);
+assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r35 must preserve the guarded race camera cache redirect');
 assert.match(index, /<strong>Rotate to landscape<\/strong>/, 'The pre-race landscape instruction must remain available');
 
 assert.match(css, /--manual-steer-left/);

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -34,7 +34,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.18 · Build 2026\.07\.21-r34/);
+assert.match(index, /TURN v1\.3\.19 · Build 2026\.07\.21-r35/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -61,7 +61,7 @@ const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, m
   fs.readFile(new URL('../../turn/orientation-compat.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.18 · Build 2026\.07\.21-r34/);
+assert.match(index, /TURN v1\.3\.19 · Build 2026\.07\.21-r35/);
 assert.match(main, /mainSceneOcclusion/);
 assert.match(main, /HUD_UPDATE_INTERVAL_MS = 1000 \/ 30/);
 assert.match(main, /recordPerformanceFrame/);

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r34 Reliable swept lap gates -->
+<!-- TURN r35 Vintage Racer orientation fix -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,33 +10,33 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.18 · Build 2026.07.21-r34</title>
+  <title>TURN v1.3.19 · Build 2026.07.21-r35</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.18',
-      id: '2026.07.21-r34',
-      cacheKey: '20260721-r34'
+      version: '1.3.19',
+      id: '2026.07.21-r35',
+      cacheKey: '20260721-r35'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260721-r34">
-  <link rel="stylesheet" href="./styles.css?build=20260721-r34">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260721-r34">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260721-r34">
-  <link rel="stylesheet" href="./install-gate.css?build=20260721-r34">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260721-r34">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260721-r34">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260721-r34">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260721-r34">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260721-r34">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260721-r34">
-  <link rel="stylesheet" href="./orientation-guard.css?build=20260721-r34">
-  <link rel="stylesheet" href="./lap-result-toast.css?build=20260721-r34">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260721-r34">
+  <link rel="manifest" href="./site.webmanifest?build=20260721-r35">
+  <link rel="stylesheet" href="./styles.css?build=20260721-r35">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260721-r35">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260721-r35">
+  <link rel="stylesheet" href="./install-gate.css?build=20260721-r35">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260721-r35">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260721-r35">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260721-r35">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260721-r35">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260721-r35">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260721-r35">
+  <link rel="stylesheet" href="./orientation-guard.css?build=20260721-r35">
+  <link rel="stylesheet" href="./lap-result-toast.css?build=20260721-r35">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260721-r35">
 
-  <script src="./install-gate.js?build=20260721-r34"></script>
-  <script src="./orientation-compat.js?build=20260721-r34"></script>
+  <script src="./install-gate.js?build=20260721-r35"></script>
+  <script src="./orientation-compat.js?build=20260721-r35"></script>
   <script type="importmap">
     {
       "imports": {
@@ -46,8 +46,8 @@
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260721-r29",
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system.js?build=20260721-r34",
         "./race/game-state.js": "./race/game-state.js?build=20260721-r34",
-        "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260721-r27",
-        "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260721-r27",
+        "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260721-r35",
+        "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260721-r35",
         "./vehicle/car-models.js?build=20260720-r19": "./vehicle/car-models.js?build=20260720-r22"
       }
     }
@@ -61,7 +61,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.18 · Build 2026.07.21-r34</span>
+        <span class="install-kicker">TURN v1.3.19 · Build 2026.07.21-r35</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -89,7 +89,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.18 · Build 2026.07.21-r34</span>
+      <span class="kicker">TURN v1.3.19 · Build 2026.07.21-r35</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -155,6 +155,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260721-r34"></script>
+  <script type="module" src="./app.js?build=20260721-r35"></script>
 </body>
 </html>

--- a/turn/vehicle/catalog.js
+++ b/turn/vehicle/catalog.js
@@ -23,7 +23,7 @@ export const CAR_PALETTE = Object.freeze([
 const RAW_CARS = [
   ['convertible', 'Convertible', 'prototype', { speed: 4, acceleration: 4, control: 4, drift: 2, boostPower: 3, boostDuration: 1 }, 0.98, 1, 1.08],
   ['classic', 'Classic', 'prototype', { speed: 3, acceleration: 2, control: 4, drift: 4, boostPower: 2, boostDuration: 3 }, 1.00, 1, 0.88],
-  ['vintage-racer', 'Vintage Racer', 'toy', { speed: 5, acceleration: 4, control: 3, drift: 2, boostPower: 3, boostDuration: 1 }, 0.96, 2, 1.28],
+  ['vintage-racer', 'Vintage Racer', 'toy', { speed: 5, acceleration: 4, control: 3, drift: 2, boostPower: 3, boostDuration: 1 }, 0.96, 0, 1.28],
   ['toy-racer', 'Toy Racer', 'toy', { speed: 4, acceleration: 5, control: 5, drift: 1, boostPower: 2, boostDuration: 1 }, 0.94, 2, 1.18],
   ['monster-truck', 'Monster Truck', 'toy', { speed: 2, acceleration: 3, control: 2, drift: 5, boostPower: 2, boostDuration: 4 }, 1.18, 2, 0.62],
   ['race-future', 'Future Racer', 'car', { speed: 5, acceleration: 5, control: 3, drift: 1, boostPower: 3, boostDuration: 1 }, 0.96, 0, 1.42],


### PR DESCRIPTION
## Summary

- flips only the **Vintage Racer** model normalization by 180° so its visible nose points the same direction as the other cars
- fixes the shared catalog orientation value, so the correction applies consistently in The Lot, the 3D viewer, races, ghosts, and spectator mode
- updates the all-car orientation regression to account for Vintage Racer's misleading front/back wheel-node labels rather than treating those labels as authoritative over the visible body
- cache-busts both historical catalog import paths so installed PWAs receive the corrected orientation
- bumps TURN to **v1.3.19 · Build 2026.07.21-r35**

## Scope

No physics, controls, lap logic, sound, vehicle balance, paint, checkpoints, outlines, or orientation-lock behavior is changed. Only Vintage Racer's model yaw normalization changes.

## Regression coverage

- all 15 cars still have explicit verified orientation corrections
- Vintage Racer is now protected at `modelYawQuarterTurns = 0`
- shared model factory, Lot, race, ghost, and viewer orientation contracts remain unchanged
- catalog cache redirects are protected at r35