### PR TITLE
Require browser play consent and restore Home portrait interception

### DIFF
--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -144,7 +144,7 @@ const releaseTarget = (filePath) => `${filePath}?build=${release.cacheKey}`;
 assert.match(index, new RegExp(`TURN v${release.version.replaceAll('.', '\\.')} · Build ${release.id.replaceAll('.', '\\.')}`));
 assert.match(index, new RegExp(`\\.\\/garage\\/lot-r10\\.css\\?build=${release.cacheKey}`));
 assert.match(index, new RegExp(`\\.\\/track-intro\\.css\\?build=${release.cacheKey}`));
-assert.match(index, new RegExp(`src="\\.\\/app\\.js\\?build=${release.cacheKey}-lot-restored"`));
+assert.match(index, new RegExp(`src="\\.\\/app\\.js\\?build=${release.cacheKey}-browser-consent"`));
 assert.equal(imports['./garage/lot-r10.js?build=20260720-r19'], releaseTarget('./garage/lot-track-select.js'));
 assert.equal(imports['./ui/track-intro.js?build=20260725-r75'], releaseTarget('./ui/track-intro.js'));
 assert.equal(imports['./race/lap-system.js?build=20260720-r19'], releaseTarget('./race/lap-system-r86.js'));

--- a/turn-lab/tests/lot-layout-production.mjs
+++ b/turn-lab/tests/lot-layout-production.mjs
@@ -31,7 +31,7 @@ assert.ok(importMapText, 'Production must expose its import map');
 const imports = JSON.parse(importMapText).imports;
 
 assert.match(index, new RegExp(`lot-layout-r60\\.css\\?build=${release.cacheKey}`), 'Production must retain the baseline Lot layout stylesheet');
-assert.match(index, new RegExp(`app\\.js\\?build=${release.cacheKey}-lot-restored`), 'Production must cache-bust the route-independent Lot fix');
+assert.match(index, new RegExp(`app\\.js\\?build=${release.cacheKey}-browser-consent`), 'Production must cache-bust the browser-gated canonical runtime');
 assert.equal(imports['./garage/lot-r10.js?build=20260720-r19'], `./garage/lot-track-select.js?build=${release.cacheKey}`, 'Production must retain the track-first compatibility wrapper');
 
 assert.match(app, /lot-layout-r60\.css\?revision=r121-viewer-r122-fit/, 'The fitted Lot rail stylesheet must bypass the previous viewer cache');

--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -53,13 +53,14 @@ assert.ok(
   'The canonical motion safe zone must load before orientation feedback'
 );
 assert.equal(imports['./render/camera.js?build=20260720-r19'], `./render/camera.js?build=${release.cacheKey}`, 'The current release must publish the guarded race camera');
-assert.match(index, /<strong>Rotate to landscape<\/strong>/, 'The pre-race landscape instruction must remain available');
+assert.match(index, /<strong>Return to landscape<\/strong>/, 'The pre-race landscape instruction must remain available above Home');
 
 assert.match(css, /--manual-steer-left/);
 assert.match(css, /content: "←"/);
 assert.match(css, /content: "→"/);
 
 assert.match(orientationGuardCss, /body\.turn-race-active \.rotate-panel/, 'The portrait warning must stay hidden during an active race');
