### PR TITLE
TURN v1.3.26 r43: Performance measurement headroom

### DIFF
--- a/turn-lab/PERFORMANCE.md
+++ b/turn-lab/PERFORMANCE.md
@@ -2,9 +2,27 @@
 
 TURN's production build exposes diagnostics only when the page is opened with `?perf=1`.
 The overlay reports frame rate, p50/p95 frame interval, frames slower than 33 ms,
-draw calls, triangles, GPU resource counts, device pixel ratio and average track-index
-checks per query. The latest sample is also available through
+draw calls, triangles, GPU resource counts, actual device pixel ratio, the active renderer
+profile and average track-index checks per query. The latest sample is also available through
 `globalThis.__turnGetPerfSnapshot()` and the `turn:perf-snapshot` browser event.
+
+## Renderer A/B profiles
+
+Normal TURN keeps the production renderer unchanged. Renderer overrides are only honored when
+`perf=1` is present, so the same release can be measured without changing the normal player build.
+
+Append these query strings to `/turn/`:
+
+- `?perf=1` — production baseline: DPR cap 2.0, 1024 shadow map.
+- `?perf=1&dpr=1.5` — lower WebGL resolution only.
+- `?perf=1&dpr=1.25` — stronger resolution reduction for comparison.
+- `?perf=1&shadow=512` — smaller shadow map only.
+- `?perf=1&dpr=1.5&shadow=512` — combined candidate profile.
+- `?perf=1&shadow=off` — diagnostic ceiling with dynamic shadows disabled.
+
+The overlay prints the requested profile and the renderer's actual DPR, so screenshots remain
+self-describing. DPR values are clamped to 0.75–2.0 and supported shadow-map sizes are 256, 512
+and 1024.
 
 ## Target-device pass
 
@@ -17,6 +35,10 @@ have loaded:
 4. Sustained drift and boost effects.
 5. The Lot with the 3D viewer open, then closed.
 6. Spectate with four rivals.
+
+For the iPad 9 baseline, run the production profile first, then repeat the most demanding
+four-rival race with DPR 1.5, shadows 512, and the combined DPR 1.5 + shadows 512 profile.
+Only run DPR 1.25 and shadows-off if the first comparison does not clearly identify the bottleneck.
 
 Record the final snapshot for each scenario together with the device and OS version.
 For the inclusive-device baseline, include a 9th-generation iPad or comparable hardware.

--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -10,17 +10,17 @@ const [index, app, audio, controls, catalogSource] = await Promise.all([
 ]);
 const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
 
-assert.match(index, /TURN v1\.3\.25 · Build 2026\.07\.22-r42/);
-assert.match(index, /\.\/app\.js\?build=20260722-r42/);
+assert.match(index, /TURN v1\.3\.26 · Build 2026\.07\.22-r43/);
+assert.match(index, /\.\/app\.js\?build=20260722-r43/);
 assert.match(
   index,
   /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/,
-  'The main runtime catalog import must use the r42 vehicle presentation catalog'
+  'The main runtime catalog import must preserve the r42 vehicle presentation catalog'
 );
 assert.match(
   index,
   /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/,
-  'The Lot must use the same r42 vehicle presentation catalog'
+  'The Lot must preserve the same r42 vehicle presentation catalog'
 );
 
 assert.match(app, /import\(withBuild\('\.\/audio\/audio-system\.js'\)\)/, 'Production must load the central audio module');

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -69,7 +69,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.25 · Build 2026\.07\.22-r42/);
+assert.match(index, /TURN v1\.3\.26 · Build 2026\.07\.22-r43/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -20,9 +20,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.25 · Build 2026\.07\.22-r42/);
-assert.match(index, /drive-pad\.css\?build=20260722-r42/);
-assert.match(index, /gameplay-v2\.css\?build=20260722-r42/);
+assert.match(index, /TURN v1\.3\.26 · Build 2026\.07\.22-r43/);
+assert.match(index, /drive-pad\.css\?build=20260722-r43/);
+assert.match(index, /gameplay-v2\.css\?build=20260722-r43/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -49,11 +49,11 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.25 · Build 2026\.07\.22-r42/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260722-r42/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r42 must preserve the latest Lot module cache redirect');
-assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r42 must serve the reduced Monster Truck scale to the main runtime');
-assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r42 must serve the same reduced Monster Truck scale inside The Lot');
+assert.match(index, /TURN v1\.3\.26 · Build 2026\.07\.22-r43/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260722-r43/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r43 must preserve the latest Lot module cache redirect');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r43 must preserve the reduced Monster Truck scale in the main runtime');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r43 must preserve the same reduced Monster Truck scale inside The Lot');
 assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -26,8 +26,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.25 · Build 2026\.07\.22-r42/);
