### PR TITLE
Explain the Super Sedan secret when it is unlocked

### DIFF
--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -149,7 +149,8 @@ assert.equal(imports['./garage/lot-r10.js?build=20260720-r19'], releaseTarget('.
 assert.equal(imports['./ui/track-intro.js?build=20260725-r75'], releaseTarget('./ui/track-intro.js'));
 assert.equal(imports['./race/lap-system.js?build=20260720-r19'], releaseTarget('./race/lap-system-r86.js'));
 
-assert.match(app, /lot-layout-r60\.css\?revision=r121-viewer/);
+assert.match(app, /lot-layout-r60\.css\?revision=r128-super-sedan-notice/);
+assert.match(app, /sports-sedan-easter-egg\.js\?revision=r128-unlock-notice/);
 assert.match(app, /installLotEnhancementRuntime/);
 assert.match(app, /lot-enhancement-runtime\.js\?revision=r121/);
 assert.ok(app.indexOf('installLotEnhancementRuntime()') < app.indexOf("withBuild('./main.js')"));
@@ -178,6 +179,9 @@ assert.match(lotLayoutCss, /min-height: clamp\(150px, 28vh, 230px\)/);
 assert.match(lotLayoutCss, /--lot-paint-rail-height: 54px/);
 assert.match(lotLayoutCss, /\.lot-viewbox-with-paint \.lot-view-host[\s\S]*inset: 0 0 var\(--lot-paint-rail-height\)/);
 assert.match(lotLayoutCss, /\.lot-view-close,[\s\S]*\.lot-view-open[\s\S]*display: none !important/);
+assert.match(lotLayoutCss, /\.lot-secret-notice \{[\s\S]*background: #d9f5c2[\s\S]*border: 3px solid var\(--ink\)/);
+assert.match(lotLayoutCss, /\.lot-secret-notice\[hidden\][\s\S]*display: none/);
+assert.match(lotLayoutCss, /\.lot-secret-notice-chip[\s\S]*background: var\(--yellow\)/);
 assert.match(lotAccessibility, /lot-selected-car-summary/);
 assert.match(lotAccessibility, /Choose car/);
 assert.match(lotAccessibility, /Choose car colour/);
@@ -226,6 +230,16 @@ assert.match(catalogSource, /SPORTS_SEDAN_EASTER_EGG_COLOR = '#666666'/);
 assert.match(catalogSource, /MAXED_VEHICLE_STATS/);
 assert.match(carModels, /loadCarSource\(car\.id\)/);
 assert.match(easterEggUi, /getEffectiveVehicleStats/);
+assert.match(easterEggUi, /isSportsSedanEasterEgg/);
+assert.match(easterEggUi, /\.lot-car-option\[aria-checked="true"\]/, 'The enhancer must identify the selected car independently of the renamed visible heading');
 assert.match(easterEggUi, /input\[type="color"\]/);
+assert.match(easterEggUi, /displayedName = unlocked \? 'Super Sedan' : car\.name/);
+assert.match(easterEggUi, /Race the \$\{displayedName\}/, 'The race button must expose the temporary Super Sedan name');
+assert.match(easterEggUi, /SECRET UNLOCKED/);
+assert.match(easterEggUi, /color code #666/);
+assert.match(easterEggUi, /Lap results with this secret car are not saved/);
+assert.match(easterEggUi, /notice\.setAttribute\('role', 'status'\)/);
+assert.match(easterEggUi, /notice\.setAttribute\('aria-live', 'polite'\)/);
+assert.match(easterEggUi, /card\.insertBefore\(notice, actions \|\| null\)/, 'The explanation must sit immediately before RACE THIS CAR');
 
 console.log(`TURN ${release.id} enhanced Lot route, expanded 3D viewer, accessibility and garage setup passed.`);

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -149,7 +149,7 @@ assert.equal(imports['./garage/lot-r10.js?build=20260720-r19'], releaseTarget('.
 assert.equal(imports['./ui/track-intro.js?build=20260725-r75'], releaseTarget('./ui/track-intro.js'));
 assert.equal(imports['./race/lap-system.js?build=20260720-r19'], releaseTarget('./race/lap-system-r86.js'));
 
-assert.match(app, /lot-layout-r60\.css\?revision=r128-super-sedan-notice/);
+assert.match(app, /lot-layout-r60\.css\?revision=r121-viewer-r122-fit-r128-super-sedan-notice/);
 assert.match(app, /sports-sedan-easter-egg\.js\?revision=r128-unlock-notice/);
 assert.match(app, /installLotEnhancementRuntime/);
 assert.match(app, /lot-enhancement-runtime\.js\?revision=r121/);
@@ -238,6 +238,7 @@ assert.match(easterEggUi, /Race the \$\{displayedName\}/, 'The race button must 
 assert.match(easterEggUi, /SECRET UNLOCKED/);
 assert.match(easterEggUi, /color code #666/);
 assert.match(easterEggUi, /Lap results with this secret car are not saved/);
+assert.match(easterEggUi, /Super Sedan unlocked\. Spoiler color code #666/);
 assert.match(easterEggUi, /notice\.setAttribute\('role', 'status'\)/);
 assert.match(easterEggUi, /notice\.setAttribute\('aria-live', 'polite'\)/);
 assert.match(easterEggUi, /card\.insertBefore\(notice, actions \|\| null\)/, 'The explanation must sit immediately before RACE THIS CAR');

--- a/turn/app.js
+++ b/turn/app.js
@@ -62,7 +62,7 @@ document.documentElement.dataset.turnDisplayLifecycle = 'platform-m6';
 installStylesheet('./r104-polish.css', 'data-turn-r104-polish');
 installStylesheet('./steering-limit-warning.css', 'data-turn-steering-limit-warning');
 installStylesheet(
-  './garage/lot-layout-r60.css?revision=r121-viewer-r122-fit',
+  './garage/lot-layout-r60.css?revision=r128-super-sedan-notice',
   'data-turn-lot-layout-r121'
 );
 
@@ -139,7 +139,9 @@ installLapResultToast();
 const { installRivalOnboarding } = await import(withBuild('./ui/rival-onboarding.js'));
 installRivalOnboarding();
 
-const { installSportsSedanEasterEggUi } = await import(withBuild('./vehicle/sports-sedan-easter-egg.js'));
+const { installSportsSedanEasterEggUi } = await import(
+  withBuild('./vehicle/sports-sedan-easter-egg.js?revision=r128-unlock-notice')
+);
 installSportsSedanEasterEggUi();
 
 const { installHarborHiddenFaceOrientation } = await import(withBuild('./tracks/harbor-hidden-face-r89.js'));

--- a/turn/app.js
+++ b/turn/app.js
@@ -62,7 +62,7 @@ document.documentElement.dataset.turnDisplayLifecycle = 'platform-m6';
 installStylesheet('./r104-polish.css', 'data-turn-r104-polish');
 installStylesheet('./steering-limit-warning.css', 'data-turn-steering-limit-warning');
 installStylesheet(
-  './garage/lot-layout-r60.css?revision=r128-super-sedan-notice',
+  './garage/lot-layout-r60.css?revision=r121-viewer-r122-fit-r128-super-sedan-notice',
   'data-turn-lot-layout-r121'
 );
 

--- a/turn/garage/lot-layout-r60.css
+++ b/turn/garage/lot-layout-r60.css
@@ -89,6 +89,37 @@
   text-transform: lowercase;
 }
 
+.lot-secret-notice {
+  margin: 8px 0 10px;
+  padding: 8px 9px 9px;
+  border: 3px solid var(--ink);
+  border-radius: 10px;
+  background: #d9f5c2;
+  box-shadow: 2px 2px 0 var(--ink);
+}
+
+.lot-secret-notice[hidden] {
+  display: none;
+}
+
+.lot-secret-notice-chip {
+  display: inline-block;
+  margin-bottom: 5px;
+  padding: 3px 7px;
+  border: 2px solid var(--ink);
+  border-radius: 999px;
+  background: var(--yellow);
+  font-size: 0.43rem;
+  letter-spacing: 0.08em;
+  line-height: 1;
+}
+
+.lot-secret-notice p {
+  margin: 0;
+  font-size: 0.52rem;
+  line-height: 1.3;
+}
+
 .lot-card-actions {
   grid-template-columns: 1fr;
 }
@@ -170,6 +201,24 @@
   .lot-stat i {
     height: 6px;
   }
+
+  .lot-secret-notice {
+    margin: 6px 0 7px;
+    padding: 6px 7px 7px;
+    border-width: 2px;
+  }
+
+  .lot-secret-notice-chip {
+    margin-bottom: 3px;
+    padding: 2px 6px;
+    border-width: 1.5px;
+    font-size: 0.36rem;
+  }
+
+  .lot-secret-notice p {
+    font-size: 0.43rem;
+    line-height: 1.22;
+  }
 }
 
 @media (max-height: 430px) {
@@ -197,5 +246,19 @@
 
   .lot-viewbox-with-paint > small {
     bottom: calc(var(--lot-paint-rail-height) + 5px);
+  }
+
+  .lot-secret-notice {
+    margin: 4px 0 5px;
+    padding: 5px 6px;
+  }
+
+  .lot-secret-notice-chip {
+    display: none;
+  }
+
+  .lot-secret-notice p {
+    font-size: 0.4rem;
+    line-height: 1.16;
   }
 }

--- a/turn/garage/lot-layout-r60.css
+++ b/turn/garage/lot-layout-r60.css
@@ -92,9 +92,9 @@
 .lot-secret-notice {
   margin: 8px 0 10px;
   padding: 8px 9px 9px;
+  background: #d9f5c2;
   border: 3px solid var(--ink);
   border-radius: 10px;
-  background: #d9f5c2;
   box-shadow: 2px 2px 0 var(--ink);
 }
 

--- a/turn/vehicle/sports-sedan-easter-egg.js
+++ b/turn/vehicle/sports-sedan-easter-egg.js
@@ -106,6 +106,10 @@ function ensureUnlockNotice(lot) {
   notice.setAttribute('role', 'status');
   notice.setAttribute('aria-live', 'polite');
   notice.setAttribute('aria-atomic', 'true');
+  notice.setAttribute(
+    'aria-label',
+    'Super Sedan unlocked. Spoiler color code #666 maxes every attribute. Lap results with this secret car are not saved.'
+  );
   notice.innerHTML = `
     <span class="lot-secret-notice-chip">SECRET UNLOCKED</span>
     <p>Spoiler <strong>color code #666</strong> maxes every attribute. Lap results with this secret car are not saved.</p>

--- a/turn/vehicle/sports-sedan-easter-egg.js
+++ b/turn/vehicle/sports-sedan-easter-egg.js
@@ -5,6 +5,7 @@ if (buildKey) catalogUrl.searchParams.set('build', buildKey);
 const {
   CAR_CATALOG,
   getEffectiveVehicleStats,
+  isSportsSedanEasterEgg,
   normalizeVehicleSecondaryColor
 } = await import(catalogUrl.href);
 
@@ -57,18 +58,20 @@ export function installSportsSedanEasterEggUi() {
 }
 
 function syncLotStats(lot) {
-  const title = lot.querySelector('.lot-car-title strong')?.textContent?.trim();
-  const car = CAR_CATALOG.find((candidate) => candidate.name === title);
+  const selectedCarId = lot.querySelector('.lot-car-option[aria-checked="true"]')?.dataset.carId;
+  const car = CAR_CATALOG.find((candidate) => candidate.id === selectedCarId);
   const rows = [...lot.querySelectorAll('.lot-stats .lot-stat')];
   if (!car || rows.length !== STAT_KEYS.length) return;
 
   const spoilerControl = [...lot.querySelectorAll('.lot-color-control')]
     .find((control) => control.querySelector('span')?.textContent?.trim() === 'SPOILER');
   const spoilerColor = spoilerControl?.querySelector('input[type="color"]')?.value;
-  const stats = getEffectiveVehicleStats({
+  const selection = {
     carId: car.id,
     secondaryColor: normalizeVehicleSecondaryColor(spoilerColor)
-  });
+  };
+  const stats = getEffectiveVehicleStats(selection);
+  const superSedanUnlocked = isSportsSedanEasterEgg(selection);
 
   rows.forEach((row, rowIndex) => {
     const value = Number(stats[STAT_KEYS[rowIndex]]) || 0;
@@ -76,4 +79,40 @@ function syncLotStats(lot) {
       pip.classList.toggle('is-full', pipIndex < value);
     });
   });
+
+  syncUnlockPresentation(lot, car, superSedanUnlocked);
+}
+
+function syncUnlockPresentation(lot, car, unlocked) {
+  const title = lot.querySelector('.lot-car-title strong');
+  const raceButton = lot.querySelector('.lot-race');
+  const notice = ensureUnlockNotice(lot);
+
+  const displayedName = unlocked ? 'Super Sedan' : car.name;
+  if (title && title.textContent !== displayedName) title.textContent = displayedName;
+  raceButton?.setAttribute('aria-label', `Race the ${displayedName}`);
+
+  notice.hidden = !unlocked;
+  lot.classList.toggle('is-super-sedan-unlocked', unlocked);
+}
+
+function ensureUnlockNotice(lot) {
+  const existing = lot.querySelector('.lot-secret-notice');
+  if (existing) return existing;
+
+  const notice = document.createElement('section');
+  notice.className = 'lot-secret-notice';
+  notice.hidden = true;
+  notice.setAttribute('role', 'status');
+  notice.setAttribute('aria-live', 'polite');
+  notice.setAttribute('aria-atomic', 'true');
+  notice.innerHTML = `
+    <span class="lot-secret-notice-chip">SECRET UNLOCKED</span>
+    <p>Spoiler <strong>color code #666</strong> maxes every attribute. Lap results with this secret car are not saved.</p>
+  `;
+
+  const card = lot.querySelector('.lot-card');
+  const actions = card?.querySelector('.lot-card-actions');
+  if (card) card.insertBefore(notice, actions || null);
+  return notice;
 }


### PR DESCRIPTION
## Super Sedan discovery

When the Sport Sedan spoiler uses **color code #666**, The Lot now explains what the player has found before they start the race.

- the visible car name temporarily changes from `Sport Sedan` to `Super Sedan`
- a pale green, black-bordered notice appears between ATTRIBUTES and RACE THIS CAR
- the notice includes a `SECRET UNLOCKED` chip
- copy: `Spoiler color code #666 maxes every attribute. Lap results with this secret car are not saved.`
- the race button's accessible name becomes `Race the Super Sedan`
- a polite screen-reader status announcement names the Super Sedan and explains both effects
- changing the spoiler away from color code #666 restores the normal Sport Sedan name and hides the notice

The enhancer now identifies the selected vehicle from the canonical selected-car control rather than the visible title, so temporarily renaming the heading cannot break the Easter egg state.

Responsive styling keeps the explanation compact on short landscape screens, and regression coverage protects the copy, placement, accessibility, cache revisions and presentation.