### PR TITLE
Align Leave Race with Restart Lap position

### DIFF
--- a/turn/ui/screen-blanking.js
+++ b/turn/ui/screen-blanking.js
@@ -218,7 +218,13 @@ export function installScreenBlanking(runtime = globalThis.__turnRuntime) {
       return;
     }
 
-    // The control is a real member of the race menu row and its first focusable item.
+    // Leave Race occupies the same first slot as Restart Lap. The optional
+    // non-visual action follows it so the destructive/navigation position is stable.
+    const leaveRaceButton = utilityGroup.querySelector('.back-to-lot-button');
+    if (leaveRaceButton?.parentElement === utilityGroup) {
+      leaveRaceButton.after(button);
+      return;
+    }
     utilityGroup.prepend(button);
   }
 


### PR DESCRIPTION
## Summary
- keep the primary race-navigation action in the first utility-menu position in both states
- place **Leave Race** first while the race is staged
- move the non-visual button directly after **Leave Race**
- preserve the non-visual button's current size, visuals, Blank screen position capture, and focus behaviour

## Design-system rule
**Restart Lap** and **Leave Race** now occupy the same screen position. This prevents the non-visual control from replacing the expected navigation action when moving between staged and active race states.

## Fallback
If the Leave Race control is unexpectedly unavailable, the non-visual control still falls back safely to the beginning of the utility group.