### PR TITLE
Refine Drive By Ear 101 courses and controls

### DIFF
--- a/.github/workflows/turn-dbe-training-tests.yml
+++ b/.github/workflows/turn-dbe-training-tests.yml
@@ -36,10 +36,10 @@ jobs:
           node-version: '24'
 
       - name: Syntax-check training modules
-        run: node --check turn/training/drive-by-ear-training.js && node --check turn-tests/drive-by-ear-training-production.mjs
+        run: find turn/training -type f -name '*.js' -print0 | xargs -0 -n1 node --check && node --check turn-tests/drive-by-ear-training-production.mjs
 
       - name: Lint training modules
-        run: npx --yes eslint@9.39.1 turn/training/drive-by-ear-training.js turn-tests/drive-by-ear-training-production.mjs
+        run: npx --yes eslint@9.39.1 turn/training/*.js turn-tests/drive-by-ear-training-production.mjs
 
       - name: Run Drive By Ear training regression
         run: node turn-tests/drive-by-ear-training-production.mjs

--- a/turn-tests/drive-by-ear-training-production.mjs
+++ b/turn-tests/drive-by-ear-training-production.mjs
@@ -1,62 +1,166 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [runtime, stages, course, view, css, fixedLayout] = await Promise.all([
+import {
+  FINISH_PROGRESS,
+  RAIL_ASSIST_START,
+  RECOVERY_LIMIT,
+  ROAD_HALF_WIDTH,
+  TRAINING_STAGES
+} from '../turn/training/stages.js';
+
+const [training, view, css, fixedLayout] = await Promise.all([
   fs.readFile(new URL('../turn/training/drive-by-ear-training.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/training/stages.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/training/course.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/training/view.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/training/drive-by-ear-training.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8')
 ]);
-const training = `${runtime}\n${stages}\n${course}\n${view}`;
 
-assert.match(fixedLayout, /training\/drive-by-ear-training\.js\?build=\$\{buildKey\}-r149-dbe-training/);
+assert.match(fixedLayout, /training\/drive-by-ear-training\.js\?build=\$\{buildKey\}-r150-dbe-training-refinement/);
 assert.match(fixedLayout, /installDriveByEarTraining\(globalThis\.__turnRuntime\)/);
 assert.match(fixedLayout, /driveByEarTraining/);
-assert.match(stages, /TRAINING_BALANCE = 0\.95/);
-assert.match(stages, /BALANCE_SUGGESTION_THRESHOLD = 75/);
-assert.match(stages, /TRAINING_CAR_ID = 'classic'/);
-assert.equal((stages.match(/id: 'dbe-training-[1-5]'/g) || []).length, 5);
-assert.match(stages, /title: 'Find the ribbon'[\s\S]*guideRails: true[\s\S]*startOffset: -6/);
-assert.match(stages, /title: 'Listen ahead'[\s\S]*guideRails: true/);
-assert.match(stages, /title: 'Leave and return'[\s\S]*guideRails: false[\s\S]*startOffset: -\(ROAD_HALF_WIDTH \+ 4\)/);
-assert.match(stages, /title: 'Trust the sequence'[\s\S]*LEFT, 3/);
-assert.match(stages, /title: 'Drive by ear'/);
-assert.match(stages, /RECOVERY_LIMIT = ROAD_HALF_WIDTH \+ 10/);
 
-assert.match(view, /homeButton\.textContent = 'DRIVE BY EAR TRAINING'/);
-assert.doesNotMatch(view, /homeButton[\s\S]{0,120}(?:complete|completed|done)/i);
-assert.doesNotMatch(training, /training-complete(?:d)?-v|localStorage.*training.*complete/i);
-assert.match(view, /class="turn-dbe-training-visual-hint" aria-hidden="true"/);
-assert.match(stages, /Try Blank screen mode for this part/);
-assert.match(view, /The screen stays on while you learn/);
-assert.match(view, /blankButton\.dataset\.state !== 'armed'/);
-assert.match(view, /Blank screen mode lets you drive using sound/);
-assert.match(view, /m8-home-menu/);
-assert.match(view, /m8-how-dialog \.m8-guide-wide/);
-assert.match(view, /m8-settings-dialog #m8AudioTitle/);
-assert.match(view, /New to these sounds\?/);
-assert.match(view, /Drive By Ear is prominent in the sound mix/);
+assert.equal(TRAINING_STAGES.length, 5, 'Training must contain exactly five authored parts');
+assert.equal(FINISH_PROGRESS, 0.94);
+assert.ok(RAIL_ASSIST_START < ROAD_HALF_WIDTH, 'The slippery guide assist must begin when the car reaches a rail');
+assert.ok(RECOVERY_LIMIT > ROAD_HALF_WIDTH + 8, 'The invisible safety zone must remain wider than the road');
 
-assert.match(course, /makeGuideRails/);
-assert.match(runtime, /constrainToCourse\(nearest, session\.stage\)/);
-assert.match(runtime, /stage\.outerLimit/);
-assert.match(runtime, /turn:pace-note-priority/);
-assert.match(runtime, /finalBeepDurationSeconds: note\.long \? 0\.17 : 0\.055/);
-assert.match(runtime, /turn:pace-note-silence/);
-assert.match(runtime, /setAudioEnabled\?\.\(true\)/);
-assert.match(runtime, /setDriveByEarEnabled\?\.\(true\)/);
-assert.match(runtime, /setBalance\?\.\(TRAINING_BALANCE\)/);
-assert.match(runtime, /await activateTrack\(snapshot\.trackId, runtime\)/);
-assert.match(runtime, /await raceSession\.selectVehicle\(snapshot\.vehicle\)/);
-assert.match(runtime, /runtime\.openLot = snapshot\.openLot/);
-assert.match(runtime, /resetButton\.textContent = snapshot\.resetLabel/);
-assert.match(runtime, /leaveButton\.textContent = snapshot\.leaveLabel/);
+const [part1, part2, part3, part4, part5] = TRAINING_STAGES;
+assert.equal(part1.points.at(-1)[1], 420, 'Part 1 must provide a substantially longer straight');
+assert.ok(part1.points.every(([x]) => x === 0), 'Part 1 must remain a clean straight');
+assert.equal(part1.guideRails, true);
+assert.equal(part1.outerLimit, RECOVERY_LIMIT);
 
-assert.match(css, /\.turn-dbe-training-home[\s\S]*--turn-action-information/);
-assert.match(css, /\.turn-dbe-training-active \.turn-dbe-training-hidden-map/);
-assert.match(css, /\.turn-dbe-training-hud\[hidden\]/);
+assert.equal(part2.notes.length, 2, 'Part 2 must contain only the gentle right and broader left');
+assert.deepEqual(
+  part2.notes.map(({ direction, severity, long }) => [direction, severity, long]),
+  [[1, 1, false], [-1, 2, false]]
+);
+assert.ok(part2.notes[0].progress <= 0.10, 'The first Part 2 BIP must play on the long straight');
+assert.ok(part2.notes[1].progress <= 0.49, 'The second Part 2 cue must play before its curve');
+assert.ok(part2.points[3][1] >= 180, 'Part 2 must begin with a long straight');
+
+assert.equal(part3.notes.length, 1);
+assert.deepEqual(
+  [part3.notes[0].direction, part3.notes[0].severity, part3.notes[0].long],
+  [1, 1, false]
+);
+assert.ok(part3.notes[0].progress <= 0.17, 'Part 3 BIP must play well before the gentle right');
+assert.equal(part3.startOffset, -(ROAD_HALF_WIDTH + 4));
+
+assert.equal(part4.notes.length, 1, 'Part 4 must describe one uninterrupted curve');
+assert.deepEqual(
+  [part4.notes[0].direction, part4.notes[0].severity, part4.notes[0].long],
+  [-1, 3, true],
+  'Part 4 must play BIP BIP BEEP in the left ear for one long tight left'
+);
+assert.match(part4.lead, /BIP BIP BEEP/);
+assert.match(part4.lead, /held final BEEP/);
+
+assert.equal(part5.notes.length, 3);
+assert.ok(part5.points[3][1] >= 180, 'Part 5 must begin with a long straight');
+assert.match(part5.visualHint, /never crosses itself/);
+
+for (const stage of TRAINING_STAGES) {
+  assertCourseHasSpace(stage);
+}
+
+assert.match(training, /const TRAINING_REVISION = 'r150-dbe-training-refinement'/);
+assert.match(training, /applySlipperyAssist\(sample, side/);
+assert.match(training, /1 - Math\.exp\(-profile\.damping \* dt\)/);
+assert.match(training, /tangential motion instead of stopping or snapping the car back onto the road/);
+assert.doesNotMatch(training, /velocity\.multiplyScalar\(stage\.guideRails \?/,
+  'Guide rails must no longer stop the car with a fixed speed multiplier');
+assert.match(training, /crossedForwardGate\(/, 'Finishing must use the physical finish gate, not nearest-route proximity');
+assert.match(training, /HARD_BOUNDARY_OVERSHOOT/);
+assert.match(training, /data-training-race-restart/);
+assert.match(training, /restartPart/);
+assert.match(training, /renderTrainingNavigation/);
+assert.match(training, /dataset\.trainingTarget/);
+
+assert.match(view, /homeButton\.textContent = 'DRIVE BY EAR 101'/);
+assert.doesNotMatch(view, /homeButton\.textContent = 'DRIVE BY EAR TRAINING'/);
+assert.match(view, /data-training-stage="\$\{index\}"/);
+assert.match(view, /Choose a training part/);
+assert.match(view, /data-training-race-previous/);
+assert.match(view, /data-training-race-restart/);
+assert.match(view, /data-training-race-next/);
+assert.match(view, /Know which sound is speaking/);
+assert.match(view, /Steering guidance/);
+assert.match(view, /Pace notes/);
+assert.match(view, /Status and safety/);
+assert.match(view, /maximum-steering two-tone/);
+assert.match(view, /These sounds are not corner instructions/);
+assert.match(view, /The ear gives the turn side/);
+assert.match(view, /held final BEEP means the curve continues/);
+
+assert.match(training, /setAudioEnabled\?\.\(true\)/);
+assert.match(training, /setDriveByEarEnabled\?\.\(true\)/);
+assert.match(training, /setBalance\?\.\(TRAINING_BALANCE\)/);
+assert.match(training, /restorePreferenceStorage\(session\.snapshot\)/);
+assert.match(training, /await activateTrack\(snapshot\.trackId, runtime\)/);
+assert.match(training, /await raceSession\.selectVehicle\(snapshot\.vehicle\)/);
+assert.match(training, /runtime\.openLot = snapshot\.openLot/);
+
+assert.match(css, /\.turn-dbe-training-home[\s\S]*white-space: nowrap/);
+assert.match(css, /\.turn-dbe-training-sound-key/);
+assert.match(css, /\.turn-dbe-training-part-picker ol/);
+assert.match(css, /\.turn-dbe-training-race-nav/);
+assert.match(css, /data-training-race-restart/);
+assert.match(css, /\.turn-dbe-training-race-nav\[hidden\]/);
 assert.match(css, /@media \(prefers-reduced-motion: reduce\)/);
 
-console.log('TURN Drive By Ear five-part training and preference restoration passed.');
+console.log('TURN Drive By Ear 101 course spacing, cues, navigation and slippery rails passed.');
+
+function assertCourseHasSpace(stage) {
+  const points = stage.points.map(([x, z]) => ({ x, z }));
+  const minimumSeparation = ROAD_HALF_WIDTH * 3;
+  for (let first = 0; first < points.length - 1; first += 1) {
+    for (let second = first + 5; second < points.length - 1; second += 1) {
+      const distance = segmentDistance(
+        points[first],
+        points[first + 1],
+        points[second],
+        points[second + 1]
+      );
+      assert.ok(
+        distance > minimumSeparation,
+        `${stage.title} brings remote course segments within ${distance.toFixed(1)} metres`
+      );
+    }
+  }
+}
+
+function segmentDistance(a, b, c, d) {
+  if (segmentsIntersect(a, b, c, d)) return 0;
+  return Math.min(
+    pointSegmentDistance(a, c, d),
+    pointSegmentDistance(b, c, d),
+    pointSegmentDistance(c, a, b),
+    pointSegmentDistance(d, a, b)
+  );
+}
+
+function segmentsIntersect(a, b, c, d) {
+  const abC = cross(a, b, c);
+  const abD = cross(a, b, d);
+  const cdA = cross(c, d, a);
+  const cdB = cross(c, d, b);
+  return abC * abD < 0 && cdA * cdB < 0;
+}
+
+function cross(a, b, c) {
+  return (b.x - a.x) * (c.z - a.z) - (b.z - a.z) * (c.x - a.x);
+}
+
+function pointSegmentDistance(point, start, end) {
+  const dx = end.x - start.x;
+  const dz = end.z - start.z;
+  const lengthSquared = dx * dx + dz * dz;
+  const projection = lengthSquared > 0
+    ? Math.max(0, Math.min(1, ((point.x - start.x) * dx + (point.z - start.z) * dz) / lengthSquared))
+    : 0;
+  const nearestX = start.x + projection * dx;
+  const nearestZ = start.z + projection * dz;
+  return Math.hypot(point.x - nearestX, point.z - nearestZ);
+}

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -107,7 +107,7 @@ export async function installM8HomeFixedLayout() {
   const achievements = installAchievements(globalThis.__turnRuntime);
 
   const { installDriveByEarTraining } = await import(
-    `/turn/training/drive-by-ear-training.js?build=${buildKey}-r149-dbe-training`
+    `/turn/training/drive-by-ear-training.js?build=${buildKey}-r150-dbe-training-refinement`
   );
   const driveByEarTraining = await installDriveByEarTraining(globalThis.__turnRuntime);
 

--- a/turn/training/drive-by-ear-training.css
+++ b/turn/training/drive-by-ear-training.css
@@ -1,5 +1,6 @@
 .turn-dbe-training-home {
   background: var(--turn-action-information, #38d9ff) !important;
+  white-space: nowrap;
 }
 
 .turn-dbe-training-how,
@@ -22,7 +23,9 @@
 
 .turn-dbe-training-how button,
 .turn-dbe-training-settings button,
-.turn-dbe-training-actions button {
+.turn-dbe-training-actions button,
+.turn-dbe-training-part-picker button,
+.turn-dbe-training-race-nav button {
   min-height: 44px;
   padding: 9px 14px;
   border: 3px solid var(--turn-ink, #08090a);
@@ -47,8 +50,8 @@
 }
 
 .turn-dbe-training-dialog .m8-dialog-card {
-  width: min(760px, calc(100vw - 28px));
-  max-height: min(86dvh, 720px);
+  width: min(820px, calc(100vw - 28px));
+  max-height: min(90dvh, 780px);
   overflow: auto;
   overscroll-behavior: contain;
 }
@@ -60,17 +63,93 @@
 }
 
 .turn-dbe-training-copy > p,
-.turn-dbe-training-copy li {
+.turn-dbe-training-copy li,
+.turn-dbe-training-sound-key dd {
   margin: 0;
   font-size: clamp(0.95rem, 1.7vw, 1.12rem);
   line-height: 1.45;
 }
 
-.turn-dbe-training-copy ol {
+.turn-dbe-training-sound-key {
   display: grid;
-  gap: 9px;
+  gap: 10px;
+  padding: 14px;
+  border: 3px solid var(--turn-ink, #08090a);
+  border-radius: 14px;
+  background: var(--turn-surface-information, #b9f3ff);
+}
+
+.turn-dbe-training-sound-key h3 {
   margin: 0;
-  padding-inline-start: 1.5em;
+  font-size: clamp(1rem, 2vw, 1.3rem);
+  text-transform: uppercase;
+}
+
+.turn-dbe-training-sound-key dl {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin: 0;
+}
+
+.turn-dbe-training-sound-key dl > div {
+  padding: 11px 12px;
+  border: 2px solid var(--turn-ink, #08090a);
+  border-radius: 11px;
+  background: var(--turn-surface-raised, #fffdf6);
+}
+
+.turn-dbe-training-sound-key dt {
+  margin-bottom: 5px;
+  font-weight: 950;
+  text-transform: uppercase;
+}
+
+.turn-dbe-training-sound-key dd {
+  font-size: clamp(0.82rem, 1.45vw, 0.98rem);
+}
+
+.turn-dbe-training-part-picker ol {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.turn-dbe-training-part-picker li:last-child {
+  grid-column: 1 / -1;
+}
+
+.turn-dbe-training-part-picker button {
+  display: grid;
+  width: 100%;
+  min-height: 0;
+  gap: 4px;
+  padding: 12px 14px;
+  border-radius: 13px;
+  background: var(--turn-surface-raised, #fffdf6);
+  line-height: 1.2;
+  text-align: left;
+  text-transform: none;
+}
+
+.turn-dbe-training-part-picker button > span {
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+}
+
+.turn-dbe-training-part-picker button > strong {
+  font-size: clamp(0.95rem, 1.8vw, 1.15rem);
+  text-transform: uppercase;
+}
+
+.turn-dbe-training-part-picker button > small {
+  font-size: clamp(0.76rem, 1.35vw, 0.92rem);
+  font-weight: 700;
+  line-height: 1.3;
+  letter-spacing: 0;
 }
 
 .turn-dbe-training-visual-hint {
@@ -93,6 +172,10 @@
   background: var(--turn-action-exit, #ff922b);
 }
 
+.turn-dbe-training-actions button[data-training-repeat] {
+  background: var(--turn-action-information, #38d9ff);
+}
+
 .turn-dbe-training-actions button[data-training-primary] {
   background: var(--turn-action-primary, #ff4fa3);
 }
@@ -100,6 +183,8 @@
 .turn-dbe-training-how button:focus-visible,
 .turn-dbe-training-settings button:focus-visible,
 .turn-dbe-training-actions button:focus-visible,
+.turn-dbe-training-part-picker button:focus-visible,
+.turn-dbe-training-race-nav button:focus-visible,
 .turn-dbe-training-home:focus-visible {
   outline: 4px solid var(--turn-focus, #ffd43b);
   outline-offset: 4px;
@@ -123,7 +208,8 @@
   pointer-events: none;
 }
 
-.turn-dbe-training-hud[hidden] {
+.turn-dbe-training-hud[hidden],
+.turn-dbe-training-race-nav[hidden] {
   display: none;
 }
 
@@ -136,6 +222,36 @@
 .turn-dbe-training-hud strong {
   font-size: clamp(0.86rem, 1.8vw, 1.12rem);
   line-height: 1.05;
+}
+
+.turn-dbe-training-race-nav {
+  position: fixed;
+  top: max(80px, calc(env(safe-area-inset-top) + 72px));
+  left: 50%;
+  z-index: 121;
+  display: flex;
+  gap: 8px;
+  transform: translateX(-50%);
+}
+
+.turn-dbe-training-race-nav button {
+  min-height: 40px;
+  padding: 7px 12px;
+  border-radius: 11px;
+  background: var(--turn-surface-raised, #fffdf6);
+  box-shadow: 3px 3px 0 #08090a;
+  font-size: clamp(0.66rem, 1.2vw, 0.82rem);
+  white-space: nowrap;
+}
+
+.turn-dbe-training-race-nav button[data-training-race-restart] {
+  background: var(--turn-action-warning, #ffd43b);
+}
+
+.turn-dbe-training-race-nav button:disabled {
+  opacity: 0.42;
+  cursor: default;
+  box-shadow: none;
 }
 
 .turn-dbe-training-active .turn-dbe-training-hidden-map,
@@ -152,6 +268,17 @@
   pointer-events: none;
 }
 
+@media (max-width: 720px) {
+  .turn-dbe-training-sound-key dl,
+  .turn-dbe-training-part-picker ol {
+    grid-template-columns: 1fr;
+  }
+
+  .turn-dbe-training-part-picker li:last-child {
+    grid-column: auto;
+  }
+}
+
 @media (max-height: 480px) and (orientation: landscape) {
   .turn-dbe-training-dialog .m8-dialog-card {
     max-height: calc(100dvh - 16px);
@@ -163,14 +290,40 @@
   }
 
   .turn-dbe-training-copy > p,
-  .turn-dbe-training-copy li {
-    font-size: 0.82rem;
+  .turn-dbe-training-copy li,
+  .turn-dbe-training-sound-key dd {
+    font-size: 0.78rem;
     line-height: 1.3;
   }
 
-  .turn-dbe-training-copy ol {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 5px 22px;
+  .turn-dbe-training-sound-key {
+    padding: 10px;
+  }
+
+  .turn-dbe-training-sound-key dl {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 7px;
+  }
+
+  .turn-dbe-training-sound-key dl > div {
+    padding: 8px;
+  }
+
+  .turn-dbe-training-part-picker ol {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 7px;
+  }
+
+  .turn-dbe-training-part-picker li:last-child {
+    grid-column: auto;
+  }
+
+  .turn-dbe-training-part-picker button {
+    padding: 8px 10px;
+  }
+
+  .turn-dbe-training-part-picker button > small {
+    font-size: 0.68rem;
   }
 
   .turn-dbe-training-actions button {
@@ -183,12 +336,26 @@
     top: max(7px, env(safe-area-inset-top));
     padding: 5px 11px;
   }
+
+  .turn-dbe-training-race-nav {
+    top: max(57px, calc(env(safe-area-inset-top) + 51px));
+    gap: 6px;
+  }
+
+  .turn-dbe-training-race-nav button {
+    min-height: 34px;
+    padding: 5px 9px;
+    border-width: 2px;
+    font-size: 0.64rem;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .turn-dbe-training-how button,
   .turn-dbe-training-settings button,
   .turn-dbe-training-actions button,
+  .turn-dbe-training-part-picker button,
+  .turn-dbe-training-race-nav button,
   .turn-dbe-training-home {
     transition: none !important;
   }

--- a/turn/training/drive-by-ear-training.js
+++ b/turn/training/drive-by-ear-training.js
@@ -8,7 +8,9 @@ import {
 import { buildTrainingCourse, disposeTrainingWorld } from './course.js';
 import {
   FINISH_PROGRESS,
+  RAIL_ASSIST_START,
   ROAD_HALF_WIDTH,
+  SAFETY_ASSIST_START,
   TRAINING_BALANCE,
   TRAINING_CAR_ID,
   TRAINING_STAGES
@@ -18,14 +20,17 @@ import {
   hideTrainingDialog,
   installTrainingView,
   renderTrainingHud,
+  renderTrainingNavigation,
   showTrainingDialog,
   updatePartDialog
 } from './view.js';
 
-const TRAINING_REVISION = 'r149-dbe-training';
+const TRAINING_REVISION = 'r150-dbe-training-refinement';
 const AUDIO_ENABLED_STORAGE_KEY = 'turn-audio-enabled-v1';
 const AUDIO_BALANCE_STORAGE_KEY = 'turn-audio-balance-v1';
 const DRIVE_BY_EAR_STORAGE_KEY = 'turn-drive-by-ear-v1';
+const MAX_PROGRESS_ADVANCE = 0.12;
+const HARD_BOUNDARY_OVERSHOOT = 4;
 let installed = false;
 
 export async function installDriveByEarTraining(runtime = globalThis.__turnRuntime) {
@@ -47,13 +52,16 @@ export async function installDriveByEarTraining(runtime = globalThis.__turnRunti
   const session = {
     active: false,
     starting: false,
+    switching: false,
     stageIndex: 0,
     stage: null,
     world: null,
     notesFired: new Set(),
     previousProgress: 0,
+    previousPosition: null,
     finishing: false,
     frame: 0,
+    lastFrameAt: 0,
     returnFocus: null,
     snapshot: null,
     preparedAccess: null
@@ -78,6 +86,7 @@ export async function installDriveByEarTraining(runtime = globalThis.__turnRunti
     open: openTraining,
     leave: leaveTraining,
     restart: restartPart,
+    startPart: (index) => startStage(index),
     getState: () => Object.freeze({
       active: session.active,
       stage: session.stageIndex + 1,
@@ -88,15 +97,22 @@ export async function installDriveByEarTraining(runtime = globalThis.__turnRunti
   return api;
 
   function bindView() {
-    view.introDialog.querySelector('[data-training-start]').addEventListener('click', prepareFirstStart);
+    for (const button of view.introDialog.querySelectorAll('[data-training-stage]')) {
+      button.addEventListener('click', () => {
+        void prepareFirstStart(Number(button.dataset.trainingStage) || 0);
+      });
+    }
     for (const button of view.introDialog.querySelectorAll('[data-training-cancel]')) {
       button.addEventListener('click', cancelIntro);
     }
     for (const button of view.partDialog.querySelectorAll('[data-training-leave]')) {
       button.addEventListener('click', () => void leaveTraining());
     }
-    view.partDialog.querySelector('[data-training-next]').addEventListener('click', () => {
-      void startStage(session.stageIndex + 1);
+    view.partDialog.querySelector('[data-training-repeat]').addEventListener('click', (event) => {
+      void startStage(Number(event.currentTarget.dataset.trainingRepeat) || 0);
+    });
+    view.partDialog.querySelector('[data-training-next]').addEventListener('click', (event) => {
+      void startStage(Number(event.currentTarget.dataset.trainingNext) || session.stageIndex + 1);
     });
     for (const button of view.completeDialog.querySelectorAll('[data-training-return]')) {
       button.addEventListener('click', () => void leaveTraining());
@@ -104,6 +120,18 @@ export async function installDriveByEarTraining(runtime = globalThis.__turnRunti
     view.completeDialog.querySelector('[data-training-again]').addEventListener('click', () => {
       void startStage(0);
     });
+
+    const previous = view.raceNavigation.querySelector('[data-training-race-previous]');
+    const restart = view.raceNavigation.querySelector('[data-training-race-restart]');
+    const next = view.raceNavigation.querySelector('[data-training-race-next]');
+    previous.addEventListener('click', () => {
+      if (!previous.disabled) void startStage(Number(previous.dataset.trainingTarget));
+    });
+    restart.addEventListener('click', restartPart);
+    next.addEventListener('click', () => {
+      if (!next.disabled) void startStage(Number(next.dataset.trainingTarget));
+    });
+
     view.introDialog.addEventListener('cancel', (event) => {
       event.preventDefault();
       cancelIntro();
@@ -131,23 +159,21 @@ export async function installDriveByEarTraining(runtime = globalThis.__turnRunti
       session.returnFocus = entryPoints?.homeButton || trigger;
     }
     view.introDialog.querySelector('[data-training-intro-copy]').textContent =
-      "Learn TURN's spatial guidance one layer at a time. Training temporarily uses the Training Car and puts Drive By Ear at 95% of the sound mix. Your car and audio choices return when you leave.";
-    showTrainingDialog(view.introDialog, '[data-training-start]');
+      "Learn TURN's spatial guidance one layer at a time. Choose any part below. Training temporarily uses the Training Car and puts Drive By Ear at 95% of the sound mix. Your car and audio choices return when you leave.";
+    showTrainingDialog(view.introDialog, '[data-training-stage="0"]');
   }
 
-  async function prepareFirstStart() {
+  async function prepareFirstStart(stageIndex = 0) {
     if (session.starting || session.active) return;
     session.starting = true;
-    const startButton = view.introDialog.querySelector('[data-training-start]');
-    startButton.disabled = true;
-    startButton.setAttribute('aria-busy', 'true');
+    setIntroBusy(true);
     try {
       session.snapshot = captureSnapshot();
       session.preparedAccess = await prepareAccess();
       await applyTemporaryPreferences();
       await applyTrainingCar();
       session.active = true;
-      await startStage(0, { first: true });
+      await startStage(stageIndex, { first: true });
     } catch (error) {
       const message = error instanceof Error
         ? `${error.message} Choose on-screen steering in Settings and try again.`
@@ -155,11 +181,18 @@ export async function installDriveByEarTraining(runtime = globalThis.__turnRunti
       if (session.snapshot) await restoreSession();
       session.active = false;
       view.introDialog.querySelector('[data-training-intro-copy]').textContent = message;
-      showTrainingDialog(view.introDialog, '[data-training-start]');
+      showTrainingDialog(view.introDialog, '[data-training-stage="0"]');
     } finally {
       session.starting = false;
-      startButton.disabled = false;
-      startButton.removeAttribute('aria-busy');
+      setIntroBusy(false);
+    }
+  }
+
+  function setIntroBusy(busy) {
+    for (const button of view.introDialog.querySelectorAll('[data-training-stage]')) {
+      button.disabled = busy;
+      if (busy) button.setAttribute('aria-busy', 'true');
+      else button.removeAttribute('aria-busy');
     }
   }
 
@@ -177,33 +210,46 @@ export async function installDriveByEarTraining(runtime = globalThis.__turnRunti
   }
 
   async function startStage(index, { first = false } = {}) {
-    const stage = TRAINING_STAGES[index];
-    session.stageIndex = index;
-    session.stage = stage;
-    session.notesFired.clear();
-    session.finishing = false;
-    silencePaceNotes();
+    const stageIndex = clamp(Math.round(Number(index) || 0), 0, TRAINING_STAGES.length - 1);
+    const stage = TRAINING_STAGES[stageIndex];
+    if (!session.active || session.switching) return false;
+    session.switching = true;
 
-    const course = buildTrainingCourse(stage, runtime.trackWidth || ROAD_HALF_WIDTH * 2);
-    overrideRuntimeTrack(stage, course);
-    positionStageStart(stage);
-    renderTrainingHud(view.visualHud, stage, index);
-    hideTrainingDialog(view.introDialog);
-    hideTrainingDialog(view.partDialog);
-    hideTrainingDialog(view.completeDialog);
-    home.hideHome();
-    document.body.classList.add('turn-dbe-training-active');
-    mapWrap.classList.add('turn-dbe-training-hidden-map');
-    resetButton.textContent = 'Restart Part';
-    leaveButton.textContent = 'Leave Training';
-    leaveButton.setAttribute('aria-label', 'Leave Drive By Ear training and return Home');
-    runtime.openLot = leaveTraining;
+    try {
+      if (runtime.state.running) raceSession.leaveRace();
+      session.stageIndex = stageIndex;
+      session.stage = stage;
+      session.notesFired.clear();
+      session.finishing = false;
+      silencePaceNotes();
 
-    const fullscreenPromise = first ? session.preparedAccess?.fullscreenPromise : Promise.resolve(false);
-    await raceSession.startGame(fullscreenPromise || Promise.resolve(false));
-    positionStageStart(stage);
-    session.previousProgress = runtime.state.progress;
-    if (!session.frame) session.frame = requestAnimationFrame(trainingFrame);
+      const course = buildTrainingCourse(stage, runtime.trackWidth || ROAD_HALF_WIDTH * 2);
+      overrideRuntimeTrack(stage, course);
+      positionStageStart(stage);
+      renderTrainingHud(view.visualHud, stage, stageIndex);
+      renderTrainingNavigation(view.raceNavigation, stageIndex);
+      hideTrainingDialog(view.introDialog);
+      hideTrainingDialog(view.partDialog);
+      hideTrainingDialog(view.completeDialog);
+      home.hideHome();
+      document.body.classList.add('turn-dbe-training-active');
+      mapWrap.classList.add('turn-dbe-training-hidden-map');
+      resetButton.textContent = 'Restart Part';
+      leaveButton.textContent = 'Leave Training';
+      leaveButton.setAttribute('aria-label', 'Leave Drive By Ear 101 and return Home');
+      runtime.openLot = leaveTraining;
+
+      const fullscreenPromise = first ? session.preparedAccess?.fullscreenPromise : Promise.resolve(false);
+      await raceSession.startGame(fullscreenPromise || Promise.resolve(false));
+      positionStageStart(stage);
+      session.previousProgress = runtime.state.progress;
+      session.previousPosition = snapshotPosition(runtime.state.position);
+      session.lastFrameAt = globalThis.performance?.now?.() || 0;
+      if (!session.frame) session.frame = requestAnimationFrame(trainingFrame);
+      return true;
+    } finally {
+      session.switching = false;
+    }
   }
 
   function overrideRuntimeTrack(stage, course) {
@@ -213,6 +259,7 @@ export async function installDriveByEarTraining(runtime = globalThis.__turnRunti
     runtime.trackSpatialIndex.replaceSamples(runtime.samples);
     runtime.trackId = stage.id;
     runtime.state.trackId = stage.id;
+    runtime.state.trackSampleCount = runtime.samples.length;
     runtime.activeTrack = Object.freeze({
       id: stage.id,
       name: stage.title,
@@ -223,7 +270,7 @@ export async function installDriveByEarTraining(runtime = globalThis.__turnRunti
     if (runtime.scene.fog?.color) {
       runtime.scene.fog.color.setHex(0x74c0fc);
       runtime.scene.fog.near = 180;
-      runtime.scene.fog.far = 700;
+      runtime.scene.fog.far = 900;
     }
     runtime.scene.add(course.world);
     runtime.activeWorld = course.world;
@@ -260,56 +307,127 @@ export async function installDriveByEarTraining(runtime = globalThis.__turnRunti
     runtime.playerCar.position.copy(runtime.state.position);
     runtime.playerCar.rotation.y = runtime.state.heading + Math.PI;
     runtime.setRacePosition?.(null, 1);
+    session.previousPosition = snapshotPosition(runtime.state.position);
   }
 
   function restartPart(event) {
-    if (!session.active) return;
+    if (!session.active || !session.stage || session.switching) return;
     event?.preventDefault?.();
     event?.stopImmediatePropagation?.();
     positionStageStart(session.stage);
     session.notesFired.clear();
     session.previousProgress = runtime.state.progress;
+    session.previousPosition = snapshotPosition(runtime.state.position);
+    session.finishing = false;
     silencePaceNotes();
   }
 
-  function trainingFrame() {
+  function trainingFrame(timestamp) {
     if (!session.active || !session.stage || !runtime.state.running) {
       session.frame = requestAnimationFrame(trainingFrame);
       return;
     }
-    const nearest = runtime.trackSpatialIndex.find(runtime.state.position);
-    constrainToCourse(nearest, session.stage);
+
+    const now = Number.isFinite(Number(timestamp))
+      ? Number(timestamp)
+      : globalThis.performance?.now?.() || 0;
+    const dt = session.lastFrameAt
+      ? clamp((now - session.lastFrameAt) / 1000, 1 / 240, 0.05)
+      : 1 / 60;
+    session.lastFrameAt = now;
+
+    let nearest = runtime.trackSpatialIndex.find(runtime.state.position);
+    if (constrainToCourse(nearest, session.stage, dt)) {
+      nearest = runtime.trackSpatialIndex.find(runtime.state.position);
+    }
+
     const progress = nearest.index / Math.max(1, runtime.samples.length - 1);
     fireScheduledNotes(session.stage, progress);
-    session.previousProgress = progress;
-    const tangent = nearest.sample?.tangent || new THREE.Vector3();
-    const forwardSpeed = runtime.state.velocity.dot(tangent);
-    if (!session.finishing && progress >= FINISH_PROGRESS && forwardSpeed > 0.8) {
+    const currentPosition = snapshotPosition(runtime.state.position);
+    const finish = runtime.samples[Math.floor(runtime.samples.length * FINISH_PROGRESS)];
+    const forwardSpeed = runtime.state.velocity.dot(finish.tangent);
+    if (
+      !session.finishing
+      && forwardSpeed > 0.8
+      && crossedForwardGate(
+        session.previousPosition,
+        currentPosition,
+        finish,
+        (runtime.trackWidth || ROAD_HALF_WIDTH * 2) * 0.62
+      )
+    ) {
       session.finishing = true;
       void completePart();
     }
+
+    session.previousProgress = progress;
+    session.previousPosition = currentPosition;
     session.frame = requestAnimationFrame(trainingFrame);
   }
 
-  function constrainToCourse(nearest, stage) {
-    if (!nearest?.sample || nearest.distance <= stage.outerLimit) return;
+  function constrainToCourse(nearest, stage, dt) {
+    if (!nearest?.sample) return false;
+    const distance = Number(nearest.distance) || 0;
     const sample = nearest.sample;
-    const dx = runtime.state.position.x - sample.point.x;
-    const dz = runtime.state.position.z - sample.point.z;
-    const lateralSign = Math.sign(dx * sample.normal.x + dz * sample.normal.z) || 1;
-    runtime.state.position.copy(sample.point).addScaledVector(sample.normal, lateralSign * stage.outerLimit);
+    const side = courseSide(runtime.state.position, sample);
+
+    if (stage.guideRails && distance > RAIL_ASSIST_START) {
+      applySlipperyAssist(sample, side, distance - RAIL_ASSIST_START, dt, {
+        damping: 6,
+        acceleration: 9
+      });
+    }
+
+    if (distance > SAFETY_ASSIST_START) {
+      applySlipperyAssist(sample, side, distance - SAFETY_ASSIST_START, dt, {
+        damping: 12,
+        acceleration: 24
+      });
+    }
+
+    if (distance <= stage.outerLimit + HARD_BOUNDARY_OVERSHOOT) {
+      runtime.state.speed = runtime.state.velocity.length();
+      return false;
+    }
+
+    // This is a remote fail-safe beyond the soft rail and safety forces. It keeps
+    // tangential motion instead of stopping or snapping the car back onto the road.
+    runtime.state.position.copy(sample.point).addScaledVector(
+      sample.normal,
+      side * (stage.outerLimit + HARD_BOUNDARY_OVERSHOOT * 0.5)
+    );
     runtime.state.position.y = sample.point.y;
-    const outward = runtime.state.velocity.dot(sample.normal) * lateralSign;
-    if (outward > 0) runtime.state.velocity.addScaledVector(sample.normal, -outward * lateralSign);
-    runtime.state.velocity.multiplyScalar(stage.guideRails ? 0.38 : 0.62);
-    runtime.state.speed *= stage.guideRails ? 0.42 : 0.68;
+    const along = runtime.state.velocity.dot(sample.tangent);
+    runtime.state.velocity.copy(sample.tangent).multiplyScalar(along * 0.82);
+    runtime.state.velocity.addScaledVector(sample.normal, -side * 4);
+    runtime.state.speed = runtime.state.velocity.length();
+    return true;
+  }
+
+  function applySlipperyAssist(sample, side, penetration, dt, profile) {
+    const outwardSpeed = runtime.state.velocity.dot(sample.normal) * side;
+    if (outwardSpeed > 0) {
+      const damping = 1 - Math.exp(-profile.damping * dt);
+      runtime.state.velocity.addScaledVector(
+        sample.normal,
+        -side * outwardSpeed * damping
+      );
+    }
+    const inwardAcceleration = profile.acceleration + Math.min(28, penetration * 3.5);
+    runtime.state.velocity.addScaledVector(
+      sample.normal,
+      -side * inwardAcceleration * dt
+    );
   }
 
   function fireScheduledNotes(stage, progress) {
-    stage.notes.forEach((note, index) => {
+    const advance = progress - session.previousProgress;
+    if (advance < 0 || advance > MAX_PROGRESS_ADVANCE) return;
+
+    stage.notes.forEach((paceNote, index) => {
       const id = `${stage.id}-note-${index + 1}`;
       if (session.notesFired.has(id)) return;
-      if (!(session.previousProgress < note.progress && progress >= note.progress)) return;
+      if (!(session.previousProgress < paceNote.progress && progress >= paceNote.progress)) return;
       session.notesFired.add(id);
       globalThis.dispatchEvent(new CustomEvent('turn:pace-note-priority', {
         detail: {
@@ -318,9 +436,9 @@ export async function installDriveByEarTraining(runtime = globalThis.__turnRunti
           trackId: stage.id,
           progress,
           groups: [Object.freeze({
-            direction: note.direction,
-            severity: note.severity,
-            finalBeepDurationSeconds: note.long ? 0.17 : 0.055
+            direction: paceNote.direction,
+            severity: paceNote.severity,
+            finalBeepDurationSeconds: paceNote.long ? 0.17 : 0.055
           })]
         }
       }));
@@ -330,8 +448,9 @@ export async function installDriveByEarTraining(runtime = globalThis.__turnRunti
   async function completePart() {
     raceSession.leaveRace();
     silencePaceNotes();
+    view.raceNavigation.hidden = true;
+    view.visualHud.hidden = true;
     if (session.stageIndex >= TRAINING_STAGES.length - 1) {
-      view.visualHud.hidden = true;
       showTrainingDialog(view.completeDialog, '[data-training-again]');
       return;
     }
@@ -371,14 +490,18 @@ export async function installDriveByEarTraining(runtime = globalThis.__turnRunti
     document.body.classList.remove('turn-dbe-training-active');
     mapWrap.classList.remove('turn-dbe-training-hidden-map');
     view.visualHud.hidden = true;
+    view.raceNavigation.hidden = true;
     Object.assign(session, {
       active: false,
       starting: false,
+      switching: false,
       stage: null,
       world: null,
       finishing: false,
+      previousPosition: null,
       snapshot: null,
-      preparedAccess: null
+      preparedAccess: null,
+      lastFrameAt: 0
     });
     session.notesFired.clear();
     home.showHome({ focus: true });
@@ -472,6 +595,45 @@ export async function installDriveByEarTraining(runtime = globalThis.__turnRunti
   }
 }
 
+function crossedForwardGate(previousPosition, currentPosition, sample, halfWidth) {
+  if (!previousPosition || !currentPosition || !sample?.point || !sample?.tangent) return false;
+  const tx = Number(sample.tangent.x) || 0;
+  const tz = Number(sample.tangent.z) || 0;
+  const length = Math.hypot(tx, tz);
+  if (length <= 1e-6) return false;
+  const tangentX = tx / length;
+  const tangentZ = tz / length;
+  const normalX = -tangentZ;
+  const normalZ = tangentX;
+  const centerX = Number(sample.point.x) || 0;
+  const centerZ = Number(sample.point.z) || 0;
+  const previousLongitudinal = (previousPosition.x - centerX) * tangentX
+    + (previousPosition.z - centerZ) * tangentZ;
+  const currentLongitudinal = (currentPosition.x - centerX) * tangentX
+    + (currentPosition.z - centerZ) * tangentZ;
+  if (!(previousLongitudinal <= 0 && currentLongitudinal > 0)) return false;
+  const step = currentLongitudinal - previousLongitudinal;
+  if (step <= 1e-6) return false;
+  const crossingT = clamp(-previousLongitudinal / step, 0, 1);
+  const crossingX = previousPosition.x + (currentPosition.x - previousPosition.x) * crossingT;
+  const crossingZ = previousPosition.z + (currentPosition.z - previousPosition.z) * crossingT;
+  const lateral = Math.abs((crossingX - centerX) * normalX + (crossingZ - centerZ) * normalZ);
+  return lateral <= halfWidth;
+}
+
+function courseSide(position, sample) {
+  const dx = (Number(position?.x) || 0) - (Number(sample?.point?.x) || 0);
+  const dz = (Number(position?.z) || 0) - (Number(sample?.point?.z) || 0);
+  return Math.sign(dx * sample.normal.x + dz * sample.normal.z) || 1;
+}
+
+function snapshotPosition(position) {
+  return {
+    x: Number(position?.x) || 0,
+    z: Number(position?.z) || 0
+  };
+}
+
 function storageSnapshot(key) {
   try {
     return Object.freeze({ available: true, value: globalThis.localStorage?.getItem(key) ?? null });
@@ -486,4 +648,8 @@ function restoreStorage(key, snapshot) {
     if (snapshot.value == null) globalThis.localStorage?.removeItem(key);
     else globalThis.localStorage?.setItem(key, snapshot.value);
   } catch (_) {}
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
 }

--- a/turn/training/stages.js
+++ b/turn/training/stages.js
@@ -4,8 +4,9 @@ export const TRAINING_CAR_ID = 'classic';
 export const SAMPLE_COUNT = 720;
 export const FINISH_PROGRESS = 0.94;
 export const ROAD_HALF_WIDTH = 13.5;
-export const RAIL_LIMIT = ROAD_HALF_WIDTH - 1.2;
+export const RAIL_ASSIST_START = ROAD_HALF_WIDTH - 1.8;
 export const RECOVERY_LIMIT = ROAD_HALF_WIDTH + 10;
+export const SAFETY_ASSIST_START = RECOVERY_LIMIT - 4;
 
 const LEFT = -1;
 const RIGHT = 1;
@@ -17,7 +18,7 @@ const note = (progress, direction, severity, long = false) => Object.freeze({
 });
 const stage = (definition) => Object.freeze({
   ...definition,
-  points: Object.freeze(definition.points),
+  points: Object.freeze(definition.points.map((point) => Object.freeze(point))),
   notes: Object.freeze(definition.notes)
 });
 
@@ -25,68 +26,77 @@ export const TRAINING_STAGES = Object.freeze([
   stage({
     id: 'dbe-training-1',
     title: 'Find the ribbon',
-    lead: 'The warm hum points toward the best route. You begin to the right of it. Steer toward the hum until it settles in the centre, then follow it to the finish.',
-    visualHint: 'Watch how the sound moves as you steer. The rails make this first straight forgiving.',
+    menuSummary: 'Centre the warm guiding hum on a long straight.',
+    lead: 'The warm continuous hum is steering guidance. You begin to the right of the best route. Steer toward the hum until it settles in the centre, then keep it there to the finish.',
+    visualHint: 'The yellow guide rails behave like slippery ice rails: they gently guide the car back without stopping it.',
     guideRails: true,
     startOffset: -6,
-    outerLimit: RAIL_LIMIT,
-    points: [[0, 0], [0, 38], [0, 78], [0, 120], [0, 164], [0, 205]],
+    outerLimit: RECOVERY_LIMIT,
+    points: [[0, 0], [0, 70], [0, 140], [0, 210], [0, 280], [0, 350], [0, 420]],
     notes: []
   }),
   stage({
     id: 'dbe-training-2',
     title: 'Listen ahead',
-    lead: 'Turn sounds play before the curve. The ear gives the direction. One beep means gentle, two means tighter, and a held final beep means the curve lasts longer.',
-    visualHint: 'The rails remain for this part so you can focus on matching each sound to the road ahead.',
+    menuSummary: 'Hear one gentle right and one broader left before they begin.',
+    lead: 'The sharp directional BIPs are pace notes. The ear gives the turn side and the count gives its severity. This course has one gentle right followed later by one broader two-BIP left.',
+    visualHint: 'Both cues play on the long approach before their curve. The guide rails remain so you can focus on matching sound to road.',
     guideRails: true,
     startOffset: 0,
-    outerLimit: RAIL_LIMIT,
+    outerLimit: RECOVERY_LIMIT,
     points: [
-      [0, 0], [0, 38], [6, 72], [24, 98], [50, 112], [86, 116],
-      [122, 116], [148, 106], [160, 82], [153, 57], [130, 42], [96, 38],
-      [62, 38], [34, 27], [20, 4], [23, -24], [43, -47], [74, -60], [112, -61]
+      [0, 0], [0, 60], [0, 120], [0, 180], [5, 220], [20, 255],
+      [50, 282], [90, 298], [140, 300], [200, 300], [250, 310],
+      [290, 335], [315, 370], [325, 415], [325, 470], [325, 530]
     ],
-    notes: [note(0.08, RIGHT, 1), note(0.34, LEFT, 2), note(0.62, LEFT, 2, true)]
+    notes: [note(0.10, RIGHT, 1), note(0.49, LEFT, 2)]
   }),
   stage({
     id: 'dbe-training-3',
     title: 'Leave and return',
-    lead: 'You begin just off the road. Gravel confirms that you are off road, and recovery guidance points toward a useful place to rejoin. Slow down, steer toward the hum and listen for normal guidance to return.',
-    visualHint: 'There are no rails along the road now. A nearby invisible safety boundary prevents you from getting lost.',
+    menuSummary: 'Use gravel and recovery guidance to rejoin, then hear one right.',
+    lead: 'You begin just off the right side of the road. Centred gravel confirms the surface; the warm recovery hum points toward a useful place to rejoin. After the long straight, one BIP in the right ear announces the gentle right.',
+    visualHint: 'There are no visible rails along the road. A wider invisible safety zone only intervenes if you travel far away.',
     guideRails: false,
     startOffset: -(ROAD_HALF_WIDTH + 4),
     outerLimit: RECOVERY_LIMIT,
-    points: [[0, 0], [0, 42], [3, 80], [18, 112], [44, 134], [80, 142], [122, 142], [164, 142]],
-    notes: [note(0.32, RIGHT, 1)]
+    points: [
+      [0, 0], [0, 60], [0, 120], [0, 180], [5, 225], [20, 265],
+      [48, 295], [88, 312], [138, 316], [198, 316], [260, 316]
+    ],
+    notes: [note(0.17, RIGHT, 1)]
   }),
   stage({
     id: 'dbe-training-4',
     title: 'Trust the sequence',
-    lead: 'Listen for three beeps before the tight curve. Use the ribbon to settle after it, then follow the next turn without rails along the road.',
-    visualHint: 'Ready to rely on the sound? Try Blank screen mode for this part.',
+    menuSummary: 'Recognise BIP BIP BEEP before one long tight left.',
+    lead: 'BIP BIP BEEP describes one long tight curve: three sounds mean tight, and the held final BEEP means the same curve continues. Hear the complete phrase in the left ear before the single long left begins.',
+    visualHint: 'This spacious course contains one uninterrupted curve and no road overlap. Try Blank screen mode when the phrase feels clear.',
     guideRails: false,
     startOffset: 0,
     outerLimit: RECOVERY_LIMIT,
     points: [
-      [0, 0], [0, 42], [-4, 76], [-20, 102], [-48, 116], [-78, 108],
-      [-98, 84], [-101, 52], [-88, 24], [-62, 7], [-28, 3], [8, 10], [38, 30], [54, 60]
+      [0, 0], [0, 60], [0, 120], [0, 180], [0, 210], [-6, 239],
+      [-22, 263], [-46, 280], [-75, 285], [-104, 280], [-128, 263],
+      [-144, 239], [-150, 210], [-150, 160], [-150, 100], [-150, 35]
     ],
-    notes: [note(0.22, LEFT, 3), note(0.70, RIGHT, 1)]
+    notes: [note(0.16, LEFT, 3, true)]
   }),
   stage({
     id: 'dbe-training-5',
     title: 'Drive by ear',
-    lead: 'Put it together. Follow the ribbon, listen ahead for the turns, and use recovery guidance if you leave the road. Smooth corrections are more useful than chasing every small movement.',
-    visualHint: 'Try the graduation run with Blank screen mode, or keep the course visible and train at your own pace.',
+    menuSummary: 'Combine ribbon, pace notes and recovery on an open course.',
+    lead: 'Put it together on a spacious course. Follow the ribbon, listen ahead for a gentle right, a broader left and a long right, and use gravel plus recovery guidance if you leave the road.',
+    visualHint: 'The route never crosses itself. Try Blank screen mode, or keep the course visible and repeat any part from the navigation controls.',
     guideRails: false,
     startOffset: 0,
     outerLimit: RECOVERY_LIMIT,
     points: [
-      [0, 0], [0, 38], [10, 72], [34, 94], [68, 100], [102, 92],
-      [126, 70], [132, 40], [120, 12], [94, -5], [62, -10], [30, -4],
-      [5, -18], [-9, -43], [-5, -72], [17, -95], [50, -105], [84, -99],
-      [112, -80], [126, -50], [122, -18], [104, 10], [78, 28]
+      [0, 0], [0, 60], [0, 120], [0, 180], [5, 225], [20, 265],
+      [50, 295], [90, 315], [140, 320], [200, 320], [260, 320],
+      [310, 330], [350, 355], [375, 390], [385, 435], [385, 490],
+      [385, 550], [395, 600], [420, 640], [460, 665], [515, 675], [575, 675]
     ],
-    notes: [note(0.08, RIGHT, 1), note(0.32, LEFT, 2), note(0.58, RIGHT, 2, true), note(0.79, LEFT, 3)]
+    notes: [note(0.08, RIGHT, 1), note(0.39, LEFT, 2), note(0.68, RIGHT, 2, true)]
   })
 ]);

--- a/turn/training/view.js
+++ b/turn/training/view.js
@@ -4,10 +4,18 @@ export function installTrainingView({ revision, openTraining, isTrainingActive }
   installStylesheet(revision);
   const dialogs = createDialogs();
   const visualHud = createVisualHud();
+  const raceNavigation = createRaceNavigation();
   const entryPoints = installEntryPoints(openTraining);
   const balanceSlider = installBalanceSuggestion();
   const blankSuggestion = installBlankScreenSuggestion({ openTraining, isTrainingActive });
-  return Object.freeze({ ...dialogs, visualHud, entryPoints, balanceSlider, blankSuggestion });
+  return Object.freeze({
+    ...dialogs,
+    visualHud,
+    raceNavigation,
+    entryPoints,
+    balanceSlider,
+    blankSuggestion
+  });
 }
 
 export function showTrainingDialog(dialog, focusSelector = '[data-training-primary]') {
@@ -31,19 +39,48 @@ export function closeSourceDialog(trigger) {
   else source.removeAttribute('open');
 }
 
-export function updatePartDialog(dialog, index) {
-  const stage = TRAINING_STAGES[index];
-  dialog.querySelector('.turn-dbe-training-part-kicker').textContent = `PART ${index + 1} OF ${TRAINING_STAGES.length}`;
+export function updatePartDialog(dialog, nextIndex) {
+  const stage = TRAINING_STAGES[nextIndex];
+  const completedIndex = Math.max(0, nextIndex - 1);
+  dialog.querySelector('.turn-dbe-training-part-kicker').textContent =
+    `PART ${completedIndex + 1} COMPLETE · NEXT: PART ${nextIndex + 1}`;
   dialog.querySelector('#turnDbePartTitle').textContent = stage.title.toUpperCase();
   dialog.querySelector('.turn-dbe-training-part-lead').textContent = stage.lead;
   dialog.querySelector('.turn-dbe-training-visual-hint').textContent = stage.visualHint;
-  dialog.querySelector('[data-training-next]').textContent = `START PART ${index + 1}`;
+  const repeat = dialog.querySelector('[data-training-repeat]');
+  repeat.dataset.trainingRepeat = String(completedIndex);
+  repeat.textContent = `REPEAT PART ${completedIndex + 1}`;
+  const next = dialog.querySelector('[data-training-next]');
+  next.dataset.trainingNext = String(nextIndex);
+  next.textContent = `START PART ${nextIndex + 1}`;
 }
 
 export function renderTrainingHud(hud, stage, index) {
   hud.querySelector('span').textContent = `PART ${index + 1} OF ${TRAINING_STAGES.length}`;
   hud.querySelector('strong').textContent = stage.title.toUpperCase();
   hud.hidden = false;
+}
+
+export function renderTrainingNavigation(navigation, index) {
+  const previous = navigation.querySelector('[data-training-race-previous]');
+  const restart = navigation.querySelector('[data-training-race-restart]');
+  const next = navigation.querySelector('[data-training-race-next]');
+  previous.disabled = index <= 0;
+  next.disabled = index >= TRAINING_STAGES.length - 1;
+  previous.dataset.trainingTarget = String(index - 1);
+  next.dataset.trainingTarget = String(index + 1);
+  previous.setAttribute(
+    'aria-label',
+    index > 0 ? `Previous: Part ${index}, ${TRAINING_STAGES[index - 1].title}` : 'No previous training part'
+  );
+  restart.setAttribute('aria-label', `Restart Part ${index + 1}, ${TRAINING_STAGES[index].title}`);
+  next.setAttribute(
+    'aria-label',
+    index < TRAINING_STAGES.length - 1
+      ? `Next: Part ${index + 2}, ${TRAINING_STAGES[index + 1].title}`
+      : 'No next training part'
+  );
+  navigation.hidden = false;
 }
 
 function installStylesheet(revision) {
@@ -65,6 +102,17 @@ function makeDialog({ className, labelledBy, content }) {
   return dialog;
 }
 
+function trainingPartList() {
+  return TRAINING_STAGES.map((stage, index) => `
+    <li>
+      <button type="button" data-training-stage="${index}">
+        <span>PART ${index + 1}</span>
+        <strong>${stage.title}</strong>
+        <small>${stage.menuSummary}</small>
+      </button>
+    </li>`).join('');
+}
+
 function createDialogs() {
   const introDialog = makeDialog({
     className: 'turn-dbe-training-intro-dialog',
@@ -72,22 +120,38 @@ function createDialogs() {
     content: `
       <article class="m8-dialog-card turn-dbe-training-card">
         <header class="m8-dialog-head">
-          <div><span>FIVE GUIDED PARTS</span><h2 id="turnDbeTrainingTitle">DRIVE BY EAR TRAINING</h2></div>
-          <button type="button" data-training-cancel aria-label="Close Drive By Ear training">×</button>
+          <div><span>FIVE GUIDED PARTS</span><h2 id="turnDbeTrainingTitle">DRIVE BY EAR 101</h2></div>
+          <button type="button" data-training-cancel aria-label="Close Drive By Ear 101">×</button>
         </header>
         <div class="turn-dbe-training-copy">
           <p data-training-intro-copy>Learn TURN's spatial guidance one layer at a time. Training temporarily uses the Training Car and puts Drive By Ear at 95% of the sound mix. Your car and audio choices return when you leave.</p>
-          <ol>
-            <li><strong>Find the ribbon.</strong> Centre the warm guiding hum on a straight.</li>
-            <li><strong>Listen ahead.</strong> Match beep direction, count and length to curves.</li>
-            <li><strong>Leave and return.</strong> Use off-road recovery guidance.</li>
-            <li><strong>Trust the sequence.</strong> Drive without rails along the road.</li>
-            <li><strong>Drive by ear.</strong> Put the complete system together.</li>
-          </ol>
+
+          <section class="turn-dbe-training-sound-key" aria-labelledby="turnDbeSoundKeyTitle">
+            <h3 id="turnDbeSoundKeyTitle">Know which sound is speaking</h3>
+            <dl>
+              <div>
+                <dt>Steering guidance</dt>
+                <dd>The warm continuous hum points toward the route. Steer toward it.</dd>
+              </div>
+              <div>
+                <dt>Pace notes</dt>
+                <dd>Sharp directional BIPs play before curves. The ear gives the turn side, the count gives severity, and a held final BEEP means the curve continues.</dd>
+              </div>
+              <div>
+                <dt>Status and safety</dt>
+                <dd>Engine, tyres, gravel and BOOST describe the car or surface. The short maximum-steering two-tone means you have reached the steering limit. These sounds are not corner instructions.</dd>
+              </div>
+            </dl>
+          </section>
+
+          <nav class="turn-dbe-training-part-picker" aria-label="Choose a training part">
+            <ol>${trainingPartList()}</ol>
+          </nav>
+
           <p class="turn-dbe-training-visual-hint" aria-hidden="true">The screen stays on while you learn. Later parts invite you to try Blank screen mode.</p>
           <div class="turn-dbe-training-actions">
             <button type="button" data-training-cancel>CANCEL</button>
-            <button type="button" data-training-primary data-training-start>START TRAINING</button>
+            <button type="button" data-training-primary data-training-stage="0">START PART 1</button>
           </div>
         </div>
       </article>`
@@ -100,13 +164,14 @@ function createDialogs() {
       <article class="m8-dialog-card turn-dbe-training-card">
         <header class="m8-dialog-head">
           <div><span class="turn-dbe-training-part-kicker"></span><h2 id="turnDbePartTitle"></h2></div>
-          <button type="button" data-training-leave aria-label="Leave Drive By Ear training">×</button>
+          <button type="button" data-training-leave aria-label="Leave Drive By Ear 101">×</button>
         </header>
         <div class="turn-dbe-training-copy">
           <p class="turn-dbe-training-part-lead"></p>
           <p class="turn-dbe-training-visual-hint" aria-hidden="true"></p>
           <div class="turn-dbe-training-actions">
             <button type="button" data-training-leave>LEAVE TRAINING</button>
+            <button type="button" data-training-repeat></button>
             <button type="button" data-training-primary data-training-next></button>
           </div>
         </div>
@@ -123,7 +188,7 @@ function createDialogs() {
           <button type="button" data-training-return aria-label="Return Home">×</button>
         </header>
         <div class="turn-dbe-training-copy">
-          <p>You have heard the guiding ribbon, pace notes and off-road recovery work together. Train again whenever you want, then take the same sounds onto any TURN track.</p>
+          <p>You have heard the guiding ribbon, pace notes, status sounds and off-road recovery work together. Train again whenever you want, then take the same sound language onto any TURN track.</p>
           <div class="turn-dbe-training-actions">
             <button type="button" data-training-return>RETURN HOME</button>
             <button type="button" data-training-primary data-training-again>TRAIN AGAIN</button>
@@ -145,6 +210,19 @@ function createVisualHud() {
   return hud;
 }
 
+function createRaceNavigation() {
+  const navigation = document.createElement('nav');
+  navigation.className = 'turn-dbe-training-race-nav';
+  navigation.hidden = true;
+  navigation.setAttribute('aria-label', 'Training part navigation');
+  navigation.innerHTML = `
+    <button type="button" data-training-race-previous>‹ PREVIOUS</button>
+    <button type="button" data-training-race-restart>RESTART PART</button>
+    <button type="button" data-training-race-next>NEXT ›</button>`;
+  document.body.appendChild(navigation);
+  return navigation;
+}
+
 function installEntryPoints(openTraining) {
   const menu = document.querySelector('.m8-home-menu');
   const howButton = menu?.querySelector('.m8-how-button');
@@ -158,22 +236,22 @@ function installEntryPoints(openTraining) {
   const homeButton = document.createElement('button');
   homeButton.type = 'button';
   homeButton.className = 'm8-feedback-button turn-dbe-training-home';
-  homeButton.textContent = 'DRIVE BY EAR TRAINING';
+  homeButton.textContent = 'DRIVE BY EAR 101';
   homeButton.setAttribute('aria-haspopup', 'dialog');
   howButton.after(homeButton);
 
   const howCallout = document.createElement('div');
   howCallout.className = 'turn-dbe-training-how';
   howCallout.innerHTML = `
-    <p><strong>Learn by listening.</strong> Try five short guided parts covering the ribbon, turn sounds and off-road recovery.</p>
-    <button type="button" data-turn-dbe-training-entry>START DRIVE BY EAR TRAINING</button>`;
+    <p><strong>Learn by listening.</strong> Try five short guided parts covering the ribbon, pace notes, status sounds and off-road recovery.</p>
+    <button type="button" data-turn-dbe-training-entry>START DRIVE BY EAR 101</button>`;
   howDisclosure.before(howCallout);
 
   const settingsCallout = document.createElement('div');
   settingsCallout.className = 'turn-dbe-training-settings';
   settingsCallout.innerHTML = `
     <p>New to these sounds?</p>
-    <button type="button" data-turn-dbe-training-entry>TRY DRIVE BY EAR TRAINING</button>`;
+    <button type="button" data-turn-dbe-training-entry>TRY DRIVE BY EAR 101</button>`;
   settingsAudio.appendChild(settingsCallout);
 
   homeButton.addEventListener('click', () => openTraining(homeButton));
@@ -193,7 +271,7 @@ function installBalanceSuggestion() {
     const current = Number(slider.value) || 0;
     if (!mentioned && previous < BALANCE_SUGGESTION_THRESHOLD && current >= BALANCE_SUGGESTION_THRESHOLD) {
       mentioned = true;
-      status.textContent = 'Drive By Ear is prominent in the sound mix. Training can help you recognise its guidance.';
+      status.textContent = 'Drive By Ear is prominent in the sound mix. Drive By Ear 101 can help you recognise its guidance.';
     }
     previous = current;
   });
@@ -213,7 +291,7 @@ function installBlankScreenSuggestion({ openTraining, isTrainingActive }) {
           <button type="button" data-blank-continue aria-label="Close training suggestion">×</button>
         </header>
         <div class="turn-dbe-training-copy">
-          <p>Blank screen mode lets you drive using sound. The five-part training introduces the ribbon, turn sounds and off-road recovery before you rely on them in a race.</p>
+          <p>Blank screen mode lets you drive using sound. Drive By Ear 101 introduces the ribbon, pace notes, status sounds and off-road recovery before you rely on them in a race.</p>
           <div class="turn-dbe-training-actions">
             <button type="button" data-blank-continue>CONTINUE</button>
             <button type="button" data-training-primary data-blank-training>TRY TRAINING</button>


### PR DESCRIPTION
## Summary

This follow-up rebuilds the five training courses from physical device feedback and changes the Home destination to **DRIVE BY EAR 101**.

## Course and cue revisions

1. **Find the ribbon**
   - extend the straight to 420 metres
   - replace the hard rail stop with a continuous slippery inward assist

2. **Listen ahead**
   - add a substantially longer opening straight
   - keep only two curves: one gentle right and one broader left
   - move both cues onto the approach before their curve
   - remove the third curve and cue

3. **Leave and return**
   - retain the off-road start
   - add a long approach and move the right-ear BIP well before the gentle right

4. **Trust the sequence**
   - replace the overlapping route with one spacious uninterrupted left hairpin
   - use one three-sound long-corner phrase: **BIP BIP BEEP**
   - explain that three sounds mean tight and the held final BEEP means long

5. **Drive by ear**
   - add a longer opening straight
   - replace the crossing/overlapping route with a wide open S-course
   - place three cues on clear approaches

## Navigation and restart

- add direct links to all five parts on the Drive By Ear 101 start screen
- add accessible **Previous**, **Restart Part** and **Next** controls during driving
- retain the existing Restart Part handling as a fallback
- allow repeating the completed part from the between-part dialog

## Sound-language clarification

The introduction now distinguishes:

- the warm continuous steering-guidance hum
- directional pace-note BIPs and held BEEPs
- status and safety sounds such as engine, tyres, gravel, BOOST and the maximum-steering two-tone

It explicitly states that status and safety sounds are not corner instructions.

## Safety and completion

- guide rails apply smooth inward acceleration and damp only outward movement; they no longer stop the car
- the wider invisible safety area also uses progressive force before a remote fail-safe
- the fail-safe preserves tangential movement rather than snapping the car onto the road
- completing a part now requires physically crossing the finish gate; proximity to a nearby finish can no longer complete the part
- regression coverage checks remote course-segment separation to prevent future overlaps and crossings

## Validation

- syntax-checked the revised modules locally
- ran the expanded Drive By Ear 101 static and geometry regression locally
- focused and complete GitHub workflows will run on this PR

## Device-test focus

- whether the guide rails feel slippery rather than restrictive
- whether all cues now precede and correctly correspond to their intended curve
- whether the Part 4 phrase is heard as BIP BIP BEEP in the correct ear
- placement and reachability of the in-race navigation controls
- finish-gate behaviour after off-road excursions