### PR TITLE
Add hidden LILYA portrait to Midnight City

### DIFF
--- a/turn-tests/midnight-city-lighting-production.mjs
+++ b/turn-tests/midnight-city-lighting-production.mjs
@@ -7,6 +7,7 @@ const [
   cityLifeSource,
   showcaseSource,
   signParkSource,
+  easterEggSource,
   registrySource
 ] = await Promise.all([
   fs.readFile(new URL('../turn/tracks/midnight-city-world-r3.js', import.meta.url), 'utf8'),
@@ -14,6 +15,7 @@ const [
   fs.readFile(new URL('../turn/tracks/midnight-city-world-r5.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/tracks/midnight-city-world-r6.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/tracks/midnight-city-world-r7.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/tracks/midnight-city-world-r8.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/tracks/registry.js', import.meta.url), 'utf8')
 ]);
 
@@ -107,8 +109,22 @@ assert.doesNotMatch(
 );
 assert.doesNotMatch(signParkSource, /new THREE\.PointLight|new THREE\.SpotLight|GLTFLoader|fetch\(/);
 
-assert.match(registrySource, /midnight-city-world-r7\.js\?build=20260801-r7/);
+await fs.access(new URL('../turn/LILYA.PNG', import.meta.url));
+assert.match(easterEggSource, /installMidnightCityWorld as installMidnightCityWorldR7/);
+assert.match(easterEggSource, /new URL\('\.\.\/LILYA\.PNG', import\.meta\.url\)\.href/);
+assert.match(easterEggSource, /x: -495\.42[\s\S]*y: 29\.8[\s\S]*z: 113\.29/);
+assert.match(easterEggSource, /side: THREE\.FrontSide/);
+assert.match(easterEggSource, /portrait\.rotation\.y = -Math\.PI \/ 2/);
+assert.match(easterEggSource, /hiddenLilyaPlacement: 'west face of the Neon Quarter building, visible from the reverse approach'/);
+assert.match(easterEggSource, /gameplayGeometryUnchanged: true/);
+assert.doesNotMatch(
+  easterEggSource,
+  /requestAnimationFrame|setAnimationLoop|setInterval|setTimeout|new THREE\.PointLight|new THREE\.SpotLight/,
+  'The hidden portrait must remain a static visual detail'
+);
+
+assert.match(registrySource, /midnight-city-world-r8\.js\?build=20260802-r8/);
 assert.match(registrySource, /'midnight-city'\(\{ scene, samples, trackWidth, runtime \}\)/);
 assert.match(registrySource, /installMidnightCityWorld\(\{ scene, samples, trackWidth, runtime \}\)/);
 
-console.log('TURN Midnight City readable signs, trackside parks and fountain showcase passed.');
+console.log('TURN Midnight City readable signs, parks, showcase and hidden portrait passed.');

--- a/turn/tracks/midnight-city-world-r8.js
+++ b/turn/tracks/midnight-city-world-r8.js
@@ -1,0 +1,77 @@
+import * as THREE from 'three';
+import { installMidnightCityWorld as installMidnightCityWorldR7 } from './midnight-city-world-r7.js?base=20260801-r7';
+
+const LILYA_TEXTURE_URL = new URL('../LILYA.PNG', import.meta.url).href;
+const LILYA_WALL = Object.freeze({
+  x: -495.42,
+  y: 29.8,
+  z: 113.29,
+  maxWidth: 44,
+  maxHeight: 48
+});
+
+export function installMidnightCityWorld(options) {
+  const world = installMidnightCityWorldR7(options);
+  installHiddenLilyaPortrait(world);
+
+  world.name = 'TURN Midnight City r8';
+  world.userData.turnMidnightCityArtDirection = Object.freeze({
+    ...(world.userData.turnMidnightCityArtDirection || {}),
+    version: 'r8',
+    hiddenLilyaPortrait: true,
+    hiddenLilyaPlacement: 'west face of the Neon Quarter building, visible from the reverse approach',
+    gameplayGeometryUnchanged: true,
+    noDynamicLightsAdded: true,
+    noIndependentAnimationLoop: true
+  });
+
+  return world;
+}
+
+function installHiddenLilyaPortrait(world) {
+  const material = new THREE.MeshBasicMaterial({
+    transparent: true,
+    alphaTest: 0.05,
+    depthWrite: false,
+    side: THREE.FrontSide,
+    toneMapped: false
+  });
+  const portrait = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), material);
+  portrait.name = 'Midnight City hidden LILYA portrait';
+  portrait.position.set(LILYA_WALL.x, LILYA_WALL.y, LILYA_WALL.z);
+  portrait.rotation.y = -Math.PI / 2;
+  portrait.visible = false;
+  portrait.renderOrder = 3;
+  portrait.userData.turnEasterEgg = 'hidden-lilya-portrait';
+  world.add(portrait);
+
+  new THREE.TextureLoader().load(
+    LILYA_TEXTURE_URL,
+    (texture) => {
+      texture.colorSpace = THREE.SRGBColorSpace;
+      texture.magFilter = THREE.LinearFilter;
+
+      const imageWidth = texture.image?.naturalWidth || texture.image?.width || 1;
+      const imageHeight = texture.image?.naturalHeight || texture.image?.height || 1;
+      const aspectRatio = imageWidth / imageHeight;
+      let width = LILYA_WALL.maxWidth;
+      let height = width / aspectRatio;
+
+      if (height > LILYA_WALL.maxHeight) {
+        height = LILYA_WALL.maxHeight;
+        width = height * aspectRatio;
+      }
+
+      material.map = texture;
+      material.needsUpdate = true;
+      portrait.scale.set(width, height, 1);
+      portrait.visible = true;
+    },
+    undefined,
+    (error) => {
+      console.warn('TURN: Midnight City could not load the hidden LILYA portrait.', error);
+    }
+  );
+
+  return portrait;
+}

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -8,7 +8,7 @@ import {
 import { installAirportWorld } from './airport-world-r52.js?build=20260722-r52';
 import { installCliffsideWorld } from './cliffside-world.js';
 import { installHarborWorld } from './harbor-world.js';
-import { installMidnightCityWorld } from './midnight-city-world-r7.js?build=20260801-r7';
+import { installMidnightCityWorld } from './midnight-city-world-r8.js?build=20260802-r8';
 import { isForgivingTrackSurface } from './airport-runoff.js?build=20260722-r52';
 
 const WORLD_INSTALLERS = Object.freeze({


### PR DESCRIPTION
## What changed

- add a new Midnight City r8 world layer that loads `turn/LILYA.PNG`
- place the portrait on the west-facing wall of the isolated Neon Quarter building highlighted in the supplied map
- face the texture toward the reverse approach, so it is discovered when driving that section in the wrong direction
- preserve the image aspect ratio and fit it within the existing facade
- keep gameplay and collision geometry unchanged
- update the Midnight City runtime cache key and regression coverage

## Placement

The portrait is mounted at the generated building’s west facade near world position `(-495.42, 29.8, 113.29)`, matching the marked building beside the western track loop.

## Validation

- confirmed `turn/LILYA.PNG` exists on `main`
- verified the r8 module syntax with `node --check`
- extended the Midnight City production regression to verify the asset, placement, facing direction, static rendering and r8 registry wiring