### PR TITLE
Fix TURN NEXT motion permission result

### DIFF
--- a/turn-next/motion-lifecycle-bridge.js
+++ b/turn-next/motion-lifecycle-bridge.js
@@ -136,7 +136,10 @@ export function installMotionLifecycleBridge({
     async () => {
       launchPending = true;
       try {
-        return await motion.requestPermission();
+        await motion.requestPermission();
+        // The canonical platform port returns true or throws, while TURN's current
+        // browser launch path still consumes the DeviceMotionEvent API contract.
+        return 'granted';
       } catch (error) {
         launchPending = false;
         throw error;

--- a/turn-tests/platform-production.mjs
+++ b/turn-tests/platform-production.mjs
@@ -136,7 +136,12 @@ const bridge = installMotionLifecycleBridge({ platform, environment: fakeEnviron
 assert.equal(bridge.route, 'platform');
 assert.equal(bridge.isAvailable(), true);
 assert.notEqual(fakeEnvironment.DeviceMotionEvent, FakeDeviceMotionEvent, 'M5 must provide TURN NEXT with a permission bridge');
-assert.equal(await fakeEnvironment.DeviceMotionEvent.requestPermission(), true);
+const legacyPermissionState = await fakeEnvironment.DeviceMotionEvent.requestPermission();
+assert.equal(
+  legacyPermissionState,
+  'granted',
+  'The M5 bridge must preserve the DeviceMotionEvent permission result consumed by the current launch path'
+);
 assert.equal(permissionRequests, 2, 'The legacy launch call must route into platform.motion.requestPermission()');
 
 const bridgeListenerA = () => {};
@@ -208,7 +213,7 @@ assert.ok(
     < nextApp.indexOf("withBuild('./main.js')"),
   'The M5 bridge must own motion before the canonical runtime registers its legacy listener'
 );
-assert.match(bridgeSource, /motion\.requestPermission\(\)/);
+assert.match(bridgeSource, /await motion\.requestPermission\(\);[\s\S]*return 'granted';/);
 assert.match(bridgeSource, /motion\.subscribe\(listener\)/);
 assert.match(bridgeSource, /launchPending && !intro\.hidden/);
 assert.match(bridgeSource, /type === 'devicemotion'/);


### PR DESCRIPTION
## Root cause

Platform M5 correctly delegated the native permission request through `platform.motion.requestPermission()`, but the platform port normalizes success to `true`. The existing TURN launch code still consumes the browser `DeviceMotionEvent.requestPermission()` contract and explicitly requires the string `granted`.

As a result, a successful iOS permission request returned `true` through the bridge, was treated as denied, and stopped TURN NEXT before The Lot could open.

## Fix

- await the platform permission port
- translate successful completion back to the legacy browser-facing result `granted`
- continue propagating denied/unavailable states as errors
- add an executable regression that reproduces the exact launch comparison
- leave production TURN unchanged

## Expected behavior

Tapping **Enable motion & race** in TURN NEXT should now proceed after permission is granted. Calling the permission API remains necessary on iOS from a user gesture, but Safari may return an existing decision without showing a fresh prompt.