### PR TITLE
TURN v1.5.0 r47: Airport track and track selection

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Run race and replay regression tests
         run: node turn-lab/tests/regression.mjs
 
+      - name: Run multi-track and Airport regression
+        run: node turn-lab/tests/multi-track-production.mjs
+
       - name: Run production manual steering regression
         run: node turn-lab/tests/manual-steering-production.mjs
 

--- a/turn-lab/tests/app-icon-production.mjs
+++ b/turn-lab/tests/app-icon-production.mjs
@@ -10,11 +10,11 @@ const index = fs.readFileSync(path.join(turnRoot, 'index.html'), 'utf8');
 const styles = fs.readFileSync(path.join(turnRoot, 'styles.css'), 'utf8');
 const manifest = JSON.parse(fs.readFileSync(path.join(turnRoot, 'site.webmanifest'), 'utf8'));
 
-assert.match(index, /TURN v1\.3\.29 · Build 2026\.07\.22-r46/);
+assert.match(index, /TURN v1\.5\.0 · Build 2026\.07\.22-r47/);
 assert.match(index, /<link rel="icon" href="\.\/favicon-r45\.ico" sizes="any">/);
 assert.match(index, /<link rel="icon" href="\.\/favicon-32-r45\.png" type="image\/png" sizes="32x32">/);
 assert.match(index, /<link rel="apple-touch-icon" href="\.\/apple-touch-icon-r45\.png" sizes="180x180">/);
-assert.match(index, /<link rel="manifest" href="\.\/site\.webmanifest\?build=20260722-r46">/);
+assert.match(index, /<link rel="manifest" href="\.\/site\.webmanifest\?build=20260722-r47">/);
 assert.match(index, /<img class="install-icon" src="\.\/icon-512-r45\.png" alt="">/);
 assert.match(index, /<h1 class="start-logo-heading" id="title">\s*<img class="start-logo" src="\.\/icon-512-r45\.png" alt="TURN">\s*<\/h1>/);
 assert.doesNotMatch(index, /apple-touch-icon-v4|icon-192-v4/);

--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -10,8 +10,8 @@ const [index, app, audio, controls, catalogSource] = await Promise.all([
 ]);
 const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
 
