### PR TITLE
Start installation outside social media browsers

### DIFF
--- a/turn-next/index.html
+++ b/turn-next/index.html
@@ -44,7 +44,7 @@
   <link rel="stylesheet" href="./styles.css?build=20260731-r120">
   <link rel="stylesheet" href="./vertical-drive.css?build=20260731-r120">
   <link rel="stylesheet" href="./hud-tuning.css?build=20260731-r120">
-  <link rel="stylesheet" href="./install-gate.css?build=20260731-r120-browser-consent">
+  <link rel="stylesheet" href="./install-gate.css?build=20260731-r120-social-browser">
   <link rel="stylesheet" href="./gameplay-features.css?build=20260731-r120">
   <link rel="stylesheet" href="./gameplay-v2.css?build=20260731-r120">
   <link rel="stylesheet" href="./position-hud-r83.css?build=20260731-r120">
@@ -67,7 +67,7 @@
   <link rel="stylesheet" href="./garage/lot-layout-r60.css?build=20260731-r120">
   <link rel="stylesheet" href="/turn-next/identity.css?source=20260731-r120-m8.5-logo">
   <script defer src="/turn-next/identity.js?source=20260731-r120-m8.5-logo"></script>
-  <script src="./install-gate.js?build=20260731-r120-browser-consent"></script>
+  <script src="./install-gate.js?build=20260731-r120-social-browser"></script>
   <script src="./motion-safe-zone.js?build=20260731-r120"></script>
   <script src="./orientation-compat.js?build=20260731-r120"></script>
   <script type="importmap">

