### PR TITLE
TURN v1.5.1 r48: Refine Airport scenery and track selection

### DIFF
--- a/turn-lab/tests/app-icon-production.mjs
+++ b/turn-lab/tests/app-icon-production.mjs
@@ -10,11 +10,11 @@ const index = fs.readFileSync(path.join(turnRoot, 'index.html'), 'utf8');
 const styles = fs.readFileSync(path.join(turnRoot, 'styles.css'), 'utf8');
 const manifest = JSON.parse(fs.readFileSync(path.join(turnRoot, 'site.webmanifest'), 'utf8'));
 
-assert.match(index, /TURN v1\.5\.0 · Build 2026\.07\.22-r47/);
+assert.match(index, /TURN v1\.5\.1 · Build 2026\.07\.22-r48/);
 assert.match(index, /<link rel="icon" href="\.\/favicon-r45\.ico" sizes="any">/);
 assert.match(index, /<link rel="icon" href="\.\/favicon-32-r45\.png" type="image\/png" sizes="32x32">/);
 assert.match(index, /<link rel="apple-touch-icon" href="\.\/apple-touch-icon-r45\.png" sizes="180x180">/);
-assert.match(index, /<link rel="manifest" href="\.\/site\.webmanifest\?build=20260722-r47">/);
+assert.match(index, /<link rel="manifest" href="\.\/site\.webmanifest\?build=20260722-r48">/);
 assert.match(index, /<img class="install-icon" src="\.\/icon-512-r45\.png" alt="">/);
 assert.match(index, /<h1 class="start-logo-heading" id="title">\s*<img class="start-logo" src="\.\/icon-512-r45\.png" alt="TURN">\s*<\/h1>/);
 assert.doesNotMatch(index, /apple-touch-icon-v4|icon-192-v4/);

--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -10,8 +10,8 @@ const [index, app, audio, controls, catalogSource] = await Promise.all([
 ]);
 const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
 
