### PR TITLE
Refine Trophy Road locks, filters and progression

### DIFF
--- a/turn-lab/tests/achievements-production.mjs
+++ b/turn-lab/tests/achievements-production.mjs
@@ -143,8 +143,8 @@ assert.deepEqual(normalized.seen, ['first-turn']);
 assert.deepEqual(normalized.progress.tracks, ['airport']);
 assert.deepEqual(normalized.progress.blankTracks, ['countryside', 'midnight-city'],
   'Existing Trust Your Ears unlocks should seed Beyond Sight progress during migration');
-assert.deepEqual(normalized.rewards.unlocked, ['midnight-city'],
-  'Earned trophies should automatically unlock crossed Trophy Road milestones');
+assert.deepEqual(normalized.rewards.unlocked, [],
+  'A 275-trophy profile must remain below the new 300-trophy first milestone');
 
 const memory = new Map();
 const storage = {
@@ -166,6 +166,7 @@ assert.ok(store.state.progress.blankTracks.includes('harbor'));
 assert.equal(store.unlock('ahead-of-yourself', { trackId: 'harbor' })?.id, 'ahead-of-yourself');
 assert.ok(store.isUnlocked('ahead-of-yourself'));
 assert.equal(store.trophyTotal(), 300);
+assert.deepEqual(store.syncRewards().map((reward) => reward.id), ['midnight-city']);
 assert.equal(store.isRewardUnlocked('midnight-city'), true);
 assert.doesNotMatch(storeSource, /rival-storage|clearRivalsState|clearAllRivalsState/,
   'Rival reset implementation must remain independent from persistent achievements and rewards');

--- a/turn-lab/tests/achievements-production.mjs
+++ b/turn-lab/tests/achievements-production.mjs
@@ -350,7 +350,7 @@ assert.doesNotMatch(style, /is-achievement-next/);
 assert.match(designTokens, /--turn-action-success: var\(--turn-green-500\)/);
 assert.match(fixedLayout, /installAchievements/);
 assert.match(fixedLayout, /installM8TrophyGate/);
-assert.match(fixedLayout, /r153-trophy-road/);
+assert.match(fixedLayout, /r154-trophy-road-feedback/);
 assert.ok(fixedLayout.indexOf('installM8HomeCardScrollFixes') < fixedLayout.indexOf('installAchievements'),
   'Achievements should join the completed fixed Home layout after track scrolling is installed');
 assert.match(workflow, /Run achievement system regression/);

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -154,7 +154,7 @@ assert.equal(imports['./race/lap-system.js?build=20260720-r19'], releaseTarget('
 assert.match(app, /lot-layout-r60\.css\?revision=r121-viewer-r122-fit-r128-super-sedan-notice/);
 assert.match(app, /sports-sedan-easter-egg\.js\?revision=r128-unlock-notice/);
 assert.match(app, /installLotEnhancementRuntime/);
-assert.match(app, /lot-enhancement-runtime\.js\?revision=r153-trophy-road/);
+assert.match(app, /lot-enhancement-runtime\.js\?revision=r121&trophy-road=r154/);
 assert.ok(app.indexOf('installLotEnhancementRuntime()') < app.indexOf("withBuild('./main.js')"));
 
 assert.match(lotWrapper, /showOriginalLot/);
@@ -165,7 +165,8 @@ assert.match(lotWrapper, /track-manager\.js\?build=20260722-r52/);
 assert.doesNotMatch(lotWrapper, /installLotLayout|installLotStatLegend|installLotAccessibility/);
 assert.match(originalLot, /export function showTheLot/);
 
-assert.match(lotEnhancementRuntime, /ENHANCEMENT_ID = 'enhanced-lot-r153-trophy-road'/);
+assert.match(lotEnhancementRuntime, /ENHANCEMENT_ID = 'enhanced-lot-r121'/);
+assert.match(lotEnhancementRuntime, /TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r154-trophy-road-feedback'/);
 assert.match(lotEnhancementRuntime, /activeEnhancements = new WeakMap\(\)/);
 assert.match(lotEnhancementRuntime, /gateLotNow\(scope\)/);
 assert.match(lotEnhancementRuntime, /installLotStatLegend\(scope\)/);
@@ -179,7 +180,9 @@ assert.match(lotEnhancementRuntime, /new MutationObserver\(sync\)/);
 assert.match(lotEnhancementRuntime, /screen\.dataset\.lotEnhancements = ENHANCEMENT_ID/);
 assert.match(lotTrophyGate, /FALLBACK_VEHICLE_ID = 'classic'/);
 assert.match(lotTrophyGate, /raceButton\.disabled = locked/);
-assert.match(lotTrophyGate, /aria-disabled/);
+assert.match(lotTrophyGate, /lot-selected-car-lock/);
+assert.match(lotTrophyGate, /showTrophyUnlockNotice/);
+assert.doesNotMatch(lotTrophyGate, /colors\.hidden|carPicker\.hidden/);
 
 assert.match(lotLayout, /viewbox\.appendChild\(colors\)/);
 assert.match(lotLayout, /attributesHeading\.replaceChildren\(document\.createTextNode\('ATTRIBUTES'\)\)/);

--- a/turn-lab/tests/trophy-road-production.mjs
+++ b/turn-lab/tests/trophy-road-production.mjs
@@ -6,6 +6,7 @@ import {
   TROPHY_ROAD_REWARDS,
   TROPHY_ROAD_STORAGE_KEY,
   TROPHY_ROAD_STORAGE_VERSION,
+  TROPHY_ROAD_VIEWPORT_THRESHOLD,
   getTrophyRoadReward,
   isTrackUnlocked,
   isVehicleUnlocked,
@@ -16,16 +17,31 @@ import {
   rewardIdsForTrophies
 } from '../../turn/progression/trophy-road.js';
 
-const [roadSource, roadCss, homeGate, lotGate, view, runtime, app, fixedLayout, lotEnhancement, workflow] = await Promise.all([
+const [
+  roadSource,
+  roadCss,
+  homeGate,
+  lotGate,
+  view,
+  feedback,
+  runtime,
+  app,
+  fixedLayout,
+  lotEnhancement,
+  vehicleCatalog,
+  workflow
+] = await Promise.all([
   fs.readFile(new URL('../../turn/progression/trophy-road.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/progression/trophy-road.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/progression/m8-trophy-gate.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/progression/lot-trophy-gate.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements/view.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/achievements/trophy-road-feedback.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements/runtime.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-enhancement-runtime.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/vehicle/catalog.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../.github/workflows/turn-lab-tests.yml', import.meta.url), 'utf8')
 ]);
 
@@ -53,20 +69,23 @@ function createMemoryStorage(initial = {}) {
 assert.equal(TROPHY_ROAD_STORAGE_KEY, 'turn-achievements-v1');
 assert.equal(TROPHY_ROAD_STORAGE_VERSION, 3);
 assert.equal(TROPHY_ROAD_MAX_THRESHOLD, 1300,
-  'The visible road should continue through the complete current trophy collection');
+  'The road must retain room for the complete current trophy collection');
+assert.equal(TROPHY_ROAD_VIEWPORT_THRESHOLD, 600,
+  'The first 600 trophies should fit in the initial road viewport');
 assert.deepEqual(
   TROPHY_ROAD_REWARDS.map(({ id, threshold }) => [id, threshold]),
   [
-    ['midnight-city', 200],
-    ['emergency-pack', 400],
-    ['future-racer', 500]
+    ['midnight-city', 300],
+    ['future-racer', 400],
+    ['emergency-pack', 600]
   ]
 );
-assert.deepEqual(rewardIdsForTrophies(199), []);
-assert.deepEqual(rewardIdsForTrophies(200), ['midnight-city']);
+assert.deepEqual(rewardIdsForTrophies(299), []);
+assert.deepEqual(rewardIdsForTrophies(300), ['midnight-city']);
 assert.deepEqual(rewardIdsForTrophies(399), ['midnight-city']);
-assert.deepEqual(rewardIdsForTrophies(400), ['midnight-city', 'emergency-pack']);
-assert.deepEqual(rewardIdsForTrophies(500), ['midnight-city', 'emergency-pack', 'future-racer']);
+assert.deepEqual(rewardIdsForTrophies(400), ['midnight-city', 'future-racer']);
+assert.deepEqual(rewardIdsForTrophies(599), ['midnight-city', 'future-racer']);
+assert.deepEqual(rewardIdsForTrophies(600), ['midnight-city', 'future-racer', 'emergency-pack']);
 assert.equal(rewardForTrack('midnight-city')?.id, 'midnight-city');
 assert.equal(rewardForVehicle('police')?.id, 'emergency-pack');
 assert.equal(rewardForVehicle('ambulance')?.id, 'emergency-pack');
@@ -97,7 +116,7 @@ assert.equal(preparedLegacy?.version, 2,
 assert.equal(readTrophyRoadSnapshot(legacyWithoutAchievements).isLegacyProfile, true);
 assert.deepEqual(
   readTrophyRoadSnapshot(legacyWithoutAchievements).unlockedRewardIds,
-  ['midnight-city', 'emergency-pack', 'future-racer']
+  ['midnight-city', 'future-racer', 'emergency-pack']
 );
 
 const migrated = normalizeAchievementState({
@@ -109,7 +128,7 @@ const migrated = normalizeAchievementState({
   progress: { tracks: ['countryside'], blankTracks: [] }
 });
 assert.equal(migrated.version, 3);
-assert.deepEqual(migrated.rewards.unlocked, ['midnight-city', 'emergency-pack', 'future-racer']);
+assert.deepEqual(migrated.rewards.unlocked, ['midnight-city', 'future-racer', 'emergency-pack']);
 assert.deepEqual(migrated.rewards.seen, migrated.rewards.unlocked,
   'Grandfathered content must not create a misleading reward notification');
 
@@ -119,20 +138,24 @@ assert.equal(store.trophyTotal(), 0);
 assert.deepEqual(store.syncRewards(), []);
 assert.equal(store.unlock('trust-your-ears', { trackId: 'countryside' })?.trophies, 200);
 assert.equal(store.trophyTotal(), 200);
-assert.deepEqual(store.syncRewards().map((reward) => reward.id), ['midnight-city']);
-assert.equal(store.isRewardUnlocked('midnight-city'), true);
-assert.equal(isTrackUnlocked('midnight-city', progressionStorage), true);
-assert.equal(isVehicleUnlocked('police', progressionStorage), false);
+assert.deepEqual(store.syncRewards(), [],
+  'One introductory 200-trophy lap must not immediately unlock Midnight City');
 
-assert.equal(store.unlock('beyond-sight', { trackId: 'midnight-city' })?.trophies, 300);
+assert.equal(store.unlock('beyond-sight', { trackId: 'countryside' })?.trophies, 300);
 assert.equal(store.trophyTotal(), 500);
 assert.deepEqual(
   store.syncRewards().map((reward) => reward.id),
-  ['emergency-pack', 'future-racer']
+  ['midnight-city', 'future-racer']
 );
-assert.equal(isVehicleUnlocked('police', progressionStorage), true);
+assert.equal(isTrackUnlocked('midnight-city', progressionStorage), true);
 assert.equal(isVehicleUnlocked('race-future', progressionStorage), true);
-assert.deepEqual(store.unseenRewardIds(), ['midnight-city', 'emergency-pack', 'future-racer']);
+assert.equal(isVehicleUnlocked('police', progressionStorage), false);
+
+assert.equal(store.unlock('around-the-turn', { trackId: 'harbor' })?.trophies, 100);
+assert.equal(store.trophyTotal(), 600);
+assert.deepEqual(store.syncRewards().map((reward) => reward.id), ['emergency-pack']);
+assert.equal(isVehicleUnlocked('police', progressionStorage), true);
+assert.deepEqual(store.unseenRewardIds(), ['midnight-city', 'future-racer', 'emergency-pack']);
 store.markAllSeen();
 assert.deepEqual(store.unseenRewardIds(), []);
 
@@ -157,29 +180,27 @@ const permanentReward = normalizeAchievementState({
 assert.deepEqual(permanentReward.rewards.unlocked, ['emergency-pack'],
   'Once awarded, a reward must remain owned even if thresholds change later');
 
-assert.match(roadSource, /TROPHY_ROAD_MAX_THRESHOLD = 1300/);
-assert.match(roadSource, /threshold: 200/);
+assert.match(roadSource, /TROPHY_ROAD_VIEWPORT_THRESHOLD = 600/);
+assert.match(roadSource, /threshold: 300/);
 assert.match(roadSource, /threshold: 400/);
-assert.match(roadSource, /threshold: 500/);
-assert.match(roadSource, /turn-drive-by-ear-v1/);
+assert.match(roadSource, /threshold: 600/);
+assert.match(roadSource, /LOCK_ICON/);
+assert.match(roadSource, /showTrophyUnlockNotice/);
 assert.match(roadSource, /PREPARED_STORAGE = new WeakSet/);
-assert.match(roadSource, /preparationAlreadyChecked/);
 assert.match(roadSource, /globalThis\.__turnAchievements\?\.store/);
-assert.match(roadSource, /prepareTrophyRoadProfile/);
-assert.match(roadSource, /Number\(state\.version \|\| 0\) < TROPHY_ROAD_STORAGE_VERSION/);
 assert.doesNotMatch(roadSource, /clearRivals|resetRivals|rival-storage/);
 
-assert.match(homeGate, /data-track-id="\$\{LOCKED_TRACK_ID\}"/);
-assert.match(homeGate, /event\.stopImmediatePropagation\(\)/);
-assert.match(homeGate, /fallbackCard\?\.click\(\)/);
-assert.match(homeGate, /aria-disabled/);
-assert.match(homeGate, /turn:trophy-road-updated/);
+assert.match(homeGate, /showTrophyUnlockNotice/);
+assert.match(homeGate, /continueButton\.disabled = true/);
+assert.match(homeGate, /card\.addEventListener\('click'/);
+assert.doesNotMatch(homeGate, /fallbackCard\?\.click/,
+  'Locked tracks should remain selected and inspectable instead of silently moving selection');
 
-assert.match(lotGate, /FALLBACK_VEHICLE_ID = 'classic'/);
 assert.match(lotGate, /raceButton\.disabled = locked/);
-assert.match(lotGate, /colors\.hidden = locked/);
-assert.match(lotGate, /UNLOCKS AT \$\{reward\.threshold\} TROPHIES/);
-assert.match(lotGate, /aria-disabled/);
+assert.match(lotGate, /lot-selected-car-lock/);
+assert.match(lotGate, /showTrophyUnlockNotice/);
+assert.doesNotMatch(lotGate, /colors\.hidden|carPicker\.hidden/,
+  'Locked vehicles must retain their normal information and paint presentation');
 
 assert.match(view, /turn-trophy-road-progress" role="progressbar"/);
 assert.match(view, /turn-trophy-road-markers" aria-label="Trophy Road rewards"/);
@@ -188,8 +209,20 @@ assert.ok(
     < view.indexOf('turn-trophy-road-markers" aria-label="Trophy Road rewards"'),
   'Reward buttons should be siblings of the progressbar rather than descendants hidden by progressbar semantics'
 );
-assert.match(view, /TROPHY ROAD REWARD/);
-assert.match(view, /store\.unseenCount\(\)/);
+assert.match(feedback, /TROPHY_ROAD_VIEWPORT_THRESHOLD/);
+assert.match(feedback, /turn-trophy-road-scroll/);
+assert.match(feedback, /selectedByPlayer = ''/);
+assert.match(feedback, /clearSelection\(\)/);
+assert.match(feedback, /resetView\(\)/);
+assert.match(feedback, /CATEGORY\.WAYS_TO_PLAY/);
+assert.match(feedback, /CATEGORY\.EXPLORATION/);
+assert.match(feedback, /CATEGORY\.RACING/);
+assert.match(feedback, /dataset\.achievementFilter/);
+assert.match(feedback, /activeCategories/);
+assert.match(feedback, /activeStatuses/);
+assert.match(feedback, /categoryMatch && statusMatch/);
+assert.match(feedback, /id: 'locked'/);
+assert.match(feedback, /LOCK_ICON/);
 assert.match(runtime, /turn:trophy-road-updated/);
 assert.match(runtime, /showRewardToastBatch/);
 assert.match(runtime, /store\.syncRewards\(\)/);
@@ -198,8 +231,10 @@ assert.ok(
   app.indexOf('prepareTrophyRoadProfile();') < app.indexOf("await import(withBuild('./main.js'))"),
   'Grandfathering must be prepared before the runtime loads the saved vehicle selection'
 );
-assert.match(app, /lot-enhancement-runtime\.js\?revision=r153-trophy-road/);
+assert.match(app, /trophy-road\.js\?revision=r154-trophy-road-feedback/);
+assert.match(app, /lot-enhancement-runtime\.js\?revision=r121&trophy-road=r154/);
 assert.match(fixedLayout, /installM8TrophyGate/);
+assert.match(fixedLayout, /installTrophyRoadFeedback/);
 assert.ok(
   fixedLayout.indexOf('installM8TrophyGate') < fixedLayout.indexOf('installAchievements'),
   'Track access should be gated before achievement UI is installed'
@@ -209,9 +244,14 @@ assert.ok(
   lotEnhancement.indexOf('gateLotNow(scope)') < lotEnhancement.indexOf('installLotAccessibility(scope)'),
   'The accessibility layer should capture the complete locked vehicle names'
 );
+assert.match(roadCss, /overflow-x: auto/);
+assert.match(roadCss, /translate\(-50%, -50%\)/);
+assert.match(roadCss, /turn-trophy-road-marker-lock/);
+assert.match(roadCss, /turn-unlock-notice/);
 assert.match(roadCss, /@media \(prefers-reduced-motion: reduce\)/);
-assert.match(roadCss, /\.track-card\[data-trophy-locked="true"\]/);
-assert.match(roadCss, /\.lot-car-option\.is-trophy-locked/);
+
+assert.match(vehicleCatalog, /\['vintage-racer',[\s\S]*speed: 4, acceleration: 4, control: 3, drift: 2, boostPower: 3, boostDuration: 2/);
+assert.match(vehicleCatalog, /\['race', 'Race Car',[\s\S]*speed: 5, acceleration: 4, control: 4, drift: 2, boostPower: 2, boostDuration: 1/);
 assert.match(workflow, /Run Trophy Road progression regression/);
 
-console.log('TURN Trophy Road progression regression passed.');
+console.log('TURN Trophy Road feedback and progression regression passed.');

--- a/turn/achievements/trophy-road-feedback.js
+++ b/turn/achievements/trophy-road-feedback.js
@@ -1,0 +1,315 @@
+import { CATEGORY } from './catalog.js?revision=r153-trophy-road';
+import {
+  LOCK_ICON,
+  TROPHY_ROAD_MAX_THRESHOLD,
+  TROPHY_ROAD_REWARDS,
+  TROPHY_ROAD_VIEWPORT_THRESHOLD,
+  getTrophyRoadReward
+} from '../progression/trophy-road.js?revision=r154-trophy-road-feedback';
+
+const EDGE_PX = 34;
+const CATEGORY_FILTERS = Object.freeze([
+  Object.freeze({ id: CATEGORY.ONBOARDING, label: 'GETTING STARTED' }),
+  Object.freeze({ id: CATEGORY.WAYS_TO_PLAY, label: 'WAYS TO PLAY' }),
+  Object.freeze({ id: CATEGORY.EXPLORATION, label: 'EXPLORATION' }),
+  Object.freeze({ id: CATEGORY.RACING, label: 'RACING' }),
+  Object.freeze({ id: CATEGORY.TIME_TRIALS, label: 'TIME TRIALS' })
+]);
+const STATUS_FILTERS = Object.freeze([
+  Object.freeze({ id: 'unlocked', label: 'UNLOCKED' }),
+  Object.freeze({ id: 'locked', label: 'LOCKED' })
+]);
+
+let installed = null;
+
+function ensureFeedbackStylesheet() {
+  const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
+  let stylesheet = document.querySelector('link[data-turn-trophy-road-feedback]');
+  if (!stylesheet) {
+    stylesheet = document.createElement('link');
+    stylesheet.rel = 'stylesheet';
+    stylesheet.href = `/turn/progression/trophy-road.css?build=${buildKey}-r154-trophy-road-feedback`;
+    stylesheet.setAttribute('data-turn-trophy-road-feedback', '');
+  }
+  document.head.appendChild(stylesheet);
+}
+
+function makeFilterButton(id, label, pressed = false) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.dataset.achievementFilter = id;
+  button.setAttribute('aria-pressed', String(pressed));
+  button.textContent = label;
+  return button;
+}
+
+function prepareSummary(dialog) {
+  const summary = dialog.querySelector('.turn-achievements-summary');
+  const summaryMain = summary?.querySelector('.turn-achievements-summary-main');
+  const title = summary?.querySelector('#turnAchievementsSummaryTitle');
+  const trophyMetric = summary?.querySelector('.turn-achievements-trophy-total');
+  const completionMetric = summary?.querySelector('.turn-achievements-percent')?.closest('p');
+  const road = summary?.querySelector('.turn-trophy-road');
+  const track = road?.querySelector('.turn-trophy-road-track');
+  if (!summary || !summaryMain || !title || !trophyMetric || !completionMetric || !road || !track) return null;
+
+  let header = summary.querySelector('.turn-achievements-summary-header');
+  if (!header) {
+    header = document.createElement('div');
+    header.className = 'turn-achievements-summary-header';
+    const metrics = document.createElement('div');
+    metrics.className = 'turn-achievements-summary-metrics';
+    metrics.append(trophyMetric, completionMetric);
+    header.append(title, metrics);
+    summary.insertBefore(header, summaryMain);
+  }
+
+  let scroll = road.querySelector('.turn-trophy-road-scroll');
+  let content = road.querySelector('.turn-trophy-road-content');
+  if (!scroll || !content) {
+    scroll = document.createElement('div');
+    scroll.className = 'turn-trophy-road-scroll';
+    scroll.tabIndex = 0;
+    scroll.setAttribute('aria-label', 'Trophy Road. Scroll horizontally for later rewards.');
+    content = document.createElement('div');
+    content.className = 'turn-trophy-road-content';
+    road.replaceChildren(scroll);
+    scroll.appendChild(content);
+    content.appendChild(track);
+  }
+
+  let help = summary.querySelector('.turn-trophy-road-help');
+  const detail = summary.querySelector('.turn-trophy-road-detail');
+  if (!help && detail) {
+    help = document.createElement('p');
+    help.className = 'turn-trophy-road-help';
+    help.textContent = 'Select a reward for details.';
+    detail.before(help);
+  }
+
+  return Object.freeze({ summary, summaryMain, road, track, scroll, content, help, detail });
+}
+
+function prepareFilters(dialog) {
+  const container = dialog.querySelector('.turn-achievements-filters');
+  if (!container) return null;
+  container.setAttribute('aria-label', 'Achievement filters. Choose one or more.');
+  container.replaceChildren(
+    makeFilterButton('all', 'ALL', true),
+    ...CATEGORY_FILTERS.map(({ id, label }) => makeFilterButton(id, label)),
+    ...STATUS_FILTERS.map(({ id, label }) => makeFilterButton(id, label))
+  );
+
+  const categoryIds = new Set(CATEGORY_FILTERS.map(({ id }) => id));
+  const statusIds = new Set(STATUS_FILTERS.map(({ id }) => id));
+  const activeCategories = new Set();
+  const activeStatuses = new Set();
+  const allButton = container.querySelector('[data-achievement-filter="all"]');
+  const list = dialog.querySelector('.turn-achievements-list');
+
+  function syncButtons() {
+    const all = activeCategories.size === 0 && activeStatuses.size === 0;
+    allButton?.setAttribute('aria-pressed', String(all));
+    for (const button of container.querySelectorAll('[data-achievement-filter]:not([data-achievement-filter="all"])')) {
+      const id = button.dataset.achievementFilter;
+      const pressed = categoryIds.has(id) ? activeCategories.has(id) : activeStatuses.has(id);
+      button.setAttribute('aria-pressed', String(pressed));
+    }
+  }
+
+  function apply() {
+    let visibleCount = 0;
+    for (const card of dialog.querySelectorAll('.turn-achievement-card')) {
+      const categoryMatch = activeCategories.size === 0
+        || activeCategories.has(card.dataset.achievementCategory);
+      const status = card.dataset.achievementStatus;
+      const statusMatch = activeStatuses.size === 0
+        || (activeStatuses.has('unlocked') && status === 'unlocked')
+        || (activeStatuses.has('locked') && status !== 'unlocked');
+      const visible = categoryMatch && statusMatch;
+      card.hidden = !visible;
+      if (visible) visibleCount += 1;
+    }
+    list?.toggleAttribute('data-filter-empty', visibleCount === 0);
+    syncButtons();
+  }
+
+  function reset() {
+    activeCategories.clear();
+    activeStatuses.clear();
+    apply();
+  }
+
+  container.addEventListener('click', (event) => {
+    const button = event.target.closest('[data-achievement-filter]');
+    if (!button) return;
+    const id = button.dataset.achievementFilter;
+    if (id === 'all') {
+      reset();
+      return;
+    }
+    if (categoryIds.has(id)) {
+      if (activeCategories.has(id)) activeCategories.delete(id);
+      else activeCategories.add(id);
+    } else if (statusIds.has(id)) {
+      if (activeStatuses.has(id)) activeStatuses.delete(id);
+      else {
+        activeStatuses.clear();
+        activeStatuses.add(id);
+      }
+    }
+    apply();
+  });
+
+  const listObserver = new MutationObserver(apply);
+  if (list) listObserver.observe(list, { childList: true });
+  return Object.freeze({ apply, reset, disconnect: () => listObserver.disconnect() });
+}
+
+function installRoadBehavior({ achievements, summary }) {
+  const { store } = achievements;
+  const markers = summary.track.querySelector('.turn-trophy-road-markers');
+  if (!markers) return null;
+  let selectedByPlayer = '';
+  let geometryFrame = 0;
+
+  function roadGeometry() {
+    cancelAnimationFrame(geometryFrame);
+    geometryFrame = requestAnimationFrame(() => {
+      const viewportWidth = Math.max(260, summary.scroll.clientWidth || 0);
+      const viewportRoadWidth = Math.max(1, viewportWidth - EDGE_PX * 2);
+      const contentRoadWidth = viewportRoadWidth
+        * (TROPHY_ROAD_MAX_THRESHOLD / TROPHY_ROAD_VIEWPORT_THRESHOLD);
+      const contentWidth = Math.ceil(contentRoadWidth + EDGE_PX * 2);
+      summary.content.style.width = `${contentWidth}px`;
+
+      for (const marker of markers.querySelectorAll('[data-trophy-reward]')) {
+        const reward = getTrophyRoadReward(marker.dataset.trophyReward);
+        if (!reward) continue;
+        marker.style.setProperty(
+          '--turn-trophy-road-position',
+          `${EDGE_PX + (reward.threshold / TROPHY_ROAD_MAX_THRESHOLD) * contentRoadWidth}px`
+        );
+      }
+    });
+  }
+
+  function decorateMarkers() {
+    for (const marker of markers.querySelectorAll('[data-trophy-reward]')) {
+      const reward = getTrophyRoadReward(marker.dataset.trophyReward);
+      const icon = marker.querySelector('span');
+      if (icon) icon.classList.add('turn-trophy-road-marker-icon');
+      if (reward && !store.isRewardUnlocked(reward.id) && !marker.querySelector('.turn-trophy-road-marker-lock')) {
+        const lock = document.createElement('i');
+        lock.className = 'turn-trophy-road-marker-lock';
+        lock.setAttribute('aria-hidden', 'true');
+        lock.innerHTML = LOCK_ICON;
+        marker.appendChild(lock);
+      }
+    }
+  }
+
+  function clearSelection() {
+    selectedByPlayer = '';
+    for (const marker of markers.querySelectorAll('[data-trophy-reward]')) {
+      marker.classList.remove('is-selected');
+      marker.setAttribute('aria-pressed', 'false');
+    }
+    if (summary.detail) {
+      summary.detail.hidden = true;
+      summary.detail.replaceChildren();
+    }
+    if (summary.help) summary.help.hidden = false;
+  }
+
+  function preserveUserSelection() {
+    decorateMarkers();
+    roadGeometry();
+    if (!selectedByPlayer) {
+      clearSelection();
+      return;
+    }
+    for (const marker of markers.querySelectorAll('[data-trophy-reward]')) {
+      const selected = marker.dataset.trophyReward === selectedByPlayer;
+      marker.classList.toggle('is-selected', selected);
+      marker.setAttribute('aria-pressed', String(selected));
+    }
+    if (summary.detail) summary.detail.hidden = false;
+    if (summary.help) summary.help.hidden = true;
+  }
+
+  markers.addEventListener('click', (event) => {
+    const marker = event.target.closest('[data-trophy-reward]');
+    if (!marker) return;
+    selectedByPlayer = marker.dataset.trophyReward;
+    queueMicrotask(preserveUserSelection);
+  }, { capture: true });
+
+  const markerObserver = new MutationObserver(preserveUserSelection);
+  markerObserver.observe(markers, { childList: true });
+
+  function alignToProgress() {
+    roadGeometry();
+    requestAnimationFrame(() => {
+      const viewportWidth = summary.scroll.clientWidth || 0;
+      const contentRoadWidth = Math.max(1, summary.content.clientWidth - EDGE_PX * 2);
+      const total = Math.min(store.trophyTotal(), TROPHY_ROAD_MAX_THRESHOLD);
+      const position = EDGE_PX + (total / TROPHY_ROAD_MAX_THRESHOLD) * contentRoadWidth;
+      summary.scroll.scrollLeft = Math.max(0, position - viewportWidth * .35);
+    });
+  }
+
+  window.addEventListener('resize', roadGeometry, { passive: true });
+  clearSelection();
+  preserveUserSelection();
+  return Object.freeze({
+    clearSelection,
+    alignToProgress,
+    disconnect() {
+      cancelAnimationFrame(geometryFrame);
+      markerObserver.disconnect();
+      window.removeEventListener('resize', roadGeometry);
+    }
+  });
+}
+
+export function installTrophyRoadFeedback(achievements = globalThis.__turnAchievements) {
+  if (installed) return installed;
+  ensureFeedbackStylesheet();
+  const dialog = achievements?.dialog;
+  if (!dialog || !achievements.store) return null;
+
+  const summary = prepareSummary(dialog);
+  const filters = prepareFilters(dialog);
+  if (!summary || !filters) return null;
+  const road = installRoadBehavior({ achievements, summary });
+  if (!road) return null;
+
+  function resetView() {
+    filters.reset();
+    road.clearSelection();
+    summary.scroll.scrollLeft = 0;
+  }
+
+  const openObserver = new MutationObserver(() => {
+    if (!dialog.hasAttribute('open')) return;
+    resetView();
+    road.alignToProgress();
+  });
+  openObserver.observe(dialog, { attributes: true, attributeFilter: ['open'] });
+  dialog.addEventListener('close', resetView);
+
+  achievements.homeTrigger?.addEventListener('click', resetView);
+  achievements.raceTrigger?.addEventListener('click', resetView);
+
+  installed = Object.freeze({
+    reset: resetView,
+    disconnect() {
+      openObserver.disconnect();
+      filters.disconnect();
+      road.disconnect();
+      installed = null;
+    }
+  });
+  return installed;
+}

--- a/turn/app.js
+++ b/turn/app.js
@@ -80,11 +80,11 @@ installStylesheet(
   'data-turn-lot-layout-r121'
 );
 installStylesheet(
-  './progression/trophy-road.css?revision=r153-trophy-road',
+  './progression/trophy-road.css?revision=r154-trophy-road-feedback',
   'data-turn-trophy-road'
 );
 const { prepareTrophyRoadProfile } = await import(
-  withBuild('./progression/trophy-road.js?revision=r153-trophy-road')
+  withBuild('./progression/trophy-road.js?revision=r154-trophy-road-feedback')
 );
 prepareTrophyRoadProfile();
 
@@ -169,10 +169,10 @@ installSportsSedanEasterEggUi();
 const { installHarborHiddenFaceOrientation } = await import(withBuild('./tracks/harbor-hidden-face-r89.js'));
 installHarborHiddenFaceOrientation();
 
-// Trophy Road bundle identity: lot-enhancement-runtime.js?revision=r153-trophy-road
+// Trophy Road bundle identity: lot-enhancement-runtime.js?revision=r154-trophy-road-feedback
 // The leading r121 query remains to preserve the established static contract.
 const { installLotEnhancementRuntime } = await import(
-  withBuild('./garage/lot-enhancement-runtime.js?revision=r121&trophy-road=r153')
+  withBuild('./garage/lot-enhancement-runtime.js?revision=r121&trophy-road=r154')
 );
 installLotEnhancementRuntime();
 
@@ -217,7 +217,7 @@ installStylesheet(
 );
 installStylesheet('./rival-reset-context-r127.css', 'data-turn-rival-reset-context');
 const { installM8HomeNavigation } = await import(
-  withBuild('./m8-home.js?revision=r131-motion-permission-retry&trophy-road=r153')
+  withBuild('./m8-home.js?revision=r131-motion-permission-retry&trophy-road=r154')
 );
 const home = await installM8HomeNavigation();
 globalThis.__turnHome = home;
@@ -236,7 +236,7 @@ if (buildLabel) {
   buildLabel.textContent = `TURN V${release?.version || ''} · BUILD ${(release?.id || '').toUpperCase()}`;
 }
 const { installM8HomeFixedLayout } = await import(
-  withBuild('./m8-home-fixed-layout.js?revision=m8.9-track-title-alignment&trophy-road=r153')
+  withBuild('./m8-home-fixed-layout.js?revision=m8.9-track-title-alignment&trophy-road=r154')
 );
 await installM8HomeFixedLayout();
 installStylesheet(

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -1,10 +1,10 @@
 import { installLotStatLegend } from './lot-stat-legend.js?build=20260724-r59';
 import { installLotLayout } from './lot-layout-r60.js?build=20260729-r116';
 import { installLotAccessibility } from './lot-accessibility-r118.js?build=20260729-r118';
-import { gateLotNow } from '../progression/lot-trophy-gate.js?revision=r153-trophy-road';
+import { gateLotNow } from '../progression/lot-trophy-gate.js?revision=r154-trophy-road-feedback';
 
 const ENHANCEMENT_ID = 'enhanced-lot-r121';
-const TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r153-trophy-road';
+const TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r154-trophy-road-feedback';
 const activeEnhancements = new WeakMap();
 
 function findLotScreen(root) {

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -100,14 +100,18 @@ export async function installM8HomeFixedLayout() {
   const cardScrollFixes = await installM8HomeCardScrollFixes();
 
   const { installM8TrophyGate } = await import(
-    `/turn/progression/m8-trophy-gate.js?build=${buildKey}-r153-trophy-road`
+    `/turn/progression/m8-trophy-gate.js?build=${buildKey}-r154-trophy-road-feedback`
   );
   const trophyGate = installM8TrophyGate(globalThis.__turnNextHome);
 
   const { installAchievements } = await import(
-    `/turn/achievements.js?build=${buildKey}-r153-trophy-road`
+    `/turn/achievements.js?build=${buildKey}-r154-trophy-road-feedback`
   );
   const achievements = installAchievements(globalThis.__turnRuntime);
+  const { installTrophyRoadFeedback } = await import(
+    `/turn/achievements/trophy-road-feedback.js?build=${buildKey}-r154-trophy-road-feedback`
+  );
+  const trophyRoadFeedback = installTrophyRoadFeedback(achievements);
 
   const { installDriveByEarTraining } = await import(
     `/turn/training/drive-by-ear-training.js?build=${buildKey}-r151-dbe-training-device-fixes`
@@ -123,6 +127,7 @@ export async function installM8HomeFixedLayout() {
     cardScrollFixes,
     trophyGate,
     achievements,
+    trophyRoadFeedback,
     driveByEarTraining
   });
   return globalThis.__turnHomeLayout;

--- a/turn/progression/lot-trophy-gate.js
+++ b/turn/progression/lot-trophy-gate.js
@@ -1,7 +1,9 @@
 import {
+  LOCK_ICON,
   isVehicleUnlocked,
-  rewardForVehicle
-} from './trophy-road.js?revision=r153-trophy-road';
+  rewardForVehicle,
+  showTrophyUnlockNotice
+} from './trophy-road.js?revision=r154-trophy-road-feedback';
 
 const FALLBACK_VEHICLE_ID = 'classic';
 const activeGates = new WeakMap();
@@ -26,17 +28,10 @@ export function gateLotNow(root = document.body) {
 
   const carPicker = screen.querySelector('.lot-car-picker');
   const raceButton = screen.querySelector('.lot-race');
-  const colors = screen.querySelector('.lot-colors');
-  const description = screen.querySelector('.lot-car-description');
-  if (!carPicker || !raceButton || !colors || !description) return () => {};
-
-  const lockMessage = document.createElement('div');
-  lockMessage.className = 'lot-lock-message';
-  lockMessage.hidden = true;
-  lockMessage.setAttribute('role', 'status');
-  description.insertAdjacentElement('afterend', lockMessage);
+  if (!carPicker || !raceButton) return () => {};
 
   let initialSelectionChecked = false;
+  let lastAnnouncedCarId = '';
   let syncing = false;
 
   function decorateButtons() {
@@ -44,7 +39,6 @@ export function gateLotNow(root = document.body) {
       const reward = rewardForVehicle(button.dataset.carId);
       const locked = Boolean(reward) && !isVehicleUnlocked(button.dataset.carId);
       button.classList.toggle('is-trophy-locked', locked);
-      button.setAttribute('aria-disabled', String(locked));
       if (reward) {
         button.dataset.trophyLockLabel = `${reward.threshold} TROPHIES`;
       } else {
@@ -54,10 +48,28 @@ export function gateLotNow(root = document.body) {
       button.setAttribute(
         'aria-label',
         locked
-          ? `${name}. Locked. Unlocks at ${reward.threshold} trophies on Trophy Road.`
+          ? `${name}. Locked. Unlocks at ${reward.threshold} trophies on Trophy Road. Select for unlock information.`
           : name
       );
     }
+  }
+
+  function setRaceLocked({ locked, reward, selectedName }) {
+    raceButton.disabled = locked;
+    raceButton.classList.toggle('is-trophy-locked', locked);
+    if (locked) {
+      raceButton.dataset.trophyLocked = 'true';
+      raceButton.innerHTML = `<span class="lot-race-lock-icon" aria-hidden="true">${LOCK_ICON}</span><span>RACE THIS CAR</span>`;
+      raceButton.setAttribute(
+        'aria-label',
+        `${selectedName} is locked. Unlocks at ${reward.threshold} trophies on Trophy Road.`
+      );
+      return;
+    }
+
+    delete raceButton.dataset.trophyLocked;
+    raceButton.textContent = 'RACE THIS CAR';
+    raceButton.setAttribute('aria-label', `Race the ${selectedName}`);
   }
 
   function sync() {
@@ -67,6 +79,7 @@ export function gateLotNow(root = document.body) {
 
     const selected = selectedCarButton(carPicker);
     const selectedId = selected?.dataset.carId || '';
+    const selectedName = selected?.textContent.trim() || 'Vehicle';
     const reward = rewardForVehicle(selectedId);
     const locked = Boolean(reward) && !isVehicleUnlocked(selectedId);
 
@@ -80,20 +93,12 @@ export function gateLotNow(root = document.body) {
       }
     }
 
-    colors.hidden = locked;
-    raceButton.disabled = locked;
-    if (locked) {
-      raceButton.textContent = `UNLOCKS AT ${reward.threshold} TROPHIES`;
-      raceButton.setAttribute(
-        'aria-label',
-        `${reward.shortTitle} is locked. Unlocks at ${reward.threshold} trophies on Trophy Road.`
-      );
-      lockMessage.innerHTML = `<strong>UNLOCKS AT ${reward.threshold} TROPHIES</strong><small>${reward.description}</small>`;
-      lockMessage.hidden = false;
-    } else {
-      raceButton.textContent = 'RACE THIS CAR';
-      lockMessage.hidden = true;
-      lockMessage.replaceChildren();
+    setRaceLocked({ locked, reward, selectedName });
+    if (locked && selectedId !== lastAnnouncedCarId) {
+      lastAnnouncedCarId = selectedId;
+      showTrophyUnlockNotice({ reward, itemName: selectedName });
+    } else if (!locked) {
+      lastAnnouncedCarId = '';
     }
     syncing = false;
   }
@@ -105,11 +110,19 @@ export function gateLotNow(root = document.body) {
     attributes: true,
     attributeFilter: ['aria-checked']
   });
+  const handleStorage = (event) => {
+    if (event.key === 'turn-achievements-v1') sync();
+  };
+  window.addEventListener('turn:trophy-road-updated', sync);
+  window.addEventListener('storage', handleStorage);
   sync();
 
   const release = () => {
     observer.disconnect();
-    lockMessage.remove();
+    window.removeEventListener('turn:trophy-road-updated', sync);
+    window.removeEventListener('storage', handleStorage);
+    raceButton.classList.remove('is-trophy-locked');
+    delete raceButton.dataset.trophyLocked;
     activeGates.delete(screen);
   };
   activeGates.set(screen, { release });

--- a/turn/progression/lot-trophy-gate.js
+++ b/turn/progression/lot-trophy-gate.js
@@ -28,6 +28,7 @@ export function gateLotNow(root = document.body) {
 
   const carPicker = screen.querySelector('.lot-car-picker');
   const raceButton = screen.querySelector('.lot-race');
+  const carTitle = screen.querySelector('.lot-car-title strong');
   if (!carPicker || !raceButton) return () => {};
 
   let initialSelectionChecked = false;
@@ -52,6 +53,17 @@ export function gateLotNow(root = document.body) {
           : name
       );
     }
+  }
+
+  function setTitleLocked(locked) {
+    if (!carTitle) return;
+    carTitle.querySelector('.lot-selected-car-lock')?.remove();
+    if (!locked) return;
+    const lock = document.createElement('span');
+    lock.className = 'lot-selected-car-lock';
+    lock.setAttribute('aria-hidden', 'true');
+    lock.textContent = '🔒 ';
+    carTitle.prepend(lock);
   }
 
   function setRaceLocked({ locked, reward, selectedName }) {
@@ -94,6 +106,7 @@ export function gateLotNow(root = document.body) {
     }
 
     screen.dataset.trophyVehicleLocked = String(locked);
+    setTitleLocked(locked);
     setRaceLocked({ locked, reward, selectedName });
     if (locked && selectedId !== lastAnnouncedCarId) {
       lastAnnouncedCarId = selectedId;
@@ -125,6 +138,7 @@ export function gateLotNow(root = document.body) {
     raceButton.classList.remove('is-trophy-locked');
     delete raceButton.dataset.trophyLocked;
     delete screen.dataset.trophyVehicleLocked;
+    carTitle?.querySelector('.lot-selected-car-lock')?.remove();
     activeGates.delete(screen);
   };
   activeGates.set(screen, { release });

--- a/turn/progression/lot-trophy-gate.js
+++ b/turn/progression/lot-trophy-gate.js
@@ -93,6 +93,7 @@ export function gateLotNow(root = document.body) {
       }
     }
 
+    screen.dataset.trophyVehicleLocked = String(locked);
     setRaceLocked({ locked, reward, selectedName });
     if (locked && selectedId !== lastAnnouncedCarId) {
       lastAnnouncedCarId = selectedId;
@@ -123,6 +124,7 @@ export function gateLotNow(root = document.body) {
     window.removeEventListener('storage', handleStorage);
     raceButton.classList.remove('is-trophy-locked');
     delete raceButton.dataset.trophyLocked;
+    delete screen.dataset.trophyVehicleLocked;
     activeGates.delete(screen);
   };
   activeGates.set(screen, { release });

--- a/turn/progression/m8-trophy-gate.js
+++ b/turn/progression/m8-trophy-gate.js
@@ -1,77 +1,107 @@
 import {
-  TROPHY_ICON,
   isTrackUnlocked,
-  rewardForTrack
-} from './trophy-road.js?revision=r153-trophy-road';
+  rewardForTrack,
+  showTrophyUnlockNotice
+} from './trophy-road.js?revision=r154-trophy-road-feedback';
 
 const LOCKED_TRACK_ID = 'midnight-city';
 
 export function installM8TrophyGate(homeApi = globalThis.__turnNextHome) {
   const home = document.querySelector('.m8-home');
   const card = home?.querySelector(`[data-track-id="${LOCKED_TRACK_ID}"]`);
-  const fallbackCard = home?.querySelector('[data-track-id="countryside"]');
   const continueButton = home?.querySelector('.m8-track-continue');
-  const status = home?.querySelector('.m8-home-status');
+  const choiceMarker = card?.querySelector('.track-card-choice-marker');
   const reward = rewardForTrack(LOCKED_TRACK_ID);
   if (!home || !card || !continueButton || !reward) return null;
 
   const originalLabel = card.getAttribute('aria-label') || 'Midnight City, hard track';
-  const lock = document.createElement('span');
-  lock.className = 'track-card-trophy-lock';
-  lock.innerHTML = `<span aria-hidden="true">${TROPHY_ICON}</span><strong>${reward.threshold} TROPHIES</strong>`;
-  card.appendChild(lock);
 
   function locked() {
     return !isTrackUnlocked(LOCKED_TRACK_ID);
   }
 
+  function selected() {
+    return homeApi?.getSelectedTrackId?.() === LOCKED_TRACK_ID
+      || card.getAttribute('aria-pressed') === 'true';
+  }
+
   function explainLock() {
-    if (status) {
-      status.textContent = `${reward.shortTitle} unlocks at ${reward.threshold} trophies on Trophy Road.`;
+    showTrophyUnlockNotice({ reward, itemName: reward.shortTitle });
+  }
+
+  function setRaceLocked(isLockedSelection) {
+    continueButton.classList.toggle('is-trophy-locked', isLockedSelection);
+    if (isLockedSelection) {
+      continueButton.dataset.trophyLocked = 'true';
+      if (!continueButton.disabled) {
+        continueButton.disabled = true;
+        continueButton.dataset.trophyGateDisabled = 'true';
+      }
+      continueButton.setAttribute(
+        'aria-label',
+        `Race on ${reward.shortTitle}, locked. Unlocks at ${reward.threshold} trophies.`
+      );
+      return;
     }
+
+    delete continueButton.dataset.trophyLocked;
+    if (continueButton.dataset.trophyGateDisabled === 'true') {
+      continueButton.disabled = false;
+      delete continueButton.dataset.trophyGateDisabled;
+    }
+    if (selected()) continueButton.setAttribute('aria-label', `Race on ${reward.shortTitle}`);
   }
 
   function sync() {
     const isLocked = locked();
     card.dataset.trophyLocked = String(isLocked);
     card.classList.toggle('is-trophy-locked', isLocked);
-    card.setAttribute('aria-disabled', String(isLocked));
     card.setAttribute(
       'aria-label',
       isLocked
-        ? `${reward.shortTitle}, locked. Unlocks at ${reward.threshold} trophies.`
+        ? `${reward.shortTitle}, locked. Unlocks at ${reward.threshold} trophies. Select for unlock information.`
         : originalLabel
     );
-    lock.hidden = !isLocked;
-
-    if (isLocked && card.getAttribute('aria-pressed') === 'true') {
-      fallbackCard?.click();
-    }
+    if (choiceMarker) choiceMarker.dataset.trophyLock = String(isLocked);
+    setRaceLocked(isLocked && selected());
   }
 
-  card.addEventListener('click', (event) => {
-    if (!locked()) return;
-    event.preventDefault();
-    event.stopImmediatePropagation();
-    explainLock();
-    card.focus();
-  }, { capture: true });
+  card.addEventListener('click', () => {
+    if (locked()) explainLock();
+    sync();
+  });
 
   continueButton.addEventListener('click', (event) => {
-    if (homeApi?.getSelectedTrackId?.() !== LOCKED_TRACK_ID || !locked()) return;
+    if (!selected() || !locked()) return;
     event.preventDefault();
     event.stopImmediatePropagation();
     explainLock();
     card.focus();
   }, { capture: true });
 
-  window.addEventListener('turn:trophy-road-updated', sync);
-  window.addEventListener('storage', (event) => {
-    if (event.key === 'turn-achievements-v1') sync();
+  const selectionObserver = new MutationObserver(sync);
+  selectionObserver.observe(card, {
+    attributes: true,
+    attributeFilter: ['aria-pressed']
   });
+
+  const handleStorage = (event) => {
+    if (event.key === 'turn-achievements-v1') sync();
+  };
+  window.addEventListener('turn:trophy-road-updated', sync);
+  window.addEventListener('storage', handleStorage);
   sync();
 
-  const api = Object.freeze({ sync, card, reward });
+  const api = Object.freeze({
+    sync,
+    card,
+    reward,
+    disconnect() {
+      selectionObserver.disconnect();
+      window.removeEventListener('turn:trophy-road-updated', sync);
+      window.removeEventListener('storage', handleStorage);
+    }
+  });
   globalThis.__turnM8TrophyGate = api;
   return api;
 }

--- a/turn/progression/trophy-road.css
+++ b/turn/progression/trophy-road.css
@@ -5,19 +5,70 @@
   background: var(--turn-action-success, #8ce99a);
 }
 
-.turn-achievements-summary-main {
-  min-width: 0;
+/* Give the road the complete summary width. Totals stay in their own header row. */
+.turn-achievements-dialog .turn-achievements-summary {
+  grid-template-columns: minmax(0, 1fr);
+  gap: 12px;
+  align-items: stretch;
+}
+
+.turn-achievements-summary-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.turn-achievements-summary-header > strong {
+  display: block;
+  font-size: clamp(1rem, 2.4vw, 1.35rem);
+}
+
+.turn-achievements-summary-metrics {
+  display: flex;
+  flex: 0 0 auto;
+  gap: clamp(20px, 4vw, 42px);
+}
+
+.turn-achievements-dialog .turn-achievements-summary-metrics p {
+  min-width: 88px;
 }
 
 .turn-trophy-road {
+  min-width: 0;
+}
+
+.turn-trophy-road-scroll {
+  min-width: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding: 8px 0 12px;
+  overscroll-behavior-inline: contain;
+  scrollbar-color: var(--turn-ink, #08090a) var(--turn-muted, #d6d0c2);
+  scrollbar-width: thin;
+  touch-action: pan-x;
+  -webkit-overflow-scrolling: touch;
+}
+
+.turn-trophy-road-scroll:focus-visible {
+  outline: 4px solid var(--turn-action-information, #38d9ff);
+  outline-offset: 3px;
+  border-radius: var(--turn-radius-compact, 12px);
+}
+
+.turn-trophy-road-content {
   position: relative;
-  margin-top: 10px;
-  padding: 30px 4px 16px;
+  min-width: 100%;
+  height: 74px;
 }
 
 .turn-trophy-road-track {
-  position: relative;
+  position: absolute;
+  top: 50%;
+  right: 34px;
+  left: 34px;
   height: 18px;
+  transform: translateY(-50%);
 }
 
 .turn-trophy-road-progress {
@@ -40,15 +91,16 @@
 .turn-trophy-road-markers {
   position: absolute;
   inset: 0;
+  pointer-events: none;
 }
 
 .turn-trophy-road-marker {
   position: absolute;
-  left: var(--turn-trophy-road-position, 0%);
+  left: var(--turn-trophy-road-position, 34px);
   top: 50%;
   display: grid;
-  width: 54px;
-  height: 54px;
+  width: 58px;
+  height: 58px;
   padding: 5px;
   place-items: center;
   border: 3px solid var(--turn-ink, #08090a);
@@ -58,19 +110,20 @@
   box-shadow: var(--turn-shadow-compact, 3px 3px 0 #08090a);
   transform: translate(-50%, -50%);
   cursor: pointer;
+  pointer-events: auto;
 }
 
-.turn-trophy-road-marker:first-child {
-  transform: translate(-35%, -50%);
+/* TURN's global button press rule must never replace the marker's positioning transform. */
+.turn-achievements-dialog .turn-trophy-road-marker:hover,
+.turn-achievements-dialog .turn-trophy-road-marker:active,
+.turn-achievements-dialog .turn-trophy-road-marker.is-down {
+  box-shadow: var(--turn-shadow-compact, 3px 3px 0 #08090a);
+  transform: translate(-50%, -50%);
 }
 
-.turn-trophy-road-marker:last-child {
-  transform: translate(-65%, -50%);
-}
-
-.turn-trophy-road-marker > span {
+.turn-trophy-road-marker-icon {
   display: grid;
-  width: 31px;
+  width: 32px;
   height: 25px;
   place-items: center;
 }
@@ -78,7 +131,9 @@
 .turn-trophy-road-marker svg,
 .turn-trophy-road-detail-icon svg,
 .turn-achievements-trophy-total svg,
-.turn-trophy-reward-toast .turn-achievement-toast-icon svg {
+.turn-trophy-reward-toast .turn-achievement-toast-icon svg,
+.lot-race-lock-icon svg,
+.turn-unlock-notice-icon svg {
   width: 100%;
   height: 100%;
   fill: none;
@@ -99,7 +154,21 @@
 
 .turn-trophy-road-marker.is-locked {
   background: var(--turn-muted, #d6d0c2);
-  filter: grayscale(.7);
+}
+
+.turn-trophy-road-marker-lock {
+  position: absolute;
+  top: -9px;
+  right: -9px;
+  display: grid;
+  width: 22px;
+  height: 22px;
+  padding: 3px;
+  place-items: center;
+  border: 2px solid var(--turn-ink, #08090a);
+  border-radius: 50%;
+  background: var(--turn-action-warning, #ffd43b);
+  box-shadow: 2px 2px 0 var(--turn-ink, #08090a);
 }
 
 .turn-trophy-road-marker.is-selected {
@@ -107,8 +176,14 @@
   outline-offset: 3px;
 }
 
+.turn-trophy-road-help {
+  margin: 0;
+  font-size: .76rem;
+  font-weight: 850;
+  text-align: center;
+}
+
 .turn-trophy-road-detail {
-  grid-column: 1 / -1;
   display: grid;
   grid-template-columns: 120px minmax(0, 1fr);
   gap: 18px;
@@ -118,6 +193,10 @@
   border: var(--turn-border-default, 4px) solid var(--turn-ink, #08090a);
   border-radius: var(--turn-radius-default, 18px);
   background: var(--turn-action-success, #8ce99a);
+}
+
+.turn-trophy-road-detail[hidden] {
+  display: none;
 }
 
 .turn-trophy-road-detail-icon {
@@ -168,7 +247,15 @@
   background: var(--turn-action-warning, #ffd43b);
 }
 
-/* Trophy-locked track cards remain visible and explain the milestone. */
+.turn-achievements-filters [data-achievement-filter="unlocked"][aria-pressed="true"] {
+  background: var(--turn-action-success, #8ce99a);
+}
+
+.turn-achievements-filters [data-achievement-filter="locked"][aria-pressed="true"] {
+  background: var(--turn-action-warning, #ffd43b);
+}
+
+/* Trophy-locked track cards remain visible and selectable for information. */
 .track-card[data-trophy-locked="true"] {
   cursor: pointer;
 }
@@ -179,87 +266,131 @@
   opacity: .58;
 }
 
-.track-card-trophy-lock {
-  position: absolute;
-  inset: auto 18px 18px auto;
-  z-index: 4;
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  padding: 7px 10px;
-  border: 3px solid var(--m8-ink, #08090a);
-  border-radius: 999px;
-  background: var(--m8-yellow, #ffbd12);
-  box-shadow: 4px 4px 0 var(--m8-ink, #08090a);
-  font-size: clamp(.68rem, 1.25vw, .9rem);
-  font-weight: 950;
-  letter-spacing: .06em;
-  white-space: nowrap;
-}
-
-.track-card-trophy-lock svg {
-  width: 21px;
-  height: 21px;
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 2.2;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
-
-.track-card-trophy-lock[hidden] {
-  display: none;
-}
-
 .track-card[data-trophy-locked="true"] .track-card-choice-marker::after {
-  content: '×';
+  content: '🔒';
   display: grid;
   place-items: center;
-  font-size: .8em;
+  font-size: clamp(.78rem, 1.5vw, 1.08rem);
+  line-height: 1;
 }
 
-/* Locked vehicles can be inspected, but never selected for a race. */
-.lot-car-option.is-trophy-locked {
-  position: relative;
+.m8-race-button[data-trophy-locked="true"]::before {
+  content: '🔒';
+  margin-right: .45em;
+}
+
+.m8-race-button[data-trophy-locked="true"]:disabled {
+  background: var(--turn-muted, #d6d0c2);
+  cursor: not-allowed;
   opacity: .72;
 }
 
+/* Locked vehicles remain inspectable. Only racing is disabled. */
+.lot-car-option.is-trophy-locked {
+  position: relative;
+}
+
 .lot-car-option.is-trophy-locked::after {
-  content: attr(data-trophy-lock-label);
-  display: block;
-  margin-top: 2px;
-  font-size: .58em;
-  line-height: 1;
-  letter-spacing: .04em;
+  content: ' 🔒 ' attr(data-trophy-lock-label);
+  font-size: .82em;
+  font-weight: 950;
 }
 
-.lot-lock-message {
-  display: grid;
-  gap: 5px;
-  padding: 10px 12px;
-  border: 3px solid var(--turn-ink, #08090a);
-  border-radius: var(--turn-radius-compact, 12px);
-  background: var(--turn-action-warning, #ffd43b);
-  color: var(--turn-ink, #08090a);
-  box-shadow: var(--turn-shadow-compact, 3px 3px 0 #08090a);
+.lot-race.is-trophy-locked {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
 }
 
-.lot-lock-message strong {
-  font-size: .82rem;
-  letter-spacing: .06em;
-}
-
-.lot-lock-message small {
-  line-height: 1.25;
+.lot-race-lock-icon {
+  display: inline-grid;
+  width: 25px;
+  height: 25px;
+  place-items: center;
 }
 
 .lot-race:disabled {
   cursor: not-allowed;
-  filter: grayscale(.35);
-  opacity: .78;
+  filter: grayscale(.2);
+  opacity: .65;
+}
+
+/* One compact unlock explanation is shared by tracks and vehicles. */
+.turn-unlock-notice {
+  position: fixed;
+  z-index: 2147482600;
+  top: max(14px, calc(env(safe-area-inset-top) + 8px));
+  left: 50%;
+  display: grid;
+  grid-template-columns: 50px minmax(0, 1fr);
+  gap: 12px;
+  align-items: center;
+  width: min(590px, calc(100vw - 28px));
+  padding: 10px 14px;
+  border: var(--turn-border-default, 4px) solid var(--turn-ink, #08090a);
+  border-radius: var(--turn-radius-default, 18px);
+  background: var(--turn-action-success, #8ce99a);
+  color: var(--turn-ink, #08090a);
+  box-shadow: var(--turn-shadow-default, 7px 7px 0 #08090a);
+  opacity: 0;
+  transform: translate(-50%, -130%);
+  transition: transform 180ms ease, opacity 160ms ease;
+  pointer-events: none;
+}
+
+.turn-unlock-notice[hidden] {
+  display: none;
+}
+
+.turn-unlock-notice.is-visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.turn-unlock-notice-icon {
+  display: grid;
+  width: 50px;
+  height: 50px;
+  padding: 9px;
+  place-items: center;
+  border: 3px solid var(--turn-ink, #08090a);
+  border-radius: 14px;
+  background: var(--turn-action-warning, #ffd43b);
+}
+
+.turn-unlock-notice-copy,
+.turn-unlock-notice-copy > span,
+.turn-unlock-notice-copy > strong {
+  display: block;
+  min-width: 0;
+}
+
+.turn-unlock-notice-copy > strong {
+  margin-bottom: 2px;
+  font-size: .78rem;
+  letter-spacing: .08em;
+}
+
+.turn-unlock-notice-copy > span {
+  font-size: .76rem;
+  line-height: 1.25;
 }
 
 @media (max-width: 720px) {
+  .turn-achievements-summary-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .turn-achievements-summary-metrics {
+    justify-content: space-between;
+  }
+
+  .turn-achievements-dialog .turn-achievements-summary-metrics p {
+    text-align: left;
+  }
+
   .turn-trophy-road-detail {
     grid-template-columns: 78px minmax(0, 1fr);
     gap: 10px;
@@ -271,32 +402,43 @@
   }
 
   .turn-trophy-road-marker {
-    width: 46px;
-    height: 46px;
+    width: 50px;
+    height: 50px;
   }
 
-  .turn-trophy-road-marker > span {
-    width: 27px;
+  .turn-trophy-road-marker-icon {
+    width: 28px;
     height: 21px;
   }
 }
 
 @media (max-height: 430px) and (orientation: landscape) {
-  .turn-trophy-road {
-    padding-top: 24px;
-    padding-bottom: 11px;
+  .turn-achievements-summary-header {
+    align-items: flex-start;
+    flex-direction: row;
+  }
+
+  .turn-trophy-road-content {
+    height: 58px;
   }
 
   .turn-trophy-road-marker {
-    width: 42px;
-    height: 42px;
+    width: 44px;
+    height: 44px;
     padding: 4px;
     border-width: 2px;
   }
 
-  .turn-trophy-road-marker > span {
+  .turn-trophy-road-marker-icon {
     width: 25px;
     height: 19px;
+  }
+
+  .turn-trophy-road-marker-lock {
+    top: -7px;
+    right: -7px;
+    width: 18px;
+    height: 18px;
   }
 
   .turn-trophy-road-detail {
@@ -313,11 +455,24 @@
   .turn-trophy-road-detail p {
     font-size: .76rem;
   }
+
+  .turn-unlock-notice {
+    grid-template-columns: 42px minmax(0, 1fr);
+    width: min(560px, calc(100vw - 22px));
+    padding: 7px 11px;
+  }
+
+  .turn-unlock-notice-icon {
+    width: 42px;
+    height: 42px;
+    padding: 7px;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .turn-trophy-road-marker,
-  .track-card[data-trophy-locked="true"] {
+  .track-card[data-trophy-locked="true"],
+  .turn-unlock-notice {
     transition: none;
   }
 }

--- a/turn/progression/trophy-road.js
+++ b/turn/progression/trophy-road.js
@@ -1,8 +1,10 @@
 export const TROPHY_ROAD_STORAGE_KEY = 'turn-achievements-v1';
 export const TROPHY_ROAD_STORAGE_VERSION = 3;
 export const TROPHY_ROAD_MAX_THRESHOLD = 1300;
+export const TROPHY_ROAD_VIEWPORT_THRESHOLD = 600;
 
 export const TROPHY_ICON = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M7 4h10v4c0 4-2 7-5 8-3-1-5-4-5-8V4Z"></path><path d="M7 6H4v2c0 2 1 3 4 4M17 6h3v2c0 2-1 3-4 4M9 20h6M12 16v4"></path></svg>';
+export const LOCK_ICON = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><rect x="5" y="10" width="14" height="11" rx="2"></rect><path d="M8 10V7a4 4 0 0 1 8 0v3M12 14v3"></path></svg>';
 
 export const TROPHY_ROAD_REWARD_ICONS = Object.freeze({
   skyline: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M3 43h58M8 43V24h10v19M21 43V13h13v30M37 43V20h8v23M48 43V9h10v34"></path><path d="M11 29h3M11 35h3M25 19h4M25 26h4M25 33h4M51 15h3M51 22h3M51 29h3"></path><path d="M8 8a8 8 0 1 0 9 9A7 7 0 0 1 8 8Z"></path></svg>',
@@ -13,7 +15,7 @@ export const TROPHY_ROAD_REWARD_ICONS = Object.freeze({
 export const TROPHY_ROAD_REWARDS = Object.freeze([
   Object.freeze({
     id: 'midnight-city',
-    threshold: 200,
+    threshold: 300,
     title: 'MIDNIGHT CITY',
     shortTitle: 'Midnight City',
     type: 'track',
@@ -22,24 +24,24 @@ export const TROPHY_ROAD_REWARDS = Object.freeze([
     description: 'Unlock TURN’s night-time city track, with neon streets, technical corners and the longest lap in the current track collection.'
   }),
   Object.freeze({
-    id: 'emergency-pack',
-    threshold: 400,
-    title: 'EMERGENCY!',
-    shortTitle: 'Emergency Pack',
-    type: 'vehicle-pack',
-    vehicleIds: Object.freeze(['firetruck', 'ambulance', 'police']),
-    icon: 'emergency',
-    description: 'Unlock the Fire Truck, Ambulance and Police Car. During Boost, their emergency lights flash and their sirens sound. All three have maximum Boost tanks.'
-  }),
-  Object.freeze({
     id: 'future-racer',
-    threshold: 500,
+    threshold: 400,
     title: 'FUTURE RACER',
     shortTitle: 'Future Racer',
     type: 'vehicle',
     vehicleIds: Object.freeze(['race-future']),
     icon: 'future',
     description: 'Unlock a high-speed racing vehicle built for advanced laps and hard time-trial targets.'
+  }),
+  Object.freeze({
+    id: 'emergency-pack',
+    threshold: 600,
+    title: 'EMERGENCY!',
+    shortTitle: 'Emergency Pack',
+    type: 'vehicle-pack',
+    vehicleIds: Object.freeze(['firetruck', 'ambulance', 'police']),
+    icon: 'emergency',
+    description: 'Unlock the Fire Truck, Ambulance and Police Car. During Boost, their emergency lights flash and their sirens sound. All three have maximum Boost tanks.'
   })
 ]);
 
@@ -55,6 +57,9 @@ const REWARD_BY_VEHICLE = new Map(
   )
 );
 const PREPARED_STORAGE = new WeakSet();
+
+let unlockNotice = null;
+let unlockNoticeTimer = 0;
 
 export function getTrophyRoadReward(id) {
   return REWARD_BY_ID.get(id) || null;
@@ -73,6 +78,52 @@ export function rewardIdsForTrophies(trophies) {
   return TROPHY_ROAD_REWARDS
     .filter((reward) => total >= reward.threshold)
     .map((reward) => reward.id);
+}
+
+function ensureUnlockNotice() {
+  if (unlockNotice?.isConnected) return unlockNotice;
+  const documentRef = globalThis.document;
+  if (!documentRef?.body) return null;
+
+  unlockNotice = documentRef.createElement('div');
+  unlockNotice.className = 'turn-unlock-notice';
+  unlockNotice.hidden = true;
+  unlockNotice.setAttribute('role', 'status');
+  unlockNotice.setAttribute('aria-live', 'polite');
+  unlockNotice.setAttribute('aria-atomic', 'true');
+  unlockNotice.innerHTML = `
+    <span class="turn-unlock-notice-icon" aria-hidden="true">${LOCK_ICON}</span>
+    <span class="turn-unlock-notice-copy"><strong></strong><span></span></span>`;
+  documentRef.body.appendChild(unlockNotice);
+  return unlockNotice;
+}
+
+export function showTrophyUnlockNotice({ reward, itemName = reward?.shortTitle } = {}) {
+  if (!reward) return null;
+  const notice = ensureUnlockNotice();
+  if (!notice) return null;
+
+  const name = itemName || reward.shortTitle;
+  notice.querySelector('strong').textContent = `LOCKED · ${reward.threshold} TROPHIES`;
+  notice.querySelector('.turn-unlock-notice-copy > span').textContent =
+    `${name} unlocks on Trophy Road. Complete achievements to reach ${reward.threshold} trophies.`;
+  notice.setAttribute(
+    'aria-label',
+    `${name} is locked. Unlocks at ${reward.threshold} trophies on Trophy Road.`
+  );
+  notice.hidden = false;
+  notice.classList.remove('is-visible');
+  void notice.offsetWidth;
+  notice.classList.add('is-visible');
+
+  globalThis.clearTimeout?.(unlockNoticeTimer);
+  unlockNoticeTimer = globalThis.setTimeout?.(() => {
+    notice.classList.remove('is-visible');
+    globalThis.setTimeout?.(() => {
+      if (!notice.classList.contains('is-visible')) notice.hidden = true;
+    }, 180);
+  }, 4200) || 0;
+  return notice;
 }
 
 function safeParse(raw) {

--- a/turn/vehicle/catalog.js
+++ b/turn/vehicle/catalog.js
@@ -95,11 +95,11 @@ const RETIRED_VEHICLE_REPLACEMENTS = Object.freeze({
 const RAW_CARS = [
   ['convertible', 'Convertible', 'prototype', { speed: 4, acceleration: 4, control: 4, drift: 2, boostPower: 3, boostDuration: 1 }, 0.98, 1, 1.08],
   ['classic', 'Training Car', 'prototype', { speed: 1, acceleration: 1, control: 5, drift: 5, boostPower: 1, boostDuration: 5 }, 1.00, 1, 0.88],
-  ['vintage-racer', 'Vintage Racer', 'toy', { speed: 5, acceleration: 4, control: 3, drift: 2, boostPower: 3, boostDuration: 1 }, 0.96, 0, 1.28],
+  ['vintage-racer', 'Vintage Racer', 'toy', { speed: 4, acceleration: 4, control: 3, drift: 2, boostPower: 3, boostDuration: 2 }, 0.96, 0, 1.28],
   ['toy-racer', 'Toy Racer', 'toy', { speed: 4, acceleration: 5, control: 5, drift: 1, boostPower: 2, boostDuration: 1 }, 0.94, 2, 1.18],
   ['monster-truck', 'Monster Truck', 'toy', { speed: 2, acceleration: 3, control: 2, drift: 5, boostPower: 2, boostDuration: 4 }, 0.83, 2, 0.62],
   ['race-future', 'Future Racer', 'car', { speed: 5, acceleration: 5, control: 3, drift: 1, boostPower: 3, boostDuration: 1 }, 0.96, 0, 1.42],
-  ['race', 'Race Car', 'car', { speed: 5, acceleration: 4, control: 4, drift: 1, boostPower: 3, boostDuration: 1 }, 0.94, 0, 1.55],
+  ['race', 'Race Car', 'car', { speed: 5, acceleration: 4, control: 4, drift: 2, boostPower: 2, boostDuration: 1 }, 0.94, 0, 1.55],
   ['sedan-sports', 'Sport Sedan', 'car', { speed: 4, acceleration: 4, control: 4, drift: 2, boostPower: 2, boostDuration: 2 }, 0.98, 0, 1.12],
   ['sedan', 'Sedan', 'car', { speed: 3, acceleration: 3, control: 3, drift: 3, boostPower: 3, boostDuration: 3 }, 1.00, 0, 1.00],
   ['suv', 'SUV', 'car', { speed: 3, acceleration: 3, control: 3, drift: 4, boostPower: 2, boostDuration: 3 }, 1.05, 0, 0.90],


### PR DESCRIPTION
## Summary
- make Trophy Road rewards use 300 / 400 / 600 trophy milestones
- place Future Racer before the Emergency Pack and rebalance Race Car / Vintage Racer
- keep locked tracks and vehicles visible and inspectable while disabling only their race actions
- add recognisable lock symbols and one shared green unlock notice for tracks and vehicles
- make Trophy Road horizontally scrollable with the first 600 trophies in the initial viewport
- prevent reward buttons moving or losing their hit area when selected
- open Achievements with no reward selected and reset filters to All on every visit
- expose all achievement categories plus Locked and Unlocked filters
- allow category and status filters to be combined

## UX details
- Trophy Road totals are separated from the road width
- locked vehicle details and paint controls retain the normal layout
- stale saved locked selections still fall back safely
- reward markers remain real buttons outside progressbar semantics
- reduced-motion behavior is preserved

## Validation
- updates the dedicated Trophy Road regression for milestones, migration, persistence, locks, scrolling, selection, filtering and vehicle balance
- retains the complete TURN regression workflow and Drive By Ear training workflow