-assert.match(index, /TURN v1\.3\.29 · Build 2026\.07\.22-r46/);
-assert.match(index, /\.\/app\.js\?build=20260722-r46/);
+assert.match(index, /TURN v1\.5\.0 · Build 2026\.07\.22-r47/);
+assert.match(index, /\.\/app\.js\?build=20260722-r47/);
 assert.match(
   index,
   /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/,

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -69,7 +69,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.29 · Build 2026\.07\.22-r46/);
+assert.match(index, /TURN v1\.5\.0 · Build 2026\.07\.22-r47/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -20,9 +20,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.29 · Build 2026\.07\.22-r46/);
-assert.match(index, /drive-pad\.css\?build=20260722-r46/);
-assert.match(index, /gameplay-v2\.css\?build=20260722-r46/);
+assert.match(index, /TURN v1\.5\.0 · Build 2026\.07\.22-r47/);
+assert.match(index, /drive-pad\.css\?build=20260722-r47/);
+assert.match(index, /gameplay-v2\.css\?build=20260722-r47/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -40,29 +40,32 @@ assert.ok(truck.tuning.boostPowerMultiplier < sedan.tuning.boostPowerMultiplier,
 assert.ok(truck.tuning.boostDurationSeconds > sedan.tuning.boostDurationSeconds, 'Truck should have a longer boost tank');
 assert.notEqual(catalog.makeGhostColor('#ff4fa3'), '#ff4fa3', 'Ghost colour should be a lighter nuance, not the original paint colour');
 
-const [index, main, lapSystem, rivalStorage, controls, carModels] = await Promise.all([
+const [index, main, lapSystem, rivalStorage, controls, carModels, lotWrapper] = await Promise.all([
   fs.readFile(path.join(turnDir, 'index.html'), 'utf8'),
   fs.readFile(path.join(turnDir, 'main.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'race/lap-system.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'race/rival-storage.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'ui/gameplay-controls.js'), 'utf8'),
-  fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8')
+  fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8'),
+  fs.readFile(path.join(turnDir, 'garage/lot-track-select.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.29 · Build 2026\.07\.22-r46/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260722-r46/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-r10\.js\?build=20260720-r25"/, 'r46 must preserve the latest Lot module cache redirect');
-assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r46 must preserve the reduced Monster Truck scale in the main runtime');
-assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r46 must preserve the same reduced Monster Truck scale inside The Lot');
+assert.match(index, /TURN v1\.5\.0 · Build 2026\.07\.22-r47/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260722-r47/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260722-r47"/, 'r47 must place track selection in front of the stable Lot implementation');
+assert.match(lotWrapper, /showOriginalLot/, 'The track-first wrapper must still delegate car selection to the verified Lot implementation');
+assert.match(lotWrapper, /await chooseTrackBeforeLot\(\)/, 'The driver must pick a track before choosing the car');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r47 must preserve the reduced Monster Truck scale in the main runtime');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r47 must preserve the same reduced Monster Truck scale inside The Lot');
 assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
-assert.match(main, /await showTheLot\(/, 'Start flow must enter The Lot before racing');
+assert.match(main, /await showTheLot\(/, 'Start flow must enter the track-first Lot wrapper before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');
 assert.match(main, /vehicleTuning: state\.vehicleTuning/, 'Selected handling profile must reach physics');
 assert.doesNotMatch(main, /wayne-wu\/webgpu-crowd-simulation/, 'Production must not depend on the old remote Sedan model');
 assert.match(lapSystem, /carId: state\.vehicleId \|\| 'sedan'/, 'Completed laps must remember their car model');
 assert.match(lapSystem, /carColor: state\.vehicleColor \|\| '#ffd43b'/, 'Completed laps must remember their paint colour');
 assert.match(lapSystem, /carSecondaryColor: state\.vehicleSecondaryColor \|\| '#f8f9fa'/, 'Completed laps must remember secondary paint');
-assert.match(rivalStorage, /version: 4/, 'Rival storage schema must include secondary paint metadata');
+assert.match(rivalStorage, /version: 5/, 'Rival storage schema must include track identity and secondary paint metadata');
 assert.match(rivalStorage, /normalizeVehicleId\(lap\.carId\)/, 'Loaded rivals must normalize stored car ids');
 assert.match(rivalStorage, /normalizeVehicleColor\(lap\.carColor\)/, 'Loaded rivals must normalize stored car colours');
 assert.match(rivalStorage, /normalizeVehicleSecondaryColor\(lap\.carSecondaryColor\)/, 'Loaded rivals must normalize secondary paint');
@@ -72,7 +75,7 @@ assert.match(carModels, /loadCarSource\(car\.id\)/, 'Car model factory must load
 
 const lotR10 = await fs.readFile(path.join(turnDir, 'garage/lot-r10.js'), 'utf8');
 const lotR10Css = await fs.readFile(path.join(turnDir, 'garage/lot-r10.css'), 'utf8');
-assert.match(main, /garage\/lot-r10\.js/, 'Production must load the r10 Lot module');
+assert.match(main, /garage\/lot-r10\.js/, 'The game core must continue to request the stable r10 Lot module contract');
 assert.match(lotR10, /UNSELECTED_COLOR = new THREE\.Color\(0x313131\)/, 'Unselected Lot cars must use #313131');
 assert.match(lotR10, /car-models\.js\?build=20260720-r22/, 'The Lot must keep the r22 outline implementation');
 assert.match(lotR10, /if \(selected \|\| record\.outline\)/, 'Unselected Lot cars must preserve their original outline materials');
@@ -95,8 +98,8 @@ assert.match(lotR10Css, /--lot-rail-width/, 'The stats and viewer rail must rese
 
 const backToLot = await fs.readFile(path.join(turnDir, 'ui/back-to-lot.js'), 'utf8');
 assert.match(main, /openLot: openLotFromRace/, 'Race runtime must expose the Back to the Lot action');
-assert.match(main, /await showTheLot\(/, 'Back to the Lot must reuse the real Lot selector');
+assert.match(main, /await showTheLot\(/, 'Back to the Lot must reuse the track-first car-selection flow');
 assert.match(backToLot, /Back to Lot/, 'Race UI must include the Back to Lot button');
 assert.match(backToLot, /back-to-lot-button/, 'Back to Lot must expose its menu hook');
 
-console.log('TURN garage production regression passed.');
+console.log('TURN garage and track-first car selection regression passed.');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -26,8 +26,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.29 · Build 2026\.07\.22-r46/);
-assert.match(index, /in-game-menu\.css\?build=20260722-r46/);
+assert.match(index, /TURN v1\.5\.0 · Build 2026\.07\.22-r47/);
+assert.match(index, /in-game-menu\.css\?build=20260722-r47/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Restart Lap<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -134,11 +134,11 @@ const [index, app, lapSystem, gameState, hud, styles, toast, toastCss, onboardin
   fs.readFile(new URL('../../turn/rival-onboarding.css', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.29 · Build 2026\.07\.22-r46/);
-assert.match(index, /lap-result-toast\.css\?build=20260722-r46/);
-assert.match(index, /rival-onboarding\.css\?build=20260722-r46/);
-assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260722-r41"/, 'r46 must preserve the r41 early invalid-lap detector');
-assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r41"/, 'r46 must preserve the r41 reset-safe invalid-lap state');
+assert.match(index, /TURN v1\.5\.0 · Build 2026\.07\.22-r47/);
+assert.match(index, /lap-result-toast\.css\?build=20260722-r47/);
+assert.match(index, /rival-onboarding\.css\?build=20260722-r47/);
+assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260722-r41"/, 'r47 must preserve the r41 early invalid-lap detector');
+assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r41"/, 'r47 must preserve the r41 reset-safe invalid-lap state');
 assert.match(app, /installLapResultToast\(\)/, 'The lap result toast must install before the game runtime starts');
 assert.match(app, /installRivalOnboarding\(\)/, 'The rival onboarding plate must install before the game runtime starts');
 assert.match(lapSystem, /turn:lap-result/, 'Completed lap finish must publish one frozen result event');

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -20,13 +20,13 @@ const [index, css, orientationGuardCss, orientationCompat, camera] = await Promi
   fs.readFile(new URL('../../turn/render/camera.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.29 · Build 2026\.07\.22-r46/);
+assert.match(index, /TURN v1\.5\.0 · Build 2026\.07\.22-r47/);
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260722-r46/);
-assert.match(index, /orientation-guard\.css\?build=20260722-r46/);
-assert.match(index, /orientation-compat\.js\?build=20260722-r46/);
-assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r46 must preserve the guarded race camera cache redirect');
+assert.match(index, /manual-steering\.css\?build=20260722-r47/);
+assert.match(index, /orientation-guard\.css\?build=20260722-r47/);
+assert.match(index, /orientation-compat\.js\?build=20260722-r47/);
+assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r47 must preserve the guarded race camera cache redirect');
 assert.match(index, /<strong>Rotate to landscape<\/strong>/, 'The pre-race landscape instruction must remain available');
 
 assert.match(css, /--manual-steer-left/);

--- a/turn-lab/tests/multi-track-production.mjs
+++ b/turn-lab/tests/multi-track-production.mjs
@@ -61,7 +61,7 @@ assert.equal(rebuilt.index, brute.index, 'Rebuilt track index must remain exact 
 assert.equal(rebuilt.sample, trackB[brute.index], 'Rebuilt index must return the active track sample object');
 assert.ok(spatialIndex.getStats().queryCount >= 1, 'Rebuilt index diagnostics must restart and record new-track queries');
 
-const [index, trackCatalog, trackManager, trackSelect, trackSelectCss, lotWrapper, airportWorld, spatialSource, rivalStorage] = await Promise.all([
+const [index, trackCatalog, trackManager, trackSelect, trackSelectCss, lotWrapper, airportWorld, spatialSource, rivalStorage, hud] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/tracks/catalog.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/tracks/track-manager.js', import.meta.url), 'utf8'),
@@ -70,7 +70,8 @@ const [index, trackCatalog, trackManager, trackSelect, trackSelectCss, lotWrappe
   fs.readFile(new URL('../../turn/garage/lot-track-select.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/tracks/airport-world.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/race/track-spatial-index.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/ui/hud.js', import.meta.url), 'utf8')
 ]);
 
 assert.match(index, /TURN v1\.5\.0 · Build 2026\.07\.22-r47/);
@@ -101,6 +102,8 @@ assert.match(trackSelect, /TRACK → CAR → RACE/);
 assert.match(trackSelect, /getStoredBestTime\(track\.id\)/, 'Selector cards must show track-specific records');
 assert.match(trackSelectCss, /grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/, 'The two launch tracks must present as peer choices');
 
+assert.match(trackManager, /initialTrackId: chosenThisSession \? activeTrackId : loadTrackSelection\(\)/, 'Later Lot visits must reopen track choice with the current course preselected');
+assert.doesNotMatch(trackManager, /if \(!force && chosenThisSession\) return activeTrackId/, 'Track selection must not be skipped on later visits to The Lot');
 assert.match(trackManager, /replaceSamples\(currentRuntime\.samples, airportTrack\.samples\)/);
 assert.match(trackManager, /currentRuntime\.trackSpatialIndex\.replaceSamples\(currentRuntime\.samples\)/, 'The shared exact spatial index must rebuild when changing tracks');
 assert.match(trackManager, /currentRuntime\.world\.visible = false/);
@@ -109,6 +112,10 @@ assert.match(trackManager, /currentRuntime\.world\.visible = true/);
 assert.match(trackManager, /loadRivalsState\([\s\S]*trackId: nextTrackId/, 'Changing track must reload only that track’s rivals');
 assert.match(trackManager, /clearRivalsState\(currentRuntime\.state, \{ trackId: activeTrackId \}\)/, 'Reset Rivals must remain scoped to the active track');
 assert.doesNotMatch(trackManager, /setAnimationLoop|requestAnimationFrame|setInterval/, 'Track switching must not create another render loop');
+
+assert.match(hud, /cached\.firstSample === firstSample/, 'The minimap cache must notice when the shared samples array is repopulated for another track');
+assert.match(hud, /cached\.lastSample === lastSample/, 'The minimap cache must not reuse the previous track drawing after a course switch');
+assert.match(hud, /firstSample,\s*lastSample,/, 'The cached minimap must remember the active course sample identities');
 
 assert.match(spatialSource, /replaceSamples\(nextSamples\)/, 'The shared spatial index must expose a controlled rebuild hook');
 assert.match(spatialSource, /return rebuild\(nextSamples\)/);
@@ -125,7 +132,7 @@ assert.match(airportWorld, /new THREE\.BoxGeometry\(455, 0\.1, 62\)/, 'Airport m
 assert.doesNotMatch(airportWorld, /GLTFLoader|fetch\(|new Audio\(/, 'Airport scenery must stay deterministic and offline-friendly');
 assert.doesNotMatch(airportWorld, /setAnimationLoop|requestAnimationFrame|setInterval/, 'Airport scenery must add no independent animation loop');
 
-console.log('TURN multi-track selection, Airport world and track-scoped rival regression passed.');
+console.log('TURN multi-track selection, Airport world, minimap switching and track-scoped rival regression passed.');
 
 function makeSamples(points) {
   return points.map(([x, z]) => ({ point: { x, z } }));

--- a/turn-lab/tests/multi-track-production.mjs
+++ b/turn-lab/tests/multi-track-production.mjs
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import { createTrackSpatialIndex, findNearestTrackBruteForce } from '../../turn/race/track-spatial-index.js';
+import {
+  clearRivalsState,
+  getStoredBestTime,
+  saveRivalsState
+} from '../../turn/race/rival-storage.js';
+
+const storage = new Map();
+const originalLocalStorage = globalThis.localStorage;
+globalThis.localStorage = {
+  getItem(key) { return storage.has(key) ? storage.get(key) : null; },
+  setItem(key, value) { storage.set(key, String(value)); },
+  removeItem(key) { storage.delete(key); }
+};
+
+try {
+  const countrysideState = {
+    trackId: 'countryside',
+    competitorLaps: [{ time: 12.73, frames: Array.from({ length: 25 }, (_, index) => ({ t: index / 10 })) }]
+  };
+  const airportState = {
+    trackId: 'airport',
+    competitorLaps: [{ time: 18.42, frames: Array.from({ length: 25 }, (_, index) => ({ t: index / 10 })) }]
+  };
+
+  assert.equal(saveRivalsState(countrysideState), true);
+  assert.equal(saveRivalsState(airportState), true);
+  assert.ok(storage.has('turn-personal-rivals-v1'), 'Track 1 must preserve the existing rival storage key');
+  assert.ok(storage.has('turn-personal-rivals-v1:airport'), 'Airport rivals must live in their own storage key');
+  assert.equal(getStoredBestTime('countryside'), 12.73);
+  assert.equal(getStoredBestTime('airport'), 18.42);
+
+  clearRivalsState(airportState);
+  assert.equal(storage.has('turn-personal-rivals-v1:airport'), false, 'Reset Rivals on Airport must clear only Airport');
+  assert.equal(storage.has('turn-personal-rivals-v1'), true, 'Reset Rivals on Airport must never erase countryside history');
+} finally {
+  if (originalLocalStorage === undefined) delete globalThis.localStorage;
+  else globalThis.localStorage = originalLocalStorage;
+}
+
+const trackA = makeSamples([
+  [-20, 0],
+  [0, 0],
+  [20, 0],
+  [40, 0]
+]);
+const trackB = makeSamples([
+  [0, 100],
+  [20, 100],
+  [40, 100],
+  [60, 100]
+]);
+const spatialIndex = createTrackSpatialIndex(trackA, { cellSize: 16 });
+assert.equal(spatialIndex.find({ x: 3, z: 2 }).index, 1, 'Initial track index must find Track A samples');
+spatialIndex.replaceSamples(trackB);
+const rebuilt = spatialIndex.find({ x: 19, z: 98 });
+const brute = findNearestTrackBruteForce(trackB, { x: 19, z: 98 });
+assert.equal(rebuilt.index, brute.index, 'Rebuilt track index must remain exact after changing courses');
+assert.equal(rebuilt.sample, trackB[brute.index], 'Rebuilt index must return the active track sample object');
+assert.ok(spatialIndex.getStats().queryCount >= 1, 'Rebuilt index diagnostics must restart and record new-track queries');
+
+const [index, trackCatalog, trackManager, trackSelect, trackSelectCss, lotWrapper, airportWorld, spatialSource, rivalStorage] = await Promise.all([
+  fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/tracks/catalog.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/tracks/track-manager.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/ui/track-select.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/track-select.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-track-select.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/tracks/airport-world.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/race/track-spatial-index.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
+]);
+
+assert.match(index, /TURN v1\.5\.0 · Build 2026\.07\.22-r47/);
+assert.match(index, /track-select\.css\?build=20260722-r47/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260722-r47"/, 'The track selector must sit before the existing Lot entry point');
+assert.match(index, /"\.\/race\/rival-storage\.js\?build=20260720-r19": "\.\/race\/rival-storage\.js\?build=20260722-r47"/, 'Production must load track-scoped rival storage');
+assert.match(index, /"\.\/race\/track-spatial-index\.js\?build=20260720-r19": "\.\/race\/track-spatial-index\.js\?build=20260722-r47"/, 'Production must load the rebuildable track index');
+assert.match(index, /Turn the device to steer/, 'Start copy must use device-neutral language');
+assert.match(index, /Steering uses device rotation/, 'Status copy must use device-neutral language');
+assert.doesNotMatch(index, /Turn the phone to steer|Steering uses phone rotation/, 'The retired phone-specific start copy must stay removed');
+
+assert.match(trackCatalog, /id: 'countryside'/);
+assert.match(trackCatalog, /difficulty: 'EASY'/);
+assert.match(trackCatalog, /id: 'airport'/);
+assert.match(trackCatalog, /difficulty: 'MEDIUM'/);
+assert.match(trackCatalog, /radiusX = 208 \+ Math\.sin\(angle \* 2 \+ 0\.35\) \* 20 \+ Math\.sin\(angle \* 3 - 0\.8\) \* 9/, 'Track 1 geometry generator must remain unchanged');
+assert.match(trackCatalog, /radiusZ = 146 \+ Math\.cos\(angle \* 2 - 0\.4\) \* 14 \+ Math\.sin\(angle \* 3 \+ 0\.6\) \* 8/, 'Track 1 geometry generator must remain unchanged');
+assert.match(trackCatalog, /TRACK_SAMPLE_COUNT = 720/, 'Both tracks must use the verified 720-sample race/checkpoint system');
+assert.match(trackCatalog, /Runway speed\. Service-road precision\./, 'Airport must keep its medium-difficulty driving identity');
+
+assert.match(lotWrapper, /await chooseTrackBeforeLot\(\)/, 'Track selection must complete before The Lot opens');
+assert.ok(
+  lotWrapper.indexOf('await chooseTrackBeforeLot()') < lotWrapper.indexOf('showOriginalLot(options)'),
+  'The flow must remain TRACK → CAR → RACE'
+);
+assert.match(trackSelect, /CHOOSE YOUR TRACK/);
+assert.match(trackSelect, /TRACK → CAR → RACE/);
+assert.match(trackSelect, /getStoredBestTime\(track\.id\)/, 'Selector cards must show track-specific records');
+assert.match(trackSelectCss, /grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/, 'The two launch tracks must present as peer choices');
+
+assert.match(trackManager, /replaceSamples\(currentRuntime\.samples, airportTrack\.samples\)/);
+assert.match(trackManager, /currentRuntime\.trackSpatialIndex\.replaceSamples\(currentRuntime\.samples\)/, 'The shared exact spatial index must rebuild when changing tracks');
+assert.match(trackManager, /currentRuntime\.world\.visible = false/);
+assert.match(trackManager, /airportWorld\.visible = true/);
+assert.match(trackManager, /currentRuntime\.world\.visible = true/);
+assert.match(trackManager, /loadRivalsState\([\s\S]*trackId: nextTrackId/, 'Changing track must reload only that track’s rivals');
+assert.match(trackManager, /clearRivalsState\(currentRuntime\.state, \{ trackId: activeTrackId \}\)/, 'Reset Rivals must remain scoped to the active track');
+assert.doesNotMatch(trackManager, /setAnimationLoop|requestAnimationFrame|setInterval/, 'Track switching must not create another render loop');
+
+assert.match(spatialSource, /replaceSamples\(nextSamples\)/, 'The shared spatial index must expose a controlled rebuild hook');
+assert.match(spatialSource, /return rebuild\(nextSamples\)/);
+assert.match(rivalStorage, /normalized === DEFAULT_TRACK_ID \? COMPETITOR_KEY : `\$\{COMPETITOR_KEY\}:\$\{normalized\}`/, 'Countryside must keep its historical storage key while later tracks are namespaced');
+assert.match(rivalStorage, /version: 5/);
+
+assert.match(airportWorld, /function makeRunway\(/);
+assert.match(airportWorld, /function makeAirportBuildings\(/);
+assert.match(airportWorld, /function makeAircraft\(/);
+assert.match(airportWorld, /function makeGroundOperations\(/);
+assert.match(airportWorld, /function makeStartGate\(/);
+assert.match(airportWorld, /new THREE\.PlaneGeometry\(520, 340\)/, 'Airport must have a large dedicated concrete field');
+assert.match(airportWorld, /new THREE\.BoxGeometry\(455, 0\.1, 62\)/, 'Airport must include its long runway landmark');
+assert.doesNotMatch(airportWorld, /GLTFLoader|fetch\(|new Audio\(/, 'Airport scenery must stay deterministic and offline-friendly');
+assert.doesNotMatch(airportWorld, /setAnimationLoop|requestAnimationFrame|setInterval/, 'Airport scenery must add no independent animation loop');
+
+console.log('TURN multi-track selection, Airport world and track-scoped rival regression passed.');
+
+function makeSamples(points) {
+  return points.map(([x, z]) => ({ point: { x, z } }));
+}

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -34,7 +34,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.29 · Build 2026\.07\.22-r46/);
+assert.match(index, /TURN v1\.5\.0 · Build 2026\.07\.22-r47/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');
@@ -45,7 +45,7 @@ assert.match(carModels, /isSecondaryPaint\(node, car\)/);
 assert.match(main, /vehicleSecondaryColor: initialVehicleSelection\.secondaryColor/);
 assert.match(main, /secondaryColor: state\.vehicleSecondaryColor/);
 assert.match(lapSystem, /carSecondaryColor: state\.vehicleSecondaryColor \|\| '#f8f9fa'/);
-assert.match(rivalStorage, /version: 4/);
+assert.match(rivalStorage, /version: 5/, 'Track-scoped rivals must preserve secondary paint metadata');
 assert.match(rivalStorage, /normalizeVehicleSecondaryColor\(lap\.carSecondaryColor\)/);
 
 console.log('TURN native and secondary paint regression passed.');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -121,11 +121,11 @@ const [index, app, main, worldAssets, worldRender, controls, menu, spectate, hud
   fs.readFile(new URL('../../turn/orientation-compat.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.3\.29 · Build 2026\.07\.22-r46/);
-assert.match(index, /"\.\/race\/replay-system\.js": "\.\/race\/replay-system\.js\?build=20260722-r43"/, 'r46 must preserve the shared replay sampler cache');
-assert.match(index, /"\.\/race\/track-spatial-index\.js\?build=20260720-r19": "\.\/race\/track-spatial-index\.js\?build=20260722-r44"/, 'r46 must preserve the bounded track search');
-assert.match(index, /"\.\/performance-monitor\.js\?build=20260720-r19": "\.\/performance-monitor\.js\?build=20260722-r43"/, 'r46 must preserve the diagnostics module');
-assert.match(index, /"\.\/world-assets\.js": "\.\/world-assets\.js\?build=20260722-r44"/, 'r46 must preserve the first tree-belt grounding pass');
+assert.match(index, /TURN v1\.5\.0 · Build 2026\.07\.22-r47/);
+assert.match(index, /"\.\/race\/replay-system\.js": "\.\/race\/replay-system\.js\?build=20260722-r43"/, 'r47 must preserve the shared replay sampler cache');
+assert.match(index, /"\.\/race\/track-spatial-index\.js\?build=20260720-r19": "\.\/race\/track-spatial-index\.js\?build=20260722-r47"/, 'r47 must use the rebuildable bounded track search');
+assert.match(index, /"\.\/performance-monitor\.js\?build=20260720-r19": "\.\/performance-monitor\.js\?build=20260722-r43"/, 'r47 must preserve the diagnostics module');
+assert.match(index, /"\.\/world-assets\.js": "\.\/world-assets\.js\?build=20260722-r44"/, 'r47 must preserve both countryside tree-grounding passes');
 assert.match(app, /installPerformanceProfile\(\)/, 'Renderer profile installation must run before the game runtime');
 assert.ok(app.indexOf('./performance-profile.js') < app.indexOf('./main.js'), 'The universal DPR cap must be ready before main.js creates the runtime');
 assert.match(profile, /DEFAULT_DPR_CAP = 1\.5/, 'The universal production DPR ceiling must stay at 1.5');
@@ -172,4 +172,4 @@ assert.doesNotMatch(orientationCompat, /requestAnimationFrame|setAnimationLoop|s
 assert.match(monitor, /turn:perf-snapshot/);
 assert.match(monitor, /trackChecksPerQuery/);
 
-console.log(`TURN universal DPR, complete tree grounding, bounded spatial search and diagnostics regression passed (${(trackChecks / trackQueries).toFixed(1)} average on-track checks vs 720).`);
+console.log(`TURN universal DPR, complete tree grounding, rebuildable bounded spatial search and diagnostics regression passed (${(trackChecks / trackQueries).toFixed(1)} average on-track checks vs 720).`);

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -1,0 +1,8 @@
+import { showTheLot as showOriginalLot } from './lot-r10.js?build=20260720-r25';
+import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r47';
+
+export async function showTheLot(options = {}) {
+  const trackId = await chooseTrackBeforeLot();
+  if (!trackId) return null;
+  return showOriginalLot(options);
+}

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r46 Invalid-lap restart cue and complete tree grounding -->
+<!-- TURN r47 Airport track and multi-track selection -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,45 +10,47 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.3.29 · Build 2026.07.22-r46</title>
+  <title>TURN v1.5.0 · Build 2026.07.22-r47</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.3.29',
-      id: '2026.07.22-r46',
-      cacheKey: '20260722-r46'
+      version: '1.5.0',
+      id: '2026.07.22-r47',
+      cacheKey: '20260722-r47'
     });
   </script>
   <link rel="icon" href="./favicon-r45.ico" sizes="any">
   <link rel="icon" href="./favicon-32-r45.png" type="image/png" sizes="32x32">
   <link rel="apple-touch-icon" href="./apple-touch-icon-r45.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260722-r46">
-  <link rel="stylesheet" href="./styles.css?build=20260722-r46">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260722-r46">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260722-r46">
-  <link rel="stylesheet" href="./install-gate.css?build=20260722-r46">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260722-r46">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260722-r46">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260722-r46">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260722-r46">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260722-r46">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260722-r46">
-  <link rel="stylesheet" href="./orientation-guard.css?build=20260722-r46">
-  <link rel="stylesheet" href="./lap-result-toast.css?build=20260722-r46">
-  <link rel="stylesheet" href="./rival-onboarding.css?build=20260722-r46">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260722-r46">
+  <link rel="manifest" href="./site.webmanifest?build=20260722-r47">
+  <link rel="stylesheet" href="./styles.css?build=20260722-r47">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260722-r47">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260722-r47">
+  <link rel="stylesheet" href="./install-gate.css?build=20260722-r47">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260722-r47">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260722-r47">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260722-r47">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260722-r47">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260722-r47">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260722-r47">
+  <link rel="stylesheet" href="./orientation-guard.css?build=20260722-r47">
+  <link rel="stylesheet" href="./lap-result-toast.css?build=20260722-r47">
+  <link rel="stylesheet" href="./rival-onboarding.css?build=20260722-r47">
+  <link rel="stylesheet" href="./track-select.css?build=20260722-r47">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260722-r47">
 
-  <script src="./install-gate.js?build=20260722-r46"></script>
-  <script src="./orientation-compat.js?build=20260722-r46"></script>
+  <script src="./install-gate.js?build=20260722-r47"></script>
+  <script src="./orientation-compat.js?build=20260722-r47"></script>
   <script type="importmap">
     {
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
-        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-r10.js?build=20260720-r25",
+        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260722-r47",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260721-r29",
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system.js?build=20260722-r41",
         "./race/game-state.js": "./race/game-state.js?build=20260722-r41",
         "./race/replay-system.js": "./race/replay-system.js?build=20260722-r43",
+        "./race/rival-storage.js?build=20260720-r19": "./race/rival-storage.js?build=20260722-r47",
         "./race/track-spatial-index.js?build=20260720-r19": "./race/track-spatial-index.js?build=20260722-r44",
         "./performance-monitor.js?build=20260720-r19": "./performance-monitor.js?build=20260722-r43",
         "./world-assets.js": "./world-assets.js?build=20260722-r44",
@@ -67,7 +69,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.3.29 · Build 2026.07.22-r46</span>
+        <span class="install-kicker">TURN v1.5.0 · Build 2026.07.22-r47</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -95,19 +97,19 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.3.29 · Build 2026.07.22-r46</span>
+      <span class="kicker">TURN v1.5.0 · Build 2026.07.22-r47</span>
       <h1 class="start-logo-heading" id="title">
         <img class="start-logo" src="./icon-512-r45.png" alt="TURN">
       </h1>
       <p class="tagline">
-        Turn the phone to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
+        Turn the device to steer. Slide one thumb between Gas, Drift and Boost. Brake and reverse share a separate control.
       </p>
       <div class="actions">
         <button id="motionButton" type="button">Enable motion &amp; race</button>
         <button class="secondary" id="manualButton" type="button">Desktop / manual mode</button>
       </div>
       <p class="status" id="status" role="status">
-        Steering uses phone rotation. Slide across the drive pad for gas, drift and boost.
+        Steering uses device rotation. Slide across the drive pad for gas, drift and boost.
       </p>
     </div>
   </section>
@@ -163,6 +165,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260722-r46"></script>
+  <script type="module" src="./app.js?build=20260722-r47"></script>
 </body>
 </html>

--- a/turn/index.html
+++ b/turn/index.html
@@ -51,7 +51,7 @@
         "./race/game-state.js": "./race/game-state.js?build=20260722-r41",
         "./race/replay-system.js": "./race/replay-system.js?build=20260722-r43",
         "./race/rival-storage.js?build=20260720-r19": "./race/rival-storage.js?build=20260722-r47",
-        "./race/track-spatial-index.js?build=20260720-r19": "./race/track-spatial-index.js?build=20260722-r44",
+        "./race/track-spatial-index.js?build=20260720-r19": "./race/track-spatial-index.js?build=20260722-r47",
         "./performance-monitor.js?build=20260720-r19": "./performance-monitor.js?build=20260722-r43",
         "./world-assets.js": "./world-assets.js?build=20260722-r44",
         "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260722-r42",

--- a/turn/race/rival-storage.js
+++ b/turn/race/rival-storage.js
@@ -10,14 +10,35 @@ import {
 
 export const RIVAL_LIMIT = 4;
 
+const DEFAULT_TRACK_ID = 'countryside';
 const GHOST_KEY = 'turn-three-ghost-v4';
 const COMPETITOR_KEY = 'turn-personal-rivals-v1';
 const LEGACY_RIVAL_COLORS = ['#38d9ff', '#ff4fa3', '#9775fa', '#ff922b'];
 
-export function saveRivalsState(state) {
+function normalizeTrackId(trackId) {
+  return typeof trackId === 'string' && trackId.trim() ? trackId.trim() : DEFAULT_TRACK_ID;
+}
+
+function rivalKey(trackId) {
+  const normalized = normalizeTrackId(trackId);
+  return normalized === DEFAULT_TRACK_ID ? COMPETITOR_KEY : `${COMPETITOR_KEY}:${normalized}`;
+}
+
+function ghostKey(trackId) {
+  const normalized = normalizeTrackId(trackId);
+  return normalized === DEFAULT_TRACK_ID ? GHOST_KEY : `${GHOST_KEY}:${normalized}`;
+}
+
+function stateTrackId(state, explicitTrackId) {
+  return normalizeTrackId(explicitTrackId || state?.trackId || DEFAULT_TRACK_ID);
+}
+
+export function saveRivalsState(state, { trackId } = {}) {
   try {
-    localStorage.setItem(COMPETITOR_KEY, JSON.stringify({
-      version: 4,
+    const activeTrackId = stateTrackId(state, trackId);
+    localStorage.setItem(rivalKey(activeTrackId), JSON.stringify({
+      version: 5,
+      trackId: activeTrackId,
       laps: state.competitorLaps
     }));
     return true;
@@ -26,13 +47,15 @@ export function saveRivalsState(state) {
   }
 }
 
-export function loadRivalsState({ state, samples, findNearestTrack }) {
+export function loadRivalsState({ state, samples, findNearestTrack, trackId }) {
+  const activeTrackId = stateTrackId(state, trackId);
+
   try {
-    const savedRivals = JSON.parse(localStorage.getItem(COMPETITOR_KEY));
+    const savedRivals = JSON.parse(localStorage.getItem(rivalKey(activeTrackId)));
     let laps = Array.isArray(savedRivals?.laps) ? savedRivals.laps : [];
 
-    if (!laps.length) {
-      const oldGhost = JSON.parse(localStorage.getItem(GHOST_KEY));
+    if (!laps.length && activeTrackId === DEFAULT_TRACK_ID) {
+      const oldGhost = JSON.parse(localStorage.getItem(ghostKey(activeTrackId)));
       if (
         oldGhost &&
         Number.isFinite(oldGhost.bestTime) &&
@@ -53,6 +76,7 @@ export function loadRivalsState({ state, samples, findNearestTrack }) {
     const startSample = samples[0];
     const findProgress = (frame) => findNearestTrack(frame).index / samples.length;
 
+    state.trackId = activeTrackId;
     state.competitorLaps = laps
       .filter(isValidLap)
       .map((lap, index) => ({
@@ -69,23 +93,43 @@ export function loadRivalsState({ state, samples, findNearestTrack }) {
       .slice(0, RIVAL_LIMIT);
 
     syncPrimaryRivalState(state);
-    if (state.competitorLaps.length) saveRivalsState(state);
+    if (state.competitorLaps.length) saveRivalsState(state, { trackId: activeTrackId });
     return state.competitorLaps;
   } catch (_) {
+    state.trackId = activeTrackId;
     state.competitorLaps = [];
     syncPrimaryRivalState(state);
     return state.competitorLaps;
   }
 }
 
-export function clearRivalsState(state) {
+export function clearRivalsState(state, { trackId } = {}) {
+  const activeTrackId = stateTrackId(state, trackId);
+  state.trackId = activeTrackId;
   state.competitorLaps = [];
   syncPrimaryRivalState(state);
 
   try {
-    localStorage.removeItem(COMPETITOR_KEY);
-    localStorage.removeItem(GHOST_KEY);
+    localStorage.removeItem(rivalKey(activeTrackId));
+    localStorage.removeItem(ghostKey(activeTrackId));
   } catch (_) {}
+}
+
+export function getStoredBestTime(trackId = DEFAULT_TRACK_ID) {
+  const activeTrackId = normalizeTrackId(trackId);
+  try {
+    const savedRivals = JSON.parse(localStorage.getItem(rivalKey(activeTrackId)));
+    const times = Array.isArray(savedRivals?.laps)
+      ? savedRivals.laps.map((lap) => Number(lap?.time)).filter(Number.isFinite)
+      : [];
+    if (times.length) return Math.min(...times);
+
+    if (activeTrackId === DEFAULT_TRACK_ID) {
+      const oldGhost = JSON.parse(localStorage.getItem(ghostKey(activeTrackId)));
+      if (Number.isFinite(Number(oldGhost?.bestTime))) return Number(oldGhost.bestTime);
+    }
+  } catch (_) {}
+  return Infinity;
 }
 
 export function syncPrimaryRivalState(state) {

--- a/turn/race/track-spatial-index.js
+++ b/turn/race/track-spatial-index.js
@@ -2,48 +2,59 @@ const DEFAULT_CELL_SIZE = 32;
 const MAX_GRID_RADIUS_BEFORE_HIERARCHY = 2;
 const HIERARCHY_LEAF_SIZE = 8;
 
-export function createTrackSpatialIndex(samples, { cellSize = DEFAULT_CELL_SIZE } = {}) {
-  if (!Array.isArray(samples) || !samples.length) {
-    throw new TypeError('TURN track index needs at least one sample');
-  }
-
+export function createTrackSpatialIndex(initialSamples, { cellSize = DEFAULT_CELL_SIZE } = {}) {
   const size = positiveNumber(cellSize, DEFAULT_CELL_SIZE);
-  const columns = new Map();
+  let samples = null;
+  let columns = null;
   let minCellX = Infinity;
   let maxCellX = -Infinity;
   let minCellZ = Infinity;
   let maxCellZ = -Infinity;
+  let hierarchy = null;
   let queryCount = 0;
   let totalChecks = 0;
   let maxChecks = 0;
   let lastChecks = 0;
 
-  for (let index = 0; index < samples.length; index += 1) {
-    const point = samples[index]?.point;
-    if (!point || !Number.isFinite(point.x) || !Number.isFinite(point.z)) {
-      throw new TypeError(`TURN track sample ${index} has no finite point`);
+  rebuild(initialSamples);
+
+  function rebuild(nextSamples) {
+    validateSamples(nextSamples);
+    samples = nextSamples;
+    columns = new Map();
+    minCellX = Infinity;
+    maxCellX = -Infinity;
+    minCellZ = Infinity;
+    maxCellZ = -Infinity;
+
+    for (let index = 0; index < samples.length; index += 1) {
+      const point = samples[index].point;
+      const cellX = Math.floor(point.x / size);
+      const cellZ = Math.floor(point.z / size);
+      let column = columns.get(cellX);
+      if (!column) {
+        column = new Map();
+        columns.set(cellX, column);
+      }
+      let bucket = column.get(cellZ);
+      if (!bucket) {
+        bucket = [];
+        column.set(cellZ, bucket);
+      }
+      bucket.push(index);
+      minCellX = Math.min(minCellX, cellX);
+      maxCellX = Math.max(maxCellX, cellX);
+      minCellZ = Math.min(minCellZ, cellZ);
+      maxCellZ = Math.max(maxCellZ, cellZ);
     }
 
-    const cellX = Math.floor(point.x / size);
-    const cellZ = Math.floor(point.z / size);
-    let column = columns.get(cellX);
-    if (!column) {
-      column = new Map();
-      columns.set(cellX, column);
-    }
-    let bucket = column.get(cellZ);
-    if (!bucket) {
-      bucket = [];
-      column.set(cellZ, bucket);
-    }
-    bucket.push(index);
-    minCellX = Math.min(minCellX, cellX);
-    maxCellX = Math.max(maxCellX, cellX);
-    minCellZ = Math.min(minCellZ, cellZ);
-    maxCellZ = Math.max(maxCellZ, cellZ);
+    hierarchy = buildTrackHierarchy(samples, 0, samples.length);
+    queryCount = 0;
+    totalChecks = 0;
+    maxChecks = 0;
+    lastChecks = 0;
+    return samples;
   }
-
-  const hierarchy = buildTrackHierarchy(samples, 0, samples.length);
 
   function find(position) {
     const x = Number(position?.x);
@@ -155,6 +166,9 @@ export function createTrackSpatialIndex(samples, { cellSize = DEFAULT_CELL_SIZE 
   return Object.freeze({
     cellSize: size,
     find,
+    replaceSamples(nextSamples) {
+      return rebuild(nextSamples);
+    },
     getStats() {
       return Object.freeze({ queryCount, totalChecks, maxChecks, lastChecks });
     }
@@ -184,6 +198,19 @@ export function findNearestTrackBruteForce(samples, position) {
     distance: Math.sqrt(bestDistanceSq),
     checks: samples.length
   };
+}
+
+function validateSamples(samples) {
+  if (!Array.isArray(samples) || !samples.length) {
+    throw new TypeError('TURN track index needs at least one sample');
+  }
+
+  for (let index = 0; index < samples.length; index += 1) {
+    const point = samples[index]?.point;
+    if (!point || !Number.isFinite(point.x) || !Number.isFinite(point.z)) {
+      throw new TypeError(`TURN track sample ${index} has no finite point`);
+    }
+  }
 }
 
 function buildTrackHierarchy(samples, start, end) {

--- a/turn/track-select.css
+++ b/turn/track-select.css
@@ -1,0 +1,311 @@
+.track-select {
+  position: fixed;
+  inset: 0;
+  z-index: 1500;
+  display: grid;
+  place-items: center;
+  overflow: auto;
+  padding: max(18px, env(safe-area-inset-top)) max(18px, env(safe-area-inset-right)) max(18px, env(safe-area-inset-bottom)) max(18px, env(safe-area-inset-left));
+  background:
+    radial-gradient(circle at 18% 18%, rgb(255 255 255 / 0.36), transparent 24%),
+    linear-gradient(145deg, #8be3ff 0%, #55c9ed 52%, #35b8e7 100%);
+  opacity: 0;
+  transition: opacity 180ms ease;
+}
+
+.track-select[hidden] {
+  display: none;
+}
+
+.track-select.is-visible {
+  opacity: 1;
+}
+
+.track-select-shell {
+  width: min(1180px, 100%);
+}
+
+.track-select-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 18px;
+}
+
+.track-select-kicker,
+.track-card-topline,
+.track-card-best span,
+.track-select-tip {
+  font-size: clamp(0.66rem, 1.4vw, 0.9rem);
+  font-weight: 900;
+  letter-spacing: 0.14em;
+}
+
+.track-select-kicker {
+  display: inline-block;
+  padding: 6px 12px;
+  border: 3px solid var(--ink);
+  border-radius: 999px;
+  background: var(--yellow);
+  box-shadow: 4px 4px 0 var(--ink);
+}
+
+.track-select h2 {
+  margin: 7px 0 0;
+  font-size: clamp(2.2rem, 7vw, 5.5rem);
+  line-height: 0.9;
+  letter-spacing: -0.05em;
+}
+
+.track-select-head p {
+  margin: 10px 0 0;
+  max-width: 680px;
+  font-weight: 800;
+  font-size: clamp(0.86rem, 1.8vw, 1.15rem);
+}
+
+.track-select-close {
+  flex: 0 0 auto;
+  width: 58px;
+  height: 58px;
+  border: 4px solid var(--ink);
+  border-radius: 50%;
+  background: var(--pink);
+  box-shadow: 5px 5px 0 var(--ink);
+  font: inherit;
+  font-size: 2rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.track-select-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(14px, 2vw, 24px);
+}
+
+.track-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-areas:
+    "top top"
+    "preview preview"
+    "copy best";
+  gap: 9px 16px;
+  min-width: 0;
+  padding: clamp(14px, 2vw, 22px);
+  border: 5px solid var(--ink);
+  border-radius: 28px;
+  background: color-mix(in srgb, var(--track-accent-soft) 52%, #fff8e8);
+  color: var(--ink);
+  box-shadow: 9px 9px 0 var(--ink);
+  text-align: left;
+  font: inherit;
+  transform: translateY(0) rotate(0deg);
+  transition: transform 150ms ease, background 150ms ease, box-shadow 150ms ease;
+  overflow: hidden;
+}
+
+.track-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: 21px;
+  box-shadow: inset 0 0 0 0 var(--track-accent);
+  transition: box-shadow 150ms ease;
+}
+
+.track-card:hover,
+.track-card:focus-visible {
+  transform: translateY(-3px);
+}
+
+.track-card.is-selected {
+  background: var(--track-accent);
+  transform: translateY(-6px) rotate(-0.5deg);
+  box-shadow: 12px 12px 0 var(--ink);
+}
+
+.track-card.is-selected::after {
+  box-shadow: inset 0 0 0 5px rgb(255 255 255 / 0.72);
+}
+
+.track-card-topline {
+  grid-area: top;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.track-card-topline strong {
+  padding: 5px 9px;
+  border: 3px solid var(--ink);
+  border-radius: 999px;
+  background: #fff8e8;
+  box-shadow: 3px 3px 0 var(--ink);
+}
+
+.track-card-preview {
+  grid-area: preview;
+  display: block;
+  height: clamp(112px, 23vh, 230px);
+  border: 4px solid var(--ink);
+  border-radius: 20px;
+  background:
+    linear-gradient(rgb(255 255 255 / 0.38), rgb(255 255 255 / 0.1)),
+    #9ae6b4;
+  overflow: hidden;
+}
+
+.track-card-airport .track-card-preview {
+  background:
+    linear-gradient(rgb(255 255 255 / 0.26), rgb(255 255 255 / 0.04)),
+    #a7b0b8;
+}
+
+.track-card-preview svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.track-preview-shadow,
+.track-preview-road,
+.track-preview-line {
+  fill: none;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+
+.track-preview-shadow {
+  stroke: var(--ink);
+  stroke-width: 25;
+}
+
+.track-preview-road {
+  stroke: #44494f;
+  stroke-width: 17;
+}
+
+.track-preview-line {
+  stroke-width: 6;
+}
+
+.track-preview-start {
+  fill: #fff8e8;
+  stroke: var(--ink);
+  stroke-width: 4;
+}
+
+.track-card-copy {
+  grid-area: copy;
+  display: grid;
+  align-content: end;
+  min-width: 0;
+}
+
+.track-card-name {
+  font-size: clamp(1.4rem, 3.5vw, 3rem);
+  line-height: 0.95;
+  letter-spacing: -0.04em;
+}
+
+.track-card-description {
+  margin-top: 5px;
+  font-size: clamp(0.72rem, 1.5vw, 1rem);
+  font-weight: 800;
+}
+
+.track-card-best {
+  grid-area: best;
+  align-self: end;
+  min-width: min(180px, 31vw);
+  padding: 9px 12px;
+  border: 3px solid var(--ink);
+  border-radius: 16px;
+  background: #fff8e8;
+  box-shadow: 4px 4px 0 var(--ink);
+}
+
+.track-card-best span,
+.track-card-best strong {
+  display: block;
+}
+
+.track-card-best strong {
+  margin-top: 2px;
+  font-size: clamp(0.78rem, 1.8vw, 1.15rem);
+  white-space: nowrap;
+}
+
+.track-select-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 18px;
+  margin-top: 24px;
+}
+
+.track-select-tip {
+  margin-right: auto;
+}
+
+.track-select-continue {
+  min-width: min(360px, 52vw);
+  padding: 15px 22px;
+  border: 4px solid var(--ink);
+  border-radius: 18px;
+  background: #8ce99a;
+  box-shadow: 6px 6px 0 var(--ink);
+  font: inherit;
+  font-size: clamp(0.88rem, 2vw, 1.2rem);
+  font-weight: 900;
+  letter-spacing: 0.08em;
+}
+
+@media (max-height: 560px) {
+  .track-select {
+    align-items: start;
+  }
+
+  .track-select-head {
+    margin-bottom: 10px;
+  }
+
+  .track-select h2 {
+    font-size: clamp(2rem, 6.5vw, 4rem);
+  }
+
+  .track-select-head p {
+    display: none;
+  }
+
+  .track-card {
+    padding: 11px 13px;
+  }
+
+  .track-card-preview {
+    height: min(27vh, 135px);
+  }
+
+  .track-select-footer {
+    margin-top: 14px;
+  }
+}
+
+@media (max-width: 760px) and (orientation: portrait) {
+  .track-select-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .track-select,
+  .track-card {
+    transition: none;
+  }
+}

--- a/turn/tracks/airport-world.js
+++ b/turn/tracks/airport-world.js
@@ -1,0 +1,446 @@
+import * as THREE from 'three';
+
+const INK = 0x08090a;
+const RUNWAY = 0x25292e;
+const TARMAC = 0x747d85;
+const CONCRETE = 0xaeb7bf;
+const WINDOW = 0x67d6f4;
+const YELLOW = 0xffd43b;
+const PINK = 0xff4fa3;
+const RED = 0xff5f67;
+const CREAM = 0xfff8e8;
+
+const blackOutlineMaterial = new THREE.MeshBasicMaterial({
+  color: INK,
+  side: THREE.BackSide
+});
+
+export function installAirportWorld({ scene, samples, trackWidth = 27 }) {
+  const world = new THREE.Group();
+  world.name = 'TURN Airport';
+  scene.add(world);
+
+  makeGround(world);
+  makeRunway(world);
+  makeRaceRoad(world, samples, trackWidth);
+  makeAirportBuildings(world);
+  makeAircraft(world);
+  makeGroundOperations(world);
+  makeDistantWorld(world);
+  makeStartGate(world, samples, trackWidth);
+
+  return world;
+}
+
+function outlinedMesh(geometry, material, scale = 1.035, { castShadow = true, receiveShadow = true } = {}) {
+  const group = new THREE.Group();
+  const outline = new THREE.Mesh(geometry, blackOutlineMaterial);
+  outline.scale.setScalar(scale);
+  outline.castShadow = false;
+  outline.receiveShadow = false;
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.castShadow = castShadow;
+  mesh.receiveShadow = receiveShadow;
+  group.add(outline, mesh);
+  return group;
+}
+
+function material(color, roughness = 0.82, metalness = 0) {
+  return new THREE.MeshStandardMaterial({ color, roughness, metalness });
+}
+
+function makeGround(world) {
+  const grass = new THREE.Mesh(
+    new THREE.PlaneGeometry(700, 560),
+    material(0xa9e98f, 1)
+  );
+  grass.rotation.x = -Math.PI / 2;
+  grass.position.y = -0.08;
+  grass.receiveShadow = true;
+  world.add(grass);
+
+  const airportBase = new THREE.Mesh(
+    new THREE.PlaneGeometry(520, 340),
+    material(CONCRETE, 0.98)
+  );
+  airportBase.rotation.x = -Math.PI / 2;
+  airportBase.position.set(15, -0.035, -4);
+  airportBase.receiveShadow = true;
+  world.add(airportBase);
+
+  const apron = new THREE.Mesh(
+    new THREE.PlaneGeometry(290, 125),
+    material(TARMAC, 0.96)
+  );
+  apron.rotation.x = -Math.PI / 2;
+  apron.position.set(45, 0.005, 113);
+  apron.receiveShadow = true;
+  world.add(apron);
+}
+
+function makeRunway(world) {
+  const runway = outlinedMesh(
+    new THREE.BoxGeometry(455, 0.1, 62),
+    material(RUNWAY, 0.98),
+    1.006,
+    { castShadow: false }
+  );
+  runway.position.set(0, 0.015, -127);
+  world.add(runway);
+
+  const white = material(CREAM, 0.88);
+  const dashGeometry = new THREE.BoxGeometry(13, 0.08, 0.8);
+  const dashes = new THREE.InstancedMesh(dashGeometry, white, 18);
+  const marker = new THREE.Object3D();
+  for (let index = 0; index < 18; index += 1) {
+    marker.position.set(-205 + index * 24, 0.12, -127);
+    marker.updateMatrix();
+    dashes.setMatrixAt(index, marker.matrix);
+  }
+  dashes.instanceMatrix.needsUpdate = true;
+  dashes.receiveShadow = true;
+  world.add(dashes);
+
+  for (const x of [-207, 207]) {
+    for (let stripe = -3; stripe <= 3; stripe += 1) {
+      const threshold = new THREE.Mesh(new THREE.BoxGeometry(17, 0.08, 2.2), white);
+      threshold.position.set(x, 0.12, -127 + stripe * 6.2);
+      threshold.receiveShadow = true;
+      world.add(threshold);
+    }
+  }
+
+  const lightGeometry = new THREE.SphereGeometry(0.42, 7, 5);
+  const lightMaterial = new THREE.MeshBasicMaterial({ color: 0xfff3a6 });
+  const lights = new THREE.InstancedMesh(lightGeometry, lightMaterial, 40);
+  let lightIndex = 0;
+  for (const z of [-157, -97]) {
+    for (let x = -215; x <= 215; x += 24) {
+      marker.position.set(x, 0.48, z);
+      marker.updateMatrix();
+      lights.setMatrixAt(lightIndex, marker.matrix);
+      lightIndex += 1;
+    }
+  }
+  lights.instanceMatrix.needsUpdate = true;
+  world.add(lights);
+}
+
+function makeRaceRoad(world, samples, trackWidth) {
+  const count = samples.length;
+  const roadPositions = [];
+  const roadColors = [];
+  const roadIndices = [];
+  const asphaltDark = new THREE.Color(0x34383d);
+  const asphaltLight = new THREE.Color(0x4a4f55);
+
+  for (let index = 0; index <= count; index += 1) {
+    const sample = samples[index % count];
+    const left = sample.point.clone().addScaledVector(sample.normal, trackWidth / 2).setY(0.17);
+    const right = sample.point.clone().addScaledVector(sample.normal, -trackWidth / 2).setY(0.17);
+    roadPositions.push(left.x, left.y, left.z, right.x, right.y, right.z);
+
+    const variation = THREE.MathUtils.clamp(
+      0.44 + Math.sin(index * 0.17) * 0.1 + Math.sin(index * 0.61 + 0.8) * 0.06,
+      0,
+      1
+    );
+    const color = asphaltDark.clone().lerp(asphaltLight, variation);
+    roadColors.push(color.r, color.g, color.b, color.r, color.g, color.b);
+  }
+
+  for (let index = 0; index < count; index += 1) {
+    const a = index * 2;
+    const b = a + 1;
+    const c = a + 2;
+    const d = a + 3;
+    roadIndices.push(a, c, b, b, c, d);
+  }
+
+  const roadGeometry = new THREE.BufferGeometry();
+  roadGeometry.setAttribute('position', new THREE.Float32BufferAttribute(roadPositions, 3));
+  roadGeometry.setAttribute('color', new THREE.Float32BufferAttribute(roadColors, 3));
+  roadGeometry.setIndex(roadIndices);
+  roadGeometry.computeVertexNormals();
+
+  const road = new THREE.Mesh(
+    roadGeometry,
+    new THREE.MeshStandardMaterial({
+      vertexColors: true,
+      roughness: 0.98,
+      metalness: 0,
+      side: THREE.DoubleSide
+    })
+  );
+  road.receiveShadow = true;
+  world.add(road);
+
+  const curbWidth = 1.75;
+  const curbSegmentLength = 12;
+  const curbColors = [new THREE.Color(0xe63946), new THREE.Color(CREAM)];
+
+  for (const side of [-1, 1]) {
+    const positions = [];
+    const colors = [];
+    for (let index = 0; index < count; index += 1) {
+      const current = samples[index];
+      const next = samples[(index + 1) % count];
+      const innerOffset = side * (trackWidth / 2 - 0.05);
+      const outerOffset = side * (trackWidth / 2 + curbWidth);
+      const a = current.point.clone().addScaledVector(current.normal, innerOffset).setY(0.205);
+      const b = current.point.clone().addScaledVector(current.normal, outerOffset).setY(0.205);
+      const c = next.point.clone().addScaledVector(next.normal, innerOffset).setY(0.205);
+      const d = next.point.clone().addScaledVector(next.normal, outerOffset).setY(0.205);
+      positions.push(
+        a.x, a.y, a.z, b.x, b.y, b.z, c.x, c.y, c.z,
+        b.x, b.y, b.z, d.x, d.y, d.z, c.x, c.y, c.z
+      );
+      const color = curbColors[Math.floor(index / curbSegmentLength) % 2];
+      for (let vertex = 0; vertex < 6; vertex += 1) colors.push(color.r, color.g, color.b);
+    }
+
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+    geometry.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
+    geometry.computeVertexNormals();
+    const curb = new THREE.Mesh(
+      geometry,
+      new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.9, side: THREE.DoubleSide })
+    );
+    curb.receiveShadow = true;
+    world.add(curb);
+  }
+
+  const dashStep = 8;
+  const dashGeometry = new THREE.BoxGeometry(0.34, 0.045, 5.2);
+  const dashMaterial = material(CREAM, 0.92);
+  const centreLine = new THREE.InstancedMesh(dashGeometry, dashMaterial, Math.ceil(count / dashStep));
+  const marker = new THREE.Object3D();
+  let cursor = 0;
+  for (let index = 0; index < count; index += dashStep) {
+    const sample = samples[index];
+    marker.position.copy(sample.point).setY(0.23);
+    marker.rotation.set(0, Math.atan2(sample.tangent.x, sample.tangent.z), 0);
+    marker.updateMatrix();
+    centreLine.setMatrixAt(cursor, marker.matrix);
+    cursor += 1;
+  }
+  centreLine.instanceMatrix.needsUpdate = true;
+  world.add(centreLine);
+}
+
+function makeAirportBuildings(world) {
+  const terminal = new THREE.Group();
+  const terminalBody = outlinedMesh(new THREE.BoxGeometry(118, 15, 24), material(0xf3ead7, 0.78), 1.018);
+  terminalBody.position.y = 7.5;
+  terminal.add(terminalBody);
+
+  const glass = material(WINDOW, 0.32, 0.08);
+  for (let x = -48; x <= 48; x += 12) {
+    const window = outlinedMesh(new THREE.BoxGeometry(8.5, 5.2, 0.45), glass, 1.025, { castShadow: false });
+    window.position.set(x, 8.5, -12.3);
+    terminal.add(window);
+  }
+
+  const roof = outlinedMesh(new THREE.BoxGeometry(126, 1.8, 28), material(0x39434d, 0.78), 1.015);
+  roof.position.y = 16.2;
+  terminal.add(roof);
+  terminal.position.set(48, 0, 158);
+  world.add(terminal);
+
+  for (const x of [10, 50, 90]) {
+    const bridge = outlinedMesh(new THREE.BoxGeometry(4.5, 4, 19), material(0xe8edf1, 0.8), 1.025);
+    bridge.position.set(x, 6.4, 139);
+    world.add(bridge);
+  }
+
+  const tower = new THREE.Group();
+  const shaft = outlinedMesh(new THREE.CylinderGeometry(5.2, 7.2, 29, 8), material(0xe6e0d5, 0.78), 1.03);
+  shaft.position.y = 14.5;
+  tower.add(shaft);
+  const cabin = outlinedMesh(new THREE.CylinderGeometry(10, 8.2, 7, 8), material(WINDOW, 0.3, 0.12), 1.035);
+  cabin.position.y = 31;
+  tower.add(cabin);
+  const cap = outlinedMesh(new THREE.CylinderGeometry(11.5, 11.5, 1.4, 8), material(0x34383d, 0.78), 1.03);
+  cap.position.y = 35;
+  tower.add(cap);
+  tower.position.set(-76, 0, 151);
+  world.add(tower);
+
+  for (const [x, z, color] of [[160, 148, 0x6b7280], [205, 122, 0x58616a]]) {
+    const hangar = new THREE.Group();
+    const body = outlinedMesh(new THREE.BoxGeometry(48, 20, 34), material(color, 0.9), 1.025);
+    body.position.y = 10;
+    hangar.add(body);
+    const door = outlinedMesh(new THREE.BoxGeometry(32, 13, 0.7), material(0x2d3339, 0.9), 1.025, { castShadow: false });
+    door.position.set(0, 6.8, -17.4);
+    hangar.add(door);
+    const stripe = new THREE.Mesh(new THREE.BoxGeometry(40, 1.2, 0.4), material(YELLOW, 0.8));
+    stripe.position.set(0, 17.2, -17.8);
+    hangar.add(stripe);
+    hangar.position.set(x, 0, z);
+    world.add(hangar);
+  }
+
+  const fuelZone = new THREE.Group();
+  for (const x of [-13, 0, 13]) {
+    const tank = outlinedMesh(new THREE.CylinderGeometry(5.2, 5.2, 14, 12), material(0xe8edf1, 0.72, 0.08), 1.028);
+    tank.rotation.z = Math.PI / 2;
+    tank.position.set(x, 5.6, 0);
+    fuelZone.add(tank);
+  }
+  fuelZone.position.set(-155, 0, 132);
+  world.add(fuelZone);
+}
+
+function makeAircraft(world) {
+  const planes = [
+    { position: [7, 1.4, 112], rotation: -0.08, color: 0xfff8e8, tail: PINK, scale: 1.05 },
+    { position: [91, 1.4, 111], rotation: 0.12, color: 0xfff8e8, tail: 0x38d9ff, scale: 0.95 },
+    { position: [151, 1.4, 68], rotation: -1.25, color: 0xe9eef2, tail: YELLOW, scale: 0.88 },
+    { position: [126, 1.4, -173], rotation: Math.PI / 2, color: 0xfff8e8, tail: RED, scale: 0.72 }
+  ];
+
+  for (const plane of planes) {
+    const model = makePlane(plane.color, plane.tail);
+    model.position.set(...plane.position);
+    model.rotation.y = plane.rotation;
+    model.scale.setScalar(plane.scale);
+    world.add(model);
+  }
+}
+
+function makePlane(bodyColor, tailColor) {
+  const plane = new THREE.Group();
+  const bodyMaterial = material(bodyColor, 0.52, 0.04);
+  const tailMaterial = material(tailColor, 0.58);
+  const darkMaterial = material(0x34383d, 0.82);
+
+  const fuselage = outlinedMesh(new THREE.BoxGeometry(4.2, 3.8, 25), bodyMaterial, 1.04);
+  fuselage.position.y = 3.4;
+  plane.add(fuselage);
+
+  const nose = outlinedMesh(new THREE.ConeGeometry(2.15, 5.5, 8), bodyMaterial, 1.04);
+  nose.rotation.x = Math.PI / 2;
+  nose.position.set(0, 3.4, -15.2);
+  plane.add(nose);
+
+  const wing = outlinedMesh(new THREE.BoxGeometry(24, 0.55, 5.8), bodyMaterial, 1.035);
+  wing.position.set(0, 3.25, -1);
+  plane.add(wing);
+
+  const tailWing = outlinedMesh(new THREE.BoxGeometry(10, 0.42, 3.2), tailMaterial, 1.04);
+  tailWing.position.set(0, 4.2, 10.2);
+  plane.add(tailWing);
+
+  const fin = outlinedMesh(new THREE.BoxGeometry(0.7, 6.5, 4.6), tailMaterial, 1.05);
+  fin.position.set(0, 6.5, 10.4);
+  fin.rotation.x = -0.18;
+  plane.add(fin);
+
+  for (const x of [-5.8, 5.8]) {
+    const engine = outlinedMesh(new THREE.CylinderGeometry(1.3, 1.3, 4.5, 10), darkMaterial, 1.04);
+    engine.rotation.x = Math.PI / 2;
+    engine.position.set(x, 2.25, -1.5);
+    plane.add(engine);
+  }
+
+  return plane;
+}
+
+function makeGroundOperations(world) {
+  const servicePalette = [YELLOW, 0xff922b, 0x38d9ff, PINK];
+  const servicePositions = [
+    [-18, 91, 0.1],
+    [58, 88, -0.2],
+    [126, 97, 0.4],
+    [-115, 114, -0.35],
+    [184, 81, 1.15]
+  ];
+
+  servicePositions.forEach(([x, z, rotation], index) => {
+    const vehicle = makeServiceVehicle(servicePalette[index % servicePalette.length]);
+    vehicle.position.set(x, 0.7, z);
+    vehicle.rotation.y = rotation;
+    world.add(vehicle);
+  });
+
+  const coneGeometry = new THREE.ConeGeometry(0.8, 2.2, 8);
+  const coneMaterial = material(0xff7b3d, 0.85);
+  const cones = new THREE.InstancedMesh(coneGeometry, coneMaterial, 28);
+  const marker = new THREE.Object3D();
+  for (let index = 0; index < 28; index += 1) {
+    const row = index < 14 ? 0 : 1;
+    marker.position.set(-8 + (index % 14) * 9, 1.1, 77 + row * 58);
+    marker.rotation.y = index * 0.31;
+    marker.updateMatrix();
+    cones.setMatrixAt(index, marker.matrix);
+  }
+  cones.instanceMatrix.needsUpdate = true;
+  world.add(cones);
+
+  for (const [x, z, rotation] of [[-45, 125, 0], [120, 138, 0.2], [-145, 83, -0.6]]) {
+    const cartTrain = new THREE.Group();
+    for (let cart = 0; cart < 3; cart += 1) {
+      const box = outlinedMesh(new THREE.BoxGeometry(4.4, 2.4, 5.2), material(0x737b84, 0.92), 1.035);
+      box.position.set(0, 1.6, cart * 6.2);
+      cartTrain.add(box);
+    }
+    cartTrain.position.set(x, 0, z);
+    cartTrain.rotation.y = rotation;
+    world.add(cartTrain);
+  }
+}
+
+function makeServiceVehicle(color) {
+  const vehicle = new THREE.Group();
+  const body = outlinedMesh(new THREE.BoxGeometry(5.5, 2.4, 8), material(color, 0.76), 1.05);
+  body.position.y = 1.8;
+  vehicle.add(body);
+  const cabin = outlinedMesh(new THREE.BoxGeometry(4.6, 2.8, 3.2), material(0xe8edf1, 0.62), 1.05);
+  cabin.position.set(0, 3.4, -1.5);
+  vehicle.add(cabin);
+  return vehicle;
+}
+
+function makeDistantWorld(world) {
+  const mountainColors = [0x718792, 0x8199a4, 0x637985];
+  const mountainPositions = [
+    [-290, 110, 100], [-250, -80, 82], [-130, 255, 104], [20, 285, 90],
+    [175, 255, 112], [310, 110, 92], [300, -95, 104]
+  ];
+  for (let index = 0; index < mountainPositions.length; index += 1) {
+    const [x, z, height] = mountainPositions[index];
+    const mountain = outlinedMesh(
+      new THREE.ConeGeometry(height * 0.72, height, 4),
+      material(mountainColors[index % mountainColors.length], 1),
+      1.018,
+      { castShadow: false, receiveShadow: false }
+    );
+    mountain.position.set(x, height / 2 - 6, z);
+    mountain.rotation.y = Math.PI / 4 + index * 0.16;
+    world.add(mountain);
+  }
+}
+
+function makeStartGate(world, samples, trackWidth) {
+  const start = samples[0];
+  const yaw = Math.atan2(start.tangent.x, start.tangent.z);
+  const gate = new THREE.Group();
+  const postGeometry = new THREE.BoxGeometry(1.5, 8.5, 1.5);
+  const beamGeometry = new THREE.BoxGeometry(trackWidth + 5, 2.3, 1.8);
+  for (const side of [-1, 1]) {
+    const post = outlinedMesh(postGeometry, material(0x39434d, 0.8), 1.07);
+    post.position.set(side * (trackWidth / 2 + 1.2), 4.25, 0);
+    gate.add(post);
+  }
+  const beam = outlinedMesh(beamGeometry, material(YELLOW, 0.72), 1.045);
+  beam.position.y = 8.5;
+  gate.add(beam);
+  const lightBar = new THREE.Mesh(new THREE.BoxGeometry(trackWidth - 5, 0.55, 2), new THREE.MeshBasicMaterial({ color: 0x38d9ff }));
+  lightBar.position.y = 8.4;
+  gate.add(lightBar);
+  gate.position.copy(start.point);
+  gate.rotation.y = yaw;
+  world.add(gate);
+}

--- a/turn/tracks/catalog.js
+++ b/turn/tracks/catalog.js
@@ -1,0 +1,125 @@
+import * as THREE from 'three';
+
+export const DEFAULT_TRACK_ID = 'countryside';
+export const TRACK_SAMPLE_COUNT = 720;
+export const TRACK_SELECTION_KEY = 'turn-selected-track-v1';
+
+const TRACKS = [
+  {
+    id: 'countryside',
+    name: 'Countryside',
+    difficulty: 'EASY',
+    eyebrow: 'TRACK 1',
+    description: 'Fast, flowing and forgiving.',
+    accent: '#ff4fa3',
+    accentSoft: '#ffc2dd',
+    sky: 0x38d9ff,
+    fog: 0x74c0fc,
+    createControlPoints() {
+      return Array.from({ length: 18 }, (_, index) => {
+        const angle = (index / 18) * Math.PI * 2;
+        const radiusX = 208 + Math.sin(angle * 2 + 0.35) * 20 + Math.sin(angle * 3 - 0.8) * 9;
+        const radiusZ = 146 + Math.cos(angle * 2 - 0.4) * 14 + Math.sin(angle * 3 + 0.6) * 8;
+        return new THREE.Vector3(Math.cos(angle) * radiusX, 0, Math.sin(angle) * radiusZ);
+      });
+    }
+  },
+  {
+    id: 'airport',
+    name: 'Airport',
+    difficulty: 'MEDIUM',
+    eyebrow: 'TRACK 2',
+    description: 'Runway speed. Service-road precision.',
+    accent: '#ffd43b',
+    accentSoft: '#fff0a6',
+    sky: 0x55c9ed,
+    fog: 0x9bdcf2,
+    createControlPoints() {
+      return [
+        [-190, -120],
+        [-105, -134],
+        [-10, -138],
+        [90, -136],
+        [178, -122],
+        [214, -86],
+        [222, -40],
+        [214, 8],
+        [191, 55],
+        [150, 92],
+        [101, 112],
+        [58, 103],
+        [27, 76],
+        [3, 40],
+        [-25, 68],
+        [-61, 101],
+        [-108, 120],
+        [-158, 111],
+        [-198, 82],
+        [-218, 43],
+        [-223, -3],
+        [-214, -51],
+        [-202, -91]
+      ].map(([x, z]) => new THREE.Vector3(x, 0, z));
+    }
+  }
+];
+
+export const TRACK_CATALOG = Object.freeze(TRACKS.map((track) => Object.freeze({ ...track })));
+
+export function getTrackDefinition(trackId = DEFAULT_TRACK_ID) {
+  return TRACK_CATALOG.find((track) => track.id === trackId) || TRACK_CATALOG[0];
+}
+
+export function normalizeTrackId(trackId) {
+  return getTrackDefinition(trackId).id;
+}
+
+export function loadTrackSelection() {
+  try {
+    return normalizeTrackId(localStorage.getItem(TRACK_SELECTION_KEY));
+  } catch (_) {
+    return DEFAULT_TRACK_ID;
+  }
+}
+
+export function saveTrackSelection(trackId) {
+  const normalized = normalizeTrackId(trackId);
+  try {
+    localStorage.setItem(TRACK_SELECTION_KEY, normalized);
+  } catch (_) {}
+  return normalized;
+}
+
+export function createTrackRuntime(trackId, sampleCount = TRACK_SAMPLE_COUNT) {
+  const definition = getTrackDefinition(trackId);
+  const controlPoints = definition.createControlPoints();
+  const curve = new THREE.CatmullRomCurve3(controlPoints, true, 'centripetal');
+  const samples = [];
+  let trackLength = 0;
+
+  for (let index = 0; index < sampleCount; index += 1) {
+    const t = index / sampleCount;
+    const point = curve.getPointAt(t);
+    const tangent = curve.getTangentAt(t).normalize();
+    const normal = new THREE.Vector3(-tangent.z, 0, tangent.x).normalize();
+    if (index > 0) trackLength += point.distanceTo(samples[index - 1].point);
+    samples.push({ point, tangent, normal, distance: trackLength });
+  }
+
+  trackLength += samples[0].point.distanceTo(samples.at(-1).point);
+
+  return {
+    id: definition.id,
+    definition,
+    controlPoints,
+    curve,
+    samples,
+    trackLength,
+    sampleCount
+  };
+}
+
+export function getTrackPreviewPoints(trackId, count = 96) {
+  const runtime = createTrackRuntime(trackId, count);
+  return runtime.samples.map((sample) => ({ x: sample.point.x, z: sample.point.z }));
+}

--- a/turn/tracks/track-manager.js
+++ b/turn/tracks/track-manager.js
@@ -32,10 +32,8 @@ else {
   }, { once: true });
 }
 
-export async function chooseTrackBeforeLot({ force = false } = {}) {
+export async function chooseTrackBeforeLot() {
   const currentRuntime = await runtimeReady;
-  if (!force && chosenThisSession) return activeTrackId;
-
   const selectedTrackId = await showTrackSelect({
     initialTrackId: chosenThisSession ? activeTrackId : loadTrackSelection()
   });
@@ -121,7 +119,7 @@ function installRuntime(nextRuntime) {
   installTrackAwareRivalReset(runtime);
 
   globalThis.__turnGetTrackId = () => activeTrackId;
-  globalThis.__turnChooseTrack = () => chooseTrackBeforeLot({ force: true });
+  globalThis.__turnChooseTrack = () => chooseTrackBeforeLot();
   runtimeReadyResolve(runtime);
 }
 

--- a/turn/tracks/track-manager.js
+++ b/turn/tracks/track-manager.js
@@ -1,0 +1,206 @@
+import * as THREE from 'three';
+import { createTrackSpatialIndex } from '../race/track-spatial-index.js?build=20260722-r44';
+import { resetRaceToStage } from '../race/game-state.js?build=20260722-r41';
+import { clearRivalsState, loadRivalsState } from '../race/rival-storage.js?build=20260722-r47';
+import {
+  DEFAULT_TRACK_ID,
+  createTrackRuntime,
+  getTrackDefinition,
+  loadTrackSelection,
+  normalizeTrackId,
+  saveTrackSelection
+} from './catalog.js?build=20260722-r47';
+import { installAirportWorld } from './airport-world.js?build=20260722-r47';
+import { showTrackSelect } from '../ui/track-select.js?build=20260722-r47';
+
+let runtime = null;
+let runtimeReadyResolve = null;
+let activeTrackId = DEFAULT_TRACK_ID;
+let chosenThisSession = false;
+let countrysideSamples = null;
+let countrysideFind = null;
+let countrysideStats = null;
+let airportTrack = null;
+let airportIndex = null;
+let airportWorld = null;
+let dynamicWorld = null;
+
+const runtimeReady = new Promise((resolve) => {
+  runtimeReadyResolve = resolve;
+});
+
+if (globalThis.__turnRuntime) installRuntime(globalThis.__turnRuntime);
+else {
+  window.addEventListener('turn:runtime-ready', (event) => {
+    installRuntime(event.detail || globalThis.__turnRuntime);
+  }, { once: true });
+}
+
+export async function chooseTrackBeforeLot({ force = false } = {}) {
+  const currentRuntime = await runtimeReady;
+  if (!force && chosenThisSession) return activeTrackId;
+
+  const selectedTrackId = await showTrackSelect({
+    initialTrackId: chosenThisSession ? activeTrackId : loadTrackSelection()
+  });
+  if (!selectedTrackId) return null;
+
+  await activateTrack(selectedTrackId, currentRuntime);
+  chosenThisSession = true;
+  return activeTrackId;
+}
+
+export async function activateTrack(trackId, currentRuntime = runtime) {
+  currentRuntime ||= await runtimeReady;
+  const nextTrackId = normalizeTrackId(trackId);
+  ensureTrackInfrastructure(currentRuntime);
+
+  if (nextTrackId === 'airport') {
+    if (!airportTrack) {
+      airportTrack = createTrackRuntime('airport', currentRuntime.trackSampleCount || 720);
+      airportIndex = createTrackSpatialIndex(airportTrack.samples, { cellSize: 32 });
+    }
+    if (!airportWorld) {
+      airportWorld = installAirportWorld({
+        scene: currentRuntime.scene,
+        samples: airportTrack.samples,
+        trackWidth: currentRuntime.trackWidth
+      });
+      airportWorld.visible = false;
+    }
+
+    replaceSamples(currentRuntime.samples, airportTrack.samples);
+    routeSpatialIndex(currentRuntime.trackSpatialIndex, airportIndex.find.bind(airportIndex), airportIndex.getStats.bind(airportIndex));
+    currentRuntime.world.visible = false;
+    airportWorld.visible = true;
+  } else {
+    replaceSamples(currentRuntime.samples, countrysideSamples);
+    routeSpatialIndex(currentRuntime.trackSpatialIndex, countrysideFind, countrysideStats);
+    currentRuntime.world.visible = true;
+    if (airportWorld) airportWorld.visible = false;
+  }
+
+  activeTrackId = nextTrackId;
+  currentRuntime.trackId = nextTrackId;
+  currentRuntime.state.trackId = nextTrackId;
+  saveTrackSelection(nextTrackId);
+  applyTrackAtmosphere(currentRuntime, nextTrackId);
+
+  for (const car of currentRuntime.competitorCars || []) car.visible = false;
+  resetRaceToStage({
+    state: currentRuntime.state,
+    samples: currentRuntime.samples,
+    showFeedback: false,
+    setRacePosition: currentRuntime.setRacePosition
+  });
+  loadRivalsState({
+    state: currentRuntime.state,
+    samples: currentRuntime.samples,
+    findNearestTrack: currentRuntime.findNearestTrack,
+    trackId: nextTrackId
+  });
+  currentRuntime.ensureCompetitorCars?.();
+
+  window.dispatchEvent(new CustomEvent('turn:track-changed', {
+    detail: {
+      trackId: nextTrackId,
+      track: getTrackDefinition(nextTrackId)
+    }
+  }));
+  publishUiState(currentRuntime, 'rivals-loaded');
+  publishUiState(currentRuntime, 'track-changed');
+  return nextTrackId;
+}
+
+function installRuntime(nextRuntime) {
+  if (!nextRuntime || runtime) return;
+  runtime = nextRuntime;
+  runtime.state.trackId = DEFAULT_TRACK_ID;
+  runtime.trackId = DEFAULT_TRACK_ID;
+  countrysideSamples = runtime.samples.slice();
+  countrysideFind = runtime.trackSpatialIndex.find.bind(runtime.trackSpatialIndex);
+  countrysideStats = runtime.trackSpatialIndex.getStats.bind(runtime.trackSpatialIndex);
+  ensureTrackInfrastructure(runtime);
+  installTrackAwareRivalReset(runtime);
+
+  globalThis.__turnGetTrackId = () => activeTrackId;
+  globalThis.__turnChooseTrack = () => chooseTrackBeforeLot({ force: true });
+  runtimeReadyResolve(runtime);
+}
+
+function ensureTrackInfrastructure(currentRuntime) {
+  if (dynamicWorld) return;
+
+  currentRuntime.ensureCompetitorCars?.();
+  dynamicWorld = new THREE.Group();
+  dynamicWorld.name = 'TURN Dynamic Race Layer';
+  currentRuntime.scene.add(dynamicWorld);
+
+  const dynamicNodes = new Set([
+    currentRuntime.playerCar,
+    ...(currentRuntime.competitorCars || [])
+  ]);
+
+  for (const child of [...currentRuntime.world.children]) {
+    if (dynamicNodes.has(child) || child?.isLineSegments || isRaceParticle(child)) {
+      dynamicWorld.attach(child);
+    }
+  }
+
+  currentRuntime.dynamicWorld = dynamicWorld;
+}
+
+function isRaceParticle(node) {
+  return node?.isMesh
+    && node.geometry?.type === 'SphereGeometry'
+    && node.material?.transparent === true
+    && node.geometry?.parameters?.radius <= 1;
+}
+
+function replaceSamples(target, source) {
+  target.splice(0, target.length, ...source);
+}
+
+function routeSpatialIndex(target, find, getStats) {
+  target.find = find;
+  target.getStats = getStats;
+}
+
+function applyTrackAtmosphere(currentRuntime, trackId) {
+  const track = getTrackDefinition(trackId);
+  currentRuntime.scene.background = new THREE.Color(track.sky);
+  if (currentRuntime.scene.fog?.color) currentRuntime.scene.fog.color.setHex(track.fog);
+}
+
+function installTrackAwareRivalReset(currentRuntime) {
+  const resetCurrentTrackRivals = () => {
+    clearRivalsState(currentRuntime.state, { trackId: activeTrackId });
+    for (const car of currentRuntime.competitorCars || []) car.visible = false;
+    currentRuntime.setRacePosition?.(null, 1);
+    showMessage('RIVALS RESET');
+    window.dispatchEvent(new CustomEvent('turn:rivals-reset'));
+    publishUiState(currentRuntime, 'rivals-reset');
+  };
+
+  globalThis.__turnResetRivals = resetCurrentTrackRivals;
+  globalThis.__turnNukeGhosts = resetCurrentTrackRivals;
+}
+
+function showMessage(text, duration = 1800) {
+  const message = document.querySelector('#message');
+  if (!message) return;
+  message.textContent = text;
+  message.classList.add('show');
+  window.setTimeout(() => message.classList.remove('show'), duration);
+}
+
+function publishUiState(currentRuntime, reason) {
+  window.dispatchEvent(new CustomEvent('turn:ui-state-change', {
+    detail: {
+      reason,
+      mode: currentRuntime.state.mode,
+      running: currentRuntime.state.running,
+      trackId: activeTrackId
+    }
+  }));
+}

--- a/turn/tracks/track-manager.js
+++ b/turn/tracks/track-manager.js
@@ -1,5 +1,4 @@
 import * as THREE from 'three';
-import { createTrackSpatialIndex } from '../race/track-spatial-index.js?build=20260722-r44';
 import { resetRaceToStage } from '../race/game-state.js?build=20260722-r41';
 import { clearRivalsState, loadRivalsState } from '../race/rival-storage.js?build=20260722-r47';
 import {
@@ -18,10 +17,7 @@ let runtimeReadyResolve = null;
 let activeTrackId = DEFAULT_TRACK_ID;
 let chosenThisSession = false;
 let countrysideSamples = null;
-let countrysideFind = null;
-let countrysideStats = null;
 let airportTrack = null;
-let airportIndex = null;
 let airportWorld = null;
 let dynamicWorld = null;
 
@@ -55,10 +51,13 @@ export async function activateTrack(trackId, currentRuntime = runtime) {
   const nextTrackId = normalizeTrackId(trackId);
   ensureTrackInfrastructure(currentRuntime);
 
+  if (typeof currentRuntime.trackSpatialIndex?.replaceSamples !== 'function') {
+    throw new Error('TURN: the active track index cannot rebuild for track changes.');
+  }
+
   if (nextTrackId === 'airport') {
     if (!airportTrack) {
       airportTrack = createTrackRuntime('airport', currentRuntime.trackSampleCount || 720);
-      airportIndex = createTrackSpatialIndex(airportTrack.samples, { cellSize: 32 });
     }
     if (!airportWorld) {
       airportWorld = installAirportWorld({
@@ -70,12 +69,12 @@ export async function activateTrack(trackId, currentRuntime = runtime) {
     }
 
     replaceSamples(currentRuntime.samples, airportTrack.samples);
-    routeSpatialIndex(currentRuntime.trackSpatialIndex, airportIndex.find.bind(airportIndex), airportIndex.getStats.bind(airportIndex));
+    currentRuntime.trackSpatialIndex.replaceSamples(currentRuntime.samples);
     currentRuntime.world.visible = false;
     airportWorld.visible = true;
   } else {
     replaceSamples(currentRuntime.samples, countrysideSamples);
-    routeSpatialIndex(currentRuntime.trackSpatialIndex, countrysideFind, countrysideStats);
+    currentRuntime.trackSpatialIndex.replaceSamples(currentRuntime.samples);
     currentRuntime.world.visible = true;
     if (airportWorld) airportWorld.visible = false;
   }
@@ -118,8 +117,6 @@ function installRuntime(nextRuntime) {
   runtime.state.trackId = DEFAULT_TRACK_ID;
   runtime.trackId = DEFAULT_TRACK_ID;
   countrysideSamples = runtime.samples.slice();
-  countrysideFind = runtime.trackSpatialIndex.find.bind(runtime.trackSpatialIndex);
-  countrysideStats = runtime.trackSpatialIndex.getStats.bind(runtime.trackSpatialIndex);
   ensureTrackInfrastructure(runtime);
   installTrackAwareRivalReset(runtime);
 
@@ -159,11 +156,6 @@ function isRaceParticle(node) {
 
 function replaceSamples(target, source) {
   target.splice(0, target.length, ...source);
-}
-
-function routeSpatialIndex(target, find, getStats) {
-  target.find = find;
-  target.getStats = getStats;
 }
 
 function applyTrackAtmosphere(currentRuntime, trackId) {

--- a/turn/ui/hud.js
+++ b/turn/ui/hud.js
@@ -82,9 +82,13 @@ function drawMap({ state, mapCanvas, mapCtx, samples, replayFrameAt }) {
 
 function getStaticMap(mapCanvas, samples) {
   const cached = mapCache.get(mapCanvas);
+  const firstSample = samples[0];
+  const lastSample = samples[samples.length - 1];
   if (
     cached &&
     cached.samples === samples &&
+    cached.firstSample === firstSample &&
+    cached.lastSample === lastSample &&
     cached.width === mapCanvas.width &&
     cached.height === mapCanvas.height
   ) {
@@ -135,6 +139,8 @@ function getStaticMap(mapCanvas, samples) {
 
   const value = {
     samples,
+    firstSample,
+    lastSample,
     width: mapCanvas.width,
     height: mapCanvas.height,
     canvas,

--- a/turn/ui/track-select.js
+++ b/turn/ui/track-select.js
@@ -1,0 +1,177 @@
+import {
+  TRACK_CATALOG,
+  getTrackPreviewPoints,
+  loadTrackSelection,
+  normalizeTrackId
+} from '../tracks/catalog.js?build=20260722-r47';
+import { getStoredBestTime } from '../race/rival-storage.js?build=20260722-r47';
+
+let activeRequest = null;
+
+export function showTrackSelect({ initialTrackId = loadTrackSelection() } = {}) {
+  if (activeRequest) return activeRequest;
+
+  activeRequest = new Promise((resolve) => {
+    const overlay = ensureOverlay();
+    const cards = [...overlay.querySelectorAll('.track-card')];
+    const continueButton = overlay.querySelector('.track-select-continue');
+    const closeButton = overlay.querySelector('.track-select-close');
+    let selectedTrackId = normalizeTrackId(initialTrackId);
+
+    function syncSelection() {
+      for (const card of cards) {
+        const selected = card.dataset.trackId === selectedTrackId;
+        card.classList.toggle('is-selected', selected);
+        card.setAttribute('aria-pressed', String(selected));
+      }
+      const track = TRACK_CATALOG.find((entry) => entry.id === selectedTrackId);
+      continueButton.textContent = `CONTINUE TO ${track?.name.toUpperCase() || 'THE TRACK'}`;
+    }
+
+    function finish(result) {
+      overlay.classList.remove('is-visible');
+      document.body.classList.remove('turn-track-select-open');
+      window.setTimeout(() => {
+        overlay.hidden = true;
+      }, 180);
+      for (const card of cards) card.removeEventListener('click', selectCard);
+      continueButton.removeEventListener('click', continueSelection);
+      closeButton.removeEventListener('click', cancelSelection);
+      activeRequest = null;
+      resolve(result);
+    }
+
+    function selectCard(event) {
+      selectedTrackId = normalizeTrackId(event.currentTarget.dataset.trackId);
+      syncSelection();
+    }
+
+    function continueSelection() {
+      finish(selectedTrackId);
+    }
+
+    function cancelSelection() {
+      finish(null);
+    }
+
+    for (const card of cards) card.addEventListener('click', selectCard);
+    continueButton.addEventListener('click', continueSelection);
+    closeButton.addEventListener('click', cancelSelection);
+
+    syncSelection();
+    overlay.hidden = false;
+    document.body.classList.add('turn-track-select-open');
+    requestAnimationFrame(() => {
+      overlay.classList.add('is-visible');
+      overlay.querySelector(`.track-card[data-track-id="${selectedTrackId}"]`)?.focus({ preventScroll: true });
+    });
+  });
+
+  return activeRequest;
+}
+
+function ensureOverlay() {
+  const existing = document.querySelector('.track-select');
+  if (existing) {
+    refreshBestTimes(existing);
+    return existing;
+  }
+
+  const overlay = document.createElement('section');
+  overlay.className = 'track-select';
+  overlay.hidden = true;
+  overlay.setAttribute('aria-labelledby', 'trackSelectTitle');
+  overlay.innerHTML = `
+    <div class="track-select-shell">
+      <header class="track-select-head">
+        <div>
+          <span class="track-select-kicker">TURN WORLD TOUR</span>
+          <h2 id="trackSelectTitle">CHOOSE YOUR TRACK</h2>
+          <p>Pick the road first. Then choose the right car for the job.</p>
+        </div>
+        <button class="track-select-close" type="button" aria-label="Close track selection">×</button>
+      </header>
+      <div class="track-select-grid">
+        ${TRACK_CATALOG.map(renderTrackCard).join('')}
+      </div>
+      <footer class="track-select-footer">
+        <span class="track-select-tip">TRACK → CAR → RACE</span>
+        <button class="track-select-continue" type="button">CONTINUE</button>
+      </footer>
+    </div>
+  `;
+  document.body.appendChild(overlay);
+  refreshBestTimes(overlay);
+  return overlay;
+}
+
+function renderTrackCard(track) {
+  const preview = makePreviewSvg(track.id, track.accent);
+  return `
+    <button
+      class="track-card track-card-${track.id}"
+      type="button"
+      data-track-id="${track.id}"
+      aria-pressed="false"
+      style="--track-accent:${track.accent};--track-accent-soft:${track.accentSoft}"
+    >
+      <span class="track-card-topline">
+        <span>${track.eyebrow}</span>
+        <strong>${track.difficulty}</strong>
+      </span>
+      <span class="track-card-preview" aria-hidden="true">${preview}</span>
+      <span class="track-card-copy">
+        <strong class="track-card-name">${track.name.toUpperCase()}</strong>
+        <span class="track-card-description">${track.description}</span>
+      </span>
+      <span class="track-card-best" data-track-best="${track.id}">
+        <span>BEST</span><strong>--:--.---</strong>
+      </span>
+    </button>
+  `;
+}
+
+function makePreviewSvg(trackId, accent) {
+  const points = getTrackPreviewPoints(trackId, 110);
+  const xs = points.map((point) => point.x);
+  const zs = points.map((point) => point.z);
+  const minX = Math.min(...xs);
+  const maxX = Math.max(...xs);
+  const minZ = Math.min(...zs);
+  const maxZ = Math.max(...zs);
+  const width = Math.max(1, maxX - minX);
+  const height = Math.max(1, maxZ - minZ);
+  const scale = Math.min(270 / width, 135 / height);
+  const offsetX = (320 - width * scale) / 2;
+  const offsetY = (185 - height * scale) / 2;
+  const path = points.map((point, index) => {
+    const x = offsetX + (point.x - minX) * scale;
+    const y = offsetY + (point.z - minZ) * scale;
+    return `${index ? 'L' : 'M'}${x.toFixed(1)} ${y.toFixed(1)}`;
+  }).join(' ');
+
+  return `
+    <svg viewBox="0 0 320 185" focusable="false">
+      <path class="track-preview-shadow" d="${path} Z"></path>
+      <path class="track-preview-road" d="${path} Z"></path>
+      <path class="track-preview-line" d="${path} Z" style="stroke:${accent}"></path>
+      <circle class="track-preview-start" cx="${(offsetX + (points[0].x - minX) * scale).toFixed(1)}" cy="${(offsetY + (points[0].z - minZ) * scale).toFixed(1)}" r="7"></circle>
+    </svg>
+  `;
+}
+
+function refreshBestTimes(overlay) {
+  for (const track of TRACK_CATALOG) {
+    const best = getStoredBestTime(track.id);
+    const strong = overlay.querySelector(`[data-track-best="${track.id}"] strong`);
+    if (strong) strong.textContent = formatTime(best);
+  }
+}
+
+function formatTime(seconds) {
+  if (!Number.isFinite(seconds)) return 'NO TIME YET';
+  const minutes = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60).toString().padStart(2, '0');
+  const ms = Math.floor((seconds % 1) * 1000).toString().padStart(3, '0');
+  return `${minutes}:${secs}.${ms}`;
+}


### PR DESCRIPTION
## Summary

Adds TURN's second playable course and introduces the multi-track flow:

**TRACK → CAR → RACE**

Track 1 remains the existing EASY Countryside circuit. Track 2 is a new MEDIUM Airport circuit built around runway speed, sweeping apron sections and a tighter service-road complex.

## Player-facing changes

- New full-screen `CHOOSE YOUR TRACK` step before The Lot.
- Track cards show difficulty, miniature circuit map, identity and track-specific best time.
- Track 1: **Countryside · EASY** with its existing geometry preserved exactly.
- Track 2: **Airport · MEDIUM** with a distinct new course.
- New Airport world with runway, apron, terminal, control tower, hangars, parked aircraft, service vehicles, baggage carts, fuel infrastructure and runway lighting.
- Start-screen copy now uses **device** rather than **phone**.
- Release milestone: **TURN v1.5.0 · Build 2026.07.22-r47**.

## Architecture and compatibility

- Existing race physics, lap/checkpoint system, ghosts, Spectate and 720-sample course model are shared by both tracks.
- Countryside keeps its existing rival/localStorage keys so current records are preserved.
- Airport rivals and best times use separate track-scoped storage.
- The shared exact track spatial index can rebuild its internal grid/hierarchy when the active course changes.
- Player/rival cars, skid marks and drive particles live in a shared dynamic scene layer so switching world scenery cannot hide gameplay objects.
- Airport scenery is procedural and offline-friendly with no new runtime asset or render-loop dependency.

## Regression coverage

Adds a dedicated multi-track production regression protecting:

- exact Countryside generator compatibility,
- EASY/MEDIUM track identities,
- track selector before The Lot,
- per-track rival isolation,
- spatial-index rebuilding and exact nearest-track results,
- Airport world landmarks,
- no extra render loops or external runtime asset fetches.

The full existing TURN regression suite will run before this PR is made ready or merged.