### PR TITLE
Stop the iOS motion-cancel reload loop

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Run TURN NEXT home navigation regression
         run: node turn-tests/home-navigation-production.mjs
 
+      - name: Run standalone motion cancellation regression
+        run: node turn-tests/motion-permission-standalone-production.mjs
+
       - name: Run Home help and all-track rival reset regression
         run: node turn-tests/how-to-play-guide-production.mjs
 

--- a/turn-tests/motion-permission-standalone-production.mjs
+++ b/turn-tests/motion-permission-standalone-production.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+
+import { installMotionPermissionCancelRecovery } from '../turn/ui/motion-permission-cancel-recovery.js';
+
+class DeniedMotionEvent {}
+Object.defineProperty(DeniedMotionEvent, 'requestPermission', {
+  configurable: true,
+  value: async () => {
+    throw new Error('Motion permission was not granted.');
+  }
+});
+
+let reloads = 0;
+const storage = new Map();
+const environment = {
+  DeviceMotionEvent: DeniedMotionEvent,
+  navigator: { standalone: true },
+  document: {
+    body: {
+      classList: {
+        contains(name) {
+          return name === 'turn-lot-open';
+        }
+      }
+    }
+  },
+  sessionStorage: {
+    getItem(key) {
+      return storage.get(key) ?? null;
+    },
+    setItem(key, value) {
+      storage.set(key, String(value));
+    },
+    removeItem(key) {
+      storage.delete(key);
+    }
+  },
+  location: {
+    reload() {
+      reloads += 1;
+    }
+  }
+};
+
+const recovery = installMotionPermissionCancelRecovery({ environment });
+assert.equal(recovery.route, 'standalone-motion-denial-recovery');
+
+await assert.rejects(
+  () => DeniedMotionEvent.requestPermission(),
+  (error) => error.message === 'Motion permission was not granted.',
+  'The first cancelled prompt stays silent in The Lot'
+);
+assert.equal(reloads, 0, 'The installed iOS app must not enter a reload loop after cancellation');
+
+await assert.rejects(
+  () => DeniedMotionEvent.requestPermission(),
+  /Motion access is still blocked by iOS\. Close and reopen TURN to try device rotation again\./,
+  'A second attempt must explain the platform block instead of appearing dead'
+);
+assert.equal(reloads, 0, 'Repeated attempts must keep the player in The Lot');
+assert.equal(storage.size, 0, 'Standalone recovery must not save a route that triggers another reload');
+
+console.log('TURN standalone motion cancellation remains interactive without a reload loop.');

--- a/turn/ui/motion-permission-cancel-recovery.js
+++ b/turn/ui/motion-permission-cancel-recovery.js
@@ -1,9 +1,19 @@
 const RETRY_STORAGE_KEY = 'turn-motion-permission-retry-v2';
 const DENIED_MESSAGE = 'Motion permission was not granted.';
+const BLOCKED_MESSAGE = 'Motion access is still blocked by iOS. Close and reopen TURN to try device rotation again.';
 const MAX_RETRY_AGE_MS = 2 * 60 * 1000;
 
 function permissionWasDismissed(error) {
   return error instanceof Error && error.message === DENIED_MESSAGE;
+}
+
+function isStandaloneApp(environment) {
+  if (environment.navigator?.standalone === true) return true;
+  try {
+    return environment.matchMedia?.('(display-mode: standalone)')?.matches === true;
+  } catch (_) {
+    return false;
+  }
 }
 
 function readCurrentLotSelection(documentRef) {
@@ -88,15 +98,26 @@ export function installMotionPermissionCancelRecovery({ environment = globalThis
   const retryState = takeRetryState(environment);
   const MotionEvent = environment.DeviceMotionEvent;
   const requestPermission = MotionEvent?.requestPermission;
+  const standaloneApp = isStandaloneApp(environment);
+  let standaloneDismissals = 0;
 
   if (typeof requestPermission === 'function') {
     Object.defineProperty(MotionEvent, 'requestPermission', {
       configurable: true,
       value: async function requestPermissionWithCancelRecovery(...args) {
         try {
-          return await requestPermission.apply(this, args);
+          const permission = await requestPermission.apply(this, args);
+          standaloneDismissals = 0;
+          return permission;
         } catch (error) {
           const lotOpen = documentRef?.body?.classList?.contains?.('turn-lot-open');
+
+          if (permissionWasDismissed(error) && lotOpen && standaloneApp) {
+            standaloneDismissals += 1;
+            if (standaloneDismissals === 1) throw error;
+            throw new Error(BLOCKED_MESSAGE);
+          }
+
           if (
             permissionWasDismissed(error)
             && lotOpen
@@ -112,7 +133,9 @@ export function installMotionPermissionCancelRecovery({ environment = globalThis
   }
 
   return Object.freeze({
-    route: 'fresh-document-motion-retry',
+    route: standaloneApp
+      ? 'standalone-motion-denial-recovery'
+      : 'fresh-document-motion-retry',
     resume(home, runtime = environment.__turnRuntime) {
       if (!retryState || typeof home?.continueToTrack !== 'function') return false;
       applySelection(runtime, retryState.selection);


### PR DESCRIPTION
## What the video revealed

The installed iOS app does not reset its motion-permission state when TURN reloads. After the first cancellation, pressing **RACE THIS CAR** causes another immediate denial, which triggers another reload. That is the loop visible in the recording.

## What changed

- detect TURN running as an installed standalone app
- never reload the installed app after a cancelled motion prompt
- keep **RACE THIS CAR** active and focused after the first cancellation
- keep the first cancellation silent, as requested
- if iOS immediately blocks the next attempt instead of showing its prompt, display a specific explanation: close and reopen TURN to try device rotation again, or use on-screen steering
- retain the fresh-document recovery only for ordinary browser mode, where it may still be effective

## Validation

- added an executable standalone-app regression
- verifies that the first cancellation remains silent
- verifies that neither the first nor repeated attempts reload the app
- verifies that the second blocked attempt reports the real platform limitation instead of appearing dead
- added the new regression to the complete TURN workflow