--- a/turn-next/scripts/build-parity-entry.mjs
+++ b/turn-next/scripts/build-parity-entry.mjs
@@ -24,7 +24,8 @@ async function main() {
   assert.match(current, /\/turn-next\/identity\.css/);
   assert.match(current, /\/turn-next\/identity\.js/);
   assert.match(current, new RegExp(`/turn-next/app\\.js\\?source=${release.cacheKey}-browser-consent`));
-  assert.match(current, new RegExp(`install-gate\\.js\\?build=${release.cacheKey}-browser-consent`));
+  assert.match(current, new RegExp(`install-gate\\.js\\?build=${release.cacheKey}-social-browser`));
+  assert.match(current, new RegExp(`install-gate\\.css\\?build=${release.cacheKey}-social-browser`));
   assert.match(current, new RegExp(`orientation-guard\\.css\\?build=${release.cacheKey}-home-portrait`));
   assert.match(current, /id="installGate"/);
   assert.match(current, /Return to landscape/);

--- a/turn-tests/release-production.mjs
+++ b/turn-tests/release-production.mjs
@@ -29,8 +29,8 @@ assert.equal(
 assert.match(index, new RegExp(`version: '${escapeRegExp(release.version)}'`));
 assert.match(index, new RegExp(`id: '${escapeRegExp(release.id)}'`));
 assert.match(index, new RegExp(`cacheKey: '${escapeRegExp(release.cacheKey)}'`));
-assert.match(index, new RegExp(`install-gate\\.js\\?build=${escapeRegExp(release.cacheKey)}-browser-consent`));
-assert.match(index, new RegExp(`install-gate\\.css\\?build=${escapeRegExp(release.cacheKey)}-browser-consent`));
+assert.match(index, new RegExp(`install-gate\\.js\\?build=${escapeRegExp(release.cacheKey)}-social-browser`));
+assert.match(index, new RegExp(`install-gate\\.css\\?build=${escapeRegExp(release.cacheKey)}-social-browser`));
 assert.match(index, new RegExp(`orientation-guard\\.css\\?build=${escapeRegExp(release.cacheKey)}-home-portrait`));
 assert.match(index, new RegExp(`app\\.js\\?build=${escapeRegExp(release.cacheKey)}-browser-consent`));
 assert.match(index, /Return to landscape/);
@@ -45,7 +45,15 @@ assert.doesNotMatch(index, /class="start-card"/);
 assert.match(installGate, /globalThis\.__turnLaunchReady = launchReady/);
 assert.match(installGate, /browserButton\.addEventListener\('click', \(\) => startBrowserGame\(gate\)\)/);
 assert.doesNotMatch(installGate, /sessionStorage|turn-play-in-browser/);
+assert.match(installGate, /Open in your device’s browser/);
+assert.match(installGate, /Not inside a social media app/);
+assert.match(installGate, /data-copy-game-address/);
+assert.match(installGate, /navigator\.clipboard\?\.writeText/);
+assert.match(installGate, /document\.execCommand\?\.\('copy'\)/);
+assert.match(installGate, /const gamePath = isNextDeployment \? '\/turn-next\/' : '\/turn\/'/);
 assert.match(installGateCss, /\.install-gate \{[\s\S]*z-index: 2000/);
+assert.match(installGateCss, /\.install-copy-address \{/);
+assert.match(installGateCss, /\.install-guide-card \{[\s\S]*max-height: 100%[\s\S]*overflow: auto/);
 assert.match(orientationGuardCss, /\.rotate-panel \{[\s\S]*z-index: 1700/);
 
 const attributeBuilds = [...index.matchAll(/(?:href|src)="\.\/[^"?]+\?build=([^"&]+)/g)].map((match) => match[1]);
@@ -105,6 +113,8 @@ assert.ok(
 
 assert.match(nextIndex, new RegExp(`TURN NEXT · Source ${escapeRegExp(visibleBuild)}`));
 assert.match(nextIndex, new RegExp(`/turn-next/app\\.js\\?source=${escapeRegExp(release.cacheKey)}-browser-consent`));
+assert.match(nextIndex, new RegExp(`install-gate\\.js\\?build=${escapeRegExp(release.cacheKey)}-social-browser`));
+assert.match(nextIndex, new RegExp(`install-gate\\.css\\?build=${escapeRegExp(release.cacheKey)}-social-browser`));
 assert.match(nextIndex, /Return to landscape/);
 assert.match(nextApp, /new URL\('\/turn\/app\.js'/);
 assert.match(nextApp, /browser-consent/);
@@ -115,7 +125,7 @@ assert.match(workflow, /node turn\/scripts\/release\.mjs --check/);
 assert.match(workflow, /node turn-tests\/release-production\.mjs/);
 assert.doesNotMatch(workflow, /node turn-lab\/scripts\/check-release\.mjs/, 'CI must verify the production release rather than the retired playable lab snapshot');
 
-console.log(`TURN ${release.id} browser-consent and Home portrait release architecture passed.`);
+console.log(`TURN ${release.id} browser-consent, social-browser onboarding and Home portrait release architecture passed.`);
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/turn-tests/turn-next-entry-production.mjs
+++ b/turn-tests/turn-next-entry-production.mjs
@@ -62,8 +62,8 @@ assert.equal(release.cacheKey, '20260731-r120');
 assert.match(productionIndex, new RegExp(`TURN v${release.version.replaceAll('.', '\\.')} · Build ${release.id.replaceAll('.', '\\.')}`));
 assert.match(productionIndex, /<meta name="theme-color" content="#08090a">/);
 assert.match(productionIndex, new RegExp(`src="\\.\\/app\\.js\\?build=${release.cacheKey}-browser-consent"`));
-assert.match(productionIndex, new RegExp(`src="\\.\\/install-gate\\.js\\?build=${release.cacheKey}-browser-consent"`));
-assert.match(productionIndex, new RegExp(`href="\\.\\/install-gate\\.css\\?build=${release.cacheKey}-browser-consent"`));
+assert.match(productionIndex, new RegExp(`src="\\.\\/install-gate\\.js\\?build=${release.cacheKey}-social-browser"`));
+assert.match(productionIndex, new RegExp(`href="\\.\\/install-gate\\.css\\?build=${release.cacheKey}-social-browser"`));
 assert.match(productionIndex, new RegExp(`href="\\.\\/orientation-guard\\.css\\?build=${release.cacheKey}-home-portrait"`));
 assert.match(productionIndex, /Return to landscape/);
 assert.match(productionIndex, /id="intro" hidden aria-hidden="true"/);
@@ -103,8 +103,22 @@ assert.ok(
   installGateSource.indexOf('gate.hidden = true') < installGateSource.indexOf('releaseBrowserLaunch?.()'),
   'The browser onboarding must leave the screen only as the explicit play action releases the runtime'
 );
+assert.match(installGateSource, /const gamePath = isNextDeployment \? '\/turn-next\/' : '\/turn\/'/);
+assert.match(installGateSource, /Open in your device’s browser/);
+assert.match(installGateSource, /Not inside a social media app/);
+assert.match(installGateSource, /data-copy-game-address/);
+assert.match(installGateSource, /navigator\.clipboard\?\.writeText/);
+assert.match(installGateSource, /document\.execCommand\?\.\('copy'\)/);
+assert.match(installGateSource, /guideSteps\.addEventListener\('click'/);
+assert.match(installGateSource, /Game address copied/);
+assert.match(installGateSource, /install-address-fallback/);
+assert.match(installGateSource, /Add \$\{appName\} to your Home Screen/);
 assert.match(installGateCss, /\.install-gate \{[\s\S]*z-index: 2000/);
-assert.match(installGateCss, /\.install-guide \{[\s\S]*z-index: 2010/);
+assert.match(installGateCss, /\.install-guide \{[\s\S]*z-index: 2010[\s\S]*overflow: auto/);
+assert.match(installGateCss, /\.install-guide-card \{[\s\S]*max-height: 100%[\s\S]*overflow: auto/);
+assert.match(installGateCss, /\.install-copy-address \{/);
+assert.match(installGateCss, /\.install-address-fallback\[hidden\]/);
+assert.match(installGateCss, /\.install-copy-status:empty/);
 
 assert.match(nextIndex, /data-turn-deployment="next"/);
 assert.match(nextIndex, /<base href="\/turn\/">/);
@@ -112,7 +126,8 @@ assert.match(nextIndex, /<meta name="robots" content="noindex,nofollow">/);
 assert.match(nextIndex, new RegExp(`TURN NEXT · Source TURN v${release.version.replaceAll('.', '\\.')} · Build ${release.id.replaceAll('.', '\\.')}`));
 assert.match(nextIndex, new RegExp(`/turn-next/storage-bootstrap\\.js\\?source=${release.cacheKey}`));
 assert.match(nextIndex, new RegExp(`/turn-next/app\\.js\\?source=${release.cacheKey}-browser-consent`));
-assert.match(nextIndex, new RegExp(`install-gate\\.js\\?build=${release.cacheKey}-browser-consent`));
+assert.match(nextIndex, new RegExp(`install-gate\\.js\\?build=${release.cacheKey}-social-browser`));
+assert.match(nextIndex, new RegExp(`install-gate\\.css\\?build=${release.cacheKey}-social-browser`));
 assert.match(nextIndex, new RegExp(`orientation-guard\\.css\\?build=${release.cacheKey}-home-portrait`));
 assert.match(nextIndex, /Return to landscape/);
 assert.ok(nextIndex.indexOf('/turn-next/storage-bootstrap.js') < nextIndex.indexOf('/turn-next/app.js'));
@@ -190,4 +205,4 @@ assert.deepEqual(
   }
 );
 
-console.log(`TURN ${release.id} requires browser consent and keeps Home behind the portrait guard; TURN NEXT mirrors both contracts.`);
+console.log(`TURN ${release.id} requires browser consent, starts installation outside social apps and keeps Home behind the portrait guard; TURN NEXT mirrors all contracts.`);

--- a/turn/index.html
+++ b/turn/index.html
@@ -41,7 +41,7 @@
   <link rel="stylesheet" href="./styles.css?build=20260731-r120">
   <link rel="stylesheet" href="./vertical-drive.css?build=20260731-r120">
   <link rel="stylesheet" href="./hud-tuning.css?build=20260731-r120">
-  <link rel="stylesheet" href="./install-gate.css?build=20260731-r120-browser-consent">
+  <link rel="stylesheet" href="./install-gate.css?build=20260731-r120-social-browser">
   <link rel="stylesheet" href="./gameplay-features.css?build=20260731-r120">
   <link rel="stylesheet" href="./gameplay-v2.css?build=20260731-r120">
   <link rel="stylesheet" href="./position-hud-r83.css?build=20260731-r120">
@@ -62,7 +62,7 @@
   <link rel="stylesheet" href="./garage/lot-r10.css?build=20260731-r120">
   <link rel="stylesheet" href="./garage/lot-stat-legend.css?build=20260731-r120">
   <link rel="stylesheet" href="./garage/lot-layout-r60.css?build=20260731-r120">
-  <script src="./install-gate.js?build=20260731-r120-browser-consent"></script>
+  <script src="./install-gate.js?build=20260731-r120-social-browser"></script>
   <script src="./motion-safe-zone.js?build=20260731-r120"></script>
   <script src="./orientation-compat.js?build=20260731-r120"></script>
   <script type="importmap">

--- a/turn/install-gate.css
+++ b/turn/install-gate.css
@@ -119,6 +119,7 @@ html.turn-standalone .install-gate,
   z-index: 2010;
   display: grid;
   place-items: end center;
+  overflow: auto;
   padding:
     max(18px, env(safe-area-inset-top))
     max(18px, env(safe-area-inset-right))
@@ -134,6 +135,10 @@ html.turn-standalone .install-gate,
 
 .install-guide-card {
   width: min(560px, 96vw);
+  max-height: 100%;
+  box-sizing: border-box;
+  overflow: auto;
+  overscroll-behavior: contain;
   padding: 22px;
   border: 5px solid var(--ink);
   border-radius: 26px;
@@ -182,6 +187,10 @@ html.turn-standalone .install-gate,
   background: white;
 }
 
+.install-step-open-browser {
+  align-items: start;
+}
+
 .install-step-number,
 .share-symbol {
   display: grid;
@@ -227,6 +236,57 @@ html.turn-standalone .install-gate,
   font-size: 0.78rem;
   line-height: 1.25;
   opacity: 0.72;
+}
+
+.install-copy-address {
+  display: block;
+  min-height: 44px;
+  margin-top: 10px;
+  padding: 8px 12px;
+  border-width: 3px;
+  border-radius: 10px;
+  background: var(--cyan);
+  box-shadow: 3px 3px 0 var(--ink);
+  font-size: 0.78rem;
+}
+
+.install-copy-address[data-copied="true"] {
+  background: #8ce99a;
+}
+
+.install-address-fallback {
+  display: grid;
+  gap: 4px;
+  margin-top: 10px;
+}
+
+.install-address-fallback[hidden] {
+  display: none;
+}
+
+.install-address-fallback > span,
+.install-copy-status {
+  display: block;
+  margin-top: 7px;
+  font-size: 0.7rem;
+  line-height: 1.3;
+  opacity: 0.78;
+}
+
+.install-address-fallback input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 8px 9px;
+  border: 2px solid var(--ink);
+  border-radius: 8px;
+  background: var(--paper);
+  color: var(--ink);
+  font: inherit;
+  font-size: 0.72rem;
+}
+
+.install-copy-status:empty {
+  display: none;
 }
 
 @media (orientation: portrait) {

--- a/turn/install-gate.js
+++ b/turn/install-gate.js
@@ -3,6 +3,10 @@
     window.matchMedia('(display-mode: standalone)').matches ||
     window.matchMedia('(display-mode: fullscreen)').matches ||
     navigator.standalone === true;
+  const isNextDeployment = document.documentElement.dataset.turnDeployment === 'next';
+  const appName = isNextDeployment ? 'TURN NEXT' : 'TURN';
+  const gamePath = isNextDeployment ? '/turn-next/' : '/turn/';
+  const gameAddress = new URL(gamePath, window.location.href).href;
 
   document.documentElement.classList.toggle('turn-standalone', isStandalone);
   document.documentElement.classList.toggle('turn-browser', !isStandalone);
@@ -43,6 +47,58 @@
     releaseBrowserLaunch?.();
   }
 
+  async function writeClipboardText(text) {
+    if (navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(text);
+        return true;
+      } catch (_) {
+        // Some social-media browsers expose Clipboard but reject the write.
+      }
+    }
+
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.inset = '-1000px auto auto -1000px';
+    document.body.appendChild(textarea);
+    textarea.select();
+    textarea.setSelectionRange(0, textarea.value.length);
+
+    let copied = false;
+    try {
+      copied = document.execCommand?.('copy') === true;
+    } catch (_) {
+      copied = false;
+    }
+    textarea.remove();
+    return copied;
+  }
+
+  async function copyGameAddress(button) {
+    const step = button.closest('.install-step');
+    const status = step?.querySelector('.install-copy-status');
+    const fallback = step?.querySelector('.install-address-fallback');
+    const fallbackInput = fallback?.querySelector('input');
+    const copied = await writeClipboardText(gameAddress);
+
+    if (copied) {
+      button.textContent = 'Game address copied';
+      button.dataset.copied = 'true';
+      if (status) status.textContent = 'Copied. Paste it into Safari, Chrome or your usual browser.';
+      return;
+    }
+
+    if (fallback && fallbackInput) {
+      fallback.hidden = false;
+      fallbackInput.focus();
+      fallbackInput.select();
+      fallbackInput.setSelectionRange(0, fallbackInput.value.length);
+    }
+    if (status) status.textContent = 'Copy the selected address, then paste it into your browser.';
+  }
+
   function initInstallGate() {
     const gate = document.querySelector('#installGate');
     const installButton = document.querySelector('#installTurnButton');
@@ -53,7 +109,10 @@
     const guideTitle = document.querySelector('#installGuideTitle');
     const guideSteps = document.querySelector('#installSteps');
 
-    if (!gate || !installButton || !browserButton || !guide) return;
+    if (
+      !gate || !installButton || !browserButton || !note || !guide ||
+      !guideClose || !guideTitle || !guideSteps
+    ) return;
 
     if (isStandalone) {
       gate.hidden = true;
@@ -66,34 +125,49 @@
 
     function showManualGuide() {
       const ios = isIOSLike();
-      guideTitle.textContent = ios ? 'Add TURN to your Home Screen' : 'Install TURN';
+      guideTitle.textContent = ios ? `Add ${appName} to your Home Screen` : `Install ${appName}`;
+
+      const openInBrowserStep = `
+        <div class="install-step install-step-open-browser">
+          <div class="install-step-number" aria-hidden="true">1</div>
+          <div>
+            <strong>Open in your device’s browser</strong>
+            <span>Not inside a social media app. Copy the game address, then paste it into Safari, Chrome or your usual browser.</span>
+            <button class="install-copy-address" type="button" data-copy-game-address>Copy game address</button>
+            <label class="install-address-fallback" hidden>
+              <span>Game address</span>
+              <input type="text" value="${gameAddress}" readonly>
+            </label>
+            <span class="install-copy-status" role="status" aria-live="polite"></span>
+          </div>
+        </div>`;
 
       guideSteps.innerHTML = ios
-        ? `
+        ? `${openInBrowserStep}
           <div class="install-step">
-            <div class="share-symbol" aria-hidden="true"></div>
+            <div class="install-step-number" aria-hidden="true">2</div>
             <div><strong>Tap Share</strong><span>Use the Share button in your browser toolbar.</span></div>
           </div>
           <div class="install-step">
-            <div class="install-step-number" aria-hidden="true">2</div>
+            <div class="install-step-number" aria-hidden="true">3</div>
             <div><strong>Add to Home Screen</strong><span>Scroll the share sheet if you do not see it immediately.</span></div>
           </div>
           <div class="install-step">
-            <div class="install-step-number" aria-hidden="true">3</div>
-            <div><strong>Open TURN from the icon</strong><span>It will launch fullscreen like an app from then on.</span></div>
+            <div class="install-step-number" aria-hidden="true">4</div>
+            <div><strong>Open ${appName} from the icon</strong><span>It will launch fullscreen like an app from then on.</span></div>
           </div>`
-        : `
+        : `${openInBrowserStep}
           <div class="install-step">
-            <div class="install-step-number" aria-hidden="true">1</div>
+            <div class="install-step-number" aria-hidden="true">2</div>
             <div><strong>Open your browser menu</strong><span>Look for Install app or Add to Home Screen.</span></div>
           </div>
           <div class="install-step">
-            <div class="install-step-number" aria-hidden="true">2</div>
-            <div><strong>Install TURN</strong><span>Confirm the installation when your browser asks.</span></div>
+            <div class="install-step-number" aria-hidden="true">3</div>
+            <div><strong>Install ${appName}</strong><span>Confirm the installation when your browser asks.</span></div>
           </div>
           <div class="install-step">
-            <div class="install-step-number" aria-hidden="true">3</div>
-            <div><strong>Launch from the new icon</strong><span>TURN will open in its standalone game view.</span></div>
+            <div class="install-step-number" aria-hidden="true">4</div>
+            <div><strong>Launch from the new icon</strong><span>${appName} will open in its standalone game view.</span></div>
           </div>`;
 
       guide.hidden = false;
@@ -112,11 +186,11 @@
         await prompt.prompt();
         const choice = await prompt.userChoice;
         if (choice?.outcome === 'accepted') {
-          installButton.textContent = 'TURN installed';
+          installButton.textContent = `${appName} installed`;
           installButton.disabled = true;
-          note.textContent = 'Open TURN from its new Home Screen icon for the fullscreen game.';
+          note.textContent = `Open ${appName} from its new Home Screen icon for the fullscreen game.`;
         } else {
-          note.textContent = 'No problem. You can install TURN whenever you are ready.';
+          note.textContent = `No problem. You can install ${appName} whenever you are ready.`;
         }
       } catch (_) {
         showManualGuide();
@@ -125,19 +199,23 @@
 
     installButton.addEventListener('click', requestInstall);
     browserButton.addEventListener('click', () => startBrowserGame(gate));
+    guideSteps.addEventListener('click', (event) => {
+      const copyButton = event.target.closest('[data-copy-game-address]');
+      if (copyButton) copyGameAddress(copyButton);
+    });
     guideClose.addEventListener('click', () => { guide.hidden = true; });
     guide.addEventListener('click', (event) => {
       if (event.target === guide) guide.hidden = true;
     });
 
     document.addEventListener('turn-install-ready', () => {
-      note.textContent = 'Your browser can install TURN directly.';
+      note.textContent = `Your browser can install ${appName} directly.`;
     });
 
     window.addEventListener('appinstalled', () => {
-      installButton.textContent = 'TURN installed';
+      installButton.textContent = `${appName} installed`;
       installButton.disabled = true;
-      note.textContent = 'Done. Open TURN from your Home Screen icon.';
+      note.textContent = `Done. Open ${appName} from your Home Screen icon.`;
     });
   }
 


### PR DESCRIPTION
## Social-share onboarding

TURN links shared through Instagram, Facebook, TikTok and similar services commonly open inside an embedded browser. Those browsers are a poor or unsupported place to install the PWA.

The manual installation guide now begins with:

1. **Open in your device’s browser**
2. Copy the canonical game address and paste it into Safari, Chrome or the player’s usual browser
3. Continue with the platform-specific Home Screen installation steps

## Copy-address control

- adds a prominent **Copy game address** button
- uses the async Clipboard API when available
- falls back to the legacy user-gesture copy command
- reveals and selects a read-only address field if copying is still blocked
- reports success or fallback instructions through an accessible live status
- copies `/turn/` in production and `/turn-next/` in the isolated test deployment

## Layout and parity

- expands the guide to four numbered steps on iOS and other platforms
- makes the guide card scroll safely in short landscape viewports
- preserves the existing explicit **Play in browser anyway** launch gate
- cache-busts the updated guide assets in TURN and TURN NEXT
- updates production, release and generated TURN NEXT parity checks