### PR TITLE
Add inclusive Home feedback and attribution

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Run TURN NEXT home navigation regression
         run: node turn-tests/home-navigation-production.mjs
 
+      - name: Run inclusive Home feedback and attribution regression
+        run: node turn-tests/home-feedback-production.mjs
+
       - name: Run track intro showcase camera regression
         run: node turn-tests/track-intro-camera-production.mjs
 

--- a/turn-tests/home-feedback-production.mjs
+++ b/turn-tests/home-feedback-production.mjs
@@ -21,7 +21,7 @@ assert.match(feedback, /FEEDBACK_EMAIL = 'erik@enkel\.design'/);
 assert.match(feedback, /trigger\.textContent = 'GIVE FEEDBACK'/);
 assert.match(feedback, /trigger\.setAttribute\('aria-haspopup', 'dialog'\)/);
 assert.match(feedback, /menu\.insertBefore\(trigger, status\)/, 'GIVE FEEDBACK must sit with the other Home menu actions, before status and RACE');
-assert.match(feedback, /class="m8-dialog m8-feedback-dialog"/);
+assert.match(feedback, /dialog\.className = 'm8-dialog m8-feedback-dialog'/);
 assert.match(feedback, /aria-labelledby', 'm8FeedbackTitle'/);
 assert.match(feedback, /<h2 id="m8FeedbackTitle">GIVE FEEDBACK<\/h2>/);
 assert.match(feedback, /Found a bug, an accessibility barrier or something that made TURN harder to use/);

--- a/turn-tests/home-feedback-production.mjs
+++ b/turn-tests/home-feedback-production.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const [app, feedback, css] = await Promise.all([
+  fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/ui/home-feedback.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/home-feedback-r135.css', import.meta.url), 'utf8')
+]);
+
+assert.match(app, /home-feedback-r135\.css\?revision=r135-inclusive-feedback/);
+assert.match(app, /data-turn-home-feedback/);
+assert.match(app, /home-feedback\.js\?revision=r135-inclusive-feedback/);
+assert.match(app, /installHomeFeedback\(\)/);
+assert.ok(
+  app.indexOf('await installM8HomeFixedLayout()') < app.indexOf('installHomeFeedback()'),
+  'The feedback button must be installed only after the fixed Home menu exists'
+);
+
+assert.match(feedback, /FEEDBACK_VERSION = 'r135-inclusive-feedback-attribution'/);
+assert.match(feedback, /FEEDBACK_EMAIL = 'erik@enkel\.design'/);
+assert.match(feedback, /trigger\.textContent = 'GIVE FEEDBACK'/);
+assert.match(feedback, /trigger\.setAttribute\('aria-haspopup', 'dialog'\)/);
+assert.match(feedback, /menu\.insertBefore\(trigger, status\)/, 'GIVE FEEDBACK must sit with the other Home menu actions, before status and RACE');
+assert.match(feedback, /class="m8-dialog m8-feedback-dialog"/);
+assert.match(feedback, /aria-labelledby', 'm8FeedbackTitle'/);
+assert.match(feedback, /<h2 id="m8FeedbackTitle">GIVE FEEDBACK<\/h2>/);
+assert.match(feedback, /Found a bug, an accessibility barrier or something that made TURN harder to use/);
+assert.match(feedback, /Feature ideas and improvement suggestions are welcome too/);
+assert.match(feedback, /Feedback from every kind of player helps make TURN better for everyone/);
+assert.match(feedback, /Mention your device, browser or assistive technology when it is relevant/);
+assert.match(feedback, /mailto:\$\{FEEDBACK_EMAIL\}\?subject=\$\{encodeURIComponent\(FEEDBACK_SUBJECT\)\}/);
+assert.match(feedback, />EMAIL FEEDBACK<\/a>/);
+assert.match(feedback, />COPY EMAIL ADDRESS<\/button>/);
+assert.match(feedback, /navigator\?\.clipboard\?\.writeText/);
+assert.match(feedback, /document\.execCommand\?\.\('copy'\)/, 'Copy email needs a fallback for browsers without the Clipboard API');
+assert.match(feedback, /role="status" aria-live="polite"/);
+assert.match(feedback, /Email address copied: \$\{FEEDBACK_EMAIL\}/);
+assert.match(feedback, /inclusive and universal design/);
+assert.match(feedback, /accessibility built into the game from the start/);
+assert.match(feedback, /© 2026/);
+assert.match(feedback, /Created by Erik Jansson, aided by OpenAI Codex/);
+assert.match(feedback, /Drive By Ear™ is inspired by/);
+assert.match(feedback, /https:\/\/ceal\.cs\.columbia\.edu\/rad\//);
+assert.match(feedback, /RAD – Racing Auditory Display/);
+assert.match(feedback, /dialog\.__turnReturnFocus\?\.focus\?\.\(\)/, 'Closing the modal must return focus to GIVE FEEDBACK');
+assert.match(feedback, /if \(event\.target === dialog\) closeDialog\(dialog\)/, 'Pressing the backdrop should close the modal without hijacking content clicks');
+
+assert.match(css, /\.m8-home-fixed-layout \.m8-feedback-button/);
+assert.match(css, /\.m8-feedback-dialog[\s\S]*width: min\(760px, calc\(100vw - 32px\)\)/);
+assert.match(css, /\.m8-feedback-email[\s\S]*background: var\(--m8-pink\)/);
+assert.match(css, /\.m8-feedback-copy[\s\S]*background: var\(--m8-yellow\)/);
+assert.match(css, /\.m8-feedback-attribution[\s\S]*border-top: 3px solid var\(--m8-ink\)/);
+assert.match(css, /@media \(max-width: 760px\) and \(orientation: portrait\)[\s\S]*grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/, 'Four Home actions should become a readable two-by-two grid in portrait');
+assert.doesNotMatch(`${feedback}\n${css}`, /setInterval|@keyframes|animation:/, 'Feedback must add no loop or decorative animation');
+
+console.log('TURN inclusive Home feedback and attribution regression passed.');

--- a/turn-tests/how-to-play-guide-production.mjs
+++ b/turn-tests/how-to-play-guide-production.mjs
@@ -46,7 +46,7 @@ assert.match(guide, /Wrong way/);
 assert.match(guide, /With a screen reader/);
 assert.match(guide, /Headphones provide the clearest left and right information/);
 assert.match(guide, /complete non-visual play/);
-assert.match(guide, /Drive By Ear supplies the continuous spatial information/);
+assert.match(guide, /Drive By Ear supplies the spatial information needed to steer and stay on course/);
 assert.match(guide, /Drive By Ear provides the continuous spatial information/);
 assert.match(guide, /root\.querySelector\('#dbeGuideScreenReaders'\)/, 'The in-race guide must replace its abbreviated screen-reader copy before it can be shown');
 assert.doesNotMatch(guide, /[;.]\s*DBE\s+(?:supplies|provides)/, 'Player-facing help must always spell out Drive By Ear');

--- a/turn/app.js
+++ b/turn/app.js
@@ -222,6 +222,14 @@ const { installM8HomeFixedLayout } = await import(
 );
 await installM8HomeFixedLayout();
 installStylesheet(
+  './home-feedback-r135.css?revision=r135-inclusive-feedback',
+  'data-turn-home-feedback'
+);
+const { installHomeFeedback } = await import(
+  withBuild('./ui/home-feedback.js?revision=r135-inclusive-feedback')
+);
+installHomeFeedback();
+installStylesheet(
   './m8-record-car-scale.css?revision=r124-balanced-crop',
   'data-turn-m8-record-car-scale'
 );

--- a/turn/home-feedback-r135.css
+++ b/turn/home-feedback-r135.css
@@ -1,0 +1,195 @@
+.m8-home-fixed-layout .m8-feedback-button {
+  align-self: auto;
+  display: block;
+  justify-self: auto;
+  width: 100%;
+  min-width: 0;
+  margin: 0 0 clamp(16px, 2.5vh, 26px);
+  padding: clamp(9px, 1.5vh, 14px) 12px;
+  border: 4px solid var(--m8-ink);
+  border-radius: 999px;
+  background: #ffd85c;
+  box-shadow: 7px 7px 0 var(--m8-ink);
+  font-size: clamp(0.9rem, 1.65vw, 1.3rem);
+  line-height: 1;
+  letter-spacing: 0.025em;
+  text-align: center;
+}
+
+.m8-home-fixed-layout .m8-feedback-button:hover {
+  transform: translateY(-2px);
+}
+
+.m8-home-fixed-layout .m8-feedback-button:active {
+  transform: translate(6px, 6px);
+  box-shadow: 1px 1px 0 var(--m8-ink);
+}
+
+.m8-home-fixed-layout .m8-feedback-button:focus-visible {
+  outline: 5px solid var(--m8-cream);
+  outline-offset: 4px;
+}
+
+.m8-feedback-dialog {
+  width: min(760px, calc(100vw - 32px));
+}
+
+.m8-feedback-card {
+  overscroll-behavior-y: contain;
+  scrollbar-gutter: stable;
+}
+
+.m8-feedback-content {
+  max-width: 66ch;
+}
+
+.m8-feedback-content p {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.m8-feedback-content p + p {
+  margin-top: 12px;
+}
+
+.m8-feedback-lead {
+  font-size: clamp(1.08rem, 2vw, 1.3rem) !important;
+  font-weight: 850;
+  line-height: 1.38 !important;
+}
+
+.m8-feedback-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-top: 24px;
+}
+
+.m8-feedback-email,
+.m8-feedback-copy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 50px;
+  padding: 11px 20px;
+  border: 4px solid var(--m8-ink);
+  border-radius: 999px;
+  color: var(--m8-ink);
+  box-shadow: 6px 6px 0 var(--m8-ink);
+  font: inherit;
+  font-weight: 950;
+  line-height: 1;
+  letter-spacing: 0.045em;
+  text-align: center;
+  text-decoration: none;
+}
+
+.m8-feedback-email {
+  background: var(--m8-pink);
+}
+
+.m8-feedback-copy {
+  background: var(--m8-yellow);
+}
+
+.m8-feedback-email:hover,
+.m8-feedback-copy:hover {
+  transform: translateY(-2px);
+}
+
+.m8-feedback-email:active,
+.m8-feedback-copy:active {
+  transform: translate(5px, 5px);
+  box-shadow: 1px 1px 0 var(--m8-ink);
+}
+
+.m8-feedback-email:focus-visible,
+.m8-feedback-copy:focus-visible,
+.m8-feedback-attribution a:focus-visible {
+  outline: 5px solid var(--m8-blue);
+  outline-offset: 4px;
+}
+
+.m8-feedback-status {
+  min-height: 1.5em;
+  margin-top: 16px !important;
+  font-weight: 850;
+}
+
+.m8-feedback-attribution {
+  margin-top: 22px;
+  padding-top: 18px;
+  border-top: 3px solid var(--m8-ink);
+}
+
+.m8-feedback-attribution p {
+  font-size: 0.88rem;
+  line-height: 1.48;
+}
+
+.m8-feedback-attribution a {
+  color: inherit;
+  font-weight: 900;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 0.18em;
+}
+
+@media (max-height: 560px) and (orientation: landscape) {
+  .m8-home-fixed-layout .m8-feedback-button {
+    margin-bottom: 13px;
+    padding-block: 8px;
+    border-width: 3px;
+    box-shadow: 5px 5px 0 var(--m8-ink);
+    font-size: 0.82rem;
+  }
+
+  .m8-feedback-dialog .m8-dialog-card {
+    padding: 18px 22px max(18px, env(safe-area-inset-bottom));
+  }
+
+  .m8-feedback-dialog .m8-dialog-head {
+    margin-bottom: 14px;
+  }
+
+  .m8-feedback-actions {
+    margin-top: 16px;
+  }
+
+  .m8-feedback-attribution {
+    margin-top: 16px;
+    padding-top: 14px;
+  }
+}
+
+@media (max-width: 760px) and (orientation: portrait) {
+  .m8-home-fixed-layout .m8-home-menu {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .m8-home-fixed-layout .m8-feedback-button {
+    margin: 0;
+    padding: 10px 5px;
+    border-width: 4px;
+    box-shadow: 7px 7px 0 var(--m8-ink);
+    font-size: 0.72rem;
+  }
+
+  .m8-feedback-actions {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .m8-feedback-email,
+  .m8-feedback-copy {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .m8-feedback-email,
+  .m8-feedback-copy,
+  .m8-feedback-button {
+    transition: none !important;
+  }
+}

--- a/turn/ui/home-feedback.js
+++ b/turn/ui/home-feedback.js
@@ -1,0 +1,139 @@
+const FEEDBACK_EMAIL = 'erik@enkel.design';
+const FEEDBACK_SUBJECT = 'TURN feedback';
+const FEEDBACK_VERSION = 'r135-inclusive-feedback-attribution';
+
+let installed = false;
+
+function openDialog(dialog, trigger) {
+  dialog.__turnReturnFocus = trigger;
+  if (typeof dialog.showModal === 'function') dialog.showModal();
+  else dialog.setAttribute('open', '');
+  dialog.querySelector('[data-dialog-close]')?.focus();
+}
+
+function closeDialog(dialog) {
+  if (typeof dialog.close === 'function' && dialog.open) {
+    dialog.close();
+    return;
+  }
+  dialog.removeAttribute('open');
+  dialog.__turnReturnFocus?.focus?.();
+}
+
+function copyWithFallback(text) {
+  const field = document.createElement('textarea');
+  field.value = text;
+  field.setAttribute('readonly', '');
+  field.setAttribute('aria-hidden', 'true');
+  field.style.position = 'fixed';
+  field.style.inset = '0 auto auto -9999px';
+  field.style.opacity = '0';
+  document.body.appendChild(field);
+  field.select();
+  field.setSelectionRange(0, field.value.length);
+  const copied = document.execCommand?.('copy') === true;
+  field.remove();
+  return copied;
+}
+
+async function copyEmailAddress(button, status) {
+  let copied = false;
+  try {
+    if (globalThis.navigator?.clipboard?.writeText) {
+      await globalThis.navigator.clipboard.writeText(FEEDBACK_EMAIL);
+      copied = true;
+    } else {
+      copied = copyWithFallback(FEEDBACK_EMAIL);
+    }
+  } catch (_) {
+    copied = copyWithFallback(FEEDBACK_EMAIL);
+  }
+
+  status.textContent = copied
+    ? `Email address copied: ${FEEDBACK_EMAIL}`
+    : `Could not copy automatically. The email address is ${FEEDBACK_EMAIL}.`;
+
+  if (copied) {
+    const originalLabel = button.textContent;
+    button.textContent = 'COPIED';
+    globalThis.setTimeout?.(() => {
+      button.textContent = originalLabel;
+    }, 1800);
+  }
+}
+
+function createFeedbackDialog() {
+  const dialog = document.createElement('dialog');
+  dialog.className = 'm8-dialog m8-feedback-dialog';
+  dialog.setAttribute('aria-labelledby', 'm8FeedbackTitle');
+  dialog.dataset.feedbackVersion = FEEDBACK_VERSION;
+  dialog.innerHTML = `
+    <article class="m8-dialog-card m8-feedback-card">
+      <header class="m8-dialog-head">
+        <div><span>HELP MAKE TURN BETTER</span><h2 id="m8FeedbackTitle">GIVE FEEDBACK</h2></div>
+        <button type="button" data-dialog-close aria-label="Close Give Feedback">×</button>
+      </header>
+
+      <div class="m8-feedback-content">
+        <p class="m8-feedback-lead">Found a bug, an accessibility barrier or something that made TURN harder to use? Tell us what happened and what you expected.</p>
+        <p>Feature ideas and improvement suggestions are welcome too. Feedback from every kind of player helps make TURN better for everyone. Mention your device, browser or assistive technology when it is relevant.</p>
+
+        <div class="m8-feedback-actions">
+          <a class="m8-feedback-email" href="mailto:${FEEDBACK_EMAIL}?subject=${encodeURIComponent(FEEDBACK_SUBJECT)}">EMAIL FEEDBACK</a>
+          <button class="m8-feedback-copy" type="button">COPY EMAIL ADDRESS</button>
+        </div>
+        <p class="m8-feedback-status" role="status" aria-live="polite"></p>
+
+        <footer class="m8-feedback-attribution">
+          <p>TURN is shaped by inclusive and universal design, with accessibility built into the game from the start.</p>
+          <p>© 2026 <a href="https://enkel.design/" target="_blank" rel="noreferrer">enkel.design</a>. Created by Erik Jansson, aided by OpenAI Codex. Drive By Ear™ is inspired by <a href="https://ceal.cs.columbia.edu/rad/" target="_blank" rel="noreferrer">RAD – Racing Auditory Display</a>.</p>
+        </footer>
+      </div>
+    </article>`;
+  document.body.appendChild(dialog);
+  return dialog;
+}
+
+export function installHomeFeedback() {
+  if (installed) return globalThis.__turnHomeFeedback;
+
+  const menu = document.querySelector('.m8-home-menu');
+  const status = menu?.querySelector('.m8-home-status');
+  if (!menu || !status) {
+    throw new Error('TURN feedback could not find the complete Home menu.');
+  }
+
+  const trigger = document.createElement('button');
+  trigger.type = 'button';
+  trigger.className = 'm8-feedback-button';
+  trigger.textContent = 'GIVE FEEDBACK';
+  trigger.setAttribute('aria-haspopup', 'dialog');
+  menu.insertBefore(trigger, status);
+
+  const dialog = createFeedbackDialog();
+  const closeButton = dialog.querySelector('[data-dialog-close]');
+  const copyButton = dialog.querySelector('.m8-feedback-copy');
+  const feedbackStatus = dialog.querySelector('.m8-feedback-status');
+
+  trigger.addEventListener('click', () => openDialog(dialog, trigger));
+  closeButton.addEventListener('click', () => closeDialog(dialog));
+  copyButton.addEventListener('click', () => copyEmailAddress(copyButton, feedbackStatus));
+  dialog.addEventListener('click', (event) => {
+    if (event.target === dialog) closeDialog(dialog);
+  });
+  dialog.addEventListener('close', () => {
+    feedbackStatus.textContent = '';
+    dialog.__turnReturnFocus?.focus?.();
+  });
+
+  installed = true;
+  globalThis.__turnHomeFeedback = Object.freeze({
+    version: FEEDBACK_VERSION,
+    email: FEEDBACK_EMAIL,
+    trigger,
+    dialog,
+    open: () => openDialog(dialog, trigger),
+    close: () => closeDialog(dialog)
+  });
+  return globalThis.__turnHomeFeedback;
+}


### PR DESCRIPTION
## What changed

- add a **GIVE FEEDBACK** action to the Home page MENU, positioned with Settings and How to Play
- open an accessible modal using the same visual and interaction pattern as TURN’s existing Home dialogs
- add an email CTA to `erik@enkel.design` with a prefilled TURN feedback subject
- add a secondary **COPY EMAIL ADDRESS** action with Clipboard API support, a legacy fallback and a polite screen-reader status message
- return focus to **GIVE FEEDBACK** when the modal closes
- keep the four portrait Home actions readable in a two-by-two grid

## Inclusive copy

The modal explicitly welcomes:

- bugs and unexpected behaviour
- accessibility barriers and assistive-technology details
- feature ideas and improvement suggestions
- feedback from every kind of player

## Attribution

The end of the modal now states that TURN is shaped by inclusive and universal design, with accessibility built in from the start, followed by:

> © 2026 enkel.design. Created by Erik Jansson, aided by OpenAI Codex. Drive By Ear™ is inspired by RAD – Racing Auditory Display.

`enkel.design` and the supplied RAD reference are linked.

## Validation

- add a dedicated production regression for menu order, dialog semantics, focus return, mailto content, copy fallback, inclusive wording, attribution links and responsive layout
- add the regression to the complete TURN GitHub Actions suite
- preserve the existing Home architecture by installing the enhancement only after the fixed MENU layout exists