### PR TITLE
TURN v1.6.1 r51: Polish Airport signage, hairpin ground and track selection

### DIFF
--- a/turn-lab/tests/app-icon-production.mjs
+++ b/turn-lab/tests/app-icon-production.mjs
@@ -10,11 +10,11 @@ const index = fs.readFileSync(path.join(turnRoot, 'index.html'), 'utf8');
 const styles = fs.readFileSync(path.join(turnRoot, 'styles.css'), 'utf8');
 const manifest = JSON.parse(fs.readFileSync(path.join(turnRoot, 'site.webmanifest'), 'utf8'));
 
-assert.match(index, /TURN v1\.6\.0 · Build 2026\.07\.22-r50/);
+assert.match(index, /TURN v1\.6\.1 · Build 2026\.07\.22-r51/);
 assert.match(index, /<link rel="icon" href="\.\/favicon-r45\.ico" sizes="any">/);
 assert.match(index, /<link rel="icon" href="\.\/favicon-32-r45\.png" type="image\/png" sizes="32x32">/);
 assert.match(index, /<link rel="apple-touch-icon" href="\.\/apple-touch-icon-r45\.png" sizes="180x180">/);
-assert.match(index, /<link rel="manifest" href="\.\/site\.webmanifest\?build=20260722-r50">/);
+assert.match(index, /<link rel="manifest" href="\.\/site\.webmanifest\?build=20260722-r51">/);
 assert.match(index, /<img class="install-icon" src="\.\/icon-512-r45\.png" alt="">/);
 assert.match(index, /<h1 class="start-logo-heading" id="title">\s*<img class="start-logo" src="\.\/icon-512-r45\.png" alt="TURN">\s*<\/h1>/);
 assert.doesNotMatch(index, /apple-touch-icon-v4|icon-192-v4/);

--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -10,8 +10,8 @@ const [index, app, audio, controls, catalogSource] = await Promise.all([
 ]);
 const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
 
