### PR TITLE
Retry motion permission after cancelling the prompt

### DIFF
--- a/turn-tests/home-navigation-production.mjs
+++ b/turn-tests/home-navigation-production.mjs
@@ -30,6 +30,7 @@ const [
 ]);
 
 assert.match(productionApp, /installM8HomeNavigation/);
+assert.match(productionApp, /m8-home\.js\?revision=r131-motion-permission-retry/);
 assert.match(productionApp, /installM8HomeFixedLayout/);
 assert.match(productionApp, /installStylesheet\('\.\/m8-home\.css'/);
 assert.match(productionApp, /m8-home-fixed-layout\.js\?revision=m8\.9-track-title-alignment/);
@@ -72,6 +73,28 @@ assert.match(homeSource, /showHome\(\{ focus: true \}\)/);
 assert.match(homeSource, /turn-steering-mode-v1/);
 assert.match(homeSource, /saveDriveByEarEnabled/);
 assert.match(homeSource, /__turnResetRivals/);
+
+const lotRaceGateStart = homeSource.indexOf('function installLotRaceGate');
+const lotRaceGateEnd = homeSource.indexOf('export async function installM8HomeNavigation');
+assert.ok(lotRaceGateStart >= 0 && lotRaceGateEnd > lotRaceGateStart, 'Home must keep a dedicated Race This Car access gate');
+const lotRaceGateSource = homeSource.slice(lotRaceGateStart, lotRaceGateEnd);
+assert.match(
+  homeSource,
+  /function motionPermissionWasDismissed\(error\) \{[\s\S]*Motion permission was not granted\./,
+  'A cancelled motion prompt must be recognized as a retryable dismissal'
+);
+assert.match(lotRaceGateSource, /status\.textContent = '';/, 'Each Race This Car attempt starts with no stale permission message');
+assert.match(
+  lotRaceGateSource,
+  /catch \(error\) \{[\s\S]*if \(!motionPermissionWasDismissed\(error\)\) \{[\s\S]*Choose on-screen steering in Settings/,
+  'Only genuine motion errors should show the fallback information; cancelling the prompt stays silent'
+);
+assert.match(
+  lotRaceGateSource,
+  /raceButton\.addEventListener\('click', gate, true\);/,
+  'The motion gate remains armed so the next Race This Car press requests permission again'
+);
+assert.match(lotRaceGateSource, /raceButton\.disabled = false;[\s\S]*raceButton\.focus\(\);/);
 
 assert.match(homeCss, /turn-m8-active \.audio-settings-button/);
 assert.match(homeCss, /turn-m8-active \.reset-rivals-button/);
@@ -152,4 +175,4 @@ assert.match(orchestrator, /function leaveRace\(\)/);
 assert.match(orchestrator, /publish\('home-open'\)/);
 assert.match(orchestrator, /phase = 'home'/);
 
-console.log('TURN production M8 Home, larger aligned track names, native scrollbar divider and NEXT wrapper contracts passed.');
+console.log('TURN production M8 Home, retryable motion permission, larger aligned track names, native scrollbar divider and NEXT wrapper contracts passed.');

--- a/turn/app.js
+++ b/turn/app.js
@@ -176,7 +176,9 @@ installStylesheet(
 );
 installStylesheet('./m8-how-to-play-r126.css', 'data-turn-m8-how-to-play');
 installStylesheet('./rival-reset-context-r127.css', 'data-turn-rival-reset-context');
-const { installM8HomeNavigation } = await import(withBuild('./m8-home.js'));
+const { installM8HomeNavigation } = await import(
+  withBuild('./m8-home.js?revision=r131-motion-permission-retry')
+);
 const home = await installM8HomeNavigation();
 globalThis.__turnHome = home;
 const { installHowToPlayGuide } = await import(

--- a/turn/m8-home.js
+++ b/turn/m8-home.js
@@ -49,6 +49,10 @@ function motionAvailable() {
   return typeof globalThis.DeviceMotionEvent !== 'undefined';
 }
 
+function motionPermissionWasDismissed(error) {
+  return error instanceof Error && error.message === 'Motion permission was not granted.';
+}
+
 function loadSteeringMode() {
   const fallback = motionAvailable() ? STEERING_MODE.MOTION : STEERING_MODE.MANUAL;
   try {
@@ -446,7 +450,9 @@ function installLotRaceGate({ raceSession, getSteeringMode, onAccessReady }) {
       raceButton.disabled = false;
       raceButton.click();
     } catch (error) {
-      status.textContent = `${error instanceof Error ? error.message : 'The race could not start.'} Choose on-screen steering in Settings to continue without motion.`;
+      if (!motionPermissionWasDismissed(error)) {
+        status.textContent = `${error instanceof Error ? error.message : 'The race could not start.'} Choose on-screen steering in Settings to continue without motion.`;
+      }
       raceButton.disabled = false;
       raceButton.focus();
     }


### PR DESCRIPTION
## What changed

- treat a cancelled motion-permission prompt as a normal, retryable dismissal
- keep the **RACE THIS CAR** permission gate armed after cancellation
- restore and refocus the button without showing the “permission was not granted” fallback message
- request motion permission again on the next **RACE THIS CAR** press
- continue to show the existing fallback information for genuine problems such as unavailable motion sensors
- refresh the Home module cache key so the fix reaches existing installations

## UX outcome

Cancelling the iOS motion prompt no longer turns into an error state. The player simply remains in The Lot and can press **RACE THIS CAR** again to get the permission prompt again, regardless of track or car.

## Accessibility

The cancelled prompt no longer produces a redundant live-region error announcement. Keyboard and assistive-technology focus returns to **RACE THIS CAR**, ready for another attempt.

## Validation

- regression coverage verifies that cancellations stay silent
- verifies that genuine motion errors retain their useful fallback information
- verifies that the click gate remains attached and the button is restored for the next permission request
- verifies the cache-busted Home module import