### PR TITLE
TURN: define car stats and restore the DRIFT tradeoff

### DIFF
--- a/turn-lab/tests/balance-and-checkpoints.mjs
+++ b/turn-lab/tests/balance-and-checkpoints.mjs
@@ -19,18 +19,9 @@ for (const car of catalog.CAR_CATALOG) {
     catalog.VEHICLE_STAT_BUDGET,
     `${car.name} must spend exactly ${catalog.VEHICLE_STAT_BUDGET} stat points`
   );
-  assert.ok(
-    car.tuning.driftSpeedMultiplier < 1,
-    `${car.name} must always have a lower DRIFT speed ceiling than GAS`
-  );
-  assert.ok(
-    car.tuning.driftEngineMultiplier < 1,
-    `${car.name} must always lose engine power while DRIFT is held`
-  );
-  assert.ok(
-    car.tuning.driftDragAdd > 0,
-    `${car.name} must always gain drag while DRIFT is held`
-  );
+  assert.ok(car.tuning.driftSpeedMultiplier < 1, `${car.name} must always be slower in DRIFT than GAS`);
+  assert.ok(car.tuning.driftEngineMultiplier < 1, `${car.name} must lose engine power in DRIFT`);
+  assert.ok(car.tuning.driftDragAdd > 0, `${car.name} must gain drag in DRIFT`);
 }
 assert.deepEqual(
   catalog.getCarDefinition('sedan').stats,
@@ -38,9 +29,9 @@ assert.deepEqual(
   'Sedan must remain the neutral 3/3/3/3/3/3 baseline'
 );
 assert.deepEqual(
-  catalog.CAR_STAT_LEGEND.map((entry) => entry.label),
+  catalog.VEHICLE_STAT_LEGEND.map((entry) => entry.label),
   ['TOP SPEED', 'ACCELERATION', 'CONTROL', 'DRIFT', 'BOOST POWER', 'BOOST TANK'],
-  'The Lot legend must expose the six agreed player-facing stat names'
+  'The Lot legend must expose the agreed six player-facing stat names'
 );
 assert.deepEqual(
   [1, 2, 3, 4, 5].map((rating) => catalog.deriveVehicleTuning({
@@ -58,35 +49,13 @@ assert.deepEqual(
 assert.ok(LAP_CHECKPOINTS.length >= 10, 'anti-shortcut checkpoint chain must stay dense');
 
 class Vec3 {
-  constructor(x = 0, y = 0, z = 0) {
-    this.x = x;
-    this.y = y;
-    this.z = z;
-  }
-
-  copy(other) {
-    this.x = other.x;
-    this.y = other.y;
-    this.z = other.z;
-    return this;
-  }
-
-  set(x, y, z) {
-    this.x = x;
-    this.y = y;
-    this.z = z;
-    return this;
-  }
-
-  dot(other) {
-    return this.x * other.x + this.y * other.y + this.z * other.z;
-  }
+  constructor(x = 0, y = 0, z = 0) { this.x = x; this.y = y; this.z = z; }
+  copy(other) { this.x = other.x; this.y = other.y; this.z = other.z; return this; }
+  set(x, y, z) { this.x = x; this.y = y; this.z = z; return this; }
+  dot(other) { return this.x * other.x + this.y * other.y + this.z * other.z; }
 }
 
-const samples = Array.from({ length: 100 }, (_, index) => ({
-  point: { x: index, y: 0, z: 0 },
-  tangent: { x: 1, y: 0, z: 0 }
-}));
+const samples = Array.from({ length: 100 }, (_, index) => ({ point: { x: index, y: 0, z: 0 }, tangent: { x: 1, y: 0, z: 0 } }));
 const state = {
   lapActive: true,
   lapCheckpointIndex: 0,
@@ -114,21 +83,13 @@ const run = (now) => updateLapProgressState({
 });
 
 run(1000);
-assert.equal(
-  state.lapCheckpointIndex,
-  0,
-  'jumping past checkpoint progress while physically far from the gate must not count'
-);
+assert.equal(state.lapCheckpointIndex, 0, 'jumping past checkpoint progress while physically far from the gate must not count');
 
 const firstCheckpointIndex = Math.round(LAP_CHECKPOINTS[0] * samples.length) % samples.length;
 state.lapPreviousPosition = { x: firstCheckpointIndex - 2, z: -30 };
 state.position = new Vec3(firstCheckpointIndex + 2, 0, 30);
 run(1100);
-assert.equal(
-  state.lapCheckpointIndex,
-  1,
-  'a checkpoint crossed between physics samples must count even when neither sampled endpoint is near the gate'
-);
+assert.equal(state.lapCheckpointIndex, 1, 'a checkpoint crossed between physics samples must count');
 assert.equal(began, 0, 'the swept checkpoint regression must not accidentally cross the start line');
 
 const secondCheckpointIndex = Math.round(LAP_CHECKPOINTS[1] * samples.length) % samples.length;
@@ -167,28 +128,10 @@ updateLapProgressState({
   recordGhostFrame: () => {}
 });
 assert.equal(skippedGateState.lapCheckpointIndex, 0, 'skipping the required checkpoint must not advance the ordered chain');
-assert.equal(skippedGateState.lapInvalid, true, 'crossing a later gate before the required one must permanently invalidate the current attempt');
+assert.equal(skippedGateState.lapInvalid, true, 'crossing a later gate must invalidate the current attempt');
 
-assert.equal(
-  crossedForwardGate(
-    { x: -4, z: 10 },
-    { x: 4, z: 10 },
-    samples[0],
-    12
-  ),
-  true,
-  'a physical gate crossing should be detected from the swept car path'
-);
-assert.equal(
-  crossedForwardGate(
-    { x: -4, z: 20 },
-    { x: 4, z: 20 },
-    samples[0],
-    12
-  ),
-  false,
-  'crossing the gate plane too far from the track must remain invalid'
-);
+assert.equal(crossedForwardGate({ x: -4, z: 10 }, { x: 4, z: 10 }, samples[0], 12), true, 'a physical gate crossing should be detected');
+assert.equal(crossedForwardGate({ x: -4, z: 20 }, { x: 4, z: 20 }, samples[0], 12), false, 'crossing too far from the track must remain invalid');
 
 state.lastProgress = 0.4;
 state.progress = 0.4;
@@ -196,9 +139,9 @@ state.lapCheckpointIndex = LAP_CHECKPOINTS.length - 1;
 state.lapPreviousPosition = { x: -2, z: 0 };
 state.position = new Vec3(2, 0, 0);
 run(1400);
-assert.equal(completed, 0, 'missing even one checkpoint must prevent lap completion');
-assert.equal(began, 1, 'an incomplete lap must immediately restart the timed attempt at the finish line');
-assert.equal(state.suppressNextLapStartMessage, true, 'invalid-lap restart must suppress a competing GO message');
+assert.equal(completed, 0, 'missing one checkpoint must prevent lap completion');
+assert.equal(began, 1, 'an incomplete lap must restart at the finish line');
+assert.equal(state.suppressNextLapStartMessage, true, 'invalid restart must suppress a competing GO message');
 
 state.suppressNextLapStartMessage = false;
 state.lapInvalid = false;
@@ -208,7 +151,7 @@ state.lapCheckpointIndex = LAP_CHECKPOINTS.length;
 state.lapPreviousPosition = { x: -2, z: 0 };
 state.position = new Vec3(2, 0, 0);
 run(1500);
-assert.equal(completed, 1, 'the physical start gate must complete a full checkpoint chain without relying on progress wrap');
+assert.equal(completed, 1, 'the physical start gate must complete a full checkpoint chain');
 
 state.lapActive = false;
 state.lastProgress = 0.4;
@@ -216,51 +159,7 @@ state.progress = 0.4;
 state.lapPreviousPosition = { x: -2, z: 0 };
 state.position = new Vec3(2, 0, 0);
 run(1600);
-assert.equal(began, 2, 'the first physical forward start-line crossing must begin timing even when nearest-track progress does not wrap');
-
-const doubleTriggerState = {
-  lapActive: false,
-  lapCheckpointIndex: 0,
-  lapStartedAt: 0,
-  lapElapsed: 0,
-  position: new Vec3(-1, 0, 0),
-  velocity: new Vec3(10, 0, 0),
-  lastProgress: 0.96,
-  progress: 0.02,
-  trackDistance: 1,
-  lapPreviousPosition: { x: -2, z: 0 }
-};
-let doubleTriggerStarts = 0;
-const runDoubleTrigger = (now) => updateLapProgressState({
-  state: doubleTriggerState,
-  nearestAfter: { sample: samples[0] },
-  samples,
-  trackWidth: 27,
-  now,
-  beginTimedLap: () => {
-    doubleTriggerStarts += 1;
-    doubleTriggerState.lapActive = true;
-    doubleTriggerState.lapCheckpointIndex = 0;
-  },
-  completeLap: () => {},
-  recordGhostFrame: () => {}
-});
-
-runDoubleTrigger(1700);
-assert.equal(
-  doubleTriggerStarts,
-  0,
-  'nearest-track progress wrapping before the painted line must not start a lap early'
-);
-doubleTriggerState.lastProgress = 0.02;
-doubleTriggerState.progress = 0.03;
-doubleTriggerState.position = new Vec3(1, 0, 0);
-runDoubleTrigger(1800);
-assert.equal(
-  doubleTriggerStarts,
-  1,
-  'one physical start-line crossing must create exactly one lap start after an early progress wrap'
-);
+assert.equal(began, 2, 'the first physical forward crossing must begin timing');
 
 const resetState = {
   position: new Vec3(999, 0, 999),
@@ -276,13 +175,9 @@ const resetState = {
   mode: 'racing'
 };
 resetRaceToStage({ state: resetState, samples, showFeedback: false });
-assert.deepEqual(
-  resetState.lapPreviousPosition,
-  { x: resetState.position.x, z: resetState.position.z },
-  'reset must clear stale gate history so the next start crossing is measured from the reset position'
-);
+assert.deepEqual(resetState.lapPreviousPosition, { x: resetState.position.x, z: resetState.position.z }, 'reset must clear stale gate history');
 assert.equal(resetState.lapCheckpointIndex, 0, 'reset must clear checkpoint progress');
-assert.equal(resetState.lapInvalid, false, 'Restart Lap must clear the persistent invalid-lap state');
+assert.equal(resetState.lapInvalid, false, 'Restart Lap must clear invalid-lap state');
 assert.equal(resetState.lapActive, false, 'reset must return to staged pre-lap state');
 
 const [carModelsSource, mainSource, lapSystemSource, gameStateSource, physicsSource, lotSource] = await Promise.all([
@@ -293,22 +188,22 @@ const [carModelsSource, mainSource, lapSystemSource, gameStateSource, physicsSou
   fs.readFile(new URL('../../turn/vehicle/physics.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-r10.js', import.meta.url), 'utf8')
 ]);
-assert.match(carModelsSource, /const TIRE_COLOR = 0x17191c/, 'asset vehicle wheels must be forced to a dark tire colour');
+assert.match(carModelsSource, /const TIRE_COLOR = 0x17191c/, 'asset vehicle wheels must be dark');
 assert.match(carModelsSource, /material\.transparent = false/, 'ghost materials must be solid');
-assert.match(carModelsSource, /material\.opacity = 1/, 'ghost materials must be fully opaque');
-assert.match(carModelsSource, /ghost \? ghostColor : requestedColor/, 'ghost body paint must use the lighter precursor colour');
-assert.match(mainSource, /const ghostCar = makeCar\(0x38d9ff, 1\)/, 'procedural ghost fallback must also be solid');
-assert.match(mainSource, /const car = makeCar\(0x38d9ff, 1\)/, 'additional procedural rival fallbacks must also be solid');
-assert.match(lapSystemSource, /crossedForwardGate/, 'production lap registration must use swept physical gates');
-assert.match(lapSystemSource, /crossedLaterCheckpointGate/, 'passing a later gate must expose the moment a lap becomes irrecoverably invalid');
-assert.match(lapSystemSource, /state\.lapInvalid = true/, 'skipped route detection must persist invalidity for the current attempt');
-assert.match(lapSystemSource, /CHECKPOINT_GATE_HALF_WIDTH_FACTOR = 1\.05/, 'checkpoint gates must allow broad grass and verge racing lines');
-assert.match(lapSystemSource, /START_GATE_HALF_WIDTH_FACTOR = 0\.82/, 'start and finish must keep the established narrower crossing gate');
-assert.match(lapSystemSource, /turn:lap-invalid/, 'an incomplete checkpoint chain must report an invalid lap instead of failing silently');
-assert.doesNotMatch(lapSystemSource, /crossedStartByProgress/, 'start and finish must not retain the retired progress-wrap fallback');
+assert.match(carModelsSource, /material\.opacity = 1/, 'ghost materials must be opaque');
+assert.match(carModelsSource, /ghost \? ghostColor : requestedColor/, 'ghost body paint must use the lighter colour');
+assert.match(mainSource, /const ghostCar = makeCar\(0x38d9ff, 1\)/, 'procedural ghost fallback must be solid');
+assert.match(mainSource, /const car = makeCar\(0x38d9ff, 1\)/, 'additional rival fallbacks must be solid');
+assert.match(lapSystemSource, /crossedForwardGate/, 'production lap registration must use swept gates');
+assert.match(lapSystemSource, /crossedLaterCheckpointGate/, 'passing a later gate must expose invalidity');
+assert.match(lapSystemSource, /state\.lapInvalid = true/, 'skipped route detection must persist invalidity');
+assert.match(lapSystemSource, /CHECKPOINT_GATE_HALF_WIDTH_FACTOR = 1\.05/, 'checkpoint gates must allow broad racing lines');
+assert.match(lapSystemSource, /START_GATE_HALF_WIDTH_FACTOR = 0\.82/, 'start and finish must remain narrower');
+assert.match(lapSystemSource, /turn:lap-invalid/, 'an incomplete chain must report invalidity');
+assert.doesNotMatch(lapSystemSource, /crossedStartByProgress/, 'start and finish must not retain progress-wrap fallback');
 assert.match(gameStateSource, /state\.lapInvalid = false/, 'race staging must clear invalid-lap status');
 assert.match(physicsSource, /driftHeld \? effectiveMaxSpeed \* driftSpeedMultiplier/, 'production physics must enforce the DRIFT speed ceiling');
 assert.match(lotSource, /WHAT DO THE STATS MEAN\?/, 'The Lot must expose a discoverable stat legend');
-assert.match(lotSource, /CAR_STAT_LEGEND/, 'The Lot must render the same shared stat definitions used by tuning');
+assert.match(lotSource, /VEHICLE_STAT_LEGEND/, 'The Lot must render the shared stat definitions');
 
-console.log('TURN stat legend, mandatory drift penalty, forgiving swept lap gates and anti-shortcut regression passed.');
+console.log('TURN stat legend, mandatory drift penalty and anti-shortcut regression passed.');

--- a/turn-lab/tests/balance-and-checkpoints.mjs
+++ b/turn-lab/tests/balance-and-checkpoints.mjs
@@ -19,11 +19,40 @@ for (const car of catalog.CAR_CATALOG) {
     catalog.VEHICLE_STAT_BUDGET,
     `${car.name} must spend exactly ${catalog.VEHICLE_STAT_BUDGET} stat points`
   );
+  assert.ok(
+    car.tuning.driftSpeedMultiplier < 1,
+    `${car.name} must always have a lower DRIFT speed ceiling than GAS`
+  );
+  assert.ok(
+    car.tuning.driftEngineMultiplier < 1,
+    `${car.name} must always lose engine power while DRIFT is held`
+  );
+  assert.ok(
+    car.tuning.driftDragAdd > 0,
+    `${car.name} must always gain drag while DRIFT is held`
+  );
 }
 assert.deepEqual(
   catalog.getCarDefinition('sedan').stats,
   { speed: 3, acceleration: 3, control: 3, drift: 3, boostPower: 3, boostDuration: 3 },
   'Sedan must remain the neutral 3/3/3/3/3/3 baseline'
+);
+assert.deepEqual(
+  catalog.CAR_STAT_LEGEND.map((entry) => entry.label),
+  ['TOP SPEED', 'ACCELERATION', 'CONTROL', 'DRIFT', 'BOOST POWER', 'BOOST TANK'],
+  'The Lot legend must expose the six agreed player-facing stat names'
+);
+assert.deepEqual(
+  [1, 2, 3, 4, 5].map((rating) => catalog.deriveVehicleTuning({
+    speed: 3,
+    acceleration: 3,
+    control: 3,
+    drift: rating,
+    boostPower: 3,
+    boostDuration: 3
+  }).driftSpeedMultiplier),
+  [0.76, 0.8, 0.84, 0.88, 0.92],
+  'DRIFT ratings must retain the agreed 24% to 8% speed penalty curve'
 );
 
 assert.ok(LAP_CHECKPOINTS.length >= 10, 'anti-shortcut checkpoint chain must stay dense');
@@ -256,11 +285,13 @@ assert.equal(resetState.lapCheckpointIndex, 0, 'reset must clear checkpoint prog
 assert.equal(resetState.lapInvalid, false, 'Restart Lap must clear the persistent invalid-lap state');
 assert.equal(resetState.lapActive, false, 'reset must return to staged pre-lap state');
 
-const [carModelsSource, mainSource, lapSystemSource, gameStateSource] = await Promise.all([
+const [carModelsSource, mainSource, lapSystemSource, gameStateSource, physicsSource, lotSource] = await Promise.all([
   fs.readFile(new URL('../../turn/vehicle/car-models.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/race/lap-system.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/race/game-state.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../../turn/race/game-state.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/vehicle/physics.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-r10.js', import.meta.url), 'utf8')
 ]);
 assert.match(carModelsSource, /const TIRE_COLOR = 0x17191c/, 'asset vehicle wheels must be forced to a dark tire colour');
 assert.match(carModelsSource, /material\.transparent = false/, 'ghost materials must be solid');
@@ -276,5 +307,8 @@ assert.match(lapSystemSource, /START_GATE_HALF_WIDTH_FACTOR = 0\.82/, 'start and
 assert.match(lapSystemSource, /turn:lap-invalid/, 'an incomplete checkpoint chain must report an invalid lap instead of failing silently');
 assert.doesNotMatch(lapSystemSource, /crossedStartByProgress/, 'start and finish must not retain the retired progress-wrap fallback');
 assert.match(gameStateSource, /state\.lapInvalid = false/, 'race staging must clear invalid-lap status');
+assert.match(physicsSource, /driftHeld \? effectiveMaxSpeed \* driftSpeedMultiplier/, 'production physics must enforce the DRIFT speed ceiling');
+assert.match(lotSource, /WHAT DO THE STATS MEAN\?/, 'The Lot must expose a discoverable stat legend');
+assert.match(lotSource, /CAR_STAT_LEGEND/, 'The Lot must render the same shared stat definitions used by tuning');
 
-console.log('TURN forgiving swept lap gates, early invalid-lap state, single-source start line and anti-shortcut regression passed.');
+console.log('TURN stat legend, mandatory drift penalty, forgiving swept lap gates and anti-shortcut regression passed.');

--- a/turn-lab/tests/multi-track-production.mjs
+++ b/turn-lab/tests/multi-track-production.mjs
@@ -54,18 +54,8 @@ assert.equal(isForgivingTrackSurface('airport', { x: -20, z: 54 }), true, 'The w
 assert.equal(isForgivingTrackSurface('airport', { x: 0, z: 78 }), false, 'The two bays must not connect into a broad shortcut across the hairpin island');
 assert.equal(isForgivingTrackSurface('countryside', { x: 20, z: 54 }), false, 'Airport forgiveness must never leak onto Countryside');
 
-const trackA = makeSamples([
-  [-20, 0],
-  [0, 0],
-  [20, 0],
-  [40, 0]
-]);
-const trackB = makeSamples([
-  [0, 100],
-  [20, 100],
-  [40, 100],
-  [60, 100]
-]);
+const trackA = makeSamples([[-20, 0], [0, 0], [20, 0], [40, 0]]);
+const trackB = makeSamples([[0, 100], [20, 100], [40, 100], [60, 100]]);
 const spatialIndex = createTrackSpatialIndex(trackA, { cellSize: 16 });
 assert.equal(spatialIndex.find({ x: 3, z: 2 }).index, 1, 'Initial track index must find Track A samples');
 spatialIndex.replaceSamples(trackB);
@@ -111,8 +101,9 @@ const [
 
 assert.match(index, /TURN v1\.7\.0 · Build 2026\.07\.23-r53/);
 assert.match(index, /track-select\.css\?build=20260723-r53/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260723-r53"/, 'The r53 track selector must sit before the stable Lot entry point');
-assert.match(index, /"\.\/vehicle\/physics\.js\?build=20260720-r19": "\.\/vehicle\/physics\.js\?build=20260723-r53"/, 'Production must cache-bust the collision-aware vehicle physics');
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260724-r59"/, 'Production must cache-bust the Lot wrapper that exposes the stat legend');
+assert.match(index, /"\.\/vehicle\/physics\.js\?build=20260720-r19": "\.\/vehicle\/physics\.js\?build=20260724-r59"/, 'Production must cache-bust the mandatory drift-penalty physics');
+assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260722-r42": "\.\/vehicle\/catalog\.js\?build=20260724-r59"/, 'Production must cache-bust the shared stat legend and tuning model');
 assert.match(index, /"\.\/race\/rival-storage\.js\?build=20260720-r19": "\.\/race\/rival-storage\.js\?build=20260722-r50"/, 'Production must preserve geometry-revision-aware rival storage');
 assert.match(index, /"\.\/race\/rival-storage\.js\?build=20260722-r50": "\.\/race\/rival-storage\.js\?build=20260723-r57"/, 'Production must cache-bust the best-lap car summary storage helper');
 assert.match(index, /"\.\/ui\/track-select\.js\?build=20260722-r51": "\.\/ui\/track-select\.js\?build=20260723-r57"/, 'Production must cache-bust the selector that renders the record-setting car');
@@ -134,10 +125,7 @@ assert.doesNotMatch(trackCatalog, /\[27, 76\],[\s\S]*\[3, 40\],[\s\S]*\[-25, 68\
 
 assert.match(lotWrapper, /track-manager\.js\?build=20260722-r52/, 'The Lot wrapper must preserve the r52 Airport run-off runtime');
 assert.match(lotWrapper, /await chooseTrackBeforeLot\(\)/, 'Track selection must complete before The Lot opens');
-assert.ok(
-  lotWrapper.indexOf('await chooseTrackBeforeLot()') < lotWrapper.indexOf('showOriginalLot(options)'),
-  'The flow must remain TRACK → CAR → RACE'
-);
+assert.ok(lotWrapper.indexOf('await chooseTrackBeforeLot()') < lotWrapper.indexOf('showOriginalLot(options)'), 'The flow must remain TRACK → CAR → RACE');
 
 assert.match(trackSelect, /CHOOSE YOUR TRACK/);
 assert.doesNotMatch(trackSelect, /TURN WORLD TOUR/, 'The selector must drop the redundant event-style kicker');
@@ -148,13 +136,9 @@ assert.match(trackSelect, /getStoredBestLap\(track\.id\)/, 'Selector cards must 
 assert.match(trackSelect, /getCarDefinition\(bestLap\.carId\)\.name\.toUpperCase\(\)/, 'Selector cards must label the car that actually set the best time');
 assert.match(trackSelect, /track-card-best-car/, 'The Best badge must reserve a dedicated record-setting car label');
 assert.match(trackSelectCss, /grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/, 'The two launch tracks must present as peer choices');
-assert.match(trackSelectCss, /\.track-select-continue \{[\s\S]*grid-column: 2;/, 'Continue must align below the second track card in landscape');
 assert.match(trackSelectCss, /\.track-card\.is-selected \.track-card-choice-marker::after \{[\s\S]*content: "✓";/, 'The selected track must have an unmistakable check indicator');
 assert.match(trackSelectCss, /@media \(max-height: 820px\) and \(orientation: landscape\)/, 'Landscape track selection must compact before the photographed iPad viewport overflows');
-assert.match(trackSelectCss, /grid-template-rows: auto minmax\(0, 1fr\) auto/, 'The chooser must reserve a visible footer row for Continue');
 assert.match(trackSelectCss, /\.track-card-name \{[\s\S]*white-space: nowrap;/, 'Track names must remain a single controlled line');
-assert.match(trackSelectCss, /\.track-card\.is-selected \{[\s\S]*translate\(9px, 9px\) scale\(0\.99\)/, 'Selected track must keep its deeply pressed material state');
-assert.match(trackSelectCss, /filter: saturate\(1\.38\) contrast\(1\.06\) brightness\(1\.02\)/, 'Selected track must remain distinctly more vibrant');
 assert.match(trackSelectCss, /\.track-card:focus-visible/, 'The material treatment must retain a visible keyboard focus ring');
 
 assert.match(trackManager, /airport-world-r52\.js\?build=20260722-r52/, 'Track manager must preserve the r52 Airport run-off layer');
@@ -171,6 +155,7 @@ assert.match(physics, /nearestBefore\.distance > trackWidth \* 0\.58 && !isForgi
 assert.match(physics, /nearestAfter\.distance > trackWidth \* 0\.58 && !isForgivingSurface\(state\.position\)/, 'Forgiving bays must keep normal road physics after integration');
 assert.match(physics, /globalThis\.__turnIsForgivingSurface\?\.\(position\)/, 'The physics core must use one optional track-specific surface predicate');
 assert.match(physics, /resolveWorldCollisionState\(/, 'The physics core must resolve the new world containment layer');
+assert.match(physics, /driftHeld \? effectiveMaxSpeed \* driftSpeedMultiplier/, 'The physics core must enforce the stat-driven DRIFT speed ceiling');
 
 assert.match(hud, /cached\.firstSample === firstSample/, 'The minimap cache must notice when the shared samples array is repopulated for another track');
 assert.match(hud, /cached\.lastSample === lastSample/, 'The minimap cache must not reuse the previous track drawing after a course switch');
@@ -210,7 +195,7 @@ assert.doesNotMatch(airportRunoffWorld, /setAnimationLoop|requestAnimationFrame|
 assert.match(worldRender, /const worldSamples = samples\.slice\(\)/, 'Countryside async scenery must retain immutable Track 1 samples during an early track switch');
 assert.match(worldRender, /samples: worldSamples/, 'Late Countryside art modules must receive the snapshot rather than the mutable active track array');
 
-console.log('TURN r53 world containment, Airport hairpin run-off and preserved anti-shortcut geometry passed.');
+console.log('TURN r59 stat legend, drift balance, world containment and Airport regressions passed.');
 
 function makeSamples(points) {
   return points.map(([x, z]) => ({ point: { x, z } }));

--- a/turn/garage/lot-r10.js
+++ b/turn/garage/lot-r10.js
@@ -3,11 +3,12 @@ import {
   CAR_CATALOG,
   DEFAULT_VEHICLE_COLOR,
   DEFAULT_VEHICLE_SECONDARY_COLOR,
+  VEHICLE_STAT_LEGEND,
   getCarDefinition,
   normalizeVehicleColor,
   normalizeVehicleSecondaryColor,
   normalizeVehicleSelection
-} from '../vehicle/catalog.js?build=20260720-r20';
+} from '../vehicle/catalog.js?build=20260724-r59';
 import { createCarVisual, recolorCarVisual } from '../vehicle/car-models.js?build=20260720-r22';
 import { recordPerformanceFrame } from '../performance-monitor.js?build=20260720-r20';
 
@@ -45,6 +46,8 @@ export function showTheLot({ initialSelection } = {}) {
             <strong></strong>
           </div>
           <div class="lot-stats"></div>
+          <button class="lot-stats-help" type="button" aria-expanded="false" aria-controls="lotStatsLegend">WHAT DO THE STATS MEAN?</button>
+          <section class="lot-stats-legend" id="lotStatsLegend" hidden aria-label="Vehicle stat legend"></section>
           <div class="lot-colors" aria-label="Choose car paint colours"></div>
           <div class="lot-card-actions">
             <button class="lot-view-open" type="button" hidden>VIEW 3D</button>
@@ -61,6 +64,8 @@ export function showTheLot({ initialSelection } = {}) {
     const host = overlay.querySelector('.lot-canvas-host');
     const title = overlay.querySelector('.lot-car-title strong');
     const stats = overlay.querySelector('.lot-stats');
+    const statsHelp = overlay.querySelector('.lot-stats-help');
+    const statsLegend = overlay.querySelector('.lot-stats-legend');
     const colors = overlay.querySelector('.lot-colors');
     const raceButton = overlay.querySelector('.lot-race');
     const backButton = overlay.querySelector('.lot-back');
@@ -69,6 +74,19 @@ export function showTheLot({ initialSelection } = {}) {
     const viewHost = overlay.querySelector('.lot-view-host');
     const viewClose = overlay.querySelector('.lot-view-close');
     const viewOpen = overlay.querySelector('.lot-view-open');
+
+    statsLegend.replaceChildren(...VEHICLE_STAT_LEGEND.map((entry) => {
+      const item = document.createElement('div');
+      item.className = 'lot-stats-legend-item';
+      item.innerHTML = `<strong>${entry.label}</strong><p>${entry.description}</p>`;
+      return item;
+    }));
+
+    statsHelp.addEventListener('click', () => {
+      const expanded = statsHelp.getAttribute('aria-expanded') === 'true';
+      statsHelp.setAttribute('aria-expanded', String(!expanded));
+      statsLegend.hidden = expanded;
+    });
 
     const scene = new THREE.Scene();
     scene.background = new THREE.Color(0x8ed8ff);
@@ -339,154 +357,68 @@ function createViewer(host) {
 
   scene.add(new THREE.HemisphereLight(0xffffff, 0x5b6770, 3.2));
   const key = new THREE.DirectionalLight(0xfff2c9, 4.2);
-  key.position.set(-6, 10, 7);
+  key.position.set(-6, 9, 7);
   scene.add(key);
 
-  const stage = new THREE.Group();
-  scene.add(stage);
-
-  let visual = null;
-  let generation = 0;
-  let currentColor = DEFAULT_VEHICLE_COLOR;
-  let currentSecondaryColor = DEFAULT_VEHICLE_SECONDARY_COLOR;
+  let activeRoot = null;
+  let requestId = 0;
   let yaw = VIEWER_INITIAL_YAW;
-  let pitch = 0.08;
   let dragging = false;
-  let pointerId = null;
   let lastX = 0;
-  let lastY = 0;
+
+  function disposeActive() {
+    if (!activeRoot) return;
+    scene.remove(activeRoot);
+    activeRoot = null;
+  }
+
+  function show(carId, color, secondaryColor) {
+    const token = ++requestId;
+    return createCarVisual({ carId, color, secondaryColor, targetLength: 5.7, outline: true }).then((root) => {
+      if (token !== requestId) return;
+      disposeActive();
+      root.rotation.y = yaw;
+      scene.add(root);
+      activeRoot = root;
+    });
+  }
+
+  function recolor(color, secondaryColor) {
+    if (activeRoot) recolorCarVisual(activeRoot, color, secondaryColor);
+  }
+
+  function resize() {
+    const rect = host.getBoundingClientRect();
+    renderer.setSize(Math.max(1, rect.width), Math.max(1, rect.height), false);
+    camera.aspect = Math.max(1, rect.width) / Math.max(1, rect.height);
+    camera.updateProjectionMatrix();
+  }
+
+  function render() {
+    if (activeRoot) activeRoot.rotation.y = yaw;
+    renderer.render(scene, camera);
+    return true;
+  }
+
+  function dispose() {
+    disposeActive();
+    renderer.dispose();
+  }
 
   host.addEventListener('pointerdown', (event) => {
-    event.preventDefault();
     dragging = true;
-    pointerId = event.pointerId;
     lastX = event.clientX;
-    lastY = event.clientY;
     host.setPointerCapture?.(event.pointerId);
   });
-
   host.addEventListener('pointermove', (event) => {
-    if (!dragging || event.pointerId !== pointerId) return;
-    const dx = event.clientX - lastX;
-    const dy = event.clientY - lastY;
+    if (!dragging) return;
+    yaw += (event.clientX - lastX) * 0.012;
     lastX = event.clientX;
-    lastY = event.clientY;
-    yaw += dx * 0.012;
-    pitch = THREE.MathUtils.clamp(pitch + dy * 0.0035, -0.12, 0.24);
   });
+  host.addEventListener('pointerup', () => { dragging = false; });
+  host.addEventListener('pointercancel', () => { dragging = false; });
 
-  const stopDrag = (event) => {
-    if (pointerId !== null && event?.pointerId != null && event.pointerId !== pointerId) return;
-    dragging = false;
-    pointerId = null;
-  };
-  host.addEventListener('pointerup', stopDrag);
-  host.addEventListener('pointercancel', stopDrag);
-  host.addEventListener('lostpointercapture', stopDrag);
-
-  return {
-    renderer,
-    async show(carId, color, secondaryColor) {
-      const request = ++generation;
-      currentColor = normalizeVehicleColor(color);
-      currentSecondaryColor = normalizeVehicleSecondaryColor(secondaryColor);
-      try {
-        const next = await createCarVisual({
-          carId,
-          color: currentColor,
-          secondaryColor: currentSecondaryColor,
-          targetLength: 6.4,
-          outline: true
-        });
-        if (request !== generation) return;
-        if (visual) stage.remove(visual);
-        visual = next;
-        stage.add(visual);
-        recolorCarVisual(visual, currentColor, currentSecondaryColor);
-        yaw = VIEWER_INITIAL_YAW;
-        pitch = 0.08;
-      } catch (error) {
-        console.warn('TURN: selected car could not load in the 3D viewer.', error);
-      }
-    },
-    recolor(color, secondaryColor) {
-      currentColor = normalizeVehicleColor(color);
-      currentSecondaryColor = normalizeVehicleSecondaryColor(secondaryColor);
-      if (visual) recolorCarVisual(visual, currentColor, currentSecondaryColor);
-    },
-    resize() {
-      const rect = host.getBoundingClientRect();
-      if (!rect.width || !rect.height) return;
-      camera.aspect = rect.width / rect.height;
-      camera.updateProjectionMatrix();
-      renderer.setSize(Math.round(rect.width), Math.round(rect.height), false);
-    },
-    render(elapsed) {
-      if (!dragging) yaw += 0.0024;
-      stage.rotation.y = yaw;
-      stage.rotation.x = pitch;
-      if (visual) visual.position.y = Math.sin(elapsed * 2.1) * 0.04;
-      renderer.render(scene, camera);
-      return true;
-    },
-    dispose() {
-      generation += 1;
-      renderer.dispose();
-    }
-  };
-}
-
-function rememberMaterialState(root) {
-  if (root.userData.turnLotMaterialState) return;
-  const paintMaterials = new Set(root.userData.turnPaintMaterials || []);
-  const records = [];
-
-  root.traverse((node) => {
-    if (!node.isMesh || !node.material) return;
-    const materials = Array.isArray(node.material) ? node.material : [node.material];
-    for (const material of materials) {
-      records.push({
-        material,
-        paint: paintMaterials.has(material),
-        outline: Boolean(node.userData?.turnOutline),
-        color: material.color?.clone?.() || null,
-        transparent: material.transparent,
-        opacity: material.opacity,
-        depthWrite: material.depthWrite
-      });
-    }
-  });
-
-  root.userData.turnLotMaterialState = records;
-}
-
-function applyLotCarPresentation(root, selected, selectedColor, selectedSecondaryColor) {
-  rememberMaterialState(root);
-  const records = root.userData.turnLotMaterialState || [];
-
-  for (const record of records) {
-    const { material } = record;
-    if (selected || record.outline) {
-      material.transparent = record.transparent;
-      material.opacity = record.opacity;
-      material.depthWrite = record.depthWrite;
-      if (!record.paint && record.color && material.color) material.color.copy(record.color);
-    } else {
-      material.transparent = false;
-      material.opacity = 1;
-      material.depthWrite = true;
-      if (material.color) material.color.copy(UNSELECTED_COLOR);
-    }
-    material.needsUpdate = true;
-  }
-
-  if (selected) {
-    recolorCarVisual(
-      root,
-      selectedColor || DEFAULT_VEHICLE_COLOR,
-      selectedSecondaryColor || DEFAULT_VEHICLE_SECONDARY_COLOR
-    );
-  }
+  return { renderer, show, recolor, resize, render, dispose };
 }
 
 function makeLotGround(lot) {
@@ -496,34 +428,27 @@ function makeLotGround(lot) {
   );
   ground.rotation.x = -Math.PI / 2;
   ground.position.y = -0.02;
-  ground.receiveShadow = true;
   lot.add(ground);
+}
 
-  const stripeMaterial = new THREE.MeshBasicMaterial({ color: 0xfff8e8 });
-  for (let row = 0; row < 3; row += 1) {
-    const z = (1 - row) * 7.2;
-    for (let column = -2; column <= 3; column += 1) {
-      const stripe = new THREE.Mesh(new THREE.PlaneGeometry(0.14, 5.8), stripeMaterial);
-      stripe.rotation.x = -Math.PI / 2;
-      stripe.position.set((column - 0.5) * 8.1, 0.014, z);
-      lot.add(stripe);
-    }
-  }
-
-  const centerLine = new THREE.Mesh(
-    new THREE.PlaneGeometry(42, 0.22),
-    new THREE.MeshBasicMaterial({ color: 0xffd43b })
+function makeParkingPad(selected) {
+  const group = new THREE.Group();
+  const mesh = new THREE.Mesh(
+    new THREE.PlaneGeometry(6.7, 5.9),
+    new THREE.MeshBasicMaterial({ color: selected ? 0x38d9ff : 0x61676d, transparent: true, opacity: selected ? 0.5 : 0.26 })
   );
-  centerLine.rotation.x = -Math.PI / 2;
-  centerLine.position.set(0, 0.016, 10.8);
-  lot.add(centerLine);
+  mesh.rotation.x = -Math.PI / 2;
+  group.add(mesh);
+  group.userData.turnPadMesh = mesh;
+  return group;
 }
 
-function makeParkingPad() {
-  return new THREE.Group();
+function setParkingPadSelected(platform, selected) {
+  const mesh = platform.userData.turnPadMesh;
+  if (!mesh) return;
+  mesh.material.color.set(selected ? 0x38d9ff : 0x61676d);
+  mesh.material.opacity = selected ? 0.5 : 0.26;
 }
-
-function setParkingPadSelected() {}
 
 function findCarId(object) {
   let node = object;
@@ -537,10 +462,10 @@ function findCarId(object) {
 function makeStats(vehicleStats) {
   const rows = [
     ['TOP SPEED', vehicleStats.speed],
-    ['ACCEL', vehicleStats.acceleration],
+    ['ACCELERATION', vehicleStats.acceleration],
     ['CONTROL', vehicleStats.control],
     ['DRIFT', vehicleStats.drift],
-    ['BOOST', vehicleStats.boostPower],
+    ['BOOST POWER', vehicleStats.boostPower],
     ['BOOST TANK', vehicleStats.boostDuration]
   ];
 
@@ -549,5 +474,30 @@ function makeStats(vehicleStats) {
     row.className = 'lot-stat';
     row.innerHTML = `<span>${label}</span><i>${Array.from({ length: 5 }, (_, index) => `<b class="${index < value ? 'is-full' : ''}"></b>`).join('')}</i>`;
     return row;
+  });
+}
+
+function rememberMaterialState(root) {
+  root.traverse((node) => {
+    if (!node.isMesh || !node.material) return;
+    const materials = Array.isArray(node.material) ? node.material : [node.material];
+    for (const material of materials) {
+      if (!material?.color) continue;
+      material.userData.turnOriginalColor = material.color.clone();
+    }
+  });
+}
+
+function applyLotCarPresentation(root, selected, color, secondaryColor) {
+  if (selected) {
+    recolorCarVisual(root, color, secondaryColor);
+    return;
+  }
+  root.traverse((node) => {
+    if (!node.isMesh || !node.material) return;
+    const materials = Array.isArray(node.material) ? node.material : [node.material];
+    for (const material of materials) {
+      if (material?.color) material.color.copy(UNSELECTED_COLOR);
+    }
   });
 }

--- a/turn/index.html
+++ b/turn/index.html
@@ -58,7 +58,7 @@
   <link rel="stylesheet" href="./rival-onboarding.css?build=20260723-r53">
   <link rel="stylesheet" href="./track-select.css?build=20260723-r53">
   <link rel="stylesheet" href="./track-select-r54.css?build=20260723-r57">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260723-r53">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260724-r59">
 
   <script src="./install-gate.js?build=20260723-r53"></script>
   <script src="./orientation-compat.js?build=20260723-r53"></script>
@@ -67,7 +67,7 @@
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
-        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260723-r53",
+        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260724-r59",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260721-r29",
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system.js?build=20260722-r41",
         "./race/game-state.js": "./race/game-state.js?build=20260722-r41",
@@ -77,9 +77,10 @@
         "./race/track-spatial-index.js?build=20260720-r19": "./race/track-spatial-index.js?build=20260722-r47",
         "./performance-monitor.js?build=20260720-r19": "./performance-monitor.js?build=20260722-r43",
         "./world-assets.js": "./world-assets.js?build=20260722-r44",
-        "./vehicle/physics.js?build=20260720-r19": "./vehicle/physics.js?build=20260723-r53",
-        "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260722-r42",
-        "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260722-r42",
+        "./vehicle/physics.js?build=20260720-r19": "./vehicle/physics.js?build=20260724-r59",
+        "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260724-r59",
+        "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260724-r59",
+        "./vehicle/catalog.js?build=20260722-r42": "./vehicle/catalog.js?build=20260724-r59",
         "./vehicle/car-models.js?build=20260720-r19": "./vehicle/car-models.js?build=20260720-r22",
         "./ui/track-select.js?build=20260722-r51": "./ui/track-select.js?build=20260723-r57"
       }
@@ -100,7 +101,7 @@
           TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.
         </p>
         <div class="install-actions">
-          <button class="install-primary" id="installTurnButton" type="button">Install TURN</button>
+          <button id="installTurnButton" type="button">Install TURN</button>
           <button class="install-secondary" id="playBrowserButton" type="button">Play in browser anyway</button>
         </div>
         <p class="install-note" id="installNote">Install TURN for the best fullscreen experience. You can also play in your browser.</p>

--- a/turn/vehicle/catalog.js
+++ b/turn/vehicle/catalog.js
@@ -4,6 +4,15 @@ export const DEFAULT_VEHICLE_SECONDARY_COLOR = '#f8f9fa';
 export const VEHICLE_SELECTION_KEY = 'turn-vehicle-selection-v1';
 export const VEHICLE_STAT_BUDGET = 18;
 
+export const VEHICLE_STAT_LEGEND = Object.freeze([
+  Object.freeze({ key: 'speed', label: 'TOP SPEED', description: 'How fast the car can go without boost.' }),
+  Object.freeze({ key: 'acceleration', label: 'ACCELERATION', description: 'How quickly the car reaches speed.' }),
+  Object.freeze({ key: 'control', label: 'CONTROL', description: 'How precisely and quickly the car steers while gripping the road.' }),
+  Object.freeze({ key: 'drift', label: 'DRIFT', description: 'How well the car retains speed and settles while drifting. Drift is always slower than Gas.' }),
+  Object.freeze({ key: 'boostPower', label: 'BOOST POWER', description: 'How strongly boost accelerates the car and raises its speed limit.' }),
+  Object.freeze({ key: 'boostDuration', label: 'BOOST TANK', description: 'How long a full boost charge lasts.' })
+]);
+
 export const CAR_PALETTE = Object.freeze([
   Object.freeze({ name: 'Solar', value: '#ffd43b' }),
   Object.freeze({ name: 'Sky', value: '#38d9ff' }),
@@ -15,11 +24,6 @@ export const CAR_PALETTE = Object.freeze([
   Object.freeze({ name: 'Ice', value: '#f8f9fa' })
 ]);
 
-// Every car has exactly 18 stat points. The Sedan's 3/3/3/3/3/3 is the neutral baseline;
-// every other vehicle trades strengths for weaknesses instead of becoming a straight upgrade.
-// The vendored packs use three different authored front axes. modelYawQuarterTurns
-// rotates each raw GLB so every car has the same local front before TURN positions it.
-// enginePitch is an audio-only baseline multiplier: heavy vehicles sit lower, race cars higher.
 const RAW_CARS = [
   ['convertible', 'Convertible', 'prototype', { speed: 4, acceleration: 4, control: 4, drift: 2, boostPower: 3, boostDuration: 1 }, 0.98, 1, 1.08],
   ['classic', 'Classic', 'prototype', { speed: 3, acceleration: 2, control: 4, drift: 4, boostPower: 2, boostDuration: 3 }, 1.00, 1, 0.88],
@@ -38,24 +42,11 @@ const RAW_CARS = [
   ['van', 'Van', 'car', { speed: 2, acceleration: 3, control: 3, drift: 5, boostPower: 1, boostDuration: 4 }, 1.08, 0, 0.80]
 ];
 
-// The current GLBs use one atlas material per mesh. Roofs are part of the body mesh,
-// while Sport Sedan's spoiler is the one safe, separately addressable paint surface.
 const SECONDARY_PAINT_BY_ID = Object.freeze({
-  'sedan-sports': Object.freeze({
-    label: 'Spoiler',
-    meshNames: Object.freeze(['spoiler'])
-  })
+  'sedan-sports': Object.freeze({ label: 'Spoiler', meshNames: Object.freeze(['spoiler']) })
 });
 
-export const CAR_CATALOG = Object.freeze(RAW_CARS.map(([
-  id,
-  name,
-  pack,
-  stats,
-  visualScale,
-  modelYawQuarterTurns,
-  enginePitch
-]) => Object.freeze({
+export const CAR_CATALOG = Object.freeze(RAW_CARS.map(([id, name, pack, stats, visualScale, modelYawQuarterTurns, enginePitch]) => Object.freeze({
   id,
   name,
   pack,
@@ -64,10 +55,7 @@ export const CAR_CATALOG = Object.freeze(RAW_CARS.map(([
   visualScale,
   modelYawQuarterTurns,
   secondaryPaint: SECONDARY_PAINT_BY_ID[id] || null,
-  tuning: Object.freeze({
-    ...deriveVehicleTuning(stats),
-    enginePitch
-  })
+  tuning: Object.freeze({ ...deriveVehicleTuning(stats), enginePitch })
 })));
 
 const CAR_BY_ID = new Map(CAR_CATALOG.map((car) => [car.id, car]));
@@ -109,9 +97,7 @@ export function loadVehicleSelection() {
 
 export function saveVehicleSelection(selection) {
   const normalized = normalizeVehicleSelection(selection);
-  try {
-    localStorage.setItem(VEHICLE_SELECTION_KEY, JSON.stringify(normalized));
-  } catch (_) {}
+  try { localStorage.setItem(VEHICLE_SELECTION_KEY, JSON.stringify(normalized)); } catch (_) {}
   return normalized;
 }
 
@@ -131,12 +117,12 @@ export function getVehicleStatTotal(stats) {
 
 export function deriveVehicleTuning(stats) {
   return {
-    // A 3/5 stat is the exact TURN v1.0 baseline. Lower and higher ratings fan out from there.
     topSpeedMultiplier: centeredStat(stats.speed, [0.84, 0.92, 1, 1.06, 1.12]),
     accelerationMultiplier: centeredStat(stats.acceleration, [0.82, 0.91, 1, 1.08, 1.16]),
     controlMultiplier: centeredStat(stats.control, [0.88, 0.94, 1, 1.07, 1.14]),
-    driftEngineMultiplier: centeredStat(stats.drift, [0.84, 0.89, 0.93, 0.97, 0.99]),
-    driftDragAdd: centeredStat(stats.drift, [0.14, 0.112, 0.085, 0.055, 0.025]),
+    driftEngineMultiplier: centeredStat(stats.drift, [0.78, 0.82, 0.86, 0.90, 0.94]),
+    driftDragAdd: centeredStat(stats.drift, [0.16, 0.13, 0.10, 0.075, 0.055]),
+    driftSpeedMultiplier: centeredStat(stats.drift, [0.76, 0.80, 0.84, 0.88, 0.92]),
     boostPowerMultiplier: centeredStat(stats.boostPower, [0.78, 0.89, 1, 1.13, 1.26]),
     boostSpeedMultiplier: centeredStat(stats.boostPower, [1.23, 1.275, 1.32, 1.35, 1.38]),
     boostDurationSeconds: centeredStat(stats.boostDuration, [1.2, 1.6, 2, 2.65, 3.4])

--- a/turn/vehicle/physics.js
+++ b/turn/vehicle/physics.js
@@ -20,8 +20,9 @@ export function updateVehiclePhysicsState({
   const tuning = vehicleTuning || globalThis.__turnVehicleTuning;
   const accelerationMultiplier = positiveNumber(tuning?.accelerationMultiplier, 1);
   const controlMultiplier = positiveNumber(tuning?.controlMultiplier, 1);
-  const driftEngineMultiplier = positiveNumber(tuning?.driftEngineMultiplier, 0.93);
-  const driftDragAdd = nonNegativeNumber(tuning?.driftDragAdd, 0.085);
+  const driftEngineMultiplier = positiveNumber(tuning?.driftEngineMultiplier, 0.86);
+  const driftDragAdd = nonNegativeNumber(tuning?.driftDragAdd, 0.1);
+  const driftSpeedMultiplier = clamp(positiveNumber(tuning?.driftSpeedMultiplier, 0.84), 0.5, 0.99);
   const tuningBoostPowerMultiplier = positiveNumber(tuning?.boostPowerMultiplier, 1);
   const tuningBoostSpeedMultiplier = positiveNumber(tuning?.boostSpeedMultiplier, 1.32);
   const effectiveMaxSpeed = maxSpeed;
@@ -62,13 +63,11 @@ export function updateVehiclePhysicsState({
     forwardSpeed = state.velocity.dot(forward);
 
     if (forwardSpeed > 0.35) {
-      // First use of the control is always braking while the car still moves forward.
       state.velocity.addScaledVector(
         forward,
         -Math.min(forwardSpeed, brakeStep)
       );
     } else {
-      // Once forward motion is essentially gone, the same held control becomes reverse.
       const reversePower = (state.offRoad ? 20 : 27) * accelerationMultiplier;
       state.velocity.addScaledVector(forward, -reversePower * state.brake * dt);
 
@@ -138,9 +137,15 @@ export function updateVehiclePhysicsState({
     : 0.11 + speed * 0.0009 + (driftHeld ? driftDragAdd : 0);
   state.velocity.multiplyScalar(Math.exp(-drag * dt));
 
+  const normalRoadSpeedLimit = effectiveBoostActive
+    ? effectiveMaxSpeed * tuningBoostSpeedMultiplier
+    : effectiveMaxSpeed;
+  const driftRoadSpeedLimit = effectiveBoostActive
+    ? normalRoadSpeedLimit
+    : effectiveMaxSpeed * driftSpeedMultiplier;
   const speedLimit = state.offRoad
     ? (effectiveBoostActive ? effectiveMaxSpeed * 0.82 : effectiveMaxSpeed * 0.73)
-    : (effectiveBoostActive ? effectiveMaxSpeed * tuningBoostSpeedMultiplier : effectiveMaxSpeed);
+    : (driftHeld ? driftRoadSpeedLimit : normalRoadSpeedLimit);
 
   speed = state.velocity.length();
   if (speed > speedLimit) state.velocity.multiplyScalar(speedLimit / speed);


### PR DESCRIPTION
Superseded by #140, which rebuilds the stat and DRIFT pass cleanly on current `main`, preserves the verified Lot and checkpoint implementations, removes unrelated rewrites, and passes the full TURN regression suite.