### PR TITLE
TURN v1.3.20 r36: Restart Lap QoL and invalid-lap feedback

### DIFF
--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -10,12 +10,12 @@ const [index, app, audio, controls, catalogSource] = await Promise.all([
 ]);
 const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
 
-assert.match(index, /TURN v1\.3\.19 · Build 2026\.07\.21-r35/);
-assert.match(index, /\.\/app\.js\?build=20260721-r35/);
+assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
+assert.match(index, /\.\/app\.js\?build=20260721-r36/);
 assert.match(
   index,
   /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r35"/,
-  'The main runtime catalog import must cache-bust the r35 orientation correction'
+  'The main runtime catalog import must preserve the r35 orientation correction'
 );
 assert.match(
   index,

--- a/turn-lab/tests/balance-and-checkpoints.mjs
+++ b/turn-lab/tests/balance-and-checkpoints.mjs
@@ -98,7 +98,7 @@ run(1100);
 assert.equal(
   state.lapCheckpointIndex,
   1,
-  'a checkpoint crossed between physics samples must count even when neither sampled endpoint is inside the old circular gate'
+  'a checkpoint crossed between physics samples must count even when neither sampled endpoint is near the gate'
 );
 assert.equal(began, 0, 'the swept checkpoint regression must not accidentally cross the start line');
 
@@ -143,8 +143,10 @@ state.lapPreviousPosition = { x: -2, z: 0 };
 state.position = new Vec3(2, 0, 0);
 run(1400);
 assert.equal(completed, 0, 'missing even one checkpoint must prevent lap completion');
-assert.equal(began, 1, 'an incomplete shortcut lap must restart the timed attempt');
+assert.equal(began, 1, 'an incomplete lap must immediately restart the timed attempt at the finish line');
+assert.equal(state.suppressNextLapStartMessage, true, 'invalid-lap restart must suppress a competing GO message');
 
+state.suppressNextLapStartMessage = false;
 state.lastProgress = 0.4;
 state.progress = 0.4;
 state.lapCheckpointIndex = LAP_CHECKPOINTS.length;
@@ -194,6 +196,8 @@ assert.match(carModelsSource, /ghost \? ghostColor : requestedColor/, 'ghost bod
 assert.match(mainSource, /const ghostCar = makeCar\(0x38d9ff, 1\)/, 'procedural ghost fallback must also be solid');
 assert.match(mainSource, /const car = makeCar\(0x38d9ff, 1\)/, 'additional procedural rival fallbacks must also be solid');
 assert.match(lapSystemSource, /crossedForwardGate/, 'production lap registration must use swept physical gates');
-assert.match(lapSystemSource, /LAP_GATE_HALF_WIDTH_FACTOR = 0\.82/, 'legitimate laps must have modest verge tolerance around the road and curbs');
+assert.match(lapSystemSource, /CHECKPOINT_GATE_HALF_WIDTH_FACTOR = 1\.05/, 'checkpoint gates must allow broad grass and verge racing lines');
+assert.match(lapSystemSource, /START_GATE_HALF_WIDTH_FACTOR = 0\.82/, 'start and finish must keep the established narrower crossing gate');
+assert.match(lapSystemSource, /turn:lap-invalid/, 'an incomplete checkpoint chain must report an invalid lap instead of failing silently');
 
-console.log('TURN balance, swept lap gates and anti-shortcut regression passed.');
+console.log('TURN forgiving swept lap gates and anti-shortcut regression passed.');

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -53,8 +53,6 @@ for (const car of catalog.CAR_CATALOG) {
     `${car.name} correction must normalize its authored nose to +Z`
   );
 
-  // createCarVisual points normalized models down local -Z. The Lot and race roots
-  // both add a half-turn, while the viewer adds a three-quarter presentation angle.
   const factoryFront = rotateYaw(correctedFront, Math.PI);
   const lotFront = rotateYaw(factoryFront, Math.PI);
   const raceFront = rotateYaw(factoryFront, Math.PI);
@@ -71,7 +69,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.19 · Build 2026\.07\.21-r35/);
+assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -20,9 +20,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.19 · Build 2026\.07\.21-r35/);
-assert.match(index, /drive-pad\.css\?build=20260721-r35/);
-assert.match(index, /gameplay-v2\.css\?build=20260721-r35/);
+assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
+assert.match(index, /drive-pad\.css\?build=20260721-r36/);
+assert.match(index, /gameplay-v2\.css\?build=20260721-r36/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');
@@ -32,6 +32,10 @@ assert.match(controls, /boostRequested = nextZone === 'boost'/, 'Boost zone must
 assert.match(controls, /boostRequested && !boostExhausted/, 'Boost must stay locked while the thumb remains in Boost after exhaustion');
 assert.match(controls, /previousZone === 'boost' && nextZone !== 'boost'\) boostExhausted = false/, 'Leaving Boost for Gas or Drift must re-arm Boost without requiring pointer release');
 assert.match(controls, /Brake · Reverse/, 'Separate brake control must advertise reverse');
+assert.match(controls, /function refillBoost\(\)/, 'Gameplay controls must expose one reset-safe boost refill path');
+assert.match(controls, /boostCharge = 1;\s*previousBoostCharge = 1;\s*boostExhausted = false;/s, 'Restarting must fully refill and unlock boost without creating a recharge transition');
+assert.match(controls, /event\.detail\?\.reason === 'race-reset'\) refillBoost\(\)/, 'The race reset event must refill boost');
+assert.match(controls, /globalThis\.__turnRefillBoost = refillBoost/, 'Boost refill must remain reusable by the runtime');
 assert.match(controls, /becameEmpty = previousBoostCharge > 0\.001 && boostCharge <= 0\.001/, 'Empty feedback must trigger on the actual depletion transition');
 assert.match(controls, /becameFull = previousBoostCharge < 0\.999 && boostCharge >= 0\.999/, 'Full feedback must trigger only when recharge crosses the full threshold');
 assert.match(controls, /flashBoostHud\('is-boost-empty-flash'\)/, 'Empty boost must trigger its distinct HUD feedback class');
