### PR TITLE
Enlarge and align track card names

### DIFF
--- a/turn-tests/home-navigation-production.mjs
+++ b/turn-tests/home-navigation-production.mjs
@@ -32,7 +32,7 @@ const [
 assert.match(productionApp, /installM8HomeNavigation/);
 assert.match(productionApp, /installM8HomeFixedLayout/);
 assert.match(productionApp, /installStylesheet\('\.\/m8-home\.css'/);
-assert.match(productionApp, /m8-home-fixed-layout\.js\?revision=m8\.8-full-track-names/);
+assert.match(productionApp, /m8-home-fixed-layout\.js\?revision=m8\.9-track-title-alignment/);
 assert.ok(productionApp.indexOf('installM8HomeNavigation()') < productionApp.indexOf('installM8HomeFixedLayout()'));
 assert.match(productionApp, /turnHomeLifecycle = 'home-m8'/);
 assert.match(productionApp, /retireLegacyStartPanel\(\)/);
@@ -85,7 +85,7 @@ assert.match(fixedLayoutSource, /oldScrollButtons\.hidden = true/);
 assert.match(fixedLayoutSource, /raceButton\.textContent = 'RACE'/);
 assert.match(fixedLayoutSource, /Race on \$\{spokenTrackName\(selectedTrackName\)\}/);
 assert.match(fixedLayoutSource, /new MutationObserver\(syncRaceLabel\)/);
-assert.match(fixedLayoutSource, /\/turn\/m8-home-card-scroll-fixes\.js\?build=\$\{buildKey\}-m8\.8-full-track-names/);
+assert.match(fixedLayoutSource, /\/turn\/m8-home-card-scroll-fixes\.js\?build=\$\{buildKey\}-m8\.9-track-title-alignment/);
 assert.match(fixedLayoutSource, /installM8HomeCardScrollFixes\(\)/);
 assert.match(fixedLayoutSource, /turnHomeLayout = LAYOUT_ID/);
 
@@ -109,8 +109,8 @@ assert.match(fixedLayoutCss, /@media \(max-height: 560px\) and \(orientation: la
 assert.match(fixedLayoutCss, /@media \(max-width: 760px\) and \(orientation: portrait\)[\s\S]*\.m8-home-fixed-layout \.m8-home-head[\s\S]*padding: 0 12px 0 0/);
 assert.match(fixedLayoutCss, /prefers-reduced-motion/);
 
-assert.match(cardScrollSource, /const FIX_ID = 'native-scroll-full-track-names-v3'/);
-assert.match(cardScrollSource, /m8-home-card-scroll-fixes\.css\?build=\$\{buildKey\}-m8\.8-full-track-names/);
+assert.match(cardScrollSource, /const FIX_ID = 'native-scroll-full-track-names-v4'/);
+assert.match(cardScrollSource, /m8-home-card-scroll-fixes\.css\?build=\$\{buildKey\}-m8\.9-track-title-alignment/);
 assert.match(cardScrollSource, /m8-track-scroll-indicator/);
 assert.match(cardScrollSource, /ResizeObserver/);
 assert.match(cardScrollSource, /rail\.style\.scrollSnapType = 'none'/);
@@ -128,13 +128,15 @@ assert.match(cardScrollCss, /scroll-snap-type: none !important/);
 assert.match(cardScrollCss, /overscroll-behavior-y: contain/);
 assert.doesNotMatch(cardScrollCss, /touch-action: none|cursor: grab|cursor: grabbing|is-drag-scrolling/);
 assert.match(cardScrollCss, /\.track-card-summary[\s\S]*display: contents/);
-assert.match(cardScrollCss, /\.track-card-choice[\s\S]*grid-row: 1/);
+assert.match(cardScrollCss, /\.track-card-choice[\s\S]*grid-row: 1[\s\S]*align-items: center/);
+assert.match(cardScrollCss, /\.track-card-choice-marker[\s\S]*margin-top: 0/);
 assert.match(cardScrollCss, /\.track-card-difficulty[\s\S]*grid-row: 2/);
 assert.match(cardScrollCss, /\.track-card-preview[\s\S]*grid-row: 1 \/ 3/);
 assert.match(cardScrollCss, /\.track-card-best[\s\S]*grid-row: 3/);
 assert.match(cardScrollCss, /\.track-card-best-model[\s\S]*justify-self: end/);
 assert.match(cardScrollCss, /grid-template-columns: minmax\(0, 1fr\) minmax\(108px, 39%\)/);
-assert.match(cardScrollCss, /\.track-card-name[\s\S]*text-overflow: clip[\s\S]*white-space: normal/);
+assert.match(cardScrollCss, /\.track-card-name[\s\S]*font-size: clamp\(1\.056rem, 1\.86vw, 1\.656rem\)[\s\S]*text-overflow: clip[\s\S]*white-space: normal/);
+assert.match(cardScrollCss, /@media \(max-height: 560px\) and \(orientation: landscape\)[\s\S]*\.track-card-name[\s\S]*font-size: clamp\(0\.96rem, 1\.704vw, 1\.296rem\)/);
 assert.doesNotMatch(cardScrollCss, /\.track-card-name[\s\S]{0,240}text-overflow: ellipsis/);
 
 assert.match(orientationGuardCss, /#intro[\s\S]*display: none !important/);
@@ -150,4 +152,4 @@ assert.match(orchestrator, /function leaveRace\(\)/);
 assert.match(orchestrator, /publish\('home-open'\)/);
 assert.match(orchestrator, /phase = 'home'/);
 
-console.log('TURN production M8 Home, complete track names, native scrollbar divider and NEXT wrapper contracts passed.');
+console.log('TURN production M8 Home, larger aligned track names, native scrollbar divider and NEXT wrapper contracts passed.');

--- a/turn/app.js
+++ b/turn/app.js
@@ -189,7 +189,7 @@ if (buildLabel) {
   buildLabel.textContent = `TURN V${release?.version || ''} · BUILD ${(release?.id || '').toUpperCase()}`;
 }
 const { installM8HomeFixedLayout } = await import(
-  withBuild('./m8-home-fixed-layout.js?revision=m8.8-full-track-names')
+  withBuild('./m8-home-fixed-layout.js?revision=m8.9-track-title-alignment')
 );
 await installM8HomeFixedLayout();
 installStylesheet(

--- a/turn/m8-home-card-scroll-fixes.css
+++ b/turn/m8-home-card-scroll-fixes.css
@@ -101,7 +101,7 @@
   grid-row: 1;
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
-  align-items: start;
+  align-items: center;
   gap: 8px;
   min-width: 0;
   align-self: start;
@@ -109,14 +109,14 @@
 
 .m8-home-card-scroll-fixes .m8-track-rail .track-card-choice-marker {
   flex: 0 0 auto;
-  margin-top: 1px;
+  margin-top: 0;
 }
 
 .m8-home-card-scroll-fixes .m8-track-rail .track-card-name {
   min-width: 0;
   max-width: 100%;
   overflow: visible;
-  font-size: clamp(0.88rem, 1.55vw, 1.38rem);
+  font-size: clamp(1.056rem, 1.86vw, 1.656rem);
   line-height: 0.9;
   letter-spacing: -0.045em;
   text-overflow: clip;
@@ -227,7 +227,7 @@
   }
 
   .m8-home-card-scroll-fixes .m8-track-rail .track-card-name {
-    font-size: clamp(0.8rem, 1.42vw, 1.08rem);
+    font-size: clamp(0.96rem, 1.704vw, 1.296rem);
     line-height: 0.88;
   }
 

--- a/turn/m8-home-card-scroll-fixes.js
+++ b/turn/m8-home-card-scroll-fixes.js
@@ -1,12 +1,12 @@
 const STYLE_ATTRIBUTE = 'data-turn-m8-card-scroll-fixes';
-const FIX_ID = 'native-scroll-full-track-names-v3';
+const FIX_ID = 'native-scroll-full-track-names-v4';
 
 function installStylesheet() {
   if (document.querySelector(`link[${STYLE_ATTRIBUTE}]`)) return;
   const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
   const stylesheet = document.createElement('link');
   stylesheet.rel = 'stylesheet';
-  stylesheet.href = `/turn/m8-home-card-scroll-fixes.css?build=${buildKey}-m8.8-full-track-names`;
+  stylesheet.href = `/turn/m8-home-card-scroll-fixes.css?build=${buildKey}-m8.9-track-title-alignment`;
   stylesheet.setAttribute(STYLE_ATTRIBUTE, '');
   document.head.appendChild(stylesheet);
 }

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -97,7 +97,7 @@ export async function installM8HomeFixedLayout() {
 
   const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
   const { installM8HomeCardScrollFixes } = await import(
-    `/turn/m8-home-card-scroll-fixes.js?build=${buildKey}-m8.8-full-track-names`
+    `/turn/m8-home-card-scroll-fixes.js?build=${buildKey}-m8.9-track-title-alignment`
   );
   const cardScrollFixes = await installM8HomeCardScrollFixes();
 


### PR DESCRIPTION
## What changed

- increase track names on the Home / Choose Track cards by 20% at both regular and compact landscape sizes
- vertically centre each track name with its radio-style selection marker
- remove the marker’s old top offset
- refresh the nested Home module and stylesheet cache keys
- extend regression coverage for the exact responsive font sizes and alignment

## UX outcome

Track names now carry more visual weight and sit on the same vertical axis as the selection control, matching the supplied reference without changing card structure or interaction.

## Validation

- updated Home navigation regression coverage
- preserved complete, wrapping track names without ellipsis
- preserved native card scrolling and all existing responsive layout rules