-assert.match(index, /in-game-menu\.css\?build=20260722-r42/);
+assert.match(index, /TURN v1\.3\.26 · Build 2026\.07\.22-r43/);
+assert.match(index, /in-game-menu\.css\?build=20260722-r43/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Restart Lap<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -134,11 +134,11 @@ const [index, app, lapSystem, gameState, hud, styles, toast, toastCss, onboardin
   fs.readFile(new URL('../../turn/rival-onboarding.css', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.25 · Build 2026\.07\.22-r42/);
-assert.match(index, /lap-result-toast\.css\?build=20260722-r42/);
-assert.match(index, /rival-onboarding\.css\?build=20260722-r42/);
-assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260722-r41"/, 'r42 must preserve the r41 early invalid-lap detector');
-assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r41"/, 'r42 must preserve the r41 reset-safe invalid-lap state');
+assert.match(index, /TURN v1\.3\.26 · Build 2026\.07\.22-r43/);
+assert.match(index, /lap-result-toast\.css\?build=20260722-r43/);
+assert.match(index, /rival-onboarding\.css\?build=20260722-r43/);
+assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260722-r41"/, 'r43 must preserve the r41 early invalid-lap detector');
+assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r41"/, 'r43 must preserve the r41 reset-safe invalid-lap state');
 assert.match(app, /installLapResultToast\(\)/, 'The lap result toast must install before the game runtime starts');
 assert.match(app, /installRivalOnboarding\(\)/, 'The rival onboarding plate must install before the game runtime starts');
 assert.match(lapSystem, /turn:lap-result/, 'Completed lap finish must publish one frozen result event');

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -20,13 +20,13 @@ const [index, css, orientationGuardCss, orientationCompat, camera] = await Promi
   fs.readFile(new URL('../../turn/render/camera.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.25 · Build 2026\.07\.22-r42/);
+assert.match(index, /TURN v1\.3\.26 · Build 2026\.07\.22-r43/);
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260722-r42/);
-assert.match(index, /orientation-guard\.css\?build=20260722-r42/);
-assert.match(index, /orientation-compat\.js\?build=20260722-r42/);
-assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r42 must preserve the guarded race camera cache redirect');
+assert.match(index, /manual-steering\.css\?build=20260722-r43/);
+assert.match(index, /orientation-guard\.css\?build=20260722-r43/);
+assert.match(index, /orientation-compat\.js\?build=20260722-r43/);
+assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r43 must preserve the guarded race camera cache redirect');
 assert.match(index, /<strong>Rotate to landscape<\/strong>/, 'The pre-race landscape instruction must remain available');
 
 assert.match(css, /--manual-steer-left/);

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -34,7 +34,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.25 · Build 2026\.07\.22-r42/);
+assert.match(index, /TURN v1\.3\.26 · Build 2026\.07\.22-r43/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import { createTrackSpatialIndex, findNearestTrackBruteForce } from '../../turn/race/track-spatial-index.js';
 import { performanceModeRequested, summarizeFrameSamples } from '../../turn/performance-monitor.js';
+import { performanceProfileFromSearch } from '../../turn/performance-profile.js';
+import { replayFrameAt } from '../../turn/race/replay-system.js';
 
 const samples = Array.from({ length: 720 }, (_, index) => {
   const angle = index / 720 * Math.PI * 2;
@@ -38,6 +40,54 @@ assert.equal(fallback.checks, samples.length);
 assert.equal(performanceModeRequested('?perf=1'), true);
 assert.equal(performanceModeRequested('?perf=0'), false);
 assert.equal(performanceModeRequested(''), false);
+
+const baselineProfile = performanceProfileFromSearch('?perf=1', 2);
+assert.equal(baselineProfile.active, false, 'Perf diagnostics alone must not change normal rendering');
+assert.equal(baselineProfile.dprCap, 2);
+assert.equal(baselineProfile.pixelRatio, 2);
+assert.equal(baselineProfile.shadowsEnabled, true);
+assert.equal(baselineProfile.shadowMapSize, 1024);
+
+const dprProfile = performanceProfileFromSearch('?perf=1&dpr=1.5', 2);
+assert.equal(dprProfile.active, true);
+assert.equal(dprProfile.dprCap, 1.5);
+assert.equal(dprProfile.pixelRatio, 1.5);
+assert.match(dprProfile.label, /DPR≤1\.50/);
+
+const lowDprProfile = performanceProfileFromSearch('?perf=1&dpr=0.2', 2);
+assert.equal(lowDprProfile.dprCap, 0.75, 'Diagnostic DPR overrides must stay within the safe lower bound');
+const highDprProfile = performanceProfileFromSearch('?perf=1&dpr=9', 3);
+assert.equal(highDprProfile.dprCap, 2, 'Diagnostic DPR overrides must never exceed the production cap');
+
+const shadowProfile = performanceProfileFromSearch('?perf=1&shadow=512', 2);
+assert.equal(shadowProfile.active, true);
+assert.equal(shadowProfile.shadowsEnabled, true);
+assert.equal(shadowProfile.shadowMapSize, 512);
+const noShadowProfile = performanceProfileFromSearch('?perf=1&shadow=off', 2);
+assert.equal(noShadowProfile.shadowsEnabled, false);
+assert.match(noShadowProfile.label, /shadows off/);
+const ignoredProfile = performanceProfileFromSearch('?dpr=1&shadow=off', 2);
+assert.equal(ignoredProfile.active, false, 'Renderer overrides must be ignored outside explicit perf mode');
+assert.equal(ignoredProfile.dprCap, 2);
+assert.equal(ignoredProfile.shadowsEnabled, true);
+
+const replayLap = {
+  time: 2,
+  frames: [
+    { t: 0, x: 0, z: 0, h: 0, s: 0, d: 0, p: 0 },
+    { t: 1, x: 10, z: 20, h: 0.5, s: 0.2, d: 0.4, p: 0.5 },
+    { t: 2, x: 20, z: 40, h: 1, s: 0.4, d: 0.8, p: 1 }
+  ]
+};
+const firstReplaySample = replayFrameAt(replayLap, 0.5);
+const repeatedReplaySample = replayFrameAt(replayLap, 0.5);
+assert.strictEqual(repeatedReplaySample, firstReplaySample, 'Repeated same-time rival sampling must reuse one interpolated frame');
+const laterReplaySample = replayFrameAt(replayLap, 0.6);
+assert.notStrictEqual(laterReplaySample, firstReplaySample, 'A new replay time must produce a fresh interpolation');
+replayLap.frames.push({ t: 3, x: 30, z: 60, h: 1.5, s: 0.6, d: 1, p: 1.5 });
+const changedReplaySample = replayFrameAt(replayLap, 0.6);
+assert.notStrictEqual(changedReplaySample, laterReplaySample, 'Changing the replay frame list must invalidate the one-sample cache');
+
 const summary = summarizeFrameSamples([10, 20, 30, 40, 50]);
 assert.equal(summary.averageMs, 30);
 assert.equal(summary.p50Ms, 30);
@@ -45,8 +95,9 @@ assert.equal(summary.p95Ms, 50);
 assert.equal(summary.slowPercent, 40);
 assert.ok(Math.abs(summary.fps - 1000 / 30) < 1e-9);
 
-const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, monitor, audio, orientationCompat] = await Promise.all([
+const [index, app, main, controls, menu, spectate, hud, physics, camera, cars, lot, monitor, profile, replay, audio, orientationCompat] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/ui/gameplay-controls.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/ui/in-game-menu.js', import.meta.url), 'utf8'),
@@ -57,11 +108,25 @@ const [index, main, controls, menu, spectate, hud, physics, camera, cars, lot, m
   fs.readFile(new URL('../../turn/vehicle/car-models.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-r10.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/performance-monitor.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/performance-profile.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/race/replay-system.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/audio/audio-system.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/orientation-compat.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.25 · Build 2026\.07\.22-r42/);
+assert.match(index, /TURN v1\.3\.26 · Build 2026\.07\.22-r43/);
+assert.match(index, /"\.\/race\/replay-system\.js": "\.\/race\/replay-system\.js\?build=20260722-r43"/, 'r43 must cache-bust the shared replay sampler');
+assert.match(index, /"\.\/performance-monitor\.js\?build=20260720-r19": "\.\/performance-monitor\.js\?build=20260722-r43"/, 'r43 must cache-bust the diagnostics module');
+assert.match(app, /installPerformanceProfile\(\)/, 'Renderer profile interception must install before the game runtime');
+assert.ok(app.indexOf('./performance-profile.js') < app.indexOf('./main.js'), 'Renderer profile interception must be ready before main.js creates the runtime');
+assert.match(profile, /params\.get\('perf'\) === '1'/, 'Renderer overrides must require explicit performance mode');
+assert.match(profile, /renderer\.setPixelRatio = \(value\) =>/, 'The DPR cap must survive TURN resize calls');
+assert.match(profile, /renderer\.shadowMap\.enabled = profile\.shadowsEnabled/, 'Shadow A/B testing must use the existing renderer without a second loop');
+assert.doesNotMatch(profile, /requestAnimationFrame|setAnimationLoop|setInterval/, 'Performance profiles must add no animation loop');
+assert.match(replay, /const replayFrameCache = new WeakMap\(\)/, 'Replay interpolation must cache the last sample per saved lap');
+assert.match(replay, /return cached\.frame/, 'Repeated same-time replay lookups must take the cache fast path');
+assert.match(monitor, /profile: currentPerformanceProfile\(\)/, 'Every performance snapshot must record its active renderer profile');
+assert.match(monitor, /actual DPR/, 'The overlay must distinguish requested profile from actual renderer DPR');
 assert.match(main, /mainSceneOcclusion/);
 assert.match(main, /HUD_UPDATE_INTERVAL_MS = 1000 \/ 30/);
 assert.match(main, /recordPerformanceFrame/);
@@ -87,4 +152,4 @@ assert.doesNotMatch(orientationCompat, /requestAnimationFrame|setAnimationLoop|s
 assert.match(monitor, /turn:perf-snapshot/);
 assert.match(monitor, /trackChecksPerQuery/);
 
-console.log(`TURN production performance and diagnostics regression passed (${(trackChecks / trackQueries).toFixed(1)} average on-track checks vs 720).`);
+console.log(`TURN production performance profiles and diagnostics regression passed (${(trackChecks / trackQueries).toFixed(1)} average on-track checks vs 720).`);

--- a/turn/app.js
+++ b/turn/app.js
@@ -6,6 +6,9 @@ function withBuild(path) {
   return url.href;
 }
 
+const { installPerformanceProfile } = await import(withBuild('./performance-profile.js'));
+installPerformanceProfile();
+
 const { installTurnAudio } = await import(withBuild('./audio/audio-system.js'));
 installTurnAudio();
 

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r42 smaller Monster Truck visual scale -->
+<!-- TURN r43 Measurable performance headroom and renderer A/B profiles -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,34 +10,34 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.25 · Build 2026.07.22-r42</title>
+  <title>TURN v1.3.26 · Build 2026.07.22-r43</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.25',
-      id: '2026.07.22-r42',
-      cacheKey: '20260722-r42'
+      version: '1.3.26',
+      id: '2026.07.22-r43',
+      cacheKey: '20260722-r43'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260722-r42">
-  <link rel="stylesheet" href="./styles.css?build=20260722-r42">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260722-r42">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260722-r42">
-  <link rel="stylesheet" href="./install-gate.css?build=20260722-r42">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260722-r42">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260722-r42">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260722-r42">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260722-r42">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260722-r42">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260722-r42">
-  <link rel="stylesheet" href="./orientation-guard.css?build=20260722-r42">
-  <link rel="stylesheet" href="./lap-result-toast.css?build=20260722-r42">
-  <link rel="stylesheet" href="./rival-onboarding.css?build=20260722-r42">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260722-r42">
+  <link rel="manifest" href="./site.webmanifest?build=20260722-r43">
+  <link rel="stylesheet" href="./styles.css?build=20260722-r43">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260722-r43">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260722-r43">
+  <link rel="stylesheet" href="./install-gate.css?build=20260722-r43">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260722-r43">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260722-r43">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260722-r43">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260722-r43">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260722-r43">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260722-r43">
+  <link rel="stylesheet" href="./orientation-guard.css?build=20260722-r43">
+  <link rel="stylesheet" href="./lap-result-toast.css?build=20260722-r43">
+  <link rel="stylesheet" href="./rival-onboarding.css?build=20260722-r43">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260722-r43">
 
-  <script src="./install-gate.js?build=20260722-r42"></script>
-  <script src="./orientation-compat.js?build=20260722-r42"></script>
+  <script src="./install-gate.js?build=20260722-r43"></script>
+  <script src="./orientation-compat.js?build=20260722-r43"></script>
   <script type="importmap">
     {
       "imports": {
@@ -47,6 +47,8 @@
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260721-r29",
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system.js?build=20260722-r41",
         "./race/game-state.js": "./race/game-state.js?build=20260722-r41",
+        "./race/replay-system.js": "./race/replay-system.js?build=20260722-r43",
+        "./performance-monitor.js?build=20260720-r19": "./performance-monitor.js?build=20260722-r43",
         "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260722-r42",
         "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260722-r42",
         "./vehicle/car-models.js?build=20260720-r19": "./vehicle/car-models.js?build=20260720-r22"
@@ -62,7 +64,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.25 · Build 2026.07.22-r42</span>
+        <span class="install-kicker">TURN v1.3.26 · Build 2026.07.22-r43</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -90,7 +92,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.25 · Build 2026.07.22-r42</span>
+      <span class="kicker">TURN v1.3.26 · Build 2026.07.22-r43</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -156,6 +158,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260722-r42"></script>
+  <script type="module" src="./app.js?build=20260722-r43"></script>
 </body>
 </html>

--- a/turn/performance-monitor.js
+++ b/turn/performance-monitor.js
@@ -98,6 +98,7 @@ export function installPerformanceMonitor({ getMode, getTrackStats } = {}) {
         label: activeLabel,
         mode: getMode?.() || null,
         samples: timeline.count,
+        profile: currentPerformanceProfile(),
         ...summary,
         ...render,
         trackChecksPerQuery: track.average
@@ -113,12 +114,24 @@ export function installPerformanceMonitor({ getMode, getTrackStats } = {}) {
 
   globalThis.__turnPerfMonitor = activeMonitor;
   globalThis.__turnGetPerfSnapshot = () => activeMonitor?.getSnapshot() || null;
-  panel.textContent = 'TURN PERF · collecting…';
+  panel.textContent = `TURN PERF · collecting…\n${currentPerformanceProfile().label}`;
   return activeMonitor;
 }
 
 export function recordPerformanceFrame(label, renderers, now, options) {
   activeMonitor?.record(label, renderers, now, options);
+}
+
+function currentPerformanceProfile() {
+  const profile = globalThis.__turnPerformanceProfile;
+  if (profile?.label) return profile;
+  return Object.freeze({
+    active: false,
+    dprCap: 2,
+    shadowsEnabled: true,
+    shadowMapSize: 1024,
+    label: 'DPR≤2.00 · shadows 1024'
+  });
 }
 
 function normalizeRenderers(renderers) {
@@ -165,9 +178,10 @@ function summarizeTrackChecks(current, previous) {
 function formatSnapshot(snapshot) {
   return [
     `TURN PERF · ${snapshot.label}`,
+    snapshot.profile?.label || 'DPR≤2.00 · shadows 1024',
     `${snapshot.fps.toFixed(1)} fps · p50 ${snapshot.p50Ms.toFixed(1)} · p95 ${snapshot.p95Ms.toFixed(1)} ms`,
     `${snapshot.drawCalls} calls · ${compactNumber(snapshot.triangles)} tris · ${snapshot.renderers} renderer${snapshot.renderers === 1 ? '' : 's'}`,
-    `${snapshot.geometries} geo · ${snapshot.textures} tex · DPR ${snapshot.pixelRatio.toFixed(2)}`,
+    `${snapshot.geometries} geo · ${snapshot.textures} tex · actual DPR ${snapshot.pixelRatio.toFixed(2)}`,
     `track ${snapshot.trackChecksPerQuery.toFixed(1)} checks/query · >33ms ${snapshot.slowPercent.toFixed(1)}%`
   ].join('\n');
 }

--- a/turn/performance-profile.js
+++ b/turn/performance-profile.js
@@ -1,0 +1,114 @@
+const DEFAULT_DPR_CAP = 2;
+const DEFAULT_SHADOW_MAP_SIZE = 1024;
+const MIN_DPR_CAP = 0.75;
+const MAX_DPR_CAP = 2;
+const SHADOW_MAP_SIZES = new Set([256, 512, 1024]);
+
+let installed = false;
+
+export function performanceProfileFromSearch(
+  search = globalThis.location?.search || '',
+  devicePixelRatio = Number(globalThis.devicePixelRatio) || 1
+) {
+  let params;
+  try {
+    params = new URLSearchParams(search);
+  } catch (_) {
+    params = new URLSearchParams();
+  }
+
+  const perfEnabled = params.get('perf') === '1';
+  const requestedDpr = Number(params.get('dpr'));
+  const dprCap = perfEnabled && Number.isFinite(requestedDpr)
+    ? clamp(requestedDpr, MIN_DPR_CAP, MAX_DPR_CAP)
+    : DEFAULT_DPR_CAP;
+
+  const shadowRequest = perfEnabled ? String(params.get('shadow') || '') : '';
+  const shadowsEnabled = shadowRequest !== 'off';
+  const requestedShadowSize = Number(shadowRequest);
+  const shadowMapSize = shadowsEnabled && SHADOW_MAP_SIZES.has(requestedShadowSize)
+    ? requestedShadowSize
+    : DEFAULT_SHADOW_MAP_SIZE;
+
+  const active = perfEnabled && (
+    params.has('dpr') ||
+    params.has('shadow')
+  );
+
+  return Object.freeze({
+    active,
+    perfEnabled,
+    dprCap,
+    pixelRatio: Math.min(Math.max(0.1, Number(devicePixelRatio) || 1), dprCap),
+    shadowsEnabled,
+    shadowMapSize,
+    label: profileLabel({ dprCap, shadowsEnabled, shadowMapSize })
+  });
+}
+
+export function installPerformanceProfile() {
+  if (installed) return globalThis.__turnPerformanceProfile || null;
+  installed = true;
+
+  const profile = performanceProfileFromSearch();
+  globalThis.__turnPerformanceProfile = profile;
+
+  const apply = (runtime) => {
+    if (!profile.active || !runtime?.renderer) return;
+    applyRendererProfile(runtime, profile);
+  };
+
+  if (globalThis.__turnRuntime) apply(globalThis.__turnRuntime);
+  else {
+    window.addEventListener('turn:runtime-ready', (event) => {
+      apply(event.detail || globalThis.__turnRuntime);
+    }, { once: true });
+  }
+
+  return profile;
+}
+
+function applyRendererProfile(runtime, profile) {
+  const { renderer, sun } = runtime;
+
+  if (!renderer.userData.turnBaseSetPixelRatio) {
+    renderer.userData.turnBaseSetPixelRatio = renderer.setPixelRatio.bind(renderer);
+  }
+  const setBasePixelRatio = renderer.userData.turnBaseSetPixelRatio;
+  renderer.setPixelRatio = (value) => {
+    const requested = Number(value);
+    const safeRequested = Number.isFinite(requested) ? requested : 1;
+    return setBasePixelRatio(Math.min(safeRequested, profile.dprCap));
+  };
+  renderer.setPixelRatio(Math.min(Number(globalThis.devicePixelRatio) || 1, profile.dprCap));
+
+  const viewport = globalThis.visualViewport;
+  const width = Math.max(1, Math.round(viewport?.width || globalThis.innerWidth || renderer.domElement.clientWidth || 1));
+  const height = Math.max(1, Math.round(viewport?.height || globalThis.innerHeight || renderer.domElement.clientHeight || 1));
+  renderer.setSize(width, height);
+
+  renderer.shadowMap.enabled = profile.shadowsEnabled;
+  if (sun) {
+    sun.castShadow = profile.shadowsEnabled;
+    if (profile.shadowsEnabled && sun.shadow?.mapSize) {
+      const sizeChanged = sun.shadow.mapSize.x !== profile.shadowMapSize || sun.shadow.mapSize.y !== profile.shadowMapSize;
+      sun.shadow.mapSize.set(profile.shadowMapSize, profile.shadowMapSize);
+      if (sizeChanged && sun.shadow.map) {
+        sun.shadow.map.dispose?.();
+        sun.shadow.map = null;
+      }
+    }
+  }
+  renderer.shadowMap.needsUpdate = true;
+
+  globalThis.__turnPerformanceProfile = Object.freeze({ ...profile, applied: true });
+}
+
+function profileLabel({ dprCap, shadowsEnabled, shadowMapSize }) {
+  const shadows = shadowsEnabled ? `shadows ${shadowMapSize}` : 'shadows off';
+  return `DPR≤${Number(dprCap).toFixed(2)} · ${shadows}`;
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}

--- a/turn/performance-profile.js
+++ b/turn/performance-profile.js
@@ -19,8 +19,12 @@ export function performanceProfileFromSearch(
   }
 
   const perfEnabled = params.get('perf') === '1';
-  const requestedDpr = Number(params.get('dpr'));
-  const dprCap = perfEnabled && Number.isFinite(requestedDpr)
+  const dprRequest = perfEnabled ? params.get('dpr') : null;
+  const requestedDpr = dprRequest == null || String(dprRequest).trim() === ''
+    ? Number.NaN
+    : Number(dprRequest);
+  const hasDprOverride = perfEnabled && Number.isFinite(requestedDpr);
+  const dprCap = hasDprOverride
     ? clamp(requestedDpr, MIN_DPR_CAP, MAX_DPR_CAP)
     : DEFAULT_DPR_CAP;
 
@@ -30,11 +34,9 @@ export function performanceProfileFromSearch(
   const shadowMapSize = shadowsEnabled && SHADOW_MAP_SIZES.has(requestedShadowSize)
     ? requestedShadowSize
     : DEFAULT_SHADOW_MAP_SIZE;
+  const hasShadowOverride = perfEnabled && params.has('shadow');
 
-  const active = perfEnabled && (
-    params.has('dpr') ||
-    params.has('shadow')
-  );
+  const active = hasDprOverride || hasShadowOverride;
 
   return Object.freeze({
     active,

--- a/turn/performance-profile.js
+++ b/turn/performance-profile.js
@@ -3,6 +3,7 @@ const DEFAULT_SHADOW_MAP_SIZE = 1024;
 const MIN_DPR_CAP = 0.75;
 const MAX_DPR_CAP = 2;
 const SHADOW_MAP_SIZES = new Set([256, 512, 1024]);
+const rendererPixelRatioSetters = new WeakMap();
 
 let installed = false;
 
@@ -71,10 +72,10 @@ export function installPerformanceProfile() {
 function applyRendererProfile(runtime, profile) {
   const { renderer, sun } = runtime;
 
-  if (!renderer.userData.turnBaseSetPixelRatio) {
-    renderer.userData.turnBaseSetPixelRatio = renderer.setPixelRatio.bind(renderer);
+  if (!rendererPixelRatioSetters.has(renderer)) {
+    rendererPixelRatioSetters.set(renderer, renderer.setPixelRatio.bind(renderer));
   }
-  const setBasePixelRatio = renderer.userData.turnBaseSetPixelRatio;
+  const setBasePixelRatio = rendererPixelRatioSetters.get(renderer);
   renderer.setPixelRatio = (value) => {
     const requested = Number(value);
     const safeRequested = Number.isFinite(requested) ? requested : 1;

--- a/turn/race/replay-system.js
+++ b/turn/race/replay-system.js
@@ -1,10 +1,24 @@
 const REPLAY_FRAME_INTERVAL = 0.045;
+const replayFrameCache = new WeakMap();
 
 export function replayFrameAt(lap, time) {
   const frames = lap?.frames || [];
   if (frames.length < 2) return null;
 
   const wrappedTime = Number.isFinite(lap?.time) && lap.time > 0 ? time % lap.time : time;
+  const cacheable = lap !== null && typeof lap === 'object';
+  if (cacheable) {
+    const cached = replayFrameCache.get(lap);
+    if (
+      cached &&
+      cached.frames === frames &&
+      cached.frameCount === frames.length &&
+      cached.time === wrappedTime
+    ) {
+      return cached.frame;
+    }
+  }
+
   let low = 0;
   let high = frames.length - 1;
 
@@ -18,8 +32,7 @@ export function replayFrameAt(lap, time) {
   const a = frames[Math.max(0, low - 1)];
   const span = Math.max(0.001, b.t - a.t);
   const alpha = clamp((wrappedTime - a.t) / span, 0, 1);
-
-  return {
+  const frame = {
     x: lerp(a.x, b.x, alpha),
     z: lerp(a.z, b.z, alpha),
     h: lerpAngle(a.h, b.h, alpha),
@@ -27,6 +40,16 @@ export function replayFrameAt(lap, time) {
     d: lerp(a.d, b.d, alpha),
     p: Number.isFinite(a.p) && Number.isFinite(b.p) ? lerp(a.p, b.p, alpha) : null
   };
+
+  if (cacheable) {
+    replayFrameCache.set(lap, {
+      frames,
+      frameCount: frames.length,
+      time: wrappedTime,
+      frame
+    });
+  }
+  return frame;
 }
 
 export function recordReplayFrame(state, interval = REPLAY_FRAME_INTERVAL) {


### PR DESCRIPTION
## Summary

Creates measurable performance headroom without changing TURN's normal visual quality, physics, handling, track or car balance.

## Changes

- Caches the last interpolated replay sample per saved rival, so repeated same-time lookups across the race scene, HUD and Spectate reuse one result instead of repeating binary search/interpolation work.
- Adds opt-in renderer A/B profiles that only activate with `perf=1`.
- Supports diagnostic DPR caps and shadow-map profiles from the same production build.
- Keeps the requested DPR cap active through TURN's later resize calls.
- Stamps every performance snapshot and overlay with the active requested profile plus the renderer's actual DPR.
- Documents a focused iPad 9 test matrix for baseline, DPR 1.5, shadows 512 and the combined profile.
- Leaves normal TURN rendering at the existing DPR 2 / 1024 shadow-map production settings.

## Diagnostic profiles

- `?perf=1` production baseline
- `?perf=1&dpr=1.5`
- `?perf=1&shadow=512`
- `?perf=1&dpr=1.5&shadow=512`
- stronger diagnostic ceilings remain available if the first comparison is inconclusive

## Regression coverage

Adds coverage for renderer profile opt-in/clamping, resize-safe DPR caps, shadow profiles, self-describing performance snapshots and same-time replay-sample reuse.

## Release

TURN v1.3.26 · Build 2026.07.22-r43