### PR TITLE
Fix the TURN Home logo and use the scrollbar as the Menu divider

### DIFF
--- a/turn-tests/home-navigation-production.mjs
+++ b/turn-tests/home-navigation-production.mjs
@@ -9,6 +9,7 @@ const [
   cardScrollSource,
   cardScrollCss,
   orientationGuardCss,
+  productionIndex,
   productionApp,
   productionMain,
   nextApp,
@@ -22,6 +23,7 @@ const [
   fs.readFile(new URL('../turn/m8-home-card-scroll-fixes.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/m8-home-card-scroll-fixes.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/orientation-guard.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/main.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-next/app.js', import.meta.url), 'utf8'),
@@ -32,9 +34,11 @@ const [
 assert.match(productionApp, /installM8HomeNavigation/);
 assert.match(productionApp, /installM8HomeFixedLayout/);
 assert.match(productionApp, /installStylesheet\('\.\/m8-home\.css'/);
+assert.match(productionApp, /m8-home-fixed-layout\.js\?revision=m8\.6-logo/);
 assert.ok(productionApp.indexOf('installM8HomeNavigation()') < productionApp.indexOf('installM8HomeFixedLayout()'));
 assert.match(productionApp, /turnHomeLifecycle = 'home-m8'/);
 assert.match(productionApp, /retireLegacyStartPanel\(\)/);
+assert.match(productionIndex, /app\.js\?build=20260731-r120-logo-final/);
 assert.match(productionMain, /createRaceSessionOrchestrator/);
 assert.equal(nextMain, productionMain, 'TURN NEXT must run the canonical M7 main runtime');
 assert.match(nextApp, /new URL\('\/turn\/app\.js'/);
@@ -76,7 +80,8 @@ assert.match(homeCss, /turn-m8-active \.audio-settings-button/);
 assert.match(homeCss, /turn-m8-active \.reset-rivals-button/);
 assert.match(homeCss, /prefers-reduced-motion/);
 
-assert.match(fixedLayoutSource, /const LAYOUT_ID = 'fixed-grid-v5'/);
+assert.match(fixedLayoutSource, /const LAYOUT_ID = 'fixed-grid-v6'/);
+assert.match(fixedLayoutSource, /m8-home-fixed-layout\.css\?build=\$\{buildKey\}-m8\.6-logo/);
 assert.match(fixedLayoutSource, /trackBrowser\.append\(headingRow, rail\)/);
 assert.match(fixedLayoutSource, /menu\.append\(settingsButton, howButton, status, raceButton\)/);
 assert.match(fixedLayoutSource, /oldScrollButtons\.hidden = true/);
@@ -97,8 +102,12 @@ assert.match(fixedLayoutCss, /-webkit-overflow-scrolling: touch/);
 assert.match(fixedLayoutCss, /\.m8-home-fixed-layout \.m8-home-menu/);
 assert.match(fixedLayoutCss, /\.m8-home-fixed-layout \.m8-home-status[\s\S]*margin: auto 0 10px/);
 assert.match(fixedLayoutCss, /\.m8-home-fixed-layout \.m8-track-continue[\s\S]*background: var\(--m8-pink\)/);
-assert.match(fixedLayoutCss, /@media \(max-height: 560px\) and \(orientation: landscape\)/);
-assert.match(fixedLayoutCss, /@media \(max-width: 760px\) and \(orientation: portrait\)/);
+assert.match(fixedLayoutCss, /\.m8-home-fixed-layout \.m8-home-head[\s\S]*padding: 0 max\(22px, env\(safe-area-inset-right\)\) 0 max\(10px, env\(safe-area-inset-left\)\)/);
+assert.match(fixedLayoutCss, /\.m8-home-fixed-layout \.m8-home-logo[\s\S]*width: auto[\s\S]*height: 100%[\s\S]*aspect-ratio: 1[\s\S]*object-fit: contain[\s\S]*object-position: left center/);
+assert.doesNotMatch(fixedLayoutCss, /object-fit: cover/);
+assert.doesNotMatch(fixedLayoutCss, /padding-block: 5px/);
+assert.match(fixedLayoutCss, /@media \(max-height: 560px\) and \(orientation: landscape\)[\s\S]*\.m8-home-fixed-layout \.m8-home-head[\s\S]*padding-block: 0/);
+assert.match(fixedLayoutCss, /@media \(max-width: 760px\) and \(orientation: portrait\)[\s\S]*\.m8-home-fixed-layout \.m8-home-head[\s\S]*padding: 0 12px/);
 assert.match(fixedLayoutCss, /prefers-reduced-motion/);
 
 assert.match(cardScrollSource, /const FIX_ID = 'native-scroll-v1'/);
@@ -138,4 +147,4 @@ assert.match(orchestrator, /function leaveRace\(\)/);
 assert.match(orchestrator, /publish\('home-open'\)/);
 assert.match(orchestrator, /phase = 'home'/);
 
-console.log('TURN production M8 Home, native track scrolling, logo tile and NEXT wrapper contracts passed.');
+console.log('TURN production M8 Home, native track scrolling, final logo cascade and NEXT wrapper contracts passed.');

--- a/turn-tests/home-navigation-production.mjs
+++ b/turn-tests/home-navigation-production.mjs
@@ -9,7 +9,6 @@ const [
   cardScrollSource,
   cardScrollCss,
   orientationGuardCss,
-  productionIndex,
   productionApp,
   productionMain,
   nextApp,
@@ -23,7 +22,6 @@ const [
   fs.readFile(new URL('../turn/m8-home-card-scroll-fixes.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/m8-home-card-scroll-fixes.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/orientation-guard.css', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/main.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-next/app.js', import.meta.url), 'utf8'),
@@ -34,11 +32,10 @@ const [
 assert.match(productionApp, /installM8HomeNavigation/);
 assert.match(productionApp, /installM8HomeFixedLayout/);
 assert.match(productionApp, /installStylesheet\('\.\/m8-home\.css'/);
-assert.match(productionApp, /m8-home-fixed-layout\.js\?revision=m8\.6-logo/);
+assert.match(productionApp, /m8-home-fixed-layout\.js\?revision=m8\.7-home-polish/);
 assert.ok(productionApp.indexOf('installM8HomeNavigation()') < productionApp.indexOf('installM8HomeFixedLayout()'));
 assert.match(productionApp, /turnHomeLifecycle = 'home-m8'/);
 assert.match(productionApp, /retireLegacyStartPanel\(\)/);
-assert.match(productionIndex, /app\.js\?build=20260731-r120-logo-final/);
 assert.match(productionMain, /createRaceSessionOrchestrator/);
 assert.equal(nextMain, productionMain, 'TURN NEXT must run the canonical M7 main runtime');
 assert.match(nextApp, /new URL\('\/turn\/app\.js'/);
@@ -80,15 +77,15 @@ assert.match(homeCss, /turn-m8-active \.audio-settings-button/);
 assert.match(homeCss, /turn-m8-active \.reset-rivals-button/);
 assert.match(homeCss, /prefers-reduced-motion/);
 
-assert.match(fixedLayoutSource, /const LAYOUT_ID = 'fixed-grid-v6'/);
-assert.match(fixedLayoutSource, /m8-home-fixed-layout\.css\?build=\$\{buildKey\}-m8\.6-logo/);
+assert.match(fixedLayoutSource, /const LAYOUT_ID = 'fixed-grid-v7'/);
+assert.match(fixedLayoutSource, /m8-home-fixed-layout\.css\?build=\$\{buildKey\}-m8\.7-home-polish/);
 assert.match(fixedLayoutSource, /trackBrowser\.append\(headingRow, rail\)/);
 assert.match(fixedLayoutSource, /menu\.append\(settingsButton, howButton, status, raceButton\)/);
 assert.match(fixedLayoutSource, /oldScrollButtons\.hidden = true/);
 assert.match(fixedLayoutSource, /raceButton\.textContent = 'RACE'/);
 assert.match(fixedLayoutSource, /Race on \$\{spokenTrackName\(selectedTrackName\)\}/);
 assert.match(fixedLayoutSource, /new MutationObserver\(syncRaceLabel\)/);
-assert.match(fixedLayoutSource, /\/turn\/m8-home-card-scroll-fixes\.js\?build=\$\{buildKey\}-m8\.4/);
+assert.match(fixedLayoutSource, /\/turn\/m8-home-card-scroll-fixes\.js\?build=\$\{buildKey\}-m8\.7-divider/);
 assert.match(fixedLayoutSource, /installM8HomeCardScrollFixes\(\)/);
 assert.match(fixedLayoutSource, /turnHomeLayout = LAYOUT_ID/);
 
@@ -99,18 +96,21 @@ assert.match(fixedLayoutCss, /grid-template-columns: repeat\(2, minmax\(0, 1fr\)
 assert.match(fixedLayoutCss, /overflow-x: hidden/);
 assert.match(fixedLayoutCss, /overflow-y: auto/);
 assert.match(fixedLayoutCss, /-webkit-overflow-scrolling: touch/);
-assert.match(fixedLayoutCss, /\.m8-home-fixed-layout \.m8-home-menu/);
+assert.match(fixedLayoutCss, /\.m8-home-fixed-layout \.m8-home-menu[\s\S]*border-left: 0/);
+assert.doesNotMatch(fixedLayoutCss, /border-left:\s*[45]px solid/);
 assert.match(fixedLayoutCss, /\.m8-home-fixed-layout \.m8-home-status[\s\S]*margin: auto 0 10px/);
 assert.match(fixedLayoutCss, /\.m8-home-fixed-layout \.m8-track-continue[\s\S]*background: var\(--m8-pink\)/);
-assert.match(fixedLayoutCss, /\.m8-home-fixed-layout \.m8-home-head[\s\S]*padding: 0 max\(22px, env\(safe-area-inset-right\)\) 0 max\(10px, env\(safe-area-inset-left\)\)/);
+assert.match(fixedLayoutCss, /\.m8-home-fixed-layout \.m8-home-head[\s\S]*padding: 0 max\(22px, env\(safe-area-inset-right\)\) 0 0/);
 assert.match(fixedLayoutCss, /\.m8-home-fixed-layout \.m8-home-logo[\s\S]*width: auto[\s\S]*height: 100%[\s\S]*aspect-ratio: 1[\s\S]*object-fit: contain[\s\S]*object-position: left center/);
 assert.doesNotMatch(fixedLayoutCss, /object-fit: cover/);
 assert.doesNotMatch(fixedLayoutCss, /padding-block: 5px/);
 assert.match(fixedLayoutCss, /@media \(max-height: 560px\) and \(orientation: landscape\)[\s\S]*\.m8-home-fixed-layout \.m8-home-head[\s\S]*padding-block: 0/);
-assert.match(fixedLayoutCss, /@media \(max-width: 760px\) and \(orientation: portrait\)[\s\S]*\.m8-home-fixed-layout \.m8-home-head[\s\S]*padding: 0 12px/);
+assert.match(fixedLayoutCss, /@media \(max-height: 560px\) and \(orientation: landscape\)[\s\S]*\.m8-home-fixed-layout \.m8-home-menu[\s\S]*border-left: 0/);
+assert.match(fixedLayoutCss, /@media \(max-width: 760px\) and \(orientation: portrait\)[\s\S]*\.m8-home-fixed-layout \.m8-home-head[\s\S]*padding: 0 12px 0 0/);
 assert.match(fixedLayoutCss, /prefers-reduced-motion/);
 
-assert.match(cardScrollSource, /const FIX_ID = 'native-scroll-v1'/);
+assert.match(cardScrollSource, /const FIX_ID = 'native-scroll-divider-v2'/);
+assert.match(cardScrollSource, /m8-home-card-scroll-fixes\.css\?build=\$\{buildKey\}-m8\.7-divider/);
 assert.match(cardScrollSource, /m8-track-scroll-indicator/);
 assert.match(cardScrollSource, /ResizeObserver/);
 assert.match(cardScrollSource, /rail\.style\.scrollSnapType = 'none'/);
@@ -147,4 +147,4 @@ assert.match(orchestrator, /function leaveRace\(\)/);
 assert.match(orchestrator, /publish\('home-open'\)/);
 assert.match(orchestrator, /phase = 'home'/);
 
-console.log('TURN production M8 Home, native track scrolling, final logo cascade and NEXT wrapper contracts passed.');
+console.log('TURN production M8 Home, native scrollbar divider, flush logo and NEXT wrapper contracts passed.');

--- a/turn-tests/turn-next-entry-production.mjs
+++ b/turn-tests/turn-next-entry-production.mjs
@@ -57,7 +57,7 @@ assert.equal(release.cacheKey, '20260731-r120');
 
 assert.match(productionIndex, new RegExp(`TURN v${release.version.replaceAll('.', '\\.')} · Build ${release.id.replaceAll('.', '\\.')}`));
 assert.match(productionIndex, /<meta name="theme-color" content="#08090a">/);
-assert.match(productionIndex, new RegExp(`src="\\.\\/app\\.js\\?build=${release.cacheKey}"`));
+assert.match(productionIndex, new RegExp(`src="\\.\\/app\\.js\\?build=${release.cacheKey}(?:-[^"]+)?"`));
 assert.match(productionIndex, /id="intro" hidden aria-hidden="true"/);
 assert.match(productionIndex, /id="motionButton"/);
 assert.match(productionIndex, /id="manualButton"/);

--- a/turn/app.js
+++ b/turn/app.js
@@ -159,7 +159,7 @@ if (buildLabel) {
   buildLabel.textContent = `TURN V${release?.version || ''} · BUILD ${(release?.id || '').toUpperCase()}`;
 }
 const { installM8HomeFixedLayout } = await import(
-  withBuild('./m8-home-fixed-layout.js?revision=m8.6-logo')
+  withBuild('./m8-home-fixed-layout.js?revision=m8.7-home-polish')
 );
 await installM8HomeFixedLayout();
 document.documentElement.dataset.turnHomeLifecycle = 'home-m8';

--- a/turn/app.js
+++ b/turn/app.js
@@ -158,7 +158,9 @@ if (buildLabel) {
   const release = globalThis.__TURN_BUILD__;
   buildLabel.textContent = `TURN V${release?.version || ''} · BUILD ${(release?.id || '').toUpperCase()}`;
 }
-const { installM8HomeFixedLayout } = await import(withBuild('./m8-home-fixed-layout.js'));
+const { installM8HomeFixedLayout } = await import(
+  withBuild('./m8-home-fixed-layout.js?revision=m8.6-logo')
+);
 await installM8HomeFixedLayout();
 document.documentElement.dataset.turnHomeLifecycle = 'home-m8';
 

--- a/turn/index.html
+++ b/turn/index.html
@@ -142,5 +142,5 @@
   </div>
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
-  <script type="module" src="./app.js?build=20260731-r120"></script>
+  <script type="module" src="./app.js?build=20260731-r120-logo-final"></script>
 </body></html>

--- a/turn/m8-home-card-scroll-fixes.js
+++ b/turn/m8-home-card-scroll-fixes.js
@@ -1,12 +1,12 @@
 const STYLE_ATTRIBUTE = 'data-turn-m8-card-scroll-fixes';
-const FIX_ID = 'native-scroll-v1';
+const FIX_ID = 'native-scroll-divider-v2';
 
 function installStylesheet() {
   if (document.querySelector(`link[${STYLE_ATTRIBUTE}]`)) return;
   const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
   const stylesheet = document.createElement('link');
   stylesheet.rel = 'stylesheet';
-  stylesheet.href = `/turn/m8-home-card-scroll-fixes.css?build=${buildKey}-m8.4`;
+  stylesheet.href = `/turn/m8-home-card-scroll-fixes.css?build=${buildKey}-m8.7-divider`;
   stylesheet.setAttribute(STYLE_ATTRIBUTE, '');
   document.head.appendChild(stylesheet);
 }

--- a/turn/m8-home-fixed-layout.css
+++ b/turn/m8-home-fixed-layout.css
@@ -16,7 +16,7 @@
   grid-template-rows: minmax(0, 1fr);
   column-gap: clamp(18px, 2.5vw, 34px);
   min-height: 0;
-  padding: 0 max(22px, env(safe-area-inset-right)) 0 max(10px, env(safe-area-inset-left));
+  padding: 0 max(22px, env(safe-area-inset-right)) 0 0;
   border-bottom: 5px solid var(--m8-ink);
 }
 
@@ -153,7 +153,7 @@
   min-width: 0;
   min-height: 0;
   padding-left: clamp(14px, 2vw, 24px);
-  border-left: 5px solid var(--m8-ink);
+  border-left: 0;
 }
 
 .m8-home-fixed-layout .m8-home-menu h2 {
@@ -273,7 +273,7 @@
 
   .m8-home-fixed-layout .m8-home-menu {
     padding-left: 12px;
-    border-left-width: 4px;
+    border-left: 0;
   }
 
   .m8-home-fixed-layout .m8-home-menu h2 {
@@ -313,7 +313,7 @@
 
   .m8-home-fixed-layout .m8-home-head {
     grid-template-columns: 82px minmax(0, 1fr);
-    padding: 0 12px;
+    padding: 0 12px 0 0;
   }
 
   .m8-home-fixed-layout .m8-home-logo {

--- a/turn/m8-home-fixed-layout.css
+++ b/turn/m8-home-fixed-layout.css
@@ -16,22 +16,29 @@
   grid-template-rows: minmax(0, 1fr);
   column-gap: clamp(18px, 2.5vw, 34px);
   min-height: 0;
-  padding: max(8px, env(safe-area-inset-top)) max(22px, env(safe-area-inset-right)) 8px max(10px, env(safe-area-inset-left));
+  padding: 0 max(22px, env(safe-area-inset-right)) 0 max(10px, env(safe-area-inset-left));
   border-bottom: 5px solid var(--m8-ink);
 }
 
 .m8-home-fixed-layout .m8-home-logo {
   grid-row: 1;
-  width: clamp(84px, 10vw, 126px);
+  align-self: stretch;
+  justify-self: start;
+  display: block;
+  width: auto;
   height: 100%;
+  max-width: 100%;
   max-height: none;
-  object-fit: cover;
+  aspect-ratio: 1;
+  object-fit: contain;
+  object-position: left center;
   filter: none;
 }
 
 .m8-home-fixed-layout .m8-home-pitch {
   grid-row: 1;
   align-self: center;
+  padding-block: max(8px, env(safe-area-inset-top)) 8px;
 }
 
 .m8-home-fixed-layout .m8-home-pitch p {
@@ -45,6 +52,7 @@
 .m8-home-fixed-layout .m8-home-build {
   align-self: center;
   justify-self: end;
+  margin-block: max(8px, env(safe-area-inset-top)) 8px;
   padding: 6px 10px;
   background: transparent;
   font-size: clamp(0.62rem, 1vw, 0.82rem);
@@ -215,11 +223,19 @@
 
   .m8-home-fixed-layout .m8-home-head {
     grid-template-columns: clamp(68px, 10vw, 84px) minmax(150px, 1fr) auto;
-    padding-block: 5px;
+    padding-block: 0;
   }
 
   .m8-home-fixed-layout .m8-home-logo {
-    width: clamp(68px, 10vw, 84px);
+    width: auto;
+  }
+
+  .m8-home-fixed-layout .m8-home-pitch {
+    padding-block: max(5px, env(safe-area-inset-top)) 5px;
+  }
+
+  .m8-home-fixed-layout .m8-home-build {
+    margin-block: max(5px, env(safe-area-inset-top)) 5px;
   }
 
   .m8-home-fixed-layout .m8-home-pitch p {
@@ -297,11 +313,15 @@
 
   .m8-home-fixed-layout .m8-home-head {
     grid-template-columns: 82px minmax(0, 1fr);
-    padding: 5px 12px;
+    padding: 0 12px;
   }
 
   .m8-home-fixed-layout .m8-home-logo {
-    width: 82px;
+    width: auto;
+  }
+
+  .m8-home-fixed-layout .m8-home-pitch {
+    padding-block: max(5px, env(safe-area-inset-top)) 5px;
   }
 
   .m8-home-fixed-layout .m8-home-build {

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -1,12 +1,12 @@
 const STYLE_ATTRIBUTE = 'data-turn-m8-fixed-home-styles';
-const LAYOUT_ID = 'fixed-grid-v6';
+const LAYOUT_ID = 'fixed-grid-v7';
 
 function installStylesheet() {
   if (document.querySelector(`link[${STYLE_ATTRIBUTE}]`)) return;
   const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
   const stylesheet = document.createElement('link');
   stylesheet.rel = 'stylesheet';
-  stylesheet.href = `/turn/m8-home-fixed-layout.css?build=${buildKey}-m8.6-logo`;
+  stylesheet.href = `/turn/m8-home-fixed-layout.css?build=${buildKey}-m8.7-home-polish`;
   stylesheet.setAttribute(STYLE_ATTRIBUTE, '');
   document.head.appendChild(stylesheet);
 }
@@ -97,7 +97,7 @@ export async function installM8HomeFixedLayout() {
 
   const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
   const { installM8HomeCardScrollFixes } = await import(
-    `/turn/m8-home-card-scroll-fixes.js?build=${buildKey}-m8.4`
+    `/turn/m8-home-card-scroll-fixes.js?build=${buildKey}-m8.7-divider`
   );
   const cardScrollFixes = await installM8HomeCardScrollFixes();
 

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -1,12 +1,12 @@
 const STYLE_ATTRIBUTE = 'data-turn-m8-fixed-home-styles';
-const LAYOUT_ID = 'fixed-grid-v5';
+const LAYOUT_ID = 'fixed-grid-v6';
 
 function installStylesheet() {
   if (document.querySelector(`link[${STYLE_ATTRIBUTE}]`)) return;
   const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
   const stylesheet = document.createElement('link');
   stylesheet.rel = 'stylesheet';
-  stylesheet.href = `/turn/m8-home-fixed-layout.css?build=${buildKey}-m8.4`;
+  stylesheet.href = `/turn/m8-home-fixed-layout.css?build=${buildKey}-m8.6-logo`;
   stylesheet.setAttribute(STYLE_ATTRIBUTE, '');
   document.head.appendChild(stylesheet);
 }


### PR DESCRIPTION
## TURN Home polish

The production screenshot exposed two competing visual seams in the Home layout.

### Logo

- remove the header’s left safe-area padding so the logo tile begins at the viewport edge
- remove vertical header padding at every breakpoint
- keep the square artwork at full header height with `object-fit: contain`
- preserve safe-area spacing on the pitch/build text instead of around the image

### Track browser and Menu

- remove the separate black border to the left of Menu
- retain the persistent custom scrollbar as the single visual divider
- preserve native iOS momentum scrolling and track selection behavior

### Delivery safeguards

- revision the production entry, fixed-layout module, layout stylesheet, scrollbar module and scrollbar stylesheet
- add regression coverage for the final winning cascade, no left logo inset, no cropping, and no duplicate Menu divider

The gameplay runtime and navigation remain unchanged. All 48 TURN regression gates pass.