### PR TITLE
Fix Midnight City pace-note timing across its full lap

### DIFF
--- a/turn-tests/midnight-city-pace-note-map-production.mjs
+++ b/turn-tests/midnight-city-pace-note-map-production.mjs
@@ -1,10 +1,16 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
 
 import { MIDNIGHT_CITY_CONTROL_POINTS } from '../turn/tracks/midnight-city-layout.js';
 import {
   PACE_NOTE_DIRECTION,
-  getTrackPaceNotes
+  getTrackPaceNotes,
+  speedAdjustedPaceNoteTrigger
 } from '../turn/tracks/pace-notes.js';
+import {
+  resetPaceNotePassage,
+  updatePaceNoteState
+} from '../turn/audio/pace-notes.js';
 
 const notes = getTrackPaceNotes('midnight-city');
 const expectedDirections = [
@@ -42,7 +48,55 @@ for (const note of notes) {
   }
 }
 
-console.log('TURN Midnight City pace notes match the rebuilt route geometry.');
+const [gameStateSource, physicsSource, paceAudioSource] = await Promise.all([
+  fs.readFile(new URL('../turn/race/game-state.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/vehicle/physics.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/audio/pace-notes.js', import.meta.url), 'utf8')
+]);
+assert.match(gameStateSource, /state\.trackSampleCount = samples\.length/);
+assert.match(physicsSource, /activeTrackSampleCount = positiveNumber\(state\.trackSampleCount, trackSampleCount\)/);
+assert.match(physicsSource, /state\.progress = nearestAfter\.index \/ activeTrackSampleCount/);
+assert.match(paceAudioSource, /const progress = normalizeProgress\(index \/ sampleCount\)/);
+assert.doesNotMatch(
+  paceAudioSource,
+  /Number\.isFinite\(Number\(state\.progress\)\) \? Number\(state\.progress\)/,
+  'Pace-note timing must not trust a progress value normalized with another track’s sample count'
+);
+
+const sampleCount = 1080;
+const speed = 35;
+const firstTrigger = speedAdjustedPaceNoteTrigger(notes[0], speed, 88) + 0.001;
+const nearestTrackIndex = Math.ceil(firstTrigger * sampleCount);
+const physicalProgress = nearestTrackIndex / sampleCount;
+const staleLegacyProgress = nearestTrackIndex / 720;
+const samples = Array.from({ length: sampleCount }, () => ({
+  tangent: { x: 0, z: 1 }
+}));
+const runtime = {
+  trackId: 'midnight-city',
+  maxSpeed: 88,
+  samples,
+  state: {
+    trackId: 'midnight-city',
+    running: true,
+    mode: 'racing',
+    lap: 1,
+    nearestTrackIndex,
+    progress: staleLegacyProgress,
+    speed,
+    velocity: { x: 0, z: speed }
+  }
+};
+
+assert.ok(staleLegacyProgress > physicalProgress * 1.49, 'The video regression must reproduce the old 1080/720 timing distortion');
+resetPaceNotePassage();
+assert.equal(
+  updatePaceNoteState(runtime, { active: true })?.id,
+  'midnight-city-1',
+  'The first note must follow physical 1080-sample progress instead of firing a later note roughly one-third of a lap early'
+);
+
+console.log('TURN Midnight City pace notes match route geometry and physical 1080-sample timing.');
 
 function controlPointTurns(points) {
   const segmentLengths = points.map((point, index) => distance2d(point, points[(index + 1) % points.length]));

--- a/turn/audio/pace-notes.js
+++ b/turn/audio/pace-notes.js
@@ -76,9 +76,10 @@ export function updatePaceNoteState(runtime, frame = {}) {
   const sampleCount = samples.length;
   const index = normalizeIndex(state.nearestTrackIndex, sampleCount);
   const sample = samples[index];
-  const progress = normalizeProgress(
-    Number.isFinite(Number(state.progress)) ? Number(state.progress) : index / sampleCount
-  );
+  // The nearest physical sample is the source of truth. Some tracks deliberately use
+  // more samples than TURN's original 720-point course, so a stale generic progress
+  // denominator must never move their pace notes earlier or make them disappear.
+  const progress = normalizeProgress(index / sampleCount);
   const previousProgress = lastProgress;
   lastProgress = progress;
 

--- a/turn/race/game-state.js
+++ b/turn/race/game-state.js
@@ -62,6 +62,7 @@ export function resetRaceToStage({
   state.heading = Math.atan2(start.tangent.x, start.tangent.z);
   state.speed = 0;
   state.driftAmount = 0;
+  state.trackSampleCount = samples.length;
   state.progress = startIndex / samples.length;
   state.lastProgress = state.progress;
   state.nearestTrackIndex = startIndex;

--- a/turn/vehicle/physics.js
+++ b/turn/vehicle/physics.js
@@ -52,6 +52,7 @@ export function updateVehiclePhysicsState({
   const tuningBoostPowerMultiplier = positiveNumber(tuning?.boostPowerMultiplier, 1);
   const tuningBoostSpeedMultiplier = positiveNumber(tuning?.boostSpeedMultiplier, 1.32);
   const effectiveMaxSpeed = maxSpeed;
+  const activeTrackSampleCount = positiveNumber(state.trackSampleCount, trackSampleCount);
   const directGas = Math.max(0, Number(analogGas) || 0);
   const directBrake = 0;
   state.throttle = Math.max(directGas, state.touchGas ? 1 : 0);
@@ -205,7 +206,7 @@ export function updateVehiclePhysicsState({
   state.trackDistance = nearestAfter.distance;
   state.offRoad = nearestAfter.distance > trackWidth * 0.58 && !isForgivingSurface(state.position);
   state.lastProgress = state.progress;
-  state.progress = nearestAfter.index / trackSampleCount;
+  state.progress = nearestAfter.index / activeTrackSampleCount;
   state.nearestTrackIndex = nearestAfter.index;
   state.speed = state.velocity.length();
 


### PR DESCRIPTION
## Full-lap review

I isolated the short high-pitched stereo phrases in the supplied 68.950-second lap and matched them to the minimap position.

The first two phrases occurred before the lap timer started and were steering-limit UI cues, not pace notes. During the timed lap, TURN delivered only ten of Midnight City's twelve authored phrases. They appeared at approximately 6.7%, 9.6%, 15.5%, 17.6%, 22.8%, 41.2%, 48.1%, 54.5%, 60.3% and 64.3% of the physical lap. The final phrase therefore played around 43.7 seconds, leaving roughly the last 25 seconds without pace notes.

Each played position was almost exactly two-thirds of its authored trigger value. That exposed the underlying mismatch: Midnight City has 1,080 physical track samples, while the inherited runtime progress value was still being divided by TURN's original 720-sample constant. The result was a 1.5× progress clock that moved notes substantially too early, skipped two middle phrases and exhausted the map long before the finish.

## Fix

- race reset records the active course's actual sample count in state
- vehicle progress uses that active count instead of the inherited 720 fallback
- pace-note detection now derives progress directly from `nearestTrackIndex / samples.length`, making physical track geometry the final source of truth
- the corrected R/R/L/L/R/L/R/R/L/R/L/R direction map remains unchanged

## Regression

The Midnight City audit now reproduces the old 1,080/720 distortion deliberately and verifies that the first physical trigger still emits `midnight-city-1`, rather than jumping ahead to a later note. It also protects the active sample-count state and physics normalization at source.

No sound design, severity, length phrasing or authored trigger windows are changed in this PR. This repairs where those existing notes play. A subsequent test lap can evaluate the subjective lead time once they are finally attached to the correct places.