-assert.match(index, /TURN v1\.5\.0 · Build 2026\.07\.22-r47/);
-assert.match(index, /\.\/app\.js\?build=20260722-r47/);
+assert.match(index, /TURN v1\.5\.1 · Build 2026\.07\.22-r48/);
+assert.match(index, /\.\/app\.js\?build=20260722-r48/);
 assert.match(
   index,
   /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/,

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -69,7 +69,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.5\.0 · Build 2026\.07\.22-r47/);
+assert.match(index, /TURN v1\.5\.1 · Build 2026\.07\.22-r48/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -20,9 +20,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.5\.0 · Build 2026\.07\.22-r47/);
-assert.match(index, /drive-pad\.css\?build=20260722-r47/);
-assert.match(index, /gameplay-v2\.css\?build=20260722-r47/);
+assert.match(index, /TURN v1\.5\.1 · Build 2026\.07\.22-r48/);
+assert.match(index, /drive-pad\.css\?build=20260722-r48/);
+assert.match(index, /gameplay-v2\.css\?build=20260722-r48/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -50,13 +50,13 @@ const [index, main, lapSystem, rivalStorage, controls, carModels, lotWrapper] = 
   fs.readFile(path.join(turnDir, 'garage/lot-track-select.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.5\.0 · Build 2026\.07\.22-r47/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260722-r47/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260722-r47"/, 'r47 must place track selection in front of the stable Lot implementation');
+assert.match(index, /TURN v1\.5\.1 · Build 2026\.07\.22-r48/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260722-r48/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260722-r48"/, 'r48 must place track selection in front of the stable Lot implementation');
 assert.match(lotWrapper, /showOriginalLot/, 'The track-first wrapper must still delegate car selection to the verified Lot implementation');
 assert.match(lotWrapper, /await chooseTrackBeforeLot\(\)/, 'The driver must pick a track before choosing the car');
-assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r47 must preserve the reduced Monster Truck scale in the main runtime');
-assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r47 must preserve the same reduced Monster Truck scale inside The Lot');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r48 must preserve the reduced Monster Truck scale in the main runtime');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r48 must preserve the same reduced Monster Truck scale inside The Lot');
 assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter the track-first Lot wrapper before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -26,8 +26,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.5\.0 · Build 2026\.07\.22-r47/);
-assert.match(index, /in-game-menu\.css\?build=20260722-r47/);
+assert.match(index, /TURN v1\.5\.1 · Build 2026\.07\.22-r48/);
+assert.match(index, /in-game-menu\.css\?build=20260722-r48/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Restart Lap<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -134,11 +134,11 @@ const [index, app, lapSystem, gameState, hud, styles, toast, toastCss, onboardin
   fs.readFile(new URL('../../turn/rival-onboarding.css', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.5\.0 · Build 2026\.07\.22-r47/);
-assert.match(index, /lap-result-toast\.css\?build=20260722-r47/);
-assert.match(index, /rival-onboarding\.css\?build=20260722-r47/);
-assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260722-r41"/, 'r47 must preserve the r41 early invalid-lap detector');
-assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r41"/, 'r47 must preserve the r41 reset-safe invalid-lap state');
+assert.match(index, /TURN v1\.5\.1 · Build 2026\.07\.22-r48/);
+assert.match(index, /lap-result-toast\.css\?build=20260722-r48/);
+assert.match(index, /rival-onboarding\.css\?build=20260722-r48/);
+assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260722-r41"/, 'r48 must preserve the r41 early invalid-lap detector');
+assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r41"/, 'r48 must preserve the r41 reset-safe invalid-lap state');
 assert.match(app, /installLapResultToast\(\)/, 'The lap result toast must install before the game runtime starts');
 assert.match(app, /installRivalOnboarding\(\)/, 'The rival onboarding plate must install before the game runtime starts');
 assert.match(lapSystem, /turn:lap-result/, 'Completed lap finish must publish one frozen result event');

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -20,13 +20,13 @@ const [index, css, orientationGuardCss, orientationCompat, camera] = await Promi
   fs.readFile(new URL('../../turn/render/camera.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.5\.0 · Build 2026\.07\.22-r47/);
+assert.match(index, /TURN v1\.5\.1 · Build 2026\.07\.22-r48/);
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260722-r47/);
-assert.match(index, /orientation-guard\.css\?build=20260722-r47/);
-assert.match(index, /orientation-compat\.js\?build=20260722-r47/);
-assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r47 must preserve the guarded race camera cache redirect');
+assert.match(index, /manual-steering\.css\?build=20260722-r48/);
+assert.match(index, /orientation-guard\.css\?build=20260722-r48/);
+assert.match(index, /orientation-compat\.js\?build=20260722-r48/);
+assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r48 must preserve the guarded race camera cache redirect');
 assert.match(index, /<strong>Rotate to landscape<\/strong>/, 'The pre-race landscape instruction must remain available');
 
 assert.match(css, /--manual-steer-left/);

--- a/turn-lab/tests/multi-track-production.mjs
+++ b/turn-lab/tests/multi-track-production.mjs
@@ -74,11 +74,11 @@ const [index, trackCatalog, trackManager, trackSelect, trackSelectCss, lotWrappe
   fs.readFile(new URL('../../turn/ui/hud.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.5\.0 · Build 2026\.07\.22-r47/);
-assert.match(index, /track-select\.css\?build=20260722-r47/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260722-r47"/, 'The track selector must sit before the existing Lot entry point');
-assert.match(index, /"\.\/race\/rival-storage\.js\?build=20260720-r19": "\.\/race\/rival-storage\.js\?build=20260722-r47"/, 'Production must load track-scoped rival storage');
-assert.match(index, /"\.\/race\/track-spatial-index\.js\?build=20260720-r19": "\.\/race\/track-spatial-index\.js\?build=20260722-r47"/, 'Production must load the rebuildable track index');
+assert.match(index, /TURN v1\.5\.1 · Build 2026\.07\.22-r48/);
+assert.match(index, /track-select\.css\?build=20260722-r48/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260722-r48"/, 'The track selector must sit before the existing Lot entry point');
+assert.match(index, /"\.\/race\/rival-storage\.js\?build=20260720-r19": "\.\/race\/rival-storage\.js\?build=20260722-r47"/, 'Production must preserve track-scoped rival storage');
+assert.match(index, /"\.\/race\/track-spatial-index\.js\?build=20260720-r19": "\.\/race\/track-spatial-index\.js\?build=20260722-r47"/, 'Production must preserve the rebuildable track index');
 assert.match(index, /Turn the device to steer/, 'Start copy must use device-neutral language');
 assert.match(index, /Steering uses device rotation/, 'Status copy must use device-neutral language');
 assert.doesNotMatch(index, /Turn the phone to steer|Steering uses phone rotation/, 'The retired phone-specific start copy must stay removed');
@@ -92,6 +92,7 @@ assert.match(trackCatalog, /radiusZ = 146 \+ Math\.cos\(angle \* 2 - 0\.4\) \* 1
 assert.match(trackCatalog, /TRACK_SAMPLE_COUNT = 720/, 'Both tracks must use the verified 720-sample race/checkpoint system');
 assert.match(trackCatalog, /Runway speed\. Service-road precision\./, 'Airport must keep its medium-difficulty driving identity');
 
+assert.match(lotWrapper, /track-manager\.js\?build=20260722-r48/, 'The Lot wrapper must load the refined Airport runtime');
 assert.match(lotWrapper, /await chooseTrackBeforeLot\(\)/, 'Track selection must complete before The Lot opens');
 assert.ok(
   lotWrapper.indexOf('await chooseTrackBeforeLot()') < lotWrapper.indexOf('showOriginalLot(options)'),
@@ -101,7 +102,12 @@ assert.match(trackSelect, /CHOOSE YOUR TRACK/);
 assert.match(trackSelect, /TRACK → CAR → RACE/);
 assert.match(trackSelect, /getStoredBestTime\(track\.id\)/, 'Selector cards must show track-specific records');
 assert.match(trackSelectCss, /grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/, 'The two launch tracks must present as peer choices');
+assert.match(trackSelectCss, /\.track-card\.is-selected \{[\s\S]*translate\(6px, 6px\) scale\(0\.985\)/, 'Selected track must visibly sink toward its shadow');
+assert.match(trackSelectCss, /\.track-card\.is-selected \{[\s\S]*3px 3px 0 var\(--ink\)/, 'Selected track must lose elevation rather than rise');
+assert.match(trackSelectCss, /filter: saturate\(1\.2\) contrast\(1\.03\)/, 'Selected track must become more vibrant');
+assert.match(trackSelectCss, /\.track-card\.is-selected:active/, 'The pressed card must still have tactile pointer-down feedback');
 
+assert.match(trackManager, /airport-world\.js\?build=20260722-r48/, 'Track manager must load the refined Airport world');
 assert.match(trackManager, /initialTrackId: chosenThisSession \? activeTrackId : loadTrackSelection\(\)/, 'Later Lot visits must reopen track choice with the current course preselected');
 assert.doesNotMatch(trackManager, /if \(!force && chosenThisSession\) return activeTrackId/, 'Track selection must not be skipped on later visits to The Lot');
 assert.match(trackManager, /replaceSamples\(currentRuntime\.samples, airportTrack\.samples\)/);
@@ -122,17 +128,22 @@ assert.match(spatialSource, /return rebuild\(nextSamples\)/);
 assert.match(rivalStorage, /normalized === DEFAULT_TRACK_ID \? COMPETITOR_KEY : `\$\{COMPETITOR_KEY\}:\$\{normalized\}`/, 'Countryside must keep its historical storage key while later tracks are namespaced');
 assert.match(rivalStorage, /version: 5/);
 
-assert.match(airportWorld, /function makeRunway\(/);
-assert.match(airportWorld, /function makeAirportBuildings\(/);
-assert.match(airportWorld, /function makeAircraft\(/);
-assert.match(airportWorld, /function makeGroundOperations\(/);
-assert.match(airportWorld, /function makeStartGate\(/);
-assert.match(airportWorld, /new THREE\.PlaneGeometry\(520, 340\)/, 'Airport must have a large dedicated concrete field');
-assert.match(airportWorld, /new THREE\.BoxGeometry\(455, 0\.1, 62\)/, 'Airport must include its long runway landmark');
-assert.doesNotMatch(airportWorld, /GLTFLoader|fetch\(|new Audio\(/, 'Airport scenery must stay deterministic and offline-friendly');
+assert.match(airportWorld, /TRACK_PROP_CLEARANCE = 25/, 'Airport props must keep a broad race-road exclusion zone');
+assert.match(airportWorld, /AIRCRAFT_CLEARANCE = 44/, 'Aircraft must keep an even wider exclusion zone for wings and fuselage');
+assert.match(airportWorld, /function placeScenerySafely\(/, 'Large scenery must pass one shared clearance gate');
+assert.match(airportWorld, /function minimumTrackDistance\(/, 'Clearance must be measured against the actual 720-sample course');
+assert.match(airportWorld, /createCarVisual\(/, 'Airport service traffic must reuse real local TURN GLB vehicle assets');
+assert.match(airportWorld, /carId: 'truck'/, 'The Airport must include an asset-backed service truck');
+assert.match(airportWorld, /carId: 'van'/, 'The Airport must include an asset-backed operations van');
+assert.match(airportWorld, /carId: 'truck-flat'/, 'The Airport must include an asset-backed flatbed vehicle');
+assert.doesNotMatch(airportWorld, /function makeServiceVehicle\(/, 'The block-box service-vehicle stand-ins must stay retired');
+assert.match(airportWorld, /AIRCRAFT_ASSET_URL/, 'Airport must attempt to upgrade parked aircraft with a real 3D asset');
+assert.match(airportWorld, /makeAircraftFallbacks\(/, 'Aircraft must have a local fallback before any remote asset is attempted');
+assert.match(airportWorld, /keeping the local fallback/, 'Offline or failed aircraft loading must degrade safely');
+assert.match(airportWorld, /world\.remove\(fallback\)/, 'A loaded aircraft asset must replace rather than overlap its fallback');
 assert.doesNotMatch(airportWorld, /setAnimationLoop|requestAnimationFrame|setInterval/, 'Airport scenery must add no independent animation loop');
 
-console.log('TURN multi-track selection, Airport world, minimap switching and track-scoped rival regression passed.');
+console.log('TURN multi-track selection, pressed track cards, safe Airport scenery and track-scoped rival regression passed.');
 
 function makeSamples(points) {
   return points.map(([x, z]) => ({ point: { x, z } }));

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -34,7 +34,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.5\.0 · Build 2026\.07\.22-r47/);
+assert.match(index, /TURN v1\.5\.1 · Build 2026\.07\.22-r48/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -121,11 +121,11 @@ const [index, app, main, worldAssets, worldRender, controls, menu, spectate, hud
   fs.readFile(new URL('../../turn/orientation-compat.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.5\.0 · Build 2026\.07\.22-r47/);
-assert.match(index, /"\.\/race\/replay-system\.js": "\.\/race\/replay-system\.js\?build=20260722-r43"/, 'r47 must preserve the shared replay sampler cache');
-assert.match(index, /"\.\/race\/track-spatial-index\.js\?build=20260720-r19": "\.\/race\/track-spatial-index\.js\?build=20260722-r47"/, 'r47 must use the rebuildable bounded track search');
-assert.match(index, /"\.\/performance-monitor\.js\?build=20260720-r19": "\.\/performance-monitor\.js\?build=20260722-r43"/, 'r47 must preserve the diagnostics module');
-assert.match(index, /"\.\/world-assets\.js": "\.\/world-assets\.js\?build=20260722-r44"/, 'r47 must preserve both countryside tree-grounding passes');
+assert.match(index, /TURN v1\.5\.1 · Build 2026\.07\.22-r48/);
+assert.match(index, /"\.\/race\/replay-system\.js": "\.\/race\/replay-system\.js\?build=20260722-r43"/, 'r48 must preserve the shared replay sampler cache');
+assert.match(index, /"\.\/race\/track-spatial-index\.js\?build=20260720-r19": "\.\/race\/track-spatial-index\.js\?build=20260722-r47"/, 'r48 must preserve the rebuildable bounded track search');
+assert.match(index, /"\.\/performance-monitor\.js\?build=20260720-r19": "\.\/performance-monitor\.js\?build=20260722-r43"/, 'r48 must preserve the diagnostics module');
+assert.match(index, /"\.\/world-assets\.js": "\.\/world-assets\.js\?build=20260722-r44"/, 'r48 must preserve both countryside tree-grounding passes');
 assert.match(app, /installPerformanceProfile\(\)/, 'Renderer profile installation must run before the game runtime');
 assert.ok(app.indexOf('./performance-profile.js') < app.indexOf('./main.js'), 'The universal DPR cap must be ready before main.js creates the runtime');
 assert.match(profile, /DEFAULT_DPR_CAP = 1\.5/, 'The universal production DPR ceiling must stay at 1.5');

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -1,5 +1,5 @@
 import { showTheLot as showOriginalLot } from './lot-r10.js?build=20260720-r25';
-import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r47';
+import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r48';
 
 export async function showTheLot(options = {}) {
   const trackId = await chooseTrackBeforeLot();

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r47 Airport track and multi-track selection -->
+<!-- TURN r48 Airport art refinement and pressed track selection -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,42 +10,42 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.5.0 · Build 2026.07.22-r47</title>
+  <title>TURN v1.5.1 · Build 2026.07.22-r48</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.5.0',
-      id: '2026.07.22-r47',
-      cacheKey: '20260722-r47'
+      version: '1.5.1',
+      id: '2026.07.22-r48',
+      cacheKey: '20260722-r48'
     });
   </script>
   <link rel="icon" href="./favicon-r45.ico" sizes="any">
   <link rel="icon" href="./favicon-32-r45.png" type="image/png" sizes="32x32">
   <link rel="apple-touch-icon" href="./apple-touch-icon-r45.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260722-r47">
-  <link rel="stylesheet" href="./styles.css?build=20260722-r47">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260722-r47">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260722-r47">
-  <link rel="stylesheet" href="./install-gate.css?build=20260722-r47">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260722-r47">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260722-r47">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260722-r47">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260722-r47">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260722-r47">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260722-r47">
-  <link rel="stylesheet" href="./orientation-guard.css?build=20260722-r47">
-  <link rel="stylesheet" href="./lap-result-toast.css?build=20260722-r47">
-  <link rel="stylesheet" href="./rival-onboarding.css?build=20260722-r47">
-  <link rel="stylesheet" href="./track-select.css?build=20260722-r47">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260722-r47">
+  <link rel="manifest" href="./site.webmanifest?build=20260722-r48">
+  <link rel="stylesheet" href="./styles.css?build=20260722-r48">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260722-r48">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260722-r48">
+  <link rel="stylesheet" href="./install-gate.css?build=20260722-r48">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260722-r48">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260722-r48">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260722-r48">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260722-r48">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260722-r48">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260722-r48">
+  <link rel="stylesheet" href="./orientation-guard.css?build=20260722-r48">
+  <link rel="stylesheet" href="./lap-result-toast.css?build=20260722-r48">
+  <link rel="stylesheet" href="./rival-onboarding.css?build=20260722-r48">
+  <link rel="stylesheet" href="./track-select.css?build=20260722-r48">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260722-r48">
 
-  <script src="./install-gate.js?build=20260722-r47"></script>
-  <script src="./orientation-compat.js?build=20260722-r47"></script>
+  <script src="./install-gate.js?build=20260722-r48"></script>
+  <script src="./orientation-compat.js?build=20260722-r48"></script>
   <script type="importmap">
     {
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
-        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260722-r47",
+        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260722-r48",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260721-r29",
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system.js?build=20260722-r41",
         "./race/game-state.js": "./race/game-state.js?build=20260722-r41",
@@ -69,7 +69,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.5.0 · Build 2026.07.22-r47</span>
+        <span class="install-kicker">TURN v1.5.1 · Build 2026.07.22-r48</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -97,7 +97,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.5.0 · Build 2026.07.22-r47</span>
+      <span class="kicker">TURN v1.5.1 · Build 2026.07.22-r48</span>
       <h1 class="start-logo-heading" id="title">
         <img class="start-logo" src="./icon-512-r45.png" alt="TURN">
       </h1>
@@ -165,6 +165,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260722-r47"></script>
+  <script type="module" src="./app.js?build=20260722-r48"></script>
 </body>
 </html>

--- a/turn/track-select.css
+++ b/turn/track-select.css
@@ -103,8 +103,12 @@
   box-shadow: 9px 9px 0 var(--ink);
   text-align: left;
   font: inherit;
-  transform: translateY(0) rotate(0deg);
-  transition: transform 150ms ease, background 150ms ease, box-shadow 150ms ease;
+  transform: translate(0, 0) scale(1);
+  transition:
+    transform 150ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    background 150ms ease,
+    box-shadow 150ms ease,
+    filter 150ms ease;
   overflow: hidden;
 }
 
@@ -123,14 +127,44 @@
   transform: translateY(-3px);
 }
 
+.track-card:active {
+  transform: translate(7px, 7px) scale(0.98);
+  box-shadow: 2px 2px 0 var(--ink);
+}
+
 .track-card.is-selected {
-  background: var(--track-accent);
-  transform: translateY(-6px) rotate(-0.5deg);
-  box-shadow: 12px 12px 0 var(--ink);
+  background: color-mix(in srgb, var(--track-accent) 94%, white 6%);
+  transform: translate(6px, 6px) scale(0.985);
+  box-shadow:
+    3px 3px 0 var(--ink),
+    inset 0 5px 0 rgb(255 255 255 / 0.24),
+    inset 0 -7px 0 rgb(8 9 10 / 0.12);
+  filter: saturate(1.2) contrast(1.03);
+}
+
+.track-card.is-selected:hover,
+.track-card.is-selected:focus-visible {
+  transform: translate(6px, 6px) scale(0.985);
+}
+
+.track-card.is-selected:active {
+  transform: translate(8px, 8px) scale(0.975);
+  box-shadow:
+    1px 1px 0 var(--ink),
+    inset 0 5px 0 rgb(255 255 255 / 0.2),
+    inset 0 -7px 0 rgb(8 9 10 / 0.16);
 }
 
 .track-card.is-selected::after {
-  box-shadow: inset 0 0 0 5px rgb(255 255 255 / 0.72);
+  box-shadow: inset 0 0 0 5px rgb(255 255 255 / 0.74);
+}
+
+.track-card.is-selected .track-card-preview {
+  transform: translateY(1px) scale(0.992);
+  filter: saturate(1.18) contrast(1.04);
+  box-shadow:
+    inset 0 4px 0 rgb(255 255 255 / 0.18),
+    inset 0 -5px 0 rgb(8 9 10 / 0.1);
 }
 
 .track-card-topline {
@@ -158,6 +192,8 @@
   background:
     linear-gradient(rgb(255 255 255 / 0.38), rgb(255 255 255 / 0.1)),
     #9ae6b4;
+  transform: translateY(0) scale(1);
+  transition: transform 150ms ease, filter 150ms ease, box-shadow 150ms ease;
   overflow: hidden;
 }
 
@@ -305,7 +341,8 @@
 
 @media (prefers-reduced-motion: reduce) {
   .track-select,
-  .track-card {
+  .track-card,
+  .track-card-preview {
     transition: none;
   }
 }

--- a/turn/tracks/airport-world.js
+++ b/turn/tracks/airport-world.js
@@ -1,4 +1,6 @@
 import * as THREE from 'three';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { createCarVisual } from '../vehicle/car-models.js?build=20260720-r19';
 
 const INK = 0x08090a;
 const RUNWAY = 0x25292e;
@@ -9,6 +11,30 @@ const YELLOW = 0xffd43b;
 const PINK = 0xff4fa3;
 const RED = 0xff5f67;
 const CREAM = 0xfff8e8;
+const TRACK_PROP_CLEARANCE = 25;
+const AIRCRAFT_CLEARANCE = 44;
+
+// This tiny low-poly aircraft was authored with Kenney AssetForge. It is an optional visual
+// enhancement only: TURN places a local procedural fallback first, so Airport remains playable
+// and visually complete if the external source is unavailable or the device is offline.
+const AIRCRAFT_ASSET_URL = 'https://raw.githubusercontent.com/crystal-bit/platform-3d/main/assets/airplane.glb';
+const aircraftLoader = new GLTFLoader();
+let aircraftSourcePromise = null;
+
+const AIRCRAFT_SLOTS = Object.freeze([
+  Object.freeze({ position: [-58, 0.35, 186], rotation: 0.08, scale: 1.05, targetLength: 25 }),
+  Object.freeze({ position: [133, 0.35, 190], rotation: -0.16, scale: 0.94, targetLength: 23 }),
+  Object.freeze({ position: [208, 0.35, 166], rotation: -1.22, scale: 0.82, targetLength: 20 }),
+  Object.freeze({ position: [108, 0.35, -190], rotation: Math.PI / 2, scale: 0.72, targetLength: 18 })
+]);
+
+const SERVICE_VEHICLE_SLOTS = Object.freeze([
+  Object.freeze({ carId: 'sedan', color: '#ffd43b', position: [-32, 0.2, 188], rotation: 1.36, targetLength: 6.1 }),
+  Object.freeze({ carId: 'van', color: '#38d9ff', position: [82, 0.2, 34], rotation: -0.32, targetLength: 7.2 }),
+  Object.freeze({ carId: 'truck', color: '#ff922b', position: [126, 0.2, 184], rotation: -0.1, targetLength: 8.4 }),
+  Object.freeze({ carId: 'truck-flat', color: '#ffd43b', position: [178, 0.2, 184], rotation: 0.18, targetLength: 8.8 }),
+  Object.freeze({ carId: 'suv', color: '#ff4fa3', position: [-112, 0.2, 172], rotation: -0.42, targetLength: 6.8 })
+]);
 
 const blackOutlineMaterial = new THREE.MeshBasicMaterial({
   color: INK,
@@ -24,21 +50,28 @@ export function installAirportWorld({ scene, samples, trackWidth = 27 }) {
   makeRunway(world);
   makeRaceRoad(world, samples, trackWidth);
   makeAirportBuildings(world);
-  makeAircraft(world);
-  makeGroundOperations(world);
+  const aircraftFallbacks = makeAircraftFallbacks(world, samples);
+  makeGroundOperations(world, samples);
   makeDistantWorld(world);
   makeStartGate(world, samples, trackWidth);
+
+  installAircraftAssets(world, samples, aircraftFallbacks).catch((error) => {
+    console.info('TURN: Airport aircraft asset unavailable; keeping the local fallback.', error);
+  });
+  installServiceVehicleAssets(world, samples).catch((error) => {
+    console.info('TURN: Airport service vehicle assets unavailable; keeping the apron clear.', error);
+  });
 
   return world;
 }
 
-function outlinedMesh(geometry, material, scale = 1.035, { castShadow = true, receiveShadow = true } = {}) {
+function outlinedMesh(geometry, meshMaterial, scale = 1.035, { castShadow = true, receiveShadow = true } = {}) {
   const group = new THREE.Group();
   const outline = new THREE.Mesh(geometry, blackOutlineMaterial);
   outline.scale.setScalar(scale);
   outline.castShadow = false;
   outline.receiveShadow = false;
-  const mesh = new THREE.Mesh(geometry, material);
+  const mesh = new THREE.Mesh(geometry, meshMaterial);
   mesh.castShadow = castShadow;
   mesh.receiveShadow = receiveShadow;
   group.add(outline, mesh);
@@ -249,8 +282,8 @@ function makeAirportBuildings(world) {
   world.add(terminal);
 
   for (const x of [10, 50, 90]) {
-    const bridge = outlinedMesh(new THREE.BoxGeometry(4.5, 4, 19), material(0xe8edf1, 0.8), 1.025);
-    bridge.position.set(x, 6.4, 139);
+    const bridge = outlinedMesh(new THREE.BoxGeometry(4.5, 4, 15), material(0xe8edf1, 0.8), 1.025);
+    bridge.position.set(x, 6.4, 146);
     world.add(bridge);
   }
 
@@ -289,25 +322,43 @@ function makeAirportBuildings(world) {
     tank.position.set(x, 5.6, 0);
     fuelZone.add(tank);
   }
-  fuelZone.position.set(-155, 0, 132);
+  fuelZone.position.set(-170, 0, 165);
   world.add(fuelZone);
 }
 
-function makeAircraft(world) {
-  const planes = [
-    { position: [7, 1.4, 112], rotation: -0.08, color: 0xfff8e8, tail: PINK, scale: 1.05 },
-    { position: [91, 1.4, 111], rotation: 0.12, color: 0xfff8e8, tail: 0x38d9ff, scale: 0.95 },
-    { position: [151, 1.4, 68], rotation: -1.25, color: 0xe9eef2, tail: YELLOW, scale: 0.88 },
-    { position: [126, 1.4, -173], rotation: Math.PI / 2, color: 0xfff8e8, tail: RED, scale: 0.72 }
-  ];
-
-  for (const plane of planes) {
-    const model = makePlane(plane.color, plane.tail);
-    model.position.set(...plane.position);
-    model.rotation.y = plane.rotation;
-    model.scale.setScalar(plane.scale);
-    world.add(model);
+function makeAircraftFallbacks(world, samples) {
+  const records = [];
+  for (let index = 0; index < AIRCRAFT_SLOTS.length; index += 1) {
+    const slot = AIRCRAFT_SLOTS[index];
+    const fallback = makePlane(CREAM, [PINK, 0x38d9ff, YELLOW, RED][index % 4]);
+    fallback.scale.setScalar(slot.scale);
+    const placed = placeScenerySafely(world, fallback, samples, slot, AIRCRAFT_CLEARANCE, `aircraft fallback ${index + 1}`);
+    if (placed) records.push({ slot, fallback });
   }
+  return records;
+}
+
+async function installAircraftAssets(world, samples, fallbackRecords) {
+  const source = await loadAircraftSource();
+  for (let index = 0; index < fallbackRecords.length; index += 1) {
+    const { slot, fallback } = fallbackRecords[index];
+    const root = new THREE.Group();
+    const model = source.clone(true);
+    prepareStaticAsset(model, { outline: true, castShadow: index < 2 });
+    normalizeModelToGround(model, slot.targetLength);
+    root.add(model);
+    root.rotation.y = slot.rotation;
+
+    if (!placeScenerySafely(world, root, samples, slot, AIRCRAFT_CLEARANCE, `aircraft asset ${index + 1}`)) continue;
+    world.remove(fallback);
+  }
+}
+
+function loadAircraftSource() {
+  if (!aircraftSourcePromise) {
+    aircraftSourcePromise = aircraftLoader.loadAsync(AIRCRAFT_ASSET_URL).then((gltf) => gltf.scene);
+  }
+  return aircraftSourcePromise;
 }
 
 function makePlane(bodyColor, tailColor) {
@@ -316,91 +367,164 @@ function makePlane(bodyColor, tailColor) {
   const tailMaterial = material(tailColor, 0.58);
   const darkMaterial = material(0x34383d, 0.82);
 
-  const fuselage = outlinedMesh(new THREE.BoxGeometry(4.2, 3.8, 25), bodyMaterial, 1.04);
-  fuselage.position.y = 3.4;
+  const fuselage = outlinedMesh(new THREE.CylinderGeometry(2.05, 1.75, 24, 10), bodyMaterial, 1.04);
+  fuselage.rotation.x = Math.PI / 2;
+  fuselage.position.y = 3.6;
   plane.add(fuselage);
 
-  const nose = outlinedMesh(new THREE.ConeGeometry(2.15, 5.5, 8), bodyMaterial, 1.04);
-  nose.rotation.x = Math.PI / 2;
-  nose.position.set(0, 3.4, -15.2);
+  const nose = outlinedMesh(new THREE.ConeGeometry(2.05, 5, 10), bodyMaterial, 1.04);
+  nose.rotation.x = -Math.PI / 2;
+  nose.position.set(0, 3.6, -14.5);
   plane.add(nose);
 
-  const wing = outlinedMesh(new THREE.BoxGeometry(24, 0.55, 5.8), bodyMaterial, 1.035);
-  wing.position.set(0, 3.25, -1);
+  const wing = outlinedMesh(new THREE.BoxGeometry(25, 0.48, 4.7), bodyMaterial, 1.035);
+  wing.position.set(0, 3.45, -1.5);
   plane.add(wing);
 
-  const tailWing = outlinedMesh(new THREE.BoxGeometry(10, 0.42, 3.2), tailMaterial, 1.04);
-  tailWing.position.set(0, 4.2, 10.2);
+  const tailWing = outlinedMesh(new THREE.BoxGeometry(10, 0.4, 3), tailMaterial, 1.04);
+  tailWing.position.set(0, 4.1, 9.7);
   plane.add(tailWing);
 
-  const fin = outlinedMesh(new THREE.BoxGeometry(0.7, 6.5, 4.6), tailMaterial, 1.05);
-  fin.position.set(0, 6.5, 10.4);
-  fin.rotation.x = -0.18;
+  const fin = outlinedMesh(new THREE.BoxGeometry(0.7, 6, 4.2), tailMaterial, 1.05);
+  fin.position.set(0, 6.5, 10.2);
+  fin.rotation.x = -0.2;
   plane.add(fin);
 
-  for (const x of [-5.8, 5.8]) {
-    const engine = outlinedMesh(new THREE.CylinderGeometry(1.3, 1.3, 4.5, 10), darkMaterial, 1.04);
+  for (const x of [-5.6, 5.6]) {
+    const engine = outlinedMesh(new THREE.CylinderGeometry(1.25, 1.25, 4.2, 10), darkMaterial, 1.04);
     engine.rotation.x = Math.PI / 2;
-    engine.position.set(x, 2.25, -1.5);
+    engine.position.set(x, 2.45, -1.7);
     plane.add(engine);
   }
 
   return plane;
 }
 
-function makeGroundOperations(world) {
-  const servicePalette = [YELLOW, 0xff922b, 0x38d9ff, PINK];
-  const servicePositions = [
-    [-18, 91, 0.1],
-    [58, 88, -0.2],
-    [126, 97, 0.4],
-    [-115, 114, -0.35],
-    [184, 81, 1.15]
-  ];
-
-  servicePositions.forEach(([x, z, rotation], index) => {
-    const vehicle = makeServiceVehicle(servicePalette[index % servicePalette.length]);
-    vehicle.position.set(x, 0.7, z);
-    vehicle.rotation.y = rotation;
-    world.add(vehicle);
-  });
-
+function makeGroundOperations(world, samples) {
   const coneGeometry = new THREE.ConeGeometry(0.8, 2.2, 8);
   const coneMaterial = material(0xff7b3d, 0.85);
-  const cones = new THREE.InstancedMesh(coneGeometry, coneMaterial, 28);
+  const coneSlots = [
+    [60, 28], [72, 30], [84, 31], [96, 32], [108, 34], [120, 36],
+    [66, 47], [78, 49], [90, 50], [102, 51], [114, 52], [126, 53]
+  ];
+  const cones = new THREE.InstancedMesh(coneGeometry, coneMaterial, coneSlots.length);
   const marker = new THREE.Object3D();
-  for (let index = 0; index < 28; index += 1) {
-    const row = index < 14 ? 0 : 1;
-    marker.position.set(-8 + (index % 14) * 9, 1.1, 77 + row * 58);
-    marker.rotation.y = index * 0.31;
+  let coneCursor = 0;
+  for (const [x, z] of coneSlots) {
+    if (minimumTrackDistance(samples, x, z) < TRACK_PROP_CLEARANCE) continue;
+    marker.position.set(x, 1.1, z);
+    marker.rotation.y = coneCursor * 0.31;
     marker.updateMatrix();
-    cones.setMatrixAt(index, marker.matrix);
+    cones.setMatrixAt(coneCursor, marker.matrix);
+    coneCursor += 1;
   }
+  cones.count = coneCursor;
   cones.instanceMatrix.needsUpdate = true;
   world.add(cones);
 
-  for (const [x, z, rotation] of [[-45, 125, 0], [120, 138, 0.2], [-145, 83, -0.6]]) {
+  const cartSlots = [
+    { position: [-92, 0, 18], rotation: -0.45 },
+    { position: [92, 0, 12], rotation: 0.18 },
+    { position: [142, 0, 32], rotation: 0.55 }
+  ];
+  for (const [index, slot] of cartSlots.entries()) {
     const cartTrain = new THREE.Group();
     for (let cart = 0; cart < 3; cart += 1) {
       const box = outlinedMesh(new THREE.BoxGeometry(4.4, 2.4, 5.2), material(0x737b84, 0.92), 1.035);
       box.position.set(0, 1.6, cart * 6.2);
       cartTrain.add(box);
     }
-    cartTrain.position.set(x, 0, z);
-    cartTrain.rotation.y = rotation;
-    world.add(cartTrain);
+    placeScenerySafely(world, cartTrain, samples, slot, TRACK_PROP_CLEARANCE + 4, `baggage carts ${index + 1}`);
   }
 }
 
-function makeServiceVehicle(color) {
-  const vehicle = new THREE.Group();
-  const body = outlinedMesh(new THREE.BoxGeometry(5.5, 2.4, 8), material(color, 0.76), 1.05);
-  body.position.y = 1.8;
-  vehicle.add(body);
-  const cabin = outlinedMesh(new THREE.BoxGeometry(4.6, 2.8, 3.2), material(0xe8edf1, 0.62), 1.05);
-  cabin.position.set(0, 3.4, -1.5);
-  vehicle.add(cabin);
-  return vehicle;
+async function installServiceVehicleAssets(world, samples) {
+  await Promise.all(SERVICE_VEHICLE_SLOTS.map(async (slot, index) => {
+    const visual = await createCarVisual({
+      carId: slot.carId,
+      color: slot.color,
+      targetLength: slot.targetLength,
+      outline: true
+    });
+    visual.rotation.y = slot.rotation;
+    visual.traverse((node) => {
+      if (node.isMesh) node.castShadow = false;
+    });
+    placeScenerySafely(world, visual, samples, slot, TRACK_PROP_CLEARANCE, `service vehicle ${index + 1}`);
+  }));
+}
+
+function placeScenerySafely(world, object, samples, slot, clearance, label) {
+  const [x, y = 0, z] = slot.position;
+  const distance = minimumTrackDistance(samples, x, z);
+  if (distance < clearance) {
+    console.warn(`TURN: skipped ${label}; ${distance.toFixed(1)}m from track is inside the ${clearance}m scenery clearance.`);
+    return false;
+  }
+  object.position.set(x, y, z);
+  if (Number.isFinite(slot.rotation)) object.rotation.y = slot.rotation;
+  world.add(object);
+  return true;
+}
+
+function minimumTrackDistance(samples, x, z) {
+  let bestDistanceSq = Infinity;
+  for (let index = 0; index < samples.length; index += 1) {
+    const point = samples[index].point;
+    const dx = x - point.x;
+    const dz = z - point.z;
+    const distanceSq = dx * dx + dz * dz;
+    if (distanceSq < bestDistanceSq) bestDistanceSq = distanceSq;
+  }
+  return Math.sqrt(bestDistanceSq);
+}
+
+function prepareStaticAsset(model, { outline = true, castShadow = false } = {}) {
+  const meshes = [];
+  model.traverse((node) => {
+    if (!node.isMesh || !node.material) return;
+    meshes.push(node);
+    const materials = Array.isArray(node.material) ? node.material : [node.material];
+    const cloned = materials.map((entry) => entry.clone());
+    node.material = Array.isArray(node.material) ? cloned : cloned[0];
+    node.castShadow = castShadow;
+    node.receiveShadow = true;
+  });
+
+  if (!outline) return;
+  for (const mesh of meshes) {
+    const outlineMeshNode = new THREE.Mesh(
+      mesh.geometry,
+      new THREE.MeshBasicMaterial({
+        color: INK,
+        side: THREE.BackSide,
+        depthTest: true,
+        depthWrite: false,
+        polygonOffset: true,
+        polygonOffsetFactor: 1,
+        polygonOffsetUnits: 1
+      })
+    );
+    outlineMeshNode.scale.setScalar(1.025);
+    outlineMeshNode.castShadow = false;
+    outlineMeshNode.receiveShadow = false;
+    mesh.add(outlineMeshNode);
+  }
+}
+
+function normalizeModelToGround(model, targetLength) {
+  model.updateMatrixWorld(true);
+  const initialBounds = new THREE.Box3().setFromObject(model);
+  const initialSize = initialBounds.getSize(new THREE.Vector3());
+  const footprintLength = Math.max(0.001, initialSize.x, initialSize.z);
+  model.scale.multiplyScalar(targetLength / footprintLength);
+  model.updateMatrixWorld(true);
+
+  const bounds = new THREE.Box3().setFromObject(model);
+  const center = bounds.getCenter(new THREE.Vector3());
+  model.position.x -= center.x;
+  model.position.z -= center.z;
+  model.position.y -= bounds.min.y;
 }
 
 function makeDistantWorld(world) {

--- a/turn/tracks/track-manager.js
+++ b/turn/tracks/track-manager.js
@@ -9,7 +9,7 @@ import {
   normalizeTrackId,
   saveTrackSelection
 } from './catalog.js?build=20260722-r47';
-import { installAirportWorld } from './airport-world.js?build=20260722-r47';
+import { installAirportWorld } from './airport-world.js?build=20260722-r48';
 import { showTrackSelect } from '../ui/track-select.js?build=20260722-r47';
 
 let runtime = null;


### PR DESCRIPTION
## Summary

Refines the new Airport track based on the first real gameplay screenshots, without changing the course geometry, race physics, vehicle balance or controls.

## Track selection

- Selected track cards now feel physically pressed: they sink toward their shadow instead of floating above it.
- Selected cards become more saturated and contrasty, with a subtle inset surface treatment.
- Pointer-down pushes the card a little deeper for a chunky Material-style button feel.

## Airport art pass

- Adds a shared scenery-clearance gate measured against the actual 720-sample racing line.
- Large aircraft require a 44 m centre clearance from the course; vehicles and smaller ground props use a 25 m+ clearance.
- Repositions aircraft, fuel tanks, baggage carts, cones and service traffic away from the racing corridor.
- Pulls jet bridges back from the road and reduces their reach.
- Replaces the blocky procedural service-vehicle stand-ins with TURN's existing local GLB vehicle assets, including operations van, service truck and flatbed.
- Keeps local procedural aircraft in place as guaranteed fallbacks, then attempts to replace them with a real low-poly aircraft GLB asynchronously. A failed or offline aircraft request leaves the fallback untouched, so the track remains playable.
- Adds no new animation/render loop.

## Release

- Bumps TURN to **v1.5.1 · Build 2026.07.22-r48**.
- Hard-busts the selector → Lot wrapper → track manager → Airport world cache chain.
- Updates the production regression expectations without weakening existing gameplay contracts.
- Expands the multi-track regression to protect the pressed selector, track-relative scenery clearance, local asset-backed service vehicles and aircraft fallback behavior.

## Validation

The full TURN regression suite will run before this PR is marked ready or merged.