### PR TITLE
Remove the gap below the TURN Home icon

### DIFF
--- a/turn/m8-home-fixed-layout.css
+++ b/turn/m8-home-fixed-layout.css
@@ -25,7 +25,7 @@
   align-self: stretch;
   justify-self: start;
   display: block;
-  box-sizing: border-box;
+  box-sizing: content-box;
   width: auto;
   height: 100%;
   max-width: 100%;


### PR DESCRIPTION
## Change

- change the Home icon box sizing from `border-box` to `content-box`
- keep the icon artwork square and full-height
- keep the 5px black divider outside the image content area
- remove the small yellow letterbox gap below the icon

## Validation

- run the complete TURN regression suite before merge