### PR TITLE
TURN v1.5.2 r49: Polish Airport placement and track selection

### DIFF
--- a/turn-lab/tests/app-icon-production.mjs
+++ b/turn-lab/tests/app-icon-production.mjs
@@ -10,11 +10,11 @@ const index = fs.readFileSync(path.join(turnRoot, 'index.html'), 'utf8');
 const styles = fs.readFileSync(path.join(turnRoot, 'styles.css'), 'utf8');
 const manifest = JSON.parse(fs.readFileSync(path.join(turnRoot, 'site.webmanifest'), 'utf8'));
 
-assert.match(index, /TURN v1\.5\.1 · Build 2026\.07\.22-r48/);
+assert.match(index, /TURN v1\.5\.2 · Build 2026\.07\.22-r49/);
 assert.match(index, /<link rel="icon" href="\.\/favicon-r45\.ico" sizes="any">/);
 assert.match(index, /<link rel="icon" href="\.\/favicon-32-r45\.png" type="image\/png" sizes="32x32">/);
 assert.match(index, /<link rel="apple-touch-icon" href="\.\/apple-touch-icon-r45\.png" sizes="180x180">/);
-assert.match(index, /<link rel="manifest" href="\.\/site\.webmanifest\?build=20260722-r48">/);
+assert.match(index, /<link rel="manifest" href="\.\/site\.webmanifest\?build=20260722-r49">/);
 assert.match(index, /<img class="install-icon" src="\.\/icon-512-r45\.png" alt="">/);
 assert.match(index, /<h1 class="start-logo-heading" id="title">\s*<img class="start-logo" src="\.\/icon-512-r45\.png" alt="TURN">\s*<\/h1>/);
 assert.doesNotMatch(index, /apple-touch-icon-v4|icon-192-v4/);

--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -10,8 +10,8 @@ const [index, app, audio, controls, catalogSource] = await Promise.all([
 ]);
 const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
 
