### PR TITLE
TURN v1.3.27 r44: Universal DPR 1.5 and bounded off-track search

### DIFF
--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -10,8 +10,8 @@ const [index, app, audio, controls, catalogSource] = await Promise.all([
 ]);
 const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
 
-assert.match(index, /TURN v1\.3\.26 · Build 2026\.07\.22-r43/);
-assert.match(index, /\.\/app\.js\?build=20260722-r43/);
+assert.match(index, /TURN v1\.3\.27 · Build 2026\.07\.22-r44/);
+assert.match(index, /\.\/app\.js\?build=20260722-r44/);
 assert.match(
   index,
   /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/,
@@ -49,62 +49,50 @@ for (const car of catalog.CAR_CATALOG) {
 assert.equal(catalog.getCarDefinition('sedan').tuning.enginePitch, 1, 'Sedan must remain the neutral engine pitch baseline');
 assert.equal(catalog.getCarDefinition('monster-truck').tuning.enginePitch, 0.62, 'Monster Truck must have the lowest deep engine baseline');
 assert.equal(catalog.getCarDefinition('race').tuning.enginePitch, 1.55, 'Race Car must have the highest F1-like engine baseline');
-assert.ok(
-  catalog.getCarDefinition('monster-truck').tuning.enginePitch < catalog.getCarDefinition('truck').tuning.enginePitch,
-  'Monster Truck must sit below the regular Truck in pitch'
-);
-assert.ok(
-  catalog.getCarDefinition('race').tuning.enginePitch > catalog.getCarDefinition('race-future').tuning.enginePitch,
-  'Race Car must remain the highest-pitched racer'
-);
+assert.ok(catalog.getCarDefinition('monster-truck').tuning.enginePitch < catalog.getCarDefinition('truck').tuning.enginePitch, 'Monster Truck must sit below the regular Truck in pitch');
+assert.ok(catalog.getCarDefinition('race').tuning.enginePitch > catalog.getCarDefinition('race-future').tuning.enginePitch, 'Race Car must remain the highest-pitched racer');
 
-assert.match(audio, /regularScrubLevel = active \? slipIntent \* driftSpeed \* 0\.0055 : 0/, 'Ordinary cornering scrub must stay nearly subliminal');
-assert.match(audio, /deliberateScrubLevel = active && driftHeld/, 'Holding DRIFT must crossfade in stronger tire scrub');
-assert.match(audio, /const gritLevel = active && driftHeld/, 'Deliberate DRIFT must add a separate low-mid grit layer');
-assert.match(audio, /gritNoise\.buffer = makeNoiseBuffer\(context, 1\.7, 0\.95\)/, 'Drift grit must use heavily smoothed low-frequency noise rather than spray-like hiss');
-assert.match(audio, /skidTone\.type = 'triangle'/, 'Strong drift must use a restrained tonal squeal instead of the retired bright white-noise skid bus');
-assert.doesNotMatch(audio, /skidNoise/, 'The spray-can-like bright skid noise loop must stay removed');
-
-assert.match(audio, /const boostLevel = boostActive \? 0\.024 : 0/, 'Boost sustain must remain quiet beneath the engine');
-assert.doesNotMatch(audio, /const boostLevel = boostActive \? 0\.16 : 0/, 'The old loud vacuum-like boost sustain must stay removed');
-assert.match(audio, /boostTone\.type = 'sine'/, 'Boost sustain must use a clean turbine-like tone');
-assert.match(audio, /case 'boost-start':/, 'Boost activation must have a layered aggressive one-shot');
-assert.match(audio, /case 'boost-empty':/, 'Boost depletion must have its own cue');
-assert.match(audio, /case 'boost-full':/, 'Boost recharge completion must have its own cue');
-
-assert.match(audio, /RIVAL_NEAR_ENTER_METERS = 10/, 'Nearby-rival sound must use a deliberate entry threshold');
-assert.match(audio, /RIVAL_NEAR_EXIT_METERS = 15/, 'Nearby-rival sound must use hysteresis before it can re-trigger');
-assert.match(audio, /case 'car-near':/, 'A nearby rival must have a restrained proximity cue');
-assert.match(audio, /case 'overtake':/, 'Position gains must have an overtake cue');
-assert.match(audio, /cueAllowed\(name, now\)/, 'Repeatable rival cues must be cooldown-protected');
-
-assert.match(audio, /case 'garage-open':/, 'The Lot must keep its restrained entrance cue');
-assert.match(audio, /case 'car-select':/, 'The Lot car field must keep its selection cue');
-assert.match(audio, /case 'paint-select':/, 'Native paint changes must keep their small confirmation cue');
-assert.match(audio, /handleLotVisibilityChange/, 'The Lot entrance cue must follow the actual open state');
-assert.match(audio, /handleLotPointerDown/, 'The Lot car field must feed selection sound');
-assert.match(audio, /handleUiChange/, 'The Lot paint picker must feed paint sound');
-assert.match(audio, /function handleUiClick\(/, 'UI buttons must receive lightweight procedural feedback');
-
-assert.match(audio, /document\.addEventListener\('pointerdown', unlockFromGesture/, 'Touch gestures must unlock audio on mobile');
-assert.match(audio, /document\.addEventListener\('keydown', unlockFromGesture/, 'Keyboard interaction must also unlock audio');
-assert.match(audio, /document\.addEventListener\('visibilitychange', handleVisibilityChange/, 'Audio must react to page visibility changes');
-assert.match(audio, /window\.addEventListener\('pagehide', handlePageHide/, 'Audio must suspend cleanly when the page is backgrounded');
-assert.match(audio, /function hardMute\(/, 'Continuous buses must hard-mute before mobile suspension');
-
-assert.doesNotMatch(audio, /requestAnimationFrame|setAnimationLoop|setInterval/, 'The audio foundation must not create a second game loop');
-assert.doesNotMatch(audio, /fetch\(|new Audio\(/, 'The sound foundation must remain procedural and offline-friendly');
-
-assert.match(controls, /function updateAudio\(now, boosting\)/, 'Existing gameplay controls must feed continuous runtime state into audio');
-assert.match(controls, /globalThis\.__turnAudio\?\.update\(/, 'Continuous sound must reuse the shared audio API');
-assert.match(controls, /runtimeState\?\.mode === runtime\?\.GAME_MODE\?\.SPECTATING/, 'Player engine audio must stay off during spectator mode');
-assert.match(controls, /document\.body\.classList\.contains\('turn-lot-open'\)/, 'Race audio must fade out while The Lot is open');
-assert.match(controls, /driftAmount: runtimeState\?\.driftAmount \|\| 0/, 'Drift sound must follow the real physics drift state');
-assert.match(controls, /boostActive: boosting/, 'Boost sound must follow the post-lockout boost state');
-assert.match(controls, /nearestRivalDistance: nearestRivalDistance\(runtime, active\)/, 'Existing rival positions must feed proximity audio without a new loop');
-assert.match(controls, /globalThis\.__turnAudio\?\.cue\('boost-empty'\)/, 'The exact empty transition must trigger its audio cue');
-assert.match(controls, /globalThis\.__turnAudio\?\.cue\('boost-full'\)/, 'The exact full transition must trigger its audio cue');
-assert.match(controls, /if \(position < lastPosition\)/, 'Only an improved race position may trigger the overtake cue');
-assert.match(controls, /globalThis\.__turnAudio\?\.cue\('overtake'/, 'Position gains must feed the shared overtake cue');
+assert.match(audio, /regularScrubLevel = active \? slipIntent \* driftSpeed \* 0\.0055 : 0/);
+assert.match(audio, /deliberateScrubLevel = active && driftHeld/);
+assert.match(audio, /const gritLevel = active && driftHeld/);
+assert.match(audio, /gritNoise\.buffer = makeNoiseBuffer\(context, 1\.7, 0\.95\)/);
+assert.match(audio, /skidTone\.type = 'triangle'/);
+assert.doesNotMatch(audio, /skidNoise/);
+assert.match(audio, /const boostLevel = boostActive \? 0\.024 : 0/);
+assert.doesNotMatch(audio, /const boostLevel = boostActive \? 0\.16 : 0/);
+assert.match(audio, /boostTone\.type = 'sine'/);
+assert.match(audio, /case 'boost-start':/);
+assert.match(audio, /case 'boost-empty':/);
+assert.match(audio, /case 'boost-full':/);
+assert.match(audio, /RIVAL_NEAR_ENTER_METERS = 10/);
+assert.match(audio, /RIVAL_NEAR_EXIT_METERS = 15/);
+assert.match(audio, /case 'car-near':/);
+assert.match(audio, /case 'overtake':/);
+assert.match(audio, /cueAllowed\(name, now\)/);
+assert.match(audio, /case 'garage-open':/);
+assert.match(audio, /case 'car-select':/);
+assert.match(audio, /case 'paint-select':/);
+assert.match(audio, /handleLotVisibilityChange/);
+assert.match(audio, /handleLotPointerDown/);
+assert.match(audio, /handleUiChange/);
+assert.match(audio, /function handleUiClick\(/);
+assert.match(audio, /document\.addEventListener\('pointerdown', unlockFromGesture/);
+assert.match(audio, /document\.addEventListener\('keydown', unlockFromGesture/);
+assert.match(audio, /document\.addEventListener\('visibilitychange', handleVisibilityChange/);
+assert.match(audio, /window\.addEventListener\('pagehide', handlePageHide/);
+assert.match(audio, /function hardMute\(/);
+assert.doesNotMatch(audio, /requestAnimationFrame|setAnimationLoop|setInterval/);
+assert.doesNotMatch(audio, /fetch\(|new Audio\(/);
+assert.match(controls, /function updateAudio\(now, boosting\)/);
+assert.match(controls, /globalThis\.__turnAudio\?\.update\(/);
+assert.match(controls, /runtimeState\?\.mode === runtime\?\.GAME_MODE\?\.SPECTATING/);
+assert.match(controls, /document\.body\.classList\.contains\('turn-lot-open'\)/);
+assert.match(controls, /driftAmount: runtimeState\?\.driftAmount \|\| 0/);
+assert.match(controls, /boostActive: boosting/);
+assert.match(controls, /nearestRivalDistance: nearestRivalDistance\(runtime, active\)/);
+assert.match(controls, /globalThis\.__turnAudio\?\.cue\('boost-empty'\)/);
+assert.match(controls, /globalThis\.__turnAudio\?\.cue\('boost-full'\)/);
+assert.match(controls, /if \(position < lastPosition\)/);
+assert.match(controls, /globalThis\.__turnAudio\?\.cue\('overtake'/);
 
 console.log('TURN drift, boost and rival sound production regression passed.');

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -69,7 +69,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.26 · Build 2026\.07\.22-r43/);
+assert.match(index, /TURN v1\.3\.27 · Build 2026\.07\.22-r44/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -20,9 +20,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.26 · Build 2026\.07\.22-r43/);
-assert.match(index, /drive-pad\.css\?build=20260722-r43/);
-assert.match(index, /gameplay-v2\.css\?build=20260722-r43/);
+assert.match(index, /TURN v1\.3\.27 · Build 2026\.07\.22-r44/);
+assert.match(index, /drive-pad\.css\?build=20260722-r44/);
+assert.match(index, /gameplay-v2\.css\?build=20260722-r44/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -49,11 +49,11 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.26 · Build 2026\.07\.22-r43/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260722-r43/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r43 must preserve the latest Lot module cache redirect');
-assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r43 must preserve the reduced Monster Truck scale in the main runtime');
-assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r43 must preserve the same reduced Monster Truck scale inside The Lot');
+assert.match(index, /TURN v1\.3\.27 · Build 2026\.07\.22-r44/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260722-r44/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r44 must preserve the latest Lot module cache redirect');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r44 must preserve the reduced Monster Truck scale in the main runtime');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r44 must preserve the same reduced Monster Truck scale inside The Lot');
 assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -26,8 +26,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.26 · Build 2026\.07\.22-r43/);
-assert.match(index, /in-game-menu\.css\?build=20260722-r43/);
+assert.match(index, /TURN v1\.3\.27 · Build 2026\.07\.22-r44/);
+assert.match(index, /in-game-menu\.css\?build=20260722-r44/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Restart Lap<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -92,21 +92,33 @@ try {
   assert.deepEqual(publishedResults.at(-1)?.detail, { position: 5, total: 5, time: 14 }, 'Every completed lap must publish the frozen last-lap result');
 
   for (const rivalTimes of [[], [11, 14], [10, 11, 12, 13]]) {
-    const rivalCountState = makeState({ recording: makeFrames(5), rivalTimes });
+    const rivalCountState = makeState({
+      recording: makeFrames(5),
+      rivalTimes
+    });
     const rivalCountResult = completeLapState({
       state: rivalCountState,
       samples,
       now: 12500,
       competitorLimit: 4,
-      saveGhost() { assert.fail('The short diagnostic replay must not alter the saved rival list'); }
+      saveGhost() {
+        assert.fail('The short diagnostic replay must not alter the saved rival list');
+      }
     });
+
     assert.equal(rivalCountResult.completedLap, true, `lap completion must not depend on having ${rivalTimes.length} rivals`);
     assert.equal(rivalCountResult.total, rivalTimes.length + 1, 'only the displayed field size should follow rival count');
-    assert.equal(rivalCountResult.position, 1 + rivalTimes.filter((time) => time < 12.5).length, 'placement must be calculated from available rival times without affecting lap validity');
+    assert.equal(
+      rivalCountResult.position,
+      1 + rivalTimes.filter((time) => time < 12.5).length,
+      'placement must be calculated from available rival times without affecting lap validity'
+    );
   }
 } finally {
-  if (originalCustomEvent === undefined) delete globalThis.CustomEvent; else globalThis.CustomEvent = originalCustomEvent;
-  if (originalDispatchEvent === undefined) delete globalThis.dispatchEvent; else globalThis.dispatchEvent = originalDispatchEvent;
+  if (originalCustomEvent === undefined) delete globalThis.CustomEvent;
+  else globalThis.CustomEvent = originalCustomEvent;
+  if (originalDispatchEvent === undefined) delete globalThis.dispatchEvent;
+  else globalThis.dispatchEvent = originalDispatchEvent;
 }
 
 const [index, app, lapSystem, gameState, hud, styles, toast, toastCss, onboarding, onboardingCss] = await Promise.all([
@@ -129,19 +141,55 @@ assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/
 assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r41"/, 'r44 must preserve the r41 reset-safe invalid-lap state');
 assert.match(app, /installLapResultToast\(\)/, 'The lap result toast must install before the game runtime starts');
 assert.match(app, /installRivalOnboarding\(\)/, 'The rival onboarding plate must install before the game runtime starts');
-assert.match(lapSystem, /turn:lap-result/);
-assert.match(lapSystem, /turn:lap-invalid/);
-assert.match(lapSystem, /crossedLaterCheckpointGate/);
-assert.match(lapSystem, /state\.lapInvalid = true/);
-assert.doesNotMatch(lapSystem, /crossedStartByProgress/);
-assert.match(gameState, /state\.lapInvalid = false/);
-assert.match(hud, /lapInvalid \? 'INVALID LAP' : formatTime\(state\.lapElapsed\)/);
-assert.match(styles, /\.chip\.is-invalid-lap \{\s*background: #ff6b6b;/s);
-assert.match(toast, /STAY ON THE TRACK!/);
-assert.match(onboarding, /CHASE YOUR BEST/);
-assert.match(onboarding, /ghost: true/);
-assert.match(onboarding, /renderer\.dispose\(\)/);
-assert.match(toastCss, /prefers-reduced-motion: reduce/);
-assert.match(onboardingCss, /\.rival-onboarding-model/);
+assert.match(lapSystem, /turn:lap-result/, 'Completed lap finish must publish one frozen result event');
+assert.match(lapSystem, /turn:lap-invalid/, 'Incomplete checkpoint chains must publish explicit invalid-lap feedback');
+assert.match(lapSystem, /crossedLaterCheckpointGate/, 'Crossing a later gate before the required one must detect an irrecoverably invalid attempt');
+assert.match(lapSystem, /state\.lapInvalid = true/, 'The invalid attempt must stay marked until the next lap begins');
+assert.match(lapSystem, /suppressNextLapStartMessage = true/, 'Invalid-lap feedback must not be obscured by a competing GO message');
+assert.doesNotMatch(lapSystem, /crossedStartByProgress/, 'Start and finish must use only the swept physical line crossing');
+assert.match(lapSystem, /const completedLap = finishedTime > 5/, 'Result visibility must be separated from replay-save eligibility');
+assert.match(lapSystem, /const validLap = completedLap && state\.recording\.length > 20/, 'Ghost saving may still require a usable recording');
+assert.match(lapSystem, /if \(completedLap\) \{\s*publishLapResult/s, 'Every completed lap must publish a result, including last place and unsaved replays');
+assert.doesNotMatch(lapSystem, /TOP ['"] \+|NEW BEST|showMessage\?\.\(message\)/, 'The retired duplicate lap-ranking message must stay removed');
+assert.match(lapSystem, /raceRivals\.filter\(\(lap\) => lap\.time < finishedTime\)\.length/, 'Finish placement must be calculated against the rivals from the completed race');
+assert.match(gameState, /state\.lapInvalid = false/, 'Restart Lap and race staging must clear invalid-lap status');
+assert.match(hud, /lapInvalid \? 'INVALID LAP' : formatTime\(state\.lapElapsed\)/, 'The TIME card must stop displaying a running time once the lap is invalid');
+assert.match(hud, /classList\.toggle\('is-invalid-lap', lapInvalid\)/, 'The TIME card must expose a persistent invalid visual state');
+assert.match(styles, /\.chip\.is-invalid-lap \{\s*background: #ff6b6b;/s, 'Invalid laps must turn the TIME card red');
+assert.match(styles, /\.chip\.is-invalid-lap strong/, 'INVALID LAP must have dedicated compact typography');
+assert.match(toast, /TOAST_VISIBLE_MS = 4000/, 'The result should remain readable for a few seconds');
+assert.match(toast, /LAST LAP/, 'Valid laps must keep the requested result label');
+assert.match(toast, /LAP INVALID/, 'Invalid laps must replace LAST LAP with an explicit failure label');
+assert.match(toast, /STAY ON THE TRACK!/, 'Invalid checkpoint chains must use player-facing track guidance');
+assert.doesNotMatch(toast, /MISSED CHECKPOINT/, 'Technical checkpoint language must stay out of the player-facing toast');
+assert.match(toast, /turn:lap-invalid/, 'The unified toast must listen for invalid-lap events');
+assert.match(toast, /lap-result-position/, 'The toast must show frozen finishing position');
+assert.match(toast, /lap-result-time/, 'The toast must show the completed lap time');
+assert.match(toast, /aria-live', 'polite'/, 'The result toast should be announced without interrupting gameplay');
+assert.doesNotMatch(gameState, /READY FOR THE LINE/, 'Restart Lap must not show redundant ready-state feedback');
+assert.match(onboarding, /CHASE YOUR BEST/, 'The first rival must introduce the core chase-your-best loop');
+assert.match(onboarding, /reason === 'lap-completed'/, 'Onboarding must be tied to the first newly saved rival after a completed lap');
+assert.match(onboarding, /!hadRival && hasRival\) schedule\(rivals\[0\]\)/, 'The onboarding must use the newly saved rival rather than the current selection');
+assert.match(onboarding, /rival\?\.carId/, 'The first-rival preview must use the saved ghost model');
+assert.match(onboarding, /rival\?\.carColor/, 'The first-rival preview must use the saved ghost body paint');
+assert.match(onboarding, /rival\?\.carSecondaryColor/, 'The first-rival preview must preserve saved secondary paint');
+assert.match(onboarding, /ghost: true/, 'The onboarding model must use the same lighter solid ghost treatment as race rivals');
+assert.match(onboarding, /targetLength: 6\.4/, 'The onboarding model must use the Lot 3D viewer presentation scale');
+assert.match(onboarding, /PerspectiveCamera\(34, 1, 0\.1, 60\)/, 'The onboarding model must reuse the Lot viewer camera language');
+assert.match(onboarding, /camera\.position\.set\(7\.8, 4\.8, 8\.8\)/, 'The onboarding model must use the Lot viewer camera position');
+assert.match(onboarding, /HemisphereLight\(0xffffff, 0x5b6770, 3\.2\)/, 'The onboarding model must use the Lot viewer ambient lighting');
+assert.match(onboarding, /VIEWER_ROTATION_RADIANS_PER_SECOND = 0\.144/, 'The onboarding preview must rotate at the same approximately 60fps Lot viewer speed');
+assert.match(onboarding, /VIEWER_FRAME_INTERVAL_MS = 1000 \/ 30/, 'The temporary onboarding renderer must stay capped at 30 fps on mobile');
+assert.match(onboarding, /renderer\.dispose\(\)/, 'The temporary onboarding renderer must be disposed after the reveal');
+assert.match(onboarding, /RESULT_TOAST_HANDOFF_MS = 4300/, 'First-rival onboarding must wait until the lap-result toast has cleared');
+assert.match(toastCss, /background: var\(--yellow\)/, 'The lap toast must share the yellow finish-result colour');
+assert.match(toastCss, /left: 50%/, 'The lap toast must occupy the central finish-message position');
+assert.match(toastCss, /top: 22%/, 'The lap toast must sit where the old TOP X LAP message appeared');
+assert.doesNotMatch(toastCss, /left: max\(112px/, 'The retired lower-left toast placement must stay removed');
+assert.match(toastCss, /prefers-reduced-motion: reduce/, 'Toast animation must respect reduced-motion preferences');
+assert.match(onboardingCss, /\.rival-onboarding-model/, 'The onboarding must reserve an adjacent host for the ghost model');
+assert.match(onboardingCss, /\.rival-onboarding-copy/, 'The CHASE YOUR BEST copy must remain a separate pill plate beside the model');
+assert.match(onboardingCss, /background: var\(--rival-onboarding-color, var\(--yellow\)\)/, 'The onboarding plate must expose the rival colour through a CSS custom property');
+assert.match(onboardingCss, /border-radius: 999px/, 'The onboarding must keep the compact pill-plate language of the old READY message');
 
 console.log('TURN persistent INVALID LAP HUD, unified lap feedback and first-rival onboarding regression passed.');

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -92,33 +92,21 @@ try {
   assert.deepEqual(publishedResults.at(-1)?.detail, { position: 5, total: 5, time: 14 }, 'Every completed lap must publish the frozen last-lap result');
 
   for (const rivalTimes of [[], [11, 14], [10, 11, 12, 13]]) {
-    const rivalCountState = makeState({
-      recording: makeFrames(5),
-      rivalTimes
-    });
+    const rivalCountState = makeState({ recording: makeFrames(5), rivalTimes });
     const rivalCountResult = completeLapState({
       state: rivalCountState,
       samples,
       now: 12500,
       competitorLimit: 4,
-      saveGhost() {
-        assert.fail('The short diagnostic replay must not alter the saved rival list');
-      }
+      saveGhost() { assert.fail('The short diagnostic replay must not alter the saved rival list'); }
     });
-
     assert.equal(rivalCountResult.completedLap, true, `lap completion must not depend on having ${rivalTimes.length} rivals`);
     assert.equal(rivalCountResult.total, rivalTimes.length + 1, 'only the displayed field size should follow rival count');
-    assert.equal(
-      rivalCountResult.position,
-      1 + rivalTimes.filter((time) => time < 12.5).length,
-      'placement must be calculated from available rival times without affecting lap validity'
-    );
+    assert.equal(rivalCountResult.position, 1 + rivalTimes.filter((time) => time < 12.5).length, 'placement must be calculated from available rival times without affecting lap validity');
   }
 } finally {
-  if (originalCustomEvent === undefined) delete globalThis.CustomEvent;
-  else globalThis.CustomEvent = originalCustomEvent;
-  if (originalDispatchEvent === undefined) delete globalThis.dispatchEvent;
-  else globalThis.dispatchEvent = originalDispatchEvent;
+  if (originalCustomEvent === undefined) delete globalThis.CustomEvent; else globalThis.CustomEvent = originalCustomEvent;
+  if (originalDispatchEvent === undefined) delete globalThis.dispatchEvent; else globalThis.dispatchEvent = originalDispatchEvent;
 }
 
 const [index, app, lapSystem, gameState, hud, styles, toast, toastCss, onboarding, onboardingCss] = await Promise.all([
@@ -134,62 +122,26 @@ const [index, app, lapSystem, gameState, hud, styles, toast, toastCss, onboardin
   fs.readFile(new URL('../../turn/rival-onboarding.css', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.26 · Build 2026\.07\.22-r43/);
-assert.match(index, /lap-result-toast\.css\?build=20260722-r43/);
-assert.match(index, /rival-onboarding\.css\?build=20260722-r43/);
-assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260722-r41"/, 'r43 must preserve the r41 early invalid-lap detector');
-assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r41"/, 'r43 must preserve the r41 reset-safe invalid-lap state');
+assert.match(index, /TURN v1\.3\.27 · Build 2026\.07\.22-r44/);
+assert.match(index, /lap-result-toast\.css\?build=20260722-r44/);
+assert.match(index, /rival-onboarding\.css\?build=20260722-r44/);
+assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260722-r41"/, 'r44 must preserve the r41 early invalid-lap detector');
+assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r41"/, 'r44 must preserve the r41 reset-safe invalid-lap state');
 assert.match(app, /installLapResultToast\(\)/, 'The lap result toast must install before the game runtime starts');
 assert.match(app, /installRivalOnboarding\(\)/, 'The rival onboarding plate must install before the game runtime starts');
-assert.match(lapSystem, /turn:lap-result/, 'Completed lap finish must publish one frozen result event');
-assert.match(lapSystem, /turn:lap-invalid/, 'Incomplete checkpoint chains must publish explicit invalid-lap feedback');
-assert.match(lapSystem, /crossedLaterCheckpointGate/, 'Crossing a later gate before the required one must detect an irrecoverably invalid attempt');
-assert.match(lapSystem, /state\.lapInvalid = true/, 'The invalid attempt must stay marked until the next lap begins');
-assert.match(lapSystem, /suppressNextLapStartMessage = true/, 'Invalid-lap feedback must not be obscured by a competing GO message');
-assert.doesNotMatch(lapSystem, /crossedStartByProgress/, 'Start and finish must use only the swept physical line crossing');
-assert.match(lapSystem, /const completedLap = finishedTime > 5/, 'Result visibility must be separated from replay-save eligibility');
-assert.match(lapSystem, /const validLap = completedLap && state\.recording\.length > 20/, 'Ghost saving may still require a usable recording');
-assert.match(lapSystem, /if \(completedLap\) \{\s*publishLapResult/s, 'Every completed lap must publish a result, including last place and unsaved replays');
-assert.doesNotMatch(lapSystem, /TOP ['"] \+|NEW BEST|showMessage\?\.\(message\)/, 'The retired duplicate lap-ranking message must stay removed');
-assert.match(lapSystem, /raceRivals\.filter\(\(lap\) => lap\.time < finishedTime\)\.length/, 'Finish placement must be calculated against the rivals from the completed race');
-assert.match(gameState, /state\.lapInvalid = false/, 'Restart Lap and race staging must clear invalid-lap status');
-assert.match(hud, /lapInvalid \? 'INVALID LAP' : formatTime\(state\.lapElapsed\)/, 'The TIME card must stop displaying a running time once the lap is invalid');
-assert.match(hud, /classList\.toggle\('is-invalid-lap', lapInvalid\)/, 'The TIME card must expose a persistent invalid visual state');
-assert.match(styles, /\.chip\.is-invalid-lap \{\s*background: #ff6b6b;/s, 'Invalid laps must turn the TIME card red');
-assert.match(styles, /\.chip\.is-invalid-lap strong/, 'INVALID LAP must have dedicated compact typography');
-assert.match(toast, /TOAST_VISIBLE_MS = 4000/, 'The result should remain readable for a few seconds');
-assert.match(toast, /LAST LAP/, 'Valid laps must keep the requested result label');
-assert.match(toast, /LAP INVALID/, 'Invalid laps must replace LAST LAP with an explicit failure label');
-assert.match(toast, /STAY ON THE TRACK!/, 'Invalid checkpoint chains must use player-facing track guidance');
-assert.doesNotMatch(toast, /MISSED CHECKPOINT/, 'Technical checkpoint language must stay out of the player-facing toast');
-assert.match(toast, /turn:lap-invalid/, 'The unified toast must listen for invalid-lap events');
-assert.match(toast, /lap-result-position/, 'The toast must show frozen finishing position');
-assert.match(toast, /lap-result-time/, 'The toast must show the completed lap time');
-assert.match(toast, /aria-live', 'polite'/, 'The result toast should be announced without interrupting gameplay');
-assert.doesNotMatch(gameState, /READY FOR THE LINE/, 'Restart Lap must not show redundant ready-state feedback');
-assert.match(onboarding, /CHASE YOUR BEST/, 'The first rival must introduce the core chase-your-best loop');
-assert.match(onboarding, /reason === 'lap-completed'/, 'Onboarding must be tied to the first newly saved rival after a completed lap');
-assert.match(onboarding, /!hadRival && hasRival\) schedule\(rivals\[0\]\)/, 'The onboarding must use the newly saved rival rather than the current selection');
-assert.match(onboarding, /rival\?\.carId/, 'The first-rival preview must use the saved ghost model');
-assert.match(onboarding, /rival\?\.carColor/, 'The first-rival preview must use the saved ghost body paint');
-assert.match(onboarding, /rival\?\.carSecondaryColor/, 'The first-rival preview must preserve saved secondary paint');
-assert.match(onboarding, /ghost: true/, 'The onboarding model must use the same lighter solid ghost treatment as race rivals');
-assert.match(onboarding, /targetLength: 6\.4/, 'The onboarding model must use the Lot 3D viewer presentation scale');
-assert.match(onboarding, /PerspectiveCamera\(34, 1, 0\.1, 60\)/, 'The onboarding model must reuse the Lot viewer camera language');
-assert.match(onboarding, /camera\.position\.set\(7\.8, 4\.8, 8\.8\)/, 'The onboarding model must use the Lot viewer camera position');
-assert.match(onboarding, /HemisphereLight\(0xffffff, 0x5b6770, 3\.2\)/, 'The onboarding model must use the Lot viewer ambient lighting');
-assert.match(onboarding, /VIEWER_ROTATION_RADIANS_PER_SECOND = 0\.144/, 'The onboarding preview must rotate at the same approximately 60fps Lot viewer speed');
-assert.match(onboarding, /VIEWER_FRAME_INTERVAL_MS = 1000 \/ 30/, 'The temporary onboarding renderer must stay capped at 30 fps on mobile');
-assert.match(onboarding, /renderer\.dispose\(\)/, 'The temporary onboarding renderer must be disposed after the reveal');
-assert.match(onboarding, /RESULT_TOAST_HANDOFF_MS = 4300/, 'First-rival onboarding must wait until the lap-result toast has cleared');
-assert.match(toastCss, /background: var\(--yellow\)/, 'The lap toast must share the yellow finish-result colour');
-assert.match(toastCss, /left: 50%/, 'The lap toast must occupy the central finish-message position');
-assert.match(toastCss, /top: 22%/, 'The lap toast must sit where the old TOP X LAP message appeared');
-assert.doesNotMatch(toastCss, /left: max\(112px/, 'The retired lower-left toast placement must stay removed');
-assert.match(toastCss, /prefers-reduced-motion: reduce/, 'Toast animation must respect reduced-motion preferences');
-assert.match(onboardingCss, /\.rival-onboarding-model/, 'The onboarding must reserve an adjacent host for the ghost model');
-assert.match(onboardingCss, /\.rival-onboarding-copy/, 'The CHASE YOUR BEST copy must remain a separate pill plate beside the model');
-assert.match(onboardingCss, /background: var\(--rival-onboarding-color, var\(--yellow\)\)/, 'The onboarding plate must expose the rival colour through a CSS custom property');
-assert.match(onboardingCss, /border-radius: 999px/, 'The onboarding must keep the compact pill-plate language of the old READY message');
+assert.match(lapSystem, /turn:lap-result/);
+assert.match(lapSystem, /turn:lap-invalid/);
+assert.match(lapSystem, /crossedLaterCheckpointGate/);
+assert.match(lapSystem, /state\.lapInvalid = true/);
+assert.doesNotMatch(lapSystem, /crossedStartByProgress/);
+assert.match(gameState, /state\.lapInvalid = false/);
+assert.match(hud, /lapInvalid \? 'INVALID LAP' : formatTime\(state\.lapElapsed\)/);
+assert.match(styles, /\.chip\.is-invalid-lap \{\s*background: #ff6b6b;/s);
+assert.match(toast, /STAY ON THE TRACK!/);
+assert.match(onboarding, /CHASE YOUR BEST/);
+assert.match(onboarding, /ghost: true/);
+assert.match(onboarding, /renderer\.dispose\(\)/);
+assert.match(toastCss, /prefers-reduced-motion: reduce/);
+assert.match(onboardingCss, /\.rival-onboarding-model/);
 
 console.log('TURN persistent INVALID LAP HUD, unified lap feedback and first-rival onboarding regression passed.');

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -20,13 +20,13 @@ const [index, css, orientationGuardCss, orientationCompat, camera] = await Promi
   fs.readFile(new URL('../../turn/render/camera.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.26 · Build 2026\.07\.22-r43/);
+assert.match(index, /TURN v1\.3\.27 · Build 2026\.07\.22-r44/);
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260722-r43/);
-assert.match(index, /orientation-guard\.css\?build=20260722-r43/);
-assert.match(index, /orientation-compat\.js\?build=20260722-r43/);
-assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r43 must preserve the guarded race camera cache redirect');
+assert.match(index, /manual-steering\.css\?build=20260722-r44/);
+assert.match(index, /orientation-guard\.css\?build=20260722-r44/);
+assert.match(index, /orientation-compat\.js\?build=20260722-r44/);
+assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r44 must preserve the guarded race camera cache redirect');
 assert.match(index, /<strong>Rotate to landscape<\/strong>/, 'The pre-race landscape instruction must remain available');
 
 assert.match(css, /--manual-steer-left/);

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -34,7 +34,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.26 · Build 2026\.07\.22-r43/);
+assert.match(index, /TURN v1\.3\.27 · Build 2026\.07\.22-r44/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -33,31 +33,35 @@ const trackQueries = checksAfterTrackPass.queryCount - checksBeforeTrackPass.que
 const trackChecks = checksAfterTrackPass.totalChecks - checksBeforeTrackPass.totalChecks;
 assert.ok(trackChecks / trackQueries < 120, 'Normal on-track queries should inspect far fewer than all 720 samples');
 
-const fallback = spatialIndex.find({ x: 5000, z: -5000 });
-const fallbackBrute = findNearestTrackBruteForce(samples, { x: 5000, z: -5000 });
-assert.equal(fallback.index, fallbackBrute.index, 'Far teleports must retain the exact full-scan fallback');
-assert.equal(fallback.checks, samples.length);
+for (const position of [{ x: 5000, z: -5000 }, { x: 0, z: 0 }]) {
+  const indexed = spatialIndex.find(position);
+  const brute = findNearestTrackBruteForce(samples, position);
+  assert.equal(indexed.index, brute.index, 'Wide off-track searches must preserve the exact nearest sample');
+  assert.ok(Math.abs(indexed.distance - brute.distance) < 1e-9);
+  assert.ok(indexed.checks < 160, `Wide off-track searches must avoid the old 720-sample spike, got ${indexed.checks}`);
+}
+
 assert.equal(performanceModeRequested('?perf=1'), true);
 assert.equal(performanceModeRequested('?perf=0'), false);
 assert.equal(performanceModeRequested(''), false);
 
 const baselineProfile = performanceProfileFromSearch('?perf=1', 2);
-assert.equal(baselineProfile.active, false, 'Perf diagnostics alone must not change normal rendering');
-assert.equal(baselineProfile.dprCap, 2);
-assert.equal(baselineProfile.pixelRatio, 2);
+assert.equal(baselineProfile.active, false, 'Perf diagnostics alone must not add a separate quality tier');
+assert.equal(baselineProfile.dprCap, 1.5, 'TURN must use one universal DPR 1.5 ceiling');
+assert.equal(baselineProfile.pixelRatio, 1.5);
 assert.equal(baselineProfile.shadowsEnabled, true);
 assert.equal(baselineProfile.shadowMapSize, 1024);
 
-const dprProfile = performanceProfileFromSearch('?perf=1&dpr=1.5', 2);
+const dprProfile = performanceProfileFromSearch('?perf=1&dpr=1.25', 2);
 assert.equal(dprProfile.active, true);
-assert.equal(dprProfile.dprCap, 1.5);
-assert.equal(dprProfile.pixelRatio, 1.5);
-assert.match(dprProfile.label, /DPR≤1\.50/);
+assert.equal(dprProfile.dprCap, 1.25);
+assert.equal(dprProfile.pixelRatio, 1.25);
+assert.match(dprProfile.label, /DPR≤1\.25/);
 
 const lowDprProfile = performanceProfileFromSearch('?perf=1&dpr=0.2', 2);
 assert.equal(lowDprProfile.dprCap, 0.75, 'Diagnostic DPR overrides must stay within the safe lower bound');
 const highDprProfile = performanceProfileFromSearch('?perf=1&dpr=9', 3);
-assert.equal(highDprProfile.dprCap, 2, 'Diagnostic DPR overrides must never exceed the production cap');
+assert.equal(highDprProfile.dprCap, 1.5, 'No diagnostic profile may exceed the universal production cap');
 
 const shadowProfile = performanceProfileFromSearch('?perf=1&shadow=512', 2);
 assert.equal(shadowProfile.active, true);
@@ -68,7 +72,8 @@ assert.equal(noShadowProfile.shadowsEnabled, false);
 assert.match(noShadowProfile.label, /shadows off/);
 const ignoredProfile = performanceProfileFromSearch('?dpr=1&shadow=off', 2);
 assert.equal(ignoredProfile.active, false, 'Renderer overrides must be ignored outside explicit perf mode');
-assert.equal(ignoredProfile.dprCap, 2);
+assert.equal(ignoredProfile.dprCap, 1.5);
+assert.equal(ignoredProfile.pixelRatio, 1.5, 'Normal play must still receive the universal DPR cap');
 assert.equal(ignoredProfile.shadowsEnabled, true);
 
 const replayLap = {
@@ -95,10 +100,11 @@ assert.equal(summary.p95Ms, 50);
 assert.equal(summary.slowPercent, 40);
 assert.ok(Math.abs(summary.fps - 1000 / 30) < 1e-9);
 
-const [index, app, main, controls, menu, spectate, hud, physics, camera, cars, lot, monitor, profile, replay, audio, orientationCompat] = await Promise.all([
+const [index, app, main, worldAssets, controls, menu, spectate, hud, physics, camera, cars, lot, monitor, profile, replay, audio, orientationCompat] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/world-assets.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/ui/gameplay-controls.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/ui/in-game-menu.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8'),
@@ -114,15 +120,23 @@ const [index, app, main, controls, menu, spectate, hud, physics, camera, cars, l
   fs.readFile(new URL('../../turn/orientation-compat.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.26 · Build 2026\.07\.22-r43/);
-assert.match(index, /"\.\/race\/replay-system\.js": "\.\/race\/replay-system\.js\?build=20260722-r43"/, 'r43 must cache-bust the shared replay sampler');
-assert.match(index, /"\.\/performance-monitor\.js\?build=20260720-r19": "\.\/performance-monitor\.js\?build=20260722-r43"/, 'r43 must cache-bust the diagnostics module');
-assert.match(app, /installPerformanceProfile\(\)/, 'Renderer profile interception must install before the game runtime');
-assert.ok(app.indexOf('./performance-profile.js') < app.indexOf('./main.js'), 'Renderer profile interception must be ready before main.js creates the runtime');
-assert.match(profile, /params\.get\('perf'\) === '1'/, 'Renderer overrides must require explicit performance mode');
+assert.match(index, /TURN v1\.3\.27 · Build 2026\.07\.22-r44/);
+assert.match(index, /"\.\/race\/replay-system\.js": "\.\/race\/replay-system\.js\?build=20260722-r43"/, 'r44 must preserve the shared replay sampler cache');
+assert.match(index, /"\.\/race\/track-spatial-index\.js\?build=20260720-r19": "\.\/race\/track-spatial-index\.js\?build=20260722-r44"/, 'r44 must cache-bust the bounded track search');
+assert.match(index, /"\.\/performance-monitor\.js\?build=20260720-r19": "\.\/performance-monitor\.js\?build=20260722-r43"/, 'r44 must preserve the diagnostics module');
+assert.match(index, /"\.\/world-assets\.js": "\.\/world-assets\.js\?build=20260722-r44"/, 'r44 must cache-bust the buried tree presentation');
+assert.match(app, /installPerformanceProfile\(\)/, 'Renderer profile installation must run before the game runtime');
+assert.ok(app.indexOf('./performance-profile.js') < app.indexOf('./main.js'), 'The universal DPR cap must be ready before main.js creates the runtime');
+assert.match(profile, /DEFAULT_DPR_CAP = 1\.5/, 'The universal production DPR ceiling must stay at 1.5');
+assert.match(profile, /MAX_DPR_CAP = 1\.5/, 'Diagnostics must never restore the retired DPR 2 tier');
+assert.match(profile, /if \(!runtime\?\.renderer\) return;/, 'The universal renderer profile must apply even without a diagnostic override');
+assert.doesNotMatch(profile, /if \(!profile\.active \|\| !runtime\?\.renderer\) return;/, 'Normal play must not bypass the universal DPR cap');
 assert.match(profile, /renderer\.setPixelRatio = \(value\) =>/, 'The DPR cap must survive TURN resize calls');
-assert.match(profile, /renderer\.shadowMap\.enabled = profile\.shadowsEnabled/, 'Shadow A/B testing must use the existing renderer without a second loop');
+assert.match(profile, /renderer\.shadowMap\.enabled = profile\.shadowsEnabled/, 'Shadow A/B testing must remain available without a second loop');
 assert.doesNotMatch(profile, /requestAnimationFrame|setAnimationLoop|setInterval/, 'Performance profiles must add no animation loop');
+assert.match(worldAssets, /groundSink = 0/, 'Only explicitly sunk world assets may move below terrain');
+assert.match(worldAssets, /model\.position\.y -= groundSink/, 'Tree sinking must happen in shared placement rather than editing the source asset');
+assert.match(worldAssets, /groundSink: targetHeight \* 0\.07/, 'Tree cluster bases must be buried proportionally at both tree sizes');
 assert.match(replay, /const replayFrameCache = new WeakMap\(\)/, 'Replay interpolation must cache the last sample per saved lap');
 assert.match(replay, /return cached\.frame/, 'Repeated same-time replay lookups must take the cache fast path');
 assert.match(monitor, /profile: currentPerformanceProfile\(\)/, 'Every performance snapshot must record its active renderer profile');
@@ -152,4 +166,4 @@ assert.doesNotMatch(orientationCompat, /requestAnimationFrame|setAnimationLoop|s
 assert.match(monitor, /turn:perf-snapshot/);
 assert.match(monitor, /trackChecksPerQuery/);
 
-console.log(`TURN production performance profiles and diagnostics regression passed (${(trackChecks / trackQueries).toFixed(1)} average on-track checks vs 720).`);
+console.log(`TURN universal DPR, bounded spatial search and diagnostics regression passed (${(trackChecks / trackQueries).toFixed(1)} average on-track checks vs 720).`);

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r43 Measurable performance headroom and renderer A/B profiles -->
+<!-- TURN r44 Universal DPR 1.5, bounded off-track search and buried tree bases -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,34 +10,34 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.26 · Build 2026.07.22-r43</title>
+  <title>TURN v1.3.27 · Build 2026.07.22-r44</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.26',
-      id: '2026.07.22-r43',
-      cacheKey: '20260722-r43'
+      version: '1.3.27',
+      id: '2026.07.22-r44',
+      cacheKey: '20260722-r44'
     });
   </script>
   <link rel="icon" href="/turn/apple-touch-icon-v4.png" type="image/png" sizes="180x180">
   <link rel="apple-touch-icon" href="/turn/apple-touch-icon-v4.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260722-r43">
-  <link rel="stylesheet" href="./styles.css?build=20260722-r43">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260722-r43">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260722-r43">
-  <link rel="stylesheet" href="./install-gate.css?build=20260722-r43">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260722-r43">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260722-r43">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260722-r43">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260722-r43">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260722-r43">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260722-r43">
-  <link rel="stylesheet" href="./orientation-guard.css?build=20260722-r43">
-  <link rel="stylesheet" href="./lap-result-toast.css?build=20260722-r43">
-  <link rel="stylesheet" href="./rival-onboarding.css?build=20260722-r43">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260722-r43">
+  <link rel="manifest" href="./site.webmanifest?build=20260722-r44">
+  <link rel="stylesheet" href="./styles.css?build=20260722-r44">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260722-r44">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260722-r44">
+  <link rel="stylesheet" href="./install-gate.css?build=20260722-r44">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260722-r44">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260722-r44">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260722-r44">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260722-r44">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260722-r44">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260722-r44">
+  <link rel="stylesheet" href="./orientation-guard.css?build=20260722-r44">
+  <link rel="stylesheet" href="./lap-result-toast.css?build=20260722-r44">
+  <link rel="stylesheet" href="./rival-onboarding.css?build=20260722-r44">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260722-r44">
 
-  <script src="./install-gate.js?build=20260722-r43"></script>
-  <script src="./orientation-compat.js?build=20260722-r43"></script>
+  <script src="./install-gate.js?build=20260722-r44"></script>
+  <script src="./orientation-compat.js?build=20260722-r44"></script>
   <script type="importmap">
     {
       "imports": {
@@ -48,7 +48,9 @@
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system.js?build=20260722-r41",
         "./race/game-state.js": "./race/game-state.js?build=20260722-r41",
         "./race/replay-system.js": "./race/replay-system.js?build=20260722-r43",
+        "./race/track-spatial-index.js?build=20260720-r19": "./race/track-spatial-index.js?build=20260722-r44",
         "./performance-monitor.js?build=20260720-r19": "./performance-monitor.js?build=20260722-r43",
+        "./world-assets.js": "./world-assets.js?build=20260722-r44",
         "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260722-r42",
         "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260722-r42",
         "./vehicle/car-models.js?build=20260720-r19": "./vehicle/car-models.js?build=20260720-r22"
@@ -64,7 +66,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.26 · Build 2026.07.22-r43</span>
+        <span class="install-kicker">TURN v1.3.27 · Build 2026.07.22-r44</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -92,7 +94,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.26 · Build 2026.07.22-r43</span>
+      <span class="kicker">TURN v1.3.27 · Build 2026.07.22-r44</span>
       <h1 id="title">TURN</h1>
       <p class="tagline">
         Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
@@ -158,6 +160,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260722-r43"></script>
+  <script type="module" src="./app.js?build=20260722-r44"></script>
 </body>
 </html>

--- a/turn/performance-profile.js
+++ b/turn/performance-profile.js
@@ -1,7 +1,7 @@
-const DEFAULT_DPR_CAP = 2;
+const DEFAULT_DPR_CAP = 1.5;
 const DEFAULT_SHADOW_MAP_SIZE = 1024;
 const MIN_DPR_CAP = 0.75;
-const MAX_DPR_CAP = 2;
+const MAX_DPR_CAP = 1.5;
 const SHADOW_MAP_SIZES = new Set([256, 512, 1024]);
 const rendererPixelRatioSetters = new WeakMap();
 
@@ -57,7 +57,7 @@ export function installPerformanceProfile() {
   globalThis.__turnPerformanceProfile = profile;
 
   const apply = (runtime) => {
-    if (!profile.active || !runtime?.renderer) return;
+    if (!runtime?.renderer) return;
     applyRendererProfile(runtime, profile);
   };
 

--- a/turn/race/track-spatial-index.js
+++ b/turn/race/track-spatial-index.js
@@ -1,4 +1,6 @@
 const DEFAULT_CELL_SIZE = 32;
+const MAX_GRID_RADIUS_BEFORE_HIERARCHY = 2;
+const HIERARCHY_LEAF_SIZE = 8;
 
 export function createTrackSpatialIndex(samples, { cellSize = DEFAULT_CELL_SIZE } = {}) {
   if (!Array.isArray(samples) || !samples.length) {
@@ -41,6 +43,8 @@ export function createTrackSpatialIndex(samples, { cellSize = DEFAULT_CELL_SIZE 
     maxCellZ = Math.max(maxCellZ, cellZ);
   }
 
+  const hierarchy = buildTrackHierarchy(samples, 0, samples.length);
+
   function find(position) {
     const x = Number(position?.x);
     const z = Number(position?.z);
@@ -51,15 +55,16 @@ export function createTrackSpatialIndex(samples, { cellSize = DEFAULT_CELL_SIZE 
     const centerCellX = Math.floor(x / size);
     const centerCellZ = Math.floor(z / size);
 
-    // Teleports or corrupt replay points outside the indexed world are rare. A full scan
-    // keeps those cases exact without making the common on-track query more complicated.
+    // Positions beyond the indexed grid used to trigger a full 720-sample scan. The exact
+    // hierarchy keeps those teleports and wide off-road excursions cheap without changing
+    // the nearest-sample result.
     if (
       centerCellX < minCellX ||
       centerCellX > maxCellX ||
       centerCellZ < minCellZ ||
       centerCellZ > maxCellZ
     ) {
-      return recordResult(findNearestTrackBruteForce(samples, position));
+      return recordResult(findNearestTrackHierarchy(samples, hierarchy, position));
     }
 
     let bestIndex = -1;
@@ -119,9 +124,18 @@ export function createTrackSpatialIndex(samples, { cellSize = DEFAULT_CELL_SIZE 
         // the brute-force tie rule as well as the exact nearest sample.
         if (bestDistanceSq < boundaryDistance * boundaryDistance) break;
       }
+
+      // The uniform grid is excellent near the road but can balloon into hundreds of
+      // checks in the lake or far across the scenery. Switch to the exact bounds hierarchy
+      // before that pathological expansion begins.
+      if (radius >= MAX_GRID_RADIUS_BEFORE_HIERARCHY) {
+        const hierarchyResult = findNearestTrackHierarchy(samples, hierarchy, position);
+        hierarchyResult.checks += checks;
+        return recordResult(hierarchyResult);
+      }
     }
 
-    if (bestIndex < 0) return recordResult(findNearestTrackBruteForce(samples, position));
+    if (bestIndex < 0) return recordResult(findNearestTrackHierarchy(samples, hierarchy, position));
     return recordResult({
       index: bestIndex,
       sample: samples[bestIndex],
@@ -170,6 +184,89 @@ export function findNearestTrackBruteForce(samples, position) {
     distance: Math.sqrt(bestDistanceSq),
     checks: samples.length
   };
+}
+
+function buildTrackHierarchy(samples, start, end) {
+  const node = {
+    start,
+    end,
+    minX: Infinity,
+    maxX: -Infinity,
+    minZ: Infinity,
+    maxZ: -Infinity,
+    left: null,
+    right: null
+  };
+
+  for (let index = start; index < end; index += 1) {
+    const point = samples[index].point;
+    node.minX = Math.min(node.minX, point.x);
+    node.maxX = Math.max(node.maxX, point.x);
+    node.minZ = Math.min(node.minZ, point.z);
+    node.maxZ = Math.max(node.maxZ, point.z);
+  }
+
+  if (end - start > HIERARCHY_LEAF_SIZE) {
+    const middle = start + Math.floor((end - start) / 2);
+    node.left = buildTrackHierarchy(samples, start, middle);
+    node.right = buildTrackHierarchy(samples, middle, end);
+  }
+
+  return node;
+}
+
+function findNearestTrackHierarchy(samples, hierarchy, position) {
+  const x = Number(position?.x);
+  const z = Number(position?.z);
+  let bestIndex = -1;
+  let bestDistanceSq = Infinity;
+  let checks = 0;
+
+  function visit(node) {
+    if (!node || distanceSqToBounds(node, x, z) > bestDistanceSq) return;
+
+    if (!node.left && !node.right) {
+      for (let index = node.start; index < node.end; index += 1) {
+        const point = samples[index].point;
+        const dx = x - point.x;
+        const dz = z - point.z;
+        const distanceSq = dx * dx + dz * dz;
+        checks += 1;
+        if (
+          distanceSq < bestDistanceSq ||
+          (distanceSq === bestDistanceSq && (bestIndex < 0 || index < bestIndex))
+        ) {
+          bestDistanceSq = distanceSq;
+          bestIndex = index;
+        }
+      }
+      return;
+    }
+
+    const leftDistance = node.left ? distanceSqToBounds(node.left, x, z) : Infinity;
+    const rightDistance = node.right ? distanceSqToBounds(node.right, x, z) : Infinity;
+    const first = leftDistance <= rightDistance ? node.left : node.right;
+    const second = first === node.left ? node.right : node.left;
+
+    visit(first);
+    visit(second);
+  }
+
+  visit(hierarchy);
+
+  if (bestIndex < 0) return findNearestTrackBruteForce(samples, position);
+  return {
+    index: bestIndex,
+    sample: samples[bestIndex],
+    distance: Math.sqrt(bestDistanceSq),
+    checks
+  };
+}
+
+function distanceSqToBounds(node, x, z) {
+  const dx = x < node.minX ? node.minX - x : x > node.maxX ? x - node.maxX : 0;
+  const dz = z < node.minZ ? node.minZ - z : z > node.maxZ ? z - node.maxZ : 0;
+  return dx * dx + dz * dz;
 }
 
 function positiveNumber(value, fallback) {

--- a/turn/world-assets.js
+++ b/turn/world-assets.js
@@ -131,7 +131,8 @@ function placeAlongTrack({
   rotationOffset = 0,
   stretch = null,
   tint = null,
-  tintAmount = 0.75
+  tintAmount = 0.75,
+  groundSink = 0
 }) {
   const { sample, position } = trackPosition(samples, index, side, trackWidth, distance);
   const model = prepareModel(source, {
@@ -143,6 +144,7 @@ function placeAlongTrack({
     tintAmount
   });
   model.position.add(position);
+  model.position.y -= groundSink;
 
   if (stretch) model.scale.multiply(stretch);
 
@@ -166,6 +168,7 @@ function placeTreeBelt({ world, samples, trackWidth, trees, tallTrees }) {
     const random = seeded01(i + 11);
     const secondRandom = seeded01(i * 3 + 7);
     const source = sources[i % sources.length];
+    const targetHeight = 7.5 + secondRandom * 7;
 
     placeAlongTrack({
       world,
@@ -175,7 +178,8 @@ function placeTreeBelt({ world, samples, trackWidth, trees, tallTrees }) {
       index: 17 + i * 37,
       side,
       distance: 17 + random * 42,
-      targetHeight: 7.5 + secondRandom * 7,
+      targetHeight,
+      groundSink: targetHeight * 0.07,
       castShadow: i % 3 === 0,
       rotationOffset: random * Math.PI * 2
     });


### PR DESCRIPTION
## Summary

Makes the iPad-tested DPR 1.5 ceiling TURN's universal rendering baseline, removes pathological far-off-track spatial-search spikes, and buries the visible green slabs beneath tree clusters.

## Changes

- Sets the universal production DPR ceiling to 1.5 for all devices.
- Keeps diagnostic DPR overrides available only below the production ceiling; DPR 2 can no longer be restored through perf mode.
- Applies the renderer profile to normal play as well as diagnostic overrides so later resize calls keep the 1.5 ceiling.
- Preserves the existing fast grid nearest-track lookup near the circuit.
- Adds an exact hierarchical bounds fallback when the grid search expands beyond two cell rings, avoiding hundreds of sample checks in the lake, scenery, or distant teleports.
- Sinks tree-group assets by 7% of their scaled height so the baked green square bases sit below the terrain.
- Keeps 1024 shadows, gameplay physics, handling, lap logic and car balance unchanged.

## Regression coverage

- Exact nearest-track equality against brute force across 1,200 random positions.
- Wide off-track and map-centre queries must stay below 160 sample checks instead of falling back to all 720.
- Universal DPR 1.5 baseline and diagnostic ceiling.
- Tree sinking remains isolated to explicitly configured assets.

## Release

TURN v1.3.27 · Build 2026.07.22-r44