### PR TITLE
Use contextual rival reset scope and full Drive By Ear naming

### DIFF
--- a/turn-tests/how-to-play-guide-production.mjs
+++ b/turn-tests/how-to-play-guide-production.mjs
@@ -1,18 +1,21 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [app, guide, css, homeReset, rivalStorage] = await Promise.all([
+const [app, guide, css, homeReset, resetCss, rivalStorage, trackManager] = await Promise.all([
   fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/ui/how-to-play-guide.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/m8-how-to-play-r126.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/ui/home-rival-reset.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/race/rival-storage.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/rival-reset-context-r127.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/race/rival-storage.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/tracks/track-manager.js', import.meta.url), 'utf8')
 ]);
 
 assert.match(app, /installStylesheet\('\.\/m8-how-to-play-r126\.css', 'data-turn-m8-how-to-play'\)/);
-assert.match(app, /how-to-play-guide\.js\?revision=r126-dbe-disclosure/);
+assert.match(app, /installStylesheet\('\.\/rival-reset-context-r127\.css', 'data-turn-rival-reset-context'\)/);
+assert.match(app, /how-to-play-guide\.js\?revision=r127-full-name/);
 assert.match(app, /installHowToPlayGuide\(\)/);
-assert.match(app, /home-rival-reset\.js\?revision=r126-all-tracks/);
+assert.match(app, /home-rival-reset\.js\?revision=r127-contextual/);
 assert.match(app, /installHomeRivalReset\(\)/);
 assert.ok(
   app.indexOf('await installM8HomeNavigation()') < app.indexOf('installHowToPlayGuide()'),
@@ -20,7 +23,7 @@ assert.ok(
 );
 assert.ok(
   app.indexOf('await installM8HomeNavigation()') < app.indexOf('installHomeRivalReset()'),
-  'The all-track reset enhancer must run only after the Home settings dialog exists'
+  'The contextual reset enhancer must run only after the shared Settings dialog exists'
 );
 
 assert.match(guide, /Holding <strong>DRIFT<\/strong> also charges <strong>BOOST<\/strong> faster/);
@@ -36,6 +39,10 @@ assert.match(guide, /Wrong way/);
 assert.match(guide, /With a screen reader/);
 assert.match(guide, /Headphones provide the clearest left and right information/);
 assert.match(guide, /complete non-visual play/);
+assert.match(guide, /Drive By Ear supplies the continuous spatial information/);
+assert.match(guide, /Drive By Ear provides the continuous spatial information/);
+assert.match(guide, /root\.querySelector\('#dbeGuideScreenReaders'\)/, 'The in-race guide must replace its abbreviated screen-reader copy before it can be shown');
+assert.doesNotMatch(guide, /[;.]\s*DBE\s+(?:supplies|provides)/, 'Player-facing help must always spell out Drive By Ear');
 
 assert.match(guide, /A long corner keeps the same number of beeps but holds the final beep longer/);
 assert.match(guide, /bip-beeeep for a long medium corner/);
@@ -48,23 +55,40 @@ assert.match(css, /cursor: pointer/);
 assert.match(css, /summary:focus-visible/);
 assert.match(css, /grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/);
 assert.match(css, /@media \(max-width: 720px\)[\s\S]*grid-template-columns: 1fr/);
-assert.doesNotMatch(`${guide}\n${css}`, /requestAnimationFrame|setInterval|setTimeout|@keyframes|animation:/, 'Help content must add no runtime loop or distracting motion');
+assert.doesNotMatch(`${guide}\n${css}`, /setInterval|setTimeout|@keyframes|animation:/, 'Help content must add no runtime loop or distracting motion');
 
+assert.match(homeReset, /function homeIsOpen\(\)/);
+assert.match(homeReset, /document\.body\.classList\.contains\('turn-home-open'\)/);
+assert.match(homeReset, /const allTracks = homeIsOpen\(\)/);
 assert.match(homeReset, /Remove every recorded personal rival from every track/);
 assert.match(homeReset, /To reset only one track, use Settings at that track’s start line/);
 assert.match(homeReset, /RESET ALL RIVALS/);
-assert.match(homeReset, /resetTarget\.textContent = 'ALL TRACKS'/);
+assert.match(homeReset, /Remove the recorded personal rivals for \$\{track\.name\}/);
+assert.match(homeReset, /Rivals on other tracks will be kept/);
+assert.match(homeReset, /resetButton\.textContent = 'RESET RIVALS'/);
+assert.match(homeReset, /resetTarget\.textContent = track\.name\.toUpperCase\(\)/);
 assert.match(homeReset, /clearAllRivalsState/);
-assert.match(homeReset, /TRACK_CATALOG\.map\(\(track\) => track\.id\)/);
-assert.match(homeReset, /Personal rivals reset on all tracks/);
-assert.match(homeReset, /event\.stopImmediatePropagation\(\)/, 'Home must replace the old selected-track reset handlers rather than also running them');
-assert.match(homeReset, /delete model\.dataset\.previewKey/, 'Pending BEST thumbnails must not reappear after an all-track reset');
-assert.doesNotMatch(homeReset, /activateTrack|__turnResetRivals/, 'Home reset must not cycle the live runtime through every track or reuse the track-specific race action');
+assert.match(homeReset, /TRACK_CATALOG\.map\(\(entry\) => entry\.id\)/);
+assert.match(homeReset, /globalThis\.__turnResetRivals\?\.\(\)/, 'The race Settings path must use the existing active-track reset only');
+assert.match(homeReset, /clearTrackCardRecord\(root, track\.id\)/);
+assert.match(homeReset, /Personal rivals reset for \$\{track\.name\}/);
+assert.match(homeReset, /raceResetButton\.textContent = 'RESET RIVALS'/);
+assert.match(homeReset, /Remove the saved personal rivals and lap records for \$\{track\.name\}/);
+assert.match(homeReset, /event\.stopImmediatePropagation\(\)/, 'The contextual handler must replace the old fixed-scope handlers rather than also running them');
+assert.match(homeReset, /delete model\.dataset\.previewKey/, 'Pending BEST thumbnails must not reappear after any reset');
+assert.doesNotMatch(homeReset, /activateTrack/, 'Resetting rivals must never change tracks behind the player');
+
+assert.match(resetCss, /\.m8-reset-rivals\.is-all-tracks/);
+assert.match(resetCss, /#ff9b91/, 'RESET ALL RIVALS must use a light warning red');
+assert.match(resetCss, /\.m8-settings-dialog \.m8-reset-rivals,[\s\S]*background: var\(--m8-yellow\) !important/, 'The active-track Settings action must retain the standard yellow treatment');
+assert.match(resetCss, /\.utility-group \.reset-rivals-button,[\s\S]*#ffd43b/, 'The direct start-line reset action must also remain yellow');
 
 assert.match(rivalStorage, /export function clearAllRivalsState\(state, trackIds = \[\]\)/);
 assert.match(rivalStorage, /localStorage\.removeItem\(rivalKey\(trackId\)\)/);
 assert.match(rivalStorage, /localStorage\.removeItem\(ghostKey\(trackId\)\)/);
 assert.match(rivalStorage, /state\.trackId = activeTrackId/, 'An all-track reset must preserve the runtime’s active track');
 assert.match(rivalStorage, /syncPrimaryRivalState\(state\)/);
+assert.match(trackManager, /clearRivalsState\(currentRuntime\.state, \{ trackId: activeTrackId \}\)/, 'The race reset implementation must clear only the current track storage key');
+assert.match(trackManager, /globalThis\.__turnResetRivals = resetCurrentTrackRivals/);
 
-console.log('TURN How to Play, detailed Drive By Ear disclosure and Home all-track rival reset passed.');
+console.log('TURN full Drive By Ear UX naming and contextual all-track/current-track rival reset passed.');

--- a/turn/app.js
+++ b/turn/app.js
@@ -169,15 +169,16 @@ await Promise.all([
 await import(withBuild('./ui/in-game-menu.js'));
 installStylesheet('./m8-home.css', 'data-turn-m8-home-styles');
 installStylesheet('./m8-how-to-play-r126.css', 'data-turn-m8-how-to-play');
+installStylesheet('./rival-reset-context-r127.css', 'data-turn-rival-reset-context');
 const { installM8HomeNavigation } = await import(withBuild('./m8-home.js'));
 const home = await installM8HomeNavigation();
 globalThis.__turnHome = home;
 const { installHowToPlayGuide } = await import(
-  withBuild('./ui/how-to-play-guide.js?revision=r126-dbe-disclosure')
+  withBuild('./ui/how-to-play-guide.js?revision=r127-full-name')
 );
 installHowToPlayGuide();
 const { installHomeRivalReset } = await import(
-  withBuild('./ui/home-rival-reset.js?revision=r126-all-tracks')
+  withBuild('./ui/home-rival-reset.js?revision=r127-contextual')
 );
 installHomeRivalReset();
 const buildLabel = document.querySelector('.m8-home-build');

--- a/turn/rival-reset-context-r127.css
+++ b/turn/rival-reset-context-r127.css
@@ -1,0 +1,14 @@
+.m8-settings-dialog .m8-reset-rivals,
+.m8-settings-dialog .m8-reset-confirm-button {
+  background: var(--m8-yellow) !important;
+}
+
+.m8-settings-dialog .m8-reset-rivals.is-all-tracks,
+.m8-settings-dialog .m8-reset-confirm-button.is-all-tracks {
+  background: #ff9b91 !important;
+}
+
+.utility-group .reset-rivals-button,
+.nuke-dialog .nuke-confirm {
+  background: #ffd43b !important;
+}

--- a/turn/ui/home-rival-reset.js
+++ b/turn/ui/home-rival-reset.js
@@ -1,7 +1,7 @@
-import { TRACK_CATALOG } from '../tracks/catalog.js';
+import { TRACK_CATALOG, normalizeTrackId } from '../tracks/catalog.js';
 import { clearAllRivalsState } from '../race/rival-storage.js';
 
-const RESET_VERSION = 'all-tracks-r126';
+const RESET_VERSION = 'contextual-r127';
 
 export function installHomeRivalReset(root = document) {
   const dialog = root.querySelector('.m8-settings-dialog');
@@ -12,6 +12,8 @@ export function installHomeRivalReset(root = document) {
   const resetCancel = card?.querySelector('.m8-reset-cancel');
   const resetConfirmButton = card?.querySelector('.m8-reset-confirm-button');
   const status = dialog?.querySelector('.m8-settings-status');
+  const raceResetButton = root.querySelector('.reset-rivals-button');
+  const raceResetDialog = root.querySelector('.nuke-dialog');
 
   if (
     !dialog
@@ -25,17 +27,69 @@ export function installHomeRivalReset(root = document) {
   ) return false;
   if (dialog.dataset.rivalResetVersion === RESET_VERSION) return true;
 
-  const description = card.querySelector('p');
-  if (description) {
-    description.textContent = 'Remove every recorded personal rival from every track. To reset only one track, use Settings at that track’s start line.';
+  function selectedTrack() {
+    const trackId = normalizeTrackId(
+      globalThis.__turnGetTrackId?.()
+      || globalThis.__turnRuntime?.trackId
+      || globalThis.__turnRuntime?.state?.trackId
+    );
+    return TRACK_CATALOG.find((track) => track.id === trackId) || TRACK_CATALOG[0];
   }
-  resetButton.textContent = 'RESET ALL RIVALS';
-  resetButton.setAttribute('aria-label', 'Reset personal rivals on all tracks');
+
+  function homeIsOpen() {
+    return document.body.classList.contains('turn-home-open');
+  }
+
+  function syncRaceResetCopy() {
+    const track = selectedTrack();
+    if (raceResetButton) {
+      raceResetButton.textContent = 'RESET RIVALS';
+      raceResetButton.setAttribute('aria-label', `Reset rivals on ${track.name}`);
+      raceResetButton.title = `Reset rivals on ${track.name}`;
+    }
+
+    const heading = raceResetDialog?.querySelector('h2');
+    const paragraph = raceResetDialog?.querySelector('p');
+    const confirm = raceResetDialog?.querySelector('.nuke-confirm');
+    if (heading) heading.textContent = 'RESET RIVALS?';
+    if (paragraph) {
+      paragraph.textContent = `Remove the saved personal rivals and lap records for ${track.name}? Rivals on other tracks will be kept.`;
+    }
+    if (confirm) confirm.textContent = 'RESET RIVALS';
+  }
+
+  function syncSettingsCopy() {
+    const allTracks = homeIsOpen();
+    const track = selectedTrack();
+    const description = card.querySelector('p');
+
+    card.dataset.resetScope = allTracks ? 'all-tracks' : 'current-track';
+    resetButton.classList.toggle('is-all-tracks', allTracks);
+    resetConfirmButton.classList.toggle('is-all-tracks', allTracks);
+
+    if (allTracks) {
+      if (description) {
+        description.textContent = 'Remove every recorded personal rival from every track. To reset only one track, use Settings at that track’s start line.';
+      }
+      resetButton.textContent = 'RESET ALL RIVALS';
+      resetButton.setAttribute('aria-label', 'Reset personal rivals on all tracks');
+      resetTarget.textContent = 'ALL TRACKS';
+    } else {
+      if (description) {
+        description.textContent = `Remove the recorded personal rivals for ${track.name}. Rivals on other tracks will be kept.`;
+      }
+      resetButton.textContent = 'RESET RIVALS';
+      resetButton.setAttribute('aria-label', `Reset personal rivals on ${track.name}`);
+      resetTarget.textContent = track.name.toUpperCase();
+    }
+
+    syncRaceResetCopy();
+  }
 
   resetButton.addEventListener('click', (event) => {
     event.preventDefault();
     event.stopImmediatePropagation();
-    resetTarget.textContent = 'ALL TRACKS';
+    syncSettingsCopy();
     resetConfirm.hidden = false;
     resetConfirmButton.focus();
   }, { capture: true });
@@ -46,13 +100,23 @@ export function installHomeRivalReset(root = document) {
     resetConfirmButton.disabled = true;
 
     try {
-      clearAllRivalsState(
-        globalThis.__turnRuntime?.state || {},
-        TRACK_CATALOG.map((track) => track.id)
-      );
-      clearTrackCardRecords(root);
+      const allTracks = homeIsOpen();
+      const track = selectedTrack();
+
+      if (allTracks) {
+        clearAllRivalsState(
+          globalThis.__turnRuntime?.state || {},
+          TRACK_CATALOG.map((entry) => entry.id)
+        );
+        clearTrackCardRecords(root);
+        status.textContent = 'Personal rivals reset on all tracks.';
+      } else {
+        globalThis.__turnResetRivals?.();
+        clearTrackCardRecord(root, track.id);
+        status.textContent = `Personal rivals reset for ${track.name}.`;
+      }
+
       resetConfirm.hidden = true;
-      status.textContent = 'Personal rivals reset on all tracks.';
       resetButton.focus();
     } finally {
       resetConfirmButton.disabled = false;
@@ -60,9 +124,16 @@ export function installHomeRivalReset(root = document) {
   }, { capture: true });
 
   resetCancel.addEventListener('click', () => {
-    resetTarget.textContent = 'ALL TRACKS';
+    requestAnimationFrame(syncSettingsCopy);
   });
 
+  dialog.addEventListener('toggle', syncSettingsCopy);
+  dialog.addEventListener('close', syncSettingsCopy);
+  raceResetButton?.addEventListener('click', syncRaceResetCopy, { capture: true });
+  window.addEventListener('turn:track-changed', syncSettingsCopy);
+  window.addEventListener('turn:ui-state-change', syncSettingsCopy);
+
+  syncSettingsCopy();
   dialog.dataset.rivalResetVersion = RESET_VERSION;
   document.documentElement.dataset.turnHomeRivalReset = RESET_VERSION;
   return true;
@@ -70,19 +141,30 @@ export function installHomeRivalReset(root = document) {
 
 function clearTrackCardRecords(root) {
   for (const bestBox of root.querySelectorAll('[data-track-best]')) {
-    const time = bestBox.querySelector('.track-card-best-time');
-    const car = bestBox.querySelector('.track-card-best-car');
-    const model = bestBox.querySelector('.track-card-best-model');
+    clearBestBox(bestBox);
+  }
+}
 
-    if (time) time.textContent = 'NO TIME YET';
-    if (car) {
-      car.textContent = '';
-      car.hidden = true;
-    }
-    if (model) {
-      model.hidden = true;
-      model.removeAttribute('src');
-      delete model.dataset.previewKey;
-    }
+function clearTrackCardRecord(root, trackId) {
+  const bestBox = [...root.querySelectorAll('[data-track-best]')].find((entry) => (
+    entry.dataset.trackBest === trackId
+  ));
+  if (bestBox) clearBestBox(bestBox);
+}
+
+function clearBestBox(bestBox) {
+  const time = bestBox.querySelector('.track-card-best-time');
+  const car = bestBox.querySelector('.track-card-best-car');
+  const model = bestBox.querySelector('.track-card-best-model');
+
+  if (time) time.textContent = 'NO TIME YET';
+  if (car) {
+    car.textContent = '';
+    car.hidden = true;
+  }
+  if (model) {
+    model.hidden = true;
+    model.removeAttribute('src');
+    delete model.dataset.previewKey;
   }
 }

--- a/turn/ui/how-to-play-guide.js
+++ b/turn/ui/how-to-play-guide.js
@@ -1,4 +1,4 @@
-const GUIDE_VERSION = 'r126-dbe-disclosure';
+const GUIDE_VERSION = 'r127-full-drive-by-ear-name';
 const PACE_NOTE_EXPLANATION = 'Before major corners, one to three beeps play in the ear on the turn side. One beep means a gentler corner, two means medium and three means tight. A long corner keeps the same number of beeps but holds the final beep longer: bip-beeeep for a long medium corner and bip-bip-beeeep for a long tight corner. Separate groups describe linked corners in the order you will meet them.';
 
 export function installHowToPlayGuide(root = document) {
@@ -8,7 +8,7 @@ export function installHowToPlayGuide(root = document) {
 
   updateDriftAndBoostCopy(dialog);
   installDriveByEarDisclosure(dialog);
-  updateAudioPanelPaceNoteCopy(root);
+  updateAudioPanelCopy(root);
 
   dialog.dataset.guideVersion = GUIDE_VERSION;
   document.documentElement.dataset.turnHowToPlayGuide = GUIDE_VERSION;
@@ -85,17 +85,23 @@ function installDriveByEarDisclosure(dialog) {
 
           <div class="m8-dbe-guide-section m8-dbe-guide-screen-reader" aria-labelledby="m8DbeScreenReader">
             <h4 id="m8DbeScreenReader">With a screen reader</h4>
-            <p>Drive By Ear is designed to work alongside screen readers, including VoiceOver. The screen reader presents menus, controls, position and lap results; DBE supplies the continuous spatial information needed to steer and stay on course. Together they are intended to provide a complete non-visual way to play TURN.</p>
+            <p>Drive By Ear is designed to work alongside screen readers, including VoiceOver. The screen reader presents menus, controls, position and lap results; Drive By Ear supplies the continuous spatial information needed to steer and stay on course. Together they are intended to provide a complete non-visual way to play TURN.</p>
           </div>
         </div>
       </details>
     </div>`;
 }
 
-function updateAudioPanelPaceNoteCopy(root) {
-  const heading = root.querySelector('#dbeGuidePaceNotes');
-  const paragraph = heading?.parentElement?.querySelector('p');
-  if (paragraph) paragraph.textContent = PACE_NOTE_EXPLANATION;
+function updateAudioPanelCopy(root) {
+  const paceHeading = root.querySelector('#dbeGuidePaceNotes');
+  const paceParagraph = paceHeading?.parentElement?.querySelector('p');
+  if (paceParagraph) paceParagraph.textContent = PACE_NOTE_EXPLANATION;
+
+  const screenReaderHeading = root.querySelector('#dbeGuideScreenReaders');
+  const screenReaderParagraph = screenReaderHeading?.parentElement?.querySelector('p');
+  if (screenReaderParagraph) {
+    screenReaderParagraph.textContent = 'Drive By Ear is designed to work alongside screen readers, including VoiceOver. The screen reader presents menus, controls, race position and lap results; Drive By Ear provides the continuous spatial information needed to steer and stay on course. Together they are intended to provide a complete non-visual way to play TURN, from choosing a car and track to completing a race.';
+  }
 }
 
 function findGuideSection(dialog, headingText) {


### PR DESCRIPTION
## Drive By Ear copy

Player-facing help now always spells out **Drive By Ear**. The Home guide and the in-race Audio guide no longer use the internal abbreviation in their screen-reader explanations.

## Contextual rival reset

The shared Settings dialog now changes scope based on where it was opened:

- **Home / Choose Your Track**
  - `RESET ALL RIVALS`
  - light warning-red action
  - confirmation targets `ALL TRACKS`
  - clears every track and refreshes every BEST card

- **Track start / race Settings**
  - `RESET RIVALS`
  - standard yellow action
  - names the active track in the description and confirmation
  - calls only the existing current-track reset, preserving rivals on every other track

The direct start-line RESET RIVALS utility and its confirmation are also normalized to yellow and track-specific copy.

## Regression

The help/reset regression now protects:

- full Drive By Ear naming in visible instructions
- Home-vs-track context detection
- warning-red all-track styling
- yellow current-track styling
- all-track storage clearing only on Home
- active-track storage clearing only from track Settings