### PR TITLE
Expand How to Play and reset Home rivals across all tracks

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Run TURN NEXT home navigation regression
         run: node turn-tests/home-navigation-production.mjs
 
+      - name: Run Home help and all-track rival reset regression
+        run: node turn-tests/how-to-play-guide-production.mjs
+
       - name: Run TURN NEXT motion safe-zone regression
         run: node turn-tests/motion-safe-zone-production.mjs
 

--- a/turn-tests/how-to-play-guide-production.mjs
+++ b/turn-tests/how-to-play-guide-production.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const [app, guide, css] = await Promise.all([
+  fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/ui/how-to-play-guide.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/m8-how-to-play-r126.css', import.meta.url), 'utf8')
+]);
+
+assert.match(app, /installStylesheet\('\.\/m8-how-to-play-r126\.css', 'data-turn-m8-how-to-play'\)/);
+assert.match(app, /how-to-play-guide\.js\?revision=r126-dbe-disclosure/);
+assert.match(app, /installHowToPlayGuide\(\)/);
+assert.ok(
+  app.indexOf('await installM8HomeNavigation()') < app.indexOf('installHowToPlayGuide()'),
+  'The enhancer must run only after the How to Play dialog exists'
+);
+
+assert.match(guide, /Holding <strong>DRIFT<\/strong> also charges <strong>BOOST<\/strong> faster/);
+assert.match(guide, /<details class="m8-dbe-guide">/);
+assert.match(guide, /<summary>Explore the Drive By Ear sounds<\/summary>/);
+assert.match(guide, /Guiding ribbon/);
+assert.match(guide, /Pace notes/);
+assert.match(guide, /Drift and grip/);
+assert.match(guide, /Engine and BOOST/);
+assert.match(guide, /Off-road recovery/);
+assert.match(guide, /Nearby rivals/);
+assert.match(guide, /Wrong way/);
+assert.match(guide, /With a screen reader/);
+assert.match(guide, /Headphones provide the clearest left and right information/);
+assert.match(guide, /complete non-visual play/);
+
+assert.match(guide, /A long corner keeps the same number of beeps but holds the final beep longer/);
+assert.match(guide, /bip-beeeep for a long medium corner/);
+assert.match(guide, /bip-bip-beeeep for a long tight corner/);
+assert.doesNotMatch(guide, /delayed extra beep|extra one-beep group|lengthMarker/);
+assert.match(guide, /root\.querySelector\('#dbeGuidePaceNotes'\)/, 'The in-race audio guide must receive the corrected long-corner language too');
+
+assert.match(css, /\.m8-dbe-guide > summary/);
+assert.match(css, /cursor: pointer/);
+assert.match(css, /summary:focus-visible/);
+assert.match(css, /grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/);
+assert.match(css, /@media \(max-width: 720px\)[\s\S]*grid-template-columns: 1fr/);
+assert.doesNotMatch(`${guide}\n${css}`, /requestAnimationFrame|setInterval|setTimeout|@keyframes|animation:/, 'Help content must add no runtime loop or distracting motion');
+
+console.log('TURN How to Play Drift charging and detailed Drive By Ear disclosure passed.');

--- a/turn-tests/how-to-play-guide-production.mjs
+++ b/turn-tests/how-to-play-guide-production.mjs
@@ -1,18 +1,26 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [app, guide, css] = await Promise.all([
+const [app, guide, css, homeReset, rivalStorage] = await Promise.all([
   fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/ui/how-to-play-guide.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/m8-how-to-play-r126.css', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/m8-how-to-play-r126.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/ui/home-rival-reset.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/race/rival-storage.js', import.meta.url), 'utf8')
 ]);
 
 assert.match(app, /installStylesheet\('\.\/m8-how-to-play-r126\.css', 'data-turn-m8-how-to-play'\)/);
 assert.match(app, /how-to-play-guide\.js\?revision=r126-dbe-disclosure/);
 assert.match(app, /installHowToPlayGuide\(\)/);
