### PR TITLE
Give Midnight City a cinematic track-intro angle

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Run TURN NEXT home navigation regression
         run: node turn-tests/home-navigation-production.mjs
 
+      - name: Run track intro showcase camera regression
+        run: node turn-tests/track-intro-camera-production.mjs
+
       - name: Run standalone motion cancellation regression
         run: node turn-tests/motion-permission-standalone-production.mjs
 

--- a/turn-tests/track-intro-camera-production.mjs
+++ b/turn-tests/track-intro-camera-production.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+import { installTrackIntroCamera } from '../turn/render/track-intro-camera.js';
+
+const [appSource, cameraSource] = await Promise.all([
+  fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/render/track-intro-camera.js', import.meta.url), 'utf8')
+]);
+
+assert.match(appSource, /installTrackIntroCamera/);
+assert.match(appSource, /track-intro-camera\.js\?revision=r133-midnight-downtown/);
+assert.match(cameraSource, /'midnight-city'/);
+assert.match(cameraSource, /position: Object\.freeze\(\[20, 150, 300\]\)/);
+assert.match(cameraSource, /target: Object\.freeze\(\[275, 3, 40\]\)/);
+assert.match(cameraSource, /fov: 52/);
+assert.doesNotMatch(cameraSource, /requestAnimationFrame|setInterval|setAnimationLoop/);
+
+const bodyClasses = new Set(['turn-track-intro']);
+const calls = [];
+const camera = {
+  fov: 68,
+  position: {
+    set(...values) {
+      calls.push(['position', ...values]);
+    }
+  },
+  up: {
+    set(...values) {
+      calls.push(['up', ...values]);
+    }
+  },
+  lookAt(...values) {
+    calls.push(['target', ...values]);
+  },
+  updateProjectionMatrix() {
+    calls.push(['projection']);
+  },
+  updateMatrixWorld(force) {
+    calls.push(['matrix', force]);
+  }
+};
+let previousHookCalls = 0;
+const scene = {
+  onBeforeRender() {
+    previousHookCalls += 1;
+  }
+};
+const runtime = {
+  scene,
+  camera,
+  activeTrack: { id: 'midnight-city' }
+};
+const environment = {
+  __turnRuntime: runtime,
+  __turnGetTrackId: () => runtime.activeTrack.id,
+  document: {
+    body: {
+      classList: {
+        contains(name) {
+          return bodyClasses.has(name);
+        }
+      }
+    }
+  }
+};
+
+assert.equal(installTrackIntroCamera({ environment }), true);
+assert.equal(installTrackIntroCamera({ environment }), false, 'The camera hook must install only once');
+scene.onBeforeRender();
+assert.equal(previousHookCalls, 1, 'Existing scene hooks must be preserved');
+assert.deepEqual(calls.find((call) => call[0] === 'position'), ['position', 20, 150, 300]);
+assert.deepEqual(calls.find((call) => call[0] === 'target'), ['target', 275, 3, 40]);
+assert.equal(camera.fov, 52, 'Midnight City uses the tighter downtown showcase field of view');
+assert.ok(calls.some((call) => call[0] === 'matrix' && call[1] === true));
+
+bodyClasses.delete('turn-track-intro');
+scene.onBeforeRender();
+assert.equal(camera.fov, 68, 'The normal race camera field of view is restored after the intro');
+
+calls.length = 0;
+runtime.activeTrack = { id: 'harbor' };
+bodyClasses.add('turn-track-intro');
+scene.onBeforeRender();
+assert.equal(calls.some((call) => call[0] === 'position'), false, 'Other track intros keep their established framing');
+
+console.log('TURN Midnight City track intro uses a filled Downtown and TURN Commons showcase angle.');

--- a/turn/app.js
+++ b/turn/app.js
@@ -166,6 +166,11 @@ await import(withBuild('./main.js'));
 document.documentElement.dataset.turnSessionLifecycle = 'orchestrator-m7';
 globalThis.__turnRaceSession = globalThis.__turnNextRaceSession;
 
