### PR TITLE
Keep Monster Truck large only in The Lot and races

### DIFF
--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -40,9 +40,12 @@ const expectedVisualScales = new Map([
   ['van', 1.08]
 ]);
 
-const expectedSizeMultipliers = new Map([
+const expectedGlobalSizeMultipliers = new Map([
   ['convertible', 0.6],
-  ['classic', 0.6],
+  ['classic', 0.6]
+]);
+
+const expectedFeaturedSizeMultipliers = new Map([
   ['monster-truck', 1.2]
 ]);
 
@@ -66,8 +69,13 @@ for (const car of catalog.CAR_CATALOG) {
   );
   assert.equal(
     car.visualSizeMultiplier,
-    expectedSizeMultipliers.get(car.id) || 1,
+    expectedGlobalSizeMultipliers.get(car.id) || 1,
     `${car.name} must keep its globally shared size multiplier`
+  );
+  assert.equal(
+    car.featuredVisualSizeMultiplier,
+    expectedFeaturedSizeMultipliers.get(car.id) || 1,
+    `${car.name} must keep its Lot-and-race featured multiplier`
   );
 
   const glb = await fs.readFile(new URL(`../../turn/assets/cars/${car.id}.glb`, import.meta.url));
@@ -102,14 +110,20 @@ const trainingCar = catalog.getCarDefinition('classic');
 const monsterTruck = catalog.getCarDefinition('monster-truck');
 assertClose(convertible.visualScale * convertible.visualSizeMultiplier, 0.588, 'Convertible effective visual scale');
 assertClose(trainingCar.visualScale * trainingCar.visualSizeMultiplier, 0.6, 'Training Car effective visual scale');
-assertClose(monsterTruck.visualScale * monsterTruck.visualSizeMultiplier, 0.996, 'Monster Truck effective visual scale');
+assertClose(monsterTruck.visualScale * monsterTruck.visualSizeMultiplier, 0.83, 'Monster Truck compact visual scale');
+assertClose(
+  monsterTruck.visualScale * monsterTruck.visualSizeMultiplier * monsterTruck.featuredVisualSizeMultiplier,
+  0.996,
+  'Monster Truck Lot-and-race visual scale'
+);
 
-const [index, releaseSource, carModels, lot, main] = await Promise.all([
+const [index, releaseSource, carModels, lot, main, trackBestCar] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/release.json', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/vehicle/car-models.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-r10.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/ui/track-best-car.js', import.meta.url), 'utf8')
 ]);
 
 const release = JSON.parse(releaseSource);
@@ -121,15 +135,28 @@ assert.match(
 );
 assert.match(
   carModels,
-  /effectiveVisualScale = car\.visualScale \* car\.visualSizeMultiplier/,
-  'The shared model factory must combine authored normalization with global size balance'
+  /FEATURED_SURFACE_TARGET_LENGTHS = new Set\(\[5\.15, 5\.5\]\)/,
+  'Only the standard Lot lineup and race target lengths may use featured sizing'
+);
+assert.match(carModels, /featuredSurface = FEATURED_SURFACE_TARGET_LENGTHS\.has\(targetLength\)/);
+assert.match(
+  carModels,
+  /featuredVisualSizeMultiplier = featuredSurface[\s\S]*\? car\.featuredVisualSizeMultiplier[\s\S]*: 1/,
+  'Featured sizing must be opt-in by surface'
+);
+assert.match(
+  carModels,
+  /effectiveVisualScale = car\.visualScale[\s\S]*\* car\.visualSizeMultiplier[\s\S]*\* featuredVisualSizeMultiplier/,
+  'The shared model factory must combine authored, global and featured scaling'
 );
 assert.match(
   carModels,
   /normalizeModelToGround\(model, targetLength \* effectiveVisualScale\)/,
-  'Every model surface must receive the same effective size through the shared factory'
+  'Every model surface must receive its resolved scale through the shared factory'
 );
 assert.match(carModels, /turnVisualSizeMultiplier = car\.visualSizeMultiplier/);
+assert.match(carModels, /turnFeaturedVisualSizeMultiplier = featuredVisualSizeMultiplier/);
+assert.match(carModels, /turnFeaturedVisualSurface = featuredSurface/);
 assert.match(carModels, /turnEffectiveVisualScale = effectiveVisualScale/);
 assert.match(carModels, /side: THREE\.BackSide/, 'Car outlines must remain inverted back-face shells');
 assert.match(carModels, /depthTest: true/, 'Car outlines must still respect the body depth buffer');