+assert.match(app, /home-rival-reset\.js\?revision=r126-all-tracks/);
+assert.match(app, /installHomeRivalReset\(\)/);
 assert.ok(
   app.indexOf('await installM8HomeNavigation()') < app.indexOf('installHowToPlayGuide()'),
-  'The enhancer must run only after the How to Play dialog exists'
+  'The guide enhancer must run only after the How to Play dialog exists'
+);
+assert.ok(
+  app.indexOf('await installM8HomeNavigation()') < app.indexOf('installHomeRivalReset()'),
+  'The all-track reset enhancer must run only after the Home settings dialog exists'
 );
 
 assert.match(guide, /Holding <strong>DRIFT<\/strong> also charges <strong>BOOST<\/strong> faster/);
@@ -42,4 +50,21 @@ assert.match(css, /grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/);
 assert.match(css, /@media \(max-width: 720px\)[\s\S]*grid-template-columns: 1fr/);
 assert.doesNotMatch(`${guide}\n${css}`, /requestAnimationFrame|setInterval|setTimeout|@keyframes|animation:/, 'Help content must add no runtime loop or distracting motion');
 
-console.log('TURN How to Play Drift charging and detailed Drive By Ear disclosure passed.');
+assert.match(homeReset, /Remove every recorded personal rival from every track/);
+assert.match(homeReset, /To reset only one track, use Settings at that track’s start line/);
+assert.match(homeReset, /RESET ALL RIVALS/);
+assert.match(homeReset, /resetTarget\.textContent = 'ALL TRACKS'/);
+assert.match(homeReset, /clearAllRivalsState/);
+assert.match(homeReset, /TRACK_CATALOG\.map\(\(track\) => track\.id\)/);
+assert.match(homeReset, /Personal rivals reset on all tracks/);
+assert.match(homeReset, /event\.stopImmediatePropagation\(\)/, 'Home must replace the old selected-track reset handlers rather than also running them');
+assert.match(homeReset, /delete model\.dataset\.previewKey/, 'Pending BEST thumbnails must not reappear after an all-track reset');
+assert.doesNotMatch(homeReset, /activateTrack|__turnResetRivals/, 'Home reset must not cycle the live runtime through every track or reuse the track-specific race action');
+
+assert.match(rivalStorage, /export function clearAllRivalsState\(state, trackIds = \[\]\)/);
+assert.match(rivalStorage, /localStorage\.removeItem\(rivalKey\(trackId\)\)/);
+assert.match(rivalStorage, /localStorage\.removeItem\(ghostKey\(trackId\)\)/);
+assert.match(rivalStorage, /state\.trackId = activeTrackId/, 'An all-track reset must preserve the runtime’s active track');
+assert.match(rivalStorage, /syncPrimaryRivalState\(state\)/);
+
+console.log('TURN How to Play, detailed Drive By Ear disclosure and Home all-track rival reset passed.');

