### PR TITLE
Polish Home typography, live steering and landscape guidance

### DIFF
--- a/turn-lab/tests/manual-steering-production.mjs
+++ b/turn-lab/tests/manual-steering-production.mjs
@@ -18,6 +18,7 @@ const [
   css,
   orientationGuardCss,
   orientationCompat,
+  liveSteering,
   camera,
   motion,
   safeZone,
@@ -29,6 +30,7 @@ const [
   fs.readFile(new URL('../../turn/manual-steering.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/orientation-guard.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/orientation-compat.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/live-steering-setting.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/render/camera.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/input/motion.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/motion-safe-zone.js', import.meta.url), 'utf8'),
@@ -48,16 +50,35 @@ assert.match(index, new RegExp(`manual-steering\\.css\\?build=${release.cacheKey
 assert.match(index, new RegExp(`orientation-guard\\.css\\?build=${release.cacheKey}`));
 assert.match(index, new RegExp(`motion-safe-zone\\.js\\?build=${release.cacheKey}`));
 assert.match(index, new RegExp(`orientation-compat\\.js\\?build=${release.cacheKey}`));
+assert.match(index, new RegExp(`live-steering-setting\\.js\\?build=${release.cacheKey}-live-steering`));
 assert.ok(
   index.indexOf('./motion-safe-zone.js') < index.indexOf('./orientation-compat.js'),
   'The canonical motion safe zone must load before orientation feedback'
 );
+assert.ok(
+  index.indexOf('./orientation-compat.js') < index.indexOf('./live-steering-setting.js'),
+  'Live steering changes must use the installed motion compatibility bridge'
+);
 assert.equal(imports['./render/camera.js?build=20260720-r19'], `./render/camera.js?build=${release.cacheKey}`, 'The current release must publish the guarded race camera');
-assert.match(index, /<strong>Return to landscape<\/strong>/, 'The pre-race landscape instruction must remain available above Home');
+assert.match(index, /<strong>ROTATE YOUR DEVICE TO LANDSCAPE<\/strong>/, 'The first-encounter landscape instruction must describe the required action');
+assert.match(index, /aria-label="Rotate your device to landscape"/);
+assert.doesNotMatch(index, /Return to landscape/);
 
 assert.match(css, /--manual-steer-left/);
 assert.match(css, /content: "←"/);
 assert.match(css, /content: "→"/);
+
+assert.match(liveSteering, /input\[name="m8Steering"\]:checked/);
+assert.match(liveSteering, /if \(!state\?\.running \|\| document\.body\.classList\.contains\('turn-home-open'\)\) return/);
+assert.match(liveSteering, /raceSession\.prepareMotionAccess\(\)/);
+assert.match(liveSteering, /raceSession\.prepareManualAccess\(\)/);
+assert.match(liveSteering, /__turnMotionLifecycle\?\.stop\?\.\(\)/);
+assert.match(liveSteering, /manualSteer\.hidden = true/);
+assert.match(liveSteering, /manualSteer\.hidden = false/);
+assert.match(liveSteering, /steering-mode-changed/);
+assert.match(liveSteering, /Steering changed to device rotation for this race\./);
+assert.match(liveSteering, /Steering changed to the on-screen control for this race\./);
+assert.match(liveSteering, /saveSteeringMode\(activeMode\)/, 'A failed motion permission change must restore the actual active preference');
 
 assert.match(orientationGuardCss, /body\.turn-race-active \.rotate-panel/, 'The portrait warning must stay hidden during an active race');
 assert.match(orientationGuardCss, /\.rotate-panel \{[\s\S]*z-index: 1700/, 'The portrait warning must sit above the M8 Home screen');
@@ -110,4 +131,4 @@ assert.doesNotMatch(camera, /camera\.rotateZ\(-state\.roll\)/, 'The camera must 
 assert.match(motion, /resolveSteeringRollLimit/);
 assert.match(motion, /return Number\.isFinite\(fallback\) && fallback > 0 \? fallback : degToRad\(14\)/, 'Motion input must retain a safe fallback when no host configuration exists');
 
-console.log(`TURN ${release.id} manual steering and canonical race orientation guard passed.`);
+console.log(`TURN ${release.id} manual and live steering plus canonical race orientation guard passed.`);

--- a/turn-next/index.html
+++ b/turn-next/index.html
@@ -65,11 +65,13 @@
   <link rel="stylesheet" href="./garage/lot-r10.css?build=20260731-r120">
   <link rel="stylesheet" href="./garage/lot-stat-legend.css?build=20260731-r120">
   <link rel="stylesheet" href="./garage/lot-layout-r60.css?build=20260731-r120">
+  <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260731-r120-menu-font">
   <link rel="stylesheet" href="/turn-next/identity.css?source=20260731-r120-m8.5-logo">
   <script defer src="/turn-next/identity.js?source=20260731-r120-m8.5-logo"></script>
   <script src="./install-gate.js?build=20260731-r120-social-browser"></script>
   <script src="./motion-safe-zone.js?build=20260731-r120"></script>
   <script src="./orientation-compat.js?build=20260731-r120"></script>
+  <script src="./live-steering-setting.js?build=20260731-r120-live-steering"></script>
   <script type="importmap">
     {
       "imports": {
@@ -133,7 +135,7 @@
   </section>
   <div id="game" aria-label="Third-person motion-controlled arcade racing game"></div>
   <section class="panel" id="intro" hidden aria-hidden="true"><button id="motionButton" type="button" hidden></button><button id="manualButton" type="button" hidden></button><p id="status" role="status" hidden></p></section>
-  <section class="rotate-panel" aria-label="Return device to landscape"><div class="rotate-card"><div class="rotate-phone" aria-hidden="true"></div><strong>Return to landscape</strong></div></section>
+  <section class="rotate-panel" aria-label="Rotate your device to landscape"><div class="rotate-card"><div class="rotate-phone" aria-hidden="true"></div><strong>ROTATE YOUR DEVICE TO LANDSCAPE</strong></div></section>
   <div class="hud" id="hud" hidden><div class="topbar"><div class="stats"><div class="chip">speed<strong><span id="speed">0</span> km/h</strong></div><div class="chip">lap<strong id="lap">1</strong></div><div class="chip">time<strong id="lapTime">0:00.000</strong></div><div class="chip">best<strong id="bestTime">--:--.---</strong></div></div><div class="map-wrap"><canvas id="map" width="300" height="210" aria-label="Track map"></canvas></div></div><div class="message" id="message" role="status"></div><div class="tilt-drive" aria-hidden="true"><span><b>brake</b><b>gas</b></span><div class="tilt-track"><i class="tilt-needle" id="tiltNeedle"></i></div><small class="tilt-value" id="tiltValue">neutral</small></div></div>
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>

--- a/turn-next/scripts/build-parity-entry.mjs
+++ b/turn-next/scripts/build-parity-entry.mjs
@@ -27,8 +27,12 @@ async function main() {
   assert.match(current, new RegExp(`install-gate\\.js\\?build=${release.cacheKey}-social-browser`));
   assert.match(current, new RegExp(`install-gate\\.css\\?build=${release.cacheKey}-social-browser`));
   assert.match(current, new RegExp(`orientation-guard\\.css\\?build=${release.cacheKey}-home-portrait`));
+  assert.match(current, new RegExp(`live-steering-setting\\.js\\?build=${release.cacheKey}-live-steering`));
+  assert.match(current, new RegExp(`m8-menu-font-fix\\.css\\?build=${release.cacheKey}-menu-font`));
   assert.match(current, /id="installGate"/);
-  assert.match(current, /Return to landscape/);
+  assert.match(current, /ROTATE YOUR DEVICE TO LANDSCAPE/);
+  assert.match(current, /aria-label="Rotate your device to landscape"/);
+  assert.doesNotMatch(current, /Return to landscape/);
   assert.match(current, /id="intro" hidden aria-hidden="true"/);
   assert.match(current, /id="motionButton"/);
   assert.match(current, /id="manualButton"/);

--- a/turn-tests/release-production.mjs
+++ b/turn-tests/release-production.mjs
@@ -3,7 +3,21 @@ import fs from 'node:fs/promises';
 
 import { checkReleaseFiles, loadReleaseDefinition } from '../turn/scripts/release.mjs';
 
-const [release, index, app, main, manifest, workflow, nextApp, nextIndex, installGate, installGateCss, orientationGuardCss] = await Promise.all([
+const [
+  release,
+  index,
+  app,
+  main,
+  manifest,
+  workflow,
+  nextApp,
+  nextIndex,
+  installGate,
+  installGateCss,
+  orientationGuardCss,
+  liveSteering,
+  menuFontCss
+] = await Promise.all([
   loadReleaseDefinition(),
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8'),
@@ -14,7 +28,9 @@ const [release, index, app, main, manifest, workflow, nextApp, nextIndex, instal
   fs.readFile(new URL('../turn-next/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/install-gate.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/install-gate.css', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/orientation-guard.css', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/orientation-guard.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/live-steering-setting.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/m8-menu-font-fix.css', import.meta.url), 'utf8')
 ]);
 
 await checkReleaseFiles();
@@ -32,8 +48,12 @@ assert.match(index, new RegExp(`cacheKey: '${escapeRegExp(release.cacheKey)}'`))
 assert.match(index, new RegExp(`install-gate\\.js\\?build=${escapeRegExp(release.cacheKey)}-social-browser`));
 assert.match(index, new RegExp(`install-gate\\.css\\?build=${escapeRegExp(release.cacheKey)}-social-browser`));
 assert.match(index, new RegExp(`orientation-guard\\.css\\?build=${escapeRegExp(release.cacheKey)}-home-portrait`));
+assert.match(index, new RegExp(`live-steering-setting\\.js\\?build=${escapeRegExp(release.cacheKey)}-live-steering`));
+assert.match(index, new RegExp(`m8-menu-font-fix\\.css\\?build=${escapeRegExp(release.cacheKey)}-menu-font`));
 assert.match(index, new RegExp(`app\\.js\\?build=${escapeRegExp(release.cacheKey)}-browser-consent`));
-assert.match(index, /Return to landscape/);
+assert.match(index, /ROTATE YOUR DEVICE TO LANDSCAPE/);
+assert.match(index, /aria-label="Rotate your device to landscape"/);
+assert.doesNotMatch(index, /Return to landscape/);
 assert.match(app, /const launchReady = globalThis\.__turnLaunchReady/);
 assert.match(app, /await launchReady/);
 assert.ok(app.indexOf('await launchReady') < app.indexOf('retireLegacyStartPanel()'));
@@ -55,6 +75,15 @@ assert.match(installGateCss, /\.install-gate \{[\s\S]*z-index: 2000/);
 assert.match(installGateCss, /\.install-copy-address \{/);
 assert.match(installGateCss, /\.install-guide-card \{[\s\S]*max-height: 100%[\s\S]*overflow: auto/);
 assert.match(orientationGuardCss, /\.rotate-panel \{[\s\S]*z-index: 1700/);
+
+assert.match(liveSteering, /raceSession\.prepareMotionAccess\(\)/);
+assert.match(liveSteering, /raceSession\.prepareManualAccess\(\)/);
+assert.match(liveSteering, /steering-mode-changed/);
+assert.match(liveSteering, /state\?\.running/);
+assert.match(menuFontCss, /\.m8-home\.m8-home-fixed-layout \.m8-home-main \.m8-home-menu h2/);
+assert.match(menuFontCss, /font-family: inherit/);
+assert.match(menuFontCss, /font-weight: 950/);
+assert.match(menuFontCss, /letter-spacing: -0\.035em/);
 
 const attributeBuilds = [...index.matchAll(/(?:href|src)="\.\/[^"?]+\?build=([^"&]+)/g)].map((match) => match[1]);
 assert.ok(attributeBuilds.length >= 15, 'Production entry document must cache-bust its local assets');
@@ -115,7 +144,10 @@ assert.match(nextIndex, new RegExp(`TURN NEXT · Source ${escapeRegExp(visibleBu
 assert.match(nextIndex, new RegExp(`/turn-next/app\\.js\\?source=${escapeRegExp(release.cacheKey)}-browser-consent`));
 assert.match(nextIndex, new RegExp(`install-gate\\.js\\?build=${escapeRegExp(release.cacheKey)}-social-browser`));
 assert.match(nextIndex, new RegExp(`install-gate\\.css\\?build=${escapeRegExp(release.cacheKey)}-social-browser`));
-assert.match(nextIndex, /Return to landscape/);
+assert.match(nextIndex, new RegExp(`live-steering-setting\\.js\\?build=${escapeRegExp(release.cacheKey)}-live-steering`));
+assert.match(nextIndex, new RegExp(`m8-menu-font-fix\\.css\\?build=${escapeRegExp(release.cacheKey)}-menu-font`));
+assert.match(nextIndex, /ROTATE YOUR DEVICE TO LANDSCAPE/);
+assert.doesNotMatch(nextIndex, /Return to landscape/);
 assert.match(nextApp, /new URL\('\/turn\/app\.js'/);
 assert.match(nextApp, /browser-consent/);
 assert.match(nextApp, /await import\(url\.href\)/);
@@ -125,7 +157,7 @@ assert.match(workflow, /node turn\/scripts\/release\.mjs --check/);
 assert.match(workflow, /node turn-tests\/release-production\.mjs/);
 assert.doesNotMatch(workflow, /node turn-lab\/scripts\/check-release\.mjs/, 'CI must verify the production release rather than the retired playable lab snapshot');
 
-console.log(`TURN ${release.id} browser-consent, social-browser onboarding and Home portrait release architecture passed.`);
+console.log(`TURN ${release.id} browser consent, social onboarding, live steering and clearer landscape guidance passed.`);
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/turn-tests/turn-next-entry-production.mjs
+++ b/turn-tests/turn-next-entry-production.mjs
@@ -19,6 +19,8 @@ const [
   installGateSource,
   installGateCss,
   orientationGuardCss,
+  liveSteeringSource,
+  menuFontCss,
   homeSource,
   homeCss,
   fixedLayoutSource,
@@ -43,6 +45,8 @@ const [
   fs.readFile(new URL('../turn/install-gate.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/install-gate.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/orientation-guard.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/live-steering-setting.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/m8-menu-font-fix.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/m8-home.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/m8-home.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8'),
@@ -65,7 +69,11 @@ assert.match(productionIndex, new RegExp(`src="\\.\\/app\\.js\\?build=${release.
 assert.match(productionIndex, new RegExp(`src="\\.\\/install-gate\\.js\\?build=${release.cacheKey}-social-browser"`));
 assert.match(productionIndex, new RegExp(`href="\\.\\/install-gate\\.css\\?build=${release.cacheKey}-social-browser"`));
 assert.match(productionIndex, new RegExp(`href="\\.\\/orientation-guard\\.css\\?build=${release.cacheKey}-home-portrait"`));
-assert.match(productionIndex, /Return to landscape/);
+assert.match(productionIndex, new RegExp(`src="\\.\\/live-steering-setting\\.js\\?build=${release.cacheKey}-live-steering"`));
+assert.match(productionIndex, new RegExp(`href="\\.\\/m8-menu-font-fix\\.css\\?build=${release.cacheKey}-menu-font"`));
+assert.match(productionIndex, /ROTATE YOUR DEVICE TO LANDSCAPE/);
+assert.match(productionIndex, /aria-label="Rotate your device to landscape"/);
+assert.doesNotMatch(productionIndex, /Return to landscape/);
 assert.match(productionIndex, /id="intro" hidden aria-hidden="true"/);
 assert.match(productionIndex, /id="motionButton"/);
 assert.match(productionIndex, /id="manualButton"/);
@@ -120,6 +128,17 @@ assert.match(installGateCss, /\.install-copy-address \{/);
 assert.match(installGateCss, /\.install-address-fallback\[hidden\]/);
 assert.match(installGateCss, /\.install-copy-status:empty/);
 
+assert.match(liveSteeringSource, /input\[name="m8Steering"\]:checked/);
+assert.match(liveSteeringSource, /raceSession\.prepareMotionAccess\(\)/);
+assert.match(liveSteeringSource, /raceSession\.prepareManualAccess\(\)/);
+assert.match(liveSteeringSource, /__turnMotionLifecycle\?\.stop\?\.\(\)/);
+assert.match(liveSteeringSource, /steering-mode-changed/);
+assert.match(liveSteeringSource, /saveSteeringMode\(activeMode\)/);
+assert.match(menuFontCss, /\.m8-home\.m8-home-fixed-layout \.m8-home-main \.m8-home-menu h2/);
+assert.match(menuFontCss, /font-family: inherit/);
+assert.match(menuFontCss, /font-weight: 950/);
+assert.match(menuFontCss, /letter-spacing: -0\.035em/);
+
 assert.match(nextIndex, /data-turn-deployment="next"/);
 assert.match(nextIndex, /<base href="\/turn\/">/);
 assert.match(nextIndex, /<meta name="robots" content="noindex,nofollow">/);
@@ -129,7 +148,11 @@ assert.match(nextIndex, new RegExp(`/turn-next/app\\.js\\?source=${release.cache
 assert.match(nextIndex, new RegExp(`install-gate\\.js\\?build=${release.cacheKey}-social-browser`));
 assert.match(nextIndex, new RegExp(`install-gate\\.css\\?build=${release.cacheKey}-social-browser`));
 assert.match(nextIndex, new RegExp(`orientation-guard\\.css\\?build=${release.cacheKey}-home-portrait`));
-assert.match(nextIndex, /Return to landscape/);
+assert.match(nextIndex, new RegExp(`live-steering-setting\\.js\\?build=${release.cacheKey}-live-steering`));
+assert.match(nextIndex, new RegExp(`m8-menu-font-fix\\.css\\?build=${release.cacheKey}-menu-font`));
+assert.match(nextIndex, /ROTATE YOUR DEVICE TO LANDSCAPE/);
+assert.match(nextIndex, /aria-label="Rotate your device to landscape"/);
+assert.doesNotMatch(nextIndex, /Return to landscape/);
 assert.ok(nextIndex.indexOf('/turn-next/storage-bootstrap.js') < nextIndex.indexOf('/turn-next/app.js'));
 assert.match(nextIndex, /\/turn-next\/identity\.css/);
 assert.match(nextIndex, /\/turn-next\/identity\.js/);
@@ -205,4 +228,4 @@ assert.deepEqual(
   }
 );
 
-console.log(`TURN ${release.id} requires browser consent, starts installation outside social apps and keeps Home behind the portrait guard; TURN NEXT mirrors all contracts.`);
+console.log(`TURN ${release.id} requires browser consent, applies staged steering changes immediately and gives first-use landscape guidance; TURN NEXT mirrors all contracts.`);

--- a/turn/index.html
+++ b/turn/index.html
@@ -62,9 +62,11 @@
   <link rel="stylesheet" href="./garage/lot-r10.css?build=20260731-r120">
   <link rel="stylesheet" href="./garage/lot-stat-legend.css?build=20260731-r120">
   <link rel="stylesheet" href="./garage/lot-layout-r60.css?build=20260731-r120">
+  <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260731-r120-menu-font">
   <script src="./install-gate.js?build=20260731-r120-social-browser"></script>
   <script src="./motion-safe-zone.js?build=20260731-r120"></script>
   <script src="./orientation-compat.js?build=20260731-r120"></script>
+  <script src="./live-steering-setting.js?build=20260731-r120-live-steering"></script>
   <script type="importmap">
     {
       "imports": {
@@ -134,7 +136,7 @@
     <button id="manualButton" type="button" hidden></button>
     <p id="status" role="status" hidden>Steering uses device rotation</p>
   </section>
-  <section class="rotate-panel" aria-label="Return device to landscape"><div class="rotate-card"><div class="rotate-phone" aria-hidden="true"></div><strong>Return to landscape</strong></div></section>
+  <section class="rotate-panel" aria-label="Rotate your device to landscape"><div class="rotate-card"><div class="rotate-phone" aria-hidden="true"></div><strong>ROTATE YOUR DEVICE TO LANDSCAPE</strong></div></section>
   <div class="hud" id="hud" hidden>
     <div class="topbar"><div class="stats"><div class="chip">speed<strong><span id="speed">0</span> km/h</strong></div><div class="chip">lap<strong id="lap">1</strong></div><div class="chip">time<strong id="lapTime">0:00.000</strong></div><div class="chip">best<strong id="bestTime">--:--.---</strong></div></div><div class="map-wrap"><canvas id="map" width="300" height="210" aria-label="Track map"></canvas></div></div>
     <div class="message" id="message" role="status"></div>

--- a/turn/live-steering-setting.js
+++ b/turn/live-steering-setting.js
@@ -1,0 +1,116 @@
+(() => {
+  const INSTALL_FLAG = '__turnLiveSteeringSettingInstalled';
+  const STEERING_MODE_KEY = 'turn-steering-mode-v1';
+  const MOTION_MODE = 'motion';
+  const MANUAL_MODE = 'manual';
+
+  if (globalThis[INSTALL_FLAG]) return;
+  globalThis[INSTALL_FLAG] = true;
+
+  function saveSteeringMode(mode) {
+    try {
+      localStorage.setItem(STEERING_MODE_KEY, mode);
+    } catch (_) {}
+  }
+
+  function syncRadios(dialog, mode) {
+    for (const radio of dialog?.querySelectorAll?.('input[name="m8Steering"]') || []) {
+      radio.checked = radio.value === mode;
+    }
+  }
+
+  function setRadiosBusy(dialog, busy) {
+    const motionAvailable = typeof globalThis.DeviceMotionEvent !== 'undefined';
+    for (const radio of dialog?.querySelectorAll?.('input[name="m8Steering"]') || []) {
+      radio.disabled = busy || (radio.value === MOTION_MODE && !motionAvailable);
+    }
+  }
+
+  function resetSteeringState(state) {
+    state.steering = 0;
+    state.manualSteering = 0;
+    state.steeringEngaged = false;
+  }
+
+  function calibrateMotionAfterSwitch(state) {
+    window.setTimeout(() => {
+      if (!state.sensorMode) return;
+      state.neutralRoll = state.targetRoll;
+      state.horizonRollReference = state.targetRoll;
+      state.roll = state.targetRoll;
+      state.neutralPitch = state.targetPitch;
+      state.pitch = state.targetPitch;
+      state.steering = 0;
+    }, 220);
+  }
+
+  function publishChange(state, mode) {
+    window.dispatchEvent(new CustomEvent('turn:ui-state-change', {
+      detail: {
+        reason: 'steering-mode-changed',
+        mode: globalThis.__turnGetGameMode?.(),
+        running: state.running,
+        steeringMode: mode
+      }
+    }));
+  }
+
+  async function applySteeringModeDuringRace(input) {
+    const requestedMode = input.value === MOTION_MODE ? MOTION_MODE : MANUAL_MODE;
+    const state = globalThis.__turnRuntime?.state;
+    const raceSession = globalThis.__turnNextRaceSession;
+    const dialog = input.closest?.('.m8-settings-dialog') || input.closest?.('dialog');
+    const status = dialog?.querySelector?.('.m8-settings-status');
+    const manualSteer = document.querySelector('#manualSteer');
+
+    // On Home, the stored preference is enough. The normal race-start gate will apply it.
+    if (!state?.running || document.body.classList.contains('turn-home-open')) return;
+    if (!raceSession) return;
+
+    setRadiosBusy(dialog, true);
+
+    try {
+      if (requestedMode === MOTION_MODE) {
+        const access = await raceSession.prepareMotionAccess();
+        await Promise.resolve(access?.fullscreenPromise).catch(() => false);
+        resetSteeringState(state);
+        if (manualSteer) manualSteer.hidden = true;
+        calibrateMotionAfterSwitch(state);
+      } else {
+        globalThis.__turnMotionLifecycle?.stop?.();
+        raceSession.prepareManualAccess();
+        resetSteeringState(state);
+        if (manualSteer) manualSteer.hidden = false;
+      }
+
+      saveSteeringMode(requestedMode);
+      syncRadios(dialog, requestedMode);
+      publishChange(state, requestedMode);
+
+      if (status) {
+        status.textContent = requestedMode === MOTION_MODE
+          ? 'Steering changed to device rotation for this race.'
+          : 'Steering changed to the on-screen control for this race.';
+      }
+    } catch (error) {
+      const activeMode = state.sensorMode ? MOTION_MODE : MANUAL_MODE;
+      saveSteeringMode(activeMode);
+      syncRadios(dialog, activeMode);
+      if (manualSteer) manualSteer.hidden = activeMode === MOTION_MODE;
+      if (status) {
+        const message = error instanceof Error && error.message
+          ? error.message
+          : 'The steering setting could not be changed.';
+        status.textContent = `${message} Steering remains ${activeMode === MOTION_MODE ? 'on device rotation' : 'on the on-screen control'}.`;
+      }
+    } finally {
+      setRadiosBusy(dialog, false);
+    }
+  }
+
+  document.addEventListener('change', (event) => {
+    const input = event.target;
+    if (!input?.matches?.('input[name="m8Steering"]:checked')) return;
+    void applySteeringModeDuringRace(input);
+  });
+})();

--- a/turn/m8-menu-font-fix.css
+++ b/turn/m8-menu-font-fix.css
@@ -1,0 +1,5 @@
+.m8-home.m8-home-fixed-layout .m8-home-main .m8-home-menu h2 {
+  font-family: inherit;
+  font-weight: 950;
+  letter-spacing: -0.035em;
+}


### PR DESCRIPTION
## Three backlog fixes

1. **Home typography**
   - makes the `MENU` heading use the same explicit font family, heavy weight and tracking as `CHOOSE YOUR TRACK`

2. **Steering changes at the start line**
   - changing between Device rotation and On-screen steering while the race is staged now takes effect immediately
   - motion permission is requested from the actual settings gesture when needed
   - switching to manual stops the motion subscription, resets steering and shows the on-screen control
   - failed motion permission restores the actually active steering choice rather than leaving a misleading saved setting
   - Home-screen changes still remain preferences for the next race, handled by the normal start gate

3. **First-use orientation copy**
   - replaces “Return to landscape” with **ROTATE YOUR DEVICE TO LANDSCAPE**
   - updates the accessible label to the same action-oriented instruction

TURN and TURN NEXT load the same cache-busted polish assets. Regression contracts cover the new assets, immediate steering path, failure recovery, typography and orientation copy.