### PR TITLE
TURN: show the record car model on track cards

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Run multi-track and Airport regression
         run: node turn-lab/tests/multi-track-production.mjs
 
+      - name: Run track record 3D model regression
+        run: node turn-lab/tests/track-best-model-production.mjs
+
       - name: Run world containment and collision regression
         run: node turn-lab/tests/world-collision-production.mjs
 

--- a/turn-lab/tests/multi-track-production.mjs
+++ b/turn-lab/tests/multi-track-production.mjs
@@ -22,7 +22,13 @@ try {
     trackId: 'countryside',
     competitorLaps: [
       { time: 13.18, carId: 'sedan', frames: Array.from({ length: 25 }, (_, index) => ({ t: index / 10 })) },
-      { time: 12.73, carId: 'monster-truck', frames: Array.from({ length: 25 }, (_, index) => ({ t: index / 10 })) }
+      {
+        time: 12.73,
+        carId: 'monster-truck',
+        carColor: '#ff4fa3',
+        carSecondaryColor: '#abcdef',
+        frames: Array.from({ length: 25 }, (_, index) => ({ t: index / 10 }))
+      }
     ]
   };
   const airportState = {
@@ -37,8 +43,21 @@ try {
   assert.equal(storage.has('turn-personal-rivals-v1:airport'), false, 'Old Airport ghosts must not leak onto the redesigned course');
   assert.equal(getStoredBestTime('countryside'), 12.73);
   assert.equal(getStoredBestTime('airport'), 22.42);
-  assert.deepEqual(getStoredBestLap('countryside'), { time: 12.73, carId: 'monster-truck' }, 'Track 1 best summary must preserve the car that set the fastest time');
-  assert.deepEqual(getStoredBestLap('airport'), { time: 22.42, carId: 'race-future' }, 'Airport best summary must preserve the car that set the fastest time');
+  assert.deepEqual(
+    getStoredBestLap('countryside'),
+    {
+      time: 12.73,
+      carId: 'monster-truck',
+      carColor: '#ff4fa3',
+      carSecondaryColor: '#abcdef'
+    },
+    'Track 1 best summary must preserve the exact car and paint that set the fastest time'
+  );
+  assert.deepEqual(
+    getStoredBestLap('airport'),
+    { time: 22.42, carId: 'race-future' },
+    'Legacy records without paint metadata must keep their compact backward-compatible summary'
+  );
 
   clearRivalsState(airportState);
   assert.equal(storage.has('turn-personal-rivals-v1:airport-r50'), false, 'Reset Rivals on Airport must clear only the r50 Airport namespace');
@@ -111,12 +130,13 @@ const [
 
 assert.match(index, /TURN v1\.7\.0 · Build 2026\.07\.23-r53/);
 assert.match(index, /track-select\.css\?build=20260723-r53/);
-assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260724-r59"/, 'Production must cache-bust the Lot wrapper that installs the vehicle stat legend');
+assert.match(index, /track-select-r61\.css\?build=20260724-r61/, 'Production must load the record-car thumbnail layout');
+assert.match(index, /"\.\/garage\/lot-r10\.js\?build=20260720-r19": "\.\/garage\/lot-track-select\.js\?build=20260724-r60"/, 'Production must preserve the compact r60 Lot layout');
 assert.match(index, /"\.\/vehicle\/physics\.js\?build=20260720-r19": "\.\/vehicle\/physics\.js\?build=20260724-r59"/, 'Production must cache-bust the mandatory DRIFT speed tradeoff');
 assert.match(index, /"\.\/vehicle\/catalog\.js\?build=20260722-r42": "\.\/vehicle\/catalog\.js\?build=20260724-r59"/, 'Production must cache-bust the shared vehicle stat definitions');
-assert.match(index, /"\.\/race\/rival-storage\.js\?build=20260720-r19": "\.\/race\/rival-storage\.js\?build=20260722-r50"/, 'Production must preserve geometry-revision-aware rival storage');
-assert.match(index, /"\.\/race\/rival-storage\.js\?build=20260722-r50": "\.\/race\/rival-storage\.js\?build=20260723-r57"/, 'Production must cache-bust the best-lap car summary storage helper');
-assert.match(index, /"\.\/ui\/track-select\.js\?build=20260722-r51": "\.\/ui\/track-select\.js\?build=20260723-r57"/, 'Production must cache-bust the selector that renders the record-setting car');
+assert.match(index, /"\.\/race\/rival-storage\.js\?build=20260720-r19": "\.\/race\/rival-storage\.js\?build=20260724-r61"/, 'Main runtime must publish paint-aware best-lap summaries');
+assert.match(index, /"\.\/race\/rival-storage\.js\?build=20260722-r50": "\.\/race\/rival-storage\.js\?build=20260724-r61"/, 'Track selector must receive the same paint-aware record storage');
+assert.match(index, /"\.\/ui\/track-select\.js\?build=20260722-r51": "\.\/ui\/track-select\.js\?build=20260724-r61"/, 'Production must publish the selector that renders the record-setting GLB');
 assert.match(index, /"\.\/race\/track-spatial-index\.js\?build=20260720-r19": "\.\/race\/track-spatial-index\.js\?build=20260722-r47"/, 'Production must preserve the rebuildable track index');
 assert.match(index, /Turn the device to steer/, 'Start copy must use device-neutral language');
 assert.match(index, /Steering uses device rotation/, 'Status copy must use device-neutral language');
@@ -147,7 +167,9 @@ assert.match(trackSelect, /track-card-choice-marker/, 'Each card must expose an 
 assert.match(trackSelect, /track-card-summary/, 'Track name and Best time must share one deliberate bottom row');
 assert.match(trackSelect, /getStoredBestLap\(track\.id\)/, 'Selector cards must read the track-specific best lap summary');
 assert.match(trackSelect, /getCarDefinition\(bestLap\.carId\)\.name\.toUpperCase\(\)/, 'Selector cards must label the car that actually set the best time');
-assert.match(trackSelect, /track-card-best-car/, 'The Best badge must reserve a dedicated record-setting car label');
+assert.match(trackSelect, /track-card-best-car/, 'The Best badge must retain the record-setting car label');
+assert.match(trackSelect, /track-card-best-model/, 'The Best badge must reserve a real model thumbnail');
+assert.match(trackSelect, /renderBestCarThumbnail\(bestLap\)/, 'The selector must render the stored car and paint rather than a generic icon');
 assert.match(trackSelectCss, /grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/, 'The two launch tracks must present as peer choices');
 assert.match(trackSelectCss, /\.track-select-continue \{[\s\S]*grid-column: 2;/, 'Continue must align below the second track card in landscape');
 assert.match(trackSelectCss, /\.track-card\.is-selected \.track-card-choice-marker::after \{[\s\S]*content: "✓";/, 'The selected track must have an unmistakable check indicator');
@@ -182,6 +204,8 @@ assert.match(rivalStorage, /airport: 'airport-r50'/, 'Airport records must stay 
 assert.match(rivalStorage, /version: 6/);
 assert.match(rivalStorage, /trackRevision: storageTrackId\(activeTrackId\)/, 'Saved rival payloads must record the geometry revision');
 assert.match(rivalStorage, /export function getStoredBestLap/, 'Storage must expose a compact best-lap summary for track selection');
+assert.match(rivalStorage, /summary\.carColor = normalizeVehicleColor\(lap\.carColor\)/, 'Paint-aware records must expose the exact primary colour');
+assert.match(rivalStorage, /summary\.carSecondaryColor = normalizeVehicleSecondaryColor\(lap\.carSecondaryColor\)/, 'Paint-aware records must expose the exact secondary colour');
 
 assert.match(airportWorld, /name = 'TURN Airport r50'/, 'The base Airport world must retain the successful r50 redesign');
 assert.match(airportWorld, /makeStartFinishDistrict\(world, samples, trackWidth\)/, 'Airport must have a deliberately designed start and finish district');
@@ -211,7 +235,7 @@ assert.doesNotMatch(airportRunoffWorld, /setAnimationLoop|requestAnimationFrame|
 assert.match(worldRender, /const worldSamples = samples\.slice\(\)/, 'Countryside async scenery must retain immutable Track 1 samples during an early track switch');
 assert.match(worldRender, /samples: worldSamples/, 'Late Countryside art modules must receive the snapshot rather than the mutable active track array');
 
-console.log('TURN r53 world containment, Airport hairpin run-off and preserved anti-shortcut geometry passed.');
+console.log('TURN r61 record-car thumbnails, Airport run-off and preserved anti-shortcut geometry passed.');
 
 function makeSamples(points) {
   return points.map(([x, z]) => ({ point: { x, z } }));

--- a/turn-lab/tests/track-best-model-production.mjs
+++ b/turn-lab/tests/track-best-model-production.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const [index, selector, renderer, css] = await Promise.all([
+  fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/ui/track-select.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/ui/track-best-car.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/track-select-r61.css', import.meta.url), 'utf8')
+]);
+
+assert.match(index, /track-select-r61\.css\?build=20260724-r61/, 'Production must load the record-car thumbnail layout');
+assert.match(index, /"\.\/ui\/track-select\.js\?build=20260722-r51": "\.\/ui\/track-select\.js\?build=20260724-r61"/, 'Production must cache-bust the enhanced selector');
+assert.match(index, /"\.\/race\/rival-storage\.js\?build=20260722-r50": "\.\/race\/rival-storage\.js\?build=20260724-r61"/, 'The selector must receive paint-aware record summaries');
+
+assert.match(selector, /track-card-best-model/, 'Every Best badge must reserve a model thumbnail');
+assert.match(selector, /renderBestCarThumbnail\(bestLap\)/, 'Best badges must request the stored record car');
+assert.match(selector, /bestLap\.carColor/, 'The thumbnail identity must include the stored body paint');
+assert.match(selector, /bestLap\.carSecondaryColor/, 'The thumbnail identity must include stored secondary paint');
+assert.match(selector, /aria-hidden="true"/, 'The decorative model must not duplicate the readable car name');
+assert.match(selector, /model\.hidden = false/, 'The model must appear only after its render succeeds');
+
+assert.match(renderer, /createCarVisual\(\{[\s\S]*carId,[\s\S]*color,[\s\S]*secondaryColor/, 'The thumbnail must use the real local GLB and its recorded paint');
+assert.match(renderer, /preserveDrawingBuffer: true/, 'The one-shot WebGL render must remain capturable after drawing');
+assert.match(renderer, /renderer\.domElement\.toDataURL\('image\/png'\)/, 'The real 3D render must become a lightweight reusable thumbnail');
+assert.match(renderer, /thumbnailCache/, 'Repeated track visits must reuse identical rendered cars');
+assert.match(renderer, /renderQueue/, 'Multiple record cars must render serially rather than opening several WebGL contexts at once');
+assert.match(renderer, /renderer\.dispose\(\)/, 'Each one-shot renderer must release GPU resources');
+assert.match(renderer, /renderer\.forceContextLoss\?\.\(\)/, 'The temporary WebGL context must be explicitly released');
+assert.doesNotMatch(renderer, /requestAnimationFrame|setAnimationLoop|setInterval/, 'Record thumbnails must add no continuous render loop');
+
+assert.match(css, /grid-template-columns: minmax\(0, 1fr\) clamp\(64px, 7\.2vw, 86px\)/, 'The Best badge must reserve a controlled model column');
+assert.match(css, /\.track-card-best-model \{[\s\S]*object-fit: contain/, 'Every vehicle shape must fit without distortion');
+assert.match(css, /@media \(max-height: 610px\) and \(orientation: landscape\)/, 'Short landscape devices must receive a compact thumbnail treatment');
+assert.match(css, /:has\(\.track-card-best-model:not\(\[hidden\]\)\)/, 'No-time cards must collapse back to the compact text-only badge');
+
+console.log('TURN track-specific record car 3D thumbnails passed.');

--- a/turn/index.html
+++ b/turn/index.html
@@ -58,6 +58,7 @@
   <link rel="stylesheet" href="./rival-onboarding.css?build=20260723-r53">
   <link rel="stylesheet" href="./track-select.css?build=20260723-r53">
   <link rel="stylesheet" href="./track-select-r54.css?build=20260723-r57">
+  <link rel="stylesheet" href="./track-select-r61.css?build=20260724-r61">
   <link rel="stylesheet" href="./garage/lot-r10.css?build=20260723-r53">
   <link rel="stylesheet" href="./garage/lot-stat-legend.css?build=20260724-r59">
   <link rel="stylesheet" href="./garage/lot-layout-r60.css?build=20260724-r60">
@@ -74,8 +75,8 @@
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system.js?build=20260722-r41",
         "./race/game-state.js": "./race/game-state.js?build=20260722-r41",
         "./race/replay-system.js": "./race/replay-system.js?build=20260722-r43",
-        "./race/rival-storage.js?build=20260720-r19": "./race/rival-storage.js?build=20260722-r50",
-        "./race/rival-storage.js?build=20260722-r50": "./race/rival-storage.js?build=20260723-r57",
+        "./race/rival-storage.js?build=20260720-r19": "./race/rival-storage.js?build=20260724-r61",
+        "./race/rival-storage.js?build=20260722-r50": "./race/rival-storage.js?build=20260724-r61",
         "./race/track-spatial-index.js?build=20260720-r19": "./race/track-spatial-index.js?build=20260722-r47",
         "./performance-monitor.js?build=20260720-r19": "./performance-monitor.js?build=20260722-r43",
         "./world-assets.js": "./world-assets.js?build=20260722-r44",
@@ -84,7 +85,7 @@
         "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260724-r59",
         "./vehicle/catalog.js?build=20260722-r42": "./vehicle/catalog.js?build=20260724-r59",
         "./vehicle/car-models.js?build=20260720-r19": "./vehicle/car-models.js?build=20260720-r22",
-        "./ui/track-select.js?build=20260722-r51": "./ui/track-select.js?build=20260723-r57"
+        "./ui/track-select.js?build=20260722-r51": "./ui/track-select.js?build=20260724-r61"
       }
     }
   </script>

--- a/turn/race/rival-storage.js
+++ b/turn/race/rival-storage.js
@@ -141,7 +141,11 @@ export function getStoredBestLap(trackId = DEFAULT_TRACK_ID) {
         if (!best || time < best.time) {
           return {
             time,
-            carId: normalizeVehicleId(lap?.carId)
+            carId: normalizeVehicleId(lap?.carId),
+            carColor: lap?.carColor
+              ? normalizeVehicleColor(lap.carColor)
+              : DEFAULT_VEHICLE_COLOR,
+            carSecondaryColor: normalizeVehicleSecondaryColor(lap?.carSecondaryColor)
           };
         }
         return best;
@@ -155,7 +159,9 @@ export function getStoredBestLap(trackId = DEFAULT_TRACK_ID) {
       if (Number.isFinite(legacyTime)) {
         return {
           time: legacyTime,
-          carId: DEFAULT_VEHICLE_ID
+          carId: DEFAULT_VEHICLE_ID,
+          carColor: DEFAULT_VEHICLE_COLOR,
+          carSecondaryColor: DEFAULT_VEHICLE_SECONDARY_COLOR
         };
       }
     }

--- a/turn/race/rival-storage.js
+++ b/turn/race/rival-storage.js
@@ -139,14 +139,15 @@ export function getStoredBestLap(trackId = DEFAULT_TRACK_ID) {
         const time = Number(lap?.time);
         if (!Number.isFinite(time)) return best;
         if (!best || time < best.time) {
-          return {
+          const summary = {
             time,
-            carId: normalizeVehicleId(lap?.carId),
-            carColor: lap?.carColor
-              ? normalizeVehicleColor(lap.carColor)
-              : DEFAULT_VEHICLE_COLOR,
-            carSecondaryColor: normalizeVehicleSecondaryColor(lap?.carSecondaryColor)
+            carId: normalizeVehicleId(lap?.carId)
           };
+          if (lap?.carColor) summary.carColor = normalizeVehicleColor(lap.carColor);
+          if (lap?.carSecondaryColor) {
+            summary.carSecondaryColor = normalizeVehicleSecondaryColor(lap.carSecondaryColor);
+          }
+          return summary;
         }
         return best;
       }, null)
@@ -159,9 +160,7 @@ export function getStoredBestLap(trackId = DEFAULT_TRACK_ID) {
       if (Number.isFinite(legacyTime)) {
         return {
           time: legacyTime,
-          carId: DEFAULT_VEHICLE_ID,
-          carColor: DEFAULT_VEHICLE_COLOR,
-          carSecondaryColor: DEFAULT_VEHICLE_SECONDARY_COLOR
+          carId: DEFAULT_VEHICLE_ID
         };
       }
     }

--- a/turn/track-select-r61.css
+++ b/turn/track-select-r61.css
@@ -1,0 +1,67 @@
+/* The Best badge uses a one-shot render of the actual stored GLB and paint.
+   It remains text-first, with the model as a compact visual confirmation. */
+
+.track-card-best {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) clamp(64px, 7.2vw, 86px);
+  align-items: center;
+  gap: clamp(4px, 0.7vw, 8px);
+  min-width: clamp(176px, 19vw, 226px);
+  padding: 5px 7px 5px 9px;
+}
+
+.track-card-best-copy {
+  min-width: 0;
+}
+
+.track-card-best-copy > span,
+.track-card-best-copy > strong,
+.track-card-best-copy > small {
+  display: block;
+}
+
+.track-card-best-model {
+  display: block;
+  width: 100%;
+  height: clamp(44px, 6.3vw, 62px);
+  object-fit: contain;
+  pointer-events: none;
+  filter: drop-shadow(2px 3px 0 rgb(8 9 10 / 0.34));
+}
+
+.track-card-best-model[hidden] {
+  display: none;
+}
+
+.track-card-best:not(:has(.track-card-best-model:not([hidden]))) {
+  grid-template-columns: 1fr;
+  min-width: clamp(112px, 13vw, 152px);
+  padding: 7px 10px;
+}
+
+@media (max-height: 820px) and (orientation: landscape) {
+  .track-card-best {
+    min-width: clamp(164px, 18vw, 210px);
+  }
+
+  .track-card-best-model {
+    height: clamp(40px, 5.6vw, 54px);
+  }
+}
+
+@media (max-height: 610px) and (orientation: landscape) {
+  .track-card-best {
+    min-width: clamp(148px, 17vw, 188px);
+    gap: 3px;
+    padding: 3px 5px 3px 7px;
+  }
+
+  .track-card-best-model {
+    height: clamp(34px, 5vw, 44px);
+  }
+
+  .track-card-best:not(:has(.track-card-best-model:not([hidden]))) {
+    min-width: 98px;
+    padding: 4px 7px;
+  }
+}

--- a/turn/ui/track-best-car.js
+++ b/turn/ui/track-best-car.js
@@ -1,0 +1,94 @@
+import * as THREE from 'three';
+import { createCarVisual } from '../vehicle/car-models.js?build=20260720-r22';
+import {
+  getCarDefinition,
+  normalizeVehicleColor,
+  normalizeVehicleSecondaryColor
+} from '../vehicle/catalog.js?build=20260724-r59';
+
+const THUMBNAIL_WIDTH = 240;
+const THUMBNAIL_HEIGHT = 140;
+const thumbnailCache = new Map();
+let renderQueue = Promise.resolve();
+
+export function renderBestCarThumbnail(bestLap) {
+  const car = getCarDefinition(bestLap?.carId);
+  const color = normalizeVehicleColor(bestLap?.carColor);
+  const secondaryColor = normalizeVehicleSecondaryColor(bestLap?.carSecondaryColor);
+  const cacheKey = `${car.id}:${color}:${secondaryColor}`;
+
+  if (!thumbnailCache.has(cacheKey)) {
+    const task = renderQueue.then(() => renderThumbnail({
+      carId: car.id,
+      color,
+      secondaryColor
+    }));
+    renderQueue = task.catch(() => {});
+    thumbnailCache.set(cacheKey, task);
+    task.catch(() => thumbnailCache.delete(cacheKey));
+  }
+
+  return thumbnailCache.get(cacheKey);
+}
+
+async function renderThumbnail({ carId, color, secondaryColor }) {
+  const renderer = new THREE.WebGLRenderer({
+    alpha: true,
+    antialias: true,
+    powerPreference: 'high-performance',
+    preserveDrawingBuffer: true
+  });
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+  renderer.setPixelRatio(1);
+  renderer.setSize(THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT, false);
+  renderer.setClearColor(0x000000, 0);
+
+  const scene = new THREE.Scene();
+  scene.add(new THREE.HemisphereLight(0xffffff, 0x56616a, 3.35));
+
+  const keyLight = new THREE.DirectionalLight(0xfff2c9, 4.25);
+  keyLight.position.set(-6, 10, 7);
+  scene.add(keyLight);
+
+  const fillLight = new THREE.DirectionalLight(0x8ed8ff, 1.45);
+  fillLight.position.set(7, 4, -6);
+  scene.add(fillLight);
+
+  const camera = new THREE.PerspectiveCamera(
+    34,
+    THUMBNAIL_WIDTH / THUMBNAIL_HEIGHT,
+    0.1,
+    60
+  );
+  camera.position.set(7.8, 4.8, 8.8);
+  camera.lookAt(0, 1.1, 0);
+
+  let visual = null;
+  try {
+    visual = await createCarVisual({
+      carId,
+      color,
+      secondaryColor,
+      targetLength: 6.4,
+      outline: true
+    });
+    visual.rotation.y = Math.PI - 0.55;
+    scene.add(visual);
+    renderer.render(scene, camera);
+    return renderer.domElement.toDataURL('image/png');
+  } finally {
+    if (visual) disposeVisualMaterials(visual);
+    renderer.dispose();
+    renderer.forceContextLoss?.();
+  }
+}
+
+function disposeVisualMaterials(root) {
+  const materials = new Set();
+  root.traverse((node) => {
+    if (!node.isMesh || !node.material) return;
+    const nodeMaterials = Array.isArray(node.material) ? node.material : [node.material];
+    for (const material of nodeMaterials) materials.add(material);
+  });
+  for (const material of materials) material.dispose?.();
+}

--- a/turn/ui/track-select.js
+++ b/turn/ui/track-select.js
@@ -5,9 +5,11 @@ import {
   normalizeTrackId
 } from '../tracks/catalog.js?build=20260722-r50';
 import { getStoredBestLap } from '../race/rival-storage.js?build=20260722-r50';
-import { getCarDefinition } from '../vehicle/catalog.js?build=20260720-r19';
+import { getCarDefinition } from '../vehicle/catalog.js?build=20260724-r59';
+import { renderBestCarThumbnail } from './track-best-car.js?build=20260724-r61';
 
 let activeRequest = null;
+let bestPreviewGeneration = 0;
 
 export function showTrackSelect({ initialTrackId = loadTrackSelection() } = {}) {
   if (activeRequest) return activeRequest;
@@ -122,9 +124,12 @@ function renderTrackCard(track) {
           <strong class="track-card-name">${track.name.toUpperCase()}</strong>
         </span>
         <span class="track-card-best" data-track-best="${track.id}">
-          <span>BEST</span>
-          <strong class="track-card-best-time">--:--.---</strong>
-          <small class="track-card-best-car" hidden></small>
+          <span class="track-card-best-copy">
+            <span>BEST</span>
+            <strong class="track-card-best-time">--:--.---</strong>
+            <small class="track-card-best-car" hidden></small>
+          </span>
+          <img class="track-card-best-model" alt="" aria-hidden="true" draggable="false" hidden>
         </span>
       </span>
     </button>
@@ -161,17 +166,43 @@ function makePreviewSvg(trackId, accent) {
 }
 
 function refreshBestTimes(overlay) {
+  const generation = ++bestPreviewGeneration;
+
   for (const track of TRACK_CATALOG) {
     const bestLap = getStoredBestLap(track.id);
     const bestBox = overlay.querySelector(`[data-track-best="${track.id}"]`);
     const time = bestBox?.querySelector('.track-card-best-time');
     const car = bestBox?.querySelector('.track-card-best-car');
+    const model = bestBox?.querySelector('.track-card-best-model');
 
     if (time) time.textContent = formatTime(bestLap?.time ?? Infinity);
     if (car) {
       car.textContent = bestLap ? getCarDefinition(bestLap.carId).name.toUpperCase() : '';
       car.hidden = !bestLap;
     }
+    if (model) {
+      model.hidden = true;
+      model.removeAttribute('src');
+      delete model.dataset.previewKey;
+    }
+
+    if (!bestLap || !model) continue;
+
+    const previewKey = [
+      track.id,
+      bestLap.carId,
+      bestLap.carColor,
+      bestLap.carSecondaryColor
+    ].join(':');
+    model.dataset.previewKey = previewKey;
+
+    renderBestCarThumbnail(bestLap).then((source) => {
+      if (generation !== bestPreviewGeneration || model.dataset.previewKey !== previewKey) return;
+      model.src = source;
+      model.hidden = false;
+    }).catch((error) => {
+      console.warn(`TURN: could not render the ${track.name} record car.`, error);
+    });
   }
 }
 


### PR DESCRIPTION
### Player-facing change
- shows the actual record-setting 3D car beside each track's Best time
- uses the exact stored car model, body colour and secondary paint
- keeps the readable car name as the accessible source of identity
- leaves no-time cards compact and text-only

### Performance
- renders each GLB once into a transparent thumbnail
- serializes thumbnail work so only one temporary WebGL context exists at a time
- caches identical model/paint combinations across later visits
- disposes the renderer immediately after capture
- adds no animation loop or persistent canvas

### Safety
- preserves legacy records that lack paint metadata
- cache-busts only track selection and rival summary assets
- adds dedicated production regression coverage and updates the multi-track contract