--- a/turn/app.js
+++ b/turn/app.js
@@ -168,9 +168,14 @@ await Promise.all([
 
 await import(withBuild('./ui/in-game-menu.js'));
 installStylesheet('./m8-home.css', 'data-turn-m8-home-styles');
+installStylesheet('./m8-how-to-play-r126.css', 'data-turn-m8-how-to-play');
 const { installM8HomeNavigation } = await import(withBuild('./m8-home.js'));
 const home = await installM8HomeNavigation();
 globalThis.__turnHome = home;
+const { installHowToPlayGuide } = await import(
+  withBuild('./ui/how-to-play-guide.js?revision=r126-dbe-disclosure')
+);
+installHowToPlayGuide();
 const buildLabel = document.querySelector('.m8-home-build');
 if (buildLabel) {
   const release = globalThis.__TURN_BUILD__;

--- a/turn/app.js
+++ b/turn/app.js
@@ -176,6 +176,10 @@ const { installHowToPlayGuide } = await import(
   withBuild('./ui/how-to-play-guide.js?revision=r126-dbe-disclosure')
 );
 installHowToPlayGuide();
+const { installHomeRivalReset } = await import(
+  withBuild('./ui/home-rival-reset.js?revision=r126-all-tracks')
+);
+installHomeRivalReset();
 const buildLabel = document.querySelector('.m8-home-build');
 if (buildLabel) {
   const release = globalThis.__TURN_BUILD__;

--- a/turn/m8-how-to-play-r126.css
+++ b/turn/m8-how-to-play-r126.css
@@ -1,0 +1,115 @@
+.m8-dbe-guide {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 3px solid var(--m8-ink);
+}
+
+.m8-dbe-guide > summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 11px 14px;
+  border: 3px solid var(--m8-ink);
+  border-radius: 14px;
+  color: var(--m8-ink);
+  background: var(--m8-yellow);
+  box-shadow: 4px 4px 0 var(--m8-ink);
+  cursor: pointer;
+  list-style: none;
+  font-weight: 950;
+  line-height: 1.2;
+}
+
+.m8-dbe-guide > summary::-webkit-details-marker {
+  display: none;
+}
+
+.m8-dbe-guide > summary::after {
+  content: "+";
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border: 2px solid var(--m8-ink);
+  border-radius: 50%;
+  background: var(--m8-cream);
+  font-size: 1.3rem;
+  line-height: 1;
+}
+
+.m8-dbe-guide[open] > summary::after {
+  content: "−";
+}
+
+.m8-dbe-guide > summary:focus-visible {
+  outline: 5px solid var(--m8-pink);
+  outline-offset: 4px;
+}
+
+.m8-dbe-guide-content {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.m8-dbe-guide-intro,
+.m8-dbe-guide-basics,
+.m8-dbe-guide-screen-reader {
+  grid-column: 1 / -1;
+}
+
+.m8-dbe-guide-intro {
+  padding: 0 2px;
+  font-weight: 800;
+}
+
+.m8-dbe-guide-basics,
+.m8-dbe-guide-section {
+  min-width: 0;
+  padding: 13px 14px;
+  border: 2px solid var(--m8-ink);
+  border-radius: 14px;
+  background: rgb(255 255 255 / 0.78);
+}
+
+.m8-dbe-guide-content h4 {
+  margin: 0 0 6px;
+  font-size: 1rem;
+  line-height: 1.15;
+}
+
+.m8-dbe-guide-content ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  line-height: 1.4;
+}
+
+.m8-dbe-guide-content li + li {
+  margin-top: 5px;
+}
+
+@media (max-width: 720px) {
+  .m8-dbe-guide-content {
+    grid-template-columns: 1fr;
+  }
+
+  .m8-dbe-guide-intro,
+  .m8-dbe-guide-basics,
+  .m8-dbe-guide-screen-reader {
+    grid-column: auto;
+  }
+}
+
+@media (max-height: 560px) and (orientation: landscape) {
+  .m8-dbe-guide-content {
+    gap: 10px;
+  }
+
+  .m8-dbe-guide-basics,
+  .m8-dbe-guide-section {
+    padding: 10px 12px;
+  }
+}

--- a/turn/race/rival-storage.js
+++ b/turn/race/rival-storage.js
@@ -121,6 +121,26 @@ export function clearRivalsState(state, { trackId } = {}) {
   } catch (_) {}
 }
 
+export function clearAllRivalsState(state, trackIds = []) {
+  const activeTrackId = stateTrackId(state);
+  const normalizedTrackIds = [...new Set([
+    activeTrackId,
+    ...trackIds
+  ].map(normalizeTrackId))];
+
+  try {
+    for (const trackId of normalizedTrackIds) {
+      localStorage.removeItem(rivalKey(trackId));
+      localStorage.removeItem(ghostKey(trackId));
+    }
+  } catch (_) {}
+
+  state.trackId = activeTrackId;
+  state.competitorLaps = [];
+  syncPrimaryRivalState(state);
+  return normalizedTrackIds.length;
+}
+
 export function getStoredBestLap(trackId = DEFAULT_TRACK_ID) {
   const activeTrackId = normalizeTrackId(trackId);
   try {

--- a/turn/ui/home-rival-reset.js
+++ b/turn/ui/home-rival-reset.js
@@ -1,0 +1,88 @@
+import { TRACK_CATALOG } from '../tracks/catalog.js';
+import { clearAllRivalsState } from '../race/rival-storage.js';
+
+const RESET_VERSION = 'all-tracks-r126';
+
+export function installHomeRivalReset(root = document) {
+  const dialog = root.querySelector('.m8-settings-dialog');
+  const card = dialog?.querySelector('.m8-record-setting');
+  const resetButton = card?.querySelector('.m8-reset-rivals');
+  const resetConfirm = card?.querySelector('.m8-reset-confirm');
+  const resetTarget = card?.querySelector('.m8-reset-track');
+  const resetCancel = card?.querySelector('.m8-reset-cancel');
+  const resetConfirmButton = card?.querySelector('.m8-reset-confirm-button');
+  const status = dialog?.querySelector('.m8-settings-status');
+
+  if (
+    !dialog
+    || !card
+    || !resetButton
+    || !resetConfirm
+    || !resetTarget
+    || !resetCancel
+    || !resetConfirmButton
+    || !status
+  ) return false;
+  if (dialog.dataset.rivalResetVersion === RESET_VERSION) return true;
+
+  const description = card.querySelector('p');
+  if (description) {
+    description.textContent = 'Remove every recorded personal rival from every track. To reset only one track, use Settings at that track’s start line.';
+  }
+  resetButton.textContent = 'RESET ALL RIVALS';
+  resetButton.setAttribute('aria-label', 'Reset personal rivals on all tracks');
+
+  resetButton.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    resetTarget.textContent = 'ALL TRACKS';
+    resetConfirm.hidden = false;
+    resetConfirmButton.focus();
+  }, { capture: true });
+
+  resetConfirmButton.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    resetConfirmButton.disabled = true;
+
+    try {
+      clearAllRivalsState(
+        globalThis.__turnRuntime?.state || {},
+        TRACK_CATALOG.map((track) => track.id)
+      );
+      clearTrackCardRecords(root);
+      resetConfirm.hidden = true;
+      status.textContent = 'Personal rivals reset on all tracks.';
+      resetButton.focus();
+    } finally {
+      resetConfirmButton.disabled = false;
+    }
+  }, { capture: true });
+
+  resetCancel.addEventListener('click', () => {
+    resetTarget.textContent = 'ALL TRACKS';
+  });
+
+  dialog.dataset.rivalResetVersion = RESET_VERSION;
+  document.documentElement.dataset.turnHomeRivalReset = RESET_VERSION;
+  return true;
+}
+
+function clearTrackCardRecords(root) {
+  for (const bestBox of root.querySelectorAll('[data-track-best]')) {
+    const time = bestBox.querySelector('.track-card-best-time');
+    const car = bestBox.querySelector('.track-card-best-car');
+    const model = bestBox.querySelector('.track-card-best-model');
+
+    if (time) time.textContent = 'NO TIME YET';
+    if (car) {
+      car.textContent = '';
+      car.hidden = true;
+    }
+    if (model) {
+      model.hidden = true;
+      model.removeAttribute('src');
+      delete model.dataset.previewKey;
+    }
+  }
+}

