### PR TITLE
TURN v1.3.29 r46: Invalid-lap UX and complete tree grounding

### DIFF
--- a/turn-lab/tests/app-icon-production.mjs
+++ b/turn-lab/tests/app-icon-production.mjs
@@ -10,11 +10,11 @@ const index = fs.readFileSync(path.join(turnRoot, 'index.html'), 'utf8');
 const styles = fs.readFileSync(path.join(turnRoot, 'styles.css'), 'utf8');
 const manifest = JSON.parse(fs.readFileSync(path.join(turnRoot, 'site.webmanifest'), 'utf8'));
 
-assert.match(index, /TURN v1\.3\.28 · Build 2026\.07\.22-r45/);
+assert.match(index, /TURN v1\.3\.29 · Build 2026\.07\.22-r46/);
 assert.match(index, /<link rel="icon" href="\.\/favicon-r45\.ico" sizes="any">/);
 assert.match(index, /<link rel="icon" href="\.\/favicon-32-r45\.png" type="image\/png" sizes="32x32">/);
 assert.match(index, /<link rel="apple-touch-icon" href="\.\/apple-touch-icon-r45\.png" sizes="180x180">/);
-assert.match(index, /<link rel="manifest" href="\.\/site\.webmanifest\?build=20260722-r45">/);
+assert.match(index, /<link rel="manifest" href="\.\/site\.webmanifest\?build=20260722-r46">/);
 assert.match(index, /<img class="install-icon" src="\.\/icon-512-r45\.png" alt="">/);
 assert.match(index, /<h1 class="start-logo-heading" id="title">\s*<img class="start-logo" src="\.\/icon-512-r45\.png" alt="TURN">\s*<\/h1>/);
 assert.doesNotMatch(index, /apple-touch-icon-v4|icon-192-v4/);

--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -10,8 +10,8 @@ const [index, app, audio, controls, catalogSource] = await Promise.all([
 ]);
 const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
 
-assert.match(index, /TURN v1\.3\.28 · Build 2026\.07\.22-r45/);
-assert.match(index, /\.\/app\.js\?build=20260722-r45/);
+assert.match(index, /TURN v1\.3\.29 · Build 2026\.07\.22-r46/);
+assert.match(index, /\.\/app\.js\?build=20260722-r46/);
 assert.match(
   index,
   /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/,

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -69,7 +69,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.28 · Build 2026\.07\.22-r45/);
+assert.match(index, /TURN v1\.3\.29 · Build 2026\.07\.22-r46/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -20,9 +20,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.28 · Build 2026\.07\.22-r45/);
-assert.match(index, /drive-pad\.css\?build=20260722-r45/);
-assert.match(index, /gameplay-v2\.css\?build=20260722-r45/);
+assert.match(index, /TURN v1\.3\.29 · Build 2026\.07\.22-r46/);
+assert.match(index, /drive-pad\.css\?build=20260722-r46/);
+assert.match(index, /gameplay-v2\.css\?build=20260722-r46/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -49,11 +49,11 @@ const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promis
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.28 · Build 2026\.07\.22-r45/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260722-r45/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r45 must preserve the latest Lot module cache redirect');
-assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r45 must preserve the reduced Monster Truck scale in the main runtime');
-assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r45 must preserve the same reduced Monster Truck scale inside The Lot');
+assert.match(index, /TURN v1\.3\.29 · Build 2026\.07\.22-r46/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260722-r46/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r46 must preserve the latest Lot module cache redirect');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r46 must preserve the reduced Monster Truck scale in the main runtime');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r46 must preserve the same reduced Monster Truck scale inside The Lot');
 assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -26,8 +26,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.28 · Build 2026\.07\.22-r45/);
-assert.match(index, /in-game-menu\.css\?build=20260722-r45/);
+assert.match(index, /TURN v1\.3\.29 · Build 2026\.07\.22-r46/);
+assert.match(index, /in-game-menu\.css\?build=20260722-r46/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Restart Lap<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);
@@ -40,6 +40,12 @@ assert.match(menu, /backToLotButton\.hidden = !visibility\.startActions/);
 assert.match(menu, /recalibrateButton\.hidden = !visibility\.startActions/);
 assert.match(menu, /resetRivalsButton\.hidden = !visibility\.startActions/);
 assert.match(menu, /const buttonOrder = \[\s*backToLotButton,\s*recalibrateButton,\s*resetRivalsButton,\s*spectateButton,\s*backToStartButton\s*\]/, 'Start actions must follow the requested order');
