### PR TITLE
Add TURN achievements and onboarding challenges

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -151,6 +151,9 @@ jobs:
       - name: Run lap result toast regression
         run: node turn-lab/tests/lap-result-toast-production.mjs
 
+      - name: Run achievement system regression
+        run: node turn-lab/tests/achievements-production.mjs
+
       - name: Run production sound foundation regression
         run: node turn-lab/tests/audio-foundation-production.mjs
 

--- a/turn-lab/tests/achievements-production.mjs
+++ b/turn-lab/tests/achievements-production.mjs
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import {
+  ACHIEVEMENTS,
+  ACHIEVEMENT_STORAGE_KEY,
+  ONBOARDING_ACHIEVEMENT_IDS,
+  loadAchievementState,
+  normalizeAchievementState
+} from '../../turn/achievements.js';
+
+const [catalog, storeSource, runtime, view, style, fixedLayout, workflow, designTokens] = await Promise.all([
+  fs.readFile(new URL('../../turn/achievements/catalog.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/achievements/store.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/achievements/runtime.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/achievements/view.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/achievements.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../.github/workflows/turn-lab-tests.yml', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/design-tokens.css', import.meta.url), 'utf8')
+]);
+
+assert.equal(ACHIEVEMENT_STORAGE_KEY, 'turn-achievements-v1');
+assert.equal(ACHIEVEMENTS.length, 13, 'The first release should ship a focused thirteen-achievement collection');
+assert.equal(ONBOARDING_ACHIEVEMENT_IDS.length, 10, 'Getting Started should contain ten onboarding achievements');
+assert.deepEqual(
+  ACHIEVEMENTS.map((achievement) => achievement.id),
+  [
+    'first-turn',
+    'take-it-from-the-top',
+    'charge-through-it',
+    'second-wind',
+    'flow-state',
+    'watch-and-learn',
+    'your-own-rival',
+    'level-head',
+    'new-wheels',
+    'new-ground',
+    'trust-your-ears',
+    'around-the-turn',
+    'ahead-of-yourself'
+  ]
+);
+assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === 'flow-state')?.points, 50);
+assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === 'flow-state')?.description || '', /Drift and Boost/);
+assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === 'flow-state')?.recommendation || '', /Training Car · Countryside/);
+assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === 'trust-your-ears')?.description || '', /Blank screen mode on from start to finish/);
+
+const empty = normalizeAchievementState(null);
+assert.deepEqual(empty.progress.tracks, []);
+assert.deepEqual(empty.seen, []);
+assert.deepEqual(empty.unlocked, {});
+
+const normalized = normalizeAchievementState({
+  version: 999,
+  unlocked: {
+    'first-turn': { unlockedAt: 123, trackId: 'countryside', vehicleId: 'classic', time: 42.5 },
+    invented: { unlockedAt: 456 }
+  },
+  seen: ['first-turn', 'invented', 'first-turn'],
+  progress: { tracks: ['airport', 'airport', 'invented'] }
+});
+assert.deepEqual(Object.keys(normalized.unlocked), ['first-turn']);
+assert.deepEqual(normalized.seen, ['first-turn']);
+assert.deepEqual(normalized.progress.tracks, ['airport']);
+
+const memory = new Map();
+const storage = {
+  getItem: (key) => memory.get(key) ?? null,
+  setItem: (key, value) => memory.set(key, value)
+};
+assert.equal(loadAchievementState(storage).storageAvailable, true);
+memory.set(ACHIEVEMENT_STORAGE_KEY, JSON.stringify(normalized));
+assert.deepEqual(Object.keys(loadAchievementState(storage).state.unlocked), ['first-turn']);
+assert.equal(loadAchievementState({ getItem: () => { throw new Error('blocked'); } }).storageAvailable, false);
+
+assert.match(catalog, /category: CATEGORY\.ONBOARDING/);
+assert.match(catalog, /id: 'flow-state'/);
+assert.match(catalog, /id: 'trust-your-ears'/);
+assert.match(catalog, /id: 'around-the-turn'/);
+assert.match(catalog, /id: 'ahead-of-yourself'/);
+assert.match(storeSource, /ACHIEVEMENT_STORAGE_KEY = 'turn-achievements-v1'/);
+assert.match(storeSource, /state\.progress\.tracks\.push/);
+assert.match(storeSource, /markAllSeen/);
+
+assert.match(runtime, /SPECTATE_REQUIRED_MS = 5000/);
+assert.match(runtime, /LAP_TOAST_DELAY_MS = 4400/,
+  'Achievement feedback must wait until the existing lap result has finished');
+assert.match(runtime, /SAMPLE_INTERVAL_MS = 100/,
+  'Driving mechanics should be sampled lightly rather than adding another frame loop');
+assert.match(runtime, /flowEligible/);
+assert.match(runtime, /usedDrift/);
+assert.match(runtime, /usedBoost/);
+assert.match(runtime, /driftChargeGained >= 0\.25/);
+assert.match(runtime, /secondWind\.sawEmpty/);
+assert.match(runtime, /secondWind\.sawRecharge/);
+assert.match(runtime, /turn-screen-blanked/);
+assert.match(runtime, /reason === 'lap-started'/);
+assert.match(runtime, /reason === 'race-reset'/);
+assert.match(runtime, /reason === 'spectate-started'/);
+assert.match(runtime, /reason === 'spectate-stopped'/);
+assert.match(runtime, /turn:lap-result/);
+assert.match(runtime, /turn:lap-invalid/);
+assert.match(runtime, /turn:track-changed/);
+assert.match(runtime, /turn:achievements-updated/);
+assert.match(runtime, /pendingTrackEntryPulse/);
+
+assert.match(view, /aria-live', 'polite'/);
+assert.match(view, /role="progressbar"/);
+assert.match(view, /data-achievement-filter="onboarding"/);
+assert.match(view, /store\.markAllSeen\(\)/);
+assert.match(view, /prefers-reduced-motion: reduce/);
+assert.match(view, /is-achievement-pulsing/);
+assert.match(view, /createTrigger\('m8-achievements-button'/);
+assert.match(view, /createTrigger\('utility turn-race-achievements-button'/);
+
+assert.match(style, /\.m8-achievements-button/);
+assert.match(style, /\.turn-race-achievements-button/);
+assert.match(style, /\.turn-achievements-dialog/);
+assert.match(style, /\.turn-achievement-toast/);
+assert.match(style, /@keyframes turn-achievement-pulse/);
+assert.match(style, /animation: turn-achievement-pulse 720ms ease-in-out 3/);
+assert.match(style, /@media \(prefers-reduced-motion: reduce\)/);
+assert.match(style, /var\(--turn-action-success/);
+
+assert.match(designTokens, /--turn-action-success: var\(--turn-green-500\)/);
+assert.match(fixedLayout, /installAchievements/);
+assert.match(fixedLayout, /achievements\.js/);
+assert.ok(fixedLayout.indexOf('installM8HomeCardScrollFixes') < fixedLayout.indexOf('installAchievements'),
+  'Achievements should join the completed fixed Home layout after track scrolling is installed');
+assert.match(workflow, /Run achievement system regression/);
+assert.match(workflow, /node turn-lab\/tests\/achievements-production\.mjs/);
+
+console.log('TURN achievement system regression passed.');

--- a/turn/achievements.css
+++ b/turn/achievements.css
@@ -1,0 +1,449 @@
+.m8-achievements-button,
+.turn-race-achievements-button {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  border: var(--turn-border-default, 4px) solid var(--turn-ink, #08090a);
+  background: var(--turn-action-success, #8ce99a);
+  color: var(--turn-ink, #08090a);
+  box-shadow: var(--turn-shadow-default, 7px 7px 0 #08090a);
+  font-weight: 950;
+  text-transform: uppercase;
+}
+
+.m8-achievements-button {
+  min-height: 54px;
+  padding: 10px 14px;
+  border-radius: var(--turn-radius-default, 18px);
+  text-align: left;
+}
+
+.turn-race-achievements-button {
+  min-height: 50px;
+  padding-inline: 12px;
+}
+
+.turn-achievements-trigger-icon {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+}
+
+.turn-achievements-trigger-icon svg,
+.turn-achievement-icon svg,
+.turn-achievement-toast-icon svg {
+  width: 100%;
+  height: 100%;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.turn-achievements-trigger-badge {
+  padding: 3px 7px;
+  border: var(--turn-border-compact, 3px) solid var(--turn-ink, #08090a);
+  border-radius: var(--turn-radius-pill, 999px);
+  background: var(--turn-action-warning, #ffd43b);
+  font-size: .64rem;
+  line-height: 1.1;
+  letter-spacing: .08em;
+  white-space: nowrap;
+}
+
+.m8-achievements-button.has-unseen-achievements,
+.turn-race-achievements-button.has-unseen-achievements {
+  box-shadow:
+    var(--turn-shadow-default, 7px 7px 0 #08090a),
+    0 0 0 5px rgb(255 212 59 / .55);
+}
+
+.m8-achievements-button.is-achievement-next,
+.turn-race-achievements-button.is-achievement-next {
+  outline: 3px solid var(--turn-action-warning, #ffd43b);
+  outline-offset: 3px;
+}
+
+@keyframes turn-achievement-pulse {
+  0%, 100% { transform: scale(1); }
+  18% { transform: scale(1.06); }
+  36% { transform: scale(1); }
+}
+
+.turn-race-achievements-button.is-achievement-pulsing {
+  animation: turn-achievement-pulse 720ms ease-in-out 3;
+  transform-origin: center;
+}
+
+.turn-achievements-dialog {
+  width: min(980px, calc(100vw - 24px));
+  max-width: 980px;
+  max-height: min(92vh, 780px);
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--turn-ink, #08090a);
+}
+
+.turn-achievements-dialog::backdrop {
+  background: rgb(8 9 10 / .72);
+}
+
+.turn-achievements-card {
+  max-height: min(92vh, 780px);
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+
+.turn-achievements-head {
+  background: var(--turn-action-success, #8ce99a);
+}
+
+.turn-achievements-content {
+  display: grid;
+  gap: 16px;
+  padding: clamp(14px, 3vw, 24px);
+  background: var(--turn-surface-page, #fff8e8);
+}
+
+.turn-achievements-summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 18px;
+  align-items: center;
+  padding: 14px;
+  border: var(--turn-border-default, 4px) solid var(--turn-ink, #08090a);
+  border-radius: var(--turn-radius-default, 18px);
+  background: var(--turn-surface-raised, #fffdf6);
+  box-shadow: var(--turn-shadow-compact, 3px 3px 0 #08090a);
+}
+
+.turn-achievements-summary > div > strong {
+  display: block;
+  font-size: clamp(1rem, 2.4vw, 1.35rem);
+}
+
+.turn-achievements-summary p {
+  min-width: 92px;
+  margin: 0;
+  text-align: right;
+}
+
+.turn-achievements-summary p span,
+.turn-achievement-copy > span,
+.turn-achievement-toast span,
+.turn-achievement-progress > span {
+  display: block;
+  font-size: .68rem;
+  font-weight: 950;
+  letter-spacing: .11em;
+  text-transform: uppercase;
+}
+
+.turn-achievements-summary p strong {
+  display: block;
+  font-size: 1.35rem;
+}
+
+.turn-achievements-total-progress,
+.turn-achievement-progress > div {
+  overflow: hidden;
+  border: var(--turn-border-compact, 3px) solid var(--turn-ink, #08090a);
+  border-radius: var(--turn-radius-pill, 999px);
+  background: var(--turn-muted, #d6d0c2);
+}
+
+.turn-achievements-total-progress {
+  height: 17px;
+  margin-top: 8px;
+}
+
+.turn-achievements-total-progress i,
+.turn-achievement-progress i {
+  display: block;
+  width: var(--turn-achievement-progress, 0%);
+  height: 100%;
+  border-right: var(--turn-border-compact, 3px) solid var(--turn-ink, #08090a);
+  background: var(--turn-action-success, #8ce99a);
+}
+
+.turn-achievements-storage-note {
+  margin: 0;
+  padding: 10px 12px;
+  border: var(--turn-border-compact, 3px) solid var(--turn-ink, #08090a);
+  border-radius: var(--turn-radius-compact, 12px);
+  background: var(--turn-action-warning, #ffd43b);
+}
+
+.turn-achievements-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 9px;
+}
+
+.turn-achievements-filters button {
+  min-height: 40px;
+  padding: 6px 12px;
+  border: var(--turn-border-compact, 3px) solid var(--turn-ink, #08090a);
+  border-radius: var(--turn-radius-pill, 999px);
+  background: var(--turn-action-utility, #fff8e8);
+  color: var(--turn-ink, #08090a);
+  box-shadow: var(--turn-shadow-compact, 3px 3px 0 #08090a);
+  font-weight: 950;
+}
+
+.turn-achievements-filters button[aria-pressed="true"] {
+  background: var(--turn-action-information, #38d9ff);
+}
+
+.turn-achievements-list {
+  display: grid;
+  gap: 13px;
+}
+
+.turn-achievement-card {
+  display: grid;
+  grid-template-columns: 78px minmax(0, 1fr) auto;
+  gap: 15px;
+  align-items: center;
+  padding: 14px;
+  border: var(--turn-border-default, 4px) solid var(--turn-ink, #08090a);
+  border-radius: var(--turn-radius-default, 18px);
+  background: var(--turn-surface-raised, #fffdf6);
+  box-shadow: var(--turn-shadow-compact, 3px 3px 0 #08090a);
+}
+
+.turn-achievement-card[hidden] {
+  display: none;
+}
+
+.turn-achievement-card.is-unlocked {
+  background: color-mix(in srgb, var(--turn-green-200, #d9f5c2) 72%, var(--turn-white, #fffdf6));
+}
+
+.turn-achievement-card.is-recommended {
+  background: color-mix(in srgb, var(--turn-blue-200, #8ed8ff) 52%, var(--turn-white, #fffdf6));
+  box-shadow:
+    var(--turn-shadow-compact, 3px 3px 0 #08090a),
+    0 0 0 4px var(--turn-action-warning, #ffd43b);
+}
+
+.turn-achievement-icon {
+  display: grid;
+  width: 78px;
+  height: 78px;
+  padding: 15px;
+  place-items: center;
+  border: var(--turn-border-default, 4px) solid var(--turn-ink, #08090a);
+  border-radius: var(--turn-radius-default, 18px);
+  background: var(--turn-action-success, #8ce99a);
+  box-shadow: var(--turn-shadow-compact, 3px 3px 0 #08090a);
+}
+
+.turn-achievement-card.is-locked:not(.is-recommended) .turn-achievement-icon {
+  background: var(--turn-muted, #d6d0c2);
+}
+
+.turn-achievement-copy {
+  min-width: 0;
+}
+
+.turn-achievement-copy h4 {
+  margin: 4px 0 5px;
+  font-size: clamp(1.05rem, 2.2vw, 1.45rem);
+  line-height: 1;
+}
+
+.turn-achievement-copy p,
+.turn-achievement-copy small {
+  display: block;
+  margin: 0;
+  line-height: 1.3;
+}
+
+.turn-achievement-copy small {
+  margin-top: 6px;
+  font-size: .75rem;
+}
+
+.turn-achievement-status {
+  justify-self: end;
+  padding: 5px 8px;
+  border: var(--turn-border-compact, 3px) solid var(--turn-ink, #08090a);
+  border-radius: var(--turn-radius-pill, 999px);
+  background: var(--turn-surface-page, #fff8e8);
+  font-size: .65rem;
+  letter-spacing: .07em;
+  white-space: nowrap;
+}
+
+.turn-achievement-card.is-recommended .turn-achievement-status {
+  background: var(--turn-action-warning, #ffd43b);
+}
+
+.turn-achievement-progress {
+  max-width: 330px;
+  margin-top: 8px;
+}
+
+.turn-achievement-progress > div {
+  height: 13px;
+  margin-top: 3px;
+}
+
+.turn-achievement-progress i {
+  background: var(--turn-action-information, #38d9ff);
+}
+
+.turn-achievement-toast {
+  position: fixed;
+  z-index: 2147482500;
+  top: max(14px, calc(env(safe-area-inset-top) + 8px));
+  left: 50%;
+  width: min(680px, calc(100vw - 24px));
+  display: grid;
+  grid-template-columns: 64px minmax(0, 1fr) auto;
+  gap: 13px;
+  align-items: center;
+  padding: 12px;
+  border: var(--turn-border-default, 4px) solid var(--turn-ink, #08090a);
+  border-radius: var(--turn-radius-default, 18px);
+  background: var(--turn-action-success, #8ce99a);
+  color: var(--turn-ink, #08090a);
+  box-shadow: var(--turn-shadow-default, 7px 7px 0 #08090a);
+  opacity: 0;
+  transform: translate(-50%, -130%);
+  transition: transform 220ms ease, opacity 180ms ease;
+  pointer-events: none;
+}
+
+.turn-achievement-toast[hidden] {
+  display: none;
+}
+
+.turn-achievement-toast.is-visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.turn-achievement-toast-icon {
+  display: grid;
+  width: 64px;
+  height: 64px;
+  padding: 12px;
+  place-items: center;
+  border: var(--turn-border-compact, 3px) solid var(--turn-ink, #08090a);
+  border-radius: var(--turn-radius-compact, 12px);
+  background: var(--turn-surface-page, #fff8e8);
+}
+
+.turn-achievement-toast strong {
+  display: block;
+  font-size: clamp(1rem, 2.4vw, 1.35rem);
+  line-height: 1;
+}
+
+.turn-achievement-toast > b {
+  padding: 5px 8px;
+  border: var(--turn-border-compact, 3px) solid var(--turn-ink, #08090a);
+  border-radius: var(--turn-radius-pill, 999px);
+  background: var(--turn-action-warning, #ffd43b);
+  font-size: .72rem;
+  white-space: nowrap;
+}
+
+@media (max-width: 720px) {
+  .turn-achievements-summary {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .turn-achievements-summary > div {
+    grid-column: 1 / -1;
+  }
+
+  .turn-achievements-summary p {
+    text-align: left;
+  }
+
+  .turn-achievement-card {
+    grid-template-columns: 64px minmax(0, 1fr);
+  }
+
+  .turn-achievement-icon {
+    width: 64px;
+    height: 64px;
+    padding: 11px;
+  }
+
+  .turn-achievement-status {
+    grid-column: 2;
+    justify-self: start;
+  }
+
+  .turn-achievement-toast {
+    grid-template-columns: 54px minmax(0, 1fr);
+  }
+
+  .turn-achievement-toast-icon {
+    width: 54px;
+    height: 54px;
+    padding: 9px;
+  }
+
+  .turn-achievement-toast > b {
+    grid-column: 2;
+    justify-self: start;
+  }
+}
+
+@media (max-height: 430px) and (orientation: landscape) {
+  .turn-achievements-dialog {
+    width: min(1040px, calc(100vw - 16px));
+    max-height: calc(100vh - 12px);
+  }
+
+  .turn-achievements-card {
+    max-height: calc(100vh - 12px);
+  }
+
+  .turn-achievements-content {
+    padding: 10px 12px 14px;
+    gap: 10px;
+  }
+
+  .turn-achievements-summary {
+    padding: 9px 11px;
+  }
+
+  .turn-achievement-card {
+    grid-template-columns: 56px minmax(0, 1fr) auto;
+    padding: 9px;
+    gap: 10px;
+  }
+
+  .turn-achievement-icon {
+    width: 56px;
+    height: 56px;
+    padding: 10px;
+  }
+
+  .turn-achievement-copy h4 {
+    margin-block: 2px 3px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .turn-race-achievements-button.is-achievement-pulsing {
+    animation: none;
+    outline: 3px solid var(--turn-action-warning, #ffd43b);
+    outline-offset: 3px;
+  }
+
+  .turn-achievement-toast {
+    transition: none;
+  }
+}

--- a/turn/achievements.js
+++ b/turn/achievements.js
@@ -1,0 +1,10 @@
+export {
+  ACHIEVEMENTS,
+  ONBOARDING_ACHIEVEMENT_IDS
+} from './achievements/catalog.js?revision=r144-achievements';
+export {
+  ACHIEVEMENT_STORAGE_KEY,
+  loadAchievementState,
+  normalizeAchievementState
+} from './achievements/store.js?revision=r144-achievements';
+export { installAchievements } from './achievements/runtime.js?revision=r144-achievements';

--- a/turn/achievements/catalog.js
+++ b/turn/achievements/catalog.js
@@ -1,0 +1,93 @@
+export const TRACK_IDS = Object.freeze([
+  'countryside',
+  'airport',
+  'cliffside',
+  'harbor',
+  'midnight-city'
+]);
+
+export const TRAINING_CAR_ID = 'classic';
+
+export const CATEGORY = Object.freeze({
+  ONBOARDING: 'onboarding',
+  WAYS_TO_PLAY: 'ways-to-play',
+  EXPLORATION: 'exploration',
+  RACING: 'racing'
+});
+
+export const CATEGORY_LABELS = Object.freeze({
+  [CATEGORY.ONBOARDING]: 'Getting started',
+  [CATEGORY.WAYS_TO_PLAY]: 'Ways to play',
+  [CATEGORY.EXPLORATION]: 'Exploration',
+  [CATEGORY.RACING]: 'Racing'
+});
+
+export const TRACK_NAMES = Object.freeze({
+  countryside: 'Countryside',
+  airport: 'Airport',
+  cliffside: 'Cliffside',
+  harbor: 'Harbor',
+  'midnight-city': 'Midnight City'
+});
+
+export const VEHICLE_NAMES = Object.freeze({
+  convertible: 'Convertible',
+  classic: 'Training Car',
+  'vintage-racer': 'Vintage Racer',
+  'toy-racer': 'Toy Racer',
+  'monster-truck': 'Monster Truck',
+  'race-future': 'Future Racer',
+  race: 'Race Car',
+  'sedan-sports': 'Sport Sedan',
+  sedan: 'Sedan',
+  suv: 'SUV',
+  firetruck: 'Fire Truck',
+  police: 'Police Car',
+  ambulance: 'Ambulance',
+  truck: 'Truck',
+  van: 'Van'
+});
+
+export const ICONS = Object.freeze({
+  flag: '<svg viewBox="0 0 24 24"><path d="M5 21V4"></path><path d="M6 5h11l-2.5 3L17 11H6"></path><path d="M3 21h6"></path></svg>',
+  restart: '<svg viewBox="0 0 24 24"><path d="M4 9V4l4 3"></path><path d="M5 7a8 8 0 1 1-1 8"></path><path d="M12 8v5l3 2"></path></svg>',
+  charge: '<svg viewBox="0 0 24 24"><path d="M7 4h8v16H7Z"></path><path d="M9 2h4"></path><path d="m13 7-3 5h3l-2 5"></path><path d="M18 9c2 1 3 3 3 5"></path></svg>',
+  wind: '<svg viewBox="0 0 24 24"><path d="M4 8h10c3 0 3-4 0-4-2 0-2 2-2 2"></path><path d="M3 12h14c4 0 4 6 0 6-2 0-3-2-2-3"></path><path d="M5 16h6"></path></svg>',
+  flow: '<svg viewBox="0 0 24 24"><path d="M3 12c3-6 6-6 9 0s6 6 9 0c-3-6-6-6-9 0s-6 6-9 0Z"></path></svg>',
+  spectate: '<svg viewBox="0 0 24 24"><path d="M2.5 12s3.5-6 9.5-6 9.5 6 9.5 6-3.5 6-9.5 6S2.5 12 2.5 12Z"></path><circle cx="12" cy="12" r="2.5"></circle><path d="m17 17 4 4"></path></svg>',
+  rival: '<svg viewBox="0 0 24 24"><path d="M3 15h8l2-5h5l3 5v4h-2"></path><path d="M5 19H3v-4"></path><circle cx="7" cy="19" r="2"></circle><circle cx="17" cy="19" r="2"></circle><path d="M4 10h6l1-3h4"></path></svg>',
+  level: '<svg viewBox="0 0 24 24"><path d="M3 8h18v8H3Z"></path><circle cx="12" cy="12" r="2"></circle><path d="M6 12h2M16 12h2"></path></svg>',
+  wheel: '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"></circle><circle cx="12" cy="12" r="3"></circle><path d="M12 3v6M4.2 8.2l5.2 3M19.8 8.2l-5.2 3M7 19l3-5.2M17 19l-3-5.2"></path></svg>',
+  map: '<svg viewBox="0 0 24 24"><path d="m3 6 6-3 6 3 6-3v15l-6 3-6-3-6 3Z"></path><path d="M9 3v15M15 6v15"></path></svg>',
+  blind: '<svg viewBox="0 0 24 24"><path d="M2.5 12s3.5-6 9.5-6 9.5 6 9.5 6-3.5 6-9.5 6S2.5 12 2.5 12Z"></path><circle cx="12" cy="12" r="2.5"></circle><path d="M4 4l16 16"></path></svg>',
+  route: '<svg viewBox="0 0 24 24"><circle cx="5" cy="18" r="2"></circle><circle cx="19" cy="6" r="2"></circle><path d="M7 18h3c3 0 3-5 6-5h1M17 6h-3c-3 0-3 4-6 4H5"></path></svg>',
+  trophy: '<svg viewBox="0 0 24 24"><path d="M7 4h10v4c0 4-2 7-5 8-3-1-5-4-5-8V4Z"></path><path d="M7 6H4v2c0 2 1 3 4 4M17 6h3v2c0 2-1 3-4 4M9 20h6M12 16v4"></path></svg>'
+});
+
+export const ACHIEVEMENTS = Object.freeze([
+  Object.freeze({ id: 'first-turn', category: CATEGORY.ONBOARDING, points: 25, title: 'FIRST TURN', description: 'Finish any valid lap.', icon: 'flag' }),
+  Object.freeze({ id: 'take-it-from-the-top', category: CATEGORY.ONBOARDING, points: 25, title: 'TAKE IT FROM THE TOP', description: 'Use Restart Lap after the current lap becomes void.', icon: 'restart' }),
+  Object.freeze({ id: 'charge-through-it', category: CATEGORY.ONBOARDING, points: 25, title: 'CHARGE THROUGH IT', description: 'Recharge at least 25% of the Boost meter while drifting in one lap.', icon: 'charge', progressMax: 25 }),
+  Object.freeze({ id: 'second-wind', category: CATEGORY.ONBOARDING, points: 25, title: 'SECOND WIND', description: 'Run Boost empty, let it recharge, then activate Boost again.', icon: 'wind' }),
+  Object.freeze({ id: 'flow-state', category: CATEGORY.ONBOARDING, points: 50, title: 'FLOW STATE', description: 'Finish a valid lap using only Drift and Boost for forward drive.', recommendation: 'Recommended: Training Car · Countryside', icon: 'flow' }),
+  Object.freeze({ id: 'watch-and-learn', category: CATEGORY.ONBOARDING, points: 25, title: 'WATCH AND LEARN', description: 'Spectate a rival for five seconds, then return to the start.', icon: 'spectate', progressMax: 5 }),
+  Object.freeze({ id: 'your-own-rival', category: CATEGORY.ONBOARDING, points: 25, title: 'YOUR OWN RIVAL', description: 'Finish a valid lap with one of your saved rivals on the track.', icon: 'rival' }),
+  Object.freeze({ id: 'level-head', category: CATEGORY.ONBOARDING, points: 25, title: 'LEVEL HEAD', description: 'Recalibrate, then finish a valid lap.', icon: 'level' }),
+  Object.freeze({ id: 'new-wheels', category: CATEGORY.ONBOARDING, points: 25, title: 'NEW WHEELS', description: 'Finish a valid lap with a vehicle other than the Training Car.', icon: 'wheel' }),
+  Object.freeze({ id: 'new-ground', category: CATEGORY.ONBOARDING, points: 25, title: 'NEW GROUND', description: 'Finish valid laps on two different tracks.', icon: 'map', progressMax: 2 }),
+  Object.freeze({ id: 'trust-your-ears', category: CATEGORY.WAYS_TO_PLAY, points: 50, title: 'TRUST YOUR EARS', description: 'Finish a valid lap with Blank screen mode on from start to finish.', icon: 'blind' }),
+  Object.freeze({ id: 'around-the-turn', category: CATEGORY.EXPLORATION, points: 100, title: 'AROUND THE TURN', description: 'Finish a valid lap on every track.', icon: 'route', progressMax: TRACK_IDS.length }),
+  Object.freeze({ id: 'ahead-of-yourself', category: CATEGORY.RACING, points: 50, title: 'AHEAD OF YOURSELF', description: 'Finish first in a lap with at least one saved rival.', icon: 'trophy' })
+]);
+
+export const ONBOARDING_ACHIEVEMENT_IDS = Object.freeze(
+  ACHIEVEMENTS
+    .filter((achievement) => achievement.category === CATEGORY.ONBOARDING)
+    .map((achievement) => achievement.id)
+);
+
+const ACHIEVEMENT_BY_ID = new Map(ACHIEVEMENTS.map((achievement) => [achievement.id, achievement]));
+
+export function getAchievement(id) {
+  return ACHIEVEMENT_BY_ID.get(id) || null;
+}

--- a/turn/achievements/runtime.js
+++ b/turn/achievements/runtime.js
@@ -1,0 +1,276 @@
+import {
+  ACHIEVEMENTS,
+  TRACK_IDS,
+  TRAINING_CAR_ID
+} from './catalog.js?revision=r144-achievements';
+import {
+  createAchievementStore,
+  normalizeAchievementState
+} from './store.js?revision=r144-achievements';
+import {
+  allOnboardingComplete,
+  createAchievementView
+} from './view.js?revision=r144-achievements';
+
+const SPECTATE_REQUIRED_MS = 5000;
+const LAP_TOAST_DELAY_MS = 4400;
+const SAMPLE_INTERVAL_MS = 100;
+
+function validCompletedLap(detail) {
+  const time = Number(detail?.time);
+  return Number.isFinite(time) && time > 5;
+}
+
+function currentBlankScreenState() {
+  return document.documentElement.classList.contains('turn-screen-blanked');
+}
+
+function unlockContext(runtime, detail = {}) {
+  return {
+    trackId: runtime?.state?.trackId || globalThis.__turnGetTrackId?.() || '',
+    vehicleId: runtime?.state?.vehicleId || '',
+    time: Number.isFinite(Number(detail.time)) ? Number(detail.time) : null
+  };
+}
+
+function makeLapAttempt(runtime, drivePad, recalibratedPending) {
+  const zone = drivePad.dataset.driveZone || '';
+  const blank = currentBlankScreenState();
+  const state = runtime.state;
+  return {
+    trackId: state.trackId || globalThis.__turnGetTrackId?.() || '',
+    vehicleId: state.vehicleId || '',
+    rivalCountAtStart: Array.isArray(state.competitorLaps) ? state.competitorLaps.length : 0,
+    recalibrated: recalibratedPending,
+    blankFromStart: blank,
+    blankThroughout: blank,
+    flowEligible: zone !== 'gas' && zone !== 'brake' && !state.touchGas && !state.touchBrake,
+    usedDrift: zone === 'drift' || globalThis.__turnDriftHeld === true,
+    usedBoost: zone === 'boost' || globalThis.__turnBoostActive === true,
+    driftChargeGained: 0,
+    lastBoostCharge: Number(globalThis.__turnBoostCharge) || 0
+  };
+}
+
+export function installAchievements(runtime = globalThis.__turnRuntime) {
+  if (!runtime || globalThis.__turnAchievements) return globalThis.__turnAchievements || null;
+
+  const utilityGroup = document.querySelector('.utility-group');
+  const drivePad = document.querySelector('.drive-pad');
+  const calibrateButton = document.querySelector('#calibrateButton');
+  if (!utilityGroup || !drivePad || !calibrateButton) {
+    throw new Error('TURN achievements could not find the complete race interface.');
+  }
+
+  const store = createAchievementStore();
+  const session = {
+    currentLap: null,
+    currentLapVoid: false,
+    recalibratedPending: false,
+    spectateStartedAt: 0,
+    pendingTrackEntryPulse: false,
+    pendingToastAchievements: [],
+    toastTimer: 0,
+    secondWind: {
+      sawActiveBoost: false,
+      sawEmpty: false,
+      sawRecharge: false,
+      previousBoostActive: false
+    }
+  };
+  const view = createAchievementView({ store, session, utilityGroup });
+
+  function scheduleToastFlush(delay = 0) {
+    window.clearTimeout(session.toastTimer);
+    session.toastTimer = window.setTimeout(() => {
+      session.toastTimer = 0;
+      view.showToastBatch(session.pendingToastAchievements.splice(0));
+    }, delay);
+  }
+
+  function queueUnlocked(achievements, { delay = 0 } = {}) {
+    for (const achievement of achievements) {
+      if (!achievement || session.pendingToastAchievements.some((item) => item.id === achievement.id)) continue;
+      session.pendingToastAchievements.push(achievement);
+    }
+    view.syncTriggers();
+    view.render();
+    if (delay >= 0) scheduleToastFlush(delay);
+  }
+
+  function unlock(ids, context, options = {}) {
+    const unlocked = ids
+      .map((id) => store.unlock(id, context))
+      .filter(Boolean);
+    if (!unlocked.length) return [];
+    window.dispatchEvent(new CustomEvent('turn:achievements-updated', {
+      detail: { unlocked: unlocked.map((achievement) => achievement.id) }
+    }));
+    queueUnlocked(unlocked, options);
+    return unlocked;
+  }
+
+  function sampleDrivingState() {
+    const state = runtime.state;
+    const charge = Math.max(0, Math.min(1, Number(globalThis.__turnBoostCharge) || 0));
+    const boostActive = globalThis.__turnBoostActive === true;
+    const driftHeld = globalThis.__turnDriftHeld === true;
+    const zone = drivePad.dataset.driveZone || '';
+
+    if (state.lapInvalid === true) {
+      session.currentLapVoid = true;
+      session.currentLap = null;
+    }
+
+    if (session.currentLap) {
+      if (zone === 'gas' || zone === 'brake' || state.touchGas || state.touchBrake) {
+        session.currentLap.flowEligible = false;
+      }
+      if (zone === 'drift' || driftHeld) session.currentLap.usedDrift = true;
+      if (zone === 'boost' || boostActive) session.currentLap.usedBoost = true;
+      if (!currentBlankScreenState()) session.currentLap.blankThroughout = false;
+
+      const delta = charge - session.currentLap.lastBoostCharge;
+      if (driftHeld && delta > 0) {
+        session.currentLap.driftChargeGained += delta;
+        if (session.currentLap.driftChargeGained >= 0.25) {
+          unlock(['charge-through-it'], unlockContext(runtime), { delay: -1 });
+        }
+      }
+      session.currentLap.lastBoostCharge = charge;
+    }
+
+    const secondWind = session.secondWind;
+    if (boostActive) secondWind.sawActiveBoost = true;
+    if (secondWind.sawActiveBoost && charge <= 0.001) secondWind.sawEmpty = true;
+    if (secondWind.sawEmpty && charge >= 0.2) secondWind.sawRecharge = true;
+    if (secondWind.sawRecharge && boostActive && !secondWind.previousBoostActive) {
+      unlock(['second-wind'], unlockContext(runtime), { delay: -1 });
+      secondWind.sawActiveBoost = false;
+      secondWind.sawEmpty = false;
+      secondWind.sawRecharge = false;
+    }
+    secondWind.previousBoostActive = boostActive;
+  }
+
+  function beginLap() {
+    session.currentLapVoid = false;
+    session.currentLap = makeLapAttempt(runtime, drivePad, session.recalibratedPending);
+    sampleDrivingState();
+    view.render();
+  }
+
+  function completeValidLap(detail) {
+    const attempt = session.currentLap || makeLapAttempt(runtime, drivePad, session.recalibratedPending);
+    const context = unlockContext(runtime, detail);
+    store.addTrack(context.trackId);
+
+    const candidates = ['first-turn'];
+    if (attempt.recalibrated) candidates.push('level-head');
+    if (attempt.vehicleId && attempt.vehicleId !== TRAINING_CAR_ID) candidates.push('new-wheels');
+    if (attempt.rivalCountAtStart > 0) candidates.push('your-own-rival');
+    if (Number(detail?.position) === 1 && Number(detail?.total) > 1 && attempt.rivalCountAtStart > 0) {
+      candidates.push('ahead-of-yourself');
+    }
+    if (attempt.flowEligible && attempt.usedDrift && attempt.usedBoost) candidates.push('flow-state');
+    if (attempt.blankFromStart && attempt.blankThroughout) candidates.push('trust-your-ears');
+    if (store.state.progress.tracks.length >= 2) candidates.push('new-ground');
+    if (TRACK_IDS.every((trackId) => store.state.progress.tracks.includes(trackId))) {
+      candidates.push('around-the-turn');
+    }
+
+    unlock(candidates, context, { delay: LAP_TOAST_DELAY_MS });
+    session.currentLap = null;
+    session.currentLapVoid = false;
+    session.recalibratedPending = false;
+  }
+
+  function syncRaceTriggerVisibility() {
+    view.raceTrigger.hidden = utilityGroup.dataset.menuState !== 'staged';
+    if (!view.raceTrigger.hidden && session.pendingTrackEntryPulse && !allOnboardingComplete(store)) {
+      session.pendingTrackEntryPulse = false;
+      view.pulseRaceTrigger();
+    }
+    if (!view.raceTrigger.hidden && session.pendingToastAchievements.length) {
+      scheduleToastFlush(300);
+    }
+  }
+
+  calibrateButton.addEventListener('click', () => {
+    session.recalibratedPending = true;
+  });
+
+  const blankObserver = typeof MutationObserver === 'function'
+    ? new MutationObserver(() => {
+        if (session.currentLap && !currentBlankScreenState()) session.currentLap.blankThroughout = false;
+      })
+    : null;
+  blankObserver?.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+
+  window.addEventListener('turn:lap-invalid', () => {
+    session.currentLapVoid = true;
+    session.currentLap = null;
+  });
+
+  window.addEventListener('turn:lap-result', (event) => {
+    if (validCompletedLap(event.detail)) completeValidLap(event.detail);
+  });
+
+  window.addEventListener('turn:track-changed', () => {
+    session.pendingTrackEntryPulse = true;
+  });
+
+  window.addEventListener('turn:ui-state-change', (event) => {
+    const reason = event.detail?.reason;
+    if (reason === 'lap-started') beginLap();
+    if (reason === 'race-reset') {
+      if (session.currentLapVoid) {
+        unlock(['take-it-from-the-top'], unlockContext(runtime), { delay: 300 });
+      } else if (session.pendingToastAchievements.length) {
+        scheduleToastFlush(300);
+      }
+      session.currentLapVoid = false;
+      session.currentLap = null;
+    }
+    if (reason === 'spectate-started') session.spectateStartedAt = performance.now();
+    if (reason === 'spectate-stopped') {
+      const watchedMs = session.spectateStartedAt
+        ? performance.now() - session.spectateStartedAt
+        : 0;
+      session.spectateStartedAt = 0;
+      if (watchedMs >= SPECTATE_REQUIRED_MS) {
+        unlock(['watch-and-learn'], unlockContext(runtime), { delay: 250 });
+      }
+    }
+    if (Object.prototype.hasOwnProperty.call(event.detail || {}, 'running') && event.detail.running === false) {
+      session.currentLap = null;
+      session.currentLapVoid = false;
+      session.spectateStartedAt = 0;
+    }
+    syncRaceTriggerVisibility();
+    view.render();
+  });
+
+  const menuObserver = typeof MutationObserver === 'function'
+    ? new MutationObserver(syncRaceTriggerVisibility)
+    : null;
+  menuObserver?.observe(utilityGroup, { attributes: true, attributeFilter: ['data-menu-state'] });
+
+  window.setInterval(sampleDrivingState, SAMPLE_INTERVAL_MS);
+  syncRaceTriggerVisibility();
+
+  const api = Object.freeze({
+    catalog: ACHIEVEMENTS,
+    store,
+    homeTrigger: view.homeTrigger,
+    raceTrigger: view.raceTrigger,
+    dialog: view.dialog,
+    toast: view.toast,
+    open: view.open,
+    close: view.close,
+    unlock: (id, context = {}) => unlock([id], context, { delay: 0 }),
+    getState: () => normalizeAchievementState(store.state)
+  });
+  globalThis.__turnAchievements = api;
+  return api;
+}

--- a/turn/achievements/store.js
+++ b/turn/achievements/store.js
@@ -1,0 +1,120 @@
+import {
+  TRACK_IDS,
+  getAchievement
+} from './catalog.js?revision=r144-achievements';
+
+export const ACHIEVEMENT_STORAGE_KEY = 'turn-achievements-v1';
+const STORAGE_VERSION = 1;
+
+function defaultStoredState() {
+  return {
+    version: STORAGE_VERSION,
+    unlocked: {},
+    seen: [],
+    progress: { tracks: [] }
+  };
+}
+
+function normalizedStringArray(value, allowed = null) {
+  if (!Array.isArray(value)) return [];
+  const unique = [...new Set(value.filter((item) => typeof item === 'string'))];
+  return allowed ? unique.filter((item) => allowed.includes(item)) : unique;
+}
+
+export function normalizeAchievementState(value) {
+  if (!value || typeof value !== 'object') return defaultStoredState();
+
+  const unlocked = {};
+  for (const [id, record] of Object.entries(value.unlocked || {})) {
+    if (!getAchievement(id) || !record || typeof record !== 'object') continue;
+    unlocked[id] = {
+      unlockedAt: Number.isFinite(Number(record.unlockedAt))
+        ? Number(record.unlockedAt)
+        : Date.now(),
+      trackId: typeof record.trackId === 'string' ? record.trackId : '',
+      vehicleId: typeof record.vehicleId === 'string' ? record.vehicleId : '',
+      time: Number.isFinite(Number(record.time)) ? Number(record.time) : null
+    };
+  }
+
+  return {
+    version: STORAGE_VERSION,
+    unlocked,
+    seen: normalizedStringArray(value.seen).filter((id) => Boolean(unlocked[id])),
+    progress: {
+      tracks: normalizedStringArray(value.progress?.tracks, TRACK_IDS)
+    }
+  };
+}
+
+export function loadAchievementState(storage = globalThis.localStorage) {
+  try {
+    const raw = storage?.getItem?.(ACHIEVEMENT_STORAGE_KEY);
+    return {
+      state: normalizeAchievementState(raw ? JSON.parse(raw) : null),
+      storageAvailable: Boolean(storage)
+    };
+  } catch (_) {
+    return { state: defaultStoredState(), storageAvailable: false };
+  }
+}
+
+export function createAchievementStore(storage = globalThis.localStorage) {
+  const loaded = loadAchievementState(storage);
+  const state = loaded.state;
+  let storageAvailable = loaded.storageAvailable;
+
+  function save() {
+    try {
+      storage?.setItem?.(ACHIEVEMENT_STORAGE_KEY, JSON.stringify(state));
+      return true;
+    } catch (_) {
+      storageAvailable = false;
+      return false;
+    }
+  }
+
+  function isUnlocked(id) {
+    return Boolean(state.unlocked[id]);
+  }
+
+  function unlock(id, context = {}) {
+    const achievement = getAchievement(id);
+    if (!achievement || isUnlocked(id)) return null;
+    state.unlocked[id] = {
+      unlockedAt: Date.now(),
+      trackId: context.trackId || '',
+      vehicleId: context.vehicleId || '',
+      time: Number.isFinite(Number(context.time)) ? Number(context.time) : null
+    };
+    save();
+    return achievement;
+  }
+
+  function addTrack(trackId) {
+    if (!TRACK_IDS.includes(trackId) || state.progress.tracks.includes(trackId)) return false;
+    state.progress.tracks.push(trackId);
+    save();
+    return true;
+  }
+
+  function markAllSeen() {
+    state.seen = Object.keys(state.unlocked);
+    save();
+  }
+
+  function unseenIds() {
+    const seen = new Set(state.seen);
+    return Object.keys(state.unlocked).filter((id) => !seen.has(id));
+  }
+
+  return Object.freeze({
+    state,
+    isUnlocked,
+    unlock,
+    addTrack,
+    markAllSeen,
+    unseenIds,
+    storageAvailable: () => storageAvailable
+  });
+}

--- a/turn/achievements/view.js
+++ b/turn/achievements/view.js
@@ -1,0 +1,335 @@
+import {
+  ACHIEVEMENTS,
+  CATEGORY,
+  CATEGORY_LABELS,
+  ICONS,
+  ONBOARDING_ACHIEVEMENT_IDS,
+  TRACK_NAMES,
+  VEHICLE_NAMES,
+  TRACK_IDS
+} from './catalog.js?revision=r144-achievements';
+
+const TOAST_VISIBLE_MS = 3600;
+
+function formatTime(seconds) {
+  if (!Number.isFinite(seconds)) return '';
+  const minutes = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60).toString().padStart(2, '0');
+  const ms = Math.floor((seconds % 1) * 1000).toString().padStart(3, '0');
+  return `${minutes}:${secs}.${ms}`;
+}
+
+function contextLine(record) {
+  if (!record) return '';
+  const parts = [];
+  if (record.trackId && TRACK_NAMES[record.trackId]) parts.push(TRACK_NAMES[record.trackId]);
+  if (record.vehicleId && VEHICLE_NAMES[record.vehicleId]) parts.push(VEHICLE_NAMES[record.vehicleId]);
+  if (record.time != null) parts.push(formatTime(record.time));
+  return parts.join(' · ');
+}
+
+export function nextOnboardingId(store) {
+  return ONBOARDING_ACHIEVEMENT_IDS.find((id) => !store.isUnlocked(id)) || '';
+}
+
+export function allOnboardingComplete(store) {
+  return !nextOnboardingId(store);
+}
+
+function progressFor(achievement, store, session) {
+  if (achievement.id === 'new-ground') return Math.min(2, store.state.progress.tracks.length);
+  if (achievement.id === 'around-the-turn') return Math.min(TRACK_IDS.length, store.state.progress.tracks.length);
+  if (achievement.id === 'charge-through-it') {
+    return Math.min(25, Math.round((session.currentLap?.driftChargeGained || 0) * 100));
+  }
+  if (achievement.id === 'watch-and-learn') {
+    if (!session.spectateStartedAt) return 0;
+    return Math.min(5, Math.floor((performance.now() - session.spectateStartedAt) / 1000));
+  }
+  return null;
+}
+
+function statusFor(achievement, store, session) {
+  if (store.isUnlocked(achievement.id)) return 'UNLOCKED';
+  const progress = progressFor(achievement, store, session);
+  if (progress != null && progress > 0) return 'IN PROGRESS';
+  return 'LOCKED';
+}
+
+function achievementCard(achievement, store, session, nextId) {
+  const unlocked = store.isUnlocked(achievement.id);
+  const record = store.state.unlocked[achievement.id];
+  const progress = progressFor(achievement, store, session);
+  const status = statusFor(achievement, store, session);
+  const recommended = !unlocked && achievement.id === nextId;
+  const classes = [
+    'turn-achievement-card',
+    unlocked ? 'is-unlocked' : 'is-locked',
+    recommended ? 'is-recommended' : ''
+  ].filter(Boolean).join(' ');
+  const progressMarkup = achievement.progressMax && !unlocked
+    ? `<div class="turn-achievement-progress">
+        <span>${progress || 0} of ${achievement.progressMax}</span>
+        <div role="progressbar" aria-label="${achievement.title} progress" aria-valuemin="0" aria-valuemax="${achievement.progressMax}" aria-valuenow="${progress || 0}">
+          <i style="--turn-achievement-progress:${Math.min(100, ((progress || 0) / achievement.progressMax) * 100)}%"></i>
+        </div>
+      </div>`
+    : '';
+  const context = unlocked ? contextLine(record) : '';
+
+  return `
+    <article class="${classes}" data-achievement-category="${achievement.category}" data-achievement-status="${status.toLowerCase().replace(' ', '-')}">
+      <div class="turn-achievement-icon" aria-hidden="true">${ICONS[achievement.icon]}</div>
+      <div class="turn-achievement-copy">
+        <span>${CATEGORY_LABELS[achievement.category]} · ${achievement.points} points</span>
+        <h4>${achievement.title}</h4>
+        <p>${achievement.description}</p>
+        ${achievement.recommendation && !unlocked ? `<small>${achievement.recommendation}</small>` : ''}
+        ${progressMarkup}
+        ${context ? `<small>Unlocked · ${context}</small>` : ''}
+      </div>
+      <strong class="turn-achievement-status">${recommended ? 'NEXT' : status === 'UNLOCKED' ? '✓ UNLOCKED' : status}</strong>
+    </article>`;
+}
+
+function installStylesheet() {
+  if (document.querySelector('link[data-turn-achievements]')) return;
+  const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
+  const stylesheet = document.createElement('link');
+  stylesheet.rel = 'stylesheet';
+  stylesheet.href = `/turn/achievements.css?build=${buildKey}-r144-achievements`;
+  stylesheet.setAttribute('data-turn-achievements', '');
+  document.head.appendChild(stylesheet);
+}
+
+function createTrigger(className, label = 'ACHIEVEMENTS') {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = className;
+  button.setAttribute('aria-haspopup', 'dialog');
+  button.innerHTML = `
+    <span class="turn-achievements-trigger-icon" aria-hidden="true">${ICONS.trophy}</span>
+    <span class="turn-achievements-trigger-label">${label}</span>
+    <span class="turn-achievements-trigger-badge" hidden></span>`;
+  return button;
+}
+
+function createDialog() {
+  const dialog = document.createElement('dialog');
+  dialog.className = 'm8-dialog turn-achievements-dialog';
+  dialog.setAttribute('aria-labelledby', 'turnAchievementsTitle');
+  dialog.innerHTML = `
+    <article class="m8-dialog-card turn-achievements-card">
+      <header class="m8-dialog-head turn-achievements-head">
+        <div><span>YOUR PROGRESS</span><h2 id="turnAchievementsTitle">ACHIEVEMENTS</h2></div>
+        <button type="button" data-dialog-close aria-label="Close Achievements">×</button>
+      </header>
+      <div class="turn-achievements-content">
+        <section class="turn-achievements-summary" aria-labelledby="turnAchievementsSummaryTitle">
+          <div>
+            <strong id="turnAchievementsSummaryTitle">0 OF ${ACHIEVEMENTS.length} UNLOCKED</strong>
+            <div class="turn-achievements-total-progress" role="progressbar" aria-label="Total achievement completion" aria-valuemin="0" aria-valuemax="${ACHIEVEMENTS.length}" aria-valuenow="0"><i></i></div>
+          </div>
+          <p><span>POINTS</span><strong class="turn-achievements-points">0</strong></p>
+          <p><span>COMPLETION</span><strong class="turn-achievements-percent">0%</strong></p>
+        </section>
+        <p class="turn-achievements-storage-note" hidden>Achievement progress is available for this session but cannot be saved because local storage is unavailable.</p>
+        <div class="turn-achievements-filters" aria-label="Achievement filters">
+          <button type="button" aria-pressed="true" data-achievement-filter="all">ALL</button>
+          <button type="button" aria-pressed="false" data-achievement-filter="onboarding">GETTING STARTED</button>
+          <button type="button" aria-pressed="false" data-achievement-filter="unlocked">UNLOCKED</button>
+        </div>
+        <div class="turn-achievements-list"></div>
+      </div>
+    </article>`;
+  document.body.appendChild(dialog);
+  return dialog;
+}
+
+function createToast() {
+  const toast = document.createElement('div');
+  toast.className = 'turn-achievement-toast';
+  toast.hidden = true;
+  toast.setAttribute('role', 'status');
+  toast.setAttribute('aria-live', 'polite');
+  toast.setAttribute('aria-atomic', 'true');
+  toast.innerHTML = `
+    <div class="turn-achievement-toast-icon" aria-hidden="true"></div>
+    <div><span>ACHIEVEMENT UNLOCKED</span><strong></strong></div>
+    <b></b>`;
+  document.body.appendChild(toast);
+  return toast;
+}
+
+function installFilters(dialog) {
+  const buttons = [...dialog.querySelectorAll('[data-achievement-filter]')];
+  let current = 'all';
+
+  function apply() {
+    for (const card of dialog.querySelectorAll('.turn-achievement-card')) {
+      const visible = current === 'all'
+        || (current === 'onboarding' && card.dataset.achievementCategory === CATEGORY.ONBOARDING)
+        || (current === 'unlocked' && card.dataset.achievementStatus === 'unlocked');
+      card.hidden = !visible;
+    }
+  }
+
+  for (const button of buttons) {
+    button.addEventListener('click', () => {
+      current = button.dataset.achievementFilter;
+      for (const candidate of buttons) candidate.setAttribute('aria-pressed', String(candidate === button));
+      apply();
+    });
+  }
+
+  return apply;
+}
+
+export function createAchievementView({ store, session, utilityGroup }) {
+  const homeMenu = document.querySelector('.m8-home-menu');
+  const homeStatus = homeMenu?.querySelector('.m8-home-status');
+  const feedbackButton = homeMenu?.querySelector('.m8-feedback-button');
+  const spectateButton = utilityGroup?.querySelector('.spectate-button');
+  if (!homeMenu || !homeStatus || !utilityGroup) {
+    throw new Error('TURN achievements could not find the complete Home and race menus.');
+  }
+
+  installStylesheet();
+  const homeTrigger = createTrigger('m8-achievements-button');
+  const raceTrigger = createTrigger('utility turn-race-achievements-button', 'Achievements');
+  if (feedbackButton) homeMenu.insertBefore(homeTrigger, feedbackButton);
+  else homeMenu.insertBefore(homeTrigger, homeStatus);
+  if (spectateButton) utilityGroup.insertBefore(raceTrigger, spectateButton);
+  else utilityGroup.appendChild(raceTrigger);
+
+  const dialog = createDialog();
+  const toast = createToast();
+  const list = dialog.querySelector('.turn-achievements-list');
+  const totalTitle = dialog.querySelector('#turnAchievementsSummaryTitle');
+  const totalProgress = dialog.querySelector('.turn-achievements-total-progress');
+  const totalProgressFill = totalProgress.querySelector('i');
+  const points = dialog.querySelector('.turn-achievements-points');
+  const percent = dialog.querySelector('.turn-achievements-percent');
+  const storageNote = dialog.querySelector('.turn-achievements-storage-note');
+  const closeButton = dialog.querySelector('[data-dialog-close]');
+  const applyFilter = installFilters(dialog);
+  let returnFocus = null;
+  let toastHideTimer = 0;
+
+  function render() {
+    const unlockedCount = Object.keys(store.state.unlocked).length;
+    const totalPoints = ACHIEVEMENTS.reduce((sum, achievement) =>
+      sum + (store.isUnlocked(achievement.id) ? achievement.points : 0), 0);
+    const completion = Math.round((unlockedCount / ACHIEVEMENTS.length) * 100);
+    totalTitle.textContent = `${unlockedCount} OF ${ACHIEVEMENTS.length} UNLOCKED`;
+    totalProgress.setAttribute('aria-valuenow', String(unlockedCount));
+    totalProgressFill.style.setProperty('--turn-achievement-progress', `${completion}%`);
+    points.textContent = String(totalPoints);
+    percent.textContent = `${completion}%`;
+    storageNote.hidden = store.storageAvailable();
+    const nextId = nextOnboardingId(store);
+    list.innerHTML = ACHIEVEMENTS
+      .map((achievement) => achievementCard(achievement, store, session, nextId))
+      .join('');
+    applyFilter();
+  }
+
+  function syncTriggers() {
+    const unseenCount = store.unseenIds().length;
+    const incompleteOnboarding = !allOnboardingComplete(store);
+    for (const button of [homeTrigger, raceTrigger]) {
+      const badge = button.querySelector('.turn-achievements-trigger-badge');
+      if (unseenCount > 0) {
+        badge.textContent = `NEW ${unseenCount}`;
+        badge.hidden = false;
+      } else if (incompleteOnboarding) {
+        badge.textContent = 'NEXT';
+        badge.hidden = false;
+      } else {
+        badge.hidden = true;
+        badge.textContent = '';
+      }
+      button.classList.toggle('has-unseen-achievements', unseenCount > 0);
+      button.classList.remove('is-achievement-next');
+    }
+    raceTrigger.hidden = utilityGroup.dataset.menuState !== 'staged';
+  }
+
+  function open(trigger) {
+    returnFocus = trigger;
+    render();
+    if (typeof dialog.showModal === 'function') dialog.showModal();
+    else dialog.setAttribute('open', '');
+    closeButton.focus();
+    store.markAllSeen();
+    syncTriggers();
+  }
+
+  function close() {
+    if (typeof dialog.close === 'function' && dialog.open) dialog.close();
+    else dialog.removeAttribute('open');
+    returnFocus?.focus?.();
+  }
+
+  homeTrigger.addEventListener('click', () => open(homeTrigger));
+  raceTrigger.addEventListener('click', () => open(raceTrigger));
+  closeButton.addEventListener('click', close);
+  dialog.addEventListener('click', (event) => {
+    if (event.target === dialog) close();
+  });
+  dialog.addEventListener('close', () => returnFocus?.focus?.());
+
+  function pulseRaceTrigger() {
+    raceTrigger.classList.remove('is-achievement-pulsing');
+    if (globalThis.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+      raceTrigger.classList.add('is-achievement-next');
+      return;
+    }
+    void raceTrigger.offsetWidth;
+    raceTrigger.classList.add('is-achievement-pulsing');
+    window.setTimeout(() => raceTrigger.classList.remove('is-achievement-pulsing'), 2300);
+  }
+
+  function showToastBatch(batch) {
+    if (!batch.length) return;
+    window.clearTimeout(toastHideTimer);
+    const first = batch[0];
+    const total = batch.reduce((sum, achievement) => sum + achievement.points, 0);
+    toast.querySelector('.turn-achievement-toast-icon').innerHTML = batch.length === 1
+      ? ICONS[first.icon]
+      : ICONS.trophy;
+    toast.querySelector('span').textContent = batch.length === 1
+      ? 'ACHIEVEMENT UNLOCKED'
+      : `${batch.length} ACHIEVEMENTS UNLOCKED`;
+    toast.querySelector('strong').textContent = batch.length === 1
+      ? first.title
+      : `${first.title} + ${batch.length - 1} MORE`;
+    toast.querySelector('b').textContent = `+${total} POINTS`;
+    toast.setAttribute('aria-label', batch.length === 1
+      ? `Achievement unlocked. ${first.title}. ${first.points} points.`
+      : `${batch.length} achievements unlocked. ${batch.map((achievement) => achievement.title).join(', ')}. ${total} points.`);
+    toast.hidden = false;
+    toast.classList.remove('is-visible');
+    void toast.offsetWidth;
+    toast.classList.add('is-visible');
+    toastHideTimer = window.setTimeout(() => {
+      toast.classList.remove('is-visible');
+      window.setTimeout(() => { toast.hidden = true; }, 220);
+    }, TOAST_VISIBLE_MS);
+  }
+
+  render();
+  syncTriggers();
+  return Object.freeze({
+    homeTrigger,
+    raceTrigger,
+    dialog,
+    toast,
+    render,
+    syncTriggers,
+    pulseRaceTrigger,
+    showToastBatch,
+    open,
+    close
+  });
+}

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -101,13 +101,19 @@ export async function installM8HomeFixedLayout() {
   );
   const cardScrollFixes = await installM8HomeCardScrollFixes();
 
+  const { installAchievements } = await import(
+    `/turn/achievements.js?build=${buildKey}-r144-achievements`
+  );
+  const achievements = installAchievements(globalThis.__turnRuntime);
+
   globalThis.__turnHomeLayout = Object.freeze({
     id: LAYOUT_ID,
     home,
     trackBrowser,
     menu,
     raceButton,
-    cardScrollFixes
+    cardScrollFixes,
+    achievements
   });
   return globalThis.__turnHomeLayout;
 }


### PR DESCRIPTION
## Summary
- add a persistent, offline-first achievement system with 13 achievements and 475 available points
- add 10 Getting Started achievements that teach TURN through real play rather than interruptive tutorials
- add Trust Your Ears, Around the TURN, and Ahead of Yourself across Ways to Play, Exploration, and Racing
- add the green Achievements destination to Home and the staged race menu
- add progress, filters, stable icons, unseen badges, accessible unlock announcements, and post-lap toast batching
- pulse the staged Achievements button three times on track entry while Getting Started remains incomplete, with a static reduced-motion alternative

## Getting Started collection
- First Turn
- Take It From the Top
- Charge Through It
- Second Wind
- Flow State
- Watch and Learn
- Your Own Rival
- Level Head
- New Wheels
- New Ground

## Important behaviour
- Flow State counts Drift and Boost zone use regardless of the Boost meter, allows coasting, and disqualifies Gas, Brake, or Reverse. Training Car and Countryside are recommendations rather than restrictions.
- Second Wind separately teaches the empty/recharge/reactivate Boost interaction.
- Trust Your Ears requires Blank screen mode from the start line through a complete valid lap.
- achievement feedback waits until the existing lap-result announcement has finished
- progress is stored in `turn-achievements-v1`; blocked storage falls back to session-only progress with an explanation in the modal
- no achievement grants a vehicle-performance advantage

## Accessibility
- every achievement has text, icon, category, point value, and explicit state
- progress uses progressbar semantics
- unlock feedback uses a polite status announcement
- button prompting respects `prefers-reduced-motion`
- the modal uses the existing dialog and focus-return pattern

## Validation
- added a dedicated achievement-system regression test
- added it to the full TURN regression workflow