### PR TITLE
Cache-bust the TURN NEXT M5 permission fix

### DIFF
--- a/turn-next/app.js
+++ b/turn-next/app.js
@@ -13,7 +13,7 @@ function withBuild(path) {
 const { createWebPlatform } = await import(new URL('./web-platform.js', platformModuleBase).href);
 const { installTurnPlatform } = await import(new URL('./platform-context.js', platformModuleBase).href);
 const { installMotionLifecycleBridge } = await import(
-  new URL(`./motion-lifecycle-bridge.js?source=${buildKey}`, stagingModuleBase).href
+  new URL(`./motion-lifecycle-bridge.js?source=${buildKey}-m5.1`, stagingModuleBase).href
 );
 const webPlatform = createWebPlatform();
 installTurnPlatform(webPlatform);

--- a/turn-next/scripts/build-parity-app.mjs
+++ b/turn-next/scripts/build-parity-app.mjs
@@ -29,7 +29,7 @@ export function buildTurnNextApp(productionApp, release) {
   output = replaceRequired(
     output,
     'function installStylesheet(path, dataAttribute) {',
-    "const { createWebPlatform } = await import(new URL('./web-platform.js', platformModuleBase).href);\nconst { installTurnPlatform } = await import(new URL('./platform-context.js', platformModuleBase).href);\nconst { installMotionLifecycleBridge } = await import(\n  new URL(`./motion-lifecycle-bridge.js?source=${buildKey}`, stagingModuleBase).href\n);\nconst webPlatform = createWebPlatform();\ninstallTurnPlatform(webPlatform);\nconst motionLifecycle = installMotionLifecycleBridge({ platform: webPlatform });\nglobalThis.__turnNextMotionLifecycle = motionLifecycle;\ndocument.documentElement.dataset.turnPlatform = 'web-adapter';\ndocument.documentElement.dataset.turnMotionLifecycle = 'platform-m5';\nconst turnNextBadgeDetail = document.querySelector('.turn-next-badge span');\nif (turnNextBadgeDetail) turnNextBadgeDetail.textContent += ' · Platform M5 · Motion Lifecycle';\n\nfunction installStylesheet(path, dataAttribute) {",
+    "const { createWebPlatform } = await import(new URL('./web-platform.js', platformModuleBase).href);\nconst { installTurnPlatform } = await import(new URL('./platform-context.js', platformModuleBase).href);\nconst { installMotionLifecycleBridge } = await import(\n  new URL(`./motion-lifecycle-bridge.js?source=${buildKey}-m5.1`, stagingModuleBase).href\n);\nconst webPlatform = createWebPlatform();\ninstallTurnPlatform(webPlatform);\nconst motionLifecycle = installMotionLifecycleBridge({ platform: webPlatform });\nglobalThis.__turnNextMotionLifecycle = motionLifecycle;\ndocument.documentElement.dataset.turnPlatform = 'web-adapter';\ndocument.documentElement.dataset.turnMotionLifecycle = 'platform-m5';\nconst turnNextBadgeDetail = document.querySelector('.turn-next-badge span');\nif (turnNextBadgeDetail) turnNextBadgeDetail.textContent += ' · Platform M5 · Motion Lifecycle';\n\nfunction installStylesheet(path, dataAttribute) {",
     'platform composition point'
   );
 
@@ -45,6 +45,7 @@ export function buildTurnNextApp(productionApp, release) {
   assert.match(output, /const productionModuleBase = new URL\('\/turn\/'/);
   assert.match(output, /const platformModuleBase = new URL\('\/turn\/platform\/'/);
   assert.match(output, /const stagingModuleBase = new URL\('\/turn-next\/'/);
+  assert.match(output, /motion-lifecycle-bridge\.js\?source=\$\{buildKey\}-m5\.1/);
   assert.match(output, /installTurnPlatform\(webPlatform\)/);
   assert.match(output, /installMotionLifecycleBridge\(\{ platform: webPlatform \}\)/);
   assert.match(output, /__turnNextMotionLifecycle = motionLifecycle/);


### PR DESCRIPTION
## Why

PR #220 fixes the incorrect permission result returned by the Platform M5 bridge. TURN NEXT still imported that bridge with the unchanged r118 query string, so an iOS PWA or browser cache could continue executing the broken module after deployment.

## Change

- add an `m5.1` suffix to the staging bridge import URL
- regenerate the deterministic TURN NEXT bootstrap
- assert the cache-busted import in the parity generator

Production TURN and its release identity remain unchanged.