### PR TITLE
Apply TURN semantic design system to production

### DIFF
--- a/turn-tests/design-system-production.mjs
+++ b/turn-tests/design-system-production.mjs
@@ -1,33 +1,53 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const design = await fs.readFile(new URL('../turn/design.html', import.meta.url), 'utf8');
+const [design, tokens, semantic, installGate, homeFeedback] = await Promise.all([
+  fs.readFile(new URL('../turn/design.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/design-tokens.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/design-semantic.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/install-gate.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/home-feedback-r135.css', import.meta.url), 'utf8')
+]);
 
 assert.match(design, /^<!doctype html>/i);
 assert.match(design, /<html lang="en">/);
 assert.match(design, /<meta name="viewport" content="width=device-width, initial-scale=1">/);
 assert.doesNotMatch(design, /user-scalable=no/);
-assert.doesNotMatch(design, /<script\b/i, 'The reference page should remain static and dependency-free');
-assert.doesNotMatch(design, /https?:\/\/(?!enkel\.design)/i, 'The specimen must not depend on third-party assets');
-assert.match(design, /src="\.\/TURNicon\.PNG"/);
+assert.doesNotMatch(design, /<script\b/i, 'The reference page must remain static');
+assert.doesNotMatch(design, /https?:\/\//i, 'The reference page must remain dependency-free');
+assert.match(design, /href="\.\/design-tokens\.css\?revision=r139-semantic-system"/);
+assert.match(design, /href="\.\/design-semantic\.css\?revision=r139-semantic-system"/);
 
 for (const token of [
   '--turn-ink',
   '--turn-paper',
+  '--turn-white',
   '--turn-yellow-600',
   '--turn-yellow-400',
+  '--turn-yellow-200',
+  '--turn-blue-600',
   '--turn-blue-500',
   '--turn-blue-300',
+  '--turn-blue-200',
   '--turn-pink-500',
+  '--turn-pink-200',
   '--turn-red-500',
+  '--turn-red-200',
   '--turn-green-500',
+  '--turn-green-200',
   '--turn-orange-500',
+  '--turn-orange-200',
   '--turn-action-primary',
+  '--turn-action-utility',
   '--turn-action-information',
   '--turn-action-success',
   '--turn-action-warning',
   '--turn-action-danger',
-  '--turn-action-exit',
+  '--turn-action-navigation',
+  '--turn-control-gas',
+  '--turn-control-drift',
+  '--turn-control-boost',
+  '--turn-control-brake',
   '--turn-border-micro',
   '--turn-border-compact',
   '--turn-border-default',
@@ -42,45 +62,102 @@ for (const token of [
   '--turn-shadow-default',
   '--turn-shadow-hero'
 ]) {
-  assert.match(design, new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  assert.match(tokens, new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
 }
 
-assert.doesNotMatch(design, /var\(--paper\)|var\(--yellow-400\)/, 'Specimens must use the normative token names');
-assert.doesNotMatch(
-  design,
-  /border:\s*(?:1\.5|5)px solid var\(--turn-ink\)/,
-  'Reusable specimen components must stay on the normative border scale'
-);
+for (const alias of [
+  '--ink: var(--turn-ink)',
+  '--paper: var(--turn-paper)',
+  '--cyan: var(--turn-blue-500)',
+  '--pink: var(--turn-pink-500)',
+  '--yellow: var(--turn-yellow-400)',
+  '--lime: var(--turn-green-500)',
+  '--m8-ink: var(--turn-ink)',
+  '--m8-cream: var(--turn-paper)',
+  '--m8-pink: var(--turn-pink-500)',
+  '--m8-yellow: var(--turn-yellow-600)',
+  '--m8-blue: var(--turn-blue-300)'
+]) {
+  assert.match(tokens, new RegExp(alias.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+}
 
-assert.match(design, /2, 3, 7, 8, 10, 12, 13, 14, 15, 16, 17, 18, 20, 21, 22, 24, 26, 28 and 30px/);
-assert.match(design, /1\.5, 2, 3, 4, 5 and 6px/);
-assert.match(design, /#ff4fa3, #ff7ab7, #ff8caf, #ff8fab/);
-assert.match(design, /#38d9ff, #68c8f2, #8ed8ff/);
-assert.match(design, /50% only on equal-width\/equal-height controls and indicators/);
-assert.match(design, /Keep the candy shop\. Label every jar\./);
+assert.match(semantic, /^@import url\('\.\/design-tokens\.css\?revision=r139-semantic-system'\);/);
+assert.match(semantic, /\.install-primary,[\s\S]*\.m8-home-fixed-layout \.m8-track-continue,[\s\S]*\.track-select-continue,[\s\S]*\.lot-race/);
+assert.match(semantic, /border-radius: var\(--turn-radius-pill\) !important;/);
+assert.match(semantic, /background: var\(--turn-action-primary\) !important;/);
+assert.match(semantic, /\.m8-home-fixed-layout \.m8-home-settings,[\s\S]*\.m8-how-button,[\s\S]*\.m8-feedback-button/);
+assert.match(semantic, /background: var\(--turn-action-utility\) !important;/);
 
-for (const section of ['audit', 'colour', 'shape', 'components', 'screens', 'migration']) {
+for (const navigationSelector of [
+  '.install-close',
+  '.track-select-close',
+  '.lot-back',
+  '.lot-view-close',
+  '.lot-stats-dialog-close',
+  '.spectate-close',
+  '.sound-guide-close',
+  '.m8-dialog-head > button',
+  '.back-to-lot-button',
+  '[data-turn-navigation-action]'
+]) {
+  assert.ok(semantic.includes(navigationSelector), `Missing navigation selector ${navigationSelector}`);
+}
+assert.match(semantic, /background: var\(--turn-action-navigation\) !important;/);
+
+assert.match(semantic, /\.drive-drift-zone,[\s\S]*background: var\(--turn-control-drift\) !important;/);
+assert.match(semantic, /\.drive-pad \.drive-gas-zone,[\s\S]*background: var\(--turn-control-gas\) !important;/);
+assert.match(semantic, /\.drive-pad \.drive-brake-zone,[\s\S]*background: var\(--turn-control-brake\) !important;/);
+assert.match(semantic, /var\(--turn-control-boost\) 0 var\(--boost-charge\)/);
+assert.doesNotMatch(semantic, /#ff3f4a|#ff5a5f|#ff7ab7|#c8db08|#d9eb12|#54c2ef/);
+
+const semanticImport = /^@import url\('\.\/design-semantic\.css\?revision=r139-semantic-system'\);/;
+assert.match(installGate, semanticImport);
+assert.match(homeFeedback, semanticImport);
+
+for (const section of ['decisions', 'colour', 'shape', 'components', 'screens', 'adoption']) {
   assert.match(design, new RegExp(`id="${section}"`));
   assert.match(design, new RegExp(`href="#${section}"`));
 }
 
+for (const decision of [
+  'Forward is pink. Navigation is orange.',
+  'Pink 500 + pill',
+  'Paper + pill',
+  'Orange 500',
+  'Gas is green',
+  'Drift is blue',
+  'Boost is yellow',
+  'Brake and Reverse are orange'
+]) {
+  assert.ok(design.includes(decision), `Missing normative decision: ${decision}`);
+}
+
+for (const primaryAction of ['Install TURN', 'Race this track', 'Race this car']) {
+  assert.ok(design.includes(primaryAction), `Missing primary-flow specimen: ${primaryAction}`);
+}
+for (const utilityAction of ['Settings', 'How to Play', 'Give Feedback']) {
+  assert.ok(design.includes(utilityAction), `Missing utility specimen: ${utilityAction}`);
+}
+
 for (const page of [
-  'TURN install page design specimen',
-  'TURN Home and track-selection design specimen',
-  'TURN The Lot design specimen',
-  'TURN race HUD and control design specimen',
-  'TURN How to Play dialog design specimen'
+  'TURN install-page component specimen',
+  'TURN Home and track-selection component specimen',
+  'TURN The Lot component specimen',
+  'TURN race component specimen',
+  'TURN dialog component specimen'
 ]) {
   assert.match(design, new RegExp(page));
 }
 
+assert.match(design, />Track preview</);
+assert.match(design, />3D car view</);
+assert.match(design, />Rotatable car view</);
+assert.match(design, />Game view</);
+assert.doesNotMatch(design, /car-shape|track-preview-sample|race-road/);
+assert.match(design, /Real components, no pretend game art\./);
+assert.match(design, /The first two migration steps are now live\./);
 assert.match(design, /class="skip-link" href="#main"/);
 assert.match(design, /aria-label="Design system sections"/);
-assert.match(design, /a:focus-visible/);
 assert.match(design, /@media \(prefers-reduced-motion: reduce\)/);
-assert.match(design, /Reference page only\. Production UI is unchanged\./);
-assert.match(design, /Introduce one shared token file/);
-assert.match(design, /Alias existing variables/);
-assert.match(design, /Remove orphan values only after parity review/);
 
-console.log('TURN design-system audit, normative tokens and five page specimens passed.');
+console.log('TURN shared tokens, aliases, semantic roles and component-only reference passed.');

--- a/turn/design-semantic.css
+++ b/turn/design-semantic.css
@@ -1,0 +1,103 @@
+@import url('./design-tokens.css?revision=r139-semantic-system');
+
+/*
+  Normative production roles.
+  Existing component selectors remain intact; this layer only assigns shared
+  semantic colour and shape decisions.
+*/
+
+/* Main forward flow: one colour and one shape. */
+.install-primary,
+.m8-home-fixed-layout .m8-track-continue,
+.track-select-continue,
+.lot-race {
+  border-radius: var(--turn-radius-pill) !important;
+  background: var(--turn-action-primary) !important;
+}
+
+/* Home menu utilities deliberately step back from the selected-track action. */
+.m8-home-fixed-layout .m8-home-settings,
+.m8-home-fixed-layout .m8-how-button,
+.m8-home-fixed-layout .m8-feedback-button {
+  background: var(--turn-action-utility) !important;
+}
+
+/* Close, leave and back always communicate navigation or context change. */
+.install-close,
+.track-select-close,
+.lot-back,
+.lot-view-close,
+.lot-stats-dialog-close,
+.spectate-close,
+.sound-guide-close,
+.m8-dialog-head > button,
+.back-to-lot-button,
+[data-turn-navigation-action] {
+  background: var(--turn-action-navigation) !important;
+}
+
+/* Driving controls use stable, literal semantics. */
+.drive-drift-zone,
+.drift {
+  background: var(--turn-control-drift) !important;
+}
+
+.drive-pad .drive-gas-zone,
+.gas {
+  background: var(--turn-control-gas) !important;
+}
+
+.drive-pad .drive-brake-zone,
+.brake {
+  background: var(--turn-control-brake) !important;
+}
+
+.drive-boost-zone {
+  background:
+    linear-gradient(
+      to top,
+      var(--turn-control-boost) 0 var(--boost-charge),
+      var(--turn-control-boost-empty) var(--boost-charge) 100%
+    ) !important;
+}
+
+.drive-pad.is-boosting .drive-boost-zone {
+  background:
+    linear-gradient(
+      to top,
+      var(--turn-yellow-600) 0 var(--boost-charge),
+      var(--turn-control-boost-empty) var(--boost-charge) 100%
+    ) !important;
+}
+
+.drive-pad[data-drive-zone="gas"] .drive-gas-zone,
+.drive-drift-zone.is-active,
+.drive-brake-zone.is-active {
+  box-shadow: inset 0 0 0 6px rgb(255 248 232 / 0.78);
+}
+
+.drive-pad[data-drive-zone="gas"] .drive-gas-zone {
+  background: var(--turn-control-gas) !important;
+}
+
+.drive-drift-zone.is-active {
+  background: var(--turn-control-drift) !important;
+}
+
+.drive-brake-zone.is-active {
+  background: var(--turn-control-brake) !important;
+}
+
+.drive-pad.is-boosting {
+  box-shadow:
+    7px 8px 0 var(--turn-ink),
+    0 0 0 5px rgb(255 212 59 / 0.32) !important;
+}
+
+.boost-hud i {
+  background: linear-gradient(90deg, var(--turn-yellow-600), var(--turn-control-boost)) !important;
+}
+
+.boost-hud.is-drift-charging i {
+  background: linear-gradient(90deg, var(--turn-control-drift), var(--turn-control-gas)) !important;
+}

--- a/turn/design-tokens.css
+++ b/turn/design-tokens.css
@@ -1,0 +1,86 @@
+:root {
+  color-scheme: dark;
+
+  /* Primitive colour families. */
+  --turn-ink: #08090a;
+  --turn-paper: #fff8e8;
+  --turn-white: #fffdf6;
+  --turn-road: #44494f;
+  --turn-muted: #d6d0c2;
+
+  --turn-yellow-600: #ffbd12;
+  --turn-yellow-400: #ffd43b;
+  --turn-yellow-200: #ffe087;
+
+  --turn-blue-600: #35b8e7;
+  --turn-blue-500: #38d9ff;
+  --turn-blue-300: #68c8f2;
+  --turn-blue-200: #8ed8ff;
+
+  --turn-pink-500: #ff4fa3;
+  --turn-pink-200: #ff8caf;
+
+  --turn-red-500: #ff6b6b;
+  --turn-red-200: #ff9b91;
+
+  --turn-green-500: #8ce99a;
+  --turn-green-200: #d9f5c2;
+
+  --turn-orange-500: #ff7b54;
+  --turn-orange-200: #ffb89f;
+
+  /* Semantic UI roles. */
+  --turn-surface-page: var(--turn-paper);
+  --turn-surface-raised: var(--turn-white);
+  --turn-action-primary: var(--turn-pink-500);
+  --turn-action-utility: var(--turn-paper);
+  --turn-action-information: var(--turn-blue-500);
+  --turn-action-success: var(--turn-green-500);
+  --turn-action-warning: var(--turn-yellow-400);
+  --turn-action-danger: var(--turn-red-500);
+  --turn-action-navigation: var(--turn-orange-500);
+
+  /* Driving-control roles. */
+  --turn-control-gas: var(--turn-green-500);
+  --turn-control-drift: var(--turn-blue-500);
+  --turn-control-boost: var(--turn-yellow-400);
+  --turn-control-boost-empty: var(--turn-yellow-200);
+  --turn-control-brake: var(--turn-orange-500);
+
+  /* Geometry. */
+  --turn-border-micro: 2px;
+  --turn-border-compact: 3px;
+  --turn-border-default: 4px;
+  --turn-border-heavy: 6px;
+  --turn-radius-micro: 8px;
+  --turn-radius-compact: 12px;
+  --turn-radius-default: 18px;
+  --turn-radius-hero: 28px;
+  --turn-radius-pill: 999px;
+  --turn-radius-circle: 50%;
+  --turn-shadow-compact: 3px 3px 0 var(--turn-ink);
+  --turn-shadow-default: 7px 7px 0 var(--turn-ink);
+  --turn-shadow-hero: 12px 12px 0 var(--turn-ink);
+
+  /* Spacing. */
+  --turn-space-1: 4px;
+  --turn-space-2: 8px;
+  --turn-space-3: 12px;
+  --turn-space-4: 16px;
+  --turn-space-6: 24px;
+  --turn-space-8: 32px;
+  --turn-space-12: 48px;
+
+  /* Backwards-compatible production aliases. */
+  --ink: var(--turn-ink);
+  --paper: var(--turn-paper);
+  --cyan: var(--turn-blue-500);
+  --pink: var(--turn-pink-500);
+  --yellow: var(--turn-yellow-400);
+  --lime: var(--turn-green-500);
+  --m8-ink: var(--turn-ink);
+  --m8-cream: var(--turn-paper);
+  --m8-pink: var(--turn-pink-500);
+  --m8-yellow: var(--turn-yellow-600);
+  --m8-blue: var(--turn-blue-300);
+}

--- a/turn/design.html
+++ b/turn/design.html
@@ -6,73 +6,12 @@
   <meta name="color-scheme" content="light">
   <meta name="robots" content="noindex">
   <title>TURN Design System</title>
+  <link rel="stylesheet" href="./design-tokens.css?revision=r139-semantic-system">
+  <link rel="stylesheet" href="./design-semantic.css?revision=r139-semantic-system">
   <style>
     :root {
       color-scheme: light;
       font-family: Inter, ui-rounded, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-
-      /* Primitive colour families. */
-      --turn-ink: #08090a;
-      --turn-paper: #fff8e8;
-      --turn-white: #fffdf6;
-      --turn-yellow-600: #ffbd12;
-      --turn-yellow-400: #ffd43b;
-      --turn-yellow-200: #ffe087;
-      --turn-blue-600: #35b8e7;
-      --turn-blue-500: #38d9ff;
-      --turn-blue-300: #68c8f2;
-      --turn-blue-200: #8ed8ff;
-      --turn-pink-500: #ff4fa3;
-      --turn-pink-200: #ff8caf;
-      --turn-red-500: #ff6b6b;
-      --turn-red-200: #ff9b91;
-      --turn-green-500: #8ce99a;
-      --turn-green-200: #d9f5c2;
-      --turn-orange-500: #ff7b54;
-      --turn-road: #44494f;
-      --turn-muted: #d6d0c2;
-
-      /* Semantic colour roles. */
-      --turn-surface-page: var(--turn-paper);
-      --turn-surface-raised: var(--turn-white);
-      --turn-action-primary: var(--turn-pink-500);
-      --turn-action-information: var(--turn-blue-500);
-      --turn-action-success: var(--turn-green-500);
-      --turn-action-warning: var(--turn-yellow-400);
-      --turn-action-danger: var(--turn-red-500);
-      --turn-action-exit: var(--turn-orange-500);
-      --turn-focus-light: var(--turn-paper);
-      --turn-focus-dark: var(--turn-ink);
-
-      /* Geometry. */
-      --turn-border-micro: 2px;
-      --turn-border-compact: 3px;
-      --turn-border-default: 4px;
-      --turn-border-heavy: 6px;
-      --turn-radius-micro: 8px;
-      --turn-radius-compact: 12px;
-      --turn-radius-default: 18px;
-      --turn-radius-hero: 28px;
-      --turn-radius-pill: 999px;
-      --turn-radius-circle: 50%;
-      --turn-shadow-compact: 3px 3px 0 var(--turn-ink);
-      --turn-shadow-default: 7px 7px 0 var(--turn-ink);
-      --turn-shadow-hero: 12px 12px 0 var(--turn-ink);
-
-      /* Spacing and type. */
-      --turn-space-1: 4px;
-      --turn-space-2: 8px;
-      --turn-space-3: 12px;
-      --turn-space-4: 16px;
-      --turn-space-6: 24px;
-      --turn-space-8: 32px;
-      --turn-space-12: 48px;
-      --turn-text-xs: 0.72rem;
-      --turn-text-sm: 0.86rem;
-      --turn-text-md: 1rem;
-      --turn-text-lg: clamp(1.3rem, 2.5vw, 2rem);
-      --turn-text-xl: clamp(2rem, 5vw, 4.3rem);
-      --turn-text-display: clamp(4rem, 12vw, 8rem);
     }
 
     * {
@@ -87,20 +26,24 @@
     body {
       margin: 0;
       background:
-        radial-gradient(circle at 8% 5%, rgb(255 79 163 / 0.2), transparent 18rem),
-        radial-gradient(circle at 93% 19%, rgb(56 217 255 / 0.2), transparent 22rem),
+        radial-gradient(circle at 8% 6%, rgb(255 79 163 / 0.18), transparent 20rem),
+        radial-gradient(circle at 94% 21%, rgb(56 217 255 / 0.18), transparent 24rem),
         var(--turn-ink);
       color: var(--turn-paper);
       font-weight: 800;
       line-height: 1.45;
     }
 
+    button,
+    a {
+      font: inherit;
+    }
+
     a {
       color: inherit;
     }
 
-    a:focus-visible,
-    summary:focus-visible {
+    :focus-visible {
       outline: 5px solid var(--turn-yellow-400);
       outline-offset: 4px;
     }
@@ -124,47 +67,32 @@
     }
 
     .site-head {
-      position: relative;
-      overflow: hidden;
       min-height: 68vh;
       display: grid;
-      align-content: center;
-      padding: clamp(36px, 7vw, 96px) max(24px, calc((100vw - 1320px) / 2));
+      align-items: center;
+      padding: clamp(44px, 8vw, 110px) max(24px, calc((100vw - 1280px) / 2));
+      overflow: hidden;
       background:
-        radial-gradient(circle at 12% 20%, var(--turn-pink-200) 0 7%, transparent 7.3%),
-        radial-gradient(circle at 86% 74%, var(--turn-yellow-200) 0 10%, transparent 10.3%),
+        radial-gradient(circle at 13% 18%, var(--turn-pink-200) 0 8%, transparent 8.3%),
+        radial-gradient(circle at 87% 75%, var(--turn-yellow-200) 0 11%, transparent 11.3%),
         linear-gradient(145deg, var(--turn-blue-500), var(--turn-green-500));
       color: var(--turn-ink);
     }
 
-    .site-head::after {
-      content: "";
-      position: absolute;
-      right: -6vw;
-      bottom: -19vw;
-      width: 54vw;
-      aspect-ratio: 1;
-      border: clamp(22px, 4vw, 58px) solid var(--turn-ink);
-      border-radius: var(--turn-radius-circle);
-      opacity: 0.08;
-    }
-
-    .hero-grid {
-      position: relative;
-      z-index: 1;
-      display: grid;
-      grid-template-columns: minmax(0, 1fr) minmax(230px, 0.55fr);
-      gap: clamp(28px, 6vw, 84px);
-      align-items: center;
-      max-width: 1320px;
+    .hero {
+      width: min(1280px, 100%);
       margin: auto;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(260px, 0.55fr);
+      gap: clamp(30px, 7vw, 96px);
+      align-items: center;
     }
 
     .eyebrow,
     .section-kicker,
     .token-label,
-    .mock-kicker {
-      font-size: var(--turn-text-xs);
+    .mock-label {
+      font-size: 0.74rem;
       font-weight: 950;
       letter-spacing: 0.16em;
       text-transform: uppercase;
@@ -180,77 +108,64 @@
       transform: rotate(-1deg);
     }
 
-    .site-head h1 {
-      margin: 24px 0 14px;
+    h1 {
       max-width: 10ch;
-      font-size: var(--turn-text-display);
+      margin: 24px 0 16px;
+      font-size: clamp(4rem, 12vw, 8.4rem);
       font-weight: 1000;
       line-height: 0.73;
       letter-spacing: -0.09em;
     }
 
-    .site-head .lede {
+    .lede {
       max-width: 48rem;
       margin: 0;
       font-size: clamp(1rem, 2vw, 1.35rem);
       line-height: 1.35;
     }
 
-    .status-chip {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      margin-top: 22px;
-      padding: 8px 12px;
-      border: var(--turn-border-compact) solid var(--turn-ink);
-      border-radius: var(--turn-radius-compact);
-      background: var(--turn-paper);
-      box-shadow: var(--turn-shadow-compact);
-      font-size: var(--turn-text-sm);
-    }
-
-    .status-chip::before {
-      content: "";
-      width: 12px;
-      aspect-ratio: 1;
-      border: 2px solid var(--turn-ink);
-      border-radius: var(--turn-radius-circle);
-      background: var(--turn-green-500);
-    }
-
-    .hero-icon {
-      display: block;
-      width: min(100%, 340px);
-      margin: auto;
+    .hero-rule {
+      padding: clamp(24px, 4vw, 42px);
       border: var(--turn-border-heavy) solid var(--turn-ink);
-      border-radius: 24%;
+      border-radius: var(--turn-radius-hero);
       background: var(--turn-paper);
       box-shadow: var(--turn-shadow-hero);
-      transform: rotate(3deg);
+      transform: rotate(2deg);
+    }
+
+    .hero-rule strong {
+      display: block;
+      margin-top: 10px;
+      font-size: clamp(1.7rem, 4vw, 3.2rem);
+      line-height: 0.95;
+      letter-spacing: -0.05em;
+    }
+
+    .hero-rule p {
+      margin: 14px 0 0;
     }
 
     .section-nav {
       position: sticky;
       z-index: 50;
       top: 0;
-      overflow-x: auto;
       display: flex;
       gap: 8px;
-      padding: 10px max(18px, calc((100vw - 1320px) / 2));
+      overflow-x: auto;
+      padding: 10px max(18px, calc((100vw - 1280px) / 2));
       border-block: var(--turn-border-default) solid var(--turn-ink);
       background: rgb(255 248 232 / 0.96);
       color: var(--turn-ink);
       backdrop-filter: blur(8px);
-      scrollbar-width: thin;
     }
 
     .section-nav a {
       flex: 0 0 auto;
       padding: 8px 12px;
       border-radius: var(--turn-radius-pill);
-      text-decoration: none;
-      font-size: var(--turn-text-sm);
+      font-size: 0.86rem;
       font-weight: 950;
+      text-decoration: none;
     }
 
     .section-nav a:hover {
@@ -258,14 +173,14 @@
     }
 
     main {
-      max-width: 1320px;
+      width: min(1280px, 100%);
       margin: auto;
-      padding: clamp(48px, 8vw, 112px) 24px 120px;
+      padding: clamp(54px, 8vw, 112px) 24px 120px;
     }
 
     .section {
       scroll-margin-top: 76px;
-      margin-top: clamp(72px, 10vw, 144px);
+      margin-top: clamp(78px, 10vw, 144px);
     }
 
     .section:first-child {
@@ -274,15 +189,15 @@
 
     .section-head {
       display: grid;
-      grid-template-columns: minmax(0, 1fr) minmax(240px, 0.62fr);
+      grid-template-columns: minmax(0, 1fr) minmax(260px, 0.62fr);
       gap: 32px;
       align-items: end;
-      margin-bottom: 32px;
+      margin-bottom: 30px;
     }
 
     .section-head h2 {
       margin: 8px 0 0;
-      font-size: var(--turn-text-xl);
+      font-size: clamp(2rem, 5vw, 4.2rem);
       line-height: 0.9;
       letter-spacing: -0.055em;
     }
@@ -292,19 +207,15 @@
       color: rgb(255 248 232 / 0.78);
     }
 
-    .audit-grid,
+    .decision-grid,
     .token-grid,
-    .component-grid,
-    .decision-grid {
+    .component-grid {
       display: grid;
       grid-template-columns: repeat(3, minmax(0, 1fr));
       gap: 18px;
     }
 
-    .audit-card,
-    .token-card,
-    .decision-card,
-    .code-card {
+    .card {
       min-width: 0;
       padding: 22px;
       border: var(--turn-border-default) solid var(--turn-ink);
@@ -314,37 +225,24 @@
       box-shadow: var(--turn-shadow-default);
     }
 
-    .audit-card h3,
-    .token-card h3,
-    .decision-card h3 {
+    .card h3 {
       margin: 8px 0 10px;
       font-size: 1.2rem;
       line-height: 1.05;
     }
 
-    .audit-card p,
-    .token-card p,
-    .decision-card p {
+    .card p {
       margin: 0;
-      font-size: var(--turn-text-sm);
-      line-height: 1.45;
+      font-size: 0.88rem;
     }
 
-    .audit-card.keep {
-      background: var(--turn-green-200);
-    }
+    .card.primary-rule { background: var(--turn-pink-200); }
+    .card.navigation-rule { background: var(--turn-orange-200); }
+    .card.utility-rule { background: var(--turn-white); }
 
-    .audit-card.consolidate {
-      background: var(--turn-yellow-200);
-    }
-
-    .audit-card.retire {
-      background: var(--turn-red-200);
-    }
-
-    .inventory-table-wrap {
-      overflow-x: auto;
+    .inventory {
       margin-top: 24px;
+      overflow-x: auto;
       border: var(--turn-border-default) solid var(--turn-ink);
       border-radius: var(--turn-radius-default);
       background: var(--turn-paper);
@@ -368,7 +266,7 @@
 
     th {
       background: var(--turn-yellow-400);
-      font-size: var(--turn-text-xs);
+      font-size: 0.72rem;
       letter-spacing: 0.12em;
       text-transform: uppercase;
     }
@@ -377,21 +275,17 @@
       border-bottom: 0;
     }
 
-    code,
-    pre {
-      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-    }
-
     code {
-      padding: 0.1em 0.35em;
+      padding: 0.12em 0.36em;
       border-radius: 6px;
       background: rgb(8 9 10 / 0.09);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
       font-size: 0.88em;
     }
 
     .swatch-grid {
       display: grid;
-      grid-template-columns: repeat(5, minmax(0, 1fr));
+      grid-template-columns: repeat(4, minmax(0, 1fr));
       gap: 14px;
     }
 
@@ -405,7 +299,7 @@
     }
 
     .swatch-colour {
-      height: 94px;
+      height: 92px;
       border-bottom: var(--turn-border-compact) solid var(--turn-ink);
       background: var(--swatch);
     }
@@ -414,99 +308,80 @@
       display: grid;
       gap: 2px;
       padding: 10px;
-      font-size: var(--turn-text-xs);
+      font-size: 0.72rem;
     }
 
     .swatch-copy strong {
-      font-size: var(--turn-text-sm);
+      font-size: 0.88rem;
     }
 
-    .shape-grid {
+    .role-grid {
       display: grid;
-      grid-template-columns: repeat(5, minmax(0, 1fr));
+      grid-template-columns: repeat(4, minmax(0, 1fr));
       gap: 14px;
       margin-top: 22px;
     }
 
-    .shape-sample {
+    .role {
+      min-height: 132px;
+      display: grid;
+      align-content: end;
+      padding: 14px;
+      border: var(--turn-border-compact) solid var(--turn-ink);
+      border-radius: var(--turn-radius-default);
+      background: var(--role);
+      color: var(--turn-ink);
+      box-shadow: var(--turn-shadow-compact);
+      font-size: 0.76rem;
+    }
+
+    .role strong {
+      display: block;
+      margin-bottom: 4px;
+      font-size: 0.9rem;
+      text-transform: uppercase;
+    }
+
+    .shape-grid {
+      display: grid;
+      grid-template-columns: repeat(6, minmax(0, 1fr));
+      gap: 14px;
+    }
+
+    .shape {
+      min-height: 108px;
       display: grid;
       place-items: center;
-      min-height: 110px;
-      padding: 14px;
+      padding: 12px;
       border: var(--turn-border-default) solid var(--turn-ink);
       background: var(--turn-blue-300);
       color: var(--turn-ink);
       box-shadow: var(--turn-shadow-default);
       text-align: center;
-      font-size: var(--turn-text-xs);
+      font-size: 0.72rem;
       letter-spacing: 0.08em;
       text-transform: uppercase;
     }
 
-    .shape-sample.micro { border-radius: var(--turn-radius-micro); }
-    .shape-sample.compact { border-radius: var(--turn-radius-compact); }
-    .shape-sample.default { border-radius: var(--turn-radius-default); }
-    .shape-sample.hero { border-radius: var(--turn-radius-hero); }
-    .shape-sample.pill { border-radius: var(--turn-radius-pill); }
-    .shape-sample.circle {
-      width: 110px;
-      min-height: 110px;
-      justify-self: center;
+    .shape.micro { border-radius: var(--turn-radius-micro); }
+    .shape.compact { border-radius: var(--turn-radius-compact); }
+    .shape.default { border-radius: var(--turn-radius-default); }
+    .shape.hero { border-radius: var(--turn-radius-hero); }
+    .shape.pill { border-radius: var(--turn-radius-pill); }
+    .shape.circle {
+      width: 108px;
       border-radius: var(--turn-radius-circle);
-      background: var(--turn-pink-500);
-    }
-
-    .semantic-grid {
-      display: grid;
-      grid-template-columns: repeat(7, minmax(0, 1fr));
-      gap: 12px;
-      margin-top: 22px;
-    }
-
-    .semantic-chip {
-      display: grid;
-      align-content: end;
-      min-height: 130px;
-      padding: 12px;
-      border: var(--turn-border-compact) solid var(--turn-ink);
-      border-radius: var(--turn-radius-default);
-      background: var(--semantic);
-      color: var(--turn-ink);
-      box-shadow: var(--turn-shadow-compact);
-      font-size: var(--turn-text-xs);
-      line-height: 1.25;
-    }
-
-    .semantic-chip strong {
-      display: block;
-      margin-bottom: 3px;
-      font-size: var(--turn-text-sm);
-      text-transform: uppercase;
-    }
-
-    .code-card {
-      margin-top: 24px;
-      background: #17191c;
-      color: #fff8e8;
-      box-shadow: 8px 8px 0 var(--turn-blue-500);
-    }
-
-    .code-card pre {
-      overflow-x: auto;
-      margin: 0;
-      font-size: 0.82rem;
-      line-height: 1.55;
-      white-space: pre;
+      background: var(--turn-orange-500);
     }
 
     .component-board {
       display: grid;
-      gap: 22px;
+      gap: 28px;
       padding: clamp(22px, 4vw, 42px);
       border: var(--turn-border-heavy) solid var(--turn-ink);
       border-radius: var(--turn-radius-hero);
       background:
-        radial-gradient(circle at 91% 9%, rgb(255 79 163 / 0.3), transparent 18%),
+        radial-gradient(circle at 91% 9%, rgb(255 79 163 / 0.28), transparent 18%),
         var(--turn-paper);
       color: var(--turn-ink);
       box-shadow: var(--turn-shadow-hero);
@@ -517,60 +392,152 @@
       flex-wrap: wrap;
       gap: 14px;
       align-items: center;
+      margin-top: 12px;
     }
 
-    .button-sample,
-    .icon-sample,
-    .chip-sample {
-      display: inline-grid;
-      place-items: center;
+    .turn-button {
+      min-height: 52px;
+      padding: 10px 18px;
       border: var(--turn-border-default) solid var(--turn-ink);
+      border-radius: var(--turn-radius-default);
+      background: var(--turn-paper);
       color: var(--turn-ink);
       box-shadow: var(--turn-shadow-default);
       font-weight: 950;
-      text-align: center;
+      letter-spacing: 0.045em;
       text-transform: uppercase;
     }
 
-    .button-sample {
-      min-height: 52px;
-      padding: 10px 18px;
-      border-radius: var(--turn-radius-default);
-      background: var(--sample-colour, var(--turn-paper));
-      letter-spacing: 0.045em;
+    .turn-button:active {
+      transform: translate(6px, 6px);
+      box-shadow: 1px 1px 0 var(--turn-ink);
     }
 
-    .button-sample.pill {
+    .turn-button.utility {
       border-radius: var(--turn-radius-pill);
+      background: var(--turn-action-utility);
     }
 
-    .icon-sample {
+    .turn-button.danger {
+      background: var(--turn-action-danger);
+    }
+
+    .icon-button {
       width: 52px;
       height: 52px;
+      padding: 0;
+      border: var(--turn-border-default) solid var(--turn-ink);
       border-radius: var(--turn-radius-circle);
-      background: var(--sample-colour, var(--turn-pink-500));
-      font-size: 1.6rem;
+      color: var(--turn-ink);
+      box-shadow: var(--turn-shadow-default);
+      font-size: 1.65rem;
+      font-weight: 950;
+      line-height: 1;
     }
 
-    .chip-sample {
-      min-height: 38px;
-      padding: 6px 10px;
-      border-width: var(--turn-border-compact);
+    .navigation-text {
+      border-radius: var(--turn-radius-default);
+      background: var(--turn-action-navigation);
+    }
+
+    .primary-flow {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 14px;
+      margin-top: 14px;
+    }
+
+    .primary-flow .turn-button {
+      width: 100%;
+    }
+
+    .drive-pad {
+      --boost-charge: 72%;
+      width: min(300px, 100%);
+      height: 300px;
+      display: grid;
+      grid-template-rows: 32% 44% 24%;
+      overflow: hidden;
+      border: var(--turn-border-default) solid var(--turn-ink);
+      border-radius: var(--turn-radius-hero);
+      background: var(--turn-control-gas);
+      box-shadow: var(--turn-shadow-default);
+    }
+
+    .drive-pad-top {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+    }
+
+    .drive-zone,
+    .drive-gas-zone,
+    .drive-brake-zone {
+      display: grid;
+      place-items: center;
+      min-width: 0;
+      min-height: 0;
+      margin: 0;
+      padding: 8px;
+      border: 0;
+      border-radius: 0;
+      box-shadow: none;
+      color: var(--turn-ink);
+      font-weight: 950;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    .drive-drift-zone {
+      border-right: var(--turn-border-micro) solid var(--turn-ink);
+    }
+
+    .drive-boost-zone {
+      border-left: var(--turn-border-micro) solid var(--turn-ink);
+    }
+
+    .drive-gas-zone,
+    .drive-brake-zone {
+      border-top: var(--turn-border-default) solid var(--turn-ink);
+    }
+
+    .control-notes {
+      display: grid;
+      gap: 10px;
+      align-content: start;
+    }
+
+    .control-note {
+      display: grid;
+      grid-template-columns: 26px 1fr;
+      gap: 10px;
+      align-items: start;
+      padding: 12px;
+      border: var(--turn-border-compact) solid var(--turn-ink);
       border-radius: var(--turn-radius-compact);
-      background: var(--sample-colour, var(--turn-paper));
-      box-shadow: var(--turn-shadow-compact);
-      font-size: var(--turn-text-xs);
-      letter-spacing: 0.08em;
+      background: var(--turn-white);
     }
 
-    .focus-demo {
-      outline: 5px solid var(--turn-blue-500);
-      outline-offset: 4px;
+    .control-note i {
+      width: 24px;
+      height: 24px;
+      border: var(--turn-border-micro) solid var(--turn-ink);
+      border-radius: var(--turn-radius-circle);
+      background: var(--note);
+    }
+
+    .control-note strong,
+    .control-note span {
+      display: block;
+    }
+
+    .control-note span {
+      margin-top: 2px;
+      font-size: 0.78rem;
     }
 
     .screen-stack {
       display: grid;
-      gap: clamp(42px, 8vw, 96px);
+      gap: clamp(48px, 8vw, 94px);
     }
 
     .screen-specimen {
@@ -587,15 +554,15 @@
 
     .screen-caption h3 {
       margin: 0;
-      font-size: var(--turn-text-lg);
+      font-size: clamp(1.35rem, 3vw, 2rem);
       line-height: 1;
     }
 
     .screen-caption p {
-      margin: 4px 0 0;
-      max-width: 66ch;
+      max-width: 70ch;
+      margin: 5px 0 0;
       color: rgb(255 248 232 / 0.72);
-      font-size: var(--turn-text-sm);
+      font-size: 0.86rem;
     }
 
     .screen-caption code {
@@ -605,14 +572,27 @@
 
     .game-screen {
       position: relative;
+      min-height: 570px;
       overflow: hidden;
-      width: 100%;
-      min-height: clamp(480px, 65vw, 760px);
       border: 8px solid var(--turn-ink);
       border-radius: var(--turn-radius-hero);
       color: var(--turn-ink);
       box-shadow: var(--turn-shadow-hero);
       container-type: inline-size;
+    }
+
+    .placeholder {
+      display: grid;
+      place-items: center;
+      min-height: 130px;
+      border: var(--turn-border-compact) dashed var(--turn-ink);
+      border-radius: var(--turn-radius-default);
+      background: rgb(255 248 232 / 0.36);
+      color: rgb(8 9 10 / 0.58);
+      font-size: clamp(0.8rem, 2cqw, 1.15rem);
+      letter-spacing: 0.16em;
+      text-align: center;
+      text-transform: uppercase;
     }
 
     .install-example {
@@ -625,376 +605,279 @@
         linear-gradient(145deg, var(--turn-blue-500), var(--turn-green-500));
     }
 
-    .install-example-grid {
-      width: min(920px, 100%);
-      display: grid;
-      grid-template-columns: minmax(150px, 0.72fr) minmax(300px, 1.28fr);
-      gap: clamp(22px, 5vw, 54px);
-      align-items: center;
-    }
-
-    .install-example .app-icon {
-      width: min(100%, 250px);
-      border: var(--turn-border-heavy) solid var(--turn-ink);
-      border-radius: 24%;
-      box-shadow: var(--turn-shadow-hero);
-      transform: rotate(-3deg);
-    }
-
-    .mock-card {
-      padding: clamp(22px, 4vw, 40px);
+    .install-card-sample {
+      width: min(680px, 100%);
+      padding: clamp(24px, 5cqw, 46px);
       border: var(--turn-border-heavy) solid var(--turn-ink);
       border-radius: var(--turn-radius-hero);
-      background: rgb(255 248 232 / 0.97);
+      background: var(--turn-paper);
       box-shadow: var(--turn-shadow-hero);
     }
 
-    .mock-card h4 {
+    .install-card-sample h4 {
       margin: 10px 0 0;
-      font-size: clamp(3.6rem, 9cqw, 7rem);
-      line-height: 0.75;
+      font-size: clamp(4rem, 12cqw, 7rem);
+      line-height: 0.72;
       letter-spacing: -0.09em;
     }
 
-    .mock-card p {
-      max-width: 34rem;
+    .install-card-sample p {
       margin: 20px 0;
-      line-height: 1.3;
+      line-height: 1.35;
     }
 
-    .mock-actions {
+    .install-actions-sample {
       display: grid;
-      gap: 10px;
+      gap: 12px;
     }
 
-    .mock-link-action {
+    .quiet-link {
       justify-self: start;
-      padding: 10px 4px;
+      padding: 8px 3px;
       text-decoration: underline;
-      text-underline-offset: 0.25em;
-      font-size: var(--turn-text-sm);
+      text-underline-offset: 0.22em;
     }
 
     .home-example {
       display: grid;
-      grid-template-rows: minmax(170px, 31%) minmax(0, 1fr);
-      background: var(--turn-blue-300);
+      grid-template-rows: 112px minmax(0, 1fr);
+      background: linear-gradient(to bottom, var(--turn-yellow-600) 0 112px, var(--turn-blue-300) 112px 100%);
     }
 
-    .home-example-head {
+    .home-head-sample {
       display: grid;
-      grid-template-columns: minmax(130px, 0.42fr) minmax(220px, 1fr) auto;
-      gap: clamp(16px, 4cqw, 44px);
+      grid-template-columns: auto 1fr auto;
+      gap: 22px;
       align-items: center;
-      padding: 22px 28px;
-      background:
-        radial-gradient(circle at 84% 28%, var(--turn-pink-200) 0 9%, transparent 9.3%),
-        var(--turn-yellow-600);
+      padding: 16px 24px;
+      border-bottom: 5px solid var(--turn-ink);
     }
 
-    .home-wordmark {
-      font-size: clamp(3.5rem, 10cqw, 7.5rem);
-      line-height: 0.7;
+    .wordmark {
+      font-size: clamp(2.8rem, 8cqw, 5.5rem);
+      font-weight: 1000;
+      line-height: 0.72;
       letter-spacing: -0.09em;
-      text-shadow: 8px 8px 0 var(--turn-paper);
-      transform: rotate(-2deg);
     }
 
-    .home-pitch {
-      max-width: 15ch;
-      font-size: clamp(1.35rem, 3.2cqw, 2.8rem);
-      font-weight: 950;
-      line-height: 0.92;
-      letter-spacing: -0.05em;
+    .pitch {
+      max-width: 18ch;
+      font-size: clamp(1rem, 2.3cqw, 1.7rem);
+      line-height: 0.95;
     }
 
-    .home-meta {
-      align-self: start;
+    .build {
+      font-size: 0.62rem;
+      letter-spacing: 0.08em;
+      text-align: right;
+    }
+
+    .home-body-sample {
       display: grid;
-      justify-items: end;
-      gap: 8px;
-      font-size: 0.65rem;
-      letter-spacing: 0.1em;
-    }
-
-    .home-meta span {
-      padding: 5px 8px;
-      border-radius: var(--turn-radius-micro);
-      background: rgb(255 248 232 / 0.55);
-    }
-
-    .home-example-main {
-      display: grid;
-      grid-template-columns: minmax(190px, 0.32fr) minmax(0, 1fr);
+      grid-template-columns: minmax(0, 1fr) minmax(210px, 27%);
       gap: 24px;
       min-height: 0;
-      padding: 22px 28px 28px;
+      padding: 24px;
     }
 
-    .home-menu {
+    .track-area {
       display: grid;
-      align-content: start;
-      gap: 12px;
+      grid-template-rows: auto minmax(0, 1fr);
+      gap: 14px;
+      min-width: 0;
     }
 
-    .home-menu .button-sample {
-      width: 100%;
-      justify-content: start;
-      min-height: 48px;
+    .track-area h4,
+    .menu-area h4 {
+      margin: 0;
+      font-size: clamp(1.6rem, 4cqw, 3rem);
+      line-height: 0.9;
+      letter-spacing: -0.04em;
     }
 
-    .home-tracks {
+    .track-list {
       display: grid;
       grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 18px;
+      gap: 14px;
       align-content: start;
     }
 
-    .home-tracks h4 {
-      grid-column: 1 / -1;
-      margin: 0;
-      font-size: clamp(1.8rem, 5cqw, 4rem);
-      line-height: 0.9;
-    }
-
-    .track-card-sample {
+    .track-card-text {
       display: grid;
       gap: 12px;
-      min-width: 0;
       padding: 14px;
       border: var(--turn-border-default) solid var(--turn-ink);
       border-radius: var(--turn-radius-hero);
-      background: var(--track-colour, var(--turn-green-500));
+      background: var(--track, var(--turn-green-500));
       box-shadow: var(--turn-shadow-default);
     }
 
-    .track-card-sample.selected {
-      transform: translate(6px, 6px);
-      box-shadow: 1px 1px 0 var(--turn-ink), inset 0 0 0 5px rgb(255 255 255 / 0.75);
+    .track-card-text.selected {
+      transform: translate(5px, 5px);
+      box-shadow: 1px 1px 0 var(--turn-ink), inset 0 0 0 5px rgb(255 255 255 / 0.76);
     }
 
-    .track-preview-sample {
-      position: relative;
-      overflow: hidden;
-      min-height: 120px;
-      border: var(--turn-border-compact) solid var(--turn-ink);
-      border-radius: var(--turn-radius-default);
-      background: #9ae6b4;
+    .track-card-text .placeholder {
+      min-height: 100px;
     }
 
-    .track-preview-sample::before,
-    .track-preview-sample::after {
-      content: "";
-      position: absolute;
-      inset: 20% 14%;
-      border: 22px solid var(--turn-ink);
-      border-radius: 48% 34% 44% 30%;
-      transform: rotate(-8deg);
-    }
-
-    .track-preview-sample::after {
-      border-width: 13px;
-      border-color: var(--turn-road);
-    }
-
-    .track-summary-sample {
+    .track-meta {
       display: flex;
       justify-content: space-between;
       gap: 10px;
       align-items: center;
     }
 
-    .track-summary-sample strong {
-      font-size: clamp(1rem, 2.5cqw, 1.7rem);
-      line-height: 0.95;
+    .track-meta strong {
+      font-size: clamp(1rem, 2.4cqw, 1.6rem);
     }
 
-    .track-summary-sample span {
+    .track-meta span {
       padding: 6px 8px;
       border: var(--turn-border-compact) solid var(--turn-ink);
       border-radius: var(--turn-radius-compact);
       background: var(--turn-paper);
       box-shadow: var(--turn-shadow-compact);
-      font-size: 0.63rem;
+      font-size: 0.6rem;
+    }
+
+    .menu-area {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      min-width: 0;
+    }
+
+    .menu-area h4 {
+      margin-bottom: 2px;
+    }
+
+    .menu-area .turn-button {
+      width: 100%;
+      font-size: clamp(0.72rem, 1.5cqw, 0.96rem);
+    }
+
+    .menu-area .m8-track-continue {
+      margin-top: auto;
     }
 
     .lot-example {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(260px, 34%);
+      gap: 20px;
+      padding: 20px;
       background: var(--turn-blue-200);
     }
 
-    .lot-scene {
-      position: absolute;
-      inset: 0 34% 0 0;
-      overflow: hidden;
-      background:
-        linear-gradient(170deg, transparent 0 59%, #52616c 59% 64%, #32383d 64% 100%),
-        linear-gradient(var(--turn-blue-200) 0 58%, #9ae6b4 58% 100%);
+    .lot-view-area {
+      display: grid;
+      grid-template-rows: auto minmax(0, 1fr);
+      gap: 14px;
+      min-width: 0;
     }
 
-    .lot-scene::before {
-      content: "THE LOT";
-      position: absolute;
-      top: 28px;
-      left: 28px;
+    .lot-title {
       font-size: clamp(2.8rem, 8cqw, 6rem);
+      font-weight: 1000;
       line-height: 0.72;
       letter-spacing: -0.08em;
       text-shadow: 4px 4px 0 var(--turn-paper);
     }
 
-    .car-shape {
-      position: absolute;
-      left: 18%;
-      bottom: 16%;
-      width: 54%;
-      height: 20%;
-      border: var(--turn-border-heavy) solid var(--turn-ink);
-      border-radius: 42% 54% 22% 18%;
-      background: var(--turn-pink-500);
-      box-shadow: 12px 14px 0 rgb(8 9 10 / 0.26);
-      transform: skewX(-5deg);
+    .lot-view-area .placeholder {
+      min-height: 360px;
+      background: linear-gradient(145deg, #c7f6ff, var(--turn-blue-200));
     }
 
-    .car-shape::before {
-      content: "";
-      position: absolute;
-      left: 23%;
-      top: -62%;
-      width: 48%;
-      height: 72%;
-      border: var(--turn-border-heavy) solid var(--turn-ink);
-      border-bottom: 0;
-      border-radius: 50% 50% 0 0;
-      background: var(--turn-blue-500);
-    }
-
-    .car-shape::after {
-      content: "";
-      position: absolute;
-      left: 10%;
-      right: 10%;
-      bottom: -27%;
-      height: 34%;
-      background:
-        radial-gradient(circle at 12% 50%, var(--turn-ink) 0 35%, transparent 37%),
-        radial-gradient(circle at 88% 50%, var(--turn-ink) 0 35%, transparent 37%);
-    }
-
-    .lot-panel {
-      position: absolute;
-      top: 20px;
-      right: 20px;
-      bottom: 20px;
-      width: calc(34% - 30px);
+    .lot-panel-sample {
+      align-self: end;
       display: grid;
-      grid-template-rows: minmax(170px, 1fr) auto;
       gap: 14px;
     }
 
-    .lot-viewer,
-    .lot-info-card {
+    .viewer-card,
+    .car-info-card {
       border: var(--turn-border-default) solid var(--turn-ink);
       border-radius: var(--turn-radius-default);
-      background: rgb(255 248 232 / 0.97);
+      background: var(--turn-paper);
       box-shadow: var(--turn-shadow-default);
     }
 
-    .lot-viewer {
-      position: relative;
+    .viewer-card {
       overflow: hidden;
-      background:
-        radial-gradient(circle, rgb(255 255 255 / 0.75), transparent 55%),
-        var(--turn-blue-200);
     }
 
-    .lot-viewer::before {
-      content: "DRAG TO ROTATE";
-      position: absolute;
-      top: 8px;
-      left: 8px;
-      padding: 4px 7px;
-      border: var(--turn-border-micro) solid var(--turn-ink);
-      border-radius: var(--turn-radius-pill);
-      background: var(--turn-yellow-400);
-      font-size: 0.48rem;
-      letter-spacing: 0.08em;
+    .viewer-card .placeholder {
+      min-height: 180px;
+      border: 0;
+      border-radius: 0;
+      background: linear-gradient(145deg, #c7f6ff, var(--turn-blue-200));
     }
 
-    .lot-viewer .car-shape {
-      left: 12%;
-      bottom: 27%;
-      width: 76%;
-      height: 20%;
-      transform: scale(0.72) skewX(-5deg);
-    }
-
-    .paint-rail {
-      position: absolute;
-      inset: auto 0 0;
+    .paint-row {
       display: grid;
       grid-template-columns: 1fr 1fr;
       gap: 6px;
-      padding: 7px;
+      padding: 8px;
       border-top: var(--turn-border-compact) solid var(--turn-ink);
-      background: var(--turn-paper);
     }
 
-    .paint-field {
+    .paint-control {
       display: flex;
       justify-content: space-between;
       align-items: center;
-      min-width: 0;
-      padding: 5px 7px;
+      gap: 6px;
+      padding: 6px 8px;
       border: var(--turn-border-micro) solid var(--turn-ink);
       border-radius: var(--turn-radius-micro);
-      font-size: 0.53rem;
+      font-size: 0.54rem;
     }
 
-    .paint-field i {
-      width: 32px;
-      height: 23px;
+    .paint-control i {
+      width: 31px;
+      height: 24px;
       border: var(--turn-border-micro) solid var(--turn-ink);
       border-radius: var(--turn-radius-micro);
-      background: var(--paint, var(--turn-pink-500));
+      background: var(--paint);
     }
 
-    .lot-info-card {
-      padding: 12px;
+    .car-info-card {
+      padding: 14px;
     }
 
-    .lot-info-card h4 {
+    .car-info-card h4 {
       display: flex;
       justify-content: space-between;
       gap: 8px;
       margin: 0;
-      padding-bottom: 8px;
+      padding-bottom: 9px;
       border-bottom: var(--turn-border-compact) solid var(--turn-ink);
-      font-size: clamp(0.82rem, 2cqw, 1.14rem);
+      font-size: 0.9rem;
     }
 
-    .stat-list {
+    .stats {
       display: grid;
-      gap: 6px;
-      margin: 12px 0;
-    }
-
-    .stat-row {
-      display: grid;
-      grid-template-columns: 78px 1fr;
-      align-items: center;
       gap: 7px;
-      font-size: 0.52rem;
+      margin: 14px 0;
+    }
+
+    .stat {
+      display: grid;
+      grid-template-columns: 88px 1fr;
+      gap: 8px;
+      align-items: center;
+      font-size: 0.54rem;
     }
 
     .stat-bar {
       display: grid;
       grid-template-columns: repeat(5, 1fr);
       gap: 3px;
-      height: 8px;
+      height: 9px;
     }
 
     .stat-bar i {
-      border: var(--turn-border-micro) solid var(--turn-ink);
+      border: 1.5px solid var(--turn-ink);
       border-radius: 2px;
       background: var(--turn-muted);
     }
@@ -1003,204 +886,119 @@
       background: var(--turn-blue-500);
     }
 
+    .car-info-card .lot-race {
+      width: 100%;
+    }
+
     .race-example {
-      background:
-        linear-gradient(90deg, #4d8d65 0 18%, transparent 18% 82%, #4d8d65 82%),
-        linear-gradient(#86caf3 0 45%, #708087 45% 100%);
+      padding: 20px;
+      background: #4d8d65;
     }
 
-    .race-road {
+    .game-view {
       position: absolute;
-      left: 23%;
-      right: 23%;
-      top: 38%;
-      bottom: -18%;
-      border-inline: 8px solid var(--turn-paper);
-      background:
-        linear-gradient(90deg, transparent 48%, var(--turn-yellow-400) 48% 52%, transparent 52%),
-        var(--turn-road);
-      clip-path: polygon(42% 0, 58% 0, 100% 100%, 0 100%);
+      inset: 20px;
+      display: grid;
+      place-items: center;
+      border: var(--turn-border-compact) dashed rgb(255 248 232 / 0.72);
+      border-radius: var(--turn-radius-default);
+      background: rgb(56 217 255 / 0.32);
+      color: rgb(255 248 232 / 0.82);
+      font-size: clamp(1rem, 3cqw, 2.2rem);
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
     }
 
-    .race-hud {
+    .hud-row {
       position: absolute;
-      inset: 18px 18px auto;
-      display: flex;
-      justify-content: space-between;
-      gap: 16px;
-    }
-
-    .race-stats {
+      z-index: 2;
+      top: 34px;
+      left: 34px;
       display: flex;
       flex-wrap: wrap;
-      gap: 8px;
+      gap: 9px;
     }
 
     .hud-chip {
-      min-width: 78px;
-      padding: 7px 9px;
+      min-width: 88px;
+      padding: 8px 10px;
       border: var(--turn-border-compact) solid var(--turn-ink);
       border-radius: var(--turn-radius-compact);
-      background: rgb(255 248 232 / 0.92);
+      background: rgb(255 248 232 / 0.94);
       box-shadow: var(--turn-shadow-compact);
-      font-size: 0.56rem;
-      letter-spacing: 0.06em;
+      font-size: 0.58rem;
+      letter-spacing: 0.07em;
       text-transform: uppercase;
     }
 
     .hud-chip strong {
       display: block;
-      margin-top: 2px;
-      font-size: clamp(0.88rem, 2cqw, 1.35rem);
+      margin-top: 3px;
+      font-size: clamp(0.9rem, 2cqw, 1.3rem);
       letter-spacing: -0.04em;
     }
 
-    .mini-map {
-      position: relative;
-      width: min(20cqw, 170px);
-      aspect-ratio: 1.45;
-      border: var(--turn-border-compact) solid var(--turn-ink);
-      border-radius: var(--turn-radius-compact);
-      background: rgb(255 255 255 / 0.86);
-      box-shadow: var(--turn-shadow-compact);
-    }
-
-    .mini-map::before,
-    .mini-map::after {
-      content: "";
+    .manual-control {
       position: absolute;
-      inset: 22% 19%;
-      border: 12px solid var(--turn-ink);
-      border-radius: 48% 30% 42% 35%;
-      transform: rotate(12deg);
-    }
-
-    .mini-map::after {
-      border-width: 7px;
-      border-color: var(--turn-road);
-    }
-
-    .manual-control-sample {
-      position: absolute;
-      left: 24px;
-      bottom: 76px;
-      width: min(24cqw, 220px);
-      height: min(16cqw, 145px);
+      z-index: 2;
+      left: 34px;
+      bottom: 34px;
+      width: min(250px, 31%);
+      min-width: 190px;
+      height: 150px;
+      display: grid;
+      place-items: center;
       border: var(--turn-border-default) solid var(--turn-ink);
       border-radius: var(--turn-radius-hero);
       background: var(--turn-yellow-400);
       box-shadow: var(--turn-shadow-default);
+      font-size: 2.2rem;
     }
 
-    .manual-control-sample::before {
-      content: "←          →";
-      position: absolute;
-      inset: 0;
+    .manual-control i {
       display: grid;
       place-items: center;
-      font-size: clamp(1.8rem, 4cqw, 3.5rem);
-      white-space: pre;
-    }
-
-    .manual-control-sample i {
-      position: absolute;
-      left: 50%;
-      top: 50%;
-      width: 42%;
-      max-width: 94px;
-      aspect-ratio: 1;
+      width: 82px;
+      height: 82px;
       border: var(--turn-border-default) solid var(--turn-ink);
       border-radius: var(--turn-radius-circle);
       background: var(--turn-blue-500);
-      box-shadow: 5px 7px 0 rgb(8 9 10 / 0.35);
-      transform: translate(-50%, -50%);
+      box-shadow: 5px 6px 0 rgb(8 9 10 / 0.32);
+      font-style: normal;
     }
 
-    .drive-pad-sample {
+    .race-example .drive-pad {
       position: absolute;
-      right: 24px;
-      bottom: 24px;
-      width: min(27cqw, 258px);
-      height: min(29cqw, 266px);
-      display: grid;
-      grid-template-rows: 32% 44% 24%;
-      overflow: hidden;
-      border: var(--turn-border-default) solid var(--turn-ink);
-      border-radius: var(--turn-radius-hero);
-      background: var(--turn-green-500);
-      box-shadow: var(--turn-shadow-default);
-      text-align: center;
-      text-transform: uppercase;
-    }
-
-    .drive-top-sample {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-    }
-
-    .drive-top-sample span,
-    .drive-gas-sample,
-    .drive-brake-sample {
-      display: grid;
-      place-items: center;
-      font-size: clamp(0.55rem, 1.4cqw, 0.95rem);
-    }
-
-    .drive-top-sample span:first-child {
-      border-right: 2px solid var(--turn-ink);
-      background: var(--turn-blue-500);
-    }
-
-    .drive-top-sample span:last-child {
-      border-left: 2px solid var(--turn-ink);
-      background: linear-gradient(to top, var(--turn-red-500) 0 72%, #ffb2aa 72%);
-    }
-
-    .drive-gas-sample {
-      border-top: var(--turn-border-default) solid var(--turn-ink);
-      background: var(--turn-green-500);
-    }
-
-    .drive-brake-sample {
-      border-top: var(--turn-border-default) solid var(--turn-ink);
-      background: var(--turn-pink-500);
-    }
-
-    .race-utilities {
-      position: absolute;
-      left: 24px;
-      bottom: 22px;
-      display: flex;
-      gap: 8px;
-    }
-
-    .race-utilities .chip-sample {
-      background: var(--turn-paper);
+      z-index: 2;
+      right: 34px;
+      bottom: 34px;
+      width: min(280px, 34%);
+      height: 300px;
     }
 
     .dialog-example {
       display: grid;
       place-items: center;
-      padding: clamp(18px, 4vw, 44px);
+      padding: clamp(20px, 4vw, 48px);
       background:
         linear-gradient(rgb(8 9 10 / 0.62), rgb(8 9 10 / 0.62)),
         linear-gradient(145deg, var(--turn-yellow-600) 0 30%, var(--turn-blue-300) 30%);
     }
 
-    .dialog-sample {
-      width: min(980px, 96%);
+    .dialog-card {
+      width: min(900px, 96%);
       max-height: 90%;
       overflow: auto;
-      padding: clamp(20px, 4cqw, 34px);
+      padding: clamp(22px, 4cqw, 36px);
       border: var(--turn-border-heavy) solid var(--turn-ink);
       border-radius: var(--turn-radius-hero);
       background:
-        radial-gradient(circle at 91% 8%, rgb(255 79 163 / 0.35), transparent 18%),
+        radial-gradient(circle at 91% 8%, rgb(255 79 163 / 0.34), transparent 18%),
         var(--turn-paper);
       box-shadow: var(--turn-shadow-hero);
     }
 
-    .dialog-head-sample {
+    .m8-dialog-head {
       display: flex;
       justify-content: space-between;
       gap: 18px;
@@ -1208,20 +1006,20 @@
       margin-bottom: 20px;
     }
 
-    .dialog-head-sample h4 {
-      margin: 2px 0 0;
+    .m8-dialog-head h4 {
+      margin: 3px 0 0;
       font-size: clamp(2rem, 5cqw, 4rem);
       line-height: 0.9;
       letter-spacing: -0.05em;
     }
 
-    .guide-grid-sample {
+    .guide-grid {
       display: grid;
       grid-template-columns: repeat(2, minmax(0, 1fr));
       gap: 14px;
     }
 
-    .guide-card-sample {
+    .guide-card {
       display: grid;
       grid-template-columns: auto 1fr;
       gap: 12px;
@@ -1232,7 +1030,7 @@
       box-shadow: var(--turn-shadow-compact);
     }
 
-    .guide-card-sample > strong {
+    .guide-card > strong {
       display: grid;
       place-items: center;
       width: 42px;
@@ -1241,33 +1039,33 @@
       background: var(--turn-yellow-400);
     }
 
-    .guide-card-sample h5,
-    .guide-card-sample p {
+    .guide-card h5,
+    .guide-card p {
       margin: 0;
     }
 
-    .guide-card-sample p {
+    .guide-card p {
       margin-top: 5px;
-      font-size: var(--turn-text-sm);
+      font-size: 0.84rem;
       line-height: 1.4;
     }
 
-    .guide-card-sample.wide {
+    .guide-card.wide {
       grid-column: 1 / -1;
       background: var(--turn-green-200);
     }
 
-    .migration-list {
+    .adoption-list {
       display: grid;
       gap: 12px;
       margin: 0;
       padding: 0;
       list-style: none;
-      counter-reset: migration;
+      counter-reset: adoption;
     }
 
-    .migration-list li {
-      counter-increment: migration;
+    .adoption-list li {
+      counter-increment: adoption;
       display: grid;
       grid-template-columns: auto 1fr;
       gap: 14px;
@@ -1280,115 +1078,73 @@
       box-shadow: var(--turn-shadow-compact);
     }
 
-    .migration-list li::before {
-      content: counter(migration);
+    .adoption-list li::before {
+      content: counter(adoption);
       display: grid;
       place-items: center;
       width: 38px;
       height: 38px;
       border-radius: var(--turn-radius-circle);
-      background: var(--turn-yellow-400);
+      background: var(--turn-green-500);
       font-weight: 1000;
     }
 
-    .migration-list strong {
+    .adoption-list strong {
       display: block;
       margin-bottom: 4px;
     }
 
-    .page-footer {
-      padding: 36px 24px 54px;
+    footer {
+      padding: 40px 24px 58px;
       border-top: var(--turn-border-default) solid var(--turn-ink);
       background: var(--turn-yellow-600);
       color: var(--turn-ink);
       text-align: center;
     }
 
-    .page-footer p {
-      max-width: 72ch;
+    footer p {
+      max-width: 76ch;
       margin: auto;
     }
 
-    @container (max-width: 760px) {
-      .home-example-head {
-        grid-template-columns: 1fr auto;
-      }
-
-      .home-pitch {
-        grid-column: 1 / -1;
-        grid-row: 2;
-      }
-
-      .home-example-main {
-        grid-template-columns: 1fr;
-      }
-
-      .home-menu {
-        grid-template-columns: repeat(2, 1fr);
-      }
-
-      .lot-scene {
-        inset: 0 42% 0 0;
-      }
-
-      .lot-panel {
-        width: calc(42% - 30px);
-      }
-    }
-
-    @media (max-width: 980px) {
-      .hero-grid,
+    @media (max-width: 960px) {
+      .hero,
       .section-head {
         grid-template-columns: 1fr;
       }
 
-      .hero-icon {
-        width: min(56vw, 300px);
+      .hero-rule {
+        max-width: 540px;
       }
 
-      .audit-grid,
+      .decision-grid,
       .token-grid,
-      .component-grid,
-      .decision-grid {
-        grid-template-columns: 1fr 1fr;
+      .component-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
       }
 
       .swatch-grid,
+      .role-grid {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+
       .shape-grid {
         grid-template-columns: repeat(3, minmax(0, 1fr));
       }
 
-      .semantic-grid {
-        grid-template-columns: repeat(4, minmax(0, 1fr));
+      .primary-flow {
+        grid-template-columns: 1fr;
       }
     }
 
     @media (max-width: 720px) {
-      .site-head {
-        min-height: auto;
-      }
-
-      .audit-grid,
+      .decision-grid,
       .token-grid,
       .component-grid,
-      .decision-grid,
       .swatch-grid,
-      .shape-grid,
-      .semantic-grid {
+      .role-grid,
+      .shape-grid {
         grid-template-columns: 1fr;
-      }
-
-      .install-example-grid {
-        grid-template-columns: 1fr;
-        text-align: center;
-      }
-
-      .install-example .app-icon {
-        width: 150px;
-      }
-
-      .mock-link-action {
-        justify-self: center;
       }
 
       .screen-caption {
@@ -1396,7 +1152,7 @@
       }
 
       .game-screen {
-        min-height: 720px;
+        min-height: 760px;
         border-radius: var(--turn-radius-default);
       }
 
@@ -1404,60 +1160,46 @@
         grid-template-rows: auto 1fr;
       }
 
-      .home-example-head {
+      .home-head-sample {
         grid-template-columns: 1fr;
         text-align: center;
       }
 
-      .home-meta {
-        justify-items: center;
+      .pitch {
+        margin: auto;
       }
 
-      .home-example-main {
+      .build {
+        text-align: center;
+      }
+
+      .home-body-sample,
+      .lot-example {
         grid-template-columns: 1fr;
       }
 
-      .home-menu,
-      .home-tracks,
-      .guide-grid-sample {
+      .track-list,
+      .guide-grid {
         grid-template-columns: 1fr;
       }
 
-      .guide-card-sample.wide {
+      .guide-card.wide {
         grid-column: auto;
       }
 
-      .lot-scene {
-        inset: 0 0 45% 0;
+      .lot-view-area .placeholder {
+        min-height: 230px;
       }
 
-      .lot-panel {
-        top: auto;
-        left: 18px;
-        right: 18px;
-        bottom: 18px;
-        width: auto;
-        height: 43%;
-        grid-template-columns: 1fr 1fr;
-        grid-template-rows: 1fr;
+      .manual-control {
+        left: 22px;
+        width: calc(45% - 28px);
+        min-width: 0;
       }
 
-      .race-hud {
-        flex-direction: column;
-      }
-
-      .mini-map {
-        display: none;
-      }
-
-      .manual-control-sample {
-        width: 42%;
-        height: 126px;
-      }
-
-      .drive-pad-sample {
-        width: 42%;
-        height: 230px;
+      .race-example .drive-pad {
+        right: 22px;
+        width: calc(55% - 28px);
       }
     }
 
@@ -1480,107 +1222,66 @@
   <a class="skip-link" href="#main">Skip to the design system</a>
 
   <header class="site-head">
-    <div class="hero-grid">
+    <div class="hero">
       <div>
-        <span class="eyebrow">Proposed normative system</span>
+        <span class="eyebrow">Normative production system</span>
         <h1>TURN DESIGN SYSTEM</h1>
-        <p class="lede">A design-system review and living specimen built from the production game. It preserves TURN’s loud, tactile, friendly character while replacing accidental variation with named colour roles, a small geometry scale and repeatable components.</p>
-        <span class="status-chip">Reference page only. Production UI is unchanged.</span>
+        <p class="lede">TURN keeps its loud, tactile and friendly character. The system underneath now names the colours, shapes and interaction roles that make that character consistent.</p>
       </div>
-      <img class="hero-icon" src="./TURNicon.PNG" alt="TURN app icon">
+      <aside class="hero-rule">
+        <span class="token-label">Core interaction rule</span>
+        <strong>Forward is pink. Navigation is orange.</strong>
+        <p>Utility actions stay quiet. Driving controls use literal, stable colours. Shape communicates interaction type, not decoration.</p>
+      </aside>
     </div>
   </header>
 
   <nav class="section-nav" aria-label="Design system sections">
-    <a href="#audit">Audit</a>
+    <a href="#decisions">Decisions</a>
     <a href="#colour">Colour</a>
     <a href="#shape">Shape</a>
     <a href="#components">Components</a>
     <a href="#screens">Game pages</a>
-    <a href="#migration">Migration</a>
+    <a href="#adoption">Adoption</a>
   </nav>
 
   <main id="main">
-    <section class="section" id="audit">
+    <section class="section" id="decisions">
       <div class="section-head">
         <div>
-          <span class="section-kicker">01 · Current-state review</span>
-          <h2>TURN already has a system. It is simply distributed.</h2>
+          <span class="section-kicker">01 · Normative decisions</span>
+          <h2>One clear path through every screen.</h2>
         </div>
-        <p>The review covers the production styles that define Install, Home, track selection, The Lot, race controls, HUD, dialogs and feedback states. The strongest identity markers are consistent. Most drift sits in intermediate radii, shade naming and shadow increments.</p>
+        <p>The visual hierarchy follows the order of interaction. Content selection comes first, quiet utilities remain adjacent, and the primary action completes the current step.</p>
       </div>
 
-      <div class="audit-grid">
-        <article class="audit-card keep">
-          <span class="token-label">Keep</span>
-          <h3>Chunky ink construction</h3>
-          <p>Near-black outlines, cream surfaces, offset hard shadows, heavy typography and saturated fields are the visual grammar of TURN. They make the interface feel physical and toy-like without looking childish.</p>
+      <div class="decision-grid">
+        <article class="card primary-rule">
+          <span class="token-label">Primary action</span>
+          <h3>Pink 500 + pill</h3>
+          <p><strong>INSTALL TURN</strong>, <strong>RACE THIS TRACK</strong> and <strong>RACE THIS CAR</strong> share the same colour and shape. Placement and wording provide the remaining context.</p>
         </article>
-        <article class="audit-card consolidate">
-          <span class="token-label">Consolidate</span>
-          <h3>Colour families and geometry</h3>
-          <p>The same intent is often represented by neighbouring hex values, radii and shadow distances. These should become controlled scales with names, not a single flattened palette.</p>
+        <article class="card utility-rule">
+          <span class="token-label">Utility action</span>
+          <h3>Paper + pill</h3>
+          <p>SETTINGS, HOW TO PLAY and GIVE FEEDBACK are visually equal and intentionally quieter than the selected-track action.</p>
         </article>
-        <article class="audit-card retire">
-          <span class="token-label">Retire</span>
-          <h3>Unexplained one-off values</h3>
-          <p>Values such as 13px, 15px, 17px and 21px radii create no distinct visual category. Raw colour values used only once also make future semantic changes unnecessarily expensive.</p>
+        <article class="card navigation-rule">
+          <span class="token-label">Navigation action</span>
+          <h3>Orange 500</h3>
+          <p>All Close, Back and Leave actions use orange. Circular X controls remain circles; textual navigation keeps its component-appropriate shape.</p>
         </article>
       </div>
 
-      <div class="inventory-table-wrap" tabindex="0" role="region" aria-label="Current design variation inventory">
+      <div class="inventory" tabindex="0" role="region" aria-label="Normative TURN interaction inventory">
         <table>
-          <thead>
-            <tr>
-              <th>Area</th>
-              <th>Observed production variation</th>
-              <th>Normative proposal</th>
-              <th>Reasoning</th>
-            </tr>
-          </thead>
+          <thead><tr><th>Role</th><th>Normative treatment</th><th>Examples</th><th>Notes</th></tr></thead>
           <tbody>
-            <tr>
-              <td>Border radius</td>
-              <td>2, 3, 7, 8, 10, 12, 13, 14, 15, 16, 17, 18, 20, 21, 22, 24, 26, 28 and 30px, plus 22–24%, 50% and 999px.</td>
-              <td><code>8</code>, <code>12</code>, <code>18</code>, <code>28</code>, <code>50%</code>, <code>999px</code></td>
-              <td>Four component radii plus explicit circle and pill semantics cover the current language without sanding off its personality.</td>
-            </tr>
-            <tr>
-              <td>Border weight</td>
-              <td>1.5, 2, 3, 4, 5 and 6px.</td>
-              <td><code>2</code>, <code>3</code>, <code>4</code>, <code>6px</code></td>
-              <td>Micro graphics, compact controls, standard components and hero/dialog construction each receive one weight.</td>
-            </tr>
-            <tr>
-              <td>Hard shadows</td>
-              <td>1.5, 2, 3, 4, 5, 6, 7, 8, 10 and 12px offsets.</td>
-              <td><code>3</code>, <code>7</code>, <code>12px</code></td>
-              <td>Compact, standard and hero elevation become predictable. Pressed states move by the same distance the shadow collapses.</td>
-            </tr>
-            <tr>
-              <td>Pink and red</td>
-              <td>#ff4fa3, #ff7ab7, #ff8caf, #ff8fab, #ff5a5f, #ff6b6b, #ff3f4a, #ff9a8e, #ff9b91 and #ffb2aa.</td>
-              <td>Pink 500/200 and Red 500/200</td>
-              <td>Pink remains TURN’s primary action colour. Red becomes exclusively danger, invalid and depletion. Pale shades are decorative or subdued states.</td>
-            </tr>
-            <tr>
-              <td>Blue</td>
-              <td>#38d9ff, #68c8f2, #8ed8ff, #8be3ff, #55c9ed, #35b8e7 and #74c0fc.</td>
-              <td>Blue 600/500/300/200</td>
-              <td>Large atmospheric fields may use lighter steps. Interactive information uses Blue 500. Unnamed bridge shades are removed.</td>
-            </tr>
-            <tr>
-              <td>Yellow and green</td>
-              <td>#ffbd12, #ffd43b, #ffe087, #8ce99a, #9ae6b4, #d9f5c2 and #eaf9ef.</td>
-              <td>Yellow 600/400/200 and Green 500/200</td>
-              <td>The existing tonal range is useful. The change is governance: each step gets a defined purpose rather than an isolated hex code.</td>
-            </tr>
-            <tr>
-              <td>Circle semantics</td>
-              <td>50% appears on close buttons, navigation arrows, radio markers, step numbers, pedals and steering knobs.</td>
-              <td>50% only on equal-width/equal-height controls and indicators.</td>
-              <td>A circle should communicate icon action, direct manipulation or a point marker. Large textual actions use a pill or rounded rectangle.</td>
-            </tr>
+            <tr><td>Primary flow</td><td>Pink 500, pill radius, standard hard shadow</td><td>Install TURN, Race this track, Race this car</td><td>Only one dominant primary action per decision point.</td></tr>
+            <tr><td>Quiet utility</td><td>Paper surface, pill radius</td><td>Settings, How to Play, Give Feedback</td><td>Equal visual weight and grouped in the menu.</td></tr>
+            <tr><td>Navigation</td><td>Orange 500</td><td>Close, Back, Leave race, Back to Lot</td><td>Orange means context change, not danger.</td></tr>
+            <tr><td>Danger</td><td>Red 500</td><td>Invalid lap, destructive confirmation, error state</td><td>Red is no longer used for ordinary navigation or Boost.</td></tr>
+            <tr><td>Driving controls</td><td>Gas green, Drift blue, Boost yellow, Brake/Reverse orange</td><td>Four-zone drive pad</td><td>Text, position and sound continue to carry meaning alongside colour.</td></tr>
           </tbody>
         </table>
       </div>
@@ -1592,53 +1293,29 @@
           <span class="section-kicker">02 · Colour</span>
           <h2>Keep the candy shop. Label every jar.</h2>
         </div>
-        <p>The normative palette preserves the production hues with the strongest visual equity. Shade steps are intentional rather than interchangeable. Track accents remain local tokens because track identity is content, not global UI semantics.</p>
+        <p>Primitive colour families preserve TURN’s current look. Semantic tokens decide where each family is used. Track accents and scene art remain local content colours.</p>
       </div>
 
-      <div class="swatch-grid" aria-label="Normative TURN colour palette">
-        <div class="swatch"><div class="swatch-colour" style="--swatch:#08090a"></div><div class="swatch-copy"><strong>Ink</strong><span>#08090A</span><span>Text, borders, hard shadows</span></div></div>
-        <div class="swatch"><div class="swatch-colour" style="--swatch:#fff8e8"></div><div class="swatch-copy"><strong>Paper</strong><span>#FFF8E8</span><span>Primary warm surface</span></div></div>
-        <div class="swatch"><div class="swatch-colour" style="--swatch:#fffdf6"></div><div class="swatch-copy"><strong>Raised white</strong><span>#FFFDF6</span><span>Cards inside paper surfaces</span></div></div>
-        <div class="swatch"><div class="swatch-colour" style="--swatch:#ffbd12"></div><div class="swatch-copy"><strong>Yellow 600</strong><span>#FFBD12</span><span>Brand field</span></div></div>
-        <div class="swatch"><div class="swatch-colour" style="--swatch:#ffd43b"></div><div class="swatch-copy"><strong>Yellow 400</strong><span>#FFD43B</span><span>Warning, highlight, labels</span></div></div>
-        <div class="swatch"><div class="swatch-colour" style="--swatch:#ffe087"></div><div class="swatch-copy"><strong>Yellow 200</strong><span>#FFE087</span><span>Decorative field</span></div></div>
-        <div class="swatch"><div class="swatch-colour" style="--swatch:#38d9ff"></div><div class="swatch-copy"><strong>Blue 500</strong><span>#38D9FF</span><span>Information and secondary action</span></div></div>
-        <div class="swatch"><div class="swatch-colour" style="--swatch:#68c8f2"></div><div class="swatch-copy"><strong>Blue 300</strong><span>#68C8F2</span><span>Home and broad surfaces</span></div></div>
-        <div class="swatch"><div class="swatch-colour" style="--swatch:#8ed8ff"></div><div class="swatch-copy"><strong>Blue 200</strong><span>#8ED8FF</span><span>Scene atmosphere</span></div></div>
-        <div class="swatch"><div class="swatch-colour" style="--swatch:#ff4fa3"></div><div class="swatch-copy"><strong>Pink 500</strong><span>#FF4FA3</span><span>Primary action</span></div></div>
-        <div class="swatch"><div class="swatch-colour" style="--swatch:#ff8caf"></div><div class="swatch-copy"><strong>Pink 200</strong><span>#FF8CAF</span><span>Decoration and tint</span></div></div>
-        <div class="swatch"><div class="swatch-colour" style="--swatch:#ff6b6b"></div><div class="swatch-copy"><strong>Red 500</strong><span>#FF6B6B</span><span>Danger, invalid, empty</span></div></div>
-        <div class="swatch"><div class="swatch-colour" style="--swatch:#ff9b91"></div><div class="swatch-copy"><strong>Red 200</strong><span>#FF9B91</span><span>Subdued destructive action</span></div></div>
-        <div class="swatch"><div class="swatch-colour" style="--swatch:#8ce99a"></div><div class="swatch-copy"><strong>Green 500</strong><span>#8CE99A</span><span>Success, gas, proceed</span></div></div>
-        <div class="swatch"><div class="swatch-colour" style="--swatch:#d9f5c2"></div><div class="swatch-copy"><strong>Green 200</strong><span>#D9F5C2</span><span>Positive information surface</span></div></div>
-        <div class="swatch"><div class="swatch-colour" style="--swatch:#ff7b54"></div><div class="swatch-copy"><strong>Orange 500</strong><span>#FF7B54</span><span>Leave, back, context change</span></div></div>
+      <div class="swatch-grid" aria-label="TURN primitive palette">
+        <div class="swatch"><div class="swatch-colour" style="--swatch:var(--turn-ink)"></div><div class="swatch-copy"><strong>Ink</strong><span>#08090A</span><span>Text, borders, hard shadows</span></div></div>
+        <div class="swatch"><div class="swatch-colour" style="--swatch:var(--turn-paper)"></div><div class="swatch-copy"><strong>Paper</strong><span>#FFF8E8</span><span>Warm surface and utility action</span></div></div>
+        <div class="swatch"><div class="swatch-colour" style="--swatch:var(--turn-pink-500)"></div><div class="swatch-copy"><strong>Pink 500</strong><span>#FF4FA3</span><span>Primary action</span></div></div>
+        <div class="swatch"><div class="swatch-colour" style="--swatch:var(--turn-orange-500)"></div><div class="swatch-copy"><strong>Orange 500</strong><span>#FF7B54</span><span>Close, Back, Leave, Brake</span></div></div>
+        <div class="swatch"><div class="swatch-colour" style="--swatch:var(--turn-blue-500)"></div><div class="swatch-copy"><strong>Blue 500</strong><span>#38D9FF</span><span>Information and Drift</span></div></div>
+        <div class="swatch"><div class="swatch-colour" style="--swatch:var(--turn-yellow-400)"></div><div class="swatch-copy"><strong>Yellow 400</strong><span>#FFD43B</span><span>Boost, warning, highlight</span></div></div>
+        <div class="swatch"><div class="swatch-colour" style="--swatch:var(--turn-green-500)"></div><div class="swatch-copy"><strong>Green 500</strong><span>#8CE99A</span><span>Gas, success, proceed</span></div></div>
+        <div class="swatch"><div class="swatch-colour" style="--swatch:var(--turn-red-500)"></div><div class="swatch-copy"><strong>Red 500</strong><span>#FF6B6B</span><span>Danger, invalid, destructive</span></div></div>
       </div>
 
-      <div class="semantic-grid" aria-label="Semantic colour assignments">
-        <div class="semantic-chip" style="--semantic:var(--turn-pink-500)"><strong>Primary</strong>Start, choose, submit, email</div>
-        <div class="semantic-chip" style="--semantic:var(--turn-blue-500)"><strong>Information</strong>Settings, audio, secondary tools</div>
-        <div class="semantic-chip" style="--semantic:var(--turn-green-500)"><strong>Success</strong>Gas, ready, proceed, confirmed</div>
-        <div class="semantic-chip" style="--semantic:var(--turn-yellow-400)"><strong>Warning</strong>Caution, recalibrate, attention</div>
-        <div class="semantic-chip" style="--semantic:var(--turn-red-500)"><strong>Danger</strong>Invalid lap, destructive confirm, empty boost</div>
-        <div class="semantic-chip" style="--semantic:var(--turn-orange-500)"><strong>Exit</strong>Leave race, back to Lot, context change</div>
-        <div class="semantic-chip" style="--semantic:var(--turn-paper)"><strong>Neutral</strong>Utility, quiet action, ordinary surface</div>
-      </div>
-
-      <div class="code-card" aria-label="Suggested colour tokens">
-        <pre><code>:root {
-  --turn-action-primary: var(--turn-pink-500);
-  --turn-action-information: var(--turn-blue-500);
-  --turn-action-success: var(--turn-green-500);
-  --turn-action-warning: var(--turn-yellow-400);
-  --turn-action-danger: var(--turn-red-500);
-  --turn-action-exit: var(--turn-orange-500);
-}
-
-/* Track identity stays local. */
-.track-card {
-  --turn-track-accent: var(--track-accent);
-  background: var(--turn-track-accent);
-}</code></pre>
+      <div class="role-grid" aria-label="TURN semantic colour roles">
+        <div class="role" style="--role:var(--turn-action-primary)"><strong>Primary</strong>Complete the current step</div>
+        <div class="role" style="--role:var(--turn-action-utility)"><strong>Utility</strong>Supporting tools and information</div>
+        <div class="role" style="--role:var(--turn-action-navigation)"><strong>Navigation</strong>Close, Back and Leave</div>
+        <div class="role" style="--role:var(--turn-action-danger)"><strong>Danger</strong>Invalid, destructive and error</div>
+        <div class="role" style="--role:var(--turn-control-gas)"><strong>Gas</strong>Acceleration control</div>
+        <div class="role" style="--role:var(--turn-control-drift)"><strong>Drift</strong>Cornering control</div>
+        <div class="role" style="--role:var(--turn-control-boost)"><strong>Boost</strong>Stored performance</div>
+        <div class="role" style="--role:var(--turn-control-brake)"><strong>Brake</strong>Brake and reverse control</div>
       </div>
     </section>
 
@@ -1648,34 +1325,22 @@
           <span class="section-kicker">03 · Shape and elevation</span>
           <h2>Six shapes, four borders, three elevations.</h2>
         </div>
-        <p>The system should feel handmade, not arbitrary. Slight rotations and scene-specific silhouettes can stay expressive. UI containers should come from a small, teachable geometry set.</p>
+        <p>50% remains a true circle, used only on equal-width and equal-height controls or indicators. Pills are elongated textual actions. Percentage radii remain valid for artwork such as the app icon.</p>
       </div>
 
-      <div class="shape-grid" aria-label="Normative corner radius scale">
-        <div class="shape-sample micro">8px<br>Micro</div>
-        <div class="shape-sample compact">12px<br>Compact</div>
-        <div class="shape-sample default">18px<br>Default</div>
-        <div class="shape-sample hero">28px<br>Hero</div>
-        <div class="shape-sample pill">999px<br>Pill</div>
-        <div class="shape-sample circle">50%<br>Circle</div>
+      <div class="shape-grid" aria-label="TURN radius scale">
+        <div class="shape micro">8px<br>Micro</div>
+        <div class="shape compact">12px<br>Compact</div>
+        <div class="shape default">18px<br>Default</div>
+        <div class="shape hero">28px<br>Hero</div>
+        <div class="shape pill">999px<br>Pill</div>
+        <div class="shape circle">50%<br>Circle</div>
       </div>
 
       <div class="token-grid" style="margin-top:22px">
-        <article class="token-card">
-          <span class="token-label">Border scale</span>
-          <h3>2 · 3 · 4 · 6px</h3>
-          <p><strong>2px</strong> for tiny internals, <strong>3px</strong> for compact controls and HUD chips, <strong>4px</strong> for ordinary components, <strong>6px</strong> for hero cards and dialogs.</p>
-        </article>
-        <article class="token-card">
-          <span class="token-label">Shadow scale</span>
-          <h3>3 · 7 · 12px</h3>
-          <p>Compact, standard and hero elevation. Decorative glow and inset feedback may be layered on top, but the hard base shadow remains one of these three.</p>
-        </article>
-        <article class="token-card">
-          <span class="token-label">Circle rule</span>
-          <h3>Equal sides only</h3>
-          <p>Use 50% for close, next/previous, radio markers, steering knobs and point indicators. Use pills for textual labels and elongated controls.</p>
-        </article>
+        <article class="card"><span class="token-label">Borders</span><h3>2 · 3 · 4 · 6px</h3><p>Micro internals, compact controls, standard components and hero/dialog construction.</p></article>
+        <article class="card"><span class="token-label">Hard shadows</span><h3>3 · 7 · 12px</h3><p>Compact, standard and hero elevation. Pressed states collapse the shadow by the same distance they move.</p></article>
+        <article class="card"><span class="token-label">Compatibility</span><h3>Aliases, not a rewrite</h3><p><code>--ink</code>, <code>--paper</code>, <code>--pink</code>, <code>--m8-pink</code> and related variables now resolve through shared primitives.</p></article>
       </div>
     </section>
 
@@ -1683,51 +1348,57 @@
       <div class="section-head">
         <div>
           <span class="section-kicker">04 · Components</span>
-          <h2>Semantic components, still unmistakably TURN.</h2>
+          <h2>Role first. Page second.</h2>
         </div>
-        <p>Colour tells the component’s job. Shape tells its interaction type. Border and shadow tell its level. Labels and icons remain the primary meaning, so colour never carries the whole message.</p>
+        <p>The same component role looks the same wherever it appears. Screen-specific layout may change size and placement, but it does not invent a new semantic colour.</p>
       </div>
 
       <div class="component-board">
         <div>
-          <span class="token-label">Actions</span>
-          <div class="component-row" style="margin-top:12px">
-            <span class="button-sample" style="--sample-colour:var(--turn-pink-500)">Primary action</span>
-            <span class="button-sample" style="--sample-colour:var(--turn-blue-500)">Information</span>
-            <span class="button-sample" style="--sample-colour:var(--turn-green-500)">Proceed</span>
-            <span class="button-sample" style="--sample-colour:var(--turn-yellow-400)">Warning</span>
-            <span class="button-sample" style="--sample-colour:var(--turn-red-500)">Danger</span>
-            <span class="button-sample" style="--sample-colour:var(--turn-orange-500)">Leave</span>
-            <span class="button-sample" style="--sample-colour:var(--turn-paper)">Neutral</span>
+          <span class="token-label">Primary flow</span>
+          <div class="primary-flow">
+            <button class="turn-button install-primary" type="button">Install TURN</button>
+            <button class="turn-button m8-track-continue" type="button">Race this track</button>
+            <button class="turn-button lot-race" type="button">Race this car</button>
           </div>
         </div>
 
         <div>
-          <span class="token-label">Shapes and states</span>
-          <div class="component-row" style="margin-top:12px">
-            <span class="button-sample pill" style="--sample-colour:var(--turn-pink-500)">Race this car</span>
-            <span class="icon-sample" aria-label="Circular close-button specimen">×</span>
-            <span class="chip-sample">Best 0:41.226</span>
-            <span class="chip-sample" style="--sample-colour:var(--turn-red-500)">Lap void</span>
-            <span class="button-sample focus-demo" style="--sample-colour:var(--turn-paper)">Focus visible</span>
+          <span class="token-label">Quiet utility menu</span>
+          <div class="component-row m8-home-fixed-layout">
+            <button class="turn-button utility m8-home-settings" type="button">Settings</button>
+            <button class="turn-button utility m8-how-button" type="button">How to Play</button>
+            <button class="turn-button utility m8-feedback-button" type="button">Give Feedback</button>
           </div>
         </div>
 
         <div>
-          <span class="token-label">Normative construction</span>
+          <span class="token-label">Navigation and danger</span>
+          <div class="component-row">
+            <button class="icon-button install-close" type="button" aria-label="Close specimen">×</button>
+            <button class="turn-button navigation-text back-to-lot-button" type="button">Back to Lot</button>
+            <button class="turn-button navigation-text" type="button" data-turn-navigation-action>Leave race</button>
+            <button class="turn-button danger" type="button">Delete rivals</button>
+          </div>
+        </div>
+
+        <div>
+          <span class="token-label">Driving controls</span>
           <div class="component-grid" style="margin-top:12px">
-            <article class="decision-card">
-              <h3>Standard button</h3>
-              <p>4px border, 18px radius, 7px shadow. Minimum 44px target, preferably 52px in gameplay-adjacent UI.</p>
-            </article>
-            <article class="decision-card">
-              <h3>Compact utility</h3>
-              <p>3px border, 12px radius, 3px shadow. Use for HUD, metadata and secondary race utilities.</p>
-            </article>
-            <article class="decision-card">
-              <h3>Dialog or hero</h3>
-              <p>6px border, 28px radius, 12px shadow. Internal cards step down to the standard component recipe.</p>
-            </article>
+            <div class="drive-pad" aria-label="Four-zone driving-control specimen">
+              <div class="drive-pad-top">
+                <button class="drive-zone drive-drift-zone" type="button">Drift</button>
+                <button class="drive-zone drive-boost-zone" type="button">Boost</button>
+              </div>
+              <button class="drive-gas-zone" type="button">Gas</button>
+              <button class="drive-brake-zone" type="button">Brake · Reverse</button>
+            </div>
+            <div class="control-notes" style="grid-column:span 2">
+              <div class="control-note" style="--note:var(--turn-control-gas)"><i></i><div><strong>Gas is green</strong><span>Forward acceleration and positive momentum.</span></div></div>
+              <div class="control-note" style="--note:var(--turn-control-drift)"><i></i><div><strong>Drift is blue</strong><span>A handling tool, not a warning or danger state.</span></div></div>
+              <div class="control-note" style="--note:var(--turn-control-boost)"><i></i><div><strong>Boost is yellow</strong><span>Charge and stored energy. Fill level remains visible inside the zone.</span></div></div>
+              <div class="control-note" style="--note:var(--turn-control-brake)"><i></i><div><strong>Brake and Reverse are orange</strong><span>Slowing, changing direction and leaving forward momentum.</span></div></div>
+            </div>
           </div>
         </div>
       </div>
@@ -1736,141 +1407,126 @@
     <section class="section" id="screens">
       <div class="section-head">
         <div>
-          <span class="section-kicker">05 · Example implementation</span>
-          <h2>The current pages, rebuilt with the normative system.</h2>
+          <span class="section-kicker">05 · Page implementation</span>
+          <h2>Real components, no pretend game art.</h2>
         </div>
-        <p>These are static reference compositions, not alternate game routes. They demonstrate how the same tokens can cover every major TURN surface without making the pages feel mechanically identical.</p>
+        <p>The examples show hierarchy, spacing and component behaviour. Car, track and world rendering are represented by labelled content areas rather than approximate illustrations.</p>
       </div>
 
       <div class="screen-stack">
         <article class="screen-specimen">
-          <div class="screen-caption">
-            <div><h3>Install</h3><p>Hero geometry, primary pink action and quiet underlined escape hatch. The app icon remains artwork and therefore keeps its percentage crop radius.</p></div>
-            <code>/turn/ · install gate</code>
-          </div>
-          <div class="game-screen install-example" role="img" aria-label="TURN install page design specimen">
-            <div class="install-example-grid">
-              <img class="app-icon" src="./TURNicon.PNG" alt="">
-              <div class="mock-card">
-                <span class="mock-kicker">TURN V1.3.0 · BUILD 2026.08.01-R122</span>
-                <h4>TURN</h4>
-                <p>TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.</p>
-                <div class="mock-actions">
-                  <span class="button-sample" style="--sample-colour:var(--turn-pink-500)">Install TURN</span>
-                  <span class="mock-link-action">Play in browser anyway</span>
-                </div>
+          <div class="screen-caption"><div><h3>Install</h3><p>The first commitment in TURN uses the same primary treatment as later Race actions. The browser fallback remains a quiet text action.</p></div><code>Install gate</code></div>
+          <div class="game-screen install-example" aria-label="TURN install-page component specimen">
+            <div class="install-card-sample">
+              <span class="mock-label">TURN V1.3.0 · BUILD R139</span>
+              <h4>TURN</h4>
+              <p>TURN is a motion-controlled arcade drift racer. Turn your device to steer and race your own best laps.</p>
+              <div class="install-actions-sample">
+                <button class="turn-button install-primary" type="button">Install TURN</button>
+                <a class="quiet-link" href="#screens">Play in browser anyway</a>
               </div>
             </div>
           </div>
         </article>
 
         <article class="screen-specimen">
-          <div class="screen-caption">
-            <div><h3>Home and track selection</h3><p>Brand yellow and sky blue remain the large fields. Menu actions use semantic colours while track cards keep their own identity accents.</p></div>
-            <code>Home · choose track</code>
-          </div>
-          <div class="game-screen home-example" role="img" aria-label="TURN Home and track-selection design specimen">
-            <div class="home-example-head">
-              <div class="home-wordmark">TURN</div>
-              <div class="home-pitch">Tilt. Drift. Boost. Race your own best laps.</div>
-              <div class="home-meta"><span>TURN V1.3.0 · BUILD R122</span><u>ABOUT TURN</u></div>
+          <div class="screen-caption"><div><h3>Home and track selection</h3><p>Track choice occupies the primary reading area. Utilities share one quiet treatment. The selected-track action sits at the bottom of the menu as the next step.</p></div><code>Choose track</code></div>
+          <div class="game-screen home-example" aria-label="TURN Home and track-selection component specimen">
+            <div class="home-head-sample">
+              <div class="wordmark">TURN</div>
+              <div class="pitch">Tilt. Drift. Boost. Race your own best laps.</div>
+              <div class="build">TURN V1.3.0<br>BUILD R139</div>
             </div>
-            <div class="home-example-main">
-              <div class="home-menu">
-                <span class="button-sample" style="--sample-colour:var(--turn-blue-500)">Settings</span>
-                <span class="button-sample" style="--sample-colour:var(--turn-yellow-400)">How to play</span>
-                <span class="button-sample" style="--sample-colour:var(--turn-pink-500)">Give feedback</span>
-                <span class="button-sample" style="--sample-colour:var(--turn-green-500)">Race</span>
-              </div>
-              <div class="home-tracks">
+            <div class="home-body-sample">
+              <section class="track-area">
                 <h4>CHOOSE TRACK</h4>
-                <div class="track-card-sample selected" style="--track-colour:#8ce99a">
-                  <div class="track-preview-sample"></div>
-                  <div class="track-summary-sample"><strong>COUNTRYSIDE</strong><span>BEST<br>0:41.226</span></div>
-                  <span class="chip-sample" style="justify-self:start">EASY</span>
+                <div class="track-list">
+                  <article class="track-card-text selected" style="--track:var(--turn-green-500)">
+                    <div class="placeholder">Track preview</div>
+                    <div class="track-meta"><strong>COUNTRYSIDE</strong><span>BEST<br>0:41.226</span></div>
+                  </article>
+                  <article class="track-card-text" style="--track:var(--turn-blue-300)">
+                    <div class="placeholder">Track preview</div>
+                    <div class="track-meta"><strong>AIRPORT</strong><span>BEST<br>0:52.110</span></div>
+                  </article>
                 </div>
-                <div class="track-card-sample" style="--track-colour:#68c8f2">
-                  <div class="track-preview-sample" style="background:#a7b0b8"></div>
-                  <div class="track-summary-sample"><strong>AIRPORT</strong><span>BEST<br>0:52.110</span></div>
-                  <span class="chip-sample" style="justify-self:start">MEDIUM</span>
-                </div>
-              </div>
+              </section>
+              <aside class="menu-area m8-home-fixed-layout">
+                <h4>MENU</h4>
+                <button class="turn-button utility m8-home-settings" type="button">Settings</button>
+                <button class="turn-button utility m8-how-button" type="button">How to Play</button>
+                <button class="turn-button utility m8-feedback-button" type="button">Give Feedback</button>
+                <button class="turn-button m8-track-continue" type="button">Race this track</button>
+              </aside>
             </div>
           </div>
         </article>
 
         <article class="screen-specimen">
-          <div class="screen-caption">
-            <div><h3>The Lot</h3><p>The scene stays playful and spatial. The side rail uses one standard card radius and shadow recipe, with micro geometry reserved for paint and stat internals.</p></div>
-            <code>The Lot · choose car</code>
-          </div>
-          <div class="game-screen lot-example" role="img" aria-label="TURN The Lot design specimen">
-            <div class="lot-scene"><div class="car-shape"></div></div>
-            <div class="lot-panel">
-              <div class="lot-viewer">
-                <div class="car-shape"></div>
-                <div class="paint-rail">
-                  <span class="paint-field">BODY <i style="--paint:#ff4fa3"></i></span>
-                  <span class="paint-field">DETAIL <i style="--paint:#ffd43b"></i></span>
+          <div class="screen-caption"><div><h3>The Lot</h3><p>The reference documents the 3D viewport, paint controls, stats and primary action without trying to draw a substitute car.</p></div><code>Choose car</code></div>
+          <div class="game-screen lot-example" aria-label="TURN The Lot component specimen">
+            <section class="lot-view-area">
+              <div class="lot-title">THE LOT</div>
+              <div class="placeholder">3D car view</div>
+            </section>
+            <aside class="lot-panel-sample">
+              <div class="viewer-card">
+                <div class="placeholder">Rotatable car view</div>
+                <div class="paint-row">
+                  <span class="paint-control">BODY <i style="--paint:var(--turn-pink-500)"></i></span>
+                  <span class="paint-control">DETAIL <i style="--paint:var(--turn-yellow-400)"></i></span>
                 </div>
               </div>
-              <div class="lot-info-card">
+              <div class="car-info-card">
                 <h4><span>CAR</span><strong>SPORTS SEDAN</strong></h4>
-                <div class="stat-list">
-                  <div class="stat-row"><span>TOP SPEED</span><span class="stat-bar"><i class="on"></i><i class="on"></i><i class="on"></i><i class="on"></i><i></i></span></div>
-                  <div class="stat-row"><span>ACCELERATION</span><span class="stat-bar"><i class="on"></i><i class="on"></i><i class="on"></i><i></i><i></i></span></div>
-                  <div class="stat-row"><span>CONTROL</span><span class="stat-bar"><i class="on"></i><i class="on"></i><i class="on"></i><i class="on"></i><i></i></span></div>
-                  <div class="stat-row"><span>DRIFT</span><span class="stat-bar"><i class="on"></i><i class="on"></i><i class="on"></i><i></i><i></i></span></div>
+                <div class="stats">
+                  <div class="stat"><span>TOP SPEED</span><span class="stat-bar"><i class="on"></i><i class="on"></i><i class="on"></i><i class="on"></i><i></i></span></div>
+                  <div class="stat"><span>ACCELERATION</span><span class="stat-bar"><i class="on"></i><i class="on"></i><i class="on"></i><i></i><i></i></span></div>
+                  <div class="stat"><span>CONTROL</span><span class="stat-bar"><i class="on"></i><i class="on"></i><i class="on"></i><i class="on"></i><i></i></span></div>
+                  <div class="stat"><span>DRIFT</span><span class="stat-bar"><i class="on"></i><i class="on"></i><i class="on"></i><i></i><i></i></span></div>
                 </div>
-                <span class="button-sample pill" style="width:100%;--sample-colour:var(--turn-pink-500)">Race this car</span>
+                <button class="turn-button lot-race" type="button">Race this car</button>
               </div>
+            </aside>
+          </div>
+        </article>
+
+        <article class="screen-specimen">
+          <div class="screen-caption"><div><h3>Race</h3><p>The world is a labelled view area. HUD, manual steering and the four-zone driving control are the actual design-system subjects.</p></div><code>Race HUD and controls</code></div>
+          <div class="game-screen race-example" aria-label="TURN race component specimen">
+            <div class="game-view">Game view</div>
+            <div class="hud-row">
+              <span class="hud-chip">Speed<strong>86 km/h</strong></span>
+              <span class="hud-chip">Lap<strong>2</strong></span>
+              <span class="hud-chip">Position<strong>3/5</strong></span>
+              <span class="hud-chip">Time<strong>0:34.822</strong></span>
+            </div>
+            <div class="manual-control" aria-label="Manual steering component"><i>↔</i></div>
+            <div class="drive-pad" aria-label="Race driving-control specimen">
+              <div class="drive-pad-top">
+                <button class="drive-zone drive-drift-zone" type="button">Drift</button>
+                <button class="drive-zone drive-boost-zone" type="button">Boost</button>
+              </div>
+              <button class="drive-gas-zone" type="button">Gas</button>
+              <button class="drive-brake-zone" type="button">Brake · Reverse</button>
             </div>
           </div>
         </article>
 
         <article class="screen-specimen">
-          <div class="screen-caption">
-            <div><h3>Race</h3><p>Compact geometry protects the view. Gameplay controls keep their large 28px housings, but internal zones use borders rather than independent radii.</p></div>
-            <code>Race · HUD and controls</code>
-          </div>
-          <div class="game-screen race-example" role="img" aria-label="TURN race HUD and control design specimen">
-            <div class="race-road"></div>
-            <div class="race-hud">
-              <div class="race-stats">
-                <span class="hud-chip">Speed<strong>86 km/h</strong></span>
-                <span class="hud-chip">Lap<strong>2</strong></span>
-                <span class="hud-chip">Position<strong>3/5</strong></span>
-                <span class="hud-chip">Time<strong>0:34.822</strong></span>
+          <div class="screen-caption"><div><h3>Dialog and guide</h3><p>Hero container outside, standard cards inside. Close is a circular orange navigation control.</p></div><code>How to Play</code></div>
+          <div class="game-screen dialog-example" aria-label="TURN dialog component specimen">
+            <div class="dialog-card">
+              <div class="m8-dialog-head">
+                <div><span class="mock-label">QUICK GUIDE</span><h4>HOW TO PLAY</h4></div>
+                <button class="icon-button" type="button" aria-label="Close How to Play">×</button>
               </div>
-              <div class="mini-map"></div>
-            </div>
-            <div class="manual-control-sample"><i></i></div>
-            <div class="race-utilities"><span class="chip-sample">Recalibrate</span><span class="chip-sample">Restart lap</span></div>
-            <div class="drive-pad-sample">
-              <div class="drive-top-sample"><span>Drift</span><span>Boost</span></div>
-              <div class="drive-gas-sample">Gas</div>
-              <div class="drive-brake-sample">Brake · Reverse</div>
-            </div>
-          </div>
-        </article>
-
-        <article class="screen-specimen">
-          <div class="screen-caption">
-            <div><h3>Dialog and guide</h3><p>Hero container outside, standard cards inside, circular icon action for Close. The warm cream base keeps dense guidance readable while colour marks content type.</p></div>
-            <code>How to play · modal</code>
-          </div>
-          <div class="game-screen dialog-example" role="img" aria-label="TURN How to Play dialog design specimen">
-            <div class="dialog-sample">
-              <div class="dialog-head-sample">
-                <div><span class="mock-kicker">QUICK GUIDE</span><h4>HOW TO PLAY</h4></div>
-                <span class="icon-sample">×</span>
-              </div>
-              <div class="guide-grid-sample">
-                <div class="guide-card-sample"><strong>1</strong><div><h5>Choose a track and car</h5><p>Your saved best lap appears on each track card.</p></div></div>
-                <div class="guide-card-sample"><strong>2</strong><div><h5>Turn the device to steer</h5><p>Hold the phone or tablet in landscape and rotate it like a steering wheel.</p></div></div>
-                <div class="guide-card-sample"><strong>3</strong><div><h5>Drive with one thumb</h5><p>Slide between Gas, Drift, Boost and Brake or Reverse.</p></div></div>
-                <div class="guide-card-sample"><strong>4</strong><div><h5>Use Drift and Boost wisely</h5><p>Fast laps come from balancing grip and speed.</p></div></div>
-                <div class="guide-card-sample wide"><strong>♪</strong><div><h5>Drive By Ear™</h5><p>Spatial sound supplies the racing line, upcoming corners, grip, recovery and nearby rivals.</p></div></div>
+              <div class="guide-grid">
+                <div class="guide-card"><strong>1</strong><div><h5>Choose a track and car</h5><p>Your saved best lap appears on each track card.</p></div></div>
+                <div class="guide-card"><strong>2</strong><div><h5>Turn the device to steer</h5><p>Hold the phone or tablet in landscape and rotate it like a steering wheel.</p></div></div>
+                <div class="guide-card"><strong>3</strong><div><h5>Drive with one thumb</h5><p>Slide between Gas, Drift, Boost and Brake or Reverse.</p></div></div>
+                <div class="guide-card"><strong>4</strong><div><h5>Use Drift and Boost wisely</h5><p>Fast laps come from balancing grip and speed.</p></div></div>
+                <div class="guide-card wide"><strong>♪</strong><div><h5>Drive By Ear™</h5><p>Spatial sound supplies the racing line, upcoming corners, grip, recovery and nearby rivals.</p></div></div>
               </div>
             </div>
           </div>
@@ -1878,28 +1534,26 @@
       </div>
     </section>
 
-    <section class="section" id="migration">
+    <section class="section" id="adoption">
       <div class="section-head">
         <div>
-          <span class="section-kicker">06 · Adoption</span>
-          <h2>Move toward the system without redesigning TURN.</h2>
+          <span class="section-kicker">06 · Production adoption</span>
+          <h2>The first two migration steps are now live.</h2>
         </div>
-        <p>The page proposes a vocabulary, not a big-bang rewrite. Adoption should happen component by component, with visual regression checks and real-device review at every step.</p>
+        <p>The system is introduced without replacing existing selectors. The compatibility layer lets TURN consolidate gradually rather than through a risky visual rewrite.</p>
       </div>
 
-      <ol class="migration-list">
-        <li><div><strong>Introduce one shared token file.</strong> Add primitives, semantic colour roles, geometry, spacing and elevation without changing existing selectors.</div></li>
-        <li><div><strong>Alias existing variables.</strong> Map <code>--ink</code>, <code>--paper</code>, <code>--pink</code>, <code>--m8-pink</code> and related variables to the new primitives so current screens remain visually stable.</div></li>
-        <li><div><strong>Normalize one component family at a time.</strong> Start with icon buttons and dialogs, then standard buttons, cards, HUD chips and The Lot rail.</div></li>
-        <li><div><strong>Replace raw semantic colours.</strong> Invalid, danger, warning, information, exit and success states should use semantic variables. Scene art and track accents may keep local raw colours.</div></li>
-        <li><div><strong>Remove orphan values only after parity review.</strong> A one-off value may encode a genuine layout constraint. Consolidate after screenshot and physical-device comparison, not through blind search-and-replace.</div></li>
-        <li><div><strong>Make this specimen executable documentation.</strong> Add component examples and state rules here whenever a new visual pattern enters TURN.</div></li>
+      <ol class="adoption-list">
+        <li><div><strong>Shared token file introduced.</strong><code>design-tokens.css</code> defines primitive colours, semantic roles, driving-control roles, geometry, spacing and elevation.</div></li>
+        <li><div><strong>Existing variables aliased.</strong><code>--ink</code>, <code>--paper</code>, <code>--cyan</code>, <code>--pink</code>, <code>--yellow</code>, <code>--lime</code> and the M8 variables resolve through the new primitives.</div></li>
+        <li><div><strong>Semantic production layer applied.</strong><code>design-semantic.css</code> assigns primary, utility, navigation and gameplay-control roles without changing component markup.</div></li>
+        <li><div><strong>Next migration step.</strong>Normalize individual component radii, border weights and shadow offsets one family at a time, with visual and real-device regression checks.</div></li>
       </ol>
     </section>
   </main>
 
-  <footer class="page-footer">
-    <p><strong>Normative proposal:</strong> preserve TURN’s black-ink construction, warm paper, saturated colour fields and tactile shadows. Standardize the hidden grammar underneath, not the personality players already recognize.</p>
+  <footer>
+    <p><strong>Normative principle:</strong> standardize the grammar underneath TURN, not the personality players already know. Saturated colour, black-ink construction, warm paper and tactile hard shadows remain the visual signature.</p>
   </footer>
 </body>
 </html>

--- a/turn/home-feedback-r135.css
+++ b/turn/home-feedback-r135.css
@@ -1,3 +1,5 @@
+@import url('./design-semantic.css?revision=r139-semantic-system');
+
 .m8-home-fixed-layout .m8-feedback-button {
   align-self: auto;
   display: block;

--- a/turn/install-gate.css
+++ b/turn/install-gate.css
@@ -1,3 +1,5 @@
+@import url('./design-semantic.css?revision=r139-semantic-system');
+
 .install-gate {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
## What changed

- add `turn/design-tokens.css` as the shared source for primitive colours, semantic roles, driving-control roles, geometry, spacing and hard-shadow elevation
- alias the existing `--ink`, `--paper`, `--cyan`, `--pink`, `--yellow`, `--lime` and M8 variables to the shared primitives
- add a small semantic production layer without changing existing component selectors

## Interaction semantics

### Primary flow
The following actions now share Pink 500 and the pill shape:

- INSTALL TURN
- RACE THIS TRACK
- RACE THIS CAR

### Quiet Home utilities
SETTINGS, HOW TO PLAY and GIVE FEEDBACK now share the quieter Paper treatment. The selected-track action remains separated at the bottom of the existing right-hand menu column.

### Navigation
Close, Back and Leave controls use Orange 500, including dialog close controls, track selection, The Lot, Spectate and the in-race Back to Lot action. Circular X controls remain circular.

### Driving controls

- Gas: Green
- Drift: Blue
- Boost: Yellow, including charge and active state
- Brake / Reverse: Orange

Red remains reserved for danger, invalid and destructive states.

## Design reference

`/turn/design.html` now reflects the production decisions and the first two migration steps. The page specimens use labelled TRACK PREVIEW, 3D CAR VIEW and GAME VIEW areas instead of approximate car, track or road illustrations. Real buttons, cards, HUD chips, dialogs, paint controls, stats and driving controls remain represented.

## Validation

The existing design-system regression now covers:

- primitive and semantic tokens
- compatibility aliases
- primary, utility, navigation and driving-control selectors
- early and late stylesheet integration
- all five component-based page specimens
- absence of the retired mock car, track and road illustrations
