### PR TITLE
Introduce TURN platform contract in TURN NEXT

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Run TURN NEXT isolation and identity regression
         run: node turn-tests/turn-next-entry-production.mjs
 
+      - name: Run web platform and motion composition regression
+        run: node turn-tests/platform-production.mjs
+
       - name: Run production race and replay regression tests
         run: node turn-tests/race-production.mjs
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,6 +19,8 @@ export default [
   },
   {
     files: [
+      'turn/input/motion.js',
+      'turn/platform/*.js',
       'turn/race/game-state.js',
       'turn/race/lap-system.js',
       'turn/race/replay-system.js',

--- a/turn-next/README.md
+++ b/turn-next/README.md
@@ -2,9 +2,18 @@
 
 `/turn-next/` is TURN’s protected architecture test runtime.
 
-## Current milestone: parity entry
+## Current milestone: platform composition
 
-The first milestone deliberately runs the current production module graph from `/turn/`. It exists to establish a permanent test URL and safe deployment boundary before core systems are moved into the new canonical source tree.
+The physical parity baseline for TURN r110 has been confirmed on real devices. TURN NEXT now begins the architecture migration while continuing to load the proven production gameplay graph from `/turn/`.
+
+Its first explicit seam is the platform layer:
+
+- `turn/platform/platform-context.js` owns the runtime platform contract.
+- `turn/platform/web-platform.js` implements motion, fullscreen and orientation services for browsers.
+- TURN NEXT installs that web platform before `main.js` loads.
+- `turn/input/motion.js` consumes the installed orientation port when present and retains the existing browser fallback for production TURN.
+
+Only screen-orientation input is routed through the platform in this milestone. Motion permission, event subscription, fullscreen and landscape lock are already represented and tested as platform services, but will be promoted one behaviour at a time after parity testing.
 
 The staging bootstrap and entry page are generated from `turn/app.js` and `turn/index.html` by:
 
@@ -24,15 +33,16 @@ Do not edit `turn-next/app.js` or `turn-next/index.html` by hand. Edit the gener
 
 ## Safety boundaries
 
-- Production `/turn/` files are not modified by the TURN NEXT bootstrap.
+- Production `/turn/` keeps its proven direct browser fallback.
 - TURN NEXT prefixes all `localStorage` and `sessionStorage` keys before production modules load.
 - It never copies production records automatically.
 - Its manifest uses the separate `/turn-next/` application id, start URL and scope.
 - The page is marked `noindex` and visibly labelled throughout gameplay.
+- The platform is installed once at startup and cannot be silently replaced later.
 
 ## Transitional architecture
 
-Reusing `/turn/` modules is temporary and intentional. This baseline proves that the staging URL, storage isolation and PWA identity work before gameplay modules are migrated behind explicit application and platform interfaces.
+Reusing `/turn/` modules remains temporary and intentional. TURN NEXT will replace dependencies one subsystem at a time behind explicit interfaces, with production parity checked after every slice.
 
 The target remains one canonical source tree that can build:
 

--- a/turn-next/app.js
+++ b/turn-next/app.js
@@ -1,12 +1,20 @@
 // Generated from turn/app.js for TURN 2026.07.28-r110. Do not edit by hand.
 const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
 const productionModuleBase = new URL('/turn/', globalThis.location?.href || 'https://enkel.design/turn-next/');
+const platformModuleBase = new URL('/turn/platform/', globalThis.location?.href || 'https://enkel.design/turn-next/');
 
 function withBuild(path) {
   const url = new URL(path, productionModuleBase);
   if (buildKey) url.searchParams.set('build', buildKey);
   return url.href;
 }
+
+const { createWebPlatform } = await import(new URL('./web-platform.js', platformModuleBase).href);
+const { installTurnPlatform } = await import(new URL('./platform-context.js', platformModuleBase).href);
+installTurnPlatform(createWebPlatform());
+document.documentElement.dataset.turnPlatform = 'web-adapter';
+const turnNextBadgeDetail = document.querySelector('.turn-next-badge span');
+if (turnNextBadgeDetail) turnNextBadgeDetail.textContent += ' · Platform M1';
 
 function installStylesheet(path, dataAttribute) {
   if (document.querySelector(`link[${dataAttribute}]`)) return;

--- a/turn-next/scripts/build-parity-app.mjs
+++ b/turn-next/scripts/build-parity-app.mjs
@@ -26,8 +26,22 @@ export function buildTurnNextApp(productionApp, release) {
   output = replaceRequired(
     output,
     "const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';\n\nfunction withBuild(path) {\n  const url = new URL(path, import.meta.url);",
-    "const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';\nconst productionModuleBase = new URL('/turn/', globalThis.location?.href || 'https://enkel.design/turn-next/');\n\nfunction withBuild(path) {\n  const url = new URL(path, productionModuleBase);",
+    "const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';\nconst productionModuleBase = new URL('/turn/', globalThis.location?.href || 'https://enkel.design/turn-next/');\nconst platformModuleBase = new URL('/turn/platform/', globalThis.location?.href || 'https://enkel.design/turn-next/');\n\nfunction withBuild(path) {\n  const url = new URL(path, productionModuleBase);",
     'module URL resolver'
+  );
+
+  output = replaceRequired(
+    output,
+    'function installStylesheet(path, dataAttribute) {',
+    `const { createWebPlatform } = await import(new URL('./web-platform.js', platformModuleBase).href);
+const { installTurnPlatform } = await import(new URL('./platform-context.js', platformModuleBase).href);
+installTurnPlatform(createWebPlatform());
+document.documentElement.dataset.turnPlatform = 'web-adapter';
+const turnNextBadgeDetail = document.querySelector('.turn-next-badge span');
+if (turnNextBadgeDetail) turnNextBadgeDetail.textContent += ' · Platform M1';
+
+function installStylesheet(path, dataAttribute) {`,
+    'platform composition point'
   );
 
   output = replaceRequired(
@@ -40,6 +54,14 @@ export function buildTurnNextApp(productionApp, release) {
   output = `// Generated from turn/app.js for TURN ${release.id}. Do not edit by hand.\n${output}`;
 
   assert.match(output, /const productionModuleBase = new URL\('\/turn\/'/);
+  assert.match(output, /const platformModuleBase = new URL\('\/turn\/platform\/'/);
+  assert.match(output, /installTurnPlatform\(createWebPlatform\(\)\)/);
+  assert.match(output, /dataset\.turnPlatform = 'web-adapter'/);
+  assert.match(output, /Platform M1/);
+  assert.ok(
+    output.indexOf('installTurnPlatform(createWebPlatform())') < output.indexOf("withBuild('./main.js')"),
+    'TURN NEXT must install its platform before the game core loads.'
+  );
   assert.match(output, /new URL\(path, productionModuleBase\)/);
   assert.doesNotMatch(output, /new URL\(path, import\.meta\.url\)/);
   assert.match(output, /TURN NEXT:/);

--- a/turn-tests/platform-production.mjs
+++ b/turn-tests/platform-production.mjs
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict';
+
+import {
+  getTurnPlatform,
+  installTurnPlatform,
+  requireTurnPlatform,
+  validateTurnPlatform
+} from '../turn/platform/platform-context.js';
+import { createWebPlatform } from '../turn/platform/web-platform.js';
+import { motionPoseFromGravity, updateMotionInputState } from '../turn/input/motion.js';
+
+const EPSILON = 1e-9;
+
+assert.equal(getTurnPlatform(), null, 'Production modules must keep a browser fallback until a platform is composed');
+assert.throws(() => requireTurnPlatform(), /has not been installed/);
+assert.throws(() => validateTurnPlatform(null), /must be an object/);
+assert.throws(
+  () => validateTurnPlatform({ kind: 'broken', motion: {}, display: {} }),
+  /motion\.isAvailable must be a function/
+);
+
+const fallbackPose = motionPoseFromGravity({
+  accelerationIncludingGravity: { x: 2, y: 0, z: 0 }
+});
+assert.ok(Math.abs(fallbackPose.roll - Math.PI / 2) < EPSILON, 'The production browser fallback must preserve current screen-space steering');
+assert.equal(fallbackPose.pitch, 0);
+assert.equal(motionPoseFromGravity({ accelerationIncludingGravity: { x: 0.1, y: 0.1, z: 0.1 } }), null);
+
+let permissionRequests = 0;
+let fullscreenRequests = 0;
+let landscapeLocks = 0;
+let subscribed = null;
+let subscribedOptions = null;
+let removed = null;
+
+class FakeDeviceMotionEvent {
+  static async requestPermission() {
+    permissionRequests += 1;
+    return 'granted';
+  }
+}
+
+const root = {
+  async requestFullscreen() {
+    fullscreenRequests += 1;
+  }
+};
+
+const fakeEnvironment = {
+  DeviceMotionEvent: FakeDeviceMotionEvent,
+  document: {
+    documentElement: root,
+    fullscreenElement: null,
+    webkitFullscreenElement: null
+  },
+  screen: {
+    orientation: {
+      angle: 90,
+      async lock(value) {
+        landscapeLocks += 1;
+        assert.equal(value, 'landscape');
+      }
+    }
+  },
+  window: {
+    orientation: 0,
+    addEventListener(type, listener, options) {
+      assert.equal(type, 'devicemotion');
+      subscribed = listener;
+      subscribedOptions = options;
+    },
+    removeEventListener(type, listener) {
+      assert.equal(type, 'devicemotion');
+      removed = listener;
+    }
+  }
+};
+
+const platform = createWebPlatform(fakeEnvironment);
+assert.equal(validateTurnPlatform(platform), true);
+assert.equal(platform.kind, 'web');
+assert.equal(platform.motion.isAvailable(), true);
+assert.ok(Math.abs(platform.motion.getScreenOrientationAngle() - Math.PI / 2) < EPSILON);
+assert.equal(await platform.motion.requestPermission(), true);
+assert.equal(permissionRequests, 1);
+
+const listener = () => {};
+const unsubscribe = platform.motion.subscribe(listener);
+assert.equal(subscribed, listener);
+assert.deepEqual(subscribedOptions, { passive: true });
+unsubscribe();
+assert.equal(removed, listener);
+
+assert.equal(await platform.display.requestFullscreen(), true);
+assert.equal(fullscreenRequests, 1);
+assert.equal(await platform.display.lockLandscape(), true);
+assert.equal(landscapeLocks, 1);
+
+assert.equal(installTurnPlatform(platform), platform);
+assert.equal(installTurnPlatform(platform), platform, 'Installing the same platform twice must be idempotent');
+assert.equal(getTurnPlatform(), platform);
+assert.equal(requireTurnPlatform(), platform);
+assert.throws(
+  () => installTurnPlatform(createWebPlatform(fakeEnvironment)),
+  /already been installed/,
+  'A runtime must not silently replace its platform after composition'
+);
+
+const adaptedPose = motionPoseFromGravity({
+  accelerationIncludingGravity: { x: 2, y: 0, z: 0 }
+});
+assert.ok(Math.abs(adaptedPose.roll) < EPSILON, 'TURN NEXT motion math must consume the installed platform orientation');
+assert.equal(adaptedPose.pitch, 0);
+
+const manualState = {
+  sensorMode: false,
+  steering: 0,
+  manualSteering: 1,
+  tiltDrive: 1
+};
+updateMotionInputState({ state: manualState, dt: 0.1, maxSteerRoll: Math.PI / 4 });
+assert.equal(manualState.steering, -1);
+assert.equal(manualState.tiltDrive, 0);
+
+class DeniedDeviceMotionEvent {
+  static async requestPermission() {
+    return 'denied';
+  }
+}
+const deniedPlatform = createWebPlatform({
+  DeviceMotionEvent: DeniedDeviceMotionEvent,
+  window: {},
+  document: {},
+  screen: {}
+});
+await assert.rejects(() => deniedPlatform.motion.requestPermission(), /was not granted/);
+
+const unavailablePlatform = createWebPlatform({ window: {}, document: {}, screen: {} });
+assert.equal(unavailablePlatform.motion.isAvailable(), false);
+await assert.rejects(() => unavailablePlatform.motion.requestPermission(), /not available/);
+assert.equal(await unavailablePlatform.display.requestFullscreen(), false);
+assert.equal(await unavailablePlatform.display.lockLandscape(), false);
+
+console.log('TURN web platform contract and TURN NEXT motion composition passed.');

--- a/turn-tests/turn-next-entry-production.mjs
+++ b/turn-tests/turn-next-entry-production.mjs
@@ -85,7 +85,7 @@ for (const requiredInstall of [
 assert.match(platformContext, /installTurnPlatform/);
 assert.match(platformContext, /requireTurnPlatform/);
 assert.match(platformContext, /validateTurnPlatform/);
-assert.doesNotMatch(platformContext, /window|document|screen|DeviceMotionEvent/, 'The platform context must remain environment-agnostic');
+assert.doesNotMatch(platformContext, /\b(?:window|document|screen|DeviceMotionEvent)\b/, 'The platform context must remain environment-agnostic');
 assert.match(webPlatform, /requestPermission/);
 assert.match(webPlatform, /addEventListener\('devicemotion'/);
 assert.match(webPlatform, /requestFullscreen/);

--- a/turn-tests/turn-next-entry-production.mjs
+++ b/turn-tests/turn-next-entry-production.mjs
@@ -1,7 +1,19 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [productionIndex, productionApp, nextIndex, nextApp, storage, identity, manifestSource, releaseSource] = await Promise.all([
+const [
+  productionIndex,
+  productionApp,
+  nextIndex,
+  nextApp,
+  storage,
+  identity,
+  manifestSource,
+  releaseSource,
+  platformContext,
+  webPlatform,
+  motionInput
+] = await Promise.all([
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-next/index.html', import.meta.url), 'utf8'),
@@ -9,7 +21,10 @@ const [productionIndex, productionApp, nextIndex, nextApp, storage, identity, ma
   fs.readFile(new URL('../turn-next/storage-bootstrap.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-next/identity.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-next/site.webmanifest', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/release.json', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/release.json', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/platform/platform-context.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/platform/web-platform.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/input/motion.js', import.meta.url), 'utf8')
 ]);
 
 const manifest = JSON.parse(manifestSource);
@@ -34,6 +49,15 @@ assert.doesNotMatch(nextIndex, /href="\.\/site\.webmanifest/);
 
 assert.match(nextApp, /Generated from turn\/app\.js/);
 assert.match(nextApp, /const productionModuleBase = new URL\('\/turn\/'/);
+assert.match(nextApp, /const platformModuleBase = new URL\('\/turn\/platform\/'/);
+assert.match(nextApp, /installTurnPlatform\(createWebPlatform\(\)\)/);
+assert.match(nextApp, /dataset\.turnPlatform = 'web-adapter'/);
+assert.match(nextApp, /Platform M1/, 'The visible staging badge must identify the active architecture milestone');
+assert.ok(
+  nextApp.indexOf('installTurnPlatform(createWebPlatform())') < nextApp.indexOf("withBuild('./main.js')"),
+  'The platform must be composed before main.js imports motion input'
+);
+assert.doesNotMatch(productionApp, /installTurnPlatform\(createWebPlatform\(\)\)/, 'Production must retain the proven browser fallback during this TURN NEXT milestone');
 assert.match(nextApp, /new URL\(path, productionModuleBase\)/);
 assert.doesNotMatch(nextApp, /new URL\(path, import\.meta\.url\)/);
 assert.match(nextApp, /TURN NEXT:/);
@@ -57,6 +81,18 @@ for (const requiredInstall of [
   assert.ok(productionApp.includes(requiredInstall), `Production bootstrap must still contain ${requiredInstall}`);
   assert.ok(nextApp.includes(requiredInstall), `TURN NEXT bootstrap must preserve ${requiredInstall}`);
 }
+
+assert.match(platformContext, /installTurnPlatform/);
+assert.match(platformContext, /requireTurnPlatform/);
+assert.match(platformContext, /validateTurnPlatform/);
+assert.doesNotMatch(platformContext, /window|document|screen|DeviceMotionEvent/, 'The platform context must remain environment-agnostic');
+assert.match(webPlatform, /requestPermission/);
+assert.match(webPlatform, /addEventListener\('devicemotion'/);
+assert.match(webPlatform, /requestFullscreen/);
+assert.match(webPlatform, /lockLandscape/);
+assert.match(motionInput, /getTurnPlatform/);
+assert.match(motionInput, /getTurnPlatform\(\)\?\.motion\?\.getScreenOrientationAngle/);
+assert.match(motionInput, /globalThis\.screen/, 'Production must retain its browser fallback until the adapter is promoted');
 
 assert.match(storage, /const LOCAL_PREFIX = 'turn-next:';/);
 assert.match(storage, /const SESSION_PREFIX = 'turn-next-session:';/);
@@ -90,4 +126,4 @@ assert.deepEqual(
   }
 );
 
-console.log(`TURN NEXT isolated parity entry for TURN ${release.id} passed.`);
+console.log(`TURN NEXT isolated platform-composition entry for TURN ${release.id} passed.`);

--- a/turn/input/motion.js
+++ b/turn/input/motion.js
@@ -1,3 +1,5 @@
+import { getTurnPlatform } from '../platform/platform-context.js';
+
 const STEERING_ENTER_THRESHOLD = degToRad(2.2);
 const STEERING_EXIT_THRESHOLD = degToRad(0.9);
 
@@ -73,10 +75,13 @@ function getScreenSpaceRoll(gravity) {
 }
 
 function getScreenOrientationAngle() {
+  const platformAngle = getTurnPlatform()?.motion?.getScreenOrientationAngle?.();
+  if (Number.isFinite(platformAngle)) return platformAngle;
+
   const degrees = Number.isFinite(globalThis.screen?.orientation?.angle)
     ? globalThis.screen.orientation.angle
     : Number(globalThis.window?.orientation || 0);
-  return degToRad(degrees);
+  return degToRad(Number.isFinite(degrees) ? degrees : 0);
 }
 
 function shortestAngle(from, to) {

--- a/turn/platform/platform-context.js
+++ b/turn/platform/platform-context.js
@@ -1,0 +1,59 @@
+const REQUIRED_PORTS = Object.freeze({
+  motion: Object.freeze([
+    'isAvailable',
+    'getScreenOrientationAngle',
+    'requestPermission',
+    'subscribe'
+  ]),
+  display: Object.freeze([
+    'requestFullscreen',
+    'lockLandscape'
+  ])
+});
+
+let installedPlatform = null;
+
+export function installTurnPlatform(platform) {
+  validateTurnPlatform(platform);
+
+  if (installedPlatform && installedPlatform !== platform) {
+    throw new Error('TURN platform has already been installed.');
+  }
+
+  installedPlatform = platform;
+  return installedPlatform;
+}
+
+export function getTurnPlatform() {
+  return installedPlatform;
+}
+
+export function requireTurnPlatform() {
+  if (!installedPlatform) {
+    throw new Error('TURN platform has not been installed.');
+  }
+  return installedPlatform;
+}
+
+export function validateTurnPlatform(platform) {
+  if (!platform || typeof platform !== 'object') {
+    throw new TypeError('TURN platform must be an object.');
+  }
+  if (typeof platform.kind !== 'string' || !platform.kind.trim()) {
+    throw new TypeError('TURN platform.kind must be a non-empty string.');
+  }
+
+  for (const [portName, methods] of Object.entries(REQUIRED_PORTS)) {
+    const port = platform[portName];
+    if (!port || typeof port !== 'object') {
+      throw new TypeError(`TURN platform.${portName} must be an object.`);
+    }
+    for (const methodName of methods) {
+      if (typeof port[methodName] !== 'function') {
+        throw new TypeError(`TURN platform.${portName}.${methodName} must be a function.`);
+      }
+    }
+  }
+
+  return true;
+}

--- a/turn/platform/web-platform.js
+++ b/turn/platform/web-platform.js
@@ -1,0 +1,88 @@
+const DEGREES_TO_RADIANS = Math.PI / 180;
+
+export function createWebPlatform(environment = globalThis) {
+  const windowRef = environment.window || environment;
+  const documentRef = environment.document || windowRef.document;
+  const screenRef = environment.screen || windowRef.screen;
+  const motionEventType = environment.DeviceMotionEvent || windowRef.DeviceMotionEvent;
+
+  const motion = Object.freeze({
+    isAvailable() {
+      return typeof motionEventType !== 'undefined' && motionEventType !== null;
+    },
+
+    getScreenOrientationAngle() {
+      const screenAngle = screenRef?.orientation?.angle;
+      const degrees = Number.isFinite(screenAngle)
+        ? screenAngle
+        : Number(windowRef?.orientation || 0);
+      return (Number.isFinite(degrees) ? degrees : 0) * DEGREES_TO_RADIANS;
+    },
+
+    async requestPermission() {
+      if (!motion.isAvailable()) {
+        throw new Error('Motion sensors are not available in this browser.');
+      }
+
+      const request = motionEventType?.requestPermission;
+      if (typeof request === 'function') {
+        const permission = await request.call(motionEventType);
+        if (permission !== 'granted') {
+          throw new Error('Motion permission was not granted.');
+        }
+      }
+
+      return true;
+    },
+
+    subscribe(listener) {
+      if (typeof listener !== 'function') {
+        throw new TypeError('TURN motion listener must be a function.');
+      }
+      if (typeof windowRef?.addEventListener !== 'function') {
+        throw new Error('Motion events are not available in this environment.');
+      }
+
+      windowRef.addEventListener('devicemotion', listener, { passive: true });
+      return () => windowRef.removeEventListener?.('devicemotion', listener);
+    }
+  });
+
+  const display = Object.freeze({
+    async requestFullscreen(root = documentRef?.documentElement) {
+      const request = root?.requestFullscreen || root?.webkitRequestFullscreen;
+      if (
+        typeof request !== 'function'
+        || documentRef?.fullscreenElement
+        || documentRef?.webkitFullscreenElement
+      ) {
+        return false;
+      }
+
+      try {
+        await request.call(root);
+        return true;
+      } catch (_) {
+        return false;
+      }
+    },
+
+    async lockLandscape() {
+      const orientation = screenRef?.orientation;
+      if (typeof orientation?.lock !== 'function') return false;
+
+      try {
+        await orientation.lock('landscape');
+        return true;
+      } catch (_) {
+        return false;
+      }
+    }
+  });
+
+  return Object.freeze({
+    kind: 'web',
+    motion,
+    display
+  });
+}


### PR DESCRIPTION
## What changed

- adds an explicit TURN platform context with validated motion and display ports
- adds a browser adapter for:
  - motion availability and permission
  - `devicemotion` subscription and cleanup
  - screen-orientation angle
  - fullscreen requests
  - landscape orientation lock
- composes the web platform only in the TURN NEXT bootstrap for this milestone
- routes `turn/input/motion.js` through the installed orientation port when present
- preserves the existing direct browser fallback for production TURN
- prevents the runtime platform from being silently replaced after startup
- labels the active staging runtime as `Platform M1` so device testing can detect stale cached bootstraps
- adds executable platform, permission, orientation, fullscreen and motion-parity tests
- adds the new modules to ESLint and the platform regression to CI
- records the milestone and its promotion boundaries in `turn-next/README.md`

## Why

The physical r110 parity checklist passed completely on iPhone/iPad and the isolated TURN NEXT runtime is now a trusted control baseline.

This is the first real architectural extraction toward iOS and Android. TURN needs semantic platform services rather than gameplay code directly depending on browser globals. The migration is deliberately incremental: TURN NEXT composes the adapter first, while production keeps its proven fallback until the new route has passed physical parity testing.

## Behavioural scope

Only screen-orientation lookup is consumed through the platform in TURN NEXT during this milestone.

The adapter already defines and tests motion permission, event subscription, fullscreen and landscape lock, but `main.js` continues using the existing implementation for those behaviours. They will be promoted separately so any regression has one small cause.

No gameplay, steering curve, physics, tracks, lap logic, audio, Drive By Ear, garage or saved-data format is intentionally changed.

## Safety properties

- production `turn/app.js` and `turn/main.js` are unchanged
- production motion keeps the existing browser-global fallback
- TURN NEXT installs the platform before `main.js` loads
- installing the same platform is idempotent
- replacing an installed platform with a different object throws
- the platform context itself contains no browser dependencies
- the generated TURN NEXT bootstrap remains synchronized with production startup order
- the visible `Platform M1` marker confirms the new bootstrap actually loaded

## Validation performed before opening

- syntax checks for all new and changed JavaScript modules
- `node turn-next/scripts/build-parity-app.mjs --check`
- `node turn-tests/platform-production.mjs`
- local executable tests confirmed:
  - unchanged production orientation fallback
  - adapter-provided 90-degree orientation conversion
  - granted and denied iOS-style motion permission
  - motion event subscription and unsubscribe
  - fullscreen success/fallback
  - landscape-lock success/fallback
  - platform contract validation and single-install rule
  - unchanged manual-steering update
- branch compare confirms exactly ten intended files

The local environment could not download ESLint, so the repository’s Actions run is the authoritative lint and full-regression validation.

## Manual parity check after merge

Open `/turn-next/` and first confirm the badge reads `Platform M1`. Then compare motion steering against production in both landscape orientations, including recalibration, device rotation near the orientation boundary and returning from background. Manual controls should remain unchanged.