### PR TITLE
TURN v1.3.21 r38: Fix start-line double lap trigger

### DIFF
--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -10,8 +10,8 @@ const [index, app, audio, controls, catalogSource] = await Promise.all([
 ]);
 const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
 
-assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
-assert.match(index, /\.\/app\.js\?build=20260721-r36/);
+assert.match(index, /TURN v1\.3\.21 · Build 2026\.07\.21-r38/);
+assert.match(index, /\.\/app\.js\?build=20260721-r38/);
 assert.match(
   index,
   /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r35"/,

--- a/turn-lab/tests/balance-and-checkpoints.mjs
+++ b/turn-lab/tests/balance-and-checkpoints.mjs
@@ -163,6 +163,50 @@ state.position = new Vec3(2, 0, 0);
 run(1600);
 assert.equal(began, 2, 'the first physical forward start-line crossing must begin timing even when nearest-track progress does not wrap');
 
+const doubleTriggerState = {
+  lapActive: false,
+  lapCheckpointIndex: 0,
+  lapStartedAt: 0,
+  lapElapsed: 0,
+  position: new Vec3(-1, 0, 0),
+  velocity: new Vec3(10, 0, 0),
+  lastProgress: 0.96,
+  progress: 0.02,
+  trackDistance: 1,
+  lapPreviousPosition: { x: -2, z: 0 }
+};
+let doubleTriggerStarts = 0;
+const runDoubleTrigger = (now) => updateLapProgressState({
+  state: doubleTriggerState,
+  nearestAfter: { sample: samples[0] },
+  samples,
+  trackWidth: 27,
+  now,
+  beginTimedLap: () => {
+    doubleTriggerStarts += 1;
+    doubleTriggerState.lapActive = true;
+    doubleTriggerState.lapCheckpointIndex = 0;
+  },
+  completeLap: () => {},
+  recordGhostFrame: () => {}
+});
+
+runDoubleTrigger(1700);
+assert.equal(
+  doubleTriggerStarts,
+  0,
+  'nearest-track progress wrapping before the painted line must not start a lap early'
+);
+doubleTriggerState.lastProgress = 0.02;
+doubleTriggerState.progress = 0.03;
+doubleTriggerState.position = new Vec3(1, 0, 0);
+runDoubleTrigger(1800);
+assert.equal(
+  doubleTriggerStarts,
+  1,
+  'one physical start-line crossing must create exactly one lap start after an early progress wrap'
+);
+
 const resetState = {
   position: new Vec3(999, 0, 999),
   velocity: new Vec3(4, 0, 2),
@@ -199,5 +243,6 @@ assert.match(lapSystemSource, /crossedForwardGate/, 'production lap registration
 assert.match(lapSystemSource, /CHECKPOINT_GATE_HALF_WIDTH_FACTOR = 1\.05/, 'checkpoint gates must allow broad grass and verge racing lines');
 assert.match(lapSystemSource, /START_GATE_HALF_WIDTH_FACTOR = 0\.82/, 'start and finish must keep the established narrower crossing gate');
 assert.match(lapSystemSource, /turn:lap-invalid/, 'an incomplete checkpoint chain must report an invalid lap instead of failing silently');
+assert.doesNotMatch(lapSystemSource, /crossedStartByProgress/, 'start and finish must not retain the retired progress-wrap fallback');
 
-console.log('TURN forgiving swept lap gates and anti-shortcut regression passed.');
+console.log('TURN forgiving swept lap gates, single-source start line and anti-shortcut regression passed.');

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -69,7 +69,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
+assert.match(index, /TURN v1\.3\.21 · Build 2026\.07\.21-r38/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -20,9 +20,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
-assert.match(index, /drive-pad\.css\?build=20260721-r36/);
-assert.match(index, /gameplay-v2\.css\?build=20260721-r36/);
+assert.match(index, /TURN v1\.3\.21 · Build 2026\.07\.21-r38/);
+assert.match(index, /drive-pad\.css\?build=20260721-r38/);
+assert.match(index, /gameplay-v2\.css\?build=20260721-r38/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -47,10 +47,10 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260721-r36/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r36 must preserve the latest Lot module cache redirect');
-assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r35"/, 'r36 must preserve the corrected Vintage Racer orientation');
+assert.match(index, /TURN v1\.3\.21 · Build 2026\.07\.21-r38/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260721-r38/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r38 must preserve the latest Lot module cache redirect');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r35"/, 'r38 must preserve the corrected Vintage Racer orientation');
 assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -26,8 +26,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
-assert.match(index, /in-game-menu\.css\?build=20260721-r36/);
+assert.match(index, /TURN v1\.3\.21 · Build 2026\.07\.21-r38/);
+assert.match(index, /in-game-menu\.css\?build=20260721-r38/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Restart Lap<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -127,14 +127,15 @@ const [index, app, lapSystem, toast, css] = await Promise.all([
   fs.readFile(new URL('../../turn/lap-result-toast.css', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
-assert.match(index, /lap-result-toast\.css\?build=20260721-r36/);
-assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260721-r36"/, 'r36 must cache-bust the more forgiving lap system');
-assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260721-r34"/, 'r36 must preserve reliable reset gate-history state');
+assert.match(index, /TURN v1\.3\.21 · Build 2026\.07\.21-r38/);
+assert.match(index, /lap-result-toast\.css\?build=20260721-r38/);
+assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260721-r38"/, 'r38 must cache-bust the single-source physical lap system');
+assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260721-r34"/, 'r38 must preserve reliable reset gate-history state');
 assert.match(app, /installLapResultToast\(\)/, 'The toast must install before the game runtime starts');
 assert.match(lapSystem, /turn:lap-result/, 'Completed lap finish must publish one frozen result event');
 assert.match(lapSystem, /turn:lap-invalid/, 'Incomplete checkpoint chains must publish explicit invalid-lap feedback');
 assert.match(lapSystem, /suppressNextLapStartMessage = true/, 'Invalid-lap feedback must not be obscured by a competing GO message');
+assert.doesNotMatch(lapSystem, /crossedStartByProgress/, 'Start and finish must use only the swept physical line crossing');
 assert.match(lapSystem, /const completedLap = finishedTime > 5/, 'Result visibility must be separated from replay-save eligibility');
 assert.match(lapSystem, /const validLap = completedLap && state\.recording\.length > 20/, 'Ghost saving may still require a usable recording');
 assert.match(lapSystem, /if \(completedLap\) \{\s*publishLapResult/s, 'Every completed lap must publish a result, including last place and unsaved replays');

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -20,13 +20,13 @@ const [index, css, orientationGuardCss, orientationCompat, camera] = await Promi
   fs.readFile(new URL('../../turn/render/camera.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
+assert.match(index, /TURN v1\.3\.21 · Build 2026\.07\.21-r38/);
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260721-r36/);
-assert.match(index, /orientation-guard\.css\?build=20260721-r36/);
-assert.match(index, /orientation-compat\.js\?build=20260721-r36/);
-assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r36 must preserve the guarded race camera cache redirect');
+assert.match(index, /manual-steering\.css\?build=20260721-r38/);
+assert.match(index, /orientation-guard\.css\?build=20260721-r38/);
+assert.match(index, /orientation-compat\.js\?build=20260721-r38/);
+assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r38 must preserve the guarded race camera cache redirect');
 assert.match(index, /<strong>Rotate to landscape<\/strong>/, 'The pre-race landscape instruction must remain available');
 
 assert.match(css, /--manual-steer-left/);

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -34,7 +34,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
+assert.match(index, /TURN v1\.3\.21 · Build 2026\.07\.21-r38/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -61,7 +61,7 @@ const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, m
   fs.readFile(new URL('../../turn/orientation-compat.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.20 · Build 2026\.07\.21-r36/);
+assert.match(index, /TURN v1\.3\.21 · Build 2026\.07\.21-r38/);
 assert.match(main, /mainSceneOcclusion/);
 assert.match(main, /HUD_UPDATE_INTERVAL_MS = 1000 \/ 30/);
 assert.match(main, /recordPerformanceFrame/);

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r36 Restart lap QoL and checkpoint feedback -->
+<!-- TURN r38 single-source physical start line -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,33 +10,33 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.20 · Build 2026.07.21-r36</title>
+  <title>TURN v1.3.21 · Build 2026.07.21-r38</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.20',
-      id: '2026.07.21-r36',
-      cacheKey: '20260721-r36'
+      version: '1.3.21',
+      id: '2026.07.21-r38',
+      cacheKey: '20260721-r38'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260721-r36">
-  <link rel="stylesheet" href="./styles.css?build=20260721-r36">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260721-r36">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260721-r36">
-  <link rel="stylesheet" href="./install-gate.css?build=20260721-r36">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260721-r36">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260721-r36">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260721-r36">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260721-r36">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260721-r36">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260721-r36">
-  <link rel="stylesheet" href="./orientation-guard.css?build=20260721-r36">
-  <link rel="stylesheet" href="./lap-result-toast.css?build=20260721-r36">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260721-r36">
+  <link rel="manifest" href="./site.webmanifest?build=20260721-r38">
+  <link rel="stylesheet" href="./styles.css?build=20260721-r38">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260721-r38">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260721-r38">
+  <link rel="stylesheet" href="./install-gate.css?build=20260721-r38">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260721-r38">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260721-r38">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260721-r38">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260721-r38">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260721-r38">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260721-r38">
+  <link rel="stylesheet" href="./orientation-guard.css?build=20260721-r38">
+  <link rel="stylesheet" href="./lap-result-toast.css?build=20260721-r38">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260721-r38">
 
-  <script src="./install-gate.js?build=20260721-r36"></script>
-  <script src="./orientation-compat.js?build=20260721-r36"></script>
+  <script src="./install-gate.js?build=20260721-r38"></script>
+  <script src="./orientation-compat.js?build=20260721-r38"></script>
   <script type="importmap">
     {
       "imports": {
@@ -44,7 +44,7 @@
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-r10.js?build=20260720-r25",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260721-r29",
-        "./race/lap-system.js?build=20260720-r19": "./race/lap-system.js?build=20260721-r36",
+        "./race/lap-system.js?build=20260720-r19": "./race/lap-system.js?build=20260721-r38",
         "./race/game-state.js": "./race/game-state.js?build=20260721-r34",
         "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260721-r35",
         "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260721-r35",
@@ -61,7 +61,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.20 · Build 2026.07.21-r36</span>
+        <span class="install-kicker">TURN v1.3.21 · Build 2026.07.21-r38</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -89,7 +89,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.20 · Build 2026.07.21-r36</span>
+      <span class="kicker">TURN v1.3.21 · Build 2026.07.21-r38</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -155,6 +155,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260721-r36"></script>
+  <script type="module" src="./app.js?build=20260721-r38"></script>
 </body>
 </html>

--- a/turn/race/lap-system.js
+++ b/turn/race/lap-system.js
@@ -89,11 +89,11 @@ export function updateLapProgressState({
     startGateHalfWidth
   );
 
-  const crossedStartByProgress = state.lastProgress > 0.82 && state.progress < 0.18;
-  const nearPhysicalStart = distanceSquared(currentPosition, startSample.point)
-    <= startGateHalfWidth * startGateHalfWidth;
-  const crossedStartOnTrack = movingForwardAtStart
-    && (crossedPhysicalStartGate || (crossedStartByProgress && nearPhysicalStart));
+  // The swept physical gate is the single source of truth for start and finish.
+  // Nearest-track progress can wrap before the car reaches the painted line, which
+  // previously caused one real crossing to be counted twice: once by progress and
+  // again by the physical gate.
+  const crossedStartOnTrack = movingForwardAtStart && crossedPhysicalStartGate;
 
   if (crossedStartOnTrack) {
     if (!state.lapActive) {


### PR DESCRIPTION
## Summary

Fixes the intermittent `LAP INVALID / MISSED CHECKPOINT` result that could appear immediately after starting or restarting a lap, and could also make legitimate completed laps appear not to count.

## Root cause

Since r34, TURN had two independent start/finish detectors active at the same time:

1. the swept physical start-line gate, and
2. the older nearest-track progress wrap fallback (`> 0.82` to `< 0.18`).

Nearest-track progress can wrap slightly before the car physically reaches the painted line. That allowed one real passage to fire twice:

- progress wrap starts or completes a lap early,
- the physical line is crossed moments later,
- TURN sees an active lap with an incomplete checkpoint chain and reports `LAP INVALID`.

r36 did not create the double detector, but it made the latent problem visible by adding explicit invalid-lap feedback. The r37 audio release did not modify lap logic.

## Fix

- Removes the legacy progress-wrap start/finish fallback.
- Makes the existing swept physical start-line gate the single source of truth for both lap start and lap completion.
- Leaves all twelve ordered checkpoint gates unchanged.
- Leaves checkpoint tolerance unchanged at `1.05 × track width`.
- Leaves the start/finish gate unchanged at `0.82 × track width`.
- Leaves physics, rivals, ghosts, audio, orientation and car balance unchanged.

## Regression coverage

Adds a reproduction of the actual failure sequence:

1. nearest-track progress wraps while the car is still before the physical start line,
2. that wrap must not start a lap,
3. the later physical line crossing must create exactly one lap start.

Existing swept-checkpoint, anti-shortcut, reset, lap result, rival-count and full TURN regressions remain in place.

## Release

Bumps production to **TURN v1.3.21 · Build 2026.07.21-r38** and cache-busts the corrected lap system for installed PWAs.