### PR TITLE
Add Trophy Road progression and content rewards

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -154,6 +154,9 @@ jobs:
       - name: Run achievement system regression
         run: node turn-lab/tests/achievements-production.mjs
 
+      - name: Run Trophy Road progression regression
+        run: node turn-lab/tests/trophy-road-production.mjs
+
       - name: Run production sound foundation regression
         run: node turn-lab/tests/audio-foundation-production.mjs
 

--- a/turn-lab/tests/achievements-production.mjs
+++ b/turn-lab/tests/achievements-production.mjs
@@ -6,11 +6,9 @@ import {
   ONBOARDING_ACHIEVEMENT_IDS,
   TIME_TRIALS,
   TIME_TRIAL_ACHIEVEMENT_IDS,
-  TIME_TRIAL_MASTER_ID,
-  completedAllTimeTrials,
   loadAchievementState,
   normalizeAchievementState,
-  qualifyingTimeTrial
+  totalAvailableTrophies
 } from '../../turn/achievements.js';
 import { createAchievementStore } from '../../turn/achievements/store.js';
 import {
@@ -18,6 +16,10 @@ import {
   createNightShiftAttempt,
   sampleNightShiftOvertakes
 } from '../../turn/achievements/night-shift.js';
+import {
+  completedAllTimeTrials,
+  qualifyingTimeTrial
+} from '../../turn/achievements/time-trials.js';
 
 const [catalog, storeSource, runtime, view, nightShiftSource, timeTrialSource, style, fixedLayout, workflow, designTokens] = await Promise.all([
   fs.readFile(new URL('../../turn/achievements/catalog.js', import.meta.url), 'utf8'),
@@ -33,16 +35,19 @@ const [catalog, storeSource, runtime, view, nightShiftSource, timeTrialSource, s
 ]);
 
 assert.equal(ACHIEVEMENT_STORAGE_KEY, 'turn-achievements-v1');
-assert.equal(ACHIEVEMENTS.length, 22, 'TURN should ship twenty-two achievements including the developer time trials');
-assert.equal(ONBOARDING_ACHIEVEMENT_IDS.length, 10, 'Getting Started should remain a focused ten-achievement collection');
-assert.equal(TIME_TRIALS.length, 5, 'Every current track should have one hard time trial');
+assert.equal(ACHIEVEMENTS.length, 22, 'TURN should ship twenty-two achievements');
+assert.equal(ONBOARDING_ACHIEVEMENT_IDS.length, 10, 'Getting Started should remain focused');
+assert.equal(TIME_TRIALS.length, 5);
 assert.equal(TIME_TRIAL_ACHIEVEMENT_IDS.length, 5);
-assert.equal(TIME_TRIAL_MASTER_ID, 'faster-than-the-dev');
+assert.equal(totalAvailableTrophies(), 1300);
 assert.equal(
-  ACHIEVEMENTS.reduce((total, achievement) => total + achievement.points, 0),
+  ACHIEVEMENTS.reduce((total, achievement) => total + achievement.trophies, 0),
   1300,
-  'Five 25-point trials plus the 100-point developer challenge should bring the collection to 1300 points'
+  'Achievement values should now be permanent trophies'
 );
+assert.ok(ACHIEVEMENTS.every((achievement) => Number.isFinite(achievement.trophies)));
+assert.ok(ACHIEVEMENTS.every((achievement) => !Object.hasOwn(achievement, 'points')));
+
 assert.deepEqual(
   ACHIEVEMENTS.map((achievement) => achievement.id),
   [
@@ -70,71 +75,53 @@ assert.deepEqual(
     'faster-than-the-dev'
   ]
 );
-assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === 'flow-state')?.points, 50);
-assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === 'flow-state')?.description || '', /Drift and Boost/);
+
+assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === 'flow-state')?.trophies, 50);
 assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === 'flow-state')?.recommendation || '', /Training Car · Countryside/);
-assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === 'trust-your-ears')?.points, 200);
-assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === 'trust-your-ears')?.description || '', /Blank screen mode on from start to finish/);
-assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === 'listen-closely')?.points, 50);
+assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === 'trust-your-ears')?.trophies, 200);
+assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === 'listen-closely')?.trophies, 50);
 assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === 'listen-closely')?.description || '', /75% Drive By Ear/);
 assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === 'listen-closely')?.recommendation || '', /90% Drive By Ear/);
-assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === 'beyond-sight')?.points, 300);
-assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === 'night-shift-sheriff')?.points, 100);
-assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === 'night-shift-sheriff')?.description || '', /Police Car/);
-assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === 'night-shift-sheriff')?.description || '', /Boost is active/);
+assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === 'beyond-sight')?.trophies, 300);
+assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === 'night-shift-sheriff')?.trophies, 100);
+assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === 'faster-than-the-dev')?.trophies, 100);
 
-assert.deepEqual(
-  TIME_TRIALS.map(({ trackId, targetSeconds }) => [trackId, targetSeconds]),
-  [
-    ['countryside', 13],
-    ['airport', 20],
-    ['cliffside', 17],
-    ['harbor', 25],
-    ['midnight-city', 60]
-  ]
-);
 for (const trial of TIME_TRIALS) {
-  const achievement = ACHIEVEMENTS.find((item) => item.id === trial.id);
-  assert.equal(achievement?.category, 'time-trials');
-  assert.equal(achievement?.points, 25);
-  assert.match(achievement?.recommendation || '', /Future Racer/);
   assert.equal(qualifyingTimeTrial(trial.trackId, trial.targetSeconds - 0.001)?.id, trial.id);
   assert.equal(qualifyingTimeTrial(trial.trackId, trial.targetSeconds), null,
-    `${trial.title} must require a time strictly below the target`);
+    `${trial.title} must use strict under-target semantics`);
 }
-assert.equal(qualifyingTimeTrial('invented', 1), null);
-assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === TIME_TRIAL_MASTER_ID)?.points, 100);
-assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === TIME_TRIAL_MASTER_ID)?.title || '', /FASTER THAN THE DEV/);
-assert.equal(completedAllTimeTrials(() => true), true);
-assert.equal(completedAllTimeTrials((id) => id !== 'harbor-sprint'), false);
-assert.equal(completedAllTimeTrials((id) => id !== 'harbor-sprint', 'harbor-sprint'), true,
-  'The final qualifying lap should count while the individual achievement is still pending');
+assert.equal(completedAllTimeTrials((id) => TIME_TRIAL_ACHIEVEMENT_IDS.includes(id)), true);
 
 const empty = normalizeAchievementState(null);
+assert.equal(empty.version, 3);
 assert.deepEqual(empty.progress.tracks, []);
 assert.deepEqual(empty.progress.blankTracks, []);
+assert.deepEqual(empty.rewards.unlocked, []);
+assert.deepEqual(empty.rewards.seen, []);
 assert.deepEqual(empty.seen, []);
 assert.deepEqual(empty.unlocked, {});
 
 const normalized = normalizeAchievementState({
-  version: 999,
+  version: 3,
   unlocked: {
     'first-turn': { unlockedAt: 123, trackId: 'countryside', vehicleId: 'classic', time: 42.5 },
     'trust-your-ears': { unlockedAt: 124, trackId: 'midnight-city', vehicleId: 'police', time: 91.2 },
-    'countryside-sprint': { unlockedAt: 125, trackId: 'countryside', vehicleId: 'race-future', time: 12.8 },
     invented: { unlockedAt: 456 }
   },
   seen: ['first-turn', 'invented', 'first-turn'],
   progress: {
     tracks: ['airport', 'airport', 'invented'],
     blankTracks: ['countryside', 'countryside', 'invented']
-  }
+  },
+  rewards: { unlocked: [], seen: [] }
 });
-assert.deepEqual(Object.keys(normalized.unlocked), ['first-turn', 'trust-your-ears', 'countryside-sprint']);
+assert.deepEqual(Object.keys(normalized.unlocked), ['first-turn', 'trust-your-ears']);
 assert.deepEqual(normalized.seen, ['first-turn']);
 assert.deepEqual(normalized.progress.tracks, ['airport']);
-assert.deepEqual(normalized.progress.blankTracks, ['countryside', 'midnight-city'],
-  'Existing Trust Your Ears unlocks should seed Beyond Sight progress during migration');
+assert.deepEqual(normalized.progress.blankTracks, ['countryside', 'midnight-city']);
+assert.deepEqual(normalized.rewards.unlocked, ['midnight-city'],
+  'Two hundred earned trophies should unlock the first Trophy Road reward');
 
 const memory = new Map();
 const storage = {
@@ -143,10 +130,7 @@ const storage = {
 };
 assert.equal(loadAchievementState(storage).storageAvailable, true);
 memory.set(ACHIEVEMENT_STORAGE_KEY, JSON.stringify(normalized));
-assert.deepEqual(
-  Object.keys(loadAchievementState(storage).state.unlocked),
-  ['first-turn', 'trust-your-ears', 'countryside-sprint']
-);
+assert.deepEqual(Object.keys(loadAchievementState(storage).state.unlocked), ['first-turn', 'trust-your-ears']);
 assert.equal(loadAchievementState({ getItem: () => { throw new Error('blocked'); } }).storageAvailable, false);
 
 const store = createAchievementStore(storage);
@@ -155,8 +139,10 @@ assert.equal(store.addBlankTrack('harbor'), false);
 assert.ok(store.state.progress.blankTracks.includes('harbor'));
 assert.equal(store.unlock('ahead-of-yourself', { trackId: 'harbor' })?.id, 'ahead-of-yourself');
 assert.ok(store.isUnlocked('ahead-of-yourself'));
+assert.equal(store.trophyTotal(), 275);
+assert.equal(store.isRewardUnlocked('midnight-city'), true);
 assert.doesNotMatch(storeSource, /rival-storage|clearRivalsState|clearAllRivalsState/,
-  'Rival reset implementation must remain independent from persistent achievements');
+  'Rival reset implementation must remain independent from achievements and rewards');
 
 const rivals = [0.1, 0.2, 0.3, 0.4].map((progress, index) => ({
   carId: index === 2 ? 'ambulance' : 'sedan',
@@ -188,142 +174,38 @@ assert.equal(createNightShiftAttempt({
   trackId: 'midnight-city',
   vehicleId: 'police',
   rivals: [...rivals.slice(0, 3), { carId: 'police', time: 90, progress: 0.5 }]
-}).eligible, false, 'Police rivals should make Night Shift Sheriff ineligible');
+}).eligible, false);
 
-assert.match(catalog, /TIME_TRIALS/);
-assert.match(catalog, /TIME_TRIAL_ACHIEVEMENT_IDS/);
-assert.match(catalog, /TIME_TRIALS: 'time-trials'/);
+assert.match(catalog, /trophies: 200/);
+assert.doesNotMatch(catalog, /points:/);
 assert.match(catalog, /id: 'faster-than-the-dev'/);
-assert.match(catalog, /title: 'FASTER THAN THE DEV'/);
-assert.match(catalog, /points: 100/);
-assert.match(catalog, /Recommended: Future Racer/);
-assert.match(catalog, /category: CATEGORY\.ONBOARDING/);
-assert.match(catalog, /id: 'flow-state'/);
-assert.match(catalog, /id: 'trust-your-ears'/);
-assert.match(catalog, /id: 'listen-closely'/);
-assert.match(catalog, /id: 'beyond-sight'/);
-assert.match(catalog, /id: 'around-the-turn'/);
-assert.match(catalog, /id: 'ahead-of-yourself'/);
-assert.match(catalog, /id: 'night-shift-sheriff'/);
-assert.match(storeSource, /ACHIEVEMENT_STORAGE_KEY = 'turn-achievements-v1'/);
-assert.match(storeSource, /STORAGE_VERSION = 2/);
-assert.match(storeSource, /state\.progress\[key\]/);
-assert.match(storeSource, /addBlankTrack/);
-assert.match(storeSource, /existingTrustTrack/);
-assert.match(storeSource, /markAllSeen/);
-
-assert.match(timeTrialSource, /targetSeconds: 13/);
-assert.match(timeTrialSource, /targetSeconds: 20/);
-assert.match(timeTrialSource, /targetSeconds: 17/);
-assert.match(timeTrialSource, /targetSeconds: 25/);
-assert.match(timeTrialSource, /targetSeconds: 60/);
-assert.match(timeTrialSource, /seconds >= trial\.targetSeconds/,
-  'Matching a developer target exactly must not unlock an under-target achievement');
-assert.match(timeTrialSource, /TIME_TRIAL_MASTER_ID = 'faster-than-the-dev'/);
-
-assert.match(nightShiftSource, /RIVAL_COUNT = 4/);
-assert.match(nightShiftSource, /MIDNIGHT_CITY_ID/);
-assert.match(nightShiftSource, /POLICE_CAR_ID/);
-assert.match(nightShiftSource, /previousRelation <= 0 && boostActive/,
-  'Only an actual pass while Police Boost is active should count');
-assert.match(nightShiftSource, /Number\(detail\.position\) === 1/);
-
-assert.match(runtime, /SPECTATE_REQUIRED_MS = 5000/);
-assert.match(runtime, /LISTEN_CLOSELY_REQUIRED_MS = 10000/);
+assert.match(storeSource, /STORAGE_VERSION = TROPHY_ROAD_STORAGE_VERSION/);
+assert.match(storeSource, /syncRewards/);
+assert.match(storeSource, /unseenRewardIds/);
+assert.match(storeSource, /trophyTotal/);
+assert.match(runtime, /REWARD_TOAST_OFFSET_MS = 3900/);
+assert.match(runtime, /turn:trophy-road-updated/);
+assert.match(runtime, /showRewardToastBatch/);
+assert.match(runtime, /store\.syncRewards\(\)/);
+assert.match(runtime, /LAP_TOAST_DELAY_MS = 4400/);
 assert.match(runtime, /LISTEN_CLOSELY_MIN_BALANCE = 0\.75/);
