### PR TITLE
Remove flashing from TURN NEXT steering-limit warning

### DIFF
--- a/turn-next/README.md
+++ b/turn-next/README.md
@@ -29,11 +29,19 @@ Limit M4 replaces the former whole-screen yellow border with directional feedbac
 
 - A red-to-transparent gradient appears only on the side being pushed.
 - The gradient begins fading in at `19°` and strengthens continuously toward the `24°` edge.
-- A fresh hard-edge crossing blinks briefly and then remains solid while the device stays at or beyond `24°`.
 - The hard-edge cue rearms below `22°`, preventing threshold jitter while ensuring a new audible cue on each genuine return to the limit.
 - Every fresh hard-edge crossing plays a short two-part cue through TURN’s existing audio system.
 - VoiceOver announces `Left steering limit reached.` and `Right steering limit reached.` only the first time each side is reached during a race session.
-- `prefers-reduced-motion` removes the blink while retaining the solid hard-edge warning.
+
+Limit M4.1 removes all visual flashing and makes the warning continuously damped:
+
+- The maximum gradient width is reduced from `18vw / 220px` to `10vw / 124px`.
+- At first visibility the gradient occupies only a small part of that width and has low opacity.
+- Both width and opacity grow continuously with the measured limit intensity and reach full strength at `24°`.
+- Approaching the limit uses a soft `260ms` transition.
+- Returning from the limit uses a slower `420ms` transition so hovering around `19°` cannot create rapid on/off blooming.
+- There are no CSS keyframes, blink classes or opacity flashes.
+- Audio, haptics and the first-per-side VoiceOver announcements remain unchanged.
 
 The shared production modules now accept an optional safe-zone configuration, but production `/turn/` retains its existing steering, horizon and feedback limits when no configuration is installed. This lets TURN NEXT test the larger range and directional warning without silently changing the live game.
 

--- a/turn-next/app.js
+++ b/turn-next/app.js
@@ -16,7 +16,16 @@ const webPlatform = createWebPlatform();
 installTurnPlatform(webPlatform);
 document.documentElement.dataset.turnPlatform = 'web-adapter';
 const turnNextBadgeDetail = document.querySelector('.turn-next-badge span');
