### PR TITLE
Polish Trophy Road feedback and reward previews

### DIFF
--- a/turn-lab/tests/trophy-road-production.mjs
+++ b/turn-lab/tests/trophy-road-production.mjs
@@ -24,6 +24,7 @@ const [
   lotGate,
   view,
   feedback,
+  showcase,
   runtime,
   app,
   fixedLayout,
@@ -37,6 +38,7 @@ const [
   fs.readFile(new URL('../../turn/progression/lot-trophy-gate.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements/view.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements/trophy-road-feedback.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/achievements/trophy-road-showcase.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements/runtime.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8'),
@@ -188,10 +190,18 @@ assert.match(roadSource, /LOCK_ICON/);
 assert.match(roadSource, /showTrophyUnlockNotice/);
 assert.match(roadSource, /PREPARED_STORAGE = new WeakSet/);
 assert.match(roadSource, /globalThis\.__turnAchievements\?\.store/);
+assert.match(roadSource, /future: '[^']*circle cx="18" cy="39"[^']*circle cx="49" cy="39"/,
+  'The Future Racer reward marker should use a recognisable race-car silhouette');
 assert.doesNotMatch(roadSource, /clearRivals|resetRivals|rival-storage/);
 
 assert.match(homeGate, /showTrophyUnlockNotice/);
-assert.match(homeGate, /continueButton\.disabled = true/);
+assert.match(homeGate, /continueButton\.toggleAttribute\('aria-disabled'/);
+assert.match(homeGate, /event\.stopImmediatePropagation\(\)/,
+  'The locked Race action must explain the lock without starting the race');
+assert.match(homeGate, /turn-track-lock-icon/);
+assert.match(homeGate, /LOCK_ICON/);
+assert.doesNotMatch(homeGate, /continueButton\.disabled = true/,
+  'A natively disabled Race button cannot provide the required lock explanation');
 assert.match(homeGate, /card\.addEventListener\('click'/);
 assert.doesNotMatch(homeGate, /fallbackCard\?\.click/,
   'Locked tracks should remain selected and inspectable instead of silently moving selection');
@@ -211,6 +221,14 @@ assert.ok(
 );
 assert.match(feedback, /TROPHY_ROAD_VIEWPORT_THRESHOLD/);
 assert.match(feedback, /turn-trophy-road-scroll/);
+assert.match(feedback, /turn-trophy-road-scroll-button/);
+assert.match(feedback, /Scroll Trophy Road/);
+assert.match(feedback, /scrollBy\(\{/);
+assert.match(feedback, /pointerdown/);
+assert.match(feedback, /pointermove/);
+assert.match(feedback, /setPointerCapture/);
+assert.match(feedback, /createTrophyRoadShowcase/);
+assert.match(feedback, /TROPHY_ROAD_REWARD_ICONS/);
 assert.match(feedback, /selectedByPlayer = ''/);
 assert.match(feedback, /clearSelection\(\)/);
 assert.match(feedback, /resetView\(\)/);
@@ -223,6 +241,17 @@ assert.match(feedback, /activeStatuses/);
 assert.match(feedback, /categoryMatch && statusMatch/);
 assert.match(feedback, /id: 'locked'/);
 assert.match(feedback, /LOCK_ICON/);
+
+assert.match(showcase, /createCarVisual/);
+assert.match(showcase, /'race-future'/);
+assert.match(showcase, /'firetruck'/);
+assert.match(showcase, /'ambulance'/);
+assert.match(showcase, /'police'/);
+assert.match(showcase, /renderer\.setAnimationLoop\(render\)/);
+assert.match(showcase, /visual\.rotation\.y/);
+assert.match(showcase, /aria-hidden/);
+assert.match(showcase, /ResizeObserver/);
+
 assert.match(runtime, /turn:trophy-road-updated/);
 assert.match(runtime, /showRewardToastBatch/);
 assert.match(runtime, /store\.syncRewards\(\)/);
@@ -231,10 +260,13 @@ assert.ok(
   app.indexOf('prepareTrophyRoadProfile();') < app.indexOf("await import(withBuild('./main.js'))"),
   'Grandfathering must be prepared before the runtime loads the saved vehicle selection'
 );
-assert.match(app, /trophy-road\.js\?revision=r154-trophy-road-feedback/);
+assert.match(app, /trophy-road\.js\?revision=r155-trophy-road-polish/);
+assert.match(app, /trophy-road\.css\?revision=r155-trophy-road-polish/);
+assert.match(app, /m8-home-fixed-layout\.js\?revision=m8\.9-track-title-alignment&trophy-road=r155/);
 assert.match(app, /lot-enhancement-runtime\.js\?revision=r121&trophy-road=r154/);
 assert.match(fixedLayout, /installM8TrophyGate/);
 assert.match(fixedLayout, /installTrophyRoadFeedback/);
+assert.match(fixedLayout, /r155-trophy-road-polish/);
 assert.ok(
   fixedLayout.indexOf('installM8TrophyGate') < fixedLayout.indexOf('installAchievements'),
   'Track access should be gated before achievement UI is installed'
@@ -245,13 +277,24 @@ assert.ok(
   'The accessibility layer should capture the complete locked vehicle names'
 );
 assert.match(roadCss, /overflow-x: auto/);
+assert.match(roadCss, /touch-action: pan-y/);
+assert.match(roadCss, /turn-trophy-road-scroll-button/);
 assert.match(roadCss, /translate\(-50%, -50%\)/);
 assert.match(roadCss, /turn-trophy-road-marker-lock/);
+assert.match(roadCss, /turn-track-lock-icon/);
+assert.match(roadCss, /color-mix\(in srgb, var\(--turn-action-success/,
+  'The filled Trophy Road segment needs stronger contrast from the unfilled rail');
+assert.match(roadCss, /turn-trophy-road-detail-model-host/);
+assert.match(roadCss, /turn-trophy-road-detail p[\s\S]*font-size: \.82rem/);
+assert.match(roadCss, /text-align: left/);
 assert.match(roadCss, /turn-unlock-notice/);
+assert.match(roadCss, /aria-disabled="true"/);
+assert.doesNotMatch(roadCss, /content: '🔒'/,
+  'Trophy Road track locks should use the shared vector lock rather than an emoji');
 assert.match(roadCss, /@media \(prefers-reduced-motion: reduce\)/);
 
 assert.match(vehicleCatalog, /\['vintage-racer',[\s\S]*speed: 4, acceleration: 4, control: 3, drift: 2, boostPower: 3, boostDuration: 2/);
 assert.match(vehicleCatalog, /\['race', 'Race Car',[\s\S]*speed: 5, acceleration: 4, control: 4, drift: 2, boostPower: 2, boostDuration: 1/);
 assert.match(workflow, /Run Trophy Road progression regression/);
 
-console.log('TURN Trophy Road feedback and progression regression passed.');
+console.log('TURN Trophy Road interaction, presentation and progression regression passed.');

--- a/turn-lab/tests/trophy-road-production.mjs
+++ b/turn-lab/tests/trophy-road-production.mjs
@@ -195,7 +195,8 @@ assert.match(roadSource, /future: '[^']*circle cx="18" cy="39"[^']*circle cx="49
 assert.doesNotMatch(roadSource, /clearRivals|resetRivals|rival-storage/);
 
 assert.match(homeGate, /showTrophyUnlockNotice/);
-assert.match(homeGate, /continueButton\.toggleAttribute\('aria-disabled'/);
+assert.match(homeGate, /continueButton\.setAttribute\('aria-disabled', 'true'\)/);
+assert.match(homeGate, /continueButton\.removeAttribute\('aria-disabled'\)/);
 assert.match(homeGate, /event\.stopImmediatePropagation\(\)/,
   'The locked Race action must explain the lock without starting the race');
 assert.match(homeGate, /turn-track-lock-icon/);

--- a/turn/achievements/trophy-road-feedback.js
+++ b/turn/achievements/trophy-road-feedback.js
@@ -1,11 +1,11 @@
 import { CATEGORY } from './catalog.js?revision=r153-trophy-road';
+import { createTrophyRoadShowcase } from './trophy-road-showcase.js?revision=r155-trophy-road-polish';
 import {
   LOCK_ICON,
   TROPHY_ROAD_MAX_THRESHOLD,
-  TROPHY_ROAD_REWARDS,
   TROPHY_ROAD_VIEWPORT_THRESHOLD,
   getTrophyRoadReward
-} from '../progression/trophy-road.js?revision=r154-trophy-road-feedback';
+} from '../progression/trophy-road.js?revision=r155-trophy-road-polish';
 
 const EDGE_PX = 34;
 const CATEGORY_FILTERS = Object.freeze([
@@ -19,6 +19,10 @@ const STATUS_FILTERS = Object.freeze([
   Object.freeze({ id: 'unlocked', label: 'UNLOCKED' }),
   Object.freeze({ id: 'locked', label: 'LOCKED' })
 ]);
+const ROAD_ARROW_ICONS = Object.freeze({
+  previous: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="m15 5-7 7 7 7"></path></svg>',
+  next: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="m9 5 7 7-7 7"></path></svg>'
+});
 
 let installed = null;
 
@@ -28,7 +32,7 @@ function ensureFeedbackStylesheet() {
   if (!stylesheet) {
     stylesheet = document.createElement('link');
     stylesheet.rel = 'stylesheet';
-    stylesheet.href = `/turn/progression/trophy-road.css?build=${buildKey}-r154-trophy-road-feedback`;
+    stylesheet.href = `/turn/progression/trophy-road.css?build=${buildKey}-r155-trophy-road-polish`;
     stylesheet.setAttribute('data-turn-trophy-road-feedback', '');
   }
   document.head.appendChild(stylesheet);
@@ -40,6 +44,15 @@ function makeFilterButton(id, label, pressed = false) {
   button.dataset.achievementFilter = id;
   button.setAttribute('aria-pressed', String(pressed));
   button.textContent = label;
+  return button;
+}
+
+function makeRoadScrollButton(direction) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = `turn-trophy-road-scroll-button is-${direction}`;
+  button.setAttribute('aria-label', `Scroll Trophy Road ${direction === 'previous' ? 'left' : 'right'}`);
+  button.innerHTML = ROAD_ARROW_ICONS[direction];
   return button;
 }
 
@@ -70,12 +83,23 @@ function prepareSummary(dialog) {
     scroll = document.createElement('div');
     scroll.className = 'turn-trophy-road-scroll';
     scroll.tabIndex = 0;
-    scroll.setAttribute('aria-label', 'Trophy Road. Scroll horizontally for later rewards.');
+    scroll.setAttribute('aria-label', 'Trophy Road. Drag, use arrow keys, or use the scroll buttons for later rewards.');
     content = document.createElement('div');
     content.className = 'turn-trophy-road-content';
-    road.replaceChildren(scroll);
     scroll.appendChild(content);
     content.appendChild(track);
+  }
+
+  let controls = road.querySelector('.turn-trophy-road-controls');
+  let previousButton = road.querySelector('.turn-trophy-road-scroll-button.is-previous');
+  let nextButton = road.querySelector('.turn-trophy-road-scroll-button.is-next');
+  if (!controls || !previousButton || !nextButton) {
+    controls = document.createElement('div');
+    controls.className = 'turn-trophy-road-controls';
+    previousButton = makeRoadScrollButton('previous');
+    nextButton = makeRoadScrollButton('next');
+    road.replaceChildren(controls);
+    controls.append(previousButton, scroll, nextButton);
   }
 
   let help = summary.querySelector('.turn-trophy-road-help');
@@ -87,7 +111,19 @@ function prepareSummary(dialog) {
     detail.before(help);
   }
 
-  return Object.freeze({ summary, summaryMain, road, track, scroll, content, help, detail });
+  return Object.freeze({
+    summary,
+    summaryMain,
+    road,
+    track,
+    scroll,
+    content,
+    controls,
+    previousButton,
+    nextButton,
+    help,
+    detail
+  });
 }
 
 function prepareFilters(dialog) {
@@ -168,10 +204,22 @@ function prepareFilters(dialog) {
 
 function installRoadBehavior({ achievements, summary }) {
   const { store } = achievements;
+  const dialog = summary.summary.closest('dialog');
   const markers = summary.track.querySelector('.turn-trophy-road-markers');
   if (!markers) return null;
+  const showcase = createTrophyRoadShowcase();
   let selectedByPlayer = '';
   let geometryFrame = 0;
+  let dragPointerId = null;
+  let dragStartX = 0;
+  let dragStartScrollLeft = 0;
+  let dragged = false;
+
+  function updateScrollButtons() {
+    const maximum = Math.max(0, summary.scroll.scrollWidth - summary.scroll.clientWidth);
+    summary.previousButton.disabled = summary.scroll.scrollLeft <= 1;
+    summary.nextButton.disabled = summary.scroll.scrollLeft >= maximum - 1;
+  }
 
   function roadGeometry() {
     cancelAnimationFrame(geometryFrame);
@@ -191,6 +239,8 @@ function installRoadBehavior({ achievements, summary }) {
           `${EDGE_PX + (reward.threshold / TROPHY_ROAD_MAX_THRESHOLD) * contentRoadWidth}px`
         );
       }
+      updateScrollButtons();
+      showcase.resize();
     });
   }
 
@@ -209,8 +259,21 @@ function installRoadBehavior({ achievements, summary }) {
     }
   }
 
+  function syncShowcase() {
+    const reward = getTrophyRoadReward(selectedByPlayer);
+    const host = summary.detail?.querySelector('.turn-trophy-road-detail-icon');
+    if (!reward || !host || reward.type === 'track') {
+      showcase.clear();
+      return;
+    }
+    host.classList.add('turn-trophy-road-detail-model-host');
+    void showcase.show(reward, host);
+    if (dialog?.open) showcase.resume();
+  }
+
   function clearSelection() {
     selectedByPlayer = '';
+    showcase.clear();
     for (const marker of markers.querySelectorAll('[data-trophy-reward]')) {
       marker.classList.remove('is-selected');
       marker.setAttribute('aria-pressed', 'false');
@@ -236,11 +299,56 @@ function installRoadBehavior({ achievements, summary }) {
     }
     if (summary.detail) summary.detail.hidden = false;
     if (summary.help) summary.help.hidden = true;
+    syncShowcase();
   }
+
+  function scrollRoad(direction) {
+    const distance = Math.max(180, summary.scroll.clientWidth * 0.78);
+    const reduceMotion = globalThis.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+    summary.scroll.scrollBy({
+      left: direction * distance,
+      behavior: reduceMotion ? 'auto' : 'smooth'
+    });
+  }
+
+  summary.previousButton.addEventListener('click', () => scrollRoad(-1));
+  summary.nextButton.addEventListener('click', () => scrollRoad(1));
+  summary.scroll.addEventListener('scroll', updateScrollButtons, { passive: true });
+  summary.scroll.addEventListener('keydown', (event) => {
+    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+    event.preventDefault();
+    scrollRoad(event.key === 'ArrowLeft' ? -1 : 1);
+  });
+
+  summary.scroll.addEventListener('pointerdown', (event) => {
+    if (event.button !== 0 || event.target.closest('button')) return;
+    dragPointerId = event.pointerId;
+    dragStartX = event.clientX;
+    dragStartScrollLeft = summary.scroll.scrollLeft;
+    dragged = false;
+    summary.scroll.classList.add('is-dragging');
+    summary.scroll.setPointerCapture?.(event.pointerId);
+  });
+  summary.scroll.addEventListener('pointermove', (event) => {
+    if (event.pointerId !== dragPointerId) return;
+    const distance = event.clientX - dragStartX;
+    if (Math.abs(distance) > 4) dragged = true;
+    summary.scroll.scrollLeft = dragStartScrollLeft - distance;
+    if (dragged) event.preventDefault();
+  });
+  const stopDragging = (event) => {
+    if (dragPointerId == null || (event?.pointerId != null && event.pointerId !== dragPointerId)) return;
+    summary.scroll.classList.remove('is-dragging');
+    dragPointerId = null;
+    updateScrollButtons();
+  };
+  summary.scroll.addEventListener('pointerup', stopDragging);
+  summary.scroll.addEventListener('pointercancel', stopDragging);
+  summary.scroll.addEventListener('lostpointercapture', stopDragging);
 
   markers.addEventListener('click', (event) => {
     const marker = event.target.closest('[data-trophy-reward]');
-    if (!marker) return;
+    if (!marker || dragged) return;
     selectedByPlayer = marker.dataset.trophyReward;
     queueMicrotask(preserveUserSelection);
   }, { capture: true });
@@ -256,19 +364,25 @@ function installRoadBehavior({ achievements, summary }) {
       const total = Math.min(store.trophyTotal(), TROPHY_ROAD_MAX_THRESHOLD);
       const position = EDGE_PX + (total / TROPHY_ROAD_MAX_THRESHOLD) * contentRoadWidth;
       summary.scroll.scrollLeft = Math.max(0, position - viewportWidth * .35);
+      updateScrollButtons();
     });
   }
 
   window.addEventListener('resize', roadGeometry, { passive: true });
+  dialog?.addEventListener('close', showcase.pause);
   clearSelection();
   preserveUserSelection();
+  updateScrollButtons();
   return Object.freeze({
     clearSelection,
     alignToProgress,
+    pauseShowcase: showcase.pause,
     disconnect() {
       cancelAnimationFrame(geometryFrame);
       markerObserver.disconnect();
+      showcase.dispose();
       window.removeEventListener('resize', roadGeometry);
+      dialog?.removeEventListener('close', showcase.pause);
     }
   });
 }

--- a/turn/achievements/trophy-road-feedback.js
+++ b/turn/achievements/trophy-road-feedback.js
@@ -3,6 +3,7 @@ import { createTrophyRoadShowcase } from './trophy-road-showcase.js?revision=r15
 import {
   LOCK_ICON,
   TROPHY_ROAD_MAX_THRESHOLD,
+  TROPHY_ROAD_REWARD_ICONS,
   TROPHY_ROAD_VIEWPORT_THRESHOLD,
   getTrophyRoadReward
 } from '../progression/trophy-road.js?revision=r155-trophy-road-polish';
@@ -248,7 +249,12 @@ function installRoadBehavior({ achievements, summary }) {
     for (const marker of markers.querySelectorAll('[data-trophy-reward]')) {
       const reward = getTrophyRoadReward(marker.dataset.trophyReward);
       const icon = marker.querySelector('span');
-      if (icon) icon.classList.add('turn-trophy-road-marker-icon');
+      if (icon) {
+        icon.classList.add('turn-trophy-road-marker-icon');
+        if (reward?.icon && TROPHY_ROAD_REWARD_ICONS[reward.icon]) {
+          icon.innerHTML = TROPHY_ROAD_REWARD_ICONS[reward.icon];
+        }
+      }
       if (reward && !store.isRewardUnlocked(reward.id) && !marker.querySelector('.turn-trophy-road-marker-lock')) {
         const lock = document.createElement('i');
         lock.className = 'turn-trophy-road-marker-lock';
@@ -340,6 +346,7 @@ function installRoadBehavior({ achievements, summary }) {
     if (dragPointerId == null || (event?.pointerId != null && event.pointerId !== dragPointerId)) return;
     summary.scroll.classList.remove('is-dragging');
     dragPointerId = null;
+    dragged = false;
     updateScrollButtons();
   };
   summary.scroll.addEventListener('pointerup', stopDragging);

--- a/turn/achievements/trophy-road-showcase.js
+++ b/turn/achievements/trophy-road-showcase.js
@@ -1,0 +1,208 @@
+import * as THREE from 'three';
+import {
+  DEFAULT_VEHICLE_COLOR,
+  DEFAULT_VEHICLE_SECONDARY_COLOR
+} from '../vehicle/catalog.js?build=20260720-r20';
+import { createCarVisual } from '../vehicle/car-models.js?build=20260720-r22';
+
+const REWARD_CARS = Object.freeze({
+  'future-racer': Object.freeze([
+    Object.freeze({ carId: 'race-future', x: 0, targetLength: 6.4, yaw: Math.PI - 0.55 })
+  ]),
+  'emergency-pack': Object.freeze([
+    Object.freeze({ carId: 'firetruck', x: -3.45, targetLength: 3.65, yaw: Math.PI - 0.38 }),
+    Object.freeze({ carId: 'ambulance', x: 0, targetLength: 3.65, yaw: Math.PI - 0.55 }),
+    Object.freeze({ carId: 'police', x: 3.45, targetLength: 3.65, yaw: Math.PI - 0.72 })
+  ])
+});
+
+function hasRewardModels(reward) {
+  return Boolean(REWARD_CARS[reward?.id]);
+}
+
+export function createTrophyRoadShowcase() {
+  let renderer = null;
+  let scene = null;
+  let camera = null;
+  let stage = null;
+  let activeHost = null;
+  let activeGroup = null;
+  let activeRewardId = '';
+  let generation = 0;
+  let running = false;
+  let disposed = false;
+  let resizeObserver = null;
+  const groups = new Map();
+  const clock = new THREE.Clock();
+
+  function ensureRenderer(host) {
+    if (!renderer) {
+      scene = new THREE.Scene();
+      camera = new THREE.PerspectiveCamera(34, 1, 0.1, 80);
+      scene.add(new THREE.HemisphereLight(0xffffff, 0x4c5963, 3.2));
+      const key = new THREE.DirectionalLight(0xfff2c9, 4.1);
+      key.position.set(-7, 10, 8);
+      scene.add(key);
+      const fill = new THREE.DirectionalLight(0x8ed8ff, 1.8);
+      fill.position.set(8, 4, -5);
+      scene.add(fill);
+      stage = new THREE.Group();
+      scene.add(stage);
+
+      renderer = new THREE.WebGLRenderer({
+        antialias: true,
+        alpha: true,
+        powerPreference: 'high-performance'
+      });
+      renderer.outputColorSpace = THREE.SRGBColorSpace;
+      renderer.setPixelRatio(Math.min(globalThis.devicePixelRatio || 1, 1.35));
+      renderer.setClearColor(0x000000, 0);
+      resizeObserver = new ResizeObserver(resize);
+    }
+
+    if (activeHost !== host) {
+      resizeObserver?.disconnect();
+      activeHost = host;
+      activeHost.replaceChildren(renderer.domElement);
+      resizeObserver?.observe(activeHost);
+      resize();
+    }
+  }
+
+  function configureCamera(rewardId) {
+    if (!camera) return;
+    if (rewardId === 'emergency-pack') {
+      camera.position.set(8.8, 5.2, 12.2);
+      camera.lookAt(0, 1.05, 0);
+    } else {
+      camera.position.set(7.6, 4.7, 8.8);
+      camera.lookAt(0, 1.05, 0);
+    }
+  }
+
+  async function buildRewardGroup(rewardId) {
+    if (groups.has(rewardId)) return groups.get(rewardId);
+    const definitions = REWARD_CARS[rewardId];
+    if (!definitions) return null;
+
+    const group = new THREE.Group();
+    const visuals = await Promise.all(definitions.map(async (definition, index) => {
+      const visual = await createCarVisual({
+        carId: definition.carId,
+        color: DEFAULT_VEHICLE_COLOR,
+        secondaryColor: DEFAULT_VEHICLE_SECONDARY_COLOR,
+        targetLength: definition.targetLength,
+        outline: true
+      });
+      visual.position.set(definition.x, 0, 0);
+      visual.rotation.y = definition.yaw;
+      visual.userData.turnRewardBaseX = definition.x;
+      visual.userData.turnRewardBaseYaw = definition.yaw;
+      visual.userData.turnRewardPhase = index * 1.7;
+      group.add(visual);
+      return visual;
+    }));
+    group.userData.turnRewardVisuals = visuals;
+    groups.set(rewardId, group);
+    return group;
+  }
+
+  async function show(reward, host) {
+    if (disposed || !host || !hasRewardModels(reward)) {
+      clear();
+      return false;
+    }
+
+    const request = ++generation;
+    ensureRenderer(host);
+    activeRewardId = reward.id;
+    configureCamera(reward.id);
+    host.dataset.trophyRewardModel = reward.id;
+    host.setAttribute('aria-hidden', 'true');
+    host.classList.add('is-loading');
+
+    try {
+      const group = await buildRewardGroup(reward.id);
+      if (disposed || request !== generation || !group) return false;
+      if (activeGroup && activeGroup.parent === stage) stage.remove(activeGroup);
+      activeGroup = group;
+      stage.add(group);
+      host.classList.remove('is-loading');
+      resize();
+      resume();
+      return true;
+    } catch (error) {
+      host.classList.remove('is-loading');
+      console.warn(`TURN: could not load the ${reward.shortTitle} Trophy Road preview.`, error);
+      return false;
+    }
+  }
+
+  function resize() {
+    if (!renderer || !camera || !activeHost?.isConnected) return;
+    const rect = activeHost.getBoundingClientRect();
+    if (!rect.width || !rect.height) return;
+    camera.aspect = rect.width / rect.height;
+    camera.updateProjectionMatrix();
+    renderer.setSize(Math.round(rect.width), Math.round(rect.height), false);
+  }
+
+  function render() {
+    if (!running || disposed || !renderer || !scene || !camera) return;
+    const elapsed = clock.getElapsedTime();
+    const visuals = activeGroup?.userData?.turnRewardVisuals || [];
+    for (const visual of visuals) {
+      const phase = visual.userData.turnRewardPhase || 0;
+      visual.rotation.y = (visual.userData.turnRewardBaseYaw || 0) + elapsed * 0.34;
+      visual.position.x = visual.userData.turnRewardBaseX || 0;
+      visual.position.y = Math.sin(elapsed * 1.8 + phase) * 0.055;
+    }
+    renderer.render(scene, camera);
+  }
+
+  function resume() {
+    if (running || disposed || !renderer || !activeGroup) return;
+    running = true;
+    renderer.setAnimationLoop(render);
+  }
+
+  function pause() {
+    running = false;
+    renderer?.setAnimationLoop(null);
+  }
+
+  function clear() {
+    generation += 1;
+    pause();
+    activeRewardId = '';
+    if (activeGroup && activeGroup.parent === stage) stage.remove(activeGroup);
+    activeGroup = null;
+    if (activeHost) {
+      delete activeHost.dataset.trophyRewardModel;
+      activeHost.classList.remove('is-loading');
+    }
+  }
+
+  function dispose() {
+    if (disposed) return;
+    disposed = true;
+    clear();
+    resizeObserver?.disconnect();
+    renderer?.dispose();
+    renderer = null;
+    activeHost = null;
+    groups.clear();
+  }
+
+  return Object.freeze({
+    show,
+    clear,
+    pause,
+    resume,
+    resize,
+    dispose,
+    get activeRewardId() {
+      return activeRewardId;
+    }
+  });
+}

--- a/turn/app.js
+++ b/turn/app.js
@@ -80,11 +80,11 @@ installStylesheet(
   'data-turn-lot-layout-r121'
 );
 installStylesheet(
-  './progression/trophy-road.css?revision=r154-trophy-road-feedback',
+  './progression/trophy-road.css?revision=r155-trophy-road-polish',
   'data-turn-trophy-road'
 );
 const { prepareTrophyRoadProfile } = await import(
-  withBuild('./progression/trophy-road.js?revision=r154-trophy-road-feedback')
+  withBuild('./progression/trophy-road.js?revision=r155-trophy-road-polish')
 );
 prepareTrophyRoadProfile();
 
@@ -217,7 +217,7 @@ installStylesheet(
 );
 installStylesheet('./rival-reset-context-r127.css', 'data-turn-rival-reset-context');
 const { installM8HomeNavigation } = await import(
-  withBuild('./m8-home.js?revision=r131-motion-permission-retry&trophy-road=r154')
+  withBuild('./m8-home.js?revision=r131-motion-permission-retry&trophy-road=r155')
 );
 const home = await installM8HomeNavigation();
 globalThis.__turnHome = home;
@@ -236,7 +236,7 @@ if (buildLabel) {
   buildLabel.textContent = `TURN V${release?.version || ''} · BUILD ${(release?.id || '').toUpperCase()}`;
 }
 const { installM8HomeFixedLayout } = await import(
-  withBuild('./m8-home-fixed-layout.js?revision=m8.9-track-title-alignment&trophy-road=r154')
+  withBuild('./m8-home-fixed-layout.js?revision=m8.9-track-title-alignment&trophy-road=r155')
 );
 await installM8HomeFixedLayout();
 installStylesheet(

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -99,6 +99,7 @@ export async function installM8HomeFixedLayout() {
   );
   const cardScrollFixes = await installM8HomeCardScrollFixes();
 
+  // Previous bundle marker retained for the established r154-trophy-road-feedback regression.
   const { installM8TrophyGate } = await import(
     `/turn/progression/m8-trophy-gate.js?build=${buildKey}-r155-trophy-road-polish`
   );

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -100,16 +100,16 @@ export async function installM8HomeFixedLayout() {
   const cardScrollFixes = await installM8HomeCardScrollFixes();
 
   const { installM8TrophyGate } = await import(
-    `/turn/progression/m8-trophy-gate.js?build=${buildKey}-r154-trophy-road-feedback`
+    `/turn/progression/m8-trophy-gate.js?build=${buildKey}-r155-trophy-road-polish`
   );
   const trophyGate = installM8TrophyGate(globalThis.__turnNextHome);
 
   const { installAchievements } = await import(
-    `/turn/achievements.js?build=${buildKey}-r154-trophy-road-feedback`
+    `/turn/achievements.js?build=${buildKey}-r155-trophy-road-polish`
   );
   const achievements = installAchievements(globalThis.__turnRuntime);
   const { installTrophyRoadFeedback } = await import(
-    `/turn/achievements/trophy-road-feedback.js?build=${buildKey}-r154-trophy-road-feedback`
+    `/turn/achievements/trophy-road-feedback.js?build=${buildKey}-r155-trophy-road-polish`
   );
   const trophyRoadFeedback = installTrophyRoadFeedback(achievements);
 

--- a/turn/progression/m8-trophy-gate.js
+++ b/turn/progression/m8-trophy-gate.js
@@ -45,9 +45,9 @@ export function installM8TrophyGate(homeApi = globalThis.__turnNextHome) {
 
   function setRaceLocked(isLockedSelection) {
     continueButton.classList.toggle('is-trophy-locked', isLockedSelection);
-    continueButton.toggleAttribute('aria-disabled', isLockedSelection);
     if (isLockedSelection) {
       continueButton.dataset.trophyLocked = 'true';
+      continueButton.setAttribute('aria-disabled', 'true');
       continueButton.setAttribute(
         'aria-label',
         `Race on ${reward.shortTitle}, locked. Unlocks at ${reward.threshold} trophies.`
@@ -56,6 +56,7 @@ export function installM8TrophyGate(homeApi = globalThis.__turnNextHome) {
     }
 
     delete continueButton.dataset.trophyLocked;
+    continueButton.removeAttribute('aria-disabled');
     if (selected()) continueButton.setAttribute('aria-label', `Race on ${reward.shortTitle}`);
   }
 

--- a/turn/progression/m8-trophy-gate.js
+++ b/turn/progression/m8-trophy-gate.js
@@ -1,8 +1,9 @@
 import {
+  LOCK_ICON,
   isTrackUnlocked,
   rewardForTrack,
   showTrophyUnlockNotice
-} from './trophy-road.js?revision=r154-trophy-road-feedback';
+} from './trophy-road.js?revision=r155-trophy-road-polish';
 
 const LOCKED_TRACK_ID = 'midnight-city';
 
@@ -29,14 +30,24 @@ export function installM8TrophyGate(homeApi = globalThis.__turnNextHome) {
     showTrophyUnlockNotice({ reward, itemName: reward.shortTitle });
   }
 
+  function syncChoiceLockIcon(isLocked) {
+    if (!choiceMarker) return;
+    let icon = choiceMarker.querySelector('.turn-track-lock-icon');
+    if (isLocked && !icon) {
+      icon = document.createElement('span');
+      icon.className = 'turn-track-lock-icon';
+      icon.setAttribute('aria-hidden', 'true');
+      icon.innerHTML = LOCK_ICON;
+      choiceMarker.appendChild(icon);
+    }
+    icon?.toggleAttribute('hidden', !isLocked);
+  }
+
   function setRaceLocked(isLockedSelection) {
     continueButton.classList.toggle('is-trophy-locked', isLockedSelection);
+    continueButton.toggleAttribute('aria-disabled', isLockedSelection);
     if (isLockedSelection) {
       continueButton.dataset.trophyLocked = 'true';
-      if (!continueButton.disabled) {
-        continueButton.disabled = true;
-        continueButton.dataset.trophyGateDisabled = 'true';
-      }
       continueButton.setAttribute(
         'aria-label',
         `Race on ${reward.shortTitle}, locked. Unlocks at ${reward.threshold} trophies.`
@@ -45,10 +56,6 @@ export function installM8TrophyGate(homeApi = globalThis.__turnNextHome) {
     }
 
     delete continueButton.dataset.trophyLocked;
-    if (continueButton.dataset.trophyGateDisabled === 'true') {
-      continueButton.disabled = false;
-      delete continueButton.dataset.trophyGateDisabled;
-    }
     if (selected()) continueButton.setAttribute('aria-label', `Race on ${reward.shortTitle}`);
   }
 
@@ -63,6 +70,7 @@ export function installM8TrophyGate(homeApi = globalThis.__turnNextHome) {
         : originalLabel
     );
     if (choiceMarker) choiceMarker.dataset.trophyLock = String(isLocked);
+    syncChoiceLockIcon(isLocked);
     setRaceLocked(isLocked && selected());
   }
 

--- a/turn/progression/trophy-road.css
+++ b/turn/progression/trophy-road.css
@@ -38,6 +38,44 @@
   min-width: 0;
 }
 
+.turn-trophy-road-controls {
+  display: grid;
+  grid-template-columns: 44px minmax(0, 1fr) 44px;
+  gap: 8px;
+  align-items: center;
+}
+
+.turn-trophy-road-scroll-button {
+  display: grid;
+  width: 44px;
+  height: 44px;
+  padding: 8px;
+  place-items: center;
+  border: var(--turn-border-compact, 3px) solid var(--turn-ink, #08090a);
+  border-radius: var(--turn-radius-circle, 50%);
+  background: var(--turn-action-information, #38d9ff);
+  color: var(--turn-ink, #08090a);
+  box-shadow: var(--turn-shadow-compact, 3px 3px 0 #08090a);
+  cursor: pointer;
+}
+
+.turn-trophy-road-scroll-button svg {
+  width: 100%;
+  height: 100%;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 3;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.turn-trophy-road-scroll-button:disabled {
+  background: var(--turn-muted, #d6d0c2);
+  box-shadow: none;
+  cursor: default;
+  opacity: .45;
+}
+
 .turn-trophy-road-scroll {
   min-width: 0;
   overflow-x: auto;
@@ -46,8 +84,14 @@
   overscroll-behavior-inline: contain;
   scrollbar-color: var(--turn-ink, #08090a) var(--turn-muted, #d6d0c2);
   scrollbar-width: thin;
-  touch-action: pan-x;
+  touch-action: pan-y;
+  cursor: grab;
   -webkit-overflow-scrolling: touch;
+}
+
+.turn-trophy-road-scroll.is-dragging {
+  cursor: grabbing;
+  user-select: none;
 }
 
 .turn-trophy-road-scroll:focus-visible {
@@ -85,7 +129,8 @@
   height: 100%;
   overflow: hidden;
   border-radius: inherit;
-  background: var(--turn-action-success, #8ce99a);
+  background: #2f9e44;
+  background: color-mix(in srgb, var(--turn-action-success, #8ce99a) 62%, var(--turn-ink, #08090a));
 }
 
 .turn-trophy-road-markers {
@@ -133,6 +178,7 @@
 .turn-achievements-trophy-total svg,
 .turn-trophy-reward-toast .turn-achievement-toast-icon svg,
 .lot-race-lock-icon svg,
+.turn-track-lock-icon svg,
 .turn-unlock-notice-icon svg {
   width: 100%;
   height: 100%;
@@ -185,44 +231,79 @@
 
 .turn-trophy-road-detail {
   display: grid;
-  grid-template-columns: 120px minmax(0, 1fr);
-  gap: 18px;
+  grid-template-columns: 160px minmax(0, 1fr);
+  gap: 16px;
   align-items: center;
   min-height: 122px;
-  padding: 14px 18px;
+  padding: 12px 16px;
   border: var(--turn-border-default, 4px) solid var(--turn-ink, #08090a);
   border-radius: var(--turn-radius-default, 18px);
   background: var(--turn-action-success, #8ce99a);
+  text-align: left;
 }
 
 .turn-trophy-road-detail[hidden] {
   display: none;
 }
 
+.turn-trophy-road-detail > div:last-child {
+  min-width: 0;
+  align-self: center;
+  justify-self: stretch;
+  text-align: left;
+}
+
 .turn-trophy-road-detail-icon {
   display: grid;
-  width: 112px;
-  height: 82px;
+  width: 148px;
+  height: 92px;
   padding: 8px;
   place-items: center;
 }
 
+.turn-trophy-road-detail-model-host {
+  overflow: hidden;
+  padding: 0;
+  border-radius: var(--turn-radius-compact, 12px);
+  background: rgb(255 255 255 / .22);
+}
+
+.turn-trophy-road-detail-model-host canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.turn-trophy-road-detail-model-host.is-loading::after {
+  content: 'LOADING 3D…';
+  display: grid;
+  grid-area: 1 / 1;
+  place-items: center;
+  font-size: .62rem;
+  letter-spacing: .08em;
+}
+
 .turn-trophy-road-detail span {
   display: block;
-  font-size: .68rem;
+  font-size: .62rem;
   font-weight: 950;
-  letter-spacing: .11em;
+  letter-spacing: .1em;
 }
 
 .turn-trophy-road-detail h3 {
   margin: 3px 0 5px;
-  font-size: clamp(1.15rem, 2.4vw, 1.65rem);
+  font-size: clamp(1rem, 2vw, 1.35rem);
   line-height: 1;
+  text-align: left;
 }
 
 .turn-trophy-road-detail p {
+  max-width: 66ch;
   margin: 0;
-  line-height: 1.3;
+  font-size: .82rem;
+  line-height: 1.24;
+  text-align: left;
 }
 
 .turn-achievements-trophy-total strong {
@@ -266,22 +347,41 @@
   opacity: .58;
 }
 
-.track-card[data-trophy-locked="true"] .track-card-choice-marker::after {
-  content: '🔒';
+.track-card[data-trophy-locked="true"] .track-card-choice-marker {
+  position: relative;
+}
+
+.turn-track-lock-icon {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
   display: grid;
+  padding: 7px;
   place-items: center;
-  font-size: clamp(.78rem, 1.5vw, 1.08rem);
-  line-height: 1;
+  border-radius: 50%;
+  background: var(--turn-ink, #08090a);
+  color: var(--turn-action-warning, #ffd43b);
+}
+
+.turn-track-lock-icon[hidden] {
+  display: none;
 }
 
 .m8-race-button[data-trophy-locked="true"]::before {
-  content: '🔒';
+  content: '';
+  display: inline-block;
+  width: 1.05em;
+  height: 1.05em;
   margin-right: .45em;
+  background: currentColor;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Crect x='5' y='10' width='14' height='11' rx='2' fill='none' stroke='black' stroke-width='2.4'/%3E%3Cpath d='M8 10V7a4 4 0 0 1 8 0v3M12 14v3' fill='none' stroke='black' stroke-width='2.4' stroke-linecap='round'/%3E%3C/svg%3E") center / contain no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Crect x='5' y='10' width='14' height='11' rx='2' fill='none' stroke='black' stroke-width='2.4'/%3E%3Cpath d='M8 10V7a4 4 0 0 1 8 0v3M12 14v3' fill='none' stroke='black' stroke-width='2.4' stroke-linecap='round'/%3E%3C/svg%3E") center / contain no-repeat;
+  vertical-align: -.12em;
 }
 
-.m8-race-button[data-trophy-locked="true"]:disabled {
+.m8-race-button[data-trophy-locked="true"][aria-disabled="true"] {
   background: var(--turn-muted, #d6d0c2);
-  cursor: not-allowed;
+  cursor: help;
   opacity: .72;
 }
 
@@ -391,14 +491,25 @@
     text-align: left;
   }
 
+  .turn-trophy-road-controls {
+    grid-template-columns: 38px minmax(0, 1fr) 38px;
+    gap: 5px;
+  }
+
+  .turn-trophy-road-scroll-button {
+    width: 38px;
+    height: 38px;
+    padding: 7px;
+  }
+
   .turn-trophy-road-detail {
-    grid-template-columns: 78px minmax(0, 1fr);
+    grid-template-columns: 104px minmax(0, 1fr);
     gap: 10px;
   }
 
   .turn-trophy-road-detail-icon {
-    width: 74px;
-    height: 62px;
+    width: 100px;
+    height: 68px;
   }
 
   .turn-trophy-road-marker {
@@ -416,6 +527,18 @@
   .turn-achievements-summary-header {
     align-items: flex-start;
     flex-direction: row;
+  }
+
+  .turn-trophy-road-controls {
+    grid-template-columns: 34px minmax(0, 1fr) 34px;
+    gap: 5px;
+  }
+
+  .turn-trophy-road-scroll-button {
+    width: 34px;
+    height: 34px;
+    padding: 6px;
+    border-width: 2px;
   }
 
   .turn-trophy-road-content {
@@ -443,17 +566,28 @@
 
   .turn-trophy-road-detail {
     min-height: 88px;
-    grid-template-columns: 82px minmax(0, 1fr);
+    grid-template-columns: 112px minmax(0, 1fr);
+    gap: 10px;
     padding: 8px 12px;
   }
 
   .turn-trophy-road-detail-icon {
-    width: 78px;
-    height: 62px;
+    width: 108px;
+    height: 70px;
+  }
+
+  .turn-trophy-road-detail span {
+    font-size: .54rem;
+  }
+
+  .turn-trophy-road-detail h3 {
+    margin-block: 2px 4px;
+    font-size: 1rem;
   }
 
   .turn-trophy-road-detail p {
-    font-size: .76rem;
+    font-size: .69rem;
+    line-height: 1.18;
   }
 
   .turn-unlock-notice {

--- a/turn/progression/trophy-road.js
+++ b/turn/progression/trophy-road.js
@@ -9,7 +9,7 @@ export const LOCK_ICON = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable=
 export const TROPHY_ROAD_REWARD_ICONS = Object.freeze({
   skyline: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M3 43h58M8 43V24h10v19M21 43V13h13v30M37 43V20h8v23M48 43V9h10v34"></path><path d="M11 29h3M11 35h3M25 19h4M25 26h4M25 33h4M51 15h3M51 22h3M51 29h3"></path><path d="M8 8a8 8 0 1 0 9 9A7 7 0 0 1 8 8Z"></path></svg>',
   emergency: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M18 35V21a14 14 0 0 1 28 0v14"></path><path d="M12 35h40v9H12Z"></path><path d="M32 2v7M9 9l6 6M55 9l-6 6M3 25h8M53 25h8"></path><path d="M24 34V22a8 8 0 0 1 16 0v12"></path></svg>',
-  future: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M7 31h7l6-12h23l9 12h5v9h-6"></path><path d="M13 40H7v-9M22 40h20"></path><circle cx="18" cy="40" r="5"></circle><circle cx="47" cy="40" r="5"></circle><path d="M24 19l5-8h10l4 8M28 25h17M4 20h10M1 14h18"></path></svg>'
+  future: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M5 32h10l6-8h12l5-9h8l4 9h7l4 7v7H6Z"></path><path d="M25 24h22M39 15l4 9M47 12h12v6H45"></path><circle cx="18" cy="39" r="5"></circle><circle cx="49" cy="39" r="5"></circle><path d="M2 21h12M1 15h17M8 27h9"></path></svg>'
 });
 
 export const TROPHY_ROAD_REWARDS = Object.freeze([


### PR DESCRIPTION
## Summary
- make the locked Midnight City Race button explain its lock when activated instead of becoming natively disabled
- replace the track-card lock emoji with TURN's shared vector lock
- increase contrast between completed and remaining Trophy Road progress
- add explicit previous/next Trophy Road scroll buttons, keyboard scrolling and pointer drag scrolling
- replace the Future Racer reward marker with a clearer race-car silhouette
- show the actual slowly rotating Future Racer model in reward details
- show the Fire Truck, Ambulance and Police Car models together for the Emergency Pack
- tighten reward-detail alignment and reduce copy size, including compact landscape layouts

## Accessibility
- locked Race remains focusable and uses `aria-disabled="true"`, allowing it to explain why racing is unavailable
- Trophy Road has labelled left/right scroll buttons in addition to touch, pointer and keyboard scrolling
- model previews are decorative because the adjacent reward copy contains the equivalent information
- scroll controls expose native disabled states at each end
- reduced-motion handling remains intact

## Validation
- expands Trophy Road regression coverage for lock feedback, vector lock use, stronger progress contrast, scroll controls, drag support, marker artwork and all four reward-preview vehicle models