### PR TITLE
Recover after cancelling iOS motion permission

### DIFF
--- a/turn-tests/home-navigation-production.mjs
+++ b/turn-tests/home-navigation-production.mjs
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
+import { installMotionPermissionCancelRecovery } from '../turn/ui/motion-permission-cancel-recovery.js';
+
 const [
   homeSource,
   homeCss,
@@ -32,6 +34,7 @@ const [
 ]);
 
 assert.match(productionApp, /installM8HomeNavigation/);
+assert.match(productionApp, /m8-home\.js\?revision=r131-motion-permission-retry/);
 assert.match(productionApp, /installM8HomeFixedLayout/);
 assert.match(productionApp, /installStylesheet\('\.\/m8-home\.css'/);
 assert.match(productionApp, /m8-home-fixed-layout\.js\?revision=m8\.9-track-title-alignment/);
@@ -74,22 +77,28 @@ assert.match(homeSource, /showHome\(\{ focus: true \}\)/);
 assert.match(homeSource, /turn-steering-mode-v1/);
 assert.match(homeSource, /saveDriveByEarEnabled/);
 assert.match(homeSource, /__turnResetRivals/);
-assert.match(homeSource, /function motionPermissionWasDismissed\(error\)/);
+
+const lotRaceGateStart = homeSource.indexOf('function installLotRaceGate');
+const lotRaceGateEnd = homeSource.indexOf('export async function installM8HomeNavigation');
+assert.ok(lotRaceGateStart >= 0 && lotRaceGateEnd > lotRaceGateStart, 'Home must keep a dedicated Race This Car access gate');
+const lotRaceGateSource = homeSource.slice(lotRaceGateStart, lotRaceGateEnd);
 assert.match(
   homeSource,
-  /if \(!motionPermissionWasDismissed\(error\)\) \{[\s\S]*Choose on-screen steering in Settings to continue without motion\./,
-  'The Lot must keep real motion failures visible while treating a cancelled prompt separately'
+  /function motionPermissionWasDismissed\(error\) \{[\s\S]*Motion permission was not granted\./,
+  'A cancelled motion prompt must be recognized as a retryable dismissal'
 );
-assert.doesNotMatch(
-  homeSource,
-  /if \(motionPermissionWasDismissed\(error\)\)[\s\S]{0,220}status\.textContent/,
-  'Cancelling the native motion prompt must not create redundant status copy'
+assert.match(lotRaceGateSource, /status\.textContent = '';/, 'Each Race This Car attempt starts with no stale permission message');
+assert.match(
+  lotRaceGateSource,
+  /catch \(error\) \{[\s\S]*if \(!motionPermissionWasDismissed\(error\)\) \{[\s\S]*Choose on-screen steering in Settings/,
+  'Only genuine motion errors should show the fallback information; cancelling the prompt stays silent'
 );
 assert.match(
-  homeSource,
-  /raceButton\.disabled = false;[\s\S]*raceButton\.focus\(\);/,
-  'The Race This Car button must be restored after a failed permission attempt'
+  lotRaceGateSource,
+  /raceButton\.addEventListener\('click', gate, true\);/,
+  'The motion gate remains armed while a fresh-document retry is prepared'
 );
+assert.match(lotRaceGateSource, /raceButton\.disabled = false;[\s\S]*raceButton\.focus\(\);/);
 
 assert.match(productionApp, /installMotionPermissionCancelRecovery/);
 assert.match(productionApp, /motion-permission-cancel-recovery\.js\?revision=r132-fresh-document/);
@@ -109,6 +118,106 @@ assert.match(
 );
 assert.match(retrySource, /void home\.continueToTrack\(\)/, 'The retry must return the player directly to The Lot');
 assert.doesNotMatch(retrySource, /textContent|aria-live/, 'The fresh-document recovery must not add permission-denied UI copy');
+
+const retryValues = new Map();
+const retryStorage = {
+  getItem(key) {
+    return retryValues.get(key) ?? null;
+  },
+  setItem(key, value) {
+    retryValues.set(key, String(value));
+  },
+  removeItem(key) {
+    retryValues.delete(key);
+  }
+};
+
+class DismissedMotionEvent {}
+Object.defineProperty(DismissedMotionEvent, 'requestPermission', {
+  configurable: true,
+  value: async () => {
+    throw new Error('Motion permission was not granted.');
+  }
+});
+
+let reloads = 0;
+const bodyPaint = {
+  dataset: { paintLabel: 'Body' },
+  querySelector() {
+    return { value: '#123456' };
+  }
+};
+const spoilerPaint = {
+  dataset: { paintLabel: 'Spoiler' },
+  querySelector() {
+    return { value: '#654321' };
+  }
+};
+const dismissedEnvironment = {
+  DeviceMotionEvent: DismissedMotionEvent,
+  document: {
+    body: { classList: { contains: (name) => name === 'turn-lot-open' } },
+    querySelector(selector) {
+      if (selector === '.lot-car-option[aria-checked="true"]') {
+        return { dataset: { carId: 'sedan-sports' } };
+      }
+      return null;
+    },
+    querySelectorAll(selector) {
+      return selector === '.lot-color-control' ? [bodyPaint, spoilerPaint] : [];
+    }
+  },
+  sessionStorage: retryStorage,
+  location: {
+    reload() {
+      reloads += 1;
+    }
+  },
+  __turnHome: { getSelectedTrackId: () => 'midnight-city' }
+};
+
+installMotionPermissionCancelRecovery({ environment: dismissedEnvironment });
+void DismissedMotionEvent.requestPermission();
+await new Promise((resolve) => setTimeout(resolve, 0));
+assert.equal(reloads, 1, 'Cancelling permission must create a fresh document so iOS can prompt again');
+assert.ok(retryValues.has('turn-motion-permission-retry-v2'), 'The retry route must be saved before reload');
+
+class FreshMotionEvent {}
+Object.defineProperty(FreshMotionEvent, 'requestPermission', {
+  configurable: true,
+  value: async () => 'granted'
+});
+let continued = 0;
+const resumedRuntime = {
+  state: {
+    vehicleId: 'classic',
+    vehicleColor: '#ffffff',
+    vehicleSecondaryColor: '#ffffff'
+  }
+};
+const freshEnvironment = {
+  DeviceMotionEvent: FreshMotionEvent,
+  document: { body: { classList: { contains: () => false } } },
+  sessionStorage: retryStorage,
+  location: { reload() {} },
+  requestAnimationFrame(callback) {
+    callback();
+    return 1;
+  },
+  __turnRuntime: resumedRuntime
+};
+const freshRecovery = installMotionPermissionCancelRecovery({ environment: freshEnvironment });
+assert.equal(freshRecovery.resume({
+  continueToTrack() {
+    continued += 1;
+    return Promise.resolve(true);
+  }
+}, resumedRuntime), true);
+assert.equal(continued, 1, 'The fresh document must reopen The Lot automatically');
+assert.equal(resumedRuntime.state.vehicleId, 'sedan-sports');
+assert.equal(resumedRuntime.state.vehicleColor, '#123456');
+assert.equal(resumedRuntime.state.vehicleSecondaryColor, '#654321');
+assert.equal(retryValues.has('turn-motion-permission-retry-v2'), false, 'The retry route is consumed only once');
 
 assert.match(homeCss, /turn-m8-active \.audio-settings-button/);
 assert.match(homeCss, /turn-m8-active \.reset-rivals-button/);
@@ -189,4 +298,4 @@ assert.match(orchestrator, /function leaveRace\(\)/);
 assert.match(orchestrator, /publish\('home-open'\)/);
 assert.match(orchestrator, /phase = 'home'/);
 
-console.log('TURN production M8 Home, recoverable motion permission, larger aligned track names, native scrollbar divider and NEXT wrapper contracts passed.');
+console.log('TURN production M8 Home, fresh-document motion permission recovery, larger aligned track names, native scrollbar divider and NEXT wrapper contracts passed.');

--- a/turn-tests/home-navigation-production.mjs
+++ b/turn-tests/home-navigation-production.mjs
@@ -13,7 +13,8 @@ const [
   productionMain,
   nextApp,
   nextMain,
-  orchestrator
+  orchestrator,
+  retrySource
 ] = await Promise.all([
   fs.readFile(new URL('../turn/m8-home.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/m8-home.css', import.meta.url), 'utf8'),
@@ -26,11 +27,11 @@ const [
   fs.readFile(new URL('../turn/main.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-next/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-next/main.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/race/session-orchestrator.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/race/session-orchestrator.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/ui/motion-permission-cancel-recovery.js', import.meta.url), 'utf8')
 ]);
 
 assert.match(productionApp, /installM8HomeNavigation/);
-assert.match(productionApp, /m8-home\.js\?revision=r131-motion-permission-retry/);
 assert.match(productionApp, /installM8HomeFixedLayout/);
 assert.match(productionApp, /installStylesheet\('\.\/m8-home\.css'/);
 assert.match(productionApp, /m8-home-fixed-layout\.js\?revision=m8\.9-track-title-alignment/);
@@ -73,28 +74,41 @@ assert.match(homeSource, /showHome\(\{ focus: true \}\)/);
 assert.match(homeSource, /turn-steering-mode-v1/);
 assert.match(homeSource, /saveDriveByEarEnabled/);
 assert.match(homeSource, /__turnResetRivals/);
-
-const lotRaceGateStart = homeSource.indexOf('function installLotRaceGate');
-const lotRaceGateEnd = homeSource.indexOf('export async function installM8HomeNavigation');
-assert.ok(lotRaceGateStart >= 0 && lotRaceGateEnd > lotRaceGateStart, 'Home must keep a dedicated Race This Car access gate');
-const lotRaceGateSource = homeSource.slice(lotRaceGateStart, lotRaceGateEnd);
+assert.match(homeSource, /function motionPermissionWasDismissed\(error\)/);
 assert.match(
   homeSource,
-  /function motionPermissionWasDismissed\(error\) \{[\s\S]*Motion permission was not granted\./,
-  'A cancelled motion prompt must be recognized as a retryable dismissal'
+  /if \(!motionPermissionWasDismissed\(error\)\) \{[\s\S]*Choose on-screen steering in Settings to continue without motion\./,
+  'The Lot must keep real motion failures visible while treating a cancelled prompt separately'
 );
-assert.match(lotRaceGateSource, /status\.textContent = '';/, 'Each Race This Car attempt starts with no stale permission message');
+assert.doesNotMatch(
+  homeSource,
+  /if \(motionPermissionWasDismissed\(error\)\)[\s\S]{0,220}status\.textContent/,
+  'Cancelling the native motion prompt must not create redundant status copy'
+);
 assert.match(
-  lotRaceGateSource,
-  /catch \(error\) \{[\s\S]*if \(!motionPermissionWasDismissed\(error\)\) \{[\s\S]*Choose on-screen steering in Settings/,
-  'Only genuine motion errors should show the fallback information; cancelling the prompt stays silent'
+  homeSource,
+  /raceButton\.disabled = false;[\s\S]*raceButton\.focus\(\);/,
+  'The Race This Car button must be restored after a failed permission attempt'
+);
+
+assert.match(productionApp, /installMotionPermissionCancelRecovery/);
+assert.match(productionApp, /motion-permission-cancel-recovery\.js\?revision=r132-fresh-document/);
+assert.match(productionApp, /motionPermissionCancelRecovery\.resume\(home, globalThis\.__turnRuntime\)/);
+assert.match(retrySource, /turn-motion-permission-retry-v2/);
+assert.match(retrySource, /\.lot-car-option\[aria-checked="true"\]/);
+assert.match(retrySource, /\.lot-color-control/);
+assert.match(
+  retrySource,
+  /permissionWasDismissed\(error\)[\s\S]*saveRetryState\(environment, documentRef\)[\s\S]*reload\(environment\)[\s\S]*return waitForever\(\)/,
+  'A cancelled iOS permission prompt must reload into a fresh document instead of silently swallowing every later denial'
 );
 assert.match(
-  lotRaceGateSource,
-  /raceButton\.addEventListener\('click', gate, true\);/,
-  'The motion gate remains armed so the next Race This Car press requests permission again'
+  retrySource,
+  /runtime\.state\.vehicleId[\s\S]*runtime\.state\.vehicleColor[\s\S]*runtime\.state\.vehicleSecondaryColor/,
+  'The selected car and paint must survive the fresh-document retry'
 );
-assert.match(lotRaceGateSource, /raceButton\.disabled = false;[\s\S]*raceButton\.focus\(\);/);
+assert.match(retrySource, /void home\.continueToTrack\(\)/, 'The retry must return the player directly to The Lot');
+assert.doesNotMatch(retrySource, /textContent|aria-live/, 'The fresh-document recovery must not add permission-denied UI copy');
 
 assert.match(homeCss, /turn-m8-active \.audio-settings-button/);
 assert.match(homeCss, /turn-m8-active \.reset-rivals-button/);
@@ -175,4 +189,4 @@ assert.match(orchestrator, /function leaveRace\(\)/);
 assert.match(orchestrator, /publish\('home-open'\)/);
 assert.match(orchestrator, /phase = 'home'/);
 
-console.log('TURN production M8 Home, retryable motion permission, larger aligned track names, native scrollbar divider and NEXT wrapper contracts passed.');
+console.log('TURN production M8 Home, recoverable motion permission, larger aligned track names, native scrollbar divider and NEXT wrapper contracts passed.');

--- a/turn-tests/home-navigation-production.mjs
+++ b/turn-tests/home-navigation-production.mjs
@@ -178,7 +178,7 @@ const dismissedEnvironment = {
 
 installMotionPermissionCancelRecovery({ environment: dismissedEnvironment });
 void DismissedMotionEvent.requestPermission();
-await new Promise((resolve) => setTimeout(resolve, 0));
+await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
 assert.equal(reloads, 1, 'Cancelling permission must create a fresh document so iOS can prompt again');
 assert.ok(retryValues.has('turn-motion-permission-retry-v2'), 'The retry route must be saved before reload');
 

--- a/turn/app.js
+++ b/turn/app.js
@@ -53,6 +53,10 @@ const webPlatform = createWebPlatform();
 installTurnPlatform(webPlatform);
 const motionLifecycle = installMotionLifecycleBridge({ platform: webPlatform });
 const displayLifecycle = installDisplayLifecycleBridge({ platform: webPlatform });
+const { installMotionPermissionCancelRecovery } = await import(
+  withBuild('./ui/motion-permission-cancel-recovery.js?revision=r132-fresh-document')
+);
+const motionPermissionCancelRecovery = installMotionPermissionCancelRecovery();
 globalThis.__turnMotionLifecycle = motionLifecycle;
 globalThis.__turnDisplayLifecycle = displayLifecycle;
 document.documentElement.dataset.turnPlatform = 'web-adapter';
@@ -181,6 +185,7 @@ const { installM8HomeNavigation } = await import(
 );
 const home = await installM8HomeNavigation();
 globalThis.__turnHome = home;
+motionPermissionCancelRecovery.resume(home, globalThis.__turnRuntime);
 const { installHowToPlayGuide } = await import(
   withBuild('./ui/how-to-play-guide.js?revision=r127-full-name')
 );

--- a/turn/ui/motion-permission-cancel-recovery.js
+++ b/turn/ui/motion-permission-cancel-recovery.js
@@ -1,0 +1,130 @@
+const RETRY_STORAGE_KEY = 'turn-motion-permission-retry-v2';
+const DENIED_MESSAGE = 'Motion permission was not granted.';
+const MAX_RETRY_AGE_MS = 2 * 60 * 1000;
+
+function permissionWasDismissed(error) {
+  return error instanceof Error && error.message === DENIED_MESSAGE;
+}
+
+function readCurrentLotSelection(documentRef) {
+  const selectedCar = documentRef?.querySelector?.('.lot-car-option[aria-checked="true"]');
+  const controls = [...(documentRef?.querySelectorAll?.('.lot-color-control') || [])];
+  const selection = {
+    carId: selectedCar?.dataset?.carId || null,
+    color: null,
+    secondaryColor: null
+  };
+
+  for (const control of controls) {
+    const input = control.querySelector?.('.lot-color-input');
+    const label = String(control.dataset?.paintLabel || '').toLowerCase();
+    if (!input?.value) continue;
+    if (label === 'body') selection.color = input.value;
+    else if (!selection.secondaryColor) selection.secondaryColor = input.value;
+  }
+
+  return selection;
+}
+
+function saveRetryState(environment, documentRef) {
+  const storage = environment.sessionStorage;
+  if (!storage?.setItem) return false;
+
+  const home = environment.__turnHome || environment.__turnNextHome;
+  const state = {
+    savedAt: Date.now(),
+    trackId: home?.getSelectedTrackId?.() || environment.__turnGetTrackId?.() || null,
+    selection: readCurrentLotSelection(documentRef)
+  };
+
+  try {
+    storage.setItem(RETRY_STORAGE_KEY, JSON.stringify(state));
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+function takeRetryState(environment) {
+  const storage = environment.sessionStorage;
+  if (!storage?.getItem || !storage?.removeItem) return null;
+
+  try {
+    const raw = storage.getItem(RETRY_STORAGE_KEY);
+    storage.removeItem(RETRY_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed || Date.now() - Number(parsed.savedAt) > MAX_RETRY_AGE_MS) return null;
+    return parsed;
+  } catch (_) {
+    return null;
+  }
+}
+
+function applySelection(runtime, selection) {
+  if (!runtime?.state || !selection) return;
+  if (selection.carId) runtime.state.vehicleId = selection.carId;
+  if (selection.color) runtime.state.vehicleColor = selection.color;
+  if (selection.secondaryColor) runtime.state.vehicleSecondaryColor = selection.secondaryColor;
+}
+
+function reload(environment) {
+  const location = environment.location;
+  if (typeof location?.reload !== 'function') return false;
+  try {
+    location.reload();
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+function waitForever() {
+  return new Promise(() => {});
+}
+
+export function installMotionPermissionCancelRecovery({ environment = globalThis } = {}) {
+  const documentRef = environment.document;
+  const retryState = takeRetryState(environment);
+  const MotionEvent = environment.DeviceMotionEvent;
+  const requestPermission = MotionEvent?.requestPermission;
+
+  if (typeof requestPermission === 'function') {
+    Object.defineProperty(MotionEvent, 'requestPermission', {
+      configurable: true,
+      value: async function requestPermissionWithCancelRecovery(...args) {
+        try {
+          return await requestPermission.apply(this, args);
+        } catch (error) {
+          const lotOpen = documentRef?.body?.classList?.contains?.('turn-lot-open');
+          if (
+            permissionWasDismissed(error)
+            && lotOpen
+            && saveRetryState(environment, documentRef)
+            && reload(environment)
+          ) {
+            return waitForever();
+          }
+          throw error;
+        }
+      }
+    });
+  }
+
+  return Object.freeze({
+    route: 'fresh-document-motion-retry',
+    resume(home, runtime = environment.__turnRuntime) {
+      if (!retryState || typeof home?.continueToTrack !== 'function') return false;
+      applySelection(runtime, retryState.selection);
+      const resume = () => {
+        void home.continueToTrack();
+      };
+      if (typeof environment.requestAnimationFrame === 'function') {
+        environment.requestAnimationFrame(resume);
+      } else {
+        environment.setTimeout?.(resume, 0);
+      }
+      return true;
+    }
+  });
+}


### PR DESCRIPTION
## Root cause

The previous fix kept the **RACE THIS CAR** gate active and hid the denial message, but iOS does not present the native motion prompt a second time in the same document after the first prompt is cancelled. The next press therefore received another immediate denial and appeared to do nothing.

## What changed

- intercept a cancelled motion request while The Lot is open
- save the selected track, car, body colour and secondary paint in session storage
- reload TURN into a genuinely fresh document so iOS can present the native prompt again
- automatically return the player to the same track and car in The Lot
- keep the cancellation silent, with no “permission was not granted” information
- preserve the existing useful fallback message for actual sensor or browser failures

## Resulting flow

1. Press **RACE THIS CAR**.
2. Cancel the native motion prompt.
3. TURN performs a quick fresh-document reload and returns directly to the same car in The Lot.
4. Press **RACE THIS CAR** again and the native permission prompt is requested again.

## Validation

- added an executable regression that simulates a cancelled permission request
- verifies that a reload is requested only after the retry state has been saved
- verifies that the same track, car and both paint colours are restored
- verifies that The Lot is reopened automatically
- retains the existing checks for silent cancellation and visible genuine errors