### PR TITLE
Keep Give Feedback compact and move attribution to About

### DIFF
--- a/turn-tests/home-feedback-production.mjs
+++ b/turn-tests/home-feedback-production.mjs
@@ -7,16 +7,16 @@ const [app, feedback, css] = await Promise.all([
   fs.readFile(new URL('../turn/home-feedback-r135.css', import.meta.url), 'utf8')
 ]);
 
-assert.match(app, /home-feedback-r135\.css\?revision=r135-inclusive-feedback/);
+assert.match(app, /home-feedback-r135\.css\?revision=r137-feedback-above-fold/);
 assert.match(app, /data-turn-home-feedback/);
-assert.match(app, /home-feedback\.js\?revision=r135-inclusive-feedback/);
+assert.match(app, /home-feedback\.js\?revision=r137-feedback-above-fold/);
 assert.match(app, /installHomeFeedback\(\)/);
 assert.ok(
   app.indexOf('await installM8HomeFixedLayout()') < app.indexOf('installHomeFeedback()'),
   'The feedback and About actions must be installed only after the fixed Home interface exists'
 );
 
-assert.match(feedback, /FEEDBACK_VERSION = 'r136-about-turn'/);
+assert.match(feedback, /FEEDBACK_VERSION = 'r137-feedback-above-fold'/);
 assert.match(feedback, /FEEDBACK_EMAIL = 'erik@enkel\.design'/);
 assert.match(feedback, /feedbackTrigger\.textContent = 'GIVE FEEDBACK'/);
 assert.match(feedback, /feedbackTrigger\.setAttribute\('aria-haspopup', 'dialog'\)/);
@@ -35,6 +35,24 @@ assert.match(feedback, /navigator\?\.clipboard\?\.writeText/);
 assert.match(feedback, /document\.execCommand\?\.\('copy'\)/, 'Copy email needs a fallback for browsers without the Clipboard API');
 assert.match(feedback, /role="status" aria-live="polite"/);
 assert.match(feedback, /Email address copied: \$\{FEEDBACK_EMAIL\}/);
+assert.match(feedback, /if \(card\) card\.scrollTop = 0/, 'Dialogs should always open at their top edge');
+
+const feedbackDialogSource = feedback.slice(
+  feedback.indexOf('function createFeedbackDialog()'),
+  feedback.indexOf('function createAboutDialog()')
+);
+const aboutDialogSource = feedback.slice(
+  feedback.indexOf('function createAboutDialog()'),
+  feedback.indexOf('function installDialogBehavior(')
+);
+
+assert.doesNotMatch(feedbackDialogSource, /attributionMarkup|m8-feedback-attribution|© 2026|inclusive and universal design/, 'Give Feedback must contain feedback content only');
+assert.match(aboutDialogSource, /\$\{attributionMarkup\(\)\}/, 'Attribution must live in About TURN');
+assert.equal(
+  (feedback.match(/\$\{attributionMarkup\(\)\}/g) || []).length,
+  1,
+  'Attribution must appear only in About TURN'
+);
 
 assert.match(feedback, /meta\.className = 'm8-home-meta'/);
 assert.match(feedback, /buildLabel\.replaceWith\(meta\)/);
