### PR TITLE
TURN v1.6.2 r52: Add forgiving Airport hairpin run-off

### DIFF
--- a/turn-lab/tests/app-icon-production.mjs
+++ b/turn-lab/tests/app-icon-production.mjs
@@ -10,11 +10,11 @@ const index = fs.readFileSync(path.join(turnRoot, 'index.html'), 'utf8');
 const styles = fs.readFileSync(path.join(turnRoot, 'styles.css'), 'utf8');
 const manifest = JSON.parse(fs.readFileSync(path.join(turnRoot, 'site.webmanifest'), 'utf8'));
 
-assert.match(index, /TURN v1\.6\.1 · Build 2026\.07\.22-r51/);
+assert.match(index, /TURN v1\.6\.2 · Build 2026\.07\.22-r52/);
 assert.match(index, /<link rel="icon" href="\.\/favicon-r45\.ico" sizes="any">/);
 assert.match(index, /<link rel="icon" href="\.\/favicon-32-r45\.png" type="image\/png" sizes="32x32">/);
 assert.match(index, /<link rel="apple-touch-icon" href="\.\/apple-touch-icon-r45\.png" sizes="180x180">/);
-assert.match(index, /<link rel="manifest" href="\.\/site\.webmanifest\?build=20260722-r51">/);
+assert.match(index, /<link rel="manifest" href="\.\/site\.webmanifest\?build=20260722-r52">/);
 assert.match(index, /<img class="install-icon" src="\.\/icon-512-r45\.png" alt="">/);
 assert.match(index, /<h1 class="start-logo-heading" id="title">\s*<img class="start-logo" src="\.\/icon-512-r45\.png" alt="TURN">\s*<\/h1>/);
 assert.doesNotMatch(index, /apple-touch-icon-v4|icon-192-v4/);

--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -10,8 +10,8 @@ const [index, app, audio, controls, catalogSource] = await Promise.all([
 ]);
 const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
 
