### PR TITLE
TURN v1.3.24 r41: Persistent INVALID LAP timer state

### DIFF
--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -10,8 +10,8 @@ const [index, app, audio, controls, catalogSource] = await Promise.all([
 ]);
 const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
 
-assert.match(index, /TURN v1\.3\.23 · Build 2026\.07\.22-r40/);
-assert.match(index, /\.\/app\.js\?build=20260722-r40/);
+assert.match(index, /TURN v1\.3\.24 · Build 2026\.07\.22-r41/);
+assert.match(index, /\.\/app\.js\?build=20260722-r41/);
 assert.match(
   index,
   /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r35"/,

--- a/turn-lab/tests/balance-and-checkpoints.mjs
+++ b/turn-lab/tests/balance-and-checkpoints.mjs
@@ -115,6 +115,31 @@ state.velocity = new Vec3(10, 0, 0);
 run(1300);
 assert.equal(state.lapCheckpointIndex, 2, 'ordered forward swept checkpoint crossing must count');
 
+const skippedGateState = {
+  lapActive: true,
+  lapInvalid: false,
+  lapCheckpointIndex: 0,
+  lapStartedAt: 0,
+  lapElapsed: 0,
+  position: new Vec3(secondCheckpointIndex + 2, 0, 0),
+  velocity: new Vec3(10, 0, 0),
+  progress: LAP_CHECKPOINTS[1],
+  trackDistance: 1,
+  lapPreviousPosition: { x: secondCheckpointIndex - 2, z: 0 }
+};
+updateLapProgressState({
+  state: skippedGateState,
+  nearestAfter: { sample: samples[secondCheckpointIndex] },
+  samples,
+  trackWidth: 27,
+  now: 1350,
+  beginTimedLap: () => assert.fail('crossing a later checkpoint must not restart the lap immediately'),
+  completeLap: () => assert.fail('crossing a later checkpoint must not complete the lap'),
+  recordGhostFrame: () => {}
+});
+assert.equal(skippedGateState.lapCheckpointIndex, 0, 'skipping the required checkpoint must not advance the ordered chain');
+assert.equal(skippedGateState.lapInvalid, true, 'crossing a later gate before the required one must permanently invalidate the current attempt');
+
 assert.equal(
   crossedForwardGate(
     { x: -4, z: 10 },
@@ -147,6 +172,7 @@ assert.equal(began, 1, 'an incomplete lap must immediately restart the timed att
 assert.equal(state.suppressNextLapStartMessage, true, 'invalid-lap restart must suppress a competing GO message');
 
 state.suppressNextLapStartMessage = false;
+state.lapInvalid = false;
 state.lastProgress = 0.4;
 state.progress = 0.4;
 state.lapCheckpointIndex = LAP_CHECKPOINTS.length;
@@ -213,6 +239,7 @@ const resetState = {
   competitorLaps: [{}, {}],
   lapPreviousPosition: { x: -999, z: -999 },
   lapCheckpointIndex: 7,
+  lapInvalid: true,
   lapStartedAt: 1234,
   lapElapsed: 9,
   recording: [{ t: 1 }],
@@ -226,12 +253,14 @@ assert.deepEqual(
   'reset must clear stale gate history so the next start crossing is measured from the reset position'
 );
 assert.equal(resetState.lapCheckpointIndex, 0, 'reset must clear checkpoint progress');
+assert.equal(resetState.lapInvalid, false, 'Restart Lap must clear the persistent invalid-lap state');
 assert.equal(resetState.lapActive, false, 'reset must return to staged pre-lap state');
 
-const [carModelsSource, mainSource, lapSystemSource] = await Promise.all([
+const [carModelsSource, mainSource, lapSystemSource, gameStateSource] = await Promise.all([
   fs.readFile(new URL('../../turn/vehicle/car-models.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/race/lap-system.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../../turn/race/lap-system.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/race/game-state.js', import.meta.url), 'utf8')
 ]);
 assert.match(carModelsSource, /const TIRE_COLOR = 0x17191c/, 'asset vehicle wheels must be forced to a dark tire colour');
 assert.match(carModelsSource, /material\.transparent = false/, 'ghost materials must be solid');
@@ -240,9 +269,12 @@ assert.match(carModelsSource, /ghost \? ghostColor : requestedColor/, 'ghost bod
 assert.match(mainSource, /const ghostCar = makeCar\(0x38d9ff, 1\)/, 'procedural ghost fallback must also be solid');
 assert.match(mainSource, /const car = makeCar\(0x38d9ff, 1\)/, 'additional procedural rival fallbacks must also be solid');
 assert.match(lapSystemSource, /crossedForwardGate/, 'production lap registration must use swept physical gates');
+assert.match(lapSystemSource, /crossedLaterCheckpointGate/, 'passing a later gate must expose the moment a lap becomes irrecoverably invalid');
+assert.match(lapSystemSource, /state\.lapInvalid = true/, 'skipped route detection must persist invalidity for the current attempt');
 assert.match(lapSystemSource, /CHECKPOINT_GATE_HALF_WIDTH_FACTOR = 1\.05/, 'checkpoint gates must allow broad grass and verge racing lines');
 assert.match(lapSystemSource, /START_GATE_HALF_WIDTH_FACTOR = 0\.82/, 'start and finish must keep the established narrower crossing gate');
 assert.match(lapSystemSource, /turn:lap-invalid/, 'an incomplete checkpoint chain must report an invalid lap instead of failing silently');
 assert.doesNotMatch(lapSystemSource, /crossedStartByProgress/, 'start and finish must not retain the retired progress-wrap fallback');
+assert.match(gameStateSource, /state\.lapInvalid = false/, 'race staging must clear invalid-lap status');
 
-console.log('TURN forgiving swept lap gates, single-source start line and anti-shortcut regression passed.');
+console.log('TURN forgiving swept lap gates, early invalid-lap state, single-source start line and anti-shortcut regression passed.');

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -69,7 +69,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.23 · Build 2026\.07\.22-r40/);
+assert.match(index, /TURN v1\.3\.24 · Build 2026\.07\.22-r41/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -20,9 +20,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.23 · Build 2026\.07\.22-r40/);
-assert.match(index, /drive-pad\.css\?build=20260722-r40/);
-assert.match(index, /gameplay-v2\.css\?build=20260722-r40/);
+assert.match(index, /TURN v1\.3\.24 · Build 2026\.07\.22-r41/);
+assert.match(index, /drive-pad\.css\?build=20260722-r41/);
+assert.match(index, /gameplay-v2\.css\?build=20260722-r41/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -47,10 +47,10 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.23 · Build 2026\.07\.22-r40/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260722-r40/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r40 must preserve the latest Lot module cache redirect');
-assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r35"/, 'r40 must preserve the corrected Vintage Racer orientation');
+assert.match(index, /TURN v1\.3\.24 · Build 2026\.07\.22-r41/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260722-r41/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r41 must preserve the latest Lot module cache redirect');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r35"/, 'r41 must preserve the corrected Vintage Racer orientation');
 assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -26,8 +26,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.23 · Build 2026\.07\.22-r40/);
-assert.match(index, /in-game-menu\.css\?build=20260722-r40/);
+assert.match(index, /TURN v1\.3\.24 · Build 2026\.07\.22-r41/);
+assert.match(index, /in-game-menu\.css\?build=20260722-r41/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Restart Lap<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -24,6 +24,7 @@ function makeState({
     recording,
     lapStartedAt: 0,
     lapCheckpointIndex: 12,
+    lapInvalid: false,
     lapActive: true,
     lap: 1,
     lapElapsed,
@@ -67,6 +68,7 @@ try {
   assert.equal(result.finishedTime, 13.5);
   assert.equal(result.position, 5, 'A lap slower than all four rivals must finish fifth');
   assert.equal(result.total, 5, 'The result must include the player plus the four rivals that actually raced');
+  assert.equal(state.lapInvalid, false, 'A newly started lap after a valid finish must begin clean');
   assert.deepEqual(state.competitorLaps.map((lap) => lap.time), [10, 11, 12, 13], 'A fifth-place lap need not replace a saved rival');
   assert.equal(publishedResults.at(-1)?.type, 'turn:lap-result');
   assert.deepEqual(publishedResults.at(-1)?.detail, { position: 5, total: 5, time: 13.5 });
@@ -119,26 +121,30 @@ try {
   else globalThis.dispatchEvent = originalDispatchEvent;
 }
 
-const [index, app, lapSystem, gameState, toast, toastCss, onboarding, onboardingCss] = await Promise.all([
+const [index, app, lapSystem, gameState, hud, styles, toast, toastCss, onboarding, onboardingCss] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/race/lap-system.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/race/game-state.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/ui/hud.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/styles.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/ui/lap-result-toast.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/lap-result-toast.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/ui/rival-onboarding.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/rival-onboarding.css', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.23 · Build 2026\.07\.22-r40/);
-assert.match(index, /lap-result-toast\.css\?build=20260722-r40/);
-assert.match(index, /rival-onboarding\.css\?build=20260722-r40/);
-assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260721-r38"/, 'r40 must preserve the corrected single-source physical lap system');
-assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r39"/, 'r40 must preserve the restart-message removal');
+assert.match(index, /TURN v1\.3\.24 · Build 2026\.07\.22-r41/);
+assert.match(index, /lap-result-toast\.css\?build=20260722-r41/);
+assert.match(index, /rival-onboarding\.css\?build=20260722-r41/);
+assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260722-r41"/, 'r41 must serve the early invalid-lap detector');
+assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r41"/, 'r41 must serve reset-safe invalid-lap state');
 assert.match(app, /installLapResultToast\(\)/, 'The lap result toast must install before the game runtime starts');
 assert.match(app, /installRivalOnboarding\(\)/, 'The rival onboarding plate must install before the game runtime starts');
 assert.match(lapSystem, /turn:lap-result/, 'Completed lap finish must publish one frozen result event');
 assert.match(lapSystem, /turn:lap-invalid/, 'Incomplete checkpoint chains must publish explicit invalid-lap feedback');
+assert.match(lapSystem, /crossedLaterCheckpointGate/, 'Crossing a later gate before the required one must detect an irrecoverably invalid attempt');
+assert.match(lapSystem, /state\.lapInvalid = true/, 'The invalid attempt must stay marked until the next lap begins');
 assert.match(lapSystem, /suppressNextLapStartMessage = true/, 'Invalid-lap feedback must not be obscured by a competing GO message');
 assert.doesNotMatch(lapSystem, /crossedStartByProgress/, 'Start and finish must use only the swept physical line crossing');
 assert.match(lapSystem, /const completedLap = finishedTime > 5/, 'Result visibility must be separated from replay-save eligibility');
@@ -146,6 +152,11 @@ assert.match(lapSystem, /const validLap = completedLap && state\.recording\.leng
 assert.match(lapSystem, /if \(completedLap\) \{\s*publishLapResult/s, 'Every completed lap must publish a result, including last place and unsaved replays');
 assert.doesNotMatch(lapSystem, /TOP ['"] \+|NEW BEST|showMessage\?\.\(message\)/, 'The retired duplicate lap-ranking message must stay removed');
 assert.match(lapSystem, /raceRivals\.filter\(\(lap\) => lap\.time < finishedTime\)\.length/, 'Finish placement must be calculated against the rivals from the completed race');
+assert.match(gameState, /state\.lapInvalid = false/, 'Restart Lap and race staging must clear invalid-lap status');
+assert.match(hud, /lapInvalid \? 'INVALID LAP' : formatTime\(state\.lapElapsed\)/, 'The TIME card must stop displaying a running time once the lap is invalid');
+assert.match(hud, /classList\.toggle\('is-invalid-lap', lapInvalid\)/, 'The TIME card must expose a persistent invalid visual state');
+assert.match(styles, /\.chip\.is-invalid-lap \{\s*background: #ff6b6b;/s, 'Invalid laps must turn the TIME card red');
+assert.match(styles, /\.chip\.is-invalid-lap strong/, 'INVALID LAP must have dedicated compact typography');
 assert.match(toast, /TOAST_VISIBLE_MS = 4000/, 'The result should remain readable for a few seconds');
 assert.match(toast, /LAST LAP/, 'Valid laps must keep the requested result label');
 assert.match(toast, /LAP INVALID/, 'Invalid laps must replace LAST LAP with an explicit failure label');
@@ -181,4 +192,4 @@ assert.match(onboardingCss, /\.rival-onboarding-copy/, 'The CHASE YOUR BEST copy
 assert.match(onboardingCss, /background: var\(--rival-onboarding-color, var\(--yellow\)\)/, 'The onboarding plate must expose the rival colour through a CSS custom property');
 assert.match(onboardingCss, /border-radius: 999px/, 'The onboarding must keep the compact pill-plate language of the old READY message');
 
-console.log('TURN unified lap feedback and rotating first-rival onboarding regression passed.');
+console.log('TURN persistent INVALID LAP HUD, unified lap feedback and first-rival onboarding regression passed.');

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -20,13 +20,13 @@ const [index, css, orientationGuardCss, orientationCompat, camera] = await Promi
   fs.readFile(new URL('../../turn/render/camera.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.23 · Build 2026\.07\.22-r40/);
+assert.match(index, /TURN v1\.3\.24 · Build 2026\.07\.22-r41/);
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260722-r40/);
-assert.match(index, /orientation-guard\.css\?build=20260722-r40/);
-assert.match(index, /orientation-compat\.js\?build=20260722-r40/);
-assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r40 must preserve the guarded race camera cache redirect');
+assert.match(index, /manual-steering\.css\?build=20260722-r41/);
+assert.match(index, /orientation-guard\.css\?build=20260722-r41/);
+assert.match(index, /orientation-compat\.js\?build=20260722-r41/);
+assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r41 must preserve the guarded race camera cache redirect');
 assert.match(index, /<strong>Rotate to landscape<\/strong>/, 'The pre-race landscape instruction must remain available');
 
 assert.match(css, /--manual-steer-left/);

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -34,7 +34,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.23 · Build 2026\.07\.22-r40/);
+assert.match(index, /TURN v1\.3\.24 · Build 2026\.07\.22-r41/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -61,7 +61,7 @@ const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, m
   fs.readFile(new URL('../../turn/orientation-compat.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.23 · Build 2026\.07\.22-r40/);
+assert.match(index, /TURN v1\.3\.24 · Build 2026\.07\.22-r41/);
 assert.match(main, /mainSceneOcclusion/);
 assert.match(main, /HUD_UPDATE_INTERVAL_MS = 1000 \/ 30/);
 assert.match(main, /recordPerformanceFrame/);

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r40 first-rival 3D ghost reveal -->
+<!-- TURN r41 persistent invalid-lap HUD state -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,34 +10,34 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.23 · Build 2026.07.22-r40</title>
+  <title>TURN v1.3.24 · Build 2026.07.22-r41</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.23',
-      id: '2026.07.22-r40',
-      cacheKey: '20260722-r40'
+      version: '1.3.24',
+      id: '2026.07.22-r41',
+      cacheKey: '20260722-r41'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260722-r40">
-  <link rel="stylesheet" href="./styles.css?build=20260722-r40">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260722-r40">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260722-r40">
-  <link rel="stylesheet" href="./install-gate.css?build=20260722-r40">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260722-r40">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260722-r40">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260722-r40">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260722-r40">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260722-r40">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260722-r40">
-  <link rel="stylesheet" href="./orientation-guard.css?build=20260722-r40">
-  <link rel="stylesheet" href="./lap-result-toast.css?build=20260722-r40">
-  <link rel="stylesheet" href="./rival-onboarding.css?build=20260722-r40">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260722-r40">
+  <link rel="manifest" href="./site.webmanifest?build=20260722-r41">
+  <link rel="stylesheet" href="./styles.css?build=20260722-r41">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260722-r41">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260722-r41">
+  <link rel="stylesheet" href="./install-gate.css?build=20260722-r41">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260722-r41">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260722-r41">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260722-r41">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260722-r41">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260722-r41">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260722-r41">
+  <link rel="stylesheet" href="./orientation-guard.css?build=20260722-r41">
+  <link rel="stylesheet" href="./lap-result-toast.css?build=20260722-r41">
+  <link rel="stylesheet" href="./rival-onboarding.css?build=20260722-r41">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260722-r41">
 
-  <script src="./install-gate.js?build=20260722-r40"></script>
-  <script src="./orientation-compat.js?build=20260722-r40"></script>
+  <script src="./install-gate.js?build=20260722-r41"></script>
+  <script src="./orientation-compat.js?build=20260722-r41"></script>
   <script type="importmap">
     {
       "imports": {
@@ -45,8 +45,8 @@
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-r10.js?build=20260720-r25",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260721-r29",
-        "./race/lap-system.js?build=20260720-r19": "./race/lap-system.js?build=20260721-r38",
-        "./race/game-state.js": "./race/game-state.js?build=20260722-r39",
+        "./race/lap-system.js?build=20260720-r19": "./race/lap-system.js?build=20260722-r41",
+        "./race/game-state.js": "./race/game-state.js?build=20260722-r41",
         "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260721-r35",
         "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260721-r35",
         "./vehicle/car-models.js?build=20260720-r19": "./vehicle/car-models.js?build=20260720-r22"
@@ -62,7 +62,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.23 · Build 2026.07.22-r40</span>
+        <span class="install-kicker">TURN v1.3.24 · Build 2026.07.22-r41</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -90,7 +90,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.23 · Build 2026.07.22-r40</span>
+      <span class="kicker">TURN v1.3.24 · Build 2026.07.22-r41</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -156,6 +156,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260722-r40"></script>
+  <script type="module" src="./app.js?build=20260722-r41"></script>
 </body>
 </html>

--- a/turn/race/game-state.js
+++ b/turn/race/game-state.js
@@ -9,6 +9,7 @@ export function installGameModeState(state) {
   state.lapCheckpointIndex = Number.isFinite(state.lapCheckpointIndex) ? state.lapCheckpointIndex : 0;
   state.lapStartedAt = Number.isFinite(state.lapStartedAt) ? state.lapStartedAt : 0;
   state.lapElapsed = Number.isFinite(state.lapElapsed) ? state.lapElapsed : 0;
+  state.lapInvalid = state.lapInvalid === true;
   state.recording = Array.isArray(state.recording) ? state.recording : [];
   state.lapPreviousPosition = validPosition(state.lapPreviousPosition)
     ? { x: Number(state.lapPreviousPosition.x), z: Number(state.lapPreviousPosition.z) }
@@ -62,6 +63,7 @@ export function resetRaceToStage({
   state.lastProgress = state.progress;
   state.nearestTrackIndex = startIndex;
   state.lapCheckpointIndex = 0;
+  state.lapInvalid = false;
   state.lapActive = false;
   state.lapStartedAt = 0;
   state.lapElapsed = 0;
@@ -72,6 +74,7 @@ export function resetRaceToStage({
 }
 
 export function prepareRaceStartState(state) {
+  state.lapInvalid = false;
   state.lapStartedAt = 0;
   state.lapElapsed = 0;
 }

--- a/turn/race/lap-system.js
+++ b/turn/race/lap-system.js
@@ -28,6 +28,7 @@ export function beginTimedLapState({ state, samples, now, showMessage }) {
 
   state.lapActive = true;
   state.lapCheckpointIndex = 0;
+  state.lapInvalid = false;
   state.lapStartedAt = now;
   state.lapElapsed = 0;
   state.lapPreviousPosition = snapshotPosition(state.position);
@@ -61,7 +62,7 @@ export function updateLapProgressState({
   const startGateHalfWidth = trackWidth * START_GATE_HALF_WIDTH_FACTOR;
   const nextCheckpoint = checkpoints[state.lapCheckpointIndex];
 
-  if (state.lapActive && nextCheckpoint != null) {
+  if (state.lapActive && !state.lapInvalid && nextCheckpoint != null) {
     const checkpointSample = checkpointSampleAt(samples, nextCheckpoint);
     const movingForwardThroughGate = state.velocity.dot(checkpointSample.tangent) > 2;
     const crossedCheckpointGate = crossedForwardGate(
@@ -77,6 +78,18 @@ export function updateLapProgressState({
 
     if (movingForwardThroughGate && (crossedCheckpointGate || insideCheckpointGate)) {
       state.lapCheckpointIndex += 1;
+    } else if (crossedLaterCheckpointGate({
+      state,
+      previousPosition,
+      currentPosition,
+      samples,
+      checkpoints,
+      checkpointGateHalfWidth
+    })) {
+      // Crossing a later ordered gate proves that the required route was skipped.
+      // Keep timing internally for rival playback, but the HUD can stop presenting
+      // the attempt as a meaningful lap time from this point onward.
+      state.lapInvalid = true;
     }
   }
 
@@ -98,7 +111,7 @@ export function updateLapProgressState({
   if (crossedStartOnTrack) {
     if (!state.lapActive) {
       beginTimedLap(now);
-    } else if (state.lapCheckpointIndex >= checkpoints.length) {
+    } else if (!state.lapInvalid && state.lapCheckpointIndex >= checkpoints.length) {
       completeLap(now);
     } else {
       publishLapInvalid({ reason: 'missed-checkpoint' });
@@ -185,6 +198,7 @@ export function completeLapState({
   }
 
   state.lapCheckpointIndex = 0;
+  state.lapInvalid = false;
   state.lapActive = true;
   state.lap += 1;
   state.lapStartedAt = now;
@@ -231,6 +245,22 @@ export function crossedForwardGate(previousPosition, currentPosition, gateSample
   const lateralDistance = Math.abs((crossingX - centerX) * nx + (crossingZ - centerZ) * nz);
 
   return lateralDistance <= halfWidth;
+}
+
+function crossedLaterCheckpointGate({
+  state,
+  previousPosition,
+  currentPosition,
+  samples,
+  checkpoints,
+  checkpointGateHalfWidth
+}) {
+  for (let index = state.lapCheckpointIndex + 1; index < checkpoints.length; index += 1) {
+    const sample = checkpointSampleAt(samples, checkpoints[index]);
+    if (state.velocity.dot(sample.tangent) <= 2) continue;
+    if (crossedForwardGate(previousPosition, currentPosition, sample, checkpointGateHalfWidth)) return true;
+  }
+  return false;
 }
 
 function publishLapResult(detail) {

--- a/turn/styles.css
+++ b/turn/styles.css
@@ -236,6 +236,16 @@ h1 {
   letter-spacing: -0.04em;
 }
 
+.chip.is-invalid-lap {
+  background: #ff6b6b;
+}
+
+.chip.is-invalid-lap strong {
+  white-space: nowrap;
+  font-size: clamp(0.82rem, 2.2vw, 1.2rem);
+  letter-spacing: -0.025em;
+}
+
 .map-wrap {
   width: min(24vw, 184px);
   aspect-ratio: 1.45;
@@ -401,6 +411,7 @@ h1 {
 @media (max-height: 430px) {
   .chip { min-width: 70px; padding: 5px 7px 6px; }
   .chip strong { font-size: 0.95rem; }
+  .chip.is-invalid-lap strong { font-size: 0.82rem; }
   .map-wrap { width: min(21vw, 142px); }
   .message { top: 17%; }
   .tilt-drive { width: min(34vw, 240px); bottom: 8px; }

--- a/turn/ui/hud.js
+++ b/turn/ui/hud.js
@@ -17,10 +17,12 @@ export function updateHudState({
   findNearestTrack,
   setRacePosition
 }) {
+  const lapInvalid = state.lapActive && state.lapInvalid === true;
   setText(speedEl, Math.round(state.speed * 3.6));
   setText(lapEl, state.lap);
-  setText(lapTimeEl, formatTime(state.lapElapsed));
+  setText(lapTimeEl, lapInvalid ? 'INVALID LAP' : formatTime(state.lapElapsed));
   setText(bestTimeEl, formatTime(state.bestTime));
+  lapTimeEl.closest?.('.chip')?.classList.toggle('is-invalid-lap', lapInvalid);
 
   const driveDisplay = state.throttle >= state.brake ? state.throttle : -state.brake;
   const drivePercent = Math.round(driveDisplay * 100);


### PR DESCRIPTION
## Summary

Makes the TIME HUD card switch to `INVALID LAP` as soon as TURN has concrete proof that the current attempt skipped the required route.

## Behavior

- A lap becomes persistently invalid when the player crosses a later ordered checkpoint gate before the checkpoint currently required.
- Broad off-road lines remain allowed as long as the player still reaches the required gate before a later one.
- The TIME card turns red and shows `INVALID LAP` instead of a ticking time for the rest of that attempt.
- Internal elapsed time continues only so rival playback and race position can keep functioning normally.
- Crossing the finish line still shows the existing `LAP INVALID / STAY ON THE TRACK!` result feedback.
- A new lap, a valid completed lap, and `RESTART LAP` all clear the invalid state immediately.

## Regression coverage

- Later-gate-before-required-gate invalidation.
- Ordered checkpoint chain remains unchanged.
- Restart clears invalid state.
- TIME card uses exact `INVALID LAP` wording and red visual treatment.
- Existing lap, ghost, orientation, garage, drive-pad, sound and performance contracts remain protected.

## Release

TURN v1.3.24 · Build 2026.07.22-r41