### PR TITLE
Polish Achievements menu placement and blank-screen icons

### DIFF
--- a/turn-tests/home-feedback-production.mjs
+++ b/turn-tests/home-feedback-production.mjs
@@ -16,11 +16,18 @@ assert.ok(
   'The feedback and About actions must be installed only after the fixed Home interface exists'
 );
 
-assert.match(feedback, /FEEDBACK_VERSION = 'r137-feedback-above-fold'/);
+assert.match(feedback, /FEEDBACK_VERSION = 'r147-achievement-menu-order'/);
 assert.match(feedback, /FEEDBACK_EMAIL = 'erik@enkel\.design'/);
 assert.match(feedback, /feedbackTrigger\.textContent = 'GIVE FEEDBACK'/);
 assert.match(feedback, /feedbackTrigger\.setAttribute\('aria-haspopup', 'dialog'\)/);
 assert.match(feedback, /menu\.insertBefore\(feedbackTrigger, status\)/, 'GIVE FEEDBACK must sit with the other Home menu actions, before status and RACE');
+assert.match(feedback, /function alignAchievementsTrigger\(menu, feedbackTrigger\)/);
+assert.match(feedback, /achievementsTrigger\.classList\.add\('m8-feedback-button'\)/,
+  'Achievements must reuse the complete Give Feedback typography and geometry');
+assert.match(feedback, /var\(--turn-action-success, #8ce99a\)/,
+  'The Home Achievements destination must use the semantic success action');
+assert.match(feedback, /feedbackTrigger\.after\(achievementsTrigger\)/,
+  'Achievements must be placed directly after Give Feedback');
 assert.match(feedback, /dialog\.className = 'm8-dialog m8-feedback-dialog'/);
 assert.match(feedback, /aria-labelledby', 'm8FeedbackTitle'/);
 assert.match(feedback, /<h2 id="m8FeedbackTitle">GIVE FEEDBACK<\/h2>/);

--- a/turn/ui/home-feedback.js
+++ b/turn/ui/home-feedback.js
@@ -1,6 +1,6 @@
 const FEEDBACK_EMAIL = 'erik@enkel.design';
 const FEEDBACK_SUBJECT = 'TURN feedback';
-const FEEDBACK_VERSION = 'r137-feedback-above-fold';
+const FEEDBACK_VERSION = 'r147-achievement-menu-order';
 
 let installed = false;
 
@@ -152,6 +152,22 @@ function createAboutTrigger() {
   return { meta, trigger, buildLabel };
 }
 
+function alignAchievementsTrigger(menu, feedbackTrigger) {
+  const achievementsTrigger = menu.querySelector('.m8-achievements-button');
+  if (!achievementsTrigger) return null;
+
+  // Reuse the complete Give Feedback button typography and geometry so the two
+  // destinations remain perfectly aligned at every responsive breakpoint.
+  achievementsTrigger.classList.add('m8-feedback-button');
+  achievementsTrigger.style.setProperty(
+    'background',
+    'var(--turn-action-success, #8ce99a)',
+    'important'
+  );
+  feedbackTrigger.after(achievementsTrigger);
+  return achievementsTrigger;
+}
+
 export function installHomeFeedback() {
   if (installed) return globalThis.__turnHomeFeedback;
 
@@ -167,6 +183,7 @@ export function installHomeFeedback() {
   feedbackTrigger.textContent = 'GIVE FEEDBACK';
   feedbackTrigger.setAttribute('aria-haspopup', 'dialog');
   menu.insertBefore(feedbackTrigger, status);
+  const achievementsTrigger = alignAchievementsTrigger(menu, feedbackTrigger);
 
   const { meta, trigger: aboutTrigger, buildLabel } = createAboutTrigger();
   const feedbackDialog = createFeedbackDialog();
@@ -185,6 +202,7 @@ export function installHomeFeedback() {
     version: FEEDBACK_VERSION,
     email: FEEDBACK_EMAIL,
     trigger: feedbackTrigger,
+    achievementsTrigger,
     dialog: feedbackDialog,
     open: () => openDialog(feedbackDialog, feedbackTrigger),
     close: () => closeDialog(feedbackDialog),

--- a/turn/ui/screen-blanking.js
+++ b/turn/ui/screen-blanking.js
@@ -66,6 +66,10 @@ function installStyles() {
       -webkit-tap-highlight-color: transparent;
     }
 
+    .utility-group[data-menu-state="staged"] .turn-screen-blank-control {
+      padding: 4px;
+    }
+
     .turn-screen-blank-control[data-state="active"] {
       position: fixed;
       left: var(--turn-screen-blank-left, 16px);
@@ -129,6 +133,10 @@ function installStyles() {
         width: 40px;
         min-width: 40px;
         min-height: 40px;
+        padding: 3px;
+      }
+
+      .utility-group[data-menu-state="staged"] .turn-screen-blank-control {
         padding: 3px;
       }
 

--- a/turn/ui/screen-blanking.js
+++ b/turn/ui/screen-blanking.js
@@ -56,7 +56,7 @@ function installStyles() {
       width: 50px;
       min-width: 50px;
       min-height: 50px;
-      padding: 9px;
+      padding: 4px;
       place-items: center;
       align-self: stretch;
       border-radius: 12px;
@@ -76,7 +76,7 @@ function installStyles() {
       height: var(--turn-screen-blank-height, 50px);
       min-height: var(--turn-screen-blank-height, 50px);
       margin: 0;
-      padding: var(--turn-screen-blank-padding, 9px);
+      padding: var(--turn-screen-blank-padding, 4px);
       align-self: auto;
       border-width: var(--turn-screen-blank-border-width, 3px);
       border-radius: var(--turn-screen-blank-radius, 12px);
@@ -90,7 +90,7 @@ function installStyles() {
       overflow: visible;
       fill: none;
       stroke: currentColor;
-      stroke-width: 2.2;
+      stroke-width: 2.4;
       stroke-linecap: round;
       stroke-linejoin: round;
     }
@@ -129,7 +129,7 @@ function installStyles() {
         width: 40px;
         min-width: 40px;
         min-height: 40px;
-        padding: 7px;
+        padding: 3px;
       }
 
       .turn-screen-blank-toast {


### PR DESCRIPTION
## Summary
- make the Home **ACHIEVEMENTS** action reuse the complete **GIVE FEEDBACK** button typography and geometry, including font family, size, weight, line height, spacing, border, radius and shadow
- keep the Achievements action on the semantic success green
- move it directly after **GIVE FEEDBACK**
- enlarge the eye, confirmation and show-screen graphics without changing the non-visual control’s touch target or position

## Non-visual control
- reduce internal padding from 9px to 4px at normal landscape sizes
- reduce compact-landscape padding from 7px to 3px
- explicitly override the generic race-menu utility padding so the larger graphics are applied in the staged race view
- carry the measured padding into Blank screen mode so the orange restore button uses the same larger icon
- slightly strengthen the icon stroke for legibility

## Validation
- extend the Home feedback regression to protect the Achievements button’s shared typography, semantic colour and order