### PR TITLE
Make MENU use the exact track-heading typography

### DIFF
--- a/turn-next/index.html
+++ b/turn-next/index.html
@@ -65,7 +65,7 @@
   <link rel="stylesheet" href="./garage/lot-r10.css?build=20260731-r120">
   <link rel="stylesheet" href="./garage/lot-stat-legend.css?build=20260731-r120">
   <link rel="stylesheet" href="./garage/lot-layout-r60.css?build=20260731-r120">
-  <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260731-r120-menu-font">
+  <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260731-r120-menu-font-v2">
   <link rel="stylesheet" href="/turn-next/identity.css?source=20260731-r120-m8.5-logo">
   <script defer src="/turn-next/identity.js?source=20260731-r120-m8.5-logo"></script>
   <script src="./install-gate.js?build=20260731-r120-social-browser"></script>

--- a/turn-tests/release-production.mjs
+++ b/turn-tests/release-production.mjs
@@ -49,7 +49,7 @@ assert.match(index, new RegExp(`install-gate\\.js\\?build=${escapeRegExp(release
 assert.match(index, new RegExp(`install-gate\\.css\\?build=${escapeRegExp(release.cacheKey)}-social-browser`));
 assert.match(index, new RegExp(`orientation-guard\\.css\\?build=${escapeRegExp(release.cacheKey)}-home-portrait`));
 assert.match(index, new RegExp(`live-steering-setting\\.js\\?build=${escapeRegExp(release.cacheKey)}-live-steering`));
-assert.match(index, new RegExp(`m8-menu-font-fix\\.css\\?build=${escapeRegExp(release.cacheKey)}-menu-font`));
+assert.match(index, new RegExp(`m8-menu-font-fix\\.css\\?build=${escapeRegExp(release.cacheKey)}-menu-font-v2`));
 assert.match(index, new RegExp(`app\\.js\\?build=${escapeRegExp(release.cacheKey)}-browser-consent`));
 assert.match(index, /ROTATE YOUR DEVICE TO LANDSCAPE/);
 assert.match(index, /aria-label="Rotate your device to landscape"/);
@@ -86,9 +86,14 @@ assert.match(liveSteering, /raceSession\.prepareMotionAccess\(\)/);
 assert.match(liveSteering, /raceSession\.prepareManualAccess\(\)/);
 assert.match(liveSteering, /steering-mode-changed/);
 assert.match(liveSteering, /state\?\.running/);
+assert.match(menuFontCss, /\.m8-home\.m8-home-fixed-layout \.m8-home-main \.m8-track-heading-row h1,/);
 assert.match(menuFontCss, /\.m8-home\.m8-home-fixed-layout \.m8-home-main \.m8-home-menu h2/);
 assert.match(menuFontCss, /font-family: inherit/);
+assert.match(menuFontCss, /font-style: normal/);
+assert.match(menuFontCss, /font-variant: normal/);
 assert.match(menuFontCss, /font-weight: 950/);
+assert.match(menuFontCss, /font-stretch: normal/);
+assert.match(menuFontCss, /line-height: 0\.95/);
 assert.match(menuFontCss, /letter-spacing: -0\.035em/);
 
 const attributeBuilds = [...index.matchAll(/(?:href|src)="\.\/[^"?]+\?build=([^"&]+)/g)].map((match) => match[1]);
@@ -151,7 +156,7 @@ assert.match(nextIndex, new RegExp(`/turn-next/app\\.js\\?source=${escapeRegExp(
 assert.match(nextIndex, new RegExp(`install-gate\\.js\\?build=${escapeRegExp(release.cacheKey)}-social-browser`));
 assert.match(nextIndex, new RegExp(`install-gate\\.css\\?build=${escapeRegExp(release.cacheKey)}-social-browser`));
 assert.match(nextIndex, new RegExp(`live-steering-setting\\.js\\?build=${escapeRegExp(release.cacheKey)}-live-steering`));
-assert.match(nextIndex, new RegExp(`m8-menu-font-fix\\.css\\?build=${escapeRegExp(release.cacheKey)}-menu-font`));
+assert.match(nextIndex, new RegExp(`m8-menu-font-fix\\.css\\?build=${escapeRegExp(release.cacheKey)}-menu-font-v2`));
 assert.match(nextIndex, /ROTATE YOUR DEVICE TO LANDSCAPE/);
 assert.doesNotMatch(nextIndex, /Return to landscape/);
 assert.match(nextApp, /new URL\('\/turn\/app\.js'/);

--- a/turn-tests/turn-next-entry-production.mjs
+++ b/turn-tests/turn-next-entry-production.mjs
@@ -70,7 +70,7 @@ assert.match(productionIndex, new RegExp(`src="\\.\\/install-gate\\.js\\?build=$
 assert.match(productionIndex, new RegExp(`href="\\.\\/install-gate\\.css\\?build=${release.cacheKey}-social-browser"`));
 assert.match(productionIndex, new RegExp(`href="\\.\\/orientation-guard\\.css\\?build=${release.cacheKey}-home-portrait"`));
 assert.match(productionIndex, new RegExp(`src="\\.\\/live-steering-setting\\.js\\?build=${release.cacheKey}-live-steering"`));
-assert.match(productionIndex, new RegExp(`href="\\.\\/m8-menu-font-fix\\.css\\?build=${release.cacheKey}-menu-font"`));
+assert.match(productionIndex, new RegExp(`href="\\.\\/m8-menu-font-fix\\.css\\?build=${release.cacheKey}-menu-font-v2"`));
 assert.match(productionIndex, /ROTATE YOUR DEVICE TO LANDSCAPE/);
 assert.match(productionIndex, /aria-label="Rotate your device to landscape"/);
 assert.doesNotMatch(productionIndex, /Return to landscape/);
@@ -141,9 +141,14 @@ assert.match(liveSteeringSource, /raceSession\.prepareManualAccess\(\)/);
 assert.match(liveSteeringSource, /__turnMotionLifecycle\?\.stop\?\.\(\)/);
 assert.match(liveSteeringSource, /steering-mode-changed/);
 assert.match(liveSteeringSource, /saveSteeringMode\(activeMode\)/);
+assert.match(menuFontCss, /\.m8-home\.m8-home-fixed-layout \.m8-home-main \.m8-track-heading-row h1,/);
 assert.match(menuFontCss, /\.m8-home\.m8-home-fixed-layout \.m8-home-main \.m8-home-menu h2/);
 assert.match(menuFontCss, /font-family: inherit/);
+assert.match(menuFontCss, /font-style: normal/);
+assert.match(menuFontCss, /font-variant: normal/);
 assert.match(menuFontCss, /font-weight: 950/);
+assert.match(menuFontCss, /font-stretch: normal/);
+assert.match(menuFontCss, /line-height: 0\.95/);
 assert.match(menuFontCss, /letter-spacing: -0\.035em/);
 
 assert.match(nextIndex, /data-turn-deployment="next"/);
@@ -156,7 +161,7 @@ assert.match(nextIndex, new RegExp(`install-gate\\.js\\?build=${release.cacheKey
 assert.match(nextIndex, new RegExp(`install-gate\\.css\\?build=${release.cacheKey}-social-browser`));
 assert.match(nextIndex, new RegExp(`orientation-guard\\.css\\?build=${release.cacheKey}-home-portrait`));
 assert.match(nextIndex, new RegExp(`live-steering-setting\\.js\\?build=${release.cacheKey}-live-steering`));
-assert.match(nextIndex, new RegExp(`m8-menu-font-fix\\.css\\?build=${release.cacheKey}-menu-font`));
+assert.match(nextIndex, new RegExp(`m8-menu-font-fix\\.css\\?build=${release.cacheKey}-menu-font-v2`));
 assert.match(nextIndex, /ROTATE YOUR DEVICE TO LANDSCAPE/);
 assert.match(nextIndex, /aria-label="Rotate your device to landscape"/);
 assert.doesNotMatch(nextIndex, /Return to landscape/);

--- a/turn/index.html
+++ b/turn/index.html
@@ -62,7 +62,7 @@
   <link rel="stylesheet" href="./garage/lot-r10.css?build=20260731-r120">
   <link rel="stylesheet" href="./garage/lot-stat-legend.css?build=20260731-r120">
   <link rel="stylesheet" href="./garage/lot-layout-r60.css?build=20260731-r120">
-  <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260731-r120-menu-font">
+  <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260731-r120-menu-font-v2">
   <script src="./install-gate.js?build=20260731-r120-social-browser"></script>
   <script src="./motion-safe-zone.js?build=20260731-r120"></script>
   <script src="./orientation-compat.js?build=20260731-r120"></script>

--- a/turn/m8-menu-font-fix.css
+++ b/turn/m8-menu-font-fix.css
@@ -1,5 +1,10 @@
+.m8-home.m8-home-fixed-layout .m8-home-main .m8-track-heading-row h1,
 .m8-home.m8-home-fixed-layout .m8-home-main .m8-home-menu h2 {
   font-family: inherit;
-  font-weight: 950;
+  font-style: normal;
+  font-variant: normal;
+  font-weight: 700;
+  font-stretch: normal;
+  line-height: 0.95;
   letter-spacing: -0.035em;
 }

--- a/turn/m8-menu-font-fix.css
+++ b/turn/m8-menu-font-fix.css
@@ -3,7 +3,7 @@
   font-family: inherit;
   font-style: normal;
   font-variant: normal;
-  font-weight: 700;
+  font-weight: 950;
   font-stretch: normal;
   line-height: 0.95;
   letter-spacing: -0.035em;


### PR DESCRIPTION
## Root cause

The previous fix styled only `MENU` and gave it an explicit weight of 950, while `CHOOSE YOUR TRACK` was still partly relying on the browser’s default heading typography. The family looked close, but the two headings were not actually governed by the same complete rule.

## Fix

- applies one shared typography rule to both `CHOOSE YOUR TRACK` and `MENU`
- explicitly aligns font family, style, variant, weight, stretch, line height and letter spacing
- keeps their intentionally different sizes
- cache-busts the stylesheet in TURN and TURN NEXT so the corrected rule is not hidden behind the previous browser cache

This removes the two independent typographic paths instead of trying to imitate one from the other.