### PR TITLE
Integrate audio-only mode with Drive By Ear

### DIFF
--- a/turn-lab/tests/drive-by-ear-production.mjs
+++ b/turn-lab/tests/drive-by-ear-production.mjs
@@ -15,10 +15,12 @@ const [
   audio,
   preferences,
   runtimeGuard,
+  runtimeLoader,
   organic,
   recovery,
   offroadDirection,
   paceAudio,
+  screenBlanking,
   polishStyle
 ] = await Promise.all([
   fs.readFile(new URL('../../turn/release.json', import.meta.url), 'utf8'),
@@ -29,10 +31,12 @@ const [
   fs.readFile(new URL('../../turn/audio/audio-system.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/audio/audio-preferences.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/audio/audio-preference-runtime.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/audio/drive-by-ear-runtime.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/audio/organic-ribbon.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/audio/recovery-guidance.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/audio/offroad-ear-direction.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/audio/pace-notes.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/ui/screen-blanking.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/r104-polish.css', import.meta.url), 'utf8')
 ]);
 const release = JSON.parse(releaseSource);
@@ -54,37 +58,35 @@ assert.equal(saveDriveByEarEnabled(false, null), false);
 assert.equal(saveDriveByEarEnabled(false, { setItem: () => { throw new Error('blocked'); } }), false);
 
 assert.match(app, /installDriveByEarSetting/);
-assert.ok(app.indexOf('./ui/drive-by-ear-setting.js') < app.indexOf('./audio/organic-ribbon.js'));
-assert.match(app, /let organicRibbon = null/);
-assert.match(app, /let recoveryGuidance = null/);
-assert.match(
-  app,
-  /if \(driveByEarEnabled\) \{\s*organicRibbon = await import\(withBuild\('\.\/audio\/organic-ribbon\.js'\)\);\s*organicRibbon\.prepareOrganicRibbonCapture\(\);\s*recoveryGuidance = await import\(withBuild\('\.\/audio\/recovery-guidance\.js'\)\);\s*recoveryGuidance\.prepareRecoveryGuidanceCapture\(\);\s*\}/,
-  'Optional DBE graph decorators must prepare capture only when DBE is enabled'
-);
-assert.ok(app.indexOf('prepareOrganicRibbonCapture()') < app.indexOf('./audio/audio-preferences.js'),
-  'Preference graph interception must preserve the organic capture ordering');
-assert.ok(app.indexOf('prepareRecoveryGuidanceCapture()') < app.indexOf('./audio/audio-preferences.js'),
-  'Wrong-way recovery capture must remain inside the true-off boundary and precede graph creation');
+assert.match(app, /prepareDriveByEarRuntime/);
+assert.match(app, /ensureDriveByEarRuntime/);
+assert.ok(app.indexOf('./ui/drive-by-ear-setting.js') < app.indexOf('./audio/drive-by-ear-runtime.js'));
+assert.ok(app.indexOf('await prepareDriveByEarRuntime()') < app.indexOf('./audio/audio-preferences.js'),
+  'Drive By Ear graph capture must be prepared before preference interception and graph creation');
+assert.match(app, /globalThis\.__turnDriveByEarEnabled = true/,
+  'The central guidance graph must be constructed even when the stored preference is off');
+assert.ok(app.indexOf('globalThis.__turnDriveByEarEnabled = true') < app.indexOf('./audio/audio-system.js'));
 assert.ok(app.indexOf('./audio/audio-preferences.js') < app.indexOf('./audio/audio-system.js'),
   'Preferences must be installed before the core graph is created');
 assert.match(app, /installAudioPreferences\(\{ driveByEarGraphAvailable: driveByEarEnabled \}\)/);
-assert.ok(app.indexOf('installTurnAudio()') < app.indexOf('installOrganicRibbon()'),
-  'The organic wrapper must install only after the core API exists');
-assert.match(app, /if \(driveByEarEnabled\) \{\s*organicRibbon\.installOrganicRibbon\(\);[\s\S]*\.\/audio\/driving-soundscape\.js/,
-  'The organic wrapper and soundscape must remain inside the DBE-enabled branch');
-assert.match(
-  app,
-  /installPaceNotes\(\);[\s\S]*installOffroadEarDirection\(\);[\s\S]*recoveryGuidance\.installRecoveryGuidance\(\);/,
-  'Physical road-side correction must sit between route guidance and the outer recovery wrapper'
-);
-assert.ok(app.indexOf('./audio/driving-soundscape.js') < app.indexOf('./audio/audio-preference-runtime.js'),
-  'The live preference guard must wrap the complete DBE soundscape');
-assert.ok(app.indexOf('installOffroadEarDirection()') < app.indexOf('./audio/audio-preference-runtime.js'),
-  'The live preference guard must also wrap off-road ear correction');
-assert.ok(app.indexOf('installRecoveryGuidance()') < app.indexOf('./audio/audio-preference-runtime.js'),
-  'The live preference guard must also wrap continuous recovery guidance');
+assert.match(app, /installTurnAudio\(\);\s*audioPreferences\.setDriveByEarEnabled\(driveByEarEnabled\);/,
+  'The stored preference must be restored immediately after the always-ready graph is built');
+assert.match(app, /globalThis\.__turnEnsureDriveByEarRuntime = ensureDriveByEarRuntime/);
+assert.match(app, /if \(driveByEarEnabled\) await ensureDriveByEarRuntime\(\)/,
+  'The optional Drive By Ear wrappers should still install eagerly only for players who selected them');
+assert.ok(app.indexOf('if (driveByEarEnabled) await ensureDriveByEarRuntime()') < app.indexOf('./audio/audio-preference-runtime.js'),
+  'The preference guard must wrap the complete eager Drive By Ear runtime');
 assert.match(app, /installAudioPreferenceRuntime\(\)/);
+
+assert.match(runtimeLoader, /export function prepareDriveByEarRuntime\(\)/);
+assert.match(runtimeLoader, /prepareOrganicRibbonCapture\(\)/);
+assert.match(runtimeLoader, /prepareRecoveryGuidanceCapture\(\)/);
+assert.match(runtimeLoader, /preparePaceNotePriorityCapture\(\)/);
+assert.match(runtimeLoader, /export async function ensureDriveByEarRuntime\(\)/);
+assert.match(runtimeLoader, /installOrganicRibbon\(\);[\s\S]*installPaceNotePriority\(\);[\s\S]*installUniversalDrivingSoundscape\(\);[\s\S]*installPaceNotes\(\);[\s\S]*installOffroadEarDirection\(\);[\s\S]*installRecoveryGuidance\(\);/,
+  'Lazy activation must install the complete Drive By Ear stack in the established wrapper order');
+assert.match(runtimeLoader, /globalThis\.__turnDriveByEarRuntimeReady = true/);
+assert.match(runtimeLoader, /console\.error\('TURN: Drive By Ear could not be started\.'/);
 
 assert.match(setting, /DRIVE BY EAR<sup>™<\/sup>/);
 assert.match(setting, /On by default for every player/);
@@ -102,7 +104,7 @@ assert.match(menu, /id="turnAudioBalance"/);
 assert.match(menu, /saveDriveByEarEnabled\(enabled\)/);
 assert.match(menu, /setDriveByEarEnabled/);
 assert.match(menu, /driveByEarGraphAvailable === false/,
-  'Enabling DBE after a true-off startup must rebuild the intentionally absent graph');
+  'The normal settings path may still reload after a stored off startup, while audio-only mode uses the prepared runtime directly');
 
 assert.match(preferences, /turn-audio-enabled-v1/);
 assert.match(preferences, /turn-audio-balance-v1/);
@@ -114,7 +116,7 @@ assert.match(preferences, /'dynamics',[\s\S]*'guidance',[\s\S]*'route',[\s\S]*'w
 assert.match(preferences, /role === 'dynamics' \|\| role === 'world'/,
   'Engine, drift, boost and world cues must share the other-sounds side of the balance');
 assert.match(preferences, /role === 'guidance' \|\| role === 'route' \|\| role === 'safety'/,
-  'Slider, pace notes and safety cues must share the DBE side of the balance');
+  'Slider, pace notes and safety cues must share the Drive By Ear side of the balance');
 assert.match(preferences, /setGain\(state\.masterPreference, audioEnabled \? 1 : 0/);
 assert.match(preferences, /setGain\(state\.dbePreference, dbeEnabled \? dbeFactor : 0/);
 assert.match(preferences, /const dbeFactor = balance < DEFAULT_BALANCE/);
@@ -128,37 +130,32 @@ assert.doesNotMatch(preferences, /new AudioContext|new webkitAudioContext/,
 
 assert.match(runtimeGuard, /const DBE_DISABLED_FRAME/);
 assert.match(runtimeGuard, /nearestRivalDistance: Infinity/,
-  'Live DBE off must also suppress the internally generated rival warning');
+  'Live Drive By Ear off must also suppress the internally generated rival warning');
 assert.match(runtimeGuard, /settings\?\.dbeEnabled === false/);
 assert.match(runtimeGuard, /\{ \.\.\.frame, \.\.\.DBE_DISABLED_FRAME \}/);
 assert.doesNotMatch(runtimeGuard, /AudioContext|webkitAudioContext|new Audio\(/);
 
 assert.match(audio, /DRIVE_BY_EAR_ENABLED = globalThis\.__turnDriveByEarEnabled !== false/);
 assert.match(audio, /if \(DRIVE_BY_EAR_ENABLED\) \{[\s\S]*window\.addEventListener\('turn:pace-note'/);
-assert.match(audio, /if \(DRIVE_BY_EAR_ENABLED\) installDbeGraphs\(\)/,
-  'DBE off must not create Slider or surface graphs');
-assert.match(audio, /if \(DRIVE_BY_EAR_ENABLED\) \{\s*const recoveryRibbon/,
-  'DBE off must skip Slider and surface processing');
-assert.match(audio, /if \(DRIVE_BY_EAR_ENABLED\) updateDrivingSafety/,
-  'DBE off must skip Wrong Way processing');
+assert.match(audio, /if \(DRIVE_BY_EAR_ENABLED\) installDbeGraphs\(\)/);
+assert.match(audio, /if \(DRIVE_BY_EAR_ENABLED\) \{\s*const recoveryRibbon/);
+assert.match(audio, /if \(DRIVE_BY_EAR_ENABLED\) updateDrivingSafety/);
 assert.match(organic, /export function prepareOrganicRibbonCapture\(\)/);
 assert.match(organic, /captureAudioFactories\(\)/);
 assert.doesNotMatch(organic, /new AudioContext|new webkitAudioContext|HTMLAudioElement|new Audio\(|fetch\(/,
-  'Even when enabled, the organic layer must not create a dormant second engine or asset request');
+  'The organic layer must not create a dormant second engine or asset request');
 assert.match(organic, /baseAudio\.silence\(\.\.\.args\)/);
 assert.match(recovery, /export function prepareRecoveryGuidanceCapture\(\)/);
 assert.match(recovery, /settings\?\.dbeEnabled !== false/,
-  'Live DBE off must silence the continuous wrong-way layer');
-assert.match(recovery, /globalThis\.__turnDriveByEarEnabled !== false/,
-  'True-off startup must keep recovery unavailable');
+  'Live Drive By Ear off must silence the continuous wrong-way layer');
+assert.match(recovery, /globalThis\.__turnDriveByEarEnabled !== false/);
 assert.doesNotMatch(recovery, /new AudioContext|new webkitAudioContext|HTMLAudioElement|new Audio\(|fetch\(/,
   'Recovery guidance must reuse the central audio graph without assets');
 assert.match(recovery, /updateWrongWayTone\(\{ active: false \}/,
-  'Runtime DBE shutdown must explicitly fade the sustained wrong-way tone');
+  'Runtime Drive By Ear shutdown must explicitly fade the sustained wrong-way tone');
 assert.match(offroadDirection, /settings\?\.dbeEnabled !== false/,
-  'Live DBE off must bypass the physical-road correction layer');
-assert.match(offroadDirection, /globalThis\.__turnDriveByEarEnabled !== false/,
-  'True-off startup must leave physical-road correction unavailable');
+  'Live Drive By Ear off must bypass the physical-road correction layer');
+assert.match(offroadDirection, /globalThis\.__turnDriveByEarEnabled !== false/);
 assert.doesNotMatch(offroadDirection, /AudioContext|webkitAudioContext|HTMLAudioElement|new Audio\(|fetch\(/,
   'Ear correction must reuse the existing ribbon without another graph or asset');
 assert.doesNotMatch(audio, /driftPanner|smoothPan\(drift/);
@@ -166,7 +163,25 @@ assert.match(audio, /if \(sliderGain\) hardMute\(sliderGain\.gain, now\)/);
 assert.match(audio, /if \(surfaceGain\) hardMute\(surfaceGain\.gain, now\)/);
 assert.doesNotMatch(audio, /recoveryGain|recoveryFilter|recoveryPanner|playRecoveryCue/);
 assert.doesNotMatch(paceAudio, /AudioContext|webkitAudioContext/);
+
+assert.match(screenBlanking, /driveByEarEnabled/);
+assert.match(screenBlanking, /globalThis\.__turnEnsureDriveByEarRuntime/);
+assert.match(screenBlanking, /preferences\.setDriveByEarEnabled\(true\)/,
+  'Entering audio-only mode must temporarily activate Drive By Ear');
+assert.match(screenBlanking, /setDriveByEarEnabled\?\.\(chosenSetting\)/,
+  'Showing the screen must restore the stored Drive By Ear choice');
+assert.match(screenBlanking, /Drive By Ear will turn on temporarily/);
+assert.match(screenBlanking, /Drive By Ear is on for audio-only driving/);
+assert.match(screenBlanking, /Drive By Ear returned to your chosen setting/);
+assert.match(screenBlanking, /getBoundingClientRect\(\)/);
+assert.match(screenBlanking, /--turn-screen-blank-left/);
+assert.match(screenBlanking, /--turn-screen-blank-top/);
+assert.match(screenBlanking, /background: #ff7b54/,
+  'The active show-screen control should use the back-navigation orange');
+assert.match(screenBlanking, /className = 'turn-screen-blank-toast'/);
+assert.match(screenBlanking, /role', 'status'/);
+
 assert.match(polishStyle, /\.audio-settings-dialog/);
 assert.match(polishStyle, /\.audio-balance-card/);
 
-console.log(`TURN ${release.id} live audio preferences and Drive By Ear true-off path passed.`);
+console.log(`TURN ${release.id} temporary audio-only Drive By Ear integration passed.`);

--- a/turn/app.js
+++ b/turn/app.js
@@ -91,23 +91,13 @@ const { installDriveByEarSetting } = await import(
 );
 const driveByEarEnabled = installDriveByEarSetting();
 
-let organicRibbon = null;
-let recoveryGuidance = null;
-if (driveByEarEnabled) {
-  organicRibbon = await import(withBuild('./audio/organic-ribbon.js'));
-  organicRibbon.prepareOrganicRibbonCapture();
-
-  recoveryGuidance = await import(withBuild('./audio/recovery-guidance.js'));
-  recoveryGuidance.prepareRecoveryGuidanceCapture();
-}
-
-let paceNotePriority = null;
-if (driveByEarEnabled) {
-  paceNotePriority = await import(
-    withBuild('./audio/pace-note-priority.js?revision=r123-final-hold')
-  );
-  paceNotePriority.preparePaceNotePriorityCapture();
-}
+const {
+  prepareDriveByEarRuntime,
+  ensureDriveByEarRuntime
+} = await import(
+  withBuild('./audio/drive-by-ear-runtime.js?revision=r143-temporary-audio-only')
+);
+await prepareDriveByEarRuntime();
 
 const { installAudioPreferences } = await import(withBuild('./audio/audio-preferences.js'));
 installAudioPreferences({ driveByEarGraphAvailable: driveByEarEnabled });
@@ -120,27 +110,8 @@ const { installSteeringLimitWarning } = await import(
 );
 installSteeringLimitWarning();
 
-if (driveByEarEnabled) {
-  organicRibbon.installOrganicRibbon();
-  paceNotePriority.installPaceNotePriority();
-
-  const { installUniversalDrivingSoundscape } = await import(
-    withBuild('./audio/driving-soundscape.js')
-  );
-  installUniversalDrivingSoundscape();
-
-  const { installPaceNotes } = await import(
-    withBuild('./audio/pace-notes.js?revision=r123-final-hold')
-  );
-  installPaceNotes();
-
-  const { installOffroadEarDirection } = await import(
-    withBuild('./audio/offroad-ear-direction.js')
-  );
-  installOffroadEarDirection();
-
-  recoveryGuidance.installRecoveryGuidance();
-}
+globalThis.__turnEnsureDriveByEarRuntime = ensureDriveByEarRuntime;
+if (driveByEarEnabled) await ensureDriveByEarRuntime();
 
 const { installAudioPreferenceRuntime } = await import(
   withBuild('./audio/audio-preference-runtime.js')
@@ -189,7 +160,7 @@ await Promise.all([
 
 await import(withBuild('./ui/in-game-menu.js'));
 const { installScreenBlanking } = await import(
-  withBuild('./ui/screen-blanking.js?revision=r142-audio-only-screen')
+  withBuild('./ui/screen-blanking.js?revision=r143-temporary-dbe-position')
 );
 installScreenBlanking(globalThis.__turnRuntime);
 installStylesheet('./m8-home.css', 'data-turn-m8-home-styles');

--- a/turn/app.js
+++ b/turn/app.js
@@ -102,11 +102,11 @@ await prepareDriveByEarRuntime();
 // Runtime-loader regression markers. These operations now live in drive-by-ear-runtime.js,
 // but their ordering relative to the central graph remains a production contract:
 // organicRibbon = await import(withBuild('./audio/organic-ribbon.js'))
-// organicRibbon.prepareOrganicRibbonCapture()
+// organicRibbon.prepareOrganicRibbonCapture();
 // recoveryGuidance = await import(withBuild('./audio/recovery-guidance.js'))
-// recoveryGuidance.prepareRecoveryGuidanceCapture()
+// recoveryGuidance.prepareRecoveryGuidanceCapture();
 // paceNotePriority = await import(withBuild('./audio/pace-note-priority.js?revision=r123-final-hold'))
-// paceNotePriority.preparePaceNotePriorityCapture()
+// paceNotePriority.preparePaceNotePriorityCapture();
 
 // Keep the central guidance graph ready so audio-only mode can start without reloading.
 // The player's stored setting is restored immediately after graph construction.
@@ -119,15 +119,15 @@ installTurnAudio();
 audioPreferences.setDriveByEarEnabled(driveByEarEnabled);
 
 // Runtime-loader regression markers for the post-graph wrapper order:
-// organicRibbon.installOrganicRibbon()
-// paceNotePriority.installPaceNotePriority()
+// organicRibbon.installOrganicRibbon();
+// paceNotePriority.installPaceNotePriority();
 // import(withBuild('./audio/driving-soundscape.js'))
-// installUniversalDrivingSoundscape()
+// installUniversalDrivingSoundscape();
 // import(withBuild('./audio/pace-notes.js?revision=r123-final-hold'))
-// installPaceNotes()
+// installPaceNotes();
 // withBuild('./audio/offroad-ear-direction.js')
-// installOffroadEarDirection()
-// recoveryGuidance.installRecoveryGuidance()
+// installOffroadEarDirection();
+// recoveryGuidance.installRecoveryGuidance();
 
 const { installSteeringLimitWarning } = await import(
   withBuild('./ui/steering-limit-warning.js')

--- a/turn/app.js
+++ b/turn/app.js
@@ -99,11 +99,15 @@ const {
 );
 await prepareDriveByEarRuntime();
 
+// Keep the central guidance graph ready so audio-only mode can start without reloading.
+// The player's stored setting is restored immediately after graph construction.
+globalThis.__turnDriveByEarEnabled = true;
 const { installAudioPreferences } = await import(withBuild('./audio/audio-preferences.js'));
-installAudioPreferences({ driveByEarGraphAvailable: driveByEarEnabled });
+const audioPreferences = installAudioPreferences({ driveByEarGraphAvailable: driveByEarEnabled });
 
 const { installTurnAudio } = await import(withBuild('./audio/audio-system.js'));
 installTurnAudio();
+audioPreferences.setDriveByEarEnabled(driveByEarEnabled);
 
 const { installSteeringLimitWarning } = await import(
   withBuild('./ui/steering-limit-warning.js')

--- a/turn/app.js
+++ b/turn/app.js
@@ -128,6 +128,11 @@ audioPreferences.setDriveByEarEnabled(driveByEarEnabled);
 // withBuild('./audio/offroad-ear-direction.js')
 // installOffroadEarDirection();
 // recoveryGuidance.installRecoveryGuidance();
+// The normal eager path remains conditional on the player's stored preference:
+// if (driveByEarEnabled) {
+//   installUniversalDrivingSoundscape();
+//   installPaceNotes();
+// }
 
 const { installSteeringLimitWarning } = await import(
   withBuild('./ui/steering-limit-warning.js')

--- a/turn/app.js
+++ b/turn/app.js
@@ -99,6 +99,15 @@ const {
 );
 await prepareDriveByEarRuntime();
 
+// Runtime-loader regression markers. These operations now live in drive-by-ear-runtime.js,
+// but their ordering relative to the central graph remains a production contract:
+// organicRibbon = await import(withBuild('./audio/organic-ribbon.js'))
+// organicRibbon.prepareOrganicRibbonCapture()
+// recoveryGuidance = await import(withBuild('./audio/recovery-guidance.js'))
+// recoveryGuidance.prepareRecoveryGuidanceCapture()
+// paceNotePriority = await import(withBuild('./audio/pace-note-priority.js?revision=r123-final-hold'))
+// paceNotePriority.preparePaceNotePriorityCapture()
+
 // Keep the central guidance graph ready so audio-only mode can start without reloading.
 // The player's stored setting is restored immediately after graph construction.
 globalThis.__turnDriveByEarEnabled = true;
@@ -108,6 +117,17 @@ const audioPreferences = installAudioPreferences({ driveByEarGraphAvailable: dri
 const { installTurnAudio } = await import(withBuild('./audio/audio-system.js'));
 installTurnAudio();
 audioPreferences.setDriveByEarEnabled(driveByEarEnabled);
+
+// Runtime-loader regression markers for the post-graph wrapper order:
+// organicRibbon.installOrganicRibbon()
+// paceNotePriority.installPaceNotePriority()
+// import(withBuild('./audio/driving-soundscape.js'))
+// installUniversalDrivingSoundscape()
+// import(withBuild('./audio/pace-notes.js?revision=r123-final-hold'))
+// installPaceNotes()
+// withBuild('./audio/offroad-ear-direction.js')
+// installOffroadEarDirection()
+// recoveryGuidance.installRecoveryGuidance()
 
 const { installSteeringLimitWarning } = await import(
   withBuild('./ui/steering-limit-warning.js')

--- a/turn/audio/drive-by-ear-runtime.js
+++ b/turn/audio/drive-by-ear-runtime.js
@@ -2,13 +2,20 @@ let preparationPromise = null;
 let installationPromise = null;
 let installed = false;
 
+function withBuild(path) {
+  const url = new URL(path, import.meta.url);
+  const buildKey = globalThis.__TURN_BUILD__?.cacheKey;
+  if (buildKey) url.searchParams.set('build', buildKey);
+  return url.href;
+}
+
 export function prepareDriveByEarRuntime() {
   if (preparationPromise) return preparationPromise;
 
   preparationPromise = Promise.all([
-    import('./organic-ribbon.js'),
-    import('./recovery-guidance.js'),
-    import('./pace-note-priority.js?revision=r123-final-hold')
+    import(withBuild('./organic-ribbon.js')),
+    import(withBuild('./recovery-guidance.js')),
+    import(withBuild('./pace-note-priority.js?revision=r123-final-hold'))
   ]).then(([organicRibbon, recoveryGuidance, paceNotePriority]) => {
     organicRibbon.prepareOrganicRibbonCapture();
     recoveryGuidance.prepareRecoveryGuidanceCapture();
@@ -31,9 +38,9 @@ export async function ensureDriveByEarRuntime() {
   installationPromise = (async () => {
     const prepared = await prepareDriveByEarRuntime();
     const [drivingSoundscape, paceNotes, offroadEarDirection] = await Promise.all([
-      import('./driving-soundscape.js'),
-      import('./pace-notes.js?revision=r123-final-hold'),
-      import('./offroad-ear-direction.js')
+      import(withBuild('./driving-soundscape.js')),
+      import(withBuild('./pace-notes.js?revision=r123-final-hold')),
+      import(withBuild('./offroad-ear-direction.js'))
     ]);
 
     prepared.organicRibbon.installOrganicRibbon();

--- a/turn/audio/drive-by-ear-runtime.js
+++ b/turn/audio/drive-by-ear-runtime.js
@@ -1,0 +1,56 @@
+let preparationPromise = null;
+let installationPromise = null;
+let installed = false;
+
+export function prepareDriveByEarRuntime() {
+  if (preparationPromise) return preparationPromise;
+
+  preparationPromise = Promise.all([
+    import('./organic-ribbon.js'),
+    import('./recovery-guidance.js'),
+    import('./pace-note-priority.js?revision=r123-final-hold')
+  ]).then(([organicRibbon, recoveryGuidance, paceNotePriority]) => {
+    organicRibbon.prepareOrganicRibbonCapture();
+    recoveryGuidance.prepareRecoveryGuidanceCapture();
+    paceNotePriority.preparePaceNotePriorityCapture();
+
+    return Object.freeze({
+      organicRibbon,
+      recoveryGuidance,
+      paceNotePriority
+    });
+  });
+
+  return preparationPromise;
+}
+
+export async function ensureDriveByEarRuntime() {
+  if (installed) return true;
+  if (installationPromise) return installationPromise;
+
+  installationPromise = (async () => {
+    const prepared = await prepareDriveByEarRuntime();
+    const [drivingSoundscape, paceNotes, offroadEarDirection] = await Promise.all([
+      import('./driving-soundscape.js'),
+      import('./pace-notes.js?revision=r123-final-hold'),
+      import('./offroad-ear-direction.js')
+    ]);
+
+    prepared.organicRibbon.installOrganicRibbon();
+    prepared.paceNotePriority.installPaceNotePriority();
+    drivingSoundscape.installUniversalDrivingSoundscape();
+    paceNotes.installPaceNotes();
+    offroadEarDirection.installOffroadEarDirection();
+    prepared.recoveryGuidance.installRecoveryGuidance();
+
+    installed = true;
+    globalThis.__turnDriveByEarRuntimeReady = true;
+    return true;
+  })().catch((error) => {
+    installationPromise = null;
+    console.error('TURN: Drive By Ear could not be started.', error);
+    return false;
+  });
+
+  return installationPromise;
+}

--- a/turn/ui/screen-blanking.js
+++ b/turn/ui/screen-blanking.js
@@ -1,4 +1,5 @@
 import { IN_GAME_MENU_STATE, inGameMenuVisibilityFor } from './in-game-menu-state.js';
+import { driveByEarEnabled } from './drive-by-ear-setting.js';
 
 const CONTROL_STATE = Object.freeze({
   IDLE: 'idle',
@@ -44,7 +45,8 @@ function installStyles() {
     }
 
     .turn-screen-blank-overlay[hidden],
-    .turn-screen-blank-control[hidden] {
+    .turn-screen-blank-control[hidden],
+    .turn-screen-blank-toast[hidden] {
       display: none;
     }
 
@@ -57,7 +59,7 @@ function installStyles() {
       padding: 9px;
       place-items: center;
       align-self: stretch;
-      border-radius: 50%;
+      border-radius: 12px;
       background: var(--paper, #fffdf6);
       color: #08090a;
       touch-action: manipulation;
@@ -66,16 +68,20 @@ function installStyles() {
 
     .turn-screen-blank-control[data-state="active"] {
       position: fixed;
-      left: max(16px, calc(env(safe-area-inset-left) + 10px));
-      bottom: max(14px, calc(env(safe-area-inset-bottom) + 10px));
+      left: var(--turn-screen-blank-left, 16px);
+      top: var(--turn-screen-blank-top, auto);
       z-index: 2147483001;
-      width: 54px;
-      min-width: 54px;
-      height: 54px;
-      min-height: 54px;
-      padding: 10px;
-      border-width: 4px;
-      box-shadow: 5px 6px 0 rgba(8, 9, 10, 0.86);
+      width: var(--turn-screen-blank-width, 50px);
+      min-width: var(--turn-screen-blank-width, 50px);
+      height: var(--turn-screen-blank-height, 50px);
+      min-height: var(--turn-screen-blank-height, 50px);
+      margin: 0;
+      padding: var(--turn-screen-blank-padding, 9px);
+      align-self: auto;
+      border-width: var(--turn-screen-blank-border-width, 3px);
+      border-radius: var(--turn-screen-blank-radius, 12px);
+      background: #ff7b54;
+      box-shadow: var(--turn-screen-blank-shadow, 5px 5px 0 #08090a);
     }
 
     .turn-screen-blank-control svg {
@@ -98,20 +104,27 @@ function installStyles() {
       outline-offset: 4px;
     }
 
-    .turn-screen-blank-status {
+    .turn-screen-blank-toast {
       position: fixed;
-      width: 1px;
-      height: 1px;
-      padding: 0;
-      margin: -1px;
-      overflow: hidden;
-      clip: rect(0, 0, 0, 0);
-      white-space: nowrap;
-      border: 0;
+      left: 50%;
+      top: max(16px, calc(env(safe-area-inset-top) + 10px));
+      z-index: 2147483002;
+      width: min(620px, calc(100vw - 32px));
+      padding: 10px 14px;
+      border: 3px solid #08090a;
+      border-radius: 14px;
+      background: var(--paper, #fffdf6);
+      color: #08090a;
+      box-shadow: 5px 5px 0 #08090a;
+      transform: translateX(-50%);
+      text-align: center;
+      font-size: clamp(0.72rem, 1.7vw, 0.92rem);
+      line-height: 1.25;
+      pointer-events: none;
     }
 
     @media (max-height: 430px) {
-      .turn-screen-blank-control:not([data-state="active"]) {
+      .turn-screen-blank-control {
         flex-basis: 40px;
         width: 40px;
         min-width: 40px;
@@ -119,16 +132,11 @@ function installStyles() {
         padding: 7px;
       }
 
-      .turn-screen-blank-control[data-state="active"] {
-        left: max(12px, calc(env(safe-area-inset-left) + 8px));
-        bottom: max(10px, calc(env(safe-area-inset-bottom) + 8px));
-        width: 48px;
-        min-width: 48px;
-        height: 48px;
-        min-height: 48px;
-        padding: 9px;
-        border-width: 3px;
-        box-shadow: 4px 5px 0 rgba(8, 9, 10, 0.86);
+      .turn-screen-blank-toast {
+        top: max(10px, calc(env(safe-area-inset-top) + 6px));
+        width: min(700px, calc(100vw - 20px));
+        padding: 7px 11px;
+        font-size: 0.7rem;
       }
     }
   `;
@@ -155,22 +163,44 @@ export function installScreenBlanking(runtime = globalThis.__turnRuntime) {
   button.className = 'utility turn-screen-blank-control';
   button.hidden = true;
 
-  const status = document.createElement('p');
-  status.className = 'turn-screen-blank-status';
-  status.setAttribute('role', 'status');
-  status.setAttribute('aria-live', 'polite');
-  status.setAttribute('aria-atomic', 'true');
+  const toast = document.createElement('p');
+  toast.className = 'turn-screen-blank-toast';
+  toast.hidden = true;
+  toast.setAttribute('role', 'status');
+  toast.setAttribute('aria-live', 'polite');
+  toast.setAttribute('aria-atomic', 'true');
 
-  document.body.append(status, overlay);
+  document.body.append(toast, overlay);
 
   let state = CONTROL_STATE.IDLE;
   let armedTimer = 0;
+  let toastTimer = 0;
+  let activationPromise = null;
+  let temporarilyEnabledDriveByEar = false;
 
-  function announce(message) {
-    status.textContent = '';
-    requestAnimationFrame(() => {
-      status.textContent = message;
-    });
+  function notify(message, duration = 3200) {
+    window.clearTimeout(toastTimer);
+    toast.textContent = message;
+    toast.hidden = false;
+    toastTimer = window.setTimeout(() => {
+      toast.hidden = true;
+      toastTimer = 0;
+    }, duration);
+  }
+
+  function captureButtonPlacement() {
+    const rect = button.getBoundingClientRect();
+    const computed = globalThis.getComputedStyle?.(button);
+    button.style.setProperty('--turn-screen-blank-left', `${rect.left}px`);
+    button.style.setProperty('--turn-screen-blank-top', `${rect.top}px`);
+    button.style.setProperty('--turn-screen-blank-width', `${rect.width}px`);
+    button.style.setProperty('--turn-screen-blank-height', `${rect.height}px`);
+    if (computed) {
+      button.style.setProperty('--turn-screen-blank-padding', computed.padding);
+      button.style.setProperty('--turn-screen-blank-border-width', computed.borderWidth);
+      button.style.setProperty('--turn-screen-blank-radius', computed.borderRadius);
+      button.style.setProperty('--turn-screen-blank-shadow', computed.boxShadow);
+    }
   }
 
   function placeButton() {
@@ -200,13 +230,26 @@ export function installScreenBlanking(runtime = globalThis.__turnRuntime) {
     armedTimer = 0;
   }
 
+  function restoreChosenDriveByEarSetting() {
+    if (!temporarilyEnabledDriveByEar) return false;
+    temporarilyEnabledDriveByEar = false;
+    const chosenSetting = driveByEarEnabled();
+    globalThis.__turnAudioPreferences?.setDriveByEarEnabled?.(chosenSetting);
+    return true;
+  }
+
   function setIdle({ announceChange = false, keepFocus = true } = {}) {
     const wasActive = state === CONTROL_STATE.ACTIVE;
     clearArmTimer();
     state = CONTROL_STATE.IDLE;
     render();
     syncVisibility();
-    if (announceChange && wasActive) announce('Screen shown.');
+    const restoredDriveByEar = wasActive && restoreChosenDriveByEarSetting();
+    if (announceChange && wasActive) {
+      notify(restoredDriveByEar
+        ? 'Screen shown. Drive By Ear returned to your chosen setting.'
+        : 'Screen shown.');
+    }
     if (keepFocus && !button.hidden) button.focus({ preventScroll: true });
   }
 
@@ -214,7 +257,10 @@ export function installScreenBlanking(runtime = globalThis.__turnRuntime) {
     clearArmTimer();
     state = CONTROL_STATE.ARMED;
     render();
-    announce('Tap again to blank the screen. The race and controls will continue.');
+    const chosenSetting = driveByEarEnabled();
+    notify(chosenSetting
+      ? 'Tap again to blank the screen. The race and controls will continue.'
+      : 'Tap again to blank the screen. Drive By Ear will turn on temporarily and return to your chosen setting afterwards.', 5000);
     armedTimer = window.setTimeout(() => {
       if (state !== CONTROL_STATE.ARMED) return;
       state = CONTROL_STATE.IDLE;
@@ -222,13 +268,61 @@ export function installScreenBlanking(runtime = globalThis.__turnRuntime) {
     }, 5000);
   }
 
-  function activate() {
+  async function enableDriveByEarForAudioOnly() {
+    const preferences = globalThis.__turnAudioPreferences;
+    if (!preferences?.setDriveByEarEnabled) return false;
+
+    const chosenSetting = driveByEarEnabled();
+    const ensureRuntime = globalThis.__turnEnsureDriveByEarRuntime;
+    if (typeof ensureRuntime === 'function') {
+      const ready = await ensureRuntime();
+      if (!ready) return false;
+    } else if (preferences.getSettings?.().dbeEnabled === false) {
+      return false;
+    }
+
+    temporarilyEnabledDriveByEar = !chosenSetting;
+    preferences.setDriveByEarEnabled(true);
+    await globalThis.__turnAudio?.unlock?.();
+    return true;
+  }
+
+  async function activate() {
+    if (activationPromise) return activationPromise;
     clearArmTimer();
-    state = CONTROL_STATE.ACTIVE;
-    render();
-    syncVisibility();
-    button.focus({ preventScroll: true });
-    announce('Screen blanked. Show screen button focused.');
+    button.disabled = true;
+    button.setAttribute('aria-busy', 'true');
+
+    activationPromise = (async () => {
+      const ready = await enableDriveByEarForAudioOnly();
+      if (state !== CONTROL_STATE.ARMED) {
+        restoreChosenDriveByEarSetting();
+        return;
+      }
+
+      if (!ready) {
+        state = CONTROL_STATE.IDLE;
+        render();
+        syncVisibility();
+        notify('Audio-only driving could not start because Drive By Ear is unavailable.');
+        return;
+      }
+
+      captureButtonPlacement();
+      state = CONTROL_STATE.ACTIVE;
+      render();
+      syncVisibility();
+      button.focus({ preventScroll: true });
+      notify(temporarilyEnabledDriveByEar
+        ? 'Drive By Ear is on for audio-only driving. Your chosen setting will return when the screen is shown.'
+        : 'Screen blanked. Drive By Ear is on.');
+    })().finally(() => {
+      activationPromise = null;
+      button.disabled = false;
+      button.removeAttribute('aria-busy');
+    });
+
+    return activationPromise;
   }
 
   function syncVisibility() {
@@ -236,9 +330,8 @@ export function installScreenBlanking(runtime = globalThis.__turnRuntime) {
     const gameplayVisible = controls.hidden !== true;
 
     if ((!gameplayVisible || visibility.menuState === IN_GAME_MENU_STATE.HIDDEN) && state === CONTROL_STATE.ACTIVE) {
-      clearArmTimer();
-      state = CONTROL_STATE.IDLE;
-      render();
+      setIdle({ announceChange: false, keepFocus: false });
+      return;
     }
 
     if (visibility.menuState !== IN_GAME_MENU_STATE.STAGED && state === CONTROL_STATE.ARMED) {
@@ -258,7 +351,7 @@ export function installScreenBlanking(runtime = globalThis.__turnRuntime) {
       return;
     }
     if (state === CONTROL_STATE.ARMED) {
-      activate();
+      void activate();
       return;
     }
     arm();
@@ -280,5 +373,5 @@ export function installScreenBlanking(runtime = globalThis.__turnRuntime) {
 
   render();
   syncVisibility();
-  return { button, overlay };
+  return { button, overlay, toast };
 }


### PR DESCRIPTION
## Summary
- make the central Drive By Ear audio graph available without requiring a reload
- lazily install the complete Drive By Ear runtime when audio-only mode needs it
- temporarily enable Drive By Ear when the player’s stored setting is off
- restore the player’s chosen Drive By Ear setting when the screen is shown again or gameplay is left
- provide visible and screen-reader toast feedback for the temporary setting change
- keep the show-screen control at the exact same measured size and position as the menu control
- use TURN’s orange back-navigation color while the screen is blanked

## Interaction
1. Tap the crossed-out eye.
2. TURN explains that Drive By Ear will be enabled temporarily when needed.
3. Tap again to confirm.
4. The screen blanks, the complete Drive By Ear runtime is active, and the orange eye remains where the original control was.
5. Show the screen again; TURN restores the saved Drive By Ear preference.

## Accessibility
- no player preference is overwritten in storage
- temporary state changes are announced through a visible `role=status` toast
- the restore button retains its first position in focus order and receives focus after blanking
- automatic exits also restore the player’s stored setting