### PR TITLE
Add About TURN attribution link

### DIFF
--- a/turn-tests/home-feedback-production.mjs
+++ b/turn-tests/home-feedback-production.mjs
@@ -13,14 +13,14 @@ assert.match(app, /home-feedback\.js\?revision=r135-inclusive-feedback/);
 assert.match(app, /installHomeFeedback\(\)/);
 assert.ok(
   app.indexOf('await installM8HomeFixedLayout()') < app.indexOf('installHomeFeedback()'),
-  'The feedback button must be installed only after the fixed Home menu exists'
+  'The feedback and About actions must be installed only after the fixed Home interface exists'
 );
 
-assert.match(feedback, /FEEDBACK_VERSION = 'r135-inclusive-feedback-attribution'/);
+assert.match(feedback, /FEEDBACK_VERSION = 'r136-about-turn'/);
 assert.match(feedback, /FEEDBACK_EMAIL = 'erik@enkel\.design'/);
-assert.match(feedback, /trigger\.textContent = 'GIVE FEEDBACK'/);
-assert.match(feedback, /trigger\.setAttribute\('aria-haspopup', 'dialog'\)/);
-assert.match(feedback, /menu\.insertBefore\(trigger, status\)/, 'GIVE FEEDBACK must sit with the other Home menu actions, before status and RACE');
+assert.match(feedback, /feedbackTrigger\.textContent = 'GIVE FEEDBACK'/);
+assert.match(feedback, /feedbackTrigger\.setAttribute\('aria-haspopup', 'dialog'\)/);
+assert.match(feedback, /menu\.insertBefore\(feedbackTrigger, status\)/, 'GIVE FEEDBACK must sit with the other Home menu actions, before status and RACE');
 assert.match(feedback, /dialog\.className = 'm8-dialog m8-feedback-dialog'/);
 assert.match(feedback, /aria-labelledby', 'm8FeedbackTitle'/);
 assert.match(feedback, /<h2 id="m8FeedbackTitle">GIVE FEEDBACK<\/h2>/);
@@ -35,6 +35,19 @@ assert.match(feedback, /navigator\?\.clipboard\?\.writeText/);
 assert.match(feedback, /document\.execCommand\?\.\('copy'\)/, 'Copy email needs a fallback for browsers without the Clipboard API');
 assert.match(feedback, /role="status" aria-live="polite"/);
 assert.match(feedback, /Email address copied: \$\{FEEDBACK_EMAIL\}/);
+
+assert.match(feedback, /meta\.className = 'm8-home-meta'/);
+assert.match(feedback, /buildLabel\.replaceWith\(meta\)/);
+assert.match(feedback, /meta\.appendChild\(buildLabel\)/);
+assert.match(feedback, /trigger\.className = 'm8-about-trigger'/);
+assert.match(feedback, /trigger\.textContent = 'ABOUT TURN'/);
+assert.match(feedback, /trigger\.setAttribute\('aria-haspopup', 'dialog'\)/);
+assert.match(feedback, /meta\.appendChild\(trigger\)/, 'ABOUT TURN must appear directly under the build information');
+assert.match(feedback, /dialog\.className = 'm8-dialog m8-about-dialog'/);
+assert.match(feedback, /aria-labelledby', 'm8AboutTitle'/);
+assert.match(feedback, /<h2 id="m8AboutTitle">ABOUT TURN<\/h2>/);
+assert.match(feedback, /TURN is a racing game about tilt steering, personal rivals and learning to drive by ear/);
+
 assert.match(feedback, /inclusive and universal design/);
 assert.match(feedback, /accessibility built into the game from the start/);
 assert.match(feedback, /© 2026/);
@@ -42,15 +55,24 @@ assert.match(feedback, /Created by Erik Jansson, aided by OpenAI Codex/);
 assert.match(feedback, /Drive By Ear™ is inspired by/);
 assert.match(feedback, /https:\/\/ceal\.cs\.columbia\.edu\/rad\//);
 assert.match(feedback, /RAD – Racing Auditory Display/);
-assert.match(feedback, /dialog\.__turnReturnFocus\?\.focus\?\.\(\)/, 'Closing the modal must return focus to GIVE FEEDBACK');
-assert.match(feedback, /if \(event\.target === dialog\) closeDialog\(dialog\)/, 'Pressing the backdrop should close the modal without hijacking content clicks');
+assert.equal(
+  (feedback.match(/\$\{attributionMarkup\(\)\}/g) || []).length,
+  2,
+  'Attribution must remain available from both Give Feedback and About TURN'
+);
+assert.match(feedback, /dialog\.__turnReturnFocus\?\.focus\?\.\(\)/, 'Closing either modal must return focus to its trigger');
+assert.match(feedback, /if \(event\.target === dialog\) closeDialog\(dialog\)/, 'Pressing a dialog backdrop should close it without hijacking content clicks');
 
 assert.match(css, /\.m8-home-fixed-layout \.m8-feedback-button/);
+assert.match(css, /\.m8-home-fixed-layout \.m8-home-meta[\s\S]*grid-column: 3[\s\S]*flex-direction: column/);
+assert.match(css, /\.m8-home-fixed-layout \.m8-about-trigger[\s\S]*font-size: clamp\(0\.62rem, 1vw, 0\.82rem\)[\s\S]*text-decoration: underline/);
 assert.match(css, /\.m8-feedback-dialog[\s\S]*width: min\(760px, calc\(100vw - 32px\)\)/);
+assert.match(css, /\.m8-about-dialog[\s\S]*width: min\(660px, calc\(100vw - 32px\)\)/);
 assert.match(css, /\.m8-feedback-email[\s\S]*background: var\(--m8-pink\)/);
 assert.match(css, /\.m8-feedback-copy[\s\S]*background: var\(--m8-yellow\)/);
 assert.match(css, /\.m8-feedback-attribution[\s\S]*border-top: 3px solid var\(--m8-ink\)/);
-assert.match(css, /@media \(max-width: 760px\) and \(orientation: portrait\)[\s\S]*grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/, 'Four Home actions should become a readable two-by-two grid in portrait');
-assert.doesNotMatch(`${feedback}\n${css}`, /setInterval|@keyframes|animation:/, 'Feedback must add no loop or decorative animation');
+assert.match(css, /@media \(max-width: 760px\) and \(orientation: portrait\)[\s\S]*grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/, 'Four Home menu actions should remain a readable two-by-two grid in portrait');
+assert.match(css, /@media \(max-width: 760px\) and \(orientation: portrait\)[\s\S]*\.m8-home-fixed-layout \.m8-home-meta[\s\S]*display: none/, 'Header metadata must stay out of the compact portrait layout');
+assert.doesNotMatch(`${feedback}\n${css}`, /setInterval|@keyframes|animation:/, 'Feedback and About must add no loop or decorative animation');
 
-console.log('TURN inclusive Home feedback and attribution regression passed.');
+console.log('TURN inclusive Home feedback and About attribution regression passed.');

--- a/turn/home-feedback-r135.css
+++ b/turn/home-feedback-r135.css
@@ -30,11 +30,59 @@
   outline-offset: 4px;
 }
 
+.m8-home-fixed-layout .m8-home-meta {
+  grid-column: 3;
+  grid-row: 1;
+  align-self: center;
+  justify-self: end;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 1px;
+  margin-block: max(8px, env(safe-area-inset-top)) 8px;
+}
+
+.m8-home-fixed-layout .m8-home-meta .m8-home-build {
+  margin: 0;
+}
+
+.m8-home-fixed-layout .m8-about-trigger {
+  margin: 0;
+  padding: 2px 10px 4px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-size: clamp(0.62rem, 1vw, 0.82rem);
+  font-weight: 900;
+  line-height: 1.1;
+  letter-spacing: 0.025em;
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 0.18em;
+  cursor: pointer;
+}
+
+.m8-home-fixed-layout .m8-about-trigger:hover {
+  text-decoration-thickness: 3px;
+}
+
+.m8-home-fixed-layout .m8-about-trigger:focus-visible {
+  outline: 4px solid var(--m8-blue);
+  outline-offset: 2px;
+}
+
 .m8-feedback-dialog {
   width: min(760px, calc(100vw - 32px));
 }
 
-.m8-feedback-card {
+.m8-about-dialog {
+  width: min(660px, calc(100vw - 32px));
+}
+
+.m8-feedback-card,
+.m8-about-card {
   overscroll-behavior-y: contain;
   scrollbar-gutter: stable;
 }
@@ -43,17 +91,24 @@
   max-width: 66ch;
 }
 
-.m8-feedback-content p {
+.m8-about-content {
+  max-width: 60ch;
+}
+
+.m8-feedback-content p,
+.m8-about-content p {
   margin: 0;
   font-size: 1rem;
   line-height: 1.5;
 }
 
-.m8-feedback-content p + p {
+.m8-feedback-content p + p,
+.m8-about-content p + p {
   margin-top: 12px;
 }
 
-.m8-feedback-lead {
+.m8-feedback-lead,
+.m8-about-lead {
   font-size: clamp(1.08rem, 2vw, 1.3rem) !important;
   font-weight: 850;
   line-height: 1.38 !important;
@@ -106,7 +161,8 @@
 
 .m8-feedback-email:focus-visible,
 .m8-feedback-copy:focus-visible,
-.m8-feedback-attribution a:focus-visible {
+.m8-feedback-attribution a:focus-visible,
+.m8-about-content a:focus-visible {
   outline: 5px solid var(--m8-blue);
   outline-offset: 4px;
 }
@@ -123,12 +179,14 @@
   border-top: 3px solid var(--m8-ink);
 }
 
-.m8-feedback-attribution p {
+.m8-feedback-attribution p,
+.m8-about-content p:not(.m8-about-lead) {
   font-size: 0.88rem;
   line-height: 1.48;
 }
 
-.m8-feedback-attribution a {
+.m8-feedback-attribution a,
+.m8-about-content a {
   color: inherit;
   font-weight: 900;
   text-decoration-thickness: 2px;
@@ -144,11 +202,17 @@
     font-size: 0.82rem;
   }
 
-  .m8-feedback-dialog .m8-dialog-card {
+  .m8-home-fixed-layout .m8-home-meta {
+    margin-block: max(5px, env(safe-area-inset-top)) 5px;
+  }
+
+  .m8-feedback-dialog .m8-dialog-card,
+  .m8-about-dialog .m8-dialog-card {
     padding: 18px 22px max(18px, env(safe-area-inset-bottom));
   }
 
-  .m8-feedback-dialog .m8-dialog-head {
+  .m8-feedback-dialog .m8-dialog-head,
+  .m8-about-dialog .m8-dialog-head {
     margin-bottom: 14px;
   }
 
@@ -165,6 +229,10 @@
 @media (max-width: 760px) and (orientation: portrait) {
   .m8-home-fixed-layout .m8-home-menu {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .m8-home-fixed-layout .m8-home-meta {
+    display: none;
   }
 
   .m8-home-fixed-layout .m8-feedback-button {
@@ -189,7 +257,8 @@
 @media (prefers-reduced-motion: reduce) {
   .m8-feedback-email,
   .m8-feedback-copy,
-  .m8-feedback-button {
+  .m8-feedback-button,
+  .m8-about-trigger {
     transition: none !important;
   }
 }

--- a/turn/ui/home-feedback.js
+++ b/turn/ui/home-feedback.js
@@ -1,6 +1,6 @@
 const FEEDBACK_EMAIL = 'erik@enkel.design';
 const FEEDBACK_SUBJECT = 'TURN feedback';
-const FEEDBACK_VERSION = 'r135-inclusive-feedback-attribution';
+const FEEDBACK_VERSION = 'r136-about-turn';
 
 let installed = false;
 
@@ -62,6 +62,12 @@ async function copyEmailAddress(button, status) {
   }
 }
 
+function attributionMarkup() {
+  return `
+    <p>TURN is shaped by inclusive and universal design, with accessibility built into the game from the start.</p>
+    <p>© 2026 <a href="https://enkel.design/" target="_blank" rel="noreferrer">enkel.design</a>. Created by Erik Jansson, aided by OpenAI Codex. Drive By Ear™ is inspired by <a href="https://ceal.cs.columbia.edu/rad/" target="_blank" rel="noreferrer">RAD – Racing Auditory Display</a>.</p>`;
+}
+
 function createFeedbackDialog() {
   const dialog = document.createElement('dialog');
   dialog.className = 'm8-dialog m8-feedback-dialog';
@@ -85,13 +91,67 @@ function createFeedbackDialog() {
         <p class="m8-feedback-status" role="status" aria-live="polite"></p>
 
         <footer class="m8-feedback-attribution">
-          <p>TURN is shaped by inclusive and universal design, with accessibility built into the game from the start.</p>
-          <p>© 2026 <a href="https://enkel.design/" target="_blank" rel="noreferrer">enkel.design</a>. Created by Erik Jansson, aided by OpenAI Codex. Drive By Ear™ is inspired by <a href="https://ceal.cs.columbia.edu/rad/" target="_blank" rel="noreferrer">RAD – Racing Auditory Display</a>.</p>
+          ${attributionMarkup()}
         </footer>
       </div>
     </article>`;
   document.body.appendChild(dialog);
   return dialog;
+}
+
+function createAboutDialog() {
+  const dialog = document.createElement('dialog');
+  dialog.className = 'm8-dialog m8-about-dialog';
+  dialog.setAttribute('aria-labelledby', 'm8AboutTitle');
+  dialog.innerHTML = `
+    <article class="m8-dialog-card m8-about-card">
+      <header class="m8-dialog-head">
+        <div><span>THE GAME</span><h2 id="m8AboutTitle">ABOUT TURN</h2></div>
+        <button type="button" data-dialog-close aria-label="Close About TURN">×</button>
+      </header>
+
+      <div class="m8-about-content">
+        <p class="m8-about-lead">TURN is a racing game about tilt steering, personal rivals and learning to drive by ear.</p>
+        ${attributionMarkup()}
+      </div>
+    </article>`;
+  document.body.appendChild(dialog);
+  return dialog;
+}
+
+function installDialogBehavior(dialog, trigger, onClose = null) {
+  const closeButton = dialog.querySelector('[data-dialog-close]');
+  trigger.addEventListener('click', () => openDialog(dialog, trigger));
+  closeButton.addEventListener('click', () => closeDialog(dialog));
+  dialog.addEventListener('click', (event) => {
+    if (event.target === dialog) closeDialog(dialog);
+  });
+  dialog.addEventListener('close', () => {
+    onClose?.();
+    dialog.__turnReturnFocus?.focus?.();
+  });
+}
+
+function createAboutTrigger() {
+  const header = document.querySelector('.m8-home-head');
+  const buildLabel = header?.querySelector('.m8-home-build');
+  if (!header || !buildLabel) {
+    throw new Error('TURN About could not find the Home build information.');
+  }
+
+  const meta = document.createElement('div');
+  meta.className = 'm8-home-meta';
+  buildLabel.replaceWith(meta);
+  meta.appendChild(buildLabel);
+
+  const trigger = document.createElement('button');
+  trigger.type = 'button';
+  trigger.className = 'm8-about-trigger';
+  trigger.textContent = 'ABOUT TURN';
+  trigger.setAttribute('aria-haspopup', 'dialog');
+  meta.appendChild(trigger);
+
+  return { meta, trigger, buildLabel };
 }
 
 export function installHomeFeedback() {
@@ -103,37 +163,41 @@ export function installHomeFeedback() {
     throw new Error('TURN feedback could not find the complete Home menu.');
   }
 
-  const trigger = document.createElement('button');
-  trigger.type = 'button';
-  trigger.className = 'm8-feedback-button';
-  trigger.textContent = 'GIVE FEEDBACK';
-  trigger.setAttribute('aria-haspopup', 'dialog');
-  menu.insertBefore(trigger, status);
+  const feedbackTrigger = document.createElement('button');
+  feedbackTrigger.type = 'button';
+  feedbackTrigger.className = 'm8-feedback-button';
+  feedbackTrigger.textContent = 'GIVE FEEDBACK';
+  feedbackTrigger.setAttribute('aria-haspopup', 'dialog');
+  menu.insertBefore(feedbackTrigger, status);
 
-  const dialog = createFeedbackDialog();
-  const closeButton = dialog.querySelector('[data-dialog-close]');
-  const copyButton = dialog.querySelector('.m8-feedback-copy');
-  const feedbackStatus = dialog.querySelector('.m8-feedback-status');
+  const { meta, trigger: aboutTrigger, buildLabel } = createAboutTrigger();
+  const feedbackDialog = createFeedbackDialog();
+  const aboutDialog = createAboutDialog();
+  const copyButton = feedbackDialog.querySelector('.m8-feedback-copy');
+  const feedbackStatus = feedbackDialog.querySelector('.m8-feedback-status');
 
-  trigger.addEventListener('click', () => openDialog(dialog, trigger));
-  closeButton.addEventListener('click', () => closeDialog(dialog));
-  copyButton.addEventListener('click', () => copyEmailAddress(copyButton, feedbackStatus));
-  dialog.addEventListener('click', (event) => {
-    if (event.target === dialog) closeDialog(dialog);
-  });
-  dialog.addEventListener('close', () => {
+  installDialogBehavior(feedbackDialog, feedbackTrigger, () => {
     feedbackStatus.textContent = '';
-    dialog.__turnReturnFocus?.focus?.();
   });
+  installDialogBehavior(aboutDialog, aboutTrigger);
+  copyButton.addEventListener('click', () => copyEmailAddress(copyButton, feedbackStatus));
 
   installed = true;
   globalThis.__turnHomeFeedback = Object.freeze({
     version: FEEDBACK_VERSION,
     email: FEEDBACK_EMAIL,
-    trigger,
-    dialog,
-    open: () => openDialog(dialog, trigger),
-    close: () => closeDialog(dialog)
+    trigger: feedbackTrigger,
+    dialog: feedbackDialog,
+    open: () => openDialog(feedbackDialog, feedbackTrigger),
+    close: () => closeDialog(feedbackDialog),
+    about: Object.freeze({
+      meta,
+      trigger: aboutTrigger,
+      buildLabel,
+      dialog: aboutDialog,
+      open: () => openDialog(aboutDialog, aboutTrigger),
+      close: () => closeDialog(aboutDialog)
+    })
   });
   return globalThis.__turnHomeFeedback;
 }


### PR DESCRIPTION
## What changed

- add a discreet, underlined **ABOUT TURN** control directly below the version/build information in the Home header
- keep **GIVE FEEDBACK** as the prominent menu action and preserve its existing feedback flow
- open a dedicated accessible About dialog using the same native dialog pattern as TURN’s other Home overlays
- describe TURN briefly and expose the complete creator, Codex and Racing Auditory Display attribution from the expected About location
- retain attribution in Give Feedback as a secondary discovery path
- return focus to the correct trigger when either dialog closes
- hide the header metadata group in the existing compact portrait layout, where the build label was already hidden

## Validation

- extend the Home feedback production regression to cover metadata grouping, About placement, dialog naming, shared attribution, focus return and responsive behavior
- preserve the existing no-animation and feedback accessibility checks