-if (turnNextBadgeDetail) turnNextBadgeDetail.textContent += ' · Platform M1 · Safe Zone M3 · Limit M4';
+if (turnNextBadgeDetail) turnNextBadgeDetail.textContent += ' · Platform M1 · Safe Zone M3 · Limit M4.1';
+
+const steadyLimitStylesheet = document.createElement('link');
+steadyLimitStylesheet.rel = 'stylesheet';
+steadyLimitStylesheet.href = new URL(
+  './steering-limit-warning.css?source=20260728-r110&stage=steady-limit-m4-1',
+  turnNextModuleBase
+).href;
+steadyLimitStylesheet.setAttribute('data-turn-next-steady-limit', '');
+document.head.appendChild(steadyLimitStylesheet);
 
 function installStylesheet(path, dataAttribute) {
   if (document.querySelector(`link[${dataAttribute}]`)) return;
@@ -63,7 +72,7 @@ const { installTurnAudio } = await import(withBuild('./audio/audio-system.js'));
 installTurnAudio();
 
 const { installTurnNextSteeringLimitWarning } = await import(
-  new URL('./steering-limit-warning.js?source=20260728-r110&stage=directional-limit-m4', turnNextModuleBase).href
+  new URL('./steering-limit-warning.js?source=20260728-r110&stage=steady-limit-m4-1', turnNextModuleBase).href
 );
 installTurnNextSteeringLimitWarning();
 

--- a/turn-next/scripts/build-parity-app.mjs
+++ b/turn-next/scripts/build-parity-app.mjs
@@ -39,7 +39,16 @@ const webPlatform = createWebPlatform();
 installTurnPlatform(webPlatform);
 document.documentElement.dataset.turnPlatform = 'web-adapter';
 const turnNextBadgeDetail = document.querySelector('.turn-next-badge span');
-if (turnNextBadgeDetail) turnNextBadgeDetail.textContent += ' · Platform M1 · Safe Zone M3 · Limit M4';
+if (turnNextBadgeDetail) turnNextBadgeDetail.textContent += ' · Platform M1 · Safe Zone M3 · Limit M4.1';
+
+const steadyLimitStylesheet = document.createElement('link');
+steadyLimitStylesheet.rel = 'stylesheet';
+steadyLimitStylesheet.href = new URL(
+  './steering-limit-warning.css?source=${release.cacheKey}&stage=steady-limit-m4-1',
+  turnNextModuleBase
+).href;
+steadyLimitStylesheet.setAttribute('data-turn-next-steady-limit', '');
+document.head.appendChild(steadyLimitStylesheet);
 
 function installStylesheet(path, dataAttribute) {`,
     'platform composition point'
@@ -51,7 +60,7 @@ function installStylesheet(path, dataAttribute) {`,
     `installTurnAudio();
 
 const { installTurnNextSteeringLimitWarning } = await import(
-  new URL('./steering-limit-warning.js?source=${release.cacheKey}&stage=directional-limit-m4', turnNextModuleBase).href
+  new URL('./steering-limit-warning.js?source=${release.cacheKey}&stage=steady-limit-m4-1', turnNextModuleBase).href
 );
 installTurnNextSteeringLimitWarning();`,
     'directional limit warning composition point'
@@ -70,10 +79,12 @@ installTurnNextSteeringLimitWarning();`,
   assert.match(output, /const platformModuleBase = new URL\('\/turn\/platform\/'/);
   assert.match(output, /const turnNextModuleBase = new URL\('\/turn-next\/'/);
   assert.match(output, /installTurnPlatform\(webPlatform\)/);
+  assert.match(output, /data-turn-next-steady-limit/);
+  assert.match(output, /steering-limit-warning\.css\?source=.*&stage=steady-limit-m4-1/);
   assert.match(output, /installTurnNextSteeringLimitWarning\(\)/);
-  assert.match(output, /steering-limit-warning\.js\?source=.*&stage=directional-limit-m4/);
+  assert.match(output, /steering-limit-warning\.js\?source=.*&stage=steady-limit-m4-1/);
   assert.match(output, /dataset\.turnPlatform = 'web-adapter'/);
-  assert.match(output, /Platform M1 · Safe Zone M3 · Limit M4/);
+  assert.match(output, /Platform M1 · Safe Zone M3 · Limit M4\.1/);
   assert.doesNotMatch(output, /orientation-freeze|installTurnNextOrientationFreeze|Orientation M2/);
   assert.ok(
     output.indexOf('installTurnPlatform(webPlatform)') < output.indexOf("withBuild('./main.js')"),

--- a/turn-next/steering-limit-warning.css
+++ b/turn-next/steering-limit-warning.css
@@ -7,56 +7,44 @@ html[data-turn-deployment="next"] .hud::before {
   top: 0;
   bottom: 0;
   z-index: 120;
-  width: clamp(88px, 18vw, 220px);
+  width: clamp(56px, 10vw, 124px);
   pointer-events: none;
-  opacity: 0;
+  opacity: var(--turn-limit-opacity, 0);
+  transform: scaleX(var(--turn-limit-growth, 0.08));
   transition:
-    opacity 70ms linear,
-    filter 90ms linear;
-  will-change: opacity;
+    opacity 420ms cubic-bezier(0.2, 0.72, 0.2, 1),
+    transform 420ms cubic-bezier(0.2, 0.72, 0.2, 1);
+  will-change: opacity, transform;
+}
+
+.turn-steering-limit-edge.is-active {
+  transition-duration: 260ms;
 }
 
 .turn-steering-limit-edge-left {
   left: 0;
+  transform-origin: left center;
   background: linear-gradient(
     90deg,
-    rgb(255 20 20 / 0.92) 0%,
-    rgb(255 32 32 / 0.58) 34%,
-    rgb(255 44 44 / 0.18) 68%,
-    rgb(255 44 44 / 0) 100%
+    rgb(255 18 18 / 0.96) 0%,
+    rgb(255 28 28 / 0.72) 24%,
+    rgb(255 40 40 / 0.3) 58%,
+    rgb(255 48 48 / 0) 100%
   );
 }
 
 .turn-steering-limit-edge-right {
   right: 0;
+  transform-origin: right center;
   background: linear-gradient(
     270deg,
-    rgb(255 20 20 / 0.92) 0%,
-    rgb(255 32 32 / 0.58) 34%,
-    rgb(255 44 44 / 0.18) 68%,
-    rgb(255 44 44 / 0) 100%
+    rgb(255 18 18 / 0.96) 0%,
+    rgb(255 28 28 / 0.72) 24%,
+    rgb(255 40 40 / 0.3) 58%,
+    rgb(255 48 48 / 0) 100%
   );
-}
-
-.turn-steering-limit-edge.is-hard {
-  filter: saturate(1.28) brightness(1.06);
-}
-
-.turn-steering-limit-edge.is-flashing {
-  animation: turn-steering-limit-edge-flash 520ms linear 1;
 }
 
 body:not(.turn-race-active) .turn-steering-limit-edge {
   display: none;
-}
-
-@keyframes turn-steering-limit-edge-flash {
-  0%, 42%, 78%, 100% { opacity: 1; }
-  24%, 61% { opacity: 0.12; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .turn-steering-limit-edge.is-flashing {
-    animation: none;
-  }
 }

--- a/turn-next/steering-limit-warning.js
+++ b/turn-next/steering-limit-warning.js
@@ -1,6 +1,8 @@
 const LIMIT_EVENT = 'turn:steering-limit-feedback';
-const FLASH_DURATION_MS = 520;
 const SECOND_TONE_DELAY_MS = 90;
+const MIN_VISIBLE_OPACITY = 0.1;
+const MIN_VISIBLE_GROWTH = 0.22;
+const HIDDEN_GROWTH = 0.08;
 
 let installed = false;
 
@@ -12,9 +14,14 @@ export function steeringLimitAnnouncement(side) {
 
 export function steeringLimitVisualOpacity(detail = {}) {
   if (!detail.active) return 0;
-  if (detail.hard) return 1;
   const intensity = clamp(Number(detail.intensity) || 0, 0, 1);
-  return 0.08 + intensity * 0.72;
+  return MIN_VISIBLE_OPACITY + intensity * (1 - MIN_VISIBLE_OPACITY);
+}
+
+export function steeringLimitVisualGrowth(detail = {}) {
+  if (!detail.active) return HIDDEN_GROWTH;
+  const intensity = clamp(Number(detail.intensity) || 0, 0, 1);
+  return MIN_VISIBLE_GROWTH + intensity * (1 - MIN_VISIBLE_GROWTH);
 }
 
 export function installTurnNextSteeringLimitWarning() {
@@ -30,18 +37,21 @@ export function installTurnNextSteeringLimitWarning() {
   document.body.append(overlays.left, overlays.right, announcer);
 
   const announcedSides = { left: false, right: false };
-  let flashTimer = 0;
   let audioTimer = 0;
   let visualsActive = false;
 
-  function clearVisuals() {
-    window.clearTimeout(flashTimer);
-    flashTimer = 0;
+  function setOverlayTarget(overlay, detail) {
+    const active = Boolean(detail?.active);
+    overlay.classList.toggle('is-active', active);
+    overlay.style.setProperty('--turn-limit-opacity', String(steeringLimitVisualOpacity(detail)));
+    overlay.style.setProperty('--turn-limit-growth', String(steeringLimitVisualGrowth(detail)));
+  }
+
+  function softenVisuals() {
     visualsActive = false;
-    for (const overlay of Object.values(overlays)) {
-      overlay.classList.remove('is-hard', 'is-flashing');
-      overlay.style.opacity = '0';
-    }
+    const hidden = { active: false, intensity: 0 };
+    setOverlayTarget(overlays.left, hidden);
+    setOverlayTarget(overlays.right, hidden);
   }
 
   function resetRaceAnnouncements() {
@@ -68,36 +78,22 @@ export function installTurnNextSteeringLimitWarning() {
     });
   }
 
-  function flash(overlay) {
-    window.clearTimeout(flashTimer);
-    overlay.classList.remove('is-flashing');
-    void overlay.offsetWidth;
-    overlay.classList.add('is-flashing');
-    flashTimer = window.setTimeout(() => {
-      overlay.classList.remove('is-flashing');
-    }, FLASH_DURATION_MS);
-  }
-
   function handleLimitFeedback(event) {
     const detail = event.detail || {};
     const side = detail.side === 'left' || detail.side === 'right' ? detail.side : null;
 
     if (!detail.active || !side) {
-      if (visualsActive) clearVisuals();
+      if (visualsActive) softenVisuals();
       return;
     }
 
     visualsActive = true;
     const activeOverlay = overlays[side];
     const inactiveOverlay = overlays[side === 'left' ? 'right' : 'left'];
-    inactiveOverlay.classList.remove('is-hard', 'is-flashing');
-    inactiveOverlay.style.opacity = '0';
-
-    activeOverlay.style.opacity = String(steeringLimitVisualOpacity(detail));
-    activeOverlay.classList.toggle('is-hard', Boolean(detail.hard));
+    setOverlayTarget(inactiveOverlay, { active: false, intensity: 0 });
+    setOverlayTarget(activeOverlay, detail);
 
     if (detail.enteredHard) {
-      flash(activeOverlay);
       playLimitCue();
       announceLimit(side);
     }
@@ -110,7 +106,7 @@ export function installTurnNextSteeringLimitWarning() {
     if (!event.detail?.running) {
       window.clearTimeout(audioTimer);
       audioTimer = 0;
-      if (visualsActive) clearVisuals();
+      if (visualsActive) softenVisuals();
       announcer.textContent = '';
     }
   });
@@ -122,6 +118,8 @@ function createEdge(side) {
   const edge = document.createElement('div');
   edge.className = `turn-steering-limit-edge turn-steering-limit-edge-${side}`;
   edge.setAttribute('aria-hidden', 'true');
+  edge.style.setProperty('--turn-limit-opacity', '0');
+  edge.style.setProperty('--turn-limit-growth', String(HIDDEN_GROWTH));
   return edge;
 }
 

--- a/turn-tests/motion-safe-zone-production.mjs
+++ b/turn-tests/motion-safe-zone-production.mjs
@@ -10,6 +10,7 @@ import {
 } from '../turn/render/camera.js';
 import {
   steeringLimitAnnouncement,
+  steeringLimitVisualGrowth,
   steeringLimitVisualOpacity
 } from '../turn-next/steering-limit-warning.js';
 
@@ -122,9 +123,13 @@ approximately(
 approximately(measuredCameraRoll(32, undefined), toRadians(-18), 1e-9);
 
 assert.equal(steeringLimitVisualOpacity({ active: false }), 0);
-approximately(steeringLimitVisualOpacity({ active: true, intensity: 0 }), 0.08);
-approximately(steeringLimitVisualOpacity({ active: true, intensity: 0.5 }), 0.44);
+approximately(steeringLimitVisualOpacity({ active: true, intensity: 0 }), 0.1);
+approximately(steeringLimitVisualOpacity({ active: true, intensity: 0.5 }), 0.55);
 assert.equal(steeringLimitVisualOpacity({ active: true, intensity: 1, hard: true }), 1);
+approximately(steeringLimitVisualGrowth({ active: false }), 0.08);
+approximately(steeringLimitVisualGrowth({ active: true, intensity: 0 }), 0.22);
+approximately(steeringLimitVisualGrowth({ active: true, intensity: 0.5 }), 0.61);
+assert.equal(steeringLimitVisualGrowth({ active: true, intensity: 1, hard: true }), 1);
 assert.equal(steeringLimitAnnouncement('left'), 'Left steering limit reached.');
 assert.equal(steeringLimitAnnouncement('right'), 'Right steering limit reached.');
 assert.equal(steeringLimitAnnouncement(null), 'Steering limit reached.');
@@ -155,9 +160,11 @@ assert.ok(
   nextIndex.indexOf('/turn-next/safe-zone-bootstrap.js') < nextIndex.indexOf('./orientation-compat.js'),
   'The safe-zone configuration must load before orientation feedback'
 );
-assert.match(nextApp, /Platform M1 · Safe Zone M3 · Limit M4/);
+assert.match(nextApp, /Platform M1 · Safe Zone M3 · Limit M4\.1/);
+assert.match(nextApp, /data-turn-next-steady-limit/);
+assert.match(nextApp, /steering-limit-warning\.css\?source=.*&stage=steady-limit-m4-1/);
 assert.match(nextApp, /installTurnNextSteeringLimitWarning\(\)/);
-assert.match(nextApp, /steering-limit-warning\.js\?source=.*&stage=directional-limit-m4/);
+assert.match(nextApp, /steering-limit-warning\.js\?source=.*&stage=steady-limit-m4-1/);
 assert.ok(
   nextApp.indexOf('installTurnNextSteeringLimitWarning()') < nextApp.indexOf("withBuild('./main.js')"),
   'Directional warning must install before the race core starts'
@@ -176,11 +183,20 @@ assert.match(warningRuntime, /announcedSides = \{ left: false, right: false \}/)
 assert.match(warningRuntime, /reason === 'race-started'/);
 assert.match(warningRuntime, /audio\?\.cue\?\.\('ui-back'\)/);
 assert.match(warningRuntime, /__turnAudio\?\.cue\?\.\('ui-tap'\)/);
+assert.match(warningRuntime, /--turn-limit-opacity/);
+assert.match(warningRuntime, /--turn-limit-growth/);
+assert.doesNotMatch(warningRuntime, /FLASH_DURATION|is-flashing|function flash/);
 assert.match(warningCss, /html\[data-turn-deployment="next"\] \.hud::before/);
+assert.match(warningCss, /width: clamp\(56px, 10vw, 124px\)/);
 assert.match(warningCss, /linear-gradient\(\s*90deg/);
 assert.match(warningCss, /linear-gradient\(\s*270deg/);
-assert.match(warningCss, /turn-steering-limit-edge-flash/);
-assert.match(warningCss, /prefers-reduced-motion: reduce/);
+assert.match(warningCss, /transform: scaleX\(var\(--turn-limit-growth/);
+assert.match(warningCss, /transform-origin: left center/);
+assert.match(warningCss, /transform-origin: right center/);
+assert.match(warningCss, /opacity 420ms/);
+assert.match(warningCss, /transform 420ms/);
+assert.match(warningCss, /transition-duration: 260ms/);
+assert.doesNotMatch(warningCss, /animation|@keyframes|is-flashing/);
 
 for (const removedPath of [
   '../turn-next/orientation-preflight.js',
@@ -197,4 +213,4 @@ for (const removedPath of [
 if (previousConfiguration === undefined) delete globalThis.__TURN_MOTION_SAFE_ZONE__;
 else globalThis.__TURN_MOTION_SAFE_ZONE__ = previousConfiguration;
 
-console.log('TURN NEXT 24-degree safe zone and directional limit warning passed.');
+console.log('TURN NEXT 24-degree safe zone and non-flashing directional limit warning passed.');

--- a/turn-tests/turn-next-entry-production.mjs
+++ b/turn-tests/turn-next-entry-production.mjs
@@ -70,10 +70,12 @@ assert.match(nextApp, /const platformModuleBase = new URL\('\/turn\/platform\/'/
 assert.match(nextApp, /const turnNextModuleBase = new URL\('\/turn-next\/'/);
 assert.match(nextApp, /const webPlatform = createWebPlatform\(\)/);
 assert.match(nextApp, /installTurnPlatform\(webPlatform\)/);
+assert.match(nextApp, /data-turn-next-steady-limit/);
+assert.match(nextApp, /steering-limit-warning\.css\?source=.*&stage=steady-limit-m4-1/);
 assert.match(nextApp, /installTurnNextSteeringLimitWarning\(\)/);
-assert.match(nextApp, /steering-limit-warning\.js\?source=.*&stage=directional-limit-m4/);
+assert.match(nextApp, /steering-limit-warning\.js\?source=.*&stage=steady-limit-m4-1/);
 assert.match(nextApp, /dataset\.turnPlatform = 'web-adapter'/);
-assert.match(nextApp, /Platform M1 · Safe Zone M3 · Limit M4/, 'The visible staging badge must identify the active platform, safe-zone and directional-limit milestones');
+assert.match(nextApp, /Platform M1 · Safe Zone M3 · Limit M4\.1/, 'The visible staging badge must identify the active platform, safe-zone and steady-limit milestones');
 assert.doesNotMatch(nextApp, /orientation-freeze|installTurnNextOrientationFreeze|Orientation M2/);
 assert.ok(
   nextApp.indexOf('installTurnPlatform(webPlatform)') < nextApp.indexOf("withBuild('./main.js')"),
@@ -122,9 +124,14 @@ assert.match(steeringLimitWarning, /Left steering limit reached\./);
 assert.match(steeringLimitWarning, /Right steering limit reached\./);
 assert.match(steeringLimitWarning, /aria-live', 'assertive'/);
 assert.match(steeringLimitWarning, /__turnAudio/);
+assert.match(steeringLimitWarning, /steeringLimitVisualGrowth/);
+assert.doesNotMatch(steeringLimitWarning, /FLASH_DURATION|is-flashing|function flash/);
 assert.match(steeringLimitWarningCss, /turn-steering-limit-edge-left/);
 assert.match(steeringLimitWarningCss, /turn-steering-limit-edge-right/);
-assert.match(steeringLimitWarningCss, /turn-steering-limit-edge-flash/);
+assert.match(steeringLimitWarningCss, /width: clamp\(56px, 10vw, 124px\)/);
+assert.match(steeringLimitWarningCss, /opacity 420ms/);
+assert.match(steeringLimitWarningCss, /transform 420ms/);
+assert.doesNotMatch(steeringLimitWarningCss, /animation|@keyframes|is-flashing/);
 
 assert.match(platformContext, /installTurnPlatform/);
 assert.match(platformContext, /requireTurnPlatform/);
@@ -178,4 +185,4 @@ assert.deepEqual(
   }
 );
 
-console.log(`TURN NEXT isolated Limit M4 entry for TURN ${release.id} passed.`);
+console.log(`TURN NEXT isolated Limit M4.1 entry for TURN ${release.id} passed.`);


### PR DESCRIPTION
## What changed

- removes the hard-edge blink from TURN NEXT entirely
- keeps the red warning on only the side being pushed
- narrows the maximum gradient from `18vw / 220px` to `10vw / 124px`
- makes both opacity and width follow the continuous 19° to 24° intensity value
- starts with a small, low-opacity gradient at 19° and reaches full width and opacity at 24°
- uses a soft 260ms approach and slower 420ms release so hovering around 19° cannot create rapid on/off blooming
- preserves the existing audible cue on every hysteresis-rearmed hard crossing
- preserves haptics and the first-per-side VoiceOver announcements
- labels the staging runtime `Platform M1 · Safe Zone M3 · Limit M4.1`

## Accessibility reason

The previous brief hard-edge blink was visually effective but unnecessary and created avoidable flashing risk under WCAG 2.3.1. The replacement has no keyframes, blink class, opacity flash or sudden hard-edge visual state. Reaching 24° changes only the continuous intensity value.

## Visual model

- below 19°: target opacity is 0 and the gradient softly recedes
- at 19°: the gradient begins at 10% opacity and 22% of its maximum width
- between 19° and 24°: opacity and width increase linearly with measured limit intensity
- at and beyond 24°: opacity and width remain at 100%
- returning from the warning takes 420ms, preventing threshold chatter from appearing as blinking

## Cache safety

TURN NEXT now appends a versioned `steady-limit-m4-1` stylesheet after the existing staging entry stylesheet and imports the warning runtime with the same stage key. This guarantees Safari receives the non-flashing assets even when it has cached Limit M4.

## Production safety

- production `/turn/` remains unchanged
- steering, horizon, 19° near threshold, 24° hard threshold, 22° audio rearm and 17.5° clear threshold remain unchanged
- no track, physics, vehicle, lap, record, Drive By Ear or pace-note code changes
- audio and VoiceOver semantics remain unchanged

## Validation added

- exact opacity and width-growth values at inactive, first-visible, halfway and hard-edge states
- no `FLASH_DURATION`, `is-flashing`, flash function, CSS animation or keyframes
- 56px / 10vw / 124px maximum width
- side-specific transform origins
- 260ms approach and 420ms release transitions
- versioned M4.1 CSS and JS composition
- production bootstrap and warning behavior remain isolated

## Physical test after merge

Open `/turn-next/` and confirm the badge reads `Platform M1 · Safe Zone M3 · Limit M4.1`.

1. Approach 19° slowly and confirm a narrow red edge grows in softly.
2. Hover around 19° and confirm it gently breathes rather than blinking on and off.
3. Continue to 24° and confirm it reaches full strength without a flash.
4. Return toward centre and confirm it shrinks and fades more slowly than it appeared.
5. Repeat on both sides and confirm audio, haptics and VoiceOver behavior are unchanged.