### PR TITLE
Improve Midnight City vehicle and street lighting

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -88,6 +88,9 @@ jobs:
       - name: Run Harbor hidden face regression
         run: node turn-tests/harbor-hidden-face-production.mjs
 
+      - name: Run Midnight City lighting regression
+        run: node turn-tests/midnight-city-lighting-production.mjs
+
       - name: Run production manual steering regression
         run: node turn-lab/tests/manual-steering-production.mjs
 

--- a/turn-tests/midnight-city-lighting-production.mjs
+++ b/turn-tests/midnight-city-lighting-production.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const [lightingSource, registrySource] = await Promise.all([
+  fs.readFile(new URL('../turn/tracks/midnight-city-world-r2.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/tracks/registry.js', import.meta.url), 'utf8')
+]);
+
+assert.match(lightingSource, /installMidnightCityWorld as installMidnightCityWorldR1/);
+assert.match(lightingSource, /const PLAYER_LIGHT_RIG_NAME = 'TURN Midnight City player light rig'/);
+assert.match(lightingSource, /for \(const side of \[-1, 1\]\)/);
+assert.match(lightingSource, /new THREE\.PointLight\(PLAYER_FILL, 6\.2, 58, 1\.72\)/);
+assert.match(lightingSource, /light\.position\.set\(side \* 1\.55, 2\.85, 2\.4\)/);
+assert.match(lightingSource, /playerCar\.add\(rig\)/);
+assert.match(lightingSource, /rig\.visible = event\.detail\?\.trackId === 'midnight-city'/);
+assert.match(lightingSource, /node\.intensity = Math\.max\(node\.intensity, 11\.5\)/);
+assert.match(lightingSource, /node\.distance = Math\.max\(node\.distance, 96\)/);
+assert.match(lightingSource, /node\.decay = 1\.5/);
+assert.match(lightingSource, /new THREE\.InstancedMesh\(geometry, poolMaterial, count\)/);
+assert.match(lightingSource, /new THREE\.CircleGeometry\(11\.5, 24\)/);
+assert.match(lightingSource, /blending: THREE\.AdditiveBlending/);
+assert.match(lightingSource, /streetLightPoolCount/);
+assert.doesNotMatch(
+  lightingSource,
+  /requestAnimationFrame|setAnimationLoop|setInterval|setTimeout/,
+  'Midnight City lighting must ride the existing render loop without creating another one'
+);
+assert.doesNotMatch(
+  lightingSource,
+  /fetch\(|GLTFLoader|TextureLoader|new Audio/,
+  'The visibility fix must add no network assets or unrelated runtime systems'
+);
+
+assert.match(registrySource, /midnight-city-world-r2\.js\?build=20260731-r120/);
+assert.match(registrySource, /'midnight-city'\(\{ scene, samples, trackWidth, runtime \}\)/);
+assert.match(registrySource, /installMidnightCityWorld\(\{ scene, samples, trackWidth, runtime \}\)/);
+
+console.log('TURN Midnight City player visibility and stronger street lighting passed.');

--- a/turn/tracks/midnight-city-world-r2.js
+++ b/turn/tracks/midnight-city-world-r2.js
@@ -1,0 +1,105 @@
+import * as THREE from 'three';
+import { installMidnightCityWorld as installMidnightCityWorldR1 } from './midnight-city-world.js?base=20260801-r1';
+
+const WARM_LIGHT = 0xffd27a;
+const PLAYER_FILL = 0xffe3b3;
+const PLAYER_LIGHT_RIG_NAME = 'TURN Midnight City player light rig';
+const STREET_POOL_NAME = 'Midnight City street-light road pools';
+
+export function installMidnightCityWorld(options) {
+  const world = installMidnightCityWorldR1(options);
+  const playerLightRig = installPlayerLightRig(options.runtime?.playerCar);
+  const streetLightCount = strengthenStreetLights(world);
+  const streetPools = makeStreetLightPools(world, options.samples || []);
+
+  world.name = 'TURN Midnight City r2';
+  world.userData.turnPlayerLightRig = playerLightRig;
+  world.userData.turnMidnightCityArtDirection = Object.freeze({
+    ...(world.userData.turnMidnightCityArtDirection || {}),
+    version: 'r2',
+    playerVisibilityLight: 'dual invisible local fill',
+    streetLightReach: 'stronger point lights and instanced road pools',
+    strengthenedStreetLightCount: streetLightCount,
+    streetLightPoolCount: streetPools?.count || 0,
+    noIndependentAnimationLoop: true
+  });
+
+  return world;
+}
+
+function installPlayerLightRig(playerCar) {
+  if (!playerCar) return null;
+
+  const existing = playerCar.getObjectByName?.(PLAYER_LIGHT_RIG_NAME);
+  if (existing) return existing;
+
+  const rig = new THREE.Group();
+  rig.name = PLAYER_LIGHT_RIG_NAME;
+
+  for (const side of [-1, 1]) {
+    const light = new THREE.PointLight(PLAYER_FILL, 6.2, 58, 1.72);
+    light.name = `Midnight City player fill ${side < 0 ? 'left' : 'right'}`;
+    light.position.set(side * 1.55, 2.85, 2.4);
+    light.castShadow = false;
+    rig.add(light);
+  }
+
+  playerCar.add(rig);
+  rig.visible = true;
+  rig.userData.turnTrackVisibility = 'midnight-city';
+
+  window.addEventListener('turn:track-changed', (event) => {
+    rig.visible = event.detail?.trackId === 'midnight-city';
+  });
+
+  return rig;
+}
+
+function strengthenStreetLights(world) {
+  let count = 0;
+  world.traverse((node) => {
+    if (!node.isPointLight || node.color?.getHex() !== WARM_LIGHT) return;
+    node.intensity = Math.max(node.intensity, 11.5);
+    node.distance = Math.max(node.distance, 96);
+    node.decay = 1.5;
+    node.castShadow = false;
+    count += 1;
+  });
+  return count;
+}
+
+function makeStreetLightPools(world, samples) {
+  if (!samples.length) return null;
+
+  const step = 45;
+  const count = Math.ceil(samples.length / step);
+  const geometry = new THREE.CircleGeometry(11.5, 24);
+  const poolMaterial = new THREE.MeshBasicMaterial({
+    color: WARM_LIGHT,
+    transparent: true,
+    opacity: 0.13,
+    depthWrite: false,
+    blending: THREE.AdditiveBlending,
+    side: THREE.DoubleSide
+  });
+  const pools = new THREE.InstancedMesh(geometry, poolMaterial, count);
+  pools.name = STREET_POOL_NAME;
+  pools.frustumCulled = false;
+
+  const marker = new THREE.Object3D();
+  let cursor = 0;
+  for (let index = 0; index < samples.length; index += step) {
+    const sample = samples[index];
+    marker.position.copy(sample.point).setY(sample.point.y + 0.205);
+    marker.rotation.set(-Math.PI / 2, 0, 0);
+    marker.scale.set(1, 1, 1);
+    marker.updateMatrix();
+    pools.setMatrixAt(cursor, marker.matrix);
+    cursor += 1;
+  }
+
+  pools.count = cursor;
+  pools.instanceMatrix.needsUpdate = true;
+  world.add(pools);
+  return pools;
+}

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -8,7 +8,7 @@ import {
 import { installAirportWorld } from './airport-world-r52.js?build=20260722-r52';
 import { installCliffsideWorld } from './cliffside-world.js';
 import { installHarborWorld } from './harbor-world.js';
-import { installMidnightCityWorld } from './midnight-city-world.js';
+import { installMidnightCityWorld } from './midnight-city-world-r2.js?build=20260731-r120';
 import { isForgivingTrackSurface } from './airport-runoff.js?build=20260722-r52';
 
 const WORLD_INSTALLERS = Object.freeze({
@@ -25,8 +25,8 @@ const WORLD_INSTALLERS = Object.freeze({
   harbor({ scene, samples, trackWidth }) {
     return installHarborWorld({ scene, samples, trackWidth });
   },
-  'midnight-city'({ scene, samples, trackWidth }) {
-    return installMidnightCityWorld({ scene, samples, trackWidth });
+  'midnight-city'({ scene, samples, trackWidth, runtime }) {
+    return installMidnightCityWorld({ scene, samples, trackWidth, runtime });
   }
 });
 


### PR DESCRIPTION
## What changes

- adds two invisible warm point lights to the player car on MIDNIGHT CITY so the vehicle and nearby road remain readable through maximum drift angles
- keeps those player-local lights active only while MIDNIGHT CITY is selected
- increases the effective intensity and reach of the existing sparse real street-light sources
- adds low-cost instanced warm road-light pools so more lamp posts visibly illuminate their surroundings without turning every street lamp into an expensive real-time light
- preserves the dark night-city mood, adds no external assets and creates no independent render loop

## Performance approach

The player receives only two local non-shadow-casting lights. Existing street PointLights remain sparse, while the extra visible illumination is an instanced additive mesh rather than dozens of additional dynamic lights.

## Regression

Adds a dedicated Midnight City lighting contract to CI covering player-light placement, track-only visibility, street-light reach, instancing and the no-extra-loop/no-network constraints.