### PR TITLE
Keep TURN NEXT upright across landscape-side flips

### DIFF
--- a/turn-next/README.md
+++ b/turn-next/README.md
@@ -22,6 +22,8 @@ Orientation M2 therefore adds a TURN NEXT-only visual compensation prototype:
 - `orientation-freeze.css` provides the transformable application viewport.
 - The generated TURN NEXT entry wraps every visual surface in `#turnAppViewport`.
 
+Physical M2 testing exposed an incorrect half-turn assumption: when iOS completed a landscape-right to landscape-left flip, the operating system had already made the web view upright, but TURN NEXT added another 180-degree transform and rendered the game upside down. Orientation M2.1 preserves quarter-turn portrait compensation while resolving completed landscape-to-landscape flips to zero additional visual rotation.
+
 This is deliberately an experiment. It cannot stop the operating system’s own rotation animation or browser chrome from rotating. It tests whether TURN can visually compensate well enough in the PWA while preserving controls, aspect ratio and motion steering. A true host-level lock remains mandatory for native iOS and Android containers.
 
 The staging bootstrap and entry page are generated from `turn/app.js` and `turn/index.html` by:
@@ -48,7 +50,7 @@ Do not edit `turn-next/app.js` or `turn-next/index.html` by hand. Edit the gener
 - Its manifest uses the separate `/turn-next/` application id, start URL and scope.
 - The page is marked `noindex` and visibly labelled throughout gameplay.
 - The platform is installed once at startup and cannot be silently replaced later.
-- Orientation M2 activates only while gameplay is running and restores ordinary responsive behaviour outside the race.
+- Orientation M2.1 activates only while gameplay is running and restores ordinary responsive behaviour outside the race.
 
 ## Transitional architecture
 

