### PR TITLE
Stop TURN NEXT track grid snapping back after drag

### DIFF
--- a/turn-next/app.js
+++ b/turn-next/app.js
@@ -148,7 +148,7 @@ const { installM8HomeNavigation } = await import(
 );
 await installM8HomeNavigation();
 const { installM8HomeFixedLayout } = await import(
-  new URL(`./m8-home-fixed-layout.js?source=${buildKey}-m8.2`, stagingModuleBase).href
+  new URL(`./m8-home-fixed-layout.js?source=${buildKey}-m8.3`, stagingModuleBase).href
 );
 await installM8HomeFixedLayout();
 document.documentElement.dataset.turnHomeLifecycle = 'home-m8';

--- a/turn-next/m8-home-card-scroll-fixes.js
+++ b/turn-next/m8-home-card-scroll-fixes.js
@@ -1,5 +1,5 @@
 const STYLE_ATTRIBUTE = 'data-turn-m8-card-scroll-fixes';
-const FIX_ID = 'card-scroll-v1';
+const FIX_ID = 'card-scroll-v2';
 const DRAG_THRESHOLD_PX = 7;
 const CLICK_SUPPRESSION_MS = 360;
 
@@ -8,7 +8,7 @@ function installStylesheet() {
   const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
   const stylesheet = document.createElement('link');
   stylesheet.rel = 'stylesheet';
-  stylesheet.href = `/turn-next/m8-home-card-scroll-fixes.css?source=${buildKey}-m8.2`;
+  stylesheet.href = `/turn-next/m8-home-card-scroll-fixes.css?source=${buildKey}-m8.3`;
   stylesheet.setAttribute(STYLE_ATTRIBUTE, '');
   document.head.appendChild(stylesheet);
 }
