### PR TITLE
Fix Midnight City sign backs, park proximity and track names

### DIFF
--- a/turn-lab/tests/multi-track-production.mjs
+++ b/turn-lab/tests/multi-track-production.mjs
@@ -122,7 +122,7 @@ const [definitions, catalog, registry, manager, world, home] = await Promise.all
   fs.readFile(new URL('../../turn/tracks/catalog.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/tracks/registry.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/tracks/track-manager.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/tracks/midnight-city-world-r6.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/tracks/midnight-city-world-r7.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/m8-home.js', import.meta.url), 'utf8')
 ]);
 
@@ -132,20 +132,20 @@ assert.match(definitions, /sampleCount: 1080/);
 assert.match(definitions, /fogNear: 250[\s\S]*fogFar: 880/);
 assert.match(definitions, /id: 'track-6-tba'[\s\S]*locked: true/);
 assert.match(catalog, /MIDNIGHT_CITY_CONTROL_POINTS\.map/);
-assert.match(registry, /midnight-city-world-r6\.js\?build=20260801-r6/);
+assert.match(registry, /midnight-city-world-r7\.js\?build=20260801-r7/);
 assert.match(registry, /definition\.sampleCount \|\| sampleCount/);
 assert.doesNotMatch(manager, /nextTrackId === 'midnight-city'/, 'The generic track manager must not gain a Midnight City special case');
 assert.match(manager, /lighting\.hemisphereIntensity \?\? 2\.7/);
 assert.match(manager, /track\.fogNear/);
-assert.match(world, /installMidnightCityWorld as installMidnightCityWorldR5/);
-assert.match(world, /installTracksideCommons/);
-assert.match(world, /TURN Commons road-facing promenade/);
-assert.match(world, /TURN Commons reflecting pond/);
-assert.match(world, /TURN Commons illuminated footbridge/);
-assert.match(world, /Midnight City showcase fountain fallback/);
-assert.match(world, /redirectAsyncFountainAsset/);
+assert.match(world, /installMidnightCityWorld as installMidnightCityWorldR6/);
+assert.match(world, /installReadableSignBacks/);
+assert.match(world, /reverse\.rotation\.y = Math\.PI/);
+assert.match(world, /label: 'VIOLET GARDENS'[\s\S]*x: -590[\s\S]*z: -125/);
+assert.match(world, /label: 'SUNRISE PARK'[\s\S]*x: 570[\s\S]*z: 145/);
+assert.match(world, /relocateSecondaryParks/);
+assert.match(world, /track-facing entrance/);
+assert.match(world, /rebuildParkTrees/);
 assert.match(world, /new THREE\.InstancedMesh/);
-assert.match(world, /new THREE\.CanvasTexture/);
 assert.match(world, /noDynamicLightsAdded: true/);
 assert.doesNotMatch(world, /setAnimationLoop|requestAnimationFrame|setInterval/, 'Static city scenery must not add an independent loop');
 assert.match(home, /TRACK_SELECTION_CATALOG\.map\(renderTrackCard\)/, 'Home must render the playable city and TBA teaser from the shared catalog');

