### PR TITLE
Restore the enhanced Lot layout in TURN r120

### DIFF
--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -105,6 +105,10 @@ const [
   controls,
   carModels,
   lotWrapper,
+  lotEnhancementRuntime,
+  lotLayout,
+  lotLayoutCss,
+  lotAccessibility,
   originalLot,
   trackIntro,
   trackIntroCss,
@@ -121,6 +125,10 @@ const [
   fs.readFile(path.join(turnDir, 'ui/gameplay-controls.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'vehicle/car-models.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'garage/lot-track-select.js'), 'utf8'),
+  fs.readFile(path.join(turnDir, 'garage/lot-enhancement-runtime.js'), 'utf8'),
+  fs.readFile(path.join(turnDir, 'garage/lot-layout-r60.js'), 'utf8'),
+  fs.readFile(path.join(turnDir, 'garage/lot-layout-r60.css'), 'utf8'),
+  fs.readFile(path.join(turnDir, 'garage/lot-accessibility-r118.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'garage/lot-r10.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'ui/track-intro.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'track-intro.css'), 'utf8'),
@@ -136,15 +144,44 @@ const releaseTarget = (filePath) => `${filePath}?build=${release.cacheKey}`;
 assert.match(index, new RegExp(`TURN v${release.version.replaceAll('.', '\\.')} · Build ${release.id.replaceAll('.', '\\.')}`));
 assert.match(index, new RegExp(`\\.\\/garage\\/lot-r10\\.css\\?build=${release.cacheKey}`));
 assert.match(index, new RegExp(`\\.\\/track-intro\\.css\\?build=${release.cacheKey}`));
+assert.match(index, new RegExp(`src="\\.\\/app\\.js\\?build=${release.cacheKey}-lot-restored"`));
 assert.equal(imports['./garage/lot-r10.js?build=20260720-r19'], releaseTarget('./garage/lot-track-select.js'));
 assert.equal(imports['./ui/track-intro.js?build=20260725-r75'], releaseTarget('./ui/track-intro.js'));
 assert.equal(imports['./race/lap-system.js?build=20260720-r19'], releaseTarget('./race/lap-system-r86.js'));
 
+assert.match(app, /lot-layout-r60\.css\?revision=r121-viewer/);
+assert.match(app, /installLotEnhancementRuntime/);
+assert.match(app, /lot-enhancement-runtime\.js\?revision=r121/);
+assert.ok(app.indexOf('installLotEnhancementRuntime()') < app.indexOf("withBuild('./main.js')"));
+
 assert.match(lotWrapper, /showOriginalLot/);
+assert.match(lotWrapper, /export async function showEnhancedLot/);
+assert.match(lotWrapper, /enhanceLotNow\(\)/);
 assert.match(lotWrapper, /await chooseTrackBeforeLot\(\)/);
-assert.match(lotWrapper, /installLotLayout\(\)/);
 assert.match(lotWrapper, /track-manager\.js\?build=20260722-r52/);
+assert.doesNotMatch(lotWrapper, /installLotLayout|installLotStatLegend|installLotAccessibility/);
 assert.match(originalLot, /export function showTheLot/);
+
+assert.match(lotEnhancementRuntime, /ENHANCEMENT_ID = 'enhanced-lot-r121'/);
+assert.match(lotEnhancementRuntime, /activeEnhancements = new WeakMap\(\)/);
+assert.match(lotEnhancementRuntime, /installLotStatLegend\(scope\)/);
+assert.match(lotEnhancementRuntime, /installLotLayout\(scope\)/);
+assert.match(lotEnhancementRuntime, /installLotAccessibility\(scope\)/);
+assert.match(lotEnhancementRuntime, /new MutationObserver\(sync\)/);
+assert.match(lotEnhancementRuntime, /screen\.dataset\.lotEnhancements = ENHANCEMENT_ID/);
+
+assert.match(lotLayout, /viewbox\.appendChild\(colors\)/);
+assert.match(lotLayout, /attributesHeading\.replaceChildren\(document\.createTextNode\('ATTRIBUTES'\)\)/);
+assert.match(lotLayout, /lot-viewbox-with-paint/);
+assert.match(lotLayoutCss, /\.lot-viewbox-with-paint[\s\S]*flex: 1 1 auto/);
+assert.match(lotLayoutCss, /min-height: clamp\(150px, 28vh, 230px\)/);
+assert.match(lotLayoutCss, /--lot-paint-rail-height: 54px/);
+assert.match(lotLayoutCss, /\.lot-viewbox-with-paint \.lot-view-host[\s\S]*inset: 0 0 var\(--lot-paint-rail-height\)/);
+assert.match(lotLayoutCss, /\.lot-view-close,[\s\S]*\.lot-view-open[\s\S]*display: none !important/);
+assert.match(lotAccessibility, /lot-selected-car-summary/);
+assert.match(lotAccessibility, /Choose car/);
+assert.match(lotAccessibility, /Choose car colour/);
+assert.match(lotAccessibility, /Car information/);
 
 assert.match(home, /activateTrack\(selectedTrackId, runtime\)/);
 assert.match(home, /showTheLot\(\{ initialSelection: selectedVehicle\(runtime\) \}\)/);
@@ -191,4 +228,4 @@ assert.match(carModels, /loadCarSource\(car\.id\)/);
 assert.match(easterEggUi, /getEffectiveVehicleStats/);
 assert.match(easterEggUi, /input\[type="color"\]/);
 
-console.log(`TURN ${release.id} garage, M8 Home-to-Lot route, Training Car and hidden Sport Sedan setup passed.`);
+console.log(`TURN ${release.id} enhanced Lot route, expanded 3D viewer, accessibility and garage setup passed.`);

--- a/turn-lab/tests/lot-layout-production.mjs
+++ b/turn-lab/tests/lot-layout-production.mjs
@@ -1,10 +1,23 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [index, releaseSource, wrapper, layout, layoutCss, lot, legend, accessibility] = await Promise.all([
+const [
+  index,
+  releaseSource,
+  app,
+  wrapper,
+  enhancementRuntime,
+  layout,
+  layoutCss,
+  lot,
+  legend,
+  accessibility
+] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/release.json', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-track-select.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-enhancement-runtime.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-layout-r60.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-layout-r60.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-r10.js', import.meta.url), 'utf8'),
@@ -17,18 +30,40 @@ const importMapText = index.match(/<script type="importmap">\s*([\s\S]*?)\s*<\/s
 assert.ok(importMapText, 'Production must expose its import map');
 const imports = JSON.parse(importMapText).imports;
 
-assert.match(index, new RegExp(`lot-layout-r60\\.css\\?build=${release.cacheKey}`), 'Production must load the compact Lot layout through the current release');
-assert.equal(imports['./garage/lot-r10.js?build=20260720-r19'], `./garage/lot-track-select.js?build=${release.cacheKey}`, 'Production must publish the wrapper that installs the compact layout');
-assert.match(wrapper, /lot-layout-r60\.js\?build=20260729-r116/, 'The wrapper must import the verified shared-panel layout enhancer');
-assert.match(wrapper, /lot-accessibility-r118\.js\?build=20260729-r118/, 'The wrapper must install the current Lot accessibility enhancer');
+assert.match(index, new RegExp(`lot-layout-r60\\.css\\?build=${release.cacheKey}`), 'Production must retain the baseline Lot layout stylesheet');
+assert.match(index, new RegExp(`app\\.js\\?build=${release.cacheKey}-lot-restored`), 'Production must cache-bust the route-independent Lot fix');
+assert.equal(imports['./garage/lot-r10.js?build=20260720-r19'], `./garage/lot-track-select.js?build=${release.cacheKey}`, 'Production must retain the track-first compatibility wrapper');
+
+assert.match(app, /lot-layout-r60\.css\?revision=r121-viewer/, 'The expanded viewer stylesheet must load after the baseline cascade');
+assert.match(app, /lot-enhancement-runtime\.js\?revision=r121/, 'Production must load the route-independent Lot enhancer');
+assert.match(app, /installLotEnhancementRuntime\(\)/, 'Production must install the Lot enhancer once');
 assert.ok(
-  wrapper.indexOf('installLotStatLegend()') < wrapper.indexOf('installLotLayout()'),
+  app.indexOf('installLotEnhancementRuntime()') < app.indexOf("withBuild('./main.js')"),
+  'The Lot enhancement observer must exist before any route can open The Lot'
+);
+
+assert.match(wrapper, /lot-enhancement-runtime\.js\?revision=r121&build=20260731-r120/, 'The compatibility wrapper must share the exact enhancement module instance');
+assert.match(wrapper, /export async function showEnhancedLot/, 'The enhanced active-track Lot must remain reusable without another track chooser');
+assert.match(wrapper, /const removeEnhancements = enhanceLotNow\(\)/, 'The compatibility wrapper must synchronously enhance before the first paint');
+assert.match(wrapper, /await chooseTrackBeforeLot\(\)/, 'The compatibility route must still choose a track before The Lot');
+assert.doesNotMatch(wrapper, /installLotLayout|installLotStatLegend|installLotAccessibility/, 'Enhancement ownership must not drift back into one navigation wrapper');
+
+assert.match(enhancementRuntime, /ENHANCEMENT_ID = 'enhanced-lot-r121'/, 'The restored Lot contract must have an explicit identity');
+assert.match(enhancementRuntime, /activeEnhancements = new WeakMap\(\)/, 'Enhancements must be idempotent per Lot screen');
+assert.match(enhancementRuntime, /installLotStatLegend\(scope\)/, 'Every Lot route must receive the stat legend');
+assert.match(enhancementRuntime, /installLotLayout\(scope\)/, 'Every Lot route must receive the shared 3D and paint layout');
+assert.match(enhancementRuntime, /installLotAccessibility\(scope\)/, 'Every Lot route must receive the r118 accessibility model');
+assert.ok(
+  enhancementRuntime.indexOf('installLotStatLegend(scope)') < enhancementRuntime.indexOf('installLotLayout(scope)'),
   'The legend trigger must exist before the layout turns it into the Attributes info icon'
 );
 assert.ok(
-  wrapper.indexOf('installLotLayout()') < wrapper.indexOf('installLotAccessibility()'),
-  'Accessibility landmarks must be attached after the paint controls reach their final DOM position'
+  enhancementRuntime.indexOf('installLotLayout(scope)') < enhancementRuntime.indexOf('installLotAccessibility(scope)'),
+  'Accessibility landmarks must attach after paint reaches its final DOM position'
 );
+assert.match(enhancementRuntime, /new MutationObserver\(sync\)/, 'The runtime must catch M8 and any future Lot route');
+assert.match(enhancementRuntime, /if \(active\) return active\.release/, 'Repeated route helpers must not install duplicate observers or headings');
+assert.match(enhancementRuntime, /released = true/, 'Cleanup must be safe when both the route and observer release the same screen');
 
 assert.match(layout, /viewbox\.removeAttribute\('aria-hidden'\)/, 'The shared 3D and paint panel must remain in the accessibility tree');
 assert.match(layout, /lot-viewbox-head'\)\?\.setAttribute\('aria-hidden', 'true'\)/, 'Decorative 3D chrome must remain hidden from assistive technology');
@@ -69,14 +104,16 @@ assert.match(accessibility, /card\.setAttribute\('role', 'region'\)/, 'Selected-
 assert.doesNotMatch(accessibility, /setInterval|requestAnimationFrame|setAnimationLoop/, 'The accessibility enhancer must not add polling or animation work');
 
 assert.match(layoutCss, /\.lot-a11y-only \{[\s\S]*clip-path: inset\(50%\)/, 'Navigation headings and summaries must be visually hidden without leaving the accessibility tree');
-assert.match(layoutCss, /--lot-paint-rail-height: 58px/, 'The 3D panel must reserve a deliberate paint-control rail');
+assert.match(layoutCss, /--lot-paint-rail-height: 54px/, 'Paint controls must use a compact dock to protect the 3D preview');
+assert.match(layoutCss, /min-height: clamp\(150px, 28vh, 230px\)/, 'The 3D viewer must receive a meaningful responsive minimum height');
 assert.match(layoutCss, /flex: 1 1 auto/, 'The 3D panel must receive the remaining rail height instead of being squashed');
 assert.match(layoutCss, /\.lot-viewbox-with-paint \.lot-colors \{[\s\S]*border-top: 3px solid var\(--ink\)/, 'Accessible paint controls must preserve their visual dock inside the 3D card');
 assert.match(layoutCss, /\.lot-card-actions \{[\s\S]*grid-template-columns: 1fr/, 'The lower card must reserve its action row for Race only');
 assert.match(layoutCss, /\.lot-stats-help \{[\s\S]*border-radius: 50%/, 'The Attributes help control must read as a conventional circular info icon');
 assert.match(layoutCss, /\.lot-view-close,[\s\S]*\.lot-view-open \{[\s\S]*display: none !important/, 'No dormant 3D close or reopen affordance may flash during setup');
+assert.match(layoutCss, /@media \(max-height: 430px\)[\s\S]*min-height: 120px/, 'Short iPhone landscapes must keep the viewer without pushing Race off-screen');
 
 assert.match(lot, /<div class="lot-colors" aria-label="Choose car paint colours"><\/div>/, 'The verified Lot must still own the live native paint controls before enhancement');
 assert.match(legend, /aria-haspopup', 'dialog'/, 'The relocated info icon must still open the full stat legend');
 
-console.log(`TURN ${release.id} explicit selected-car summary and current-radio navigation passed.`);
+console.log(`TURN ${release.id} route-independent enhanced Lot, expanded viewer and selected-car accessibility passed.`);

--- a/turn-lab/tests/stat-legend-production.mjs
+++ b/turn-lab/tests/stat-legend-production.mjs
@@ -14,10 +14,11 @@ assert.match(
   'The DRIFT legend must state the permanent speed tradeoff'
 );
 
-const [index, releaseSource, wrapper, legendModule, legendCss, lotSource, physicsSource] = await Promise.all([
+const [index, releaseSource, wrapper, enhancementRuntime, legendModule, legendCss, lotSource, physicsSource] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/release.json', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-track-select.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-enhancement-runtime.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-stat-legend.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-stat-legend.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-r10.js', import.meta.url), 'utf8'),
@@ -33,15 +34,20 @@ assert.match(index, new RegExp(`lot-stat-legend\\.css\\?build=${release.cacheKey
 assert.equal(imports['./garage/lot-r10.js?build=20260720-r19'], `./garage/lot-track-select.js?build=${release.cacheKey}`, 'Production must publish the compact Lot wrapper through the current release');
 assert.equal(imports['./vehicle/physics.js?build=20260720-r19'], `./vehicle/physics.js?build=${release.cacheKey}`, 'Production must publish the mandatory DRIFT penalty through the current release');
 assert.equal(imports['./vehicle/catalog.js?build=20260720-r19'], `./vehicle/catalog.js?build=${release.cacheKey}`, 'Production must publish the shared stat definitions through the current release');
-assert.match(wrapper, /const lotResult = showOriginalLot\(options\)/, 'The verified Lot must mount before the legend connects to it');
+assert.match(wrapper, /const lotResult = showOriginalLot\(options\)/, 'The verified Lot must mount synchronously before enhancement');
 assert.ok(
-  wrapper.indexOf('showOriginalLot(options)') < wrapper.indexOf('installLotStatLegend()'),
-  'Legend mounting must use the already-created synchronous Lot DOM'
+  wrapper.indexOf('showOriginalLot(options)') < wrapper.indexOf('enhanceLotNow()'),
+  'Enhancement must connect to the already-created synchronous Lot DOM'
+);
+assert.match(enhancementRuntime, /installLotStatLegend\(scope\)/, 'Every Lot route must mount the shared stat legend');
+assert.ok(
+  enhancementRuntime.indexOf('installLotStatLegend(scope)') < enhancementRuntime.indexOf('installLotLayout(scope)'),
+  'The legend trigger must exist before the compact layout turns it into an info icon'
 );
 assert.match(legendModule, /VEHICLE_STAT_LEGEND/, 'The in-game legend must use the shared source of truth');
 assert.match(legendModule, /aria-modal/, 'The legend must open as an accessible modal');
 assert.match(legendModule, /WHAT DO THE STATS MEAN\?/, 'The legend trigger must be discoverable before the compact layout turns it into an info icon');
-assert.doesNotMatch(legendModule, /mountObserver|subtree: true/, 'The legend must not observe the whole game DOM');
+assert.doesNotMatch(legendModule, /mountObserver|subtree: true/, 'The legend module must not observe the whole game DOM');
 assert.match(legendModule, /statsObserver\.observe\(stats, \{ childList: true \}\)/, 'Only actual car-stat replacement must trigger relabelling');
 assert.match(legendModule, /label\.textContent !== definition\.label/, 'Relabelling must not rewrite unchanged labels');
 assert.match(legendModule, /trigger\.remove\(\)/, 'Legend cleanup must remove its injected trigger');
@@ -52,4 +58,4 @@ assert.match(physicsSource, /baseSpeedLimit \* effectiveDriftSpeedMultiplier/, '
 assert.match(physicsSource, /3\.2 \* driftStabilityMultiplier/, 'The DRIFT stat must improve recovery from a slide');
 assert.match(physicsSource, /0\.42 \* driftStabilityMultiplier/, 'The DRIFT stat must improve lateral stability while the control is held');
 
-console.log(`TURN ${release.id} shared in-game vehicle stat legend passed.`);
+console.log(`TURN ${release.id} route-independent shared vehicle stat legend passed.`);

--- a/turn/app.js
+++ b/turn/app.js
@@ -56,6 +56,10 @@ document.documentElement.dataset.turnDisplayLifecycle = 'platform-m6';
 
 installStylesheet('./r104-polish.css', 'data-turn-r104-polish');
 installStylesheet('./steering-limit-warning.css', 'data-turn-steering-limit-warning');
+installStylesheet(
+  './garage/lot-layout-r60.css?revision=r121-viewer',
+  'data-turn-lot-layout-r121'
+);
 
 const { installPerformanceProfile } = await import(withBuild('./performance-profile.js'));
 installPerformanceProfile();

--- a/turn/app.js
+++ b/turn/app.js
@@ -132,6 +132,11 @@ installSportsSedanEasterEggUi();
 const { installHarborHiddenFaceOrientation } = await import(withBuild('./tracks/harbor-hidden-face-r89.js'));
 installHarborHiddenFaceOrientation();
 
+const { installLotEnhancementRuntime } = await import(
+  withBuild('./garage/lot-enhancement-runtime.js?revision=r121')
+);
+installLotEnhancementRuntime();
+
 await import(withBuild('./input/analog-gas.js'));
 await import(withBuild('./ui/gameplay-controls.js'));
 const { installRaceSpeech } = await import(withBuild('./ui/race-speech.js'));

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -1,0 +1,72 @@
+import { installLotStatLegend } from './lot-stat-legend.js?build=20260724-r59';
+import { installLotLayout } from './lot-layout-r60.js?build=20260729-r116';
+import { installLotAccessibility } from './lot-accessibility-r118.js?build=20260729-r118';
+
+const ENHANCEMENT_ID = 'enhanced-lot-r121';
+const activeEnhancements = new WeakMap();
+
+function findLotScreen(root) {
+  if (root?.matches?.('.lot-screen')) return root;
+  return root?.querySelector?.('.lot-screen') || null;
+}
+
+export function enhanceLotNow(root = document.body) {
+  const screen = findLotScreen(root);
+  if (!screen) return () => {};
+
+  const active = activeEnhancements.get(screen);
+  if (active) return active.release;
+
+  const scope = screen.parentElement || document.body;
+  const removeStatLegend = installLotStatLegend(scope);
+  const removeLayout = installLotLayout(scope);
+  const removeAccessibility = installLotAccessibility(scope);
+  let released = false;
+
+  const release = () => {
+    if (released) return;
+    released = true;
+    removeAccessibility();
+    removeLayout();
+    removeStatLegend();
+    activeEnhancements.delete(screen);
+    delete screen.dataset.lotEnhancements;
+  };
+
+  screen.dataset.lotEnhancements = ENHANCEMENT_ID;
+  activeEnhancements.set(screen, { release });
+  return release;
+}
+
+export function installLotEnhancementRuntime(root = document.body) {
+  let currentScreen = null;
+  let releaseCurrent = () => {};
+
+  const sync = () => {
+    const nextScreen = findLotScreen(root);
+    if (nextScreen === currentScreen) return;
+
+    releaseCurrent();
+    currentScreen = nextScreen;
+    releaseCurrent = nextScreen ? enhanceLotNow(nextScreen) : () => {};
+  };
+
+  const observer = new MutationObserver(sync);
+  observer.observe(root, { childList: true, subtree: true });
+  sync();
+
+  const runtime = Object.freeze({
+    id: ENHANCEMENT_ID,
+    sync,
+    disconnect() {
+      observer.disconnect();
+      releaseCurrent();
+      currentScreen = null;
+      releaseCurrent = () => {};
+    }
+  });
+
+  globalThis.__turnLotEnhancements = runtime;
+  document.documentElement.dataset.turnLotEnhancements = ENHANCEMENT_ID;
+  return runtime;
+}

--- a/turn/garage/lot-layout-r60.css
+++ b/turn/garage/lot-layout-r60.css
@@ -12,9 +12,9 @@
 }
 
 .lot-viewbox-with-paint {
-  --lot-paint-rail-height: 58px;
+  --lot-paint-rail-height: 54px;
   flex: 1 1 auto;
-  min-height: 136px;
+  min-height: clamp(150px, 28vh, 230px);
   overflow: hidden;
 }
 
@@ -46,7 +46,7 @@
   display: grid;
   min-height: var(--lot-paint-rail-height);
   margin: 0;
-  padding: 8px;
+  padding: 7px 8px;
   grid-template-columns: 1fr;
   border-top: 3px solid var(--ink);
   background: rgb(255 248 232 / 0.98);
@@ -58,7 +58,7 @@
 
 .lot-viewbox-with-paint .lot-color-control {
   min-width: 0;
-  min-height: 39px;
+  min-height: 37px;
   box-shadow: none;
 }
 
@@ -100,18 +100,18 @@
 
 @media (max-height: 430px) {
   .lot-viewbox-with-paint {
-    --lot-paint-rail-height: 49px;
-    min-height: 116px;
+    --lot-paint-rail-height: 47px;
+    min-height: 120px;
     flex-basis: auto;
   }
 
   .lot-viewbox-with-paint .lot-colors {
     gap: 5px;
-    padding: 6px;
+    padding: 5px 6px;
   }
 
   .lot-viewbox-with-paint .lot-color-control {
-    min-height: 34px;
+    min-height: 33px;
     grid-template-columns: minmax(0, 1fr) 32px;
     padding: 3px 4px 3px 6px;
   }

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -3,6 +3,15 @@ import { enhanceLotNow } from './lot-enhancement-runtime.js?revision=r121&build=
 import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r52';
 import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
 
+export async function showTheLot(options = {}) {
+  const trackId = await chooseTrackBeforeLot();
+  if (!trackId) return null;
+
+  const selection = await showEnhancedLot(options);
+  if (selection) await showTrackIntro(trackId);
+  return selection;
+}
+
 export async function showEnhancedLot(options = {}) {
   const lotResult = showOriginalLot(options);
   const removeEnhancements = enhanceLotNow();
@@ -12,13 +21,4 @@ export async function showEnhancedLot(options = {}) {
   } finally {
     removeEnhancements();
   }
-}
-
-export async function showTheLot(options = {}) {
-  const trackId = await chooseTrackBeforeLot();
-  if (!trackId) return null;
-
-  const selection = await showEnhancedLot(options);
-  if (selection) await showTrackIntro(trackId);
-  return selection;
 }

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -1,5 +1,5 @@
 import { showTheLot as showOriginalLot } from './lot-r10.js?build=20260720-r25';
-import { enhanceLotNow } from './lot-enhancement-runtime.js?build=20260801-r121';
+import { enhanceLotNow } from './lot-enhancement-runtime.js?revision=r121&build=20260731-r120';
 import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r52';
 import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
 

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -1,22 +1,16 @@
 import { showTheLot as showOriginalLot } from './lot-r10.js?build=20260720-r25';
-import { installLotStatLegend } from './lot-stat-legend.js?build=20260724-r59';
-import { installLotLayout } from './lot-layout-r60.js?build=20260729-r116';
-import { installLotAccessibility } from './lot-accessibility-r118.js?build=20260729-r118';
+import { enhanceLotNow } from './lot-enhancement-runtime.js?build=20260801-r121';
 import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r52';
 import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
 
 export async function showEnhancedLot(options = {}) {
   const lotResult = showOriginalLot(options);
-  const removeStatLegend = installLotStatLegend();
-  const removeLotLayout = installLotLayout();
-  const removeLotAccessibility = installLotAccessibility();
+  const removeEnhancements = enhanceLotNow();
 
   try {
     return await lotResult;
   } finally {
-    removeLotAccessibility();
-    removeLotLayout();
-    removeStatLegend();
+    removeEnhancements();
   }
 }
 

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -5,24 +5,26 @@ import { installLotAccessibility } from './lot-accessibility-r118.js?build=20260
 import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r52';
 import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
 
-export async function showTheLot(options = {}) {
-  const trackId = await chooseTrackBeforeLot();
-  if (!trackId) return null;
-
+export async function showEnhancedLot(options = {}) {
   const lotResult = showOriginalLot(options);
   const removeStatLegend = installLotStatLegend();
   const removeLotLayout = installLotLayout();
   const removeLotAccessibility = installLotAccessibility();
-  let selection = null;
 
   try {
-    selection = await lotResult;
+    return await lotResult;
   } finally {
     removeLotAccessibility();
     removeLotLayout();
     removeStatLegend();
   }
+}
 
+export async function showTheLot(options = {}) {
+  const trackId = await chooseTrackBeforeLot();
+  if (!trackId) return null;
+
+  const selection = await showEnhancedLot(options);
   if (selection) await showTrackIntro(trackId);
   return selection;
 }

--- a/turn/index.html
+++ b/turn/index.html
@@ -142,5 +142,5 @@
   </div>
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
-  <script type="module" src="./app.js?build=20260731-r120-logo-final"></script>
+  <script type="module" src="./app.js?build=20260731-r120-lot-restored"></script>
 </body></html>


### PR DESCRIPTION
## Root cause

M8 Home correctly chooses the track before The Lot, but then opens the bare `lot-r10.js` screen. The finished r118 Lot enhancements were owned by the old track-first wrapper, so the new route bypassed:

- the combined 3D preview and paint panel
- the Attributes heading and stat legend
- the r118 VoiceOver summary and radio semantics

This made production r120 fall back to the older split-panel layout.

## Fix

- add one idempotent Lot enhancement runtime installed before the game core
- apply the r118 layout, stat legend and accessibility stack to every Lot route
- keep the legacy track-first wrapper working through the same shared runtime
- preserve the new Home → Lot route without reintroducing a second track chooser
- give the 3D viewer a larger responsive minimum height
- compact the paint rail slightly to leave more room for the rotating vehicle
- cache-bust the production entry, enhancement module and viewer stylesheet

## Regression coverage

The garage regression now verifies:

- runtime installation before `main.js`
- route-independent enhancement
- idempotent cleanup
- paint controls docked inside the 3D panel
- ATTRIBUTES heading and stat legend
- r118 screen-reader summaries and car ordering
- enlarged viewer dimensions and compact short-screen fallback

Production version metadata remains v1.25.0 / r120; this is a cache-revisioned layout regression fix.