### PR TITLE
Give Home section headings the same size

### DIFF
--- a/turn-next/index.html
+++ b/turn-next/index.html
@@ -65,7 +65,7 @@
   <link rel="stylesheet" href="./garage/lot-r10.css?build=20260731-r120">
   <link rel="stylesheet" href="./garage/lot-stat-legend.css?build=20260731-r120">
   <link rel="stylesheet" href="./garage/lot-layout-r60.css?build=20260731-r120">
-  <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260731-r120-menu-font-v2">
+  <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260731-r120-menu-font-v3">
   <link rel="stylesheet" href="/turn-next/identity.css?source=20260731-r120-m8.5-logo">
   <script defer src="/turn-next/identity.js?source=20260731-r120-m8.5-logo"></script>
   <script src="./install-gate.js?build=20260731-r120-social-browser"></script>

--- a/turn-tests/release-production.mjs
+++ b/turn-tests/release-production.mjs
@@ -49,7 +49,7 @@ assert.match(index, new RegExp(`install-gate\\.js\\?build=${escapeRegExp(release
 assert.match(index, new RegExp(`install-gate\\.css\\?build=${escapeRegExp(release.cacheKey)}-social-browser`));
 assert.match(index, new RegExp(`orientation-guard\\.css\\?build=${escapeRegExp(release.cacheKey)}-home-portrait`));
 assert.match(index, new RegExp(`live-steering-setting\\.js\\?build=${escapeRegExp(release.cacheKey)}-live-steering`));
-assert.match(index, new RegExp(`m8-menu-font-fix\\.css\\?build=${escapeRegExp(release.cacheKey)}-menu-font-v2`));
+assert.match(index, new RegExp(`m8-menu-font-fix\\.css\\?build=${escapeRegExp(release.cacheKey)}-menu-font-v3`));
 assert.match(index, new RegExp(`app\\.js\\?build=${escapeRegExp(release.cacheKey)}-browser-consent`));
 assert.match(index, /ROTATE YOUR DEVICE TO LANDSCAPE/);
 assert.match(index, /aria-label="Rotate your device to landscape"/);
@@ -89,6 +89,7 @@ assert.match(liveSteering, /state\?\.running/);
 assert.match(menuFontCss, /\.m8-home\.m8-home-fixed-layout \.m8-home-main \.m8-track-heading-row h1,/);
 assert.match(menuFontCss, /\.m8-home\.m8-home-fixed-layout \.m8-home-main \.m8-home-menu h2/);
 assert.match(menuFontCss, /font-family: inherit/);
+assert.match(menuFontCss, /font-size: clamp\(1\.65rem, 3\.2vw, 3rem\)/);
 assert.match(menuFontCss, /font-style: normal/);
 assert.match(menuFontCss, /font-variant: normal/);
 assert.match(menuFontCss, /font-weight: 950/);
@@ -156,7 +157,7 @@ assert.match(nextIndex, new RegExp(`/turn-next/app\\.js\\?source=${escapeRegExp(
 assert.match(nextIndex, new RegExp(`install-gate\\.js\\?build=${escapeRegExp(release.cacheKey)}-social-browser`));
 assert.match(nextIndex, new RegExp(`install-gate\\.css\\?build=${escapeRegExp(release.cacheKey)}-social-browser`));
 assert.match(nextIndex, new RegExp(`live-steering-setting\\.js\\?build=${escapeRegExp(release.cacheKey)}-live-steering`));
-assert.match(nextIndex, new RegExp(`m8-menu-font-fix\\.css\\?build=${escapeRegExp(release.cacheKey)}-menu-font-v2`));
+assert.match(nextIndex, new RegExp(`m8-menu-font-fix\\.css\\?build=${escapeRegExp(release.cacheKey)}-menu-font-v3`));
 assert.match(nextIndex, /ROTATE YOUR DEVICE TO LANDSCAPE/);
 assert.doesNotMatch(nextIndex, /Return to landscape/);
 assert.match(nextApp, /new URL\('\/turn\/app\.js'/);
@@ -168,7 +169,7 @@ assert.match(workflow, /node turn\/scripts\/release\.mjs --check/);
 assert.match(workflow, /node turn-tests\/release-production\.mjs/);
 assert.doesNotMatch(workflow, /node turn-lab\/scripts\/check-release\.mjs/, 'CI must verify the production release rather than the retired playable lab snapshot');
 
-console.log(`TURN ${release.id} browser consent, clearer social onboarding, live steering and landscape guidance passed.`);
+console.log(`TURN ${release.id} browser consent, clearer social onboarding, equal Home heading size, live steering and landscape guidance passed.`);
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/turn-tests/turn-next-entry-production.mjs
+++ b/turn-tests/turn-next-entry-production.mjs
@@ -70,7 +70,7 @@ assert.match(productionIndex, new RegExp(`src="\\.\\/install-gate\\.js\\?build=$
 assert.match(productionIndex, new RegExp(`href="\\.\\/install-gate\\.css\\?build=${release.cacheKey}-social-browser"`));
 assert.match(productionIndex, new RegExp(`href="\\.\\/orientation-guard\\.css\\?build=${release.cacheKey}-home-portrait"`));
 assert.match(productionIndex, new RegExp(`src="\\.\\/live-steering-setting\\.js\\?build=${release.cacheKey}-live-steering"`));
-assert.match(productionIndex, new RegExp(`href="\\.\\/m8-menu-font-fix\\.css\\?build=${release.cacheKey}-menu-font-v2"`));
+assert.match(productionIndex, new RegExp(`href="\\.\\/m8-menu-font-fix\\.css\\?build=${release.cacheKey}-menu-font-v3"`));
 assert.match(productionIndex, /ROTATE YOUR DEVICE TO LANDSCAPE/);
 assert.match(productionIndex, /aria-label="Rotate your device to landscape"/);
 assert.doesNotMatch(productionIndex, /Return to landscape/);
@@ -144,6 +144,7 @@ assert.match(liveSteeringSource, /saveSteeringMode\(activeMode\)/);
 assert.match(menuFontCss, /\.m8-home\.m8-home-fixed-layout \.m8-home-main \.m8-track-heading-row h1,/);
 assert.match(menuFontCss, /\.m8-home\.m8-home-fixed-layout \.m8-home-main \.m8-home-menu h2/);
 assert.match(menuFontCss, /font-family: inherit/);
+assert.match(menuFontCss, /font-size: clamp\(1\.65rem, 3\.2vw, 3rem\)/);
 assert.match(menuFontCss, /font-style: normal/);
 assert.match(menuFontCss, /font-variant: normal/);
 assert.match(menuFontCss, /font-weight: 950/);
@@ -161,7 +162,7 @@ assert.match(nextIndex, new RegExp(`install-gate\\.js\\?build=${release.cacheKey
 assert.match(nextIndex, new RegExp(`install-gate\\.css\\?build=${release.cacheKey}-social-browser`));
 assert.match(nextIndex, new RegExp(`orientation-guard\\.css\\?build=${release.cacheKey}-home-portrait`));
 assert.match(nextIndex, new RegExp(`live-steering-setting\\.js\\?build=${release.cacheKey}-live-steering`));
-assert.match(nextIndex, new RegExp(`m8-menu-font-fix\\.css\\?build=${release.cacheKey}-menu-font-v2`));
+assert.match(nextIndex, new RegExp(`m8-menu-font-fix\\.css\\?build=${release.cacheKey}-menu-font-v3`));
 assert.match(nextIndex, /ROTATE YOUR DEVICE TO LANDSCAPE/);
 assert.match(nextIndex, /aria-label="Rotate your device to landscape"/);
 assert.doesNotMatch(nextIndex, /Return to landscape/);
@@ -240,4 +241,4 @@ assert.deepEqual(
   }
 );
 
-console.log(`TURN ${release.id} requires browser consent, uses concise social-browser instructions and mirrors all contracts in TURN NEXT.`);
+console.log(`TURN ${release.id} requires browser consent, uses concise social-browser instructions, keeps equal Home heading sizes and mirrors all contracts in TURN NEXT.`);

--- a/turn/index.html
+++ b/turn/index.html
@@ -62,7 +62,7 @@
   <link rel="stylesheet" href="./garage/lot-r10.css?build=20260731-r120">
   <link rel="stylesheet" href="./garage/lot-stat-legend.css?build=20260731-r120">
   <link rel="stylesheet" href="./garage/lot-layout-r60.css?build=20260731-r120">
-  <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260731-r120-menu-font-v2">
+  <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260731-r120-menu-font-v3">
   <script src="./install-gate.js?build=20260731-r120-social-browser"></script>
   <script src="./motion-safe-zone.js?build=20260731-r120"></script>
   <script src="./orientation-compat.js?build=20260731-r120"></script>

--- a/turn/m8-menu-font-fix.css
+++ b/turn/m8-menu-font-fix.css
@@ -1,6 +1,7 @@
 .m8-home.m8-home-fixed-layout .m8-home-main .m8-track-heading-row h1,
 .m8-home.m8-home-fixed-layout .m8-home-main .m8-home-menu h2 {
   font-family: inherit;
+  font-size: clamp(1.65rem, 3.2vw, 3rem);
   font-style: normal;
   font-variant: normal;
   font-weight: 950;


### PR DESCRIPTION
## Why

`CHOOSE YOUR TRACK` and `MENU` are parallel visual section labels in the Home layout, so there is no useful visual hierarchy gained by making `MENU` smaller.

They are not currently the same HTML element: `CHOOSE YOUR TRACK` is the page’s `h1`, while `MENU` is the `h2` that labels the adjacent menu region. That semantic structure remains appropriate, but HTML heading level does not require a different visual size.

## Change

- gives both headings the same responsive font size: `clamp(1.65rem, 3.2vw, 3rem)`
- retains the already shared family, weight, line height and spacing
- keeps the existing `h1`/`h2` document outline
- cache-busts the typography stylesheet in TURN and TURN NEXT
- extends release and parity regressions to require the shared size