### PR TITLE
Stabilize Trophy Road reward selection and scrolling

### DIFF
--- a/turn-lab/tests/trophy-road-production.mjs
+++ b/turn-lab/tests/trophy-road-production.mjs
@@ -256,7 +256,7 @@ assert.match(showcase, /groupPromises = new Map/,
   'Repeated renders should share one in-flight model load per reward');
 assert.ok(
   showcase.indexOf('const group = await buildRewardGroup(reward.id)')
-    < showcase.indexOf('attachRenderer(host)'),
+    < showcase.lastIndexOf('attachRenderer(host);'),
   'Static reward artwork must remain visible until the 3D model is ready'
 );
 assert.match(showcase, /renderer\.setAnimationLoop\(render\)/);
@@ -295,7 +295,7 @@ assert.doesNotMatch(roadCss, /turn-trophy-road-scroll\.is-dragging/);
 assert.match(roadCss, /turn-trophy-road-scroll-button/);
 assert.match(roadCss, /pointer-events: none/,
   'Inactive Trophy Road scroll buttons must not remain clickable');
-assert.match(roadCss, /data-trophy-reward="future-racer"[\s\S]*Formula car/,
+assert.match(roadCss, /Formula car[\s\S]*data-trophy-reward="future-racer"/,
   'The Future Racer milestone should use a simple Formula-style line icon');
 assert.match(roadCss, /translate\(-50%, -50%\)/);
 assert.match(roadCss, /turn-trophy-road-marker-lock/);

--- a/turn-lab/tests/trophy-road-production.mjs
+++ b/turn-lab/tests/trophy-road-production.mjs
@@ -190,8 +190,6 @@ assert.match(roadSource, /LOCK_ICON/);
 assert.match(roadSource, /showTrophyUnlockNotice/);
 assert.match(roadSource, /PREPARED_STORAGE = new WeakSet/);
 assert.match(roadSource, /globalThis\.__turnAchievements\?\.store/);
-assert.match(roadSource, /future: '[^']*circle cx="18" cy="39"[^']*circle cx="49" cy="39"/,
-  'The Future Racer reward marker should use a recognisable race-car silhouette');
 assert.doesNotMatch(roadSource, /clearRivals|resetRivals|rival-storage/);
 
 assert.match(homeGate, /showTrophyUnlockNotice/);
@@ -225,12 +223,18 @@ assert.match(feedback, /turn-trophy-road-scroll/);
 assert.match(feedback, /turn-trophy-road-scroll-button/);
 assert.match(feedback, /Scroll Trophy Road/);
 assert.match(feedback, /scrollBy\(\{/);
-assert.match(feedback, /pointerdown/);
-assert.match(feedback, /pointermove/);
-assert.match(feedback, /setPointerCapture/);
+assert.match(feedback, /previousButton\.disabled = atStart/,
+  'The left scroll button must be truly inactive at the start of the road');
+assert.match(feedback, /syncScrollButtons: updateScrollButtons/);
+assert.doesNotMatch(feedback, /pointerdown|pointermove|setPointerCapture/,
+  'Custom Trophy Road drag scrolling should remain disabled until it is reliable');
 assert.match(feedback, /createTrophyRoadShowcase/);
 assert.match(feedback, /TROPHY_ROAD_REWARD_ICONS/);
 assert.match(feedback, /selectedByPlayer = ''/);
+assert.match(feedback, /selectedByPlayer = marker\.dataset\.trophyReward;[\s\S]*preserveUserSelection\(\);/,
+  'Reward details must synchronize after the base view finishes the same click');
+assert.doesNotMatch(feedback, /queueMicrotask\(preserveUserSelection\)/,
+  'Reward selection must not race a deferred duplicate render');
 assert.match(feedback, /clearSelection\(\)/);
 assert.match(feedback, /resetView\(\)/);
 assert.match(feedback, /CATEGORY\.WAYS_TO_PLAY/);
@@ -248,6 +252,13 @@ assert.match(showcase, /'race-future'/);
 assert.match(showcase, /'firetruck'/);
 assert.match(showcase, /'ambulance'/);
 assert.match(showcase, /'police'/);
+assert.match(showcase, /groupPromises = new Map/,
+  'Repeated renders should share one in-flight model load per reward');
+assert.ok(
+  showcase.indexOf('const group = await buildRewardGroup(reward.id)')
+    < showcase.indexOf('attachRenderer(host)'),
+  'Static reward artwork must remain visible until the 3D model is ready'
+);
 assert.match(showcase, /renderer\.setAnimationLoop\(render\)/);
 assert.match(showcase, /visual\.rotation\.y/);
 assert.match(showcase, /aria-hidden/);
@@ -261,13 +272,13 @@ assert.ok(
   app.indexOf('prepareTrophyRoadProfile();') < app.indexOf("await import(withBuild('./main.js'))"),
   'Grandfathering must be prepared before the runtime loads the saved vehicle selection'
 );
-assert.match(app, /trophy-road\.js\?revision=r155-trophy-road-polish/);
-assert.match(app, /trophy-road\.css\?revision=r155-trophy-road-polish/);
-assert.match(app, /m8-home-fixed-layout\.js\?revision=m8\.9-track-title-alignment&trophy-road=r155/);
+assert.match(app, /trophy-road\.js\?revision=r156-trophy-road-selection/);
+assert.match(app, /trophy-road\.css\?revision=r156-trophy-road-selection/);
+assert.match(app, /m8-home-fixed-layout\.js\?revision=m8\.9-track-title-alignment&trophy-road=r156/);
 assert.match(app, /lot-enhancement-runtime\.js\?revision=r121&trophy-road=r154/);
 assert.match(fixedLayout, /installM8TrophyGate/);
 assert.match(fixedLayout, /installTrophyRoadFeedback/);
-assert.match(fixedLayout, /r155-trophy-road-polish/);
+assert.match(fixedLayout, /r156-trophy-road-selection/);
 assert.ok(
   fixedLayout.indexOf('installM8TrophyGate') < fixedLayout.indexOf('installAchievements'),
   'Track access should be gated before achievement UI is installed'
@@ -279,7 +290,13 @@ assert.ok(
 );
 assert.match(roadCss, /overflow-x: auto/);
 assert.match(roadCss, /touch-action: pan-y/);
+assert.match(roadCss, /cursor: default/);
+assert.doesNotMatch(roadCss, /turn-trophy-road-scroll\.is-dragging/);
 assert.match(roadCss, /turn-trophy-road-scroll-button/);
+assert.match(roadCss, /pointer-events: none/,
+  'Inactive Trophy Road scroll buttons must not remain clickable');
+assert.match(roadCss, /data-trophy-reward="future-racer"[\s\S]*Formula car/,
+  'The Future Racer milestone should use a simple Formula-style line icon');
 assert.match(roadCss, /translate\(-50%, -50%\)/);
 assert.match(roadCss, /turn-trophy-road-marker-lock/);
 assert.match(roadCss, /turn-track-lock-icon/);

--- a/turn/achievements/trophy-road-feedback.js
+++ b/turn/achievements/trophy-road-feedback.js
@@ -1,12 +1,12 @@
 import { CATEGORY } from './catalog.js?revision=r153-trophy-road';
-import { createTrophyRoadShowcase } from './trophy-road-showcase.js?revision=r155-trophy-road-polish';
+import { createTrophyRoadShowcase } from './trophy-road-showcase.js?revision=r156-trophy-road-selection';
 import {
   LOCK_ICON,
   TROPHY_ROAD_MAX_THRESHOLD,
   TROPHY_ROAD_REWARD_ICONS,
   TROPHY_ROAD_VIEWPORT_THRESHOLD,
   getTrophyRoadReward
-} from '../progression/trophy-road.js?revision=r155-trophy-road-polish';
+} from '../progression/trophy-road.js?revision=r156-trophy-road-selection';
 
 const EDGE_PX = 34;
 const CATEGORY_FILTERS = Object.freeze([
@@ -33,7 +33,7 @@ function ensureFeedbackStylesheet() {
   if (!stylesheet) {
     stylesheet = document.createElement('link');
     stylesheet.rel = 'stylesheet';
-    stylesheet.href = `/turn/progression/trophy-road.css?build=${buildKey}-r155-trophy-road-polish`;
+    stylesheet.href = `/turn/progression/trophy-road.css?build=${buildKey}-r156-trophy-road-selection`;
     stylesheet.setAttribute('data-turn-trophy-road-feedback', '');
   }
   document.head.appendChild(stylesheet);
@@ -84,7 +84,7 @@ function prepareSummary(dialog) {
     scroll = document.createElement('div');
     scroll.className = 'turn-trophy-road-scroll';
     scroll.tabIndex = 0;
-    scroll.setAttribute('aria-label', 'Trophy Road. Drag, use arrow keys, or use the scroll buttons for later rewards.');
+    scroll.setAttribute('aria-label', 'Trophy Road. Use arrow keys or the scroll buttons for later rewards.');
     content = document.createElement('div');
     content.className = 'turn-trophy-road-content';
     scroll.appendChild(content);
@@ -211,15 +211,15 @@ function installRoadBehavior({ achievements, summary }) {
   const showcase = createTrophyRoadShowcase();
   let selectedByPlayer = '';
   let geometryFrame = 0;
-  let dragPointerId = null;
-  let dragStartX = 0;
-  let dragStartScrollLeft = 0;
-  let dragged = false;
 
   function updateScrollButtons() {
     const maximum = Math.max(0, summary.scroll.scrollWidth - summary.scroll.clientWidth);
-    summary.previousButton.disabled = summary.scroll.scrollLeft <= 1;
-    summary.nextButton.disabled = summary.scroll.scrollLeft >= maximum - 1;
+    const atStart = summary.scroll.scrollLeft <= 1;
+    const atEnd = maximum <= 1 || summary.scroll.scrollLeft >= maximum - 1;
+    summary.previousButton.disabled = atStart;
+    summary.previousButton.setAttribute('aria-disabled', String(atStart));
+    summary.nextButton.disabled = atEnd;
+    summary.nextButton.setAttribute('aria-disabled', String(atEnd));
   }
 
   function roadGeometry() {
@@ -326,39 +326,14 @@ function installRoadBehavior({ achievements, summary }) {
     scrollRoad(event.key === 'ArrowLeft' ? -1 : 1);
   });
 
-  summary.scroll.addEventListener('pointerdown', (event) => {
-    if (event.button !== 0 || event.target.closest('button')) return;
-    dragPointerId = event.pointerId;
-    dragStartX = event.clientX;
-    dragStartScrollLeft = summary.scroll.scrollLeft;
-    dragged = false;
-    summary.scroll.classList.add('is-dragging');
-    summary.scroll.setPointerCapture?.(event.pointerId);
-  });
-  summary.scroll.addEventListener('pointermove', (event) => {
-    if (event.pointerId !== dragPointerId) return;
-    const distance = event.clientX - dragStartX;
-    if (Math.abs(distance) > 4) dragged = true;
-    summary.scroll.scrollLeft = dragStartScrollLeft - distance;
-    if (dragged) event.preventDefault();
-  });
-  const stopDragging = (event) => {
-    if (dragPointerId == null || (event?.pointerId != null && event.pointerId !== dragPointerId)) return;
-    summary.scroll.classList.remove('is-dragging');
-    dragPointerId = null;
-    dragged = false;
-    updateScrollButtons();
-  };
-  summary.scroll.addEventListener('pointerup', stopDragging);
-  summary.scroll.addEventListener('pointercancel', stopDragging);
-  summary.scroll.addEventListener('lostpointercapture', stopDragging);
-
+  // The base achievement view renders the selected reward first. This later
+  // bubble listener then attaches the correct 3D showcase to that finished card.
   markers.addEventListener('click', (event) => {
     const marker = event.target.closest('[data-trophy-reward]');
-    if (!marker || dragged) return;
+    if (!marker) return;
     selectedByPlayer = marker.dataset.trophyReward;
-    queueMicrotask(preserveUserSelection);
-  }, { capture: true });
+    preserveUserSelection();
+  });
 
   const markerObserver = new MutationObserver(preserveUserSelection);
   markerObserver.observe(markers, { childList: true });
@@ -383,6 +358,7 @@ function installRoadBehavior({ achievements, summary }) {
   return Object.freeze({
     clearSelection,
     alignToProgress,
+    syncScrollButtons: updateScrollButtons,
     pauseShowcase: showcase.pause,
     disconnect() {
       cancelAnimationFrame(geometryFrame);
@@ -410,6 +386,7 @@ export function installTrophyRoadFeedback(achievements = globalThis.__turnAchiev
     filters.reset();
     road.clearSelection();
     summary.scroll.scrollLeft = 0;
+    road.syncScrollButtons();
   }
 
   const openObserver = new MutationObserver(() => {

--- a/turn/achievements/trophy-road-showcase.js
+++ b/turn/achievements/trophy-road-showcase.js
@@ -33,40 +33,43 @@ export function createTrophyRoadShowcase() {
   let disposed = false;
   let resizeObserver = null;
   const groups = new Map();
+  const groupPromises = new Map();
   const clock = new THREE.Clock();
 
-  function ensureRenderer(host) {
-    if (!renderer) {
-      scene = new THREE.Scene();
-      camera = new THREE.PerspectiveCamera(34, 1, 0.1, 80);
-      scene.add(new THREE.HemisphereLight(0xffffff, 0x4c5963, 3.2));
-      const key = new THREE.DirectionalLight(0xfff2c9, 4.1);
-      key.position.set(-7, 10, 8);
-      scene.add(key);
-      const fill = new THREE.DirectionalLight(0x8ed8ff, 1.8);
-      fill.position.set(8, 4, -5);
-      scene.add(fill);
-      stage = new THREE.Group();
-      scene.add(stage);
+  function ensureRenderer() {
+    if (renderer) return;
 
-      renderer = new THREE.WebGLRenderer({
-        antialias: true,
-        alpha: true,
-        powerPreference: 'high-performance'
-      });
-      renderer.outputColorSpace = THREE.SRGBColorSpace;
-      renderer.setPixelRatio(Math.min(globalThis.devicePixelRatio || 1, 1.35));
-      renderer.setClearColor(0x000000, 0);
-      resizeObserver = new ResizeObserver(resize);
-    }
+    scene = new THREE.Scene();
+    camera = new THREE.PerspectiveCamera(34, 1, 0.1, 80);
+    scene.add(new THREE.HemisphereLight(0xffffff, 0x4c5963, 3.2));
+    const key = new THREE.DirectionalLight(0xfff2c9, 4.1);
+    key.position.set(-7, 10, 8);
+    scene.add(key);
+    const fill = new THREE.DirectionalLight(0x8ed8ff, 1.8);
+    fill.position.set(8, 4, -5);
+    scene.add(fill);
+    stage = new THREE.Group();
+    scene.add(stage);
 
-    if (activeHost !== host) {
-      resizeObserver?.disconnect();
-      activeHost = host;
-      activeHost.replaceChildren(renderer.domElement);
-      resizeObserver?.observe(activeHost);
-      resize();
-    }
+    renderer = new THREE.WebGLRenderer({
+      antialias: true,
+      alpha: true,
+      powerPreference: 'high-performance'
+    });
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    renderer.setPixelRatio(Math.min(globalThis.devicePixelRatio || 1, 1.35));
+    renderer.setClearColor(0x000000, 0);
+    resizeObserver = new ResizeObserver(resize);
+  }
+
+  function attachRenderer(host) {
+    ensureRenderer();
+    if (activeHost === host && renderer.domElement.parentElement === host) return;
+    resizeObserver?.disconnect();
+    activeHost = host;
+    activeHost.replaceChildren(renderer.domElement);
+    resizeObserver?.observe(activeHost);
+    resize();
   }
 
   function configureCamera(rewardId) {
@@ -82,29 +85,39 @@ export function createTrophyRoadShowcase() {
 
   async function buildRewardGroup(rewardId) {
     if (groups.has(rewardId)) return groups.get(rewardId);
+    if (groupPromises.has(rewardId)) return groupPromises.get(rewardId);
     const definitions = REWARD_CARS[rewardId];
     if (!definitions) return null;
 
-    const group = new THREE.Group();
-    const visuals = await Promise.all(definitions.map(async (definition, index) => {
-      const visual = await createCarVisual({
-        carId: definition.carId,
-        color: DEFAULT_VEHICLE_COLOR,
-        secondaryColor: DEFAULT_VEHICLE_SECONDARY_COLOR,
-        targetLength: definition.targetLength,
-        outline: true
-      });
-      visual.position.set(definition.x, 0, 0);
-      visual.rotation.y = definition.yaw;
-      visual.userData.turnRewardBaseX = definition.x;
-      visual.userData.turnRewardBaseYaw = definition.yaw;
-      visual.userData.turnRewardPhase = index * 1.7;
-      group.add(visual);
-      return visual;
-    }));
-    group.userData.turnRewardVisuals = visuals;
-    groups.set(rewardId, group);
-    return group;
+    const request = (async () => {
+      const group = new THREE.Group();
+      const visuals = await Promise.all(definitions.map(async (definition, index) => {
+        const visual = await createCarVisual({
+          carId: definition.carId,
+          color: DEFAULT_VEHICLE_COLOR,
+          secondaryColor: DEFAULT_VEHICLE_SECONDARY_COLOR,
+          targetLength: definition.targetLength,
+          outline: true
+        });
+        visual.position.set(definition.x, 0, 0);
+        visual.rotation.y = definition.yaw;
+        visual.userData.turnRewardBaseX = definition.x;
+        visual.userData.turnRewardBaseYaw = definition.yaw;
+        visual.userData.turnRewardPhase = index * 1.7;
+        group.add(visual);
+        return visual;
+      }));
+      group.userData.turnRewardVisuals = visuals;
+      groups.set(rewardId, group);
+      return group;
+    })();
+
+    groupPromises.set(rewardId, request);
+    try {
+      return await request;
+    } finally {
+      groupPromises.delete(rewardId);
+    }
   }
 
   async function show(reward, host) {
@@ -114,7 +127,7 @@ export function createTrophyRoadShowcase() {
     }
 
     const request = ++generation;
-    ensureRenderer(host);
+    ensureRenderer();
     activeRewardId = reward.id;
     configureCamera(reward.id);
     host.dataset.trophyRewardModel = reward.id;
@@ -124,15 +137,17 @@ export function createTrophyRoadShowcase() {
     try {
       const group = await buildRewardGroup(reward.id);
       if (disposed || request !== generation || !group) return false;
+
       if (activeGroup && activeGroup.parent === stage) stage.remove(activeGroup);
       activeGroup = group;
       stage.add(group);
+      attachRenderer(host);
       host.classList.remove('is-loading');
       resize();
       resume();
       return true;
     } catch (error) {
-      host.classList.remove('is-loading');
+      if (request === generation) host.classList.remove('is-loading');
       console.warn(`TURN: could not load the ${reward.shortTitle} Trophy Road preview.`, error);
       return false;
     }
@@ -177,10 +192,13 @@ export function createTrophyRoadShowcase() {
     activeRewardId = '';
     if (activeGroup && activeGroup.parent === stage) stage.remove(activeGroup);
     activeGroup = null;
+    resizeObserver?.disconnect();
     if (activeHost) {
       delete activeHost.dataset.trophyRewardModel;
       activeHost.classList.remove('is-loading');
     }
+    renderer?.domElement?.remove();
+    activeHost = null;
   }
 
   function dispose() {
@@ -192,6 +210,7 @@ export function createTrophyRoadShowcase() {
     renderer = null;
     activeHost = null;
     groups.clear();
+    groupPromises.clear();
   }
 
   return Object.freeze({

--- a/turn/app.js
+++ b/turn/app.js
@@ -80,11 +80,11 @@ installStylesheet(
   'data-turn-lot-layout-r121'
 );
 installStylesheet(
-  './progression/trophy-road.css?revision=r155-trophy-road-polish',
+  './progression/trophy-road.css?revision=r156-trophy-road-selection',
   'data-turn-trophy-road'
 );
 const { prepareTrophyRoadProfile } = await import(
-  withBuild('./progression/trophy-road.js?revision=r155-trophy-road-polish')
+  withBuild('./progression/trophy-road.js?revision=r156-trophy-road-selection')
 );
 prepareTrophyRoadProfile();
 
@@ -217,7 +217,7 @@ installStylesheet(
 );
 installStylesheet('./rival-reset-context-r127.css', 'data-turn-rival-reset-context');
 const { installM8HomeNavigation } = await import(
-  withBuild('./m8-home.js?revision=r131-motion-permission-retry&trophy-road=r155')
+  withBuild('./m8-home.js?revision=r131-motion-permission-retry&trophy-road=r154')
 );
 const home = await installM8HomeNavigation();
 globalThis.__turnHome = home;
@@ -236,7 +236,7 @@ if (buildLabel) {
   buildLabel.textContent = `TURN V${release?.version || ''} · BUILD ${(release?.id || '').toUpperCase()}`;
 }
 const { installM8HomeFixedLayout } = await import(
-  withBuild('./m8-home-fixed-layout.js?revision=m8.9-track-title-alignment&trophy-road=r155')
+  withBuild('./m8-home-fixed-layout.js?revision=m8.9-track-title-alignment&trophy-road=r156')
 );
 await installM8HomeFixedLayout();
 installStylesheet(

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -110,7 +110,7 @@ export async function installM8HomeFixedLayout() {
   );
   const achievements = installAchievements(globalThis.__turnRuntime);
   const { installTrophyRoadFeedback } = await import(
-    `/turn/achievements/trophy-road-feedback.js?build=${buildKey}-r155-trophy-road-polish`
+    `/turn/achievements/trophy-road-feedback.js?build=${buildKey}-r156-trophy-road-selection`
   );
   const trophyRoadFeedback = installTrophyRoadFeedback(achievements);
 

--- a/turn/progression/trophy-road.css
+++ b/turn/progression/trophy-road.css
@@ -69,11 +69,13 @@
   stroke-linejoin: round;
 }
 
-.turn-trophy-road-scroll-button:disabled {
+.turn-trophy-road-scroll-button:disabled,
+.turn-trophy-road-scroll-button[aria-disabled="true"] {
   background: var(--turn-muted, #d6d0c2);
   box-shadow: none;
   cursor: default;
-  opacity: .45;
+  opacity: .32;
+  pointer-events: none;
 }
 
 .turn-trophy-road-scroll {
@@ -85,13 +87,8 @@
   scrollbar-color: var(--turn-ink, #08090a) var(--turn-muted, #d6d0c2);
   scrollbar-width: thin;
   touch-action: pan-y;
-  cursor: grab;
+  cursor: default;
   -webkit-overflow-scrolling: touch;
-}
-
-.turn-trophy-road-scroll.is-dragging {
-  cursor: grabbing;
-  user-select: none;
 }
 
 .turn-trophy-road-scroll:focus-visible {
@@ -171,6 +168,20 @@
   width: 32px;
   height: 25px;
   place-items: center;
+}
+
+/* A compact side-profile Formula car: front wing, long nose, cockpit and rear wing. */
+.turn-trophy-road-marker[data-trophy-reward="future-racer"] .turn-trophy-road-marker-icon svg {
+  display: none;
+}
+
+.turn-trophy-road-marker[data-trophy-reward="future-racer"] .turn-trophy-road-marker-icon::before {
+  content: '';
+  width: 100%;
+  height: 100%;
+  background: currentColor;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 48'%3E%3Cpath d='M3 32h12l7-5 4-10h10l5 9h10l3-8h7v7h-7l7 7v5H4Z' fill='none' stroke='black' stroke-width='3' stroke-linejoin='round'/%3E%3Cpath d='M23 27h28M29 17l5 10M5 27v-6h13M52 18h9M53 24h8' fill='none' stroke='black' stroke-width='3' stroke-linecap='round'/%3E%3Ccircle cx='18' cy='39' r='5' fill='none' stroke='black' stroke-width='3'/%3E%3Ccircle cx='49' cy='39' r='5' fill='none' stroke='black' stroke-width='3'/%3E%3C/svg%3E") center / contain no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 48'%3E%3Cpath d='M3 32h12l7-5 4-10h10l5 9h10l3-8h7v7h-7l7 7v5H4Z' fill='none' stroke='black' stroke-width='3' stroke-linejoin='round'/%3E%3Cpath d='M23 27h28M29 17l5 10M5 27v-6h13M52 18h9M53 24h8' fill='none' stroke='black' stroke-width='3' stroke-linecap='round'/%3E%3Ccircle cx='18' cy='39' r='5' fill='none' stroke='black' stroke-width='3'/%3E%3Ccircle cx='49' cy='39' r='5' fill='none' stroke='black' stroke-width='3'/%3E%3C/svg%3E") center / contain no-repeat;
 }
 
 .turn-trophy-road-marker svg,
@@ -279,9 +290,15 @@
   content: 'LOADING 3D…';
   display: grid;
   grid-area: 1 / 1;
-  place-items: center;
-  font-size: .62rem;
+  place-items: end center;
+  padding-bottom: 4px;
+  font-size: .56rem;
   letter-spacing: .08em;
+}
+
+.turn-trophy-road-detail-model-host.is-loading > svg {
+  grid-area: 1 / 1;
+  opacity: .7;
 }
 
 .turn-trophy-road-detail span {


### PR DESCRIPTION
## Summary
- make reward selection update the detail card on the first tap without racing a deferred second render
- keep the static reward artwork visible while the 3D model is loading
- share one in-flight model load when the same reward renders twice
- remove custom drag-to-scroll behavior for now and keep the explicit scroll buttons and keyboard controls
- make the left scroll button truly inactive whenever the road is at its starting edge
- replace the Future Racer milestone artwork with a clearer Formula-style line icon

## Interaction details
- the base achievement view finishes updating the selected reward first; the Trophy Road enhancement then attaches the corresponding 3D preview synchronously on the same click
- switching between Future Racer and Emergency Pack is generation-safe, so a late model load cannot replace the currently selected reward
- inactive road buttons use native disabled state, `aria-disabled`, no shadow, and no pointer interaction

## Validation
- expands the Trophy Road regression for first-tap synchronization, no custom pointer drag, scroll-button edge states, retained loading artwork, shared model promises, Formula-style milestone artwork, and refreshed bundle revisions