### PR TITLE
TURN v1.3.23 r40: Rotating ghost model in first-rival onboarding

### DIFF
--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -10,8 +10,8 @@ const [index, app, audio, controls, catalogSource] = await Promise.all([
 ]);
 const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
 
-assert.match(index, /TURN v1\.3\.22 · Build 2026\.07\.22-r39/);
-assert.match(index, /\.\/app\.js\?build=20260722-r39/);
+assert.match(index, /TURN v1\.3\.23 · Build 2026\.07\.22-r40/);
+assert.match(index, /\.\/app\.js\?build=20260722-r40/);
 assert.match(
   index,
   /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r35"/,

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -69,7 +69,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.22 · Build 2026\.07\.22-r39/);
+assert.match(index, /TURN v1\.3\.23 · Build 2026\.07\.22-r40/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -20,9 +20,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.22 · Build 2026\.07\.22-r39/);
-assert.match(index, /drive-pad\.css\?build=20260722-r39/);
-assert.match(index, /gameplay-v2\.css\?build=20260722-r39/);
+assert.match(index, /TURN v1\.3\.23 · Build 2026\.07\.22-r40/);
+assert.match(index, /drive-pad\.css\?build=20260722-r40/);
+assert.match(index, /gameplay-v2\.css\?build=20260722-r40/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -47,10 +47,10 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.22 · Build 2026\.07\.22-r39/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260722-r39/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r39 must preserve the latest Lot module cache redirect');
-assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r35"/, 'r39 must preserve the corrected Vintage Racer orientation');
+assert.match(index, /TURN v1\.3\.23 · Build 2026\.07\.22-r40/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260722-r40/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r40 must preserve the latest Lot module cache redirect');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r35"/, 'r40 must preserve the corrected Vintage Racer orientation');
 assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -26,8 +26,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.22 · Build 2026\.07\.22-r39/);
-assert.match(index, /in-game-menu\.css\?build=20260722-r39/);
+assert.match(index, /TURN v1\.3\.23 · Build 2026\.07\.22-r40/);
+assert.match(index, /in-game-menu\.css\?build=20260722-r40/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Restart Lap<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -130,11 +130,11 @@ const [index, app, lapSystem, gameState, toast, toastCss, onboarding, onboarding
   fs.readFile(new URL('../../turn/rival-onboarding.css', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.22 · Build 2026\.07\.22-r39/);
-assert.match(index, /lap-result-toast\.css\?build=20260722-r39/);
-assert.match(index, /rival-onboarding\.css\?build=20260722-r39/);
-assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260721-r38"/, 'r39 must preserve the corrected single-source physical lap system');
-assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r39"/, 'r39 must cache-bust the restart-message removal');
+assert.match(index, /TURN v1\.3\.23 · Build 2026\.07\.22-r40/);
+assert.match(index, /lap-result-toast\.css\?build=20260722-r40/);
+assert.match(index, /rival-onboarding\.css\?build=20260722-r40/);
+assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260721-r38"/, 'r40 must preserve the corrected single-source physical lap system');
+assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r39"/, 'r40 must preserve the restart-message removal');
 assert.match(app, /installLapResultToast\(\)/, 'The lap result toast must install before the game runtime starts');
 assert.match(app, /installRivalOnboarding\(\)/, 'The rival onboarding plate must install before the game runtime starts');
 assert.match(lapSystem, /turn:lap-result/, 'Completed lap finish must publish one frozen result event');
@@ -158,15 +158,27 @@ assert.match(toast, /aria-live', 'polite'/, 'The result toast should be announce
 assert.doesNotMatch(gameState, /READY FOR THE LINE/, 'Restart Lap must not show redundant ready-state feedback');
 assert.match(onboarding, /CHASE YOUR BEST/, 'The first rival must introduce the core chase-your-best loop');
 assert.match(onboarding, /reason === 'lap-completed'/, 'Onboarding must be tied to the first newly saved rival after a completed lap');
-assert.match(onboarding, /!hadRival && hasRival/, 'The onboarding plate must only trigger on the zero-to-one rival transition');
-assert.match(onboarding, /makeGhostColor\(color\)/, 'The onboarding plate must use the same lighter body colour as the ghost car');
+assert.match(onboarding, /!hadRival && hasRival\) schedule\(rivals\[0\]\)/, 'The onboarding must use the newly saved rival rather than the current selection');
+assert.match(onboarding, /rival\?\.carId/, 'The first-rival preview must use the saved ghost model');
+assert.match(onboarding, /rival\?\.carColor/, 'The first-rival preview must use the saved ghost body paint');
+assert.match(onboarding, /rival\?\.carSecondaryColor/, 'The first-rival preview must preserve saved secondary paint');
+assert.match(onboarding, /ghost: true/, 'The onboarding model must use the same lighter solid ghost treatment as race rivals');
+assert.match(onboarding, /targetLength: 6\.4/, 'The onboarding model must use the Lot 3D viewer presentation scale');
+assert.match(onboarding, /PerspectiveCamera\(34, 1, 0\.1, 60\)/, 'The onboarding model must reuse the Lot viewer camera language');
+assert.match(onboarding, /camera\.position\.set\(7\.8, 4\.8, 8\.8\)/, 'The onboarding model must use the Lot viewer camera position');
+assert.match(onboarding, /HemisphereLight\(0xffffff, 0x5b6770, 3\.2\)/, 'The onboarding model must use the Lot viewer ambient lighting');
+assert.match(onboarding, /VIEWER_ROTATION_RADIANS_PER_SECOND = 0\.144/, 'The onboarding preview must rotate at the same approximately 60fps Lot viewer speed');
+assert.match(onboarding, /VIEWER_FRAME_INTERVAL_MS = 1000 \/ 30/, 'The temporary onboarding renderer must stay capped at 30 fps on mobile');
+assert.match(onboarding, /renderer\.dispose\(\)/, 'The temporary onboarding renderer must be disposed after the reveal');
 assert.match(onboarding, /RESULT_TOAST_HANDOFF_MS = 4300/, 'First-rival onboarding must wait until the lap-result toast has cleared');
 assert.match(toastCss, /background: var\(--yellow\)/, 'The lap toast must share the yellow finish-result colour');
 assert.match(toastCss, /left: 50%/, 'The lap toast must occupy the central finish-message position');
 assert.match(toastCss, /top: 22%/, 'The lap toast must sit where the old TOP X LAP message appeared');
 assert.doesNotMatch(toastCss, /left: max\(112px/, 'The retired lower-left toast placement must stay removed');
 assert.match(toastCss, /prefers-reduced-motion: reduce/, 'Toast animation must respect reduced-motion preferences');
+assert.match(onboardingCss, /\.rival-onboarding-model/, 'The onboarding must reserve an adjacent host for the ghost model');
+assert.match(onboardingCss, /\.rival-onboarding-copy/, 'The CHASE YOUR BEST copy must remain a separate pill plate beside the model');
 assert.match(onboardingCss, /background: var\(--rival-onboarding-color, var\(--yellow\)\)/, 'The onboarding plate must expose the rival colour through a CSS custom property');
 assert.match(onboardingCss, /border-radius: 999px/, 'The onboarding must keep the compact pill-plate language of the old READY message');
 
-console.log('TURN unified lap feedback and first-rival onboarding regression passed.');
+console.log('TURN unified lap feedback and rotating first-rival onboarding regression passed.');

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -20,13 +20,13 @@ const [index, css, orientationGuardCss, orientationCompat, camera] = await Promi
   fs.readFile(new URL('../../turn/render/camera.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.22 · Build 2026\.07\.22-r39/);
+assert.match(index, /TURN v1\.3\.23 · Build 2026\.07\.22-r40/);
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260722-r39/);
-assert.match(index, /orientation-guard\.css\?build=20260722-r39/);
-assert.match(index, /orientation-compat\.js\?build=20260722-r39/);
-assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r39 must preserve the guarded race camera cache redirect');
+assert.match(index, /manual-steering\.css\?build=20260722-r40/);
+assert.match(index, /orientation-guard\.css\?build=20260722-r40/);
+assert.match(index, /orientation-compat\.js\?build=20260722-r40/);
+assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r40 must preserve the guarded race camera cache redirect');
 assert.match(index, /<strong>Rotate to landscape<\/strong>/, 'The pre-race landscape instruction must remain available');
 
 assert.match(css, /--manual-steer-left/);

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -34,7 +34,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.22 · Build 2026\.07\.22-r39/);
+assert.match(index, /TURN v1\.3\.23 · Build 2026\.07\.22-r40/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -61,7 +61,7 @@ const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, m
   fs.readFile(new URL('../../turn/orientation-compat.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.22 · Build 2026\.07\.22-r39/);
+assert.match(index, /TURN v1\.3\.23 · Build 2026\.07\.22-r40/);
 assert.match(main, /mainSceneOcclusion/);
 assert.match(main, /HUD_UPDATE_INTERVAL_MS = 1000 \/ 30/);
 assert.match(main, /recordPerformanceFrame/);

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r39 clearer lap feedback and first-rival onboarding -->
+<!-- TURN r40 first-rival 3D ghost reveal -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,34 +10,34 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.22 · Build 2026.07.22-r39</title>
+  <title>TURN v1.3.23 · Build 2026.07.22-r40</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.22',
-      id: '2026.07.22-r39',
-      cacheKey: '20260722-r39'
+      version: '1.3.23',
+      id: '2026.07.22-r40',
+      cacheKey: '20260722-r40'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260722-r39">
-  <link rel="stylesheet" href="./styles.css?build=20260722-r39">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260722-r39">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260722-r39">
-  <link rel="stylesheet" href="./install-gate.css?build=20260722-r39">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260722-r39">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260722-r39">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260722-r39">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260722-r39">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260722-r39">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260722-r39">
-  <link rel="stylesheet" href="./orientation-guard.css?build=20260722-r39">
-  <link rel="stylesheet" href="./lap-result-toast.css?build=20260722-r39">
-  <link rel="stylesheet" href="./rival-onboarding.css?build=20260722-r39">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260722-r39">
+  <link rel="manifest" href="./site.webmanifest?build=20260722-r40">
+  <link rel="stylesheet" href="./styles.css?build=20260722-r40">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260722-r40">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260722-r40">
+  <link rel="stylesheet" href="./install-gate.css?build=20260722-r40">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260722-r40">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260722-r40">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260722-r40">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260722-r40">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260722-r40">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260722-r40">
+  <link rel="stylesheet" href="./orientation-guard.css?build=20260722-r40">
+  <link rel="stylesheet" href="./lap-result-toast.css?build=20260722-r40">
+  <link rel="stylesheet" href="./rival-onboarding.css?build=20260722-r40">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260722-r40">
 
-  <script src="./install-gate.js?build=20260722-r39"></script>
-  <script src="./orientation-compat.js?build=20260722-r39"></script>
+  <script src="./install-gate.js?build=20260722-r40"></script>
+  <script src="./orientation-compat.js?build=20260722-r40"></script>
   <script type="importmap">
     {
       "imports": {
@@ -62,7 +62,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.22 · Build 2026.07.22-r39</span>
+        <span class="install-kicker">TURN v1.3.23 · Build 2026.07.22-r40</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -90,7 +90,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.22 · Build 2026.07.22-r39</span>
+      <span class="kicker">TURN v1.3.23 · Build 2026.07.22-r40</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -156,6 +156,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260722-r39"></script>
+  <script type="module" src="./app.js?build=20260722-r40"></script>
 </body>
 </html>

--- a/turn/rival-onboarding.css
+++ b/turn/rival-onboarding.css
@@ -2,7 +2,31 @@
   position: absolute;
   z-index: 35;
   left: 50%;
-  top: 22%;
+  top: 20%;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  pointer-events: none;
+  opacity: 0;
+  transform: translate(-50%, 8px) scale(0.97);
+  transition: opacity 150ms ease, transform 190ms cubic-bezier(0.2, 0.85, 0.3, 1.16);
+}
+
+.rival-onboarding-model {
+  width: clamp(86px, 11vw, 126px);
+  height: clamp(62px, 8vw, 92px);
+  flex: 0 0 auto;
+  margin-right: -8px;
+  filter: drop-shadow(4px 5px 0 rgb(8 9 10 / 0.32));
+}
+
+.rival-onboarding-model canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.rival-onboarding-copy {
   padding: 7px 14px;
   border: 3px solid var(--ink);
   border-radius: 999px;
@@ -12,25 +36,31 @@
   font-size: clamp(0.75rem, 2vw, 1rem);
   letter-spacing: 0.02em;
   white-space: nowrap;
-  pointer-events: none;
-  opacity: 0;
-  transform: translate(-50%, 8px) rotate(-2deg) scale(0.97);
-  transition: opacity 150ms ease, transform 190ms cubic-bezier(0.2, 0.85, 0.3, 1.16);
+  transform: rotate(-2deg);
 }
 
 .rival-onboarding.is-visible {
   opacity: 1;
-  transform: translate(-50%, 0) rotate(-2deg) scale(1);
+  transform: translate(-50%, 0) scale(1);
 }
 
 .rival-onboarding.is-leaving {
   opacity: 0;
-  transform: translate(-50%, 5px) rotate(-2deg) scale(0.98);
+  transform: translate(-50%, 5px) scale(0.98);
+}
+
+.rival-onboarding.is-model-unavailable .rival-onboarding-model {
+  display: none;
 }
 
 @media (max-height: 430px) {
   .rival-onboarding {
-    top: 17%;
+    top: 16%;
+  }
+
+  .rival-onboarding-model {
+    width: 82px;
+    height: 58px;
   }
 }
 
@@ -38,7 +68,7 @@
   .rival-onboarding,
   .rival-onboarding.is-visible,
   .rival-onboarding.is-leaving {
-    transform: translateX(-50%) rotate(-2deg);
+    transform: translateX(-50%);
     transition: opacity 120ms linear;
   }
 }

--- a/turn/ui/rival-onboarding.js
+++ b/turn/ui/rival-onboarding.js
@@ -12,6 +12,8 @@ const RESULT_TOAST_HANDOFF_MS = 4300;
 const ONBOARDING_VISIBLE_MS = 3200;
 const ONBOARDING_EXIT_MS = 180;
 const VIEWER_INITIAL_YAW = Math.PI - 0.55;
+const VIEWER_ROTATION_RADIANS_PER_SECOND = 0.144;
+const VIEWER_FRAME_INTERVAL_MS = 1000 / 30;
 
 export function installRivalOnboarding() {
   if (globalThis.__turnRivalOnboardingInstalled) return;
@@ -89,6 +91,7 @@ export function installRivalOnboarding() {
     plate.hidden = false;
     plate.classList.remove('is-visible', 'is-leaving');
     preview?.resize();
+    preview?.start();
     void plate.offsetWidth;
     plate.classList.add('is-visible');
     hideTimer = window.setTimeout(() => hide(), ONBOARDING_VISIBLE_MS);
@@ -116,11 +119,6 @@ export function installRivalOnboarding() {
       reveal();
     }, RESULT_TOAST_HANDOFF_MS);
   }
-
-  globalThis.__turnRenderRivalOnboarding = (now) => {
-    if (!preview || plate.hidden) return null;
-    return preview.render(now) ? preview.renderer : null;
-  };
 
   window.addEventListener('turn:rivals-reset', () => {
     hadRival = false;
@@ -173,6 +171,10 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
 
   let visual = null;
   let disposed = false;
+  let active = false;
+  let animationFrame = 0;
+  let lastTickAt = 0;
+  let lastRenderAt = 0;
   let yaw = VIEWER_INITIAL_YAW;
   const reducedMotion = globalThis.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches === true;
 
@@ -183,6 +185,26 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
     camera.aspect = rect.width / rect.height;
     camera.updateProjectionMatrix();
     renderer.setSize(Math.round(rect.width), Math.round(rect.height), false);
+  };
+
+  const renderFrame = (now) => {
+    if (disposed) return;
+    stage.rotation.y = yaw;
+    stage.rotation.x = 0.08;
+    if (visual) visual.position.y = reducedMotion ? 0 : Math.sin((now / 1000) * 2.1) * 0.04;
+    renderer.render(scene, camera);
+  };
+
+  const tick = (now) => {
+    if (!active || disposed) return;
+    const dt = Math.min(0.1, Math.max(0, (now - lastTickAt) / 1000));
+    lastTickAt = now;
+    if (!reducedMotion) yaw += dt * VIEWER_ROTATION_RADIANS_PER_SECOND;
+    if (now - lastRenderAt >= VIEWER_FRAME_INTERVAL_MS) {
+      lastRenderAt = now;
+      renderFrame(now);
+    }
+    animationFrame = requestAnimationFrame(tick);
   };
 
   const observer = typeof ResizeObserver === 'function' ? new ResizeObserver(resize) : null;
@@ -200,6 +222,7 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
     visual = next;
     stage.add(visual);
     resize();
+    if (active) renderFrame(performance.now());
   }).catch((error) => {
     if (disposed) return;
     console.warn('TURN: first rival could not load in the onboarding viewer.', error);
@@ -211,18 +234,21 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
   return {
     renderer,
     resize,
-    render(now) {
-      if (disposed) return false;
-      if (!reducedMotion) yaw += 0.0024;
-      stage.rotation.y = yaw;
-      stage.rotation.x = 0.08;
-      if (visual) visual.position.y = reducedMotion ? 0 : Math.sin((now / 1000) * 2.1) * 0.04;
-      renderer.render(scene, camera);
-      return true;
+    start() {
+      if (disposed || active) return;
+      active = true;
+      resize();
+      const now = performance.now();
+      lastTickAt = now;
+      lastRenderAt = 0;
+      renderFrame(now);
+      if (!reducedMotion) animationFrame = requestAnimationFrame(tick);
     },
     dispose() {
       if (disposed) return;
       disposed = true;
+      active = false;
+      cancelAnimationFrame(animationFrame);
       observer?.disconnect();
       renderer.dispose();
       renderer.domElement.remove();

--- a/turn/ui/rival-onboarding.js
+++ b/turn/ui/rival-onboarding.js
@@ -1,8 +1,17 @@
-import { loadVehicleSelection, makeGhostColor } from '../vehicle/catalog.js?build=20260720-r19';
+import * as THREE from 'three';
+import {
+  DEFAULT_VEHICLE_COLOR,
+  DEFAULT_VEHICLE_SECONDARY_COLOR,
+  makeGhostColor,
+  normalizeVehicleColor,
+  normalizeVehicleSecondaryColor
+} from '../vehicle/catalog.js?build=20260720-r19';
+import { createCarVisual } from '../vehicle/car-models.js?build=20260720-r22';
 
 const RESULT_TOAST_HANDOFF_MS = 4300;
-const ONBOARDING_VISIBLE_MS = 2800;
+const ONBOARDING_VISIBLE_MS = 3200;
 const ONBOARDING_EXIT_MS = 180;
+const VIEWER_INITIAL_YAW = Math.PI - 0.55;
 
 export function installRivalOnboarding() {
   if (globalThis.__turnRivalOnboardingInstalled) return;
@@ -17,13 +26,23 @@ export function installRivalOnboarding() {
   plate.setAttribute('role', 'status');
   plate.setAttribute('aria-live', 'polite');
   plate.setAttribute('aria-atomic', 'true');
-  plate.textContent = 'CHASE YOUR BEST';
+
+  const modelHost = document.createElement('div');
+  modelHost.className = 'rival-onboarding-model';
+  modelHost.setAttribute('aria-hidden', 'true');
+
+  const copy = document.createElement('div');
+  copy.className = 'rival-onboarding-copy';
+  copy.textContent = 'CHASE YOUR BEST';
+
+  plate.append(modelHost, copy);
   hud.appendChild(plate);
 
   let hadRival = false;
   let showTimer = 0;
   let hideTimer = 0;
   let exitTimer = 0;
+  let preview = null;
 
   function clearTimers() {
     window.clearTimeout(showTimer);
@@ -34,13 +53,24 @@ export function installRivalOnboarding() {
     exitTimer = 0;
   }
 
+  function destroyPreview() {
+    preview?.dispose();
+    preview = null;
+    modelHost.replaceChildren();
+    plate.classList.remove('is-model-unavailable');
+  }
+
   function hide({ immediate = false } = {}) {
     clearTimers();
-    if (plate.hidden) return;
+    if (plate.hidden) {
+      destroyPreview();
+      return;
+    }
 
     if (immediate) {
       plate.hidden = true;
       plate.classList.remove('is-visible', 'is-leaving');
+      destroyPreview();
       return;
     }
 
@@ -50,28 +80,47 @@ export function installRivalOnboarding() {
       plate.hidden = true;
       plate.classList.remove('is-leaving');
       exitTimer = 0;
+      destroyPreview();
     }, ONBOARDING_EXIT_MS);
   }
 
-  function reveal(color) {
-    plate.style.setProperty('--rival-onboarding-color', makeGhostColor(color));
+  function reveal() {
+    clearTimers();
     plate.hidden = false;
     plate.classList.remove('is-visible', 'is-leaving');
+    preview?.resize();
     void plate.offsetWidth;
     plate.classList.add('is-visible');
     hideTimer = window.setTimeout(() => hide(), ONBOARDING_VISIBLE_MS);
   }
 
-  function schedule() {
+  function schedule(rival) {
     clearTimers();
+    destroyPreview();
     plate.hidden = true;
     plate.classList.remove('is-visible', 'is-leaving');
-    const color = loadVehicleSelection().color;
+
+    const carId = rival?.carId || 'sedan';
+    const color = normalizeVehicleColor(rival?.carColor || DEFAULT_VEHICLE_COLOR);
+    const secondaryColor = normalizeVehicleSecondaryColor(
+      rival?.carSecondaryColor || DEFAULT_VEHICLE_SECONDARY_COLOR
+    );
+
+    plate.style.setProperty('--rival-onboarding-color', makeGhostColor(color));
+    preview = createGhostPreview({ modelHost, carId, color, secondaryColor, onError() {
+      plate.classList.add('is-model-unavailable');
+    } });
+
     showTimer = window.setTimeout(() => {
       showTimer = 0;
-      reveal(color);
+      reveal();
     }, RESULT_TOAST_HANDOFF_MS);
   }
+
+  globalThis.__turnRenderRivalOnboarding = (now) => {
+    if (!preview || plate.hidden) return null;
+    return preview.render(now) ? preview.renderer : null;
+  };
 
   window.addEventListener('turn:rivals-reset', () => {
     hadRival = false;
@@ -80,12 +129,13 @@ export function installRivalOnboarding() {
 
   window.addEventListener('turn:ui-state-change', (event) => {
     const reason = event.detail?.reason;
-    const hasRival = Boolean(globalThis.__turnHasGhosts?.());
+    const rivals = globalThis.__turnRuntime?.state?.competitorLaps || [];
+    const hasRival = rivals.length > 0;
 
     if (reason === 'rivals-loaded' || reason === 'race-started') {
       hadRival = hasRival;
     } else if (reason === 'lap-completed') {
-      if (!hadRival && hasRival) schedule();
+      if (!hadRival && hasRival) schedule(rivals[0]);
       hadRival = hasRival;
     }
 
@@ -93,4 +143,89 @@ export function installRivalOnboarding() {
       hide({ immediate: true });
     }
   });
+}
+
+function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }) {
+  const scene = new THREE.Scene();
+  const renderer = new THREE.WebGLRenderer({
+    antialias: true,
+    alpha: true,
+    powerPreference: 'high-performance'
+  });
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+  renderer.setPixelRatio(Math.min(devicePixelRatio, 1.35));
+  renderer.setClearColor(0x000000, 0);
+  modelHost.appendChild(renderer.domElement);
+
+  const camera = new THREE.PerspectiveCamera(34, 1, 0.1, 60);
+  camera.position.set(7.8, 4.8, 8.8);
+  camera.lookAt(0, 1.1, 0);
+
+  scene.add(new THREE.HemisphereLight(0xffffff, 0x5b6770, 3.2));
+  const key = new THREE.DirectionalLight(0xfff2c9, 4.2);
+  key.position.set(-6, 10, 7);
+  scene.add(key);
+
+  const stage = new THREE.Group();
+  stage.rotation.y = VIEWER_INITIAL_YAW;
+  stage.rotation.x = 0.08;
+  scene.add(stage);
+
+  let visual = null;
+  let disposed = false;
+  let yaw = VIEWER_INITIAL_YAW;
+  const reducedMotion = globalThis.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches === true;
+
+  const resize = () => {
+    if (disposed) return;
+    const rect = modelHost.getBoundingClientRect();
+    if (!rect.width || !rect.height) return;
+    camera.aspect = rect.width / rect.height;
+    camera.updateProjectionMatrix();
+    renderer.setSize(Math.round(rect.width), Math.round(rect.height), false);
+  };
+
+  const observer = typeof ResizeObserver === 'function' ? new ResizeObserver(resize) : null;
+  observer?.observe(modelHost);
+
+  void createCarVisual({
+    carId,
+    color,
+    secondaryColor,
+    ghost: true,
+    targetLength: 6.4,
+    outline: true
+  }).then((next) => {
+    if (disposed) return;
+    visual = next;
+    stage.add(visual);
+    resize();
+  }).catch((error) => {
+    if (disposed) return;
+    console.warn('TURN: first rival could not load in the onboarding viewer.', error);
+    onError?.(error);
+  });
+
+  resize();
+
+  return {
+    renderer,
+    resize,
+    render(now) {
+      if (disposed) return false;
+      if (!reducedMotion) yaw += 0.0024;
+      stage.rotation.y = yaw;
+      stage.rotation.x = 0.08;
+      if (visual) visual.position.y = reducedMotion ? 0 : Math.sin((now / 1000) * 2.1) * 0.04;
+      renderer.render(scene, camera);
+      return true;
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      observer?.disconnect();
+      renderer.dispose();
+      renderer.domElement.remove();
+    }
+  };
 }


### PR DESCRIPTION
## Summary

Makes the first-rival `CHASE YOUR BEST` onboarding reveal show the actual saved ghost car model beside the sign.

## Changes

- Uses the first newly saved rival's real `carId`, body colour and secondary colour.
- Renders the preview through `createCarVisual(..., ghost: true)` so it matches the lighter solid ghost seen in races and Spectate.
- Reuses The Lot 3D viewer presentation language: camera position/FOV, lighting, 6.4 target length, initial yaw, gentle bob and slow rotation speed.
- Places the rotating 3D ghost adjacent to the `CHASE YOUR BEST` pill.
- Keeps the mini renderer temporary: it runs only during the 3.2-second reveal, is capped at 30 fps, respects reduced motion, and is disposed afterward.
- Leaves lap logic, gameplay physics, rival storage and normal race rendering unchanged.

## Regression coverage

The lap/onboarding regression now protects the saved rival model and paint source, ghost rendering mode, Lot-style viewer parameters, 30 fps cap, renderer disposal and adjacent model layout.

## Release

TURN v1.3.23 · Build 2026.07.22-r40