-assert.match(index, /TURN v1\.6\.0 · Build 2026\.07\.22-r50/);
-assert.match(index, /\.\/app\.js\?build=20260722-r50/);
+assert.match(index, /TURN v1\.6\.1 · Build 2026\.07\.22-r51/);
+assert.match(index, /\.\/app\.js\?build=20260722-r51/);
 assert.match(
   index,
   /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/,

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -69,7 +69,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.0 · Build 2026\.07\.22-r50/);
+assert.match(index, /TURN v1\.6\.1 · Build 2026\.07\.22-r51/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -20,9 +20,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.0 · Build 2026\.07\.22-r50/);
-assert.match(index, /drive-pad\.css\?build=20260722-r50/);
-assert.match(index, /gameplay-v2\.css\?build=20260722-r50/);
+assert.match(index, /TURN v1\.6\.1 · Build 2026\.07\.22-r51/);
+assert.match(index, /drive-pad\.css\?build=20260722-r51/);
+assert.match(index, /gameplay-v2\.css\?build=20260722-r51/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -50,14 +50,14 @@ const [index, main, lapSystem, rivalStorage, controls, carModels, lotWrapper] = 
   fs.readFile(path.join(turnDir, 'garage/lot-track-select.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.0 · Build 2026\.07\.22-r50/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260722-r50/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260722-r50"/, 'r50 must place track selection in front of the stable Lot implementation');
+assert.match(index, /TURN v1\.6\.1 · Build 2026\.07\.22-r51/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260722-r51/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260722-r51"/, 'r51 must place track selection in front of the stable Lot implementation');
 assert.match(lotWrapper, /showOriginalLot/, 'The track-first wrapper must still delegate car selection to the verified Lot implementation');
 assert.match(lotWrapper, /await chooseTrackBeforeLot\(\)/, 'The driver must pick a track before choosing the car');
-assert.match(lotWrapper, /track-manager\.js\?build=20260722-r50/, 'The Lot wrapper must load the redesigned Airport runtime');
-assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r50 must preserve the reduced Monster Truck scale in the main runtime');
-assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r50 must preserve the same reduced Monster Truck scale inside The Lot');
+assert.match(lotWrapper, /track-manager\.js\?build=20260722-r51/, 'The Lot wrapper must load the r51 Airport polish runtime');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r51 must preserve the reduced Monster Truck scale in the main runtime');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r51 must preserve the same reduced Monster Truck scale inside The Lot');
 assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter the track-first Lot wrapper before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -26,8 +26,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.0 · Build 2026\.07\.22-r50/);
-assert.match(index, /in-game-menu\.css\?build=20260722-r50/);
+assert.match(index, /TURN v1\.6\.1 · Build 2026\.07\.22-r51/);
+assert.match(index, /in-game-menu\.css\?build=20260722-r51/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Restart Lap<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -134,11 +134,11 @@ const [index, app, lapSystem, gameState, hud, styles, toast, toastCss, onboardin
   fs.readFile(new URL('../../turn/rival-onboarding.css', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.0 · Build 2026\.07\.22-r50/);
-assert.match(index, /lap-result-toast\.css\?build=20260722-r50/);
-assert.match(index, /rival-onboarding\.css\?build=20260722-r50/);
-assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260722-r41"/, 'r50 must preserve the r41 early invalid-lap detector');
-assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r41"/, 'r50 must preserve the r41 reset-safe invalid-lap state');
+assert.match(index, /TURN v1\.6\.1 · Build 2026\.07\.22-r51/);
+assert.match(index, /lap-result-toast\.css\?build=20260722-r51/);
+assert.match(index, /rival-onboarding\.css\?build=20260722-r51/);
+assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260722-r41"/, 'r51 must preserve the r41 early invalid-lap detector');
+assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r41"/, 'r51 must preserve the r41 reset-safe invalid-lap state');
 assert.match(app, /installLapResultToast\(\)/, 'The lap result toast must install before the game runtime starts');
 assert.match(app, /installRivalOnboarding\(\)/, 'The rival onboarding plate must install before the game runtime starts');
 assert.match(lapSystem, /turn:lap-result/, 'Completed lap finish must publish one frozen result event');

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -20,13 +20,13 @@ const [index, css, orientationGuardCss, orientationCompat, camera] = await Promi
   fs.readFile(new URL('../../turn/render/camera.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.0 · Build 2026\.07\.22-r50/);
+assert.match(index, /TURN v1\.6\.1 · Build 2026\.07\.22-r51/);
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260722-r50/);
-assert.match(index, /orientation-guard\.css\?build=20260722-r50/);
-assert.match(index, /orientation-compat\.js\?build=20260722-r50/);
-assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r50 must preserve the guarded race camera cache redirect');
+assert.match(index, /manual-steering\.css\?build=20260722-r51/);
+assert.match(index, /orientation-guard\.css\?build=20260722-r51/);
+assert.match(index, /orientation-compat\.js\?build=20260722-r51/);
+assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r51 must preserve the guarded race camera cache redirect');
 assert.match(index, /<strong>Rotate to landscape<\/strong>/, 'The pre-race landscape instruction must remain available');
 
 assert.match(css, /--manual-steer-left/);

--- a/turn-lab/tests/multi-track-production.mjs
+++ b/turn-lab/tests/multi-track-production.mjs
@@ -60,7 +60,7 @@ const rebuilt = spatialIndex.find({ x: 19, z: 98 });
 const brute = findNearestTrackBruteForce(trackB, { x: 19, z: 98 });
 assert.equal(rebuilt.index, brute.index, 'Rebuilt track index must remain exact after changing courses');
 assert.equal(rebuilt.sample, trackB[brute.index], 'Rebuilt index must return the active track sample object');
-assert.ok(spatialIndex.getStats().queryCount >= 1, 'Rebuilt index diagnostics must restart and record new-track queries');
+assert.ok(spatialIndex.getStats().queryCount >= 1, 'Rebuilt track index diagnostics must restart and record new-track queries');
 
 const [
   index,
@@ -70,6 +70,7 @@ const [
   trackSelectCss,
   lotWrapper,
   airportWorld,
+  airportPolish,
   spatialSource,
   rivalStorage,
   hud,
@@ -82,16 +83,17 @@ const [
   fs.readFile(new URL('../../turn/track-select.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-track-select.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/tracks/airport-world-r50.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/tracks/airport-world-r51.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/race/track-spatial-index.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/ui/hud.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/render/world.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.0 · Build 2026\.07\.22-r50/);
-assert.match(index, /track-select\.css\?build=20260722-r50/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260722-r50"/, 'The r50 track selector must sit before the stable Lot entry point');
-assert.match(index, /"\.\/race\/rival-storage\.js\?build=20260720-r19": "\.\/race\/rival-storage\.js\?build=20260722-r50"/, 'Production must load geometry-revision-aware rival storage');
+assert.match(index, /TURN v1\.6\.1 · Build 2026\.07\.22-r51/);
+assert.match(index, /track-select\.css\?build=20260722-r51/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260722-r51"/, 'The r51 track selector must sit before the stable Lot entry point');
+assert.match(index, /"\.\/race\/rival-storage\.js\?build=20260720-r19": "\.\/race\/rival-storage\.js\?build=20260722-r50"/, 'Production must preserve geometry-revision-aware rival storage');
 assert.match(index, /"\.\/race\/track-spatial-index\.js\?build=20260720-r19": "\.\/race\/track-spatial-index\.js\?build=20260722-r47"/, 'Production must preserve the rebuildable track index');
 assert.match(index, /Turn the device to steer/, 'Start copy must use device-neutral language');
 assert.match(index, /Steering uses device rotation/, 'Status copy must use device-neutral language');
@@ -108,26 +110,30 @@ assert.match(trackCatalog, /Runway speed\. Apron precision\./, 'Airport must kee
 assert.match(trackCatalog, /\[25, 43\],[\s\S]*\[0, 22\],[\s\S]*\[-25, 43\]/, 'The service-road hairpin must use a broad symmetric entry and exit around its apex');
 assert.doesNotMatch(trackCatalog, /\[27, 76\],[\s\S]*\[3, 40\],[\s\S]*\[-25, 68\]/, 'The pinched r49 hairpin geometry must stay retired');
 
-assert.match(lotWrapper, /track-manager\.js\?build=20260722-r50/, 'The Lot wrapper must load the redesigned Airport runtime');
+assert.match(lotWrapper, /track-manager\.js\?build=20260722-r51/, 'The Lot wrapper must load the r51 Airport polish runtime');
 assert.match(lotWrapper, /await chooseTrackBeforeLot\(\)/, 'Track selection must complete before The Lot opens');
 assert.ok(
   lotWrapper.indexOf('await chooseTrackBeforeLot()') < lotWrapper.indexOf('showOriginalLot(options)'),
   'The flow must remain TRACK → CAR → RACE'
 );
+
 assert.match(trackSelect, /CHOOSE YOUR TRACK/);
-assert.match(trackSelect, /TRACK → CAR → RACE/);
+assert.doesNotMatch(trackSelect, /TURN WORLD TOUR/, 'The selector must drop the redundant event-style kicker');
+assert.doesNotMatch(trackSelect, /TRACK → CAR → RACE/, 'The selector must drop the redundant footer instruction');
+assert.match(trackSelect, /track-card-choice-marker/, 'Each card must expose an explicit radio/check selection marker');
+assert.match(trackSelect, /track-card-summary/, 'Track name and Best time must share one deliberate bottom row');
 assert.match(trackSelect, /getStoredBestTime\(track\.id\)/, 'Selector cards must show track-specific records');
 assert.match(trackSelectCss, /grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/, 'The two launch tracks must present as peer choices');
+assert.match(trackSelectCss, /\.track-select-continue \{[\s\S]*grid-column: 2;/, 'Continue must align below the second track card in landscape');
+assert.match(trackSelectCss, /\.track-card\.is-selected \.track-card-choice-marker::after \{[\s\S]*content: "✓";/, 'The selected track must have an unmistakable check indicator');
 assert.match(trackSelectCss, /@media \(max-height: 820px\) and \(orientation: landscape\)/, 'Landscape track selection must compact before the photographed iPad viewport overflows');
 assert.match(trackSelectCss, /grid-template-rows: auto minmax\(0, 1fr\) auto/, 'The chooser must reserve a visible footer row for Continue');
-assert.match(trackSelectCss, /\.track-select-shell \{[\s\S]*min-height: 0;/, 'The chooser shell must be allowed to shrink inside the viewport');
-assert.match(trackSelectCss, /\.track-card-copy \{[\s\S]*overflow: hidden;/, 'Track copy must not render underneath the Best card');
 assert.match(trackSelectCss, /\.track-card-name \{[\s\S]*white-space: nowrap;/, 'Track names must remain a single controlled line');
 assert.match(trackSelectCss, /\.track-card\.is-selected \{[\s\S]*translate\(9px, 9px\) scale\(0\.99\)/, 'Selected track must keep its deeply pressed material state');
 assert.match(trackSelectCss, /filter: saturate\(1\.38\) contrast\(1\.06\) brightness\(1\.02\)/, 'Selected track must remain distinctly more vibrant');
 assert.match(trackSelectCss, /\.track-card:focus-visible/, 'The material treatment must retain a visible keyboard focus ring');
 
-assert.match(trackManager, /airport-world-r50\.js\?build=20260722-r50/, 'Track manager must load the redesigned r50 Airport world');
+assert.match(trackManager, /airport-world-r51\.js\?build=20260722-r51/, 'Track manager must load the r51 Airport polish layer');
 assert.match(trackManager, /initialTrackId: chosenThisSession \? activeTrackId : loadTrackSelection\(\)/, 'Later Lot visits must reopen track choice with the current course preselected');
 assert.doesNotMatch(trackManager, /if \(!force && chosenThisSession\) return activeTrackId/, 'Track selection must not be skipped on later visits to The Lot');
 assert.match(trackManager, /replaceSamples\(currentRuntime\.samples, airportTrack\.samples\)/);
@@ -141,38 +147,32 @@ assert.match(hud, /cached\.lastSample === lastSample/, 'The minimap cache must n
 assert.match(spatialSource, /replaceSamples\(nextSamples\)/, 'The shared spatial index must expose a controlled rebuild hook');
 assert.match(spatialSource, /return rebuild\(nextSamples\)/);
 
-assert.match(rivalStorage, /airport: 'airport-r50'/, 'Airport records must be revision-scoped after the geometry redesign');
+assert.match(rivalStorage, /airport: 'airport-r50'/, 'Airport records must stay on the r50 geometry namespace because r51 does not change the course');
 assert.match(rivalStorage, /version: 6/);
 assert.match(rivalStorage, /trackRevision: storageTrackId\(activeTrackId\)/, 'Saved rival payloads must record the geometry revision');
 
-assert.match(airportWorld, /name = 'TURN Airport r50'/, 'The active world must identify the r50 redesign');
+assert.match(airportWorld, /name = 'TURN Airport r50'/, 'The base Airport world must retain the successful r50 redesign');
 assert.match(airportWorld, /makeStartFinishDistrict\(world, samples, trackWidth\)/, 'Airport must have a deliberately designed start and finish district');
 assert.match(airportWorld, /TURN AIRPORT/, 'The start gantry must carry a real Airport identity');
 assert.match(airportWorld, /TURN INTERNATIONAL/, 'The terminal must anchor the opening vista');
-assert.match(airportWorld, /makeTerminalCampus\(world, samples\)/, 'Terminal, tower and hangars must be composed as one visual campus');
-assert.match(airportWorld, /makeHangar\(world, samples/, 'The airport must retain the successful hangar language from the r49 screenshots');
-assert.match(airportWorld, /makeAircraftApron\(world, samples\)/, 'Aircraft and ground operations must be arranged as a coherent apron');
+assert.match(airportWorld, /makeTerminalCampus\(world, samples\)/, 'Terminal, tower and hangars must remain one visual campus');
+assert.match(airportWorld, /makeAircraftApron\(world, samples\)/, 'Aircraft and ground operations must remain a coherent apron');
 assert.match(airportWorld, /createCarVisual\(/, 'Airport service traffic must reuse real local TURN GLB vehicle assets');
-assert.match(airportWorld, /carId: 'truck'/);
-assert.match(airportWorld, /carId: 'van'/);
-assert.match(airportWorld, /carId: 'truck-flat'/);
-assert.match(airportWorld, /SUMMER_INDUSTRIAL_COMMIT = '0831a1937a59562b6165ccfab30f64f35c957b6f'/, 'Summer Engine industrial art must be pinned to an immutable source revision');
-assert.match(airportWorld, /building-a\.glb/);
-assert.match(airportWorld, /building-b\.glb/);
-assert.match(airportWorld, /building-c\.glb/);
-assert.match(airportWorld, /detail-tank\.glb/);
-assert.match(airportWorld, /keeping local Airport fallbacks/, 'Remote industrial enrichment must fail safely');
-assert.match(airportWorld, /makeMaintenanceFallback/, 'The Airport must remain visually complete without network assets');
-assert.doesNotMatch(airportWorld, /crystal-bit\/platform-3d/, 'The odd external aircraft dependency from r48 must stay retired');
+assert.match(airportWorld, /SUMMER_INDUSTRIAL_COMMIT = '0831a1937a59562b6165ccfab30f64f35c957b6f'/, 'Summer Engine industrial art must stay pinned to an immutable source revision');
 assert.match(airportWorld, /new THREE\.Box3\(\)\.setFromObject\(object\)/, 'Curated scenery safety must still use actual rendered bounds');
-assert.match(airportWorld, /radius: Math\.hypot\(size\.x, size\.z\) \* 0\.5/, 'Scenery footprint safety must include both width and depth');
-assert.match(airportWorld, /new THREE\.SphereGeometry\(1, 12, 7\)/, 'Distant scenery must use broad hills instead of the old giant pyramid silhouettes');
 assert.doesNotMatch(airportWorld, /setAnimationLoop|requestAnimationFrame|setInterval/, 'Airport scenery must add no independent animation loop');
+
+assert.match(airportPolish, /airport-world-r50\.js\?build=20260722-r50/, 'r51 must refine rather than fork the successful r50 Airport composition');
+assert.match(airportPolish, /panel\.rotation\.y \+= Math\.PI/, 'Canvas-text signs must face the player instead of rendering mirrored');
+assert.match(airportPolish, /APRON_SAFE_DEPTH = 116/, 'The apron ground patch must stop before the steep service-road hairpin');
+assert.match(airportPolish, /APRON_SAFE_Z = -62/, 'The trimmed apron must remain centred under the terminal and aircraft district');
+assert.match(airportPolish, /APRON_SOURCE_DEPTH = 150/, 'The r51 ground fix must identify the photographed r50 apron patch explicitly');
+assert.doesNotMatch(airportPolish, /setAnimationLoop|requestAnimationFrame|setInterval/, 'The Airport polish layer must remain a one-time setup cost');
 
 assert.match(worldRender, /const worldSamples = samples\.slice\(\)/, 'Countryside async scenery must retain immutable Track 1 samples during an early track switch');
 assert.match(worldRender, /samples: worldSamples/, 'Late Countryside art modules must receive the snapshot rather than the mutable active track array');
 
-console.log('TURN r50 multi-track selection, viewport-safe chooser, redesigned Airport scenery and geometry-revision rivals passed.');
+console.log('TURN r51 readable Airport signs, hairpin-safe ground and explicit track selection passed.');
 
 function makeSamples(points) {
   return points.map(([x, z]) => ({ point: { x, z } }));

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -34,7 +34,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.0 · Build 2026\.07\.22-r50/);
+assert.match(index, /TURN v1\.6\.1 · Build 2026\.07\.22-r51/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -100,7 +100,7 @@ assert.equal(summary.p95Ms, 50);
 assert.equal(summary.slowPercent, 40);
 assert.ok(Math.abs(summary.fps - 1000 / 30) < 1e-9);
 
-const [index, app, main, worldAssets, worldRender, controls, menu, spectate, hud, physics, camera, cars, lot, monitor, profile, replay, audio, orientationCompat, airportWorld] = await Promise.all([
+const [index, app, main, worldAssets, worldRender, controls, menu, spectate, hud, physics, camera, cars, lot, monitor, profile, replay, audio, orientationCompat, airportWorld, airportPolish] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8'),
@@ -119,14 +119,15 @@ const [index, app, main, worldAssets, worldRender, controls, menu, spectate, hud
   fs.readFile(new URL('../../turn/race/replay-system.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/audio/audio-system.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/orientation-compat.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/tracks/airport-world-r50.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../../turn/tracks/airport-world-r50.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/tracks/airport-world-r51.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.0 · Build 2026\.07\.22-r50/);
-assert.match(index, /"\.\/race\/replay-system\.js": "\.\/race\/replay-system\.js\?build=20260722-r43"/, 'r50 must preserve the shared replay sampler cache');
-assert.match(index, /"\.\/race\/track-spatial-index\.js\?build=20260720-r19": "\.\/race\/track-spatial-index\.js\?build=20260722-r47"/, 'r50 must preserve the rebuildable bounded track search');
-assert.match(index, /"\.\/performance-monitor\.js\?build=20260720-r19": "\.\/performance-monitor\.js\?build=20260722-r43"/, 'r50 must preserve the diagnostics module');
-assert.match(index, /"\.\/world-assets\.js": "\.\/world-assets\.js\?build=20260722-r44"/, 'r50 must preserve both countryside tree-grounding passes');
+assert.match(index, /TURN v1\.6\.1 · Build 2026\.07\.22-r51/);
+assert.match(index, /"\.\/race\/replay-system\.js": "\.\/race\/replay-system\.js\?build=20260722-r43"/, 'r51 must preserve the shared replay sampler cache');
+assert.match(index, /"\.\/race\/track-spatial-index\.js\?build=20260720-r19": "\.\/race\/track-spatial-index\.js\?build=20260722-r47"/, 'r51 must preserve the rebuildable bounded track search');
+assert.match(index, /"\.\/performance-monitor\.js\?build=20260720-r19": "\.\/performance-monitor\.js\?build=20260722-r43"/, 'r51 must preserve the diagnostics module');
+assert.match(index, /"\.\/world-assets\.js": "\.\/world-assets\.js\?build=20260722-r44"/, 'r51 must preserve both countryside tree-grounding passes');
 assert.match(app, /installPerformanceProfile\(\)/, 'Renderer profile installation must run before the game runtime');
 assert.ok(app.indexOf('./performance-profile.js') < app.indexOf('./main.js'), 'The universal DPR cap must be ready before main.js creates the runtime');
 assert.match(profile, /DEFAULT_DPR_CAP = 1\.5/, 'The universal production DPR ceiling must stay at 1.5');
@@ -173,6 +174,7 @@ assert.doesNotMatch(audio, /requestAnimationFrame|setAnimationLoop|setInterval/,
 assert.doesNotMatch(orientationCompat, /requestAnimationFrame|setAnimationLoop|setInterval/, 'The orientation guard must remain event-driven and add no render loop');
 assert.doesNotMatch(airportWorld, /requestAnimationFrame|setAnimationLoop|setInterval/, 'The redesigned Airport world must stay a one-time setup cost');
 assert.match(airportWorld, /new THREE\.Box3\(\)\.setFromObject\(object\)/, 'Airport safety must use measured object bounds without adding a runtime loop');
+assert.doesNotMatch(airportPolish, /requestAnimationFrame|setAnimationLoop|setInterval/, 'The r51 Airport polish layer must remain a one-time setup cost');
 assert.match(monitor, /turn:perf-snapshot/);
 assert.match(monitor, /trackChecksPerQuery/);
 

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -1,5 +1,5 @@
 import { showTheLot as showOriginalLot } from './lot-r10.js?build=20260720-r25';
-import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r50';
+import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r51';
 
 export async function showTheLot(options = {}) {
   const trackId = await chooseTrackBeforeLot();

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r50 Airport redesign, smooth service hairpin and viewport-safe track selection -->
+<!-- TURN r51 Airport signage/ground polish and simplified track selection -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,42 +10,42 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.6.0 · Build 2026.07.22-r50</title>
+  <title>TURN v1.6.1 · Build 2026.07.22-r51</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.6.0',
-      id: '2026.07.22-r50',
-      cacheKey: '20260722-r50'
+      version: '1.6.1',
+      id: '2026.07.22-r51',
+      cacheKey: '20260722-r51'
     });
   </script>
   <link rel="icon" href="./favicon-r45.ico" sizes="any">
   <link rel="icon" href="./favicon-32-r45.png" type="image/png" sizes="32x32">
   <link rel="apple-touch-icon" href="./apple-touch-icon-r45.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260722-r50">
-  <link rel="stylesheet" href="./styles.css?build=20260722-r50">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260722-r50">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260722-r50">
-  <link rel="stylesheet" href="./install-gate.css?build=20260722-r50">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260722-r50">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260722-r50">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260722-r50">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260722-r50">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260722-r50">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260722-r50">
-  <link rel="stylesheet" href="./orientation-guard.css?build=20260722-r50">
-  <link rel="stylesheet" href="./lap-result-toast.css?build=20260722-r50">
-  <link rel="stylesheet" href="./rival-onboarding.css?build=20260722-r50">
-  <link rel="stylesheet" href="./track-select.css?build=20260722-r50">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260722-r50">
+  <link rel="manifest" href="./site.webmanifest?build=20260722-r51">
+  <link rel="stylesheet" href="./styles.css?build=20260722-r51">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260722-r51">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260722-r51">
+  <link rel="stylesheet" href="./install-gate.css?build=20260722-r51">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260722-r51">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260722-r51">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260722-r51">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260722-r51">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260722-r51">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260722-r51">
+  <link rel="stylesheet" href="./orientation-guard.css?build=20260722-r51">
+  <link rel="stylesheet" href="./lap-result-toast.css?build=20260722-r51">
+  <link rel="stylesheet" href="./rival-onboarding.css?build=20260722-r51">
+  <link rel="stylesheet" href="./track-select.css?build=20260722-r51">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260722-r51">
 
-  <script src="./install-gate.js?build=20260722-r50"></script>
-  <script src="./orientation-compat.js?build=20260722-r50"></script>
+  <script src="./install-gate.js?build=20260722-r51"></script>
+  <script src="./orientation-compat.js?build=20260722-r51"></script>
   <script type="importmap">
     {
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
-        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260722-r50",
+        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260722-r51",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260721-r29",
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system.js?build=20260722-r41",
         "./race/game-state.js": "./race/game-state.js?build=20260722-r41",
@@ -69,7 +69,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.6.0 · Build 2026.07.22-r50</span>
+        <span class="install-kicker">TURN v1.6.1 · Build 2026.07.22-r51</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -97,7 +97,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.6.0 · Build 2026.07.22-r50</span>
+      <span class="kicker">TURN v1.6.1 · Build 2026.07.22-r51</span>
       <h1 class="start-logo-heading" id="title">
         <img class="start-logo" src="./icon-512-r45.png" alt="TURN">
       </h1>
@@ -165,6 +165,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260722-r50"></script>
+  <script type="module" src="./app.js?build=20260722-r51"></script>
 </body>
 </html>

--- a/turn/track-select.css
+++ b/turn/track-select.css
@@ -5,9 +5,9 @@
   display: grid;
   place-items: center;
   overflow: auto;
-  padding: max(12px, env(safe-area-inset-top)) max(14px, env(safe-area-inset-right)) max(12px, env(safe-area-inset-bottom)) max(14px, env(safe-area-inset-left));
+  padding: max(16px, env(safe-area-inset-top)) max(18px, env(safe-area-inset-right)) max(16px, env(safe-area-inset-bottom)) max(18px, env(safe-area-inset-left));
   background:
-    radial-gradient(circle at 18% 18%, rgb(255 255 255 / 0.36), transparent 24%),
+    radial-gradient(circle at 18% 18%, rgb(255 255 255 / 0.34), transparent 25%),
     linear-gradient(145deg, #8be3ff 0%, #55c9ed 52%, #35b8e7 100%);
   opacity: 0;
   transition: opacity 180ms ease;
@@ -28,77 +28,48 @@
 
 .track-select-head {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 24px;
-  margin-bottom: 18px;
-}
-
-.track-select-kicker,
-.track-card-topline,
-.track-card-best span,
-.track-select-tip {
-  font-size: clamp(0.66rem, 1.4vw, 0.9rem);
-  font-weight: 900;
-  letter-spacing: 0.14em;
-}
-
-.track-select-kicker {
-  display: inline-block;
-  padding: 6px 12px;
-  border: 3px solid var(--ink);
-  border-radius: 999px;
-  background: var(--yellow);
-  box-shadow: 4px 4px 0 var(--ink);
+  margin-bottom: clamp(14px, 2.3vh, 24px);
 }
 
 .track-select h2 {
-  margin: 7px 0 0;
-  font-size: clamp(2.2rem, 7vw, 5.5rem);
-  line-height: 0.9;
-  letter-spacing: -0.05em;
-}
-
-.track-select-head p {
-  margin: 10px 0 0;
-  max-width: 680px;
-  font-weight: 800;
-  font-size: clamp(0.86rem, 1.8vw, 1.15rem);
+  margin: 0;
+  font-size: clamp(2.15rem, 5vw, 4.45rem);
+  line-height: 0.94;
+  letter-spacing: -0.045em;
 }
 
 .track-select-close {
   flex: 0 0 auto;
-  width: 58px;
-  height: 58px;
+  width: 56px;
+  height: 56px;
   border: 4px solid var(--ink);
   border-radius: 50%;
   background: var(--pink);
   box-shadow: 5px 5px 0 var(--ink);
   font: inherit;
-  font-size: 2rem;
+  font-size: 1.95rem;
   font-weight: 900;
   line-height: 1;
 }
 
-.track-select-grid {
+.track-select-grid,
+.track-select-footer {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: clamp(14px, 2vw, 24px);
-  min-height: 0;
 }
 
 .track-card {
   position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  grid-template-areas:
-    "top top"
-    "preview preview"
-    "copy best";
-  gap: 9px 16px;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  gap: clamp(9px, 1.5vh, 14px);
   min-width: 0;
   min-height: 0;
-  padding: clamp(14px, 2vw, 22px);
+  padding: clamp(13px, 1.7vw, 20px);
   border: 5px solid var(--ink);
   border-radius: 28px;
   background: color-mix(in srgb, var(--track-accent-soft) 52%, #fff8e8);
@@ -175,26 +146,14 @@
     inset 0 0 0 9px rgb(8 9 10 / 0.08);
 }
 
-.track-card.is-selected .track-card-preview {
-  transform: translate(2px, 3px) scale(0.992);
-  filter: saturate(1.32) contrast(1.07) brightness(1.02);
-  box-shadow:
-    1px 1px 0 var(--ink),
-    inset 0 5px 0 rgb(255 255 255 / 0.2),
-    inset 0 -7px 0 rgb(8 9 10 / 0.15);
-}
-
-.track-card.is-selected .track-card-topline strong,
-.track-card.is-selected .track-card-best {
-  transform: translate(2px, 2px);
-  box-shadow:
-    1px 1px 0 var(--ink),
-    inset 0 3px 0 rgb(255 255 255 / 0.24),
-    inset 0 -4px 0 rgb(8 9 10 / 0.1);
+.track-card-topline,
+.track-card-best span {
+  font-size: clamp(0.66rem, 1.35vw, 0.88rem);
+  font-weight: 900;
+  letter-spacing: 0.14em;
 }
 
 .track-card-topline {
-  grid-area: top;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -211,9 +170,9 @@
 }
 
 .track-card-preview {
-  grid-area: preview;
   display: block;
-  height: clamp(108px, 21vh, 220px);
+  height: clamp(118px, 23vh, 218px);
+  min-height: 0;
   border: 4px solid var(--ink);
   border-radius: 20px;
   background:
@@ -228,6 +187,15 @@
   background:
     linear-gradient(rgb(255 255 255 / 0.26), rgb(255 255 255 / 0.04)),
     #a7b0b8;
+}
+
+.track-card.is-selected .track-card-preview {
+  transform: translate(2px, 3px) scale(0.992);
+  filter: saturate(1.32) contrast(1.07) brightness(1.02);
+  box-shadow:
+    1px 1px 0 var(--ink),
+    inset 0 5px 0 rgb(255 255 255 / 0.2),
+    inset 0 -7px 0 rgb(8 9 10 / 0.15);
 }
 
 .track-card-preview svg {
@@ -264,35 +232,60 @@
   stroke-width: 4;
 }
 
-.track-card-copy {
-  grid-area: copy;
+.track-card-summary {
   display: grid;
-  align-content: end;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: clamp(10px, 1.5vw, 18px);
   min-width: 0;
-  overflow: hidden;
+}
+
+.track-card-choice {
+  display: flex;
+  align-items: center;
+  gap: clamp(9px, 1.2vw, 14px);
+  min-width: 0;
+}
+
+.track-card-choice-marker {
+  position: relative;
+  flex: 0 0 auto;
+  width: clamp(30px, 3.4vw, 42px);
+  height: clamp(30px, 3.4vw, 42px);
+  border: 4px solid var(--ink);
+  border-radius: 50%;
+  background: #fff8e8;
+}
+
+.track-card.is-selected .track-card-choice-marker {
+  background: var(--ink);
+}
+
+.track-card.is-selected .track-card-choice-marker::after {
+  content: "✓";
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: #fff8e8;
+  font-size: clamp(1rem, 2vw, 1.45rem);
+  font-weight: 900;
+  line-height: 1;
 }
 
 .track-card-name {
   min-width: 0;
-  font-size: clamp(1.3rem, 2.8vw, 2.55rem);
+  font-size: clamp(1.18rem, 2.35vw, 2rem);
   line-height: 0.95;
-  letter-spacing: -0.04em;
+  letter-spacing: -0.035em;
   white-space: nowrap;
 }
 
-.track-card-description {
-  margin-top: 5px;
-  font-size: clamp(0.72rem, 1.45vw, 0.96rem);
-  font-weight: 800;
-}
-
 .track-card-best {
-  grid-area: best;
-  align-self: end;
-  min-width: clamp(118px, 15vw, 172px);
-  padding: 9px 12px;
+  min-width: clamp(112px, 13vw, 152px);
+  padding: 7px 10px;
   border: 3px solid var(--ink);
-  border-radius: 16px;
+  border-radius: 15px;
   background: #fff8e8;
   box-shadow: 4px 4px 0 var(--ink);
   transition: transform 150ms ease, box-shadow 150ms ease;
@@ -304,43 +297,46 @@
 }
 
 .track-card-best strong {
-  margin-top: 2px;
-  font-size: clamp(0.78rem, 1.65vw, 1.1rem);
+  margin-top: 1px;
+  font-size: clamp(0.76rem, 1.5vw, 1.02rem);
   white-space: nowrap;
 }
 
-.track-select-footer {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 18px;
-  margin-top: 18px;
+.track-card.is-selected .track-card-topline strong,
+.track-card.is-selected .track-card-best {
+  transform: translate(2px, 2px);
+  box-shadow:
+    1px 1px 0 var(--ink),
+    inset 0 3px 0 rgb(255 255 255 / 0.24),
+    inset 0 -4px 0 rgb(8 9 10 / 0.1);
 }
 
-.track-select-tip {
-  margin-right: auto;
+.track-select-footer {
+  margin-top: clamp(12px, 2vh, 20px);
 }
 
 .track-select-continue {
-  min-width: min(360px, 52vw);
-  padding: 14px 22px;
+  grid-column: 2;
+  width: 100%;
+  padding: 12px 20px;
   border: 4px solid var(--ink);
   border-radius: 18px;
   background: #8ce99a;
   box-shadow: 6px 6px 0 var(--ink);
   font: inherit;
-  font-size: clamp(0.88rem, 2vw, 1.2rem);
+  font-size: clamp(0.84rem, 1.8vw, 1.12rem);
   font-weight: 900;
   letter-spacing: 0.08em;
 }
 
-/* iPad and phone landscape are the primary TURN surfaces. Keep the entire chooser
-   inside one viewport instead of forcing the Continue action below the fold. */
+/* iPad and phone landscape are TURN's primary surfaces. The whole chooser is one
+   deliberate composition: title, two equal track cards, then Continue below the
+   selected-card column. Nothing is allowed to escape the viewport. */
 @media (max-height: 820px) and (orientation: landscape) {
   .track-select {
     place-items: stretch center;
     overflow: hidden;
-    padding: max(8px, env(safe-area-inset-top)) max(12px, env(safe-area-inset-right)) max(8px, env(safe-area-inset-bottom)) max(12px, env(safe-area-inset-left));
+    padding: max(9px, env(safe-area-inset-top)) max(13px, env(safe-area-inset-right)) max(9px, env(safe-area-inset-bottom)) max(13px, env(safe-area-inset-left));
   }
 
   .track-select-shell {
@@ -352,25 +348,11 @@
   }
 
   .track-select-head {
-    align-items: center;
-    gap: 16px;
     margin-bottom: 9px;
   }
 
-  .track-select-kicker {
-    padding: 4px 10px;
-    border-width: 3px;
-    box-shadow: 3px 3px 0 var(--ink);
-  }
-
   .track-select h2 {
-    margin-top: 4px;
-    font-size: clamp(2rem, 5.4vw, 4.35rem);
-    line-height: 0.86;
-  }
-
-  .track-select-head p {
-    display: none;
+    font-size: clamp(2rem, 4.8vw, 3.85rem);
   }
 
   .track-select-close {
@@ -381,16 +363,15 @@
     font-size: 1.7rem;
   }
 
-  .track-select-grid {
-    min-height: 0;
+  .track-select-grid,
+  .track-select-footer {
     gap: clamp(10px, 1.5vw, 18px);
-    align-items: stretch;
   }
 
   .track-card {
     grid-template-rows: auto minmax(0, 1fr) auto;
-    gap: 6px 11px;
-    padding: clamp(9px, 1.25vw, 14px);
+    gap: 7px;
+    padding: clamp(9px, 1.2vw, 14px);
     border-width: 4px;
     border-radius: 24px;
     box-shadow: 8px 8px 0 var(--ink);
@@ -398,64 +379,92 @@
 
   .track-card-preview {
     height: auto;
-    min-height: 80px;
-    max-height: 21vh;
+    min-height: 76px;
+    max-height: 23vh;
     border-width: 3px;
     border-radius: 17px;
   }
 
-  .track-card-name {
-    font-size: clamp(1.2rem, 2.7vw, 2rem);
+  .track-card-summary {
+    gap: 9px;
   }
 
-  .track-card-description {
-    margin-top: 3px;
-    font-size: clamp(0.66rem, 1.25vw, 0.86rem);
-    line-height: 1.05;
+  .track-card-choice {
+    gap: 8px;
+  }
+
+  .track-card-choice-marker {
+    width: clamp(28px, 3vw, 36px);
+    height: clamp(28px, 3vw, 36px);
+    border-width: 3px;
+  }
+
+  .track-card-name {
+    font-size: clamp(1.08rem, 2.15vw, 1.72rem);
   }
 
   .track-card-best {
-    min-width: clamp(108px, 13.5vw, 150px);
-    padding: 6px 9px;
-    border-width: 3px;
-    border-radius: 14px;
+    min-width: clamp(105px, 12.5vw, 140px);
+    padding: 5px 8px;
+    border-radius: 13px;
   }
 
   .track-card-best strong {
-    font-size: clamp(0.75rem, 1.45vw, 1rem);
+    font-size: clamp(0.72rem, 1.35vw, 0.94rem);
   }
 
   .track-select-footer {
     margin-top: 9px;
-    gap: 12px;
   }
 
   .track-select-continue {
-    min-width: min(330px, 46vw);
-    padding: 10px 18px;
+    padding: 9px 16px;
     border-width: 3px;
     box-shadow: 5px 5px 0 var(--ink);
-    font-size: clamp(0.8rem, 1.65vw, 1.02rem);
+    font-size: clamp(0.78rem, 1.5vw, 0.98rem);
   }
 }
 
 @media (max-height: 610px) and (orientation: landscape) {
-  .track-select-kicker {
-    display: none;
+  .track-select h2 {
+    font-size: clamp(1.75rem, 4.1vw, 3rem);
   }
 
-  .track-select h2 {
-    margin: 0;
-    font-size: clamp(1.8rem, 4.8vw, 3.4rem);
+  .track-select-head {
+    margin-bottom: 6px;
+  }
+
+  .track-card {
+    gap: 5px;
+    padding: 8px;
+  }
+
+  .track-card-topline,
+  .track-card-best span {
+    font-size: clamp(0.58rem, 1.12vw, 0.74rem);
+  }
+
+  .track-card-topline strong {
+    padding: 3px 7px;
   }
 
   .track-card-preview {
-    max-height: 18vh;
+    min-height: 68px;
+    max-height: 20vh;
   }
 
-  .track-card-description,
-  .track-select-tip {
-    display: none;
+  .track-card-choice-marker {
+    width: 28px;
+    height: 28px;
+  }
+
+  .track-card-name {
+    font-size: clamp(0.98rem, 1.9vw, 1.42rem);
+  }
+
+  .track-card-best {
+    min-width: 98px;
+    padding: 4px 7px;
   }
 
   .track-select-footer {
@@ -469,8 +478,13 @@
     overflow: auto;
   }
 
-  .track-select-grid {
+  .track-select-grid,
+  .track-select-footer {
     grid-template-columns: 1fr;
+  }
+
+  .track-select-continue {
+    grid-column: 1;
   }
 
   .track-card-name {

--- a/turn/tracks/airport-world-r51.js
+++ b/turn/tracks/airport-world-r51.js
@@ -1,0 +1,65 @@
+import * as THREE from 'three';
+import { installAirportWorld as installAirportWorldR50 } from './airport-world-r50.js?build=20260722-r50';
+
+const APRON_SOURCE_WIDTH = 390;
+const APRON_SOURCE_DEPTH = 150;
+const APRON_SAFE_DEPTH = 116;
+const APRON_SAFE_Z = -62;
+const APRON_COLOR = 0x89929b;
+
+export function installAirportWorld(options) {
+  const world = installAirportWorldR50(options);
+  fixAirportTextFacing(world);
+  pullApronClearOfHairpin(world);
+
+  world.name = 'TURN Airport r51';
+  world.userData.turnAirportArtDirection = Object.freeze({
+    ...(world.userData.turnAirportArtDirection || {}),
+    version: 'r51',
+    readableSigns: true,
+    hairpinGroundClearance: true
+  });
+
+  return world;
+}
+
+function fixAirportTextFacing(world) {
+  const textPanels = [];
+  world.traverse((node) => {
+    if (
+      node?.isMesh
+      && node.geometry?.type === 'PlaneGeometry'
+      && node.material?.map?.isCanvasTexture
+    ) {
+      textPanels.push(node);
+    }
+  });
+
+  for (const panel of textPanels) panel.rotation.y += Math.PI;
+}
+
+function pullApronClearOfHairpin(world) {
+  const apron = world.children.find((node) => {
+    if (!node?.isMesh || node.geometry?.type !== 'PlaneGeometry') return false;
+    const parameters = node.geometry.parameters || {};
+    return nearly(parameters.width, APRON_SOURCE_WIDTH)
+      && nearly(parameters.height, APRON_SOURCE_DEPTH)
+      && node.material?.color?.getHex?.() === APRON_COLOR;
+  });
+
+  if (!apron) {
+    console.warn('TURN: Airport r51 could not find the apron ground patch to trim.');
+    return;
+  }
+
+  // r50's apron reached z=26 while the inner service-road hairpin turns around z=22,
+  // so the straight edge of the rectangular ground plane visibly cut through the bend.
+  // Keep the apron under the terminal/aircraft district, but end it well before the hairpin.
+  apron.scale.y = APRON_SAFE_DEPTH / APRON_SOURCE_DEPTH;
+  apron.position.z = APRON_SAFE_Z;
+  apron.updateMatrixWorld(true);
+}
+
+function nearly(value, expected) {
+  return Math.abs(Number(value) - expected) < 0.001;
+}

--- a/turn/tracks/track-manager.js
+++ b/turn/tracks/track-manager.js
@@ -9,8 +9,8 @@ import {
   normalizeTrackId,
   saveTrackSelection
 } from './catalog.js?build=20260722-r50';
-import { installAirportWorld } from './airport-world-r50.js?build=20260722-r50';
-import { showTrackSelect } from '../ui/track-select.js?build=20260722-r50';
+import { installAirportWorld } from './airport-world-r51.js?build=20260722-r51';
+import { showTrackSelect } from '../ui/track-select.js?build=20260722-r51';
 
 let runtime = null;
 let runtimeReadyResolve = null;

--- a/turn/ui/track-select.js
+++ b/turn/ui/track-select.js
@@ -84,18 +84,13 @@ function ensureOverlay() {
   overlay.innerHTML = `
     <div class="track-select-shell">
       <header class="track-select-head">
-        <div>
-          <span class="track-select-kicker">TURN WORLD TOUR</span>
-          <h2 id="trackSelectTitle">CHOOSE YOUR TRACK</h2>
-          <p>Pick the road first. Then choose the right car for the job.</p>
-        </div>
+        <h2 id="trackSelectTitle">CHOOSE YOUR TRACK</h2>
         <button class="track-select-close" type="button" aria-label="Close track selection">×</button>
       </header>
       <div class="track-select-grid">
         ${TRACK_CATALOG.map(renderTrackCard).join('')}
       </div>
       <footer class="track-select-footer">
-        <span class="track-select-tip">TRACK → CAR → RACE</span>
         <button class="track-select-continue" type="button">CONTINUE</button>
       </footer>
     </div>
@@ -120,12 +115,14 @@ function renderTrackCard(track) {
         <strong>${track.difficulty}</strong>
       </span>
       <span class="track-card-preview" aria-hidden="true">${preview}</span>
-      <span class="track-card-copy">
-        <strong class="track-card-name">${track.name.toUpperCase()}</strong>
-        <span class="track-card-description">${track.description}</span>
-      </span>
-      <span class="track-card-best" data-track-best="${track.id}">
-        <span>BEST</span><strong>--:--.---</strong>
+      <span class="track-card-summary">
+        <span class="track-card-choice">
+          <span class="track-card-choice-marker" aria-hidden="true"></span>
+          <strong class="track-card-name">${track.name.toUpperCase()}</strong>
+        </span>
+        <span class="track-card-best" data-track-best="${track.id}">
+          <span>BEST</span><strong>--:--.---</strong>
+        </span>
       </span>
     </button>
   `;


### PR DESCRIPTION
## Summary

A focused r51 polish pass based directly on the first real-device screenshots of the r50 Airport redesign.

## Airport fixes

- Fixes mirrored `TURN AIRPORT` and `TURN INTERNATIONAL` canvas-text signs by correcting their facing in the active Airport scene.
- Trims and repositions the rectangular apron ground patch so its straight edge no longer cuts through the steep inner service-road hairpin.
- Preserves the successful r50 Airport composition, track geometry and r50 rival/record namespace.
- Adds no new animation loop or recurring runtime work.

## Track-selection redesign

- Rebuilds the chooser around the supplied mockup.
- Removes the redundant `TURN WORLD TOUR` kicker, helper paragraph and `TRACK → CAR → RACE` footer copy.
- Gives every card an explicit radio/check selection marker.
- Places the track name and Best time together in one clean bottom row.
- Aligns the Continue button beneath the second card in landscape.
- Keeps the deeply pressed selected-card treatment, keyboard focus treatment and reduced-motion support.
- Retains viewport-aware compression for iPhone and iPad landscape.

## Release

**TURN v1.6.1 · Build 2026.07.22-r51**

The TURN regression workflow will validate the release before merge.