@@ -71,4 +75,4 @@ assert.ok(state.velocity.z < -0.1, 'Holding Brake after stopping must engage rev
 for (let i = 0; i < 100; i += 1) updateVehiclePhysicsState(physicsArgs);
 assert.ok(state.velocity.z >= -(80 * 0.32 + 0.5), 'Reverse must stay capped well below forward top speed');
 
-console.log('TURN unified drive pad and reverse regression passed.');
+console.log('TURN unified drive pad, restart boost refill and reverse regression passed.');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -47,10 +47,10 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.19 · Build 2026\.07\.21-r35/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260721-r35/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r35 must preserve the latest Lot module cache redirect');
-assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r35"/, 'r35 must cache-bust the corrected Vintage Racer orientation');
+assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260721-r36/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r36 must preserve the latest Lot module cache redirect');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r35"/, 'r36 must preserve the corrected Vintage Racer orientation');
 assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -26,11 +26,13 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.19 · Build 2026\.07\.21-r35/);
-assert.match(index, /in-game-menu\.css\?build=20260721-r35/);
+assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
+assert.match(index, /in-game-menu\.css\?build=20260721-r36/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
-assert.match(index, /id="resetButton"[^>]*>Back to Start<\/button>/);
+assert.match(index, /id="resetButton"[^>]*>Restart Lap<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);
+assert.match(menu, /backToStartButton\.textContent = 'Restart Lap'/, 'The race reset action should describe restarting the lap rather than navigating away');
+assert.match(menu, /Restart the current lap from the start line/, 'Restart Lap must expose an accurate accessible label');
 assert.match(menu, /inGameMenuVisibilityFor\(runtime\.state\.mode\)/, 'Menu visibility must follow the explicit game mode');
 assert.doesNotMatch(menu, /state\.speed/, 'Menu visibility must not infer race state from speed');
 assert.match(menu, /backToStartButton\.hidden = !visibility\.backToStart/);
@@ -47,4 +49,4 @@ assert.match(css, /\.utility-group\[data-menu-state="staged"\]/);
 assert.match(css, /\.utility-group\[data-menu-state="racing"\] \.back-to-start-button/);
 assert.match(css, /\.utility-group\[data-menu-state="hidden"\]/);
 
-console.log('TURN state-aware in-game menu regression passed.');
+console.log('TURN state-aware in-game menu and Restart Lap regression passed.');

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -127,26 +127,31 @@ const [index, app, lapSystem, toast, css] = await Promise.all([
   fs.readFile(new URL('../../turn/lap-result-toast.css', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.19 · Build 2026\.07\.21-r35/);
-assert.match(index, /lap-result-toast\.css\?build=20260721-r35/);
-assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260721-r34"/, 'r35 must preserve the reliable r34 production lap system');
-assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260721-r34"/, 'r35 must preserve reset gate-history state');
+assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
+assert.match(index, /lap-result-toast\.css\?build=20260721-r36/);
+assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260721-r36"/, 'r36 must cache-bust the more forgiving lap system');
+assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260721-r34"/, 'r36 must preserve reliable reset gate-history state');
 assert.match(app, /installLapResultToast\(\)/, 'The toast must install before the game runtime starts');
 assert.match(lapSystem, /turn:lap-result/, 'Completed lap finish must publish one frozen result event');
+assert.match(lapSystem, /turn:lap-invalid/, 'Incomplete checkpoint chains must publish explicit invalid-lap feedback');
+assert.match(lapSystem, /suppressNextLapStartMessage = true/, 'Invalid-lap feedback must not be obscured by a competing GO message');
 assert.match(lapSystem, /const completedLap = finishedTime > 5/, 'Result visibility must be separated from replay-save eligibility');
 assert.match(lapSystem, /const validLap = completedLap && state\.recording\.length > 20/, 'Ghost saving may still require a usable recording');
 assert.match(lapSystem, /if \(completedLap\) \{\s*publishLapResult/s, 'Every completed lap must publish a result, including last place and unsaved replays');
 assert.doesNotMatch(lapSystem, /TOP ['"] \+|NEW BEST|showMessage\?\.\(message\)/, 'The retired duplicate lap-ranking message must stay removed');
 assert.match(lapSystem, /raceRivals\.filter\(\(lap\) => lap\.time < finishedTime\)\.length/, 'Finish placement must be calculated against the rivals from the completed race');
 assert.match(toast, /TOAST_VISIBLE_MS = 4000/, 'The result should remain readable for a few seconds');
-assert.match(toast, /LAST LAP/, 'The toast must use the requested result label');
+assert.match(toast, /LAST LAP/, 'Valid laps must keep the requested result label');
+assert.match(toast, /LAP INVALID/, 'Invalid laps must replace LAST LAP with an explicit failure label');
+assert.match(toast, /MISSED CHECKPOINT/, 'Invalid checkpoint chains must explain why the lap did not count');
+assert.match(toast, /turn:lap-invalid/, 'The unified toast must listen for invalid-lap events');
 assert.match(toast, /lap-result-position/, 'The toast must show frozen finishing position');
 assert.match(toast, /lap-result-time/, 'The toast must show the completed lap time');
 assert.match(toast, /aria-live', 'polite'/, 'The result toast should be announced without interrupting gameplay');
 assert.match(css, /background: var\(--yellow\)/, 'The toast must share the yellow finish-result colour');
-assert.match(css, /left: 50%/, 'The last-lap toast must occupy the former central finish-message position');
-assert.match(css, /top: 22%/, 'The last-lap toast must sit where the old TOP X LAP message appeared');
+assert.match(css, /left: 50%/, 'The lap toast must occupy the central finish-message position');
+assert.match(css, /top: 22%/, 'The lap toast must sit where the old TOP X LAP message appeared');
 assert.doesNotMatch(css, /left: max\(112px/, 'The retired lower-left toast placement must stay removed');
 assert.match(css, /prefers-reduced-motion: reduce/, 'Toast animation must respect reduced-motion preferences');
 
-console.log('TURN reliable unified last-lap result regression passed.');
+console.log('TURN unified valid and invalid lap result toast regression passed.');

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -20,13 +20,13 @@ const [index, css, orientationGuardCss, orientationCompat, camera] = await Promi
   fs.readFile(new URL('../../turn/render/camera.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.19 · Build 2026\.07\.21-r35/);
+assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260721-r35/);
-assert.match(index, /orientation-guard\.css\?build=20260721-r35/);
-assert.match(index, /orientation-compat\.js\?build=20260721-r35/);
-assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r35 must preserve the guarded race camera cache redirect');
+assert.match(index, /manual-steering\.css\?build=20260721-r36/);
+assert.match(index, /orientation-guard\.css\?build=20260721-r36/);
+assert.match(index, /orientation-compat\.js\?build=20260721-r36/);
+assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r36 must preserve the guarded race camera cache redirect');
 assert.match(index, /<strong>Rotate to landscape<\/strong>/, 'The pre-race landscape instruction must remain available');
 
 assert.match(css, /--manual-steer-left/);

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -34,7 +34,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.19 · Build 2026\.07\.21-r35/);
+assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -61,7 +61,7 @@ const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, m
   fs.readFile(new URL('../../turn/orientation-compat.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.19 · Build 2026\.07\.21-r35/);
+assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
 assert.match(main, /mainSceneOcclusion/);
 assert.match(main, /HUD_UPDATE_INTERVAL_MS = 1000 \/ 30/);
 assert.match(main, /recordPerformanceFrame/);

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r35 Vintage Racer orientation fix -->
+<!-- TURN r36 Restart lap QoL and checkpoint feedback -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,33 +10,33 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.19 · Build 2026.07.21-r35</title>
+  <title>TURN v1.3.20 · Build 2026.07.21-r36</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.19',
-      id: '2026.07.21-r35',
-      cacheKey: '20260721-r35'
+      version: '1.3.20',
+      id: '2026.07.21-r36',
+      cacheKey: '20260721-r36'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260721-r35">
-  <link rel="stylesheet" href="./styles.css?build=20260721-r35">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260721-r35">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260721-r35">
-  <link rel="stylesheet" href="./install-gate.css?build=20260721-r35">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260721-r35">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260721-r35">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260721-r35">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260721-r35">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260721-r35">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260721-r35">
-  <link rel="stylesheet" href="./orientation-guard.css?build=20260721-r35">
-  <link rel="stylesheet" href="./lap-result-toast.css?build=20260721-r35">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260721-r35">
+  <link rel="manifest" href="./site.webmanifest?build=20260721-r36">
+  <link rel="stylesheet" href="./styles.css?build=20260721-r36">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260721-r36">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260721-r36">
+  <link rel="stylesheet" href="./install-gate.css?build=20260721-r36">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260721-r36">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260721-r36">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260721-r36">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260721-r36">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260721-r36">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260721-r36">
+  <link rel="stylesheet" href="./orientation-guard.css?build=20260721-r36">
+  <link rel="stylesheet" href="./lap-result-toast.css?build=20260721-r36">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260721-r36">
 
-  <script src="./install-gate.js?build=20260721-r35"></script>
-  <script src="./orientation-compat.js?build=20260721-r35"></script>
+  <script src="./install-gate.js?build=20260721-r36"></script>
+  <script src="./orientation-compat.js?build=20260721-r36"></script>
   <script type="importmap">
     {
       "imports": {
@@ -44,7 +44,7 @@
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-r10.js?build=20260720-r25",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260721-r29",
-        "./race/lap-system.js?build=20260720-r19": "./race/lap-system.js?build=20260721-r34",
+        "./race/lap-system.js?build=20260720-r19": "./race/lap-system.js?build=20260721-r36",
         "./race/game-state.js": "./race/game-state.js?build=20260721-r34",
         "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260721-r35",
         "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260721-r35",
@@ -61,7 +61,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.19 · Build 2026.07.21-r35</span>
+        <span class="install-kicker">TURN v1.3.20 · Build 2026.07.21-r36</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -89,7 +89,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.19 · Build 2026.07.21-r35</span>
+      <span class="kicker">TURN v1.3.20 · Build 2026.07.21-r36</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -147,7 +147,7 @@
   <div class="controls" id="controls" hidden>
     <div class="utility-group">
       <button class="utility" id="calibrateButton" type="button">Recalibrate</button>
-      <button class="utility" id="resetButton" type="button">Back to Start</button>
+      <button class="utility" id="resetButton" type="button">Restart Lap</button>
     </div>
     <div class="pedals">
       <button class="pedal brake" id="brakeButton" type="button">Brake</button>
@@ -155,6 +155,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260721-r35"></script>
+  <script type="module" src="./app.js?build=20260721-r36"></script>
 </body>
 </html>

--- a/turn/race/lap-system.js
+++ b/turn/race/lap-system.js
@@ -13,10 +13,12 @@ export const LAP_CHECKPOINTS = Object.freeze([
   0.94
 ]);
 
-// The gate spans the whole road, both curbs and a modest amount of verge. The
-// ordered twelve-gate chain still prevents major shortcuts, while a legitimate
-// lap is no longer invalidated by briefly putting two wheels beyond a curb.
-const LAP_GATE_HALF_WIDTH_FACTOR = 0.82;
+// Checkpoints are intentionally broader than the rendered road. TURN rewards
+// adventurous racing lines, so grass and verge excursions should still count as
+// a legitimate circuit. The ordered twelve-gate chain remains the anti-shortcut
+// mechanism. Start/finish stays narrower to avoid accidental lap crossings.
+const CHECKPOINT_GATE_HALF_WIDTH_FACTOR = 1.05;
+const START_GATE_HALF_WIDTH_FACTOR = 0.82;
 const GATE_EPSILON = 1e-6;
 
 export function beginTimedLapState({ state, samples, now, showMessage }) {
@@ -53,7 +55,8 @@ export function updateLapProgressState({
 }) {
   const currentPosition = snapshotPosition(state.position);
   const previousPosition = state.lapPreviousPosition || currentPosition;
-  const gateHalfWidth = trackWidth * LAP_GATE_HALF_WIDTH_FACTOR;
+  const checkpointGateHalfWidth = trackWidth * CHECKPOINT_GATE_HALF_WIDTH_FACTOR;
+  const startGateHalfWidth = trackWidth * START_GATE_HALF_WIDTH_FACTOR;
   const nextCheckpoint = checkpoints[state.lapCheckpointIndex];
 
   if (state.lapActive && nextCheckpoint != null) {
@@ -63,14 +66,15 @@ export function updateLapProgressState({
       previousPosition,
       currentPosition,
       checkpointSample,
-      gateHalfWidth
+      checkpointGateHalfWidth
     );
 
     // Keep a close-range fallback for the first frame after legacy/restored state,
     // but normal play uses the swept crossing above so a gate cannot fall between
     // two physics samples.
     const insideCheckpointGate = !state.lapPreviousPosition
-      && distanceSquared(currentPosition, checkpointSample.point) <= gateHalfWidth * gateHalfWidth;
+      && distanceSquared(currentPosition, checkpointSample.point)
+        <= checkpointGateHalfWidth * checkpointGateHalfWidth;
 
     if (movingForwardThroughGate && (crossedCheckpointGate || insideCheckpointGate)) {
       state.lapCheckpointIndex += 1;
@@ -83,7 +87,7 @@ export function updateLapProgressState({
     previousPosition,
     currentPosition,
     startSample,
-    gateHalfWidth
+    startGateHalfWidth
   );
 
   // Retain the old progress-wrap signal as a compatibility fallback, but require
@@ -91,7 +95,7 @@ export function updateLapProgressState({
   // is now the primary source of truth.
   const crossedStartByProgress = state.lastProgress > 0.82 && state.progress < 0.18;
   const nearPhysicalStart = distanceSquared(currentPosition, startSample.point)
-    <= gateHalfWidth * gateHalfWidth;
+    <= startGateHalfWidth * startGateHalfWidth;
   const crossedStartOnTrack = movingForwardAtStart
     && (crossedPhysicalStartGate || (crossedStartByProgress && nearPhysicalStart));
 
@@ -101,10 +105,11 @@ export function updateLapProgressState({
     } else if (state.lapCheckpointIndex >= checkpoints.length) {
       completeLap(now);
     } else {
-      // Crossing the line without every ordered physical gate starts a fresh timed
-      // attempt. This preserves the anti-shortcut contract while avoiding false
-      // misses caused by point-sampled gates.
-      beginTimedLap(now);
+      // A failed anti-shortcut check should never be silent. The finish crossing
+      // also starts the next attempt, but without a competing GO message so the
+      // player has time to understand why the previous lap did not count.
+      publishLapInvalid({ reason: 'missed-checkpoint' });
+      beginTimedLap(now, { showStartMessage: false });
     }
   }
 
@@ -237,8 +242,16 @@ export function crossedForwardGate(previousPosition, currentPosition, gateSample
 }
 
 function publishLapResult(detail) {
+  publishEvent('turn:lap-result', detail);
+}
+
+function publishLapInvalid(detail) {
+  publishEvent('turn:lap-invalid', detail);
+}
+
+function publishEvent(type, detail) {
   if (typeof globalThis.dispatchEvent !== 'function' || typeof globalThis.CustomEvent !== 'function') return;
-  globalThis.dispatchEvent(new globalThis.CustomEvent('turn:lap-result', { detail }));
+  globalThis.dispatchEvent(new globalThis.CustomEvent(type, { detail }));
 }
 
 function checkpointSampleAt(samples, progress) {

--- a/turn/race/lap-system.js
+++ b/turn/race/lap-system.js
@@ -23,6 +23,8 @@ const GATE_EPSILON = 1e-6;
 
 export function beginTimedLapState({ state, samples, now, showMessage }) {
   const start = samples[0];
+  const suppressStartMessage = state.suppressNextLapStartMessage === true;
+  state.suppressNextLapStartMessage = false;
 
   state.lapActive = true;
   state.lapCheckpointIndex = 0;
@@ -39,7 +41,7 @@ export function beginTimedLapState({ state, samples, now, showMessage }) {
     p: 0
   }];
 
-  showMessage?.('GO!');
+  if (!suppressStartMessage) showMessage?.('GO!');
 }
 
 export function updateLapProgressState({
@@ -69,9 +71,6 @@ export function updateLapProgressState({
       checkpointGateHalfWidth
     );
 
-    // Keep a close-range fallback for the first frame after legacy/restored state,
-    // but normal play uses the swept crossing above so a gate cannot fall between
-    // two physics samples.
     const insideCheckpointGate = !state.lapPreviousPosition
       && distanceSquared(currentPosition, checkpointSample.point)
         <= checkpointGateHalfWidth * checkpointGateHalfWidth;
@@ -90,9 +89,6 @@ export function updateLapProgressState({
     startGateHalfWidth
   );
 
-  // Retain the old progress-wrap signal as a compatibility fallback, but require
-  // the car to actually be near the physical start gate. The physical swept gate
-  // is now the primary source of truth.
   const crossedStartByProgress = state.lastProgress > 0.82 && state.progress < 0.18;
   const nearPhysicalStart = distanceSquared(currentPosition, startSample.point)
     <= startGateHalfWidth * startGateHalfWidth;
@@ -105,11 +101,9 @@ export function updateLapProgressState({
     } else if (state.lapCheckpointIndex >= checkpoints.length) {
       completeLap(now);
     } else {
-      // A failed anti-shortcut check should never be silent. The finish crossing
-      // also starts the next attempt, but without a competing GO message so the
-      // player has time to understand why the previous lap did not count.
       publishLapInvalid({ reason: 'missed-checkpoint' });
-      beginTimedLap(now, { showStartMessage: false });
+      state.suppressNextLapStartMessage = true;
+      beginTimedLap(now);
     }
   }
 
@@ -138,8 +132,6 @@ export function completeLapState({
   let finishingTotal = null;
 
   if (completedLap) {
-    // Freeze the race result before the saved top-four rival list is updated. The last-lap
-    // result is meaningful even when this run is too slow to become a saved rival.
     const raceRivals = state.competitorLaps
       .filter((lap) => Number.isFinite(lap?.time))
       .slice(0, competitorLimit);

--- a/turn/ui/gameplay-controls.js
+++ b/turn/ui/gameplay-controls.js
@@ -170,6 +170,28 @@ function installGameplayUi() {
     return Math.max(0.8, Math.min(5, duration));
   }
 
+  function refillBoost() {
+    window.clearTimeout(boostFlashTimer);
+    boostFlashTimer = 0;
+    boostCharge = 1;
+    previousBoostCharge = 1;
+    boostExhausted = false;
+    globalThis.__turnBoostCharge = 1;
+    boostVisualDirty = true;
+    lastBoostVisualAt = -Infinity;
+    publishedChargePercent = null;
+    publishedAriaPercent = null;
+    publishedLocked = null;
+    drivePad.style.setProperty('--boost-charge', '100%');
+    boostHud.style.setProperty('--boost-charge', '100%');
+    boostHud.setAttribute('aria-label', 'Boost 100 percent charged');
+    drivePad.classList.remove('is-boost-locked');
+    boostZone.classList.remove('is-locked');
+    boostHud.classList.remove('is-boost-full-flash', 'is-boost-empty-flash');
+  }
+
+  globalThis.__turnRefillBoost = refillBoost;
+
   function zoneFromPointer(event) {
     const rect = drivePad.getBoundingClientRect();
     const margin = 24;
@@ -299,6 +321,9 @@ function installGameplayUi() {
   window.addEventListener('blur', () => {
     releaseDrive();
     centerManualSteerVisual();
+  });
+  window.addEventListener('turn:ui-state-change', (event) => {
+    if (event.detail?.reason === 'race-reset') refillBoost();
   });
   document.addEventListener('visibilitychange', () => {
     if (document.hidden) {

--- a/turn/ui/in-game-menu.js
+++ b/turn/ui/in-game-menu.js
@@ -28,8 +28,8 @@ function install(runtime) {
 
   runtime.__inGameMenuInstalled = true;
 
-  backToStartButton.textContent = 'Back to Start';
-  backToStartButton.setAttribute('aria-label', 'Return to the start');
+  backToStartButton.textContent = 'Restart Lap';
+  backToStartButton.setAttribute('aria-label', 'Restart the current lap from the start line');
   backToStartButton.classList.add('back-to-start-button');
 
   recalibrateButton.textContent = 'Recalibrate';

--- a/turn/ui/lap-result-toast.js
+++ b/turn/ui/lap-result-toast.js
@@ -95,7 +95,9 @@ export function installLapResultToast() {
   window.addEventListener('turn:lap-result', (event) => showResult(event.detail));
   window.addEventListener('turn:lap-invalid', (event) => showInvalid(event.detail));
   window.addEventListener('turn:ui-state-change', (event) => {
-    if (!event.detail?.running) hide({ immediate: true });
+    if (!event.detail?.running || event.detail?.reason === 'race-reset') {
+      hide({ immediate: true });
+    }
   });
 }
 

--- a/turn/ui/lap-result-toast.js
+++ b/turn/ui/lap-result-toast.js
@@ -24,7 +24,9 @@ export function installLapResultToast() {
   `;
   hud.appendChild(toast);
 
+  const label = toast.querySelector('span');
   const position = toast.querySelector('.lap-result-position');
+  const separator = toast.querySelector('i');
   const time = toast.querySelector('.lap-result-time');
   let hideTimer = 0;
   let exitTimer = 0;
@@ -42,7 +44,7 @@ export function installLapResultToast() {
 
     if (immediate) {
       toast.hidden = true;
-      toast.classList.remove('is-visible', 'is-leaving');
+      toast.classList.remove('is-visible', 'is-leaving', 'is-invalid');
       return;
     }
 
@@ -50,29 +52,48 @@ export function installLapResultToast() {
     toast.classList.add('is-leaving');
     exitTimer = window.setTimeout(() => {
       toast.hidden = true;
-      toast.classList.remove('is-leaving');
+      toast.classList.remove('is-leaving', 'is-invalid');
       exitTimer = 0;
     }, TOAST_EXIT_MS);
   }
 
-  function show(result) {
+  function reveal() {
+    clearTimers();
+    toast.hidden = false;
+    toast.classList.remove('is-visible', 'is-leaving');
+    void toast.offsetWidth;
+    toast.classList.add('is-visible');
+    hideTimer = window.setTimeout(() => hide(), TOAST_VISIBLE_MS);
+  }
+
+  function showResult(result) {
     const place = Number(result?.position);
     const total = Number(result?.total);
     const seconds = Number(result?.time);
     if (!Number.isFinite(place) || !Number.isFinite(total) || !Number.isFinite(seconds)) return;
 
-    clearTimers();
+    label.textContent = 'LAST LAP';
     position.textContent = `${Math.max(1, Math.round(place))}/${Math.max(1, Math.round(total))}`;
+    separator.hidden = false;
+    time.hidden = false;
     time.textContent = formatLapTime(seconds);
-    toast.hidden = false;
-    toast.classList.remove('is-visible', 'is-leaving');
-    void toast.offsetWidth;
-    toast.classList.add('is-visible');
-
-    hideTimer = window.setTimeout(() => hide(), TOAST_VISIBLE_MS);
+    toast.classList.remove('is-invalid');
+    reveal();
   }
 
-  window.addEventListener('turn:lap-result', (event) => show(event.detail));
+  function showInvalid(result) {
+    label.textContent = 'LAP INVALID';
+    position.textContent = result?.reason === 'missed-checkpoint'
+      ? 'MISSED CHECKPOINT'
+      : 'TRY AGAIN';
+    separator.hidden = true;
+    time.hidden = true;
+    toast.classList.add('is-invalid');
+    reveal();
+  }
+
+  window.addEventListener('turn:lap-result', (event) => showResult(event.detail));
+  window.addEventListener('turn:lap-invalid', (event) => showInvalid(event.detail));
   window.addEventListener('turn:ui-state-change', (event) => {
     if (!event.detail?.running) hide({ immediate: true });
   });


### PR DESCRIPTION
## Summary

- renames **Back to Start** to **Restart Lap** so the control describes what it actually does
- refills BOOST to 100% whenever the race is reset/restarted, without firing the normal boost-full recharge cue
- widens the twelve ordered checkpoint gates from `0.82 × track width` to `1.05 × track width` so broad grass/verge racing lines are less likely to invalidate a legitimate lap
- keeps the start/finish gate at the established narrower `0.82 × track width` tolerance
- replaces silent failed lap registration with the central result toast: **LAP INVALID / MISSED CHECKPOINT**
- suppresses the competing `GO!` message when an invalid finish immediately starts the next timed attempt
- clears stale lap-result feedback when Restart Lap is used
- bumps TURN to **v1.3.20 · Build 2026.07.21-r36** and cache-busts the changed lap system

## Intended behavior

- Restart Lap returns the car to the staged start position and immediately restores full boost
- every normal valid lap still produces the existing LAST LAP placement/time toast
- crossing the finish without the full ordered checkpoint chain does not count as a completed lap and instead clearly reports why
- the next timed attempt starts immediately from that finish crossing
- rivals, physics, car balance, sound design, orientation behavior, ghost storage, and the twelve-checkpoint anti-shortcut order remain unchanged

## Regression coverage

- boost refill is tied to the existing `race-reset` lifecycle event and cannot create a fake boost-full transition
- Restart Lap naming is protected in both markup and the in-game menu
- broad checkpoint tolerance and the narrower start/finish tolerance are both protected
- invalid checkpoint chains must publish `turn:lap-invalid`
- invalid-lap feedback must use `LAP INVALID / MISSED CHECKPOINT`
- existing valid/last-place lap result behavior remains protected

No new render loop, timer loop, physics behavior, or asset dependency is introduced.