### PR TITLE
Polish social-browser installation copy

### DIFF
--- a/turn-tests/release-production.mjs
+++ b/turn-tests/release-production.mjs
@@ -65,8 +65,14 @@ assert.doesNotMatch(index, /class="start-card"/);
 assert.match(installGate, /globalThis\.__turnLaunchReady = launchReady/);
 assert.match(installGate, /browserButton\.addEventListener\('click', \(\) => startBrowserGame\(gate\)\)/);
 assert.doesNotMatch(installGate, /sessionStorage|turn-play-in-browser/);
-assert.match(installGate, /Open in your device’s browser/);
-assert.match(installGate, /Not inside a social media app/);
+assert.match(installGate, /Open \$\{appName\} in \$\{browserContext\.preferredBrowser\}/);
+assert.match(installGate, /You’re viewing \$\{appName\} inside \$\{browserContext\.containerName\}/);
+assert.match(installGate, /Copy the address, then open \$\{browserContext\.preferredBrowser\} and paste it into the address bar/);
+assert.match(installGate, /Copy \$\{appName\} address/);
+assert.match(installGate, /In \$\{targetName\}, tap …, then Share/);
+assert.match(installGate, /Choose Add to Home Screen/);
+assert.match(installGate, /Open \$\{appName\} from your Home Screen/);
+assert.doesNotMatch(installGate, /Not inside a social media app|Open in your device’s browser/);
 assert.match(installGate, /data-copy-game-address/);
 assert.match(installGate, /navigator\.clipboard\?\.writeText/);
 assert.match(installGate, /document\.execCommand\?\.\('copy'\)/);
@@ -157,7 +163,7 @@ assert.match(workflow, /node turn\/scripts\/release\.mjs --check/);
 assert.match(workflow, /node turn-tests\/release-production\.mjs/);
 assert.doesNotMatch(workflow, /node turn-lab\/scripts\/check-release\.mjs/, 'CI must verify the production release rather than the retired playable lab snapshot');
 
-console.log(`TURN ${release.id} browser consent, social onboarding, live steering and clearer landscape guidance passed.`);
+console.log(`TURN ${release.id} browser consent, clearer social onboarding, live steering and landscape guidance passed.`);
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/turn-tests/turn-next-entry-production.mjs
+++ b/turn-tests/turn-next-entry-production.mjs
@@ -112,13 +112,20 @@ assert.ok(
   'The browser onboarding must leave the screen only as the explicit play action releases the runtime'
 );
 assert.match(installGateSource, /const gamePath = isNextDeployment \? '\/turn-next\/' : '\/turn\/'/);
-assert.match(installGateSource, /Open in your device’s browser/);
-assert.match(installGateSource, /Not inside a social media app/);
+assert.match(installGateSource, /Open \$\{appName\} in \$\{browserContext\.preferredBrowser\}/);
+assert.match(installGateSource, /You’re viewing \$\{appName\} inside \$\{browserContext\.containerName\}/);
+assert.match(installGateSource, /Copy the address, then open \$\{browserContext\.preferredBrowser\} and paste it into the address bar/);
+assert.match(installGateSource, /Copy \$\{appName\} address/);
+assert.match(installGateSource, /In \$\{targetName\}, tap …, then Share/);
+assert.match(installGateSource, /Choose Add to Home Screen/);
+assert.match(installGateSource, /Open \$\{appName\} from your Home Screen/);
+assert.match(installGateSource, /\$\{appName\} address copied/);
+assert.match(installGateSource, /Copied\. Now open \$\{browserContext\.preferredBrowser\} and paste the address/);
+assert.doesNotMatch(installGateSource, /Not inside a social media app|Open in your device’s browser|Game address copied/);
 assert.match(installGateSource, /data-copy-game-address/);
 assert.match(installGateSource, /navigator\.clipboard\?\.writeText/);
 assert.match(installGateSource, /document\.execCommand\?\.\('copy'\)/);
 assert.match(installGateSource, /guideSteps\.addEventListener\('click'/);
-assert.match(installGateSource, /Game address copied/);
 assert.match(installGateSource, /install-address-fallback/);
 assert.match(installGateSource, /Add \$\{appName\} to your Home Screen/);
 assert.match(installGateCss, /\.install-gate \{[\s\S]*z-index: 2000/);
@@ -228,4 +235,4 @@ assert.deepEqual(
   }
 );
 
-console.log(`TURN ${release.id} requires browser consent, applies staged steering changes immediately and gives first-use landscape guidance; TURN NEXT mirrors all contracts.`);
+console.log(`TURN ${release.id} requires browser consent, uses concise social-browser instructions and mirrors all contracts in TURN NEXT.`);

--- a/turn/install-gate.js
+++ b/turn/install-gate.js
@@ -159,9 +159,11 @@
     const copied = await writeClipboardText(gameAddress);
 
     if (copied) {
-      button.textContent = 'Game address copied';
+      button.textContent = `${appName} address copied`;
       button.dataset.copied = 'true';
-      if (status) status.textContent = `Copied. Paste it into ${browserContext.preferredBrowser}.`;
+      if (status) {
+        status.textContent = `Copied. Now open ${browserContext.preferredBrowser} and paste the address.`;
+      }
       return;
     }
 
@@ -171,7 +173,9 @@
       fallbackInput.select();
       fallbackInput.setSelectionRange(0, fallbackInput.value.length);
     }
