### PR TITLE
TURN v1.7.0 r53: Add invisible world containment and collision foundation

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Run multi-track and Airport regression
         run: node turn-lab/tests/multi-track-production.mjs
 
+      - name: Run world containment and collision regression
+        run: node turn-lab/tests/world-collision-production.mjs
+
       - name: Run production manual steering regression
         run: node turn-lab/tests/manual-steering-production.mjs
 

--- a/turn-lab/tests/app-icon-production.mjs
+++ b/turn-lab/tests/app-icon-production.mjs
@@ -10,11 +10,11 @@ const index = fs.readFileSync(path.join(turnRoot, 'index.html'), 'utf8');
 const styles = fs.readFileSync(path.join(turnRoot, 'styles.css'), 'utf8');
 const manifest = JSON.parse(fs.readFileSync(path.join(turnRoot, 'site.webmanifest'), 'utf8'));
 
-assert.match(index, /TURN v1\.6\.2 · Build 2026\.07\.22-r52/);
+assert.match(index, /TURN v1\.7\.0 · Build 2026\.07\.23-r53/);
 assert.match(index, /<link rel="icon" href="\.\/favicon-r45\.ico" sizes="any">/);
 assert.match(index, /<link rel="icon" href="\.\/favicon-32-r45\.png" type="image\/png" sizes="32x32">/);
 assert.match(index, /<link rel="apple-touch-icon" href="\.\/apple-touch-icon-r45\.png" sizes="180x180">/);
-assert.match(index, /<link rel="manifest" href="\.\/site\.webmanifest\?build=20260722-r52">/);
+assert.match(index, /<link rel="manifest" href="\.\/site\.webmanifest\?build=20260723-r53">/);
 assert.match(index, /<img class="install-icon" src="\.\/icon-512-r45\.png" alt="">/);
 assert.match(index, /<h1 class="start-logo-heading" id="title">\s*<img class="start-logo" src="\.\/icon-512-r45\.png" alt="TURN">\s*<\/h1>/);
 assert.doesNotMatch(index, /apple-touch-icon-v4|icon-192-v4/);

--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -10,8 +10,8 @@ const [index, app, audio, controls, catalogSource] = await Promise.all([
 ]);
 const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
 
