### PR TITLE
Rebalance Convertible, Training Car and Monster Truck sizes

### DIFF
--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -100,9 +100,9 @@ for (const car of catalog.CAR_CATALOG) {
 const convertible = catalog.getCarDefinition('convertible');
 const trainingCar = catalog.getCarDefinition('classic');
 const monsterTruck = catalog.getCarDefinition('monster-truck');
-assert.equal(convertible.visualScale * convertible.visualSizeMultiplier, 0.588);
-assert.equal(trainingCar.visualScale * trainingCar.visualSizeMultiplier, 0.6);
-assert.equal(monsterTruck.visualScale * monsterTruck.visualSizeMultiplier, 0.996);
+assertClose(convertible.visualScale * convertible.visualSizeMultiplier, 0.588, 'Convertible effective visual scale');
+assertClose(trainingCar.visualScale * trainingCar.visualSizeMultiplier, 0.6, 'Training Car effective visual scale');
+assertClose(monsterTruck.visualScale * monsterTruck.visualSizeMultiplier, 0.996, 'Monster Truck effective visual scale');
 
 const [index, releaseSource, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
@@ -143,6 +143,13 @@ assert.match(main, /playerCar\.rotation\.y = state\.heading \+ Math\.PI/);
 assert.match(main, /car\.rotation\.y = frame\.h \+ Math\.PI/);
 
 console.log(`TURN ${release.id} car orientation and shared visual sizing passed for all 15 models.`);
+
+function assertClose(actual, expected, label) {
+  assert.ok(
+    Math.abs(actual - expected) < 1e-12,
+    `${label} must equal ${expected}; received ${actual}`
+  );
+}
 
 function readGlbJson(buffer, carId) {
   assert.equal(buffer.toString('utf8', 0, 4), 'glTF', `${carId} must remain a binary glTF`);

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -22,17 +22,41 @@ const expectedQuarterTurns = new Map([
   ['van', 0]
 ]);
 
+const expectedVisualScales = new Map([
+  ['convertible', 0.588],
+  ['classic', 0.6],
+  ['vintage-racer', 0.96],
+  ['toy-racer', 0.94],
+  ['monster-truck', 0.996],
+  ['race-future', 0.96],
+  ['race', 0.94],
+  ['sedan-sports', 0.98],
+  ['sedan', 1],
+  ['suv', 1.05],
+  ['suv-luxury', 1.06],
+  ['hatchback-sports', 0.96],
+  ['truck-flat', 1.12],
+  ['truck', 1.12],
+  ['van', 1.08]
+]);
+
 // Vintage Racer's GLB wheel labels describe the axles opposite to the visible body nose.
 // Keep the visual orientation verified by gameplay instead of trusting those labels literally.
 const reversedWheelLabelAxes = new Set(['vintage-racer']);
 
 assert.equal(catalog.CAR_CATALOG.length, expectedQuarterTurns.size);
+assert.equal(catalog.CAR_CATALOG.length, expectedVisualScales.size);
 
 for (const car of catalog.CAR_CATALOG) {
   assert.equal(
     car.modelYawQuarterTurns,
     expectedQuarterTurns.get(car.id),
     `${car.name} must keep its verified GLB orientation correction`
+  );
+  assert.equal(
+    car.visualScale,
+    expectedVisualScales.get(car.id),
+    `${car.name} must keep its globally shared visual scale`
   );
 
   const glb = await fs.readFile(new URL(`../../turn/assets/cars/${car.id}.glb`, import.meta.url));
@@ -77,6 +101,11 @@ assert.match(
   /model\.rotation\.y = Math\.PI \+ car\.modelYawQuarterTurns \* Math\.PI \/ 2/,
   'The shared model factory must apply the catalog correction'
 );
+assert.match(
+  carModels,
+  /normalizeModelToGround\(model, targetLength \* car\.visualScale\)/,
+  'Every model surface must receive the same catalog visual scale through the shared factory'
+);
 assert.match(carModels, /side: THREE\.BackSide/, 'Car outlines must remain inverted back-face shells');
 assert.match(carModels, /depthTest: true/, 'Car outlines must still respect the body depth buffer');
 assert.match(carModels, /depthWrite: false/, 'Car outlines must not write depth and compete with body surfaces');
@@ -88,7 +117,7 @@ assert.match(lot, /VIEWER_INITIAL_YAW = Math\.PI - 0\.55/, 'The viewer must star
 assert.match(main, /playerCar\.rotation\.y = state\.heading \+ Math\.PI/);
 assert.match(main, /car\.rotation\.y = frame\.h \+ Math\.PI/);
 
-console.log(`TURN ${release.id} car orientation passed for all 15 models.`);
+console.log(`TURN ${release.id} car orientation and shared visual scale passed for all 15 models.`);
 
 function readGlbJson(buffer, carId) {
   assert.equal(buffer.toString('utf8', 0, 4), 'glTF', `${carId} must remain a binary glTF`);

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -23,11 +23,11 @@ const expectedQuarterTurns = new Map([
 ]);
 
 const expectedVisualScales = new Map([
-  ['convertible', 0.588],
-  ['classic', 0.6],
+  ['convertible', 0.98],
+  ['classic', 1],
   ['vintage-racer', 0.96],
   ['toy-racer', 0.94],
-  ['monster-truck', 0.996],
+  ['monster-truck', 0.83],
   ['race-future', 0.96],
   ['race', 0.94],
   ['sedan-sports', 0.98],
@@ -38,6 +38,12 @@ const expectedVisualScales = new Map([
   ['truck-flat', 1.12],
   ['truck', 1.12],
   ['van', 1.08]
+]);
+
+const expectedSizeMultipliers = new Map([
+  ['convertible', 0.6],
+  ['classic', 0.6],
+  ['monster-truck', 1.2]
 ]);
 
 // Vintage Racer's GLB wheel labels describe the axles opposite to the visible body nose.
@@ -56,7 +62,12 @@ for (const car of catalog.CAR_CATALOG) {
   assert.equal(
     car.visualScale,
     expectedVisualScales.get(car.id),
-    `${car.name} must keep its globally shared visual scale`
+    `${car.name} must keep its authored model-normalization scale`
+  );
+  assert.equal(
+    car.visualSizeMultiplier,
+    expectedSizeMultipliers.get(car.id) || 1,
+    `${car.name} must keep its globally shared size multiplier`
   );
 
   const glb = await fs.readFile(new URL(`../../turn/assets/cars/${car.id}.glb`, import.meta.url));
@@ -86,6 +97,13 @@ for (const car of catalog.CAR_CATALOG) {
   assert.ok(viewerFront.z > 0, `${car.name} must open on a front three-quarter view`);
 }
 
+const convertible = catalog.getCarDefinition('convertible');
+const trainingCar = catalog.getCarDefinition('classic');
+const monsterTruck = catalog.getCarDefinition('monster-truck');
+assert.equal(convertible.visualScale * convertible.visualSizeMultiplier, 0.588);
+assert.equal(trainingCar.visualScale * trainingCar.visualSizeMultiplier, 0.6);
+assert.equal(monsterTruck.visualScale * monsterTruck.visualSizeMultiplier, 0.996);
+
 const [index, releaseSource, carModels, lot, main] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/release.json', import.meta.url), 'utf8'),
@@ -103,9 +121,16 @@ assert.match(
 );
 assert.match(
   carModels,
-  /normalizeModelToGround\(model, targetLength \* car\.visualScale\)/,
-  'Every model surface must receive the same catalog visual scale through the shared factory'
+  /effectiveVisualScale = car\.visualScale \* car\.visualSizeMultiplier/,
+  'The shared model factory must combine authored normalization with global size balance'
 );
+assert.match(
+  carModels,
+  /normalizeModelToGround\(model, targetLength \* effectiveVisualScale\)/,
+  'Every model surface must receive the same effective size through the shared factory'
+);
+assert.match(carModels, /turnVisualSizeMultiplier = car\.visualSizeMultiplier/);
+assert.match(carModels, /turnEffectiveVisualScale = effectiveVisualScale/);
 assert.match(carModels, /side: THREE\.BackSide/, 'Car outlines must remain inverted back-face shells');
 assert.match(carModels, /depthTest: true/, 'Car outlines must still respect the body depth buffer');
 assert.match(carModels, /depthWrite: false/, 'Car outlines must not write depth and compete with body surfaces');
@@ -117,7 +142,7 @@ assert.match(lot, /VIEWER_INITIAL_YAW = Math\.PI - 0\.55/, 'The viewer must star
 assert.match(main, /playerCar\.rotation\.y = state\.heading \+ Math\.PI/);
 assert.match(main, /car\.rotation\.y = frame\.h \+ Math\.PI/);
 
-console.log(`TURN ${release.id} car orientation and shared visual scale passed for all 15 models.`);
+console.log(`TURN ${release.id} car orientation and shared visual sizing passed for all 15 models.`);
 
 function readGlbJson(buffer, carId) {
   assert.equal(buffer.toString('utf8', 0, 4), 'glTF', `${carId} must remain a binary glTF`);

--- a/turn/vehicle/car-models.js
+++ b/turn/vehicle/car-models.js
@@ -106,13 +106,16 @@ export async function createCarVisual({
   }
 
   if (outline) addOutlines(model);
-  normalizeModelToGround(model, targetLength * car.visualScale);
+  const effectiveVisualScale = car.visualScale * car.visualSizeMultiplier;
+  normalizeModelToGround(model, targetLength * effectiveVisualScale);
 
   root.userData.turnCarId = car.id;
   root.userData.turnCarColor = requestedColor;
   root.userData.turnCarSecondaryColor = requestedSecondaryColor;
   root.userData.turnGhost = ghost;
   root.userData.turnModelYawQuarterTurns = car.modelYawQuarterTurns;
+  root.userData.turnVisualSizeMultiplier = car.visualSizeMultiplier;
+  root.userData.turnEffectiveVisualScale = effectiveVisualScale;
   root.userData.turnPrimaryPaintMaterials = primaryPaintMaterials;
   root.userData.turnSecondaryPaintMaterials = secondaryPaintMaterials;
   root.userData.turnPaintMaterials = [...primaryPaintMaterials, ...secondaryPaintMaterials];

--- a/turn/vehicle/catalog.js
+++ b/turn/vehicle/catalog.js
@@ -58,6 +58,14 @@ export const CAR_PALETTE = Object.freeze([
   Object.freeze({ name: 'Ice', value: '#f8f9fa' })
 ]);
 
+// Global balance adjustments are kept separate from each GLB's authored normalization.
+// They follow the shared model factory into The Lot, race, rivals, Spectate and previews.
+const VISUAL_SIZE_MULTIPLIER_BY_ID = Object.freeze({
+  convertible: 0.6,
+  classic: 0.6,
+  'monster-truck': 1.2
+});
+
 // Every car has exactly 18 stat points. The Sedan's 3/3/3/3/3/3 is the neutral baseline;
 // every other vehicle trades strengths for weaknesses instead of becoming a straight upgrade.
 // Training Car deliberately spends its budget on control, drift and a long boost tank so new
@@ -65,14 +73,13 @@ export const CAR_PALETTE = Object.freeze([
 // LEGACY_VEHICLE_ID preserves the Sedan identity of pre-catalog rivals that never stored a car id.
 // The vendored packs use three different authored front axes. modelYawQuarterTurns
 // rotates each raw GLB so every car has the same local front before TURN positions it.
-// visualScale is global: it follows the model through The Lot, race, rivals, Spectate and previews.
 // enginePitch is an audio-only baseline multiplier: heavy vehicles sit lower, race cars higher.
 const RAW_CARS = [
-  ['convertible', 'Convertible', 'prototype', { speed: 4, acceleration: 4, control: 4, drift: 2, boostPower: 3, boostDuration: 1 }, 0.588, 1, 1.08],
-  ['classic', 'Training Car', 'prototype', { speed: 1, acceleration: 1, control: 5, drift: 5, boostPower: 1, boostDuration: 5 }, 0.60, 1, 0.88],
+  ['convertible', 'Convertible', 'prototype', { speed: 4, acceleration: 4, control: 4, drift: 2, boostPower: 3, boostDuration: 1 }, 0.98, 1, 1.08],
+  ['classic', 'Training Car', 'prototype', { speed: 1, acceleration: 1, control: 5, drift: 5, boostPower: 1, boostDuration: 5 }, 1.00, 1, 0.88],
   ['vintage-racer', 'Vintage Racer', 'toy', { speed: 5, acceleration: 4, control: 3, drift: 2, boostPower: 3, boostDuration: 1 }, 0.96, 0, 1.28],
   ['toy-racer', 'Toy Racer', 'toy', { speed: 4, acceleration: 5, control: 5, drift: 1, boostPower: 2, boostDuration: 1 }, 0.94, 2, 1.18],
-  ['monster-truck', 'Monster Truck', 'toy', { speed: 2, acceleration: 3, control: 2, drift: 5, boostPower: 2, boostDuration: 4 }, 0.996, 2, 0.62],
+  ['monster-truck', 'Monster Truck', 'toy', { speed: 2, acceleration: 3, control: 2, drift: 5, boostPower: 2, boostDuration: 4 }, 0.83, 2, 0.62],
   ['race-future', 'Future Racer', 'car', { speed: 5, acceleration: 5, control: 3, drift: 1, boostPower: 3, boostDuration: 1 }, 0.96, 0, 1.42],
   ['race', 'Race Car', 'car', { speed: 5, acceleration: 4, control: 4, drift: 1, boostPower: 3, boostDuration: 1 }, 0.94, 0, 1.55],
   ['sedan-sports', 'Sport Sedan', 'car', { speed: 4, acceleration: 4, control: 4, drift: 2, boostPower: 2, boostDuration: 2 }, 0.98, 0, 1.12],
@@ -109,6 +116,7 @@ export const CAR_CATALOG = Object.freeze(RAW_CARS.map(([
   asset: `./assets/cars/${id}.glb`,
   stats: Object.freeze({ ...stats }),
   visualScale,
+  visualSizeMultiplier: VISUAL_SIZE_MULTIPLIER_BY_ID[id] || 1,
   modelYawQuarterTurns,
   secondaryPaint: SECONDARY_PAINT_BY_ID[id] || null,
   tuning: Object.freeze({

--- a/turn/vehicle/catalog.js
+++ b/turn/vehicle/catalog.js
@@ -65,13 +65,14 @@ export const CAR_PALETTE = Object.freeze([
 // LEGACY_VEHICLE_ID preserves the Sedan identity of pre-catalog rivals that never stored a car id.
 // The vendored packs use three different authored front axes. modelYawQuarterTurns
 // rotates each raw GLB so every car has the same local front before TURN positions it.
+// visualScale is global: it follows the model through The Lot, race, rivals, Spectate and previews.
 // enginePitch is an audio-only baseline multiplier: heavy vehicles sit lower, race cars higher.
 const RAW_CARS = [
-  ['convertible', 'Convertible', 'prototype', { speed: 4, acceleration: 4, control: 4, drift: 2, boostPower: 3, boostDuration: 1 }, 0.98, 1, 1.08],
-  ['classic', 'Training Car', 'prototype', { speed: 1, acceleration: 1, control: 5, drift: 5, boostPower: 1, boostDuration: 5 }, 1.00, 1, 0.88],
+  ['convertible', 'Convertible', 'prototype', { speed: 4, acceleration: 4, control: 4, drift: 2, boostPower: 3, boostDuration: 1 }, 0.588, 1, 1.08],
+  ['classic', 'Training Car', 'prototype', { speed: 1, acceleration: 1, control: 5, drift: 5, boostPower: 1, boostDuration: 5 }, 0.60, 1, 0.88],
   ['vintage-racer', 'Vintage Racer', 'toy', { speed: 5, acceleration: 4, control: 3, drift: 2, boostPower: 3, boostDuration: 1 }, 0.96, 0, 1.28],
   ['toy-racer', 'Toy Racer', 'toy', { speed: 4, acceleration: 5, control: 5, drift: 1, boostPower: 2, boostDuration: 1 }, 0.94, 2, 1.18],
-  ['monster-truck', 'Monster Truck', 'toy', { speed: 2, acceleration: 3, control: 2, drift: 5, boostPower: 2, boostDuration: 4 }, 0.83, 2, 0.62],
+  ['monster-truck', 'Monster Truck', 'toy', { speed: 2, acceleration: 3, control: 2, drift: 5, boostPower: 2, boostDuration: 4 }, 0.996, 2, 0.62],
   ['race-future', 'Future Racer', 'car', { speed: 5, acceleration: 5, control: 3, drift: 1, boostPower: 3, boostDuration: 1 }, 0.96, 0, 1.42],
   ['race', 'Race Car', 'car', { speed: 5, acceleration: 4, control: 4, drift: 1, boostPower: 3, boostDuration: 1 }, 0.94, 0, 1.55],
   ['sedan-sports', 'Sport Sedan', 'car', { speed: 4, acceleration: 4, control: 4, drift: 2, boostPower: 2, boostDuration: 2 }, 0.98, 0, 1.12],


### PR DESCRIPTION
## Visual size balance

- decrease Convertible by 40% with a global `0.6` multiplier
- decrease Training Car by 40% with a global `0.6` multiplier
- increase Monster Truck by 20% with a global `1.2` multiplier

## Scope

The multiplier is applied inside the shared `createCarVisual()` factory, after each GLB's existing normalization. It therefore affects:

- The Lot and expanded car viewer
- player car during races
- personal rivals and ghost cars
- Spectate
- track intro and record-car previews
- any track scenery that uses the shared car factory

Physics, collision, tuning, stats and original asset-normalization values are unchanged.

## Regression coverage

- verify all 15 authored normalization values remain stable
- verify the three requested global multipliers
- verify effective scales of `0.588`, `0.600` and `0.996`
- verify the shared factory applies the multiplier to every car surface