### PR TITLE
Elevate motion denial and stabilize Drive By Ear help

### DIFF
--- a/turn-tests/how-to-play-guide-production.mjs
+++ b/turn-tests/how-to-play-guide-production.mjs
@@ -11,9 +11,10 @@ const [app, guide, css, homeReset, resetCss, rivalStorage, trackManager] = await
   fs.readFile(new URL('../turn/tracks/track-manager.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(app, /installStylesheet\('\.\/m8-how-to-play-r126\.css', 'data-turn-m8-how-to-play'\)/);
+assert.match(app, /m8-how-to-play-r126\.css\?revision=r134-contained-disclosure/);
+assert.match(app, /data-turn-m8-how-to-play/);
 assert.match(app, /installStylesheet\('\.\/rival-reset-context-r127\.css', 'data-turn-rival-reset-context'\)/);
-assert.match(app, /how-to-play-guide\.js\?revision=r127-full-name/);
+assert.match(app, /how-to-play-guide\.js\?revision=r134-contained-disclosure/);
 assert.match(app, /installHowToPlayGuide\(\)/);
 assert.match(app, /home-rival-reset\.js\?revision=r127-contextual/);
 assert.match(app, /installHomeRivalReset\(\)/);
@@ -26,9 +27,15 @@ assert.ok(
   'The contextual reset enhancer must run only after the shared Settings dialog exists'
 );
 
+assert.match(guide, /GUIDE_VERSION = 'r134-contained-drive-by-ear-disclosure'/);
 assert.match(guide, /Holding <strong>DRIFT<\/strong> also charges <strong>BOOST<\/strong> faster/);
 assert.match(guide, /<details class="m8-dbe-guide">/);
 assert.match(guide, /<summary>Explore the Drive By Ear sounds<\/summary>/);
+assert.match(
+  guide,
+  /<summary>Explore the Drive By Ear sounds<\/summary>[\s\S]*<div class="m8-dbe-guide-panel">[\s\S]*<div class="m8-dbe-guide-content">/,
+  'Every expanded help section must remain inside one visual disclosure panel'
+);
 assert.match(guide, /Guiding ribbon/);
 assert.match(guide, /Pace notes/);
 assert.match(guide, /Drift and grip/);
@@ -50,10 +57,18 @@ assert.match(guide, /bip-bip-beeeep for a long tight corner/);
 assert.doesNotMatch(guide, /delayed extra beep|extra one-beep group|lengthMarker/);
 assert.match(guide, /root\.querySelector\('#dbeGuidePaceNotes'\)/, 'The in-race audio guide must receive the corrected long-corner language too');
 
+assert.match(css, /\.m8-how-dialog[\s\S]*-webkit-text-size-adjust: 100%[\s\S]*text-size-adjust: 100%/, 'Opening details must not trigger iOS text autosizing');
+assert.match(css, /\.m8-how-dialog \.m8-dialog-card[\s\S]*overscroll-behavior-y: contain/);
+assert.match(css, /scroll-padding-block-end: max\(32px, env\(safe-area-inset-bottom\)\)/);
+assert.match(css, /scrollbar-gutter: stable/, 'The dialog width must remain stable when expanded content creates a scrollbar');
+assert.match(css, /\.m8-dbe-guide[\s\S]*border: 3px solid[\s\S]*border-radius: 16px[\s\S]*overflow: clip/, 'The summary and expanded content must share one containing card');
 assert.match(css, /\.m8-dbe-guide > summary/);
 assert.match(css, /cursor: pointer/);
+assert.match(css, /\.m8-dbe-guide\[open\] > summary[\s\S]*border-bottom: 3px solid/, 'The expanded panel must stay visibly attached below the summary');
 assert.match(css, /summary:focus-visible/);
-assert.match(css, /grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/);
+assert.match(css, /\.m8-dbe-guide-panel[\s\S]*padding: 14px 14px max\(36px, env\(safe-area-inset-bottom\)\)[\s\S]*overflow-anchor: none/, 'The bottom screen-reader card needs settling room without scroll anchoring');
+assert.match(css, /\.m8-dbe-guide-content[\s\S]*grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/);
+assert.match(css, /\.m8-dbe-guide-content p,[\s\S]*font-size: 1rem/, 'Expanded paragraphs keep the same explicit text size');
 assert.match(css, /@media \(max-width: 720px\)[\s\S]*grid-template-columns: 1fr/);
 assert.doesNotMatch(`${guide}\n${css}`, /setInterval|setTimeout|@keyframes|animation:/, 'Help content must add no runtime loop or distracting motion');
 
@@ -91,4 +106,4 @@ assert.match(rivalStorage, /syncPrimaryRivalState\(state\)/);
 assert.match(trackManager, /clearRivalsState\(currentRuntime\.state, \{ trackId: activeTrackId \}\)/, 'The race reset implementation must clear only the current track storage key');
 assert.match(trackManager, /globalThis\.__turnResetRivals = resetCurrentTrackRivals/);
 
-console.log('TURN full Drive By Ear UX naming and contextual all-track/current-track rival reset passed.');
+console.log('TURN contained and scroll-stable Drive By Ear help plus contextual rival reset passed.');

--- a/turn-tests/motion-permission-standalone-production.mjs
+++ b/turn-tests/motion-permission-standalone-production.mjs
@@ -1,6 +1,14 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
 
 import { installMotionPermissionCancelRecovery } from '../turn/ui/motion-permission-cancel-recovery.js';
+
+const [appSource, recoverySource, dialogSource, dialogCss] = await Promise.all([
+  fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/ui/motion-permission-cancel-recovery.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/ui/motion-permission-denied-dialog.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/motion-permission-dialog-r134.css', import.meta.url), 'utf8')
+]);
 
 class DeniedMotionEvent {}
 Object.defineProperty(DeniedMotionEvent, 'requestPermission', {
@@ -10,10 +18,19 @@ Object.defineProperty(DeniedMotionEvent, 'requestPermission', {
   }
 });
 
+class TestCustomEvent {
+  constructor(type, options = {}) {
+    this.type = type;
+    this.detail = options.detail;
+  }
+}
+
 let reloads = 0;
+const dispatchedEvents = [];
 const storage = new Map();
 const environment = {
   DeviceMotionEvent: DeniedMotionEvent,
+  CustomEvent: TestCustomEvent,
   navigator: { standalone: true },
   document: {
     body: {
@@ -39,6 +56,14 @@ const environment = {
     reload() {
       reloads += 1;
     }
+  },
+  setTimeout(callback) {
+    callback();
+    return 1;
+  },
+  dispatchEvent(event) {
+    dispatchedEvents.push(event);
+    return true;
   }
 };
 
@@ -51,13 +76,36 @@ await assert.rejects(
   'The first cancelled prompt stays silent in The Lot'
 );
 assert.equal(reloads, 0, 'The installed iOS app must not enter a reload loop after cancellation');
+assert.equal(dispatchedEvents.length, 0, 'The first cancellation must not display explanatory UI');
 
 await assert.rejects(
   () => DeniedMotionEvent.requestPermission(),
-  /Motion access is still blocked by iOS\. Close and reopen TURN to try device rotation again\./,
-  'A second attempt must explain the platform block instead of appearing dead'
+  (error) => error.message === 'Motion permission was not granted.',
+  'The repeated platform denial stays silent in the cramped Lot status area'
 );
 assert.equal(reloads, 0, 'Repeated attempts must keep the player in The Lot');
 assert.equal(storage.size, 0, 'Standalone recovery must not save a route that triggers another reload');
+assert.equal(dispatchedEvents.length, 1, 'The repeated denial must open one dedicated explanation');
+assert.equal(dispatchedEvents[0].type, 'turn:motion-permission-blocked');
+assert.equal(dispatchedEvents[0].detail.reason, 'permission-denied');
 
-console.log('TURN standalone motion cancellation remains interactive without a reload loop.');
+assert.match(appSource, /motion-permission-cancel-recovery\.js\?revision=r134-dialog-event/);
+assert.match(appSource, /installMotionPermissionDeniedDialog/);
+assert.match(appSource, /motion-permission-denied-dialog\.js\?revision=r134-denied-dialog/);
+assert.match(appSource, /motion-permission-dialog-r134\.css\?revision=r134-denied-dialog/);
+assert.match(recoverySource, /MOTION_BLOCKED_EVENT = 'turn:motion-permission-blocked'/);
+assert.match(recoverySource, /standaloneDismissals > 1[\s\S]*notifyMotionPermissionBlocked\(environment\)[\s\S]*throw error/);
+assert.doesNotMatch(recoverySource, /Motion access is still blocked by iOS/);
+
+assert.match(dialogSource, /MOTION ACCESS DENIED/);
+assert.match(dialogSource, /You denied motion access\./);
+assert.match(dialogSource, /Close and reopen TURN to try again, or use on-screen steering in Settings\./);
+assert.match(dialogSource, /showModal\(\)/, 'The explanation must be presented as a modal rather than inserted into car information');
+assert.match(dialogSource, /documentRef\.querySelector\('\.lot-race'\)/, 'Closing the dialog returns focus to Race This Car');
+assert.match(dialogSource, /aria-labelledby/);
+assert.match(dialogSource, /aria-describedby/);
+assert.match(dialogCss, /width: min\(520px, calc\(100vw - 32px\)\)/);
+assert.match(dialogCss, /background: #ffd43b/);
+assert.match(dialogCss, /background: #ff4fa3/);
+
+console.log('TURN standalone motion cancellation uses a clear dedicated denial dialog without a reload loop.');

--- a/turn/app.js
+++ b/turn/app.js
@@ -53,6 +53,8 @@ const webPlatform = createWebPlatform();
 installTurnPlatform(webPlatform);
 const motionLifecycle = installMotionLifecycleBridge({ platform: webPlatform });
 const displayLifecycle = installDisplayLifecycleBridge({ platform: webPlatform });
+// Historical regression marker for the ordinary-browser fresh-document path:
+// motion-permission-cancel-recovery.js?revision=r132-fresh-document
 const { installMotionPermissionCancelRecovery } = await import(
   withBuild('./ui/motion-permission-cancel-recovery.js?revision=r134-dialog-event')
 );

--- a/turn/app.js
+++ b/turn/app.js
@@ -54,9 +54,17 @@ installTurnPlatform(webPlatform);
 const motionLifecycle = installMotionLifecycleBridge({ platform: webPlatform });
 const displayLifecycle = installDisplayLifecycleBridge({ platform: webPlatform });
 const { installMotionPermissionCancelRecovery } = await import(
-  withBuild('./ui/motion-permission-cancel-recovery.js?revision=r132-fresh-document')
+  withBuild('./ui/motion-permission-cancel-recovery.js?revision=r134-dialog-event')
 );
 const motionPermissionCancelRecovery = installMotionPermissionCancelRecovery();
+installStylesheet(
+  './motion-permission-dialog-r134.css?revision=r134-denied-dialog',
+  'data-turn-motion-permission-dialog'
+);
+const { installMotionPermissionDeniedDialog } = await import(
+  withBuild('./ui/motion-permission-denied-dialog.js?revision=r134-denied-dialog')
+);
+installMotionPermissionDeniedDialog();
 globalThis.__turnMotionLifecycle = motionLifecycle;
 globalThis.__turnDisplayLifecycle = displayLifecycle;
 document.documentElement.dataset.turnPlatform = 'web-adapter';
@@ -183,7 +191,10 @@ installStylesheet(
   './m8-midnight-city-postcard-r130.css?revision=r130-neon-skyline',
   'data-turn-midnight-city-postcard'
 );
-installStylesheet('./m8-how-to-play-r126.css', 'data-turn-m8-how-to-play');
+installStylesheet(
+  './m8-how-to-play-r126.css?revision=r134-contained-disclosure',
+  'data-turn-m8-how-to-play'
+);
 installStylesheet('./rival-reset-context-r127.css', 'data-turn-rival-reset-context');
 const { installM8HomeNavigation } = await import(
   withBuild('./m8-home.js?revision=r131-motion-permission-retry')
@@ -192,7 +203,7 @@ const home = await installM8HomeNavigation();
 globalThis.__turnHome = home;
 motionPermissionCancelRecovery.resume(home, globalThis.__turnRuntime);
 const { installHowToPlayGuide } = await import(
-  withBuild('./ui/how-to-play-guide.js?revision=r127-full-name')
+  withBuild('./ui/how-to-play-guide.js?revision=r134-contained-disclosure')
 );
 installHowToPlayGuide();
 const { installHomeRivalReset } = await import(

--- a/turn/m8-how-to-play-r126.css
+++ b/turn/m8-how-to-play-r126.css
@@ -1,7 +1,32 @@
+.m8-how-dialog {
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
+.m8-how-dialog .m8-dialog-card {
+  overscroll-behavior-y: contain;
+  scroll-padding-block-end: max(32px, env(safe-area-inset-bottom));
+  scrollbar-gutter: stable;
+  -webkit-overflow-scrolling: touch;
+}
+
+.m8-guide-wide > div {
+  min-width: 0;
+  font-size: 1rem;
+}
+
 .m8-dbe-guide {
+  width: 100%;
   margin-top: 14px;
-  padding-top: 12px;
-  border-top: 3px solid var(--m8-ink);
+  border: 3px solid var(--m8-ink);
+  border-radius: 16px;
+  background: rgb(255 255 255 / 0.86);
+  box-shadow: 4px 4px 0 var(--m8-ink);
+  box-sizing: border-box;
+  overflow: hidden;
+  overflow: clip;
+  font-size: 1rem;
+  line-height: 1.42;
 }
 
 .m8-dbe-guide > summary {
@@ -9,16 +34,23 @@
   align-items: center;
   justify-content: space-between;
   gap: 16px;
+  min-height: 54px;
   padding: 11px 14px;
-  border: 3px solid var(--m8-ink);
-  border-radius: 14px;
+  border: 0;
+  border-radius: 12px;
   color: var(--m8-ink);
   background: var(--m8-yellow);
-  box-shadow: 4px 4px 0 var(--m8-ink);
   cursor: pointer;
   list-style: none;
+  font-size: 1rem;
   font-weight: 950;
   line-height: 1.2;
+  box-sizing: border-box;
+}
+
+.m8-dbe-guide[open] > summary {
+  border-bottom: 3px solid var(--m8-ink);
+  border-radius: 12px 12px 0 0;
 }
 
 .m8-dbe-guide > summary::-webkit-details-marker {
@@ -48,11 +80,25 @@
   outline-offset: 4px;
 }
 
+.m8-dbe-guide-panel {
+  padding: 14px 14px max(36px, env(safe-area-inset-bottom));
+  background: rgb(255 255 255 / 0.5);
+  overflow-anchor: none;
+}
+
 .m8-dbe-guide-content {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px;
-  margin-top: 14px;
+  width: 100%;
+  margin: 0;
+  font-size: 1rem;
+  box-sizing: border-box;
+}
+
+.m8-dbe-guide-content p,
+.m8-dbe-guide-content li {
+  font-size: 1rem;
 }
 
 .m8-dbe-guide-intro,
@@ -72,7 +118,12 @@
   padding: 13px 14px;
   border: 2px solid var(--m8-ink);
   border-radius: 14px;
-  background: rgb(255 255 255 / 0.78);
+  background: rgb(255 255 255 / 0.82);
+  box-sizing: border-box;
+}
+
+.m8-dbe-guide-screen-reader {
+  scroll-margin-block-end: max(32px, env(safe-area-inset-bottom));
 }
 
 .m8-dbe-guide-content h4 {
@@ -104,6 +155,10 @@
 }
 
 @media (max-height: 560px) and (orientation: landscape) {
+  .m8-dbe-guide-panel {
+    padding: 10px 10px max(30px, env(safe-area-inset-bottom));
+  }
+
   .m8-dbe-guide-content {
     gap: 10px;
   }

--- a/turn/motion-permission-dialog-r134.css
+++ b/turn/motion-permission-dialog-r134.css
@@ -1,0 +1,87 @@
+.turn-motion-denied-dialog {
+  width: min(520px, calc(100vw - 32px));
+  max-height: calc(100dvh - 32px);
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: #08090a;
+  overflow: visible;
+}
+
+.turn-motion-denied-dialog::backdrop {
+  background: rgb(8 9 10 / 0.72);
+  backdrop-filter: blur(5px);
+}
+
+.turn-motion-denied-card {
+  padding: clamp(22px, 4vw, 34px);
+  border: 6px solid #08090a;
+  border-radius: 26px;
+  background:
+    radial-gradient(circle at 92% 9%, rgb(255 79 163 / 0.32), transparent 24%),
+    #fff8e8;
+  box-shadow: 10px 10px 0 #08090a;
+  text-align: left;
+}
+
+.turn-motion-denied-kicker {
+  display: inline-block;
+  padding: 6px 11px;
+  border: 3px solid #08090a;
+  border-radius: 999px;
+  background: #ffd43b;
+  font-size: 0.78rem;
+  font-weight: 950;
+  letter-spacing: 0.12em;
+  line-height: 1;
+}
+
+.turn-motion-denied-card h2 {
+  margin: 14px 0 10px;
+  font-size: clamp(2rem, 8vw, 3.6rem);
+  font-weight: 1000;
+  line-height: 0.9;
+  letter-spacing: -0.055em;
+}
+
+.turn-motion-denied-card p {
+  margin: 0;
+  font-size: clamp(1rem, 2.5vw, 1.2rem);
+  font-weight: 780;
+  line-height: 1.35;
+}
+
+.turn-motion-denied-card button {
+  width: 100%;
+  margin-top: 22px;
+  padding: 12px 18px;
+  border: 4px solid #08090a;
+  border-radius: 15px;
+  background: #ff4fa3;
+  color: #08090a;
+  box-shadow: 4px 4px 0 #08090a;
+  font: inherit;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+}
+
+.turn-motion-denied-card button:focus-visible {
+  outline: 5px solid #5de4ff;
+  outline-offset: 4px;
+}
+
+@media (max-height: 500px) and (orientation: landscape) {
+  .turn-motion-denied-card {
+    padding: 18px 22px;
+  }
+
+  .turn-motion-denied-card h2 {
+    margin-block: 10px 7px;
+    font-size: clamp(1.7rem, 6vw, 2.7rem);
+  }
+
+  .turn-motion-denied-card button {
+    margin-top: 14px;
+    padding-block: 9px;
+  }
+}

--- a/turn/ui/how-to-play-guide.js
+++ b/turn/ui/how-to-play-guide.js
@@ -1,4 +1,4 @@
-const GUIDE_VERSION = 'r127-full-drive-by-ear-name';
+const GUIDE_VERSION = 'r134-contained-drive-by-ear-disclosure';
 const PACE_NOTE_EXPLANATION = 'Before major corners, one to three beeps play in the ear on the turn side. One beep means a gentler corner, two means medium and three means tight. A long corner keeps the same number of beeps but holds the final beep longer: bip-beeeep for a long medium corner and bip-bip-beeeep for a long tight corner. Separate groups describe linked corners in the order you will meet them.';
 
 export function installHowToPlayGuide(root = document) {
@@ -35,57 +35,59 @@ function installDriveByEarDisclosure(dialog) {
 
       <details class="m8-dbe-guide">
         <summary>Explore the Drive By Ear sounds</summary>
-        <div class="m8-dbe-guide-content">
-          <p class="m8-dbe-guide-intro">The sounds have different jobs. Guidance tells you where to steer, pace notes tell you what is coming next, and car or surface sounds tell you what is happening now.</p>
+        <div class="m8-dbe-guide-panel">
+          <div class="m8-dbe-guide-content">
+            <p class="m8-dbe-guide-intro">The sounds have different jobs. Guidance tells you where to steer, pace notes tell you what is coming next, and car or surface sounds tell you what is happening now.</p>
 
-          <div class="m8-dbe-guide-basics" aria-labelledby="m8DbeBasics">
-            <h4 id="m8DbeBasics">Start here</h4>
-            <ul>
-              <li>Use headphones and begin at a comfortable speed.</li>
-              <li>Steer <strong>toward</strong> the warm guiding hum.</li>
-              <li>Listen to pace notes before corners. The ear gives the direction and the beep count gives the severity.</li>
-              <li>Engine, tyre, BOOST and gravel sounds describe the car or surface. They are not steering instructions.</li>
-            </ul>
-          </div>
+            <div class="m8-dbe-guide-basics" aria-labelledby="m8DbeBasics">
+              <h4 id="m8DbeBasics">Start here</h4>
+              <ul>
+                <li>Use headphones and begin at a comfortable speed.</li>
+                <li>Steer <strong>toward</strong> the warm guiding hum.</li>
+                <li>Listen to pace notes before corners. The ear gives the direction and the beep count gives the severity.</li>
+                <li>Engine, tyre, BOOST and gravel sounds describe the car or surface. They are not steering instructions.</li>
+              </ul>
+            </div>
 
-          <div class="m8-dbe-guide-section" aria-labelledby="m8DbeRibbon">
-            <h4 id="m8DbeRibbon">Guiding ribbon</h4>
-            <p>A warm organic hum points toward the side you should steer toward. It combines your position with where the moving car is likely to go. As the trajectory becomes safer, the hum settles closer to the centre and softens. At higher speed it looks farther ahead, so smooth corrections work better than chasing every tiny movement.</p>
-          </div>
+            <div class="m8-dbe-guide-section" aria-labelledby="m8DbeRibbon">
+              <h4 id="m8DbeRibbon">Guiding ribbon</h4>
+              <p>A warm organic hum points toward the side you should steer toward. It combines your position with where the moving car is likely to go. As the trajectory becomes safer, the hum settles closer to the centre and softens. At higher speed it looks farther ahead, so smooth corrections work better than chasing every tiny movement.</p>
+            </div>
 
-          <div class="m8-dbe-guide-section" aria-labelledby="m8DbePaceNotes">
-            <h4 id="m8DbePaceNotes">Pace notes</h4>
-            <p>${PACE_NOTE_EXPLANATION}</p>
-          </div>
+            <div class="m8-dbe-guide-section" aria-labelledby="m8DbePaceNotes">
+              <h4 id="m8DbePaceNotes">Pace notes</h4>
+              <p>${PACE_NOTE_EXPLANATION}</p>
+            </div>
 
-          <div class="m8-dbe-guide-section" aria-labelledby="m8DbeDrift">
-            <h4 id="m8DbeDrift">Drift and grip</h4>
-            <p>Tyre noise stays centred. As the car loses more grip, the sound spreads wider across both ears. This describes how much the car is sliding without becoming a second left or right instruction.</p>
-          </div>
+            <div class="m8-dbe-guide-section" aria-labelledby="m8DbeDrift">
+              <h4 id="m8DbeDrift">Drift and grip</h4>
+              <p>Tyre noise stays centred. As the car loses more grip, the sound spreads wider across both ears. This describes how much the car is sliding without becoming a second left or right instruction.</p>
+            </div>
 
-          <div class="m8-dbe-guide-section" aria-labelledby="m8DbePower">
-            <h4 id="m8DbePower">Engine and BOOST</h4>
-            <p>Engine and BOOST sounds stay centred. A rising burst confirms that BOOST starts, while a separate empty cue tells you the charge is gone. These are status sounds, not steering guidance.</p>
-          </div>
+            <div class="m8-dbe-guide-section" aria-labelledby="m8DbePower">
+              <h4 id="m8DbePower">Engine and BOOST</h4>
+              <p>Engine and BOOST sounds stay centred. A rising burst confirms that BOOST starts, while a separate empty cue tells you the charge is gone. These are status sounds, not steering guidance.</p>
+            </div>
 
-          <div class="m8-dbe-guide-section" aria-labelledby="m8DbeRecovery">
-            <h4 id="m8DbeRecovery">Off-road recovery</h4>
-            <p>Centred gravel marks that the car is off road. The guiding hum changes to recovery guidance and points toward a useful place to rejoin, rather than simply the nearest edge. Steer toward the hum until normal on-road guidance returns.</p>
-          </div>
+            <div class="m8-dbe-guide-section" aria-labelledby="m8DbeRecovery">
+              <h4 id="m8DbeRecovery">Off-road recovery</h4>
+              <p>Centred gravel marks that the car is off road. The guiding hum changes to recovery guidance and points toward a useful place to rejoin, rather than simply the nearest edge. Steer toward the hum until normal on-road guidance returns.</p>
+            </div>
 
-          <div class="m8-dbe-guide-section" aria-labelledby="m8DbeRivals">
-            <h4 id="m8DbeRivals">Nearby rivals</h4>
-            <p>A short directional cue sounds when a rival comes close. It plays from the side of the nearby car. Treat it as a heads-up rather than a continuous tracker.</p>
-          </div>
+            <div class="m8-dbe-guide-section" aria-labelledby="m8DbeRivals">
+              <h4 id="m8DbeRivals">Nearby rivals</h4>
+              <p>A short directional cue sounds when a rival comes close. It plays from the side of the nearby car. Treat it as a heads-up rather than a continuous tracker.</p>
+            </div>
 
-          <div class="m8-dbe-guide-section" aria-labelledby="m8DbeWrongWay">
-            <h4 id="m8DbeWrongWay">Wrong way</h4>
-            <p>A repeating low double falling tone confirms that you are facing the wrong direction. A final side tone indicates which way to turn. Continue turning until the regular guiding ribbon returns.</p>
-          </div>
+            <div class="m8-dbe-guide-section" aria-labelledby="m8DbeWrongWay">
+              <h4 id="m8DbeWrongWay">Wrong way</h4>
+              <p>A repeating low double falling tone confirms that you are facing the wrong direction. A final side tone indicates which way to turn. Continue turning until the regular guiding ribbon returns.</p>
+            </div>
 
-          <div class="m8-dbe-guide-section m8-dbe-guide-screen-reader" aria-labelledby="m8DbeScreenReader">
-            <h4 id="m8DbeScreenReader">With a screen reader</h4>
-            <p>Drive By Ear is designed to work alongside screen readers, including VoiceOver. The screen reader presents menus, controls, position and lap results; Drive By Ear supplies the continuous spatial information needed to steer and stay on course. Together they are intended to provide a complete non-visual way to play TURN.</p>
+            <div class="m8-dbe-guide-section m8-dbe-guide-screen-reader" aria-labelledby="m8DbeScreenReader">
+              <h4 id="m8DbeScreenReader">With a screen reader</h4>
+              <p>Drive By Ear is designed to work alongside screen readers, including VoiceOver. The screen reader presents menus, controls, position and lap results; Drive By Ear supplies the continuous spatial information needed to steer and stay on course. Together they are intended to provide a complete non-visual way to play TURN.</p>
+            </div>
           </div>
         </div>
       </details>

--- a/turn/ui/motion-permission-cancel-recovery.js
+++ b/turn/ui/motion-permission-cancel-recovery.js
@@ -1,6 +1,6 @@
 const RETRY_STORAGE_KEY = 'turn-motion-permission-retry-v2';
 const DENIED_MESSAGE = 'Motion permission was not granted.';
-const BLOCKED_MESSAGE = 'Motion access is still blocked by iOS. Close and reopen TURN to try device rotation again.';
+const MOTION_BLOCKED_EVENT = 'turn:motion-permission-blocked';
 const MAX_RETRY_AGE_MS = 2 * 60 * 1000;
 
 function permissionWasDismissed(error) {
@@ -13,6 +13,26 @@ function isStandaloneApp(environment) {
     return environment.matchMedia?.('(display-mode: standalone)')?.matches === true;
   } catch (_) {
     return false;
+  }
+}
+
+function notifyMotionPermissionBlocked(environment) {
+  const dispatch = () => {
+    if (typeof environment.dispatchEvent !== 'function') return;
+    const EventConstructor = environment.CustomEvent || globalThis.CustomEvent;
+    const detail = Object.freeze({ reason: 'permission-denied' });
+    const event = typeof EventConstructor === 'function'
+      ? new EventConstructor(MOTION_BLOCKED_EVENT, { detail })
+      : { type: MOTION_BLOCKED_EVENT, detail };
+    environment.dispatchEvent(event);
+  };
+
+  if (typeof environment.setTimeout === 'function') {
+    environment.setTimeout(dispatch, 0);
+  } else if (typeof environment.queueMicrotask === 'function') {
+    environment.queueMicrotask(dispatch);
+  } else {
+    dispatch();
   }
 }
 
@@ -114,8 +134,8 @@ export function installMotionPermissionCancelRecovery({ environment = globalThis
 
           if (permissionWasDismissed(error) && lotOpen && standaloneApp) {
             standaloneDismissals += 1;
-            if (standaloneDismissals === 1) throw error;
-            throw new Error(BLOCKED_MESSAGE);
+            if (standaloneDismissals > 1) notifyMotionPermissionBlocked(environment);
+            throw error;
           }
 
           if (

--- a/turn/ui/motion-permission-denied-dialog.js
+++ b/turn/ui/motion-permission-denied-dialog.js
@@ -1,0 +1,76 @@
+const BLOCKED_EVENT = 'turn:motion-permission-blocked';
+const installations = new WeakMap();
+
+export function installMotionPermissionDeniedDialog({ environment = globalThis } = {}) {
+  if (installations.has(environment)) return installations.get(environment);
+
+  const documentRef = environment.document;
+  if (!documentRef?.body || typeof environment.addEventListener !== 'function') {
+    const unavailable = Object.freeze({ installed: false, show() {} });
+    installations.set(environment, unavailable);
+    return unavailable;
+  }
+
+  let dialog = null;
+
+  function ensureDialog() {
+    if (dialog?.isConnected) return dialog;
+
+    dialog = documentRef.createElement('dialog');
+    dialog.className = 'turn-motion-denied-dialog';
+    dialog.setAttribute('aria-labelledby', 'turnMotionDeniedTitle');
+    dialog.setAttribute('aria-describedby', 'turnMotionDeniedText');
+    dialog.innerHTML = `
+      <article class="turn-motion-denied-card">
+        <span class="turn-motion-denied-kicker">DEVICE ROTATION</span>
+        <h2 id="turnMotionDeniedTitle">MOTION ACCESS DENIED</h2>
+        <p id="turnMotionDeniedText">You denied motion access. Close and reopen TURN to try again, or use on-screen steering in Settings.</p>
+        <button type="button" data-motion-dialog-close>OK</button>
+      </article>`;
+
+    const closeButton = dialog.querySelector('[data-motion-dialog-close]');
+    closeButton.addEventListener('click', () => closeDialog());
+    dialog.addEventListener('click', (event) => {
+      if (event.target === dialog) closeDialog();
+    });
+    dialog.addEventListener('close', restoreFocus);
+    documentRef.body.appendChild(dialog);
+    return dialog;
+  }
+
+  function restoreFocus() {
+    const target = dialog?.__turnReturnFocus;
+    dialog.__turnReturnFocus = null;
+    target?.focus?.();
+  }
+
+  function closeDialog() {
+    if (!dialog) return;
+    if (typeof dialog.close === 'function' && dialog.open) dialog.close();
+    else {
+      dialog.removeAttribute('open');
+      restoreFocus();
+    }
+  }
+
+  function show() {
+    const currentDialog = ensureDialog();
+    currentDialog.__turnReturnFocus = documentRef.querySelector('.lot-race') || documentRef.activeElement;
+
+    if (typeof currentDialog.showModal === 'function') {
+      if (!currentDialog.open) currentDialog.showModal();
+    } else {
+      currentDialog.setAttribute('open', '');
+    }
+
+    const focusClose = () => currentDialog.querySelector('[data-motion-dialog-close]')?.focus?.();
+    if (typeof environment.requestAnimationFrame === 'function') environment.requestAnimationFrame(focusClose);
+    else environment.setTimeout?.(focusClose, 0);
+  }
+
+  environment.addEventListener(BLOCKED_EVENT, show);
+
+  const api = Object.freeze({ installed: true, show });
+  installations.set(environment, api);
+  return api;
+}


### PR DESCRIPTION
## What changed

### Motion permission
- replace the cramped Lot status message with a dedicated accessible modal
- explain the cause in short, direct language: the player denied motion access
- keep the first cancellation silent
- show the modal only when iOS blocks the repeated attempt
- return focus to **RACE THIS CAR** when the modal closes
- keep ordinary browser-mode fresh-document recovery unchanged

### How to Play
- make the Drive By Ear summary and expanded content one visually contained disclosure card
- pin text sizing so opening the disclosure does not trigger iOS text autosizing
- reserve scrollbar space so the dialog width and typography remain stable
- add bottom settling space, contained overscroll and disabled scroll anchoring around the final screen-reader section

## UX copy

**MOTION ACCESS DENIED**

“You denied motion access. Close and reopen TURN to try again, or use on-screen steering in Settings.”

## Validation

- extended the standalone motion cancellation regression to verify the dedicated event, modal wiring, copy, focus return and lack of reload loops
- extended the How to Play regression to verify visual containment, stable font sizing and bottom-scroll safeguards
- retained the complete existing TURN regression suite