### PR TITLE
Visualise TURN achievement system proposal

### DIFF
--- a/turn/achievements-design.html
+++ b/turn/achievements-design.html
@@ -1,0 +1,573 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
+  <title>TURN Achievement System Proposal</title>
+  <link rel="stylesheet" href="./design-tokens.css">
+  <link rel="stylesheet" href="./design-semantic.css">
+  <style>
+    :root {
+      color-scheme: light;
+      font-family: Inter, ui-rounded, system-ui, sans-serif;
+      background: var(--turn-ink);
+      color: var(--turn-paper);
+    }
+
+    * { box-sizing: border-box; }
+    body { margin: 0; background: var(--turn-ink); font-weight: 800; line-height: 1.4; }
+    button { font: inherit; }
+    button:focus-visible,
+    a:focus-visible {
+      outline: 5px solid var(--turn-form-control-focus);
+      outline-offset: 4px;
+    }
+
+    .page-head {
+      padding: clamp(36px, 7vw, 86px) max(22px, calc((100vw - 1180px) / 2));
+      background: linear-gradient(145deg, var(--turn-green-500), var(--turn-blue-500));
+      color: var(--turn-ink);
+      border-bottom: 6px solid var(--turn-ink);
+    }
+
+    .page-head-inner {
+      width: min(1180px, 100%);
+      margin: auto;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 24px;
+      align-items: center;
+    }
+
+    .eyebrow,
+    .label {
+      font-size: .74rem;
+      letter-spacing: .14em;
+      text-transform: uppercase;
+      font-weight: 950;
+    }
+
+    .eyebrow {
+      display: inline-block;
+      padding: 7px 11px;
+      border: 3px solid var(--turn-ink);
+      border-radius: var(--turn-radius-pill);
+      background: var(--turn-paper);
+      box-shadow: var(--turn-shadow-compact);
+    }
+
+    h1 {
+      max-width: 11ch;
+      margin: 18px 0 10px;
+      font-size: clamp(3.2rem, 9vw, 7rem);
+      line-height: .8;
+      letter-spacing: -.07em;
+    }
+
+    .page-head p { max-width: 68ch; margin: 0; font-size: clamp(1rem, 2vw, 1.25rem); }
+    .page-head img { width: min(150px, 24vw); border: 5px solid var(--turn-ink); border-radius: 24%; box-shadow: var(--turn-shadow-default); }
+
+    main { width: min(1180px, 100%); margin: auto; padding: 60px 22px 110px; }
+    section + section { margin-top: 84px; }
+    .section-head { display: grid; grid-template-columns: minmax(0, 1fr) minmax(260px, .55fr); gap: 28px; align-items: end; margin-bottom: 24px; }
+    .section-head h2 { margin: 6px 0 0; font-size: clamp(2.1rem, 5vw, 4.1rem); line-height: .9; letter-spacing: -.05em; }
+    .section-head p { margin: 0; color: rgb(255 248 232 / .78); }
+
+    .board,
+    .card {
+      border: 4px solid var(--turn-ink);
+      border-radius: var(--turn-radius-default);
+      background: var(--turn-paper);
+      color: var(--turn-ink);
+      box-shadow: var(--turn-shadow-default);
+    }
+
+    .board { padding: clamp(16px, 3vw, 28px); }
+    .card { padding: 18px; }
+    .card h3 { margin: 6px 0; }
+    .card p { margin: 0; }
+
+    .start-prototype {
+      min-height: 540px;
+      display: grid;
+      grid-template-columns: minmax(0, 1.35fr) minmax(260px, .55fr);
+      gap: 18px;
+      padding: 22px;
+      border: 8px solid var(--turn-ink);
+      border-radius: var(--turn-radius-hero);
+      background: var(--turn-blue-300);
+      color: var(--turn-ink);
+      box-shadow: var(--turn-shadow-hero);
+    }
+
+    .track-placeholder {
+      display: grid;
+      place-items: center;
+      min-height: 440px;
+      border: 4px dashed var(--turn-ink);
+      border-radius: var(--turn-radius-default);
+      background: rgb(255 255 255 / .28);
+      font-size: clamp(1.4rem, 4vw, 3rem);
+      letter-spacing: .06em;
+      text-align: center;
+    }
+
+    .menu {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .menu-button,
+    .filter-button,
+    .status-pill {
+      border: 4px solid var(--turn-ink);
+      color: var(--turn-ink);
+      font-weight: 950;
+      text-transform: uppercase;
+    }
+
+    .menu-button {
+      min-height: 58px;
+      padding: 12px 16px;
+      border-radius: var(--turn-radius-default);
+      background: var(--turn-action-utility);
+      box-shadow: var(--turn-shadow-default);
+      text-align: left;
+    }
+
+    .menu-button.achievements {
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr) auto;
+      gap: 11px;
+      align-items: center;
+      background: var(--turn-action-success);
+    }
+
+    .menu-button.primary {
+      margin-top: auto;
+      border-radius: var(--turn-radius-pill);
+      background: var(--turn-action-primary);
+      text-align: center;
+    }
+
+    .menu-icon { width: 30px; height: 30px; }
+    .menu-icon svg,
+    .achievement-icon svg,
+    .toast-icon svg {
+      width: 100%;
+      height: 100%;
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 2.2;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+
+    .new-badge {
+      padding: 4px 8px;
+      border: 3px solid var(--turn-ink);
+      border-radius: var(--turn-radius-pill);
+      background: var(--turn-yellow-400);
+      font-size: .7rem;
+      letter-spacing: .08em;
+    }
+
+    .dialog-shell {
+      overflow: hidden;
+      border: 6px solid var(--turn-ink);
+      border-radius: var(--turn-radius-hero);
+      background: var(--turn-paper);
+      color: var(--turn-ink);
+      box-shadow: var(--turn-shadow-hero);
+    }
+
+    .dialog-head {
+      display: flex;
+      justify-content: space-between;
+      gap: 18px;
+      align-items: center;
+      padding: 18px 20px;
+      border-bottom: 4px solid var(--turn-ink);
+      background: var(--turn-action-success);
+    }
+
+    .dialog-head h3 { margin: 0; font-size: clamp(1.8rem, 4vw, 3rem); letter-spacing: -.04em; }
+    .close-button {
+      width: 52px;
+      height: 52px;
+      border: 4px solid var(--turn-ink);
+      border-radius: var(--turn-radius-circle);
+      background: var(--turn-action-navigation);
+      color: var(--turn-ink);
+      box-shadow: var(--turn-shadow-compact);
+      font-size: 1.7rem;
+      line-height: 1;
+    }
+
+    .dialog-body { padding: clamp(16px, 3vw, 26px); }
+    .summary-strip {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto auto;
+      gap: 18px;
+      align-items: center;
+      padding: 16px;
+      border: 4px solid var(--turn-ink);
+      border-radius: var(--turn-radius-default);
+      background: var(--turn-white);
+      box-shadow: var(--turn-shadow-compact);
+    }
+
+    .summary-main strong { display: block; font-size: 1.25rem; }
+    .progress-track {
+      height: 18px;
+      margin-top: 8px;
+      overflow: hidden;
+      border: 3px solid var(--turn-ink);
+      border-radius: var(--turn-radius-pill);
+      background: var(--turn-muted);
+    }
+
+    .progress-track span { display: block; width: 8.333%; height: 100%; background: var(--turn-action-success); border-right: 3px solid var(--turn-ink); }
+    .summary-stat { min-width: 92px; text-align: right; }
+    .summary-stat strong { display: block; font-size: 1.35rem; }
+
+    .filters { display: flex; flex-wrap: wrap; gap: 10px; margin: 18px 0; }
+    .filter-button {
+      min-height: 42px;
+      padding: 7px 13px;
+      border-width: 3px;
+      border-radius: var(--turn-radius-pill);
+      background: var(--turn-action-utility);
+      box-shadow: var(--turn-shadow-compact);
+    }
+
+    .filter-button[aria-pressed="true"] { background: var(--turn-action-information); }
+    .achievement-list { display: grid; gap: 14px; }
+
+    .achievement-card {
+      display: grid;
+      grid-template-columns: 88px minmax(0, 1fr) auto;
+      gap: 16px;
+      align-items: center;
+      padding: 15px;
+      border: 4px solid var(--turn-ink);
+      border-radius: var(--turn-radius-default);
+      background: var(--turn-white);
+      box-shadow: var(--turn-shadow-compact);
+    }
+
+    .achievement-card.unlocked { background: color-mix(in srgb, var(--turn-green-200) 72%, var(--turn-white)); }
+    .achievement-card.hidden { background: color-mix(in srgb, var(--turn-muted) 70%, var(--turn-white)); }
+
+    .achievement-icon {
+      display: grid;
+      place-items: center;
+      width: 88px;
+      height: 88px;
+      padding: 18px;
+      border: 4px solid var(--turn-ink);
+      border-radius: var(--turn-radius-default);
+      background: var(--turn-action-success);
+      box-shadow: var(--turn-shadow-compact);
+    }
+
+    .achievement-card.locked .achievement-icon { background: var(--turn-muted); }
+    .achievement-card.hidden .achievement-icon { background: var(--turn-road); color: var(--turn-paper); font-size: 2.4rem; }
+    .achievement-copy h4 { margin: 3px 0 5px; font-size: clamp(1.25rem, 2.5vw, 1.75rem); line-height: 1; }
+    .achievement-copy p { margin: 0; }
+    .achievement-copy .meta { margin-top: 7px; font-size: .8rem; letter-spacing: .06em; text-transform: uppercase; }
+
+    .status-pill {
+      justify-self: end;
+      padding: 7px 10px;
+      border-width: 3px;
+      border-radius: var(--turn-radius-pill);
+      background: var(--turn-paper);
+      white-space: nowrap;
+      font-size: .72rem;
+      letter-spacing: .08em;
+    }
+
+    .locked-progress { margin-top: 9px; }
+    .locked-progress .progress-track { max-width: 320px; height: 14px; margin-top: 4px; }
+    .locked-progress .progress-track span { width: 60%; background: var(--turn-action-information); }
+
+    .toast-stage {
+      min-height: 330px;
+      display: grid;
+      place-items: start center;
+      padding: 28px;
+      border: 8px solid var(--turn-ink);
+      border-radius: var(--turn-radius-hero);
+      background: linear-gradient(var(--turn-road), #272b30);
+      box-shadow: var(--turn-shadow-hero);
+    }
+
+    .achievement-toast {
+      width: min(660px, 100%);
+      display: grid;
+      grid-template-columns: 66px minmax(0, 1fr) auto;
+      gap: 14px;
+      align-items: center;
+      padding: 13px;
+      border: 4px solid var(--turn-ink);
+      border-radius: var(--turn-radius-default);
+      background: var(--turn-action-success);
+      color: var(--turn-ink);
+      box-shadow: var(--turn-shadow-default);
+    }
+
+    .toast-icon {
+      width: 66px;
+      height: 66px;
+      padding: 13px;
+      border: 3px solid var(--turn-ink);
+      border-radius: var(--turn-radius-compact);
+      background: var(--turn-paper);
+    }
+
+    .toast-copy strong { display: block; }
+    .toast-title { font-size: 1.35rem; line-height: 1; }
+    .toast-points { padding: 6px 9px; border: 3px solid var(--turn-ink); border-radius: var(--turn-radius-pill); background: var(--turn-yellow-400); white-space: nowrap; }
+
+    .principles { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 16px; }
+    .sequence { margin: 0; padding-left: 1.3rem; }
+    .sequence li + li { margin-top: 8px; }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+
+    .decision {
+      padding: 18px;
+      border: 4px solid var(--turn-ink);
+      border-radius: var(--turn-radius-default);
+      background: var(--turn-yellow-200);
+      color: var(--turn-ink);
+      box-shadow: var(--turn-shadow-default);
+    }
+
+    .decision h3 { margin: 0 0 7px; }
+    .decision p { margin: 0; }
+
+    @media (max-width: 860px) {
+      .page-head-inner,
+      .section-head,
+      .start-prototype,
+      .principles { grid-template-columns: 1fr; }
+      .page-head img { display: none; }
+      .track-placeholder { min-height: 260px; }
+      .summary-strip { grid-template-columns: 1fr 1fr; }
+      .summary-main { grid-column: 1 / -1; }
+      .summary-stat { text-align: left; }
+    }
+
+    @media (max-width: 620px) {
+      .achievement-card { grid-template-columns: 70px minmax(0, 1fr); }
+      .achievement-icon { width: 70px; height: 70px; padding: 13px; }
+      .status-pill { grid-column: 2; justify-self: start; }
+      .achievement-toast { grid-template-columns: 54px minmax(0, 1fr); }
+      .toast-icon { width: 54px; height: 54px; padding: 10px; }
+      .toast-points { grid-column: 2; justify-self: start; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; }
+    }
+  </style>
+</head>
+<body>
+  <header class="page-head">
+    <div class="page-head-inner">
+      <div>
+        <span class="eyebrow">Design proposal · not production</span>
+        <h1>TURN ACHIEVEMENTS</h1>
+        <p>A recognizable achievement system that rewards exploration and different ways to play without competing with the race itself.</p>
+      </div>
+      <img src="./TURNicon.PNG" alt="TURN app icon">
+    </div>
+  </header>
+
+  <main>
+    <section aria-labelledby="entry-heading">
+      <div class="section-head">
+        <div><span class="label">01 · Entry point</span><h2 id="entry-heading">Success has a stable home.</h2></div>
+        <p>The Achievements destination is available from Home and the staged pre-race menu. It remains subordinate to the pink primary race action.</p>
+      </div>
+
+      <div class="start-prototype" aria-label="Start page menu proposal">
+        <div class="track-placeholder">TRACK CHOOSER<br>UNCHANGED</div>
+        <div class="menu">
+          <button class="menu-button" type="button">SETTINGS</button>
+          <button class="menu-button" type="button">HOW TO PLAY</button>
+          <button class="menu-button achievements" type="button">
+            <span class="menu-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24"><path d="M7 4h10v4c0 4-2 7-5 8-3-1-5-4-5-8V4Z"></path><path d="M7 6H4v2c0 2 1 3 4 4M17 6h3v2c0 2-1 3-4 4M9 20h6M12 16v4"></path></svg>
+            </span>
+            <span>ACHIEVEMENTS</span>
+            <span class="new-badge">NEW 1</span>
+          </button>
+          <button class="menu-button" type="button">GIVE FEEDBACK</button>
+          <button class="menu-button primary" type="button">RACE THIS TRACK</button>
+        </div>
+      </div>
+    </section>
+
+    <section aria-labelledby="modal-heading">
+      <div class="section-head">
+        <div><span class="label">02 · Collection</span><h2 id="modal-heading">Clear goals, visible progress.</h2></div>
+        <p>The collection uses familiar icon, title, description, progress and unlocked states. Colour supports status but never carries it alone.</p>
+      </div>
+
+      <div class="dialog-shell" role="dialog" aria-modal="false" aria-labelledby="achievement-dialog-title">
+        <div class="dialog-head">
+          <h3 id="achievement-dialog-title">ACHIEVEMENTS</h3>
+          <button class="close-button" type="button" aria-label="Close Achievements">×</button>
+        </div>
+        <div class="dialog-body">
+          <div class="summary-strip">
+            <div class="summary-main">
+              <strong>1 OF 12 UNLOCKED</strong>
+              <div class="progress-track" role="progressbar" aria-label="Achievement completion" aria-valuemin="0" aria-valuemax="12" aria-valuenow="1"><span></span></div>
+            </div>
+            <div class="summary-stat"><span class="label">Points</span><strong>50</strong></div>
+            <div class="summary-stat"><span class="label">Completion</span><strong>8%</strong></div>
+          </div>
+
+          <div class="filters" aria-label="Achievement filters">
+            <button class="filter-button" type="button" aria-pressed="true">ALL</button>
+            <button class="filter-button" type="button" aria-pressed="false">UNLOCKED</button>
+            <button class="filter-button" type="button" aria-pressed="false">IN PROGRESS</button>
+            <button class="filter-button" type="button" aria-pressed="false">HIDDEN</button>
+          </div>
+
+          <div class="achievement-list">
+            <article class="achievement-card unlocked">
+              <div class="achievement-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24"><path d="M2.5 12s3.5-6 9.5-6 9.5 6 9.5 6-3.5 6-9.5 6S2.5 12 2.5 12Z"></path><circle cx="12" cy="12" r="2.5"></circle><path d="M4 4l16 16"></path></svg>
+              </div>
+              <div class="achievement-copy">
+                <span class="label">Ways to play · 50 points</span>
+                <h4>TRUST YOUR EARS</h4>
+                <p>Finish a valid lap with Blank screen mode on from start to finish.</p>
+                <p class="meta">Unlocked · Countryside · Training Car</p>
+              </div>
+              <span class="status-pill">✓ UNLOCKED</span>
+            </article>
+
+            <article class="achievement-card locked">
+              <div class="achievement-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24"><path d="M4 18 8.5 8l3.5 4 3.5-7L20 18Z"></path><path d="M4 18h16"></path></svg>
+              </div>
+              <div class="achievement-copy">
+                <span class="label">Exploration · 100 points</span>
+                <h4>AROUND THE TURN</h4>
+                <p>Finish a valid lap on every track.</p>
+                <div class="locked-progress">
+                  <span class="label">3 of 5 tracks</span>
+                  <div class="progress-track" role="progressbar" aria-label="Three of five tracks completed" aria-valuemin="0" aria-valuemax="5" aria-valuenow="3"><span></span></div>
+                </div>
+              </div>
+              <span class="status-pill">IN PROGRESS</span>
+            </article>
+
+            <article class="achievement-card hidden">
+              <div class="achievement-icon" aria-hidden="true">?</div>
+              <div class="achievement-copy">
+                <span class="label">Hidden · 100 points</span>
+                <h4>HIDDEN ACHIEVEMENT</h4>
+                <p>Keep racing to discover this achievement.</p>
+                <p class="meta">The name, icon and requirement appear after unlock.</p>
+              </div>
+              <span class="status-pill">LOCKED</span>
+            </article>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section aria-labelledby="toast-heading">
+      <div class="section-head">
+        <div><span class="label">03 · Unlock feedback</span><h2 id="toast-heading">Celebrate after the driving task.</h2></div>
+        <p>The unlock toast waits until the lap result has completed. It does not interrupt pace notes, the lap summary or immediate recovery guidance.</p>
+      </div>
+
+      <div class="toast-stage">
+        <div class="achievement-toast" role="status" aria-live="polite" aria-atomic="true">
+          <div class="toast-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24"><path d="M2.5 12s3.5-6 9.5-6 9.5 6 9.5 6-3.5 6-9.5 6S2.5 12 2.5 12Z"></path><circle cx="12" cy="12" r="2.5"></circle><path d="M4 4l16 16"></path></svg>
+          </div>
+          <div class="toast-copy">
+            <span class="label">Achievement unlocked</span>
+            <strong class="toast-title">TRUST YOUR EARS</strong>
+          </div>
+          <strong class="toast-points">+50 POINTS</strong>
+        </div>
+      </div>
+    </section>
+
+    <section aria-labelledby="rules-heading">
+      <div class="section-head">
+        <div><span class="label">04 · Product rules</span><h2 id="rules-heading">A small system with room to grow.</h2></div>
+        <p>TURN owns the definitions and local progress first. Native platform achievements can later mirror the same stable identifiers.</p>
+      </div>
+
+      <div class="principles">
+        <article class="card">
+          <span class="label">Recognition</span>
+          <h3>Use the familiar grammar</h3>
+          <p>Icon, memorable name, plain requirement, point value, progress and a persistent unlocked state.</p>
+        </article>
+        <article class="card">
+          <span class="label">Fair criteria</span>
+          <h3>Whole-lap requirement</h3>
+          <p><strong>TRUST YOUR EARS</strong> starts only when Blank screen mode is active before the start line and remains active until a valid lap completes.</p>
+        </article>
+        <article class="card">
+          <span class="label">No power advantage</span>
+          <h3>Status, goals and cosmetics</h3>
+          <p>Achievement points show completion. Future rewards should be cosmetic or choice-expanding, not stronger car performance.</p>
+        </article>
+        <article class="card">
+          <span class="label">Accessibility</span>
+          <h3>Equivalent feedback</h3>
+          <p>Text, icon and spoken status convey the same result. Motion and sound are supplementary and respect existing preferences.</p>
+        </article>
+        <article class="card">
+          <span class="label">Rarity</span>
+          <h3>Do not invent percentages</h3>
+          <p>Show designed point value now. Add real completion rarity only when TURN has trustworthy aggregate player data.</p>
+        </article>
+        <article class="card">
+          <span class="label">Scope</span>
+          <h3>Base collection first</h3>
+          <p>Start with roughly 10–15 durable achievements across racing, technique, exploration, collection and ways to play.</p>
+        </article>
+      </div>
+    </section>
+
+    <section aria-labelledby="sequence-heading">
+      <div class="section-head">
+        <div><span class="label">05 · Announcement order</span><h2 id="sequence-heading">Protect the race audio hierarchy.</h2></div>
+        <p>The order is deterministic so an achievement never masks information needed to drive or understand the lap result.</p>
+      </div>
+
+      <div class="board">
+        <ol class="sequence">
+          <li>Finish and validate the lap.</li>
+          <li>Present and speak the existing lap result.</li>
+          <li>Unlock the achievement in persistent storage.</li>
+          <li>After the lap result completes, show the toast and announce: “Achievement unlocked. Trust Your Ears.”</li>
+          <li>Mark the Achievements menu button with <strong>NEW 1</strong> until the collection is opened.</li>
+        </ol>
+      </div>
+    </section>
+
+    <section aria-labelledby="recommendation-heading">
+      <div class="decision">
+        <h3 id="recommendation-heading">Recommended first release</h3>
+        <p>Add the green <strong>ACHIEVEMENTS</strong> entry on Home and in the staged pre-race menu, ship a 10–15 item base collection, and use <strong>TRUST YOUR EARS</strong> as the first implemented achievement. Keep the modal unavailable during an active timed lap; surface new unlocks through the post-lap toast and the menu badge.</p>
+      </div>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Purpose
Design-only proposal for TURN's achievement system. No production achievement logic is added.

## Prototype
Adds `turn/achievements-design.html`, using the current TURN design tokens and semantic roles.

## Proposed interaction
- green `ACHIEVEMENTS` entry on Home and in the staged pre-race menu
- persistent collection with icon, memorable title, plain requirement, progress, points and unlocked state
- `NEW` badge for unseen unlocks
- post-lap unlock toast that waits until the existing lap result has completed
- hidden achievements supported without spoilers
- real completion rarity deferred until TURN has trustworthy aggregate data

## First achievement
**TRUST YOUR EARS**

Finish a valid lap with Blank screen mode on from start to finish, on any track with any vehicle.

The crossed-out eye from Blank screen mode is reused as the achievement icon.

## Accessibility and audio priority
- icon, text and status labels provide equivalent information
- progress uses native progressbar semantics
- toast uses a polite status announcement rather than an interruptive alert
- pace notes, recovery guidance and the lap result retain higher priority
- reduced-motion preferences are respected

## Product direction
The proposal assumes TURN-owned, versioned achievement definitions and local progress first, with future Game Center / Google Play / platform adapters mirroring the same stable IDs.