### PR TITLE
TURN v1.3.22 r39: Clearer lap feedback and first-rival onboarding

### DIFF
--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -10,8 +10,8 @@ const [index, app, audio, controls, catalogSource] = await Promise.all([
 ]);
 const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
 
-assert.match(index, /TURN v1\.3\.21 · Build 2026\.07\.21-r38/);
-assert.match(index, /\.\/app\.js\?build=20260721-r38/);
+assert.match(index, /TURN v1\.3\.22 · Build 2026\.07\.22-r39/);
+assert.match(index, /\.\/app\.js\?build=20260722-r39/);
 assert.match(
   index,
   /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r35"/,

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -69,7 +69,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.21 · Build 2026\.07\.21-r38/);
+assert.match(index, /TURN v1\.3\.22 · Build 2026\.07\.22-r39/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -20,9 +20,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.21 · Build 2026\.07\.21-r38/);
-assert.match(index, /drive-pad\.css\?build=20260721-r38/);
-assert.match(index, /gameplay-v2\.css\?build=20260721-r38/);
+assert.match(index, /TURN v1\.3\.22 · Build 2026\.07\.22-r39/);
+assert.match(index, /drive-pad\.css\?build=20260722-r39/);
+assert.match(index, /gameplay-v2\.css\?build=20260722-r39/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -47,10 +47,10 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.21 · Build 2026\.07\.21-r38/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260721-r38/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r38 must preserve the latest Lot module cache redirect');
-assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r35"/, 'r38 must preserve the corrected Vintage Racer orientation');
+assert.match(index, /TURN v1\.3\.22 · Build 2026\.07\.22-r39/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260722-r39/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r39 must preserve the latest Lot module cache redirect');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r35"/, 'r39 must preserve the corrected Vintage Racer orientation');
 assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -26,8 +26,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.21 · Build 2026\.07\.21-r38/);
-assert.match(index, /in-game-menu\.css\?build=20260721-r38/);
+assert.match(index, /TURN v1\.3\.22 · Build 2026\.07\.22-r39/);
+assert.match(index, /in-game-menu\.css\?build=20260722-r39/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Restart Lap<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -119,19 +119,24 @@ try {
   else globalThis.dispatchEvent = originalDispatchEvent;
 }
 
-const [index, app, lapSystem, toast, css] = await Promise.all([
+const [index, app, lapSystem, gameState, toast, toastCss, onboarding, onboardingCss] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/race/lap-system.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/race/game-state.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/ui/lap-result-toast.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/lap-result-toast.css', import.meta.url), 'utf8')
+  fs.readFile(new URL('../../turn/lap-result-toast.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/ui/rival-onboarding.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/rival-onboarding.css', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.21 · Build 2026\.07\.21-r38/);
-assert.match(index, /lap-result-toast\.css\?build=20260721-r38/);
-assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260721-r38"/, 'r38 must cache-bust the single-source physical lap system');
-assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260721-r34"/, 'r38 must preserve reliable reset gate-history state');
-assert.match(app, /installLapResultToast\(\)/, 'The toast must install before the game runtime starts');
+assert.match(index, /TURN v1\.3\.22 · Build 2026\.07\.22-r39/);
+assert.match(index, /lap-result-toast\.css\?build=20260722-r39/);
+assert.match(index, /rival-onboarding\.css\?build=20260722-r39/);
+assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260721-r38"/, 'r39 must preserve the corrected single-source physical lap system');
+assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r39"/, 'r39 must cache-bust the restart-message removal');
+assert.match(app, /installLapResultToast\(\)/, 'The lap result toast must install before the game runtime starts');
+assert.match(app, /installRivalOnboarding\(\)/, 'The rival onboarding plate must install before the game runtime starts');
 assert.match(lapSystem, /turn:lap-result/, 'Completed lap finish must publish one frozen result event');
 assert.match(lapSystem, /turn:lap-invalid/, 'Incomplete checkpoint chains must publish explicit invalid-lap feedback');
 assert.match(lapSystem, /suppressNextLapStartMessage = true/, 'Invalid-lap feedback must not be obscured by a competing GO message');
@@ -144,15 +149,24 @@ assert.match(lapSystem, /raceRivals\.filter\(\(lap\) => lap\.time < finishedTime
 assert.match(toast, /TOAST_VISIBLE_MS = 4000/, 'The result should remain readable for a few seconds');
 assert.match(toast, /LAST LAP/, 'Valid laps must keep the requested result label');
 assert.match(toast, /LAP INVALID/, 'Invalid laps must replace LAST LAP with an explicit failure label');
-assert.match(toast, /MISSED CHECKPOINT/, 'Invalid checkpoint chains must explain why the lap did not count');
+assert.match(toast, /STAY ON THE TRACK!/, 'Invalid checkpoint chains must use player-facing track guidance');
+assert.doesNotMatch(toast, /MISSED CHECKPOINT/, 'Technical checkpoint language must stay out of the player-facing toast');
 assert.match(toast, /turn:lap-invalid/, 'The unified toast must listen for invalid-lap events');
 assert.match(toast, /lap-result-position/, 'The toast must show frozen finishing position');
 assert.match(toast, /lap-result-time/, 'The toast must show the completed lap time');
 assert.match(toast, /aria-live', 'polite'/, 'The result toast should be announced without interrupting gameplay');
-assert.match(css, /background: var\(--yellow\)/, 'The toast must share the yellow finish-result colour');
-assert.match(css, /left: 50%/, 'The lap toast must occupy the central finish-message position');
-assert.match(css, /top: 22%/, 'The lap toast must sit where the old TOP X LAP message appeared');
-assert.doesNotMatch(css, /left: max\(112px/, 'The retired lower-left toast placement must stay removed');
-assert.match(css, /prefers-reduced-motion: reduce/, 'Toast animation must respect reduced-motion preferences');
+assert.doesNotMatch(gameState, /READY FOR THE LINE/, 'Restart Lap must not show redundant ready-state feedback');
+assert.match(onboarding, /CHASE YOUR BEST/, 'The first rival must introduce the core chase-your-best loop');
+assert.match(onboarding, /reason === 'lap-completed'/, 'Onboarding must be tied to the first newly saved rival after a completed lap');
+assert.match(onboarding, /!hadRival && hasRival/, 'The onboarding plate must only trigger on the zero-to-one rival transition');
+assert.match(onboarding, /makeGhostColor\(color\)/, 'The onboarding plate must use the same lighter body colour as the ghost car');
+assert.match(onboarding, /RESULT_TOAST_HANDOFF_MS = 4300/, 'First-rival onboarding must wait until the lap-result toast has cleared');
+assert.match(toastCss, /background: var\(--yellow\)/, 'The lap toast must share the yellow finish-result colour');
+assert.match(toastCss, /left: 50%/, 'The lap toast must occupy the central finish-message position');
+assert.match(toastCss, /top: 22%/, 'The lap toast must sit where the old TOP X LAP message appeared');
+assert.doesNotMatch(toastCss, /left: max\(112px/, 'The retired lower-left toast placement must stay removed');
+assert.match(toastCss, /prefers-reduced-motion: reduce/, 'Toast animation must respect reduced-motion preferences');
+assert.match(onboardingCss, /background: var\(--rival-onboarding-color, var\(--yellow\)\)/, 'The onboarding plate must expose the rival colour through a CSS custom property');
+assert.match(onboardingCss, /border-radius: 999px/, 'The onboarding must keep the compact pill-plate language of the old READY message');
 
-console.log('TURN unified valid and invalid lap result toast regression passed.');
+console.log('TURN unified lap feedback and first-rival onboarding regression passed.');

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -20,13 +20,13 @@ const [index, css, orientationGuardCss, orientationCompat, camera] = await Promi
   fs.readFile(new URL('../../turn/render/camera.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.21 · Build 2026\.07\.21-r38/);
+assert.match(index, /TURN v1\.3\.22 · Build 2026\.07\.22-r39/);
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260721-r38/);
-assert.match(index, /orientation-guard\.css\?build=20260721-r38/);
-assert.match(index, /orientation-compat\.js\?build=20260721-r38/);
-assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r38 must preserve the guarded race camera cache redirect');
+assert.match(index, /manual-steering\.css\?build=20260722-r39/);
+assert.match(index, /orientation-guard\.css\?build=20260722-r39/);
+assert.match(index, /orientation-compat\.js\?build=20260722-r39/);
+assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r39 must preserve the guarded race camera cache redirect');
 assert.match(index, /<strong>Rotate to landscape<\/strong>/, 'The pre-race landscape instruction must remain available');
 
 assert.match(css, /--manual-steer-left/);

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -34,7 +34,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.21 · Build 2026\.07\.21-r38/);
+assert.match(index, /TURN v1\.3\.22 · Build 2026\.07\.22-r39/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -61,7 +61,7 @@ const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, m
   fs.readFile(new URL('../../turn/orientation-compat.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.21 · Build 2026\.07\.21-r38/);
+assert.match(index, /TURN v1\.3\.22 · Build 2026\.07\.22-r39/);
 assert.match(main, /mainSceneOcclusion/);
 assert.match(main, /HUD_UPDATE_INTERVAL_MS = 1000 \/ 30/);
 assert.match(main, /recordPerformanceFrame/);

--- a/turn/app.js
+++ b/turn/app.js
@@ -12,6 +12,9 @@ installTurnAudio();
 const { installLapResultToast } = await import(withBuild('./ui/lap-result-toast.js'));
 installLapResultToast();
 
+const { installRivalOnboarding } = await import(withBuild('./ui/rival-onboarding.js'));
+installRivalOnboarding();
+
 await import(withBuild('./input/analog-gas.js'));
 await import(withBuild('./ui/gameplay-controls.js'));
 await import(withBuild('./main.js'));

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r38 single-source physical start line -->
+<!-- TURN r39 clearer lap feedback and first-rival onboarding -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,33 +10,34 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.21 · Build 2026.07.21-r38</title>
+  <title>TURN v1.3.22 · Build 2026.07.22-r39</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.21',
-      id: '2026.07.21-r38',
-      cacheKey: '20260721-r38'
+      version: '1.3.22',
+      id: '2026.07.22-r39',
+      cacheKey: '20260722-r39'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260721-r38">
-  <link rel="stylesheet" href="./styles.css?build=20260721-r38">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260721-r38">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260721-r38">
-  <link rel="stylesheet" href="./install-gate.css?build=20260721-r38">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260721-r38">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260721-r38">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260721-r38">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260721-r38">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260721-r38">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260721-r38">
-  <link rel="stylesheet" href="./orientation-guard.css?build=20260721-r38">
-  <link rel="stylesheet" href="./lap-result-toast.css?build=20260721-r38">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260721-r38">
+  <link rel="manifest" href="./site.webmanifest?build=20260722-r39">
+  <link rel="stylesheet" href="./styles.css?build=20260722-r39">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260722-r39">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260722-r39">
+  <link rel="stylesheet" href="./install-gate.css?build=20260722-r39">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260722-r39">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260722-r39">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260722-r39">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260722-r39">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260722-r39">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260722-r39">
+  <link rel="stylesheet" href="./orientation-guard.css?build=20260722-r39">
+  <link rel="stylesheet" href="./lap-result-toast.css?build=20260722-r39">
+  <link rel="stylesheet" href="./rival-onboarding.css?build=20260722-r39">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260722-r39">
 
-  <script src="./install-gate.js?build=20260721-r38"></script>
-  <script src="./orientation-compat.js?build=20260721-r38"></script>
+  <script src="./install-gate.js?build=20260722-r39"></script>
+  <script src="./orientation-compat.js?build=20260722-r39"></script>
   <script type="importmap">
     {
       "imports": {
@@ -45,7 +46,7 @@
         "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-r10.js?build=20260720-r25",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260721-r29",
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system.js?build=20260721-r38",
-        "./race/game-state.js": "./race/game-state.js?build=20260721-r34",
+        "./race/game-state.js": "./race/game-state.js?build=20260722-r39",
         "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260721-r35",
         "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260721-r35",
         "./vehicle/car-models.js?build=20260720-r19": "./vehicle/car-models.js?build=20260720-r22"
@@ -61,7 +62,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.21 · Build 2026.07.21-r38</span>
+        <span class="install-kicker">TURN v1.3.22 · Build 2026.07.22-r39</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -89,7 +90,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.21 · Build 2026.07.21-r38</span>
+      <span class="kicker">TURN v1.3.22 · Build 2026.07.22-r39</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -155,6 +156,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260721-r38"></script>
+  <script type="module" src="./app.js?build=20260722-r39"></script>
 </body>
 </html>

--- a/turn/race/game-state.js
+++ b/turn/race/game-state.js
@@ -69,7 +69,6 @@ export function resetRaceToStage({
   state.recording = [];
 
   setRacePosition?.(null, state.competitorLaps.length + 1);
-  if (showFeedback) showMessage?.('READY FOR THE LINE');
 }
 
 export function prepareRaceStartState(state) {

--- a/turn/rival-onboarding.css
+++ b/turn/rival-onboarding.css
@@ -1,0 +1,44 @@
+.rival-onboarding {
+  position: absolute;
+  z-index: 35;
+  left: 50%;
+  top: 22%;
+  padding: 7px 14px;
+  border: 3px solid var(--ink);
+  border-radius: 999px;
+  background: var(--rival-onboarding-color, var(--yellow));
+  color: var(--ink);
+  box-shadow: 4px 4px 0 var(--ink);
+  font-size: clamp(0.75rem, 2vw, 1rem);
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transform: translate(-50%, 8px) rotate(-2deg) scale(0.97);
+  transition: opacity 150ms ease, transform 190ms cubic-bezier(0.2, 0.85, 0.3, 1.16);
+}
+
+.rival-onboarding.is-visible {
+  opacity: 1;
+  transform: translate(-50%, 0) rotate(-2deg) scale(1);
+}
+
+.rival-onboarding.is-leaving {
+  opacity: 0;
+  transform: translate(-50%, 5px) rotate(-2deg) scale(0.98);
+}
+
+@media (max-height: 430px) {
+  .rival-onboarding {
+    top: 17%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rival-onboarding,
+  .rival-onboarding.is-visible,
+  .rival-onboarding.is-leaving {
+    transform: translateX(-50%) rotate(-2deg);
+    transition: opacity 120ms linear;
+  }
+}

--- a/turn/ui/lap-result-toast.js
+++ b/turn/ui/lap-result-toast.js
@@ -84,7 +84,7 @@ export function installLapResultToast() {
   function showInvalid(result) {
     label.textContent = 'LAP INVALID';
     position.textContent = result?.reason === 'missed-checkpoint'
-      ? 'MISSED CHECKPOINT'
+      ? 'STAY ON THE TRACK!'
       : 'TRY AGAIN';
     separator.hidden = true;
     time.hidden = true;

--- a/turn/ui/rival-onboarding.js
+++ b/turn/ui/rival-onboarding.js
@@ -1,0 +1,81 @@
+import { makeGhostColor } from '../vehicle/catalog.js?build=20260720-r19';
+
+const RESULT_TOAST_HANDOFF_MS = 4300;
+const ONBOARDING_VISIBLE_MS = 2800;
+const ONBOARDING_EXIT_MS = 180;
+
+export function installRivalOnboarding() {
+  if (globalThis.__turnRivalOnboardingInstalled) return;
+  globalThis.__turnRivalOnboardingInstalled = true;
+
+  const hud = document.querySelector('#hud');
+  if (!hud) return;
+
+  const plate = document.createElement('div');
+  plate.className = 'rival-onboarding';
+  plate.hidden = true;
+  plate.setAttribute('role', 'status');
+  plate.setAttribute('aria-live', 'polite');
+  plate.setAttribute('aria-atomic', 'true');
+  plate.textContent = 'CHASE YOUR BEST';
+  hud.appendChild(plate);
+
+  let showTimer = 0;
+  let hideTimer = 0;
+  let exitTimer = 0;
+
+  function clearTimers() {
+    window.clearTimeout(showTimer);
+    window.clearTimeout(hideTimer);
+    window.clearTimeout(exitTimer);
+    showTimer = 0;
+    hideTimer = 0;
+    exitTimer = 0;
+  }
+
+  function hide({ immediate = false } = {}) {
+    clearTimers();
+    if (plate.hidden) return;
+
+    if (immediate) {
+      plate.hidden = true;
+      plate.classList.remove('is-visible', 'is-leaving');
+      return;
+    }
+
+    plate.classList.remove('is-visible');
+    plate.classList.add('is-leaving');
+    exitTimer = window.setTimeout(() => {
+      plate.hidden = true;
+      plate.classList.remove('is-leaving');
+      exitTimer = 0;
+    }, ONBOARDING_EXIT_MS);
+  }
+
+  function reveal(color) {
+    plate.style.setProperty('--rival-onboarding-color', makeGhostColor(color));
+    plate.hidden = false;
+    plate.classList.remove('is-visible', 'is-leaving');
+    void plate.offsetWidth;
+    plate.classList.add('is-visible');
+    hideTimer = window.setTimeout(() => hide(), ONBOARDING_VISIBLE_MS);
+  }
+
+  function schedule(detail) {
+    clearTimers();
+    plate.hidden = true;
+    plate.classList.remove('is-visible', 'is-leaving');
+    showTimer = window.setTimeout(() => {
+      showTimer = 0;
+      reveal(detail?.color);
+    }, RESULT_TOAST_HANDOFF_MS);
+  }
+
+  window.addEventListener('turn:first-rival', (event) => schedule(event.detail));
+  window.addEventListener('turn:rivals-reset', () => hide({ immediate: true }));
+  window.addEventListener('turn:ui-state-change', (event) => {
+    if (!event.detail?.running || event.detail?.reason === 'race-reset') {
+      hide({ immediate: true });
+    }
+  });
+}

--- a/turn/ui/rival-onboarding.js
+++ b/turn/ui/rival-onboarding.js
@@ -1,4 +1,4 @@
-import { makeGhostColor } from '../vehicle/catalog.js?build=20260720-r19';
+import { loadVehicleSelection, makeGhostColor } from '../vehicle/catalog.js?build=20260720-r19';
 
 const RESULT_TOAST_HANDOFF_MS = 4300;
 const ONBOARDING_VISIBLE_MS = 2800;
@@ -20,6 +20,7 @@ export function installRivalOnboarding() {
   plate.textContent = 'CHASE YOUR BEST';
   hud.appendChild(plate);
 
+  let hadRival = false;
   let showTimer = 0;
   let hideTimer = 0;
   let exitTimer = 0;
@@ -61,20 +62,34 @@ export function installRivalOnboarding() {
     hideTimer = window.setTimeout(() => hide(), ONBOARDING_VISIBLE_MS);
   }
 
-  function schedule(detail) {
+  function schedule() {
     clearTimers();
     plate.hidden = true;
     plate.classList.remove('is-visible', 'is-leaving');
+    const color = loadVehicleSelection().color;
     showTimer = window.setTimeout(() => {
       showTimer = 0;
-      reveal(detail?.color);
+      reveal(color);
     }, RESULT_TOAST_HANDOFF_MS);
   }
 
-  window.addEventListener('turn:first-rival', (event) => schedule(event.detail));
-  window.addEventListener('turn:rivals-reset', () => hide({ immediate: true }));
+  window.addEventListener('turn:rivals-reset', () => {
+    hadRival = false;
+    hide({ immediate: true });
+  });
+
   window.addEventListener('turn:ui-state-change', (event) => {
-    if (!event.detail?.running || event.detail?.reason === 'race-reset') {
+    const reason = event.detail?.reason;
+    const hasRival = Boolean(globalThis.__turnHasGhosts?.());
+
+    if (reason === 'rivals-loaded' || reason === 'race-started') {
+      hadRival = hasRival;
+    } else if (reason === 'lap-completed') {
+      if (!hadRival && hasRival) schedule();
+      hadRival = hasRival;
+    }
+
+    if (!event.detail?.running || reason === 'race-reset') {
       hide({ immediate: true });
     }
   });


### PR DESCRIPTION
## Summary

Polishes three pieces of race feedback without changing gameplay, physics, lap validity, rival storage or car balance.

## Changes

- Replaces the technical invalid-lap message `MISSED CHECKPOINT` with player-facing `STAY ON THE TRACK!`.
- Removes the redundant `READY FOR THE LINE` message after `RESTART LAP`.
- Adds a one-time onboarding plate when the saved rival list first transitions from 0 to 1: `CHASE YOUR BEST`.
- Colors that onboarding plate with the same lighter `makeGhostColor()` paint used by the new rival car.
- Delays the onboarding plate until the four-second LAST LAP result has cleared, so the messages do not compete.
- Resetting rivals resets the onboarding transition, so a newly created first rival can explain itself again.

## Regression coverage

The existing lap-result regression now also protects:

- `STAY ON THE TRACK!` player-facing copy,
- removal of `READY FOR THE LINE`,
- zero-to-one rival onboarding only,
- use of the real ghost color transform,
- result-toast-to-onboarding handoff timing,
- r39 cache busts for the changed game-state and new onboarding assets.

## Release

TURN v1.3.22 · Build 2026.07.22-r39