+const { installTrackIntroCamera } = await import(
+  withBuild('./render/track-intro-camera.js?revision=r133-midnight-downtown')
+);
+installTrackIntroCamera();
+
 await Promise.all([
   import(withBuild('./render/world.js')),
   import(withBuild('./ui/spectate.js')),

--- a/turn/render/track-intro-camera.js
+++ b/turn/render/track-intro-camera.js
@@ -1,0 +1,60 @@
+const INTRO_CAMERA_PRESETS = Object.freeze({
+  'midnight-city': Object.freeze({
+    // Frame TURN Commons in the foreground and look diagonally into Downtown.
+    // This avoids the empty centre produced by the generic small-track overview.
+    position: Object.freeze([20, 150, 300]),
+    target: Object.freeze([275, 3, 40]),
+    fov: 52
+  })
+});
+
+export function installTrackIntroCamera({ environment = globalThis } = {}) {
+  const runtime = environment.__turnRuntime;
+  const scene = runtime?.scene;
+  const camera = runtime?.camera;
+  const body = environment.document?.body;
+  if (!scene || !camera || !body || runtime.__trackIntroCameraInstalled) return false;
+
+  runtime.__trackIntroCameraInstalled = true;
+  const previousOnBeforeRender = scene.onBeforeRender;
+  let presetApplied = false;
+  let previousFov = camera.fov;
+
+  scene.onBeforeRender = function trackIntroCameraBeforeRender(...args) {
+    previousOnBeforeRender?.apply(this, args);
+
+    const trackId = environment.__turnGetTrackId?.()
+      || runtime.activeTrack?.id
+      || runtime.trackId;
+    const preset = INTRO_CAMERA_PRESETS[trackId];
+    const introVisible = body.classList.contains('turn-track-intro');
+
+    if (!introVisible || !preset) {
+      if (presetApplied) {
+        camera.fov = previousFov;
+        camera.updateProjectionMatrix();
+        camera.updateMatrixWorld(true);
+        presetApplied = false;
+      }
+      return;
+    }
+
+    if (!presetApplied) {
+      previousFov = camera.fov;
+      presetApplied = true;
+    }
+
+    camera.position.set(...preset.position);
+    camera.up.set(0, 1, 0);
+    camera.lookAt(...preset.target);
+    camera.fov = preset.fov;
+    camera.updateProjectionMatrix();
+    camera.updateMatrixWorld(true);
+  };
+
+  runtime.trackIntroCamera = Object.freeze({
+    route: 'track-intro-camera-v1',
+    presets: Object.freeze(Object.keys(INTRO_CAMERA_PRESETS))
+  });
+  return true;
+}


### PR DESCRIPTION
## What changed

- add a dedicated camera composition for the Midnight City track-intro screen
- replace the generic small-track overview with a tighter diagonal view through TURN Commons into Downtown
- keep the established intro framing for Countryside, Airport, Cliffside and Harbor unchanged
- restore the normal camera field of view immediately after the intro
- preserve existing scene render hooks rather than replacing them

## UX outcome

Midnight City now uses its detailed parks, roads, neon buildings and skyline as the loading-screen backdrop instead of placing the title over a large empty central area. The angle is static and deliberately framed, so it feels like an inviting city postcard without adding distracting motion.

## Performance and accessibility

- no new assets, textures, lights or render loop
- the existing scene is simply viewed from a better angle during the short intro
- no animation is added, including for reduced-motion users
- the hidden LILYA texture remains far outside the intro camera’s lazy-load range

## Validation

- added an executable track-intro camera regression
- verifies the Midnight City position, target and field of view
- verifies existing scene hooks are preserved
- verifies the normal field of view is restored after the intro
- verifies other tracks keep their current framing
- added the regression to the complete TURN workflow