### PR TITLE
Replace Midnight City light pools with clear low-cost guidance

### DIFF
--- a/turn-tests/midnight-city-lighting-production.mjs
+++ b/turn-tests/midnight-city-lighting-production.mjs
@@ -2,28 +2,48 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
 const [lightingSource, registrySource] = await Promise.all([
-  fs.readFile(new URL('../turn/tracks/midnight-city-world-r2.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/tracks/midnight-city-world-r3.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/tracks/registry.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(lightingSource, /installMidnightCityWorld as installMidnightCityWorldR1/);
-assert.match(lightingSource, /const PLAYER_LIGHT_RIG_NAME = 'TURN Midnight City player light rig'/);
-assert.match(lightingSource, /for \(const side of \[-1, 1\]\)/);
-assert.match(lightingSource, /new THREE\.PointLight\(PLAYER_FILL, 6\.2, 58, 1\.72\)/);
-assert.match(lightingSource, /light\.position\.set\(side \* 1\.55, 2\.85, 2\.4\)/);
-assert.match(lightingSource, /playerCar\.add\(rig\)/);
-assert.match(lightingSource, /rig\.visible = event\.detail\?\.trackId === 'midnight-city'/);
-assert.match(lightingSource, /node\.intensity = Math\.max\(node\.intensity, 11\.5\)/);
-assert.match(lightingSource, /node\.distance = Math\.max\(node\.distance, 96\)/);
-assert.match(lightingSource, /node\.decay = 1\.5/);
-assert.match(lightingSource, /new THREE\.InstancedMesh\(geometry, poolMaterial, count\)/);
-assert.match(lightingSource, /new THREE\.CircleGeometry\(11\.5, 24\)/);
+assert.match(lightingSource, /installMidnightCityWorld as installMidnightCityWorldR2/);
+assert.match(lightingSource, /removeUnanchoredStreetPools\(world\)/);
+assert.match(lightingSource, /world\.getObjectByName\(STREET_POOL_NAME\)/);
+assert.match(lightingSource, /pools\.parent\?\.remove\(pools\)/);
+assert.doesNotMatch(lightingSource, /new THREE\.CircleGeometry\(11\.5, 24\)/);
+
+assert.match(lightingSource, /new THREE\.PointLight\(PLAYER_FILL, 3\.1, 17, 2\)/);
+assert.match(lightingSource, /const HEADLIGHT_PROJECTION_NAME = 'Midnight City projected headlights'/);
+assert.match(lightingSource, /makeHeadlightWedge/);
+assert.match(lightingSource, /farZ: -38/);
 assert.match(lightingSource, /blending: THREE\.AdditiveBlending/);
-assert.match(lightingSource, /streetLightPoolCount/);
+assert.match(lightingSource, /toneMapped: false/);
+assert.equal(
+  (lightingSource.match(/new THREE\.PointLight/g) || []).length,
+  1,
+  'The clarity pass may add only one short-range player light'
+);
+
+assert.match(lightingSource, /if \(index % 2 === 1\) \{[\s\S]*light\.visible = false/);
+assert.match(lightingSource, /bulbOffset = side \* \(trackWidth \/ 2 \+ 4\.68\)/);
+assert.match(lightingSource, /light\.intensity = 7\.2/);
+assert.match(lightingSource, /light\.distance = 62/);
+assert.match(lightingSource, /light\.decay = 1\.9/);
+assert.match(lightingSource, /six sparse real lights anchored to visible lamp posts/);
+
+assert.match(lightingSource, /const LEFT_EDGE = 0x74e8ff/);
+assert.match(lightingSource, /const RIGHT_EDGE = 0xffd27a/);
+assert.match(lightingSource, /makeTrackBorderGuidance/);
+assert.match(lightingSource, /makeEdgeRibbon/);
+assert.match(lightingSource, /makeEdgeStuds/);
+assert.match(lightingSource, /new THREE\.InstancedMesh/);
+assert.match(lightingSource, /continuous cyan-left amber-right reflective ribbons and studs/);
+assert.match(lightingSource, /new THREE\.MeshBasicMaterial/);
+
 assert.doesNotMatch(
   lightingSource,
   /requestAnimationFrame|setAnimationLoop|setInterval|setTimeout/,
-  'Midnight City lighting must ride the existing render loop without creating another one'
+  'Midnight City clarity must ride the existing vehicle and render transforms without another loop'
 );
 assert.doesNotMatch(
   lightingSource,
@@ -31,8 +51,8 @@ assert.doesNotMatch(
   'The visibility fix must add no network assets or unrelated runtime systems'
 );
 
-assert.match(registrySource, /midnight-city-world-r2\.js\?build=20260731-r120/);
+assert.match(registrySource, /midnight-city-world-r3\.js\?build=20260731-r120/);
 assert.match(registrySource, /'midnight-city'\(\{ scene, samples, trackWidth, runtime \}\)/);
 assert.match(registrySource, /installMidnightCityWorld\(\{ scene, samples, trackWidth, runtime \}\)/);
 
-console.log('TURN Midnight City player visibility and stronger street lighting passed.');
+console.log('TURN Midnight City projected headlights, anchored lamps and reflective borders passed.');

--- a/turn/tracks/midnight-city-world-r3.js
+++ b/turn/tracks/midnight-city-world-r3.js
@@ -1,0 +1,255 @@
+import * as THREE from 'three';
+import { installMidnightCityWorld as installMidnightCityWorldR2 } from './midnight-city-world-r2.js?base=20260801-r2';
+
+const WARM_LIGHT = 0xffd27a;
+const PLAYER_FILL = 0xffe3b3;
+const LEFT_EDGE = 0x74e8ff;
+const RIGHT_EDGE = 0xffd27a;
+const PLAYER_LIGHT_RIG_NAME = 'TURN Midnight City player light rig';
+const STREET_POOL_NAME = 'Midnight City street-light road pools';
+const HEADLIGHT_PROJECTION_NAME = 'Midnight City projected headlights';
+const EDGE_GUIDANCE_NAME = 'Midnight City reflective track borders';
+const TRACK_Y = 0.16;
+
+export function installMidnightCityWorld(options) {
+  const world = installMidnightCityWorldR2(options);
+  const samples = options.samples || [];
+  const trackWidth = options.trackWidth || 27;
+
+  const removedPoolCount = removeUnanchoredStreetPools(world);
+  const playerLighting = replacePlayerLighting(options.runtime?.playerCar);
+  const streetLighting = alignSparseStreetLights(world, samples, trackWidth);
+  const edgeGuidance = makeTrackBorderGuidance(world, samples, trackWidth);
+
+  world.name = 'TURN Midnight City r3';
+  world.userData.turnPlayerLightRig = playerLighting;
+  world.userData.turnMidnightCityArtDirection = Object.freeze({
+    ...(world.userData.turnMidnightCityArtDirection || {}),
+    version: 'r3',
+    playerVisibilityLight: 'one short-range fill plus projected unlit headlights',
+    streetLightReach: 'six sparse real lights anchored to visible lamp posts',
+    randomRoadPoolsRemoved: removedPoolCount > 0,
+    activeStreetLightCount: streetLighting.active,
+    disabledStreetLightCount: streetLighting.disabled,
+    trackBorderGuidance: 'continuous cyan-left amber-right reflective ribbons and studs',
+    edgeGuidanceMeshes: edgeGuidance,
+    noIndependentAnimationLoop: true
+  });
+
+  return world;
+}
+
+function removeUnanchoredStreetPools(world) {
+  const pools = world.getObjectByName(STREET_POOL_NAME);
+  if (!pools) return 0;
+
+  pools.parent?.remove(pools);
+  pools.geometry?.dispose?.();
+  if (Array.isArray(pools.material)) {
+    for (const entry of pools.material) entry.dispose?.();
+  } else {
+    pools.material?.dispose?.();
+  }
+  return pools.count || 1;
+}
+
+function replacePlayerLighting(playerCar) {
+  if (!playerCar) return null;
+
+  const rig = playerCar.getObjectByName?.(PLAYER_LIGHT_RIG_NAME);
+  if (!rig) return null;
+
+  for (const child of [...rig.children]) rig.remove(child);
+
+  const fill = new THREE.PointLight(PLAYER_FILL, 3.1, 17, 2);
+  fill.name = 'Midnight City player visibility fill';
+  fill.position.set(0, 2.55, 0.45);
+  fill.castShadow = false;
+  rig.add(fill);
+
+  const headlights = new THREE.Group();
+  headlights.name = HEADLIGHT_PROJECTION_NAME;
+  headlights.add(
+    makeHeadlightWedge({
+      nearWidth: 3.8,
+      farWidth: 17,
+      nearZ: -1.7,
+      farZ: -38,
+      opacity: 0.075
+    }),
+    makeHeadlightWedge({
+      nearWidth: 2.5,
+      farWidth: 9.5,
+      nearZ: -1.4,
+      farZ: -28,
+      opacity: 0.14
+    })
+  );
+  rig.add(headlights);
+
+  return rig;
+}
+
+function makeHeadlightWedge({ nearWidth, farWidth, nearZ, farZ, opacity }) {
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute([
+    -nearWidth / 2, 0.24, nearZ,
+    nearWidth / 2, 0.24, nearZ,
+    -farWidth / 2, 0.24, farZ,
+    farWidth / 2, 0.24, farZ
+  ], 3));
+  geometry.setIndex([0, 2, 1, 1, 2, 3]);
+  geometry.computeVertexNormals();
+
+  const beam = new THREE.Mesh(
+    geometry,
+    new THREE.MeshBasicMaterial({
+      color: PLAYER_FILL,
+      transparent: true,
+      opacity,
+      depthWrite: false,
+      depthTest: true,
+      blending: THREE.AdditiveBlending,
+      side: THREE.DoubleSide,
+      toneMapped: false,
+      polygonOffset: true,
+      polygonOffsetFactor: -1,
+      polygonOffsetUnits: -2
+    })
+  );
+  beam.renderOrder = 5;
+  return beam;
+}
+
+function alignSparseStreetLights(world, samples, trackWidth) {
+  if (!samples.length) return { active: 0, disabled: 0 };
+
+  const lights = [];
+  world.traverse((node) => {
+    if (node.isPointLight && node.color?.getHex() === WARM_LIGHT) lights.push(node);
+  });
+
+  let active = 0;
+  let disabled = 0;
+  for (let index = 0; index < lights.length; index += 1) {
+    const light = lights[index];
+    if (index % 2 === 1) {
+      light.visible = false;
+      disabled += 1;
+      continue;
+    }
+
+    const sampleIndex = (index * 90) % samples.length;
+    const sample = samples[sampleIndex];
+    const side = active % 2 === 0 ? 1 : -1;
+    const bulbOffset = side * (trackWidth / 2 + 4.68);
+
+    light.visible = true;
+    light.position.copy(sample.point)
+      .addScaledVector(sample.normal, bulbOffset)
+      .setY(sample.point.y + 7.35);
+    light.intensity = 7.2;
+    light.distance = 62;
+    light.decay = 1.9;
+    light.castShadow = false;
+    light.name = `Midnight City anchored street light ${active + 1}`;
+    active += 1;
+  }
+
+  return { active, disabled };
+}
+
+function makeTrackBorderGuidance(world, samples, trackWidth) {
+  if (!samples.length) return 0;
+
+  const guidance = new THREE.Group();
+  guidance.name = EDGE_GUIDANCE_NAME;
+
+  for (const side of [1, -1]) {
+    const color = side > 0 ? LEFT_EDGE : RIGHT_EDGE;
+    const ribbon = makeEdgeRibbon(samples, side, trackWidth, color);
+    const studs = makeEdgeStuds(samples, side, trackWidth, color);
+    guidance.add(ribbon, studs);
+  }
+
+  world.add(guidance);
+  return guidance.children.length;
+}
+
+function makeEdgeRibbon(samples, side, trackWidth, color) {
+  const halfWidth = trackWidth / 2;
+  const ribbonWidth = 0.46;
+  const centreOffset = side * (halfWidth - 0.18);
+  const innerOffset = centreOffset - ribbonWidth / 2;
+  const outerOffset = centreOffset + ribbonWidth / 2;
+  const positions = [];
+  const indices = [];
+
+  for (let index = 0; index <= samples.length; index += 1) {
+    const sample = samples[index % samples.length];
+    const inner = sample.point.clone()
+      .addScaledVector(sample.normal, innerOffset)
+      .setY(sample.point.y + TRACK_Y + 0.085);
+    const outer = sample.point.clone()
+      .addScaledVector(sample.normal, outerOffset)
+      .setY(sample.point.y + TRACK_Y + 0.085);
+    positions.push(inner.x, inner.y, inner.z, outer.x, outer.y, outer.z);
+  }
+
+  for (let index = 0; index < samples.length; index += 1) {
+    const a = index * 2;
+    const b = a + 1;
+    const c = a + 2;
+    const d = a + 3;
+    indices.push(a, c, b, b, c, d);
+  }
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  geometry.setIndex(indices);
+
+  const ribbon = new THREE.Mesh(
+    geometry,
+    new THREE.MeshBasicMaterial({
+      color,
+      transparent: true,
+      opacity: 0.82,
+      depthWrite: false,
+      side: THREE.DoubleSide,
+      toneMapped: false
+    })
+  );
+  ribbon.name = `Midnight City ${side > 0 ? 'left' : 'right'} reflective edge ribbon`;
+  ribbon.renderOrder = 4;
+  return ribbon;
+}
+
+function makeEdgeStuds(samples, side, trackWidth, color) {
+  const step = 9;
+  const count = Math.ceil(samples.length / step);
+  const geometry = new THREE.BoxGeometry(0.48, 0.055, 1.35);
+  const studs = new THREE.InstancedMesh(
+    geometry,
+    new THREE.MeshBasicMaterial({ color, toneMapped: false }),
+    count
+  );
+  const marker = new THREE.Object3D();
+  let cursor = 0;
+
+  for (let index = 0; index < samples.length; index += step) {
+    const sample = samples[index];
+    marker.position.copy(sample.point)
+      .addScaledVector(sample.normal, side * (trackWidth / 2 - 0.72))
+      .setY(sample.point.y + TRACK_Y + 0.125);
+    marker.rotation.set(0, Math.atan2(sample.tangent.x, sample.tangent.z), 0);
+    marker.updateMatrix();
+    studs.setMatrixAt(cursor, marker.matrix);
+    cursor += 1;
+  }
+
+  studs.count = cursor;
+  studs.instanceMatrix.needsUpdate = true;
+  studs.name = `Midnight City ${side > 0 ? 'left' : 'right'} reflective edge studs`;
+  studs.frustumCulled = false;
+  return studs;
+}

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -8,7 +8,7 @@ import {
 import { installAirportWorld } from './airport-world-r52.js?build=20260722-r52';
 import { installCliffsideWorld } from './cliffside-world.js';
 import { installHarborWorld } from './harbor-world.js';
-import { installMidnightCityWorld } from './midnight-city-world-r2.js?build=20260731-r120';
+import { installMidnightCityWorld } from './midnight-city-world-r3.js?build=20260731-r120';
 import { isForgivingTrackSurface } from './airport-runoff.js?build=20260722-r52';
 
 const WORLD_INSTALLERS = Object.freeze({


### PR DESCRIPTION
## Why

The r2 lighting pass made the car visible, but the local point lights mostly lit the vehicle rather than the road ahead. Its additive road circles also appeared detached from the actual lamp posts, while the dark track borders remained difficult to read.

## New direction

This pass avoids solving the whole scene with more dynamic lights.

- removes the unanchored circular street-light pools
- replaces the two broad player point lights with one short-range, shadowless car fill
- adds two cheap unlit headlight wedges attached to the car, giving clear forward road illumination without another per-frame system
- reduces the real environmental lights from twelve visible point lights to six
- anchors those six lights to visible lamp positions on alternating sides of the road
- adds continuous unlit track-border ribbons, cyan on the left and amber on the right
- adds instanced reflective edge studs for distance, motion and curve readability

## Performance

The important guidance now comes from MeshBasicMaterial geometry and instancing rather than additional scene lighting. There is one short-range player PointLight and six sparse environmental PointLights, all without shadows. No new animation loop, network asset or texture loader is introduced.

## Regression

Updates the Midnight City lighting contract to require removal of the random pools, a single local dynamic light, projected headlights, anchored sparse lamps and continuous side-coded track borders.