### PR TITLE
Add developer time trial achievements

### DIFF
--- a/turn-lab/tests/achievements-production.mjs
+++ b/turn-lab/tests/achievements-production.mjs
@@ -4,8 +4,13 @@ import {
   ACHIEVEMENTS,
   ACHIEVEMENT_STORAGE_KEY,
   ONBOARDING_ACHIEVEMENT_IDS,
+  TIME_TRIALS,
+  TIME_TRIAL_ACHIEVEMENT_IDS,
+  TIME_TRIAL_MASTER_ID,
+  completedAllTimeTrials,
   loadAchievementState,
-  normalizeAchievementState
+  normalizeAchievementState,
+  qualifyingTimeTrial
 } from '../../turn/achievements.js';
 import { createAchievementStore } from '../../turn/achievements/store.js';
 import {
@@ -14,12 +19,13 @@ import {
   sampleNightShiftOvertakes
 } from '../../turn/achievements/night-shift.js';
 
-const [catalog, storeSource, runtime, view, nightShiftSource, style, fixedLayout, workflow, designTokens] = await Promise.all([
+const [catalog, storeSource, runtime, view, nightShiftSource, timeTrialSource, style, fixedLayout, workflow, designTokens] = await Promise.all([
   fs.readFile(new URL('../../turn/achievements/catalog.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements/store.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements/runtime.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements/view.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements/night-shift.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/achievements/time-trials.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../.github/workflows/turn-lab-tests.yml', import.meta.url), 'utf8'),
@@ -27,12 +33,15 @@ const [catalog, storeSource, runtime, view, nightShiftSource, style, fixedLayout
 ]);
 
 assert.equal(ACHIEVEMENT_STORAGE_KEY, 'turn-achievements-v1');
-assert.equal(ACHIEVEMENTS.length, 16, 'TURN should ship the expanded sixteen-achievement collection');
+assert.equal(ACHIEVEMENTS.length, 22, 'TURN should ship twenty-two achievements including the developer time trials');
 assert.equal(ONBOARDING_ACHIEVEMENT_IDS.length, 10, 'Getting Started should remain a focused ten-achievement collection');
+assert.equal(TIME_TRIALS.length, 5, 'Every current track should have one hard time trial');
+assert.equal(TIME_TRIAL_ACHIEVEMENT_IDS.length, 5);
+assert.equal(TIME_TRIAL_MASTER_ID, 'faster-than-the-dev');
 assert.equal(
   ACHIEVEMENTS.reduce((total, achievement) => total + achievement.points, 0),
-  1075,
-  'Achievement point values should reflect the flagship non-visual challenges'
+  1300,
+  'Five 25-point trials plus the 100-point developer challenge should bring the collection to 1300 points'
 );
 assert.deepEqual(
   ACHIEVEMENTS.map((achievement) => achievement.id),
@@ -52,7 +61,13 @@ assert.deepEqual(
     'beyond-sight',
     'around-the-turn',
     'ahead-of-yourself',
-    'night-shift-sheriff'
+    'night-shift-sheriff',
+    'countryside-sprint',
+    'airport-sprint',
+    'cliffside-sprint',
+    'harbor-sprint',
+    'midnight-sprint',
+    'faster-than-the-dev'
   ]
 );
 assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === 'flow-state')?.points, 50);
@@ -68,6 +83,33 @@ assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === 'night-shift-
 assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === 'night-shift-sheriff')?.description || '', /Police Car/);
 assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === 'night-shift-sheriff')?.description || '', /Boost is active/);
 