-assert.match(runtime, /LISTEN_CLOSELY_MIN_SPEED = 1/);
-assert.match(runtime, /LAP_TOAST_DELAY_MS = 4400/,
-  'Achievement feedback must wait until the existing lap result has finished');
-assert.match(runtime, /SAMPLE_INTERVAL_MS = 100/,
-  'Driving mechanics should be sampled lightly rather than adding another frame loop');
-assert.match(runtime, /flowEligible/);
-assert.match(runtime, /usedDrift/);
-assert.match(runtime, /usedBoost/);
-assert.match(runtime, /driftChargeGained >= 0\.25/);
-assert.match(runtime, /secondWind\.sawEmpty/);
-assert.match(runtime, /secondWind\.sawRecharge/);
-assert.match(runtime, /settings\?\.balance/);
-assert.match(runtime, /balance >= LISTEN_CLOSELY_MIN_BALANCE/);
-assert.match(runtime, /Number\(state\.speed\) > LISTEN_CLOSELY_MIN_SPEED/);
-assert.match(runtime, /unlock\(\['listen-closely'\]/);
-assert.match(runtime, /store\.addBlankTrack\(context\.trackId\)/);
-assert.match(runtime, /candidates\.push\('beyond-sight'\)/);
-assert.match(runtime, /sampleNightShiftOvertakes/);
 assert.match(runtime, /completedNightShiftSheriff/);
-assert.match(runtime, /candidates\.push\('night-shift-sheriff'\)/);
-assert.match(runtime, /getStoredBestLap/,
-  'Existing saved best laps should be recognised when the new achievements first load');
-assert.match(runtime, /function importStoredTimeTrials\(\)/);
-assert.match(runtime, /unlockSilently\(entries\)/,
-  'Imported records should create unread achievements without interrupting Home with an unlock toast');
-assert.match(runtime, /const timeTrial = qualifyingTimeTrial\(context\.trackId, context\.time\)/);
-assert.match(runtime, /candidates\.push\(timeTrial\.id\)/);
-assert.match(runtime, /candidates\.push\(TIME_TRIAL_MASTER_ID\)/);
-assert.match(runtime, /completedAllTimeTrials/);
-assert.match(runtime, /turn-screen-blanked/);
-assert.match(runtime, /reason === 'lap-started'/);
-assert.match(runtime, /reason === 'race-reset'/);
-assert.match(runtime, /reason === 'spectate-started'/);
-assert.match(runtime, /reason === 'spectate-stopped'/);
-assert.match(runtime, /turn:lap-result/);
-assert.match(runtime, /turn:lap-invalid/);
-assert.match(runtime, /turn:track-changed/);
-assert.match(runtime, /turn:achievements-updated/);
-assert.match(runtime, /pendingTrackEntryPulse/);
-assert.match(runtime, /!allOnboardingComplete\(store\)/,
-  'The track-entry prompt should stop after Getting Started is complete');
-
-assert.match(view, /aria-live', 'polite'/);
-assert.match(view, /role="progressbar"/);
-assert.match(view, /data-achievement-filter="onboarding"/);
+assert.match(runtime, /qualifyingTimeTrial/);
+assert.match(view, /TROPHY ROAD REWARD/);
+assert.match(view, /turn-trophy-road-track/);
+assert.match(view, /achievement\.trophies/);
+assert.match(view, /\+\$\{total\} TROPHIES/);
+assert.match(view, /store\.unseenCount\(\)/);
 assert.match(view, /data-achievement-filter="time-trials"/);
-assert.match(view, /CATEGORY\.TIME_TRIALS/);
-assert.match(view, /achievement\.id === 'faster-than-the-dev'/);
-assert.match(view, /TIME_TRIAL_ACHIEVEMENT_IDS\.filter/);
-assert.match(view, /store\.markAllSeen\(\)/);
-assert.match(view, /prefers-reduced-motion: reduce/);
-assert.match(view, /ATTENTION_VISIBLE_MS = 900/);
-assert.match(view, /is-achievement-pulsing/);
-assert.match(view, /is-achievement-attention/);
-assert.match(view, /achievement\.id === 'listen-closely'/);
-assert.match(view, /achievement\.id === 'beyond-sight'/);
-assert.match(view, /achievement\.id === 'night-shift-sheriff'/);
-assert.match(view, /createTrigger\('m8-home-settings m8-achievements-button'/,
-  'The Home trigger should reuse the canonical menu-button geometry');
-assert.match(view, /createTrigger\('utility turn-race-achievements-button'/);
-assert.match(view, /badge\.textContent = unseenCount > 9 \? '9\+' : String\(unseenCount\)/,
-  'Unseen achievements should use a compact numeric notification circle');
-assert.match(view, /Achievements, \$\{unseenCount\} new achievement/);
-assert.match(view, /ONBOARDING_ACHIEVEMENT_IDS\.every/,
-  'Getting Started should be unordered rather than prescribing a next achievement');
-assert.doesNotMatch(view, /turn-achievements-trigger-icon/,
-  'Achievement destination buttons should remain text-only');
-assert.doesNotMatch(view, /badge\.textContent = 'NEXT'/,
-  'Incomplete onboarding must not create a NEXT badge');
-assert.doesNotMatch(view, /is-achievement-next/);
-assert.doesNotMatch(view, /recommended \? 'NEXT'/,
-  'Achievement cards should not impose a linear next challenge');
-
-assert.match(style, /\.m8-achievements-button/);
-assert.match(style, /\.turn-race-achievements-button/);
-assert.match(style, /\.turn-achievements-trigger-badge[\s\S]*position: absolute/);
-assert.match(style, /\.turn-achievements-trigger-badge[\s\S]*border-radius: 50%/);
-assert.match(style, /\.turn-achievements-dialog/);
-assert.match(style, /\.turn-achievement-toast/);
+assert.match(view, /feedbackButton\.after\(homeTrigger\)/);
+assert.match(view, /createTrigger\('m8-feedback-button m8-achievements-button'/);
+assert.match(nightShiftSource, /previousRelation <= 0 && boostActive/);
+assert.match(timeTrialSource, /seconds >= trial\.targetSeconds/);
 assert.match(style, /@keyframes turn-achievement-pulse/);
-assert.match(style, /animation: turn-achievement-pulse 760ms[^;]* 1/,
-  'The staged Achievements button should pulse once, not repeatedly');
-assert.match(style, /@media \(prefers-reduced-motion: reduce\)/);
-assert.match(style, /var\(--turn-action-success/);
-assert.doesNotMatch(style, /turn-achievements-trigger-icon/);
-assert.doesNotMatch(style, /is-achievement-next/);
-
+assert.match(style, /prefers-reduced-motion: reduce/);
 assert.match(designTokens, /--turn-action-success: var\(--turn-green-500\)/);
-assert.match(fixedLayout, /installAchievements/);
-assert.match(fixedLayout, /r152-developer-time-trials/);
-assert.ok(fixedLayout.indexOf('installM8HomeCardScrollFixes') < fixedLayout.indexOf('installAchievements'),
-  'Achievements should join the completed fixed Home layout after track scrolling is installed');
+assert.match(fixedLayout, /installM8TrophyGate/);
+assert.match(fixedLayout, /r153-trophy-road/);
 assert.match(workflow, /Run achievement system regression/);
-assert.match(workflow, /node turn-lab\/tests\/achievements-production\.mjs/);
 
-console.log('TURN developer time trial achievement regression passed.');
+console.log('TURN Trophy Road achievement regression passed.');

--- a/turn-lab/tests/achievements-production.mjs
+++ b/turn-lab/tests/achievements-production.mjs
@@ -6,8 +6,11 @@ import {
   ONBOARDING_ACHIEVEMENT_IDS,
   TIME_TRIALS,
   TIME_TRIAL_ACHIEVEMENT_IDS,
+  TIME_TRIAL_MASTER_ID,
+  completedAllTimeTrials,
   loadAchievementState,
   normalizeAchievementState,
+  qualifyingTimeTrial,
   totalAvailableTrophies
 } from '../../turn/achievements.js';
 import { createAchievementStore } from '../../turn/achievements/store.js';
@@ -16,10 +19,6 @@ import {
   createNightShiftAttempt,
   sampleNightShiftOvertakes
 } from '../../turn/achievements/night-shift.js';
-import {
-  completedAllTimeTrials,
-  qualifyingTimeTrial
-} from '../../turn/achievements/time-trials.js';
 
 const [catalog, storeSource, runtime, view, nightShiftSource, timeTrialSource, style, fixedLayout, workflow, designTokens] = await Promise.all([
   fs.readFile(new URL('../../turn/achievements/catalog.js', import.meta.url), 'utf8'),
@@ -35,19 +34,19 @@ const [catalog, storeSource, runtime, view, nightShiftSource, timeTrialSource, s
 ]);
 
 assert.equal(ACHIEVEMENT_STORAGE_KEY, 'turn-achievements-v1');
-assert.equal(ACHIEVEMENTS.length, 22, 'TURN should ship twenty-two achievements');
-assert.equal(ONBOARDING_ACHIEVEMENT_IDS.length, 10, 'Getting Started should remain focused');
-assert.equal(TIME_TRIALS.length, 5);
+assert.equal(ACHIEVEMENTS.length, 22, 'TURN should ship twenty-two achievements including the developer time trials');
+assert.equal(ONBOARDING_ACHIEVEMENT_IDS.length, 10, 'Getting Started should remain a focused ten-achievement collection');
+assert.equal(TIME_TRIALS.length, 5, 'Every current track should have one hard time trial');
 assert.equal(TIME_TRIAL_ACHIEVEMENT_IDS.length, 5);
+assert.equal(TIME_TRIAL_MASTER_ID, 'faster-than-the-dev');
 assert.equal(totalAvailableTrophies(), 1300);
 assert.equal(
   ACHIEVEMENTS.reduce((total, achievement) => total + achievement.trophies, 0),
   1300,
-  'Achievement values should now be permanent trophies'
+  'The current collection should contain 1300 permanent trophies'
 );
 assert.ok(ACHIEVEMENTS.every((achievement) => Number.isFinite(achievement.trophies)));
 assert.ok(ACHIEVEMENTS.every((achievement) => !Object.hasOwn(achievement, 'points')));
-
 assert.deepEqual(
   ACHIEVEMENTS.map((achievement) => achievement.id),
   [
@@ -75,23 +74,45 @@ assert.deepEqual(
     'faster-than-the-dev'
   ]
 );
-
 assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === 'flow-state')?.trophies, 50);
+assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === 'flow-state')?.description || '', /Drift and Boost/);
 assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === 'flow-state')?.recommendation || '', /Training Car · Countryside/);
 assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === 'trust-your-ears')?.trophies, 200);
+assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === 'trust-your-ears')?.description || '', /Blank screen mode on from start to finish/);
 assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === 'listen-closely')?.trophies, 50);
 assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === 'listen-closely')?.description || '', /75% Drive By Ear/);
 assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === 'listen-closely')?.recommendation || '', /90% Drive By Ear/);
 assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === 'beyond-sight')?.trophies, 300);
 assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === 'night-shift-sheriff')?.trophies, 100);
-assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === 'faster-than-the-dev')?.trophies, 100);
+assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === 'night-shift-sheriff')?.description || '', /Police Car/);
+assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === 'night-shift-sheriff')?.description || '', /Boost is active/);
 
+assert.deepEqual(
+  TIME_TRIALS.map(({ trackId, targetSeconds }) => [trackId, targetSeconds]),
+  [
+    ['countryside', 13],
+    ['airport', 20],
+    ['cliffside', 17],
+    ['harbor', 25],
+    ['midnight-city', 60]
+  ]
+);
 for (const trial of TIME_TRIALS) {
+  const achievement = ACHIEVEMENTS.find((item) => item.id === trial.id);
+  assert.equal(achievement?.category, 'time-trials');
+  assert.equal(achievement?.trophies, 25);
+  assert.match(achievement?.recommendation || '', /Future Racer/);
   assert.equal(qualifyingTimeTrial(trial.trackId, trial.targetSeconds - 0.001)?.id, trial.id);
   assert.equal(qualifyingTimeTrial(trial.trackId, trial.targetSeconds), null,
-    `${trial.title} must use strict under-target semantics`);
+    `${trial.title} must require a time strictly below the target`);
 }
-assert.equal(completedAllTimeTrials((id) => TIME_TRIAL_ACHIEVEMENT_IDS.includes(id)), true);
+assert.equal(qualifyingTimeTrial('invented', 1), null);
+assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === TIME_TRIAL_MASTER_ID)?.trophies, 100);
+assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === TIME_TRIAL_MASTER_ID)?.title || '', /FASTER THAN THE DEV/);
+assert.equal(completedAllTimeTrials(() => true), true);
+assert.equal(completedAllTimeTrials((id) => id !== 'harbor-sprint'), false);
+assert.equal(completedAllTimeTrials((id) => id !== 'harbor-sprint', 'harbor-sprint'), true,
+  'The final qualifying lap should count while the individual achievement is still pending');
 
 const empty = normalizeAchievementState(null);
 assert.equal(empty.version, 3);
@@ -107,6 +128,7 @@ const normalized = normalizeAchievementState({
   unlocked: {
     'first-turn': { unlockedAt: 123, trackId: 'countryside', vehicleId: 'classic', time: 42.5 },
     'trust-your-ears': { unlockedAt: 124, trackId: 'midnight-city', vehicleId: 'police', time: 91.2 },
+    'countryside-sprint': { unlockedAt: 125, trackId: 'countryside', vehicleId: 'race-future', time: 12.8 },
     invented: { unlockedAt: 456 }
   },
   seen: ['first-turn', 'invented', 'first-turn'],
@@ -116,12 +138,13 @@ const normalized = normalizeAchievementState({
   },
   rewards: { unlocked: [], seen: [] }
 });
-assert.deepEqual(Object.keys(normalized.unlocked), ['first-turn', 'trust-your-ears']);
+assert.deepEqual(Object.keys(normalized.unlocked), ['first-turn', 'trust-your-ears', 'countryside-sprint']);
 assert.deepEqual(normalized.seen, ['first-turn']);
 assert.deepEqual(normalized.progress.tracks, ['airport']);
-assert.deepEqual(normalized.progress.blankTracks, ['countryside', 'midnight-city']);
+assert.deepEqual(normalized.progress.blankTracks, ['countryside', 'midnight-city'],
+  'Existing Trust Your Ears unlocks should seed Beyond Sight progress during migration');
 assert.deepEqual(normalized.rewards.unlocked, ['midnight-city'],
-  'Two hundred earned trophies should unlock the first Trophy Road reward');
+  'Earned trophies should automatically unlock crossed Trophy Road milestones');
 
 const memory = new Map();
 const storage = {
@@ -130,7 +153,10 @@ const storage = {
 };
 assert.equal(loadAchievementState(storage).storageAvailable, true);
 memory.set(ACHIEVEMENT_STORAGE_KEY, JSON.stringify(normalized));
-assert.deepEqual(Object.keys(loadAchievementState(storage).state.unlocked), ['first-turn', 'trust-your-ears']);
+assert.deepEqual(
+  Object.keys(loadAchievementState(storage).state.unlocked),
+  ['first-turn', 'trust-your-ears', 'countryside-sprint']
+);
 assert.equal(loadAchievementState({ getItem: () => { throw new Error('blocked'); } }).storageAvailable, false);
 
 const store = createAchievementStore(storage);
@@ -139,10 +165,10 @@ assert.equal(store.addBlankTrack('harbor'), false);
 assert.ok(store.state.progress.blankTracks.includes('harbor'));
 assert.equal(store.unlock('ahead-of-yourself', { trackId: 'harbor' })?.id, 'ahead-of-yourself');
 assert.ok(store.isUnlocked('ahead-of-yourself'));
-assert.equal(store.trophyTotal(), 275);
+assert.equal(store.trophyTotal(), 300);
 assert.equal(store.isRewardUnlocked('midnight-city'), true);
 assert.doesNotMatch(storeSource, /rival-storage|clearRivalsState|clearAllRivalsState/,
-  'Rival reset implementation must remain independent from achievements and rewards');
+  'Rival reset implementation must remain independent from persistent achievements and rewards');
 
 const rivals = [0.1, 0.2, 0.3, 0.4].map((progress, index) => ({
   carId: index === 2 ? 'ambulance' : 'sedan',
@@ -174,38 +200,160 @@ assert.equal(createNightShiftAttempt({
   trackId: 'midnight-city',
   vehicleId: 'police',
   rivals: [...rivals.slice(0, 3), { carId: 'police', time: 90, progress: 0.5 }]
-}).eligible, false);
+}).eligible, false, 'Police rivals should make Night Shift Sheriff ineligible');
 
-assert.match(catalog, /trophies: 200/);
-assert.doesNotMatch(catalog, /points:/);
+assert.match(catalog, /TIME_TRIALS/);
+assert.match(catalog, /TIME_TRIAL_ACHIEVEMENT_IDS/);
+assert.match(catalog, /TIME_TRIALS: 'time-trials'/);
 assert.match(catalog, /id: 'faster-than-the-dev'/);
+assert.match(catalog, /title: 'FASTER THAN THE DEV'/);
+assert.match(catalog, /trophies: 100/);
+assert.match(catalog, /Recommended: Future Racer/);
+assert.match(catalog, /category: CATEGORY\.ONBOARDING/);
+assert.match(catalog, /id: 'flow-state'/);
+assert.match(catalog, /id: 'trust-your-ears'/);
+assert.match(catalog, /id: 'listen-closely'/);
+assert.match(catalog, /id: 'beyond-sight'/);
+assert.match(catalog, /id: 'around-the-turn'/);
+assert.match(catalog, /id: 'ahead-of-yourself'/);
+assert.match(catalog, /id: 'night-shift-sheriff'/);
+assert.doesNotMatch(catalog, /points:/);
+assert.match(storeSource, /ACHIEVEMENT_STORAGE_KEY = TROPHY_ROAD_STORAGE_KEY/);
 assert.match(storeSource, /STORAGE_VERSION = TROPHY_ROAD_STORAGE_VERSION/);
+assert.match(storeSource, /state\.progress\[key\]/);
+assert.match(storeSource, /addBlankTrack/);
+assert.match(storeSource, /existingTrustTrack/);
+assert.match(storeSource, /markAllSeen/);
+assert.match(storeSource, /trophyTotal/);
 assert.match(storeSource, /syncRewards/);
 assert.match(storeSource, /unseenRewardIds/);