+assert.match(menu, /closest\('\.chip'\)/, 'Restart Lap must follow the TIME card validity state rather than duplicate race logic');
+assert.match(menu, /classList\.contains\('is-invalid-lap'\)/, 'The TIME card invalid class must be the shared source of truth');
+assert.match(menu, /new MutationObserver\(\(\) => syncLapValidity\(\)\)/, 'Invalid-lap feedback must remain event-driven rather than adding another loop');
+assert.match(menu, /classList\.toggle\('is-lap-invalid', invalid\)/, 'Restart Lap must stay red while the visible TIME card is invalid');
+assert.match(menu, /classList\.add\('is-lap-invalid-pulse'\)/, 'Restart Lap must pulse once when the lap first becomes invalid');
+assert.doesNotMatch(menu, /setInterval|setAnimationLoop/, 'Invalid-lap button feedback must not add a polling loop');
 assert.match(controls, /Reset Rivals/);
 assert.match(controls, /globalThis\.__turnResetRivals/);
 assert.match(backToLot, /Back to Lot/);
@@ -47,6 +53,9 @@ assert.match(main, /globalThis\.__turnResetRivals = resetRivals/);
 assert.match(spectate, /spectateButton\.hidden = !current\.available/, 'Spectate must remain conditional on a saved rival');
 assert.match(css, /\.utility-group\[data-menu-state="staged"\]/);
 assert.match(css, /\.utility-group\[data-menu-state="racing"\] \.back-to-start-button/);