@@ -47,19 +65,14 @@ assert.match(feedback, /dialog\.className = 'm8-dialog m8-about-dialog'/);
 assert.match(feedback, /aria-labelledby', 'm8AboutTitle'/);
 assert.match(feedback, /<h2 id="m8AboutTitle">ABOUT TURN<\/h2>/);
 assert.match(feedback, /TURN is a racing game about tilt steering, personal rivals and learning to drive by ear/);
-
-assert.match(feedback, /inclusive and universal design/);
-assert.match(feedback, /accessibility built into the game from the start/);
+assert.match(feedback, /inclusive and universal design so everyone can play/);
+assert.match(feedback, /regardless of ability or how they interact with the game/);
+assert.doesNotMatch(feedback, /accessibility built into the game from the start/);
 assert.match(feedback, /© 2026/);
 assert.match(feedback, /Created by Erik Jansson, aided by OpenAI Codex/);
 assert.match(feedback, /Drive By Ear™ is inspired by/);
 assert.match(feedback, /https:\/\/ceal\.cs\.columbia\.edu\/rad\//);
 assert.match(feedback, /RAD – Racing Auditory Display/);
-assert.equal(
-  (feedback.match(/\$\{attributionMarkup\(\)\}/g) || []).length,
-  2,
-  'Attribution must remain available from both Give Feedback and About TURN'
-);
 assert.match(feedback, /dialog\.__turnReturnFocus\?\.focus\?\.\(\)/, 'Closing either modal must return focus to its trigger');
 assert.match(feedback, /if \(event\.target === dialog\) closeDialog\(dialog\)/, 'Pressing a dialog backdrop should close it without hijacking content clicks');
 
@@ -68,11 +81,15 @@ assert.match(css, /\.m8-home-fixed-layout \.m8-home-meta[\s\S]*grid-column: 3[\s
 assert.match(css, /\.m8-home-fixed-layout \.m8-about-trigger[\s\S]*font-size: clamp\(0\.62rem, 1vw, 0\.82rem\)[\s\S]*text-decoration: underline/);
 assert.match(css, /\.m8-feedback-dialog[\s\S]*width: min\(760px, calc\(100vw - 32px\)\)/);
 assert.match(css, /\.m8-about-dialog[\s\S]*width: min\(660px, calc\(100vw - 32px\)\)/);
+assert.match(css, /\.m8-feedback-dialog \.m8-dialog-head[\s\S]*margin-bottom: clamp\(14px, 2vh, 20px\)/, 'Feedback heading spacing should stay compact');
+assert.match(css, /\.m8-feedback-actions[\s\S]*margin-top: clamp\(16px, 2\.5vh, 22px\)/, 'Feedback actions should remain close to the copy');
+assert.match(css, /\.m8-feedback-status[\s\S]*min-height: 0[\s\S]*margin-top: 0 !important/);
+assert.match(css, /\.m8-feedback-status:not\(:empty\)[\s\S]*min-height: 1\.5em/, 'The live region should consume space only when it has a message');
+assert.doesNotMatch(css, /\.m8-feedback-attribution/, 'Removed feedback attribution must leave no stale layout rules');
 assert.match(css, /\.m8-feedback-email[\s\S]*background: var\(--m8-pink\)/);
 assert.match(css, /\.m8-feedback-copy[\s\S]*background: var\(--m8-yellow\)/);
-assert.match(css, /\.m8-feedback-attribution[\s\S]*border-top: 3px solid var\(--m8-ink\)/);
 assert.match(css, /@media \(max-width: 760px\) and \(orientation: portrait\)[\s\S]*grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/, 'Four Home menu actions should remain a readable two-by-two grid in portrait');
 assert.match(css, /@media \(max-width: 760px\) and \(orientation: portrait\)[\s\S]*\.m8-home-fixed-layout \.m8-home-meta[\s\S]*display: none/, 'Header metadata must stay out of the compact portrait layout');
 assert.doesNotMatch(`${feedback}\n${css}`, /setInterval|@keyframes|animation:/, 'Feedback and About must add no loop or decorative animation');
 
-console.log('TURN inclusive Home feedback and About attribution regression passed.');
+console.log('TURN compact Home feedback and About-only attribution regression passed.');

--- a/turn/app.js
+++ b/turn/app.js
@@ -222,11 +222,11 @@ const { installM8HomeFixedLayout } = await import(
 );
 await installM8HomeFixedLayout();
 installStylesheet(
-  './home-feedback-r135.css?revision=r135-inclusive-feedback',
+  './home-feedback-r135.css?revision=r137-feedback-above-fold',
   'data-turn-home-feedback'
 );
 const { installHomeFeedback } = await import(
-  withBuild('./ui/home-feedback.js?revision=r135-inclusive-feedback')
+  withBuild('./ui/home-feedback.js?revision=r137-feedback-above-fold')
 );
 installHomeFeedback();
 installStylesheet(

--- a/turn/home-feedback-r135.css
+++ b/turn/home-feedback-r135.css
@@ -87,6 +87,10 @@
   scrollbar-gutter: stable;
 }
 
+.m8-feedback-dialog .m8-dialog-head {
+  margin-bottom: clamp(14px, 2vh, 20px);
+}
+
 .m8-feedback-content {
   max-width: 66ch;
 }
@@ -118,7 +122,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 14px;
-  margin-top: 24px;
+  margin-top: clamp(16px, 2.5vh, 22px);
 }
 
 .m8-feedback-email,
@@ -161,31 +165,27 @@
 
 .m8-feedback-email:focus-visible,
 .m8-feedback-copy:focus-visible,
-.m8-feedback-attribution a:focus-visible,
 .m8-about-content a:focus-visible {
   outline: 5px solid var(--m8-blue);
   outline-offset: 4px;
 }
 
 .m8-feedback-status {
-  min-height: 1.5em;
-  margin-top: 16px !important;
+  min-height: 0;
+  margin-top: 0 !important;
   font-weight: 850;
 }
 
-.m8-feedback-attribution {
-  margin-top: 22px;
-  padding-top: 18px;
-  border-top: 3px solid var(--m8-ink);
+.m8-feedback-status:not(:empty) {
+  min-height: 1.5em;
+  margin-top: 16px !important;
 }
 
-.m8-feedback-attribution p,
 .m8-about-content p:not(.m8-about-lead) {
   font-size: 0.88rem;
   line-height: 1.48;
 }
 
-.m8-feedback-attribution a,
 .m8-about-content a {
   color: inherit;
   font-weight: 900;
@@ -218,11 +218,6 @@
 
   .m8-feedback-actions {
     margin-top: 16px;
-  }
-
-  .m8-feedback-attribution {
-    margin-top: 16px;
-    padding-top: 14px;
   }
 }
 

--- a/turn/ui/home-feedback.js
+++ b/turn/ui/home-feedback.js
@@ -1,11 +1,13 @@
 const FEEDBACK_EMAIL = 'erik@enkel.design';
 const FEEDBACK_SUBJECT = 'TURN feedback';
-const FEEDBACK_VERSION = 'r136-about-turn';
+const FEEDBACK_VERSION = 'r137-feedback-above-fold';
 
 let installed = false;
 
 function openDialog(dialog, trigger) {
   dialog.__turnReturnFocus = trigger;
+  const card = dialog.querySelector('.m8-dialog-card');
+  if (card) card.scrollTop = 0;
   if (typeof dialog.showModal === 'function') dialog.showModal();
   else dialog.setAttribute('open', '');
   dialog.querySelector('[data-dialog-close]')?.focus();
@@ -64,7 +66,7 @@ async function copyEmailAddress(button, status) {
 
 function attributionMarkup() {
   return `
-    <p>TURN is shaped by inclusive and universal design, with accessibility built into the game from the start.</p>
+    <p>TURN is shaped by inclusive and universal design so everyone can play, regardless of ability or how they interact with the game.</p>
     <p>© 2026 <a href="https://enkel.design/" target="_blank" rel="noreferrer">enkel.design</a>. Created by Erik Jansson, aided by OpenAI Codex. Drive By Ear™ is inspired by <a href="https://ceal.cs.columbia.edu/rad/" target="_blank" rel="noreferrer">RAD – Racing Auditory Display</a>.</p>`;
 }
 
@@ -89,10 +91,6 @@ function createFeedbackDialog() {
           <button class="m8-feedback-copy" type="button">COPY EMAIL ADDRESS</button>
         </div>
         <p class="m8-feedback-status" role="status" aria-live="polite"></p>
-
-        <footer class="m8-feedback-attribution">
-          ${attributionMarkup()}
-        </footer>
       </div>
     </article>`;
   document.body.appendChild(dialog);


### PR DESCRIPTION
## What changed

- remove all About and attribution content from the **GIVE FEEDBACK** dialog
- keep the feedback dialog focused on reporting bugs, accessibility barriers and improvement ideas
- collapse the empty live-status region and tighten vertical spacing so the complete feedback flow is more likely to remain above the fold
- reset dialog scroll position whenever a Home dialog opens
- keep the complete attribution exclusively in **ABOUT TURN**
- replace the previous accessibility wording with: “TURN is shaped by inclusive and universal design so everyone can play, regardless of ability or how they interact with the game.”
- bump the feedback asset revision so the updated interface is not masked by cached files

## Validation

- extend the production regression to enforce feedback-only content in GIVE FEEDBACK
- enforce a single attribution location in ABOUT TURN
- cover the new inclusive wording, compact spacing, collapsible live region and top-edge opening behavior