### PR TITLE
Load LILYA only for deliberate wrong-way discovery

### DIFF
--- a/turn-tests/midnight-city-lighting-production.mjs
+++ b/turn-tests/midnight-city-lighting-production.mjs
@@ -15,7 +15,7 @@ const [
   fs.readFile(new URL('../turn/tracks/midnight-city-world-r5.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/tracks/midnight-city-world-r6.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/tracks/midnight-city-world-r7.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/tracks/midnight-city-world-r10.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/tracks/midnight-city-world-r11.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/tracks/registry.js', import.meta.url), 'utf8')
 ]);
 
@@ -72,11 +72,21 @@ assert.match(easterEggSource, /new URL\('\.\.\/LILYA\.PNG', import\.meta\.url\)\
 assert.match(easterEggSource, /x: -500\.70[\s\S]*y: 11\.96[\s\S]*z: 40\.20/);
 assert.match(easterEggSource, /maxWidth: 46[\s\S]*maxHeight: 21/);
 assert.match(easterEggSource, /const LILYA_WALL_NORMAL = new THREE\.Vector3\(-1, 0, 0\)/);
+assert.match(easterEggSource, /const LILYA_MAX_TRACK_ALIGNMENT = -0\.62/);
+assert.match(easterEggSource, /const LILYA_DISCOVERY_HOLD_MS = 650/);
 assert.match(easterEggSource, /side: THREE\.FrontSide/);
 assert.match(easterEggSource, /portrait\.rotation\.y = -Math\.PI \/ 2/);
-assert.match(easterEggSource, /armViewTriggeredTextureLoad\(world, portrait\)/);
+assert.match(easterEggSource, /armWrongWayTextureLoad\(world, portrait, options\)/);
 assert.match(easterEggSource, /wallToCamera\.dot\(LILYA_WALL_NORMAL\) < LILYA_MIN_FRONT_DOT/);
 assert.match(easterEggSource, /cameraForward\.dot\(cameraToWall\) < LILYA_MIN_VIEW_DOT/);
+assert.match(easterEggSource, /playerFacesAgainstRaceDirection\(runtime, trackSamples\)/);
+assert.match(easterEggSource, /state\?\.running !== true/);
+assert.match(easterEggSource, /const forwardX = Math\.sin\(state\.heading\)/);
+assert.match(easterEggSource, /const forwardZ = Math\.cos\(state\.heading\)/);
+assert.match(easterEggSource, /return trackAlignment <= LILYA_MAX_TRACK_ALIGNMENT/);
+assert.match(easterEggSource, /now - discoveryStartedAt < LILYA_DISCOVERY_HOLD_MS/);
+assert.match(easterEggSource, /hiddenLilyaWrongWayOnly: true/);
+assert.match(easterEggSource, /hiddenLilyaDiscoveryHoldMs: LILYA_DISCOVERY_HOLD_MS/);
 assert.match(easterEggSource, /texture\.generateMipmaps = false/);
 assert.match(
   easterEggSource,
@@ -90,8 +100,8 @@ assert.doesNotMatch(
   'The hidden portrait must use the existing render loop without adding timers or lights'
 );
 
-assert.match(registrySource, /midnight-city-world-r10\.js\?build=20260802-r10/);
+assert.match(registrySource, /midnight-city-world-r11\.js\?build=20260802-r11/);
 assert.match(registrySource, /'midnight-city'\(\{ scene, samples, trackWidth, runtime \}\)/);
 assert.match(registrySource, /installMidnightCityWorld\(\{ scene, samples, trackWidth, runtime \}\)/);
 
-console.log('TURN Midnight City lighting, scenery and corrected lazy LILYA wall placement passed.');
+console.log('TURN Midnight City lighting, scenery and wrong-way-only lazy LILYA placement passed.');

--- a/turn/tracks/midnight-city-world-r11.js
+++ b/turn/tracks/midnight-city-world-r11.js
@@ -1,0 +1,197 @@
+import * as THREE from 'three';
+import { installMidnightCityWorld as installMidnightCityWorldR7 } from './midnight-city-world-r7.js?base=20260801-r7';
+
+const LILYA_TEXTURE_URL = new URL('../LILYA.PNG', import.meta.url).href;
+
+// This is the surviving low Neon Quarter building inside the western hairpin.
+// The portrait belongs on its west facade, the vertical wall marked in the map close-up.
+const LILYA_WALL = Object.freeze({
+  x: -500.70,
+  y: 11.96,
+  z: 40.20,
+  maxWidth: 46,
+  maxHeight: 21
+});
+const LILYA_WALL_NORMAL = new THREE.Vector3(-1, 0, 0);
+const LILYA_LOAD_DISTANCE = 220;
+const LILYA_LOAD_DISTANCE_SQUARED = LILYA_LOAD_DISTANCE * LILYA_LOAD_DISTANCE;
+const LILYA_MIN_VIEW_DOT = 0.56;
+const LILYA_MIN_FRONT_DOT = 0.12;
+const LILYA_MAX_TRACK_ALIGNMENT = -0.62;
+const LILYA_DISCOVERY_HOLD_MS = 650;
+
+export function installMidnightCityWorld(options) {
+  const world = installMidnightCityWorldR7(options);
+  const portrait = installHiddenLilyaPortrait(world);
+  const lazyLoadArmed = armWrongWayTextureLoad(world, portrait, options);
+
+  world.name = 'TURN Midnight City r11';
+  world.userData.turnMidnightCityArtDirection = Object.freeze({
+    ...(world.userData.turnMidnightCityArtDirection || {}),
+    version: 'r11',
+    hiddenLilyaPortrait: true,
+    hiddenLilyaPlacement: 'west facade of the surviving low Neon Quarter building inside the western hairpin',
+    hiddenLilyaLazyLoad: lazyLoadArmed
+      ? 'load only after the player approaches from the visible side, looks at the wall and remains turned against race direction'
+      : 'unavailable because the race-road render trigger was not found',
+    hiddenLilyaWrongWayOnly: true,
+    hiddenLilyaDiscoveryHoldMs: LILYA_DISCOVERY_HOLD_MS,
+    hiddenLilyaMipmaps: false,
+    hiddenLilyaFitsFacade: true,
+    gameplayGeometryUnchanged: true,
+    noDynamicLightsAdded: true,
+    noIndependentAnimationLoop: true
+  });
+
+  return world;
+}
+
+function installHiddenLilyaPortrait(world) {
+  const material = new THREE.MeshBasicMaterial({
+    transparent: true,
+    alphaTest: 0.05,
+    depthWrite: false,
+    side: THREE.FrontSide,
+    toneMapped: false,
+    polygonOffset: true,
+    polygonOffsetFactor: -2,
+    polygonOffsetUnits: -2
+  });
+  const portrait = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), material);
+  portrait.name = 'Midnight City hidden LILYA portrait';
+  portrait.position.set(LILYA_WALL.x, LILYA_WALL.y, LILYA_WALL.z);
+  portrait.rotation.y = -Math.PI / 2;
+  portrait.visible = false;
+  portrait.renderOrder = 4;
+  portrait.userData.turnEasterEgg = 'hidden-lilya-portrait';
+  world.add(portrait);
+  return portrait;
+}
+
+function armWrongWayTextureLoad(world, portrait, options = {}) {
+  const road = world.getObjectByName('Midnight City race road');
+  if (!road) {
+    console.warn('TURN: Midnight City could not arm the hidden LILYA portrait lazy loader.');
+    return false;
+  }
+
+  const runtime = options.runtime;
+  const trackSamples = options.samples || options.trackRuntime?.samples || [];
+  const wallPosition = new THREE.Vector3(LILYA_WALL.x, LILYA_WALL.y, LILYA_WALL.z);
+  const cameraPosition = new THREE.Vector3();
+  const cameraForward = new THREE.Vector3();
+  const cameraToWall = new THREE.Vector3();
+  const wallToCamera = new THREE.Vector3();
+  const previousOnBeforeRender = road.onBeforeRender;
+  let discoveryStartedAt = null;
+  let loadStarted = false;
+
+  function restoreRoadRenderHook() {
+    if (road.onBeforeRender === wrongWayTriggeredLoad) {
+      road.onBeforeRender = previousOnBeforeRender;
+    }
+  }
+
+  function resetDiscoveryHold() {
+    discoveryStartedAt = null;
+  }
+
+  function wrongWayTriggeredLoad(...args) {
+    previousOnBeforeRender?.call(this, ...args);
+    if (loadStarted) return;
+
+    const camera = args[2];
+    if (!camera?.isCamera) {
+      resetDiscoveryHold();
+      return;
+    }
+
+    camera.getWorldPosition(cameraPosition);
+    if (cameraPosition.distanceToSquared(wallPosition) > LILYA_LOAD_DISTANCE_SQUARED) {
+      resetDiscoveryHold();
+      return;
+    }
+
+    wallToCamera.copy(cameraPosition).sub(wallPosition).normalize();
+    if (wallToCamera.dot(LILYA_WALL_NORMAL) < LILYA_MIN_FRONT_DOT) {
+      resetDiscoveryHold();
+      return;
+    }
+
+    camera.getWorldDirection(cameraForward);
+    cameraToWall.copy(wallPosition).sub(cameraPosition).normalize();
+    if (cameraForward.dot(cameraToWall) < LILYA_MIN_VIEW_DOT) {
+      resetDiscoveryHold();
+      return;
+    }
+
+    if (!playerFacesAgainstRaceDirection(runtime, trackSamples)) {
+      resetDiscoveryHold();
+      return;
+    }
+
+    const now = globalThis.performance?.now?.() ?? Date.now();
+    if (discoveryStartedAt == null) {
+      discoveryStartedAt = now;
+      return;
+    }
+    if (now - discoveryStartedAt < LILYA_DISCOVERY_HOLD_MS) return;
+
+    loadStarted = true;
+    restoreRoadRenderHook();
+    loadLilyaTexture(portrait);
+  }
+
+  road.onBeforeRender = wrongWayTriggeredLoad;
+  portrait.userData.turnLazyTexture = 'wrong-way-camera-proximity-front-side-view-direction-and-hold';
+  return true;
+}
+
+function playerFacesAgainstRaceDirection(runtime, trackSamples) {
+  const state = runtime?.state;
+  const sample = trackSamples[state?.nearestTrackIndex];
+  if (
+    state?.running !== true
+    || !Number.isFinite(state.heading)
+    || !sample?.tangent
+  ) {
+    return false;
+  }
+
+  const forwardX = Math.sin(state.heading);
+  const forwardZ = Math.cos(state.heading);
+  const trackAlignment = forwardX * sample.tangent.x + forwardZ * sample.tangent.z;
+  return trackAlignment <= LILYA_MAX_TRACK_ALIGNMENT;
+}
+
+function loadLilyaTexture(portrait) {
+  new THREE.TextureLoader().load(
+    LILYA_TEXTURE_URL,
+    (texture) => {
+      texture.colorSpace = THREE.SRGBColorSpace;
+      texture.generateMipmaps = false;
+      texture.minFilter = THREE.LinearFilter;
+      texture.magFilter = THREE.LinearFilter;
+
+      const imageWidth = texture.image?.naturalWidth || texture.image?.width || 1;
+      const imageHeight = texture.image?.naturalHeight || texture.image?.height || 1;
+      const aspectRatio = imageWidth / imageHeight;
+      let width = LILYA_WALL.maxWidth;
+      let height = width / aspectRatio;
+
+      if (height > LILYA_WALL.maxHeight) {
+        height = LILYA_WALL.maxHeight;
+        width = height * aspectRatio;
+      }
+
+      portrait.material.map = texture;
+      portrait.material.needsUpdate = true;
+      portrait.scale.set(width, height, 1);
+      portrait.visible = true;
+    },
+    undefined,
+    (error) => {
+      console.warn('TURN: Midnight City could not load the hidden LILYA portrait.', error);
+    }
+  );
+}

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -8,8 +8,8 @@ import {
 import { installAirportWorld } from './airport-world-r52.js?build=20260722-r52';
 import { installCliffsideWorld } from './cliffside-world.js';
 import { installHarborWorld } from './harbor-world.js';
-// Historical regression marker: midnight-city-world-r9.js?build=20260802-r9
-import { installMidnightCityWorld } from './midnight-city-world-r10.js?build=20260802-r10';
+// Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10
+import { installMidnightCityWorld } from './midnight-city-world-r11.js?build=20260802-r11';
 import { isForgivingTrackSurface } from './airport-runoff.js?build=20260722-r52';
 
 const WORLD_INSTALLERS = Object.freeze({


### PR DESCRIPTION
## What changed

- replace the broad camera-only LILYA trigger with a deliberate wrong-way discovery gate
- require the player car to face substantially against the local race direction before the texture can load
- retain the existing proximity, visible-wall-side and camera-facing checks
- require the complete discovery pose to remain stable for 650 ms, so a split-second glimpse during a regular lap cannot start the 2 MB texture request
- keep the portrait hidden and unloaded until every condition is satisfied

## UX outcome

A normal lap past the western hairpin no longer loads LILYA when the wall flickers briefly into view. The avatar appears only when the player turns around, approaches from the wall’s visible side and deliberately looks at it from the opposite direction.

## Performance

- regular laps do not request, decode or upload `LILYA.PNG`
- no timer, extra render loop, light or asset was added
- the existing road render hook performs the small directional check and removes itself permanently after loading begins

## Validation

- updated the Midnight City regression to require the negative track-alignment threshold
- verifies the 650 ms discovery hold
- verifies the existing camera, facade-side, placement, no-mipmap and no-extra-loop safeguards
- updates the runtime registry to Midnight City r11