+assert.match(css, /\.back-to-start-button\.is-lap-invalid \{\s*background: #ff6b6b;/s, 'Restart Lap must use the same invalid red as the TIME card');
+assert.match(css, /@keyframes turn-restart-invalid-pulse/, 'The invalid restart cue must pulse exactly through a dedicated one-shot animation');
+assert.match(css, /prefers-reduced-motion: reduce/, 'The restart cue must respect reduced-motion preferences');
 assert.match(css, /\.utility-group\[data-menu-state="hidden"\]/);
 
-console.log('TURN state-aware in-game menu and Restart Lap regression passed.');
+console.log('TURN state-aware in-game menu and invalid-lap Restart Lap cue regression passed.');

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -134,11 +134,11 @@ const [index, app, lapSystem, gameState, hud, styles, toast, toastCss, onboardin
   fs.readFile(new URL('../../turn/rival-onboarding.css', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.28 · Build 2026\.07\.22-r45/);
-assert.match(index, /lap-result-toast\.css\?build=20260722-r45/);
-assert.match(index, /rival-onboarding\.css\?build=20260722-r45/);
-assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260722-r41"/, 'r45 must preserve the r41 early invalid-lap detector');
-assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r41"/, 'r45 must preserve the r41 reset-safe invalid-lap state');
+assert.match(index, /TURN v1\.3\.29 · Build 2026\.07\.22-r46/);
+assert.match(index, /lap-result-toast\.css\?build=20260722-r46/);
+assert.match(index, /rival-onboarding\.css\?build=20260722-r46/);
+assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260722-r41"/, 'r46 must preserve the r41 early invalid-lap detector');
+assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r41"/, 'r46 must preserve the r41 reset-safe invalid-lap state');
 assert.match(app, /installLapResultToast\(\)/, 'The lap result toast must install before the game runtime starts');
 assert.match(app, /installRivalOnboarding\(\)/, 'The rival onboarding plate must install before the game runtime starts');
 assert.match(lapSystem, /turn:lap-result/, 'Completed lap finish must publish one frozen result event');
@@ -182,7 +182,8 @@ assert.match(onboarding, /VIEWER_ROTATION_RADIANS_PER_SECOND = 0\.144/, 'The onb
 assert.match(onboarding, /VIEWER_FRAME_INTERVAL_MS = 1000 \/ 30/, 'The temporary onboarding renderer must stay capped at 30 fps on mobile');
 assert.match(onboarding, /renderer\.dispose\(\)/, 'The temporary onboarding renderer must be disposed after the reveal');
 assert.match(onboarding, /RESULT_TOAST_HANDOFF_MS = 4300/, 'First-rival onboarding must wait until the lap-result toast has cleared');
-assert.match(toastCss, /background: var\(--yellow\)/, 'The lap toast must share the yellow finish-result colour');
+assert.match(toastCss, /background: var\(--yellow\)/, 'Valid lap results must keep the yellow finish-result colour');
+assert.match(toastCss, /\.lap-result-toast\.is-invalid \{\s*background: #ff6b6b;/s, 'STAY ON THE TRACK must use the same red invalid-lap colour as the TIME card');
 assert.match(toastCss, /left: 50%/, 'The lap toast must occupy the central finish-message position');
 assert.match(toastCss, /top: 22%/, 'The lap toast must sit where the old TOP X LAP message appeared');
 assert.doesNotMatch(toastCss, /left: max\(112px/, 'The retired lower-left toast placement must stay removed');
@@ -192,4 +193,4 @@ assert.match(onboardingCss, /\.rival-onboarding-copy/, 'The CHASE YOUR BEST copy
 assert.match(onboardingCss, /background: var\(--rival-onboarding-color, var\(--yellow\)\)/, 'The onboarding plate must expose the rival colour through a CSS custom property');
 assert.match(onboardingCss, /border-radius: 999px/, 'The onboarding must keep the compact pill-plate language of the old READY message');
 
-console.log('TURN persistent INVALID LAP HUD, unified lap feedback and first-rival onboarding regression passed.');
+console.log('TURN persistent INVALID LAP HUD, red invalid toast and first-rival onboarding regression passed.');

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -20,13 +20,13 @@ const [index, css, orientationGuardCss, orientationCompat, camera] = await Promi
   fs.readFile(new URL('../../turn/render/camera.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.28 · Build 2026\.07\.22-r45/);
+assert.match(index, /TURN v1\.3\.29 · Build 2026\.07\.22-r46/);
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260722-r45/);
-assert.match(index, /orientation-guard\.css\?build=20260722-r45/);
-assert.match(index, /orientation-compat\.js\?build=20260722-r45/);
-assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r45 must preserve the guarded race camera cache redirect');
+assert.match(index, /manual-steering\.css\?build=20260722-r46/);
+assert.match(index, /orientation-guard\.css\?build=20260722-r46/);
+assert.match(index, /orientation-compat\.js\?build=20260722-r46/);
+assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r46 must preserve the guarded race camera cache redirect');
 assert.match(index, /<strong>Rotate to landscape<\/strong>/, 'The pre-race landscape instruction must remain available');
 
 assert.match(css, /--manual-steer-left/);

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -34,7 +34,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.28 · Build 2026\.07\.22-r45/);
+assert.match(index, /TURN v1\.3\.29 · Build 2026\.07\.22-r46/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -100,11 +100,12 @@ assert.equal(summary.p95Ms, 50);
 assert.equal(summary.slowPercent, 40);
 assert.ok(Math.abs(summary.fps - 1000 / 30) < 1e-9);
 
-const [index, app, main, worldAssets, controls, menu, spectate, hud, physics, camera, cars, lot, monitor, profile, replay, audio, orientationCompat] = await Promise.all([
+const [index, app, main, worldAssets, worldRender, controls, menu, spectate, hud, physics, camera, cars, lot, monitor, profile, replay, audio, orientationCompat] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/world-assets.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/render/world.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/ui/gameplay-controls.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/ui/in-game-menu.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8'),
@@ -120,11 +121,11 @@ const [index, app, main, worldAssets, controls, menu, spectate, hud, physics, ca
   fs.readFile(new URL('../../turn/orientation-compat.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.28 · Build 2026\.07\.22-r45/);
-assert.match(index, /"\.\/race\/replay-system\.js": "\.\/race\/replay-system\.js\?build=20260722-r43"/, 'r45 must preserve the shared replay sampler cache');
-assert.match(index, /"\.\/race\/track-spatial-index\.js\?build=20260720-r19": "\.\/race\/track-spatial-index\.js\?build=20260722-r44"/, 'r45 must cache-bust the bounded track search');
-assert.match(index, /"\.\/performance-monitor\.js\?build=20260720-r19": "\.\/performance-monitor\.js\?build=20260722-r43"/, 'r45 must preserve the diagnostics module');
-assert.match(index, /"\.\/world-assets\.js": "\.\/world-assets\.js\?build=20260722-r44"/, 'r45 must cache-bust the buried tree presentation');
+assert.match(index, /TURN v1\.3\.29 · Build 2026\.07\.22-r46/);
+assert.match(index, /"\.\/race\/replay-system\.js": "\.\/race\/replay-system\.js\?build=20260722-r43"/, 'r46 must preserve the shared replay sampler cache');
+assert.match(index, /"\.\/race\/track-spatial-index\.js\?build=20260720-r19": "\.\/race\/track-spatial-index\.js\?build=20260722-r44"/, 'r46 must preserve the bounded track search');
+assert.match(index, /"\.\/performance-monitor\.js\?build=20260720-r19": "\.\/performance-monitor\.js\?build=20260722-r43"/, 'r46 must preserve the diagnostics module');
+assert.match(index, /"\.\/world-assets\.js": "\.\/world-assets\.js\?build=20260722-r44"/, 'r46 must preserve the first tree-belt grounding pass');
 assert.match(app, /installPerformanceProfile\(\)/, 'Renderer profile installation must run before the game runtime');
 assert.ok(app.indexOf('./performance-profile.js') < app.indexOf('./main.js'), 'The universal DPR cap must be ready before main.js creates the runtime');
 assert.match(profile, /DEFAULT_DPR_CAP = 1\.5/, 'The universal production DPR ceiling must stay at 1.5');
@@ -134,9 +135,14 @@ assert.doesNotMatch(profile, /if \(!profile\.active \|\| !runtime\?\.renderer\) 
 assert.match(profile, /renderer\.setPixelRatio = \(value\) =>/, 'The DPR cap must survive TURN resize calls');
 assert.match(profile, /renderer\.shadowMap\.enabled = profile\.shadowsEnabled/, 'Shadow A/B testing must remain available without a second loop');
 assert.doesNotMatch(profile, /requestAnimationFrame|setAnimationLoop|setInterval/, 'Performance profiles must add no animation loop');
-assert.match(worldAssets, /groundSink = 0/, 'Only explicitly sunk world assets may move below terrain');
-assert.match(worldAssets, /model\.position\.y -= groundSink/, 'Tree sinking must happen in shared placement rather than editing the source asset');
-assert.match(worldAssets, /groundSink: targetHeight \* 0\.07/, 'Tree cluster bases must be buried proportionally at both tree sizes');
+assert.match(worldAssets, /groundSink = 0/, 'Only explicitly sunk base-world assets may move below terrain');
+assert.match(worldAssets, /model\.position\.y -= groundSink/, 'The first tree belt must sink in shared placement rather than edit the source asset');
+assert.match(worldAssets, /groundSink: targetHeight \* 0\.07/, 'The first tree-belt bases must remain buried proportionally at both tree sizes');
+assert.match(worldRender, /TREE_CLUSTER_SINK_RATIO = 0\.07/, 'Late forest clusters must use the same proportional grounding as the first tree belt');
+assert.match(worldRender, /const beautyBaselineChildren = new Set\(world\.children\)/, 'Late tree grounding must only inspect scenery added by the beauty pass');
+assert.match(worldRender, /groundLateTreeClusters\(world, beautyBaselineChildren\)/, 'Late forest clusters must be grounded after asynchronous beauty assets finish loading');
+assert.match(worldRender, /size\.x >= 5\s*&& size\.z >= 5/, 'The late grounding filter must stay restricted to broad tree-cluster groups');
+assert.doesNotMatch(worldRender, /requestAnimationFrame|setAnimationLoop|setInterval/, 'Tree grounding must stay a one-time scenery setup cost');
 assert.match(replay, /const replayFrameCache = new WeakMap\(\)/, 'Replay interpolation must cache the last sample per saved lap');
 assert.match(replay, /return cached\.frame/, 'Repeated same-time replay lookups must take the cache fast path');
 assert.match(monitor, /profile: currentPerformanceProfile\(\)/, 'Every performance snapshot must record its active renderer profile');
@@ -166,4 +172,4 @@ assert.doesNotMatch(orientationCompat, /requestAnimationFrame|setAnimationLoop|s
 assert.match(monitor, /turn:perf-snapshot/);
 assert.match(monitor, /trackChecksPerQuery/);
 
-console.log(`TURN universal DPR, bounded spatial search and diagnostics regression passed (${(trackChecks / trackQueries).toFixed(1)} average on-track checks vs 720).`);
+console.log(`TURN universal DPR, complete tree grounding, bounded spatial search and diagnostics regression passed (${(trackChecks / trackQueries).toFixed(1)} average on-track checks vs 720).`);

--- a/turn/in-game-menu.css
+++ b/turn/in-game-menu.css
@@ -23,6 +23,20 @@
   background: var(--paper);
 }
 
+.back-to-start-button.is-lap-invalid {
+  background: #ff6b6b;
+}
+
+.back-to-start-button.is-lap-invalid-pulse {
+  animation: turn-restart-invalid-pulse 680ms cubic-bezier(0.2, 0.85, 0.3, 1.2) 1;
+}
+
+@keyframes turn-restart-invalid-pulse {
+  0%, 100% { transform: scale(1); }
+  36% { transform: scale(1.08); }
+  64% { transform: scale(0.985); }
+}
+
 .utility-group[data-menu-state="hidden"] {
   display: none;
 }
@@ -37,5 +51,11 @@
     min-height: 40px;
     padding: 6px clamp(8px, 1.2vw, 13px);
     font-size: clamp(0.52rem, 1.18vw, 0.64rem);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .back-to-start-button.is-lap-invalid-pulse {
+    animation: none;
   }
 }

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r45 New application icon and start-screen branding -->
+<!-- TURN r46 Invalid-lap restart cue and complete tree grounding -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,35 +10,35 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.28 · Build 2026.07.22-r45</title>
+  <title>TURN v1.3.29 · Build 2026.07.22-r46</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.28',
-      id: '2026.07.22-r45',
-      cacheKey: '20260722-r45'
+      version: '1.3.29',
+      id: '2026.07.22-r46',
+      cacheKey: '20260722-r46'
     });
   </script>
   <link rel="icon" href="./favicon-r45.ico" sizes="any">
   <link rel="icon" href="./favicon-32-r45.png" type="image/png" sizes="32x32">
   <link rel="apple-touch-icon" href="./apple-touch-icon-r45.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260722-r45">
-  <link rel="stylesheet" href="./styles.css?build=20260722-r45">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260722-r45">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260722-r45">
-  <link rel="stylesheet" href="./install-gate.css?build=20260722-r45">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260722-r45">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260722-r45">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260722-r45">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260722-r45">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260722-r45">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260722-r45">
-  <link rel="stylesheet" href="./orientation-guard.css?build=20260722-r45">
-  <link rel="stylesheet" href="./lap-result-toast.css?build=20260722-r45">
-  <link rel="stylesheet" href="./rival-onboarding.css?build=20260722-r45">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260722-r45">
+  <link rel="manifest" href="./site.webmanifest?build=20260722-r46">
+  <link rel="stylesheet" href="./styles.css?build=20260722-r46">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260722-r46">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260722-r46">
+  <link rel="stylesheet" href="./install-gate.css?build=20260722-r46">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260722-r46">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260722-r46">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260722-r46">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260722-r46">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260722-r46">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260722-r46">
+  <link rel="stylesheet" href="./orientation-guard.css?build=20260722-r46">
+  <link rel="stylesheet" href="./lap-result-toast.css?build=20260722-r46">
+  <link rel="stylesheet" href="./rival-onboarding.css?build=20260722-r46">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260722-r46">
 
-  <script src="./install-gate.js?build=20260722-r45"></script>
-  <script src="./orientation-compat.js?build=20260722-r45"></script>
+  <script src="./install-gate.js?build=20260722-r46"></script>
+  <script src="./orientation-compat.js?build=20260722-r46"></script>
   <script type="importmap">
     {
       "imports": {
@@ -67,7 +67,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.28 · Build 2026.07.22-r45</span>
+        <span class="install-kicker">TURN v1.3.29 · Build 2026.07.22-r46</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -95,7 +95,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.28 · Build 2026.07.22-r45</span>
+      <span class="kicker">TURN v1.3.29 · Build 2026.07.22-r46</span>
       <h1 class="start-logo-heading" id="title">
         <img class="start-logo" src="./icon-512-r45.png" alt="TURN">
       </h1>
@@ -163,6 +163,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260722-r45"></script>
+  <script type="module" src="./app.js?build=20260722-r46"></script>
 </body>
 </html>

--- a/turn/lap-result-toast.css
+++ b/turn/lap-result-toast.css
@@ -17,6 +17,10 @@
   transition: opacity 180ms ease, transform 220ms cubic-bezier(0.2, 0.85, 0.3, 1.18);
 }
 
+.lap-result-toast.is-invalid {
+  background: #ff6b6b;
+}
+
 .lap-result-toast[hidden] {
   display: none;
 }

--- a/turn/render/world.js
+++ b/turn/render/world.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 
 const buildId = new URL(import.meta.url).searchParams.get('build');
+const TREE_CLUSTER_SINK_RATIO = 0.07;
 
 function moduleUrl(relativePath) {
   const url = new URL(relativePath, import.meta.url);
@@ -33,6 +34,35 @@ function waitForRuntime() {
   window.addEventListener('turn:runtime-ready', (event) => {
     install(event.detail || globalThis.__turnRuntime);
   }, { once: true });
+}
+
+function groundLateTreeClusters(world, baselineChildren) {
+  const bounds = new THREE.Box3();
+  const size = new THREE.Vector3();
+  let groundedCount = 0;
+
+  for (const child of world.children) {
+    if (baselineChildren.has(child) || !child?.isGroup) continue;
+
+    bounds.setFromObject(child);
+    bounds.getSize(size);
+
+    // The late Kenney forest clusters are broad, ground-level groups between 8 and 16 m
+    // tall. Flags are narrow and clouds are elevated, so this keeps the grounding fix
+    // isolated to the slab-backed tree groups added by the beauty pass.
+    const treeCluster = bounds.min.y > -1.5
+      && bounds.min.y < 2.5
+      && size.y >= 6
+      && size.y <= 18
+      && size.x >= 5
+      && size.z >= 5;
+
+    if (!treeCluster) continue;
+    child.position.y -= size.y * TREE_CLUSTER_SINK_RATIO;
+    groundedCount += 1;
+  }
+
+  if (groundedCount) console.info(`TURN: grounded ${groundedCount} late tree clusters.`);
 }
 
 async function install(runtime) {
@@ -77,9 +107,12 @@ async function install(runtime) {
     installTrackIdentity({ world, samples, trackWidth });
     installSectionIntensity({ world, samples, trackWidth });
 
-    installWorldBeauty({ world, scene, samples, trackWidth, sun, hemi }).catch((error) => {
-      console.warn('TURN: world beauty pass failed, keeping base world.', error);
-    });
+    const beautyBaselineChildren = new Set(world.children);
+    installWorldBeauty({ world, scene, samples, trackWidth, sun, hemi })
+      .then(() => groundLateTreeClusters(world, beautyBaselineChildren))
+      .catch((error) => {
+        console.warn('TURN: world beauty pass failed, keeping base world.', error);
+      });
   } catch (error) {
     console.warn('TURN: standalone world bootstrap failed, keeping base world.', error);
   }

--- a/turn/ui/in-game-menu.js
+++ b/turn/ui/in-game-menu.js
@@ -20,6 +20,7 @@ function install(runtime) {
   const backToLotButton = document.querySelector('.back-to-lot-button');
   const resetRivalsButton = document.querySelector('.reset-rivals-button');
   const spectateButton = document.querySelector('.spectate-button');
+  const lapTimeChip = document.querySelector('#lapTime')?.closest('.chip');
 
   if (!utilityGroup || !backToStartButton || !recalibrateButton || !backToLotButton || !resetRivalsButton || !spectateButton) {
     requestAnimationFrame(() => install(runtime));
@@ -46,6 +47,43 @@ function install(runtime) {
   for (const button of buttonOrder) utilityGroup.appendChild(button);
 
   let previousMenuState = null;
+  let lapInvalid = false;
+  let invalidPulseTimer = 0;
+
+  function setRestartLapInvalid(nextInvalid, { pulse = false } = {}) {
+    const invalid = nextInvalid === true;
+    const becameInvalid = invalid && !lapInvalid;
+    lapInvalid = invalid;
+    backToStartButton.classList.toggle('is-lap-invalid', invalid);
+
+    if (!invalid) {
+      window.clearTimeout(invalidPulseTimer);
+      invalidPulseTimer = 0;
+      backToStartButton.classList.remove('is-lap-invalid-pulse');
+      return;
+    }
+
+    if (!pulse || !becameInvalid) return;
+    window.clearTimeout(invalidPulseTimer);
+    backToStartButton.classList.remove('is-lap-invalid-pulse');
+    void backToStartButton.offsetWidth;
+    backToStartButton.classList.add('is-lap-invalid-pulse');
+    invalidPulseTimer = window.setTimeout(() => {
+      backToStartButton.classList.remove('is-lap-invalid-pulse');
+      invalidPulseTimer = 0;
+    }, 760);
+  }
+
+  function syncLapValidity({ pulseOnEntry = true } = {}) {
+    const invalid = lapTimeChip?.classList.contains('is-invalid-lap') === true;
+    setRestartLapInvalid(invalid, { pulse: pulseOnEntry });
+  }
+
+  const lapValidityObserver = lapTimeChip && typeof MutationObserver === 'function'
+    ? new MutationObserver(() => syncLapValidity())
+    : null;
+  lapValidityObserver?.observe(lapTimeChip, { attributes: true, attributeFilter: ['class'] });
+
   function syncMenu() {
     const visibility = inGameMenuVisibilityFor(runtime.state.mode);
     if (visibility.menuState !== previousMenuState) {
@@ -62,8 +100,17 @@ function install(runtime) {
     }
   }
 
-  window.addEventListener('turn:ui-state-change', syncMenu);
+  window.addEventListener('turn:ui-state-change', (event) => {
+    syncMenu();
+    if (!event.detail?.running || event.detail?.reason === 'race-reset') {
+      setRestartLapInvalid(false);
+    } else {
+      syncLapValidity();
+    }
+  });
+
   syncMenu();
+  syncLapValidity({ pulseOnEntry: false });
 }
 
 waitForRuntime();


### PR DESCRIPTION
## Summary

Finishes the tree-base cleanup and improves invalid-lap recovery feedback.

## Changes

- Grounds the 38 late forest tree clusters added by the asynchronous world beauty pass, using the same 7% proportional sink as the original r44 tree belt.
- Keeps the late grounding filter restricted to broad, ground-level tree groups so flags, clouds and unrelated scenery are untouched.
- Makes RESTART LAP stay red while the visible TIME card is in INVALID LAP state.
- Pulses RESTART LAP once when the TIME card first becomes invalid.
- Makes the LAP INVALID / STAY ON THE TRACK! toast use the same red as the invalid TIME card.
- Preserves the r45 icon and start-screen branding assets unchanged.
- No physics, checkpoint, handling, car-balance or audio changes.

## Regression coverage

- Shared TIME-card validity state drives the restart cue.
- Restart cue remains event-driven and respects reduced motion.
- Invalid-lap toast red is locked in.
- Both the original r44 tree belt and the late beauty-pass forest clusters are protected against visible slab regressions.

## Release

TURN v1.3.29 · Build 2026.07.22-r46