### PR TITLE
Keep the Super Sedan race action above the fold

### DIFF
--- a/turn-lab/tests/lot-layout-production.mjs
+++ b/turn-lab/tests/lot-layout-production.mjs
@@ -34,7 +34,7 @@ assert.match(index, new RegExp(`lot-layout-r60\\.css\\?build=${release.cacheKey}
 assert.match(index, new RegExp(`app\\.js\\?build=${release.cacheKey}-browser-consent`), 'Production must cache-bust the browser-gated canonical runtime');
 assert.equal(imports['./garage/lot-r10.js?build=20260720-r19'], `./garage/lot-track-select.js?build=${release.cacheKey}`, 'Production must retain the track-first compatibility wrapper');
 
-assert.match(app, /lot-layout-r60\.css\?revision=r121-viewer-r122-fit/, 'The fitted Lot rail stylesheet must bypass the previous viewer cache');
+assert.match(app, /lot-layout-r60\.css\?revision=r121-viewer-r122-fit-r128-super-sedan-notice-r129-race-button-fit/, 'The Super Sedan fit stylesheet must bypass the previous notice cache');
 assert.match(app, /lot-enhancement-runtime\.js\?revision=r121/, 'Production must load the route-independent Lot enhancer');
 assert.match(app, /installLotEnhancementRuntime\(\)/, 'Production must install the Lot enhancer once');
 assert.ok(
@@ -108,15 +108,20 @@ assert.match(layoutCss, /--lot-paint-rail-height: 54px/, 'Paint controls must us
 assert.match(layoutCss, /min-height: clamp\(150px, 28vh, 230px\)/, 'The 3D viewer must receive a meaningful responsive minimum height');
 assert.match(layoutCss, /flex: 1 1 auto/, 'The 3D panel must receive the remaining rail height instead of being squashed');
 assert.match(layoutCss, /\.lot-viewbox-with-paint \.lot-colors \{[\s\S]*border-top: 3px solid var\(--ink\)/, 'Accessible paint controls must preserve their visual dock inside the 3D card');
-assert.match(layoutCss, /\.lot-card-actions \{[\s\S]*grid-template-columns: 1fr/, 'The lower card must reserve its action row for Race only');
+assert.match(layoutCss, /\.lot-card-actions \{[\s\S]*grid-template-columns: 1fr[\s\S]*margin-top: 4px/, 'Race This Car must follow the secret notice with only the explicit minimum gap');
+assert.match(layoutCss, /\.lot-secret-notice \{[\s\S]*margin: 8px 0 0/, 'The secret notice must not reserve an additional bottom margin above Race This Car');
+assert.match(layoutCss, /\.lot-screen\.is-super-sedan-unlocked \.lot-card \{[\s\S]*display: flex[\s\S]*flex-direction: column/, 'The unlocked card must keep the notice and action in one deterministic vertical flow');
+assert.match(layoutCss, /\.lot-screen\.is-super-sedan-unlocked \.lot-viewbox-with-paint \{[\s\S]*min-height: clamp\(132px, 22vh, 176px\)/, 'The temporary secret message must borrow enough rail height to keep Race This Car above the fold');
 assert.match(layoutCss, /\.lot-stats-help \{[\s\S]*border-radius: 50%/, 'The Attributes help control must read as a conventional circular info icon');
 assert.match(layoutCss, /\.lot-race \{[\s\S]*background: var\(--pink\)/, 'Race This Car must use the pink action treatment shown in the fitted design');
 assert.match(layoutCss, /\.lot-view-close,[\s\S]*\.lot-view-open \{[\s\S]*display: none !important/, 'No dormant 3D close or reopen affordance may flash during setup');
 assert.match(layoutCss, /@media \(max-height: 520px\)[\s\S]*\.lot-side \{[\s\S]*top: max\(62px,[\s\S]*\.lot-card \{[\s\S]*padding: 9px/, 'Tablet-sized short landscapes must compact the rail before Race can leave the viewport');
+assert.match(layoutCss, /@media \(max-height: 520px\)[\s\S]*\.lot-screen\.is-super-sedan-unlocked \.lot-viewbox-with-paint \{[\s\S]*min-height: 112px/, 'Short tablet landscapes must give the unlocked action enough room');
 assert.match(layoutCss, /@media \(max-height: 520px\)[\s\S]*min-height: 140px/, 'The fitted layout must preserve a useful 3D preview on short tablet landscapes');
+assert.match(layoutCss, /@media \(max-height: 430px\)[\s\S]*\.lot-screen\.is-super-sedan-unlocked \.lot-viewbox-with-paint \{[\s\S]*min-height: 96px/, 'Short iPhone landscapes must prioritise the unlocked race action without removing the viewer');
 assert.match(layoutCss, /@media \(max-height: 430px\)[\s\S]*min-height: 120px/, 'Short iPhone landscapes must keep the viewer without pushing Race off-screen');
 
 assert.match(lot, /<div class="lot-colors" aria-label="Choose car paint colours"><\/div>/, 'The verified Lot must still own the live native paint controls before enhancement');
 assert.match(legend, /aria-haspopup', 'dialog'/, 'The relocated info icon must still open the full stat legend');
 
-console.log(`TURN ${release.id} route-independent enhanced Lot, fitted short-landscape rail and selected-car accessibility passed.`);
+console.log(`TURN ${release.id} route-independent enhanced Lot, fitted Super Sedan action rail and selected-car accessibility passed.`);

--- a/turn/app.js
+++ b/turn/app.js
@@ -62,7 +62,7 @@ document.documentElement.dataset.turnDisplayLifecycle = 'platform-m6';
 installStylesheet('./r104-polish.css', 'data-turn-r104-polish');
 installStylesheet('./steering-limit-warning.css', 'data-turn-steering-limit-warning');
 installStylesheet(
-  './garage/lot-layout-r60.css?revision=r121-viewer-r122-fit-r128-super-sedan-notice',
+  './garage/lot-layout-r60.css?revision=r121-viewer-r122-fit-r128-super-sedan-notice-r129-race-button-fit',
   'data-turn-lot-layout-r121'
 );
 

--- a/turn/garage/lot-layout-r60.css
+++ b/turn/garage/lot-layout-r60.css
@@ -90,8 +90,8 @@
 }
 
 .lot-secret-notice {
-  margin: 8px 0 10px;
-  padding: 8px 9px 9px;
+  margin: 8px 0 0;
+  padding: 7px 8px 8px;
   background: #d9f5c2;
   border: 3px solid var(--ink);
   border-radius: 10px;
@@ -104,7 +104,7 @@
 
 .lot-secret-notice-chip {
   display: inline-block;
-  margin-bottom: 5px;
+  margin-bottom: 4px;
   padding: 3px 7px;
   border: 2px solid var(--ink);
   border-radius: 999px;
@@ -116,12 +116,22 @@
 
 .lot-secret-notice p {
   margin: 0;
-  font-size: 0.52rem;
-  line-height: 1.3;
+  font-size: 0.5rem;
+  line-height: 1.24;
+}
+
+.lot-screen.is-super-sedan-unlocked .lot-card {
+  display: flex;
+  flex-direction: column;
+}
+
+.lot-screen.is-super-sedan-unlocked .lot-viewbox-with-paint {
+  min-height: clamp(132px, 22vh, 176px);
 }
 
 .lot-card-actions {
   grid-template-columns: 1fr;
+  margin-top: 4px;
 }
 
 .lot-race {
@@ -147,6 +157,10 @@
   .lot-viewbox-with-paint {
     --lot-paint-rail-height: 50px;
     min-height: 140px;
+  }
+
+  .lot-screen.is-super-sedan-unlocked .lot-viewbox-with-paint {
+    min-height: 112px;
   }
 
   .lot-viewbox-with-paint .lot-colors {
@@ -203,7 +217,7 @@
   }
 
   .lot-secret-notice {
-    margin: 6px 0 7px;
+    margin-top: 6px;
     padding: 6px 7px 7px;
     border-width: 2px;
   }
@@ -217,7 +231,11 @@
 
   .lot-secret-notice p {
     font-size: 0.43rem;
-    line-height: 1.22;
+    line-height: 1.18;
+  }
+
+  .lot-card-actions {
+    margin-top: 3px;
   }
 }
 
@@ -226,6 +244,10 @@
     --lot-paint-rail-height: 47px;
     min-height: 120px;
     flex-basis: auto;
+  }
+
+  .lot-screen.is-super-sedan-unlocked .lot-viewbox-with-paint {
+    min-height: 96px;
   }
 
   .lot-viewbox-with-paint .lot-colors {
@@ -249,7 +271,7 @@
   }
 
   .lot-secret-notice {
-    margin: 4px 0 5px;
+    margin-top: 4px;
     padding: 5px 6px;
   }
 
@@ -259,6 +281,10 @@
 
   .lot-secret-notice p {
     font-size: 0.4rem;
-    line-height: 1.16;
+    line-height: 1.13;
+  }
+
+  .lot-card-actions {
+    margin-top: 2px;
   }
 }


### PR DESCRIPTION
## Super Sedan Lot fit

The secret message was adding enough height to push `RACE THIS CAR` partly below the viewport.

This change:

- removes the notice's bottom margin
- gives the notice and race action one explicit 4 px gap
- keeps the unlocked card in one deterministic vertical flow
- temporarily lets the 3D viewer surrender some height while the Super Sedan notice is visible
- adds tighter protected values for short tablet and iPhone landscape heights
- refreshes the fitted Lot stylesheet cache
- extends the Lot layout regression contract so the action cannot drift below the fold again

The normal Lot layout is unchanged when the Super Sedan secret is not active.