--- a/turn-next/m8-home-card-scroll-fixes.css
+++ b/turn-next/m8-home-card-scroll-fixes.css
@@ -85,7 +85,7 @@
 
 .m8-home-card-scroll-fixes .m8-track-rail .track-card {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(112px, 43%);
+  grid-template-columns: minmax(0, 1fr) minmax(108px, 39%);
   grid-template-rows: auto auto minmax(0, 1fr);
   align-items: start;
   gap: 5px clamp(8px, 1vw, 13px);
@@ -101,7 +101,7 @@
   grid-row: 1;
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
-  align-items: center;
+  align-items: start;
   gap: 8px;
   min-width: 0;
   align-self: start;
@@ -109,15 +109,21 @@
 
 .m8-home-card-scroll-fixes .m8-track-rail .track-card-choice-marker {
   flex: 0 0 auto;
+  margin-top: 1px;
 }
 
 .m8-home-card-scroll-fixes .m8-track-rail .track-card-name {
   min-width: 0;
-  overflow: hidden;
-  font-size: clamp(1rem, 2vw, 1.72rem);
-  line-height: 1;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  max-width: 100%;
+  overflow: visible;
+  font-size: clamp(0.88rem, 1.55vw, 1.38rem);
+  line-height: 0.9;
+  letter-spacing: -0.045em;
+  text-overflow: clip;
+  white-space: normal;
+  overflow-wrap: normal;
+  word-break: normal;
+  hyphens: none;
 }
 
 .m8-home-card-scroll-fixes .m8-track-rail .track-card-difficulty {
@@ -215,13 +221,14 @@
   }
 
   .m8-home-card-scroll-fixes .m8-track-rail .track-card {
-    grid-template-columns: minmax(0, 1fr) minmax(98px, 42%);
+    grid-template-columns: minmax(0, 1fr) minmax(94px, 38%);
     grid-template-rows: auto auto minmax(0, 1fr);
     gap: 3px 8px;
   }
 
   .m8-home-card-scroll-fixes .m8-track-rail .track-card-name {
-    font-size: clamp(0.92rem, 1.85vw, 1.25rem);
+    font-size: clamp(0.8rem, 1.42vw, 1.08rem);
+    line-height: 0.88;
   }
 
   .m8-home-card-scroll-fixes .m8-track-rail .track-card-preview {
@@ -244,7 +251,7 @@
   }
 
   .m8-home-card-scroll-fixes .m8-track-rail .track-card {
-    grid-template-columns: minmax(0, 1fr) minmax(108px, 40%);
+    grid-template-columns: minmax(0, 1fr) minmax(104px, 38%);
   }
 }
 

--- a/turn-next/m8-home-card-scroll-fixes.js
+++ b/turn-next/m8-home-card-scroll-fixes.js
@@ -1,12 +1,12 @@
 const STYLE_ATTRIBUTE = 'data-turn-m8-card-scroll-fixes';
-const FIX_ID = 'native-scroll-v1';
+const FIX_ID = 'native-scroll-full-track-names-v3';
 
 function installStylesheet() {
   if (document.querySelector(`link[${STYLE_ATTRIBUTE}]`)) return;
   const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
   const stylesheet = document.createElement('link');
   stylesheet.rel = 'stylesheet';
-  stylesheet.href = `/turn-next/m8-home-card-scroll-fixes.css?source=${buildKey}-m8.4`;
+  stylesheet.href = `/turn-next/m8-home-card-scroll-fixes.css?source=${buildKey}-m8.8-full-track-names`;
   stylesheet.setAttribute(STYLE_ATTRIBUTE, '');
   document.head.appendChild(stylesheet);
 }

