### PR TITLE
TURN v1.3.25 r42: Reduce Monster Truck visual scale

### DIFF
--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -10,17 +10,17 @@ const [index, app, audio, controls, catalogSource] = await Promise.all([
 ]);
 const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
 
-assert.match(index, /TURN v1\.3\.24 · Build 2026\.07\.22-r41/);
-assert.match(index, /\.\/app\.js\?build=20260722-r41/);
+assert.match(index, /TURN v1\.3\.25 · Build 2026\.07\.22-r42/);
+assert.match(index, /\.\/app\.js\?build=20260722-r42/);
 assert.match(
   index,
-  /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r35"/,
-  'The main runtime catalog import must preserve the r35 orientation correction'
+  /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/,
+  'The main runtime catalog import must use the r42 vehicle presentation catalog'
 );
 assert.match(
   index,
-  /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260721-r35"/,
-  'The Lot catalog import must use the same corrected r35 catalog'
+  /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/,
+  'The Lot must use the same r42 vehicle presentation catalog'
 );
 
 assert.match(app, /import\(withBuild\('\.\/audio\/audio-system\.js'\)\)/, 'Production must load the central audio module');

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -69,7 +69,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.24 · Build 2026\.07\.22-r41/);
+assert.match(index, /TURN v1\.3\.25 · Build 2026\.07\.22-r42/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -20,9 +20,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.24 · Build 2026\.07\.22-r41/);
-assert.match(index, /drive-pad\.css\?build=20260722-r41/);
-assert.match(index, /gameplay-v2\.css\?build=20260722-r41/);
+assert.match(index, /TURN v1\.3\.25 · Build 2026\.07\.22-r42/);
+assert.match(index, /drive-pad\.css\?build=20260722-r42/);
+assert.match(index, /gameplay-v2\.css\?build=20260722-r42/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -17,6 +17,8 @@ assert.equal(brickFiles.length, 9, 'The vendored Kenney Brick Kit subset should 
 const sedan = catalog.getCarDefinition('sedan');
 const race = catalog.getCarDefinition('race');
 const truck = catalog.getCarDefinition('truck');
+const monsterTruck = catalog.getCarDefinition('monster-truck');
+assert.equal(monsterTruck.visualScale, 0.83, 'Monster Truck must stay at the reduced visual scale so it fits the shared 3D viewer and race field');
 assert.equal(sedan.tuning.topSpeedMultiplier, 1, 'Sedan top speed must remain the v1.0 baseline');
 assert.equal(sedan.tuning.accelerationMultiplier, 1, 'Sedan acceleration must remain the v1.0 baseline');
 assert.equal(sedan.tuning.controlMultiplier, 1, 'Sedan control must remain the v1.0 baseline');
@@ -47,10 +49,11 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.24 · Build 2026\.07\.22-r41/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260722-r41/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r41 must preserve the latest Lot module cache redirect');
-assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260721-r35"/, 'r41 must preserve the corrected Vintage Racer orientation');
+assert.match(index, /TURN v1\.3\.25 · Build 2026\.07\.22-r42/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260722-r42/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r42 must preserve the latest Lot module cache redirect');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r42 must serve the reduced Monster Truck scale to the main runtime');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r42 must serve the same reduced Monster Truck scale inside The Lot');
 assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -26,8 +26,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.24 · Build 2026\.07\.22-r41/);
-assert.match(index, /in-game-menu\.css\?build=20260722-r41/);
+assert.match(index, /TURN v1\.3\.25 · Build 2026\.07\.22-r42/);
+assert.match(index, /in-game-menu\.css\?build=20260722-r42/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Restart Lap<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -134,11 +134,11 @@ const [index, app, lapSystem, gameState, hud, styles, toast, toastCss, onboardin
   fs.readFile(new URL('../../turn/rival-onboarding.css', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.24 · Build 2026\.07\.22-r41/);
-assert.match(index, /lap-result-toast\.css\?build=20260722-r41/);
-assert.match(index, /rival-onboarding\.css\?build=20260722-r41/);
-assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260722-r41"/, 'r41 must serve the early invalid-lap detector');
-assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r41"/, 'r41 must serve reset-safe invalid-lap state');
+assert.match(index, /TURN v1\.3\.25 · Build 2026\.07\.22-r42/);
+assert.match(index, /lap-result-toast\.css\?build=20260722-r42/);
+assert.match(index, /rival-onboarding\.css\?build=20260722-r42/);
+assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260722-r41"/, 'r42 must preserve the r41 early invalid-lap detector');
+assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r41"/, 'r42 must preserve the r41 reset-safe invalid-lap state');
 assert.match(app, /installLapResultToast\(\)/, 'The lap result toast must install before the game runtime starts');
 assert.match(app, /installRivalOnboarding\(\)/, 'The rival onboarding plate must install before the game runtime starts');
 assert.match(lapSystem, /turn:lap-result/, 'Completed lap finish must publish one frozen result event');

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -20,13 +20,13 @@ const [index, css, orientationGuardCss, orientationCompat, camera] = await Promi
   fs.readFile(new URL('../../turn/render/camera.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.24 · Build 2026\.07\.22-r41/);
+assert.match(index, /TURN v1\.3\.25 · Build 2026\.07\.22-r42/);
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260722-r41/);
-assert.match(index, /orientation-guard\.css\?build=20260722-r41/);
-assert.match(index, /orientation-compat\.js\?build=20260722-r41/);
-assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r41 must preserve the guarded race camera cache redirect');
+assert.match(index, /manual-steering\.css\?build=20260722-r42/);
+assert.match(index, /orientation-guard\.css\?build=20260722-r42/);
+assert.match(index, /orientation-compat\.js\?build=20260722-r42/);
+assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r42 must preserve the guarded race camera cache redirect');
 assert.match(index, /<strong>Rotate to landscape<\/strong>/, 'The pre-race landscape instruction must remain available');
 
 assert.match(css, /--manual-steer-left/);

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -34,7 +34,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.24 · Build 2026\.07\.22-r41/);
+assert.match(index, /TURN v1\.3\.25 · Build 2026\.07\.22-r42/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -61,7 +61,7 @@ const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, m
   fs.readFile(new URL('../../turn/orientation-compat.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.24 · Build 2026\.07\.22-r41/);
+assert.match(index, /TURN v1\.3\.25 · Build 2026\.07\.22-r42/);
 assert.match(main, /mainSceneOcclusion/);
 assert.match(main, /HUD_UPDATE_INTERVAL_MS = 1000 \/ 30/);
 assert.match(main, /recordPerformanceFrame/);

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r41 persistent invalid-lap HUD state -->
+<!-- TURN r42 smaller Monster Truck visual scale -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,34 +10,34 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.24 · Build 2026.07.22-r41</title>
+  <title>TURN v1.3.25 · Build 2026.07.22-r42</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.24',
-      id: '2026.07.22-r41',
-      cacheKey: '20260722-r41'
+      version: '1.3.25',
+      id: '2026.07.22-r42',
+      cacheKey: '20260722-r42'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260722-r41">
-  <link rel="stylesheet" href="./styles.css?build=20260722-r41">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260722-r41">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260722-r41">
-  <link rel="stylesheet" href="./install-gate.css?build=20260722-r41">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260722-r41">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260722-r41">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260722-r41">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260722-r41">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260722-r41">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260722-r41">
-  <link rel="stylesheet" href="./orientation-guard.css?build=20260722-r41">
-  <link rel="stylesheet" href="./lap-result-toast.css?build=20260722-r41">
-  <link rel="stylesheet" href="./rival-onboarding.css?build=20260722-r41">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260722-r41">
+  <link rel="manifest" href="./site.webmanifest?build=20260722-r42">
+  <link rel="stylesheet" href="./styles.css?build=20260722-r42">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260722-r42">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260722-r42">
+  <link rel="stylesheet" href="./install-gate.css?build=20260722-r42">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260722-r42">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260722-r42">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260722-r42">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260722-r42">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260722-r42">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260722-r42">
+  <link rel="stylesheet" href="./orientation-guard.css?build=20260722-r42">
+  <link rel="stylesheet" href="./lap-result-toast.css?build=20260722-r42">
+  <link rel="stylesheet" href="./rival-onboarding.css?build=20260722-r42">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260722-r42">
 
-  <script src="./install-gate.js?build=20260722-r41"></script>
-  <script src="./orientation-compat.js?build=20260722-r41"></script>
+  <script src="./install-gate.js?build=20260722-r42"></script>
+  <script src="./orientation-compat.js?build=20260722-r42"></script>
   <script type="importmap">
     {
       "imports": {
@@ -47,8 +47,8 @@
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260721-r29",
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system.js?build=20260722-r41",
         "./race/game-state.js": "./race/game-state.js?build=20260722-r41",
-        "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260721-r35",
-        "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260721-r35",
+        "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260722-r42",
+        "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260722-r42",
         "./vehicle/car-models.js?build=20260720-r19": "./vehicle/car-models.js?build=20260720-r22"
       }
     }
@@ -62,7 +62,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.24 · Build 2026.07.22-r41</span>
+        <span class="install-kicker">TURN v1.3.25 · Build 2026.07.22-r42</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -90,7 +90,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.24 · Build 2026.07.22-r41</span>
+      <span class="kicker">TURN v1.3.25 · Build 2026.07.22-r42</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -156,6 +156,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260722-r41"></script>
+  <script type="module" src="./app.js?build=20260722-r42"></script>
 </body>
 </html>

--- a/turn/vehicle/catalog.js
+++ b/turn/vehicle/catalog.js
@@ -25,7 +25,7 @@ const RAW_CARS = [
   ['classic', 'Classic', 'prototype', { speed: 3, acceleration: 2, control: 4, drift: 4, boostPower: 2, boostDuration: 3 }, 1.00, 1, 0.88],
   ['vintage-racer', 'Vintage Racer', 'toy', { speed: 5, acceleration: 4, control: 3, drift: 2, boostPower: 3, boostDuration: 1 }, 0.96, 0, 1.28],
   ['toy-racer', 'Toy Racer', 'toy', { speed: 4, acceleration: 5, control: 5, drift: 1, boostPower: 2, boostDuration: 1 }, 0.94, 2, 1.18],
-  ['monster-truck', 'Monster Truck', 'toy', { speed: 2, acceleration: 3, control: 2, drift: 5, boostPower: 2, boostDuration: 4 }, 1.18, 2, 0.62],
+  ['monster-truck', 'Monster Truck', 'toy', { speed: 2, acceleration: 3, control: 2, drift: 5, boostPower: 2, boostDuration: 4 }, 0.83, 2, 0.62],
   ['race-future', 'Future Racer', 'car', { speed: 5, acceleration: 5, control: 3, drift: 1, boostPower: 3, boostDuration: 1 }, 0.96, 0, 1.42],
   ['race', 'Race Car', 'car', { speed: 5, acceleration: 4, control: 4, drift: 1, boostPower: 3, boostDuration: 1 }, 0.94, 0, 1.55],
   ['sedan-sports', 'Sport Sedan', 'car', { speed: 4, acceleration: 4, control: 4, drift: 2, boostPower: 2, boostDuration: 2 }, 0.98, 0, 1.12],


### PR DESCRIPTION
## Summary

Reduces the Monster Truck's shared visual scale from `1.18` to `0.83`, approximately 30% smaller.

## Why

The Monster Truck was noticeably oversized compared with the rest of the vehicle field and did not fit comfortably inside the shared 3D viewer.

## Behavior

- Uses the existing per-car `visualScale` in the shared vehicle catalog.
- The smaller scale therefore applies consistently in The Lot, the 3D viewer, races, ghosts, Spectate and first-rival onboarding.
- Vehicle stats, tuning, physics and handling are unchanged.
- r42 cache redirects force both the main runtime and The Lot to load the updated catalog.

## Regression coverage

- Locks the Monster Truck visual scale to `0.83`.
- Preserves the existing 15-car catalog, stat balance, Lot presentation and shared model pipeline.

## Release

TURN v1.3.25 · Build 2026.07.22-r42