### PR TITLE
Keep Race This Car visible in short Lot viewports

### DIFF
--- a/turn-lab/tests/lot-layout-production.mjs
+++ b/turn-lab/tests/lot-layout-production.mjs
@@ -34,7 +34,7 @@ assert.match(index, new RegExp(`lot-layout-r60\\.css\\?build=${release.cacheKey}
 assert.match(index, new RegExp(`app\\.js\\?build=${release.cacheKey}-lot-restored`), 'Production must cache-bust the route-independent Lot fix');
 assert.equal(imports['./garage/lot-r10.js?build=20260720-r19'], `./garage/lot-track-select.js?build=${release.cacheKey}`, 'Production must retain the track-first compatibility wrapper');
 
-assert.match(app, /lot-layout-r60\.css\?revision=r121-viewer/, 'The expanded viewer stylesheet must load after the baseline cascade');
+assert.match(app, /lot-layout-r60\.css\?revision=r121-viewer-r122-fit/, 'The fitted Lot rail stylesheet must bypass the previous viewer cache');
 assert.match(app, /lot-enhancement-runtime\.js\?revision=r121/, 'Production must load the route-independent Lot enhancer');
 assert.match(app, /installLotEnhancementRuntime\(\)/, 'Production must install the Lot enhancer once');
 assert.ok(
@@ -110,10 +110,13 @@ assert.match(layoutCss, /flex: 1 1 auto/, 'The 3D panel must receive the remaini
 assert.match(layoutCss, /\.lot-viewbox-with-paint \.lot-colors \{[\s\S]*border-top: 3px solid var\(--ink\)/, 'Accessible paint controls must preserve their visual dock inside the 3D card');
 assert.match(layoutCss, /\.lot-card-actions \{[\s\S]*grid-template-columns: 1fr/, 'The lower card must reserve its action row for Race only');
 assert.match(layoutCss, /\.lot-stats-help \{[\s\S]*border-radius: 50%/, 'The Attributes help control must read as a conventional circular info icon');
+assert.match(layoutCss, /\.lot-race \{[\s\S]*background: var\(--pink\)/, 'Race This Car must use the pink action treatment shown in the fitted design');
 assert.match(layoutCss, /\.lot-view-close,[\s\S]*\.lot-view-open \{[\s\S]*display: none !important/, 'No dormant 3D close or reopen affordance may flash during setup');
+assert.match(layoutCss, /@media \(max-height: 520px\)[\s\S]*\.lot-side \{[\s\S]*top: max\(62px,[\s\S]*\.lot-card \{[\s\S]*padding: 9px/, 'Tablet-sized short landscapes must compact the rail before Race can leave the viewport');
+assert.match(layoutCss, /@media \(max-height: 520px\)[\s\S]*min-height: 140px/, 'The fitted layout must preserve a useful 3D preview on short tablet landscapes');
 assert.match(layoutCss, /@media \(max-height: 430px\)[\s\S]*min-height: 120px/, 'Short iPhone landscapes must keep the viewer without pushing Race off-screen');
 
 assert.match(lot, /<div class="lot-colors" aria-label="Choose car paint colours"><\/div>/, 'The verified Lot must still own the live native paint controls before enhancement');
 assert.match(legend, /aria-haspopup', 'dialog'/, 'The relocated info icon must still open the full stat legend');
 
-console.log(`TURN ${release.id} route-independent enhanced Lot, expanded viewer and selected-car accessibility passed.`);
+console.log(`TURN ${release.id} route-independent enhanced Lot, fitted short-landscape rail and selected-car accessibility passed.`);

--- a/turn/app.js
+++ b/turn/app.js
@@ -57,7 +57,7 @@ document.documentElement.dataset.turnDisplayLifecycle = 'platform-m6';
 installStylesheet('./r104-polish.css', 'data-turn-r104-polish');
 installStylesheet('./steering-limit-warning.css', 'data-turn-steering-limit-warning');
 installStylesheet(
-  './garage/lot-layout-r60.css?revision=r121-viewer',
+  './garage/lot-layout-r60.css?revision=r121-viewer-r122-fit',
   'data-turn-lot-layout-r121'
 );
 

--- a/turn/garage/lot-layout-r60.css
+++ b/turn/garage/lot-layout-r60.css
@@ -93,9 +93,83 @@
   grid-template-columns: 1fr;
 }
 
+.lot-race {
+  background: var(--pink);
+}
+
 .lot-view-close,
 .lot-view-open {
   display: none !important;
+}
+
+@media (max-height: 520px) {
+  .lot-side {
+    top: max(62px, calc(env(safe-area-inset-top) + 54px));
+    gap: 7px;
+  }
+
+  .lot-viewbox {
+    border-width: 3px;
+    box-shadow: 5px 5px 0 var(--ink);
+  }
+
+  .lot-viewbox-with-paint {
+    --lot-paint-rail-height: 50px;
+    min-height: 140px;
+  }
+
+  .lot-viewbox-with-paint .lot-colors {
+    gap: 5px;
+    padding: 5px 6px;
+  }
+
+  .lot-viewbox-with-paint .lot-color-control {
+    min-height: 35px;
+    grid-template-columns: minmax(0, 1fr) 34px;
+    padding: 3px 4px 3px 6px;
+  }
+
+  .lot-viewbox-with-paint .lot-color-input {
+    width: 34px;
+    height: 26px;
+  }
+
+  .lot-viewbox-with-paint > small {
+    bottom: calc(var(--lot-paint-rail-height) + 5px);
+  }
+
+  .lot-card {
+    padding: 9px;
+    border-width: 3px;
+    box-shadow: 5px 5px 0 var(--ink);
+  }
+
+  .lot-car-title {
+    padding-bottom: 5px;
+  }
+
+  .lot-car-description {
+    margin-top: 5px;
+    line-height: 1.25;
+  }
+
+  .lot-stats {
+    gap: 2px;
+    margin: 6px 0;
+  }
+
+  .lot-stat {
+    grid-template-columns: 68px 1fr;
+    gap: 6px;
+  }
+
+  .lot-stat > span {
+    font-size: 0.43rem;
+  }
+
+  .lot-stat i {
+    height: 6px;
+  }
 }
 
 @media (max-height: 430px) {


### PR DESCRIPTION
## The Lot viewport fit

The production screenshot shows the selected-car card exceeding the available height in short landscape viewports, leaving **Race This Car** clipped below the screen.

### Fix

- add a compact rail layout for viewports up to 520 px tall, covering the affected iPad-style landscape size that missed the existing 430 px phone breakpoint
- reclaim height from the rail top offset, panel chrome, card padding, paint dock and stat spacing
- keep the car description and a useful 3D preview at this intermediate size
- retain the more aggressive existing phone fallback below 430 px
- use the pink Race action treatment shown in the target layout
- cache-bust the fitted stylesheet without changing v1.25.0 / r120 release metadata

### Regression coverage

The Lot layout contract now verifies the new intermediate breakpoint, preserved 3D minimum height, pink action treatment and stylesheet cache revision.