### PR TITLE
Match Achievements menu text size exactly

### DIFF
--- a/turn-tests/home-feedback-production.mjs
+++ b/turn-tests/home-feedback-production.mjs
@@ -16,14 +16,20 @@ assert.ok(
   'The feedback and About actions must be installed only after the fixed Home interface exists'
 );
 
-assert.match(feedback, /FEEDBACK_VERSION = 'r147-achievement-menu-order'/);
+assert.match(feedback, /FEEDBACK_VERSION = 'r148-achievement-font-match'/);
 assert.match(feedback, /FEEDBACK_EMAIL = 'erik@enkel\.design'/);
 assert.match(feedback, /feedbackTrigger\.textContent = 'GIVE FEEDBACK'/);
 assert.match(feedback, /feedbackTrigger\.setAttribute\('aria-haspopup', 'dialog'\)/);
 assert.match(feedback, /menu\.insertBefore\(feedbackTrigger, status\)/, 'GIVE FEEDBACK must sit with the other Home menu actions, before status and RACE');
 assert.match(feedback, /function alignAchievementsTrigger\(menu, feedbackTrigger\)/);
+assert.match(feedback, /achievementsTrigger\.classList\.remove\('m8-home-settings'\)/,
+  'Achievements must drop the Settings class that scales descendant spans to 1.25em');
 assert.match(feedback, /achievementsTrigger\.classList\.add\('m8-feedback-button'\)/,
   'Achievements must reuse the complete Give Feedback typography and geometry');
+assert.ok(
+  feedback.indexOf("classList.remove('m8-home-settings')") < feedback.indexOf("classList.add('m8-feedback-button')"),
+  'The conflicting Settings typography must be removed before Give Feedback styling is applied'
+);
 assert.match(feedback, /var\(--turn-action-success, #8ce99a\)/,
   'The Home Achievements destination must use the semantic success action');
 assert.match(feedback, /feedbackTrigger\.after\(achievementsTrigger\)/,

--- a/turn/ui/home-feedback.js
+++ b/turn/ui/home-feedback.js
@@ -1,6 +1,6 @@
 const FEEDBACK_EMAIL = 'erik@enkel.design';
 const FEEDBACK_SUBJECT = 'TURN feedback';
-const FEEDBACK_VERSION = 'r147-achievement-menu-order';
+const FEEDBACK_VERSION = 'r148-achievement-font-match';
 
 let installed = false;
 
@@ -156,8 +156,9 @@ function alignAchievementsTrigger(menu, feedbackTrigger) {
   const achievementsTrigger = menu.querySelector('.m8-achievements-button');
   if (!achievementsTrigger) return null;
 
-  // Reuse the complete Give Feedback button typography and geometry so the two
-  // destinations remain perfectly aligned at every responsive breakpoint.
+  // The temporary Settings class also enlarges every descendant span to 1.25em.
+  // Remove it before reusing Give Feedback so the label matches the other menu text exactly.
+  achievementsTrigger.classList.remove('m8-home-settings');
   achievementsTrigger.classList.add('m8-feedback-button');
   achievementsTrigger.style.setProperty(
     'background',


### PR DESCRIPTION
## Summary
- remove the temporary `m8-home-settings` class from the Home Achievements button once the final menu is assembled
- keep the shared `m8-feedback-button` class for the exact same typography and geometry as Give Feedback
- retain the semantic success green and current menu order

## Root cause
The Settings class contains a legacy descendant rule that enlarges every nested `span` to `1.25em`. The Achievements label is wrapped in a span for its unread badge, so the button inherited the correct button font but its visible label was still scaled up by 25%.

## Validation
- add a regression assertion that the conflicting Settings class is removed before the shared Give Feedback styling is applied