--- a/turn-next/m8-home-fixed-layout.js
+++ b/turn-next/m8-home-fixed-layout.js
@@ -97,7 +97,7 @@ export async function installM8HomeFixedLayout() {
 
   const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
   const { installM8HomeCardScrollFixes } = await import(
-    `/turn-next/m8-home-card-scroll-fixes.js?source=${buildKey}-m8.4`
+    `/turn-next/m8-home-card-scroll-fixes.js?source=${buildKey}-m8.8-full-track-names`
   );
   const cardScrollFixes = await installM8HomeCardScrollFixes();
 

--- a/turn-tests/home-navigation-production.mjs
+++ b/turn-tests/home-navigation-production.mjs
@@ -85,7 +85,7 @@ assert.match(fixedLayoutSource, /oldScrollButtons\.hidden = true/);
 assert.match(fixedLayoutSource, /raceButton\.textContent = 'RACE'/);
 assert.match(fixedLayoutSource, /Race on \$\{spokenTrackName\(selectedTrackName\)\}/);
 assert.match(fixedLayoutSource, /new MutationObserver\(syncRaceLabel\)/);
-assert.match(fixedLayoutSource, /\/turn\/m8-home-card-scroll-fixes\.js\?build=\$\{buildKey\}-m8\.7-divider/);
+assert.match(fixedLayoutSource, /\/turn\/m8-home-card-scroll-fixes\.js\?build=\$\{buildKey\}-m8\.8-full-track-names/);
 assert.match(fixedLayoutSource, /installM8HomeCardScrollFixes\(\)/);
 assert.match(fixedLayoutSource, /turnHomeLayout = LAYOUT_ID/);
 
@@ -109,8 +109,8 @@ assert.match(fixedLayoutCss, /@media \(max-height: 560px\) and \(orientation: la
 assert.match(fixedLayoutCss, /@media \(max-width: 760px\) and \(orientation: portrait\)[\s\S]*\.m8-home-fixed-layout \.m8-home-head[\s\S]*padding: 0 12px 0 0/);
 assert.match(fixedLayoutCss, /prefers-reduced-motion/);
 
-assert.match(cardScrollSource, /const FIX_ID = 'native-scroll-divider-v2'/);
-assert.match(cardScrollSource, /m8-home-card-scroll-fixes\.css\?build=\$\{buildKey\}-m8\.7-divider/);
+assert.match(cardScrollSource, /const FIX_ID = 'native-scroll-full-track-names-v3'/);
+assert.match(cardScrollSource, /m8-home-card-scroll-fixes\.css\?build=\$\{buildKey\}-m8\.8-full-track-names/);
 assert.match(cardScrollSource, /m8-track-scroll-indicator/);
 assert.match(cardScrollSource, /ResizeObserver/);
 assert.match(cardScrollSource, /rail\.style\.scrollSnapType = 'none'/);
@@ -133,6 +133,9 @@ assert.match(cardScrollCss, /\.track-card-difficulty[\s\S]*grid-row: 2/);
 assert.match(cardScrollCss, /\.track-card-preview[\s\S]*grid-row: 1 \/ 3/);
 assert.match(cardScrollCss, /\.track-card-best[\s\S]*grid-row: 3/);
 assert.match(cardScrollCss, /\.track-card-best-model[\s\S]*justify-self: end/);
+assert.match(cardScrollCss, /grid-template-columns: minmax\(0, 1fr\) minmax\(108px, 39%\)/);
+assert.match(cardScrollCss, /\.track-card-name[\s\S]*text-overflow: clip[\s\S]*white-space: normal/);
+assert.doesNotMatch(cardScrollCss, /\.track-card-name[\s\S]{0,240}text-overflow: ellipsis/);
 
 assert.match(orientationGuardCss, /#intro[\s\S]*display: none !important/);
 assert.match(orientationGuardCss, /\.m8-home-fixed-layout \.m8-home-head[\s\S]*padding-top: 0/);
@@ -147,4 +150,4 @@ assert.match(orchestrator, /function leaveRace\(\)/);
 assert.match(orchestrator, /publish\('home-open'\)/);
 assert.match(orchestrator, /phase = 'home'/);
 
-console.log('TURN production M8 Home, native scrollbar divider, flush logo and NEXT wrapper contracts passed.');
+console.log('TURN production M8 Home, complete track names, native scrollbar divider and NEXT wrapper contracts passed.');

--- a/turn-tests/home-navigation-production.mjs
+++ b/turn-tests/home-navigation-production.mjs
@@ -32,7 +32,7 @@ const [
 assert.match(productionApp, /installM8HomeNavigation/);
 assert.match(productionApp, /installM8HomeFixedLayout/);
 assert.match(productionApp, /installStylesheet\('\.\/m8-home\.css'/);
-assert.match(productionApp, /m8-home-fixed-layout\.js\?revision=m8\.7-home-polish/);
+assert.match(productionApp, /m8-home-fixed-layout\.js\?revision=m8\.8-full-track-names/);
 assert.ok(productionApp.indexOf('installM8HomeNavigation()') < productionApp.indexOf('installM8HomeFixedLayout()'));
 assert.match(productionApp, /turnHomeLifecycle = 'home-m8'/);
 assert.match(productionApp, /retireLegacyStartPanel\(\)/);

--- a/turn-tests/midnight-city-lighting-production.mjs
+++ b/turn-tests/midnight-city-lighting-production.mjs
@@ -1,11 +1,19 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [claritySource, districtSource, cityLifeSource, showcaseSource, registrySource] = await Promise.all([
+const [
+  claritySource,
+  districtSource,
+  cityLifeSource,
+  showcaseSource,
+  signParkSource,
+  registrySource
+] = await Promise.all([
   fs.readFile(new URL('../turn/tracks/midnight-city-world-r3.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/tracks/midnight-city-world-r4.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/tracks/midnight-city-world-r5.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/tracks/midnight-city-world-r6.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/tracks/midnight-city-world-r7.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/tracks/registry.js', import.meta.url), 'utf8')
 ]);
 
@@ -77,8 +85,30 @@ assert.doesNotMatch(
 assert.doesNotMatch(showcaseSource, /new THREE\.PointLight|new THREE\.SpotLight/);
 assert.doesNotMatch(showcaseSource, /GLTFLoader|fetch\(/, 'The showcase must reuse the already pinned r5 asset loader');
 
-assert.match(registrySource, /midnight-city-world-r6\.js\?build=20260801-r6/);
+assert.match(signParkSource, /installMidnightCityWorld as installMidnightCityWorldR6/);
+assert.match(signParkSource, /installReadableSignBacks\(world\)/);
+assert.match(signParkSource, /node\.name\?\.startsWith\('Midnight City neon sign '\)/);
+assert.match(signParkSource, /node\.name\?\.startsWith\('Midnight City district sign '\)/);
+assert.match(signParkSource, /node\.name === 'Midnight City showcase park title TURN COMMONS'/);
+assert.match(signParkSource, /material\.side = THREE\.FrontSide/);
+assert.match(signParkSource, /reverse\.rotation\.y = Math\.PI/);
+assert.match(signParkSource, /signTechnique: 'separate front-facing planes on each side, never mirrored DoubleSide text'/);
+assert.match(signParkSource, /label: 'VIOLET GARDENS'[\s\S]*x: -590[\s\S]*z: -125/);
+assert.match(signParkSource, /label: 'SUNRISE PARK'[\s\S]*x: 570[\s\S]*z: 145/);
+assert.match(signParkSource, /relocateSecondaryParks\(world\)/);
+assert.match(signParkSource, /Midnight City \$\{park\.label\} track-facing entrance/);
+assert.match(signParkSource, /rebuildParkTrees\(world\)/);
+assert.match(signParkSource, /Midnight City trackside park tree trunks r7/);
+assert.match(signParkSource, /noDynamicLightsAdded: true/);
+assert.doesNotMatch(
+  signParkSource,
+  /requestAnimationFrame|setAnimationLoop|setInterval|setTimeout/,
+  'Readable signs and trackside parks must remain static'
+);
+assert.doesNotMatch(signParkSource, /new THREE\.PointLight|new THREE\.SpotLight|GLTFLoader|fetch\(/);
+
+assert.match(registrySource, /midnight-city-world-r7\.js\?build=20260801-r7/);
 assert.match(registrySource, /'midnight-city'\(\{ scene, samples, trackWidth, runtime \}\)/);
 assert.match(registrySource, /installMidnightCityWorld\(\{ scene, samples, trackWidth, runtime \}\)/);
 
-console.log('TURN Commons trackside fountain, promenade, reflecting pond, bridge and framed park passed.');
+console.log('TURN Midnight City readable signs, trackside parks and fountain showcase passed.');

--- a/turn/app.js
+++ b/turn/app.js
@@ -173,9 +173,7 @@ if (buildLabel) {
   buildLabel.textContent = `TURN V${release?.version || ''} · BUILD ${(release?.id || '').toUpperCase()}`;
 }
 const { installM8HomeFixedLayout } = await import(
-  withBuild('./m8-home-fixed-layout.js?revision=m8.7-home-polish')
+  withBuild('./m8-home-fixed-layout.js?revision=m8.8-full-track-names')
 );
 await installM8HomeFixedLayout();
 document.documentElement.dataset.turnHomeLifecycle = 'home-m8';
-
-console.info(`TURN: ${globalThis.__TURN_BUILD__?.id || 'development'} loaded with the promoted M5–M8 runtime.`);

--- a/turn/m8-home-card-scroll-fixes.css
+++ b/turn/m8-home-card-scroll-fixes.css
@@ -85,7 +85,7 @@
 
 .m8-home-card-scroll-fixes .m8-track-rail .track-card {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(112px, 43%);
+  grid-template-columns: minmax(0, 1fr) minmax(108px, 39%);
   grid-template-rows: auto auto minmax(0, 1fr);
   align-items: start;
   gap: 5px clamp(8px, 1vw, 13px);
@@ -101,7 +101,7 @@
   grid-row: 1;
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
-  align-items: center;
+  align-items: start;
   gap: 8px;
   min-width: 0;
   align-self: start;
@@ -109,15 +109,21 @@
 
 .m8-home-card-scroll-fixes .m8-track-rail .track-card-choice-marker {
   flex: 0 0 auto;
+  margin-top: 1px;
 }
 
 .m8-home-card-scroll-fixes .m8-track-rail .track-card-name {
   min-width: 0;
-  overflow: hidden;
-  font-size: clamp(1rem, 2vw, 1.72rem);
-  line-height: 1;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  max-width: 100%;
+  overflow: visible;
+  font-size: clamp(0.88rem, 1.55vw, 1.38rem);
+  line-height: 0.9;
+  letter-spacing: -0.045em;
+  text-overflow: clip;
+  white-space: normal;
+  overflow-wrap: normal;
+  word-break: normal;
+  hyphens: none;
 }
 
 .m8-home-card-scroll-fixes .m8-track-rail .track-card-difficulty {
@@ -215,13 +221,14 @@
   }
 
   .m8-home-card-scroll-fixes .m8-track-rail .track-card {
-    grid-template-columns: minmax(0, 1fr) minmax(98px, 42%);
+    grid-template-columns: minmax(0, 1fr) minmax(94px, 38%);
     grid-template-rows: auto auto minmax(0, 1fr);
     gap: 3px 8px;
   }
 
   .m8-home-card-scroll-fixes .m8-track-rail .track-card-name {
-    font-size: clamp(0.92rem, 1.85vw, 1.25rem);
+    font-size: clamp(0.8rem, 1.42vw, 1.08rem);
+    line-height: 0.88;
   }
 
   .m8-home-card-scroll-fixes .m8-track-rail .track-card-preview {
@@ -244,7 +251,7 @@
   }
 
   .m8-home-card-scroll-fixes .m8-track-rail .track-card {
-    grid-template-columns: minmax(0, 1fr) minmax(108px, 40%);
+    grid-template-columns: minmax(0, 1fr) minmax(104px, 38%);
   }
 }
 

--- a/turn/m8-home-card-scroll-fixes.js
+++ b/turn/m8-home-card-scroll-fixes.js
@@ -1,12 +1,12 @@
 const STYLE_ATTRIBUTE = 'data-turn-m8-card-scroll-fixes';
-const FIX_ID = 'native-scroll-divider-v2';
+const FIX_ID = 'native-scroll-full-track-names-v3';
 
 function installStylesheet() {
   if (document.querySelector(`link[${STYLE_ATTRIBUTE}]`)) return;
   const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
   const stylesheet = document.createElement('link');
   stylesheet.rel = 'stylesheet';
-  stylesheet.href = `/turn/m8-home-card-scroll-fixes.css?build=${buildKey}-m8.7-divider`;
+  stylesheet.href = `/turn/m8-home-card-scroll-fixes.css?build=${buildKey}-m8.8-full-track-names`;
   stylesheet.setAttribute(STYLE_ATTRIBUTE, '');
   document.head.appendChild(stylesheet);
 }

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -97,7 +97,7 @@ export async function installM8HomeFixedLayout() {
 
   const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
   const { installM8HomeCardScrollFixes } = await import(
-    `/turn/m8-home-card-scroll-fixes.js?build=${buildKey}-m8.7-divider`
+    `/turn/m8-home-card-scroll-fixes.js?build=${buildKey}-m8.8-full-track-names`
   );
   const cardScrollFixes = await installM8HomeCardScrollFixes();
 

--- a/turn/tracks/midnight-city-world-r7.js
+++ b/turn/tracks/midnight-city-world-r7.js
@@ -1,0 +1,273 @@
+import * as THREE from 'three';
+import { installMidnightCityWorld as installMidnightCityWorldR6 } from './midnight-city-world-r6.js?base=20260801-r6';
+
+const TRACK_Y = 0.16;
+const COMMONS_CENTER = Object.freeze({ x: 80, z: 75 });
+const COLORS = Object.freeze({
+  trunk: 0x4b3024,
+  foliage: 0x174f40,
+  cyan: 0x5de4ff,
+  violet: 0x9d7cff,
+  yellow: 0xffdc68,
+  path: 0x343d49,
+  pathTrim: 0xb8f7ff
+});
+
+const SECONDARY_PARKS = Object.freeze([
+  Object.freeze({
+    label: 'VIOLET GARDENS',
+    x: -590,
+    z: -125,
+    radius: 42,
+    color: COLORS.violet,
+    roadSide: 1
+  }),
+  Object.freeze({
+    label: 'SUNRISE PARK',
+    x: 570,
+    z: 145,
+    radius: 44,
+    color: COLORS.yellow,
+    roadSide: -1
+  })
+]);
+
+export function installMidnightCityWorld(options) {
+  const world = installMidnightCityWorldR6(options);
+
+  const readableSigns = installReadableSignBacks(world);
+  const relocatedParks = relocateSecondaryParks(world);
+  const treeResult = rebuildParkTrees(world);
+
+  world.name = 'TURN Midnight City r7';
+  world.userData.turnMidnightCityArtDirection = Object.freeze({
+    ...(world.userData.turnMidnightCityArtDirection || {}),
+    version: 'r7',
+    readableTwoSidedSigns: readableSigns,
+    signTechnique: 'separate front-facing planes on each side, never mirrored DoubleSide text',
+    secondaryParkLocations: Object.freeze(SECONDARY_PARKS.map(({ label, x, z }) => Object.freeze({ label, x, z }))),
+    secondaryParksRelocatedTrackside: relocatedParks,
+    secondaryParkApproaches: relocatedParks,
+    rebuiltParkTreeCount: treeResult.treeCount,
+    noDynamicLightsAdded: true,
+    noIndependentAnimationLoop: true
+  });
+
+  return world;
+}
+
+function installReadableSignBacks(world) {
+  const signs = [];
+  world.traverse((node) => {
+    if (!node.isMesh || !node.material || node.userData.turnReadableSignBack) return;
+    const isCitySign =
+      node.name?.startsWith('Midnight City neon sign ') ||
+      node.name?.startsWith('Midnight City district sign ') ||
+      node.name === 'Midnight City showcase park title TURN COMMONS';
+    const materials = Array.isArray(node.material) ? node.material : [node.material];
+    if (isCitySign && materials.some((material) => material?.map)) signs.push(node);
+  });
+
+  for (const sign of signs) {
+    const materials = Array.isArray(sign.material) ? sign.material : [sign.material];
+    for (const material of materials) {
+      material.side = THREE.FrontSide;
+      material.needsUpdate = true;
+    }
+
+    const reverseMaterials = materials.map((material) => {
+      const clone = material.clone();
+      clone.side = THREE.FrontSide;
+      clone.needsUpdate = true;
+      return clone;
+    });
+    const reverse = new THREE.Mesh(
+      sign.geometry,
+      Array.isArray(sign.material) ? reverseMaterials : reverseMaterials[0]
+    );
+    reverse.name = `${sign.name} readable reverse`;
+    reverse.position.z = -0.012;
+    reverse.rotation.y = Math.PI;
+    reverse.renderOrder = sign.renderOrder;
+    reverse.frustumCulled = sign.frustumCulled;
+    reverse.userData.turnReadableSignBack = true;
+    sign.add(reverse);
+    sign.userData.turnReadableSignPair = true;
+  }
+
+  return signs.length;
+}
+
+function relocateSecondaryParks(world) {
+  let relocated = 0;
+  for (const park of SECONDARY_PARKS) {
+    const group = world.getObjectByName(`Midnight City park ${park.label}`);
+    if (!group) continue;
+    group.position.set(park.x, group.position.y, park.z);
+    group.name = `Midnight City trackside park ${park.label}`;
+    addParkApproach(group, park);
+    relocated += 1;
+  }
+  return relocated;
+}
+
+function addParkApproach(group, park) {
+  const approach = new THREE.Group();
+  approach.name = `Midnight City ${park.label} track-facing entrance`;
+
+  const path = new THREE.Mesh(
+    new THREE.PlaneGeometry(park.radius * 0.72, 8.5),
+    new THREE.MeshBasicMaterial({
+      color: COLORS.path,
+      side: THREE.DoubleSide,
+      toneMapped: false
+    })
+  );
+  path.rotation.x = -Math.PI / 2;
+  path.position.set(park.roadSide * park.radius * 0.68, TRACK_Y + 0.07, 0);
+  path.name = `${park.label} entrance path`;
+  approach.add(path);
+
+  for (const z of [-4.55, 4.55]) {
+    const trim = new THREE.Mesh(
+      new THREE.PlaneGeometry(park.radius * 0.72, 0.45),
+      new THREE.MeshBasicMaterial({
+        color: park.color,
+        transparent: true,
+        opacity: 0.9,
+        side: THREE.DoubleSide,
+        toneMapped: false
+      })
+    );
+    trim.rotation.x = -Math.PI / 2;
+    trim.position.set(park.roadSide * park.radius * 0.68, TRACK_Y + 0.082, z);
+    approach.add(trim);
+  }
+
+  const gateMaterial = new THREE.MeshBasicMaterial({ color: park.color, toneMapped: false });
+  for (const z of [-5.5, 5.5]) {
+    const gate = new THREE.Mesh(new THREE.BoxGeometry(0.55, 4.6, 0.55), gateMaterial);
+    gate.position.set(park.roadSide * (park.radius + 1.5), TRACK_Y + 2.3, z);
+    approach.add(gate);
+  }
+
+  group.add(approach);
+}
+
+function rebuildParkTrees(world) {
+  const removals = [];
+  world.traverse((node) => {
+    if (
+      node.name === 'Midnight City reframed park tree trunks' ||
+      node.name?.startsWith('Midnight City reframed park crowns ')
+    ) {
+      removals.push(node);
+    }
+  });
+  for (const node of removals) disposeAndRemove(node);
+
+  const trees = [];
+  addCommonsTrees(trees);
+  for (const park of SECONDARY_PARKS) addSecondaryParkTrees(trees, park);
+  installTreeInstances(world, trees);
+  return { removedMeshes: removals.length, treeCount: trees.length };
+}
+
+function addCommonsTrees(trees) {
+  for (let index = 0; index < 23; index += 1) {
+    const angle = (index / 23) * Math.PI * 2;
+    const roadFacingOpening = angle > Math.PI * 1.52 || angle < Math.PI * 0.12;
+    if (roadFacingOpening && index % 2 === 0) continue;
+    const radiusX = 47 + pseudo(index * 11) * 3;
+    const radiusZ = 38 + pseudo(index * 17) * 4;
+    trees.push({
+      x: COMMONS_CENTER.x + Math.cos(angle) * radiusX,
+      z: COMMONS_CENTER.z + Math.sin(angle) * radiusZ,
+      height: 7 + pseudo(index * 29) * 4,
+      color: COLORS.cyan
+    });
+  }
+}
+
+function addSecondaryParkTrees(trees, park) {
+  for (let index = 0; index < 15; index += 1) {
+    const angle = (index / 15) * Math.PI * 2;
+    const facesRoad = park.roadSide > 0
+      ? Math.cos(angle) > 0.72
+      : Math.cos(angle) < -0.72;
+    if (facesRoad && index % 2 === 0) continue;
+    const radius = park.radius * (0.74 + pseudo(index * 13 + park.x) * 0.14);
+    trees.push({
+      x: park.x + Math.cos(angle) * radius,
+      z: park.z + Math.sin(angle) * radius,
+      height: 5.4 + pseudo(index * 31 + park.z) * 3.5,
+      color: park.color
+    });
+  }
+}
+
+function installTreeInstances(world, trees) {
+  if (!trees.length) return;
+
+  const trunkMesh = new THREE.InstancedMesh(
+    new THREE.CylinderGeometry(0.34, 0.52, 1, 7),
+    new THREE.MeshStandardMaterial({ color: COLORS.trunk, roughness: 1 }),
+    trees.length
+  );
+  trunkMesh.name = 'Midnight City trackside park tree trunks r7';
+
+  const crownGroups = new Map();
+  for (const tree of trees) {
+    if (!crownGroups.has(tree.color)) crownGroups.set(tree.color, []);
+    crownGroups.get(tree.color).push(tree);
+  }
+
+  const marker = new THREE.Object3D();
+  for (let index = 0; index < trees.length; index += 1) {
+    const tree = trees[index];
+    const trunkHeight = tree.height * 0.42;
+    marker.position.set(tree.x, TRACK_Y + trunkHeight / 2, tree.z);
+    marker.scale.set(1, trunkHeight, 1);
+    marker.rotation.set(0, pseudo(index) * Math.PI, 0);
+    marker.updateMatrix();
+    trunkMesh.setMatrixAt(index, marker.matrix);
+  }
+  trunkMesh.instanceMatrix.needsUpdate = true;
+  world.add(trunkMesh);
+
+  for (const [color, entries] of crownGroups) {
+    const materialColor = new THREE.Color(COLORS.foliage).lerp(new THREE.Color(color), 0.18);
+    const crownMesh = new THREE.InstancedMesh(
+      new THREE.ConeGeometry(1, 1, 8),
+      new THREE.MeshStandardMaterial({
+        color: materialColor,
+        roughness: 0.94,
+        metalness: 0
+      }),
+      entries.length
+    );
+    crownMesh.name = `Midnight City trackside park crowns r7 ${color.toString(16)}`;
+    for (let index = 0; index < entries.length; index += 1) {
+      const tree = entries[index];
+      marker.position.set(tree.x, TRACK_Y + tree.height * 0.76, tree.z);
+      marker.scale.set(2.3 + tree.height * 0.2, tree.height * 0.82, 2.3 + tree.height * 0.2);
+      marker.rotation.set(0, pseudo(index + color) * Math.PI, 0);
+      marker.updateMatrix();
+      crownMesh.setMatrixAt(index, marker.matrix);
+    }
+    crownMesh.instanceMatrix.needsUpdate = true;
+    world.add(crownMesh);
+  }
+}
+
+function disposeAndRemove(node) {
+  node.parent?.remove(node);
+  node.geometry?.dispose?.();
+  const materials = Array.isArray(node.material) ? node.material : [node.material];
+  for (const material of materials) material?.dispose?.();
+}
+
+function pseudo(seed) {
+  const value = Math.sin(seed * 12.9898 + 78.233) * 43758.5453;
+  return value - Math.floor(value);
+}

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -8,7 +8,7 @@ import {
 import { installAirportWorld } from './airport-world-r52.js?build=20260722-r52';
 import { installCliffsideWorld } from './cliffside-world.js';
 import { installHarborWorld } from './harbor-world.js';
-import { installMidnightCityWorld } from './midnight-city-world-r6.js?build=20260801-r6';
+import { installMidnightCityWorld } from './midnight-city-world-r7.js?build=20260801-r7';
 import { isForgivingTrackSurface } from './airport-runoff.js?build=20260722-r52';
 
 const WORLD_INSTALLERS = Object.freeze({


### PR DESCRIPTION
## Midnight City signs

The neon signs were rendered with one `DoubleSide` textured plane. That makes the reverse side legible only as mirrored text. This pass converts every lore sign, district sign and TURN Commons title into a proper two-face sign:

- the original surface is front-facing only
- a separate plane faces the reverse direction
- both sides use normally oriented text
- HARBOR, AIRPORT, CLIFFSIDE, TURN AVENUE, DRIFT LANE, district names and TURN COMMONS all use the same treatment

## Parks brought to the road

Violet Gardens and Sunrise Park were both more than 120 world units from the nearest route segment. They now sit immediately outside the western and eastern road boundaries:

- Violet Gardens moves to `(-590, -125)`
- Sunrise Park moves to `(570, 145)`
- both receive a track-facing entrance path, neon trim and entrance pylons
- their tree rings are rebuilt at the new positions while preserving the open road-facing view
- TURN Commons and its fountain showcase remain unchanged

## Full track names

The Home card layout explicitly applied ellipsis and `white-space: nowrap`, so COUNTRYSIDE and MIDNIGHT CITY were intentionally being cropped. The updated responsive card layout:

- removes the ellipsis
- permits natural two-line names
- gives the title column more width
- uses a slightly smaller responsive title size on compact landscape screens
- applies identically to TURN and TURN NEXT

## Performance

All new city work remains static. No dynamic lights, render loop, timer, model request or texture download is introduced. Trees remain instanced and sign backs reuse the existing geometry and texture.