### PR TITLE
Add stronger inertia to TURN NEXT steering-limit warning

### DIFF
--- a/turn-next/README.md
+++ b/turn-next/README.md
@@ -33,15 +33,19 @@ Limit M4 replaces the former whole-screen yellow border with directional feedbac
 - Every fresh hard-edge crossing plays a short two-part cue through TURN’s existing audio system.
 - VoiceOver announces `Left steering limit reached.` and `Right steering limit reached.` only the first time each side is reached during a race session.
 
-Limit M4.1 removes all visual flashing and makes the warning continuously damped:
+Limit M4.1 removed all visual flashing and replaced the hard-edge animation with continuously changing width and opacity.
 
-- The maximum gradient width is reduced from `18vw / 220px` to `10vw / 124px`.
-- At first visibility the gradient occupies only a small part of that width and has low opacity.
-- Both width and opacity grow continuously with the measured limit intensity and reach full strength at `24°`.
-- Approaching the limit uses a soft `260ms` transition.
-- Returning from the limit uses a slower `420ms` transition so hovering around `19°` cannot create rapid on/off blooming.
-- There are no CSS keyframes, blink classes or opacity flashes.
-- Audio, haptics and the first-per-side VoiceOver announcements remain unchanged.
+Limit M4.2 adds true visual inertia after physical testing still showed threshold shimmer and nervous movement during fast curves:
+
+- The maximum gradient is halved again, from `10vw / 124px` to `5vw / 62px`.
+- CSS transitions no longer chase every sensor update.
+- A request-animation-frame controller owns the displayed opacity and width independently from the latest sensor target.
+- A brief `300ms` hold absorbs momentary drops below the `19°` visibility threshold.
+- Increasing warning strength uses a `360ms` exponential time constant.
+- Decreasing warning strength uses a slower `780ms` exponential time constant.
+- The visual therefore approaches and recedes continuously instead of repeatedly restarting a transition.
+- There are no keyframes, blink classes, opacity flashes or abrupt visual changes at the `24°` edge.
+- Audio, haptics and the first-per-side VoiceOver announcements remain unchanged and still use the existing `22°` hard-cue rearm threshold.
 
 The shared production modules now accept an optional safe-zone configuration, but production `/turn/` retains its existing steering, horizon and feedback limits when no configuration is installed. This lets TURN NEXT test the larger range and directional warning without silently changing the live game.
 

--- a/turn-next/app.js
+++ b/turn-next/app.js
@@ -16,12 +16,12 @@ const webPlatform = createWebPlatform();
 installTurnPlatform(webPlatform);
 document.documentElement.dataset.turnPlatform = 'web-adapter';
 const turnNextBadgeDetail = document.querySelector('.turn-next-badge span');
-if (turnNextBadgeDetail) turnNextBadgeDetail.textContent += ' · Platform M1 · Safe Zone M3 · Limit M4.1';
+if (turnNextBadgeDetail) turnNextBadgeDetail.textContent += ' · Platform M1 · Safe Zone M3 · Limit M4.2';
 
 const steadyLimitStylesheet = document.createElement('link');
 steadyLimitStylesheet.rel = 'stylesheet';
 steadyLimitStylesheet.href = new URL(
-  './steering-limit-warning.css?source=20260728-r110&stage=steady-limit-m4-1',
+  './steering-limit-warning.css?source=20260728-r110&stage=inertial-limit-m4-2',
   turnNextModuleBase
 ).href;
 steadyLimitStylesheet.setAttribute('data-turn-next-steady-limit', '');
@@ -72,7 +72,7 @@ const { installTurnAudio } = await import(withBuild('./audio/audio-system.js'));
 installTurnAudio();
 
 const { installTurnNextSteeringLimitWarning } = await import(
-  new URL('./steering-limit-warning.js?source=20260728-r110&stage=steady-limit-m4-1', turnNextModuleBase).href
+  new URL('./steering-limit-warning.js?source=20260728-r110&stage=inertial-limit-m4-2', turnNextModuleBase).href
 );
 installTurnNextSteeringLimitWarning();
 

