### PR TITLE
TURN: show the car behind each best track time

### DIFF
--- a/turn-lab/tests/multi-track-production.mjs
+++ b/turn-lab/tests/multi-track-production.mjs
@@ -4,6 +4,7 @@ import { createTrackSpatialIndex, findNearestTrackBruteForce } from '../../turn/
 import { AIRPORT_HAIRPIN_RUNOFF_ZONES, isForgivingTrackSurface } from '../../turn/tracks/airport-runoff.js';
 import {
   clearRivalsState,
+  getStoredBestLap,
   getStoredBestTime,
   saveRivalsState
 } from '../../turn/race/rival-storage.js';
@@ -19,11 +20,14 @@ globalThis.localStorage = {
 try {
   const countrysideState = {
     trackId: 'countryside',
-    competitorLaps: [{ time: 12.73, frames: Array.from({ length: 25 }, (_, index) => ({ t: index / 10 })) }]
+    competitorLaps: [
+      { time: 13.18, carId: 'sedan', frames: Array.from({ length: 25 }, (_, index) => ({ t: index / 10 })) },
+      { time: 12.73, carId: 'monster-truck', frames: Array.from({ length: 25 }, (_, index) => ({ t: index / 10 })) }
+    ]
   };
   const airportState = {
     trackId: 'airport',
-    competitorLaps: [{ time: 22.42, frames: Array.from({ length: 25 }, (_, index) => ({ t: index / 10 })) }]
+    competitorLaps: [{ time: 22.42, carId: 'race-future', frames: Array.from({ length: 25 }, (_, index) => ({ t: index / 10 })) }]
   };
 
   assert.equal(saveRivalsState(countrysideState), true);
@@ -33,6 +37,8 @@ try {
   assert.equal(storage.has('turn-personal-rivals-v1:airport'), false, 'Old Airport ghosts must not leak onto the redesigned course');
   assert.equal(getStoredBestTime('countryside'), 12.73);
   assert.equal(getStoredBestTime('airport'), 22.42);
+  assert.deepEqual(getStoredBestLap('countryside'), { time: 12.73, carId: 'monster-truck' }, 'Track 1 best summary must preserve the car that set the fastest time');
+  assert.deepEqual(getStoredBestLap('airport'), { time: 22.42, carId: 'race-future' }, 'Airport best summary must preserve the car that set the fastest time');
 
   clearRivalsState(airportState);
   assert.equal(storage.has('turn-personal-rivals-v1:airport-r50'), false, 'Reset Rivals on Airport must clear only the r50 Airport namespace');
@@ -108,6 +114,8 @@ assert.match(index, /track-select\.css\?build=20260723-r53/);
 assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260723-r53"/, 'The r53 track selector must sit before the stable Lot entry point');
 assert.match(index, /"\.\/vehicle\/physics\.js\?build=20260720-r19": "\.\/vehicle\/physics\.js\?build=20260723-r53"/, 'Production must cache-bust the collision-aware vehicle physics');
 assert.match(index, /"\.\/race\/rival-storage\.js\?build=20260720-r19": "\.\/race\/rival-storage\.js\?build=20260722-r50"/, 'Production must preserve geometry-revision-aware rival storage');
+assert.match(index, /"\.\/race\/rival-storage\.js\?build=20260722-r50": "\.\/race\/rival-storage\.js\?build=20260723-r57"/, 'Production must cache-bust the best-lap car summary storage helper');
+assert.match(index, /"\.\/ui\/track-select\.js\?build=20260722-r51": "\.\/ui\/track-select\.js\?build=20260723-r57"/, 'Production must cache-bust the selector that renders the record-setting car');
 assert.match(index, /"\.\/race\/track-spatial-index\.js\?build=20260720-r19": "\.\/race\/track-spatial-index\.js\?build=20260722-r47"/, 'Production must preserve the rebuildable track index');
 assert.match(index, /Turn the device to steer/, 'Start copy must use device-neutral language');
 assert.match(index, /Steering uses device rotation/, 'Status copy must use device-neutral language');
@@ -136,7 +144,9 @@ assert.doesNotMatch(trackSelect, /TURN WORLD TOUR/, 'The selector must drop the 
 assert.doesNotMatch(trackSelect, /TRACK → CAR → RACE/, 'The selector must drop the redundant footer instruction');
 assert.match(trackSelect, /track-card-choice-marker/, 'Each card must expose an explicit radio/check selection marker');
 assert.match(trackSelect, /track-card-summary/, 'Track name and Best time must share one deliberate bottom row');
-assert.match(trackSelect, /getStoredBestTime\(track\.id\)/, 'Selector cards must show track-specific records');
+assert.match(trackSelect, /getStoredBestLap\(track\.id\)/, 'Selector cards must read the track-specific best lap summary');
+assert.match(trackSelect, /getCarDefinition\(bestLap\.carId\)\.name\.toUpperCase\(\)/, 'Selector cards must label the car that actually set the best time');
+assert.match(trackSelect, /track-card-best-car/, 'The Best badge must reserve a dedicated record-setting car label');
 assert.match(trackSelectCss, /grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/, 'The two launch tracks must present as peer choices');
 assert.match(trackSelectCss, /\.track-select-continue \{[\s\S]*grid-column: 2;/, 'Continue must align below the second track card in landscape');
 assert.match(trackSelectCss, /\.track-card\.is-selected \.track-card-choice-marker::after \{[\s\S]*content: "✓";/, 'The selected track must have an unmistakable check indicator');
@@ -170,6 +180,7 @@ assert.match(spatialSource, /return rebuild\(nextSamples\)/);
 assert.match(rivalStorage, /airport: 'airport-r50'/, 'Airport records must stay on the r50 geometry namespace because r53 does not change the course');
 assert.match(rivalStorage, /version: 6/);
 assert.match(rivalStorage, /trackRevision: storageTrackId\(activeTrackId\)/, 'Saved rival payloads must record the geometry revision');
+assert.match(rivalStorage, /export function getStoredBestLap/, 'Storage must expose a compact best-lap summary for track selection');
 
 assert.match(airportWorld, /name = 'TURN Airport r50'/, 'The base Airport world must retain the successful r50 redesign');
 assert.match(airportWorld, /makeStartFinishDistrict\(world, samples, trackWidth\)/, 'Airport must have a deliberately designed start and finish district');
@@ -194,7 +205,7 @@ assert.match(airportRunoff, /pointInsideCapsule/, 'The run-off predicate must us
 assert.match(airportRunoffWorld, /airport-world-r51\.js\?build=20260722-r51/, 'r52 must preserve the successful r51 Airport polish');
 assert.match(airportRunoffWorld, /installHairpinRunoff\(world\)/, 'The forgiving zones must have visible paved run-off surfaces');
 assert.match(airportRunoffWorld, /RUNOFF = 0x89929b/, 'The run-off must read as a distinct service apron rather than thicker race asphalt');
-assert.doesNotMatch(airportRunoffWorld, /setAnimationLoop|requestAnimationFrame|setInterval/, 'The run-off layer must remain a one-time setup cost');
+assert.doesNotMatch(airportRunoffWorld, /setAnimationLoop|requestAnimationFrame|setInterval/, 'The Airport run-off layer must remain a one-time setup cost');
 
 assert.match(worldRender, /const worldSamples = samples\.slice\(\)/, 'Countryside async scenery must retain immutable Track 1 samples during an early track switch');
 assert.match(worldRender, /samples: worldSamples/, 'Late Countryside art modules must receive the snapshot rather than the mutable active track array');

--- a/turn/index.html
+++ b/turn/index.html
@@ -52,13 +52,15 @@
         "./race/game-state.js": "./race/game-state.js?build=20260722-r41",
         "./race/replay-system.js": "./race/replay-system.js?build=20260722-r43",
         "./race/rival-storage.js?build=20260720-r19": "./race/rival-storage.js?build=20260722-r50",
+        "./race/rival-storage.js?build=20260722-r50": "./race/rival-storage.js?build=20260723-r57",
         "./race/track-spatial-index.js?build=20260720-r19": "./race/track-spatial-index.js?build=20260722-r47",
         "./performance-monitor.js?build=20260720-r19": "./performance-monitor.js?build=20260722-r43",
         "./world-assets.js": "./world-assets.js?build=20260722-r44",
         "./vehicle/physics.js?build=20260720-r19": "./vehicle/physics.js?build=20260723-r53",
         "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260722-r42",
         "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260722-r42",
-        "./vehicle/car-models.js?build=20260720-r19": "./vehicle/car-models.js?build=20260720-r22"
+        "./vehicle/car-models.js?build=20260720-r19": "./vehicle/car-models.js?build=20260720-r22",
+        "./ui/track-select.js?build=20260722-r51": "./ui/track-select.js?build=20260723-r57"
       }
     }
   </script>

--- a/turn/index.html
+++ b/turn/index.html
@@ -36,7 +36,7 @@
   <link rel="stylesheet" href="./lap-result-toast.css?build=20260723-r53">
   <link rel="stylesheet" href="./rival-onboarding.css?build=20260723-r53">
   <link rel="stylesheet" href="./track-select.css?build=20260723-r53">
-  <link rel="stylesheet" href="./track-select-r54.css?build=20260723-r56">
+  <link rel="stylesheet" href="./track-select-r54.css?build=20260723-r57">
   <link rel="stylesheet" href="./garage/lot-r10.css?build=20260723-r53">
 
   <script src="./install-gate.js?build=20260723-r53"></script>

--- a/turn/race/rival-storage.js
+++ b/turn/race/rival-storage.js
@@ -130,21 +130,41 @@ export function clearRivalsState(state, { trackId } = {}) {
   } catch (_) {}
 }
 
-export function getStoredBestTime(trackId = DEFAULT_TRACK_ID) {
+export function getStoredBestLap(trackId = DEFAULT_TRACK_ID) {
   const activeTrackId = normalizeTrackId(trackId);
   try {
     const savedRivals = JSON.parse(localStorage.getItem(rivalKey(activeTrackId)));
-    const times = Array.isArray(savedRivals?.laps)
-      ? savedRivals.laps.map((lap) => Number(lap?.time)).filter(Number.isFinite)
-      : [];
-    if (times.length) return Math.min(...times);
+    const bestLap = Array.isArray(savedRivals?.laps)
+      ? savedRivals.laps.reduce((best, lap) => {
+        const time = Number(lap?.time);
+        if (!Number.isFinite(time)) return best;
+        if (!best || time < best.time) {
+          return {
+            time,
+            carId: normalizeVehicleId(lap?.carId)
+          };
+        }
+        return best;
+      }, null)
+      : null;
+    if (bestLap) return bestLap;
 
     if (activeTrackId === DEFAULT_TRACK_ID) {
       const oldGhost = JSON.parse(localStorage.getItem(ghostKey(activeTrackId)));
-      if (Number.isFinite(Number(oldGhost?.bestTime))) return Number(oldGhost.bestTime);
+      const legacyTime = Number(oldGhost?.bestTime);
+      if (Number.isFinite(legacyTime)) {
+        return {
+          time: legacyTime,
+          carId: DEFAULT_VEHICLE_ID
+        };
+      }
     }
   } catch (_) {}
-  return Infinity;
+  return null;
+}
+
+export function getStoredBestTime(trackId = DEFAULT_TRACK_ID) {
+  return getStoredBestLap(trackId)?.time ?? Infinity;
 }
 
 export function syncPrimaryRivalState(state) {

--- a/turn/track-select-r54.css
+++ b/turn/track-select-r54.css
@@ -45,6 +45,21 @@
   box-shadow: 4px 4px 0 var(--ink);
 }
 
+.track-card-best-car {
+  display: block;
+  margin-top: 3px;
+  font-size: clamp(0.58rem, 1.05vw, 0.74rem);
+  font-weight: 900;
+  line-height: 1.05;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  opacity: 0.72;
+}
+
+.track-card-best-car[hidden] {
+  display: none;
+}
+
 @media (max-height: 820px) and (orientation: landscape) {
   .track-select {
     place-items: center;

--- a/turn/ui/track-select.js
+++ b/turn/ui/track-select.js
@@ -4,7 +4,8 @@ import {
   loadTrackSelection,
   normalizeTrackId
 } from '../tracks/catalog.js?build=20260722-r50';
-import { getStoredBestTime } from '../race/rival-storage.js?build=20260722-r50';
+import { getStoredBestLap } from '../race/rival-storage.js?build=20260722-r50';
+import { getCarDefinition } from '../vehicle/catalog.js?build=20260720-r19';
 
 let activeRequest = null;
 
@@ -121,7 +122,9 @@ function renderTrackCard(track) {
           <strong class="track-card-name">${track.name.toUpperCase()}</strong>
         </span>
         <span class="track-card-best" data-track-best="${track.id}">
-          <span>BEST</span><strong>--:--.---</strong>
+          <span>BEST</span>
+          <strong class="track-card-best-time">--:--.---</strong>
+          <small class="track-card-best-car" hidden></small>
         </span>
       </span>
     </button>
@@ -159,9 +162,16 @@ function makePreviewSvg(trackId, accent) {
 
 function refreshBestTimes(overlay) {
   for (const track of TRACK_CATALOG) {
-    const best = getStoredBestTime(track.id);
-    const strong = overlay.querySelector(`[data-track-best="${track.id}"] strong`);
-    if (strong) strong.textContent = formatTime(best);
+    const bestLap = getStoredBestLap(track.id);
+    const bestBox = overlay.querySelector(`[data-track-best="${track.id}"]`);
+    const time = bestBox?.querySelector('.track-card-best-time');
+    const car = bestBox?.querySelector('.track-card-best-car');
+
+    if (time) time.textContent = formatTime(bestLap?.time ?? Infinity);
+    if (car) {
+      car.textContent = bestLap ? getCarDefinition(bestLap.carId).name.toUpperCase() : '';
+      car.hidden = !bestLap;
+    }
   }
 }
 


### PR DESCRIPTION
Small track-selector enhancement on top of the current main branch.

- reads the actual fastest stored lap for each track, including its recorded car ID
- shows the car name directly under the best time in the BEST badge
- keeps NO TIME YET clean by hiding the car row when there is no record
- preserves legacy countryside ghost compatibility by using the same Sedan fallback already used during rival migration
- adds targeted module and stylesheet cache-busting so the updated selector/storage code reaches installed iOS web apps