### PR TITLE
TURN: compact the track chooser layout

### DIFF
--- a/turn/index.html
+++ b/turn/index.html
@@ -36,6 +36,7 @@
   <link rel="stylesheet" href="./lap-result-toast.css?build=20260723-r53">
   <link rel="stylesheet" href="./rival-onboarding.css?build=20260723-r53">
   <link rel="stylesheet" href="./track-select.css?build=20260723-r53">
+  <link rel="stylesheet" href="./track-select-r54.css?build=20260723-r54">
   <link rel="stylesheet" href="./garage/lot-r10.css?build=20260723-r53">
 
   <script src="./install-gate.js?build=20260723-r53"></script>

--- a/turn/track-select-r54.css
+++ b/turn/track-select-r54.css
@@ -1,0 +1,57 @@
+/* TURN track chooser layout polish.
+   Keep the selector compact and composed in landscape rather than stretching the cards
+   to consume every spare vertical pixel. */
+
+.track-select h2 {
+  color: var(--ink);
+}
+
+@media (max-height: 820px) and (orientation: landscape) {
+  .track-select {
+    place-items: center;
+  }
+
+  .track-select-shell {
+    grid-template-rows: auto auto auto;
+    height: auto;
+    max-height: 100%;
+    align-self: center;
+  }
+
+  .track-select-head {
+    margin-bottom: clamp(18px, 4vh, 28px);
+  }
+
+  .track-select-grid {
+    align-items: start;
+  }
+
+  .track-card {
+    align-self: start;
+  }
+
+  .track-card-preview {
+    height: clamp(82px, 23vh, 132px);
+    min-height: 82px;
+    max-height: none;
+  }
+
+  .track-select-footer {
+    margin-top: clamp(12px, 2.4vh, 18px);
+  }
+}
+
+@media (max-height: 610px) and (orientation: landscape) {
+  .track-select-head {
+    margin-bottom: 12px;
+  }
+
+  .track-card-preview {
+    height: clamp(68px, 20vh, 96px);
+    min-height: 68px;
+  }
+
+  .track-select-footer {
+    margin-top: 8px;
+  }
+}


### PR DESCRIPTION
Small UI polish matching the supplied mockup:

- make `CHOOSE YOUR TRACK` use TURN's black ink colour instead of inheriting white
- stop the landscape chooser from stretching both track cards to fill all spare vertical space
- vertically center the compact chooser composition
- keep card previews at a deliberate landscape height so the cards, title and Continue button read as one balanced panel
- preserve the tighter fallback for very short landscape screens

This is intentionally a presentation-only hotfix on top of r53, loaded through a cache-busted CSS override.