### PR TITLE
Mount LILYA on the visible wall and lazy load it

### DIFF
--- a/turn-lab/tests/multi-track-production.mjs
+++ b/turn-lab/tests/multi-track-production.mjs
@@ -132,7 +132,7 @@ assert.match(definitions, /sampleCount: 1080/);
 assert.match(definitions, /fogNear: 250[\s\S]*fogFar: 880/);
 assert.match(definitions, /id: 'track-6-tba'[\s\S]*locked: true/);
 assert.match(catalog, /MIDNIGHT_CITY_CONTROL_POINTS\.map/);
-assert.match(registry, /midnight-city-world-r7\.js\?build=20260801-r7/);
+assert.match(registry, /midnight-city-world-r9\.js\?build=20260802-r9/);
 assert.match(registry, /definition\.sampleCount \|\| sampleCount/);
 assert.doesNotMatch(manager, /nextTrackId === 'midnight-city'/, 'The generic track manager must not gain a Midnight City special case');
 assert.match(manager, /lighting\.hemisphereIntensity \?\? 2\.7/);

--- a/turn-tests/midnight-city-lighting-production.mjs
+++ b/turn-tests/midnight-city-lighting-production.mjs
@@ -15,7 +15,7 @@ const [
   fs.readFile(new URL('../turn/tracks/midnight-city-world-r5.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/tracks/midnight-city-world-r6.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/tracks/midnight-city-world-r7.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/tracks/midnight-city-world-r8.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/tracks/midnight-city-world-r9.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/tracks/registry.js', import.meta.url), 'utf8')
 ]);
 
