### PR TITLE
Encode long curves by holding the final pace-note beep

### DIFF
--- a/turn-lab/tests/pace-notes-production.mjs
+++ b/turn-lab/tests/pace-notes-production.mjs
@@ -7,7 +7,6 @@ import {
 } from '../../turn/tracks/pace-notes.js';
 import {
   paceNoteDuration,
-  paceNoteLengthTailCount,
   paceNotePhraseGroups,
   progressCrossedForward,
   progressInRange,
@@ -91,20 +90,38 @@ for (const trackId of ['countryside', 'cliffside', 'harbor']) {
   );
 }
 
-assert.equal(paceNoteLengthTailCount(PACE_NOTE_LENGTH.MEDIUM), 0, 'The baseline medium phrase must stay clean');
-assert.equal(paceNoteLengthTailCount(PACE_NOTE_LENGTH.LONG), 1, 'A long authored corner must add exactly one sparse tail');
-const longPhrase = paceNotePhraseGroups(airportNotes[1].groups);
-assert.equal(longPhrase.length, 2);
-assert.deepEqual(
-  longPhrase.map((group) => [group.direction, group.severity, group.lengthMarker === true]),
-  [[1, 1, false], [1, 1, true]],
-  'The long-corner marker must be a delayed same-pitch echo on the same side'
+const regularTightPhrase = paceNotePhraseGroups([{ direction: 1, severity: 3 }]);
+const longTightPhrase = paceNotePhraseGroups([{ direction: 1, severity: 3, length: PACE_NOTE_LENGTH.LONG }]);
+assert.equal(regularTightPhrase.length, 1, 'A regular tight curve must remain one three-beep group');
+assert.equal(longTightPhrase.length, 1, 'A long tight curve must not gain a fourth beep');
+assert.equal(regularTightPhrase[0].finalBeepDurationSeconds, 0.055);
+assert.equal(longTightPhrase[0].finalBeepDurationSeconds, 0.17, 'A long curve must hold its existing final beep');
+assert.equal('lengthMarker' in longTightPhrase[0], false, 'The retired extra-tail marker must not return');
+assert.ok(
+  paceNoteDuration(longTightPhrase) > paceNoteDuration(regularTightPhrase),
+  'bip-bip-beep must last longer than bip-bip-bip without changing beep count'
 );
+
+const longMediumPhrase = paceNotePhraseGroups([{
+  direction: -1,
+  severity: 2,
+  length: PACE_NOTE_LENGTH.LONG
+}]);
+assert.deepEqual(
+  longMediumPhrase.map((group) => [group.direction, group.severity, group.finalBeepDurationSeconds]),
+  [[-1, 2, 0.17]],
+  'A long medium curve must encode bip-beep as one two-beep group'
+);
+
 const linkedAirportPhrase = paceNotePhraseGroups(airportNotes[2].groups);
 assert.deepEqual(
-  linkedAirportPhrase.map((group) => [group.direction, group.severity, group.lengthMarker === true]),
-  [[1, 2, false], [1, 1, true], [-1, 3, false]],
-  'A long first corner must carry one tail before the linked direction changes'
+  linkedAirportPhrase.map((group) => [
+    group.direction,
+    group.severity,
+    group.finalBeepDurationSeconds
+  ]),
+  [[1, 2, 0.17], [-1, 3, 0.055]],
+  'A linked phrase must hold only the final beep of the authored long first corner before direction changes'
 );
 assert.ok(paceNoteDuration(airportNotes[2].groups) < 1, 'The longest authored phrase must remain under one second');
 assert.ok(
@@ -229,7 +246,9 @@ assert.match(paceAudio, /now - lastCheckedAt >= PACE_NOTE_UPDATE_INTERVAL_MS/);
 assert.match(paceAudio, /baseAudio\.update\(frame, now\)/, 'Pace-note detection must remain inside the central audio update path');
 assert.match(paceAudio, /progressCrossedForward\(previousProgress, progress, trigger\)/, 'Skipped progress windows must still trigger');
 assert.match(paceAudio, /groups: paceNotePhraseGroups\(note\.groups\)/, 'Authored corner length must be translated before entering playback');
-assert.match(paceAudio, /lengthMarker: true/);
+assert.match(paceAudio, /LONG_NOTE_DURATION_SECONDS = 0\.17/);
+assert.match(paceAudio, /finalBeepDurationSeconds:/);
+assert.doesNotMatch(paceAudio, /lengthMarker|paceNoteLengthTailCount/, 'Long curves must not synthesize an extra beep group');
 assert.match(paceAudio, /firedNoteIds\.size >= notes\.length/, 'A completed pace-note lap must take the fast path');
 assert.match(paceAudio, /turn:pace-note-priority/, 'Production must dispatch into the reliable priority queue');
 assert.doesNotMatch(paceAudio, /state\.offRoad === true/, 'Off-road recovery must not suppress an upcoming corner');
@@ -242,6 +261,11 @@ assert.match(priorityAudio, /context\.addEventListener\?\.\('statechange'/, 'Aut
 assert.match(priorityAudio, /priorityBus\.connect\(masterGain\)/, 'Pace notes must use the shared context while bypassing route and safety muting');
 assert.match(priorityAudio, /panner\.connect\(priorityBus\)/);
 assert.match(priorityAudio, /PACE_NOTE_LEVEL = 0\.084/, 'The critical route phrase must remain prominent in the app mix');
+assert.match(priorityAudio, /PACE_NOTE_LONG_DURATION_SECONDS = 0\.17/);
+assert.match(priorityAudio, /index === severity - 1[\s\S]*paceNoteFinalBeepDuration\(group\)/, 'Only the final regular beep may be lengthened');
+assert.match(priorityAudio, /schedulePaceNoteBeep\(cursor, pan, severity, duration\)/, 'Playback must hold the final beep rather than schedule a tail');
+assert.match(priorityAudio, /const endAt = startAt \+ duration/);
+assert.doesNotMatch(priorityAudio, /lengthMarker/, 'Priority playback must not depend on the retired extra-beep marker');
 assert.doesNotMatch(priorityAudio, /safetyMode|offRoadLatched/, 'Ribbon, recovery and wrong-way state must never veto a queued pace note');
 assert.doesNotMatch(priorityAudio, /new AudioContext|new webkitAudioContext|new Audio\(|fetch\(/, 'Priority playback must reuse TURN’s one AudioContext and generated tones');
 assert.doesNotMatch(priorityAudio, /requestAnimationFrame|setInterval|setTimeout/, 'Reliability must use existing updates and state changes rather than another loop');
@@ -259,4 +283,4 @@ assert.match(audioPanel, /Off road, centred gravel marks the surface/);
 assert.match(audioPanel, /nearby-rival warnings are directional/);
 assert.doesNotMatch(audioPanel, /TURN RIBBON|TURN PULSE|ROAD EDGE|CORNER FLOW|AIRPORT/, 'The audio guide must not resurrect retired or track-specific DBE generations');
 
-console.log(`TURN ${release.id} frame-safe, interruption-resilient priority pace notes passed.`);
+console.log(`TURN ${release.id} final-beep long-curve encoding and priority pace notes passed.`);

--- a/turn/app.js
+++ b/turn/app.js
@@ -89,7 +89,9 @@ if (driveByEarEnabled) {
 
 let paceNotePriority = null;
 if (driveByEarEnabled) {
-  paceNotePriority = await import(withBuild('./audio/pace-note-priority.js'));
+  paceNotePriority = await import(
+    withBuild('./audio/pace-note-priority.js?revision=r123-final-hold')
+  );
   paceNotePriority.preparePaceNotePriorityCapture();
 }
 
@@ -113,7 +115,9 @@ if (driveByEarEnabled) {
   );
   installUniversalDrivingSoundscape();
 
-  const { installPaceNotes } = await import(withBuild('./audio/pace-notes.js'));
+  const { installPaceNotes } = await import(
+    withBuild('./audio/pace-notes.js?revision=r123-final-hold')
+  );
   installPaceNotes();
 
   const { installOffroadEarDirection } = await import(

--- a/turn/audio/pace-note-priority.js
+++ b/turn/audio/pace-note-priority.js
@@ -2,6 +2,7 @@ const PACE_NOTE_EVENT = 'turn:pace-note-priority';
 const PACE_NOTE_SILENCE_EVENT = 'turn:pace-note-silence';
 const PACE_NOTE_LEVEL = 0.084;
 const PACE_NOTE_DURATION_SECONDS = 0.055;
+const PACE_NOTE_LONG_DURATION_SECONDS = 0.17;
 const PACE_NOTE_STEP_SECONDS = 0.105;
 const PACE_NOTE_GROUP_GAP_SECONDS = 0.22;
 const PACE_NOTE_PHRASE_GAP_SECONDS = 0.07;
@@ -190,6 +191,7 @@ function handleContextStateChange() {
 
 function schedulePaceNoteGroups(groups, startAt) {
   let cursor = startAt;
+  let phraseEndAt = startAt;
 
   groups.forEach((group, groupIndex) => {
     const direction = Math.sign(Number(group?.direction) || 0);
@@ -197,7 +199,11 @@ function schedulePaceNoteGroups(groups, startAt) {
     const pan = direction < 0 ? -0.96 : 0.96;
 
     for (let index = 0; index < severity; index += 1) {
-      schedulePaceNoteBeep(cursor, pan, severity);
+      const duration = index === severity - 1
+        ? paceNoteFinalBeepDuration(group)
+        : PACE_NOTE_DURATION_SECONDS;
+      schedulePaceNoteBeep(cursor, pan, severity, duration);
+      phraseEndAt = Math.max(phraseEndAt, cursor + duration);
       cursor += PACE_NOTE_STEP_SECONDS;
     }
 
@@ -206,10 +212,18 @@ function schedulePaceNoteGroups(groups, startAt) {
     }
   });
 
-  return cursor;
+  return Math.max(cursor, phraseEndAt);
 }
 
-function schedulePaceNoteBeep(startAt, pan, severity) {
+function paceNoteFinalBeepDuration(group) {
+  return clamp(
+    Number(group?.finalBeepDurationSeconds) || PACE_NOTE_DURATION_SECONDS,
+    PACE_NOTE_DURATION_SECONDS,
+    PACE_NOTE_LONG_DURATION_SECONDS
+  );
+}
+
+function schedulePaceNoteBeep(startAt, pan, severity, duration = PACE_NOTE_DURATION_SECONDS) {
   const context = CAPTURED_GRAPH.context;
   if (!context || context.state !== 'running' || !priorityBus) {
     throw new Error('Pace-note audio graph is not ready');
@@ -218,7 +232,7 @@ function schedulePaceNoteBeep(startAt, pan, severity) {
   const oscillator = context.createOscillator();
   const gain = context.createGain();
   const panner = createPannerNode(context);
-  const endAt = startAt + PACE_NOTE_DURATION_SECONDS;
+  const endAt = startAt + duration;
   const baseFrequency = 650 + severity * 38;
 
   oscillator.type = 'triangle';

--- a/turn/audio/pace-notes.js
+++ b/turn/audio/pace-notes.js
@@ -7,6 +7,7 @@ const PACE_NOTE_UPDATE_INTERVAL_MS = 1000 / 30;
 const MIN_FORWARD_SPEED = 0.25;
 const MAX_FORWARD_PROGRESS_DELTA = 0.22;
 const NOTE_DURATION_SECONDS = 0.055;
+const LONG_NOTE_DURATION_SECONDS = 0.17;
 const NOTE_STEP_SECONDS = 0.105;
 const GROUP_GAP_SECONDS = 0.22;
 
@@ -141,39 +142,40 @@ export function progressCrossedForward(previousProgress, progress, target) {
   return distanceToTarget > 0 && distanceToTarget <= advance;
 }
 
-export function paceNoteLengthTailCount(length) {
-  return String(length || 'short').toLowerCase() === 'long' ? 1 : 0;
-}
-
 export function paceNotePhraseGroups(groups = []) {
-  const phrase = [];
-
-  for (const group of groups) {
-    phrase.push({ ...group });
-    const tailCount = paceNoteLengthTailCount(group?.length);
-    for (let index = 0; index < tailCount; index += 1) {
-      phrase.push({
-        direction: group?.direction,
-        severity: 1,
-        lengthMarker: true
-      });
-    }
-  }
-
-  return phrase;
+  return groups.map((group) => Object.freeze({
+    ...group,
+    finalBeepDurationSeconds: isLongCorner(group?.length)
+      ? LONG_NOTE_DURATION_SECONDS
+      : NOTE_DURATION_SECONDS
+  }));
 }
 
 export function paceNoteDuration(groups = []) {
   const phrase = paceNotePhraseGroups(groups);
-  let duration = 0;
+  let cursor = 0;
+  let phraseEnd = 0;
 
   phrase.forEach((group, groupIndex) => {
     const count = clamp(Math.round(Number(group?.severity) || 1), 1, 3);
-    duration += NOTE_DURATION_SECONDS + (count - 1) * NOTE_STEP_SECONDS;
-    if (groupIndex < phrase.length - 1) duration += GROUP_GAP_SECONDS;
+    for (let index = 0; index < count; index += 1) {
+      const duration = index === count - 1
+        ? group.finalBeepDurationSeconds
+        : NOTE_DURATION_SECONDS;
+      phraseEnd = Math.max(phraseEnd, cursor + duration);
+      cursor += NOTE_STEP_SECONDS;
+    }
+
+    if (groupIndex < phrase.length - 1) {
+      cursor += GROUP_GAP_SECONDS - NOTE_STEP_SECONDS;
+    }
   });
 
-  return duration;
+  return phraseEnd;
+}
+
+function isLongCorner(length) {
+  return String(length || '').toLowerCase() === 'long';
 }
 
 function installResetListeners() {


### PR DESCRIPTION
## Problem

Long curves were currently encoded by appending a separate one-beep group after the normal phrase. That explains the occasional extra beep:

- regular tight: `bip · bip · bip`
- current long tight: `bip · bip · bip · bip`

The intended language was instead to lengthen the final regular beep without changing the count.

## Fix

The phrase model now preserves one group per authored corner and carries an explicit final-beep duration:

- regular tight: `bip · bip · bip`
- long tight: `bip · bip · beeeep`
- long medium: `bip · beeeep`
- long mild: `beeeep`

Regular beeps remain 55 ms. The final beep of a long corner is held for 170 ms. Direction, severity, trigger position and linked-corner structure are unchanged.

The priority playback scheduler now applies the longer duration only to the final beep in each long group and waits for its actual end before admitting the next phrase. The former synthetic tail group and `lengthMarker` contract are removed.

## Delivery and regression

- refreshes both pace-note modules through a dedicated revision query
- verifies long curves retain exactly the same beep count as regular curves
- protects `bip-bip-beep` and `bip-beep` phrase semantics
- rejects the retired extra-tail marker
- keeps the reliable shared-AudioContext priority queue and all existing timing/route checks