### PR TITLE
Add five-part Drive By Ear training

### DIFF
--- a/.github/workflows/turn-dbe-training-tests.yml
+++ b/.github/workflows/turn-dbe-training-tests.yml
@@ -1,0 +1,45 @@
+name: TURN Drive By Ear training regression
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'turn/training/**'
+      - 'turn/m8-home-fixed-layout.js'
+      - 'turn-tests/drive-by-ear-training-production.mjs'
+      - 'eslint.config.mjs'
+      - '.github/workflows/turn-dbe-training-tests.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'turn/training/**'
+      - 'turn/m8-home-fixed-layout.js'
+      - 'turn-tests/drive-by-ear-training-production.mjs'
+      - 'eslint.config.mjs'
+      - '.github/workflows/turn-dbe-training-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  training:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Syntax-check training modules
+        run: node --check turn/training/drive-by-ear-training.js && node --check turn-tests/drive-by-ear-training-production.mjs
+
+      - name: Lint training modules
+        run: npx --yes eslint@9.39.1 turn/training/drive-by-ear-training.js turn-tests/drive-by-ear-training-production.mjs
+
+      - name: Run Drive By Ear training regression
+        run: node turn-tests/drive-by-ear-training-production.mjs

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,7 @@ const readonlyGlobals = {
   document: 'readonly',
   CustomEvent: 'readonly',
   requestAnimationFrame: 'readonly',
+  cancelAnimationFrame: 'readonly',
   MutationObserver: 'readonly'
 };
 
@@ -32,6 +33,7 @@ export default [
       'turn/race/track-spatial-index.js',
       'turn/render/camera.js',
       'turn/render/covered-rendering.js',
+      'turn/training/*.js',
       'turn/ui/steering-limit-warning.js',
       'turn/ui/track-select.js',
       'turn/vehicle/catalog.js',

--- a/turn-tests/drive-by-ear-training-production.mjs
+++ b/turn-tests/drive-by-ear-training-production.mjs
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const [training, css, fixedLayout] = await Promise.all([
+  fs.readFile(new URL('../turn/training/drive-by-ear-training.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/training/drive-by-ear-training.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8')
+]);
+
+assert.match(fixedLayout, /training\/drive-by-ear-training\.js\?build=\$\{buildKey\}-r149-dbe-training/);
+assert.match(fixedLayout, /installDriveByEarTraining\(globalThis\.__turnRuntime\)/);
+assert.match(fixedLayout, /driveByEarTraining/);
+
+assert.match(training, /const TRAINING_BALANCE = 0\.95/);
+assert.match(training, /const BALANCE_SUGGESTION_THRESHOLD = 75/);
+assert.match(training, /const TRAINING_CAR_ID = 'classic'/);
+assert.match(training, /DRIVE BY EAR TRAINING/);
+assert.match(training, /homeButton\.textContent = 'DRIVE BY EAR TRAINING'/);
+assert.doesNotMatch(training, /homeButton[\s\S]{0,120}(?:complete|completed|done)/i, 'The permanent Home training destination must never become a completion-status button');
+assert.doesNotMatch(training, /training-complete(?:d)?-v|localStorage.*training.*complete/i, 'Training completion must not create a persistent button status');
+
+assert.equal((training.match(/id: 'dbe-training-[1-5]'/g) || []).length, 5, 'Training must contain exactly five authored parts');
+assert.match(training, /title: 'Find the ribbon'[\s\S]*guideRails: true[\s\S]*startOffset: -6/);
+assert.match(training, /title: 'Listen ahead'[\s\S]*guideRails: true/);
+assert.match(training, /title: 'Leave and return'[\s\S]*guideRails: false[\s\S]*startOffset: -\(ROAD_HALF_WIDTH \+ 4\)/);
+assert.match(training, /title: 'Trust the sequence'[\s\S]*severity: 3/);
+assert.match(training, /title: 'Drive by ear'/);
+assert.match(training, /const RECOVERY_LIMIT = ROAD_HALF_WIDTH \+ 10/);
+assert.match(training, /constrainToCourse\(nearest, stage\)/);
+assert.match(training, /runtime\.state\.position\.copy\(sample\.point\)\.addScaledVector\(sample\.normal, lateralSign \* stage\.outerLimit\)/);
+
+assert.match(training, /finalBeepDurationSeconds: note\.long \? 0\.17 : 0\.055/);
+assert.match(training, /turn:pace-note-priority/);
+assert.match(training, /turn:pace-note-silence/);
+assert.match(training, /PACE_NOTE_DIRECTION\.RIGHT, severity: 1/);
+assert.match(training, /PACE_NOTE_DIRECTION\.LEFT, severity: 2/);
+assert.match(training, /PACE_NOTE_DIRECTION\.LEFT, severity: 3/);
+
+assert.match(training, /class="turn-dbe-training-visual-hint" aria-hidden="true"/);
+assert.match(training, /Try Blank screen mode for this part/);
+assert.match(training, /The screen stays on while you learn/);
+assert.match(training, /MutationObserver[\s\S]*blankButton\.dataset\.state !== 'armed'/);
+assert.match(training, /Blank screen mode lets you drive using sound/);
+
+assert.match(training, /m8-home-menu/);
+assert.match(training, /m8-how-dialog \.m8-guide-wide/);
+assert.match(training, /m8-settings-dialog #m8AudioTitle/);
+assert.match(training, /New to these sounds\?/);
+assert.match(training, /Drive By Ear is prominent in the sound mix/);
+
+assert.match(training, /setAudioEnabled\?\.\(true\)/);
+assert.match(training, /setDriveByEarEnabled\?\.\(true\)/);
+assert.match(training, /setBalance\?\.\(TRAINING_BALANCE\)/);
+assert.match(training, /restorePreferenceStorage\(\)/);
+assert.match(training, /await activateTrack\(snapshot\.trackId, runtime\)/);
+assert.match(training, /await raceSession\.selectVehicle\(snapshot\.vehicle\)/);
+assert.match(training, /runtime\.openLot = snapshot\.openLot/);
+assert.match(training, /resetButton\.textContent = snapshot\.resetLabel/);
+assert.match(training, /leaveButton\.textContent = snapshot\.leaveLabel/);
+
+assert.match(css, /\.turn-dbe-training-home[\s\S]*--turn-action-information/);
+assert.match(css, /\.turn-dbe-training-active \.turn-dbe-training-hidden-map/);
+assert.match(css, /\.turn-dbe-training-hud\[hidden\]/);
+assert.match(css, /@media \(prefers-reduced-motion: reduce\)/);
+
+console.log('TURN Drive By Ear five-part training and preference restoration passed.');

--- a/turn-tests/drive-by-ear-training-production.mjs
+++ b/turn-tests/drive-by-ear-training-production.mjs
@@ -1,62 +1,58 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [training, css, fixedLayout] = await Promise.all([
+const [runtime, stages, course, view, css, fixedLayout] = await Promise.all([
   fs.readFile(new URL('../turn/training/drive-by-ear-training.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/training/stages.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/training/course.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/training/view.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/training/drive-by-ear-training.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8')
 ]);
+const training = `${runtime}\n${stages}\n${course}\n${view}`;
 
 assert.match(fixedLayout, /training\/drive-by-ear-training\.js\?build=\$\{buildKey\}-r149-dbe-training/);
 assert.match(fixedLayout, /installDriveByEarTraining\(globalThis\.__turnRuntime\)/);
 assert.match(fixedLayout, /driveByEarTraining/);
+assert.match(stages, /TRAINING_BALANCE = 0\.95/);
+assert.match(stages, /BALANCE_SUGGESTION_THRESHOLD = 75/);
+assert.match(stages, /TRAINING_CAR_ID = 'classic'/);
+assert.equal((stages.match(/id: 'dbe-training-[1-5]'/g) || []).length, 5);
+assert.match(stages, /title: 'Find the ribbon'[\s\S]*guideRails: true[\s\S]*startOffset: -6/);
+assert.match(stages, /title: 'Listen ahead'[\s\S]*guideRails: true/);
+assert.match(stages, /title: 'Leave and return'[\s\S]*guideRails: false[\s\S]*startOffset: -\(ROAD_HALF_WIDTH \+ 4\)/);
+assert.match(stages, /title: 'Trust the sequence'[\s\S]*LEFT, 3/);
+assert.match(stages, /title: 'Drive by ear'/);
+assert.match(stages, /RECOVERY_LIMIT = ROAD_HALF_WIDTH \+ 10/);
 
-assert.match(training, /const TRAINING_BALANCE = 0\.95/);
-assert.match(training, /const BALANCE_SUGGESTION_THRESHOLD = 75/);
-assert.match(training, /const TRAINING_CAR_ID = 'classic'/);
-assert.match(training, /DRIVE BY EAR TRAINING/);
-assert.match(training, /homeButton\.textContent = 'DRIVE BY EAR TRAINING'/);
-assert.doesNotMatch(training, /homeButton[\s\S]{0,120}(?:complete|completed|done)/i, 'The permanent Home training destination must never become a completion-status button');
-assert.doesNotMatch(training, /training-complete(?:d)?-v|localStorage.*training.*complete/i, 'Training completion must not create a persistent button status');
+assert.match(view, /homeButton\.textContent = 'DRIVE BY EAR TRAINING'/);
+assert.doesNotMatch(view, /homeButton[\s\S]{0,120}(?:complete|completed|done)/i);
+assert.doesNotMatch(training, /training-complete(?:d)?-v|localStorage.*training.*complete/i);
+assert.match(view, /class="turn-dbe-training-visual-hint" aria-hidden="true"/);
+assert.match(stages, /Try Blank screen mode for this part/);
+assert.match(view, /The screen stays on while you learn/);
+assert.match(view, /blankButton\.dataset\.state !== 'armed'/);
+assert.match(view, /Blank screen mode lets you drive using sound/);
+assert.match(view, /m8-home-menu/);
+assert.match(view, /m8-how-dialog \.m8-guide-wide/);
+assert.match(view, /m8-settings-dialog #m8AudioTitle/);
+assert.match(view, /New to these sounds\?/);
+assert.match(view, /Drive By Ear is prominent in the sound mix/);
 
-assert.equal((training.match(/id: 'dbe-training-[1-5]'/g) || []).length, 5, 'Training must contain exactly five authored parts');
-assert.match(training, /title: 'Find the ribbon'[\s\S]*guideRails: true[\s\S]*startOffset: -6/);
-assert.match(training, /title: 'Listen ahead'[\s\S]*guideRails: true/);
-assert.match(training, /title: 'Leave and return'[\s\S]*guideRails: false[\s\S]*startOffset: -\(ROAD_HALF_WIDTH \+ 4\)/);
-assert.match(training, /title: 'Trust the sequence'[\s\S]*severity: 3/);
-assert.match(training, /title: 'Drive by ear'/);
-assert.match(training, /const RECOVERY_LIMIT = ROAD_HALF_WIDTH \+ 10/);
-assert.match(training, /constrainToCourse\(nearest, stage\)/);
-assert.match(training, /runtime\.state\.position\.copy\(sample\.point\)\.addScaledVector\(sample\.normal, lateralSign \* stage\.outerLimit\)/);
-
-assert.match(training, /finalBeepDurationSeconds: note\.long \? 0\.17 : 0\.055/);
-assert.match(training, /turn:pace-note-priority/);
-assert.match(training, /turn:pace-note-silence/);
-assert.match(training, /PACE_NOTE_DIRECTION\.RIGHT, severity: 1/);
-assert.match(training, /PACE_NOTE_DIRECTION\.LEFT, severity: 2/);
-assert.match(training, /PACE_NOTE_DIRECTION\.LEFT, severity: 3/);
-
-assert.match(training, /class="turn-dbe-training-visual-hint" aria-hidden="true"/);
-assert.match(training, /Try Blank screen mode for this part/);
-assert.match(training, /The screen stays on while you learn/);
-assert.match(training, /MutationObserver[\s\S]*blankButton\.dataset\.state !== 'armed'/);
-assert.match(training, /Blank screen mode lets you drive using sound/);
-
-assert.match(training, /m8-home-menu/);
-assert.match(training, /m8-how-dialog \.m8-guide-wide/);
-assert.match(training, /m8-settings-dialog #m8AudioTitle/);
-assert.match(training, /New to these sounds\?/);
-assert.match(training, /Drive By Ear is prominent in the sound mix/);
-
-assert.match(training, /setAudioEnabled\?\.\(true\)/);
-assert.match(training, /setDriveByEarEnabled\?\.\(true\)/);
-assert.match(training, /setBalance\?\.\(TRAINING_BALANCE\)/);
-assert.match(training, /restorePreferenceStorage\(\)/);
-assert.match(training, /await activateTrack\(snapshot\.trackId, runtime\)/);
-assert.match(training, /await raceSession\.selectVehicle\(snapshot\.vehicle\)/);
-assert.match(training, /runtime\.openLot = snapshot\.openLot/);
-assert.match(training, /resetButton\.textContent = snapshot\.resetLabel/);
-assert.match(training, /leaveButton\.textContent = snapshot\.leaveLabel/);
+assert.match(course, /makeGuideRails/);
+assert.match(runtime, /constrainToCourse\(nearest, session\.stage\)/);
+assert.match(runtime, /stage\.outerLimit/);
+assert.match(runtime, /turn:pace-note-priority/);
+assert.match(runtime, /finalBeepDurationSeconds: note\.long \? 0\.17 : 0\.055/);
+assert.match(runtime, /turn:pace-note-silence/);
+assert.match(runtime, /setAudioEnabled\?\.\(true\)/);
+assert.match(runtime, /setDriveByEarEnabled\?\.\(true\)/);
+assert.match(runtime, /setBalance\?\.\(TRAINING_BALANCE\)/);
+assert.match(runtime, /await activateTrack\(snapshot\.trackId, runtime\)/);
+assert.match(runtime, /await raceSession\.selectVehicle\(snapshot\.vehicle\)/);
+assert.match(runtime, /runtime\.openLot = snapshot\.openLot/);
+assert.match(runtime, /resetButton\.textContent = snapshot\.resetLabel/);
+assert.match(runtime, /leaveButton\.textContent = snapshot\.leaveLabel/);
 
 assert.match(css, /\.turn-dbe-training-home[\s\S]*--turn-action-information/);
 assert.match(css, /\.turn-dbe-training-active \.turn-dbe-training-hidden-map/);

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -106,6 +106,11 @@ export async function installM8HomeFixedLayout() {
   );
   const achievements = installAchievements(globalThis.__turnRuntime);
 
+  const { installDriveByEarTraining } = await import(
+    `/turn/training/drive-by-ear-training.js?build=${buildKey}-r149-dbe-training`
+  );
+  const driveByEarTraining = await installDriveByEarTraining(globalThis.__turnRuntime);
+
   globalThis.__turnHomeLayout = Object.freeze({
     id: LAYOUT_ID,
     home,
@@ -113,7 +118,8 @@ export async function installM8HomeFixedLayout() {
     menu,
     raceButton,
     cardScrollFixes,
-    achievements
+    achievements,
+    driveByEarTraining
   });
   return globalThis.__turnHomeLayout;
 }

--- a/turn/training/course.js
+++ b/turn/training/course.js
@@ -1,0 +1,157 @@
+import * as THREE from 'three';
+import { FINISH_PROGRESS, SAMPLE_COUNT } from './stages.js';
+
+export function buildTrainingCourse(stage, trackWidth) {
+  const samples = sampleStage(stage);
+  const world = new THREE.Group();
+  world.name = `TURN Drive By Ear Training · ${stage.title}`;
+  world.add(makeGround(samples), makeRoad(samples, trackWidth), makeRoadEdges(samples, trackWidth));
+  if (stage.guideRails) world.add(makeGuideRails(samples, trackWidth));
+  world.add(
+    makeLineMarker(samples[8], trackWidth, 0xffd43b),
+    makeLineMarker(samples[Math.floor(samples.length * FINISH_PROGRESS)], trackWidth, 0xff4fa3),
+    makeFinishArch(samples[Math.floor(samples.length * FINISH_PROGRESS)], trackWidth)
+  );
+  return Object.freeze({ samples, world });
+}
+
+export function disposeTrainingWorld(world) {
+  if (!world) return;
+  world.traverse((node) => {
+    node.geometry?.dispose?.();
+    if (Array.isArray(node.material)) node.material.forEach((material) => material?.dispose?.());
+    else node.material?.dispose?.();
+  });
+  world.removeFromParent();
+}
+
+function sampleStage(stage) {
+  const points = stage.points.map(([x, z]) => new THREE.Vector3(x, 0, z));
+  const curve = new THREE.CatmullRomCurve3(points, false, 'centripetal');
+  const samples = [];
+  let distance = 0;
+  for (let index = 0; index < SAMPLE_COUNT; index += 1) {
+    const progress = index / (SAMPLE_COUNT - 1);
+    const point = curve.getPointAt(progress);
+    const tangent = curve.getTangentAt(progress).normalize();
+    const normal = new THREE.Vector3(-tangent.z, 0, tangent.x).normalize();
+    if (index > 0) distance += point.distanceTo(samples[index - 1].point);
+    samples.push({ point, tangent, normal, distance });
+  }
+  return samples;
+}
+
+function makeGround(samples) {
+  const xs = samples.map((sample) => sample.point.x);
+  const zs = samples.map((sample) => sample.point.z);
+  const minX = Math.min(...xs) - 70;
+  const maxX = Math.max(...xs) + 70;
+  const minZ = Math.min(...zs) - 70;
+  const maxZ = Math.max(...zs) + 70;
+  const ground = new THREE.Mesh(
+    new THREE.PlaneGeometry(maxX - minX, maxZ - minZ),
+    new THREE.MeshStandardMaterial({ color: 0x8ce99a, roughness: 1 })
+  );
+  ground.rotation.x = -Math.PI / 2;
+  ground.position.set((minX + maxX) / 2, -0.03, (minZ + maxZ) / 2);
+  ground.receiveShadow = true;
+  return ground;
+}
+
+function makeRoad(samples, trackWidth) {
+  const positions = [];
+  const indices = [];
+  for (let index = 0; index < samples.length; index += 1) {
+    const sample = samples[index];
+    const left = sample.point.clone().addScaledVector(sample.normal, trackWidth / 2);
+    const right = sample.point.clone().addScaledVector(sample.normal, -trackWidth / 2);
+    left.y = 0.11;
+    right.y = 0.11;
+    positions.push(left.x, left.y, left.z, right.x, right.y, right.z);
+    if (index >= samples.length - 1) continue;
+    const offset = index * 2;
+    indices.push(offset, offset + 2, offset + 1, offset + 1, offset + 2, offset + 3);
+  }
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  geometry.setIndex(indices);
+  geometry.computeVertexNormals();
+  const road = new THREE.Mesh(
+    geometry,
+    new THREE.MeshStandardMaterial({ color: 0x454a50, roughness: 0.92 })
+  );
+  road.receiveShadow = true;
+  return road;
+}
+
+function makeRoadEdges(samples, trackWidth) {
+  const group = new THREE.Group();
+  for (const side of [-1, 1]) {
+    const positions = [];
+    for (const sample of samples) {
+      const point = sample.point.clone().addScaledVector(sample.normal, side * trackWidth / 2);
+      positions.push(point.x, 0.19, point.z);
+    }
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+    group.add(new THREE.Line(geometry, new THREE.LineBasicMaterial({ color: 0xfff8e8 })));
+  }
+  return group;
+}
+
+function makeGuideRails(samples, trackWidth) {
+  const group = new THREE.Group();
+  for (const side of [-1, 1]) {
+    const points = samples
+      .filter((_, index) => index % 12 === 0 || index === samples.length - 1)
+      .map((sample) => {
+        const point = sample.point.clone().addScaledVector(sample.normal, side * (trackWidth / 2 + 0.45));
+        point.y = 1.15;
+        return point;
+      });
+    const curve = new THREE.CatmullRomCurve3(points, false, 'centripetal');
+    group.add(
+      new THREE.Mesh(
+        new THREE.TubeGeometry(curve, 90, 0.72, 6, false),
+        new THREE.MeshBasicMaterial({ color: 0x08090a })
+      ),
+      new THREE.Mesh(
+        new THREE.TubeGeometry(curve, 90, 0.43, 6, false),
+        new THREE.MeshStandardMaterial({ color: 0xffd43b, roughness: 0.72 })
+      )
+    );
+  }
+  return group;
+}
+
+function makeLineMarker(sample, trackWidth, color) {
+  const marker = new THREE.Mesh(
+    new THREE.BoxGeometry(trackWidth + 0.4, 0.12, 1.8),
+    new THREE.MeshStandardMaterial({ color, roughness: 0.78 })
+  );
+  marker.position.copy(sample.point);
+  marker.position.y = 0.2;
+  marker.rotation.y = Math.atan2(sample.tangent.x, sample.tangent.z);
+  return marker;
+}
+
+function makeFinishArch(sample, trackWidth) {
+  const arch = new THREE.Group();
+  const beam = new THREE.Mesh(
+    new THREE.BoxGeometry(trackWidth + 5, 2, 1.4),
+    new THREE.MeshStandardMaterial({ color: 0xff4fa3, roughness: 0.7 })
+  );
+  beam.position.y = 8.5;
+  arch.add(beam);
+  for (const side of [-1, 1]) {
+    const post = new THREE.Mesh(
+      new THREE.BoxGeometry(1.2, 8.5, 1.2),
+      new THREE.MeshStandardMaterial({ color: 0xffd43b, roughness: 0.75 })
+    );
+    post.position.set(side * (trackWidth / 2 + 1.4), 4.25, 0);
+    arch.add(post);
+  }
+  arch.position.copy(sample.point);
+  arch.rotation.y = Math.atan2(sample.tangent.x, sample.tangent.z);
+  return arch;
+}

--- a/turn/training/drive-by-ear-training.css
+++ b/turn/training/drive-by-ear-training.css
@@ -1,0 +1,195 @@
+.turn-dbe-training-home {
+  background: var(--turn-action-information, #38d9ff) !important;
+}
+
+.turn-dbe-training-how,
+.turn-dbe-training-settings {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+  padding: 14px;
+  border: 3px solid var(--turn-ink, #08090a);
+  border-radius: 14px;
+  background: var(--turn-surface-information, #b9f3ff);
+  color: var(--turn-ink, #08090a);
+  box-shadow: 4px 4px 0 var(--turn-ink, #08090a);
+}
+
+.turn-dbe-training-how p,
+.turn-dbe-training-settings p {
+  margin: 0;
+}
+
+.turn-dbe-training-how button,
+.turn-dbe-training-settings button,
+.turn-dbe-training-actions button {
+  min-height: 44px;
+  padding: 9px 14px;
+  border: 3px solid var(--turn-ink, #08090a);
+  border-radius: 999px;
+  background: var(--turn-action-information, #38d9ff);
+  color: var(--turn-ink, #08090a);
+  box-shadow: 4px 4px 0 var(--turn-ink, #08090a);
+  font: inherit;
+  font-weight: 900;
+  line-height: 1;
+  letter-spacing: 0.035em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.turn-dbe-training-settings {
+  margin-top: 16px;
+}
+
+.turn-dbe-training-settings p {
+  font-weight: 800;
+}
+
+.turn-dbe-training-dialog .m8-dialog-card {
+  width: min(760px, calc(100vw - 28px));
+  max-height: min(86dvh, 720px);
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+
+.turn-dbe-training-copy {
+  display: grid;
+  gap: 15px;
+  padding: clamp(16px, 3vw, 26px);
+}
+
+.turn-dbe-training-copy > p,
+.turn-dbe-training-copy li {
+  margin: 0;
+  font-size: clamp(0.95rem, 1.7vw, 1.12rem);
+  line-height: 1.45;
+}
+
+.turn-dbe-training-copy ol {
+  display: grid;
+  gap: 9px;
+  margin: 0;
+  padding-inline-start: 1.5em;
+}
+
+.turn-dbe-training-visual-hint {
+  padding: 12px 14px;
+  border: 3px solid var(--turn-ink, #08090a);
+  border-radius: 12px;
+  background: var(--turn-warning-soft, #fff1a8);
+  font-weight: 800;
+}
+
+.turn-dbe-training-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 4px;
+}
+
+.turn-dbe-training-actions button:not([data-training-primary]) {
+  background: var(--turn-action-exit, #ff922b);
+}
+
+.turn-dbe-training-actions button[data-training-primary] {
+  background: var(--turn-action-primary, #ff4fa3);
+}
+
+.turn-dbe-training-how button:focus-visible,
+.turn-dbe-training-settings button:focus-visible,
+.turn-dbe-training-actions button:focus-visible,
+.turn-dbe-training-home:focus-visible {
+  outline: 4px solid var(--turn-focus, #ffd43b);
+  outline-offset: 4px;
+}
+
+.turn-dbe-training-hud {
+  position: fixed;
+  top: max(12px, env(safe-area-inset-top));
+  left: 50%;
+  z-index: 120;
+  display: grid;
+  min-width: min(360px, calc(100vw - 180px));
+  padding: 8px 14px;
+  border: 3px solid #08090a;
+  border-radius: 14px;
+  background: #b9f3ff;
+  color: #08090a;
+  box-shadow: 5px 5px 0 #08090a;
+  transform: translateX(-50%);
+  text-align: center;
+  pointer-events: none;
+}
+
+.turn-dbe-training-hud[hidden] {
+  display: none;
+}
+
+.turn-dbe-training-hud span {
+  font-size: clamp(0.62rem, 1.25vw, 0.76rem);
+  font-weight: 900;
+  letter-spacing: 0.12em;
+}
+
+.turn-dbe-training-hud strong {
+  font-size: clamp(0.86rem, 1.8vw, 1.12rem);
+  line-height: 1.05;
+}
+
+.turn-dbe-training-active .turn-dbe-training-hidden-map,
+.turn-dbe-training-active .topbar .chip:nth-child(2),
+.turn-dbe-training-active .topbar .chip:nth-child(3),
+.turn-dbe-training-active .topbar .chip:nth-child(4),
+.turn-dbe-training-active .spectate-button,
+.turn-dbe-training-active .turn-race-achievements-button,
+.turn-dbe-training-active .m8-race-settings-button {
+  display: none !important;
+}
+
+.turn-dbe-training-active .topbar {
+  pointer-events: none;
+}
+
+@media (max-height: 480px) and (orientation: landscape) {
+  .turn-dbe-training-dialog .m8-dialog-card {
+    max-height: calc(100dvh - 16px);
+  }
+
+  .turn-dbe-training-copy {
+    gap: 9px;
+    padding: 12px 16px 14px;
+  }
+
+  .turn-dbe-training-copy > p,
+  .turn-dbe-training-copy li {
+    font-size: 0.82rem;
+    line-height: 1.3;
+  }
+
+  .turn-dbe-training-copy ol {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 5px 22px;
+  }
+
+  .turn-dbe-training-actions button {
+    min-height: 38px;
+    padding-block: 7px;
+    font-size: 0.76rem;
+  }
+
+  .turn-dbe-training-hud {
+    top: max(7px, env(safe-area-inset-top));
+    padding: 5px 11px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .turn-dbe-training-how button,
+  .turn-dbe-training-settings button,
+  .turn-dbe-training-actions button,
+  .turn-dbe-training-home {
+    transition: none !important;
+  }
+}

--- a/turn/training/drive-by-ear-training.js
+++ b/turn/training/drive-by-ear-training.js
@@ -1,0 +1,489 @@
+import * as THREE from 'three';
+import { activateTrack } from '/turn/tracks/track-manager.js?source=20260729-r118-m8';
+import {
+  DEFAULT_VEHICLE_COLOR,
+  DEFAULT_VEHICLE_SECONDARY_COLOR,
+  VEHICLE_SELECTION_KEY
+} from '/turn/vehicle/catalog.js?build=20260720-r19';
+import { buildTrainingCourse, disposeTrainingWorld } from './course.js';
+import {
+  FINISH_PROGRESS,
+  ROAD_HALF_WIDTH,
+  TRAINING_BALANCE,
+  TRAINING_CAR_ID,
+  TRAINING_STAGES
+} from './stages.js';
+import {
+  closeSourceDialog,
+  hideTrainingDialog,
+  installTrainingView,
+  renderTrainingHud,
+  showTrainingDialog,
+  updatePartDialog
+} from './view.js';
+
+const TRAINING_REVISION = 'r149-dbe-training';
+const AUDIO_ENABLED_STORAGE_KEY = 'turn-audio-enabled-v1';
+const AUDIO_BALANCE_STORAGE_KEY = 'turn-audio-balance-v1';
+const DRIVE_BY_EAR_STORAGE_KEY = 'turn-drive-by-ear-v1';
+let installed = false;
+
+export async function installDriveByEarTraining(runtime = globalThis.__turnRuntime) {
+  if (installed) return globalThis.__turnDriveByEarTraining;
+  const home = globalThis.__turnHome;
+  const raceSession = globalThis.__turnRaceSession;
+  if (!runtime || !home || !raceSession) {
+    throw new Error('TURN Drive By Ear training requires the M8 Home and race-session runtime.');
+  }
+
+  const resetButton = document.querySelector('#resetButton');
+  const leaveButton = document.querySelector('.back-to-lot-button');
+  const mapWrap = document.querySelector('.map-wrap');
+  if (!resetButton || !leaveButton || !mapWrap) {
+    throw new Error('TURN Drive By Ear training could not find the complete race utility interface.');
+  }
+  installed = true;
+
+  const session = {
+    active: false,
+    starting: false,
+    stageIndex: 0,
+    stage: null,
+    world: null,
+    notesFired: new Set(),
+    previousProgress: 0,
+    finishing: false,
+    frame: 0,
+    returnFocus: null,
+    snapshot: null,
+    preparedAccess: null
+  };
+  let entryPoints = null;
+
+  const view = installTrainingView({
+    revision: TRAINING_REVISION,
+    openTraining,
+    isTrainingActive: () => session.active
+  });
+  entryPoints = view.entryPoints;
+  bindView();
+  resetButton.addEventListener('click', restartPart, true);
+  globalThis.addEventListener('pagehide', restorePreferencesForPageExit);
+
+  const api = Object.freeze({
+    revision: TRAINING_REVISION,
+    stages: TRAINING_STAGES,
+    entryPoints,
+    ...view,
+    open: openTraining,
+    leave: leaveTraining,
+    restart: restartPart,
+    getState: () => Object.freeze({
+      active: session.active,
+      stage: session.stageIndex + 1,
+      stageId: session.stage?.id || null
+    })
+  });
+  globalThis.__turnDriveByEarTraining = api;
+  return api;
+
+  function bindView() {
+    view.introDialog.querySelector('[data-training-start]').addEventListener('click', prepareFirstStart);
+    for (const button of view.introDialog.querySelectorAll('[data-training-cancel]')) {
+      button.addEventListener('click', cancelIntro);
+    }
+    for (const button of view.partDialog.querySelectorAll('[data-training-leave]')) {
+      button.addEventListener('click', () => void leaveTraining());
+    }
+    view.partDialog.querySelector('[data-training-next]').addEventListener('click', () => {
+      void startStage(session.stageIndex + 1);
+    });
+    for (const button of view.completeDialog.querySelectorAll('[data-training-return]')) {
+      button.addEventListener('click', () => void leaveTraining());
+    }
+    view.completeDialog.querySelector('[data-training-again]').addEventListener('click', () => {
+      void startStage(0);
+    });
+    view.introDialog.addEventListener('cancel', (event) => {
+      event.preventDefault();
+      cancelIntro();
+    });
+    for (const dialog of [view.partDialog, view.completeDialog]) {
+      dialog.addEventListener('cancel', (event) => {
+        event.preventDefault();
+        void leaveTraining();
+      });
+    }
+  }
+
+  function cancelIntro() {
+    hideTrainingDialog(view.introDialog);
+    session.returnFocus?.focus?.();
+  }
+
+  function openTraining(trigger) {
+    if (session.active) return;
+    session.returnFocus = trigger;
+    closeSourceDialog(trigger);
+    if (runtime.state.running) {
+      raceSession.leaveRace();
+      home.showHome();
+      session.returnFocus = entryPoints?.homeButton || trigger;
+    }
+    view.introDialog.querySelector('[data-training-intro-copy]').textContent =
+      "Learn TURN's spatial guidance one layer at a time. Training temporarily uses the Training Car and puts Drive By Ear at 95% of the sound mix. Your car and audio choices return when you leave.";
+    showTrainingDialog(view.introDialog, '[data-training-start]');
+  }
+
+  async function prepareFirstStart() {
+    if (session.starting || session.active) return;
+    session.starting = true;
+    const startButton = view.introDialog.querySelector('[data-training-start]');
+    startButton.disabled = true;
+    startButton.setAttribute('aria-busy', 'true');
+    try {
+      session.snapshot = captureSnapshot();
+      session.preparedAccess = await prepareAccess();
+      await applyTemporaryPreferences();
+      await applyTrainingCar();
+      session.active = true;
+      await startStage(0, { first: true });
+    } catch (error) {
+      const message = error instanceof Error
+        ? `${error.message} Choose on-screen steering in Settings and try again.`
+        : 'Training could not start. Choose on-screen steering in Settings and try again.';
+      if (session.snapshot) await restoreSession();
+      session.active = false;
+      view.introDialog.querySelector('[data-training-intro-copy]').textContent = message;
+      showTrainingDialog(view.introDialog, '[data-training-start]');
+    } finally {
+      session.starting = false;
+      startButton.disabled = false;
+      startButton.removeAttribute('aria-busy');
+    }
+  }
+
+  async function prepareAccess() {
+    const steeringMode = home.getSteeringMode?.() || 'manual';
+    if (steeringMode === 'motion' && runtime.state.sensorMode) {
+      return Object.freeze({
+        mode: 'motion',
+        fullscreenPromise: raceSession.requestGameFullscreen()
+      });
+    }
+    return steeringMode === 'motion'
+      ? raceSession.prepareMotionAccess()
+      : raceSession.prepareManualAccess();
+  }
+
+  async function startStage(index, { first = false } = {}) {
+    const stage = TRAINING_STAGES[index];
+    session.stageIndex = index;
+    session.stage = stage;
+    session.notesFired.clear();
+    session.finishing = false;
+    silencePaceNotes();
+
+    const course = buildTrainingCourse(stage, runtime.trackWidth || ROAD_HALF_WIDTH * 2);
+    overrideRuntimeTrack(stage, course);
+    positionStageStart(stage);
+    renderTrainingHud(view.visualHud, stage, index);
+    hideTrainingDialog(view.introDialog);
+    hideTrainingDialog(view.partDialog);
+    hideTrainingDialog(view.completeDialog);
+    home.hideHome();
+    document.body.classList.add('turn-dbe-training-active');
+    mapWrap.classList.add('turn-dbe-training-hidden-map');
+    resetButton.textContent = 'Restart Part';
+    leaveButton.textContent = 'Leave Training';
+    leaveButton.setAttribute('aria-label', 'Leave Drive By Ear training and return Home');
+    runtime.openLot = leaveTraining;
+
+    const fullscreenPromise = first ? session.preparedAccess?.fullscreenPromise : Promise.resolve(false);
+    await raceSession.startGame(fullscreenPromise || Promise.resolve(false));
+    positionStageStart(stage);
+    session.previousProgress = runtime.state.progress;
+    if (!session.frame) session.frame = requestAnimationFrame(trainingFrame);
+  }
+
+  function overrideRuntimeTrack(stage, course) {
+    clearTrainingWorld();
+    if (runtime.activeWorld) runtime.activeWorld.visible = false;
+    runtime.samples.splice(0, runtime.samples.length, ...course.samples);
+    runtime.trackSpatialIndex.replaceSamples(runtime.samples);
+    runtime.trackId = stage.id;
+    runtime.state.trackId = stage.id;
+    runtime.activeTrack = Object.freeze({
+      id: stage.id,
+      name: stage.title,
+      collisionProfile: null,
+      freeRoamDistance: stage.outerLimit
+    });
+    runtime.scene.background = new THREE.Color(0x38d9ff);
+    if (runtime.scene.fog?.color) {
+      runtime.scene.fog.color.setHex(0x74c0fc);
+      runtime.scene.fog.near = 180;
+      runtime.scene.fog.far = 700;
+    }
+    runtime.scene.add(course.world);
+    runtime.activeWorld = course.world;
+    session.world = course.world;
+    globalThis.__turnGetTrackId = () => stage.id;
+    globalThis.__turnGetCollisionProfile = () => null;
+    globalThis.__turnIsForgivingSurface = () => false;
+    window.dispatchEvent(new CustomEvent('turn:track-changed', {
+      detail: { trackId: stage.id, track: runtime.activeTrack, training: true }
+    }));
+  }
+
+  function positionStageStart(stage) {
+    const startIndex = 8;
+    const start = runtime.samples[startIndex];
+    runtime.setGameMode(runtime.GAME_MODE.STAGED);
+    runtime.state.position.copy(start.point).addScaledVector(start.normal, stage.startOffset);
+    runtime.state.position.y = start.point.y;
+    runtime.state.velocity.set(0, 0, 0);
+    runtime.state.heading = Math.atan2(start.tangent.x, start.tangent.z);
+    runtime.state.speed = 0;
+    runtime.state.driftAmount = 0;
+    runtime.state.offRoad = Math.abs(stage.startOffset) > ROAD_HALF_WIDTH;
+    runtime.state.trackDistance = Math.abs(stage.startOffset);
+    runtime.state.progress = startIndex / runtime.samples.length;
+    runtime.state.lastProgress = runtime.state.progress;
+    runtime.state.nearestTrackIndex = startIndex;
+    runtime.state.lapCheckpointIndex = 0;
+    runtime.state.lapInvalid = false;
+    runtime.state.lapStartedAt = 0;
+    runtime.state.lapElapsed = 0;
+    runtime.state.lapPreviousPosition = { x: runtime.state.position.x, z: runtime.state.position.z };
+    runtime.state.recording = [];
+    runtime.playerCar.position.copy(runtime.state.position);
+    runtime.playerCar.rotation.y = runtime.state.heading + Math.PI;
+    runtime.setRacePosition?.(null, 1);
+  }
+
+  function restartPart(event) {
+    if (!session.active) return;
+    event?.preventDefault?.();
+    event?.stopImmediatePropagation?.();
+    positionStageStart(session.stage);
+    session.notesFired.clear();
+    session.previousProgress = runtime.state.progress;
+    silencePaceNotes();
+  }
+
+  function trainingFrame() {
+    if (!session.active || !session.stage || !runtime.state.running) {
+      session.frame = requestAnimationFrame(trainingFrame);
+      return;
+    }
+    const nearest = runtime.trackSpatialIndex.find(runtime.state.position);
+    constrainToCourse(nearest, session.stage);
+    const progress = nearest.index / Math.max(1, runtime.samples.length - 1);
+    fireScheduledNotes(session.stage, progress);
+    session.previousProgress = progress;
+    const tangent = nearest.sample?.tangent || new THREE.Vector3();
+    const forwardSpeed = runtime.state.velocity.dot(tangent);
+    if (!session.finishing && progress >= FINISH_PROGRESS && forwardSpeed > 0.8) {
+      session.finishing = true;
+      void completePart();
+    }
+    session.frame = requestAnimationFrame(trainingFrame);
+  }
+
+  function constrainToCourse(nearest, stage) {
+    if (!nearest?.sample || nearest.distance <= stage.outerLimit) return;
+    const sample = nearest.sample;
+    const dx = runtime.state.position.x - sample.point.x;
+    const dz = runtime.state.position.z - sample.point.z;
+    const lateralSign = Math.sign(dx * sample.normal.x + dz * sample.normal.z) || 1;
+    runtime.state.position.copy(sample.point).addScaledVector(sample.normal, lateralSign * stage.outerLimit);
+    runtime.state.position.y = sample.point.y;
+    const outward = runtime.state.velocity.dot(sample.normal) * lateralSign;
+    if (outward > 0) runtime.state.velocity.addScaledVector(sample.normal, -outward * lateralSign);
+    runtime.state.velocity.multiplyScalar(stage.guideRails ? 0.38 : 0.62);
+    runtime.state.speed *= stage.guideRails ? 0.42 : 0.68;
+  }
+
+  function fireScheduledNotes(stage, progress) {
+    stage.notes.forEach((note, index) => {
+      const id = `${stage.id}-note-${index + 1}`;
+      if (session.notesFired.has(id)) return;
+      if (!(session.previousProgress < note.progress && progress >= note.progress)) return;
+      session.notesFired.add(id);
+      globalThis.dispatchEvent(new CustomEvent('turn:pace-note-priority', {
+        detail: {
+          id,
+          passageKey: `${stage.id}:${id}`,
+          trackId: stage.id,
+          progress,
+          groups: [Object.freeze({
+            direction: note.direction,
+            severity: note.severity,
+            finalBeepDurationSeconds: note.long ? 0.17 : 0.055
+          })]
+        }
+      }));
+    });
+  }
+
+  async function completePart() {
+    raceSession.leaveRace();
+    silencePaceNotes();
+    if (session.stageIndex >= TRAINING_STAGES.length - 1) {
+      view.visualHud.hidden = true;
+      showTrainingDialog(view.completeDialog, '[data-training-again]');
+      return;
+    }
+    updatePartDialog(view.partDialog, session.stageIndex + 1);
+    showTrainingDialog(view.partDialog, '[data-training-next]');
+  }
+
+  async function leaveTraining() {
+    hideTrainingDialog(view.introDialog);
+    hideTrainingDialog(view.partDialog);
+    hideTrainingDialog(view.completeDialog);
+    await restoreSession();
+    session.returnFocus?.focus?.();
+    return true;
+  }
+
+  async function restoreSession() {
+    stopFrameLoop();
+    silencePaceNotes();
+    raceSession.leaveRace();
+    clearTrainingWorld();
+    const snapshot = session.snapshot;
+    if (snapshot) {
+      globalThis.__turnGetTrackId = snapshot.globals.getTrackId;
+      globalThis.__turnGetCollisionProfile = snapshot.globals.collisionProfile;
+      globalThis.__turnIsForgivingSurface = snapshot.globals.forgivingSurface;
+      restoreAudio(snapshot);
+      await activateTrack(snapshot.trackId, runtime);
+      await raceSession.selectVehicle(snapshot.vehicle);
+      restorePreferenceStorage(snapshot);
+      runtime.openLot = snapshot.openLot;
+      resetButton.textContent = snapshot.resetLabel;
+      leaveButton.textContent = snapshot.leaveLabel;
+      if (snapshot.leaveAriaLabel == null) leaveButton.removeAttribute('aria-label');
+      else leaveButton.setAttribute('aria-label', snapshot.leaveAriaLabel);
+    }
+    document.body.classList.remove('turn-dbe-training-active');
+    mapWrap.classList.remove('turn-dbe-training-hidden-map');
+    view.visualHud.hidden = true;
+    Object.assign(session, {
+      active: false,
+      starting: false,
+      stage: null,
+      world: null,
+      finishing: false,
+      snapshot: null,
+      preparedAccess: null
+    });
+    session.notesFired.clear();
+    home.showHome({ focus: true });
+  }
+
+  function captureSnapshot() {
+    const preferences = globalThis.__turnAudioPreferences?.getSettings?.() || {};
+    return Object.freeze({
+      trackId: home.getSelectedTrackId?.() || runtime.state.trackId || 'countryside',
+      vehicle: Object.freeze({
+        carId: runtime.state.vehicleId,
+        color: runtime.state.vehicleColor,
+        secondaryColor: runtime.state.vehicleSecondaryColor
+      }),
+      audio: Object.freeze({
+        audioEnabled: preferences.audioEnabled !== false,
+        dbeEnabled: preferences.dbeEnabled !== false,
+        balance: Number.isFinite(Number(preferences.balance)) ? Number(preferences.balance) : 0.5
+      }),
+      storage: Object.freeze({
+        audioEnabled: storageSnapshot(AUDIO_ENABLED_STORAGE_KEY),
+        balance: storageSnapshot(AUDIO_BALANCE_STORAGE_KEY),
+        dbe: storageSnapshot(DRIVE_BY_EAR_STORAGE_KEY),
+        vehicle: storageSnapshot(VEHICLE_SELECTION_KEY)
+      }),
+      globals: Object.freeze({
+        getTrackId: globalThis.__turnGetTrackId,
+        collisionProfile: globalThis.__turnGetCollisionProfile,
+        forgivingSurface: globalThis.__turnIsForgivingSurface
+      }),
+      openLot: runtime.openLot,
+      resetLabel: resetButton.textContent,
+      leaveLabel: leaveButton.textContent,
+      leaveAriaLabel: leaveButton.getAttribute('aria-label')
+    });
+  }
+
+  async function applyTemporaryPreferences() {
+    await globalThis.__turnEnsureDriveByEarRuntime?.();
+    const preferences = globalThis.__turnAudioPreferences;
+    preferences?.setAudioEnabled?.(true);
+    preferences?.setDriveByEarEnabled?.(true);
+    preferences?.setBalance?.(TRAINING_BALANCE);
+    restorePreferenceStorage(session.snapshot);
+    await globalThis.__turnAudio?.unlock?.();
+  }
+
+  async function applyTrainingCar() {
+    await raceSession.selectVehicle({
+      carId: TRAINING_CAR_ID,
+      color: DEFAULT_VEHICLE_COLOR,
+      secondaryColor: DEFAULT_VEHICLE_SECONDARY_COLOR
+    });
+    restoreStorage(VEHICLE_SELECTION_KEY, session.snapshot?.storage?.vehicle);
+  }
+
+  function restoreAudio(snapshot) {
+    const preferences = globalThis.__turnAudioPreferences;
+    preferences?.setAudioEnabled?.(snapshot.audio.audioEnabled);
+    preferences?.setDriveByEarEnabled?.(snapshot.audio.dbeEnabled);
+    preferences?.setBalance?.(snapshot.audio.balance);
+    restorePreferenceStorage(snapshot);
+  }
+
+  function restorePreferencesForPageExit() {
+    if (!session.active || !session.snapshot) return;
+    restoreAudio(session.snapshot);
+  }
+
+  function restorePreferenceStorage(snapshot) {
+    const storage = snapshot?.storage;
+    if (!storage) return;
+    restoreStorage(AUDIO_ENABLED_STORAGE_KEY, storage.audioEnabled);
+    restoreStorage(AUDIO_BALANCE_STORAGE_KEY, storage.balance);
+    restoreStorage(DRIVE_BY_EAR_STORAGE_KEY, storage.dbe);
+    restoreStorage(VEHICLE_SELECTION_KEY, storage.vehicle);
+  }
+
+  function clearTrainingWorld() {
+    disposeTrainingWorld(session.world);
+    session.world = null;
+  }
+
+  function stopFrameLoop() {
+    if (session.frame) cancelAnimationFrame(session.frame);
+    session.frame = 0;
+  }
+
+  function silencePaceNotes() {
+    globalThis.dispatchEvent(new CustomEvent('turn:pace-note-silence'));
+  }
+}
+
+function storageSnapshot(key) {
+  try {
+    return Object.freeze({ available: true, value: globalThis.localStorage?.getItem(key) ?? null });
+  } catch (_) {
+    return Object.freeze({ available: false, value: null });
+  }
+}
+
+function restoreStorage(key, snapshot) {
+  if (!snapshot?.available) return;
+  try {
+    if (snapshot.value == null) globalThis.localStorage?.removeItem(key);
+    else globalThis.localStorage?.setItem(key, snapshot.value);
+  } catch (_) {}
+}

--- a/turn/training/stages.js
+++ b/turn/training/stages.js
@@ -1,0 +1,92 @@
+export const TRAINING_BALANCE = 0.95;
+export const BALANCE_SUGGESTION_THRESHOLD = 75;
+export const TRAINING_CAR_ID = 'classic';
+export const SAMPLE_COUNT = 720;
+export const FINISH_PROGRESS = 0.94;
+export const ROAD_HALF_WIDTH = 13.5;
+export const RAIL_LIMIT = ROAD_HALF_WIDTH - 1.2;
+export const RECOVERY_LIMIT = ROAD_HALF_WIDTH + 10;
+
+const LEFT = -1;
+const RIGHT = 1;
+const note = (progress, direction, severity, long = false) => Object.freeze({
+  progress,
+  direction,
+  severity,
+  long
+});
+const stage = (definition) => Object.freeze({
+  ...definition,
+  points: Object.freeze(definition.points),
+  notes: Object.freeze(definition.notes)
+});
+
+export const TRAINING_STAGES = Object.freeze([
+  stage({
+    id: 'dbe-training-1',
+    title: 'Find the ribbon',
+    lead: 'The warm hum points toward the best route. You begin to the right of it. Steer toward the hum until it settles in the centre, then follow it to the finish.',
+    visualHint: 'Watch how the sound moves as you steer. The rails make this first straight forgiving.',
+    guideRails: true,
+    startOffset: -6,
+    outerLimit: RAIL_LIMIT,
+    points: [[0, 0], [0, 38], [0, 78], [0, 120], [0, 164], [0, 205]],
+    notes: []
+  }),
+  stage({
+    id: 'dbe-training-2',
+    title: 'Listen ahead',
+    lead: 'Turn sounds play before the curve. The ear gives the direction. One beep means gentle, two means tighter, and a held final beep means the curve lasts longer.',
+    visualHint: 'The rails remain for this part so you can focus on matching each sound to the road ahead.',
+    guideRails: true,
+    startOffset: 0,
+    outerLimit: RAIL_LIMIT,
+    points: [
+      [0, 0], [0, 38], [6, 72], [24, 98], [50, 112], [86, 116],
+      [122, 116], [148, 106], [160, 82], [153, 57], [130, 42], [96, 38],
+      [62, 38], [34, 27], [20, 4], [23, -24], [43, -47], [74, -60], [112, -61]
+    ],
+    notes: [note(0.08, RIGHT, 1), note(0.34, LEFT, 2), note(0.62, LEFT, 2, true)]
+  }),
+  stage({
+    id: 'dbe-training-3',
+    title: 'Leave and return',
+    lead: 'You begin just off the road. Gravel confirms that you are off road, and recovery guidance points toward a useful place to rejoin. Slow down, steer toward the hum and listen for normal guidance to return.',
+    visualHint: 'There are no rails along the road now. A nearby invisible safety boundary prevents you from getting lost.',
+    guideRails: false,
+    startOffset: -(ROAD_HALF_WIDTH + 4),
+    outerLimit: RECOVERY_LIMIT,
+    points: [[0, 0], [0, 42], [3, 80], [18, 112], [44, 134], [80, 142], [122, 142], [164, 142]],
+    notes: [note(0.32, RIGHT, 1)]
+  }),
+  stage({
+    id: 'dbe-training-4',
+    title: 'Trust the sequence',
+    lead: 'Listen for three beeps before the tight curve. Use the ribbon to settle after it, then follow the next turn without rails along the road.',
+    visualHint: 'Ready to rely on the sound? Try Blank screen mode for this part.',
+    guideRails: false,
+    startOffset: 0,
+    outerLimit: RECOVERY_LIMIT,
+    points: [
+      [0, 0], [0, 42], [-4, 76], [-20, 102], [-48, 116], [-78, 108],
+      [-98, 84], [-101, 52], [-88, 24], [-62, 7], [-28, 3], [8, 10], [38, 30], [54, 60]
+    ],
+    notes: [note(0.22, LEFT, 3), note(0.70, RIGHT, 1)]
+  }),
+  stage({
+    id: 'dbe-training-5',
+    title: 'Drive by ear',
+    lead: 'Put it together. Follow the ribbon, listen ahead for the turns, and use recovery guidance if you leave the road. Smooth corrections are more useful than chasing every small movement.',
+    visualHint: 'Try the graduation run with Blank screen mode, or keep the course visible and train at your own pace.',
+    guideRails: false,
+    startOffset: 0,
+    outerLimit: RECOVERY_LIMIT,
+    points: [
+      [0, 0], [0, 38], [10, 72], [34, 94], [68, 100], [102, 92],
+      [126, 70], [132, 40], [120, 12], [94, -5], [62, -10], [30, -4],
+      [5, -18], [-9, -43], [-5, -72], [17, -95], [50, -105], [84, -99],
+      [112, -80], [126, -50], [122, -18], [104, 10], [78, 28]
+    ],
+    notes: [note(0.08, RIGHT, 1), note(0.32, LEFT, 2), note(0.58, RIGHT, 2, true), note(0.79, LEFT, 3)]
+  })
+]);

--- a/turn/training/view.js
+++ b/turn/training/view.js
@@ -1,0 +1,247 @@
+import { BALANCE_SUGGESTION_THRESHOLD, TRAINING_STAGES } from './stages.js';
+
+export function installTrainingView({ revision, openTraining, isTrainingActive }) {
+  installStylesheet(revision);
+  const dialogs = createDialogs();
+  const visualHud = createVisualHud();
+  const entryPoints = installEntryPoints(openTraining);
+  const balanceSlider = installBalanceSuggestion();
+  const blankSuggestion = installBlankScreenSuggestion({ openTraining, isTrainingActive });
+  return Object.freeze({ ...dialogs, visualHud, entryPoints, balanceSlider, blankSuggestion });
+}
+
+export function showTrainingDialog(dialog, focusSelector = '[data-training-primary]') {
+  const card = dialog.querySelector('.m8-dialog-card');
+  if (card) card.scrollTop = 0;
+  if (typeof dialog.showModal === 'function') dialog.showModal();
+  else dialog.setAttribute('open', '');
+  dialog.querySelector(focusSelector)?.focus();
+}
+
+export function hideTrainingDialog(dialog) {
+  if (typeof dialog.close === 'function' && dialog.open) dialog.close();
+  else dialog.removeAttribute('open');
+}
+
+export function closeSourceDialog(trigger) {
+  const source = trigger?.closest?.('dialog');
+  if (!source) return;
+  source.__turnReturnFocus = null;
+  if (typeof source.close === 'function' && source.open) source.close();
+  else source.removeAttribute('open');
+}
+
+export function updatePartDialog(dialog, index) {
+  const stage = TRAINING_STAGES[index];
+  dialog.querySelector('.turn-dbe-training-part-kicker').textContent = `PART ${index + 1} OF ${TRAINING_STAGES.length}`;
+  dialog.querySelector('#turnDbePartTitle').textContent = stage.title.toUpperCase();
+  dialog.querySelector('.turn-dbe-training-part-lead').textContent = stage.lead;
+  dialog.querySelector('.turn-dbe-training-visual-hint').textContent = stage.visualHint;
+  dialog.querySelector('[data-training-next]').textContent = `START PART ${index + 1}`;
+}
+
+export function renderTrainingHud(hud, stage, index) {
+  hud.querySelector('span').textContent = `PART ${index + 1} OF ${TRAINING_STAGES.length}`;
+  hud.querySelector('strong').textContent = stage.title.toUpperCase();
+  hud.hidden = false;
+}
+
+function installStylesheet(revision) {
+  if (document.querySelector('link[data-turn-dbe-training]')) return;
+  const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
+  const stylesheet = document.createElement('link');
+  stylesheet.rel = 'stylesheet';
+  stylesheet.href = `/turn/training/drive-by-ear-training.css?build=${buildKey}-${revision}`;
+  stylesheet.setAttribute('data-turn-dbe-training', '');
+  document.head.appendChild(stylesheet);
+}
+
+function makeDialog({ className, labelledBy, content }) {
+  const dialog = document.createElement('dialog');
+  dialog.className = `m8-dialog turn-dbe-training-dialog ${className}`;
+  dialog.setAttribute('aria-labelledby', labelledBy);
+  dialog.innerHTML = content;
+  document.body.appendChild(dialog);
+  return dialog;
+}
+
+function createDialogs() {
+  const introDialog = makeDialog({
+    className: 'turn-dbe-training-intro-dialog',
+    labelledBy: 'turnDbeTrainingTitle',
+    content: `
+      <article class="m8-dialog-card turn-dbe-training-card">
+        <header class="m8-dialog-head">
+          <div><span>FIVE GUIDED PARTS</span><h2 id="turnDbeTrainingTitle">DRIVE BY EAR TRAINING</h2></div>
+          <button type="button" data-training-cancel aria-label="Close Drive By Ear training">×</button>
+        </header>
+        <div class="turn-dbe-training-copy">
+          <p data-training-intro-copy>Learn TURN's spatial guidance one layer at a time. Training temporarily uses the Training Car and puts Drive By Ear at 95% of the sound mix. Your car and audio choices return when you leave.</p>
+          <ol>
+            <li><strong>Find the ribbon.</strong> Centre the warm guiding hum on a straight.</li>
+            <li><strong>Listen ahead.</strong> Match beep direction, count and length to curves.</li>
+            <li><strong>Leave and return.</strong> Use off-road recovery guidance.</li>
+            <li><strong>Trust the sequence.</strong> Drive without rails along the road.</li>
+            <li><strong>Drive by ear.</strong> Put the complete system together.</li>
+          </ol>
+          <p class="turn-dbe-training-visual-hint" aria-hidden="true">The screen stays on while you learn. Later parts invite you to try Blank screen mode.</p>
+          <div class="turn-dbe-training-actions">
+            <button type="button" data-training-cancel>CANCEL</button>
+            <button type="button" data-training-primary data-training-start>START TRAINING</button>
+          </div>
+        </div>
+      </article>`
+  });
+
+  const partDialog = makeDialog({
+    className: 'turn-dbe-training-part-dialog',
+    labelledBy: 'turnDbePartTitle',
+    content: `
+      <article class="m8-dialog-card turn-dbe-training-card">
+        <header class="m8-dialog-head">
+          <div><span class="turn-dbe-training-part-kicker"></span><h2 id="turnDbePartTitle"></h2></div>
+          <button type="button" data-training-leave aria-label="Leave Drive By Ear training">×</button>
+        </header>
+        <div class="turn-dbe-training-copy">
+          <p class="turn-dbe-training-part-lead"></p>
+          <p class="turn-dbe-training-visual-hint" aria-hidden="true"></p>
+          <div class="turn-dbe-training-actions">
+            <button type="button" data-training-leave>LEAVE TRAINING</button>
+            <button type="button" data-training-primary data-training-next></button>
+          </div>
+        </div>
+      </article>`
+  });
+
+  const completeDialog = makeDialog({
+    className: 'turn-dbe-training-complete-dialog',
+    labelledBy: 'turnDbeCompleteTitle',
+    content: `
+      <article class="m8-dialog-card turn-dbe-training-card">
+        <header class="m8-dialog-head">
+          <div><span>TRAINING</span><h2 id="turnDbeCompleteTitle">DRIVE BY EAR</h2></div>
+          <button type="button" data-training-return aria-label="Return Home">×</button>
+        </header>
+        <div class="turn-dbe-training-copy">
+          <p>You have heard the guiding ribbon, pace notes and off-road recovery work together. Train again whenever you want, then take the same sounds onto any TURN track.</p>
+          <div class="turn-dbe-training-actions">
+            <button type="button" data-training-return>RETURN HOME</button>
+            <button type="button" data-training-primary data-training-again>TRAIN AGAIN</button>
+          </div>
+        </div>
+      </article>`
+  });
+
+  return Object.freeze({ introDialog, partDialog, completeDialog });
+}
+
+function createVisualHud() {
+  const hud = document.createElement('div');
+  hud.className = 'turn-dbe-training-hud';
+  hud.hidden = true;
+  hud.setAttribute('aria-hidden', 'true');
+  hud.innerHTML = '<span></span><strong></strong>';
+  document.body.appendChild(hud);
+  return hud;
+}
+
+function installEntryPoints(openTraining) {
+  const menu = document.querySelector('.m8-home-menu');
+  const howButton = menu?.querySelector('.m8-how-button');
+  const howGuide = document.querySelector('.m8-how-dialog .m8-guide-wide > div');
+  const howDisclosure = howGuide?.querySelector('.m8-dbe-guide');
+  const settingsAudio = document.querySelector('.m8-settings-dialog #m8AudioTitle')?.closest('.m8-setting-card');
+  if (!menu || !howButton || !howGuide || !howDisclosure || !settingsAudio) {
+    throw new Error('TURN Drive By Ear training could not find the Home, How to Play and Settings entry points.');
+  }
+
+  const homeButton = document.createElement('button');
+  homeButton.type = 'button';
+  homeButton.className = 'm8-feedback-button turn-dbe-training-home';
+  homeButton.textContent = 'DRIVE BY EAR TRAINING';
+  homeButton.setAttribute('aria-haspopup', 'dialog');
+  howButton.after(homeButton);
+
+  const howCallout = document.createElement('div');
+  howCallout.className = 'turn-dbe-training-how';
+  howCallout.innerHTML = `
+    <p><strong>Learn by listening.</strong> Try five short guided parts covering the ribbon, turn sounds and off-road recovery.</p>
+    <button type="button" data-turn-dbe-training-entry>START DRIVE BY EAR TRAINING</button>`;
+  howDisclosure.before(howCallout);
+
+  const settingsCallout = document.createElement('div');
+  settingsCallout.className = 'turn-dbe-training-settings';
+  settingsCallout.innerHTML = `
+    <p>New to these sounds?</p>
+    <button type="button" data-turn-dbe-training-entry>TRY DRIVE BY EAR TRAINING</button>`;
+  settingsAudio.appendChild(settingsCallout);
+
+  homeButton.addEventListener('click', () => openTraining(homeButton));
+  for (const button of document.querySelectorAll('[data-turn-dbe-training-entry]')) {
+    button.addEventListener('click', () => openTraining(button));
+  }
+  return Object.freeze({ homeButton, howCallout, settingsCallout });
+}
+
+function installBalanceSuggestion() {
+  const slider = document.querySelector('.m8-settings-dialog #m8AudioBalance');
+  const status = document.querySelector('.m8-settings-dialog .m8-settings-status');
+  if (!slider || !status) return null;
+  let previous = Number(slider.value) || 0;
+  let mentioned = false;
+  slider.addEventListener('input', () => {
+    const current = Number(slider.value) || 0;
+    if (!mentioned && previous < BALANCE_SUGGESTION_THRESHOLD && current >= BALANCE_SUGGESTION_THRESHOLD) {
+      mentioned = true;
+      status.textContent = 'Drive By Ear is prominent in the sound mix. Training can help you recognise its guidance.';
+    }
+    previous = current;
+  });
+  return slider;
+}
+
+function installBlankScreenSuggestion({ openTraining, isTrainingActive }) {
+  const blankButton = document.querySelector('.turn-screen-blank-control');
+  if (!blankButton || typeof MutationObserver !== 'function') return null;
+  const dialog = makeDialog({
+    className: 'turn-dbe-training-blank-dialog',
+    labelledBy: 'turnDbeBlankSuggestionTitle',
+    content: `
+      <article class="m8-dialog-card turn-dbe-training-card">
+        <header class="m8-dialog-head">
+          <div><span>BLANK SCREEN MODE</span><h2 id="turnDbeBlankSuggestionTitle">DRIVE BY EAR</h2></div>
+          <button type="button" data-blank-continue aria-label="Close training suggestion">×</button>
+        </header>
+        <div class="turn-dbe-training-copy">
+          <p>Blank screen mode lets you drive using sound. The five-part training introduces the ribbon, turn sounds and off-road recovery before you rely on them in a race.</p>
+          <div class="turn-dbe-training-actions">
+            <button type="button" data-blank-continue>CONTINUE</button>
+            <button type="button" data-training-primary data-blank-training>TRY TRAINING</button>
+          </div>
+        </div>
+      </article>`
+  });
+  let suggested = false;
+  const continueBlanking = () => {
+    hideTrainingDialog(dialog);
+    blankButton.focus({ preventScroll: true });
+  };
+  for (const button of dialog.querySelectorAll('[data-blank-continue]')) {
+    button.addEventListener('click', continueBlanking);
+  }
+  dialog.querySelector('[data-blank-training]').addEventListener('click', () => {
+    hideTrainingDialog(dialog);
+    openTraining(blankButton);
+  });
+  dialog.addEventListener('cancel', (event) => {
+    event.preventDefault();
+    continueBlanking();
+  });
+  const observer = new MutationObserver(() => {
+    if (suggested || isTrainingActive() || blankButton.dataset.state !== 'armed') return;
+    suggested = true;
+    showTrainingDialog(dialog, '[data-blank-training]');
+  });
+  observer.observe(blankButton, { attributes: true, attributeFilter: ['data-state'] });
+  return Object.freeze({ dialog, observer });
+}


### PR DESCRIPTION
## Summary
- add a dedicated five-part Drive By Ear training mode without placing it among the ordinary track cards
- add permanent clean entry points from Home, How to Play and Settings
- suggest training the first time a player arms Blank screen mode and when the Drive By Ear balance first crosses 75% in a session
- keep sighted-only Blank screen recommendations hidden from assistive technology

## Training sequence
1. **Find the ribbon** — a straight with guide rails; the Training Car begins right of the route hum
2. **Listen ahead** — guide rails plus a gentle right, tighter left and long tighter left with the agreed beep patterns
3. **Leave and return** — no rails along the road; starts just off road and teaches recovery guidance
4. **Trust the sequence** — no road rails, a three-beep tight curve and a sighted-only Blank screen invitation
5. **Drive by ear** — a compact graduation course combining ribbon, pace notes and recovery

## Safety and session behaviour
- parts 3–5 allow a narrow off-road recovery area but use a nearby invisible outer boundary so the player cannot get lost
- training temporarily enables audio, Drive By Ear and a 95% Drive By Ear balance
- training temporarily selects the Training Car
- the previous track, car, paint, audio settings, balance and storage values are restored when training ends or the page is hidden
- training creates no ordinary track records or rivals
- Restart Lap and Leave Race become Restart Part and Leave Training during the session

## Completion treatment
The Home button never gains a completed label, badge or persistent completion state. It remains a clean invitation to train again.

## Validation
- syntax-checked all new JavaScript modules locally
- added a dedicated static regression for the five parts, entry points, audio restoration, safe boundaries, pace-note patterns and permanent clean Home label
- added a focused GitHub Actions workflow for the training modules

## Physical test focus
- pace-note timing against the authored curves
- ribbon direction from the deliberately offset Part 1 start
- recovery guidance and outer-boundary feel in Parts 3–5
- motion permission/fullscreen flow from each entry point
- preference restoration after leaving, repeating and cancelling training
- VoiceOver focus and silence of sighted-only recommendations