@@ -112,19 +112,28 @@ assert.doesNotMatch(signParkSource, /new THREE\.PointLight|new THREE\.SpotLight|
 await fs.access(new URL('../turn/LILYA.PNG', import.meta.url));
 assert.match(easterEggSource, /installMidnightCityWorld as installMidnightCityWorldR7/);
 assert.match(easterEggSource, /new URL\('\.\.\/LILYA\.PNG', import\.meta\.url\)\.href/);
-assert.match(easterEggSource, /x: -495\.42[\s\S]*y: 29\.8[\s\S]*z: 113\.29/);
+assert.match(easterEggSource, /x: -474\.52[\s\S]*y: 29\.8[\s\S]*z: 140\.12/);
 assert.match(easterEggSource, /side: THREE\.FrontSide/);
-assert.match(easterEggSource, /portrait\.rotation\.y = -Math\.PI \/ 2/);
-assert.match(easterEggSource, /hiddenLilyaPlacement: 'west face of the Neon Quarter building, visible from the reverse approach'/);
+assert.match(easterEggSource, /portrait\.rotation\.y = 0/);
+assert.match(easterEggSource, /armViewTriggeredTextureLoad\(world, portrait\)/);
+assert.match(easterEggSource, /world\.getObjectByName\('Midnight City race road'\)/);
+assert.match(easterEggSource, /road\.onBeforeRender = viewTriggeredLoad/);
+assert.match(easterEggSource, /camera\.getWorldPosition\(cameraPosition\)/);
+assert.match(easterEggSource, /camera\.getWorldDirection\(cameraForward\)/);
+assert.match(easterEggSource, /cameraForward\.dot\(cameraToWall\) < LILYA_MIN_VIEW_DOT/);
+assert.match(easterEggSource, /loadLilyaTexture\(portrait\)/);
+assert.match(easterEggSource, /texture\.generateMipmaps = false/);
+assert.match(easterEggSource, /hiddenLilyaPlacement: 'north road-facing facade of the Neon Quarter building, visible from the reverse approach'/);
+assert.match(easterEggSource, /hiddenLilyaLazyLoad: lazyLoadArmed/);
 assert.match(easterEggSource, /gameplayGeometryUnchanged: true/);
 assert.doesNotMatch(
   easterEggSource,
   /requestAnimationFrame|setAnimationLoop|setInterval|setTimeout|new THREE\.PointLight|new THREE\.SpotLight/,
-  'The hidden portrait must remain a static visual detail'
+  'The hidden portrait must use the existing render loop without adding timers or lights'
 );
 
-assert.match(registrySource, /midnight-city-world-r8\.js\?build=20260802-r8/);
+assert.match(registrySource, /midnight-city-world-r9\.js\?build=20260802-r9/);
 assert.match(registrySource, /'midnight-city'\(\{ scene, samples, trackWidth, runtime \}\)/);
 assert.match(registrySource, /installMidnightCityWorld\(\{ scene, samples, trackWidth, runtime \}\)/);
 
-console.log('TURN Midnight City readable signs, parks, showcase and hidden portrait passed.');
+console.log('TURN Midnight City readable signs, parks, showcase and lazy hidden portrait passed.');

--- a/turn/tracks/midnight-city-world-r9.js
+++ b/turn/tracks/midnight-city-world-r9.js
@@ -1,0 +1,135 @@
+import * as THREE from 'three';
+import { installMidnightCityWorld as installMidnightCityWorldR7 } from './midnight-city-world-r7.js?base=20260801-r7';
+
+const LILYA_TEXTURE_URL = new URL('../LILYA.PNG', import.meta.url).href;
+const LILYA_WALL = Object.freeze({
+  x: -474.52,
+  y: 29.8,
+  z: 140.12,
+  maxWidth: 38,
+  maxHeight: 48
+});
+const LILYA_LOAD_DISTANCE = 260;
+const LILYA_LOAD_DISTANCE_SQUARED = LILYA_LOAD_DISTANCE * LILYA_LOAD_DISTANCE;
+const LILYA_MIN_VIEW_DOT = 0.52;
+
+export function installMidnightCityWorld(options) {
+  const world = installMidnightCityWorldR7(options);
+  const portrait = installHiddenLilyaPortrait(world);
+  const lazyLoadArmed = armViewTriggeredTextureLoad(world, portrait);
+
+  world.name = 'TURN Midnight City r9';
+  world.userData.turnMidnightCityArtDirection = Object.freeze({
+    ...(world.userData.turnMidnightCityArtDirection || {}),
+    version: 'r9',
+    hiddenLilyaPortrait: true,
+    hiddenLilyaPlacement: 'north road-facing facade of the Neon Quarter building, visible from the reverse approach',
+    hiddenLilyaLazyLoad: lazyLoadArmed
+      ? 'load only when the camera approaches and looks toward the wall'
+      : 'unavailable because the race-road render trigger was not found',
+    hiddenLilyaMipmaps: false,
+    gameplayGeometryUnchanged: true,
+    noDynamicLightsAdded: true,
+    noIndependentAnimationLoop: true
+  });
+
+  return world;
+}
+
+function installHiddenLilyaPortrait(world) {
+  const material = new THREE.MeshBasicMaterial({
+    transparent: true,
+    alphaTest: 0.05,
+    depthWrite: false,
+    side: THREE.FrontSide,
+    toneMapped: false,
+    polygonOffset: true,
+    polygonOffsetFactor: -2,
+    polygonOffsetUnits: -2
+  });
+  const portrait = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), material);
+  portrait.name = 'Midnight City hidden LILYA portrait';
+  portrait.position.set(LILYA_WALL.x, LILYA_WALL.y, LILYA_WALL.z);
+  portrait.rotation.y = 0;
+  portrait.visible = false;
+  portrait.renderOrder = 4;
+  portrait.userData.turnEasterEgg = 'hidden-lilya-portrait';
+  world.add(portrait);
+  return portrait;
+}
+
+function armViewTriggeredTextureLoad(world, portrait) {
+  const road = world.getObjectByName('Midnight City race road');
+  if (!road) {
+    console.warn('TURN: Midnight City could not arm the hidden LILYA portrait lazy loader.');
+    return false;
+  }
+
+  const wallPosition = new THREE.Vector3(LILYA_WALL.x, LILYA_WALL.y, LILYA_WALL.z);
+  const cameraPosition = new THREE.Vector3();
+  const cameraForward = new THREE.Vector3();
+  const cameraToWall = new THREE.Vector3();
+  const previousOnBeforeRender = road.onBeforeRender;
+  let loadStarted = false;
+
+  function restoreRoadRenderHook() {
+    if (road.onBeforeRender === viewTriggeredLoad) {
+      road.onBeforeRender = previousOnBeforeRender;
+    }
+  }
+
+  function viewTriggeredLoad(...args) {
+    previousOnBeforeRender?.call(this, ...args);
+    if (loadStarted) return;
+
+    const camera = args[2];
+    if (!camera?.isCamera) return;
+
+    camera.getWorldPosition(cameraPosition);
+    if (cameraPosition.distanceToSquared(wallPosition) > LILYA_LOAD_DISTANCE_SQUARED) return;
+
+    camera.getWorldDirection(cameraForward);
+    cameraToWall.copy(wallPosition).sub(cameraPosition).normalize();
+    if (cameraForward.dot(cameraToWall) < LILYA_MIN_VIEW_DOT) return;
+
+    loadStarted = true;
+    restoreRoadRenderHook();
+    loadLilyaTexture(portrait);
+  }
+
+  road.onBeforeRender = viewTriggeredLoad;
+  portrait.userData.turnLazyTexture = 'camera-proximity-and-view-direction';
+  return true;
+}
+
+function loadLilyaTexture(portrait) {
+  new THREE.TextureLoader().load(
+    LILYA_TEXTURE_URL,
+    (texture) => {
+      texture.colorSpace = THREE.SRGBColorSpace;
+      texture.generateMipmaps = false;
+      texture.minFilter = THREE.LinearFilter;
+      texture.magFilter = THREE.LinearFilter;
+
+      const imageWidth = texture.image?.naturalWidth || texture.image?.width || 1;
+      const imageHeight = texture.image?.naturalHeight || texture.image?.height || 1;
+      const aspectRatio = imageWidth / imageHeight;
+      let width = LILYA_WALL.maxWidth;
+      let height = width / aspectRatio;
+
+      if (height > LILYA_WALL.maxHeight) {
+        height = LILYA_WALL.maxHeight;
+        width = height * aspectRatio;
+      }
+
+      portrait.material.map = texture;
+      portrait.material.needsUpdate = true;
+      portrait.scale.set(width, height, 1);
+      portrait.visible = true;
+    },
+    undefined,
+    (error) => {
+      console.warn('TURN: Midnight City could not load the hidden LILYA portrait.', error);
+    }
+  );
+}

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -8,7 +8,7 @@ import {
 import { installAirportWorld } from './airport-world-r52.js?build=20260722-r52';
 import { installCliffsideWorld } from './cliffside-world.js';
 import { installHarborWorld } from './harbor-world.js';
-import { installMidnightCityWorld } from './midnight-city-world-r8.js?build=20260802-r8';
+import { installMidnightCityWorld } from './midnight-city-world-r9.js?build=20260802-r9';
 import { isForgivingTrackSurface } from './airport-runoff.js?build=20260722-r52';
 
 const WORLD_INSTALLERS = Object.freeze({


### PR DESCRIPTION
## What changed

- replace the r8 placement with a new Midnight City r9 layer based directly on r7, avoiding the old eager texture request
- move `LILYA.PNG` from the oblique west face to the broad north, road-facing facade of the marked Neon Quarter building
- offset the portrait slightly in front of the facade and use polygon offset to avoid z-fighting with the building and window bands
- lazy-load the 2 MB image only when the camera is within 260 world units and actually looking toward that wall
- detach the render hook as soon as loading begins, so there is no permanent per-frame check
- disable texture mipmap generation to reduce upload work and texture memory
- keep collision and gameplay geometry unchanged

## Performance

Regular Midnight City runs no longer request, decode or upload `LILYA.PNG` unless the player approaches while looking toward the hidden wall. The check piggybacks on the existing road render callback and adds no timer, animation loop or draw call.

## Validation

- `node --check` passes for the new r9 world module and updated regression file
- production regression coverage verifies the new facade coordinates, front-facing orientation, camera-triggered loading, no mipmaps and r9 registry wiring