-assert.match(index, /TURN v1\.6\.2 · Build 2026\.07\.22-r52/);
-assert.match(index, /\.\/app\.js\?build=20260722-r52/);
+assert.match(index, /TURN v1\.7\.0 · Build 2026\.07\.23-r53/);
+assert.match(index, /\.\/app\.js\?build=20260723-r53/);
 assert.match(
   index,
   /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/,

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -69,7 +69,7 @@ const [index, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.2 · Build 2026\.07\.22-r52/);
+assert.match(index, /TURN v1\.7\.0 · Build 2026\.07\.23-r53/);
 assert.match(
   carModels,
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,

--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -20,9 +20,9 @@ const [index, controls, css, gameplayCss, analogGas, spectate] = await Promise.a
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.2 · Build 2026\.07\.22-r52/);
-assert.match(index, /drive-pad\.css\?build=20260722-r52/);
-assert.match(index, /gameplay-v2\.css\?build=20260722-r52/);
+assert.match(index, /TURN v1\.7\.0 · Build 2026\.07\.23-r53/);
+assert.match(index, /drive-pad\.css\?build=20260723-r53/);
+assert.match(index, /gameplay-v2\.css\?build=20260723-r53/);
 assert.match(controls, /className = 'drive-pad'/, 'Gameplay controls must create one unified drive pad');
 assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad must split into Drift and Boost');
 assert.match(controls, /return 'gas'/, 'Bottom drive pad must map to Gas');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -50,14 +50,14 @@ const [index, main, lapSystem, rivalStorage, controls, carModels, lotWrapper] = 
   fs.readFile(path.join(turnDir, 'garage/lot-track-select.js'), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.2 · Build 2026\.07\.22-r52/);
-assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260722-r52/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260722-r52"/, 'r52 must place track selection in front of the stable Lot implementation');
+assert.match(index, /TURN v1\.7\.0 · Build 2026\.07\.23-r53/);
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260723-r53/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260723-r53"/, 'r53 must place track selection in front of the stable Lot implementation');
 assert.match(lotWrapper, /showOriginalLot/, 'The track-first wrapper must still delegate car selection to the verified Lot implementation');
 assert.match(lotWrapper, /await chooseTrackBeforeLot\(\)/, 'The driver must pick a track before choosing the car');
-assert.match(lotWrapper, /track-manager\.js\?build=20260722-r52/, 'The Lot wrapper must load the r52 Airport run-off runtime');
-assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r52 must preserve the reduced Monster Truck scale in the main runtime');
-assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r52 must preserve the same reduced Monster Truck scale inside The Lot');
+assert.match(lotWrapper, /track-manager\.js\?build=20260722-r52/, 'r53 must preserve the verified r52 Airport run-off runtime');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r19": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r53 must preserve the reduced Monster Truck scale in the main runtime');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260720-r20": "\.\/vehicle\/catalog\.js\?build=20260722-r42"/, 'r53 must preserve the same reduced Monster Truck scale inside The Lot');
 assert.match(index, /"\.\/vehicle\/car-models\.js\?build=20260720-r19": "\.\/vehicle\/car-models\.js\?build=20260720-r22"/, 'The stable r22 outline module cache redirect must remain in place');
 assert.match(main, /await showTheLot\(/, 'Start flow must enter the track-first Lot wrapper before racing');
 assert.match(main, /maxSpeed: MAX_SPEED \* state\.vehicleTuning\.topSpeedMultiplier/, 'Selected top speed must reach physics');

--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -26,8 +26,8 @@ const [index, app, menu, controls, backToLot, main, css, spectate] = await Promi
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.2 · Build 2026\.07\.22-r52/);
-assert.match(index, /in-game-menu\.css\?build=20260722-r52/);
+assert.match(index, /TURN v1\.7\.0 · Build 2026\.07\.23-r53/);
+assert.match(index, /in-game-menu\.css\?build=20260723-r53/);
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(index, /id="resetButton"[^>]*>Restart Lap<\/button>/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -134,11 +134,11 @@ const [index, app, lapSystem, gameState, hud, styles, toast, toastCss, onboardin
   fs.readFile(new URL('../../turn/rival-onboarding.css', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.2 · Build 2026\.07\.22-r52/);
-assert.match(index, /lap-result-toast\.css\?build=20260722-r52/);
-assert.match(index, /rival-onboarding\.css\?build=20260722-r52/);
-assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260722-r41"/, 'r52 must preserve the r41 early invalid-lap detector');
-assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r41"/, 'r52 must preserve the r41 reset-safe invalid-lap state');
+assert.match(index, /TURN v1\.7\.0 · Build 2026\.07\.23-r53/);
+assert.match(index, /lap-result-toast\.css\?build=20260723-r53/);
+assert.match(index, /rival-onboarding\.css\?build=20260723-r53/);
+assert.match(index, /"\.\/race\/lap-system\.js\?build=20260720-r19": "\.\/race\/lap-system\.js\?build=20260722-r41"/, 'r53 must preserve the r41 early invalid-lap detector');
+assert.match(index, /"\.\/race\/game-state\.js": "\.\/race\/game-state\.js\?build=20260722-r41"/, 'r53 must preserve the r41 reset-safe invalid-lap state');
 assert.match(app, /installLapResultToast\(\)/, 'The lap result toast must install before the game runtime starts');
 assert.match(app, /installRivalOnboarding\(\)/, 'The rival onboarding plate must install before the game runtime starts');
 assert.match(lapSystem, /turn:lap-result/, 'Completed lap finish must publish one frozen result event');

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -20,13 +20,13 @@ const [index, css, orientationGuardCss, orientationCompat, camera] = await Promi
   fs.readFile(new URL('../../turn/render/camera.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.2 · Build 2026\.07\.22-r52/);
+assert.match(index, /TURN v1\.7\.0 · Build 2026\.07\.23-r53/);
 assert.match(index, /role="slider"/);
 assert.match(index, /manual-steer-knob/);
-assert.match(index, /manual-steering\.css\?build=20260722-r52/);
-assert.match(index, /orientation-guard\.css\?build=20260722-r52/);
-assert.match(index, /orientation-compat\.js\?build=20260722-r52/);
-assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r52 must preserve the guarded race camera cache redirect');
+assert.match(index, /manual-steering\.css\?build=20260723-r53/);
+assert.match(index, /orientation-guard\.css\?build=20260723-r53/);
+assert.match(index, /orientation-compat\.js\?build=20260723-r53/);
+assert.match(index, /"\.\/render\/camera\.js\?build=20260720-r19": "\.\/render\/camera\.js\?build=20260721-r29"/, 'r53 must preserve the guarded race camera cache redirect');
 assert.match(index, /<strong>Rotate to landscape<\/strong>/, 'The pre-race landscape instruction must remain available');
 
 assert.match(css, /--manual-steer-left/);

--- a/turn-lab/tests/multi-track-production.mjs
+++ b/turn-lab/tests/multi-track-production.mjs
@@ -103,10 +103,10 @@ const [
   fs.readFile(new URL('../../turn/render/world.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.2 · Build 2026\.07\.22-r52/);
-assert.match(index, /track-select\.css\?build=20260722-r52/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260722-r52"/, 'The r52 track selector must sit before the stable Lot entry point');
-assert.match(index, /"\.\/vehicle\/physics\.js\?build=20260720-r19": "\.\/vehicle\/physics\.js\?build=20260722-r52"/, 'Production must cache-bust the run-off-aware vehicle physics');
+assert.match(index, /TURN v1\.7\.0 · Build 2026\.07\.23-r53/);
+assert.match(index, /track-select\.css\?build=20260723-r53/);
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260723-r53"/, 'The r53 track selector must sit before the stable Lot entry point');
+assert.match(index, /"\.\/vehicle\/physics\.js\?build=20260720-r19": "\.\/vehicle\/physics\.js\?build=20260723-r53"/, 'Production must cache-bust the collision-aware vehicle physics');
 assert.match(index, /"\.\/race\/rival-storage\.js\?build=20260720-r19": "\.\/race\/rival-storage\.js\?build=20260722-r50"/, 'Production must preserve geometry-revision-aware rival storage');
 assert.match(index, /"\.\/race\/track-spatial-index\.js\?build=20260720-r19": "\.\/race\/track-spatial-index\.js\?build=20260722-r47"/, 'Production must preserve the rebuildable track index');
 assert.match(index, /Turn the device to steer/, 'Start copy must use device-neutral language');
@@ -124,7 +124,7 @@ assert.match(trackCatalog, /Runway speed\. Apron precision\./, 'Airport must kee
 assert.match(trackCatalog, /\[25, 43\],[\s\S]*\[0, 22\],[\s\S]*\[-25, 43\]/, 'The service-road hairpin must use a broad symmetric entry and exit around its apex');
 assert.doesNotMatch(trackCatalog, /\[27, 76\],[\s\S]*\[3, 40\],[\s\S]*\[-25, 68\]/, 'The pinched r49 hairpin geometry must stay retired');
 
-assert.match(lotWrapper, /track-manager\.js\?build=20260722-r52/, 'The Lot wrapper must load the r52 Airport run-off runtime');
+assert.match(lotWrapper, /track-manager\.js\?build=20260722-r52/, 'The Lot wrapper must preserve the r52 Airport run-off runtime');
 assert.match(lotWrapper, /await chooseTrackBeforeLot\(\)/, 'Track selection must complete before The Lot opens');
 assert.ok(
   lotWrapper.indexOf('await chooseTrackBeforeLot()') < lotWrapper.indexOf('showOriginalLot(options)'),
@@ -147,7 +147,7 @@ assert.match(trackSelectCss, /\.track-card\.is-selected \{[\s\S]*translate\(9px,
 assert.match(trackSelectCss, /filter: saturate\(1\.38\) contrast\(1\.06\) brightness\(1\.02\)/, 'Selected track must remain distinctly more vibrant');
 assert.match(trackSelectCss, /\.track-card:focus-visible/, 'The material treatment must retain a visible keyboard focus ring');
 
-assert.match(trackManager, /airport-world-r52\.js\?build=20260722-r52/, 'Track manager must load the r52 Airport run-off layer');
+assert.match(trackManager, /airport-world-r52\.js\?build=20260722-r52/, 'Track manager must preserve the r52 Airport run-off layer');
 assert.match(trackManager, /__turnIsForgivingSurface = \(position\) => isForgivingTrackSurface\(activeTrackId, position\)/, 'Vehicle physics must receive forgiveness only from the active track');
 assert.match(trackManager, /initialTrackId: chosenThisSession \? activeTrackId : loadTrackSelection\(\)/, 'Later Lot visits must reopen track choice with the current course preselected');
 assert.doesNotMatch(trackManager, /if \(!force && chosenThisSession\) return activeTrackId/, 'Track selection must not be skipped on later visits to The Lot');
@@ -160,13 +160,14 @@ assert.doesNotMatch(trackManager, /setAnimationLoop|requestAnimationFrame|setInt
 assert.match(physics, /nearestBefore\.distance > trackWidth \* 0\.58 && !isForgivingSurface\(state\.position\)/, 'Forgiving bays must keep normal road physics before integration');
 assert.match(physics, /nearestAfter\.distance > trackWidth \* 0\.58 && !isForgivingSurface\(state\.position\)/, 'Forgiving bays must keep normal road physics after integration');
 assert.match(physics, /globalThis\.__turnIsForgivingSurface\?\.\(position\)/, 'The physics core must use one optional track-specific surface predicate');
+assert.match(physics, /resolveWorldCollisionState\(/, 'The physics core must resolve the new world containment layer');
 
 assert.match(hud, /cached\.firstSample === firstSample/, 'The minimap cache must notice when the shared samples array is repopulated for another track');
 assert.match(hud, /cached\.lastSample === lastSample/, 'The minimap cache must not reuse the previous track drawing after a course switch');
 assert.match(spatialSource, /replaceSamples\(nextSamples\)/, 'The shared spatial index must expose a controlled rebuild hook');
 assert.match(spatialSource, /return rebuild\(nextSamples\)/);
 
-assert.match(rivalStorage, /airport: 'airport-r50'/, 'Airport records must stay on the r50 geometry namespace because r52 does not change the course');
+assert.match(rivalStorage, /airport: 'airport-r50'/, 'Airport records must stay on the r50 geometry namespace because r53 does not change the course');
 assert.match(rivalStorage, /version: 6/);
 assert.match(rivalStorage, /trackRevision: storageTrackId\(activeTrackId\)/, 'Saved rival payloads must record the geometry revision');
 
@@ -198,7 +199,7 @@ assert.doesNotMatch(airportRunoffWorld, /setAnimationLoop|requestAnimationFrame|
 assert.match(worldRender, /const worldSamples = samples\.slice\(\)/, 'Countryside async scenery must retain immutable Track 1 samples during an early track switch');
 assert.match(worldRender, /samples: worldSamples/, 'Late Countryside art modules must receive the snapshot rather than the mutable active track array');
 
-console.log('TURN r52 Airport hairpin run-off, forgiving surface physics and preserved anti-shortcut geometry passed.');
+console.log('TURN r53 world containment, Airport hairpin run-off and preserved anti-shortcut geometry passed.');
 
 function makeSamples(points) {
   return points.map(([x, z]) => ({ point: { x, z } }));

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -34,7 +34,7 @@ const [index, lot, css, carModels, main, lapSystem, rivalStorage] = await Promis
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.2 · Build 2026\.07\.22-r52/);
+assert.match(index, /TURN v1\.7\.0 · Build 2026\.07\.23-r53/);
 assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
 assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -100,7 +100,7 @@ assert.equal(summary.p95Ms, 50);
 assert.equal(summary.slowPercent, 40);
 assert.ok(Math.abs(summary.fps - 1000 / 30) < 1e-9);
 
-const [index, app, main, worldAssets, worldRender, controls, menu, spectate, hud, physics, camera, cars, lot, monitor, profile, replay, audio, orientationCompat, airportWorld, airportPolish] = await Promise.all([
+const [index, app, main, worldAssets, worldRender, controls, menu, spectate, hud, physics, camera, cars, lot, monitor, profile, replay, audio, orientationCompat, airportWorld, airportPolish, worldCollision] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8'),
@@ -120,14 +120,15 @@ const [index, app, main, worldAssets, worldRender, controls, menu, spectate, hud
   fs.readFile(new URL('../../turn/audio/audio-system.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/orientation-compat.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/tracks/airport-world-r50.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/tracks/airport-world-r51.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../../turn/tracks/airport-world-r51.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/race/world-collision.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /TURN v1\.6\.2 · Build 2026\.07\.22-r52/);
-assert.match(index, /"\.\/race\/replay-system\.js": "\.\/race\/replay-system\.js\?build=20260722-r43"/, 'r52 must preserve the shared replay sampler cache');
-assert.match(index, /"\.\/race\/track-spatial-index\.js\?build=20260720-r19": "\.\/race\/track-spatial-index\.js\?build=20260722-r47"/, 'r52 must preserve the rebuildable bounded track search');
-assert.match(index, /"\.\/performance-monitor\.js\?build=20260720-r19": "\.\/performance-monitor\.js\?build=20260722-r43"/, 'r52 must preserve the diagnostics module');
-assert.match(index, /"\.\/world-assets\.js": "\.\/world-assets\.js\?build=20260722-r44"/, 'r52 must preserve both countryside tree-grounding passes');
+assert.match(index, /TURN v1\.7\.0 · Build 2026\.07\.23-r53/);
+assert.match(index, /"\.\/race\/replay-system\.js": "\.\/race\/replay-system\.js\?build=20260722-r43"/, 'r53 must preserve the shared replay sampler cache');
+assert.match(index, /"\.\/race\/track-spatial-index\.js\?build=20260720-r19": "\.\/race\/track-spatial-index\.js\?build=20260722-r47"/, 'r53 must preserve the rebuildable bounded track search');
+assert.match(index, /"\.\/performance-monitor\.js\?build=20260720-r19": "\.\/performance-monitor\.js\?build=20260722-r43"/, 'r53 must preserve the diagnostics module');
+assert.match(index, /"\.\/world-assets\.js": "\.\/world-assets\.js\?build=20260722-r44"/, 'r53 must preserve both countryside tree-grounding passes');
 assert.match(app, /installPerformanceProfile\(\)/, 'Renderer profile installation must run before the game runtime');
 assert.ok(app.indexOf('./performance-profile.js') < app.indexOf('./main.js'), 'The universal DPR cap must be ready before main.js creates the runtime');
 assert.match(profile, /DEFAULT_DPR_CAP = 1\.5/, 'The universal production DPR ceiling must stay at 1.5');
@@ -175,7 +176,8 @@ assert.doesNotMatch(orientationCompat, /requestAnimationFrame|setAnimationLoop|s
 assert.doesNotMatch(airportWorld, /requestAnimationFrame|setAnimationLoop|setInterval/, 'The redesigned Airport world must stay a one-time setup cost');
 assert.match(airportWorld, /new THREE\.Box3\(\)\.setFromObject\(object\)/, 'Airport safety must use measured object bounds without adding a runtime loop');
 assert.doesNotMatch(airportPolish, /requestAnimationFrame|setAnimationLoop|setInterval/, 'The r51 Airport polish layer must remain a one-time setup cost');
+assert.doesNotMatch(worldCollision, /requestAnimationFrame|setAnimationLoop|setInterval/, 'World containment must run inside the existing fixed physics step without adding another loop');
 assert.match(monitor, /turn:perf-snapshot/);
 assert.match(monitor, /trackChecksPerQuery/);
 
-console.log(`TURN universal DPR, complete tree grounding, rebuildable bounded spatial search and diagnostics regression passed (${(trackChecks / trackQueries).toFixed(1)} average on-track checks vs 720).`);
+console.log(`TURN universal DPR, world containment, complete tree grounding, rebuildable bounded spatial search and diagnostics regression passed (${(trackChecks / trackQueries).toFixed(1)} average on-track checks vs 720).`);

--- a/turn-lab/tests/world-collision-production.mjs
+++ b/turn-lab/tests/world-collision-production.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import {
+  WORLD_FREE_ROAM_DISTANCE,
+  resolveWorldCollisionState
+} from '../../turn/race/world-collision.js';
+
+function makeState({ x = 0, z = 0, vx = 0, vz = 0 } = {}) {
+  return {
+    position: { x, y: 0.18, z },
+    velocity: {
+      x: vx,
+      y: 0,
+      z: vz,
+      length() { return Math.hypot(this.x, this.y, this.z); }
+    },
+    speed: Math.hypot(vx, vz)
+  };
+}
+
+assert.equal(WORLD_FREE_ROAM_DISTANCE.countryside, 170, 'Countryside must stop free roaming before its mountain ring');
+assert.equal(WORLD_FREE_ROAM_DISTANCE.airport, 95, 'Airport must stop free roaming before its close distant hills');
+
+const countryside = makeState({ x: 220, vx: 30 });
+const countrysideCollision = resolveWorldCollisionState({
+  state: countryside,
+  trackId: 'countryside',
+  nearestTrack: { distance: 220, sample: { point: { x: 0, z: 0 } } }
+});
+assert.equal(countrysideCollision.boundary, true);
+assert.ok(countryside.position.x < 170, 'The car radius must be kept inside the invisible world wall');
+assert.ok(countryside.velocity.x < 0, 'An outward impact must bounce slightly back into the playable world');
+assert.ok(countryside.speed < 30, 'World-wall impacts must shed speed rather than pinball at full velocity');
+
+const airport = makeState({ z: -130, vz: -25 });
+const airportCollision = resolveWorldCollisionState({
+  state: airport,
+  trackId: 'airport',
+  nearestTrack: { distance: 130, sample: { point: { x: 0, z: 0 } } }
+});
+assert.equal(airportCollision.boundary, true);
+assert.ok(Math.abs(airport.position.z) < 95, 'Airport containment must use its tighter scenery-safe envelope');
+assert.ok(airport.velocity.z > 0, 'The Airport wall must return outward velocity toward the world');
+
+const inside = makeState({ x: 40, vx: 12 });
+const insideCollision = resolveWorldCollisionState({
+  state: inside,
+  trackId: 'airport',
+  nearestTrack: { distance: 40, sample: { point: { x: 0, z: 0 } } }
+});
+assert.equal(insideCollision.collided, false, 'Normal off-road exploration inside the world envelope must remain untouched');
+assert.equal(inside.position.x, 40);
+assert.equal(inside.velocity.x, 12);
+
+const circleState = makeState({ x: 2, vx: -10 });
+const circleCollision = resolveWorldCollisionState({
+  state: circleState,
+  trackId: 'airport',
+  nearestTrack: { distance: 0, sample: { point: { x: 2, z: 0 } } },
+  collisionProfile: {
+    freeRoamDistance: 500,
+    colliders: [{ type: 'circle', x: 0, z: 0, radius: 5 }]
+  }
+});
+assert.equal(circleCollision.obstacles, 1, 'The collision foundation must already support circular scenery colliders');
+assert.ok(circleState.position.x >= 7.5, 'Circular colliders must include the player-car safety radius');
+
+const boxState = makeState({ x: 0, z: 0, vx: 0, vz: 12 });
+const boxCollision = resolveWorldCollisionState({
+  state: boxState,
+  trackId: 'airport',
+  nearestTrack: { distance: 0, sample: { point: { x: 0, z: 0 } } },
+  collisionProfile: {
+    freeRoamDistance: 500,
+    colliders: [{ type: 'box', minX: -4, maxX: 4, minZ: -6, maxZ: 6 }]
+  }
+});
+assert.equal(boxCollision.obstacles, 1, 'The collision foundation must support box colliders for buildings and large props');
+assert.ok(Math.abs(boxState.position.x) >= 6.5 || Math.abs(boxState.position.z) >= 8.5, 'Box collisions must eject the car beyond the expanded solid footprint');
+
+const [index, physics] = await Promise.all([
+  fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/vehicle/physics.js', import.meta.url), 'utf8')
+]);
+
+assert.match(index, /TURN v1\.7\.0 · Build 2026\.07\.23-r53/);
+assert.match(index, /"\.\/vehicle\/physics\.js\?build=20260720-r19": "\.\/vehicle\/physics\.js\?build=20260723-r53"/, 'Production must cache-bust the collision-aware physics module');
+assert.match(physics, /world-collision\.js\?build=20260723-r53/, 'Vehicle physics must load the world collision resolver');
+assert.match(physics, /resolveWorldCollisionState\(/, 'Every physics step must resolve the world boundary after movement');
+assert.match(physics, /if \(collision\.collided\) nearestAfter = findNearestTrack\(state\.position\)/, 'Track progress must be recomputed after a collision moves the car');
+
+console.log('TURN track-aware invisible world walls and collision foundation regression passed.');

--- a/turn/index.html
+++ b/turn/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN r52 Airport hairpin run-off and forgiving surface physics -->
+<!-- TURN r53 track-aware world containment and collision foundation -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -10,42 +10,42 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.6.2 · Build 2026.07.22-r52</title>
+  <title>TURN v1.7.0 · Build 2026.07.23-r53</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
-      version: '1.6.2',
-      id: '2026.07.22-r52',
-      cacheKey: '20260722-r52'
+      version: '1.7.0',
+      id: '2026.07.23-r53',
+      cacheKey: '20260723-r53'
     });
   </script>
   <link rel="icon" href="./favicon-r45.ico" sizes="any">
   <link rel="icon" href="./favicon-32-r45.png" type="image/png" sizes="32x32">
   <link rel="apple-touch-icon" href="./apple-touch-icon-r45.png" sizes="180x180">
-  <link rel="manifest" href="./site.webmanifest?build=20260722-r52">
-  <link rel="stylesheet" href="./styles.css?build=20260722-r52">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260722-r52">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260722-r52">
-  <link rel="stylesheet" href="./install-gate.css?build=20260722-r52">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260722-r52">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260722-r52">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260722-r52">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260722-r52">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260722-r52">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260722-r52">
-  <link rel="stylesheet" href="./orientation-guard.css?build=20260722-r52">
-  <link rel="stylesheet" href="./lap-result-toast.css?build=20260722-r52">
-  <link rel="stylesheet" href="./rival-onboarding.css?build=20260722-r52">
-  <link rel="stylesheet" href="./track-select.css?build=20260722-r52">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260722-r52">
+  <link rel="manifest" href="./site.webmanifest?build=20260723-r53">
+  <link rel="stylesheet" href="./styles.css?build=20260723-r53">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260723-r53">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260723-r53">
+  <link rel="stylesheet" href="./install-gate.css?build=20260723-r53">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260723-r53">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260723-r53">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260723-r53">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260723-r53">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260723-r53">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260723-r53">
+  <link rel="stylesheet" href="./orientation-guard.css?build=20260723-r53">
+  <link rel="stylesheet" href="./lap-result-toast.css?build=20260723-r53">
+  <link rel="stylesheet" href="./rival-onboarding.css?build=20260723-r53">
+  <link rel="stylesheet" href="./track-select.css?build=20260723-r53">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260723-r53">
 
-  <script src="./install-gate.js?build=20260722-r52"></script>
-  <script src="./orientation-compat.js?build=20260722-r52"></script>
+  <script src="./install-gate.js?build=20260723-r53"></script>
+  <script src="./orientation-compat.js?build=20260723-r53"></script>
   <script type="importmap">
     {
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
-        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260722-r52",
+        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260723-r53",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260721-r29",
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system.js?build=20260722-r41",
         "./race/game-state.js": "./race/game-state.js?build=20260722-r41",
@@ -54,7 +54,7 @@
         "./race/track-spatial-index.js?build=20260720-r19": "./race/track-spatial-index.js?build=20260722-r47",
         "./performance-monitor.js?build=20260720-r19": "./performance-monitor.js?build=20260722-r43",
         "./world-assets.js": "./world-assets.js?build=20260722-r44",
-        "./vehicle/physics.js?build=20260720-r19": "./vehicle/physics.js?build=20260722-r52",
+        "./vehicle/physics.js?build=20260720-r19": "./vehicle/physics.js?build=20260723-r53",
         "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260722-r42",
         "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260722-r42",
         "./vehicle/car-models.js?build=20260720-r19": "./vehicle/car-models.js?build=20260720-r22"
@@ -70,7 +70,7 @@
       </div>
 
       <div class="install-card">
-        <span class="install-kicker">TURN v1.6.2 · Build 2026.07.22-r52</span>
+        <span class="install-kicker">TURN v1.7.0 · Build 2026.07.23-r53</span>
         <h1 id="installTitle">TURN</h1>
         <p class="install-copy">
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
@@ -98,7 +98,7 @@
 
   <section class="panel" id="intro" aria-labelledby="title">
     <div class="start-card">
-      <span class="kicker">TURN v1.6.2 · Build 2026.07.22-r52</span>
+      <span class="kicker">TURN v1.7.0 · Build 2026.07.23-r53</span>
       <h1 class="start-logo-heading" id="title">
         <img class="start-logo" src="./icon-512-r45.png" alt="TURN">
       </h1>
@@ -166,6 +166,6 @@
     </div>
   </div>
 
-  <script type="module" src="./app.js?build=20260722-r52"></script>
+  <script type="module" src="./app.js?build=20260723-r53"></script>
 </body>
 </html>

--- a/turn/race/world-collision.js
+++ b/turn/race/world-collision.js
@@ -1,0 +1,162 @@
+const DEFAULT_CAR_RADIUS = 2.6;
+const COLLISION_BOUNCE = 0.16;
+const COLLISION_TANGENT_RETENTION = 0.78;
+const MAX_COLLIDER_RESOLVES = 4;
+const EPSILON = 1e-6;
+
+export const WORLD_FREE_ROAM_DISTANCE = Object.freeze({
+  countryside: 170,
+  airport: 95
+});
+
+export function resolveWorldCollisionState({
+  state,
+  trackId = 'countryside',
+  nearestTrack = null,
+  collisionProfile = null,
+  carRadius = DEFAULT_CAR_RADIUS
+}) {
+  if (!state?.position || !state?.velocity) {
+    return { collided: false, boundary: false, obstacles: 0 };
+  }
+
+  let boundary = false;
+  let obstacles = 0;
+  const freeRoamDistance = positiveNumber(
+    collisionProfile?.freeRoamDistance,
+    WORLD_FREE_ROAM_DISTANCE[trackId] || WORLD_FREE_ROAM_DISTANCE.countryside
+  );
+
+  if (nearestTrack?.sample?.point && Number.isFinite(nearestTrack.distance)) {
+    boundary = resolveTrackEnvelopeBoundary({
+      state,
+      nearestTrack,
+      limit: Math.max(1, freeRoamDistance - Math.max(0, Number(carRadius) || 0))
+    });
+  }
+
+  for (const collider of collisionProfile?.colliders || []) {
+    if (obstacles >= MAX_COLLIDER_RESOLVES) break;
+    if (resolveStaticCollider(state, collider, carRadius)) obstacles += 1;
+  }
+
+  if (boundary || obstacles) {
+    state.position.y = 0.18;
+    state.speed = vectorLength(state.velocity);
+  }
+
+  return {
+    collided: boundary || obstacles > 0,
+    boundary,
+    obstacles
+  };
+}
+
+function resolveTrackEnvelopeBoundary({ state, nearestTrack, limit }) {
+  if (nearestTrack.distance <= limit) return false;
+
+  const anchor = nearestTrack.sample.point;
+  let dx = state.position.x - anchor.x;
+  let dz = state.position.z - anchor.z;
+  let length = Math.hypot(dx, dz);
+
+  if (length < EPSILON) {
+    dx = -(Number(state.velocity.x) || 0);
+    dz = -(Number(state.velocity.z) || 0);
+    length = Math.hypot(dx, dz) || 1;
+  }
+
+  const outwardX = dx / length;
+  const outwardZ = dz / length;
+  state.position.x = anchor.x + outwardX * limit;
+  state.position.z = anchor.z + outwardZ * limit;
+
+  // The collision normal points back into the playable world.
+  applyCollisionResponse(state.velocity, -outwardX, -outwardZ);
+  return true;
+}
+
+function resolveStaticCollider(state, collider, carRadius) {
+  if (!collider || collider.enabled === false) return false;
+  if (collider.type === 'circle') return resolveCircleCollider(state, collider, carRadius);
+  if (collider.type === 'box') return resolveBoxCollider(state, collider, carRadius);
+  return false;
+}
+
+function resolveCircleCollider(state, collider, carRadius) {
+  const centerX = Number(collider.x) || 0;
+  const centerZ = Number(collider.z) || 0;
+  const radius = Math.max(0, Number(collider.radius) || 0) + Math.max(0, Number(carRadius) || 0);
+  let dx = state.position.x - centerX;
+  let dz = state.position.z - centerZ;
+  const distance = Math.hypot(dx, dz);
+  if (distance >= radius) return false;
+
+  let length = distance;
+  if (length < EPSILON) {
+    dx = -(Number(state.velocity.x) || 0) || 1;
+    dz = -(Number(state.velocity.z) || 0);
+    length = Math.hypot(dx, dz) || 1;
+  }
+
+  const normalX = dx / length;
+  const normalZ = dz / length;
+  state.position.x = centerX + normalX * radius;
+  state.position.z = centerZ + normalZ * radius;
+  applyCollisionResponse(state.velocity, normalX, normalZ);
+  return true;
+}
+
+function resolveBoxCollider(state, collider, carRadius) {
+  const padding = Math.max(0, Number(carRadius) || 0);
+  const minX = Number(collider.minX) - padding;
+  const maxX = Number(collider.maxX) + padding;
+  const minZ = Number(collider.minZ) - padding;
+  const maxZ = Number(collider.maxZ) + padding;
+
+  if (![minX, maxX, minZ, maxZ].every(Number.isFinite)) return false;
+  if (
+    state.position.x <= minX || state.position.x >= maxX
+    || state.position.z <= minZ || state.position.z >= maxZ
+  ) return false;
+
+  const candidates = [
+    { penetration: state.position.x - minX, x: minX, z: state.position.z, nx: -1, nz: 0 },
+    { penetration: maxX - state.position.x, x: maxX, z: state.position.z, nx: 1, nz: 0 },
+    { penetration: state.position.z - minZ, x: state.position.x, z: minZ, nx: 0, nz: -1 },
+    { penetration: maxZ - state.position.z, x: state.position.x, z: maxZ, nx: 0, nz: 1 }
+  ];
+  candidates.sort((a, b) => a.penetration - b.penetration);
+  const escape = candidates[0];
+
+  state.position.x = escape.x;
+  state.position.z = escape.z;
+  applyCollisionResponse(state.velocity, escape.nx, escape.nz);
+  return true;
+}
+
+function applyCollisionResponse(velocity, normalX, normalZ) {
+  const vx = Number(velocity.x) || 0;
+  const vz = Number(velocity.z) || 0;
+  const normalSpeed = vx * normalX + vz * normalZ;
+  if (normalSpeed >= 0) return;
+
+  const tangentX = -normalZ;
+  const tangentZ = normalX;
+  const tangentSpeed = vx * tangentX + vz * tangentZ;
+  const bouncedNormalSpeed = -normalSpeed * COLLISION_BOUNCE;
+  const retainedTangentSpeed = tangentSpeed * COLLISION_TANGENT_RETENTION;
+
+  velocity.x = normalX * bouncedNormalSpeed + tangentX * retainedTangentSpeed;
+  velocity.z = normalZ * bouncedNormalSpeed + tangentZ * retainedTangentSpeed;
+}
+
+function vectorLength(vector) {
+  if (typeof vector?.length === 'function') return vector.length();
+  return Math.hypot(Number(vector?.x) || 0, Number(vector?.y) || 0, Number(vector?.z) || 0);
+}
+
+function positiveNumber(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : fallback;
+}

--- a/turn/vehicle/physics.js
+++ b/turn/vehicle/physics.js
@@ -1,3 +1,5 @@
+import { resolveWorldCollisionState } from '../race/world-collision.js?build=20260723-r53';
+
 export function updateVehiclePhysicsState({
   state,
   dt,
@@ -147,12 +149,21 @@ export function updateVehiclePhysicsState({
   state.position.y = 0.18;
   state.speed = state.velocity.length();
 
-  const nearestAfter = findNearestTrack(state.position);
+  let nearestAfter = findNearestTrack(state.position);
+  const collision = resolveWorldCollisionState({
+    state,
+    trackId: state.trackId,
+    nearestTrack: nearestAfter,
+    collisionProfile: currentCollisionProfile()
+  });
+  if (collision.collided) nearestAfter = findNearestTrack(state.position);
+
   state.trackDistance = nearestAfter.distance;
   state.offRoad = nearestAfter.distance > trackWidth * 0.58 && !isForgivingSurface(state.position);
   state.lastProgress = state.progress;
   state.progress = nearestAfter.index / trackSampleCount;
   state.nearestTrackIndex = nearestAfter.index;
+  state.speed = state.velocity.length();
 
   return nearestAfter;
 }
@@ -162,6 +173,14 @@ function isForgivingSurface(position) {
     return globalThis.__turnIsForgivingSurface?.(position) === true;
   } catch (_) {
     return false;
+  }
+}
+
+function currentCollisionProfile() {
+  try {
+    return globalThis.__turnGetCollisionProfile?.() || null;
+  } catch (_) {
+    return null;
   }
 }
 


### PR DESCRIPTION
## Summary

Adds the first real world-collision foundation to TURN, focused on the most important gameplay failure first: cars can no longer drive through the distant mountain belt and escape the authored world.

## Invisible world containment

- Adds a track-aware invisible world boundary based on distance from the nearest point of the active course.
- Keeps generous free-roam space around each circuit instead of putting the game inside an obvious rectangular box.
- Uses a wider Countryside envelope and a tighter Airport envelope because Airport's distant hills sit closer to the course.
- Resolves containment during every existing fixed physics step, with no new animation loop.
- Pushes the car back to the playable edge and removes most impact speed with a small inward rebound instead of teleporting or hard-freezing it.
- Recomputes nearest-track progress after a collision moves the car.

## Collision foundation

- Adds reusable circular and box collider support for future trees, buildings and large scenery assets.
- Keeps collider profiles optional so solid scenery can be introduced deliberately per track instead of making every decorative prop unexpectedly physical.
- Preserves Airport hairpin run-off physics and the existing checkpoint/anti-shortcut system.

## Backlog

- Airport runway integration has been recorded separately as issue #133.

## Release

**TURN v1.7.0 · Build 2026.07.23-r53**

A dedicated world-collision regression has been added to the full TURN CI suite.