+assert.match(orientationGuardCss, /\.rotate-panel \{[\s\S]*z-index: 1700/, 'The portrait warning must sit above the M8 Home screen');
 assert.doesNotMatch(orientationGuardCss, /\.hud::before|turn-steering-limit-pulse|@keyframes/, 'The obsolete whole-screen warning must remain removed');
 
 assert.match(safeZone, /SAFE_ZONE_DEGREES = 24/);

--- a/turn-next/app.js
+++ b/turn-next/app.js
@@ -1,6 +1,6 @@
 // Generated from the canonical TURN v1.25.0 runtime. Do not edit by hand.
 const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
 const url = new URL('/turn/app.js', globalThis.location?.href || 'https://enkel.design/turn-next/');
-if (buildKey) url.searchParams.set('build', buildKey);
+if (buildKey) url.searchParams.set('build', `${buildKey}-browser-consent`);
 await import(url.href);
 console.info(`TURN NEXT: ${globalThis.__TURN_BUILD__?.id || 'development'} loaded through the canonical TURN runtime.`);

--- a/turn-next/index.html
+++ b/turn-next/index.html
@@ -44,7 +44,7 @@
   <link rel="stylesheet" href="./styles.css?build=20260731-r120">
   <link rel="stylesheet" href="./vertical-drive.css?build=20260731-r120">
   <link rel="stylesheet" href="./hud-tuning.css?build=20260731-r120">
-  <link rel="stylesheet" href="./install-gate.css?build=20260731-r120">
+  <link rel="stylesheet" href="./install-gate.css?build=20260731-r120-browser-consent">
   <link rel="stylesheet" href="./gameplay-features.css?build=20260731-r120">
   <link rel="stylesheet" href="./gameplay-v2.css?build=20260731-r120">
   <link rel="stylesheet" href="./position-hud-r83.css?build=20260731-r120">
@@ -52,7 +52,7 @@
   <link rel="stylesheet" href="./in-game-menu.css?build=20260731-r120">
   <link rel="stylesheet" href="./spectate-v3.css?build=20260731-r120">
   <link rel="stylesheet" href="./manual-steering.css?build=20260731-r120">
-  <link rel="stylesheet" href="./orientation-guard.css?build=20260731-r120">
+  <link rel="stylesheet" href="./orientation-guard.css?build=20260731-r120-home-portrait">
   <link rel="stylesheet" href="./lap-result-toast.css?build=20260731-r120">
   <link rel="stylesheet" href="./rival-onboarding.css?build=20260731-r120">
   <link rel="stylesheet" href="./track-select.css?build=20260731-r120">
@@ -67,7 +67,7 @@
   <link rel="stylesheet" href="./garage/lot-layout-r60.css?build=20260731-r120">
   <link rel="stylesheet" href="/turn-next/identity.css?source=20260731-r120-m8.5-logo">
   <script defer src="/turn-next/identity.js?source=20260731-r120-m8.5-logo"></script>
-  <script src="./install-gate.js?build=20260731-r120"></script>
+  <script src="./install-gate.js?build=20260731-r120-browser-consent"></script>
   <script src="./motion-safe-zone.js?build=20260731-r120"></script>
   <script src="./orientation-compat.js?build=20260731-r120"></script>
   <script type="importmap">
@@ -133,9 +133,9 @@
   </section>
   <div id="game" aria-label="Third-person motion-controlled arcade racing game"></div>
   <section class="panel" id="intro" hidden aria-hidden="true"><button id="motionButton" type="button" hidden></button><button id="manualButton" type="button" hidden></button><p id="status" role="status" hidden></p></section>
-  <section class="rotate-panel" aria-label="Rotate device"><div class="rotate-card"><div class="rotate-phone" aria-hidden="true"></div><strong>Rotate to landscape</strong></div></section>
+  <section class="rotate-panel" aria-label="Return device to landscape"><div class="rotate-card"><div class="rotate-phone" aria-hidden="true"></div><strong>Return to landscape</strong></div></section>
   <div class="hud" id="hud" hidden><div class="topbar"><div class="stats"><div class="chip">speed<strong><span id="speed">0</span> km/h</strong></div><div class="chip">lap<strong id="lap">1</strong></div><div class="chip">time<strong id="lapTime">0:00.000</strong></div><div class="chip">best<strong id="bestTime">--:--.---</strong></div></div><div class="map-wrap"><canvas id="map" width="300" height="210" aria-label="Track map"></canvas></div></div><div class="message" id="message" role="status"></div><div class="tilt-drive" aria-hidden="true"><span><b>brake</b><b>gas</b></span><div class="tilt-track"><i class="tilt-needle" id="tiltNeedle"></i></div><small class="tilt-value" id="tiltValue">neutral</small></div></div>
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
-  <script type="module" src="/turn-next/app.js?source=20260731-r120-promoted"></script>
+  <script type="module" src="/turn-next/app.js?source=20260731-r120-browser-consent"></script>
 </body></html>

--- a/turn-next/scripts/build-parity-app.mjs
+++ b/turn-next/scripts/build-parity-app.mjs
@@ -9,7 +9,7 @@ const releasePath = path.join(repositoryRoot, 'turn', 'release.json');
 const outputPath = path.join(repositoryRoot, 'turn-next', 'app.js');
 
 export function buildTurnNextApp(release) {
-  return `// Generated from the canonical TURN v${release.version} runtime. Do not edit by hand.\nconst buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';\nconst url = new URL('/turn/app.js', globalThis.location?.href || 'https://enkel.design/turn-next/');\nif (buildKey) url.searchParams.set('build', buildKey);\nawait import(url.href);\nconsole.info(\`TURN NEXT: \${globalThis.__TURN_BUILD__?.id || 'development'} loaded through the canonical TURN runtime.\`);\n`;
+  return `// Generated from the canonical TURN v${release.version} runtime. Do not edit by hand.\nconst buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';\nconst url = new URL('/turn/app.js', globalThis.location?.href || 'https://enkel.design/turn-next/');\nif (buildKey) url.searchParams.set('build', \`${'${buildKey}'}-browser-consent\`);\nawait import(url.href);\nconsole.info(\`TURN NEXT: \${globalThis.__TURN_BUILD__?.id || 'development'} loaded through the canonical TURN runtime.\`);\n`;
 }
 
 async function main() {
@@ -19,6 +19,7 @@ async function main() {
   if (process.argv.includes('--check')) {
     const current = await fs.readFile(outputPath, 'utf8').catch(() => null);
     assert.equal(current, generated, 'turn-next/app.js is stale. Run node turn-next/scripts/build-parity-app.mjs.');
+    assert.match(current, /browser-consent/);
     assert.match(current, /await import\(url\.href\)/);
     assert.doesNotMatch(current, /installMotionLifecycleBridge|installM8HomeNavigation/);
     console.log(`TURN NEXT bootstrap wraps canonical TURN ${release.id}.`);

--- a/turn-next/scripts/build-parity-entry.mjs
+++ b/turn-next/scripts/build-parity-entry.mjs
@@ -23,8 +23,11 @@ async function main() {
   assert.match(current, /\/turn-next\/site\.webmanifest/);
   assert.match(current, /\/turn-next\/identity\.css/);
   assert.match(current, /\/turn-next\/identity\.js/);
-  assert.match(current, new RegExp(`/turn-next/app\\.js\\?source=${release.cacheKey}-promoted`));
+  assert.match(current, new RegExp(`/turn-next/app\\.js\\?source=${release.cacheKey}-browser-consent`));
+  assert.match(current, new RegExp(`install-gate\\.js\\?build=${release.cacheKey}-browser-consent`));
+  assert.match(current, new RegExp(`orientation-guard\\.css\\?build=${release.cacheKey}-home-portrait`));
   assert.match(current, /id="installGate"/);
+  assert.match(current, /Return to landscape/);
   assert.match(current, /id="intro" hidden aria-hidden="true"/);
   assert.match(current, /id="motionButton"/);
   assert.match(current, /id="manualButton"/);

--- a/turn-tests/release-production.mjs
+++ b/turn-tests/release-production.mjs
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 
 import { checkReleaseFiles, loadReleaseDefinition } from '../turn/scripts/release.mjs';
 
-const [release, index, app, main, manifest, workflow, nextApp, nextIndex] = await Promise.all([
+const [release, index, app, main, manifest, workflow, nextApp, nextIndex, installGate, installGateCss, orientationGuardCss] = await Promise.all([
   loadReleaseDefinition(),
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8'),
@@ -11,7 +11,10 @@ const [release, index, app, main, manifest, workflow, nextApp, nextIndex] = awai
   fs.readFile(new URL('../turn/site.webmanifest', import.meta.url), 'utf8'),
   fs.readFile(new URL('../.github/workflows/turn-lab-tests.yml', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-next/app.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn-next/index.html', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn-next/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/install-gate.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/install-gate.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/orientation-guard.css', import.meta.url), 'utf8')
 ]);
 
 await checkReleaseFiles();
@@ -26,10 +29,24 @@ assert.equal(
 assert.match(index, new RegExp(`version: '${escapeRegExp(release.version)}'`));
 assert.match(index, new RegExp(`id: '${escapeRegExp(release.id)}'`));
 assert.match(index, new RegExp(`cacheKey: '${escapeRegExp(release.cacheKey)}'`));
+assert.match(index, new RegExp(`install-gate\\.js\\?build=${escapeRegExp(release.cacheKey)}-browser-consent`));
+assert.match(index, new RegExp(`install-gate\\.css\\?build=${escapeRegExp(release.cacheKey)}-browser-consent`));
+assert.match(index, new RegExp(`orientation-guard\\.css\\?build=${escapeRegExp(release.cacheKey)}-home-portrait`));
+assert.match(index, new RegExp(`app\\.js\\?build=${escapeRegExp(release.cacheKey)}-browser-consent`));
+assert.match(index, /Return to landscape/);
+assert.match(app, /const launchReady = globalThis\.__turnLaunchReady/);
+assert.match(app, /await launchReady/);
+assert.ok(app.indexOf('await launchReady') < app.indexOf('retireLegacyStartPanel()'));
 assert.match(app, /const release = globalThis\.__TURN_BUILD__/);
 assert.match(app, /buildLabel\.textContent = `TURN V\$\{release\?\.version \|\| ''\} · BUILD \$\{\(release\?\.id \|\| ''\)\.toUpperCase\(\)\}`/);
 assert.match(app, /retireLegacyStartPanel\(\)/);
 assert.doesNotMatch(index, /class="start-card"/);
+
+assert.match(installGate, /globalThis\.__turnLaunchReady = launchReady/);
+assert.match(installGate, /browserButton\.addEventListener\('click', \(\) => startBrowserGame\(gate\)\)/);
+assert.doesNotMatch(installGate, /sessionStorage|turn-play-in-browser/);
+assert.match(installGateCss, /\.install-gate \{[\s\S]*z-index: 2000/);
+assert.match(orientationGuardCss, /\.rotate-panel \{[\s\S]*z-index: 1700/);
 
 const attributeBuilds = [...index.matchAll(/(?:href|src)="\.\/[^"?]+\?build=([^"&]+)/g)].map((match) => match[1]);
 assert.ok(attributeBuilds.length >= 15, 'Production entry document must cache-bust its local assets');
@@ -87,8 +104,10 @@ assert.ok(
 );
 
 assert.match(nextIndex, new RegExp(`TURN NEXT · Source ${escapeRegExp(visibleBuild)}`));
-assert.match(nextIndex, new RegExp(`/turn-next/app\\.js\\?source=${escapeRegExp(release.cacheKey)}-promoted`));
+assert.match(nextIndex, new RegExp(`/turn-next/app\\.js\\?source=${escapeRegExp(release.cacheKey)}-browser-consent`));
+assert.match(nextIndex, /Return to landscape/);
 assert.match(nextApp, /new URL\('\/turn\/app\.js'/);
+assert.match(nextApp, /browser-consent/);
 assert.match(nextApp, /await import\(url\.href\)/);
 assert.doesNotMatch(nextApp, /installM8HomeNavigation|installMotionLifecycleBridge/);
 
@@ -96,7 +115,7 @@ assert.match(workflow, /node turn\/scripts\/release\.mjs --check/);
 assert.match(workflow, /node turn-tests\/release-production\.mjs/);
 assert.doesNotMatch(workflow, /node turn-lab\/scripts\/check-release\.mjs/, 'CI must verify the production release rather than the retired playable lab snapshot');
 
-console.log(`TURN ${release.id} promoted M5–M8 production release architecture passed.`);
+console.log(`TURN ${release.id} browser-consent and Home portrait release architecture passed.`);
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/turn-tests/turn-next-entry-production.mjs
+++ b/turn-tests/turn-next-entry-production.mjs
@@ -16,6 +16,8 @@ const [
   webPlatform,
   motionLifecycleBridge,
   displayLifecycleBridge,
+  installGateSource,
+  installGateCss,
   orientationGuardCss,
   homeSource,
   homeCss,
@@ -38,6 +40,8 @@ const [
   fs.readFile(new URL('../turn/platform/web-platform.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/motion-lifecycle-bridge.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/display-lifecycle-bridge.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/install-gate.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/install-gate.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/orientation-guard.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/m8-home.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/m8-home.css', import.meta.url), 'utf8'),
@@ -57,13 +61,23 @@ assert.equal(release.cacheKey, '20260731-r120');
 
 assert.match(productionIndex, new RegExp(`TURN v${release.version.replaceAll('.', '\\.')} · Build ${release.id.replaceAll('.', '\\.')}`));
 assert.match(productionIndex, /<meta name="theme-color" content="#08090a">/);
-assert.match(productionIndex, new RegExp(`src="\\.\\/app\\.js\\?build=${release.cacheKey}(?:-[^"]+)?"`));
+assert.match(productionIndex, new RegExp(`src="\\.\\/app\\.js\\?build=${release.cacheKey}-browser-consent"`));
+assert.match(productionIndex, new RegExp(`src="\\.\\/install-gate\\.js\\?build=${release.cacheKey}-browser-consent"`));
+assert.match(productionIndex, new RegExp(`href="\\.\\/install-gate\\.css\\?build=${release.cacheKey}-browser-consent"`));
+assert.match(productionIndex, new RegExp(`href="\\.\\/orientation-guard\\.css\\?build=${release.cacheKey}-home-portrait"`));
+assert.match(productionIndex, /Return to landscape/);
 assert.match(productionIndex, /id="intro" hidden aria-hidden="true"/);
 assert.match(productionIndex, /id="motionButton"/);
 assert.match(productionIndex, /id="manualButton"/);
 assert.match(productionIndex, /id="status"/);
 assert.doesNotMatch(productionIndex, /class="start-card"|Enable motion &amp; race|Desktop \/ manual mode/);
 
+assert.match(productionApp, /const launchReady = globalThis\.__turnLaunchReady/);
+assert.match(productionApp, /await launchReady/);
+assert.ok(
+  productionApp.indexOf('await launchReady') < productionApp.indexOf('retireLegacyStartPanel()'),
+  'No TURN runtime or Home setup may run before browser launch consent resolves'
+);
 assert.match(productionApp, /retireLegacyStartPanel\(\)/);
 assert.match(productionApp, /createWebPlatform/);
 assert.match(productionApp, /installTurnPlatform\(webPlatform\)/);
@@ -79,12 +93,28 @@ assert.match(productionMain, /createRaceSessionOrchestrator/);
 assert.match(productionMain, /openLot: raceSession\.openLotFromRace/);
 assert.equal(nextMain, productionMain, 'TURN NEXT main must mirror canonical TURN exactly');
 
+assert.match(installGateSource, /globalThis\.__turnLaunchReady = launchReady/);
+assert.match(installGateSource, /Promise\.resolve\(\{ mode: 'standalone' \}\)/);
+assert.match(installGateSource, /browserButton\.addEventListener\('click', \(\) => startBrowserGame\(gate\)\)/);
+assert.match(installGateSource, /releaseBrowserLaunch\?\.\(\)/);
+assert.match(installGateSource, /gate\.hidden = false/);
+assert.doesNotMatch(installGateSource, /sessionStorage|turn-play-in-browser/);
+assert.ok(
+  installGateSource.indexOf('gate.hidden = true') < installGateSource.indexOf('releaseBrowserLaunch?.()'),
+  'The browser onboarding must leave the screen only as the explicit play action releases the runtime'
+);
+assert.match(installGateCss, /\.install-gate \{[\s\S]*z-index: 2000/);
+assert.match(installGateCss, /\.install-guide \{[\s\S]*z-index: 2010/);
+
 assert.match(nextIndex, /data-turn-deployment="next"/);
 assert.match(nextIndex, /<base href="\/turn\/">/);
 assert.match(nextIndex, /<meta name="robots" content="noindex,nofollow">/);
 assert.match(nextIndex, new RegExp(`TURN NEXT · Source TURN v${release.version.replaceAll('.', '\\.')} · Build ${release.id.replaceAll('.', '\\.')}`));
 assert.match(nextIndex, new RegExp(`/turn-next/storage-bootstrap\\.js\\?source=${release.cacheKey}`));
-assert.match(nextIndex, new RegExp(`/turn-next/app\\.js\\?source=${release.cacheKey}-promoted`));
+assert.match(nextIndex, new RegExp(`/turn-next/app\\.js\\?source=${release.cacheKey}-browser-consent`));
+assert.match(nextIndex, new RegExp(`install-gate\\.js\\?build=${release.cacheKey}-browser-consent`));
+assert.match(nextIndex, new RegExp(`orientation-guard\\.css\\?build=${release.cacheKey}-home-portrait`));
+assert.match(nextIndex, /Return to landscape/);
 assert.ok(nextIndex.indexOf('/turn-next/storage-bootstrap.js') < nextIndex.indexOf('/turn-next/app.js'));
 assert.match(nextIndex, /\/turn-next\/identity\.css/);
 assert.match(nextIndex, /\/turn-next\/identity\.js/);
@@ -92,6 +122,7 @@ assert.match(nextIndex, /\/turn-next\/site\.webmanifest/);
 assert.doesNotMatch(nextIndex, /class="start-card"|Enable motion &amp; race|Desktop \/ manual mode/);
 
 assert.match(nextApp, /new URL\('\/turn\/app\.js'/);
+assert.match(nextApp, /browser-consent/);
 assert.match(nextApp, /await import\(url\.href\)/);
 assert.doesNotMatch(nextApp, /installMotionLifecycleBridge|installDisplayLifecycleBridge|installM8HomeNavigation|installM8HomeFixedLayout/);
 
@@ -107,6 +138,7 @@ assert.match(displayLifecycleBridge, /display\.lockLandscape\(\)/);
 assert.match(homeSource, /TRACK_SELECTION_CATALOG\.map\(renderTrackCard\)/);
 assert.match(homeSource, /raceSession\.prepareMotionAccess\(\)/);
 assert.match(homeSource, /runtime\.openLot = leaveRaceForHome/);
+assert.match(homeCss, /\.m8-home \{[\s\S]*z-index: 1400/);
 assert.match(homeCss, /turn-m8-active \.audio-settings-button/);
 assert.match(fixedLayoutSource, /installM8HomeCardScrollFixes\(\)/);
 assert.match(fixedLayoutCss, /grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/);
@@ -117,6 +149,7 @@ assert.match(cardScrollCss, /-webkit-overflow-scrolling: touch/);
 
 assert.match(orientationGuardCss, /#intro[\s\S]*display: none !important/);
 assert.match(orientationGuardCss, /body[\s\S]*position: fixed/);
+assert.match(orientationGuardCss, /\.rotate-panel \{[\s\S]*z-index: 1700/);
 assert.match(orientationGuardCss, /object-fit: contain/);
 assert.doesNotMatch(orientationGuardCss, /100lvh/);
 
@@ -157,4 +190,4 @@ assert.deepEqual(
   }
 );
 
-console.log(`TURN ${release.id} owns M5–M8; TURN NEXT is an isolated canonical wrapper.`);
+console.log(`TURN ${release.id} requires browser consent and keeps Home behind the portrait guard; TURN NEXT mirrors both contracts.`);

--- a/turn/app.js
+++ b/turn/app.js
@@ -1,3 +1,8 @@
+const launchReady = globalThis.__turnLaunchReady;
+if (launchReady && typeof launchReady.then === 'function') {
+  await launchReady;
+}
+
 const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
 const moduleBase = new URL('/turn/', globalThis.location?.href || 'https://enkel.design/turn/');
 

--- a/turn/index.html
+++ b/turn/index.html
@@ -41,7 +41,7 @@
   <link rel="stylesheet" href="./styles.css?build=20260731-r120">
   <link rel="stylesheet" href="./vertical-drive.css?build=20260731-r120">
   <link rel="stylesheet" href="./hud-tuning.css?build=20260731-r120">
-  <link rel="stylesheet" href="./install-gate.css?build=20260731-r120">
+  <link rel="stylesheet" href="./install-gate.css?build=20260731-r120-browser-consent">
   <link rel="stylesheet" href="./gameplay-features.css?build=20260731-r120">
   <link rel="stylesheet" href="./gameplay-v2.css?build=20260731-r120">
   <link rel="stylesheet" href="./position-hud-r83.css?build=20260731-r120">
@@ -49,7 +49,7 @@
   <link rel="stylesheet" href="./in-game-menu.css?build=20260731-r120">
   <link rel="stylesheet" href="./spectate-v3.css?build=20260731-r120">
   <link rel="stylesheet" href="./manual-steering.css?build=20260731-r120">
-  <link rel="stylesheet" href="./orientation-guard.css?build=20260731-r120">
+  <link rel="stylesheet" href="./orientation-guard.css?build=20260731-r120-home-portrait">
   <link rel="stylesheet" href="./lap-result-toast.css?build=20260731-r120">
   <link rel="stylesheet" href="./rival-onboarding.css?build=20260731-r120">
   <link rel="stylesheet" href="./track-select.css?build=20260731-r120">
@@ -62,7 +62,7 @@
   <link rel="stylesheet" href="./garage/lot-r10.css?build=20260731-r120">
   <link rel="stylesheet" href="./garage/lot-stat-legend.css?build=20260731-r120">
   <link rel="stylesheet" href="./garage/lot-layout-r60.css?build=20260731-r120">
-  <script src="./install-gate.js?build=20260731-r120"></script>
+  <script src="./install-gate.js?build=20260731-r120-browser-consent"></script>
   <script src="./motion-safe-zone.js?build=20260731-r120"></script>
   <script src="./orientation-compat.js?build=20260731-r120"></script>
   <script type="importmap">
@@ -134,7 +134,7 @@
     <button id="manualButton" type="button" hidden></button>
     <p id="status" role="status" hidden>Steering uses device rotation</p>
   </section>
-  <section class="rotate-panel" aria-label="Rotate device"><div class="rotate-card"><div class="rotate-phone" aria-hidden="true"></div><strong>Rotate to landscape</strong></div></section>
+  <section class="rotate-panel" aria-label="Return device to landscape"><div class="rotate-card"><div class="rotate-phone" aria-hidden="true"></div><strong>Return to landscape</strong></div></section>
   <div class="hud" id="hud" hidden>
     <div class="topbar"><div class="stats"><div class="chip">speed<strong><span id="speed">0</span> km/h</strong></div><div class="chip">lap<strong id="lap">1</strong></div><div class="chip">time<strong id="lapTime">0:00.000</strong></div><div class="chip">best<strong id="bestTime">--:--.---</strong></div></div><div class="map-wrap"><canvas id="map" width="300" height="210" aria-label="Track map"></canvas></div></div>
     <div class="message" id="message" role="status"></div>
@@ -142,5 +142,5 @@
   </div>
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
-  <script type="module" src="./app.js?build=20260731-r120-lot-restored"></script>
+  <script type="module" src="./app.js?build=20260731-r120-browser-consent"></script>
 </body></html>

--- a/turn/install-gate.css
+++ b/turn/install-gate.css
@@ -1,7 +1,7 @@
 .install-gate {
   position: absolute;
   inset: 0;
-  z-index: 120;
+  z-index: 2000;
   display: grid;
   place-items: center;
   overflow: auto;
@@ -116,7 +116,7 @@ html.turn-standalone .install-gate,
 .install-guide {
   position: absolute;
   inset: 0;
-  z-index: 130;
+  z-index: 2010;
   display: grid;
   place-items: end center;
   padding:

--- a/turn/install-gate.js
+++ b/turn/install-gate.js
@@ -8,6 +8,23 @@
   document.documentElement.classList.toggle('turn-browser', !isStandalone);
 
   let deferredInstallPrompt = null;
+  let releaseBrowserLaunch = null;
+  let browserLaunchReleased = false;
+
+  const launchReady = isStandalone
+    ? Promise.resolve({ mode: 'standalone' })
+    : new Promise((resolve) => {
+      releaseBrowserLaunch = () => {
+        if (browserLaunchReleased) return;
+        browserLaunchReleased = true;
+        document.documentElement.classList.add('turn-browser-launched');
+        resolve({ mode: 'browser' });
+        document.dispatchEvent(new CustomEvent('turn-browser-play'));
+      };
+    });
+
+  globalThis.__turnLaunchReady = launchReady;
+  globalThis.__turnStartBrowserGame = releaseBrowserLaunch;
 
   window.addEventListener('beforeinstallprompt', (event) => {
     event.preventDefault();
@@ -20,11 +37,10 @@
       (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
   }
 
-  function hideGateForBrowserSession(gate) {
-    try {
-      sessionStorage.setItem('turn-play-in-browser', '1');
-    } catch (_) {}
+  function startBrowserGame(gate) {
+    if (isStandalone) return;
     gate.hidden = true;
+    releaseBrowserLaunch?.();
   }
 
   function initInstallGate() {
@@ -44,13 +60,8 @@
       return;
     }
 
-    try {
-      if (sessionStorage.getItem('turn-play-in-browser') === '1') {
-        gate.hidden = true;
-        return;
-      }
-    } catch (_) {}
-
+    // Browser launch is deliberately never remembered. Every fresh page load remains on
+    // installation onboarding until the player explicitly chooses Play in browser.
     gate.hidden = false;
 
     function showManualGuide() {
@@ -113,7 +124,7 @@
     }
 
     installButton.addEventListener('click', requestInstall);
-    browserButton.addEventListener('click', () => hideGateForBrowserSession(gate));
+    browserButton.addEventListener('click', () => startBrowserGame(gate));
     guideClose.addEventListener('click', () => { guide.hidden = true; });
     guide.addEventListener('click', (event) => {
       if (event.target === guide) guide.hidden = true;

--- a/turn/orientation-guard.css
+++ b/turn/orientation-guard.css
@@ -29,6 +29,12 @@ body {
   min-height: 0;
 }
 
+/* M8 Home sits at z-index 1400. Keep the portrait interception above it while
+   leaving the browser installation gate as the topmost pre-launch surface. */
+.rotate-panel {
+  z-index: 1700;
+}
+
 #intro {
   display: none !important;
 }


### PR DESCRIPTION
## Browser launch gate

The installation onboarding was only visual. The canonical TURN runtime continued booting underneath it, and the newer M8 Home layer eventually appeared above the low-z-index gate. A previously stored session flag could also bypass onboarding on later page loads.

This change makes browser consent an actual runtime boundary:

- `install-gate.js` creates a launch promise synchronously before the module runtime loads
- standalone/Home Screen launches resolve immediately
- browser launches remain paused on onboarding until **Play in browser anyway** is explicitly activated
- browser consent is deliberately not persisted across reloads
- the gate and runtime assets receive distinct cache revisions
- TURN NEXT uses the same canonical contract

## Portrait interception on Home

M8 Home uses z-index 1400 while the legacy portrait guard used z-index 80, so the track browser covered the guard.

- raise the portrait interception above M8 Home
- keep installation onboarding above both surfaces
- update the prompt to **Return to landscape**
- cache-bust the orientation stylesheet in TURN and TURN NEXT

## Regression coverage

Production and TURN NEXT contracts now verify:

- runtime initialization waits for `__turnLaunchReady`
- only the explicit browser button releases the waiting runtime
- no session-storage bypass remains
- standalone mode resolves immediately
- onboarding, portrait guard and M8 Home have the intended stacking order
- both deployment entries carry the new cache revisions and prompt copy
- TURN NEXT generated wrapper and entry checks remain aligned.