--- a/turn/ui/how-to-play-guide.js
+++ b/turn/ui/how-to-play-guide.js
@@ -1,0 +1,105 @@
+const GUIDE_VERSION = 'r126-dbe-disclosure';
+const PACE_NOTE_EXPLANATION = 'Before major corners, one to three beeps play in the ear on the turn side. One beep means a gentler corner, two means medium and three means tight. A long corner keeps the same number of beeps but holds the final beep longer: bip-beeeep for a long medium corner and bip-bip-beeeep for a long tight corner. Separate groups describe linked corners in the order you will meet them.';
+
+export function installHowToPlayGuide(root = document) {
+  const dialog = root.querySelector('.m8-how-dialog');
+  if (!dialog) return false;
+  if (dialog.dataset.guideVersion === GUIDE_VERSION) return true;
+
+  updateDriftAndBoostCopy(dialog);
+  installDriveByEarDisclosure(dialog);
+  updateAudioPanelPaceNoteCopy(root);
+
+  dialog.dataset.guideVersion = GUIDE_VERSION;
+  document.documentElement.dataset.turnHowToPlayGuide = GUIDE_VERSION;
+  return true;
+}
+
+function updateDriftAndBoostCopy(dialog) {
+  const section = findGuideSection(dialog, 'Use Drift and Boost wisely');
+  const paragraph = section?.querySelector('p');
+  if (!paragraph) return;
+
+  paragraph.innerHTML = 'DRIFT helps the car rotate but costs grip. Holding <strong>DRIFT</strong> also charges <strong>BOOST</strong> faster, so a controlled slide can prepare the next burst. BOOST gives speed but can make the next corner harder. Fast laps come from balancing both.';
+}
+
+function installDriveByEarDisclosure(dialog) {
+  const section = dialog.querySelector('.m8-guide-wide');
+  if (!section) return;
+
+  section.innerHTML = `
+    <strong aria-hidden="true">♪</strong>
+    <div>
+      <h3>Drive By Ear™</h3>
+      <p>Drive By Ear turns the racing line, upcoming corners, grip, surfaces, recovery and nearby rivals into spatial sound. Steer toward the warm guiding hum. Headphones provide the clearest left and right information. Together with a screen reader, it is designed to support complete non-visual play.</p>
+
+      <details class="m8-dbe-guide">
+        <summary>Explore the Drive By Ear sounds</summary>
+        <div class="m8-dbe-guide-content">
+          <p class="m8-dbe-guide-intro">The sounds have different jobs. Guidance tells you where to steer, pace notes tell you what is coming next, and car or surface sounds tell you what is happening now.</p>
+
+          <div class="m8-dbe-guide-basics" aria-labelledby="m8DbeBasics">
+            <h4 id="m8DbeBasics">Start here</h4>
+            <ul>
+              <li>Use headphones and begin at a comfortable speed.</li>
+              <li>Steer <strong>toward</strong> the warm guiding hum.</li>
+              <li>Listen to pace notes before corners. The ear gives the direction and the beep count gives the severity.</li>
+              <li>Engine, tyre, BOOST and gravel sounds describe the car or surface. They are not steering instructions.</li>
+            </ul>
+          </div>
+
+          <div class="m8-dbe-guide-section" aria-labelledby="m8DbeRibbon">
+            <h4 id="m8DbeRibbon">Guiding ribbon</h4>
+            <p>A warm organic hum points toward the side you should steer toward. It combines your position with where the moving car is likely to go. As the trajectory becomes safer, the hum settles closer to the centre and softens. At higher speed it looks farther ahead, so smooth corrections work better than chasing every tiny movement.</p>
+          </div>
+
+          <div class="m8-dbe-guide-section" aria-labelledby="m8DbePaceNotes">
+            <h4 id="m8DbePaceNotes">Pace notes</h4>
+            <p>${PACE_NOTE_EXPLANATION}</p>
+          </div>
+
+          <div class="m8-dbe-guide-section" aria-labelledby="m8DbeDrift">
+            <h4 id="m8DbeDrift">Drift and grip</h4>
+            <p>Tyre noise stays centred. As the car loses more grip, the sound spreads wider across both ears. This describes how much the car is sliding without becoming a second left or right instruction.</p>
+          </div>
+
+          <div class="m8-dbe-guide-section" aria-labelledby="m8DbePower">
+            <h4 id="m8DbePower">Engine and BOOST</h4>
+            <p>Engine and BOOST sounds stay centred. A rising burst confirms that BOOST starts, while a separate empty cue tells you the charge is gone. These are status sounds, not steering guidance.</p>
+          </div>
+
+          <div class="m8-dbe-guide-section" aria-labelledby="m8DbeRecovery">
+            <h4 id="m8DbeRecovery">Off-road recovery</h4>
+            <p>Centred gravel marks that the car is off road. The guiding hum changes to recovery guidance and points toward a useful place to rejoin, rather than simply the nearest edge. Steer toward the hum until normal on-road guidance returns.</p>
+          </div>
+
+          <div class="m8-dbe-guide-section" aria-labelledby="m8DbeRivals">
+            <h4 id="m8DbeRivals">Nearby rivals</h4>
+            <p>A short directional cue sounds when a rival comes close. It plays from the side of the nearby car. Treat it as a heads-up rather than a continuous tracker.</p>
+          </div>
+
+          <div class="m8-dbe-guide-section" aria-labelledby="m8DbeWrongWay">
+            <h4 id="m8DbeWrongWay">Wrong way</h4>
+            <p>A repeating low double falling tone confirms that you are facing the wrong direction. A final side tone indicates which way to turn. Continue turning until the regular guiding ribbon returns.</p>
+          </div>
+
+          <div class="m8-dbe-guide-section m8-dbe-guide-screen-reader" aria-labelledby="m8DbeScreenReader">
+            <h4 id="m8DbeScreenReader">With a screen reader</h4>
+            <p>Drive By Ear is designed to work alongside screen readers, including VoiceOver. The screen reader presents menus, controls, position and lap results; DBE supplies the continuous spatial information needed to steer and stay on course. Together they are intended to provide a complete non-visual way to play TURN.</p>
+          </div>
+        </div>
+      </details>
+    </div>`;
+}
+
+function updateAudioPanelPaceNoteCopy(root) {
+  const heading = root.querySelector('#dbeGuidePaceNotes');
+  const paragraph = heading?.parentElement?.querySelector('p');
+  if (paragraph) paragraph.textContent = PACE_NOTE_EXPLANATION;
+}
+
+function findGuideSection(dialog, headingText) {
+  return [...dialog.querySelectorAll('.m8-guide-grid > section')].find((section) => (
+    section.querySelector('h3')?.textContent?.trim() === headingText
+  ));
+}


### PR DESCRIPTION
## How to Play

Adds the two missing pieces to the Home HOW TO PLAY dialog:

- the Drift/Boost card now explains that holding DRIFT charges BOOST faster
- Drive By Ear becomes an expandable sound guide rather than one short paragraph

The disclosure explains the guiding ribbon, corrected pace-note grammar, drift/grip, engine and BOOST status sounds, off-road recovery, nearby rivals, wrong-way guidance, headphones and screen-reader use. It uses native `details`/`summary`, remains keyboard accessible, and adds no animation or runtime loop.

The in-race Audio guide also receives the corrected long-corner wording: long curves keep the normal beep count and hold the final beep rather than adding another beep.

## Home Settings rival reset

The RESET RIVALS action opened from the Home/track-selection Settings now clearly resets personal rivals on **all tracks**:

- button: `RESET ALL RIVALS`
- confirmation target: `ALL TRACKS`
- all current track-revision and legacy ghost keys are removed
- every BEST card updates immediately to `NO TIME YET`
- the active runtime track is preserved

The track-specific RESET RIVALS action at a track’s start line is unchanged. Home copy tells players to use that action when they only want to clear one track.

## Regression

Adds a dedicated Home help/all-track reset gate and runs it in the TURN regression workflow.