-    if (status) status.textContent = `Copy the selected address, then paste it into ${browserContext.preferredBrowser}.`;
+    if (status) {
+      status.textContent = `Copy the selected address, then open ${browserContext.preferredBrowser} and paste it into the address bar.`;
+    }
   }
 
   function installStep(number, title, detail, className = '') {
@@ -184,17 +188,17 @@
 
   function externalBrowserStep(number) {
     const source = browserContext.containerName
-      ? `This page is open inside ${browserContext.containerName}.`
-      : 'This page appears to be open inside another app.';
+      ? `You’re viewing ${appName} inside ${browserContext.containerName}.`
+      : `You’re viewing ${appName} inside another app.`;
     return `
       <div class="install-step install-step-open-browser">
         <div class="install-step-number" aria-hidden="true">${number}</div>
         <div>
-          <strong>Open in your device’s browser</strong>
-          <span>${source} Not inside a social media app. Copy the game address, then paste it into ${browserContext.preferredBrowser}.</span>
-          <button class="install-copy-address" type="button" data-copy-game-address>Copy game address</button>
+          <strong>Open ${appName} in ${browserContext.preferredBrowser}</strong>
+          <span>${source} Copy the address, then open ${browserContext.preferredBrowser} and paste it into the address bar.</span>
+          <button class="install-copy-address" type="button" data-copy-game-address>Copy ${appName} address</button>
           <label class="install-address-fallback" hidden>
-            <span>Game address</span>
+            <span>${appName} address</span>
             <input type="text" value="${gameAddress}" readonly>
           </label>
           <span class="install-copy-status" role="status" aria-live="polite"></span>
@@ -211,46 +215,47 @@
       : browserContext.name;
 
     if (browserContext.ios) {
-      const menuTitle = ['safari', 'chrome', 'edge'].includes(targetId)
-        ? 'Tap …, then Share'
-        : `Open ${targetName}’s menu, then Share`;
-      const menuDetail = ['safari', 'chrome', 'edge'].includes(targetId)
-        ? `In ${targetName}, tap the … menu and choose Share.`
-        : `Open the menu in ${targetName} and choose Share.`;
+      const usesEllipsisMenu = ['safari', 'chrome', 'edge'].includes(targetId);
+      const menuTitle = usesEllipsisMenu
+        ? `In ${targetName}, tap …, then Share`
+        : `In ${targetName}, open the menu, then Share`;
+      const menuDetail = usesEllipsisMenu
+        ? `After ${appName} opens, tap … and choose Share.`
+        : `After ${appName} opens, open the browser menu and choose Share.`;
       return [
         installStep(startNumber, menuTitle, menuDetail),
-        installStep(startNumber + 1, 'Add to Home Screen', 'Scroll the share sheet if you do not see it immediately.'),
-        installStep(startNumber + 2, `Open ${appName} from the icon`, 'It will launch fullscreen like an app from then on.')
+        installStep(startNumber + 1, 'Choose Add to Home Screen', 'Scroll down in the Share sheet if it is not visible.'),
+        installStep(startNumber + 2, `Open ${appName} from your Home Screen`, `From now on, ${appName} opens fullscreen like an app.`)
       ].join('');
     }
 
     if (browserContext.android && targetId === 'samsung') {
       return [
-        installStep(startNumber, 'Tap ☰ in Samsung Internet', 'Open the browser menu.'),
-        installStep(startNumber + 1, 'Add the page to your Home screen', 'Choose Add page to, then Home screen.'),
-        installStep(startNumber + 2, `Open ${appName} from the icon`, 'It will launch in its standalone game view.')
+        installStep(startNumber, 'In Samsung Internet, tap ☰', `After ${appName} opens, tap ☰ to open the browser menu.`),
+        installStep(startNumber + 1, 'Choose Add page to, then Home screen', 'Confirm when Samsung Internet asks.'),
+        installStep(startNumber + 2, `Open ${appName} from your Home screen`, `From now on, ${appName} opens in its standalone game view.`)
       ].join('');
     }
 
     if (browserContext.android) {
       return [
-        installStep(startNumber, `Tap ⋮ in ${targetName}`, 'Open the browser menu.'),
-        installStep(startNumber + 1, `Install ${appName}`, 'Choose Install app or Add to Home screen.'),
-        installStep(startNumber + 2, `Open ${appName} from the icon`, 'It will launch in its standalone game view.')
+        installStep(startNumber, `In ${targetName}, tap ⋮`, `After ${appName} opens, tap ⋮ to open the browser menu.`),
+        installStep(startNumber + 1, `Choose Install ${appName}`, 'Depending on the browser, this may be called Add to Home screen.'),
+        installStep(startNumber + 2, `Open ${appName} from your Home screen`, `From now on, ${appName} opens in its standalone game view.`)
       ].join('');
     }
 
     if (targetId === 'safari') {
       return [
-        installStep(startNumber, 'Open Safari’s File menu', 'Choose Add to Dock.'),
-        installStep(startNumber + 1, `Open ${appName} from the new icon`, 'It will launch in its standalone game view.')
+        installStep(startNumber, 'In Safari, open the File menu', 'Choose Add to Dock.'),
+        installStep(startNumber + 1, `Open ${appName} from the Dock`, `From now on, ${appName} opens in its standalone game view.`)
       ].join('');
     }
 
     return [
-      installStep(startNumber, `Open ${targetName}’s menu`, `Look for Install ${appName}, Install app or Add to Home Screen.`),
-      installStep(startNumber + 1, `Install ${appName}`, 'Confirm the installation when your browser asks.'),
-      installStep(startNumber + 2, 'Launch from the new icon', `${appName} will open in its standalone game view.`)
+      installStep(startNumber, `Open ${targetName}’s menu`, `Choose Install ${appName} or Add to Home Screen.`),
+      installStep(startNumber + 1, `Confirm the installation`, `Your browser will add ${appName} to your apps.`),
+      installStep(startNumber + 2, `Open ${appName} from the new icon`, `${appName} will open in its standalone game view.`)
     ].join('');
   }
 
@@ -279,7 +284,8 @@
     gate.hidden = false;
 
     if (browserContext.needsExternalBrowserStep) {
-      note.textContent = `For reliable installation, open this page in ${browserContext.preferredBrowser}. You can still play here.`;
+      const currentApp = browserContext.containerName || 'this app';
+      note.textContent = `To install ${appName}, open it in ${browserContext.preferredBrowser}. You can still play inside ${currentApp}.`;
     } else if (browserContext.id !== 'unknown') {
       note.textContent = `Install ${appName} from ${browserContext.name} for the best fullscreen experience. You can also play here.`;
     }


### PR DESCRIPTION
## UX copy review

The existing first step mixed a destination instruction with a fragment and a negation:

> This page is open inside Facebook. Not inside a social media app.

That made the user mentally untangle both where they are and where they should go.

## Revised flow

For an iPhone link opened in Facebook, the guide now says:

1. **Open TURN in Safari**
   - “You’re viewing TURN inside Facebook. Copy the address, then open Safari and paste it into the address bar.”
   - **Copy TURN address**
2. **In Safari, tap …, then Share**
   - “After TURN opens, tap … and choose Share.”
3. **Choose Add to Home Screen**
4. **Open TURN from your Home Screen**

The same pattern adapts to TURN NEXT, Android/Chrome, Samsung Internet and desktop browsers. Clipboard success and fallback messages now tell the player what to do next instead of merely confirming that copying happened.

## Principles

- names the actual destination browser in the heading
- removes the contradictory negation
- keeps one action per step
- uses TURN-specific button labels
- makes each following instruction conditional on TURN already being open in the target browser
- preserves the browser-aware detection and all launch/install behaviour