### PR TITLE
Fix Drive By Ear 101 device feedback

### DIFF
--- a/turn-tests/drive-by-ear-training-production.mjs
+++ b/turn-tests/drive-by-ear-training-production.mjs
@@ -16,13 +16,16 @@ const [training, view, css, fixedLayout] = await Promise.all([
   fs.readFile(new URL('../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(fixedLayout, /training\/drive-by-ear-training\.js\?build=\$\{buildKey\}-r150-dbe-training-refinement/);
+assert.match(fixedLayout, /training\/drive-by-ear-training\.js\?build=\$\{buildKey\}-r151-dbe-training-device-fixes/);
 assert.match(fixedLayout, /installDriveByEarTraining\(globalThis\.__turnRuntime\)/);
 assert.match(fixedLayout, /driveByEarTraining/);
 
 assert.equal(TRAINING_STAGES.length, 5, 'Training must contain exactly five authored parts');
 assert.equal(FINISH_PROGRESS, 0.94);
-assert.ok(RAIL_ASSIST_START < ROAD_HALF_WIDTH, 'The slippery guide assist must begin when the car reaches a rail');
+assert.ok(
+  RAIL_ASSIST_START > ROAD_HALF_WIDTH && RAIL_ASSIST_START < ROAD_HALF_WIDTH + 1,
+  'The slippery guide assist must begin at the visible rail rather than inside the road'
+);
 assert.ok(RECOVERY_LIMIT > ROAD_HALF_WIDTH + 8, 'The invisible safety zone must remain wider than the road');
 
 const [part1, part2, part3, part4, part5] = TRAINING_STAGES;
@@ -34,7 +37,8 @@ assert.equal(part1.outerLimit, RECOVERY_LIMIT);
 assert.equal(part2.notes.length, 2, 'Part 2 must contain only the gentle right and broader left');
 assert.deepEqual(
   part2.notes.map(({ direction, severity, long }) => [direction, severity, long]),
-  [[1, 1, false], [-1, 2, false]]
+  [[-1, 1, false], [1, 2, false]],
+  'Training ear values must use the physical-device mapping: right negative, left positive'
 );
 assert.ok(part2.notes[0].progress <= 0.10, 'The first Part 2 BIP must play on the long straight');
 assert.ok(part2.notes[1].progress <= 0.49, 'The second Part 2 cue must play before its curve');
@@ -43,7 +47,7 @@ assert.ok(part2.points[3][1] >= 180, 'Part 2 must begin with a long straight');
 assert.equal(part3.notes.length, 1);
 assert.deepEqual(
   [part3.notes[0].direction, part3.notes[0].severity, part3.notes[0].long],
-  [1, 1, false]
+  [-1, 1, false]
 );
 assert.ok(part3.notes[0].progress <= 0.17, 'Part 3 BIP must play well before the gentle right');
 assert.equal(part3.startOffset, -(ROAD_HALF_WIDTH + 4));
@@ -51,15 +55,27 @@ assert.equal(part3.startOffset, -(ROAD_HALF_WIDTH + 4));
 assert.equal(part4.notes.length, 1, 'Part 4 must describe one uninterrupted curve');
 assert.deepEqual(
   [part4.notes[0].direction, part4.notes[0].severity, part4.notes[0].long],
-  [-1, 3, true],
-  'Part 4 must play BIP BIP BEEP in the left ear for one long tight left'
+  [1, 3, true],
+  'Part 4 must play BIP BIP BEEP in the physically verified left ear'
 );
 assert.match(part4.lead, /BIP BIP BEEP/);
 assert.match(part4.lead, /held final BEEP/);
 
 assert.equal(part5.notes.length, 3);
-assert.ok(part5.points[3][1] >= 180, 'Part 5 must begin with a long straight');
-assert.match(part5.visualHint, /never crosses itself/);
+assert.ok(part5.points[3][1] >= 210, 'Part 5 must begin with a long straight');
+assert.deepEqual(
+  part5.notes.map(({ direction, severity, long }) => [direction, severity, long]),
+  [[-1, 1, false], [-1, 2, false], [1, 2, true]],
+  'Part 5 must end with BIP BIP right followed by BIP BEEP left'
+);
+assert.equal(
+  part5.notes[1].progress,
+  part5.notes[2].progress,
+  'The final right-left pair must enqueue as one linked pace-note sequence'
+);
+assert.match(part5.lead, /BIP BIP in the right ear/);
+assert.match(part5.lead, /BIP BEEP in the left/);
+assert.match(part5.visualHint, /final two curves follow closely/);
 
 for (const stage of TRAINING_STAGES) {
   assertCourseHasSpace(stage);
@@ -93,6 +109,16 @@ assert.match(view, /maximum-steering two-tone/);
 assert.match(view, /These sounds are not corner instructions/);
 assert.match(view, /The ear gives the turn side/);
 assert.match(view, /held final BEEP means the curve continues/);
+assert.match(view, /dialog\.classList\.contains\('turn-dbe-training-intro-dialog'\)/);
+assert.match(view, /dialog\.querySelector\('\[data-training-cancel\]'\)/);
+assert.match(view, /focus\(\{ preventScroll: true \}\)/);
+assert.equal(
+  (view.match(/requestAnimationFrame\(\(\) =>/g) || []).length >= 2,
+  true,
+  'The long introduction must reset its scroll after WebKit applies delayed focus scrolling'
+);
+assert.match(view, /card\.scrollTop = 0/);
+assert.match(view, /behavior: 'instant'/);
 
 assert.match(training, /setAudioEnabled\?\.\(true\)/);
 assert.match(training, /setDriveByEarEnabled\?\.\(true\)/);
@@ -110,7 +136,7 @@ assert.match(css, /data-training-race-restart/);
 assert.match(css, /\.turn-dbe-training-race-nav\[hidden\]/);
 assert.match(css, /@media \(prefers-reduced-motion: reduce\)/);
 
-console.log('TURN Drive By Ear 101 course spacing, cues, navigation and slippery rails passed.');
+console.log('TURN Drive By Ear 101 device cue mapping, modal position and linked sequence passed.');
 
 function assertCourseHasSpace(stage) {
   const points = stage.points.map(([x, z]) => ({ x, z }));

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -14,7 +14,6 @@ function installStylesheet() {
 function waitForHome() {
   const existing = document.querySelector('.m8-home');
   if (existing) return Promise.resolve(existing);
-
   return new Promise((resolve) => {
     const observer = new MutationObserver(() => {
       const home = document.querySelector('.m8-home');
@@ -67,7 +66,6 @@ export async function installM8HomeFixedLayout() {
   settingsButton.textContent = 'SETTINGS';
   howButton.textContent = 'HOW TO PLAY';
   raceButton.classList.add('m8-race-button');
-
   menu.append(settingsButton, howButton, status, raceButton);
 
   if (oldScrollButtons) {
@@ -107,7 +105,7 @@ export async function installM8HomeFixedLayout() {
   const achievements = installAchievements(globalThis.__turnRuntime);
 
   const { installDriveByEarTraining } = await import(
-    `/turn/training/drive-by-ear-training.js?build=${buildKey}-r150-dbe-training-refinement`
+    `/turn/training/drive-by-ear-training.js?build=${buildKey}-r151-dbe-training-device-fixes`
   );
   const driveByEarTraining = await installDriveByEarTraining(globalThis.__turnRuntime);
 

--- a/turn/training/stages.js
+++ b/turn/training/stages.js
@@ -4,12 +4,17 @@ export const TRAINING_CAR_ID = 'classic';
 export const SAMPLE_COUNT = 720;
 export const FINISH_PROGRESS = 0.94;
 export const ROAD_HALF_WIDTH = 13.5;
-export const RAIL_ASSIST_START = ROAD_HALF_WIDTH - 1.8;
+// The visible tube begins just outside the asphalt. Starting assistance inside the
+// road made the car react before touching anything and felt arbitrary on device.
+export const RAIL_ASSIST_START = ROAD_HALF_WIDTH + 0.35;
 export const RECOVERY_LIMIT = ROAD_HALF_WIDTH + 10;
 export const SAFETY_ASSIST_START = RECOVERY_LIMIT - 4;
 
-const LEFT = -1;
-const RIGHT = 1;
+// Physical landscape-device testing shows the shared priority panner reaches the
+// opposite ear for these authored training-course turns. Keep the stage definitions
+// semantic and map course left/right to the ear values that players actually hear.
+const LEFT = 1;
+const RIGHT = -1;
 const note = (progress, direction, severity, long = false) => Object.freeze({
   progress,
   direction,
@@ -85,18 +90,21 @@ export const TRAINING_STAGES = Object.freeze([
   stage({
     id: 'dbe-training-5',
     title: 'Drive by ear',
-    menuSummary: 'Combine ribbon, pace notes and recovery on an open course.',
-    lead: 'Put it together on a spacious course. Follow the ribbon, listen ahead for a gentle right, a broader left and a long right, and use gravel plus recovery guidance if you leave the road.',
-    visualHint: 'The route never crosses itself. Try Blank screen mode, or keep the course visible and repeat any part from the navigation controls.',
+    menuSummary: 'Combine the ribbon with a linked right–left pace-note sequence.',
+    lead: 'Put it together on a spacious course. After the first gentle right, listen for a linked sequence: BIP BIP in the right ear, then BIP BEEP in the left for the long curve immediately after it. Use gravel plus recovery guidance if you leave the road.',
+    visualHint: 'The final two curves follow closely without crossing the route. Try Blank screen mode, or keep the course visible and repeat any part from the navigation controls.',
     guideRails: false,
     startOffset: 0,
     outerLimit: RECOVERY_LIMIT,
     points: [
-      [0, 0], [0, 60], [0, 120], [0, 180], [5, 225], [20, 265],
-      [50, 295], [90, 315], [140, 320], [200, 320], [260, 320],
-      [310, 330], [350, 355], [375, 390], [385, 435], [385, 490],
-      [385, 550], [395, 600], [420, 640], [460, 665], [515, 675], [575, 675]
+      [0, 0], [0, 70], [0, 140], [0, 210], [5, 250], [20, 285],
+      [50, 310], [90, 325], [140, 330], [200, 330], [260, 330],
+      [305, 325], [340, 305], [360, 275], [368, 235], [368, 195],
+      [375, 160], [395, 130], [425, 108], [465, 95], [510, 94],
+      [560, 102], [615, 110], [680, 110]
     ],
-    notes: [note(0.08, RIGHT, 1), note(0.39, LEFT, 2), note(0.68, RIGHT, 2, true)]
+    // The matching progress values intentionally enqueue one linked phrase:
+    // BIP BIP right, followed by BIP BEEP left.
+    notes: [note(0.08, RIGHT, 1), note(0.43, RIGHT, 2), note(0.43, LEFT, 2, true)]
   })
 ]);

--- a/turn/training/view.js
+++ b/turn/training/view.js
@@ -20,10 +20,29 @@ export function installTrainingView({ revision, openTraining, isTrainingActive }
 
 export function showTrainingDialog(dialog, focusSelector = '[data-training-primary]') {
   const card = dialog.querySelector('.m8-dialog-card');
-  if (card) card.scrollTop = 0;
   if (typeof dialog.showModal === 'function') dialog.showModal();
   else dialog.setAttribute('open', '');
-  dialog.querySelector(focusSelector)?.focus();
+
+  // Focusing the first part button made iOS scroll the long introduction down to
+  // that button. Keep initial focus at the visible top of the introductory modal.
+  const requestedTarget = dialog.querySelector(focusSelector);
+  const focusTarget = dialog.classList.contains('turn-dbe-training-intro-dialog')
+    ? dialog.querySelector('[data-training-cancel]') || requestedTarget
+    : requestedTarget;
+
+  resetDialogScroll(dialog, card);
+  try {
+    focusTarget?.focus({ preventScroll: true });
+  } catch (_) {
+    focusTarget?.focus?.();
+  }
+
+  // WebKit may apply a delayed focus scroll after showModal(). Reset on the next
+  // two frames so the heading remains visible when the dialog has fully settled.
+  requestAnimationFrame(() => {
+    resetDialogScroll(dialog, card);
+    requestAnimationFrame(() => resetDialogScroll(dialog, card));
+  });
 }
 
 export function hideTrainingDialog(dialog) {
@@ -81,6 +100,15 @@ export function renderTrainingNavigation(navigation, index) {
       : 'No next training part'
   );
   navigation.hidden = false;
+}
+
+function resetDialogScroll(dialog, card) {
+  dialog.scrollTop = 0;
+  if (!card) return;
+  card.scrollTop = 0;
+  try {
+    card.scrollTo({ top: 0, left: 0, behavior: 'instant' });
+  } catch (_) {}
 }
 
 function installStylesheet(revision) {


### PR DESCRIPTION
## Changes
- force the Drive By Ear 101 introduction to open at the top on iOS, with top-of-dialog focus and delayed scroll correction
- invert the training-only pace-note ear mapping based on physical device testing
- start guide-rail assistance at the visible rail instead of almost two metres inside the road
- rebuild the end of Part 5 so the last two curves follow closely
- enqueue the final Part 5 phrase as BIP BIP right, then BIP BEEP left
- refresh the production module URL and expand regression coverage

## Validation target
- focused Drive By Ear 101 workflow
- complete TURN regression suite