### PR TITLE
Remap Midnight City pace notes to rebuilt route

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -145,6 +145,9 @@ jobs:
       - name: Run all-track auditory pace-note regression
         run: node turn-lab/tests/pace-notes-production.mjs
 
+      - name: Audit Midnight City pace notes against route geometry
+        run: node turn-tests/midnight-city-pace-note-map-production.mjs
+
       - name: Run Drive By Ear preference and shutdown regression
         run: node turn-lab/tests/drive-by-ear-production.mjs
 

--- a/turn-tests/midnight-city-pace-note-map-production.mjs
+++ b/turn-tests/midnight-city-pace-note-map-production.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 
-import { createTrackRuntime } from '../turn/tracks/catalog.js';
+import { MIDNIGHT_CITY_CONTROL_POINTS } from '../turn/tracks/midnight-city-layout.js';
 import {
   PACE_NOTE_DIRECTION,
   getTrackPaceNotes
@@ -29,9 +29,9 @@ assert.deepEqual(
   'Midnight City must preserve the rebuilt route’s R R L L R L R R L R L R sequence'
 );
 
-const runtime = createTrackRuntime('midnight-city', 1080);
+const routeTurns = controlPointTurns(MIDNIGHT_CITY_CONTROL_POINTS);
 for (const note of notes) {
-  const routeDirection = directionFromGeometry(runtime, note.triggerEnd);
+  const routeDirection = directionNearProgress(routeTurns, note.triggerEnd);
   assert.notEqual(routeDirection, 0, `${note.id} must sit before a geometrically identifiable bend`);
   for (const group of note.groups) {
     assert.equal(
@@ -44,15 +44,40 @@ for (const note of notes) {
 
 console.log('TURN Midnight City pace notes match the rebuilt route geometry.');
 
-function directionFromGeometry(runtime, progress) {
-  const lookAround = 0.018;
-  const before = runtime.curve.getTangentAt(wrap(progress - lookAround));
-  const after = runtime.curve.getTangentAt(wrap(progress + lookAround));
-  const signedTurn = before.x * after.z - before.z * after.x;
-  if (Math.abs(signedTurn) < 0.02) return 0;
+function controlPointTurns(points) {
+  const segmentLengths = points.map((point, index) => distance2d(point, points[(index + 1) % points.length]));
+  const totalLength = segmentLengths.reduce((sum, length) => sum + length, 0);
+  let travelled = 0;
+
+  return points.map((point, index) => {
+    const previous = points[(index - 1 + points.length) % points.length];
+    const next = points[(index + 1) % points.length];
+    const incoming = [point[0] - previous[0], point[2] - previous[2]];
+    const outgoing = [next[0] - point[0], next[2] - point[2]];
+    const signedAngle = Math.atan2(
+      incoming[0] * outgoing[1] - incoming[1] * outgoing[0],
+      incoming[0] * outgoing[0] + incoming[1] * outgoing[1]
+    );
+    const turn = { progress: travelled / totalLength, signedAngle };
+    travelled += segmentLengths[index];
+    return turn;
+  });
+}
+
+function directionNearProgress(turns, progress) {
+  const radius = 0.035;
+  const signedTurn = turns
+    .filter((turn) => circularDistance(turn.progress, progress) <= radius)
+    .reduce((sum, turn) => sum + turn.signedAngle, 0);
+  if (Math.abs(signedTurn) < 0.08) return 0;
   return signedTurn > 0 ? PACE_NOTE_DIRECTION.RIGHT : PACE_NOTE_DIRECTION.LEFT;
 }
 
-function wrap(value) {
-  return ((value % 1) + 1) % 1;
+function circularDistance(a, b) {
+  const direct = Math.abs(a - b);
+  return Math.min(direct, 1 - direct);
+}
+
+function distance2d(a, b) {
+  return Math.hypot(b[0] - a[0], b[2] - a[2]);
 }

--- a/turn-tests/midnight-city-pace-note-map-production.mjs
+++ b/turn-tests/midnight-city-pace-note-map-production.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+
+import { createTrackRuntime } from '../turn/tracks/catalog.js';
+import {
+  PACE_NOTE_DIRECTION,
+  getTrackPaceNotes
+} from '../turn/tracks/pace-notes.js';
+
+const notes = getTrackPaceNotes('midnight-city');
+const expectedDirections = [
+  PACE_NOTE_DIRECTION.RIGHT,
+  PACE_NOTE_DIRECTION.RIGHT,
+  PACE_NOTE_DIRECTION.LEFT,
+  PACE_NOTE_DIRECTION.LEFT,
+  PACE_NOTE_DIRECTION.RIGHT,
+  PACE_NOTE_DIRECTION.LEFT,
+  PACE_NOTE_DIRECTION.RIGHT,
+  PACE_NOTE_DIRECTION.RIGHT,
+  PACE_NOTE_DIRECTION.LEFT,
+  PACE_NOTE_DIRECTION.RIGHT,
+  PACE_NOTE_DIRECTION.LEFT,
+  PACE_NOTE_DIRECTION.RIGHT
+];
+
+assert.equal(notes.length, expectedDirections.length, 'Midnight City must keep all twelve authored approach notes');
+assert.deepEqual(
+  notes.map((note) => note.groups[0]?.direction),
+  expectedDirections,
+  'Midnight City must preserve the rebuilt route’s R R L L R L R R L R L R sequence'
+);
+
+const runtime = createTrackRuntime('midnight-city', 1080);
+for (const note of notes) {
+  const routeDirection = directionFromGeometry(runtime, note.triggerEnd);
+  assert.notEqual(routeDirection, 0, `${note.id} must sit before a geometrically identifiable bend`);
+  for (const group of note.groups) {
+    assert.equal(
+      group.direction,
+      routeDirection,
+      `${note.id} must point toward the same side as the current Midnight City geometry`
+    );
+  }
+}
+
+console.log('TURN Midnight City pace notes match the rebuilt route geometry.');
+
+function directionFromGeometry(runtime, progress) {
+  const lookAround = 0.018;
+  const before = runtime.curve.getTangentAt(wrap(progress - lookAround));
+  const after = runtime.curve.getTangentAt(wrap(progress + lookAround));
+  const signedTurn = before.x * after.z - before.z * after.x;
+  if (Math.abs(signedTurn) < 0.02) return 0;
+  return signedTurn > 0 ? PACE_NOTE_DIRECTION.RIGHT : PACE_NOTE_DIRECTION.LEFT;
+}
+
+function wrap(value) {
+  return ((value % 1) + 1) % 1;
+}

--- a/turn/tracks/pace-notes.js
+++ b/turn/tracks/pace-notes.js
@@ -106,47 +106,50 @@ const HARBOR_PACE_NOTES = Object.freeze([
   ])
 ]);
 
+// MIDNIGHT CITY was rebuilt after its first pace-note map. The trigger windows still
+// line up with the new bends, but the old left/right sequence was mirrored. These
+// directions follow the current route geometry in increasing track-progress order.
 const MIDNIGHT_CITY_PACE_NOTES = Object.freeze([
   createPaceNote('midnight-city-1', 0.102, 0.128, [
-    { direction: PACE_NOTE_DIRECTION.LEFT, severity: 2, length: PACE_NOTE_LENGTH.LONG }
+    { direction: PACE_NOTE_DIRECTION.RIGHT, severity: 2, length: PACE_NOTE_LENGTH.LONG }
   ]),
   createPaceNote('midnight-city-2', 0.145, 0.176, [
-    { direction: PACE_NOTE_DIRECTION.LEFT, severity: 3, length: PACE_NOTE_LENGTH.LONG }
+    { direction: PACE_NOTE_DIRECTION.RIGHT, severity: 3, length: PACE_NOTE_LENGTH.LONG }
   ]),
   createPaceNote('midnight-city-3', 0.232, 0.262, [
-    { direction: PACE_NOTE_DIRECTION.RIGHT, severity: 2, length: PACE_NOTE_LENGTH.MEDIUM },
-    { direction: PACE_NOTE_DIRECTION.RIGHT, severity: 3, length: PACE_NOTE_LENGTH.SHORT }
+    { direction: PACE_NOTE_DIRECTION.LEFT, severity: 2, length: PACE_NOTE_LENGTH.MEDIUM },
+    { direction: PACE_NOTE_DIRECTION.LEFT, severity: 3, length: PACE_NOTE_LENGTH.SHORT }
   ]),
   createPaceNote('midnight-city-4', 0.266, 0.292, [
-    { direction: PACE_NOTE_DIRECTION.RIGHT, severity: 3, length: PACE_NOTE_LENGTH.MEDIUM }
+    { direction: PACE_NOTE_DIRECTION.LEFT, severity: 3, length: PACE_NOTE_LENGTH.MEDIUM }
   ]),
   createPaceNote('midnight-city-5', 0.338, 0.372, [
-    { direction: PACE_NOTE_DIRECTION.LEFT, severity: 2, length: PACE_NOTE_LENGTH.MEDIUM },
-    { direction: PACE_NOTE_DIRECTION.LEFT, severity: 3, length: PACE_NOTE_LENGTH.MEDIUM }
-  ]),
-  createPaceNote('midnight-city-6', 0.450, 0.480, [
-    { direction: PACE_NOTE_DIRECTION.RIGHT, severity: 3, length: PACE_NOTE_LENGTH.MEDIUM }
-  ]),
-  createPaceNote('midnight-city-7', 0.490, 0.520, [
-    { direction: PACE_NOTE_DIRECTION.LEFT, severity: 3, length: PACE_NOTE_LENGTH.MEDIUM }
-  ]),
-  createPaceNote('midnight-city-8', 0.622, 0.656, [
-    { direction: PACE_NOTE_DIRECTION.LEFT, severity: 2, length: PACE_NOTE_LENGTH.LONG },
-    { direction: PACE_NOTE_DIRECTION.LEFT, severity: 3, length: PACE_NOTE_LENGTH.MEDIUM }
-  ]),
-  createPaceNote('midnight-city-9', 0.722, 0.754, [
     { direction: PACE_NOTE_DIRECTION.RIGHT, severity: 2, length: PACE_NOTE_LENGTH.MEDIUM },
     { direction: PACE_NOTE_DIRECTION.RIGHT, severity: 3, length: PACE_NOTE_LENGTH.MEDIUM }
   ]),
-  createPaceNote('midnight-city-10', 0.818, 0.852, [
+  createPaceNote('midnight-city-6', 0.450, 0.480, [
+    { direction: PACE_NOTE_DIRECTION.LEFT, severity: 3, length: PACE_NOTE_LENGTH.MEDIUM }
+  ]),
+  createPaceNote('midnight-city-7', 0.490, 0.520, [
+    { direction: PACE_NOTE_DIRECTION.RIGHT, severity: 3, length: PACE_NOTE_LENGTH.MEDIUM }
+  ]),
+  createPaceNote('midnight-city-8', 0.622, 0.656, [
+    { direction: PACE_NOTE_DIRECTION.RIGHT, severity: 2, length: PACE_NOTE_LENGTH.LONG },
+    { direction: PACE_NOTE_DIRECTION.RIGHT, severity: 3, length: PACE_NOTE_LENGTH.MEDIUM }
+  ]),
+  createPaceNote('midnight-city-9', 0.722, 0.754, [
     { direction: PACE_NOTE_DIRECTION.LEFT, severity: 2, length: PACE_NOTE_LENGTH.MEDIUM },
     { direction: PACE_NOTE_DIRECTION.LEFT, severity: 3, length: PACE_NOTE_LENGTH.MEDIUM }
   ]),
-  createPaceNote('midnight-city-11', 0.906, 0.938, [
+  createPaceNote('midnight-city-10', 0.818, 0.852, [
+    { direction: PACE_NOTE_DIRECTION.RIGHT, severity: 2, length: PACE_NOTE_LENGTH.MEDIUM },
     { direction: PACE_NOTE_DIRECTION.RIGHT, severity: 3, length: PACE_NOTE_LENGTH.MEDIUM }
   ]),
+  createPaceNote('midnight-city-11', 0.906, 0.938, [
+    { direction: PACE_NOTE_DIRECTION.LEFT, severity: 3, length: PACE_NOTE_LENGTH.MEDIUM }
+  ]),
   createPaceNote('midnight-city-12', 0.958, 0.982, [
-    { direction: PACE_NOTE_DIRECTION.LEFT, severity: 2, length: PACE_NOTE_LENGTH.MEDIUM }
+    { direction: PACE_NOTE_DIRECTION.RIGHT, severity: 2, length: PACE_NOTE_LENGTH.MEDIUM }
   ])
 ]);
 


### PR DESCRIPTION
## Finding

The current Midnight City trigger windows still align with the rebuilt course, but every authored left/right direction is mirrored. The original reshape commit moved the windows without adding Midnight City to the protected all-track map regression, so the bad direction sequence survived.

## Fix

- flips the twelve Midnight City note directions to the current route sequence: `R R L L R L R R L R L R`
- preserves the existing trigger windows, severities and corner-length phrasing
- adds a dedicated geometry-backed regression that samples the current Catmull-Rom route around each note and verifies that the authored side matches the actual bend
- adds that audit to the TURN regression workflow

## Authoring process

Future route edits no longer rely only on a hand-drawn map or remembered sequence. The route geometry provides an automatic left/right audit. A hand-marked or play-tested map remains useful for the subjective layer: deciding severity, length, linked phrases and exactly how early each warning should arrive.