### PR TITLE
Refine achievement menu buttons and notifications

### DIFF
--- a/turn-lab/tests/achievements-production.mjs
+++ b/turn-lab/tests/achievements-production.mjs
@@ -103,24 +103,46 @@ assert.match(runtime, /turn:lap-invalid/);
 assert.match(runtime, /turn:track-changed/);
 assert.match(runtime, /turn:achievements-updated/);
 assert.match(runtime, /pendingTrackEntryPulse/);
+assert.match(runtime, /!allOnboardingComplete\(store\)/,
+  'The track-entry prompt should stop after Getting Started is complete');
 
 assert.match(view, /aria-live', 'polite'/);
 assert.match(view, /role="progressbar"/);
 assert.match(view, /data-achievement-filter="onboarding"/);
 assert.match(view, /store\.markAllSeen\(\)/);
 assert.match(view, /prefers-reduced-motion: reduce/);
+assert.match(view, /ATTENTION_VISIBLE_MS = 900/);
 assert.match(view, /is-achievement-pulsing/);
-assert.match(view, /createTrigger\('m8-achievements-button'/);
+assert.match(view, /is-achievement-attention/);
+assert.match(view, /createTrigger\('m8-home-settings m8-achievements-button'/,
+  'The Home trigger should reuse the canonical menu-button geometry');
 assert.match(view, /createTrigger\('utility turn-race-achievements-button'/);
+assert.match(view, /badge\.textContent = unseenCount > 9 \? '9\+' : String\(unseenCount\)/,
+  'Unseen achievements should use a compact numeric notification circle');
+assert.match(view, /Achievements, \$\{unseenCount\} new achievement/);
+assert.match(view, /ONBOARDING_ACHIEVEMENT_IDS\.every/,
+  'Getting Started should be unordered rather than prescribing a next achievement');
+assert.doesNotMatch(view, /turn-achievements-trigger-icon/,
+  'Achievement destination buttons should remain text-only');
+assert.doesNotMatch(view, /badge\.textContent = 'NEXT'/,
+  'Incomplete onboarding must not create a NEXT badge');
+assert.doesNotMatch(view, /is-achievement-next/);
+assert.doesNotMatch(view, /recommended \? 'NEXT'/,
+  'Achievement cards should not impose a linear next challenge');
 
 assert.match(style, /\.m8-achievements-button/);
 assert.match(style, /\.turn-race-achievements-button/);
+assert.match(style, /\.turn-achievements-trigger-badge[\s\S]*position: absolute/);
+assert.match(style, /\.turn-achievements-trigger-badge[\s\S]*border-radius: 50%/);
 assert.match(style, /\.turn-achievements-dialog/);
 assert.match(style, /\.turn-achievement-toast/);
 assert.match(style, /@keyframes turn-achievement-pulse/);
-assert.match(style, /animation: turn-achievement-pulse 720ms ease-in-out 3/);
+assert.match(style, /animation: turn-achievement-pulse 760ms[^;]* 1/,
+  'The staged Achievements button should pulse once, not repeatedly');
 assert.match(style, /@media \(prefers-reduced-motion: reduce\)/);
 assert.match(style, /var\(--turn-action-success/);
+assert.doesNotMatch(style, /turn-achievements-trigger-icon/);
+assert.doesNotMatch(style, /is-achievement-next/);
 
 assert.match(designTokens, /--turn-action-success: var\(--turn-green-500\)/);
 assert.match(fixedLayout, /installAchievements/);

--- a/turn/achievements.css
+++ b/turn/achievements.css
@@ -1,38 +1,45 @@
 .m8-achievements-button,
 .turn-race-achievements-button {
   position: relative;
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 10px;
-  border: var(--turn-border-default, 4px) solid var(--turn-ink, #08090a);
   background: var(--turn-action-success, #8ce99a);
   color: var(--turn-ink, #08090a);
-  box-shadow: var(--turn-shadow-default, 7px 7px 0 #08090a);
   font-weight: 950;
   text-transform: uppercase;
 }
 
-.m8-achievements-button {
-  min-height: 54px;
-  padding: 10px 14px;
-  border-radius: var(--turn-radius-default, 18px);
-  text-align: left;
+.turn-achievements-trigger-label {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.turn-race-achievements-button {
-  min-height: 50px;
-  padding-inline: 12px;
-}
-
-.turn-achievements-trigger-icon {
+.turn-achievements-trigger-badge {
+  position: absolute;
+  z-index: 2;
+  top: -11px;
+  right: -11px;
   display: grid;
-  width: 28px;
-  height: 28px;
+  width: 30px;
+  height: 30px;
+  padding: 0;
   place-items: center;
+  border: var(--turn-border-compact, 3px) solid var(--turn-ink, #08090a);
+  border-radius: 50%;
+  background: var(--turn-action-warning, #ffd43b);
+  color: var(--turn-ink, #08090a);
+  box-shadow: var(--turn-shadow-compact, 3px 3px 0 #08090a);
+  font-size: .68rem;
+  line-height: 1;
+  letter-spacing: 0;
+  pointer-events: none;
 }
 
-.turn-achievements-trigger-icon svg,
+.turn-achievements-trigger-badge[hidden] {
+  display: none;
+}
+
 .turn-achievement-icon svg,
 .turn-achievement-toast-icon svg {
   width: 100%;
@@ -44,39 +51,20 @@
   stroke-linejoin: round;
 }
 
-.turn-achievements-trigger-badge {
-  padding: 3px 7px;
-  border: var(--turn-border-compact, 3px) solid var(--turn-ink, #08090a);
-  border-radius: var(--turn-radius-pill, 999px);
-  background: var(--turn-action-warning, #ffd43b);
-  font-size: .64rem;
-  line-height: 1.1;
-  letter-spacing: .08em;
-  white-space: nowrap;
-}
-
-.m8-achievements-button.has-unseen-achievements,
-.turn-race-achievements-button.has-unseen-achievements {
-  box-shadow:
-    var(--turn-shadow-default, 7px 7px 0 #08090a),
-    0 0 0 5px rgb(255 212 59 / .55);
-}
-
-.m8-achievements-button.is-achievement-next,
-.turn-race-achievements-button.is-achievement-next {
-  outline: 3px solid var(--turn-action-warning, #ffd43b);
-  outline-offset: 3px;
-}
-
 @keyframes turn-achievement-pulse {
   0%, 100% { transform: scale(1); }
-  18% { transform: scale(1.06); }
-  36% { transform: scale(1); }
+  42% { transform: scale(1.06); }
+  72% { transform: scale(.99); }
 }
 
 .turn-race-achievements-button.is-achievement-pulsing {
-  animation: turn-achievement-pulse 720ms ease-in-out 3;
+  animation: turn-achievement-pulse 760ms cubic-bezier(.2, .85, .3, 1.2) 1;
   transform-origin: center;
+}
+
+.turn-race-achievements-button.is-achievement-attention {
+  outline: 4px solid var(--turn-action-warning, #ffd43b);
+  outline-offset: 3px;
 }
 
 .turn-achievements-dialog {
@@ -225,13 +213,6 @@
   background: color-mix(in srgb, var(--turn-green-200, #d9f5c2) 72%, var(--turn-white, #fffdf6));
 }
 
-.turn-achievement-card.is-recommended {
-  background: color-mix(in srgb, var(--turn-blue-200, #8ed8ff) 52%, var(--turn-white, #fffdf6));
-  box-shadow:
-    var(--turn-shadow-compact, 3px 3px 0 #08090a),
-    0 0 0 4px var(--turn-action-warning, #ffd43b);
-}
-
 .turn-achievement-icon {
   display: grid;
   width: 78px;
@@ -244,7 +225,7 @@
   box-shadow: var(--turn-shadow-compact, 3px 3px 0 #08090a);
 }
 
-.turn-achievement-card.is-locked:not(.is-recommended) .turn-achievement-icon {
+.turn-achievement-card.is-locked .turn-achievement-icon {
   background: var(--turn-muted, #d6d0c2);
 }
 
@@ -279,10 +260,6 @@
   font-size: .65rem;
   letter-spacing: .07em;
   white-space: nowrap;
-}
-
-.turn-achievement-card.is-recommended .turn-achievement-status {
-  background: var(--turn-action-warning, #ffd43b);
 }
 
 .turn-achievement-progress {
@@ -401,6 +378,15 @@
 }
 
 @media (max-height: 430px) and (orientation: landscape) {
+  .turn-achievements-trigger-badge {
+    top: -8px;
+    right: -8px;
+    width: 24px;
+    height: 24px;
+    border-width: 2px;
+    font-size: .58rem;
+  }
+
   .turn-achievements-dialog {
     width: min(1040px, calc(100vw - 16px));
     max-height: calc(100vh - 12px);
@@ -439,8 +425,6 @@
 @media (prefers-reduced-motion: reduce) {
   .turn-race-achievements-button.is-achievement-pulsing {
     animation: none;
-    outline: 3px solid var(--turn-action-warning, #ffd43b);
-    outline-offset: 3px;
   }
 
   .turn-achievement-toast {

--- a/turn/achievements/view.js
+++ b/turn/achievements/view.js
@@ -10,6 +10,7 @@ import {
 } from './catalog.js?revision=r144-achievements';
 
 const TOAST_VISIBLE_MS = 3600;
+const ATTENTION_VISIBLE_MS = 900;
 
 function formatTime(seconds) {
   if (!Number.isFinite(seconds)) return '';
@@ -28,12 +29,8 @@ function contextLine(record) {
   return parts.join(' · ');
 }
 
-export function nextOnboardingId(store) {
-  return ONBOARDING_ACHIEVEMENT_IDS.find((id) => !store.isUnlocked(id)) || '';
-}
-
 export function allOnboardingComplete(store) {
-  return !nextOnboardingId(store);
+  return ONBOARDING_ACHIEVEMENT_IDS.every((id) => store.isUnlocked(id));
 }
 
 function progressFor(achievement, store, session) {
@@ -56,17 +53,15 @@ function statusFor(achievement, store, session) {
   return 'LOCKED';
 }
 
-function achievementCard(achievement, store, session, nextId) {
+function achievementCard(achievement, store, session) {
   const unlocked = store.isUnlocked(achievement.id);
   const record = store.state.unlocked[achievement.id];
   const progress = progressFor(achievement, store, session);
   const status = statusFor(achievement, store, session);
-  const recommended = !unlocked && achievement.id === nextId;
   const classes = [
     'turn-achievement-card',
-    unlocked ? 'is-unlocked' : 'is-locked',
-    recommended ? 'is-recommended' : ''
-  ].filter(Boolean).join(' ');
+    unlocked ? 'is-unlocked' : 'is-locked'
+  ].join(' ');
   const progressMarkup = achievement.progressMax && !unlocked
     ? `<div class="turn-achievement-progress">
         <span>${progress || 0} of ${achievement.progressMax}</span>
@@ -88,7 +83,7 @@ function achievementCard(achievement, store, session, nextId) {
         ${progressMarkup}
         ${context ? `<small>Unlocked · ${context}</small>` : ''}
       </div>
-      <strong class="turn-achievement-status">${recommended ? 'NEXT' : status === 'UNLOCKED' ? '✓ UNLOCKED' : status}</strong>
+      <strong class="turn-achievement-status">${status === 'UNLOCKED' ? '✓ UNLOCKED' : status}</strong>
     </article>`;
 }
 
@@ -97,7 +92,7 @@ function installStylesheet() {
   const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
   const stylesheet = document.createElement('link');
   stylesheet.rel = 'stylesheet';
-  stylesheet.href = `/turn/achievements.css?build=${buildKey}-r144-achievements`;
+  stylesheet.href = `/turn/achievements.css?build=${buildKey}-r145-button-notifications`;
   stylesheet.setAttribute('data-turn-achievements', '');
   document.head.appendChild(stylesheet);
 }
@@ -107,10 +102,10 @@ function createTrigger(className, label = 'ACHIEVEMENTS') {
   button.type = 'button';
   button.className = className;
   button.setAttribute('aria-haspopup', 'dialog');
+  button.setAttribute('aria-label', 'Achievements');
   button.innerHTML = `
-    <span class="turn-achievements-trigger-icon" aria-hidden="true">${ICONS.trophy}</span>
     <span class="turn-achievements-trigger-label">${label}</span>
-    <span class="turn-achievements-trigger-badge" hidden></span>`;
+    <span class="turn-achievements-trigger-badge" aria-hidden="true" hidden></span>`;
   return button;
 }
 
@@ -215,6 +210,7 @@ export function createAchievementView({ store, session, utilityGroup }) {
   const applyFilter = installFilters(dialog);
   let returnFocus = null;
   let toastHideTimer = 0;
+  let attentionTimer = 0;
 
   function render() {
     const unlockedCount = Object.keys(store.state.unlocked).length;
@@ -227,30 +223,29 @@ export function createAchievementView({ store, session, utilityGroup }) {
     points.textContent = String(totalPoints);
     percent.textContent = `${completion}%`;
     storageNote.hidden = store.storageAvailable();
-    const nextId = nextOnboardingId(store);
     list.innerHTML = ACHIEVEMENTS
-      .map((achievement) => achievementCard(achievement, store, session, nextId))
+      .map((achievement) => achievementCard(achievement, store, session))
       .join('');
     applyFilter();
   }
 
   function syncTriggers() {
     const unseenCount = store.unseenIds().length;
-    const incompleteOnboarding = !allOnboardingComplete(store);
     for (const button of [homeTrigger, raceTrigger]) {
       const badge = button.querySelector('.turn-achievements-trigger-badge');
       if (unseenCount > 0) {
-        badge.textContent = `NEW ${unseenCount}`;
+        badge.textContent = unseenCount > 9 ? '9+' : String(unseenCount);
         badge.hidden = false;
-      } else if (incompleteOnboarding) {
-        badge.textContent = 'NEXT';
-        badge.hidden = false;
+        button.setAttribute(
+          'aria-label',
+          `Achievements, ${unseenCount} new achievement${unseenCount === 1 ? '' : 's'}`
+        );
       } else {
         badge.hidden = true;
         badge.textContent = '';
+        button.setAttribute('aria-label', 'Achievements');
       }
       button.classList.toggle('has-unseen-achievements', unseenCount > 0);
-      button.classList.remove('is-achievement-next');
     }
     raceTrigger.hidden = utilityGroup.dataset.menuState !== 'staged';
   }
@@ -280,14 +275,18 @@ export function createAchievementView({ store, session, utilityGroup }) {
   dialog.addEventListener('close', () => returnFocus?.focus?.());
 
   function pulseRaceTrigger() {
-    raceTrigger.classList.remove('is-achievement-pulsing');
-    if (globalThis.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
-      raceTrigger.classList.add('is-achievement-next');
-      return;
-    }
+    window.clearTimeout(attentionTimer);
+    raceTrigger.classList.remove('is-achievement-pulsing', 'is-achievement-attention');
     void raceTrigger.offsetWidth;
-    raceTrigger.classList.add('is-achievement-pulsing');
-    window.setTimeout(() => raceTrigger.classList.remove('is-achievement-pulsing'), 2300);
+    if (globalThis.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+      raceTrigger.classList.add('is-achievement-attention');
+    } else {
+      raceTrigger.classList.add('is-achievement-pulsing');
+    }
+    attentionTimer = window.setTimeout(() => {
+      raceTrigger.classList.remove('is-achievement-pulsing', 'is-achievement-attention');
+      attentionTimer = 0;
+    }, ATTENTION_VISIBLE_MS);
   }
 
   function showToastBatch(batch) {

--- a/turn/achievements/view.js
+++ b/turn/achievements/view.js
@@ -190,7 +190,8 @@ export function createAchievementView({ store, session, utilityGroup }) {
   }
 
   installStylesheet();
-  const homeTrigger = createTrigger('m8-achievements-button');
+  const homeTrigger = createTrigger('m8-home-settings m8-achievements-button');
+  homeTrigger.style.setProperty('background', 'var(--turn-action-success, #8ce99a)');
   const raceTrigger = createTrigger('utility turn-race-achievements-button', 'Achievements');
   if (feedbackButton) homeMenu.insertBefore(homeTrigger, feedbackButton);
   else homeMenu.insertBefore(homeTrigger, homeStatus);


### PR DESCRIPTION
## Summary
- make the Home Achievements button reuse the exact Settings/How to Play menu-button geometry
- remove trophy icons from both Home and staged race-menu buttons
- remove the ambiguous NEXT badge and linear next-achievement treatment
- let beginners complete Getting Started achievements in any order
- pulse the staged Achievements button once on track entry while Getting Started remains unfinished
- replace pre-notification labels with a compact numeric notification circle only for unlocked achievements the player has not yet opened in the list

## Interaction details
- the notification circle shows the unseen count, capped visually at `9+`
- opening Achievements marks current unlocks as seen and clears the circle
- the button accessible name includes the unseen count
- reduced-motion mode uses a brief static outline instead of scale animation
- achievement cards and unlock toasts retain their icons; only destination buttons are text-only

## Validation
- updated the achievement regression to cover text-only buttons, unordered onboarding, one pulse, reduced-motion attention, and unseen notification circles