### PR TITLE
Add mobile external keyboard controls and desktop support gate

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Run web platform and motion composition regression
         run: node turn-tests/platform-production.mjs
 
+      - name: Run external keyboard and desktop support gate regression
+        run: node turn-tests/external-keyboard-and-device-gate-production.mjs
+
       - name: Run TURN NEXT race-session orchestration regression
         run: node turn-tests/session-orchestrator-production.mjs
 

--- a/turn-tests/external-keyboard-and-device-gate-production.mjs
+++ b/turn-tests/external-keyboard-and-device-gate-production.mjs
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import {
+  EXTERNAL_KEYBOARD_BINDINGS,
+  keyboardActionForCode
+} from '../turn/input/external-keyboard-controls.js';
+import { isTurnPhoneOrTablet } from '../turn/ui/device-support-message.js';
+import { updateMotionInputState } from '../turn/input/motion.js';
+
+const expectedBindings = Object.freeze({
+  ArrowLeft: 'steer-left',
+  KeyA: 'steer-left',
+  ArrowRight: 'steer-right',
+  KeyD: 'steer-right',
+  ArrowUp: 'gas',
+  KeyW: 'gas',
+  ArrowDown: 'brake',
+  KeyS: 'brake',
+  Space: 'brake',
+  KeyQ: 'drift',
+  ShiftLeft: 'drift',
+  ShiftRight: 'drift',
+  KeyE: 'boost',
+  ControlLeft: 'boost',
+  ControlRight: 'boost',
+  KeyR: 'restart'
+});
+
+assert.deepEqual(EXTERNAL_KEYBOARD_BINDINGS, expectedBindings);
+for (const [code, action] of Object.entries(expectedBindings)) {
+  assert.equal(keyboardActionForCode(code), action, `${code} must map to ${action}`);
+}
+assert.equal(keyboardActionForCode('Escape'), null);
+
+const makeEnvironment = ({ userAgent = '', platform = '', maxTouchPoints = 0, mobile = false, coarse = false } = {}) => ({
+  navigator: {
+    userAgent,
+    platform,
+    maxTouchPoints,
+    userAgentData: { mobile }
+  },
+  matchMedia: () => ({ matches: coarse })
+});
+
+assert.equal(
+  isTurnPhoneOrTablet(makeEnvironment({ userAgent: 'Mozilla/5.0 (iPhone)', maxTouchPoints: 5, coarse: true })),
+  true,
+  'iPhone must retain the rotate-to-landscape guidance'
+);
+assert.equal(
+  isTurnPhoneOrTablet(makeEnvironment({ userAgent: 'Mozilla/5.0 (Macintosh)', platform: 'MacIntel', maxTouchPoints: 5 })),
+  true,
+  'iPad desktop-class user agents must still be treated as tablets'
+);
+assert.equal(
+  isTurnPhoneOrTablet(makeEnvironment({ userAgent: 'Mozilla/5.0 (Linux; Android 16)', maxTouchPoints: 10 })),
+  true,
+  'Android tablets must retain the supported-device path'
+);
+assert.equal(
+  isTurnPhoneOrTablet(makeEnvironment({ userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)' })),
+  false,
+  'ordinary desktop browsers must receive the unsupported-device message'
+);
+
+const motionState = {
+  sensorMode: true,
+  manualSteering: 1,
+  steering: 0,
+  tiltDrive: 0,
+  roll: 0,
+  targetRoll: 0,
+  pitch: 0,
+  targetPitch: 0,
+  neutralRoll: 0,
+  steeringEngaged: false
+};
+updateMotionInputState({ state: motionState, dt: 0.1, maxSteerRoll: Math.PI / 4 });
+assert.ok(
+  motionState.steering < -0.9,
+  'a held external-keyboard direction must temporarily override motion steering'
+);
+motionState.manualSteering = 0;
+updateMotionInputState({ state: motionState, dt: 0.1, maxSteerRoll: Math.PI / 4 });
+assert.ok(
+  motionState.steering > -0.9,
+  'releasing the keyboard must hand steering back toward the motion sensor'
+);
+
+const [app, keyboard, deviceMessage, deviceCss, guide, index, motion] = await Promise.all([
+  fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/input/external-keyboard-controls.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/ui/device-support-message.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/device-support-message-r138.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/ui/how-to-play-guide.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/input/motion.js', import.meta.url), 'utf8')
+]);
+
+assert.match(app, /installDeviceSupportMessage\(\)/, 'production must install device-aware support guidance');
+assert.match(app, /device-support-message-r138\.css/, 'production must install the desktop support-gate styling');
+assert.match(app, /installExternalKeyboardControls\(\)/, 'production must install external keyboard controls');
+assert.ok(
+  app.indexOf("./ui/gameplay-controls.js") < app.indexOf('installExternalKeyboardControls()')
+    && app.indexOf('installExternalKeyboardControls()') < app.indexOf("./main.js"),
+  'the keyboard owner must install after the unified drive pad and before legacy global keyboard listeners'
+);
+
+assert.match(keyboard, /event\.stopImmediatePropagation\(\)/, 'owned keyboard events must not leak into legacy global shortcuts');
+assert.match(keyboard, /dialog\[open\]/, 'driving shortcuts must stop while a modal dialog is open');
+assert.match(keyboard, /interactiveTarget\(event\.target\)/, 'driving shortcuts must not fire through ordinary controls');
+assert.match(keyboard, /turn-desktop-device/, 'the external keyboard route must remain disabled by the desktop support gate');
+assert.match(keyboard, /runtimeState\(\)[\s\S]*state\?\.running/, 'keyboard input must be scoped to an active TURN session');
+assert.match(keyboard, /requestedDriveZone[\s\S]*brake[\s\S]*boost[\s\S]*drift[\s\S]*gas/, 'brake, boost, drift and gas priority must be deterministic');
+assert.match(keyboard, /pointerdown/, 'keyboard driving must enter the same continuous drive-pad pathway as touch');
+assert.match(keyboard, /pointermove/, 'held-key transitions must slide through the same drive zones as touch');
+assert.match(keyboard, /pointerup/, 'releasing the keyboard must release the continuous drive surface');
+assert.match(keyboard, /manualSteer\.tabIndex = 0/, 'the exposed steering slider must be keyboard focusable');
+assert.match(keyboard, /aria-valuetext/, 'the steering slider must expose a human-readable direction and amount');
+assert.match(keyboard, /windowRef\.addEventListener\('blur', releaseAllInputs\)/, 'lost window focus must release every held driving input');
+assert.match(keyboard, /visibilitychange/, 'backgrounding the app must release every held driving input');
+
+assert.match(deviceMessage, /TURN IS MADE FOR PHONES AND TABLETS/, 'desktop users need an honest supported-device message');
+assert.match(deviceMessage, /Open TURN on a phone or tablet/, 'the desktop gate must provide a concrete next step');
+assert.match(deviceMessage, /ROTATE YOUR DEVICE TO LANDSCAPE/, 'supported touch devices must retain the landscape instruction');
+assert.match(deviceMessage, /MacIntel[\s\S]*touchPoints > 1/, 'iPad desktop-class user agents must not be mistaken for desktop computers');
+assert.match(deviceCss, /\.turn-desktop-device \.rotate-panel \{[\s\S]*display: grid !important;/, 'desktop must show the support gate in either browser-window orientation');
+assert.match(deviceCss, /\.turn-desktop-device \.rotate-phone \{[\s\S]*display: none;/, 'desktop guidance must not show an impossible rotate-phone illustration');
+assert.match(index, /ROTATE YOUR DEVICE TO LANDSCAPE/, 'the static document must retain a useful pre-module mobile fallback');
+
+assert.match(
+  guide,
+  /Arrow keys or W, A, S and D to drive; Q or Shift for DRIFT; E or Control for BOOST; Space for BRAKE\/REVERSE; and R to restart the lap/,
+  'How to Play must document the complete external-keyboard mapping'
+);
+assert.match(motion, /manualOverride/, 'motion composition must explicitly support a held keyboard override');
+assert.match(motion, /hands control back to the sensor on release/, 'the keyboard override contract must preserve motion steering after release');
+
+console.log('TURN external keyboard controls and device-aware desktop gate passed.');

--- a/turn-tests/how-to-play-guide-production.mjs
+++ b/turn-tests/how-to-play-guide-production.mjs
@@ -14,7 +14,7 @@ const [app, guide, css, homeReset, resetCss, rivalStorage, trackManager] = await
 assert.match(app, /m8-how-to-play-r126\.css\?revision=r134-contained-disclosure/);
 assert.match(app, /data-turn-m8-how-to-play/);
 assert.match(app, /installStylesheet\('\.\/rival-reset-context-r127\.css', 'data-turn-rival-reset-context'\)/);
-assert.match(app, /how-to-play-guide\.js\?revision=r134-contained-disclosure/);
+assert.match(app, /how-to-play-guide\.js\?revision=r138-external-keyboard-controls/);
 assert.match(app, /installHowToPlayGuide\(\)/);
 assert.match(app, /home-rival-reset\.js\?revision=r127-contextual/);
 assert.match(app, /installHomeRivalReset\(\)/);
@@ -27,8 +27,13 @@ assert.ok(
   'The contextual reset enhancer must run only after the shared Settings dialog exists'
 );
 
-assert.match(guide, /GUIDE_VERSION = 'r134-contained-drive-by-ear-disclosure'/);
+assert.match(guide, /GUIDE_VERSION = 'r138-external-keyboard-controls'/);
 assert.match(guide, /Holding <strong>DRIFT<\/strong> also charges <strong>BOOST<\/strong> faster/);
+assert.match(
+  guide,
+  /Arrow keys or W, A, S and D to drive; Q or Shift for DRIFT; E or Control for BOOST; Space for BRAKE\/REVERSE; and R to restart the lap/,
+  'How to Play must expose the complete external keyboard map'
+);
 assert.match(guide, /<details class="m8-dbe-guide">/);
 assert.match(guide, /<summary>Explore the Drive By Ear sounds<\/summary>/);
 assert.match(

--- a/turn/app.js
+++ b/turn/app.js
@@ -73,6 +73,15 @@ document.documentElement.dataset.turnPlatform = 'web-adapter';
 document.documentElement.dataset.turnMotionLifecycle = 'platform-m5';
 document.documentElement.dataset.turnDisplayLifecycle = 'platform-m6';
 
+installStylesheet(
+  './device-support-message-r138.css?revision=r138-desktop-gate',
+  'data-turn-device-support-message'
+);
+const { installDeviceSupportMessage } = await import(
+  withBuild('./ui/device-support-message.js?revision=r138-desktop-gate')
+);
+installDeviceSupportMessage();
+
 installStylesheet('./r104-polish.css', 'data-turn-r104-polish');
 installStylesheet('./steering-limit-warning.css', 'data-turn-steering-limit-warning');
 installStylesheet(
@@ -168,6 +177,10 @@ installLotEnhancementRuntime();
 
 await import(withBuild('./input/analog-gas.js'));
 await import(withBuild('./ui/gameplay-controls.js'));
+const { installExternalKeyboardControls } = await import(
+  withBuild('./input/external-keyboard-controls.js?revision=r138-mobile-external-keyboard')
+);
+installExternalKeyboardControls();
 const { installRaceSpeech } = await import(withBuild('./ui/race-speech.js'));
 installRaceSpeech();
 const { installRacePositionLayout } = await import(withBuild('./ui/race-position-layout.js'));

--- a/turn/app.js
+++ b/turn/app.js
@@ -218,7 +218,7 @@ const home = await installM8HomeNavigation();
 globalThis.__turnHome = home;
 motionPermissionCancelRecovery.resume(home, globalThis.__turnRuntime);
 const { installHowToPlayGuide } = await import(
-  withBuild('./ui/how-to-play-guide.js?revision=r134-contained-disclosure')
+  withBuild('./ui/how-to-play-guide.js?revision=r138-external-keyboard-controls')
 );
 installHowToPlayGuide();
 const { installHomeRivalReset } = await import(

--- a/turn/device-support-message-r138.css
+++ b/turn/device-support-message-r138.css
@@ -1,0 +1,41 @@
+.rotate-card {
+  max-width: min(600px, calc(100vw - 40px));
+}
+
+.turn-device-support-detail {
+  display: block;
+  max-width: 38ch;
+  margin: 12px auto 0;
+  font-size: clamp(0.88rem, 2.2vw, 1.08rem);
+  line-height: 1.4;
+}
+
+.turn-phone-tablet-device .turn-device-support-detail {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.turn-desktop-device .rotate-panel {
+  display: grid !important;
+}
+
+.turn-desktop-device .rotate-phone {
+  display: none;
+}
+
+.turn-desktop-device .rotate-card {
+  padding: clamp(28px, 5vw, 48px);
+}
+
+.turn-desktop-device .rotate-card strong {
+  display: block;
+  font-size: clamp(1.45rem, 4vw, 2.6rem);
+  line-height: 1;
+}

--- a/turn/input/external-keyboard-controls.js
+++ b/turn/input/external-keyboard-controls.js
@@ -1,0 +1,312 @@
+const KEYBOARD_POINTER_ID = 2147483001;
+
+export const EXTERNAL_KEYBOARD_BINDINGS = Object.freeze({
+  ArrowLeft: 'steer-left',
+  KeyA: 'steer-left',
+  ArrowRight: 'steer-right',
+  KeyD: 'steer-right',
+  ArrowUp: 'gas',
+  KeyW: 'gas',
+  ArrowDown: 'brake',
+  KeyS: 'brake',
+  Space: 'brake',
+  KeyQ: 'drift',
+  ShiftLeft: 'drift',
+  ShiftRight: 'drift',
+  KeyE: 'boost',
+  ControlLeft: 'boost',
+  ControlRight: 'boost',
+  KeyR: 'restart'
+});
+
+export function keyboardActionForCode(code) {
+  return EXTERNAL_KEYBOARD_BINDINGS[String(code || '')] || null;
+}
+
+export function installExternalKeyboardControls({ environment = globalThis } = {}) {
+  const documentRef = environment.document;
+  const windowRef = environment.window || environment;
+  if (!documentRef?.body || typeof windowRef?.addEventListener !== 'function') {
+    return Object.freeze({ installed: false, release() {} });
+  }
+
+  if (environment.__turnExternalKeyboardControls?.installed) {
+    return environment.__turnExternalKeyboardControls;
+  }
+
+  const controls = documentRef.querySelector('#controls');
+  const drivePad = documentRef.querySelector('.drive-pad');
+  const manualSteer = documentRef.querySelector('#manualSteer');
+  const resetButton = documentRef.querySelector('#resetButton');
+  const zoneElements = Object.freeze({
+    gas: documentRef.querySelector('.drive-gas-zone'),
+    brake: documentRef.querySelector('.drive-brake-zone'),
+    drift: documentRef.querySelector('.drive-drift-zone'),
+    boost: documentRef.querySelector('.drive-boost-zone')
+  });
+
+  if (!controls || !drivePad || !manualSteer || !resetButton || Object.values(zoneElements).some((element) => !element)) {
+    const unavailable = Object.freeze({ installed: false, release() {} });
+    environment.__turnExternalKeyboardControls = unavailable;
+    return unavailable;
+  }
+
+  manualSteer.tabIndex = 0;
+  manualSteer.setAttribute(
+    'aria-label',
+    'Steering. Use Left and Right Arrow keys or A and D. Steering returns to centre when released.'
+  );
+  setSteeringVisual(manualSteer, 0);
+
+  const heldCodes = new Map();
+  let keyboardPointerActive = false;
+  let activeDriveZone = null;
+  let activeSteering = 0;
+  let released = false;
+
+  function runtimeState() {
+    return environment.__turnRuntime?.state || null;
+  }
+
+  function isDesktopGate() {
+    return documentRef.documentElement.classList.contains('turn-desktop-device');
+  }
+
+  function hasBlockingOverlay() {
+    if (documentRef.body.classList.contains('turn-home-open')) return true;
+    if (documentRef.body.classList.contains('turn-lot-open')) return true;
+    if (documentRef.body.classList.contains('turn-spectating')) return true;
+    if (documentRef.querySelector('dialog[open]')) return true;
+    return Boolean(documentRef.querySelector('[role="dialog"]:not([hidden])'));
+  }
+
+  function interactiveTarget(target) {
+    if (!(target instanceof environment.Element)) return false;
+    if (target.closest('.drive-pad, #manualSteer')) return false;
+    return Boolean(target.closest(
+      'a, button, input, select, textarea, summary, [contenteditable="true"], [role="button"], [role="radio"], [role="slider"]'
+    ));
+  }
+
+  function acceptsDrivingInput(event) {
+    const state = runtimeState();
+    if (!state?.running || documentRef.hidden || controls.hidden || isDesktopGate() || hasBlockingOverlay()) return false;
+    return !interactiveTarget(event.target);
+  }
+
+  function activeActions() {
+    return new Set(heldCodes.values());
+  }
+
+  function requestedDriveZone(actions) {
+    if (actions.has('brake')) return 'brake';
+    if (actions.has('boost')) return 'boost';
+    if (actions.has('drift')) return 'drift';
+    if (actions.has('gas')) return 'gas';
+    return null;
+  }
+
+  function requestedSteering(actions) {
+    const left = actions.has('steer-left') ? 1 : 0;
+    const right = actions.has('steer-right') ? 1 : 0;
+    return right - left;
+  }
+
+  function createKeyboardPointerEvent(type, target) {
+    const rect = target.getBoundingClientRect();
+    const clientX = rect.left + rect.width / 2;
+    const clientY = rect.top + rect.height / 2;
+    const init = {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      pointerId: KEYBOARD_POINTER_ID,
+      pointerType: 'keyboard',
+      isPrimary: true,
+      button: 0,
+      buttons: type === 'pointerup' || type === 'pointercancel' ? 0 : 1,
+      clientX,
+      clientY
+    };
+
+    if (typeof environment.PointerEvent === 'function') {
+      return new environment.PointerEvent(type, init);
+    }
+
+    const event = new environment.Event(type, init);
+    for (const [property, value] of Object.entries(init)) {
+      try {
+        Object.defineProperty(event, property, { configurable: true, value });
+      } catch (_) {}
+    }
+    return event;
+  }
+
+  function dispatchKeyboardPointer(type, zoneName) {
+    const target = zoneElements[zoneName] || drivePad;
+    const hadOwnSet = Object.prototype.hasOwnProperty.call(drivePad, 'setPointerCapture');
+    const hadOwnRelease = Object.prototype.hasOwnProperty.call(drivePad, 'releasePointerCapture');
+    const originalSet = drivePad.setPointerCapture;
+    const originalRelease = drivePad.releasePointerCapture;
+
+    try {
+      drivePad.setPointerCapture = function setPointerCapture(pointerId) {
+        if (pointerId === KEYBOARD_POINTER_ID) return;
+        return originalSet?.call(this, pointerId);
+      };
+      drivePad.releasePointerCapture = function releasePointerCapture(pointerId) {
+        if (pointerId === KEYBOARD_POINTER_ID) return;
+        return originalRelease?.call(this, pointerId);
+      };
+      target.dispatchEvent(createKeyboardPointerEvent(type, target));
+    } finally {
+      if (hadOwnSet) drivePad.setPointerCapture = originalSet;
+      else delete drivePad.setPointerCapture;
+      if (hadOwnRelease) drivePad.releasePointerCapture = originalRelease;
+      else delete drivePad.releasePointerCapture;
+    }
+  }
+
+  function syncDriveZone(nextZone) {
+    if (nextZone === activeDriveZone) return;
+
+    if (!keyboardPointerActive && nextZone) {
+      dispatchKeyboardPointer('pointerdown', nextZone);
+      keyboardPointerActive = true;
+    } else if (keyboardPointerActive && nextZone) {
+      dispatchKeyboardPointer('pointermove', nextZone);
+    } else if (keyboardPointerActive) {
+      dispatchKeyboardPointer('pointerup', activeDriveZone);
+      keyboardPointerActive = false;
+    }
+
+    activeDriveZone = nextZone;
+  }
+
+  function syncSteering(nextSteering) {
+    if (nextSteering === activeSteering) return;
+    activeSteering = nextSteering;
+    const state = runtimeState();
+    if (state) state.manualSteering = nextSteering;
+    setSteeringVisual(manualSteer, nextSteering);
+  }
+
+  function syncInputs() {
+    const actions = activeActions();
+    syncSteering(requestedSteering(actions));
+    syncDriveZone(requestedDriveZone(actions));
+  }
+
+  function releaseAllInputs() {
+    if (!heldCodes.size && !keyboardPointerActive && activeSteering === 0) return;
+    heldCodes.clear();
+    syncSteering(0);
+    syncDriveZone(null);
+  }
+
+  function consume(event) {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  }
+
+  function onKeyDown(event) {
+    const action = keyboardActionForCode(event.code);
+    if (!action || !acceptsDrivingInput(event)) return;
+    consume(event);
+
+    if (action === 'restart') {
+      if (!event.repeat && !resetButton.hidden && !resetButton.disabled) resetButton.click();
+      return;
+    }
+
+    if (heldCodes.has(event.code)) return;
+    heldCodes.set(event.code, action);
+    syncInputs();
+  }
+
+  function onKeyUp(event) {
+    const action = keyboardActionForCode(event.code);
+    if (!action) return;
+
+    if (heldCodes.has(event.code)) {
+      consume(event);
+      heldCodes.delete(event.code);
+      syncInputs();
+      return;
+    }
+
+    if (acceptsDrivingInput(event)) consume(event);
+  }
+
+  function onUiStateChange(event) {
+    const reason = event.detail?.reason;
+    if (!event.detail?.running || reason === 'race-reset' || reason === 'home-open' || reason === 'lot-open' || reason === 'spectate-started') {
+      releaseAllInputs();
+    }
+  }
+
+  function onVisibilityChange() {
+    if (documentRef.hidden) releaseAllInputs();
+  }
+
+  function onFocusIn(event) {
+    if (interactiveTarget(event.target)) releaseAllInputs();
+  }
+
+  const overlayObserver = typeof environment.MutationObserver === 'function'
+    ? new environment.MutationObserver(() => {
+      if (heldCodes.size && hasBlockingOverlay()) releaseAllInputs();
+    })
+    : null;
+  overlayObserver?.observe(documentRef.body, {
+    subtree: true,
+    childList: true,
+    attributes: true,
+    attributeFilter: ['open', 'hidden']
+  });
+
+  windowRef.addEventListener('keydown', onKeyDown, { capture: true });
+  windowRef.addEventListener('keyup', onKeyUp, { capture: true });
+  windowRef.addEventListener('blur', releaseAllInputs);
+  windowRef.addEventListener('turn:ui-state-change', onUiStateChange);
+  documentRef.addEventListener('visibilitychange', onVisibilityChange);
+  documentRef.addEventListener('focusin', onFocusIn);
+
+  const api = Object.freeze({
+    installed: true,
+    bindings: EXTERNAL_KEYBOARD_BINDINGS,
+    release() {
+      if (released) return;
+      released = true;
+      releaseAllInputs();
+      overlayObserver?.disconnect();
+      windowRef.removeEventListener('keydown', onKeyDown, { capture: true });
+      windowRef.removeEventListener('keyup', onKeyUp, { capture: true });
+      windowRef.removeEventListener('blur', releaseAllInputs);
+      windowRef.removeEventListener('turn:ui-state-change', onUiStateChange);
+      documentRef.removeEventListener('visibilitychange', onVisibilityChange);
+      documentRef.removeEventListener('focusin', onFocusIn);
+      if (environment.__turnExternalKeyboardControls === api) {
+        delete environment.__turnExternalKeyboardControls;
+      }
+    }
+  });
+
+  environment.__turnExternalKeyboardControls = api;
+  documentRef.documentElement.dataset.turnExternalKeyboard = 'arrows-wasd-qer-space-shift-control';
+  return api;
+}
+
+function setSteeringVisual(element, value) {
+  const steering = Math.max(-1, Math.min(1, Number(value) || 0));
+  const percent = Math.round(steering * 100);
+  element.style.setProperty('--manual-steer-left', `${50 + steering * 28}%`);
+  element.setAttribute('aria-valuenow', String(percent));
+  element.setAttribute('aria-valuetext', steeringValueText(percent));
+  element.classList.toggle('is-steering', steering !== 0);
+}
+
+function steeringValueText(percent) {
+  if (percent === 0) return 'Centred';
+  return `${Math.abs(percent)} percent ${percent < 0 ? 'left' : 'right'}`;
+}

--- a/turn/input/external-keyboard-controls.js
+++ b/turn/input/external-keyboard-controls.js
@@ -19,8 +19,33 @@ export const EXTERNAL_KEYBOARD_BINDINGS = Object.freeze({
   KeyR: 'restart'
 });
 
+const FALLBACK_KEY_BINDINGS = Object.freeze({
+  arrowleft: 'steer-left',
+  a: 'steer-left',
+  arrowright: 'steer-right',
+  d: 'steer-right',
+  arrowup: 'gas',
+  w: 'gas',
+  arrowdown: 'brake',
+  s: 'brake',
+  ' ': 'brake',
+  spacebar: 'brake',
+  q: 'drift',
+  shift: 'drift',
+  e: 'boost',
+  control: 'boost',
+  ctrl: 'boost',
+  r: 'restart'
+});
+
 export function keyboardActionForCode(code) {
   return EXTERNAL_KEYBOARD_BINDINGS[String(code || '')] || null;
+}
+
+export function keyboardActionForEvent(event = {}) {
+  return keyboardActionForCode(event.code)
+    || FALLBACK_KEY_BINDINGS[String(event.key || '').toLowerCase()]
+    || null;
 }
 
 export function installExternalKeyboardControls({ environment = globalThis } = {}) {
@@ -58,10 +83,11 @@ export function installExternalKeyboardControls({ environment = globalThis } = {
   );
   setSteeringVisual(manualSteer, 0);
 
-  const heldCodes = new Map();
+  const heldKeys = new Map();
   let keyboardPointerActive = false;
   let activeDriveZone = null;
   let activeSteering = 0;
+  let pointerBridgeFailed = false;
   let released = false;
 
   function runtimeState() {
@@ -81,7 +107,8 @@ export function installExternalKeyboardControls({ environment = globalThis } = {
   }
 
   function interactiveTarget(target) {
-    if (!(target instanceof environment.Element)) return false;
+    const ElementConstructor = environment.Element;
+    if (typeof ElementConstructor !== 'function' || !(target instanceof ElementConstructor)) return false;
     if (target.closest('.drive-pad, #manualSteer')) return false;
     return Boolean(target.closest(
       'a, button, input, select, textarea, summary, [contenteditable="true"], [role="button"], [role="radio"], [role="slider"]'
@@ -95,7 +122,7 @@ export function installExternalKeyboardControls({ environment = globalThis } = {
   }
 
   function activeActions() {
-    return new Set(heldCodes.values());
+    return new Set(heldKeys.values());
   }
 
   function requestedDriveZone(actions) {
@@ -159,6 +186,13 @@ export function installExternalKeyboardControls({ environment = globalThis } = {
         return originalRelease?.call(this, pointerId);
       };
       target.dispatchEvent(createKeyboardPointerEvent(type, target));
+      return true;
+    } catch (error) {
+      if (!pointerBridgeFailed) {
+        pointerBridgeFailed = true;
+        console.warn('TURN: external keyboard could not enter the unified drive surface.', error);
+      }
+      return false;
     } finally {
       if (hadOwnSet) drivePad.setPointerCapture = originalSet;
       else delete drivePad.setPointerCapture;
@@ -171,10 +205,10 @@ export function installExternalKeyboardControls({ environment = globalThis } = {
     if (nextZone === activeDriveZone) return;
 
     if (!keyboardPointerActive && nextZone) {
-      dispatchKeyboardPointer('pointerdown', nextZone);
+      if (!dispatchKeyboardPointer('pointerdown', nextZone)) return;
       keyboardPointerActive = true;
     } else if (keyboardPointerActive && nextZone) {
-      dispatchKeyboardPointer('pointermove', nextZone);
+      if (!dispatchKeyboardPointer('pointermove', nextZone)) return;
     } else if (keyboardPointerActive) {
       dispatchKeyboardPointer('pointerup', activeDriveZone);
       keyboardPointerActive = false;
@@ -198,8 +232,8 @@ export function installExternalKeyboardControls({ environment = globalThis } = {
   }
 
   function releaseAllInputs() {
-    if (!heldCodes.size && !keyboardPointerActive && activeSteering === 0) return;
-    heldCodes.clear();
+    if (!heldKeys.size && !keyboardPointerActive && activeSteering === 0) return;
+    heldKeys.clear();
     syncSteering(0);
     syncDriveZone(null);
   }
@@ -209,8 +243,12 @@ export function installExternalKeyboardControls({ environment = globalThis } = {
     event.stopImmediatePropagation();
   }
 
+  function keyIdentifier(event) {
+    return String(event.code || event.key || '');
+  }
+
   function onKeyDown(event) {
-    const action = keyboardActionForCode(event.code);
+    const action = keyboardActionForEvent(event);
     if (!action || !acceptsDrivingInput(event)) return;
     consume(event);
 
@@ -219,18 +257,20 @@ export function installExternalKeyboardControls({ environment = globalThis } = {
       return;
     }
 
-    if (heldCodes.has(event.code)) return;
-    heldCodes.set(event.code, action);
+    const identifier = keyIdentifier(event);
+    if (heldKeys.has(identifier)) return;
+    heldKeys.set(identifier, action);
     syncInputs();
   }
 
   function onKeyUp(event) {
-    const action = keyboardActionForCode(event.code);
+    const action = keyboardActionForEvent(event);
     if (!action) return;
 
-    if (heldCodes.has(event.code)) {
+    const identifier = keyIdentifier(event);
+    if (heldKeys.has(identifier)) {
       consume(event);
-      heldCodes.delete(event.code);
+      heldKeys.delete(identifier);
       syncInputs();
       return;
     }
@@ -253,17 +293,13 @@ export function installExternalKeyboardControls({ environment = globalThis } = {
     if (interactiveTarget(event.target)) releaseAllInputs();
   }
 
-  const overlayObserver = typeof environment.MutationObserver === 'function'
-    ? new environment.MutationObserver(() => {
-      if (heldCodes.size && hasBlockingOverlay()) releaseAllInputs();
-    })
-    : null;
-  overlayObserver?.observe(documentRef.body, {
-    subtree: true,
-    childList: true,
-    attributes: true,
-    attributeFilter: ['open', 'hidden']
-  });
+  function onDocumentClick() {
+    const checkAfterClick = () => {
+      if (heldKeys.size && hasBlockingOverlay()) releaseAllInputs();
+    };
+    if (typeof environment.queueMicrotask === 'function') environment.queueMicrotask(checkAfterClick);
+    else Promise.resolve().then(checkAfterClick);
+  }
 
   windowRef.addEventListener('keydown', onKeyDown, { capture: true });
   windowRef.addEventListener('keyup', onKeyUp, { capture: true });
@@ -271,6 +307,7 @@ export function installExternalKeyboardControls({ environment = globalThis } = {
   windowRef.addEventListener('turn:ui-state-change', onUiStateChange);
   documentRef.addEventListener('visibilitychange', onVisibilityChange);
   documentRef.addEventListener('focusin', onFocusIn);
+  documentRef.addEventListener('click', onDocumentClick, { capture: true });
 
   const api = Object.freeze({
     installed: true,
@@ -279,13 +316,13 @@ export function installExternalKeyboardControls({ environment = globalThis } = {
       if (released) return;
       released = true;
       releaseAllInputs();
-      overlayObserver?.disconnect();
       windowRef.removeEventListener('keydown', onKeyDown, { capture: true });
       windowRef.removeEventListener('keyup', onKeyUp, { capture: true });
       windowRef.removeEventListener('blur', releaseAllInputs);
       windowRef.removeEventListener('turn:ui-state-change', onUiStateChange);
       documentRef.removeEventListener('visibilitychange', onVisibilityChange);
       documentRef.removeEventListener('focusin', onFocusIn);
+      documentRef.removeEventListener('click', onDocumentClick, { capture: true });
       if (environment.__turnExternalKeyboardControls === api) {
         delete environment.__turnExternalKeyboardControls;
       }

--- a/turn/input/motion.js
+++ b/turn/input/motion.js
@@ -35,10 +35,15 @@ export function resolveSteeringRollLimit(
 }
 
 export function updateMotionInputState({ state, dt, maxSteerRoll }) {
-  if (!state.sensorMode) {
-    // Manual input is expressed in screen space (left = -1, right = +1), while
-    // TURN's vehicle yaw convention uses the opposite sign.
-    state.steering = lerp(state.steering, -state.manualSteering, Math.min(1, dt * 10));
+  const manualSteering = clamp(Number(state.manualSteering) || 0, -1, 1);
+  const manualOverride = Math.abs(manualSteering) > 0.001;
+
+  if (!state.sensorMode || manualOverride) {
+    // Manual and external-keyboard input is expressed in screen space
+    // (left = -1, right = +1), while TURN's vehicle yaw convention uses
+    // the opposite sign. A held keyboard direction temporarily overrides
+    // motion steering and hands control back to the sensor on release.
+    state.steering = lerp(state.steering, -manualSteering, Math.min(1, dt * 10));
     state.tiltDrive = 0;
     return;
   }

--- a/turn/ui/device-support-message.js
+++ b/turn/ui/device-support-message.js
@@ -1,0 +1,57 @@
+const MOBILE_DEVICE_CLASS = 'turn-phone-tablet-device';
+const DESKTOP_DEVICE_CLASS = 'turn-desktop-device';
+
+export function isTurnPhoneOrTablet(environment = globalThis) {
+  const navigatorRef = environment.navigator || {};
+  const userAgent = String(navigatorRef.userAgent || '');
+  const platform = String(navigatorRef.platform || '');
+  const touchPoints = Number(navigatorRef.maxTouchPoints) || 0;
+  const userAgentMobile = navigatorRef.userAgentData?.mobile === true;
+  const ios = /iPad|iPhone|iPod/i.test(userAgent)
+    || (platform === 'MacIntel' && touchPoints > 1);
+  const android = /Android/i.test(userAgent);
+  const coarsePointer = environment.matchMedia?.('(any-pointer: coarse)')?.matches === true;
+
+  return userAgentMobile || ios || android || (touchPoints > 0 && coarsePointer);
+}
+
+export function installDeviceSupportMessage({ environment = globalThis } = {}) {
+  const documentRef = environment.document;
+  const root = documentRef?.documentElement;
+  const panel = documentRef?.querySelector('.rotate-panel');
+  const card = panel?.querySelector('.rotate-card');
+  const title = card?.querySelector('strong');
+  if (!root || !panel || !card || !title) {
+    return Object.freeze({ installed: false, device: 'unknown' });
+  }
+
+  const mobileDevice = isTurnPhoneOrTablet(environment);
+  const device = mobileDevice ? 'phone-tablet' : 'desktop';
+  root.classList.toggle(MOBILE_DEVICE_CLASS, mobileDevice);
+  root.classList.toggle(DESKTOP_DEVICE_CLASS, !mobileDevice);
+  root.dataset.turnDeviceClass = device;
+
+  title.id = 'turnDeviceSupportTitle';
+  const detail = documentRef.createElement('span');
+  detail.id = 'turnDeviceSupportDetail';
+  detail.className = 'turn-device-support-detail';
+
+  if (mobileDevice) {
+    title.textContent = 'ROTATE YOUR DEVICE TO LANDSCAPE';
+    detail.textContent = 'TURN uses the device as a steering wheel while racing.';
+  } else {
+    title.textContent = 'TURN IS MADE FOR PHONES AND TABLETS';
+    detail.textContent = 'Open TURN on a phone or tablet. Rotate that device to landscape before racing.';
+  }
+
+  card.querySelector('.turn-device-support-detail')?.remove();
+  card.appendChild(detail);
+  panel.removeAttribute('aria-label');
+  panel.setAttribute('role', 'region');
+  panel.setAttribute('aria-labelledby', title.id);
+  panel.setAttribute('aria-describedby', detail.id);
+
+  const api = Object.freeze({ installed: true, device, mobileDevice, panel, title, detail });
+  environment.__turnDeviceSupport = api;
+  return api;
+}

--- a/turn/ui/device-support-message.js
+++ b/turn/ui/device-support-message.js
@@ -39,9 +39,13 @@ export function installDeviceSupportMessage({ environment = globalThis } = {}) {
   if (mobileDevice) {
     title.textContent = 'ROTATE YOUR DEVICE TO LANDSCAPE';
     detail.textContent = 'TURN uses the device as a steering wheel while racing.';
+    panel.style.removeProperty('display');
   } else {
     title.textContent = 'TURN IS MADE FOR PHONES AND TABLETS';
     detail.textContent = 'Open TURN on a phone or tablet. Rotate that device to landscape before racing.';
+    // The desktop message is a support boundary, not an orientation hint. Keep it
+    // visible even when a desktop browser window happens to be wider than tall.
+    panel.style.setProperty('display', 'grid', 'important');
   }
 
   card.querySelector('.turn-device-support-detail')?.remove();

--- a/turn/ui/how-to-play-guide.js
+++ b/turn/ui/how-to-play-guide.js
@@ -1,4 +1,4 @@
-const GUIDE_VERSION = 'r134-contained-drive-by-ear-disclosure';
+const GUIDE_VERSION = 'r138-external-keyboard-controls';
 const PACE_NOTE_EXPLANATION = 'Before major corners, one to three beeps play in the ear on the turn side. One beep means a gentler corner, two means medium and three means tight. A long corner keeps the same number of beeps but holds the final beep longer: bip-beeeep for a long medium corner and bip-bip-beeeep for a long tight corner. Separate groups describe linked corners in the order you will meet them.';
 
 export function installHowToPlayGuide(root = document) {
@@ -20,7 +20,7 @@ function updateDriftAndBoostCopy(dialog) {
   const paragraph = section?.querySelector('p');
   if (!paragraph) return;
 
-  paragraph.innerHTML = 'DRIFT helps the car rotate but costs grip. Holding <strong>DRIFT</strong> also charges <strong>BOOST</strong> faster, so a controlled slide can prepare the next burst. BOOST gives speed but can make the next corner harder. Fast laps come from balancing both.';
+  paragraph.innerHTML = 'DRIFT helps the car rotate but costs grip. Holding <strong>DRIFT</strong> also charges <strong>BOOST</strong> faster, so a controlled slide can prepare the next burst. BOOST gives speed but can make the next corner harder. Fast laps come from balancing both. With an external keyboard, use Arrow keys or W, A, S and D to drive; Q or Shift for DRIFT; E or Control for BOOST; Space for BRAKE/REVERSE; and R to restart the lap.';
 }
 
 function installDriveByEarDisclosure(dialog) {


### PR DESCRIPTION
## What changed

- add external-keyboard driving support for TURN on supported phones and tablets
- support Arrow keys and W/A/S/D for steering, gas and brake/reverse
- support Q or Shift for Drift, E or Control for Boost, Space for Brake/Reverse and R for Restart Lap
- route keyboard Gas, Brake, Drift and Boost through the same continuous four-zone drive surface as touch
- let a held keyboard steering direction temporarily override motion steering, then return control to the sensor on release
- make the on-screen steering slider focusable with readable direction/value semantics
- scope keyboard input to active gameplay and suppress it in Home, The Lot, Spectate, dialogs and ordinary controls
- release held inputs on blur, backgrounding, route changes and modal opening
- replace the impossible desktop “Rotate device” instruction with a persistent supported-device gate
- keep the existing landscape instruction for phones and tablets, including iPads using desktop-class user agents
- document the complete external-keyboard mapping in How to Play

## Product boundary

Desktop play remains unsupported. The keyboard route is intended for external keyboards connected to supported phones and tablets. Desktop browsers now receive a clear message to open TURN on a phone or tablet instead of being told to rotate an unrotatable device.

## Validation

- add a dedicated production regression for the complete key map, motion override, input scoping, device classification and desktop gate
- integrate it into the full TURN regression workflow
- update the existing How to Play regression for the keyboard instructions

Addresses the keyboard and shortcut portions of accessibility audit #279.