### PR TITLE
Fix TURN NEXT track cards and drag scrolling

### DIFF
--- a/turn-next/app.js
+++ b/turn-next/app.js
@@ -148,7 +148,7 @@ const { installM8HomeNavigation } = await import(
 );
 await installM8HomeNavigation();
 const { installM8HomeFixedLayout } = await import(
-  new URL(`./m8-home-fixed-layout.js?source=${buildKey}-m8.1`, stagingModuleBase).href
+  new URL(`./m8-home-fixed-layout.js?source=${buildKey}-m8.2`, stagingModuleBase).href
 );
 await installM8HomeFixedLayout();
 document.documentElement.dataset.turnHomeLifecycle = 'home-m8';

--- a/turn-next/m8-home-card-scroll-fixes.css
+++ b/turn-next/m8-home-card-scroll-fixes.css
@@ -1,0 +1,251 @@
+.m8-home-card-scroll-fixes .m8-track-scroll-viewport {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.m8-home-card-scroll-fixes .m8-track-rail {
+  height: 100%;
+  padding-right: 25px;
+  scrollbar-width: none;
+  touch-action: none;
+  cursor: grab;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.m8-home-card-scroll-fixes .m8-track-rail::-webkit-scrollbar {
+  display: none;
+}
+
+.m8-home-card-scroll-fixes .m8-track-rail.is-drag-scrolling {
+  cursor: grabbing;
+  scroll-snap-type: none;
+}
+
+.m8-home-card-scroll-fixes .m8-track-scroll-indicator {
+  position: absolute;
+  top: 3px;
+  right: 2px;
+  bottom: 14px;
+  width: 15px;
+  border: 3px solid var(--m8-ink);
+  border-radius: 999px;
+  background: var(--m8-cream);
+  box-shadow: 2px 2px 0 var(--m8-ink);
+  pointer-events: none;
+}
+
+.m8-home-card-scroll-fixes .m8-track-scroll-indicator[hidden] {
+  display: none;
+}
+
+.m8-home-card-scroll-fixes .m8-track-scroll-thumb {
+  position: absolute;
+  left: 1px;
+  right: 1px;
+  top: 0;
+  min-height: 24px;
+  border-radius: 999px;
+  background: var(--m8-yellow);
+  box-shadow: inset 0 0 0 2px var(--m8-ink);
+}
+
+.m8-home-card-scroll-fixes .m8-track-scroll-indicator::before,
+.m8-home-card-scroll-fixes .m8-track-scroll-indicator::after {
+  position: absolute;
+  left: 50%;
+  z-index: 2;
+  width: 0;
+  height: 0;
+  content: '';
+  transform: translateX(-50%);
+  border-inline: 3px solid transparent;
+}
+
+.m8-home-card-scroll-fixes .m8-track-scroll-indicator::before {
+  top: 4px;
+  border-bottom: 5px solid var(--m8-ink);
+}
+
+.m8-home-card-scroll-fixes .m8-track-scroll-indicator::after {
+  bottom: 4px;
+  border-top: 5px solid var(--m8-ink);
+}
+
+.m8-home-card-scroll-fixes .m8-track-scroll-indicator.is-at-start::before,
+.m8-home-card-scroll-fixes .m8-track-scroll-indicator.is-at-end::after {
+  opacity: 0.25;
+}
+
+.m8-home-card-scroll-fixes .m8-track-rail .track-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(112px, 43%);
+  grid-template-rows: auto auto minmax(0, 1fr);
+  align-items: start;
+  gap: 5px clamp(8px, 1vw, 13px);
+  overflow: hidden;
+}
+
+.m8-home-card-scroll-fixes .m8-track-rail .track-card-summary {
+  display: contents;
+}
+
+.m8-home-card-scroll-fixes .m8-track-rail .track-card-choice {
+  grid-column: 1;
+  grid-row: 1;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  align-self: start;
+}
+
+.m8-home-card-scroll-fixes .m8-track-rail .track-card-choice-marker {
+  flex: 0 0 auto;
+}
+
+.m8-home-card-scroll-fixes .m8-track-rail .track-card-name {
+  min-width: 0;
+  overflow: hidden;
+  font-size: clamp(1rem, 2vw, 1.72rem);
+  line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.m8-home-card-scroll-fixes .m8-track-rail .track-card-difficulty {
+  grid-column: 1;
+  grid-row: 2;
+  align-self: start;
+  justify-self: start;
+  margin: 1px 0 0;
+  padding: 3px clamp(12px, 1.4vw, 18px);
+  font-size: clamp(0.62rem, 1vw, 0.82rem);
+  line-height: 1;
+}
+
+.m8-home-card-scroll-fixes .m8-track-rail .track-card-preview {
+  grid-column: 2;
+  grid-row: 1 / 3;
+  align-self: start;
+  width: 100%;
+  min-width: 0;
+  min-height: 0;
+  height: clamp(76px, 12vh, 112px);
+  margin: 0;
+}
+
+.m8-home-card-scroll-fixes .m8-track-rail .track-card-best {
+  grid-column: 1 / -1;
+  grid-row: 3;
+  align-self: end;
+  display: grid;
+  grid-template-columns: minmax(0, auto) minmax(72px, 1fr);
+  align-items: end;
+  gap: 10px;
+  min-width: 0;
+  margin-top: 2px;
+}
+
+.m8-home-card-scroll-fixes .m8-track-rail .track-card-best-copy {
+  align-self: end;
+  min-width: 0;
+  text-align: left;
+}
+
+.m8-home-card-scroll-fixes .m8-track-rail .track-card-best-copy > span,
+.m8-home-card-scroll-fixes .m8-track-rail .track-card-best-copy > strong,
+.m8-home-card-scroll-fixes .m8-track-rail .track-card-best-copy > small {
+  display: block;
+}
+
+.m8-home-card-scroll-fixes .m8-track-rail .track-card-best-copy > span {
+  margin-bottom: 1px;
+  font-size: clamp(0.62rem, 1vw, 0.82rem);
+  line-height: 1;
+  letter-spacing: 0.08em;
+}
+
+.m8-home-card-scroll-fixes .m8-track-rail .track-card-best-time {
+  font-size: clamp(1rem, 1.85vw, 1.5rem);
+  line-height: 1;
+  letter-spacing: 0.08em;
+  white-space: nowrap;
+}
+
+.m8-home-card-scroll-fixes .m8-track-rail .track-card-best-car {
+  max-width: 19ch;
+  overflow: hidden;
+  font-size: clamp(0.62rem, 1vw, 0.84rem);
+  line-height: 1.05;
+  letter-spacing: 0.07em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.m8-home-card-scroll-fixes .m8-track-rail .track-card-best-model {
+  justify-self: end;
+  align-self: end;
+  width: clamp(72px, 9vw, 118px);
+  height: clamp(43px, 7vh, 70px);
+  object-fit: contain;
+  margin: 0 4px 0 0;
+}
+
+.m8-home-card-scroll-fixes .m8-track-rail .track-card-coming-soon {
+  grid-template-columns: 1fr;
+}
+
+@media (max-height: 560px) and (orientation: landscape) {
+  .m8-home-card-scroll-fixes .m8-track-rail {
+    padding-right: 22px;
+  }
+
+  .m8-home-card-scroll-fixes .m8-track-scroll-indicator {
+    bottom: 10px;
+    width: 13px;
+    border-width: 2px;
+  }
+
+  .m8-home-card-scroll-fixes .m8-track-rail .track-card {
+    grid-template-columns: minmax(0, 1fr) minmax(98px, 42%);
+    grid-template-rows: auto auto minmax(0, 1fr);
+    gap: 3px 8px;
+  }
+
+  .m8-home-card-scroll-fixes .m8-track-rail .track-card-name {
+    font-size: clamp(0.92rem, 1.85vw, 1.25rem);
+  }
+
+  .m8-home-card-scroll-fixes .m8-track-rail .track-card-preview {
+    height: 70px;
+  }
+
+  .m8-home-card-scroll-fixes .m8-track-rail .track-card-best {
+    gap: 6px;
+  }
+
+  .m8-home-card-scroll-fixes .m8-track-rail .track-card-best-model {
+    width: clamp(60px, 8vw, 88px);
+    height: 42px;
+  }
+}
+
+@media (max-width: 760px) and (orientation: portrait) {
+  .m8-home-card-scroll-fixes .m8-track-rail {
+    padding-right: 22px;
+  }
+
+  .m8-home-card-scroll-fixes .m8-track-rail .track-card {
+    grid-template-columns: minmax(0, 1fr) minmax(108px, 40%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .m8-home-card-scroll-fixes .m8-track-rail {
+    scroll-behavior: auto !important;
+  }
+}

--- a/turn-next/m8-home-card-scroll-fixes.js
+++ b/turn-next/m8-home-card-scroll-fixes.js
@@ -1,0 +1,220 @@
+const STYLE_ATTRIBUTE = 'data-turn-m8-card-scroll-fixes';
+const FIX_ID = 'card-scroll-v1';
+const DRAG_THRESHOLD_PX = 7;
+const CLICK_SUPPRESSION_MS = 360;
+
+function installStylesheet() {
+  if (document.querySelector(`link[${STYLE_ATTRIBUTE}]`)) return;
+  const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
+  const stylesheet = document.createElement('link');
+  stylesheet.rel = 'stylesheet';
+  stylesheet.href = `/turn-next/m8-home-card-scroll-fixes.css?source=${buildKey}-m8.2`;
+  stylesheet.setAttribute(STYLE_ATTRIBUTE, '');
+  document.head.appendChild(stylesheet);
+}
+
+function waitForFixedHome() {
+  const existing = document.querySelector('.m8-home-fixed-layout .m8-track-rail');
+  if (existing) return Promise.resolve(existing);
+
+  return new Promise((resolve) => {
+    const observer = new MutationObserver(() => {
+      const rail = document.querySelector('.m8-home-fixed-layout .m8-track-rail');
+      if (!rail) return;
+      observer.disconnect();
+      resolve(rail);
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+  });
+}
+
+function installScrollIndicator(rail) {
+  const existingViewport = rail.closest('.m8-track-scroll-viewport');
+  if (existingViewport) {
+    return {
+      viewport: existingViewport,
+      indicator: existingViewport.querySelector('.m8-track-scroll-indicator'),
+      thumb: existingViewport.querySelector('.m8-track-scroll-thumb')
+    };
+  }
+
+  const viewport = document.createElement('div');
+  viewport.className = 'm8-track-scroll-viewport';
+  rail.replaceWith(viewport);
+  viewport.appendChild(rail);
+
+  const indicator = document.createElement('div');
+  indicator.className = 'm8-track-scroll-indicator';
+  indicator.setAttribute('aria-hidden', 'true');
+  indicator.innerHTML = '<span class="m8-track-scroll-thumb"></span>';
+  viewport.appendChild(indicator);
+
+  return {
+    viewport,
+    indicator,
+    thumb: indicator.querySelector('.m8-track-scroll-thumb')
+  };
+}
+
+function installIndicatorSync(rail, indicator, thumb) {
+  let animationFrame = 0;
+
+  const sync = () => {
+    animationFrame = 0;
+    const maximum = Math.max(0, rail.scrollHeight - rail.clientHeight);
+    const hasOverflow = maximum > 2;
+    indicator.hidden = !hasOverflow;
+    if (!hasOverflow) return;
+
+    const visibleRatio = Math.min(1, rail.clientHeight / Math.max(rail.clientHeight, rail.scrollHeight));
+    const thumbPercent = Math.max(18, visibleRatio * 100);
+    const progress = Math.min(1, Math.max(0, rail.scrollTop / maximum));
+    thumb.style.height = `${thumbPercent}%`;
+    thumb.style.top = `${progress * (100 - thumbPercent)}%`;
+    indicator.classList.toggle('is-at-start', progress <= 0.01);
+    indicator.classList.toggle('is-at-end', progress >= 0.99);
+  };
+
+  const requestSync = () => {
+    if (animationFrame) return;
+    animationFrame = requestAnimationFrame(sync);
+  };
+
+  rail.addEventListener('scroll', requestSync, { passive: true });
+  window.addEventListener('resize', requestSync, { passive: true });
+  const resizeObserver = typeof ResizeObserver === 'function' ? new ResizeObserver(requestSync) : null;
+  resizeObserver?.observe(rail);
+  for (const card of rail.querySelectorAll('.track-card')) resizeObserver?.observe(card);
+  requestSync();
+
+  return { sync: requestSync, disconnect: () => resizeObserver?.disconnect() };
+}
+
+function installDragScrolling(rail) {
+  let pointerId = null;
+  let startY = 0;
+  let startScrollTop = 0;
+  let lastY = 0;
+  let lastTime = 0;
+  let velocity = 0;
+  let dragged = false;
+  let suppressClicksUntil = 0;
+  let inertiaFrame = 0;
+
+  const stopInertia = () => {
+    if (!inertiaFrame) return;
+    cancelAnimationFrame(inertiaFrame);
+    inertiaFrame = 0;
+  };
+
+  const startInertia = () => {
+    if (Math.abs(velocity) < 0.04) return;
+    let previousTime = performance.now();
+
+    const step = (time) => {
+      const elapsed = Math.min(32, time - previousTime);
+      previousTime = time;
+      const before = rail.scrollTop;
+      rail.scrollTop += velocity * elapsed;
+      const hitBoundary = rail.scrollTop === before && Math.abs(velocity) > 0.05;
+      velocity *= Math.pow(0.91, elapsed / 16.67);
+
+      if (hitBoundary || Math.abs(velocity) < 0.025) {
+        inertiaFrame = 0;
+        return;
+      }
+      inertiaFrame = requestAnimationFrame(step);
+    };
+
+    inertiaFrame = requestAnimationFrame(step);
+  };
+
+  rail.addEventListener('pointerdown', (event) => {
+    if (!event.isPrimary || event.button !== 0) return;
+    stopInertia();
+    pointerId = event.pointerId;
+    startY = event.clientY;
+    startScrollTop = rail.scrollTop;
+    lastY = event.clientY;
+    lastTime = event.timeStamp;
+    velocity = 0;
+    dragged = false;
+  });
+
+  rail.addEventListener('pointermove', (event) => {
+    if (event.pointerId !== pointerId) return;
+    const distance = event.clientY - startY;
+    if (!dragged && Math.abs(distance) < DRAG_THRESHOLD_PX) return;
+
+    if (!dragged) {
+      dragged = true;
+      rail.classList.add('is-drag-scrolling');
+      rail.setPointerCapture?.(pointerId);
+    }
+
+    event.preventDefault();
+    rail.scrollTop = startScrollTop - distance;
+
+    const elapsed = Math.max(1, event.timeStamp - lastTime);
+    velocity = (lastY - event.clientY) / elapsed;
+    lastY = event.clientY;
+    lastTime = event.timeStamp;
+  }, { passive: false });
+
+  const finish = (event) => {
+    if (event.pointerId !== pointerId) return;
+    if (dragged) {
+      event.preventDefault();
+      suppressClicksUntil = performance.now() + CLICK_SUPPRESSION_MS;
+      startInertia();
+    }
+    rail.classList.remove('is-drag-scrolling');
+    if (rail.hasPointerCapture?.(pointerId)) rail.releasePointerCapture(pointerId);
+    pointerId = null;
+    dragged = false;
+  };
+
+  rail.addEventListener('pointerup', finish, { passive: false });
+  rail.addEventListener('pointercancel', finish, { passive: false });
+  rail.addEventListener('lostpointercapture', () => {
+    rail.classList.remove('is-drag-scrolling');
+    pointerId = null;
+    dragged = false;
+  });
+
+  rail.addEventListener('click', (event) => {
+    if (performance.now() > suppressClicksUntil) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  }, true);
+
+  return { stopInertia };
+}
+
+export async function installM8HomeCardScrollFixes() {
+  installStylesheet();
+  const rail = await waitForFixedHome();
+  const home = rail.closest('.m8-home');
+  if (!home) throw new Error('TURN M8 card and scroll fixes could not find Home.');
+  if (home.dataset.m8CardScrollFixes === FIX_ID) return globalThis.__turnNextHomeCardScrollFixes;
+
+  const { viewport, indicator, thumb } = installScrollIndicator(rail);
+  if (!indicator || !thumb) throw new Error('TURN M8 could not create the track scroll indicator.');
+  const indicatorSync = installIndicatorSync(rail, indicator, thumb);
+  const dragScrolling = installDragScrolling(rail);
+
+  home.classList.add('m8-home-card-scroll-fixes');
+  home.dataset.m8CardScrollFixes = FIX_ID;
+  document.documentElement.dataset.turnHomeCardScrollFixes = FIX_ID;
+
+  globalThis.__turnNextHomeCardScrollFixes = Object.freeze({
+    id: FIX_ID,
+    home,
+    rail,
+    viewport,
+    indicator,
+    syncIndicator: indicatorSync.sync,
+    stopInertia: dragScrolling.stopInertia
+  });
+  return globalThis.__turnNextHomeCardScrollFixes;
+}

--- a/turn-next/m8-home-fixed-layout.js
+++ b/turn-next/m8-home-fixed-layout.js
@@ -1,12 +1,12 @@
 const STYLE_ATTRIBUTE = 'data-turn-m8-fixed-home-styles';
-const LAYOUT_ID = 'fixed-grid-v2';
+const LAYOUT_ID = 'fixed-grid-v3';
 
 function installStylesheet() {
   if (document.querySelector(`link[${STYLE_ATTRIBUTE}]`)) return;
   const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
   const stylesheet = document.createElement('link');
   stylesheet.rel = 'stylesheet';
-  stylesheet.href = `/turn-next/m8-home-fixed-layout.css?source=${buildKey}-m8.1`;
+  stylesheet.href = `/turn-next/m8-home-fixed-layout.css?source=${buildKey}-m8.2`;
   stylesheet.setAttribute(STYLE_ATTRIBUTE, '');
   document.head.appendChild(stylesheet);
 }
@@ -95,12 +95,19 @@ export async function installM8HomeFixedLayout() {
   home.dataset.m8HomeLayout = LAYOUT_ID;
   document.documentElement.dataset.turnHomeLayout = LAYOUT_ID;
 
+  const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
+  const { installM8HomeCardScrollFixes } = await import(
+    `/turn-next/m8-home-card-scroll-fixes.js?source=${buildKey}-m8.2`
+  );
+  const cardScrollFixes = await installM8HomeCardScrollFixes();
+
   globalThis.__turnNextHomeLayout = Object.freeze({
     id: LAYOUT_ID,
     home,
     trackBrowser,
     menu,
-    raceButton
+    raceButton,
+    cardScrollFixes
   });
   return globalThis.__turnNextHomeLayout;
 }

--- a/turn-next/scripts/build-parity-app.mjs
+++ b/turn-next/scripts/build-parity-app.mjs
@@ -43,7 +43,7 @@ export function buildTurnNextApp(productionApp, release) {
   output = replaceRequired(
     output,
     "await import(withBuild('./ui/in-game-menu.js'));",
-    "await import(withBuild('./ui/in-game-menu.js'));\nconst m8StyleAttribute = 'data-turn-m8-home-styles';\nif (!document.querySelector(`link[${m8StyleAttribute}]`)) {\n  const stylesheet = document.createElement('link');\n  stylesheet.rel = 'stylesheet';\n  stylesheet.href = new URL(`./m8-home.css?source=${buildKey}-m8`, stagingModuleBase).href;\n  stylesheet.setAttribute(m8StyleAttribute, '');\n  document.head.appendChild(stylesheet);\n}\nconst { installM8HomeNavigation } = await import(\n  new URL(`./m8-home.js?source=${buildKey}-m8`, stagingModuleBase).href\n);\nawait installM8HomeNavigation();\nconst { installM8HomeFixedLayout } = await import(\n  new URL(`./m8-home-fixed-layout.js?source=${buildKey}-m8.1`, stagingModuleBase).href\n);\nawait installM8HomeFixedLayout();\ndocument.documentElement.dataset.turnHomeLifecycle = 'home-m8';",
+    "await import(withBuild('./ui/in-game-menu.js'));\nconst m8StyleAttribute = 'data-turn-m8-home-styles';\nif (!document.querySelector(`link[${m8StyleAttribute}]`)) {\n  const stylesheet = document.createElement('link');\n  stylesheet.rel = 'stylesheet';\n  stylesheet.href = new URL(`./m8-home.css?source=${buildKey}-m8`, stagingModuleBase).href;\n  stylesheet.setAttribute(m8StyleAttribute, '');\n  document.head.appendChild(stylesheet);\n}\nconst { installM8HomeNavigation } = await import(\n  new URL(`./m8-home.js?source=${buildKey}-m8`, stagingModuleBase).href\n);\nawait installM8HomeNavigation();\nconst { installM8HomeFixedLayout } = await import(\n  new URL(`./m8-home-fixed-layout.js?source=${buildKey}-m8.2`, stagingModuleBase).href\n);\nawait installM8HomeFixedLayout();\ndocument.documentElement.dataset.turnHomeLifecycle = 'home-m8';",
     'M8 home composition point'
   );
 
@@ -73,7 +73,7 @@ export function buildTurnNextApp(productionApp, release) {
   assert.match(output, /main\.js\?source=\$\{buildKey\}-m8/);
   assert.match(output, /m8-home\.css\?source=\$\{buildKey\}-m8/);
   assert.match(output, /m8-home\.js\?source=\$\{buildKey\}-m8/);
-  assert.match(output, /m8-home-fixed-layout\.js\?source=\$\{buildKey\}-m8\.1/);
+  assert.match(output, /m8-home-fixed-layout\.js\?source=\$\{buildKey\}-m8\.2/);
   assert.match(output, /installM8HomeNavigation\(\)/);
   assert.match(output, /installM8HomeFixedLayout\(\)/);
   assert.match(output, /installStylesheet\('\.\/steering-limit-warning\.css'/);

--- a/turn-tests/home-navigation-production.mjs
+++ b/turn-tests/home-navigation-production.mjs
@@ -6,6 +6,8 @@ const [
   homeCss,
   fixedLayoutSource,
   fixedLayoutCss,
+  cardScrollSource,
+  cardScrollCss,
   productionApp,
   productionMain,
   nextApp,
@@ -16,6 +18,8 @@ const [
   fs.readFile(new URL('../turn-next/m8-home.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-next/m8-home-fixed-layout.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-next/m8-home-fixed-layout.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn-next/m8-home-card-scroll-fixes.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn-next/m8-home-card-scroll-fixes.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/main.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-next/app.js', import.meta.url), 'utf8'),
@@ -23,11 +27,11 @@ const [
   fs.readFile(new URL('../turn/race/session-orchestrator.js', import.meta.url), 'utf8')
 ]);
 
-assert.doesNotMatch(productionApp, /installM8HomeNavigation|m8-home-fixed-layout|installM8HomeFixedLayout/);
+assert.doesNotMatch(productionApp, /installM8HomeNavigation|m8-home-fixed-layout|installM8HomeFixedLayout|m8-home-card-scroll/);
 assert.doesNotMatch(productionMain, /createRaceSessionOrchestrator/);
 assert.match(nextApp, /installM8HomeNavigation/);
 assert.match(nextApp, /installM8HomeFixedLayout/);
-assert.match(nextApp, /m8-home-fixed-layout\.js\?source=\$\{buildKey\}-m8\.1/);
+assert.match(nextApp, /m8-home-fixed-layout\.js\?source=\$\{buildKey\}-m8\.2/);
 assert.ok(nextApp.indexOf('installM8HomeNavigation()') < nextApp.indexOf('installM8HomeFixedLayout()'));
 assert.match(nextApp, /turnHomeLifecycle = 'home-m8'/);
 assert.match(nextMain, /session-orchestrator\.js\?source=20260729-r118-m8/);
@@ -68,13 +72,15 @@ assert.match(homeCss, /turn-m8-active \.audio-settings-button/);
 assert.match(homeCss, /turn-m8-active \.reset-rivals-button/);
 assert.match(homeCss, /prefers-reduced-motion/);
 
-assert.match(fixedLayoutSource, /const LAYOUT_ID = 'fixed-grid-v2'/);
+assert.match(fixedLayoutSource, /const LAYOUT_ID = 'fixed-grid-v3'/);
 assert.match(fixedLayoutSource, /trackBrowser\.append\(headingRow, rail\)/);
 assert.match(fixedLayoutSource, /menu\.append\(settingsButton, howButton, status, raceButton\)/);
 assert.match(fixedLayoutSource, /oldScrollButtons\.hidden = true/);
 assert.match(fixedLayoutSource, /raceButton\.textContent = 'RACE'/);
 assert.match(fixedLayoutSource, /Race on \$\{spokenTrackName\(selectedTrackName\)\}/);
 assert.match(fixedLayoutSource, /new MutationObserver\(syncRaceLabel\)/);
+assert.match(fixedLayoutSource, /m8-home-card-scroll-fixes\.js\?source=\$\{buildKey\}-m8\.2/);
+assert.match(fixedLayoutSource, /installM8HomeCardScrollFixes\(\)/);
 assert.match(fixedLayoutSource, /turnHomeLayout = LAYOUT_ID/);
 
 assert.match(fixedLayoutCss, /height: 100dvh/);
@@ -91,6 +97,28 @@ assert.match(fixedLayoutCss, /@media \(max-height: 560px\) and \(orientation: la
 assert.match(fixedLayoutCss, /@media \(max-width: 760px\) and \(orientation: portrait\)/);
 assert.match(fixedLayoutCss, /prefers-reduced-motion/);
 
+assert.match(cardScrollSource, /const DRAG_THRESHOLD_PX = 7/);
+assert.match(cardScrollSource, /m8-track-scroll-indicator/);
+assert.match(cardScrollSource, /rail\.scrollTop = startScrollTop - distance/);
+assert.match(cardScrollSource, /rail\.setPointerCapture/);
+assert.match(cardScrollSource, /CLICK_SUPPRESSION_MS/);
+assert.match(cardScrollSource, /event\.stopImmediatePropagation\(\)/);
+assert.match(cardScrollSource, /startInertia\(\)/);
+assert.match(cardScrollSource, /ResizeObserver/);
+assert.match(cardScrollSource, /turnHomeCardScrollFixes = FIX_ID/);
+
+assert.match(cardScrollCss, /\.m8-track-scroll-viewport/);
+assert.match(cardScrollCss, /\.m8-track-scroll-indicator/);
+assert.match(cardScrollCss, /\.m8-track-scroll-thumb/);
+assert.match(cardScrollCss, /touch-action: none/);
+assert.match(cardScrollCss, /cursor: grab/);
+assert.match(cardScrollCss, /\.track-card-summary[\s\S]*display: contents/);
+assert.match(cardScrollCss, /\.track-card-choice[\s\S]*grid-row: 1/);
+assert.match(cardScrollCss, /\.track-card-difficulty[\s\S]*grid-row: 2/);
+assert.match(cardScrollCss, /\.track-card-preview[\s\S]*grid-row: 1 \/ 3/);
+assert.match(cardScrollCss, /\.track-card-best[\s\S]*grid-row: 3/);
+assert.match(cardScrollCss, /\.track-card-best-model[\s\S]*justify-self: end/);
+
 assert.match(orchestrator, /async function prepareMotionAccess\(\)/);
 assert.match(orchestrator, /function prepareManualAccess\(\)/);
 assert.match(orchestrator, /async function selectVehicle\(selection\)/);
@@ -98,4 +126,4 @@ assert.match(orchestrator, /function leaveRace\(\)/);
 assert.match(orchestrator, /publish\('home-open'\)/);
 assert.match(orchestrator, /phase = 'home'/);
 
-console.log('TURN NEXT M8 fixed Home, Help, Settings and navigation contracts passed.');
+console.log('TURN NEXT M8 fixed Home, card layout, drag scrolling and navigation contracts passed.');


### PR DESCRIPTION
## TURN NEXT M8.2 card and scroll refinement

Addresses the three issues found in the device recording without changing production TURN.

### Track-card anatomy

- Track name and selection marker occupy a dedicated top-left region
- Difficulty sits directly below the track name
- Track preview occupies the top-right region
- Best time and record-car name occupy the lower-left region
- The record-car thumbnail occupies the lower-right region
- Long names and record labels truncate safely instead of overlapping

### Scrolling

- Adds an always-visible custom vertical scroll-position indicator whenever more tracks are available below
- Supports grab-and-drag scrolling from anywhere inside the track area, including directly over a track card
- Uses a movement threshold so a tap still selects a track
- Suppresses the synthetic card click after a drag
- Adds light inertial continuation after release

### Delivery

- Loads as a separate TURN NEXT-only M8.2 layer
- Uses a fresh cache identity for iOS/PWA testing
- Adds regression contracts for the card regions, indicator and pointer gesture behavior