@@ -197,6 +197,13 @@ export async function installM8HomeCardScrollFixes() {
   const home = rail.closest('.m8-home');
   if (!home) throw new Error('TURN M8 card and scroll fixes could not find Home.');
   if (home.dataset.m8CardScrollFixes === FIX_ID) return globalThis.__turnNextHomeCardScrollFixes;
+
+  // The compact grid is only slightly taller than its viewport. Vertical snap points
+  // pulled it back to the first row after pointer release, making the bottom row
+  // impossible to leave fully visible. Free scrolling must preserve the released position.
+  rail.style.scrollSnapType = 'none';
+  rail.style.scrollSnapStop = 'normal';
+  rail.dataset.scrollRelease = 'free';
 
   const { viewport, indicator, thumb } = installScrollIndicator(rail);
   if (!indicator || !thumb) throw new Error('TURN M8 could not create the track scroll indicator.');

--- a/turn-next/m8-home-fixed-layout.js
+++ b/turn-next/m8-home-fixed-layout.js
@@ -1,12 +1,12 @@
 const STYLE_ATTRIBUTE = 'data-turn-m8-fixed-home-styles';
-const LAYOUT_ID = 'fixed-grid-v3';
+const LAYOUT_ID = 'fixed-grid-v4';
 
 function installStylesheet() {
   if (document.querySelector(`link[${STYLE_ATTRIBUTE}]`)) return;
   const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
   const stylesheet = document.createElement('link');
   stylesheet.rel = 'stylesheet';
-  stylesheet.href = `/turn-next/m8-home-fixed-layout.css?source=${buildKey}-m8.2`;
+  stylesheet.href = `/turn-next/m8-home-fixed-layout.css?source=${buildKey}-m8.3`;
   stylesheet.setAttribute(STYLE_ATTRIBUTE, '');
   document.head.appendChild(stylesheet);
 }
@@ -97,7 +97,7 @@ export async function installM8HomeFixedLayout() {
 
   const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
   const { installM8HomeCardScrollFixes } = await import(
-    `/turn-next/m8-home-card-scroll-fixes.js?source=${buildKey}-m8.2`
+    `/turn-next/m8-home-card-scroll-fixes.js?source=${buildKey}-m8.3`
   );
   const cardScrollFixes = await installM8HomeCardScrollFixes();
 

--- a/turn-next/scripts/build-parity-app.mjs
+++ b/turn-next/scripts/build-parity-app.mjs
@@ -43,7 +43,7 @@ export function buildTurnNextApp(productionApp, release) {
   output = replaceRequired(
     output,
     "await import(withBuild('./ui/in-game-menu.js'));",
-    "await import(withBuild('./ui/in-game-menu.js'));\nconst m8StyleAttribute = 'data-turn-m8-home-styles';\nif (!document.querySelector(`link[${m8StyleAttribute}]`)) {\n  const stylesheet = document.createElement('link');\n  stylesheet.rel = 'stylesheet';\n  stylesheet.href = new URL(`./m8-home.css?source=${buildKey}-m8`, stagingModuleBase).href;\n  stylesheet.setAttribute(m8StyleAttribute, '');\n  document.head.appendChild(stylesheet);\n}\nconst { installM8HomeNavigation } = await import(\n  new URL(`./m8-home.js?source=${buildKey}-m8`, stagingModuleBase).href\n);\nawait installM8HomeNavigation();\nconst { installM8HomeFixedLayout } = await import(\n  new URL(`./m8-home-fixed-layout.js?source=${buildKey}-m8.2`, stagingModuleBase).href\n);\nawait installM8HomeFixedLayout();\ndocument.documentElement.dataset.turnHomeLifecycle = 'home-m8';",
+    "await import(withBuild('./ui/in-game-menu.js'));\nconst m8StyleAttribute = 'data-turn-m8-home-styles';\nif (!document.querySelector(`link[${m8StyleAttribute}]`)) {\n  const stylesheet = document.createElement('link');\n  stylesheet.rel = 'stylesheet';\n  stylesheet.href = new URL(`./m8-home.css?source=${buildKey}-m8`, stagingModuleBase).href;\n  stylesheet.setAttribute(m8StyleAttribute, '');\n  document.head.appendChild(stylesheet);\n}\nconst { installM8HomeNavigation } = await import(\n  new URL(`./m8-home.js?source=${buildKey}-m8`, stagingModuleBase).href\n);\nawait installM8HomeNavigation();\nconst { installM8HomeFixedLayout } = await import(\n  new URL(`./m8-home-fixed-layout.js?source=${buildKey}-m8.3`, stagingModuleBase).href\n);\nawait installM8HomeFixedLayout();\ndocument.documentElement.dataset.turnHomeLifecycle = 'home-m8';",
     'M8 home composition point'
   );
 
@@ -73,7 +73,7 @@ export function buildTurnNextApp(productionApp, release) {
   assert.match(output, /main\.js\?source=\$\{buildKey\}-m8/);
   assert.match(output, /m8-home\.css\?source=\$\{buildKey\}-m8/);
   assert.match(output, /m8-home\.js\?source=\$\{buildKey\}-m8/);
-  assert.match(output, /m8-home-fixed-layout\.js\?source=\$\{buildKey\}-m8\.2/);
+  assert.match(output, /m8-home-fixed-layout\.js\?source=\$\{buildKey\}-m8\.3/);
   assert.match(output, /installM8HomeNavigation\(\)/);
   assert.match(output, /installM8HomeFixedLayout\(\)/);
   assert.match(output, /installStylesheet\('\.\/steering-limit-warning\.css'/);

--- a/turn-tests/home-navigation-production.mjs
+++ b/turn-tests/home-navigation-production.mjs
@@ -31,7 +31,7 @@ assert.doesNotMatch(productionApp, /installM8HomeNavigation|m8-home-fixed-layout
 assert.doesNotMatch(productionMain, /createRaceSessionOrchestrator/);
 assert.match(nextApp, /installM8HomeNavigation/);
 assert.match(nextApp, /installM8HomeFixedLayout/);
-assert.match(nextApp, /m8-home-fixed-layout\.js\?source=\$\{buildKey\}-m8\.2/);
+assert.match(nextApp, /m8-home-fixed-layout\.js\?source=\$\{buildKey\}-m8\.3/);
 assert.ok(nextApp.indexOf('installM8HomeNavigation()') < nextApp.indexOf('installM8HomeFixedLayout()'));
 assert.match(nextApp, /turnHomeLifecycle = 'home-m8'/);
 assert.match(nextMain, /session-orchestrator\.js\?source=20260729-r118-m8/);
@@ -72,14 +72,14 @@ assert.match(homeCss, /turn-m8-active \.audio-settings-button/);
 assert.match(homeCss, /turn-m8-active \.reset-rivals-button/);
 assert.match(homeCss, /prefers-reduced-motion/);
 
-assert.match(fixedLayoutSource, /const LAYOUT_ID = 'fixed-grid-v3'/);
+assert.match(fixedLayoutSource, /const LAYOUT_ID = 'fixed-grid-v4'/);
 assert.match(fixedLayoutSource, /trackBrowser\.append\(headingRow, rail\)/);
 assert.match(fixedLayoutSource, /menu\.append\(settingsButton, howButton, status, raceButton\)/);
 assert.match(fixedLayoutSource, /oldScrollButtons\.hidden = true/);
 assert.match(fixedLayoutSource, /raceButton\.textContent = 'RACE'/);
 assert.match(fixedLayoutSource, /Race on \$\{spokenTrackName\(selectedTrackName\)\}/);
 assert.match(fixedLayoutSource, /new MutationObserver\(syncRaceLabel\)/);
-assert.match(fixedLayoutSource, /m8-home-card-scroll-fixes\.js\?source=\$\{buildKey\}-m8\.2/);
+assert.match(fixedLayoutSource, /m8-home-card-scroll-fixes\.js\?source=\$\{buildKey\}-m8\.3/);
 assert.match(fixedLayoutSource, /installM8HomeCardScrollFixes\(\)/);
 assert.match(fixedLayoutSource, /turnHomeLayout = LAYOUT_ID/);
 
@@ -97,6 +97,7 @@ assert.match(fixedLayoutCss, /@media \(max-height: 560px\) and \(orientation: la
 assert.match(fixedLayoutCss, /@media \(max-width: 760px\) and \(orientation: portrait\)/);
 assert.match(fixedLayoutCss, /prefers-reduced-motion/);
 
+assert.match(cardScrollSource, /const FIX_ID = 'card-scroll-v2'/);
 assert.match(cardScrollSource, /const DRAG_THRESHOLD_PX = 7/);
 assert.match(cardScrollSource, /m8-track-scroll-indicator/);
 assert.match(cardScrollSource, /rail\.scrollTop = startScrollTop - distance/);
@@ -105,6 +106,13 @@ assert.match(cardScrollSource, /CLICK_SUPPRESSION_MS/);
 assert.match(cardScrollSource, /event\.stopImmediatePropagation\(\)/);
 assert.match(cardScrollSource, /startInertia\(\)/);
 assert.match(cardScrollSource, /ResizeObserver/);
+assert.match(cardScrollSource, /rail\.style\.scrollSnapType = 'none'/);
+assert.match(cardScrollSource, /rail\.style\.scrollSnapStop = 'normal'/);
+assert.match(cardScrollSource, /rail\.dataset\.scrollRelease = 'free'/);
+assert.ok(
+  cardScrollSource.indexOf("rail.style.scrollSnapType = 'none'") < cardScrollSource.indexOf('installDragScrolling(rail)'),
+  'Free scrolling must be established before pointer dragging is installed.'
+);
 assert.match(cardScrollSource, /turnHomeCardScrollFixes = FIX_ID/);
 
 assert.match(cardScrollCss, /\.m8-track-scroll-viewport/);
@@ -126,4 +134,4 @@ assert.match(orchestrator, /function leaveRace\(\)/);
 assert.match(orchestrator, /publish\('home-open'\)/);
 assert.match(orchestrator, /phase = 'home'/);
 
-console.log('TURN NEXT M8 fixed Home, card layout, drag scrolling and navigation contracts passed.');
+console.log('TURN NEXT M8 fixed Home, free drag scrolling and navigation contracts passed.');

--- a/turn-tests/home-navigation-production.mjs
+++ b/turn-tests/home-navigation-production.mjs
@@ -110,7 +110,7 @@ assert.match(cardScrollSource, /rail\.style\.scrollSnapType = 'none'/);
 assert.match(cardScrollSource, /rail\.style\.scrollSnapStop = 'normal'/);
 assert.match(cardScrollSource, /rail\.dataset\.scrollRelease = 'free'/);
 assert.ok(
-  cardScrollSource.indexOf("rail.style.scrollSnapType = 'none'") < cardScrollSource.indexOf('installDragScrolling(rail)'),
+  cardScrollSource.indexOf("rail.style.scrollSnapType = 'none'") < cardScrollSource.lastIndexOf('installDragScrolling(rail)'),
   'Free scrolling must be established before pointer dragging is installed.'
 );
 assert.match(cardScrollSource, /turnHomeCardScrollFixes = FIX_ID/);


### PR DESCRIPTION
## TURN NEXT M8.3 scroll release fix

The device recording showed that drag scrolling worked while the pointer was down, but the grid animated back toward the first row after release.

### Cause

The fixed grid retained its earlier vertical `scroll-snap-type: y proximity`. M8.2 temporarily disabled snapping only while dragging, then restored it before inertia completed. Because this compact grid has only a small scroll range, Safari chose the first-row snap point and pulled the content back upward.

### Fix

- Disable vertical scroll snapping for the compact track grid
- Preserve the exact released scroll position
- Keep drag inertia, tap selection, click suppression and the custom position indicator
- Cache-bust the fixed-layout and card-scroll modules as M8.3
- Add regression contracts for free scrolling before pointer handling

Production TURN remains unchanged.