--- a/turn-next/scripts/build-parity-app.mjs
+++ b/turn-next/scripts/build-parity-app.mjs
@@ -39,12 +39,12 @@ const webPlatform = createWebPlatform();
 installTurnPlatform(webPlatform);
 document.documentElement.dataset.turnPlatform = 'web-adapter';
 const turnNextBadgeDetail = document.querySelector('.turn-next-badge span');
-if (turnNextBadgeDetail) turnNextBadgeDetail.textContent += ' · Platform M1 · Safe Zone M3 · Limit M4.1';
+if (turnNextBadgeDetail) turnNextBadgeDetail.textContent += ' · Platform M1 · Safe Zone M3 · Limit M4.2';
 
 const steadyLimitStylesheet = document.createElement('link');
 steadyLimitStylesheet.rel = 'stylesheet';
 steadyLimitStylesheet.href = new URL(
-  './steering-limit-warning.css?source=${release.cacheKey}&stage=steady-limit-m4-1',
+  './steering-limit-warning.css?source=${release.cacheKey}&stage=inertial-limit-m4-2',
   turnNextModuleBase
 ).href;
 steadyLimitStylesheet.setAttribute('data-turn-next-steady-limit', '');
@@ -60,7 +60,7 @@ function installStylesheet(path, dataAttribute) {`,
     `installTurnAudio();
 
 const { installTurnNextSteeringLimitWarning } = await import(
-  new URL('./steering-limit-warning.js?source=${release.cacheKey}&stage=steady-limit-m4-1', turnNextModuleBase).href
+  new URL('./steering-limit-warning.js?source=${release.cacheKey}&stage=inertial-limit-m4-2', turnNextModuleBase).href
 );
 installTurnNextSteeringLimitWarning();`,
     'directional limit warning composition point'
@@ -80,11 +80,11 @@ installTurnNextSteeringLimitWarning();`,
   assert.match(output, /const turnNextModuleBase = new URL\('\/turn-next\/'/);
   assert.match(output, /installTurnPlatform\(webPlatform\)/);
   assert.match(output, /data-turn-next-steady-limit/);
-  assert.match(output, /steering-limit-warning\.css\?source=.*&stage=steady-limit-m4-1/);
+  assert.match(output, /steering-limit-warning\.css\?source=.*&stage=inertial-limit-m4-2/);
   assert.match(output, /installTurnNextSteeringLimitWarning\(\)/);
-  assert.match(output, /steering-limit-warning\.js\?source=.*&stage=steady-limit-m4-1/);
+  assert.match(output, /steering-limit-warning\.js\?source=.*&stage=inertial-limit-m4-2/);
   assert.match(output, /dataset\.turnPlatform = 'web-adapter'/);
-  assert.match(output, /Platform M1 · Safe Zone M3 · Limit M4\.1/);
+  assert.match(output, /Platform M1 · Safe Zone M3 · Limit M4\.2/);
   assert.doesNotMatch(output, /orientation-freeze|installTurnNextOrientationFreeze|Orientation M2/);
   assert.ok(
     output.indexOf('installTurnPlatform(webPlatform)') < output.indexOf("withBuild('./main.js')"),

--- a/turn-next/steering-limit-warning.css
+++ b/turn-next/steering-limit-warning.css
@@ -7,18 +7,11 @@ html[data-turn-deployment="next"] .hud::before {
   top: 0;
   bottom: 0;
   z-index: 120;
-  width: clamp(56px, 10vw, 124px);
+  width: clamp(28px, 5vw, 62px);
   pointer-events: none;
   opacity: var(--turn-limit-opacity, 0);
-  transform: scaleX(var(--turn-limit-growth, 0.08));
-  transition:
-    opacity 420ms cubic-bezier(0.2, 0.72, 0.2, 1),
-    transform 420ms cubic-bezier(0.2, 0.72, 0.2, 1);
+  transform: scaleX(var(--turn-limit-growth, 0.12));
   will-change: opacity, transform;
-}
-
-.turn-steering-limit-edge.is-active {
-  transition-duration: 260ms;
 }
 
 .turn-steering-limit-edge-left {

--- a/turn-next/steering-limit-warning.css
+++ b/turn-next/steering-limit-warning.css
@@ -11,6 +11,7 @@ html[data-turn-deployment="next"] .hud::before {
   pointer-events: none;
   opacity: var(--turn-limit-opacity, 0);
   transform: scaleX(var(--turn-limit-growth, 0.12));
+  transition: none;
   will-change: opacity, transform;
 }
 

--- a/turn-next/steering-limit-warning.js
+++ b/turn-next/steering-limit-warning.js
@@ -1,8 +1,13 @@
 const LIMIT_EVENT = 'turn:steering-limit-feedback';
 const SECOND_TONE_DELAY_MS = 90;
-const MIN_VISIBLE_OPACITY = 0.1;
-const MIN_VISIBLE_GROWTH = 0.22;
-const HIDDEN_GROWTH = 0.08;
+const MIN_VISIBLE_OPACITY = 0.08;
+const MIN_VISIBLE_GROWTH = 0.3;
+const HIDDEN_GROWTH = 0.12;
+const VISUAL_RELEASE_HOLD_MS = 300;
+const VISUAL_ATTACK_TAU_MS = 360;
+const VISUAL_RELEASE_TAU_MS = 780;
+const MAX_FRAME_DELTA_MS = 64;
+const VISUAL_EPSILON = 0.001;
 
 let installed = false;
 
@@ -24,34 +29,121 @@ export function steeringLimitVisualGrowth(detail = {}) {
   return MIN_VISIBLE_GROWTH + intensity * (1 - MIN_VISIBLE_GROWTH);
 }
 
+export function steeringLimitInertialStep(current, target, elapsedMs, timeConstantMs) {
+  const elapsed = Math.max(0, Number(elapsedMs) || 0);
+  const timeConstant = Math.max(1, Number(timeConstantMs) || 1);
+  const blend = 1 - Math.exp(-elapsed / timeConstant);
+  return current + (target - current) * blend;
+}
+
 export function installTurnNextSteeringLimitWarning() {
   if (installed) return true;
   if (!document.body) return false;
   installed = true;
 
-  const overlays = {
-    left: createEdge('left'),
-    right: createEdge('right')
+  const states = {
+    left: createVisualState('left'),
+    right: createVisualState('right')
   };
   const announcer = createAnnouncer();
-  document.body.append(overlays.left, overlays.right, announcer);
+  document.body.append(states.left.overlay, states.right.overlay, announcer);
 
   const announcedSides = { left: false, right: false };
   let audioTimer = 0;
-  let visualsActive = false;
+  let animationFrame = 0;
+  let previousFrameTime = 0;
 
-  function setOverlayTarget(overlay, detail) {
-    const active = Boolean(detail?.active);
-    overlay.classList.toggle('is-active', active);
-    overlay.style.setProperty('--turn-limit-opacity', String(steeringLimitVisualOpacity(detail)));
-    overlay.style.setProperty('--turn-limit-growth', String(steeringLimitVisualGrowth(detail)));
+  function applyState(state) {
+    state.overlay.style.setProperty('--turn-limit-opacity', state.currentOpacity.toFixed(4));
+    state.overlay.style.setProperty('--turn-limit-growth', state.currentGrowth.toFixed(4));
   }
 
-  function softenVisuals() {
-    visualsActive = false;
-    const hidden = { active: false, intensity: 0 };
-    setOverlayTarget(overlays.left, hidden);
-    setOverlayTarget(overlays.right, hidden);
+  function setVisibleTarget(state, detail) {
+    state.releaseAt = 0;
+    state.targetOpacity = steeringLimitVisualOpacity(detail);
+    state.targetGrowth = steeringLimitVisualGrowth(detail);
+  }
+
+  function setHiddenTarget(state) {
+    state.releaseAt = 0;
+    state.targetOpacity = 0;
+    state.targetGrowth = HIDDEN_GROWTH;
+  }
+
+  function scheduleSoftRelease(state, now) {
+    if (state.targetOpacity <= 0 && state.currentOpacity <= VISUAL_EPSILON) return;
+    state.releaseAt = Math.max(state.releaseAt, now + VISUAL_RELEASE_HOLD_MS);
+  }
+
+  function resetVisualsImmediately() {
+    if (animationFrame) window.cancelAnimationFrame(animationFrame);
+    animationFrame = 0;
+    previousFrameTime = 0;
+    for (const state of Object.values(states)) {
+      state.releaseAt = 0;
+      state.currentOpacity = 0;
+      state.targetOpacity = 0;
+      state.currentGrowth = HIDDEN_GROWTH;
+      state.targetGrowth = HIDDEN_GROWTH;
+      applyState(state);
+    }
+  }
+
+  function stateNeedsAnimation(state, now) {
+    return state.releaseAt > now ||
+      Math.abs(state.currentOpacity - state.targetOpacity) > VISUAL_EPSILON ||
+      Math.abs(state.currentGrowth - state.targetGrowth) > VISUAL_EPSILON;
+  }
+
+  function animateVisuals(timestamp) {
+    animationFrame = 0;
+    const now = Number.isFinite(timestamp) ? timestamp : currentTime();
+    const elapsed = previousFrameTime
+      ? Math.min(MAX_FRAME_DELTA_MS, Math.max(0, now - previousFrameTime))
+      : 16;
+    previousFrameTime = now;
+    let keepAnimating = false;
+
+    for (const state of Object.values(states)) {
+      if (state.releaseAt && now >= state.releaseAt) setHiddenTarget(state);
+
+      const opacityTau = state.targetOpacity >= state.currentOpacity
+        ? VISUAL_ATTACK_TAU_MS
+        : VISUAL_RELEASE_TAU_MS;
+      const growthTau = state.targetGrowth >= state.currentGrowth
+        ? VISUAL_ATTACK_TAU_MS
+        : VISUAL_RELEASE_TAU_MS;
+
+      state.currentOpacity = steeringLimitInertialStep(
+        state.currentOpacity,
+        state.targetOpacity,
+        elapsed,
+        opacityTau
+      );
+      state.currentGrowth = steeringLimitInertialStep(
+        state.currentGrowth,
+        state.targetGrowth,
+        elapsed,
+        growthTau
+      );
+
+      if (Math.abs(state.currentOpacity - state.targetOpacity) <= VISUAL_EPSILON) {
+        state.currentOpacity = state.targetOpacity;
+      }
+      if (Math.abs(state.currentGrowth - state.targetGrowth) <= VISUAL_EPSILON) {
+        state.currentGrowth = state.targetGrowth;
+      }
+
+      applyState(state);
+      keepAnimating ||= stateNeedsAnimation(state, now);
+    }
+
+    if (keepAnimating) animationFrame = window.requestAnimationFrame(animateVisuals);
+    else previousFrameTime = 0;
+  }
+
+  function requestVisualAnimation() {
+    if (!animationFrame) animationFrame = window.requestAnimationFrame(animateVisuals);
   }
 
   function resetRaceAnnouncements() {
@@ -81,17 +173,20 @@ export function installTurnNextSteeringLimitWarning() {
   function handleLimitFeedback(event) {
     const detail = event.detail || {};
     const side = detail.side === 'left' || detail.side === 'right' ? detail.side : null;
+    const now = currentTime();
 
     if (!detail.active || !side) {
-      if (visualsActive) softenVisuals();
+      scheduleSoftRelease(states.left, now);
+      scheduleSoftRelease(states.right, now);
+      requestVisualAnimation();
       return;
     }
 
-    visualsActive = true;
-    const activeOverlay = overlays[side];
-    const inactiveOverlay = overlays[side === 'left' ? 'right' : 'left'];
-    setOverlayTarget(inactiveOverlay, { active: false, intensity: 0 });
-    setOverlayTarget(activeOverlay, detail);
+    const activeState = states[side];
+    const inactiveState = states[side === 'left' ? 'right' : 'left'];
+    setVisibleTarget(activeState, detail);
+    setHiddenTarget(inactiveState);
+    requestVisualAnimation();
 
     if (detail.enteredHard) {
       playLimitCue();
@@ -106,7 +201,7 @@ export function installTurnNextSteeringLimitWarning() {
     if (!event.detail?.running) {
       window.clearTimeout(audioTimer);
       audioTimer = 0;
-      if (visualsActive) softenVisuals();
+      resetVisualsImmediately();
       announcer.textContent = '';
     }
   });
@@ -114,13 +209,20 @@ export function installTurnNextSteeringLimitWarning() {
   return true;
 }
 
-function createEdge(side) {
-  const edge = document.createElement('div');
-  edge.className = `turn-steering-limit-edge turn-steering-limit-edge-${side}`;
-  edge.setAttribute('aria-hidden', 'true');
-  edge.style.setProperty('--turn-limit-opacity', '0');
-  edge.style.setProperty('--turn-limit-growth', String(HIDDEN_GROWTH));
-  return edge;
+function createVisualState(side) {
+  const overlay = document.createElement('div');
+  overlay.className = `turn-steering-limit-edge turn-steering-limit-edge-${side}`;
+  overlay.setAttribute('aria-hidden', 'true');
+  overlay.style.setProperty('--turn-limit-opacity', '0');
+  overlay.style.setProperty('--turn-limit-growth', String(HIDDEN_GROWTH));
+  return {
+    overlay,
+    currentOpacity: 0,
+    targetOpacity: 0,
+    currentGrowth: HIDDEN_GROWTH,
+    targetGrowth: HIDDEN_GROWTH,
+    releaseAt: 0
+  };
 }
 
 function createAnnouncer() {
@@ -129,6 +231,10 @@ function createAnnouncer() {
   announcer.setAttribute('aria-live', 'assertive');
   announcer.setAttribute('aria-atomic', 'true');
   return announcer;
+}
+
+function currentTime() {
+  return globalThis.performance?.now?.() ?? Date.now();
 }
 
 function clamp(value, min, max) {

--- a/turn-tests/motion-safe-zone-production.mjs
+++ b/turn-tests/motion-safe-zone-production.mjs
@@ -10,6 +10,7 @@ import {
 } from '../turn/render/camera.js';
 import {
   steeringLimitAnnouncement,
+  steeringLimitInertialStep,
   steeringLimitVisualGrowth,
   steeringLimitVisualOpacity
 } from '../turn-next/steering-limit-warning.js';
@@ -123,13 +124,25 @@ approximately(
 approximately(measuredCameraRoll(32, undefined), toRadians(-18), 1e-9);
 
 assert.equal(steeringLimitVisualOpacity({ active: false }), 0);
-approximately(steeringLimitVisualOpacity({ active: true, intensity: 0 }), 0.1);
-approximately(steeringLimitVisualOpacity({ active: true, intensity: 0.5 }), 0.55);
+approximately(steeringLimitVisualOpacity({ active: true, intensity: 0 }), 0.08);
+approximately(steeringLimitVisualOpacity({ active: true, intensity: 0.5 }), 0.54);
 assert.equal(steeringLimitVisualOpacity({ active: true, intensity: 1, hard: true }), 1);
-approximately(steeringLimitVisualGrowth({ active: false }), 0.08);
-approximately(steeringLimitVisualGrowth({ active: true, intensity: 0 }), 0.22);
-approximately(steeringLimitVisualGrowth({ active: true, intensity: 0.5 }), 0.61);
+approximately(steeringLimitVisualGrowth({ active: false }), 0.12);
+approximately(steeringLimitVisualGrowth({ active: true, intensity: 0 }), 0.3);
+approximately(steeringLimitVisualGrowth({ active: true, intensity: 0.5 }), 0.65);
 assert.equal(steeringLimitVisualGrowth({ active: true, intensity: 1, hard: true }), 1);
+
+const attackAfterOneTau = steeringLimitInertialStep(0, 1, 360, 360);
+approximately(attackAfterOneTau, 1 - Math.exp(-1));
+assert.ok(attackAfterOneTau > 0 && attackAfterOneTau < 1, 'Inertial attack must approach without snapping');
+const releaseAfterOneTau = steeringLimitInertialStep(1, 0, 780, 780);
+approximately(releaseAfterOneTau, Math.exp(-1));
+assert.ok(releaseAfterOneTau > 0 && releaseAfterOneTau < 1, 'Inertial release must retain visible energy');
+assert.ok(
+  steeringLimitInertialStep(1, 0, 16, 780) > steeringLimitInertialStep(1, 0, 16, 360),
+  'Release must be slower than attack for softer threshold behavior'
+);
+
 assert.equal(steeringLimitAnnouncement('left'), 'Left steering limit reached.');
 assert.equal(steeringLimitAnnouncement('right'), 'Right steering limit reached.');
 assert.equal(steeringLimitAnnouncement(null), 'Steering limit reached.');
@@ -160,11 +173,11 @@ assert.ok(
   nextIndex.indexOf('/turn-next/safe-zone-bootstrap.js') < nextIndex.indexOf('./orientation-compat.js'),
   'The safe-zone configuration must load before orientation feedback'
 );
-assert.match(nextApp, /Platform M1 · Safe Zone M3 · Limit M4\.1/);
+assert.match(nextApp, /Platform M1 · Safe Zone M3 · Limit M4\.2/);
 assert.match(nextApp, /data-turn-next-steady-limit/);
-assert.match(nextApp, /steering-limit-warning\.css\?source=.*&stage=steady-limit-m4-1/);
+assert.match(nextApp, /steering-limit-warning\.css\?source=.*&stage=inertial-limit-m4-2/);
 assert.match(nextApp, /installTurnNextSteeringLimitWarning\(\)/);
-assert.match(nextApp, /steering-limit-warning\.js\?source=.*&stage=steady-limit-m4-1/);
+assert.match(nextApp, /steering-limit-warning\.js\?source=.*&stage=inertial-limit-m4-2/);
 assert.ok(
   nextApp.indexOf('installTurnNextSteeringLimitWarning()') < nextApp.indexOf("withBuild('./main.js')"),
   'Directional warning must install before the race core starts'
@@ -183,20 +196,23 @@ assert.match(warningRuntime, /announcedSides = \{ left: false, right: false \}/)
 assert.match(warningRuntime, /reason === 'race-started'/);
 assert.match(warningRuntime, /audio\?\.cue\?\.\('ui-back'\)/);
 assert.match(warningRuntime, /__turnAudio\?\.cue\?\.\('ui-tap'\)/);
+assert.match(warningRuntime, /VISUAL_RELEASE_HOLD_MS = 300/);
+assert.match(warningRuntime, /VISUAL_ATTACK_TAU_MS = 360/);
+assert.match(warningRuntime, /VISUAL_RELEASE_TAU_MS = 780/);
+assert.match(warningRuntime, /steeringLimitInertialStep/);
+assert.match(warningRuntime, /requestAnimationFrame\(animateVisuals\)/);
+assert.match(warningRuntime, /releaseAt/);
 assert.match(warningRuntime, /--turn-limit-opacity/);
 assert.match(warningRuntime, /--turn-limit-growth/);
 assert.doesNotMatch(warningRuntime, /FLASH_DURATION|is-flashing|function flash/);
 assert.match(warningCss, /html\[data-turn-deployment="next"\] \.hud::before/);
-assert.match(warningCss, /width: clamp\(56px, 10vw, 124px\)/);
+assert.match(warningCss, /width: clamp\(28px, 5vw, 62px\)/);
 assert.match(warningCss, /linear-gradient\(\s*90deg/);
 assert.match(warningCss, /linear-gradient\(\s*270deg/);
 assert.match(warningCss, /transform: scaleX\(var\(--turn-limit-growth/);
 assert.match(warningCss, /transform-origin: left center/);
 assert.match(warningCss, /transform-origin: right center/);
-assert.match(warningCss, /opacity 420ms/);
-assert.match(warningCss, /transform 420ms/);
-assert.match(warningCss, /transition-duration: 260ms/);
-assert.doesNotMatch(warningCss, /animation|@keyframes|is-flashing/);
+assert.doesNotMatch(warningCss, /transition|animation|@keyframes|is-flashing/);
 
 for (const removedPath of [
   '../turn-next/orientation-preflight.js',
@@ -213,4 +229,4 @@ for (const removedPath of [
 if (previousConfiguration === undefined) delete globalThis.__TURN_MOTION_SAFE_ZONE__;
 else globalThis.__TURN_MOTION_SAFE_ZONE__ = previousConfiguration;
 
-console.log('TURN NEXT 24-degree safe zone and non-flashing directional limit warning passed.');
+console.log('TURN NEXT 24-degree safe zone and inertial directional limit warning passed.');

--- a/turn-tests/motion-safe-zone-production.mjs
+++ b/turn-tests/motion-safe-zone-production.mjs
@@ -212,7 +212,8 @@ assert.match(warningCss, /linear-gradient\(\s*270deg/);
 assert.match(warningCss, /transform: scaleX\(var\(--turn-limit-growth/);
 assert.match(warningCss, /transform-origin: left center/);
 assert.match(warningCss, /transform-origin: right center/);
-assert.doesNotMatch(warningCss, /transition|animation|@keyframes|is-flashing/);
+assert.match(warningCss, /transition: none/);
+assert.doesNotMatch(warningCss, /transition-duration|animation|@keyframes|is-flashing/);
 
 for (const removedPath of [
   '../turn-next/orientation-preflight.js',

--- a/turn-tests/turn-next-entry-production.mjs
+++ b/turn-tests/turn-next-entry-production.mjs
@@ -134,7 +134,8 @@ assert.doesNotMatch(steeringLimitWarning, /FLASH_DURATION|is-flashing|function f
 assert.match(steeringLimitWarningCss, /turn-steering-limit-edge-left/);
 assert.match(steeringLimitWarningCss, /turn-steering-limit-edge-right/);
 assert.match(steeringLimitWarningCss, /width: clamp\(28px, 5vw, 62px\)/);
-assert.doesNotMatch(steeringLimitWarningCss, /transition|animation|@keyframes|is-flashing/);
+assert.match(steeringLimitWarningCss, /transition: none/);
+assert.doesNotMatch(steeringLimitWarningCss, /transition-duration|animation|@keyframes|is-flashing/);
 
 assert.match(platformContext, /installTurnPlatform/);
 assert.match(platformContext, /requireTurnPlatform/);

--- a/turn-tests/turn-next-entry-production.mjs
+++ b/turn-tests/turn-next-entry-production.mjs
@@ -71,11 +71,11 @@ assert.match(nextApp, /const turnNextModuleBase = new URL\('\/turn-next\/'/);
 assert.match(nextApp, /const webPlatform = createWebPlatform\(\)/);
 assert.match(nextApp, /installTurnPlatform\(webPlatform\)/);
 assert.match(nextApp, /data-turn-next-steady-limit/);
-assert.match(nextApp, /steering-limit-warning\.css\?source=.*&stage=steady-limit-m4-1/);
+assert.match(nextApp, /steering-limit-warning\.css\?source=.*&stage=inertial-limit-m4-2/);
 assert.match(nextApp, /installTurnNextSteeringLimitWarning\(\)/);
-assert.match(nextApp, /steering-limit-warning\.js\?source=.*&stage=steady-limit-m4-1/);
+assert.match(nextApp, /steering-limit-warning\.js\?source=.*&stage=inertial-limit-m4-2/);
 assert.match(nextApp, /dataset\.turnPlatform = 'web-adapter'/);
-assert.match(nextApp, /Platform M1 · Safe Zone M3 · Limit M4\.1/, 'The visible staging badge must identify the active platform, safe-zone and steady-limit milestones');
+assert.match(nextApp, /Platform M1 · Safe Zone M3 · Limit M4\.2/, 'The visible staging badge must identify the active platform, safe-zone and inertial-limit milestones');
 assert.doesNotMatch(nextApp, /orientation-freeze|installTurnNextOrientationFreeze|Orientation M2/);
 assert.ok(
   nextApp.indexOf('installTurnPlatform(webPlatform)') < nextApp.indexOf("withBuild('./main.js')"),
@@ -125,13 +125,16 @@ assert.match(steeringLimitWarning, /Right steering limit reached\./);
 assert.match(steeringLimitWarning, /aria-live', 'assertive'/);
 assert.match(steeringLimitWarning, /__turnAudio/);
 assert.match(steeringLimitWarning, /steeringLimitVisualGrowth/);
+assert.match(steeringLimitWarning, /steeringLimitInertialStep/);
+assert.match(steeringLimitWarning, /VISUAL_RELEASE_HOLD_MS = 300/);
+assert.match(steeringLimitWarning, /VISUAL_ATTACK_TAU_MS = 360/);
+assert.match(steeringLimitWarning, /VISUAL_RELEASE_TAU_MS = 780/);
+assert.match(steeringLimitWarning, /requestAnimationFrame\(animateVisuals\)/);
 assert.doesNotMatch(steeringLimitWarning, /FLASH_DURATION|is-flashing|function flash/);
 assert.match(steeringLimitWarningCss, /turn-steering-limit-edge-left/);
 assert.match(steeringLimitWarningCss, /turn-steering-limit-edge-right/);
-assert.match(steeringLimitWarningCss, /width: clamp\(56px, 10vw, 124px\)/);
-assert.match(steeringLimitWarningCss, /opacity 420ms/);
-assert.match(steeringLimitWarningCss, /transform 420ms/);
-assert.doesNotMatch(steeringLimitWarningCss, /animation|@keyframes|is-flashing/);
+assert.match(steeringLimitWarningCss, /width: clamp\(28px, 5vw, 62px\)/);
+assert.doesNotMatch(steeringLimitWarningCss, /transition|animation|@keyframes|is-flashing/);
 
 assert.match(platformContext, /installTurnPlatform/);
 assert.match(platformContext, /requireTurnPlatform/);
@@ -185,4 +188,4 @@ assert.deepEqual(
   }
 );
 
-console.log(`TURN NEXT isolated Limit M4.1 entry for TURN ${release.id} passed.`);
+console.log(`TURN NEXT isolated Limit M4.2 entry for TURN ${release.id} passed.`);


### PR DESCRIPTION
## What changed

- halves the maximum red side-gradient again, from `10vw / 124px` to `5vw / 62px`
- replaces continuously retargeted CSS transitions with a request-animation-frame visual controller
- gives opacity and width their own remembered displayed values instead of rendering the latest sensor target directly
- holds the current visual target for `300ms` after a brief drop below the `19°` visibility threshold
- approaches stronger warning input with a `360ms` exponential time constant
- recedes with a slower `780ms` exponential time constant
- explicitly applies `transition: none` so a cached earlier Limit stylesheet cannot interfere with the inertial controller
- labels TURN NEXT `Platform M1 · Safe Zone M3 · Limit M4.2`

## Why

Physical recordings of M4.1 showed two remaining problems:

1. hovering around the `19°` threshold could still create visible on/off shimmer
2. rapid corrections through curves made the gradient respond too nervously to every sensor change

Longer CSS transitions did not fully solve this because each new sensor event moved the transition target again. M4.2 instead treats the warning like a damped instrument needle: the sensor updates a target, while the displayed value approaches that target independently.

## Visual behavior

- below `19°`, the warning does not immediately disappear; it holds for `300ms` to absorb threshold noise
- after the hold, it recedes gradually using the slower release constant
- when warning intensity increases, it grows smoothly without jumping to the new value
- at and beyond `24°`, the target remains full strength, with no separate visual hard-edge event
- switching sides lets the old side recede while the new side grows, avoiding a hard visual cut

## Preserved behavior

- steering and horizon remain clamped at `24°`
- the audible cue still fires on every hysteresis-rearmed hard crossing
- the cue still rearms below `22°`
- haptics remain unchanged where supported
- VoiceOver still announces each side only once per race
- production `/turn/` remains unchanged

## Validation added

- numerical exponential attack and release behavior
- release is explicitly slower than attack
- `300ms` threshold hold
- `360ms` attack and `780ms` release constants
- requestAnimationFrame-owned visual updates
- `28px / 5vw / 62px` maximum width
- explicit `transition: none` override for cached earlier styles
- no keyframes, animation, blink class or transition-duration rule
- versioned M4.2 CSS and JS cache keys

## Physical test after merge

Open `/turn-next/` and confirm the badge reads `Platform M1 · Safe Zone M3 · Limit M4.2`.

1. Hover repeatedly around `19°`; the edge should no longer wink on and off.
2. Make small rapid corrections near the limit; the edge should move with visible inertia rather than tracking every twitch.
3. Sweep gradually from `19°` to `24°`; it should still become fully salient.
4. Return to centre; it should linger briefly and then recede softly.
5. Drive the same curves shown in the supplied recording and judge whether the narrower gradient remains sufficiently noticeable.
6. Confirm audio, haptics and VoiceOver behavior are unchanged.