@@ -137,12 +164,25 @@ assert.match(carModels, /depthWrite: false/, 'Car outlines must not write depth 
 assert.match(carModels, /polygonOffset: true/, 'Car outlines must use a depth offset for stable close surface intersections');
 assert.match(carModels, /polygonOffsetFactor: 1/);
 assert.match(carModels, /polygonOffsetUnits: 1/);
+
+assert.match(lot, /targetLength: 5\.15/, 'The standard Lot lineup must use the featured surface size');
+assert.match(lot, /targetLength: 6\.4/, 'The expanded 3D viewer must retain its compact-safe size');
+assert.equal((lot.match(/targetLength: 5\.15/g) || []).length, 1);
+assert.equal((lot.match(/targetLength: 6\.4/g) || []).length, 1);
+assert.match(main, /targetLength: 5\.5/, 'Race cars and rivals must use the featured surface size');
+assert.match(trackBestCar, /targetLength: 6\.4/, 'Home record thumbnails must retain their compact-safe size');
+assert.doesNotMatch(
+  carModels,
+  /FEATURED_SURFACE_TARGET_LENGTHS = new Set\(\[[^\]]*6\.4/,
+  'Expanded 3D and record-preview target lengths must never receive featured sizing'
+);
+
 assert.match(lot, /visual\.rotation\.y = Math\.PI/, 'The Lot must map local -Z to the camera-facing direction');
 assert.match(lot, /VIEWER_INITIAL_YAW = Math\.PI - 0\.55/, 'The viewer must start on the normalized front');
 assert.match(main, /playerCar\.rotation\.y = state\.heading \+ Math\.PI/);
 assert.match(main, /car\.rotation\.y = frame\.h \+ Math\.PI/);
 
-console.log(`TURN ${release.id} car orientation and shared visual sizing passed for all 15 models.`);
+console.log(`TURN ${release.id} car orientation and surface-specific visual sizing passed for all 15 models.`);
 
 function assertClose(actual, expected, label) {
   assert.ok(

--- a/turn/vehicle/car-models.js
+++ b/turn/vehicle/car-models.js
@@ -12,6 +12,10 @@ const loader = new GLTFLoader();
 const sourceCache = new Map();
 const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
 const TIRE_COLOR = 0x17191c;
+// Existing production surfaces use stable target lengths: 5.15 for the standard
+// Lot lineup and 5.5 for race cars. The expanded viewer and record thumbnails use
+// 6.4 and intentionally keep the authored scale.
+const FEATURED_SURFACE_TARGET_LENGTHS = new Set([5.15, 5.5]);
 
 export async function preloadCarModels(carIds) {
   await Promise.all(carIds.map((carId) => loadCarSource(carId).catch(() => null)));
@@ -106,7 +110,13 @@ export async function createCarVisual({
   }
 
   if (outline) addOutlines(model);
-  const effectiveVisualScale = car.visualScale * car.visualSizeMultiplier;
+  const featuredSurface = FEATURED_SURFACE_TARGET_LENGTHS.has(targetLength);
+  const featuredVisualSizeMultiplier = featuredSurface
+    ? car.featuredVisualSizeMultiplier
+    : 1;
+  const effectiveVisualScale = car.visualScale
+    * car.visualSizeMultiplier
+    * featuredVisualSizeMultiplier;
   normalizeModelToGround(model, targetLength * effectiveVisualScale);
 
   root.userData.turnCarId = car.id;
@@ -115,6 +125,8 @@ export async function createCarVisual({
   root.userData.turnGhost = ghost;
   root.userData.turnModelYawQuarterTurns = car.modelYawQuarterTurns;
   root.userData.turnVisualSizeMultiplier = car.visualSizeMultiplier;
+  root.userData.turnFeaturedVisualSizeMultiplier = featuredVisualSizeMultiplier;
+  root.userData.turnFeaturedVisualSurface = featuredSurface;
   root.userData.turnEffectiveVisualScale = effectiveVisualScale;
   root.userData.turnPrimaryPaintMaterials = primaryPaintMaterials;
   root.userData.turnSecondaryPaintMaterials = secondaryPaintMaterials;

--- a/turn/vehicle/catalog.js
+++ b/turn/vehicle/catalog.js
@@ -59,10 +59,15 @@ export const CAR_PALETTE = Object.freeze([
 ]);
 
 // Global balance adjustments are kept separate from each GLB's authored normalization.
-// They follow the shared model factory into The Lot, race, rivals, Spectate and previews.
+// Convertible and Training Car use these sizes on every surface.
 const VISUAL_SIZE_MULTIPLIER_BY_ID = Object.freeze({
   convertible: 0.6,
-  classic: 0.6,
+  classic: 0.6
+});
+
+// Featured adjustments are only used in the standard Lot lineup and during a race.
+// Compact previews and the expanded 3D viewer retain the authored model scale.
+const FEATURED_VISUAL_SIZE_MULTIPLIER_BY_ID = Object.freeze({
   'monster-truck': 1.2
 });
 
@@ -117,6 +122,7 @@ export const CAR_CATALOG = Object.freeze(RAW_CARS.map(([
   stats: Object.freeze({ ...stats }),
   visualScale,
   visualSizeMultiplier: VISUAL_SIZE_MULTIPLIER_BY_ID[id] || 1,
+  featuredVisualSizeMultiplier: FEATURED_VISUAL_SIZE_MULTIPLIER_BY_ID[id] || 1,
   modelYawQuarterTurns,
   secondaryPaint: SECONDARY_PAINT_BY_ID[id] || null,
   tuning: Object.freeze({


### PR DESCRIPTION
## Change

- keep Convertible and Training Car at their global 60% size
- restore Monster Truck to its authored size in compact and constrained surfaces
- retain the Monster Truck 120% size only in:
  - the standard The Lot lineup
  - actual races, including player car, rivals and Spectate

## Explicitly excluded

- expanded 3D viewer
- Home best-car thumbnails
- track intro and other compact previews
- scenery and onboarding surfaces

## Implementation

- split global and featured visual-size multipliers in the vehicle catalog
- resolve the featured multiplier only for the established standard-Lot and race target lengths in the shared car factory
- preserve physics, collision, tuning, camera and GLB normalization

## Regression coverage

- verify authored scales for all 15 cars
- verify global 0.6 multipliers for Convertible and Training Car
- verify Monster Truck is 0.83 on compact surfaces and 0.996 in The Lot/race
- verify the expanded viewer and Home record thumbnail use the compact-safe 6.4 target length
- verify the featured surface contract contains only standard Lot 5.15 and race 5.5