--- a/turn-next/app.js
+++ b/turn-next/app.js
@@ -15,12 +15,12 @@ const { installTurnPlatform } = await import(new URL('./platform-context.js', pl
 const webPlatform = createWebPlatform();
 installTurnPlatform(webPlatform);
 const { installTurnNextOrientationFreeze } = await import(
-  new URL('./orientation-freeze.js?source=20260728-r110', turnNextModuleBase).href
+  new URL('./orientation-freeze.js?source=20260728-r110&stage=orientation-m2-1', turnNextModuleBase).href
 );
 installTurnNextOrientationFreeze({ platform: webPlatform });
 document.documentElement.dataset.turnPlatform = 'web-adapter';
 const turnNextBadgeDetail = document.querySelector('.turn-next-badge span');
-if (turnNextBadgeDetail) turnNextBadgeDetail.textContent += ' · Platform M1 · Orientation M2';
+if (turnNextBadgeDetail) turnNextBadgeDetail.textContent += ' · Platform M1 · Orientation M2.1';
 
 function installStylesheet(path, dataAttribute) {
   if (document.querySelector(`link[${dataAttribute}]`)) return;

--- a/turn-next/orientation-freeze.js
+++ b/turn-next/orientation-freeze.js
@@ -15,6 +15,16 @@ export function snapToQuarterTurn(value) {
   );
 }
 
+export function resolveOrientationFreezeRotation(lockedAngle, currentAngle) {
+  const rotation = snapToQuarterTurn(Number(currentAngle) - Number(lockedAngle));
+
+  // WebKit already turns the rendered page upright when it completes a flip from one
+  // landscape side to the other. Applying another half-turn here duplicates that OS
+  // correction and leaves TURN upside down. Only portrait quarter-turn states need
+  // visual compensation from the frozen landscape viewport.
+  return Math.abs(rotation) === HALF_TURN_DEGREES ? 0 : rotation;
+}
+
 export function calculateOrientationFreezeTransform({
   lockedAngle,
   currentAngle,
@@ -27,7 +37,7 @@ export function calculateOrientationFreezeTransform({
   const height = Math.max(1, Number(logicalHeight) || 1);
   const availableWidth = Math.max(1, Number(viewportWidth) || 1);
   const availableHeight = Math.max(1, Number(viewportHeight) || 1);
-  const rotation = snapToQuarterTurn(Number(currentAngle) - Number(lockedAngle));
+  const rotation = resolveOrientationFreezeRotation(lockedAngle, currentAngle);
   const swapsAxes = Math.abs(rotation) % HALF_TURN_DEGREES === QUARTER_TURN_DEGREES;
   const rotatedWidth = swapsAxes ? height : width;
   const rotatedHeight = swapsAxes ? width : height;

--- a/turn-next/scripts/build-parity-app.mjs
+++ b/turn-next/scripts/build-parity-app.mjs
@@ -38,12 +38,12 @@ const { installTurnPlatform } = await import(new URL('./platform-context.js', pl
 const webPlatform = createWebPlatform();
 installTurnPlatform(webPlatform);
 const { installTurnNextOrientationFreeze } = await import(
-  new URL('./orientation-freeze.js?source=${release.cacheKey}', turnNextModuleBase).href
+  new URL('./orientation-freeze.js?source=${release.cacheKey}&stage=orientation-m2-1', turnNextModuleBase).href
 );
 installTurnNextOrientationFreeze({ platform: webPlatform });
 document.documentElement.dataset.turnPlatform = 'web-adapter';
 const turnNextBadgeDetail = document.querySelector('.turn-next-badge span');
-if (turnNextBadgeDetail) turnNextBadgeDetail.textContent += ' · Platform M1 · Orientation M2';
+if (turnNextBadgeDetail) turnNextBadgeDetail.textContent += ' · Platform M1 · Orientation M2.1';
 
 function installStylesheet(path, dataAttribute) {`,
     'platform composition point'
@@ -63,8 +63,9 @@ function installStylesheet(path, dataAttribute) {`,
   assert.match(output, /const turnNextModuleBase = new URL\('\/turn-next\/'/);
   assert.match(output, /installTurnPlatform\(webPlatform\)/);
   assert.match(output, /installTurnNextOrientationFreeze\(\{ platform: webPlatform \}\)/);
+  assert.match(output, /orientation-freeze\.js\?source=.*&stage=orientation-m2-1/);
   assert.match(output, /dataset\.turnPlatform = 'web-adapter'/);
-  assert.match(output, /Platform M1 · Orientation M2/);
+  assert.match(output, /Platform M1 · Orientation M2\.1/);
   assert.ok(
     output.indexOf('installTurnPlatform(webPlatform)') < output.indexOf("withBuild('./main.js')"),
     'TURN NEXT must install its platform before the game core loads.'

--- a/turn-tests/orientation-freeze-production.mjs
+++ b/turn-tests/orientation-freeze-production.mjs
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises';
 import {
   calculateOrientationFreezeTransform,
   normalizeDegrees,
+  resolveOrientationFreezeRotation,
   snapToQuarterTurn
 } from '../turn-next/orientation-freeze.js';
 
@@ -13,6 +14,11 @@ assert.equal(normalizeDegrees(540), 180);
 assert.equal(snapToQuarterTurn(43), 0);
 assert.equal(snapToQuarterTurn(47), 90);
 assert.equal(snapToQuarterTurn(-136), 180);
+
+assert.equal(resolveOrientationFreezeRotation(90, 0), -90);
+assert.equal(resolveOrientationFreezeRotation(-90, 0), 90);
+assert.equal(resolveOrientationFreezeRotation(90, -90), 0);
+assert.equal(resolveOrientationFreezeRotation(-90, 90), 0);
 
 const portraitTurn = calculateOrientationFreezeTransform({
   lockedAngle: 90,
@@ -46,8 +52,25 @@ const oppositeLandscape = calculateOrientationFreezeTransform({
   viewportWidth: 844,
   viewportHeight: 390
 });
-assert.equal(oppositeLandscape.rotation, 180, 'The opposite landscape side must counter-rotate by a half turn');
+assert.equal(
+  oppositeLandscape.rotation,
+  0,
+  'The OS-completed landscape-side flip must remain upright without a duplicate half-turn'
+);
 assert.equal(oppositeLandscape.scale, 1);
+assert.equal(oppositeLandscape.rotatedWidth, 844);
+assert.equal(oppositeLandscape.rotatedHeight, 390);
+
+const oppositeLandscapeReverse = calculateOrientationFreezeTransform({
+  lockedAngle: -90,
+  currentAngle: 90,
+  logicalWidth: 844,
+  logicalHeight: 390,
+  viewportWidth: 844,
+  viewportHeight: 390
+});
+assert.equal(oppositeLandscapeReverse.rotation, 0);
+assert.equal(oppositeLandscapeReverse.scale, 1);
 
 const constrainedViewport = calculateOrientationFreezeTransform({
   lockedAngle: 90,
@@ -91,12 +114,15 @@ assert.match(preflight, /__TURN_NEXT_ORIENTATION_PREFLIGHT__/);
 assert.match(preflight, /getViewportSize/);
 
 assert.match(nextApp, /installTurnNextOrientationFreeze/);
-assert.match(nextApp, /Platform M1 · Orientation M2/);
+assert.match(nextApp, /Platform M1 · Orientation M2\.1/);
+assert.match(nextApp, /orientation-freeze\.js\?source=.*&stage=orientation-m2-1/);
 assert.ok(
   nextApp.indexOf('installTurnNextOrientationFreeze') < nextApp.indexOf("withBuild('./main.js')"),
   'Visual compensation must install before the production game core registers resize handlers'
 );
 
+assert.match(freezeSource, /resolveOrientationFreezeRotation/);
+assert.match(freezeSource, /Math\.abs\(rotation\) === HALF_TURN_DEGREES \? 0 : rotation/);
 assert.match(freezeSource, /turn:ui-state-change/);
 assert.match(freezeSource, /turn:runtime-ready/);
 assert.match(freezeSource, /renderer\.setSize = function setOrientationAwareSize/);


### PR DESCRIPTION
## What changed

- corrects the Orientation M2 half-turn rule that made TURN NEXT upside down after iOS flipped from one landscape side to the other
- keeps quarter-turn compensation for portrait intermediate states
- resolves completed `+90° ↔ -90°` landscape changes to `0°` additional CSS rotation because WebKit has already rendered the page upright
- covers both charging-port directions in deterministic geometry tests
- adds explicit source assertions preventing the duplicate half-turn from returning
- labels the staging runtime `Platform M1 · Orientation M2.1`
- adds a staging-specific module query so iOS cannot reuse the cached faulty M2 script
- documents the physical-test finding and correction

## Root cause

Orientation M2 calculated visual compensation as the full snapped difference between the race-start screen angle and the current screen angle. A completed landscape-right to landscape-left change therefore produced `180°`.

That assumption was wrong for the browser viewport. iOS had already completed its own 180-degree interface flip and made the web content upright. TURN NEXT then applied a second 180-degree transform to `#turnAppViewport`, leaving the entire game upside down. The original M2 test encoded this incorrect expectation.

## Correct behaviour

- landscape to portrait intermediate state: compensate by `±90°`
- landscape side to opposite landscape side after the OS flip: apply `0°` additional rotation
- starting the race with either charging-port direction remains valid
- production `/turn/` remains untouched

## Validation added

- `locked +90° → current 0°` resolves to `-90°`
- `locked -90° → current 0°` resolves to `+90°`
- `locked +90° → current -90°` resolves to `0°`
- `locked -90° → current +90°` resolves to `0°`
- opposite-landscape viewport dimensions and scale remain unchanged
- generated TURN NEXT bootstrap must include the M2.1 cache-buster and visible badge

## Physical retest after merge

Open `/turn-next/`, confirm the badge reads `Platform M1 · Orientation M2.1`, start in either landscape direction, then rotate 180 degrees to the opposite landscape side. After the iOS flip settles, TURN must be upright rather than upside down.

Issue #198 continues to track the broader goal of eliminating visible OS rotation during gameplay.