+assert.deepEqual(
+  TIME_TRIALS.map(({ trackId, targetSeconds }) => [trackId, targetSeconds]),
+  [
+    ['countryside', 13],
+    ['airport', 20],
+    ['cliffside', 17],
+    ['harbor', 25],
+    ['midnight-city', 60]
+  ]
+);
+for (const trial of TIME_TRIALS) {
+  const achievement = ACHIEVEMENTS.find((item) => item.id === trial.id);
+  assert.equal(achievement?.category, 'time-trials');
+  assert.equal(achievement?.points, 25);
+  assert.match(achievement?.recommendation || '', /Future Racer/);
+  assert.equal(qualifyingTimeTrial(trial.trackId, trial.targetSeconds - 0.001)?.id, trial.id);
+  assert.equal(qualifyingTimeTrial(trial.trackId, trial.targetSeconds), null,
+    `${trial.title} must require a time strictly below the target`);
+}
+assert.equal(qualifyingTimeTrial('invented', 1), null);
+assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === TIME_TRIAL_MASTER_ID)?.points, 100);
+assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === TIME_TRIAL_MASTER_ID)?.title || '', /FASTER THAN THE DEV/);
+assert.equal(completedAllTimeTrials(() => true), true);
+assert.equal(completedAllTimeTrials((id) => id !== 'harbor-sprint'), false);
+assert.equal(completedAllTimeTrials((id) => id !== 'harbor-sprint', 'harbor-sprint'), true,
+  'The final qualifying lap should count while the individual achievement is still pending');
+
 const empty = normalizeAchievementState(null);
 assert.deepEqual(empty.progress.tracks, []);
 assert.deepEqual(empty.progress.blankTracks, []);