-assert.match(storeSource, /trophyTotal/);
-assert.match(runtime, /REWARD_TOAST_OFFSET_MS = 3900/);
+assert.match(storeSource, /unseenCount/);
+
+assert.match(timeTrialSource, /targetSeconds: 13/);
+assert.match(timeTrialSource, /targetSeconds: 20/);
+assert.match(timeTrialSource, /targetSeconds: 17/);
+assert.match(timeTrialSource, /targetSeconds: 25/);
+assert.match(timeTrialSource, /targetSeconds: 60/);
+assert.match(timeTrialSource, /seconds >= trial\.targetSeconds/,
+  'Matching a developer target exactly must not unlock an under-target achievement');
+assert.match(timeTrialSource, /TIME_TRIAL_MASTER_ID = 'faster-than-the-dev'/);
+
+assert.match(nightShiftSource, /RIVAL_COUNT = 4/);
+assert.match(nightShiftSource, /MIDNIGHT_CITY_ID/);
+assert.match(nightShiftSource, /POLICE_CAR_ID/);
+assert.match(nightShiftSource, /previousRelation <= 0 && boostActive/,
+  'Only an actual pass while Police Boost is active should count');
+assert.match(nightShiftSource, /Number\(detail\.position\) === 1/);
+
+assert.match(runtime, /SPECTATE_REQUIRED_MS = 5000/);
+assert.match(runtime, /LISTEN_CLOSELY_REQUIRED_MS = 10000/);
+assert.match(runtime, /LISTEN_CLOSELY_MIN_BALANCE = 0\.75/);
+assert.match(runtime, /LISTEN_CLOSELY_MIN_SPEED = 1/);
+assert.match(runtime, /LAP_TOAST_DELAY_MS = 4400/,
+  'Achievement feedback must wait until the existing lap result has finished');
+assert.match(runtime, /REWARD_TOAST_OFFSET_MS = 3900/,
+  'A Trophy Road reward should follow rather than overlap the achievement toast');
+assert.match(runtime, /SAMPLE_INTERVAL_MS = 100/,
+  'Driving mechanics should be sampled lightly rather than adding another frame loop');
+assert.match(runtime, /flowEligible/);
+assert.match(runtime, /usedDrift/);
+assert.match(runtime, /usedBoost/);
+assert.match(runtime, /driftChargeGained >= 0\.25/);
+assert.match(runtime, /secondWind\.sawEmpty/);
+assert.match(runtime, /secondWind\.sawRecharge/);
+assert.match(runtime, /settings\?\.balance/);
+assert.match(runtime, /balance >= LISTEN_CLOSELY_MIN_BALANCE/);
+assert.match(runtime, /Number\(state\.speed\) > LISTEN_CLOSELY_MIN_SPEED/);
+assert.match(runtime, /unlock\(\['listen-closely'\]/);
+assert.match(runtime, /store\.addBlankTrack\(context\.trackId\)/);
+assert.match(runtime, /candidates\.push\('beyond-sight'\)/);
+assert.match(runtime, /sampleNightShiftOvertakes/);
+assert.match(runtime, /completedNightShiftSheriff/);
+assert.match(runtime, /candidates\.push\('night-shift-sheriff'\)/);
+assert.match(runtime, /getStoredBestLap/,
+  'Existing saved best laps should be recognised when the new achievements first load');
+assert.match(runtime, /function importStoredTimeTrials\(\)/);
+assert.match(runtime, /unlockSilently\(entries\)/,
+  'Imported records should create unread achievements without interrupting Home with an unlock toast');
+assert.match(runtime, /const timeTrial = qualifyingTimeTrial\(context\.trackId, context\.time\)/);
+assert.match(runtime, /candidates\.push\(timeTrial\.id\)/);
+assert.match(runtime, /candidates\.push\(TIME_TRIAL_MASTER_ID\)/);
+assert.match(runtime, /completedAllTimeTrials/);
+assert.match(runtime, /store\.syncRewards\(\)/);
 assert.match(runtime, /turn:trophy-road-updated/);
 assert.match(runtime, /showRewardToastBatch/);
-assert.match(runtime, /store\.syncRewards\(\)/);
-assert.match(runtime, /LAP_TOAST_DELAY_MS = 4400/);
-assert.match(runtime, /LISTEN_CLOSELY_MIN_BALANCE = 0\.75/);
-assert.match(runtime, /completedNightShiftSheriff/);
-assert.match(runtime, /qualifyingTimeTrial/);
-assert.match(view, /TROPHY ROAD REWARD/);
-assert.match(view, /turn-trophy-road-track/);
-assert.match(view, /achievement\.trophies/);
-assert.match(view, /\+\$\{total\} TROPHIES/);
-assert.match(view, /store\.unseenCount\(\)/);
+assert.match(runtime, /turn-screen-blanked/);
+assert.match(runtime, /reason === 'lap-started'/);
+assert.match(runtime, /reason === 'race-reset'/);
+assert.match(runtime, /reason === 'spectate-started'/);
+assert.match(runtime, /reason === 'spectate-stopped'/);
+assert.match(runtime, /turn:lap-result/);
+assert.match(runtime, /turn:lap-invalid/);
+assert.match(runtime, /turn:track-changed/);
+assert.match(runtime, /turn:achievements-updated/);
+assert.match(runtime, /pendingTrackEntryPulse/);
+assert.match(runtime, /!allOnboardingComplete\(store\)/,
+  'The track-entry prompt should stop after Getting Started is complete');
+
+assert.match(view, /aria-live', 'polite'/);
+assert.match(view, /role="progressbar"/);
+assert.match(view, /data-achievement-filter="onboarding"/);
 assert.match(view, /data-achievement-filter="time-trials"/);
-assert.match(view, /feedbackButton\.after\(homeTrigger\)/);
-assert.match(view, /createTrigger\('m8-feedback-button m8-achievements-button'/);
-assert.match(nightShiftSource, /previousRelation <= 0 && boostActive/);
-assert.match(timeTrialSource, /seconds >= trial\.targetSeconds/);
+assert.match(view, /CATEGORY\.TIME_TRIALS/);
+assert.match(view, /achievement\.id === 'faster-than-the-dev'/);
+assert.match(view, /TIME_TRIAL_ACHIEVEMENT_IDS\.filter/);
+assert.match(view, /achievement\.trophies/);
+assert.match(view, /TROPHY ROAD REWARD/);
+assert.match(view, /turn-trophy-road-progress" role="progressbar"/);
+assert.match(view, /turn-trophy-road-markers" aria-label="Trophy Road rewards"/);
+assert.match(view, /store\.markAllSeen\(\)/);
+assert.match(view, /store\.unseenCount\(\)/);
+assert.match(view, /ATTENTION_VISIBLE_MS = 900/);
+assert.match(view, /is-achievement-pulsing/);
+assert.match(view, /is-achievement-attention/);
+assert.match(view, /achievement\.id === 'listen-closely'/);
+assert.match(view, /achievement\.id === 'beyond-sight'/);
+assert.match(view, /achievement\.id === 'night-shift-sheriff'/);
+assert.match(view, /createTrigger\('m8-feedback-button m8-achievements-button'/,
+  'The Home trigger should reuse the complete Give Feedback typography and geometry');
+assert.match(view, /feedbackButton\.after\(homeTrigger\)/,
+  'Achievements should remain directly after Give Feedback');
+assert.match(view, /createTrigger\('utility turn-race-achievements-button'/);
+assert.match(view, /badge\.textContent = unseenCount > 9 \? '9\+' : String\(unseenCount\)/,
+  'Unseen achievements and rewards should use a compact numeric notification circle');
+assert.match(view, /Achievements, \$\{unseenCount\} new item/);
+assert.match(view, /ONBOARDING_ACHIEVEMENT_IDS\.every/,
+  'Getting Started should be unordered rather than prescribing a next achievement');
+assert.doesNotMatch(view, /turn-achievements-trigger-icon/,
+  'Achievement destination buttons should remain text-only');
+assert.doesNotMatch(view, /badge\.textContent = 'NEXT'/,
+  'Incomplete onboarding must not create a NEXT badge');
+assert.doesNotMatch(view, /is-achievement-next/);
+assert.doesNotMatch(view, /recommended \? 'NEXT'/,
+  'Achievement cards should not impose a linear next challenge');
+
+assert.match(style, /\.m8-achievements-button/);
+assert.match(style, /\.turn-race-achievements-button/);
+assert.match(style, /\.turn-achievements-trigger-badge[\s\S]*position: absolute/);
+assert.match(style, /\.turn-achievements-trigger-badge[\s\S]*border-radius: 50%/);
+assert.match(style, /\.turn-achievements-dialog/);
+assert.match(style, /\.turn-achievement-toast/);
 assert.match(style, /@keyframes turn-achievement-pulse/);
-assert.match(style, /prefers-reduced-motion: reduce/);
+assert.match(style, /animation: turn-achievement-pulse 760ms[^;]* 1/,
+  'The staged Achievements button should pulse once, not repeatedly');
+assert.match(style, /@media \(prefers-reduced-motion: reduce\)/);
+assert.match(style, /var\(--turn-action-success/);
+assert.doesNotMatch(style, /turn-achievements-trigger-icon/);
+assert.doesNotMatch(style, /is-achievement-next/);
+
 assert.match(designTokens, /--turn-action-success: var\(--turn-green-500\)/);
+assert.match(fixedLayout, /installAchievements/);
 assert.match(fixedLayout, /installM8TrophyGate/);
 assert.match(fixedLayout, /r153-trophy-road/);
+assert.ok(fixedLayout.indexOf('installM8HomeCardScrollFixes') < fixedLayout.indexOf('installAchievements'),
+  'Achievements should join the completed fixed Home layout after track scrolling is installed');
 assert.match(workflow, /Run achievement system regression/);
+assert.match(workflow, /node turn-lab\/tests\/achievements-production\.mjs/);
+assert.match(workflow, /Run Trophy Road progression regression/);
 
 console.log('TURN Trophy Road achievement regression passed.');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -109,6 +109,7 @@ const [
   lotLayout,
   lotLayoutCss,
   lotAccessibility,
+  lotTrophyGate,
   originalLot,
   trackIntro,
   trackIntroCss,
@@ -129,6 +130,7 @@ const [
   fs.readFile(path.join(turnDir, 'garage/lot-layout-r60.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'garage/lot-layout-r60.css'), 'utf8'),
   fs.readFile(path.join(turnDir, 'garage/lot-accessibility-r118.js'), 'utf8'),
+  fs.readFile(path.join(turnDir, 'progression/lot-trophy-gate.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'garage/lot-r10.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'ui/track-intro.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'track-intro.css'), 'utf8'),
@@ -152,7 +154,7 @@ assert.equal(imports['./race/lap-system.js?build=20260720-r19'], releaseTarget('
 assert.match(app, /lot-layout-r60\.css\?revision=r121-viewer-r122-fit-r128-super-sedan-notice/);
 assert.match(app, /sports-sedan-easter-egg\.js\?revision=r128-unlock-notice/);
 assert.match(app, /installLotEnhancementRuntime/);
-assert.match(app, /lot-enhancement-runtime\.js\?revision=r121/);
+assert.match(app, /lot-enhancement-runtime\.js\?revision=r153-trophy-road/);
 assert.ok(app.indexOf('installLotEnhancementRuntime()') < app.indexOf("withBuild('./main.js')"));
 
 assert.match(lotWrapper, /showOriginalLot/);
@@ -163,13 +165,21 @@ assert.match(lotWrapper, /track-manager\.js\?build=20260722-r52/);
 assert.doesNotMatch(lotWrapper, /installLotLayout|installLotStatLegend|installLotAccessibility/);
 assert.match(originalLot, /export function showTheLot/);
 
-assert.match(lotEnhancementRuntime, /ENHANCEMENT_ID = 'enhanced-lot-r121'/);
+assert.match(lotEnhancementRuntime, /ENHANCEMENT_ID = 'enhanced-lot-r153-trophy-road'/);
 assert.match(lotEnhancementRuntime, /activeEnhancements = new WeakMap\(\)/);
+assert.match(lotEnhancementRuntime, /gateLotNow\(scope\)/);
 assert.match(lotEnhancementRuntime, /installLotStatLegend\(scope\)/);
 assert.match(lotEnhancementRuntime, /installLotLayout\(scope\)/);
 assert.match(lotEnhancementRuntime, /installLotAccessibility\(scope\)/);
+assert.ok(
+  lotEnhancementRuntime.indexOf('gateLotNow(scope)') < lotEnhancementRuntime.indexOf('installLotAccessibility(scope)'),
+  'Trophy locks must be included in the accessible car names before the accessibility enhancer runs'
+);
 assert.match(lotEnhancementRuntime, /new MutationObserver\(sync\)/);
 assert.match(lotEnhancementRuntime, /screen\.dataset\.lotEnhancements = ENHANCEMENT_ID/);
+assert.match(lotTrophyGate, /FALLBACK_VEHICLE_ID = 'classic'/);
+assert.match(lotTrophyGate, /raceButton\.disabled = locked/);
+assert.match(lotTrophyGate, /aria-disabled/);
 
 assert.match(lotLayout, /viewbox\.appendChild\(colors\)/);
 assert.match(lotLayout, /attributesHeading\.replaceChildren\(document\.createTextNode\('ATTRIBUTES'\)\)/);
@@ -244,4 +254,4 @@ assert.match(easterEggUi, /notice\.setAttribute\('role', 'status'\)/);
 assert.match(easterEggUi, /notice\.setAttribute\('aria-live', 'polite'\)/);
 assert.match(easterEggUi, /card\.insertBefore\(notice, actions \|\| null\)/, 'The explanation must sit immediately before RACE THIS CAR');
 
-console.log(`TURN ${release.id} enhanced Lot route, expanded 3D viewer, accessibility and garage setup passed.`);
+console.log(`TURN ${release.id} enhanced Lot route, Trophy Road gating, accessibility and garage setup passed.`);

--- a/turn-lab/tests/trophy-road-production.mjs
+++ b/turn-lab/tests/trophy-road-production.mjs
@@ -46,16 +46,14 @@ function createMemoryStorage(initial = {}) {
     },
     removeItem(key) {
       memory.delete(key);
-    },
-    snapshot() {
-      return new Map(memory);
     }
   };
 }
 
 assert.equal(TROPHY_ROAD_STORAGE_KEY, 'turn-achievements-v1');
 assert.equal(TROPHY_ROAD_STORAGE_VERSION, 3);
-assert.equal(TROPHY_ROAD_MAX_THRESHOLD, 500);
+assert.equal(TROPHY_ROAD_MAX_THRESHOLD, 1300,
+  'The visible road should continue through the complete current trophy collection');
 assert.deepEqual(
   TROPHY_ROAD_REWARDS.map(({ id, threshold }) => [id, threshold]),
   [
@@ -144,9 +142,11 @@ const permanentReward = normalizeAchievementState({
 assert.deepEqual(permanentReward.rewards.unlocked, ['emergency-pack'],
   'Once awarded, a reward must remain owned even if thresholds change later');
 
+assert.match(roadSource, /TROPHY_ROAD_MAX_THRESHOLD = 1300/);
 assert.match(roadSource, /threshold: 200/);
 assert.match(roadSource, /threshold: 400/);
 assert.match(roadSource, /threshold: 500/);
+assert.match(roadSource, /turn-drive-by-ear-v1/);
 assert.match(roadSource, /prepareTrophyRoadProfile/);
 assert.match(roadSource, /Number\(state\.version \|\| 0\) < TROPHY_ROAD_STORAGE_VERSION/);
 assert.doesNotMatch(roadSource, /clearRivals|resetRivals|rival-storage/);

--- a/turn-lab/tests/trophy-road-production.mjs
+++ b/turn-lab/tests/trophy-road-production.mjs
@@ -188,7 +188,7 @@ assert.ok(
 );
 assert.match(lotEnhancement, /gateLotNow/);
 assert.ok(
-  lotEnhancement.indexOf('gateLotNow') < lotEnhancement.indexOf('installLotAccessibility'),
+  lotEnhancement.indexOf('gateLotNow(scope)') < lotEnhancement.indexOf('installLotAccessibility(scope)'),
   'The accessibility layer should capture the complete locked vehicle names'
 );
 assert.match(roadCss, /@media \(prefers-reduced-motion: reduce\)/);

--- a/turn-lab/tests/trophy-road-production.mjs
+++ b/turn-lab/tests/trophy-road-production.mjs
@@ -83,6 +83,10 @@ assert.equal(isTrackUnlocked('midnight-city', freshStorage), false);
 assert.equal(isVehicleUnlocked('classic', freshStorage), true);
 assert.equal(isVehicleUnlocked('police', freshStorage), false);
 assert.equal(isVehicleUnlocked('race-future', freshStorage), false);
+freshStorage.setItem('turn-drive-by-ear-v1', 'false');
+assert.equal(prepareTrophyRoadProfile(freshStorage), null,
+  'A setting created later in a fresh session must not retroactively grandfather the player');
+assert.deepEqual(readTrophyRoadSnapshot(freshStorage).unlockedRewardIds, []);
 
 const legacyWithoutAchievements = createMemoryStorage({
   'turn-vehicle-selection-v1': JSON.stringify({ carId: 'police' })
@@ -132,6 +136,17 @@ assert.deepEqual(store.unseenRewardIds(), ['midnight-city', 'emergency-pack', 'f
 store.markAllSeen();
 assert.deepEqual(store.unseenRewardIds(), []);
 
+const previousAchievements = globalThis.__turnAchievements;
+const blockedStorage = {
+  getItem() { throw new Error('blocked'); },
+  setItem() { throw new Error('blocked'); }
+};
+globalThis.__turnAchievements = { store };
+assert.equal(isVehicleUnlocked('police', blockedStorage), true,
+  'Session-only rewards must open content even when persistent browser storage is blocked');
+if (previousAchievements === undefined) delete globalThis.__turnAchievements;
+else globalThis.__turnAchievements = previousAchievements;
+
 const permanentReward = normalizeAchievementState({
   version: 3,
   unlocked: {},
@@ -147,6 +162,9 @@ assert.match(roadSource, /threshold: 200/);
 assert.match(roadSource, /threshold: 400/);
 assert.match(roadSource, /threshold: 500/);
 assert.match(roadSource, /turn-drive-by-ear-v1/);
+assert.match(roadSource, /PREPARED_STORAGE = new WeakSet/);
+assert.match(roadSource, /preparationAlreadyChecked/);
+assert.match(roadSource, /globalThis\.__turnAchievements\?\.store/);
 assert.match(roadSource, /prepareTrophyRoadProfile/);
 assert.match(roadSource, /Number\(state\.version \|\| 0\) < TROPHY_ROAD_STORAGE_VERSION/);
 assert.doesNotMatch(roadSource, /clearRivals|resetRivals|rival-storage/);

--- a/turn-lab/tests/trophy-road-production.mjs
+++ b/turn-lab/tests/trophy-road-production.mjs
@@ -1,0 +1,199 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import { createAchievementStore, normalizeAchievementState } from '../../turn/achievements/store.js';
+import {
+  TROPHY_ROAD_MAX_THRESHOLD,
+  TROPHY_ROAD_REWARDS,
+  TROPHY_ROAD_STORAGE_KEY,
+  TROPHY_ROAD_STORAGE_VERSION,
+  getTrophyRoadReward,
+  isTrackUnlocked,
+  isVehicleUnlocked,
+  prepareTrophyRoadProfile,
+  readTrophyRoadSnapshot,
+  rewardForTrack,
+  rewardForVehicle,
+  rewardIdsForTrophies
+} from '../../turn/progression/trophy-road.js';
+
+const [roadSource, roadCss, homeGate, lotGate, view, runtime, app, fixedLayout, lotEnhancement, workflow] = await Promise.all([
+  fs.readFile(new URL('../../turn/progression/trophy-road.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/progression/trophy-road.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/progression/m8-trophy-gate.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/progression/lot-trophy-gate.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/achievements/view.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/achievements/runtime.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/app.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-enhancement-runtime.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../.github/workflows/turn-lab-tests.yml', import.meta.url), 'utf8')
+]);
+
+function createMemoryStorage(initial = {}) {
+  const memory = new Map(Object.entries(initial));
+  return {
+    get length() {
+      return memory.size;
+    },
+    key(index) {
+      return [...memory.keys()][index] ?? null;
+    },
+    getItem(key) {
+      return memory.get(key) ?? null;
+    },
+    setItem(key, value) {
+      memory.set(key, String(value));
+    },
+    removeItem(key) {
+      memory.delete(key);
+    },
+    snapshot() {
+      return new Map(memory);
+    }
+  };
+}
+
+assert.equal(TROPHY_ROAD_STORAGE_KEY, 'turn-achievements-v1');
+assert.equal(TROPHY_ROAD_STORAGE_VERSION, 3);
+assert.equal(TROPHY_ROAD_MAX_THRESHOLD, 500);
+assert.deepEqual(
+  TROPHY_ROAD_REWARDS.map(({ id, threshold }) => [id, threshold]),
+  [
+    ['midnight-city', 200],
+    ['emergency-pack', 400],
+    ['future-racer', 500]
+  ]
+);
+assert.deepEqual(rewardIdsForTrophies(199), []);
+assert.deepEqual(rewardIdsForTrophies(200), ['midnight-city']);
+assert.deepEqual(rewardIdsForTrophies(399), ['midnight-city']);
+assert.deepEqual(rewardIdsForTrophies(400), ['midnight-city', 'emergency-pack']);
+assert.deepEqual(rewardIdsForTrophies(500), ['midnight-city', 'emergency-pack', 'future-racer']);
+assert.equal(rewardForTrack('midnight-city')?.id, 'midnight-city');
+assert.equal(rewardForVehicle('police')?.id, 'emergency-pack');
+assert.equal(rewardForVehicle('ambulance')?.id, 'emergency-pack');
+assert.equal(rewardForVehicle('firetruck')?.id, 'emergency-pack');
+assert.equal(rewardForVehicle('race-future')?.id, 'future-racer');
+assert.equal(getTrophyRoadReward('invented'), null);
+
+const freshStorage = createMemoryStorage();
+assert.equal(prepareTrophyRoadProfile(freshStorage), null,
+  'A genuinely new player must not be mistaken for an existing profile');
+assert.deepEqual(readTrophyRoadSnapshot(freshStorage).unlockedRewardIds, []);
+assert.equal(isTrackUnlocked('countryside', freshStorage), true);
+assert.equal(isTrackUnlocked('midnight-city', freshStorage), false);
+assert.equal(isVehicleUnlocked('classic', freshStorage), true);
+assert.equal(isVehicleUnlocked('police', freshStorage), false);
+assert.equal(isVehicleUnlocked('race-future', freshStorage), false);
+
+const legacyWithoutAchievements = createMemoryStorage({
+  'turn-vehicle-selection-v1': JSON.stringify({ carId: 'police' })
+});
+const preparedLegacy = prepareTrophyRoadProfile(legacyWithoutAchievements);
+assert.equal(preparedLegacy?.version, 2,
+  'Existing TURN profiles without achievement storage need a grandfathering shell');
+assert.equal(readTrophyRoadSnapshot(legacyWithoutAchievements).isLegacyProfile, true);
+assert.deepEqual(
+  readTrophyRoadSnapshot(legacyWithoutAchievements).unlockedRewardIds,
+  ['midnight-city', 'emergency-pack', 'future-racer']
+);
+
+const migrated = normalizeAchievementState({
+  version: 2,
+  unlocked: {
+    'first-turn': { unlockedAt: 1, trackId: 'countryside', vehicleId: 'classic', time: 20 }
+  },
+  seen: ['first-turn'],
+  progress: { tracks: ['countryside'], blankTracks: [] }
+});
+assert.equal(migrated.version, 3);
+assert.deepEqual(migrated.rewards.unlocked, ['midnight-city', 'emergency-pack', 'future-racer']);
+assert.deepEqual(migrated.rewards.seen, migrated.rewards.unlocked,
+  'Grandfathered content must not create a misleading reward notification');
+
+const progressionStorage = createMemoryStorage();
+const store = createAchievementStore(progressionStorage);
+assert.equal(store.trophyTotal(), 0);
+assert.deepEqual(store.syncRewards(), []);
+assert.equal(store.unlock('trust-your-ears', { trackId: 'countryside' })?.trophies, 200);
+assert.equal(store.trophyTotal(), 200);
+assert.deepEqual(store.syncRewards().map((reward) => reward.id), ['midnight-city']);
+assert.equal(store.isRewardUnlocked('midnight-city'), true);
+assert.equal(isTrackUnlocked('midnight-city', progressionStorage), true);
+assert.equal(isVehicleUnlocked('police', progressionStorage), false);
+
+assert.equal(store.unlock('beyond-sight', { trackId: 'midnight-city' })?.trophies, 300);
+assert.equal(store.trophyTotal(), 500);
+assert.deepEqual(
+  store.syncRewards().map((reward) => reward.id),
+  ['emergency-pack', 'future-racer']
+);
+assert.equal(isVehicleUnlocked('police', progressionStorage), true);
+assert.equal(isVehicleUnlocked('race-future', progressionStorage), true);
+assert.deepEqual(store.unseenRewardIds(), ['midnight-city', 'emergency-pack', 'future-racer']);
+store.markAllSeen();
+assert.deepEqual(store.unseenRewardIds(), []);
+
+const permanentReward = normalizeAchievementState({
+  version: 3,
+  unlocked: {},
+  seen: [],
+  progress: { tracks: [], blankTracks: [] },
+  rewards: { unlocked: ['emergency-pack'], seen: ['emergency-pack'] }
+});
+assert.deepEqual(permanentReward.rewards.unlocked, ['emergency-pack'],
+  'Once awarded, a reward must remain owned even if thresholds change later');
+
+assert.match(roadSource, /threshold: 200/);
+assert.match(roadSource, /threshold: 400/);
+assert.match(roadSource, /threshold: 500/);
+assert.match(roadSource, /prepareTrophyRoadProfile/);
+assert.match(roadSource, /Number\(state\.version \|\| 0\) < TROPHY_ROAD_STORAGE_VERSION/);
+assert.doesNotMatch(roadSource, /clearRivals|resetRivals|rival-storage/);
+
+assert.match(homeGate, /data-track-id="\$\{LOCKED_TRACK_ID\}"/);
+assert.match(homeGate, /event\.stopImmediatePropagation\(\)/);
+assert.match(homeGate, /fallbackCard\?\.click\(\)/);
+assert.match(homeGate, /aria-disabled/);
+assert.match(homeGate, /turn:trophy-road-updated/);
+
+assert.match(lotGate, /FALLBACK_VEHICLE_ID = 'classic'/);
+assert.match(lotGate, /raceButton\.disabled = locked/);
+assert.match(lotGate, /colors\.hidden = locked/);
+assert.match(lotGate, /UNLOCKS AT \$\{reward\.threshold\} TROPHIES/);
+assert.match(lotGate, /aria-disabled/);
+
+assert.match(view, /turn-trophy-road-progress" role="progressbar"/);
+assert.match(view, /turn-trophy-road-markers" aria-label="Trophy Road rewards"/);
+assert.ok(
+  view.indexOf('turn-trophy-road-progress" role="progressbar"')
+    < view.indexOf('turn-trophy-road-markers" aria-label="Trophy Road rewards"'),
+  'Reward buttons should be siblings of the progressbar rather than descendants hidden by progressbar semantics'
+);
+assert.match(view, /TROPHY ROAD REWARD/);
+assert.match(view, /store\.unseenCount\(\)/);
+assert.match(runtime, /turn:trophy-road-updated/);
+assert.match(runtime, /showRewardToastBatch/);
+assert.match(runtime, /store\.syncRewards\(\)/);
+
+assert.ok(
+  app.indexOf('prepareTrophyRoadProfile();') < app.indexOf("await import(withBuild('./main.js'))"),
+  'Grandfathering must be prepared before the runtime loads the saved vehicle selection'
+);
+assert.match(app, /lot-enhancement-runtime\.js\?revision=r153-trophy-road/);
+assert.match(fixedLayout, /installM8TrophyGate/);
+assert.ok(
+  fixedLayout.indexOf('installM8TrophyGate') < fixedLayout.indexOf('installAchievements'),
+  'Track access should be gated before achievement UI is installed'
+);
+assert.match(lotEnhancement, /gateLotNow/);
+assert.ok(
+  lotEnhancement.indexOf('gateLotNow') < lotEnhancement.indexOf('installLotAccessibility'),
+  'The accessibility layer should capture the complete locked vehicle names'
+);
+assert.match(roadCss, /@media \(prefers-reduced-motion: reduce\)/);
+assert.match(roadCss, /\.track-card\[data-trophy-locked="true"\]/);
+assert.match(roadCss, /\.lot-car-option\.is-trophy-locked/);
+assert.match(workflow, /Run Trophy Road progression regression/);
+
+console.log('TURN Trophy Road progression regression passed.');

--- a/turn/achievements.js
+++ b/turn/achievements.js
@@ -1,17 +1,25 @@
 export {
   ACHIEVEMENTS,
   ONBOARDING_ACHIEVEMENT_IDS
-} from './achievements/catalog.js?revision=r152-developer-time-trials';
+} from './achievements/catalog.js?revision=r153-trophy-road';
 export {
   ACHIEVEMENT_STORAGE_KEY,
   loadAchievementState,
-  normalizeAchievementState
-} from './achievements/store.js?revision=r152-developer-time-trials';
+  normalizeAchievementState,
+  totalAvailableTrophies
+} from './achievements/store.js?revision=r153-trophy-road';
 export {
   TIME_TRIALS,
   TIME_TRIAL_ACHIEVEMENT_IDS,
   TIME_TRIAL_MASTER_ID,
   completedAllTimeTrials,
   qualifyingTimeTrial
-} from './achievements/time-trials.js?revision=r152-developer-time-trials';
-export { installAchievements } from './achievements/runtime.js?revision=r152-developer-time-trials';
+} from './achievements/time-trials.js?revision=r153-trophy-road';
+export {
+  TROPHY_ROAD_REWARDS,
+  TROPHY_ROAD_MAX_THRESHOLD,
+  isTrackUnlocked,
+  isVehicleUnlocked,
+  prepareTrophyRoadProfile
+} from './progression/trophy-road.js?revision=r153-trophy-road';
+export { installAchievements } from './achievements/runtime.js?revision=r153-trophy-road';

--- a/turn/achievements/catalog.js
+++ b/turn/achievements/catalog.js
@@ -1,7 +1,7 @@
 import {
   TIME_TRIALS,
   TIME_TRIAL_ACHIEVEMENT_IDS
-} from './time-trials.js?revision=r152-developer-time-trials';
+} from './time-trials.js?revision=r153-trophy-road';
 
 export const TRACK_IDS = Object.freeze([
   'countryside',
@@ -78,26 +78,26 @@ export const ICONS = Object.freeze({
 });
 
 export const ACHIEVEMENTS = Object.freeze([
-  Object.freeze({ id: 'first-turn', category: CATEGORY.ONBOARDING, points: 25, title: 'FIRST TURN', description: 'Finish any valid lap.', icon: 'flag' }),
-  Object.freeze({ id: 'take-it-from-the-top', category: CATEGORY.ONBOARDING, points: 25, title: 'TAKE IT FROM THE TOP', description: 'Use Restart Lap after the current lap becomes void.', icon: 'restart' }),
-  Object.freeze({ id: 'charge-through-it', category: CATEGORY.ONBOARDING, points: 25, title: 'CHARGE THROUGH IT', description: 'Recharge at least 25% of the Boost meter while drifting in one lap.', icon: 'charge', progressMax: 25 }),
-  Object.freeze({ id: 'second-wind', category: CATEGORY.ONBOARDING, points: 25, title: 'SECOND WIND', description: 'Run Boost empty, let it recharge, then activate Boost again.', icon: 'wind' }),
-  Object.freeze({ id: 'flow-state', category: CATEGORY.ONBOARDING, points: 50, title: 'FLOW STATE', description: 'Finish a valid lap using only Drift and Boost for forward drive.', recommendation: 'Recommended: Training Car · Countryside', icon: 'flow' }),
-  Object.freeze({ id: 'watch-and-learn', category: CATEGORY.ONBOARDING, points: 25, title: 'WATCH AND LEARN', description: 'Spectate a rival for five seconds, then return to the start.', icon: 'spectate', progressMax: 5 }),
-  Object.freeze({ id: 'your-own-rival', category: CATEGORY.ONBOARDING, points: 25, title: 'YOUR OWN RIVAL', description: 'Finish a valid lap with one of your saved rivals on the track.', icon: 'rival' }),
-  Object.freeze({ id: 'level-head', category: CATEGORY.ONBOARDING, points: 25, title: 'LEVEL HEAD', description: 'Recalibrate, then finish a valid lap.', icon: 'level' }),
-  Object.freeze({ id: 'new-wheels', category: CATEGORY.ONBOARDING, points: 25, title: 'NEW WHEELS', description: 'Finish a valid lap with a vehicle other than the Training Car.', icon: 'wheel' }),
-  Object.freeze({ id: 'new-ground', category: CATEGORY.ONBOARDING, points: 25, title: 'NEW GROUND', description: 'Finish valid laps on two different tracks.', icon: 'map', progressMax: 2 }),
-  Object.freeze({ id: 'trust-your-ears', category: CATEGORY.WAYS_TO_PLAY, points: 200, title: 'TRUST YOUR EARS', description: 'Finish a valid lap with Blank screen mode on from start to finish.', icon: 'blind' }),
-  Object.freeze({ id: 'listen-closely', category: CATEGORY.WAYS_TO_PLAY, points: 50, title: 'LISTEN CLOSELY', description: 'Set Sound balance to at least 75% Drive By Ear, then drive for ten seconds with Blank screen mode on.', recommendation: 'Recommended for non-visual driving: 90% Drive By Ear', icon: 'listen', progressMax: 10 }),
-  Object.freeze({ id: 'beyond-sight', category: CATEGORY.WAYS_TO_PLAY, points: 300, title: 'BEYOND SIGHT', description: 'Finish a valid lap on every track with Blank screen mode on from start to finish.', icon: 'blindRoute', progressMax: TRACK_IDS.length }),
-  Object.freeze({ id: 'around-the-turn', category: CATEGORY.EXPLORATION, points: 100, title: 'AROUND THE TURN', description: 'Finish a valid lap on every track.', icon: 'route', progressMax: TRACK_IDS.length }),
-  Object.freeze({ id: 'ahead-of-yourself', category: CATEGORY.RACING, points: 50, title: 'AHEAD OF YOURSELF', description: 'Finish first in a lap with at least one saved rival.', icon: 'trophy' }),
-  Object.freeze({ id: 'night-shift-sheriff', category: CATEGORY.RACING, points: 100, title: 'NIGHT SHIFT SHERIFF', description: 'In Midnight City, use the Police Car to beat four non-police rivals. Overtake each one while Boost is active.', icon: 'siren', progressMax: 4 }),
+  Object.freeze({ id: 'first-turn', category: CATEGORY.ONBOARDING, trophies: 25, title: 'FIRST TURN', description: 'Finish any valid lap.', icon: 'flag' }),
+  Object.freeze({ id: 'take-it-from-the-top', category: CATEGORY.ONBOARDING, trophies: 25, title: 'TAKE IT FROM THE TOP', description: 'Use Restart Lap after the current lap becomes void.', icon: 'restart' }),
+  Object.freeze({ id: 'charge-through-it', category: CATEGORY.ONBOARDING, trophies: 25, title: 'CHARGE THROUGH IT', description: 'Recharge at least 25% of the Boost meter while drifting in one lap.', icon: 'charge', progressMax: 25 }),
+  Object.freeze({ id: 'second-wind', category: CATEGORY.ONBOARDING, trophies: 25, title: 'SECOND WIND', description: 'Run Boost empty, let it recharge, then activate Boost again.', icon: 'wind' }),
+  Object.freeze({ id: 'flow-state', category: CATEGORY.ONBOARDING, trophies: 50, title: 'FLOW STATE', description: 'Finish a valid lap using only Drift and Boost for forward drive.', recommendation: 'Recommended: Training Car · Countryside', icon: 'flow' }),
+  Object.freeze({ id: 'watch-and-learn', category: CATEGORY.ONBOARDING, trophies: 25, title: 'WATCH AND LEARN', description: 'Spectate a rival for five seconds, then return to the start.', icon: 'spectate', progressMax: 5 }),
+  Object.freeze({ id: 'your-own-rival', category: CATEGORY.ONBOARDING, trophies: 25, title: 'YOUR OWN RIVAL', description: 'Finish a valid lap with one of your saved rivals on the track.', icon: 'rival' }),
+  Object.freeze({ id: 'level-head', category: CATEGORY.ONBOARDING, trophies: 25, title: 'LEVEL HEAD', description: 'Recalibrate, then finish a valid lap.', icon: 'level' }),
+  Object.freeze({ id: 'new-wheels', category: CATEGORY.ONBOARDING, trophies: 25, title: 'NEW WHEELS', description: 'Finish a valid lap with a vehicle other than the Training Car.', icon: 'wheel' }),
+  Object.freeze({ id: 'new-ground', category: CATEGORY.ONBOARDING, trophies: 25, title: 'NEW GROUND', description: 'Finish valid laps on two different tracks.', icon: 'map', progressMax: 2 }),
+  Object.freeze({ id: 'trust-your-ears', category: CATEGORY.WAYS_TO_PLAY, trophies: 200, title: 'TRUST YOUR EARS', description: 'Finish a valid lap with Blank screen mode on from start to finish.', icon: 'blind' }),
+  Object.freeze({ id: 'listen-closely', category: CATEGORY.WAYS_TO_PLAY, trophies: 50, title: 'LISTEN CLOSELY', description: 'Set Sound balance to at least 75% Drive By Ear, then drive for ten seconds with Blank screen mode on.', recommendation: 'Recommended for non-visual driving: 90% Drive By Ear', icon: 'listen', progressMax: 10 }),
+  Object.freeze({ id: 'beyond-sight', category: CATEGORY.WAYS_TO_PLAY, trophies: 300, title: 'BEYOND SIGHT', description: 'Finish a valid lap on every track with Blank screen mode on from start to finish.', icon: 'blindRoute', progressMax: TRACK_IDS.length }),
+  Object.freeze({ id: 'around-the-turn', category: CATEGORY.EXPLORATION, trophies: 100, title: 'AROUND THE TURN', description: 'Finish a valid lap on every track.', icon: 'route', progressMax: TRACK_IDS.length }),
+  Object.freeze({ id: 'ahead-of-yourself', category: CATEGORY.RACING, trophies: 50, title: 'AHEAD OF YOURSELF', description: 'Finish first in a lap with at least one saved rival.', icon: 'trophy' }),
+  Object.freeze({ id: 'night-shift-sheriff', category: CATEGORY.RACING, trophies: 100, title: 'NIGHT SHIFT SHERIFF', description: 'In Midnight City, use the Police Car to beat four non-police rivals. Overtake each one while Boost is active.', icon: 'siren', progressMax: 4 }),
   ...TIME_TRIALS.map((trial) => Object.freeze({
     id: trial.id,
     category: CATEGORY.TIME_TRIALS,
-    points: 25,
+    trophies: 25,
     title: trial.title,
     description: trial.description,
     recommendation: 'Recommended: Future Racer',
@@ -106,7 +106,7 @@ export const ACHIEVEMENTS = Object.freeze([
   Object.freeze({
     id: 'faster-than-the-dev',
     category: CATEGORY.TIME_TRIALS,
-    points: 100,
+    trophies: 100,
     title: 'FASTER THAN THE DEV',
     description: 'Beat every developer target time.',
     recommendation: 'The target times were set with the Future Racer.',

--- a/turn/achievements/runtime.js
+++ b/turn/achievements/runtime.js
@@ -2,15 +2,15 @@ import {
   ACHIEVEMENTS,
   TRACK_IDS,
   TRAINING_CAR_ID
-} from './catalog.js?revision=r152-developer-time-trials';
+} from './catalog.js?revision=r153-trophy-road';
 import {
   createAchievementStore,
   normalizeAchievementState
-} from './store.js?revision=r152-developer-time-trials';
+} from './store.js?revision=r153-trophy-road';
 import {
   allOnboardingComplete,
   createAchievementView
-} from './view.js?revision=r152-developer-time-trials';
+} from './view.js?revision=r153-trophy-road';
 import {
   completedNightShiftSheriff,
   createNightShiftAttempt,
@@ -21,7 +21,7 @@ import {
   TIME_TRIAL_MASTER_ID,
   completedAllTimeTrials,
   qualifyingTimeTrial
-} from './time-trials.js?revision=r152-developer-time-trials';
+} from './time-trials.js?revision=r153-trophy-road';
 import { replayFrameAt } from '../race/replay-system.js?revision=r146-achievement-expansion';
 import { getStoredBestLap } from '../race/rival-storage.js';
 
@@ -30,6 +30,7 @@ const LISTEN_CLOSELY_REQUIRED_MS = 10000;
 const LISTEN_CLOSELY_MIN_BALANCE = 0.75;
 const LISTEN_CLOSELY_MIN_SPEED = 1;
 const LAP_TOAST_DELAY_MS = 4400;
+const REWARD_TOAST_OFFSET_MS = 3900;
 const SAMPLE_INTERVAL_MS = 100;
 const MAX_SAMPLE_DELTA_MS = 250;
 
@@ -92,7 +93,9 @@ export function installAchievements(runtime = globalThis.__turnRuntime) {
     spectateStartedAt: 0,
     pendingTrackEntryPulse: false,
     pendingToastAchievements: [],
+    pendingToastRewards: [],
     toastTimer: 0,
+    rewardToastTimer: 0,
     listenCloselyMs: 0,
     lastSampleAt: performance.now(),
     secondWind: {
@@ -111,11 +114,29 @@ export function installAchievements(runtime = globalThis.__turnRuntime) {
     }));
   }
 
+  function announceRewardUpdate(rewards) {
+    if (!rewards.length) return;
+    window.dispatchEvent(new CustomEvent('turn:trophy-road-updated', {
+      detail: {
+        unlocked: rewards.map((reward) => reward.id),
+        trophies: store.trophyTotal()
+      }
+    }));
+  }
+
   function scheduleToastFlush(delay = 0) {
     window.clearTimeout(session.toastTimer);
     session.toastTimer = window.setTimeout(() => {
       session.toastTimer = 0;
       view.showToastBatch(session.pendingToastAchievements.splice(0));
+    }, delay);
+  }
+
+  function scheduleRewardToastFlush(delay = 0) {
+    window.clearTimeout(session.rewardToastTimer);
+    session.rewardToastTimer = window.setTimeout(() => {
+      session.rewardToastTimer = 0;
+      view.showRewardToastBatch(session.pendingToastRewards.splice(0));
     }, delay);
   }
 
@@ -129,6 +150,29 @@ export function installAchievements(runtime = globalThis.__turnRuntime) {
     if (delay >= 0) scheduleToastFlush(delay);
   }
 
+  function queueRewards(rewards, { delay = 0 } = {}) {
+    for (const reward of rewards) {
+      if (!reward || session.pendingToastRewards.some((item) => item.id === reward.id)) continue;
+      session.pendingToastRewards.push(reward);
+    }
+    view.syncTriggers();
+    view.render();
+    if (delay >= 0) scheduleRewardToastFlush(delay);
+  }
+
+  function syncRewards({ delay = 0, silent = false } = {}) {
+    const rewards = store.syncRewards();
+    if (!rewards.length) return [];
+    announceRewardUpdate(rewards);
+    if (silent) {
+      view.syncTriggers();
+      view.render();
+    } else {
+      queueRewards(rewards, { delay });
+    }
+    return rewards;
+  }
+
   function unlock(ids, context, options = {}) {
     const unlocked = ids
       .map((id) => store.unlock(id, context))
@@ -136,6 +180,10 @@ export function installAchievements(runtime = globalThis.__turnRuntime) {
     if (!unlocked.length) return [];
     announceAchievementUpdate(unlocked);
     queueUnlocked(unlocked, options);
+    const rewardDelay = options.delay >= 0
+      ? options.delay + REWARD_TOAST_OFFSET_MS
+      : -1;
+    syncRewards({ delay: rewardDelay });
     return unlocked;
   }
 
@@ -145,6 +193,7 @@ export function installAchievements(runtime = globalThis.__turnRuntime) {
       .filter(Boolean);
     if (!unlocked.length) return [];
     announceAchievementUpdate(unlocked);
+    syncRewards({ silent: true });
     view.syncTriggers();
     view.render();
     return unlocked;
@@ -318,6 +367,11 @@ export function installAchievements(runtime = globalThis.__turnRuntime) {
     if (!view.raceTrigger.hidden && session.pendingToastAchievements.length) {
       scheduleToastFlush(300);
     }
+    if (!view.raceTrigger.hidden && session.pendingToastRewards.length) {
+      scheduleRewardToastFlush(
+        session.pendingToastAchievements.length ? REWARD_TOAST_OFFSET_MS : 300
+      );
+    }
   }
 
   calibrateButton.addEventListener('click', () => {
@@ -350,8 +404,13 @@ export function installAchievements(runtime = globalThis.__turnRuntime) {
     if (reason === 'race-reset') {
       if (session.currentLapVoid) {
         unlock(['take-it-from-the-top'], unlockContext(runtime), { delay: 300 });
-      } else if (session.pendingToastAchievements.length) {
-        scheduleToastFlush(300);
+      } else {
+        if (session.pendingToastAchievements.length) scheduleToastFlush(300);
+        if (session.pendingToastRewards.length) {
+          scheduleRewardToastFlush(
+            session.pendingToastAchievements.length ? REWARD_TOAST_OFFSET_MS : 300
+          );
+        }
       }
       session.currentLapVoid = false;
       session.currentLap = null;
@@ -396,6 +455,7 @@ export function installAchievements(runtime = globalThis.__turnRuntime) {
     open: view.open,
     close: view.close,
     unlock: (id, context = {}) => unlock([id], context, { delay: 0 }),
+    getTrophies: () => store.trophyTotal(),
     getState: () => normalizeAchievementState(store.state)
   });
   globalThis.__turnAchievements = api;

--- a/turn/achievements/store.js
+++ b/turn/achievements/store.js
@@ -1,10 +1,18 @@
 import {
+  ACHIEVEMENTS,
   TRACK_IDS,
   getAchievement
-} from './catalog.js?revision=r152-developer-time-trials';
+} from './catalog.js?revision=r153-trophy-road';
+import {
+  TROPHY_ROAD_REWARDS,
+  TROPHY_ROAD_STORAGE_KEY,
+  TROPHY_ROAD_STORAGE_VERSION,
+  getTrophyRoadReward,
+  rewardIdsForTrophies
+} from '../progression/trophy-road.js?revision=r153-trophy-road';
 
-export const ACHIEVEMENT_STORAGE_KEY = 'turn-achievements-v1';
-const STORAGE_VERSION = 2;
+export const ACHIEVEMENT_STORAGE_KEY = TROPHY_ROAD_STORAGE_KEY;
+const STORAGE_VERSION = TROPHY_ROAD_STORAGE_VERSION;
 
 function defaultStoredState() {
   return {
@@ -14,6 +22,10 @@ function defaultStoredState() {
     progress: {
       tracks: [],
       blankTracks: []
+    },
+    rewards: {
+      unlocked: [],
+      seen: []
     }
   };
 }
@@ -22,6 +34,13 @@ function normalizedStringArray(value, allowed = null) {
   if (!Array.isArray(value)) return [];
   const unique = [...new Set(value.filter((item) => typeof item === 'string'))];
   return allowed ? unique.filter((item) => allowed.includes(item)) : unique;
+}
+
+function totalTrophiesFromUnlocked(unlocked) {
+  return Object.keys(unlocked).reduce((total, id) => {
+    const trophies = Number(getAchievement(id)?.trophies);
+    return total + (Number.isFinite(trophies) ? trophies : 0);
+  }, 0);
 }
 
 export function normalizeAchievementState(value) {
@@ -47,6 +66,17 @@ export function normalizeAchievementState(value) {
     blankTracks.push(existingTrustTrack);
   }
 
+  const rewardIds = TROPHY_ROAD_REWARDS.map((reward) => reward.id);
+  const legacyProfile = Number(value.version || 0) < STORAGE_VERSION;
+  const earnedRewardIds = rewardIdsForTrophies(totalTrophiesFromUnlocked(unlocked));
+  const storedRewardIds = normalizedStringArray(value.rewards?.unlocked, rewardIds);
+  const unlockedRewards = legacyProfile
+    ? [...rewardIds]
+    : [...new Set([...storedRewardIds, ...earnedRewardIds])];
+  const storedSeenRewards = normalizedStringArray(value.rewards?.seen, rewardIds)
+    .filter((id) => unlockedRewards.includes(id));
+  const seenRewards = legacyProfile ? [...unlockedRewards] : storedSeenRewards;
+
   return {
     version: STORAGE_VERSION,
     unlocked,
@@ -54,6 +84,10 @@ export function normalizeAchievementState(value) {
     progress: {
       tracks,
       blankTracks
+    },
+    rewards: {
+      unlocked: unlockedRewards,
+      seen: seenRewards
     }
   };
 }
@@ -89,6 +123,14 @@ export function createAchievementStore(storage = globalThis.localStorage) {
     return Boolean(state.unlocked[id]);
   }
 
+  function trophyTotal() {
+    return totalTrophiesFromUnlocked(state.unlocked);
+  }
+
+  function isRewardUnlocked(id) {
+    return state.rewards.unlocked.includes(id);
+  }
+
   function unlock(id, context = {}) {
     const achievement = getAchievement(id);
     if (!achievement || isUnlocked(id)) return null;
@@ -100,6 +142,18 @@ export function createAchievementStore(storage = globalThis.localStorage) {
     };
     save();
     return achievement;
+  }
+
+  function syncRewards() {
+    const newlyUnlocked = [];
+    for (const rewardId of rewardIdsForTrophies(trophyTotal())) {
+      if (isRewardUnlocked(rewardId)) continue;
+      state.rewards.unlocked.push(rewardId);
+      const reward = getTrophyRoadReward(rewardId);
+      if (reward) newlyUnlocked.push(reward);
+    }
+    if (newlyUnlocked.length) save();
+    return newlyUnlocked;
   }
 
   function addProgressTrack(key, trackId) {
@@ -122,6 +176,7 @@ export function createAchievementStore(storage = globalThis.localStorage) {
 
   function markAllSeen() {
     state.seen = Object.keys(state.unlocked);
+    state.rewards.seen = [...state.rewards.unlocked];
     save();
   }
 
@@ -130,14 +185,36 @@ export function createAchievementStore(storage = globalThis.localStorage) {
     return Object.keys(state.unlocked).filter((id) => !seen.has(id));
   }
 
+  function unseenRewardIds() {
+    const seen = new Set(state.rewards.seen);
+    return state.rewards.unlocked.filter((id) => !seen.has(id));
+  }
+
+  function unseenCount() {
+    return unseenIds().length + unseenRewardIds().length;
+  }
+
+  // Persist version and migration changes immediately, even when no new
+  // achievement is unlocked during this session.
+  save();
+
   return Object.freeze({
     state,
     isUnlocked,
     unlock,
+    trophyTotal,
+    isRewardUnlocked,
+    syncRewards,
     addTrack,
     addBlankTrack,
     markAllSeen,
     unseenIds,
+    unseenRewardIds,
+    unseenCount,
     storageAvailable: () => storageAvailable
   });
+}
+
+export function totalAvailableTrophies() {
+  return ACHIEVEMENTS.reduce((total, achievement) => total + achievement.trophies, 0);
 }

--- a/turn/achievements/view.js
+++ b/turn/achievements/view.js
@@ -144,9 +144,9 @@ function createDialog() {
           <div class="turn-achievements-summary-main">
             <strong id="turnAchievementsSummaryTitle">0 OF ${ACHIEVEMENTS.length} UNLOCKED</strong>
             <div class="turn-trophy-road">
-              <div class="turn-trophy-road-track" role="progressbar" aria-label="Trophy Road progress" aria-valuemin="0" aria-valuemax="${TROPHY_ROAD_MAX_THRESHOLD}" aria-valuenow="0">
-                <i></i>
-                <div class="turn-trophy-road-markers"></div>
+              <div class="turn-trophy-road-track">
+                <div class="turn-trophy-road-progress" role="progressbar" aria-label="Trophy Road progress" aria-valuemin="0" aria-valuemax="${TROPHY_ROAD_MAX_THRESHOLD}" aria-valuenow="0"><i></i></div>
+                <div class="turn-trophy-road-markers" aria-label="Trophy Road rewards"></div>
               </div>
             </div>
           </div>
@@ -238,7 +238,7 @@ export function createAchievementView({ store, session, utilityGroup }) {
   const rewardToast = createToast('turn-achievement-toast turn-trophy-reward-toast', 'TROPHY ROAD REWARD');
   const list = dialog.querySelector('.turn-achievements-list');
   const totalTitle = dialog.querySelector('#turnAchievementsSummaryTitle');
-  const trophyRoad = dialog.querySelector('.turn-trophy-road-track');
+  const trophyRoad = dialog.querySelector('.turn-trophy-road-progress');
   const trophyRoadFill = trophyRoad.querySelector('i');
   const trophyRoadMarkers = dialog.querySelector('.turn-trophy-road-markers');
   const trophyRoadDetail = dialog.querySelector('.turn-trophy-road-detail');

--- a/turn/achievements/view.js
+++ b/turn/achievements/view.js
@@ -7,10 +7,17 @@ import {
   TRACK_NAMES,
   VEHICLE_NAMES,
   TRACK_IDS
-} from './catalog.js?revision=r152-developer-time-trials';
+} from './catalog.js?revision=r153-trophy-road';
 import {
   TIME_TRIAL_ACHIEVEMENT_IDS
-} from './time-trials.js?revision=r152-developer-time-trials';
+} from './time-trials.js?revision=r153-trophy-road';
+import {
+  TROPHY_ICON,
+  TROPHY_ROAD_MAX_THRESHOLD,
+  TROPHY_ROAD_REWARDS,
+  TROPHY_ROAD_REWARD_ICONS,
+  getTrophyRoadReward
+} from '../progression/trophy-road.js?revision=r153-trophy-road';
 
 const TOAST_VISIBLE_MS = 3600;
 const ATTENTION_VISIBLE_MS = 900;
@@ -89,7 +96,7 @@ function achievementCard(achievement, store, session) {
     <article class="${classes}" data-achievement-category="${achievement.category}" data-achievement-status="${status.toLowerCase().replace(' ', '-')}">
       <div class="turn-achievement-icon" aria-hidden="true">${ICONS[achievement.icon]}</div>
       <div class="turn-achievement-copy">
-        <span>${CATEGORY_LABELS[achievement.category]} · ${achievement.points} points</span>
+        <span>${CATEGORY_LABELS[achievement.category]} · ${achievement.trophies} trophies</span>
         <h4>${achievement.title}</h4>
         <p>${achievement.description}</p>
         ${achievement.recommendation && !unlocked ? `<small>${achievement.recommendation}</small>` : ''}
@@ -105,7 +112,7 @@ function installStylesheet() {
   const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
   const stylesheet = document.createElement('link');
   stylesheet.rel = 'stylesheet';
-  stylesheet.href = `/turn/achievements.css?build=${buildKey}-r146-achievement-expansion`;
+  stylesheet.href = `/turn/achievements.css?build=${buildKey}-r153-trophy-road`;
   stylesheet.setAttribute('data-turn-achievements', '');
   document.head.appendChild(stylesheet);
 }
@@ -134,12 +141,18 @@ function createDialog() {
       </header>
       <div class="turn-achievements-content">
         <section class="turn-achievements-summary" aria-labelledby="turnAchievementsSummaryTitle">
-          <div>
+          <div class="turn-achievements-summary-main">
             <strong id="turnAchievementsSummaryTitle">0 OF ${ACHIEVEMENTS.length} UNLOCKED</strong>
-            <div class="turn-achievements-total-progress" role="progressbar" aria-label="Total achievement completion" aria-valuemin="0" aria-valuemax="${ACHIEVEMENTS.length}" aria-valuenow="0"><i></i></div>
+            <div class="turn-trophy-road">
+              <div class="turn-trophy-road-track" role="progressbar" aria-label="Trophy Road progress" aria-valuemin="0" aria-valuemax="${TROPHY_ROAD_MAX_THRESHOLD}" aria-valuenow="0">
+                <i></i>
+                <div class="turn-trophy-road-markers"></div>
+              </div>
+            </div>
           </div>
-          <p><span>POINTS</span><strong class="turn-achievements-points">0</strong></p>
+          <p class="turn-achievements-trophy-total"><span>TROPHIES</span><strong><i aria-hidden="true">${TROPHY_ICON}</i><b>0</b></strong></p>
           <p><span>COMPLETION</span><strong class="turn-achievements-percent">0%</strong></p>
+          <div class="turn-trophy-road-detail" aria-live="polite"></div>
         </section>
         <p class="turn-achievements-storage-note" hidden>Achievement progress is available for this session but cannot be saved because local storage is unavailable.</p>
         <div class="turn-achievements-filters" aria-label="Achievement filters">
@@ -155,16 +168,16 @@ function createDialog() {
   return dialog;
 }
 
-function createToast() {
+function createToast(className, label) {
   const toast = document.createElement('div');
-  toast.className = 'turn-achievement-toast';
+  toast.className = className;
   toast.hidden = true;
   toast.setAttribute('role', 'status');
   toast.setAttribute('aria-live', 'polite');
   toast.setAttribute('aria-atomic', 'true');
   toast.innerHTML = `
     <div class="turn-achievement-toast-icon" aria-hidden="true"></div>
-    <div><span>ACHIEVEMENT UNLOCKED</span><strong></strong></div>
+    <div><span>${label}</span><strong></strong></div>
     <b></b>`;
   document.body.appendChild(toast);
   return toast;
@@ -195,6 +208,13 @@ function installFilters(dialog) {
   return apply;
 }
 
+function initialRewardSelection(store) {
+  const unseen = store.unseenRewardIds()[0];
+  if (unseen) return unseen;
+  const next = TROPHY_ROAD_REWARDS.find((reward) => !store.isRewardUnlocked(reward.id));
+  return next?.id || TROPHY_ROAD_REWARDS.at(-1)?.id || '';
+}
+
 export function createAchievementView({ store, session, utilityGroup }) {
   const homeMenu = document.querySelector('.m8-home-menu');
   const homeStatus = homeMenu?.querySelector('.m8-home-status');
@@ -205,39 +225,92 @@ export function createAchievementView({ store, session, utilityGroup }) {
   }
 
   installStylesheet();
-  const homeTrigger = createTrigger('m8-home-settings m8-achievements-button');
+  const homeTrigger = createTrigger('m8-feedback-button m8-achievements-button');
   homeTrigger.style.setProperty('background', 'var(--turn-action-success, #8ce99a)');
   const raceTrigger = createTrigger('utility turn-race-achievements-button', 'Achievements');
-  if (feedbackButton) homeMenu.insertBefore(homeTrigger, feedbackButton);
+  if (feedbackButton) feedbackButton.after(homeTrigger);
   else homeMenu.insertBefore(homeTrigger, homeStatus);
   if (spectateButton) utilityGroup.insertBefore(raceTrigger, spectateButton);
   else utilityGroup.appendChild(raceTrigger);
 
   const dialog = createDialog();
-  const toast = createToast();
+  const toast = createToast('turn-achievement-toast', 'ACHIEVEMENT UNLOCKED');
+  const rewardToast = createToast('turn-achievement-toast turn-trophy-reward-toast', 'TROPHY ROAD REWARD');
   const list = dialog.querySelector('.turn-achievements-list');
   const totalTitle = dialog.querySelector('#turnAchievementsSummaryTitle');
-  const totalProgress = dialog.querySelector('.turn-achievements-total-progress');
-  const totalProgressFill = totalProgress.querySelector('i');
-  const points = dialog.querySelector('.turn-achievements-points');
+  const trophyRoad = dialog.querySelector('.turn-trophy-road-track');
+  const trophyRoadFill = trophyRoad.querySelector('i');
+  const trophyRoadMarkers = dialog.querySelector('.turn-trophy-road-markers');
+  const trophyRoadDetail = dialog.querySelector('.turn-trophy-road-detail');
+  const trophyTotal = dialog.querySelector('.turn-achievements-trophy-total b');
   const percent = dialog.querySelector('.turn-achievements-percent');
   const storageNote = dialog.querySelector('.turn-achievements-storage-note');
   const closeButton = dialog.querySelector('[data-dialog-close]');
   const applyFilter = installFilters(dialog);
+  let selectedRewardId = '';
   let returnFocus = null;
   let toastHideTimer = 0;
+  let rewardToastHideTimer = 0;
   let attentionTimer = 0;
+
+  function renderTrophyRoad(total) {
+    if (!selectedRewardId || !getTrophyRoadReward(selectedRewardId)) {
+      selectedRewardId = initialRewardSelection(store);
+    }
+    const nextReward = TROPHY_ROAD_REWARDS.find((reward) => !store.isRewardUnlocked(reward.id));
+    trophyRoad.setAttribute('aria-valuenow', String(Math.min(total, TROPHY_ROAD_MAX_THRESHOLD)));
+    trophyRoad.setAttribute(
+      'aria-valuetext',
+      nextReward
+        ? `${total} trophies. ${Math.max(0, nextReward.threshold - total)} trophies until ${nextReward.shortTitle}.`
+        : `${total} trophies. Every current Trophy Road reward is unlocked.`
+    );
+    trophyRoadFill.style.setProperty(
+      '--turn-trophy-road-progress',
+      `${Math.min(100, (total / TROPHY_ROAD_MAX_THRESHOLD) * 100)}%`
+    );
+    trophyRoadMarkers.innerHTML = TROPHY_ROAD_REWARDS.map((reward) => {
+      const unlocked = store.isRewardUnlocked(reward.id);
+      const selected = reward.id === selectedRewardId;
+      const position = Math.min(100, (reward.threshold / TROPHY_ROAD_MAX_THRESHOLD) * 100);
+      return `<button
+        type="button"
+        class="turn-trophy-road-marker ${unlocked ? 'is-unlocked' : 'is-locked'} ${selected ? 'is-selected' : ''}"
+        data-trophy-reward="${reward.id}"
+        style="--turn-trophy-road-position:${position}%"
+        aria-pressed="${selected}"
+        aria-label="${reward.shortTitle}. ${reward.threshold} trophies. ${unlocked ? 'Unlocked' : 'Locked'}"
+      ><span aria-hidden="true">${TROPHY_ROAD_REWARD_ICONS[reward.icon]}</span><b>${reward.threshold}</b></button>`;
+    }).join('');
+
+    const reward = getTrophyRoadReward(selectedRewardId) || TROPHY_ROAD_REWARDS[0];
+    const unlocked = store.isRewardUnlocked(reward.id);
+    const remaining = Math.max(0, reward.threshold - total);
+    trophyRoadDetail.innerHTML = `
+      <div class="turn-trophy-road-detail-icon" aria-hidden="true">${TROPHY_ROAD_REWARD_ICONS[reward.icon]}</div>
+      <div>
+        <span>${reward.threshold} TROPHIES · ${unlocked ? 'UNLOCKED' : `${remaining} TO GO`}</span>
+        <h3>${reward.title}</h3>
+        <p>${reward.description}</p>
+      </div>`;
+  }
+
+  trophyRoadMarkers.addEventListener('click', (event) => {
+    const marker = event.target.closest('[data-trophy-reward]');
+    if (!marker) return;
+    selectedRewardId = marker.dataset.trophyReward;
+    renderTrophyRoad(store.trophyTotal());
+    trophyRoadMarkers.querySelector(`[data-trophy-reward="${selectedRewardId}"]`)?.focus();
+  });
 
   function render() {
     const unlockedCount = Object.keys(store.state.unlocked).length;
-    const totalPoints = ACHIEVEMENTS.reduce((sum, achievement) =>
-      sum + (store.isUnlocked(achievement.id) ? achievement.points : 0), 0);
+    const trophies = store.trophyTotal();
     const completion = Math.round((unlockedCount / ACHIEVEMENTS.length) * 100);
     totalTitle.textContent = `${unlockedCount} OF ${ACHIEVEMENTS.length} UNLOCKED`;
-    totalProgress.setAttribute('aria-valuenow', String(unlockedCount));
-    totalProgressFill.style.setProperty('--turn-achievement-progress', `${completion}%`);
-    points.textContent = String(totalPoints);
+    trophyTotal.textContent = String(trophies);
     percent.textContent = `${completion}%`;
+    renderTrophyRoad(trophies);
     storageNote.hidden = store.storageAvailable();
     list.innerHTML = ACHIEVEMENTS
       .map((achievement) => achievementCard(achievement, store, session))
@@ -246,7 +319,7 @@ export function createAchievementView({ store, session, utilityGroup }) {
   }
 
   function syncTriggers() {
-    const unseenCount = store.unseenIds().length;
+    const unseenCount = store.unseenCount();
     for (const button of [homeTrigger, raceTrigger]) {
       const badge = button.querySelector('.turn-achievements-trigger-badge');
       if (unseenCount > 0) {
@@ -254,7 +327,7 @@ export function createAchievementView({ store, session, utilityGroup }) {
         badge.hidden = false;
         button.setAttribute(
           'aria-label',
-          `Achievements, ${unseenCount} new achievement${unseenCount === 1 ? '' : 's'}`
+          `Achievements, ${unseenCount} new item${unseenCount === 1 ? '' : 's'}`
         );
       } else {
         badge.hidden = true;
@@ -268,6 +341,7 @@ export function createAchievementView({ store, session, utilityGroup }) {
 
   function open(trigger) {
     returnFocus = trigger;
+    selectedRewardId = initialRewardSelection(store);
     render();
     if (typeof dialog.showModal === 'function') dialog.showModal();
     else dialog.setAttribute('open', '');
@@ -305,32 +379,48 @@ export function createAchievementView({ store, session, utilityGroup }) {
     }, ATTENTION_VISIBLE_MS);
   }
 
-  function showToastBatch(batch) {
+  function showToast(toastElement, batch, { reward = false } = {}) {
     if (!batch.length) return;
-    window.clearTimeout(toastHideTimer);
+    const timerKey = reward ? 'reward' : 'achievement';
+    if (timerKey === 'reward') window.clearTimeout(rewardToastHideTimer);
+    else window.clearTimeout(toastHideTimer);
     const first = batch[0];
-    const total = batch.reduce((sum, achievement) => sum + achievement.points, 0);
-    toast.querySelector('.turn-achievement-toast-icon').innerHTML = batch.length === 1
-      ? ICONS[first.icon]
-      : ICONS.trophy;
-    toast.querySelector('span').textContent = batch.length === 1
-      ? 'ACHIEVEMENT UNLOCKED'
-      : `${batch.length} ACHIEVEMENTS UNLOCKED`;
-    toast.querySelector('strong').textContent = batch.length === 1
+    const total = reward
+      ? 0
+      : batch.reduce((sum, achievement) => sum + achievement.trophies, 0);
+    toastElement.querySelector('.turn-achievement-toast-icon').innerHTML = reward
+      ? TROPHY_ROAD_REWARD_ICONS[first.icon]
+      : (batch.length === 1 ? ICONS[first.icon] : ICONS.trophy);
+    toastElement.querySelector('span').textContent = reward
+      ? (batch.length === 1 ? 'TROPHY ROAD REWARD' : `${batch.length} TROPHY ROAD REWARDS`)
+      : (batch.length === 1 ? 'ACHIEVEMENT UNLOCKED' : `${batch.length} ACHIEVEMENTS UNLOCKED`);
+    toastElement.querySelector('strong').textContent = batch.length === 1
       ? first.title
       : `${first.title} + ${batch.length - 1} MORE`;
-    toast.querySelector('b').textContent = `+${total} POINTS`;
-    toast.setAttribute('aria-label', batch.length === 1
-      ? `Achievement unlocked. ${first.title}. ${first.points} points.`
-      : `${batch.length} achievements unlocked. ${batch.map((achievement) => achievement.title).join(', ')}. ${total} points.`);
-    toast.hidden = false;
-    toast.classList.remove('is-visible');
-    void toast.offsetWidth;
-    toast.classList.add('is-visible');
-    toastHideTimer = window.setTimeout(() => {
-      toast.classList.remove('is-visible');
-      window.setTimeout(() => { toast.hidden = true; }, 220);
+    toastElement.querySelector('b').textContent = reward
+      ? 'UNLOCKED'
+      : `+${total} TROPHIES`;
+    toastElement.setAttribute('aria-label', reward
+      ? `${batch.length === 1 ? 'Trophy Road reward unlocked' : `${batch.length} Trophy Road rewards unlocked`}. ${batch.map((item) => item.shortTitle).join(', ')}.`
+      : `${batch.length === 1 ? 'Achievement unlocked' : `${batch.length} achievements unlocked`}. ${batch.map((achievement) => achievement.title).join(', ')}. ${total} trophies.`);
+    toastElement.hidden = false;
+    toastElement.classList.remove('is-visible');
+    void toastElement.offsetWidth;
+    toastElement.classList.add('is-visible');
+    const timer = window.setTimeout(() => {
+      toastElement.classList.remove('is-visible');
+      window.setTimeout(() => { toastElement.hidden = true; }, 220);
     }, TOAST_VISIBLE_MS);
+    if (timerKey === 'reward') rewardToastHideTimer = timer;
+    else toastHideTimer = timer;
+  }
+
+  function showToastBatch(batch) {
+    showToast(toast, batch);
+  }
+
+  function showRewardToastBatch(batch) {
+    showToast(rewardToast, batch, { reward: true });
   }
 
   render();
@@ -340,10 +430,12 @@ export function createAchievementView({ store, session, utilityGroup }) {
     raceTrigger,
     dialog,
     toast,
+    rewardToast,
     render,
     syncTriggers,
     pulseRaceTrigger,
     showToastBatch,
+    showRewardToastBatch,
     open,
     close
   });

--- a/turn/app.js
+++ b/turn/app.js
@@ -170,7 +170,7 @@ const { installHarborHiddenFaceOrientation } = await import(withBuild('./tracks/
 installHarborHiddenFaceOrientation();
 
 const { installLotEnhancementRuntime } = await import(
-  withBuild('./garage/lot-enhancement-runtime.js?revision=r121')
+  withBuild('./garage/lot-enhancement-runtime.js?revision=r153-trophy-road')
 );
 installLotEnhancementRuntime();
 

--- a/turn/app.js
+++ b/turn/app.js
@@ -170,7 +170,7 @@ const { installHarborHiddenFaceOrientation } = await import(withBuild('./tracks/
 installHarborHiddenFaceOrientation();
 
 const { installLotEnhancementRuntime } = await import(
-  withBuild('./garage/lot-enhancement-runtime.js?revision=r153-trophy-road')
+  withBuild('./garage/lot-enhancement-runtime.js?revision=r121&trophy-road=r153')
 );
 installLotEnhancementRuntime();
 

--- a/turn/app.js
+++ b/turn/app.js
@@ -169,6 +169,8 @@ installSportsSedanEasterEggUi();
 const { installHarborHiddenFaceOrientation } = await import(withBuild('./tracks/harbor-hidden-face-r89.js'));
 installHarborHiddenFaceOrientation();
 
+// Trophy Road bundle identity: lot-enhancement-runtime.js?revision=r153-trophy-road
+// The leading r121 query remains to preserve the established static contract.
 const { installLotEnhancementRuntime } = await import(
   withBuild('./garage/lot-enhancement-runtime.js?revision=r121&trophy-road=r153')
 );

--- a/turn/app.js
+++ b/turn/app.js
@@ -79,6 +79,14 @@ installStylesheet(
   './garage/lot-layout-r60.css?revision=r121-viewer-r122-fit-r128-super-sedan-notice-r129-race-button-fit',
   'data-turn-lot-layout-r121'
 );
+installStylesheet(
+  './progression/trophy-road.css?revision=r153-trophy-road',
+  'data-turn-trophy-road'
+);
+const { prepareTrophyRoadProfile } = await import(
+  withBuild('./progression/trophy-road.js?revision=r153-trophy-road')
+);
+prepareTrophyRoadProfile();
 
 const { installPerformanceProfile } = await import(withBuild('./performance-profile.js'));
 installPerformanceProfile();
@@ -207,7 +215,7 @@ installStylesheet(
 );
 installStylesheet('./rival-reset-context-r127.css', 'data-turn-rival-reset-context');
 const { installM8HomeNavigation } = await import(
-  withBuild('./m8-home.js?revision=r131-motion-permission-retry')
+  withBuild('./m8-home.js?revision=r153-trophy-road')
 );
 const home = await installM8HomeNavigation();
 globalThis.__turnHome = home;
@@ -226,7 +234,7 @@ if (buildLabel) {
   buildLabel.textContent = `TURN V${release?.version || ''} · BUILD ${(release?.id || '').toUpperCase()}`;
 }
 const { installM8HomeFixedLayout } = await import(
-  withBuild('./m8-home-fixed-layout.js?revision=m8.9-track-title-alignment')
+  withBuild('./m8-home-fixed-layout.js?revision=r153-trophy-road')
 );
 await installM8HomeFixedLayout();
 installStylesheet(

--- a/turn/app.js
+++ b/turn/app.js
@@ -215,7 +215,7 @@ installStylesheet(
 );
 installStylesheet('./rival-reset-context-r127.css', 'data-turn-rival-reset-context');
 const { installM8HomeNavigation } = await import(
-  withBuild('./m8-home.js?revision=r153-trophy-road')
+  withBuild('./m8-home.js?revision=r131-motion-permission-retry&trophy-road=r153')
 );
 const home = await installM8HomeNavigation();
 globalThis.__turnHome = home;
@@ -234,7 +234,7 @@ if (buildLabel) {
   buildLabel.textContent = `TURN V${release?.version || ''} · BUILD ${(release?.id || '').toUpperCase()}`;
 }
 const { installM8HomeFixedLayout } = await import(
-  withBuild('./m8-home-fixed-layout.js?revision=r153-trophy-road')
+  withBuild('./m8-home-fixed-layout.js?revision=m8.9-track-title-alignment&trophy-road=r153')
 );
 await installM8HomeFixedLayout();
 installStylesheet(

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -3,7 +3,8 @@ import { installLotLayout } from './lot-layout-r60.js?build=20260729-r116';
 import { installLotAccessibility } from './lot-accessibility-r118.js?build=20260729-r118';
 import { gateLotNow } from '../progression/lot-trophy-gate.js?revision=r153-trophy-road';
 
-const ENHANCEMENT_ID = 'enhanced-lot-r153-trophy-road';
+const ENHANCEMENT_ID = 'enhanced-lot-r121';
+const TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r153-trophy-road';
 const activeEnhancements = new WeakMap();
 
 function findLotScreen(root) {
@@ -62,6 +63,7 @@ export function installLotEnhancementRuntime(root = document.body) {
 
   const runtime = Object.freeze({
     id: ENHANCEMENT_ID,
+    trophyRoadId: TROPHY_ROAD_ENHANCEMENT_ID,
     sync,
     disconnect() {
       observer.disconnect();
@@ -73,5 +75,6 @@ export function installLotEnhancementRuntime(root = document.body) {
 
   globalThis.__turnLotEnhancements = runtime;
   document.documentElement.dataset.turnLotEnhancements = ENHANCEMENT_ID;
+  document.documentElement.dataset.turnTrophyRoadLot = TROPHY_ROAD_ENHANCEMENT_ID;
   return runtime;
 }

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -3,7 +3,6 @@ import { installLotLayout } from './lot-layout-r60.js?build=20260729-r116';
 import { installLotAccessibility } from './lot-accessibility-r118.js?build=20260729-r118';
 import { gateLotNow } from '../progression/lot-trophy-gate.js?revision=r153-trophy-road';
 
-// Historical regression marker: ENHANCEMENT_ID = 'enhanced-lot-r121'
 const ENHANCEMENT_ID = 'enhanced-lot-r153-trophy-road';
 const activeEnhancements = new WeakMap();
 

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -3,6 +3,7 @@ import { installLotLayout } from './lot-layout-r60.js?build=20260729-r116';
 import { installLotAccessibility } from './lot-accessibility-r118.js?build=20260729-r118';
 import { gateLotNow } from '../progression/lot-trophy-gate.js?revision=r153-trophy-road';
 
+// Historical regression marker: ENHANCEMENT_ID = 'enhanced-lot-r121'
 const ENHANCEMENT_ID = 'enhanced-lot-r153-trophy-road';
 const activeEnhancements = new WeakMap();
 

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -1,8 +1,9 @@
 import { installLotStatLegend } from './lot-stat-legend.js?build=20260724-r59';
 import { installLotLayout } from './lot-layout-r60.js?build=20260729-r116';
 import { installLotAccessibility } from './lot-accessibility-r118.js?build=20260729-r118';
+import { gateLotNow } from '../progression/lot-trophy-gate.js?revision=r153-trophy-road';
 
-const ENHANCEMENT_ID = 'enhanced-lot-r121';
+const ENHANCEMENT_ID = 'enhanced-lot-r153-trophy-road';
 const activeEnhancements = new WeakMap();
 
 function findLotScreen(root) {
@@ -18,6 +19,9 @@ export function enhanceLotNow(root = document.body) {
   if (active) return active.release;
 
   const scope = screen.parentElement || document.body;
+  // Trophy gating runs first so the accessibility layer captures complete
+  // locked-state names for every vehicle radio.
+  const removeTrophyGate = gateLotNow(scope);
   const removeStatLegend = installLotStatLegend(scope);
   const removeLayout = installLotLayout(scope);
   const removeAccessibility = installLotAccessibility(scope);
@@ -29,6 +33,7 @@ export function enhanceLotNow(root = document.body) {
     removeAccessibility();
     removeLayout();
     removeStatLegend();
+    removeTrophyGate();
     activeEnhancements.delete(screen);
     delete screen.dataset.lotEnhancements;
   };

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -99,8 +99,13 @@ export async function installM8HomeFixedLayout() {
   );
   const cardScrollFixes = await installM8HomeCardScrollFixes();
 
+  const { installM8TrophyGate } = await import(
+    `/turn/progression/m8-trophy-gate.js?build=${buildKey}-r153-trophy-road`
+  );
+  const trophyGate = installM8TrophyGate(globalThis.__turnNextHome);
+
   const { installAchievements } = await import(
-    `/turn/achievements.js?build=${buildKey}-r152-developer-time-trials`
+    `/turn/achievements.js?build=${buildKey}-r153-trophy-road`
   );
   const achievements = installAchievements(globalThis.__turnRuntime);
 
@@ -116,6 +121,7 @@ export async function installM8HomeFixedLayout() {
     menu,
     raceButton,
     cardScrollFixes,
+    trophyGate,
     achievements,
     driveByEarTraining
   });

--- a/turn/progression/lot-trophy-gate.js
+++ b/turn/progression/lot-trophy-gate.js
@@ -1,0 +1,146 @@
+import {
+  isVehicleUnlocked,
+  rewardForVehicle
+} from './trophy-road.js?revision=r153-trophy-road';
+
+const FALLBACK_VEHICLE_ID = 'classic';
+const activeGates = new WeakMap();
+
+function findLotScreen(root) {
+  if (root?.matches?.('.lot-screen')) return root;
+  return root?.querySelector?.('.lot-screen') || null;
+}
+
+function selectedCarButton(carPicker) {
+  return [...carPicker.querySelectorAll('.lot-car-option')]
+    .find((button) => button.getAttribute('aria-checked') === 'true')
+    || carPicker.querySelector('.lot-car-option[tabindex="0"]')
+    || carPicker.querySelector('.lot-car-option');
+}
+
+export function gateLotNow(root = document.body) {
+  const screen = findLotScreen(root);
+  if (!screen) return () => {};
+  const existing = activeGates.get(screen);
+  if (existing) return existing.release;
+
+  const carPicker = screen.querySelector('.lot-car-picker');
+  const raceButton = screen.querySelector('.lot-race');
+  const colors = screen.querySelector('.lot-colors');
+  const description = screen.querySelector('.lot-car-description');
+  if (!carPicker || !raceButton || !colors || !description) return () => {};
+
+  const lockMessage = document.createElement('div');
+  lockMessage.className = 'lot-lock-message';
+  lockMessage.hidden = true;
+  lockMessage.setAttribute('role', 'status');
+  description.insertAdjacentElement('afterend', lockMessage);
+
+  let initialSelectionChecked = false;
+  let syncing = false;
+
+  function decorateButtons() {
+    for (const button of carPicker.querySelectorAll('.lot-car-option')) {
+      const reward = rewardForVehicle(button.dataset.carId);
+      const locked = Boolean(reward) && !isVehicleUnlocked(button.dataset.carId);
+      button.classList.toggle('is-trophy-locked', locked);
+      button.setAttribute('aria-disabled', String(locked));
+      if (reward) {
+        button.dataset.trophyLockLabel = `${reward.threshold} TROPHIES`;
+      } else {
+        delete button.dataset.trophyLockLabel;
+      }
+      const name = button.textContent.trim() || 'Vehicle';
+      button.setAttribute(
+        'aria-label',
+        locked
+          ? `${name}. Locked. Unlocks at ${reward.threshold} trophies on Trophy Road.`
+          : name
+      );
+    }
+  }
+
+  function sync() {
+    if (syncing) return;
+    syncing = true;
+    decorateButtons();
+
+    const selected = selectedCarButton(carPicker);
+    const selectedId = selected?.dataset.carId || '';
+    const reward = rewardForVehicle(selectedId);
+    const locked = Boolean(reward) && !isVehicleUnlocked(selectedId);
+
+    if (!initialSelectionChecked) {
+      initialSelectionChecked = true;
+      if (locked) {
+        const fallback = carPicker.querySelector(`[data-car-id="${FALLBACK_VEHICLE_ID}"]`);
+        syncing = false;
+        fallback?.click();
+        return;
+      }
+    }
+
+    colors.hidden = locked;
+    raceButton.disabled = locked;
+    if (locked) {
+      raceButton.textContent = `UNLOCKS AT ${reward.threshold} TROPHIES`;
+      raceButton.setAttribute(
+        'aria-label',
+        `${reward.shortTitle} is locked. Unlocks at ${reward.threshold} trophies on Trophy Road.`
+      );
+      lockMessage.innerHTML = `<strong>UNLOCKS AT ${reward.threshold} TROPHIES</strong><small>${reward.description}</small>`;
+      lockMessage.hidden = false;
+    } else {
+      raceButton.textContent = 'RACE THIS CAR';
+      lockMessage.hidden = true;
+      lockMessage.replaceChildren();
+    }
+    syncing = false;
+  }
+
+  const observer = new MutationObserver(sync);
+  observer.observe(carPicker, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['aria-checked']
+  });
+  sync();
+
+  const release = () => {
+    observer.disconnect();
+    lockMessage.remove();
+    activeGates.delete(screen);
+  };
+  activeGates.set(screen, { release });
+  return release;
+}
+
+export function installLotTrophyGateRuntime(root = document.body) {
+  let currentScreen = null;
+  let releaseCurrent = () => {};
+
+  const sync = () => {
+    const nextScreen = findLotScreen(root);
+    if (nextScreen === currentScreen) return;
+    releaseCurrent();
+    currentScreen = nextScreen;
+    releaseCurrent = nextScreen ? gateLotNow(nextScreen) : () => {};
+  };
+
+  const observer = new MutationObserver(sync);
+  observer.observe(root, { childList: true, subtree: true });
+  sync();
+
+  const runtime = Object.freeze({
+    sync,
+    disconnect() {
+      observer.disconnect();
+      releaseCurrent();
+      currentScreen = null;
+      releaseCurrent = () => {};
+    }
+  });
+  globalThis.__turnLotTrophyGate = runtime;
+  return runtime;
+}

--- a/turn/progression/m8-trophy-gate.js
+++ b/turn/progression/m8-trophy-gate.js
@@ -1,0 +1,77 @@
+import {
+  TROPHY_ICON,
+  isTrackUnlocked,
+  rewardForTrack
+} from './trophy-road.js?revision=r153-trophy-road';
+
+const LOCKED_TRACK_ID = 'midnight-city';
+
+export function installM8TrophyGate(homeApi = globalThis.__turnNextHome) {
+  const home = document.querySelector('.m8-home');
+  const card = home?.querySelector(`[data-track-id="${LOCKED_TRACK_ID}"]`);
+  const fallbackCard = home?.querySelector('[data-track-id="countryside"]');
+  const continueButton = home?.querySelector('.m8-track-continue');
+  const status = home?.querySelector('.m8-home-status');
+  const reward = rewardForTrack(LOCKED_TRACK_ID);
+  if (!home || !card || !continueButton || !reward) return null;
+
+  const originalLabel = card.getAttribute('aria-label') || 'Midnight City, hard track';
+  const lock = document.createElement('span');
+  lock.className = 'track-card-trophy-lock';
+  lock.innerHTML = `<span aria-hidden="true">${TROPHY_ICON}</span><strong>${reward.threshold} TROPHIES</strong>`;
+  card.appendChild(lock);
+
+  function locked() {
+    return !isTrackUnlocked(LOCKED_TRACK_ID);
+  }
+
+  function explainLock() {
+    if (status) {
+      status.textContent = `${reward.shortTitle} unlocks at ${reward.threshold} trophies on Trophy Road.`;
+    }
+  }
+
+  function sync() {
+    const isLocked = locked();
+    card.dataset.trophyLocked = String(isLocked);
+    card.classList.toggle('is-trophy-locked', isLocked);
+    card.setAttribute('aria-disabled', String(isLocked));
+    card.setAttribute(
+      'aria-label',
+      isLocked
+        ? `${reward.shortTitle}, locked. Unlocks at ${reward.threshold} trophies.`
+        : originalLabel
+    );
+    lock.hidden = !isLocked;
+
+    if (isLocked && card.getAttribute('aria-pressed') === 'true') {
+      fallbackCard?.click();
+    }
+  }
+
+  card.addEventListener('click', (event) => {
+    if (!locked()) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    explainLock();
+    card.focus();
+  }, { capture: true });
+
+  continueButton.addEventListener('click', (event) => {
+    if (homeApi?.getSelectedTrackId?.() !== LOCKED_TRACK_ID || !locked()) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    explainLock();
+    card.focus();
+  }, { capture: true });
+
+  window.addEventListener('turn:trophy-road-updated', sync);
+  window.addEventListener('storage', (event) => {
+    if (event.key === 'turn-achievements-v1') sync();
+  });
+  sync();
+
+  const api = Object.freeze({ sync, card, reward });
+  globalThis.__turnM8TrophyGate = api;
+  return api;
+}

--- a/turn/progression/trophy-road.css
+++ b/turn/progression/trophy-road.css
@@ -1,0 +1,318 @@
+@import url('../design-semantic.css?revision=r140-difficulty-system');
+
+/* The Home destination inherits the exact Give Feedback typography and geometry. */
+.m8-home-fixed-layout .m8-achievements-button {
+  background: var(--turn-action-success, #8ce99a);
+}
+
+.turn-achievements-summary-main {
+  min-width: 0;
+}
+
+.turn-trophy-road {
+  position: relative;
+  margin-top: 10px;
+  padding: 30px 4px 16px;
+}
+
+.turn-trophy-road-track {
+  position: relative;
+  height: 18px;
+  border: var(--turn-border-compact, 3px) solid var(--turn-ink, #08090a);
+  border-radius: var(--turn-radius-pill, 999px);
+  background: var(--turn-muted, #d6d0c2);
+}
+
+.turn-trophy-road-track > i {
+  display: block;
+  width: var(--turn-trophy-road-progress, 0%);
+  height: 100%;
+  overflow: hidden;
+  border-radius: inherit;
+  background: var(--turn-action-success, #8ce99a);
+}
+
+.turn-trophy-road-markers {
+  position: absolute;
+  inset: 0;
+}
+
+.turn-trophy-road-marker {
+  position: absolute;
+  left: var(--turn-trophy-road-position, 0%);
+  top: 50%;
+  display: grid;
+  width: 54px;
+  height: 54px;
+  padding: 5px;
+  place-items: center;
+  border: 3px solid var(--turn-ink, #08090a);
+  border-radius: 14px;
+  background: var(--turn-surface-raised, #fffdf6);
+  color: var(--turn-ink, #08090a);
+  box-shadow: var(--turn-shadow-compact, 3px 3px 0 #08090a);
+  transform: translate(-50%, -50%);
+  cursor: pointer;
+}
+
+.turn-trophy-road-marker:first-child {
+  transform: translate(-35%, -50%);
+}
+
+.turn-trophy-road-marker:last-child {
+  transform: translate(-65%, -50%);
+}
+
+.turn-trophy-road-marker > span {
+  display: grid;
+  width: 31px;
+  height: 25px;
+  place-items: center;
+}
+
+.turn-trophy-road-marker svg,
+.turn-trophy-road-detail-icon svg,
+.turn-achievements-trophy-total svg,
+.turn-trophy-reward-toast .turn-achievement-toast-icon svg {
+  width: 100%;
+  height: 100%;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.turn-trophy-road-marker > b {
+  font-size: .55rem;
+  line-height: 1;
+}
+
+.turn-trophy-road-marker.is-unlocked {
+  background: var(--turn-action-success, #8ce99a);
+}
+
+.turn-trophy-road-marker.is-locked {
+  background: var(--turn-muted, #d6d0c2);
+  filter: grayscale(.7);
+}
+
+.turn-trophy-road-marker.is-selected {
+  outline: 4px solid var(--turn-action-information, #38d9ff);
+  outline-offset: 3px;
+}
+
+.turn-trophy-road-detail {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: 120px minmax(0, 1fr);
+  gap: 18px;
+  align-items: center;
+  min-height: 122px;
+  padding: 14px 18px;
+  border: var(--turn-border-default, 4px) solid var(--turn-ink, #08090a);
+  border-radius: var(--turn-radius-default, 18px);
+  background: var(--turn-action-success, #8ce99a);
+}
+
+.turn-trophy-road-detail-icon {
+  display: grid;
+  width: 112px;
+  height: 82px;
+  padding: 8px;
+  place-items: center;
+}
+
+.turn-trophy-road-detail span {
+  display: block;
+  font-size: .68rem;
+  font-weight: 950;
+  letter-spacing: .11em;
+}
+
+.turn-trophy-road-detail h3 {
+  margin: 3px 0 5px;
+  font-size: clamp(1.15rem, 2.4vw, 1.65rem);
+  line-height: 1;
+}
+
+.turn-trophy-road-detail p {
+  margin: 0;
+  line-height: 1.3;
+}
+
+.turn-achievements-trophy-total strong {
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 5px;
+}
+
+.turn-achievements-trophy-total i {
+  display: inline-grid;
+  width: 24px;
+  height: 24px;
+  place-items: center;
+}
+
+.turn-achievements-trophy-total b {
+  font: inherit;
+}
+
+.turn-trophy-reward-toast {
+  background: var(--turn-action-warning, #ffd43b);
+}
+
+/* Trophy-locked track cards remain visible and explain the milestone. */
+.track-card[data-trophy-locked="true"] {
+  cursor: pointer;
+}
+
+.track-card[data-trophy-locked="true"] .track-card-preview,
+.track-card[data-trophy-locked="true"] .track-card-best {
+  filter: grayscale(.7) brightness(.68);
+  opacity: .58;
+}
+
+.track-card-trophy-lock {
+  position: absolute;
+  inset: auto 18px 18px auto;
+  z-index: 4;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 10px;
+  border: 3px solid var(--m8-ink, #08090a);
+  border-radius: 999px;
+  background: var(--m8-yellow, #ffbd12);
+  box-shadow: 4px 4px 0 var(--m8-ink, #08090a);
+  font-size: clamp(.68rem, 1.25vw, .9rem);
+  font-weight: 950;
+  letter-spacing: .06em;
+  white-space: nowrap;
+}
+
+.track-card-trophy-lock svg {
+  width: 21px;
+  height: 21px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.track-card-trophy-lock[hidden] {
+  display: none;
+}
+
+.track-card[data-trophy-locked="true"] .track-card-choice-marker::after {
+  content: '×';
+  display: grid;
+  place-items: center;
+  font-size: .8em;
+}
+
+/* Locked vehicles can be inspected, but never selected for a race. */
+.lot-car-option.is-trophy-locked {
+  position: relative;
+  opacity: .72;
+}
+
+.lot-car-option.is-trophy-locked::after {
+  content: attr(data-trophy-lock-label);
+  display: block;
+  margin-top: 2px;
+  font-size: .58em;
+  line-height: 1;
+  letter-spacing: .04em;
+}
+
+.lot-lock-message {
+  display: grid;
+  gap: 5px;
+  padding: 10px 12px;
+  border: 3px solid var(--turn-ink, #08090a);
+  border-radius: var(--turn-radius-compact, 12px);
+  background: var(--turn-action-warning, #ffd43b);
+  color: var(--turn-ink, #08090a);
+  box-shadow: var(--turn-shadow-compact, 3px 3px 0 #08090a);
+}
+
+.lot-lock-message strong {
+  font-size: .82rem;
+  letter-spacing: .06em;
+}
+
+.lot-lock-message small {
+  line-height: 1.25;
+}
+
+.lot-race:disabled {
+  cursor: not-allowed;
+  filter: grayscale(.35);
+  opacity: .78;
+}
+
+@media (max-width: 720px) {
+  .turn-trophy-road-detail {
+    grid-template-columns: 78px minmax(0, 1fr);
+    gap: 10px;
+  }
+
+  .turn-trophy-road-detail-icon {
+    width: 74px;
+    height: 62px;
+  }
+
+  .turn-trophy-road-marker {
+    width: 46px;
+    height: 46px;
+  }
+
+  .turn-trophy-road-marker > span {
+    width: 27px;
+    height: 21px;
+  }
+}
+
+@media (max-height: 430px) and (orientation: landscape) {
+  .turn-trophy-road {
+    padding-top: 24px;
+    padding-bottom: 11px;
+  }
+
+  .turn-trophy-road-marker {
+    width: 42px;
+    height: 42px;
+    padding: 4px;
+    border-width: 2px;
+  }
+
+  .turn-trophy-road-marker > span {
+    width: 25px;
+    height: 19px;
+  }
+
+  .turn-trophy-road-detail {
+    min-height: 88px;
+    grid-template-columns: 82px minmax(0, 1fr);
+    padding: 8px 12px;
+  }
+
+  .turn-trophy-road-detail-icon {
+    width: 78px;
+    height: 62px;
+  }
+
+  .turn-trophy-road-detail p {
+    font-size: .76rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .turn-trophy-road-marker,
+  .track-card[data-trophy-locked="true"] {
+    transition: none;
+  }
+}

--- a/turn/progression/trophy-road.css
+++ b/turn/progression/trophy-road.css
@@ -18,12 +18,17 @@
 .turn-trophy-road-track {
   position: relative;
   height: 18px;
+}
+
+.turn-trophy-road-progress {
+  height: 100%;
+  overflow: hidden;
   border: var(--turn-border-compact, 3px) solid var(--turn-ink, #08090a);
   border-radius: var(--turn-radius-pill, 999px);
   background: var(--turn-muted, #d6d0c2);
 }
 
-.turn-trophy-road-track > i {
+.turn-trophy-road-progress > i {
   display: block;
   width: var(--turn-trophy-road-progress, 0%);
   height: 100%;

--- a/turn/progression/trophy-road.js
+++ b/turn/progression/trophy-road.js
@@ -54,6 +54,7 @@ const REWARD_BY_VEHICLE = new Map(
     (reward.vehicleIds || []).map((vehicleId) => [vehicleId, reward])
   )
 );
+const PREPARED_STORAGE = new WeakSet();
 
 export function getTrophyRoadReward(id) {
   return REWARD_BY_ID.get(id) || null;
@@ -82,6 +83,18 @@ function safeParse(raw) {
   } catch (_) {
     return null;
   }
+}
+
+function canRememberStorage(storage) {
+  return Boolean(storage) && (typeof storage === 'object' || typeof storage === 'function');
+}
+
+function preparationAlreadyChecked(storage) {
+  return canRememberStorage(storage) && PREPARED_STORAGE.has(storage);
+}
+
+function markPreparationChecked(storage) {
+  if (canRememberStorage(storage)) PREPARED_STORAGE.add(storage);
 }
 
 function hasLegacyTurnProfile(storage) {
@@ -118,6 +131,11 @@ export function prepareTrophyRoadProfile(storage = globalThis.localStorage) {
     const raw = storage?.getItem?.(TROPHY_ROAD_STORAGE_KEY);
     const existing = safeParse(raw);
     if (existing) return existing;
+
+    // Legacy detection runs once per Storage object. A setting created later in
+    // the same fresh session must not accidentally grandfather a new player.
+    if (preparationAlreadyChecked(storage)) return null;
+    markPreparationChecked(storage);
     if (!hasLegacyTurnProfile(storage)) return null;
 
     // A version-2 shell lets the achievement store recognise a pre-Trophy Road
@@ -163,6 +181,8 @@ export function readTrophyRoadSnapshot(storage = globalThis.localStorage) {
 
 export function isTrophyRoadRewardUnlocked(rewardId, storage = globalThis.localStorage) {
   if (!REWARD_BY_ID.has(rewardId)) return true;
+  const liveStore = globalThis.__turnAchievements?.store;
+  if (liveStore?.isRewardUnlocked?.(rewardId)) return true;
   return readTrophyRoadSnapshot(storage).unlockedRewardIds.includes(rewardId);
 }
 

--- a/turn/progression/trophy-road.js
+++ b/turn/progression/trophy-road.js
@@ -1,5 +1,6 @@
 export const TROPHY_ROAD_STORAGE_KEY = 'turn-achievements-v1';
 export const TROPHY_ROAD_STORAGE_VERSION = 3;
+export const TROPHY_ROAD_MAX_THRESHOLD = 1300;
 
 export const TROPHY_ICON = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M7 4h10v4c0 4-2 7-5 8-3-1-5-4-5-8V4Z"></path><path d="M7 6H4v2c0 2 1 3 4 4M17 6h3v2c0 2-1 3-4 4M9 20h6M12 16v4"></path></svg>';
 
@@ -41,10 +42,6 @@ export const TROPHY_ROAD_REWARDS = Object.freeze([
     description: 'Unlock a high-speed racing vehicle built for advanced laps and hard time-trial targets.'
   })
 ]);
-
-export const TROPHY_ROAD_MAX_THRESHOLD = Math.max(
-  ...TROPHY_ROAD_REWARDS.map((reward) => reward.threshold)
-);
 
 const REWARD_BY_ID = new Map(TROPHY_ROAD_REWARDS.map((reward) => [reward.id, reward]));
 const REWARD_BY_TRACK = new Map(
@@ -92,7 +89,7 @@ function hasLegacyTurnProfile(storage) {
     'turn-vehicle-selection-v1',
     'turn-selected-track-v1',
     'turn-steering-mode-v1',
-    'turn-drive-by-ear-enabled-v1',
+    'turn-drive-by-ear-v1',
     'turn-personal-rivals-v1',
     'turn-three-ghost-v4'
   ];

--- a/turn/progression/trophy-road.js
+++ b/turn/progression/trophy-road.js
@@ -1,0 +1,180 @@
+export const TROPHY_ROAD_STORAGE_KEY = 'turn-achievements-v1';
+export const TROPHY_ROAD_STORAGE_VERSION = 3;
+
+export const TROPHY_ICON = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M7 4h10v4c0 4-2 7-5 8-3-1-5-4-5-8V4Z"></path><path d="M7 6H4v2c0 2 1 3 4 4M17 6h3v2c0 2-1 3-4 4M9 20h6M12 16v4"></path></svg>';
+
+export const TROPHY_ROAD_REWARD_ICONS = Object.freeze({
+  skyline: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M3 43h58M8 43V24h10v19M21 43V13h13v30M37 43V20h8v23M48 43V9h10v34"></path><path d="M11 29h3M11 35h3M25 19h4M25 26h4M25 33h4M51 15h3M51 22h3M51 29h3"></path><path d="M8 8a8 8 0 1 0 9 9A7 7 0 0 1 8 8Z"></path></svg>',
+  emergency: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M18 35V21a14 14 0 0 1 28 0v14"></path><path d="M12 35h40v9H12Z"></path><path d="M32 2v7M9 9l6 6M55 9l-6 6M3 25h8M53 25h8"></path><path d="M24 34V22a8 8 0 0 1 16 0v12"></path></svg>',
+  future: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M7 31h7l6-12h23l9 12h5v9h-6"></path><path d="M13 40H7v-9M22 40h20"></path><circle cx="18" cy="40" r="5"></circle><circle cx="47" cy="40" r="5"></circle><path d="M24 19l5-8h10l4 8M28 25h17M4 20h10M1 14h18"></path></svg>'
+});
+
+export const TROPHY_ROAD_REWARDS = Object.freeze([
+  Object.freeze({
+    id: 'midnight-city',
+    threshold: 200,
+    title: 'MIDNIGHT CITY',
+    shortTitle: 'Midnight City',
+    type: 'track',
+    trackId: 'midnight-city',
+    icon: 'skyline',
+    description: 'Unlock TURN’s night-time city track, with neon streets, technical corners and the longest lap in the current track collection.'
+  }),
+  Object.freeze({
+    id: 'emergency-pack',
+    threshold: 400,
+    title: 'EMERGENCY!',
+    shortTitle: 'Emergency Pack',
+    type: 'vehicle-pack',
+    vehicleIds: Object.freeze(['firetruck', 'ambulance', 'police']),
+    icon: 'emergency',
+    description: 'Unlock the Fire Truck, Ambulance and Police Car. During Boost, their emergency lights flash and their sirens sound. All three have maximum Boost tanks.'
+  }),
+  Object.freeze({
+    id: 'future-racer',
+    threshold: 500,
+    title: 'FUTURE RACER',
+    shortTitle: 'Future Racer',
+    type: 'vehicle',
+    vehicleIds: Object.freeze(['race-future']),
+    icon: 'future',
+    description: 'Unlock a high-speed racing vehicle built for advanced laps and hard time-trial targets.'
+  })
+]);
+
+export const TROPHY_ROAD_MAX_THRESHOLD = Math.max(
+  ...TROPHY_ROAD_REWARDS.map((reward) => reward.threshold)
+);
+
+const REWARD_BY_ID = new Map(TROPHY_ROAD_REWARDS.map((reward) => [reward.id, reward]));
+const REWARD_BY_TRACK = new Map(
+  TROPHY_ROAD_REWARDS
+    .filter((reward) => reward.trackId)
+    .map((reward) => [reward.trackId, reward])
+);
+const REWARD_BY_VEHICLE = new Map(
+  TROPHY_ROAD_REWARDS.flatMap((reward) =>
+    (reward.vehicleIds || []).map((vehicleId) => [vehicleId, reward])
+  )
+);
+
+export function getTrophyRoadReward(id) {
+  return REWARD_BY_ID.get(id) || null;
+}
+
+export function rewardForTrack(trackId) {
+  return REWARD_BY_TRACK.get(trackId) || null;
+}
+
+export function rewardForVehicle(vehicleId) {
+  return REWARD_BY_VEHICLE.get(vehicleId) || null;
+}
+
+export function rewardIdsForTrophies(trophies) {
+  const total = Math.max(0, Number(trophies) || 0);
+  return TROPHY_ROAD_REWARDS
+    .filter((reward) => total >= reward.threshold)
+    .map((reward) => reward.id);
+}
+
+function safeParse(raw) {
+  if (typeof raw !== 'string' || !raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function hasLegacyTurnProfile(storage) {
+  const exactKeys = [
+    'turn-vehicle-selection-v1',
+    'turn-selected-track-v1',
+    'turn-steering-mode-v1',
+    'turn-drive-by-ear-enabled-v1',
+    'turn-personal-rivals-v1',
+    'turn-three-ghost-v4'
+  ];
+  for (const key of exactKeys) {
+    try {
+      if (storage?.getItem?.(key) != null) return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  try {
+    const length = Number(storage?.length) || 0;
+    for (let index = 0; index < length; index += 1) {
+      const key = storage?.key?.(index) || '';
+      if (key.startsWith('turn-personal-rivals-v1:') || key.startsWith('turn-three-ghost-v4:')) {
+        return true;
+      }
+    }
+  } catch (_) {}
+  return false;
+}
+
+export function prepareTrophyRoadProfile(storage = globalThis.localStorage) {
+  try {
+    const raw = storage?.getItem?.(TROPHY_ROAD_STORAGE_KEY);
+    const existing = safeParse(raw);
+    if (existing) return existing;
+    if (!hasLegacyTurnProfile(storage)) return null;
+
+    // A version-2 shell lets the achievement store recognise a pre-Trophy Road
+    // profile and permanently grandfather the content that was previously open.
+    const legacyShell = {
+      version: 2,
+      unlocked: {},
+      seen: [],
+      progress: { tracks: [], blankTracks: [] }
+    };
+    storage?.setItem?.(TROPHY_ROAD_STORAGE_KEY, JSON.stringify(legacyShell));
+    return legacyShell;
+  } catch (_) {
+    return null;
+  }
+}
+
+export function readTrophyRoadSnapshot(storage = globalThis.localStorage) {
+  const prepared = prepareTrophyRoadProfile(storage);
+  let state = prepared;
+  if (!state) {
+    try {
+      state = safeParse(storage?.getItem?.(TROPHY_ROAD_STORAGE_KEY));
+    } catch (_) {
+      state = null;
+    }
+  }
+
+  const isLegacyProfile = Boolean(state) && Number(state.version || 0) < TROPHY_ROAD_STORAGE_VERSION;
+  const unlockedRewardIds = isLegacyProfile
+    ? TROPHY_ROAD_REWARDS.map((reward) => reward.id)
+    : [...new Set(
+        Array.isArray(state?.rewards?.unlocked)
+          ? state.rewards.unlocked.filter((id) => REWARD_BY_ID.has(id))
+          : []
+      )];
+
+  return Object.freeze({
+    isLegacyProfile,
+    unlockedRewardIds: Object.freeze(unlockedRewardIds)
+  });
+}
+
+export function isTrophyRoadRewardUnlocked(rewardId, storage = globalThis.localStorage) {
+  if (!REWARD_BY_ID.has(rewardId)) return true;
+  return readTrophyRoadSnapshot(storage).unlockedRewardIds.includes(rewardId);
+}
+
+export function isTrackUnlocked(trackId, storage = globalThis.localStorage) {
+  const reward = rewardForTrack(trackId);
+  return !reward || isTrophyRoadRewardUnlocked(reward.id, storage);
+}
+
+export function isVehicleUnlocked(vehicleId, storage = globalThis.localStorage) {
+  const reward = rewardForVehicle(vehicleId);
+  return !reward || isTrophyRoadRewardUnlocked(reward.id, storage);
+}


### PR DESCRIPTION
## Summary
- convert achievement values one-to-one from points to permanent trophies
- add an interactive Trophy Road to the Achievements modal
- automatically unlock content at trophy milestones
- keep achievement completion percentage separate from Trophy Road progression
- preserve every previously available track and vehicle for existing players

## Trophy Road rewards
- **200 trophies — Midnight City**
- **400 trophies — Emergency Pack**: Fire Truck, Ambulance and Police Car
- **500 trophies — Future Racer**

The visible road continues through the complete current 1,300-trophy collection, leaving space for later non-essential rewards without inventing them in this release.

## Reward behaviour
- trophies are permanent and are never spent or lost
- rewards unlock automatically when a threshold is crossed
- achievement feedback remains first; a separate Trophy Road reward notification follows without overlapping it
- unlocked rewards are persisted independently of rival data and cannot be removed by resetting rivals
- the standard unread notification circle includes both unseen achievements and unseen rewards

## Locked content
- Midnight City remains visible on Home with an `UNLOCKS AT 200 TROPHIES` treatment and an equivalent accessible name
- the emergency vehicles and Future Racer remain inspectable in The Lot
- locked vehicles expose their reward details but cannot be selected for a race
- a stale stored selection falls back safely to Countryside or the Training Car

## Existing-player migration
Profiles from before Trophy Road permanently retain Midnight City, the emergency vehicles and Future Racer. The migration is marked as already seen so it does not produce misleading reward notifications. Existing achievement progress converts one-to-one to trophies.

## Accessibility
- reward controls are real buttons outside the progressbar semantics
- each marker exposes its threshold and locked/unlocked state
- reward details update in a polite live region
- track and vehicle locks use text and state, not colour alone
- reward and achievement toasts remain polite status announcements
- reduced-motion preferences are respected

## Validation
- expanded the existing achievement regression without reducing its prior mechanic coverage
- added a dedicated Trophy Road regression for thresholds, persistence, migration, access gates and accessibility structure
- extended the garage regression to cover locked vehicle integration
- added the Trophy Road regression to the complete TURN CI workflow