### PR TITLE
Rollback TURN v1.4.0 r37 to v1.3.20 r36

### DIFF
--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -10,8 +10,8 @@ const [index, app, audio, controls, catalogSource] = await Promise.all([
 ]);
 const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
 
-assert.match(index, /TURN v1\.4\.0 · Build 2026\.07\.21-r37/);
-assert.match(index, /\.\/app\.js\?build=20260721-r37/);
+assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
+assert.match(index, /\.\/app\.js\?build=20260721-r36/);
 assert.match(
   index,
   /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r35"/,
@@ -37,7 +37,7 @@ assert.match(audio, /unlock,\s*update,\s*cue,\s*silence/, 'The shared audio API 
 
 assert.match(audio, /function installEngineGraph\(/, 'The foundation must provide a continuous engine layer');
 assert.match(audio, /function installDriftGraph\(/, 'The foundation must provide a continuous drift layer');
-assert.match(audio, /function installBoostGraph\(/, 'The foundation must provide a dedicated boost one-shot bus');
+assert.match(audio, /function installBoostGraph\(/, 'The foundation must provide a continuous boost layer');
 assert.match(audio, /globalThis\.__turnVehicleTuning\?\.enginePitch/, 'Engine frequency must follow the selected car tuning');
 assert.match(audio, /engineBaseHz = \(52 \+ speedRatio \* 96 \+ throttle \* 24\) \* enginePitch \* boostEngineLift/, 'Per-car pitch and boost lift must stay connected to the engine bed');
 assert.match(audio, /const boostEngineLift = boostActive \? 1\.055 : 1/, 'Boost must lift the engine subtly rather than replace it');
@@ -58,28 +58,17 @@ assert.ok(
   'Race Car must remain the highest-pitched racer'
 );
 
-assert.match(audio, /regularScrubLevel = active \? slipIntent \* driftSpeed \* 0\.0032 : 0/, 'Ordinary cornering scrub must stay nearly subliminal');
+assert.match(audio, /regularScrubLevel = active \? slipIntent \* driftSpeed \* 0\.0055 : 0/, 'Ordinary cornering scrub must stay nearly subliminal');
 assert.match(audio, /deliberateScrubLevel = active && driftHeld/, 'Holding DRIFT must crossfade in stronger tire scrub');
-assert.match(audio, /const driftBedDuck = driftHeld \? 1 - strongSlip \* 0\.42 : 1/, 'Strong slip must duck the continuous spray-like bed beneath the squeal');
-assert.match(audio, /driftNoise\.buffer = makeNoiseBuffer\(context, 1\.6, 0\.92\)/, 'The friction bed must use smoother, darker noise than the old spray-like layer');
 assert.match(audio, /const gritLevel = active && driftHeld/, 'Deliberate DRIFT must add a separate low-mid grit layer');
 assert.match(audio, /gritNoise\.buffer = makeNoiseBuffer\(context, 1\.7, 0\.95\)/, 'Drift grit must use heavily smoothed low-frequency noise rather than spray-like hiss');
-assert.match(audio, /skidTone\.type = 'triangle'/, 'Strong drift must keep a controlled tonal tire squeal');
-assert.match(audio, /skidTone\.frequency, 2600 \+ speedRatio \* 1800 \+ strongSlip \* 900/, 'The drift squeal must live substantially higher than the retired low whistle');
-assert.match(audio, /skidPulse\.buffer = makeSkidPulseBuffer\(context, 1\.25\)/, 'The squeal must use a reusable procedural grip-slip pulse buffer');
-assert.match(audio, /skidPulse\.playbackRate, 0\.8 \+ speedRatio \* 0\.35 \+ strongSlip \* 0\.55/, 'Skid chopping must accelerate with speed and slip');
-assert.match(audio, /skidPulseDepth\.gain\.value = 0\.965/, 'The chopped squeal must have deep articulation rather than mild tremolo');
-assert.match(audio, /function makeSkidPulseBuffer\(/, 'The skid articulation must remain procedural and deterministic');
-assert.match(audio, /skidWobbleDepth\.gain, 10 \+ strongSlip \* 22/, 'The high squeal must retain subtle pitch instability under hard slip');
+assert.match(audio, /skidTone\.type = 'triangle'/, 'Strong drift must use a restrained tonal squeal instead of the retired bright white-noise skid bus');
 assert.doesNotMatch(audio, /skidNoise/, 'The spray-can-like bright skid noise loop must stay removed');
 
-assert.match(audio, /case 'boost-start':\s*playBoostBlast\(now\);/s, 'Boost activation must trigger the dedicated short blast');
-assert.match(audio, /function playBoostBlast\(/, 'Boost must use a dedicated transient designer rather than a sustain loop');
-assert.match(audio, /const duration = 0\.105/, 'The main boost blast must stay around one tenth of a second');
-assert.match(audio, /source\.buffer = makeNoiseBuffer\(context, 0\.14, 0\.42\)/, 'The boost blast must include a brief broad pressure-noise transient');
-assert.match(audio, /no continuous oscillator\/noise bed/, 'The boost graph must remain one-shot only');
-assert.doesNotMatch(audio, /const boostLevel = boostActive/, 'Boost must not restore a continuous vacuum-like sustain level');
-assert.doesNotMatch(audio, /boostNoise\.loop|boostTone\.type/, 'Boost must not run a looping noise or turbine oscillator while held');
+assert.match(audio, /const boostLevel = boostActive \? 0\.024 : 0/, 'Boost sustain must remain quiet beneath the engine');
+assert.doesNotMatch(audio, /const boostLevel = boostActive \? 0\.16 : 0/, 'The old loud vacuum-like boost sustain must stay removed');
+assert.match(audio, /boostTone\.type = 'sine'/, 'Boost sustain must use a clean turbine-like tone');
+assert.match(audio, /case 'boost-start':/, 'Boost activation must have a layered aggressive one-shot');
 assert.match(audio, /case 'boost-empty':/, 'Boost depletion must have its own cue');
 assert.match(audio, /case 'boost-full':/, 'Boost recharge completion must have its own cue');
 
@@ -118,4 +107,4 @@ assert.match(controls, /globalThis\.__turnAudio\?\.cue\('boost-full'\)/, 'The ex
 assert.match(controls, /if \(position < lastPosition\)/, 'Only an improved race position may trigger the overtake cue');
 assert.match(controls, /globalThis\.__turnAudio\?\.cue\('overtake'/, 'Position gains must feed the shared overtake cue');
 
-console.log('TURN chopped drift, transient boost and rival sound production regression passed.');
+console.log('TURN drift, boost and rival sound production regression passed.');

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -69,7 +69,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.4\.0 · Build 2026\.07\.21-r37/);
+assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -20,9 +20,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.4\.0 · Build 2026\.07\.21-r37/);
-assert.match(index, /drive-pad\.css\?build=20260721-r37/);
-assert.match(index, /gameplay-v2\.css\?build=20260721-r37/);
+assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
+assert.match(index, /drive-pad\.css\?build=20260721-r36/);
+assert.match(index, /gameplay-v2\.css\?build=20260721-r36/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -47,10 +47,10 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.4\.0 · Build 2026\.07\.21-r37/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260721-r37/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r37 must preserve the latest Lot module cache redirect');
-assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r35"/, 'r37 must preserve the corrected Vintage Racer orientation');
+assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260721-r36/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r36 must preserve the latest Lot module cache redirect');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r35"/, 'r36 must preserve the corrected Vintage Racer orientation');
 assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -26,8 +26,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.4\.0 · Build 2026\.07\.21-r37/);
-assert.match(index, /in-game-menu\.css\?build=20260721-r37/);
+assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
+assert.match(index, /in-game-menu\.css\?build=20260721-r36/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Restart Lap<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -127,10 +127,10 @@ const [index, app, lapSystem, toast, css] = await Promise.all([
   fs.readFile(new URL('../../turn/lap-result-toast.css', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.4\.0 · Build 2026\.07\.21-r37/);
-assert.match(index, /lap-result-toast\.css\?build=20260721-r37/);
-assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260721-r36"/, 'r37 must preserve the more forgiving r36 lap system cache redirect');
-assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260721-r34"/, 'r37 must preserve reliable reset gate-history state');
+assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
+assert.match(index, /lap-result-toast\.css\?build=20260721-r36/);
+assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260721-r36"/, 'r36 must cache-bust the more forgiving lap system');
+assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260721-r34"/, 'r36 must preserve reliable reset gate-history state');
 assert.match(app, /installLapResultToast\(\)/, 'The toast must install before the game runtime starts');
 assert.match(lapSystem, /turn:lap-result/, 'Completed lap finish must publish one frozen result event');
 assert.match(lapSystem, /turn:lap-invalid/, 'Incomplete checkpoint chains must publish explicit invalid-lap feedback');

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -20,13 +20,13 @@ const [index, css, orientationGuardCss, orientationCompat, camera] = await Promi
   fs.readFile(new URL('../../turn/render/camera.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.4\.0 · Build 2026\.07\.21-r37/);
+assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260721-r37/);
-assert.match(index, /orientation-guard\.css\?build=20260721-r37/);
-assert.match(index, /orientation-compat\.js\?build=20260721-r37/);
-assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r37 must preserve the guarded race camera cache redirect');
+assert.match(index, /manual-steering\.css\?build=20260721-r36/);
+assert.match(index, /orientation-guard\.css\?build=20260721-r36/);
+assert.match(index, /orientation-compat\.js\?build=20260721-r36/);
+assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r36 must preserve the guarded race camera cache redirect');
 assert.match(index, /<strong>Rotate to landscape<\/strong>/, 'The pre-race landscape instruction must remain available');
 
 assert.match(css, /--manual-steer-left/);

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -34,7 +34,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.4\.0 · Build 2026\.07\.21-r37/);
+assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -61,7 +61,7 @@ const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, m
   fs.readFile(new URL('../../turn/orientation-compat.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.4\.0 · Build 2026\.07\.21-r37/);
+assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
 assert.match(main, /mainSceneOcclusion/);
 assert.match(main, /HUD_UPDATE_INTERVAL_MS = 1000 \/ 30/);
 assert.match(main, /recordPerformanceFrame/);

--- a/turn/audio/audio-system.js
+++ b/turn/audio/audio-system.js
@@ -18,12 +18,9 @@ let gritFilter = null;
 let skidGain = null;
 let skidFilter = null;
 let skidTone = null;
-let skidChopGain = null;
-let skidPulse = null;
-let skidPulseDepth = null;
-let skidWobble = null;
-let skidWobbleDepth = null;
 let boostGain = null;
+let boostFilter = null;
+let boostTone = null;
 let lastUpdateAt = -Infinity;
 let lastBoostActive = false;
 let rivalNearLatched = false;
@@ -118,34 +115,36 @@ export function update(frame = {}, now = performance.now()) {
     0.06
   );
 
-  // Drift is split into roles: a quiet friction bed, low-mid body grit, and a bright chopped
-  // squeal. Strong slip ducks the continuous bed so the tires read as grip/slip pulses, not spray.
+  // Drift should read as traction loss rather than broadband spray. Normal slip is nearly
+  // subliminal; deliberate DRIFT crossfades in tire scrub, low-mid body grit and a small squeal.
   const slipIntent = clamp((driftAmount - 0.14) / 0.86, 0, 1);
   const strongSlip = clamp((driftAmount - 0.32) / 0.68, 0, 1);
   const driftSpeed = clamp((speed - 10) / 42, 0, 1);
-  const regularScrubLevel = active ? slipIntent * driftSpeed * 0.0032 : 0;
+  const regularScrubLevel = active ? slipIntent * driftSpeed * 0.0055 : 0;
   const deliberateScrubLevel = active && driftHeld
-    ? driftSpeed * (0.006 + slipIntent * 0.011)
+    ? driftSpeed * (0.014 + slipIntent * 0.024)
     : 0;
-  const driftBedDuck = driftHeld ? 1 - strongSlip * 0.42 : 1;
   const gritLevel = active && driftHeld
-    ? driftSpeed * (0.007 + slipIntent * 0.018)
+    ? driftSpeed * (0.007 + slipIntent * 0.021)
     : regularScrubLevel * 0.32;
   const skidLevel = active && driftHeld
-    ? driftSpeed * strongSlip * (0.012 + strongSlip * 0.008)
+    ? driftSpeed * strongSlip * 0.012
     : 0;
 
-  smooth(driftGain.gain, (regularScrubLevel + deliberateScrubLevel) * driftBedDuck, audioNow, 0.075);
-  smooth(driftFilter.frequency, 680 + speedRatio * 620 + slipIntent * 180, audioNow, 0.085);
+  smooth(driftGain.gain, regularScrubLevel + deliberateScrubLevel, audioNow, 0.075);
+  smooth(driftFilter.frequency, 820 + speedRatio * 980 + slipIntent * 260, audioNow, 0.085);
   smooth(gritGain.gain, gritLevel, audioNow, 0.09);
   smooth(gritFilter.frequency, 300 + speedRatio * 330 + slipIntent * 180, audioNow, 0.1);
-  smooth(skidGain.gain, skidLevel, audioNow, 0.055);
-  smooth(skidTone.frequency, 2600 + speedRatio * 1800 + strongSlip * 900, audioNow, 0.045);
-  smooth(skidFilter.frequency, 3300 + speedRatio * 2100 + strongSlip * 900, audioNow, 0.06);
-  smooth(skidPulse.playbackRate, 0.8 + speedRatio * 0.35 + strongSlip * 0.55, audioNow, 0.08);
-  smooth(skidWobbleDepth.gain, 10 + strongSlip * 22, audioNow, 0.09);
+  smooth(skidGain.gain, skidLevel, audioNow, 0.08);
+  smooth(skidTone.frequency, 720 + speedRatio * 520 + strongSlip * 190, audioNow, 0.07);
+  smooth(skidFilter.frequency, 980 + speedRatio * 520, audioNow, 0.09);
 
-  // BOOST is a one-shot blast. The only continuous cue is the small engine pitch lift above.
+  // The boost sustain is intentionally quiet. Most of the character lives in the start cue.
+  const boostLevel = boostActive ? 0.024 : 0;
+  smooth(boostGain.gain, boostLevel, audioNow, boostActive ? 0.055 : 0.12);
+  smooth(boostFilter.frequency, 1150 + speedRatio * 1450, audioNow, 0.07);
+  smooth(boostTone.frequency, 430 + speedRatio * 430, audioNow, 0.06);
+
   if (boostActive && !lastBoostActive) playCueNow('boost-start');
   lastBoostActive = boostActive;
 
@@ -165,6 +164,7 @@ export function silence() {
   hardMute(driftGain.gain, now);
   hardMute(gritGain.gain, now);
   hardMute(skidGain.gain, now);
+  hardMute(boostGain.gain, now);
   lastBoostActive = false;
   rivalNearLatched = false;
 }
@@ -233,8 +233,8 @@ function installDriftGraph() {
   driftGain.gain.value = 0;
   driftFilter = context.createBiquadFilter();
   driftFilter.type = 'bandpass';
-  driftFilter.frequency.value = 900;
-  driftFilter.Q.value = 0.62;
+  driftFilter.frequency.value = 980;
+  driftFilter.Q.value = 0.72;
 
   gritGain = context.createGain();
   gritGain.gain.value = 0;
@@ -247,14 +247,11 @@ function installDriftGraph() {
   skidGain.gain.value = 0;
   skidFilter = context.createBiquadFilter();
   skidFilter.type = 'bandpass';
-  skidFilter.frequency.value = 4200;
-  skidFilter.Q.value = 1.8;
-
-  skidChopGain = context.createGain();
-  skidChopGain.gain.value = 0.035;
+  skidFilter.frequency.value = 1150;
+  skidFilter.Q.value = 1.35;
 
   const driftNoise = context.createBufferSource();
-  driftNoise.buffer = makeNoiseBuffer(context, 1.6, 0.92);
+  driftNoise.buffer = makeNoiseBuffer(context, 1.6, 0.86);
   driftNoise.loop = true;
   driftNoise.connect(driftFilter);
   driftFilter.connect(driftGain);
@@ -269,44 +266,47 @@ function installDriftGraph() {
 
   skidTone = context.createOscillator();
   skidTone.type = 'triangle';
-  skidTone.frequency.value = 3400;
+  skidTone.frequency.value = 820;
   skidTone.connect(skidFilter);
-  skidFilter.connect(skidChopGain);
-  skidChopGain.connect(skidGain);
+  skidFilter.connect(skidGain);
   skidGain.connect(masterGain);
-
-  // A deterministic unipolar control buffer creates uneven, click-safe grip/slip pulses.
-  // Playback rate follows speed and slip, so a hard fast drift chatters faster than a lazy slide.
-  skidPulse = context.createBufferSource();
-  skidPulse.buffer = makeSkidPulseBuffer(context, 1.25);
-  skidPulse.loop = true;
-  skidPulse.playbackRate.value = 1;
-  skidPulseDepth = context.createGain();
-  skidPulseDepth.gain.value = 0.965;
-  skidPulse.connect(skidPulseDepth);
-  skidPulseDepth.connect(skidChopGain.gain);
-
-  // A few cents of independent pitch movement stops the high note becoming a static synth whistle.
-  skidWobble = context.createOscillator();
-  skidWobble.type = 'sine';
-  skidWobble.frequency.value = 8.3;
-  skidWobbleDepth = context.createGain();
-  skidWobbleDepth.gain.value = 10;
-  skidWobble.connect(skidWobbleDepth);
-  skidWobbleDepth.connect(skidTone.detune);
 
   driftNoise.start();
   gritNoise.start();
   skidTone.start();
-  skidPulse.start();
-  skidWobble.start();
 }
 
 function installBoostGraph() {
-  // Keep a dedicated bus for the boost transient, but no continuous oscillator/noise bed.
   boostGain = context.createGain();
-  boostGain.gain.value = 1;
+  boostGain.gain.value = 0;
+
+  boostFilter = context.createBiquadFilter();
+  boostFilter.type = 'bandpass';
+  boostFilter.frequency.value = 1500;
+  boostFilter.Q.value = 1.2;
+
+  const boostNoiseMix = context.createGain();
+  boostNoiseMix.gain.value = 0.12;
+  const boostToneMix = context.createGain();
+  boostToneMix.gain.value = 0.58;
+
+  const boostNoise = context.createBufferSource();
+  boostNoise.buffer = makeNoiseBuffer(context, 1.3, 0.91);
+  boostNoise.loop = true;
+  boostNoise.connect(boostNoiseMix);
+
+  boostTone = context.createOscillator();
+  boostTone.type = 'sine';
+  boostTone.frequency.value = 430;
+  boostTone.connect(boostToneMix);
+
+  boostNoiseMix.connect(boostFilter);
+  boostToneMix.connect(boostFilter);
+  boostFilter.connect(boostGain);
   boostGain.connect(masterGain);
+
+  boostNoise.start();
+  boostTone.start();
 }
 
 function updateRivalProximity(active, distance) {
@@ -353,7 +353,11 @@ function playCueNow(name, options = {}) {
       playTone(560, 760, 0.065, 0.032, 'triangle', now);
       break;
     case 'boost-start':
-      playBoostBlast(now);
+      // Spool, pressure punch, then a short whoosh. The quiet sustain takes over underneath.
+      playTone(260, 980, 0.18, 0.038, 'sine', now);
+      playTone(86, 54, 0.085, 0.05, 'triangle', now + 0.015);
+      playNoiseBurst(now + 0.025, 0.23, 0.045, 520, 3200, 0.84);
+      playTone(620, 1080, 0.19, 0.018, 'triangle', now + 0.035);
       break;
     case 'boost-empty':
       playTone(860, 230, 0.2, 0.034, 'sine', now);
@@ -399,44 +403,7 @@ function cueAllowed(name, now) {
   return true;
 }
 
-function playBoostBlast(startAt) {
-  const duration = 0.105;
-  const endAt = startAt + duration;
-  const source = context.createBufferSource();
-  const highpass = context.createBiquadFilter();
-  const lowpass = context.createBiquadFilter();
-  const gain = context.createGain();
-
-  source.buffer = makeNoiseBuffer(context, 0.14, 0.42);
-
-  highpass.type = 'highpass';
-  highpass.frequency.value = 180;
-  highpass.Q.value = 0.55;
-
-  lowpass.type = 'lowpass';
-  lowpass.Q.value = 0.78;
-  lowpass.frequency.setValueAtTime(9600, startAt);
-  lowpass.frequency.exponentialRampToValueAtTime(1700, endAt);
-
-  gain.gain.setValueAtTime(0.0001, startAt);
-  gain.gain.exponentialRampToValueAtTime(0.046, startAt + 0.0025);
-  gain.gain.exponentialRampToValueAtTime(0.0001, endAt);
-
-  source.connect(highpass);
-  highpass.connect(lowpass);
-  lowpass.connect(gain);
-  gain.connect(boostGain);
-
-  source.start(startAt);
-  source.stop(endAt + 0.015);
-
-  // Three tiny components read as one compact pressure hit rather than a turbine spool.
-  playTone(145, 68, 0.075, 0.034, 'triangle', startAt, boostGain);
-  playTone(920, 280, 0.055, 0.021, 'triangle', startAt, boostGain);
-  playTone(2800, 1350, 0.06, 0.01, 'sine', startAt + 0.002, boostGain);
-}
-
-function playTone(startHz, endHz, duration, level, type, startAt, destination = masterGain) {
+function playTone(startHz, endHz, duration, level, type, startAt) {
   const oscillator = context.createOscillator();
   const gain = context.createGain();
   const endAt = startAt + duration;
@@ -450,7 +417,7 @@ function playTone(startHz, endHz, duration, level, type, startAt, destination = 
   gain.gain.exponentialRampToValueAtTime(0.0001, endAt);
 
   oscillator.connect(gain);
-  gain.connect(destination);
+  gain.connect(masterGain);
   oscillator.start(startAt);
   oscillator.stop(endAt + 0.02);
 }
@@ -491,40 +458,6 @@ function makeNoiseBuffer(audioContext, seconds, smoothing = 0.72) {
     previous = previous * memory + white * fresh;
     data[index] = previous;
   }
-  return buffer;
-}
-
-function makeSkidPulseBuffer(audioContext, seconds = 1.25) {
-  const frameCount = Math.max(1, Math.ceil(audioContext.sampleRate * seconds));
-  const buffer = audioContext.createBuffer(1, frameCount, audioContext.sampleRate);
-  const data = buffer.getChannelData(0);
-  const pattern = [0.052, 0.032, 0.071, 0.025, 0.044, 0.04, 0.064, 0.028, 0.057, 0.035, 0.078, 0.03];
-  let sampleIndex = 0;
-  let segmentIndex = 0;
-  let pulseOn = true;
-
-  while (sampleIndex < frameCount) {
-    const segmentSeconds = pattern[segmentIndex % pattern.length];
-    const segmentSamples = Math.max(1, Math.round(segmentSeconds * audioContext.sampleRate));
-    const pulseIndex = Math.floor(segmentIndex / 2);
-    const pulsePeak = 0.74 + ((pulseIndex * 37) % 22) / 100;
-
-    for (let localIndex = 0; localIndex < segmentSamples && sampleIndex < frameCount; localIndex += 1, sampleIndex += 1) {
-      if (!pulseOn) {
-        data[sampleIndex] = 0;
-        continue;
-      }
-
-      const phase = localIndex / Math.max(1, segmentSamples - 1);
-      const edge = clamp(Math.min(phase / 0.16, (1 - phase) / 0.24), 0, 1);
-      const easedEdge = Math.sin(edge * Math.PI * 0.5) ** 2;
-      data[sampleIndex] = pulsePeak * easedEdge;
-    }
-
-    pulseOn = !pulseOn;
-    segmentIndex += 1;
-  }
-
   return buffer;
 }
 

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r37 Chopped drift and boost blast -->
+<!-- TURN r36 Restart lap QoL and checkpoint feedback -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,33 +10,33 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.4.0 · Build 2026.07.21-r37</title>
+  <title>TURN v1.3.20 · Build 2026.07.21-r36</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.4.0',
-      id: '2026.07.21-r37',
-      cacheKey: '20260721-r37'
+      version: '1.3.20',
+      id: '2026.07.21-r36',
+      cacheKey: '20260721-r36'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260721-r37">
-  <link rel="stylesheet" href="./styles.css?build=20260721-r37">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260721-r37">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260721-r37">
-  <link rel="stylesheet" href="./install-gate.css?build=20260721-r37">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260721-r37">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260721-r37">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260721-r37">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260721-r37">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260721-r37">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260721-r37">
-  <link rel="stylesheet" href="./orientation-guard.css?build=20260721-r37">
-  <link rel="stylesheet" href="./lap-result-toast.css?build=20260721-r37">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260721-r37">
+  <link rel="manifest" href="./site.webmanifest?build=20260721-r36">
+  <link rel="stylesheet" href="./styles.css?build=20260721-r36">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260721-r36">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260721-r36">
+  <link rel="stylesheet" href="./install-gate.css?build=20260721-r36">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260721-r36">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260721-r36">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260721-r36">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260721-r36">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260721-r36">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260721-r36">
+  <link rel="stylesheet" href="./orientation-guard.css?build=20260721-r36">
+  <link rel="stylesheet" href="./lap-result-toast.css?build=20260721-r36">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260721-r36">
 
-  <script src="./install-gate.js?build=20260721-r37"></script>
-  <script src="./orientation-compat.js?build=20260721-r37"></script>
+  <script src="./install-gate.js?build=20260721-r36"></script>
+  <script src="./orientation-compat.js?build=20260721-r36"></script>
   <script type="importmap">
     {
       "imports": {
@@ -61,7 +61,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.4.0 · Build 2026.07.21-r37</span>
+        <span class="install-kicker">TURN v1.3.20 · Build 2026.07.21-r36</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -89,7 +89,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.4.0 · Build 2026.07.21-r37</span>
+      <span class="kicker">TURN v1.3.20 · Build 2026.07.21-r36</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -155,6 +155,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260721-r37"></script>
+  <script type="module" src="./app.js?build=20260721-r36"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Restores TURN exactly to **v1.3.20 · Build 2026.07.21-r36**, the state merged via PR #115.

This rolls back PR #116 in full, including its audio redesign and release/test updates, because the r37 update introduced several gameplay/runtime regressions during real-device play.

### Restored
- r36 production audio system and sound behavior
- r36 release/build/cache markers
- all r36 regression expectations affected by PR #116

### Scope
The rollback changes exactly the same 11 files that PR #116 changed, in reverse. No later work exists on `main`, so no unrelated changes are being discarded.

The improved r37 sound direction can be revisited later as a smaller, isolated iteration after stability is restored.