-assert.match(index, /TURN v1\.5\.1 · Build 2026\.07\.22-r48/);
-assert.match(index, /\.\/app\.js\?build=20260722-r48/);
+assert.match(index, /TURN v1\.5\.2 · Build 2026\.07\.22-r49/);
+assert.match(index, /\.\/app\.js\?build=20260722-r49/);
 assert.match(
   index,
   /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/,

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -69,7 +69,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.5\.1 · Build 2026\.07\.22-r48/);
+assert.match(index, /TURN v1\.5\.2 · Build 2026\.07\.22-r49/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -20,9 +20,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.5\.1 · Build 2026\.07\.22-r48/);
-assert.match(index, /drive-pad\.css\?build=20260722-r48/);
-assert.match(index, /gameplay-v2\.css\?build=20260722-r48/);
+assert.match(index, /TURN v1\.5\.2 · Build 2026\.07\.22-r49/);
+assert.match(index, /drive-pad\.css\?build=20260722-r49/);
+assert.match(index, /gameplay-v2\.css\?build=20260722-r49/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -50,13 +50,14 @@ const [index, main, lapSystem, rivalStorage, controls, carModels, lotWrapper] = 
   fs.readFile(path.join(turnDir, 'garage/lot-track-select.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.5\.1 · Build 2026\.07\.22-r48/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260722-r48/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260722-r48"/, 'r48 must place track selection in front of the stable Lot implementation');
+assert.match(index, /TURN v1\.5\.2 · Build 2026\.07\.22-r49/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260722-r49/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260722-r49"/, 'r49 must place track selection in front of the stable Lot implementation');
 assert.match(lotWrapper, /showOriginalLot/, 'The track-first wrapper must still delegate car selection to the verified Lot implementation');
 assert.match(lotWrapper, /await chooseTrackBeforeLot\(\)/, 'The driver must pick a track before choosing the car');
-assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r48 must preserve the reduced Monster Truck scale in the main runtime');
-assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r48 must preserve the same reduced Monster Truck scale inside The Lot');
+assert.match(lotWrapper, /track-manager\.js\?build=20260722-r49/, 'The Lot wrapper must load the footprint-aware Airport runtime');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r49 must preserve the reduced Monster Truck scale in the main runtime');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r49 must preserve the same reduced Monster Truck scale inside The Lot');
 assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter the track-first Lot wrapper before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -26,8 +26,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.5\.1 · Build 2026\.07\.22-r48/);
-assert.match(index, /in-game-menu\.css\?build=20260722-r48/);
+assert.match(index, /TURN v1\.5\.2 · Build 2026\.07\.22-r49/);
+assert.match(index, /in-game-menu\.css\?build=20260722-r49/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Restart Lap<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -134,11 +134,11 @@ const [index, app, lapSystem, gameState, hud, styles, toast, toastCss, onboardin
   fs.readFile(new URL('../../turn/rival-onboarding.css', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.5\.1 · Build 2026\.07\.22-r48/);
-assert.match(index, /lap-result-toast\.css\?build=20260722-r48/);
-assert.match(index, /rival-onboarding\.css\?build=20260722-r48/);
-assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260722-r41"/, 'r48 must preserve the r41 early invalid-lap detector');
-assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r41"/, 'r48 must preserve the r41 reset-safe invalid-lap state');
+assert.match(index, /TURN v1\.5\.2 · Build 2026\.07\.22-r49/);
+assert.match(index, /lap-result-toast\.css\?build=20260722-r49/);
+assert.match(index, /rival-onboarding\.css\?build=20260722-r49/);
+assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260722-r41"/, 'r49 must preserve the r41 early invalid-lap detector');
+assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r41"/, 'r49 must preserve the r41 reset-safe invalid-lap state');
 assert.match(app, /installLapResultToast\(\)/, 'The lap result toast must install before the game runtime starts');
 assert.match(app, /installRivalOnboarding\(\)/, 'The rival onboarding plate must install before the game runtime starts');
 assert.match(lapSystem, /turn:lap-result/, 'Completed lap finish must publish one frozen result event');

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -20,13 +20,13 @@ const [index, css, orientationGuardCss, orientationCompat, camera] = await Promi
   fs.readFile(new URL('../../turn/render/camera.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.5\.1 · Build 2026\.07\.22-r48/);
+assert.match(index, /TURN v1\.5\.2 · Build 2026\.07\.22-r49/);
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260722-r48/);
-assert.match(index, /orientation-guard\.css\?build=20260722-r48/);
-assert.match(index, /orientation-compat\.js\?build=20260722-r48/);
-assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r48 must preserve the guarded race camera cache redirect');
+assert.match(index, /manual-steering\.css\?build=20260722-r49/);
+assert.match(index, /orientation-guard\.css\?build=20260722-r49/);
+assert.match(index, /orientation-compat\.js\?build=20260722-r49/);
+assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r49 must preserve the guarded race camera cache redirect');
 assert.match(index, /<strong>Rotate to landscape<\/strong>/, 'The pre-race landscape instruction must remain available');
 
 assert.match(css, /--manual-steer-left/);

--- a/turn-lab/tests/multi-track-production.mjs
+++ b/turn-lab/tests/multi-track-production.mjs
@@ -61,7 +61,7 @@ assert.equal(rebuilt.index, brute.index, 'Rebuilt track index must remain exact 
 assert.equal(rebuilt.sample, trackB[brute.index], 'Rebuilt index must return the active track sample object');
 assert.ok(spatialIndex.getStats().queryCount >= 1, 'Rebuilt index diagnostics must restart and record new-track queries');
 
-const [index, trackCatalog, trackManager, trackSelect, trackSelectCss, lotWrapper, airportWorld, spatialSource, rivalStorage, hud] = await Promise.all([
+const [index, trackCatalog, trackManager, trackSelect, trackSelectCss, lotWrapper, airportWorld, airportArtPass, spatialSource, rivalStorage, hud] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/tracks/catalog.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/tracks/track-manager.js', import.meta.url), 'utf8'),
@@ -69,14 +69,15 @@ const [index, trackCatalog, trackManager, trackSelect, trackSelectCss, lotWrappe
   fs.readFile(new URL('../../turn/track-select.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-track-select.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/tracks/airport-world.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/tracks/airport-world-r49.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/race/track-spatial-index.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/ui/hud.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.5\.1 · Build 2026\.07\.22-r48/);
-assert.match(index, /track-select\.css\?build=20260722-r48/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260722-r48"/, 'The track selector must sit before the existing Lot entry point');
+assert.match(index, /TURN v1\.5\.2 · Build 2026\.07\.22-r49/);
+assert.match(index, /track-select\.css\?build=20260722-r49/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260722-r49"/, 'The track selector must sit before the existing Lot entry point');
 assert.match(index, /"\.\/race\/rival-storage\.js\?build=20260720-r19": "\.\/race\/rival-storage\.js\?build=20260722-r47"/, 'Production must preserve track-scoped rival storage');
 assert.match(index, /"\.\/race\/track-spatial-index\.js\?build=20260720-r19": "\.\/race\/track-spatial-index\.js\?build=20260722-r47"/, 'Production must preserve the rebuildable track index');
 assert.match(index, /Turn the device to steer/, 'Start copy must use device-neutral language');
@@ -92,7 +93,7 @@ assert.match(trackCatalog, /radiusZ = 146 \+ Math\.cos\(angle \* 2 - 0\.4\) \* 1
 assert.match(trackCatalog, /TRACK_SAMPLE_COUNT = 720/, 'Both tracks must use the verified 720-sample race/checkpoint system');
 assert.match(trackCatalog, /Runway speed\. Service-road precision\./, 'Airport must keep its medium-difficulty driving identity');
 
-assert.match(lotWrapper, /track-manager\.js\?build=20260722-r48/, 'The Lot wrapper must load the refined Airport runtime');
+assert.match(lotWrapper, /track-manager\.js\?build=20260722-r49/, 'The Lot wrapper must load the footprint-aware Airport runtime');
 assert.match(lotWrapper, /await chooseTrackBeforeLot\(\)/, 'Track selection must complete before The Lot opens');
 assert.ok(
   lotWrapper.indexOf('await chooseTrackBeforeLot()') < lotWrapper.indexOf('showOriginalLot(options)'),
@@ -102,12 +103,15 @@ assert.match(trackSelect, /CHOOSE YOUR TRACK/);
 assert.match(trackSelect, /TRACK → CAR → RACE/);
 assert.match(trackSelect, /getStoredBestTime\(track\.id\)/, 'Selector cards must show track-specific records');
 assert.match(trackSelectCss, /grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/, 'The two launch tracks must present as peer choices');
-assert.match(trackSelectCss, /\.track-card\.is-selected \{[\s\S]*translate\(6px, 6px\) scale\(0\.985\)/, 'Selected track must visibly sink toward its shadow');
-assert.match(trackSelectCss, /\.track-card\.is-selected \{[\s\S]*3px 3px 0 var\(--ink\)/, 'Selected track must lose elevation rather than rise');
-assert.match(trackSelectCss, /filter: saturate\(1\.2\) contrast\(1\.03\)/, 'Selected track must become more vibrant');
+assert.match(trackSelectCss, /\.track-card\.is-selected \{[\s\S]*translate\(9px, 9px\) scale\(0\.99\)/, 'Selected track must sit almost flush with its original elevation');
+assert.match(trackSelectCss, /\.track-card\.is-selected \{[\s\S]*1px 1px 0 var\(--ink\)/, 'Selected track must compress its external shadow to a near-flat pressed state');
+assert.match(trackSelectCss, /filter: saturate\(1\.38\) contrast\(1\.06\) brightness\(1\.02\)/, 'Selected track must become distinctly more vibrant');
+assert.match(trackSelectCss, /\.track-card\.is-selected \.track-card-preview/, 'The selected preview itself must sink with the card');
+assert.match(trackSelectCss, /\.track-card\.is-selected \.track-card-topline strong,\s*\.track-card\.is-selected \.track-card-best/, 'Selected metadata chips must share the depressed material treatment');
 assert.match(trackSelectCss, /\.track-card\.is-selected:active/, 'The pressed card must still have tactile pointer-down feedback');
+assert.match(trackSelectCss, /\.track-card:focus-visible/, 'The deeper material treatment must retain a visible keyboard focus ring');
 
-assert.match(trackManager, /airport-world\.js\?build=20260722-r48/, 'Track manager must load the refined Airport world');
+assert.match(trackManager, /airport-world-r49\.js\?build=20260722-r49/, 'Track manager must load the r49 Airport art-direction safety layer');
 assert.match(trackManager, /initialTrackId: chosenThisSession \? activeTrackId : loadTrackSelection\(\)/, 'Later Lot visits must reopen track choice with the current course preselected');
 assert.doesNotMatch(trackManager, /if \(!force && chosenThisSession\) return activeTrackId/, 'Track selection must not be skipped on later visits to The Lot');
 assert.match(trackManager, /replaceSamples\(currentRuntime\.samples, airportTrack\.samples\)/);
@@ -128,10 +132,9 @@ assert.match(spatialSource, /return rebuild\(nextSamples\)/);
 assert.match(rivalStorage, /normalized === DEFAULT_TRACK_ID \? COMPETITOR_KEY : `\$\{COMPETITOR_KEY\}:\$\{normalized\}`/, 'Countryside must keep its historical storage key while later tracks are namespaced');
 assert.match(rivalStorage, /version: 5/);
 
-assert.match(airportWorld, /TRACK_PROP_CLEARANCE = 25/, 'Airport props must keep a broad race-road exclusion zone');
-assert.match(airportWorld, /AIRCRAFT_CLEARANCE = 44/, 'Aircraft must keep an even wider exclusion zone for wings and fuselage');
-assert.match(airportWorld, /function placeScenerySafely\(/, 'Large scenery must pass one shared clearance gate');
-assert.match(airportWorld, /function minimumTrackDistance\(/, 'Clearance must be measured against the actual 720-sample course');
+assert.match(airportWorld, /TRACK_PROP_CLEARANCE = 25/, 'The base Airport world must keep its broad race-road exclusion zone');
+assert.match(airportWorld, /AIRCRAFT_CLEARANCE = 44/, 'The base Airport world must keep its aircraft exclusion zone before the art pass');
+assert.match(airportWorld, /function placeScenerySafely\(/, 'Base scenery must still pass one shared clearance gate');
 assert.match(airportWorld, /createCarVisual\(/, 'Airport service traffic must reuse real local TURN GLB vehicle assets');
 assert.match(airportWorld, /carId: 'truck'/, 'The Airport must include an asset-backed service truck');
 assert.match(airportWorld, /carId: 'van'/, 'The Airport must include an asset-backed operations van');
@@ -141,9 +144,22 @@ assert.match(airportWorld, /AIRCRAFT_ASSET_URL/, 'Airport must attempt to upgrad
 assert.match(airportWorld, /makeAircraftFallbacks\(/, 'Aircraft must have a local fallback before any remote asset is attempted');
 assert.match(airportWorld, /keeping the local fallback/, 'Offline or failed aircraft loading must degrade safely');
 assert.match(airportWorld, /world\.remove\(fallback\)/, 'A loaded aircraft asset must replace rather than overlap its fallback');
+
+assert.match(airportArtPass, /airport-world\.js\?build=20260722-r48/, 'r49 must refine rather than fork the verified r48 Airport foundation');
+assert.match(airportArtPass, /AIRCRAFT_VIEW_CLEARANCE = 60/, 'Large aircraft must receive extra visual breathing room beyond physical track clearance');
+assert.match(airportArtPass, /BAGGAGE_CLEARANCE = 44/, 'Baggage trains must be kept well away from the racing sightline');
+assert.match(airportArtPass, /HORIZON_MIN_DISTANCE = 430/, 'Oversized mountains must be pulled into the distant horizon');
+assert.match(airportArtPass, /HORIZON_SCALE = 0\.54/, 'The giant r48 pyramid forms must be substantially reduced');
+assert.match(airportArtPass, /child\.scale\.multiplyScalar\(0\.58\)/, 'Bulky baggage trains must be scaled down before placement');
+assert.match(airportArtPass, /new THREE\.Box3\(\)\.setFromObject\(object\)/, 'Scenery clearance must measure the actual rendered object footprint');
+assert.match(airportArtPass, /radius: Math\.hypot\(size\.x, size\.z\) \* 0\.5/, 'Footprint radius must include both object width and depth');
+assert.match(airportArtPass, /requiredDistance = baseClearance \+ footprint\.radius/, 'The full object footprint must be added to track clearance');
+assert.match(airportArtPass, /world\.add = \(\.\.\.objects\) =>/, 'Late-loaded aircraft and service assets must pass through the same safety gate');
+assert.match(airportArtPass, /turnAirportFootprintValidated/, 'Validated scenery must be marked to avoid accidental repeated processing');
+assert.doesNotMatch(airportArtPass, /setAnimationLoop|requestAnimationFrame|setInterval/, 'The r49 Airport art pass must remain a one-time setup cost');
 assert.doesNotMatch(airportWorld, /setAnimationLoop|requestAnimationFrame|setInterval/, 'Airport scenery must add no independent animation loop');
 
-console.log('TURN multi-track selection, pressed track cards, safe Airport scenery and track-scoped rival regression passed.');
+console.log('TURN multi-track selection, deeply pressed track cards, footprint-safe Airport scenery and track-scoped rival regression passed.');
 
 function makeSamples(points) {
   return points.map(([x, z]) => ({ point: { x, z } }));

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -34,7 +34,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.5\.1 · Build 2026\.07\.22-r48/);
+assert.match(index, /TURN v1\.5\.2 · Build 2026\.07\.22-r49/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -100,7 +100,7 @@ assert.equal(summary.p95Ms, 50);
 assert.equal(summary.slowPercent, 40);
 assert.ok(Math.abs(summary.fps - 1000 / 30) < 1e-9);
 
-const [index, app, main, worldAssets, worldRender, controls, menu, spectate, hud, physics, camera, cars, lot, monitor, profile, replay, audio, orientationCompat] = await Promise.all([
+const [index, app, main, worldAssets, worldRender, controls, menu, spectate, hud, physics, camera, cars, lot, monitor, profile, replay, audio, orientationCompat, airportArtPass] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8'),
@@ -118,14 +118,15 @@ const [index, app, main, worldAssets, worldRender, controls, menu, spectate, hud
   fs.readFile(new URL('../../turn/performance-profile.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/race/replay-system.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/audio/audio-system.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/orientation-compat.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../../turn/orientation-compat.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/tracks/airport-world-r49.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.5\.1 · Build 2026\.07\.22-r48/);
-assert.match(index, /"\.\/race\/replay-system\.js": "\.\/race\/replay-system\.js\?build=20260722-r43"/, 'r48 must preserve the shared replay sampler cache');
-assert.match(index, /"\.\/race\/track-spatial-index\.js\?build=20260720-r19": "\.\/race\/track-spatial-index\.js\?build=20260722-r47"/, 'r48 must preserve the rebuildable bounded track search');
-assert.match(index, /"\.\/performance-monitor\.js\?build=20260720-r19": "\.\/performance-monitor\.js\?build=20260722-r43"/, 'r48 must preserve the diagnostics module');
-assert.match(index, /"\.\/world-assets\.js": "\.\/world-assets\.js\?build=20260722-r44"/, 'r48 must preserve both countryside tree-grounding passes');
+assert.match(index, /TURN v1\.5\.2 · Build 2026\.07\.22-r49/);
+assert.match(index, /"\.\/race\/replay-system\.js": "\.\/race\/replay-system\.js\?build=20260722-r43"/, 'r49 must preserve the shared replay sampler cache');
+assert.match(index, /"\.\/race\/track-spatial-index\.js\?build=20260720-r19": "\.\/race\/track-spatial-index\.js\?build=20260722-r47"/, 'r49 must preserve the rebuildable bounded track search');
+assert.match(index, /"\.\/performance-monitor\.js\?build=20260720-r19": "\.\/performance-monitor\.js\?build=20260722-r43"/, 'r49 must preserve the diagnostics module');
+assert.match(index, /"\.\/world-assets\.js": "\.\/world-assets\.js\?build=20260722-r44"/, 'r49 must preserve both countryside tree-grounding passes');
 assert.match(app, /installPerformanceProfile\(\)/, 'Renderer profile installation must run before the game runtime');
 assert.ok(app.indexOf('./performance-profile.js') < app.indexOf('./main.js'), 'The universal DPR cap must be ready before main.js creates the runtime');
 assert.match(profile, /DEFAULT_DPR_CAP = 1\.5/, 'The universal production DPR ceiling must stay at 1.5');
@@ -169,6 +170,8 @@ assert.doesNotMatch(lot, /GLTFLoader|InstancedMesh|installBrickScenery/, 'The cl
 assert.match(audio, /AUDIO_UPDATE_INTERVAL_MS = 1000 \/ 30/, 'Audio state must stay capped at 30 Hz');
 assert.doesNotMatch(audio, /requestAnimationFrame|setAnimationLoop|setInterval/, 'New sound cues must not add a second loop');
 assert.doesNotMatch(orientationCompat, /requestAnimationFrame|setAnimationLoop|setInterval/, 'The orientation guard must remain event-driven and add no render loop');
+assert.doesNotMatch(airportArtPass, /requestAnimationFrame|setAnimationLoop|setInterval/, 'The Airport footprint art pass must stay a one-time setup cost');
+assert.match(airportArtPass, /new THREE\.Box3\(\)\.setFromObject\(object\)/, 'Airport safety must use measured object bounds without adding a runtime loop');
 assert.match(monitor, /turn:perf-snapshot/);
 assert.match(monitor, /trackChecksPerQuery/);
 

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -1,5 +1,5 @@
 import { showTheLot as showOriginalLot } from './lot-r10.js?build=20260720-r25';
-import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r48';
+import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r49';
 
 export async function showTheLot(options = {}) {
   const trackId = await chooseTrackBeforeLot();

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r48 Airport art refinement and pressed track selection -->
+<!-- TURN r49 Footprint-aware Airport art pass and deeper track selection -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,42 +10,42 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.5.1 · Build 2026.07.22-r48</title>
+  <title>TURN v1.5.2 · Build 2026.07.22-r49</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.5.1',
-      id: '2026.07.22-r48',
-      cacheKey: '20260722-r48'
+      version: '1.5.2',
+      id: '2026.07.22-r49',
+      cacheKey: '20260722-r49'
     });
   </script>
   <link rel="icon" href="./favicon-r45.ico" sizes="any">
   <link rel="icon" href="./favicon-32-r45.png" type="image/png" sizes="32x32">
   <link rel="apple-touch-icon" href="./apple-touch-icon-r45.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260722-r48">
-  <link rel="stylesheet" href="./styles.css?build=20260722-r48">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260722-r48">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260722-r48">
-  <link rel="stylesheet" href="./install-gate.css?build=20260722-r48">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260722-r48">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260722-r48">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260722-r48">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260722-r48">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260722-r48">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260722-r48">
-  <link rel="stylesheet" href="./orientation-guard.css?build=20260722-r48">
-  <link rel="stylesheet" href="./lap-result-toast.css?build=20260722-r48">
-  <link rel="stylesheet" href="./rival-onboarding.css?build=20260722-r48">
-  <link rel="stylesheet" href="./track-select.css?build=20260722-r48">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260722-r48">
+  <link rel="manifest" href="./site.webmanifest?build=20260722-r49">
+  <link rel="stylesheet" href="./styles.css?build=20260722-r49">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260722-r49">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260722-r49">
+  <link rel="stylesheet" href="./install-gate.css?build=20260722-r49">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260722-r49">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260722-r49">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260722-r49">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260722-r49">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260722-r49">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260722-r49">
+  <link rel="stylesheet" href="./orientation-guard.css?build=20260722-r49">
+  <link rel="stylesheet" href="./lap-result-toast.css?build=20260722-r49">
+  <link rel="stylesheet" href="./rival-onboarding.css?build=20260722-r49">
+  <link rel="stylesheet" href="./track-select.css?build=20260722-r49">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260722-r49">
 
-  <script src="./install-gate.js?build=20260722-r48"></script>
-  <script src="./orientation-compat.js?build=20260722-r48"></script>
+  <script src="./install-gate.js?build=20260722-r49"></script>
+  <script src="./orientation-compat.js?build=20260722-r49"></script>
   <script type="importmap">
     {
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
-        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260722-r48",
+        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260722-r49",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260721-r29",
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system.js?build=20260722-r41",
         "./race/game-state.js": "./race/game-state.js?build=20260722-r41",
@@ -69,7 +69,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.5.1 · Build 2026.07.22-r48</span>
+        <span class="install-kicker">TURN v1.5.2 · Build 2026.07.22-r49</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -97,7 +97,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.5.1 · Build 2026.07.22-r48</span>
+      <span class="kicker">TURN v1.5.2 · Build 2026.07.22-r49</span>
       <h1 class="start-logo-heading" id="title">
         <img class="start-logo" src="./icon-512-r45.png" alt="TURN">
       </h1>
@@ -165,6 +165,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260722-r48"></script>
+  <script type="module" src="./app.js?build=20260722-r49"></script>
 </body>
 </html>

--- a/turn/track-select.css
+++ b/turn/track-select.css
@@ -100,10 +100,11 @@
   border-radius: 28px;
   background: color-mix(in srgb, var(--track-accent-soft) 52%, #fff8e8);
   color: var(--ink);
-  box-shadow: 9px 9px 0 var(--ink);
+  box-shadow: 10px 10px 0 var(--ink);
   text-align: left;
   font: inherit;
   transform: translate(0, 0) scale(1);
+  filter: saturate(0.78) brightness(0.98);
   transition:
     transform 150ms cubic-bezier(0.2, 0.8, 0.2, 1),
     background 150ms ease,
@@ -122,49 +123,71 @@
   transition: box-shadow 150ms ease;
 }
 
-.track-card:hover,
+.track-card:hover {
+  transform: translateY(-3px);
+  filter: saturate(0.9) brightness(1);
+}
+
 .track-card:focus-visible {
   transform: translateY(-3px);
+  outline: 5px solid #fff8e8;
+  outline-offset: 4px;
+  filter: saturate(0.94) brightness(1);
 }
 
 .track-card:active {
-  transform: translate(7px, 7px) scale(0.98);
+  transform: translate(8px, 8px) scale(0.985);
   box-shadow: 2px 2px 0 var(--ink);
 }
 
 .track-card.is-selected {
-  background: color-mix(in srgb, var(--track-accent) 94%, white 6%);
-  transform: translate(6px, 6px) scale(0.985);
+  background: color-mix(in srgb, var(--track-accent) 97%, white 3%);
+  transform: translate(9px, 9px) scale(0.99);
   box-shadow:
-    3px 3px 0 var(--ink),
-    inset 0 5px 0 rgb(255 255 255 / 0.24),
-    inset 0 -7px 0 rgb(8 9 10 / 0.12);
-  filter: saturate(1.2) contrast(1.03);
+    1px 1px 0 var(--ink),
+    inset 0 7px 0 rgb(255 255 255 / 0.3),
+    inset 0 -10px 0 rgb(8 9 10 / 0.18),
+    inset 0 0 28px rgb(255 255 255 / 0.12);
+  filter: saturate(1.38) contrast(1.06) brightness(1.02);
 }
 
 .track-card.is-selected:hover,
 .track-card.is-selected:focus-visible {
-  transform: translate(6px, 6px) scale(0.985);
+  transform: translate(9px, 9px) scale(0.99);
+  filter: saturate(1.42) contrast(1.07) brightness(1.03);
 }
 
 .track-card.is-selected:active {
-  transform: translate(8px, 8px) scale(0.975);
+  transform: translate(10px, 10px) scale(0.982);
   box-shadow:
-    1px 1px 0 var(--ink),
-    inset 0 5px 0 rgb(255 255 255 / 0.2),
-    inset 0 -7px 0 rgb(8 9 10 / 0.16);
+    0 0 0 var(--ink),
+    inset 0 8px 0 rgb(255 255 255 / 0.28),
+    inset 0 -11px 0 rgb(8 9 10 / 0.22),
+    inset 0 0 30px rgb(255 255 255 / 0.1);
 }
 
 .track-card.is-selected::after {
-  box-shadow: inset 0 0 0 5px rgb(255 255 255 / 0.74);
+  box-shadow:
+    inset 0 0 0 5px rgb(255 255 255 / 0.78),
+    inset 0 0 0 9px rgb(8 9 10 / 0.08);
 }
 
 .track-card.is-selected .track-card-preview {
-  transform: translateY(1px) scale(0.992);
-  filter: saturate(1.18) contrast(1.04);
+  transform: translate(2px, 3px) scale(0.992);
+  filter: saturate(1.32) contrast(1.07) brightness(1.02);
   box-shadow:
-    inset 0 4px 0 rgb(255 255 255 / 0.18),
-    inset 0 -5px 0 rgb(8 9 10 / 0.1);
+    1px 1px 0 var(--ink),
+    inset 0 5px 0 rgb(255 255 255 / 0.2),
+    inset 0 -7px 0 rgb(8 9 10 / 0.15);
+}
+
+.track-card.is-selected .track-card-topline strong,
+.track-card.is-selected .track-card-best {
+  transform: translate(2px, 2px);
+  box-shadow:
+    1px 1px 0 var(--ink),
+    inset 0 3px 0 rgb(255 255 255 / 0.24),
+    inset 0 -4px 0 rgb(8 9 10 / 0.1);
 }
 
 .track-card-topline {
@@ -181,6 +204,7 @@
   border-radius: 999px;
   background: #fff8e8;
   box-shadow: 3px 3px 0 var(--ink);
+  transition: transform 150ms ease, box-shadow 150ms ease;
 }
 
 .track-card-preview {
@@ -265,6 +289,7 @@
   border-radius: 16px;
   background: #fff8e8;
   box-shadow: 4px 4px 0 var(--ink);
+  transition: transform 150ms ease, box-shadow 150ms ease;
 }
 
 .track-card-best span,
@@ -342,7 +367,9 @@
 @media (prefers-reduced-motion: reduce) {
   .track-select,
   .track-card,
-  .track-card-preview {
+  .track-card-preview,
+  .track-card-topline strong,
+  .track-card-best {
     transition: none;
   }
 }

--- a/turn/tracks/airport-world-r49.js
+++ b/turn/tracks/airport-world-r49.js
@@ -1,0 +1,242 @@
+import * as THREE from 'three';
+import { installAirportWorld as installBaseAirportWorld } from './airport-world.js?build=20260722-r48';
+
+const APRON_SCENERY_CLEARANCE = 30;
+const SERVICE_VEHICLE_CLEARANCE = 38;
+const AIRCRAFT_VIEW_CLEARANCE = 60;
+const BAGGAGE_CLEARANCE = 44;
+const HORIZON_MIN_DISTANCE = 430;
+const HORIZON_SCALE = 0.54;
+
+export function installAirportWorld(options) {
+  const world = installBaseAirportWorld(options);
+  const samples = options.samples;
+
+  world.name = 'TURN Airport r49';
+  polishExistingScenery(world, samples);
+  installLateAssetClearanceGate(world, samples);
+
+  return world;
+}
+
+function polishExistingScenery(world, samples) {
+  let mountainsPolished = 0;
+  let baggageTrainsPolished = 0;
+  let apronObjectsMoved = 0;
+
+  for (const child of [...world.children]) {
+    if (isOversizedHorizonMountain(child)) {
+      polishHorizonMountain(child);
+      mountainsPolished += 1;
+      continue;
+    }
+
+    if (isBaggageTrain(child)) {
+      child.scale.multiplyScalar(0.58);
+      child.updateMatrixWorld(true);
+      if (moveObjectToTrackClearance(child, samples, BAGGAGE_CLEARANCE)) apronObjectsMoved += 1;
+      child.userData.turnAirportFootprintValidated = true;
+      baggageTrainsPolished += 1;
+      continue;
+    }
+
+    if (!isApronScenery(child)) continue;
+
+    const clearance = isAircraftLike(child)
+      ? AIRCRAFT_VIEW_CLEARANCE
+      : APRON_SCENERY_CLEARANCE;
+    if (moveObjectToTrackClearance(child, samples, clearance)) apronObjectsMoved += 1;
+    child.userData.turnAirportFootprintValidated = true;
+  }
+
+  world.userData.turnAirportArtPass = Object.freeze({
+    mountainsPolished,
+    baggageTrainsPolished,
+    apronObjectsMoved,
+    footprintAware: true
+  });
+}
+
+function installLateAssetClearanceGate(world, samples) {
+  const addToWorld = world.add.bind(world);
+
+  world.add = (...objects) => {
+    for (const object of objects) {
+      if (shouldValidateLateScenery(object)) {
+        const footprint = horizontalFootprint(object);
+        const clearance = footprint.radius >= 9
+          ? AIRCRAFT_VIEW_CLEARANCE
+          : SERVICE_VEHICLE_CLEARANCE;
+        moveObjectToTrackClearance(object, samples, clearance);
+        object.userData.turnAirportFootprintValidated = true;
+      }
+      addToWorld(object);
+    }
+    return world;
+  };
+}
+
+function shouldValidateLateScenery(object) {
+  return Boolean(
+    object?.isGroup
+      && object.children.length
+      && !object.userData?.turnAirportFootprintValidated
+  );
+}
+
+function isApronScenery(object) {
+  if (!object?.isGroup || object.position.z < 105) return false;
+  const footprint = horizontalFootprint(object);
+  return footprint.radius > 1 && footprint.radius < 95;
+}
+
+function isAircraftLike(object) {
+  let longFuselage = false;
+  let wideWing = false;
+
+  object.traverse((node) => {
+    const geometry = node.geometry;
+    if (!geometry) return;
+
+    if (
+      geometry.type === 'CylinderGeometry'
+      && Number(geometry.parameters?.height) >= 18
+    ) {
+      longFuselage = true;
+    }
+
+    if (
+      geometry.type === 'BoxGeometry'
+      && Math.max(
+        Number(geometry.parameters?.width) || 0,
+        Number(geometry.parameters?.depth) || 0
+      ) >= 18
+    ) {
+      wideWing = true;
+    }
+  });
+
+  return longFuselage && wideWing;
+}
+
+function isBaggageTrain(object) {
+  if (!object?.isGroup) return false;
+  let cartBoxes = 0;
+
+  object.traverse((node) => {
+    if (node.geometry?.type !== 'BoxGeometry') return;
+    const { width = 0, height = 0, depth = 0 } = node.geometry.parameters || {};
+    if (
+      width >= 4 && width <= 5
+      && height >= 2 && height <= 3
+      && depth >= 5 && depth <= 6
+    ) {
+      cartBoxes += 1;
+    }
+  });
+
+  return cartBoxes >= 3;
+}
+
+function isOversizedHorizonMountain(object) {
+  if (!object?.isGroup) return false;
+  let oversizedCone = false;
+
+  object.traverse((node) => {
+    if (node.geometry?.type !== 'ConeGeometry') return;
+    const radius = Number(node.geometry.parameters?.radius) || 0;
+    const height = Number(node.geometry.parameters?.height) || 0;
+    if (radius >= 45 && height >= 78) oversizedCone = true;
+  });
+
+  return oversizedCone;
+}
+
+function polishHorizonMountain(mountain) {
+  mountain.scale.multiplyScalar(HORIZON_SCALE);
+
+  const radialDistance = Math.hypot(mountain.position.x, mountain.position.z);
+  if (radialDistance < HORIZON_MIN_DISTANCE) {
+    const scale = HORIZON_MIN_DISTANCE / Math.max(1, radialDistance);
+    mountain.position.x *= scale;
+    mountain.position.z *= scale;
+  }
+
+  mountain.updateMatrixWorld(true);
+  const bounds = new THREE.Box3().setFromObject(mountain);
+  if (!bounds.isEmpty()) {
+    mountain.position.y += -7 - bounds.min.y;
+  }
+  mountain.updateMatrixWorld(true);
+}
+
+function moveObjectToTrackClearance(object, samples, baseClearance) {
+  let moved = false;
+
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    object.updateMatrixWorld(true);
+    const footprint = horizontalFootprint(object);
+    const nearest = nearestTrackPoint(samples, footprint.center.x, footprint.center.z);
+    const requiredDistance = baseClearance + footprint.radius;
+
+    if (nearest.distance >= requiredDistance) break;
+
+    let dx = footprint.center.x - nearest.point.x;
+    let dz = footprint.center.z - nearest.point.z;
+    let length = Math.hypot(dx, dz);
+
+    if (length < 0.001) {
+      dx = footprint.center.x || object.position.x || 1;
+      dz = footprint.center.z || object.position.z || 0;
+      length = Math.max(0.001, Math.hypot(dx, dz));
+    }
+
+    const pushDistance = requiredDistance - nearest.distance + 3;
+    object.position.x += dx / length * pushDistance;
+    object.position.z += dz / length * pushDistance;
+    moved = true;
+  }
+
+  object.updateMatrixWorld(true);
+  return moved;
+}
+
+function horizontalFootprint(object) {
+  object.updateMatrixWorld(true);
+  const bounds = new THREE.Box3().setFromObject(object);
+
+  if (bounds.isEmpty()) {
+    return {
+      center: new THREE.Vector3(object.position.x, 0, object.position.z),
+      radius: 0
+    };
+  }
+
+  const center = bounds.getCenter(new THREE.Vector3());
+  const size = bounds.getSize(new THREE.Vector3());
+  return {
+    center,
+    radius: Math.hypot(size.x, size.z) * 0.5
+  };
+}
+
+function nearestTrackPoint(samples, x, z) {
+  let bestPoint = samples[0]?.point || { x: 0, z: 0 };
+  let bestDistanceSq = Infinity;
+
+  for (let index = 0; index < samples.length; index += 1) {
+    const point = samples[index].point;
+    const dx = x - point.x;
+    const dz = z - point.z;
+    const distanceSq = dx * dx + dz * dz;
+    if (distanceSq < bestDistanceSq) {
+      bestDistanceSq = distanceSq;
+      bestPoint = point;
+    }
+  }
+
+  return {
+    point: bestPoint,
+    distance: Math.sqrt(bestDistanceSq)
+  };
+}

--- a/turn/tracks/track-manager.js
+++ b/turn/tracks/track-manager.js
@@ -9,7 +9,7 @@ import {
   normalizeTrackId,
   saveTrackSelection
 } from './catalog.js?build=20260722-r47';
-import { installAirportWorld } from './airport-world.js?build=20260722-r48';
+import { installAirportWorld } from './airport-world-r49.js?build=20260722-r49';
 import { showTrackSelect } from '../ui/track-select.js?build=20260722-r47';
 
 let runtime = null;


### PR DESCRIPTION
## Summary

Refines the new Airport track based on real gameplay screenshots and deepens the track-selection interaction.

## Track selection

- Selected map cards now read as physically pressed into the surface rather than merely highlighted.
- The selected card compresses almost all external elevation, gains stronger inset depth and becomes substantially more saturated.
- Its map preview and metadata chips sink with the parent card for one coherent Material-style pushed state.
- Unselected tracks stay quieter and visibly raised.
- Keyboard focus and reduced-motion behavior remain intact.

## Airport scenery safety pass

The screenshots exposed a placement bug in the r48 world: large scenery was cleared from the track using only each object's origin point, so a plane wing, baggage train or giant background form could still intrude into the racing corridor.

r49 adds a one-time art-direction layer on top of the verified r48 Airport world:

- measures actual rendered bounds with `THREE.Box3`,
- derives a horizontal footprint radius from both width and depth,
- adds that footprint to the required track clearance,
- iteratively pushes bulky apron objects away from the actual 720-sample racing line,
- applies extra visual breathing room to aircraft,
- shrinks and clears the oversized baggage trains,
- reduces the giant pyramid-like mountains and pushes them beyond the near horizon,
- routes asynchronously loaded aircraft and service-vehicle groups through the same footprint-aware safety gate.

The pass is one-time setup only and adds no render, animation or polling loop.

## Assets

The existing r48 asset strategy is preserved: Airport service traffic uses real local TURN GLB vehicle models and parked aircraft attempt a real GLB with a local fallback. The supplied Summer Engine links are useful art direction, but this PR does not claim to vendor those specific models because their downloadable binaries were not available through the current repo tooling.

## Compatibility

No changes to:

- vehicle physics or tuning,
- drive-pad and boost lockout behavior,
- lap/checkpoint logic,
- ghost/rival semantics,
- orientation handling,
- sound design.

Release: **TURN v1.5.2 · Build 2026.07.22-r49**.

## Regression coverage

The multi-track and performance regressions now explicitly protect:

- the near-flat vibrant selected-card state,
- measured bounding-box footprint clearance,
- aircraft and baggage visual clearances,
- distant/reduced mountains,
- late-loaded GLB scenery validation,
- no extra animation/render loop,
- all existing TURN gameplay contracts.