-assert.match(index, /TURN v1\.6\.1 · Build 2026\.07\.22-r51/);
-assert.match(index, /\.\/app\.js\?build=20260722-r51/);
+assert.match(index, /TURN v1\.6\.2 · Build 2026\.07\.22-r52/);
+assert.match(index, /\.\/app\.js\?build=20260722-r52/);
 assert.match(
   index,
   /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/,

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -69,7 +69,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.1 · Build 2026\.07\.22-r51/);
+assert.match(index, /TURN v1\.6\.2 · Build 2026\.07\.22-r52/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -20,9 +20,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.1 · Build 2026\.07\.22-r51/);
-assert.match(index, /drive-pad\.css\?build=20260722-r51/);
-assert.match(index, /gameplay-v2\.css\?build=20260722-r51/);
+assert.match(index, /TURN v1\.6\.2 · Build 2026\.07\.22-r52/);
+assert.match(index, /drive-pad\.css\?build=20260722-r52/);
+assert.match(index, /gameplay-v2\.css\?build=20260722-r52/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -50,14 +50,14 @@ const [index, main, lapSystem, rivalStorage, controls, carModels, lotWrapper] = 
   fs.readFile(path.join(turnDir, 'garage/lot-track-select.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.1 · Build 2026\.07\.22-r51/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260722-r51/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260722-r51"/, 'r51 must place track selection in front of the stable Lot implementation');
+assert.match(index, /TURN v1\.6\.2 · Build 2026\.07\.22-r52/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260722-r52/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260722-r52"/, 'r52 must place track selection in front of the stable Lot implementation');
 assert.match(lotWrapper, /showOriginalLot/, 'The track-first wrapper must still delegate car selection to the verified Lot implementation');
 assert.match(lotWrapper, /await chooseTrackBeforeLot\(\)/, 'The driver must pick a track before choosing the car');
-assert.match(lotWrapper, /track-manager\.js\?build=20260722-r51/, 'The Lot wrapper must load the r51 Airport polish runtime');
-assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r51 must preserve the reduced Monster Truck scale in the main runtime');
-assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r51 must preserve the same reduced Monster Truck scale inside The Lot');
+assert.match(lotWrapper, /track-manager\.js\?build=20260722-r52/, 'The Lot wrapper must load the r52 Airport run-off runtime');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r52 must preserve the reduced Monster Truck scale in the main runtime');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r52 must preserve the same reduced Monster Truck scale inside The Lot');
 assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter the track-first Lot wrapper before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -26,8 +26,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.1 · Build 2026\.07\.22-r51/);
-assert.match(index, /in-game-menu\.css\?build=20260722-r51/);
+assert.match(index, /TURN v1\.6\.2 · Build 2026\.07\.22-r52/);
+assert.match(index, /in-game-menu\.css\?build=20260722-r52/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Restart Lap<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -134,11 +134,11 @@ const [index, app, lapSystem, gameState, hud, styles, toast, toastCss, onboardin
   fs.readFile(new URL('../../turn/rival-onboarding.css', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.1 · Build 2026\.07\.22-r51/);
-assert.match(index, /lap-result-toast\.css\?build=20260722-r51/);
-assert.match(index, /rival-onboarding\.css\?build=20260722-r51/);
-assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260722-r41"/, 'r51 must preserve the r41 early invalid-lap detector');
-assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r41"/, 'r51 must preserve the r41 reset-safe invalid-lap state');
+assert.match(index, /TURN v1\.6\.2 · Build 2026\.07\.22-r52/);
+assert.match(index, /lap-result-toast\.css\?build=20260722-r52/);
+assert.match(index, /rival-onboarding\.css\?build=20260722-r52/);
+assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260722-r41"/, 'r52 must preserve the r41 early invalid-lap detector');
+assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r41"/, 'r52 must preserve the r41 reset-safe invalid-lap state');
 assert.match(app, /installLapResultToast\(\)/, 'The lap result toast must install before the game runtime starts');
 assert.match(app, /installRivalOnboarding\(\)/, 'The rival onboarding plate must install before the game runtime starts');
 assert.match(lapSystem, /turn:lap-result/, 'Completed lap finish must publish one frozen result event');

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -20,13 +20,13 @@ const [index, css, orientationGuardCss, orientationCompat, camera] = await Promi
   fs.readFile(new URL('../../turn/render/camera.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.1 · Build 2026\.07\.22-r51/);
+assert.match(index, /TURN v1\.6\.2 · Build 2026\.07\.22-r52/);
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260722-r51/);
-assert.match(index, /orientation-guard\.css\?build=20260722-r51/);
-assert.match(index, /orientation-compat\.js\?build=20260722-r51/);
-assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r51 must preserve the guarded race camera cache redirect');
+assert.match(index, /manual-steering\.css\?build=20260722-r52/);
+assert.match(index, /orientation-guard\.css\?build=20260722-r52/);
+assert.match(index, /orientation-compat\.js\?build=20260722-r52/);
+assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r52 must preserve the guarded race camera cache redirect');
 assert.match(index, /<strong>Rotate to landscape<\/strong>/, 'The pre-race landscape instruction must remain available');
 
 assert.match(css, /--manual-steer-left/);

--- a/turn-lab/tests/multi-track-production.mjs
+++ b/turn-lab/tests/multi-track-production.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import { createTrackSpatialIndex, findNearestTrackBruteForce } from '../../turn/race/track-spatial-index.js';
+import { AIRPORT_HAIRPIN_RUNOFF_ZONES, isForgivingTrackSurface } from '../../turn/tracks/airport-runoff.js';
 import {
   clearRivalsState,
   getStoredBestTime,
@@ -41,6 +42,12 @@ try {
   else globalThis.localStorage = originalLocalStorage;
 }
 
+assert.equal(AIRPORT_HAIRPIN_RUNOFF_ZONES.length, 2, 'The tight Airport hairpin must receive two deliberate run-off bays');
+assert.equal(isForgivingTrackSurface('airport', { x: 20, z: 54 }), true, 'The eastern run-off bay must provide normal road physics');
+assert.equal(isForgivingTrackSurface('airport', { x: -20, z: 54 }), true, 'The western run-off bay must provide normal road physics');
+assert.equal(isForgivingTrackSurface('airport', { x: 0, z: 78 }), false, 'The two bays must not connect into a broad shortcut across the hairpin island');
+assert.equal(isForgivingTrackSurface('countryside', { x: 20, z: 54 }), false, 'Airport forgiveness must never leak onto Countryside');
+
 const trackA = makeSamples([
   [-20, 0],
   [0, 0],
@@ -71,6 +78,9 @@ const [
   lotWrapper,
   airportWorld,
   airportPolish,
+  airportRunoff,
+  airportRunoffWorld,
+  physics,
   spatialSource,
   rivalStorage,
   hud,
@@ -84,15 +94,19 @@ const [
   fs.readFile(new URL('../../turn/garage/lot-track-select.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/tracks/airport-world-r50.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/tracks/airport-world-r51.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/tracks/airport-runoff.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/tracks/airport-world-r52.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/vehicle/physics.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/race/track-spatial-index.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/ui/hud.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/render/world.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.1 · Build 2026\.07\.22-r51/);
-assert.match(index, /track-select\.css\?build=20260722-r51/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260722-r51"/, 'The r51 track selector must sit before the stable Lot entry point');
+assert.match(index, /TURN v1\.6\.2 · Build 2026\.07\.22-r52/);
+assert.match(index, /track-select\.css\?build=20260722-r52/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260722-r52"/, 'The r52 track selector must sit before the stable Lot entry point');
+assert.match(index, /"\.\/vehicle\/physics\.js\?build=20260720-r19": "\.\/vehicle\/physics\.js\?build=20260722-r52"/, 'Production must cache-bust the run-off-aware vehicle physics');
 assert.match(index, /"\.\/race\/rival-storage\.js\?build=20260720-r19": "\.\/race\/rival-storage\.js\?build=20260722-r50"/, 'Production must preserve geometry-revision-aware rival storage');
 assert.match(index, /"\.\/race\/track-spatial-index\.js\?build=20260720-r19": "\.\/race\/track-spatial-index\.js\?build=20260722-r47"/, 'Production must preserve the rebuildable track index');
 assert.match(index, /Turn the device to steer/, 'Start copy must use device-neutral language');
@@ -110,7 +124,7 @@ assert.match(trackCatalog, /Runway speed\. Apron precision\./, 'Airport must kee
 assert.match(trackCatalog, /\[25, 43\],[\s\S]*\[0, 22\],[\s\S]*\[-25, 43\]/, 'The service-road hairpin must use a broad symmetric entry and exit around its apex');
 assert.doesNotMatch(trackCatalog, /\[27, 76\],[\s\S]*\[3, 40\],[\s\S]*\[-25, 68\]/, 'The pinched r49 hairpin geometry must stay retired');
 
-assert.match(lotWrapper, /track-manager\.js\?build=20260722-r51/, 'The Lot wrapper must load the r51 Airport polish runtime');
+assert.match(lotWrapper, /track-manager\.js\?build=20260722-r52/, 'The Lot wrapper must load the r52 Airport run-off runtime');
 assert.match(lotWrapper, /await chooseTrackBeforeLot\(\)/, 'Track selection must complete before The Lot opens');
 assert.ok(
   lotWrapper.indexOf('await chooseTrackBeforeLot()') < lotWrapper.indexOf('showOriginalLot(options)'),
@@ -133,7 +147,8 @@ assert.match(trackSelectCss, /\.track-card\.is-selected \{[\s\S]*translate\(9px,
 assert.match(trackSelectCss, /filter: saturate\(1\.38\) contrast\(1\.06\) brightness\(1\.02\)/, 'Selected track must remain distinctly more vibrant');
 assert.match(trackSelectCss, /\.track-card:focus-visible/, 'The material treatment must retain a visible keyboard focus ring');
 
-assert.match(trackManager, /airport-world-r51\.js\?build=20260722-r51/, 'Track manager must load the r51 Airport polish layer');
+assert.match(trackManager, /airport-world-r52\.js\?build=20260722-r52/, 'Track manager must load the r52 Airport run-off layer');
+assert.match(trackManager, /__turnIsForgivingSurface = \(position\) => isForgivingTrackSurface\(activeTrackId, position\)/, 'Vehicle physics must receive forgiveness only from the active track');
 assert.match(trackManager, /initialTrackId: chosenThisSession \? activeTrackId : loadTrackSelection\(\)/, 'Later Lot visits must reopen track choice with the current course preselected');
 assert.doesNotMatch(trackManager, /if \(!force && chosenThisSession\) return activeTrackId/, 'Track selection must not be skipped on later visits to The Lot');
 assert.match(trackManager, /replaceSamples\(currentRuntime\.samples, airportTrack\.samples\)/);
@@ -142,12 +157,16 @@ assert.match(trackManager, /loadRivalsState\([\s\S]*trackId: nextTrackId/, 'Chan
 assert.match(trackManager, /clearRivalsState\(currentRuntime\.state, \{ trackId: activeTrackId \}\)/, 'Reset Rivals must remain scoped to the active track');
 assert.doesNotMatch(trackManager, /setAnimationLoop|requestAnimationFrame|setInterval/, 'Track switching must not create another render loop');
 
+assert.match(physics, /nearestBefore\.distance > trackWidth \* 0\.58 && !isForgivingSurface\(state\.position\)/, 'Forgiving bays must keep normal road physics before integration');
+assert.match(physics, /nearestAfter\.distance > trackWidth \* 0\.58 && !isForgivingSurface\(state\.position\)/, 'Forgiving bays must keep normal road physics after integration');
+assert.match(physics, /globalThis\.__turnIsForgivingSurface\?\.\(position\)/, 'The physics core must use one optional track-specific surface predicate');
+
 assert.match(hud, /cached\.firstSample === firstSample/, 'The minimap cache must notice when the shared samples array is repopulated for another track');
 assert.match(hud, /cached\.lastSample === lastSample/, 'The minimap cache must not reuse the previous track drawing after a course switch');
 assert.match(spatialSource, /replaceSamples\(nextSamples\)/, 'The shared spatial index must expose a controlled rebuild hook');
 assert.match(spatialSource, /return rebuild\(nextSamples\)/);
 
-assert.match(rivalStorage, /airport: 'airport-r50'/, 'Airport records must stay on the r50 geometry namespace because r51 does not change the course');
+assert.match(rivalStorage, /airport: 'airport-r50'/, 'Airport records must stay on the r50 geometry namespace because r52 does not change the course');
 assert.match(rivalStorage, /version: 6/);
 assert.match(rivalStorage, /trackRevision: storageTrackId\(activeTrackId\)/, 'Saved rival payloads must record the geometry revision');
 
@@ -169,10 +188,17 @@ assert.match(airportPolish, /APRON_SAFE_Z = -62/, 'The trimmed apron must remain
 assert.match(airportPolish, /APRON_SOURCE_DEPTH = 150/, 'The r51 ground fix must identify the photographed r50 apron patch explicitly');
 assert.doesNotMatch(airportPolish, /setAnimationLoop|requestAnimationFrame|setInterval/, 'The Airport polish layer must remain a one-time setup cost');
 
+assert.match(airportRunoff, /AIRPORT_HAIRPIN_RUNOFF_ZONES/, 'The forgiving surface geometry must be defined once for visuals and physics');
+assert.match(airportRunoff, /pointInsideCapsule/, 'The run-off predicate must use compact capsule zones rather than widening the whole track');
+assert.match(airportRunoffWorld, /airport-world-r51\.js\?build=20260722-r51/, 'r52 must preserve the successful r51 Airport polish');
+assert.match(airportRunoffWorld, /installHairpinRunoff\(world\)/, 'The forgiving zones must have visible paved run-off surfaces');
+assert.match(airportRunoffWorld, /RUNOFF = 0x89929b/, 'The run-off must read as a distinct service apron rather than thicker race asphalt');
+assert.doesNotMatch(airportRunoffWorld, /setAnimationLoop|requestAnimationFrame|setInterval/, 'The run-off layer must remain a one-time setup cost');
+
 assert.match(worldRender, /const worldSamples = samples\.slice\(\)/, 'Countryside async scenery must retain immutable Track 1 samples during an early track switch');
 assert.match(worldRender, /samples: worldSamples/, 'Late Countryside art modules must receive the snapshot rather than the mutable active track array');
 
-console.log('TURN r51 readable Airport signs, hairpin-safe ground and explicit track selection passed.');
+console.log('TURN r52 Airport hairpin run-off, forgiving surface physics and preserved anti-shortcut geometry passed.');
 
 function makeSamples(points) {
   return points.map(([x, z]) => ({ point: { x, z } }));

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -34,7 +34,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.1 · Build 2026\.07\.22-r51/);
+assert.match(index, /TURN v1\.6\.2 · Build 2026\.07\.22-r52/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -123,11 +123,11 @@ const [index, app, main, worldAssets, worldRender, controls, menu, spectate, hud
   fs.readFile(new URL('../../turn/tracks/airport-world-r51.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.1 · Build 2026\.07\.22-r51/);
-assert.match(index, /"\.\/race\/replay-system\.js": "\.\/race\/replay-system\.js\?build=20260722-r43"/, 'r51 must preserve the shared replay sampler cache');
-assert.match(index, /"\.\/race\/track-spatial-index\.js\?build=20260720-r19": "\.\/race\/track-spatial-index\.js\?build=20260722-r47"/, 'r51 must preserve the rebuildable bounded track search');
-assert.match(index, /"\.\/performance-monitor\.js\?build=20260720-r19": "\.\/performance-monitor\.js\?build=20260722-r43"/, 'r51 must preserve the diagnostics module');
-assert.match(index, /"\.\/world-assets\.js": "\.\/world-assets\.js\?build=20260722-r44"/, 'r51 must preserve both countryside tree-grounding passes');
+assert.match(index, /TURN v1\.6\.2 · Build 2026\.07\.22-r52/);
+assert.match(index, /"\.\/race\/replay-system\.js": "\.\/race\/replay-system\.js\?build=20260722-r43"/, 'r52 must preserve the shared replay sampler cache');
+assert.match(index, /"\.\/race\/track-spatial-index\.js\?build=20260720-r19": "\.\/race\/track-spatial-index\.js\?build=20260722-r47"/, 'r52 must preserve the rebuildable bounded track search');
+assert.match(index, /"\.\/performance-monitor\.js\?build=20260720-r19": "\.\/performance-monitor\.js\?build=20260722-r43"/, 'r52 must preserve the diagnostics module');
+assert.match(index, /"\.\/world-assets\.js": "\.\/world-assets\.js\?build=20260722-r44"/, 'r52 must preserve both countryside tree-grounding passes');
 assert.match(app, /installPerformanceProfile\(\)/, 'Renderer profile installation must run before the game runtime');
 assert.ok(app.indexOf('./performance-profile.js') < app.indexOf('./main.js'), 'The universal DPR cap must be ready before main.js creates the runtime');
 assert.match(profile, /DEFAULT_DPR_CAP = 1\.5/, 'The universal production DPR ceiling must stay at 1.5');

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -1,5 +1,5 @@
 import { showTheLot as showOriginalLot } from './lot-r10.js?build=20260720-r25';
-import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r51';
+import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r52';
 
 export async function showTheLot(options = {}) {
   const trackId = await chooseTrackBeforeLot();

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r51 Airport signage/ground polish and simplified track selection -->
+<!-- TURN r52 Airport hairpin run-off and forgiving surface physics -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,42 +10,42 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.6.1 · Build 2026.07.22-r51</title>
+  <title>TURN v1.6.2 · Build 2026.07.22-r52</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.6.1',
-      id: '2026.07.22-r51',
-      cacheKey: '20260722-r51'
+      version: '1.6.2',
+      id: '2026.07.22-r52',
+      cacheKey: '20260722-r52'
     });
   </script>
   <link rel="icon" href="./favicon-r45.ico" sizes="any">
   <link rel="icon" href="./favicon-32-r45.png" type="image/png" sizes="32x32">
   <link rel="apple-touch-icon" href="./apple-touch-icon-r45.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260722-r51">
-  <link rel="stylesheet" href="./styles.css?build=20260722-r51">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260722-r51">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260722-r51">
-  <link rel="stylesheet" href="./install-gate.css?build=20260722-r51">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260722-r51">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260722-r51">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260722-r51">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260722-r51">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260722-r51">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260722-r51">
-  <link rel="stylesheet" href="./orientation-guard.css?build=20260722-r51">
-  <link rel="stylesheet" href="./lap-result-toast.css?build=20260722-r51">
-  <link rel="stylesheet" href="./rival-onboarding.css?build=20260722-r51">
-  <link rel="stylesheet" href="./track-select.css?build=20260722-r51">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260722-r51">
+  <link rel="manifest" href="./site.webmanifest?build=20260722-r52">
+  <link rel="stylesheet" href="./styles.css?build=20260722-r52">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260722-r52">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260722-r52">
+  <link rel="stylesheet" href="./install-gate.css?build=20260722-r52">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260722-r52">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260722-r52">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260722-r52">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260722-r52">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260722-r52">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260722-r52">
+  <link rel="stylesheet" href="./orientation-guard.css?build=20260722-r52">
+  <link rel="stylesheet" href="./lap-result-toast.css?build=20260722-r52">
+  <link rel="stylesheet" href="./rival-onboarding.css?build=20260722-r52">
+  <link rel="stylesheet" href="./track-select.css?build=20260722-r52">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260722-r52">
 
-  <script src="./install-gate.js?build=20260722-r51"></script>
-  <script src="./orientation-compat.js?build=20260722-r51"></script>
+  <script src="./install-gate.js?build=20260722-r52"></script>
+  <script src="./orientation-compat.js?build=20260722-r52"></script>
   <script type="importmap">
     {
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
-        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260722-r51",
+        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260722-r52",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260721-r29",
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system.js?build=20260722-r41",
         "./race/game-state.js": "./race/game-state.js?build=20260722-r41",
@@ -54,6 +54,7 @@
         "./race/track-spatial-index.js?build=20260720-r19": "./race/track-spatial-index.js?build=20260722-r47",
         "./performance-monitor.js?build=20260720-r19": "./performance-monitor.js?build=20260722-r43",
         "./world-assets.js": "./world-assets.js?build=20260722-r44",
+        "./vehicle/physics.js?build=20260720-r19": "./vehicle/physics.js?build=20260722-r52",
         "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260722-r42",
         "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260722-r42",
         "./vehicle/car-models.js?build=20260720-r19": "./vehicle/car-models.js?build=20260720-r22"
@@ -69,7 +70,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.6.1 · Build 2026.07.22-r51</span>
+        <span class="install-kicker">TURN v1.6.2 · Build 2026.07.22-r52</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -97,7 +98,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.6.1 · Build 2026.07.22-r51</span>
+      <span class="kicker">TURN v1.6.2 · Build 2026.07.22-r52</span>
       <h1 class="start-logo-heading" id="title">
         <img class="start-logo" src="./icon-512-r45.png" alt="TURN">
       </h1>
@@ -165,6 +166,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260722-r51"></script>
+  <script type="module" src="./app.js?build=20260722-r52"></script>
 </body>
 </html>

--- a/turn/tracks/airport-runoff.js
+++ b/turn/tracks/airport-runoff.js
@@ -1,0 +1,45 @@
+export const AIRPORT_HAIRPIN_RUNOFF_ZONES = Object.freeze([
+  Object.freeze({
+    id: 'hairpin-east',
+    from: Object.freeze({ x: 8, z: 31 }),
+    to: Object.freeze({ x: 31, z: 77 }),
+    radius: 14
+  }),
+  Object.freeze({
+    id: 'hairpin-west',
+    from: Object.freeze({ x: -8, z: 31 }),
+    to: Object.freeze({ x: -31, z: 77 }),
+    radius: 14
+  })
+]);
+
+export function isForgivingTrackSurface(trackId, position) {
+  if (trackId !== 'airport' || !position) return false;
+  return AIRPORT_HAIRPIN_RUNOFF_ZONES.some((zone) => pointInsideCapsule(position, zone));
+}
+
+export function pointInsideCapsule(position, zone) {
+  const px = Number(position?.x);
+  const pz = Number(position?.z);
+  if (!Number.isFinite(px) || !Number.isFinite(pz)) return false;
+
+  const ax = zone.from.x;
+  const az = zone.from.z;
+  const bx = zone.to.x;
+  const bz = zone.to.z;
+  const dx = bx - ax;
+  const dz = bz - az;
+  const lengthSquared = dx * dx + dz * dz;
+  const t = lengthSquared > 0
+    ? clamp(((px - ax) * dx + (pz - az) * dz) / lengthSquared, 0, 1)
+    : 0;
+  const nearestX = ax + dx * t;
+  const nearestZ = az + dz * t;
+  const offsetX = px - nearestX;
+  const offsetZ = pz - nearestZ;
+  return offsetX * offsetX + offsetZ * offsetZ <= zone.radius * zone.radius;
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}

--- a/turn/tracks/airport-world-r52.js
+++ b/turn/tracks/airport-world-r52.js
@@ -1,0 +1,69 @@
+import * as THREE from 'three';
+import { installAirportWorld as installAirportWorldR51 } from './airport-world-r51.js?build=20260722-r51';
+import { AIRPORT_HAIRPIN_RUNOFF_ZONES } from './airport-runoff.js?build=20260722-r52';
+
+const INK = 0x08090a;
+const RUNOFF = 0x89929b;
+
+export function installAirportWorld(options) {
+  const world = installAirportWorldR51(options);
+  installHairpinRunoff(world);
+
+  world.name = 'TURN Airport r52';
+  world.userData.turnAirportArtDirection = Object.freeze({
+    ...(world.userData.turnAirportArtDirection || {}),
+    version: 'r52',
+    hairpinRunoff: true,
+    forgivingHairpinSurface: true
+  });
+
+  return world;
+}
+
+function installHairpinRunoff(world) {
+  const runoff = new THREE.Group();
+  runoff.name = 'Airport Hairpin Run-off';
+
+  for (const zone of AIRPORT_HAIRPIN_RUNOFF_ZONES) {
+    runoff.add(makeCapsule(zone, zone.radius + 1.35, INK, 0.105));
+    runoff.add(makeCapsule(zone, zone.radius, RUNOFF, 0.125));
+  }
+
+  world.add(runoff);
+}
+
+function makeCapsule(zone, radius, color, y) {
+  const dx = zone.to.x - zone.from.x;
+  const dz = zone.to.z - zone.from.z;
+  const length = Math.hypot(dx, dz);
+  const group = new THREE.Group();
+  const material = new THREE.MeshStandardMaterial({
+    color,
+    roughness: 0.96,
+    metalness: 0,
+    side: THREE.DoubleSide
+  });
+
+  const body = new THREE.Mesh(new THREE.PlaneGeometry(radius * 2, length), material);
+  body.rotation.x = Math.PI / 2;
+  body.position.y = y;
+  body.receiveShadow = true;
+  group.add(body);
+
+  const capGeometry = new THREE.CircleGeometry(radius, 28);
+  for (const direction of [-1, 1]) {
+    const cap = new THREE.Mesh(capGeometry, material);
+    cap.rotation.x = Math.PI / 2;
+    cap.position.set(0, y, direction * length / 2);
+    cap.receiveShadow = true;
+    group.add(cap);
+  }
+
+  group.position.set(
+    (zone.from.x + zone.to.x) / 2,
+    0,
+    (zone.from.z + zone.to.z) / 2
+  );
+  group.rotation.y = Math.atan2(dx, dz);
+  return group;
+}

--- a/turn/tracks/track-manager.js
+++ b/turn/tracks/track-manager.js
@@ -9,7 +9,8 @@ import {
   normalizeTrackId,
   saveTrackSelection
 } from './catalog.js?build=20260722-r50';
-import { installAirportWorld } from './airport-world-r51.js?build=20260722-r51';
+import { installAirportWorld } from './airport-world-r52.js?build=20260722-r52';
+import { isForgivingTrackSurface } from './airport-runoff.js?build=20260722-r52';
 import { showTrackSelect } from '../ui/track-select.js?build=20260722-r51';
 
 let runtime = null;
@@ -120,6 +121,7 @@ function installRuntime(nextRuntime) {
 
   globalThis.__turnGetTrackId = () => activeTrackId;
   globalThis.__turnChooseTrack = () => chooseTrackBeforeLot();
+  globalThis.__turnIsForgivingSurface = (position) => isForgivingTrackSurface(activeTrackId, position);
   runtimeReadyResolve(runtime);
 }
 

--- a/turn/vehicle/physics.js
+++ b/turn/vehicle/physics.js
@@ -31,7 +31,7 @@ export function updateVehiclePhysicsState({
   const nearestBefore = findNearestTrack(state.position);
   state.nearestTrackIndex = nearestBefore.index;
   state.trackDistance = nearestBefore.distance;
-  state.offRoad = nearestBefore.distance > trackWidth * 0.58;
+  state.offRoad = nearestBefore.distance > trackWidth * 0.58 && !isForgivingSurface(state.position);
 
   const forward = getForward();
   const right = getRight();
@@ -149,12 +149,20 @@ export function updateVehiclePhysicsState({
 
   const nearestAfter = findNearestTrack(state.position);
   state.trackDistance = nearestAfter.distance;
-  state.offRoad = nearestAfter.distance > trackWidth * 0.58;
+  state.offRoad = nearestAfter.distance > trackWidth * 0.58 && !isForgivingSurface(state.position);
   state.lastProgress = state.progress;
   state.progress = nearestAfter.index / trackSampleCount;
   state.nearestTrackIndex = nearestAfter.index;
 
   return nearestAfter;
+}
+
+function isForgivingSurface(position) {
+  try {
+    return globalThis.__turnIsForgivingSurface?.(position) === true;
+  } catch (_) {
+    return false;
+  }
 }
 
 function positiveNumber(value, fallback) {


### PR DESCRIPTION
## Summary

Adds deliberate run-off space around the Airport service-road hairpin so the corner remains challenging without demanding a turning radius that several TURN cars cannot comfortably achieve.

## Hairpin run-off

- Adds two compact paved run-off bays on the inside of the two tight hairpin legs.
- Keeps them visually distinct from the race asphalt, so the track itself does not simply look wider.
- Uses one shared capsule-zone definition for both rendering and driving physics.
- Gives cars normal road grip, acceleration and speed behavior while they are on those marked run-off surfaces.
- Keeps the two bays separated away from the apex so they do not become a broad shortcut through the hairpin island.

## Race integrity

- Leaves the Airport track geometry unchanged, so existing r50+ Airport records and rivals remain valid.
- Leaves the ordered checkpoint and anti-shortcut system completely unchanged.
- Scopes the forgiving physics strictly to Airport; Countryside is unaffected.
- Adds no new render loop, interval or recurring scenery work.

## Release

**TURN v1.6.2 · Build 2026.07.22-r52**

The full TURN regression suite will validate the release before merge.