@@ -79,6 +121,7 @@ const normalized = normalizeAchievementState({
   unlocked: {
     'first-turn': { unlockedAt: 123, trackId: 'countryside', vehicleId: 'classic', time: 42.5 },
     'trust-your-ears': { unlockedAt: 124, trackId: 'midnight-city', vehicleId: 'police', time: 91.2 },
+    'countryside-sprint': { unlockedAt: 125, trackId: 'countryside', vehicleId: 'race-future', time: 12.8 },
     invented: { unlockedAt: 456 }
   },
   seen: ['first-turn', 'invented', 'first-turn'],
@@ -87,7 +130,7 @@ const normalized = normalizeAchievementState({
     blankTracks: ['countryside', 'countryside', 'invented']
   }
 });
-assert.deepEqual(Object.keys(normalized.unlocked), ['first-turn', 'trust-your-ears']);
+assert.deepEqual(Object.keys(normalized.unlocked), ['first-turn', 'trust-your-ears', 'countryside-sprint']);
 assert.deepEqual(normalized.seen, ['first-turn']);
 assert.deepEqual(normalized.progress.tracks, ['airport']);
 assert.deepEqual(normalized.progress.blankTracks, ['countryside', 'midnight-city'],
@@ -100,7 +143,10 @@ const storage = {
 };
 assert.equal(loadAchievementState(storage).storageAvailable, true);
 memory.set(ACHIEVEMENT_STORAGE_KEY, JSON.stringify(normalized));
-assert.deepEqual(Object.keys(loadAchievementState(storage).state.unlocked), ['first-turn', 'trust-your-ears']);
+assert.deepEqual(
+  Object.keys(loadAchievementState(storage).state.unlocked),
+  ['first-turn', 'trust-your-ears', 'countryside-sprint']
+);
 assert.equal(loadAchievementState({ getItem: () => { throw new Error('blocked'); } }).storageAvailable, false);
 
 const store = createAchievementStore(storage);
@@ -144,6 +190,13 @@ assert.equal(createNightShiftAttempt({
   rivals: [...rivals.slice(0, 3), { carId: 'police', time: 90, progress: 0.5 }]
 }).eligible, false, 'Police rivals should make Night Shift Sheriff ineligible');
 
+assert.match(catalog, /TIME_TRIALS/);
+assert.match(catalog, /TIME_TRIAL_ACHIEVEMENT_IDS/);
+assert.match(catalog, /TIME_TRIALS: 'time-trials'/);
+assert.match(catalog, /id: 'faster-than-the-dev'/);
+assert.match(catalog, /title: 'FASTER THAN THE DEV'/);
+assert.match(catalog, /points: 100/);
+assert.match(catalog, /Recommended: Future Racer/);
 assert.match(catalog, /category: CATEGORY\.ONBOARDING/);
 assert.match(catalog, /id: 'flow-state'/);
 assert.match(catalog, /id: 'trust-your-ears'/);
@@ -158,6 +211,15 @@ assert.match(storeSource, /state\.progress\[key\]/);
 assert.match(storeSource, /addBlankTrack/);
 assert.match(storeSource, /existingTrustTrack/);
 assert.match(storeSource, /markAllSeen/);
+
+assert.match(timeTrialSource, /targetSeconds: 13/);
+assert.match(timeTrialSource, /targetSeconds: 20/);
+assert.match(timeTrialSource, /targetSeconds: 17/);
+assert.match(timeTrialSource, /targetSeconds: 25/);
+assert.match(timeTrialSource, /targetSeconds: 60/);
+assert.match(timeTrialSource, /seconds >= trial\.targetSeconds/,
+  'Matching a developer target exactly must not unlock an under-target achievement');
+assert.match(timeTrialSource, /TIME_TRIAL_MASTER_ID = 'faster-than-the-dev'/);
 
 assert.match(nightShiftSource, /RIVAL_COUNT = 4/);
 assert.match(nightShiftSource, /MIDNIGHT_CITY_ID/);
@@ -189,6 +251,15 @@ assert.match(runtime, /candidates\.push\('beyond-sight'\)/);
 assert.match(runtime, /sampleNightShiftOvertakes/);
 assert.match(runtime, /completedNightShiftSheriff/);
 assert.match(runtime, /candidates\.push\('night-shift-sheriff'\)/);
+assert.match(runtime, /getStoredBestLap/,
+  'Existing saved best laps should be recognised when the new achievements first load');
+assert.match(runtime, /function importStoredTimeTrials\(\)/);
+assert.match(runtime, /unlockSilently\(entries\)/,
+  'Imported records should create unread achievements without interrupting Home with an unlock toast');
+assert.match(runtime, /const timeTrial = qualifyingTimeTrial\(context\.trackId, context\.time\)/);
+assert.match(runtime, /candidates\.push\(timeTrial\.id\)/);
+assert.match(runtime, /candidates\.push\(TIME_TRIAL_MASTER_ID\)/);
+assert.match(runtime, /completedAllTimeTrials/);
 assert.match(runtime, /turn-screen-blanked/);
 assert.match(runtime, /reason === 'lap-started'/);
 assert.match(runtime, /reason === 'race-reset'/);
@@ -205,6 +276,10 @@ assert.match(runtime, /!allOnboardingComplete\(store\)/,
 assert.match(view, /aria-live', 'polite'/);
 assert.match(view, /role="progressbar"/);
 assert.match(view, /data-achievement-filter="onboarding"/);
+assert.match(view, /data-achievement-filter="time-trials"/);
+assert.match(view, /CATEGORY\.TIME_TRIALS/);
+assert.match(view, /achievement\.id === 'faster-than-the-dev'/);
+assert.match(view, /TIME_TRIAL_ACHIEVEMENT_IDS\.filter/);
 assert.match(view, /store\.markAllSeen\(\)/);
 assert.match(view, /prefers-reduced-motion: reduce/);
 assert.match(view, /ATTENTION_VISIBLE_MS = 900/);
@@ -245,10 +320,10 @@ assert.doesNotMatch(style, /is-achievement-next/);
 
 assert.match(designTokens, /--turn-action-success: var\(--turn-green-500\)/);
 assert.match(fixedLayout, /installAchievements/);
-assert.match(fixedLayout, /r146-achievement-expansion/);
+assert.match(fixedLayout, /r152-developer-time-trials/);
 assert.ok(fixedLayout.indexOf('installM8HomeCardScrollFixes') < fixedLayout.indexOf('installAchievements'),
   'Achievements should join the completed fixed Home layout after track scrolling is installed');
 assert.match(workflow, /Run achievement system regression/);
 assert.match(workflow, /node turn-lab\/tests\/achievements-production\.mjs/);
 
-console.log('TURN expanded achievement system regression passed.');
+console.log('TURN developer time trial achievement regression passed.');

--- a/turn/achievements.js
+++ b/turn/achievements.js
@@ -1,10 +1,17 @@
 export {
   ACHIEVEMENTS,
   ONBOARDING_ACHIEVEMENT_IDS
-} from './achievements/catalog.js?revision=r146-achievement-expansion';
+} from './achievements/catalog.js?revision=r152-developer-time-trials';
 export {
   ACHIEVEMENT_STORAGE_KEY,
   loadAchievementState,
   normalizeAchievementState
-} from './achievements/store.js?revision=r146-achievement-expansion';
-export { installAchievements } from './achievements/runtime.js?revision=r146-achievement-expansion';
+} from './achievements/store.js?revision=r152-developer-time-trials';
+export {
+  TIME_TRIALS,
+  TIME_TRIAL_ACHIEVEMENT_IDS,
+  TIME_TRIAL_MASTER_ID,
+  completedAllTimeTrials,
+  qualifyingTimeTrial
+} from './achievements/time-trials.js?revision=r152-developer-time-trials';
+export { installAchievements } from './achievements/runtime.js?revision=r152-developer-time-trials';

--- a/turn/achievements/catalog.js
+++ b/turn/achievements/catalog.js
@@ -1,3 +1,8 @@
+import {
+  TIME_TRIALS,
+  TIME_TRIAL_ACHIEVEMENT_IDS
+} from './time-trials.js?revision=r152-developer-time-trials';
+
 export const TRACK_IDS = Object.freeze([
   'countryside',
   'airport',
@@ -14,14 +19,16 @@ export const CATEGORY = Object.freeze({
   ONBOARDING: 'onboarding',
   WAYS_TO_PLAY: 'ways-to-play',
   EXPLORATION: 'exploration',
-  RACING: 'racing'
+  RACING: 'racing',
+  TIME_TRIALS: 'time-trials'
 });
 
 export const CATEGORY_LABELS = Object.freeze({
   [CATEGORY.ONBOARDING]: 'Getting started',
   [CATEGORY.WAYS_TO_PLAY]: 'Ways to play',
   [CATEGORY.EXPLORATION]: 'Exploration',
-  [CATEGORY.RACING]: 'Racing'
+  [CATEGORY.RACING]: 'Racing',
+  [CATEGORY.TIME_TRIALS]: 'Time trials'
 });
 
 export const TRACK_NAMES = Object.freeze({
@@ -66,7 +73,8 @@ export const ICONS = Object.freeze({
   blindRoute: '<svg viewBox="0 0 24 24"><circle cx="5" cy="18" r="2"></circle><circle cx="19" cy="6" r="2"></circle><path d="M7 18h3c3 0 3-5 6-5h1M17 6h-3c-3 0-3 4-6 4H5"></path><path d="M4 4l16 16"></path></svg>',
   route: '<svg viewBox="0 0 24 24"><circle cx="5" cy="18" r="2"></circle><circle cx="19" cy="6" r="2"></circle><path d="M7 18h3c3 0 3-5 6-5h1M17 6h-3c-3 0-3 4-6 4H5"></path></svg>',
   trophy: '<svg viewBox="0 0 24 24"><path d="M7 4h10v4c0 4-2 7-5 8-3-1-5-4-5-8V4Z"></path><path d="M7 6H4v2c0 2 1 3 4 4M17 6h3v2c0 2-1 3-4 4M9 20h6M12 16v4"></path></svg>',
-  siren: '<svg viewBox="0 0 24 24"><path d="M7 16v-5a5 5 0 0 1 10 0v5"></path><path d="M5 16h14v4H5Z"></path><path d="M12 2v3M4.5 5.5l2 2M19.5 5.5l-2 2M2 12h3M19 12h3"></path></svg>'
+  siren: '<svg viewBox="0 0 24 24"><path d="M7 16v-5a5 5 0 0 1 10 0v5"></path><path d="M5 16h14v4H5Z"></path><path d="M12 2v3M4.5 5.5l2 2M19.5 5.5l-2 2M2 12h3M19 12h3"></path></svg>',
+  stopwatch: '<svg viewBox="0 0 24 24"><circle cx="12" cy="13" r="8"></circle><path d="M9 2h6M12 5V2M18 7l2-2M12 13l3-3"></path></svg>'
 });
 
 export const ACHIEVEMENTS = Object.freeze([
@@ -85,7 +93,26 @@ export const ACHIEVEMENTS = Object.freeze([
   Object.freeze({ id: 'beyond-sight', category: CATEGORY.WAYS_TO_PLAY, points: 300, title: 'BEYOND SIGHT', description: 'Finish a valid lap on every track with Blank screen mode on from start to finish.', icon: 'blindRoute', progressMax: TRACK_IDS.length }),
   Object.freeze({ id: 'around-the-turn', category: CATEGORY.EXPLORATION, points: 100, title: 'AROUND THE TURN', description: 'Finish a valid lap on every track.', icon: 'route', progressMax: TRACK_IDS.length }),
   Object.freeze({ id: 'ahead-of-yourself', category: CATEGORY.RACING, points: 50, title: 'AHEAD OF YOURSELF', description: 'Finish first in a lap with at least one saved rival.', icon: 'trophy' }),
-  Object.freeze({ id: 'night-shift-sheriff', category: CATEGORY.RACING, points: 100, title: 'NIGHT SHIFT SHERIFF', description: 'In Midnight City, use the Police Car to beat four non-police rivals. Overtake each one while Boost is active.', icon: 'siren', progressMax: 4 })
+  Object.freeze({ id: 'night-shift-sheriff', category: CATEGORY.RACING, points: 100, title: 'NIGHT SHIFT SHERIFF', description: 'In Midnight City, use the Police Car to beat four non-police rivals. Overtake each one while Boost is active.', icon: 'siren', progressMax: 4 }),
+  ...TIME_TRIALS.map((trial) => Object.freeze({
+    id: trial.id,
+    category: CATEGORY.TIME_TRIALS,
+    points: 25,
+    title: trial.title,
+    description: trial.description,
+    recommendation: 'Recommended: Future Racer',
+    icon: 'stopwatch'
+  })),
+  Object.freeze({
+    id: 'faster-than-the-dev',
+    category: CATEGORY.TIME_TRIALS,
+    points: 100,
+    title: 'FASTER THAN THE DEV',
+    description: 'Beat every developer target time.',
+    recommendation: 'The target times were set with the Future Racer.',
+    icon: 'trophy',
+    progressMax: TIME_TRIAL_ACHIEVEMENT_IDS.length
+  })
 ]);
 
 export const ONBOARDING_ACHIEVEMENT_IDS = Object.freeze(

--- a/turn/achievements/runtime.js
+++ b/turn/achievements/runtime.js
@@ -2,21 +2,28 @@ import {
   ACHIEVEMENTS,
   TRACK_IDS,
   TRAINING_CAR_ID
-} from './catalog.js?revision=r146-achievement-expansion';
+} from './catalog.js?revision=r152-developer-time-trials';
 import {
   createAchievementStore,
   normalizeAchievementState
-} from './store.js?revision=r146-achievement-expansion';
+} from './store.js?revision=r152-developer-time-trials';
 import {
   allOnboardingComplete,
   createAchievementView
-} from './view.js?revision=r146-achievement-expansion';
+} from './view.js?revision=r152-developer-time-trials';
 import {
   completedNightShiftSheriff,
   createNightShiftAttempt,
   sampleNightShiftOvertakes
 } from './night-shift.js?revision=r146-achievement-expansion';
+import {
+  TIME_TRIALS,
+  TIME_TRIAL_MASTER_ID,
+  completedAllTimeTrials,
+  qualifyingTimeTrial
+} from './time-trials.js?revision=r152-developer-time-trials';
 import { replayFrameAt } from '../race/replay-system.js?revision=r146-achievement-expansion';
+import { getStoredBestLap } from '../race/rival-storage.js';
 
 const SPECTATE_REQUIRED_MS = 5000;
 const LISTEN_CLOSELY_REQUIRED_MS = 10000;
@@ -97,6 +104,13 @@ export function installAchievements(runtime = globalThis.__turnRuntime) {
   };
   const view = createAchievementView({ store, session, utilityGroup });
 
+  function announceAchievementUpdate(unlocked) {
+    if (!unlocked.length) return;
+    window.dispatchEvent(new CustomEvent('turn:achievements-updated', {
+      detail: { unlocked: unlocked.map((achievement) => achievement.id) }
+    }));
+  }
+
   function scheduleToastFlush(delay = 0) {
     window.clearTimeout(session.toastTimer);
     session.toastTimer = window.setTimeout(() => {
@@ -120,11 +134,52 @@ export function installAchievements(runtime = globalThis.__turnRuntime) {
       .map((id) => store.unlock(id, context))
       .filter(Boolean);
     if (!unlocked.length) return [];
-    window.dispatchEvent(new CustomEvent('turn:achievements-updated', {
-      detail: { unlocked: unlocked.map((achievement) => achievement.id) }
-    }));
+    announceAchievementUpdate(unlocked);
     queueUnlocked(unlocked, options);
     return unlocked;
+  }
+
+  function unlockSilently(entries) {
+    const unlocked = entries
+      .map(({ id, context }) => store.unlock(id, context))
+      .filter(Boolean);
+    if (!unlocked.length) return [];
+    announceAchievementUpdate(unlocked);
+    view.syncTriggers();
+    view.render();
+    return unlocked;
+  }
+
+  function importStoredTimeTrials() {
+    const entries = [];
+    const pendingIds = new Set();
+
+    for (const trial of TIME_TRIALS) {
+      const bestLap = getStoredBestLap(trial.trackId);
+      const qualified = qualifyingTimeTrial(trial.trackId, bestLap?.time);
+      if (!qualified) continue;
+      pendingIds.add(qualified.id);
+      entries.push({
+        id: qualified.id,
+        context: {
+          trackId: trial.trackId,
+          vehicleId: bestLap?.carId || '',
+          time: Number(bestLap?.time)
+        }
+      });
+    }
+
+    const completesSet = completedAllTimeTrials(
+      (id) => store.isUnlocked(id) || pendingIds.has(id)
+    );
+    if (completesSet) {
+      entries.push({
+        id: TIME_TRIAL_MASTER_ID,
+        context: { trackId: '', vehicleId: '', time: null }
+      });
+    }
+
+    unlockSilently(entries);
   }
 
   function sampleListenClosely(state, elapsedMs) {
@@ -240,6 +295,14 @@ export function installAchievements(runtime = globalThis.__turnRuntime) {
       candidates.push('around-the-turn');
     }
 
+    const timeTrial = qualifyingTimeTrial(context.trackId, context.time);
+    if (timeTrial) {
+      candidates.push(timeTrial.id);
+      if (completedAllTimeTrials((id) => store.isUnlocked(id), timeTrial.id)) {
+        candidates.push(TIME_TRIAL_MASTER_ID);
+      }
+    }
+
     unlock(candidates, context, { delay: LAP_TOAST_DELAY_MS });
     session.currentLap = null;
     session.currentLapVoid = false;
@@ -319,6 +382,7 @@ export function installAchievements(runtime = globalThis.__turnRuntime) {
     : null;
   menuObserver?.observe(utilityGroup, { attributes: true, attributeFilter: ['data-menu-state'] });
 
+  importStoredTimeTrials();
   window.setInterval(sampleDrivingState, SAMPLE_INTERVAL_MS);
   syncRaceTriggerVisibility();
 

--- a/turn/achievements/store.js
+++ b/turn/achievements/store.js
@@ -1,7 +1,7 @@
 import {
   TRACK_IDS,
   getAchievement
-} from './catalog.js?revision=r146-achievement-expansion';
+} from './catalog.js?revision=r152-developer-time-trials';
 
 export const ACHIEVEMENT_STORAGE_KEY = 'turn-achievements-v1';
 const STORAGE_VERSION = 2;

--- a/turn/achievements/time-trials.js
+++ b/turn/achievements/time-trials.js
@@ -1,0 +1,59 @@
+export const TIME_TRIALS = Object.freeze([
+  Object.freeze({
+    id: 'countryside-sprint',
+    trackId: 'countryside',
+    targetSeconds: 13,
+    title: 'COUNTRYSIDE SPRINT',
+    description: 'Finish Countryside in under 13 seconds.'
+  }),
+  Object.freeze({
+    id: 'airport-sprint',
+    trackId: 'airport',
+    targetSeconds: 20,
+    title: 'AIRPORT SPRINT',
+    description: 'Finish Airport in under 20 seconds.'
+  }),
+  Object.freeze({
+    id: 'cliffside-sprint',
+    trackId: 'cliffside',
+    targetSeconds: 17,
+    title: 'CLIFFSIDE SPRINT',
+    description: 'Finish Cliffside in under 17 seconds.'
+  }),
+  Object.freeze({
+    id: 'harbor-sprint',
+    trackId: 'harbor',
+    targetSeconds: 25,
+    title: 'HARBOR SPRINT',
+    description: 'Finish Harbor in under 25 seconds.'
+  }),
+  Object.freeze({
+    id: 'midnight-sprint',
+    trackId: 'midnight-city',
+    targetSeconds: 60,
+    title: 'MIDNIGHT SPRINT',
+    description: 'Finish Midnight City in under one minute.'
+  })
+]);
+
+export const TIME_TRIAL_ACHIEVEMENT_IDS = Object.freeze(
+  TIME_TRIALS.map((trial) => trial.id)
+);
+
+export const TIME_TRIAL_MASTER_ID = 'faster-than-the-dev';
+
+const TIME_TRIAL_BY_TRACK = new Map(
+  TIME_TRIALS.map((trial) => [trial.trackId, trial])
+);
+
+export function qualifyingTimeTrial(trackId, time) {
+  const trial = TIME_TRIAL_BY_TRACK.get(trackId);
+  const seconds = Number(time);
+  if (!trial || !Number.isFinite(seconds) || seconds >= trial.targetSeconds) return null;
+  return trial;
+}
+
+export function completedAllTimeTrials(isUnlocked, pendingId = '') {
+  if (typeof isUnlocked !== 'function') return false;
+  return TIME_TRIAL_ACHIEVEMENT_IDS.every((id) => id === pendingId || isUnlocked(id));
+}

--- a/turn/achievements/view.js
+++ b/turn/achievements/view.js
@@ -7,7 +7,10 @@ import {
   TRACK_NAMES,
   VEHICLE_NAMES,
   TRACK_IDS
-} from './catalog.js?revision=r146-achievement-expansion';
+} from './catalog.js?revision=r152-developer-time-trials';
+import {
+  TIME_TRIAL_ACHIEVEMENT_IDS
+} from './time-trials.js?revision=r152-developer-time-trials';
 
 const TOAST_VISIBLE_MS = 3600;
 const ATTENTION_VISIBLE_MS = 900;
@@ -37,6 +40,9 @@ function progressFor(achievement, store, session) {
   if (achievement.id === 'new-ground') return Math.min(2, store.state.progress.tracks.length);
   if (achievement.id === 'around-the-turn') return Math.min(TRACK_IDS.length, store.state.progress.tracks.length);
   if (achievement.id === 'beyond-sight') return Math.min(TRACK_IDS.length, store.state.progress.blankTracks.length);
+  if (achievement.id === 'faster-than-the-dev') {
+    return TIME_TRIAL_ACHIEVEMENT_IDS.filter((id) => store.isUnlocked(id)).length;
+  }
   if (achievement.id === 'listen-closely') {
     return Math.min(10, Math.floor((session.listenCloselyMs || 0) / 1000));
   }
@@ -139,6 +145,7 @@ function createDialog() {
         <div class="turn-achievements-filters" aria-label="Achievement filters">
           <button type="button" aria-pressed="true" data-achievement-filter="all">ALL</button>
           <button type="button" aria-pressed="false" data-achievement-filter="onboarding">GETTING STARTED</button>
+          <button type="button" aria-pressed="false" data-achievement-filter="time-trials">TIME TRIALS</button>
           <button type="button" aria-pressed="false" data-achievement-filter="unlocked">UNLOCKED</button>
         </div>
         <div class="turn-achievements-list"></div>
@@ -171,6 +178,7 @@ function installFilters(dialog) {
     for (const card of dialog.querySelectorAll('.turn-achievement-card')) {
       const visible = current === 'all'
         || (current === 'onboarding' && card.dataset.achievementCategory === CATEGORY.ONBOARDING)
+        || (current === 'time-trials' && card.dataset.achievementCategory === CATEGORY.TIME_TRIALS)
         || (current === 'unlocked' && card.dataset.achievementStatus === 'unlocked');
       card.hidden = !visible;
     }

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -100,7 +100,7 @@ export async function installM8HomeFixedLayout() {
   const cardScrollFixes = await installM8HomeCardScrollFixes();
 
   const { installAchievements } = await import(
-    `/turn/achievements.js?build=${buildKey}-r146-achievement-expansion`
+    `/turn/achievements.js?build=${buildKey}-r152-developer-time-trials`
   );
   const achievements = installAchievements(globalThis.__turnRuntime);
 


### PR DESCRIPTION
## Summary
- add a new **Time trials** achievement category
- add one strict under-target challenge for every current track
- add **FASTER THAN THE DEV** for completing the full set
- recognise qualifying best laps already stored in TURN without interrupting Home with an unlock toast
- show imported achievements through the conventional unread notification circle
- add a **TIME TRIALS** filter and completion progress for the set achievement

## Target times
- **COUNTRYSIDE SPRINT** — under 13 seconds — 25 points
- **AIRPORT SPRINT** — under 20 seconds — 25 points
- **CLIFFSIDE SPRINT** — under 17 seconds — 25 points
- **HARBOR SPRINT** — under 25 seconds — 25 points
- **MIDNIGHT SPRINT** — under 60 seconds — 25 points
- **FASTER THAN THE DEV** — beat all five targets — 100 points

The thresholds are strict: matching a target exactly does not unlock it.

## Vehicle rule
Any vehicle counts. The achievement cards recommend the **Future Racer**, since that is the vehicle used to establish the developer targets.

## Persistence
Already unlocked trials remain independent from rival resets. Existing saved best laps are imported as evidence when this achievement revision first loads; imported achievements are marked unread but do not trigger a startup toast.

## Validation
- pure threshold tests cover every track and strict `<` semantics
- final-lap completion logic covers the master achievement
- migration tests preserve new IDs in the existing achievement storage schema
- regression coverage protects stored-record import, category filtering, points, order and cache revision