### PR TITLE
Add hidden achievements and expand Trophy Road rewards

### DIFF
--- a/turn-lab/tests/achievements-production.mjs
+++ b/turn-lab/tests/achievements-production.mjs
@@ -20,13 +20,36 @@ import {
   sampleNightShiftOvertakes
 } from '../../turn/achievements/night-shift.js';
 
-const [catalog, storeSource, runtime, view, nightShiftSource, timeTrialSource, style, fixedLayout, workflow, designTokens] = await Promise.all([
+const [
+  catalog,
+  secretCatalog,
+  secretEvents,
+  secretRuntime,
+  storeSource,
+  runtime,
+  view,
+  nightShiftSource,
+  timeTrialSource,
+  lilyaSource,
+  darvidSource,
+  sedanSource,
+  style,
+  fixedLayout,
+  workflow,
+  designTokens
+] = await Promise.all([
   fs.readFile(new URL('../../turn/achievements/catalog.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/achievements/secret-catalog.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/achievements/secret-events.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/achievements/secret-achievements.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements/store.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements/runtime.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements/view.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements/night-shift.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements/time-trials.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/tracks/midnight-city-world-r11.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/tracks/harbor-hidden-face-r89.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/vehicle/sports-sedan-easter-egg.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../.github/workflows/turn-lab-tests.yml', import.meta.url), 'utf8'),
@@ -34,16 +57,18 @@ const [catalog, storeSource, runtime, view, nightShiftSource, timeTrialSource, s
 ]);
 
 assert.equal(ACHIEVEMENT_STORAGE_KEY, 'turn-achievements-v1');
-assert.equal(ACHIEVEMENTS.length, 22, 'TURN should ship twenty-two achievements including the developer time trials');
-assert.equal(ONBOARDING_ACHIEVEMENT_IDS.length, 10, 'Getting Started should remain a focused ten-achievement collection');
+assert.equal(ACHIEVEMENTS.length, 25,
+  'TURN should ship twenty-five achievements including three hidden discoveries');
+assert.equal(ONBOARDING_ACHIEVEMENT_IDS.length, 10,
+  'Getting Started should remain a focused ten-achievement collection');
 assert.equal(TIME_TRIALS.length, 5, 'Every current track should have one hard time trial');
 assert.equal(TIME_TRIAL_ACHIEVEMENT_IDS.length, 5);
 assert.equal(TIME_TRIAL_MASTER_ID, 'faster-than-the-dev');
-assert.equal(totalAvailableTrophies(), 1300);
+assert.equal(totalAvailableTrophies(), 1375);
 assert.equal(
   ACHIEVEMENTS.reduce((total, achievement) => total + achievement.trophies, 0),
-  1300,
-  'The current collection should contain 1300 permanent trophies'
+  1375,
+  'The current collection should contain 1375 permanent trophies'
 );
 assert.ok(ACHIEVEMENTS.every((achievement) => Number.isFinite(achievement.trophies)));
 assert.ok(ACHIEVEMENTS.every((achievement) => !Object.hasOwn(achievement, 'points')));
@@ -66,6 +91,9 @@ assert.deepEqual(
     'around-the-turn',
     'ahead-of-yourself',
     'night-shift-sheriff',
+    'find-lilya',
+    'find-darvid',
+    'satans-sedan',
     'countryside-sprint',
     'airport-sprint',
     'cliffside-sprint',
@@ -74,6 +102,7 @@ assert.deepEqual(
     'faster-than-the-dev'
   ]
 );
+
 assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === 'flow-state')?.trophies, 50);
 assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === 'flow-state')?.description || '', /Drift and Boost/);
 assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === 'flow-state')?.recommendation || '', /Training Car · Countryside/);
@@ -86,6 +115,16 @@ assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === 'beyond-sight
 assert.equal(ACHIEVEMENTS.find((achievement) => achievement.id === 'night-shift-sheriff')?.trophies, 100);
 assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === 'night-shift-sheriff')?.description || '', /Police Car/);
 assert.match(ACHIEVEMENTS.find((achievement) => achievement.id === 'night-shift-sheriff')?.description || '', /Boost is active/);
+
+for (const id of ['find-lilya', 'find-darvid', 'satans-sedan']) {
+  const achievement = ACHIEVEMENTS.find((item) => item.id === id);
+  assert.equal(achievement?.hidden, true, `${id} must remain a hidden achievement`);
+  assert.equal(achievement?.trophies, 25, `${id} should award 25 trophies`);
+  assert.equal(achievement?.category, 'exploration');
+}
+assert.equal(ACHIEVEMENTS.find((item) => item.id === 'find-lilya')?.title, 'FIND LILYA!');
+assert.equal(ACHIEVEMENTS.find((item) => item.id === 'find-darvid')?.title, 'FIND DARVID!');
+assert.equal(ACHIEVEMENTS.find((item) => item.id === 'satans-sedan')?.title, 'SATAN’S SEDAN');
 
 assert.deepEqual(
   TIME_TRIALS.map(({ trackId, targetSeconds }) => [trackId, targetSeconds]),
@@ -115,7 +154,7 @@ assert.equal(completedAllTimeTrials((id) => id !== 'harbor-sprint', 'harbor-spri
   'The final qualifying lap should count while the individual achievement is still pending');
 
 const empty = normalizeAchievementState(null);
-assert.equal(empty.version, 3);
+assert.equal(empty.version, 4);
 assert.deepEqual(empty.progress.tracks, []);
 assert.deepEqual(empty.progress.blankTracks, []);
 assert.deepEqual(empty.rewards.unlocked, []);
@@ -138,13 +177,16 @@ const normalized = normalizeAchievementState({
   },
   rewards: { unlocked: [], seen: [] }
 });
+assert.equal(normalized.version, 4);
 assert.deepEqual(Object.keys(normalized.unlocked), ['first-turn', 'trust-your-ears', 'countryside-sprint']);
 assert.deepEqual(normalized.seen, ['first-turn']);
 assert.deepEqual(normalized.progress.tracks, ['airport']);
 assert.deepEqual(normalized.progress.blankTracks, ['countryside', 'midnight-city'],
   'Existing Trust Your Ears unlocks should seed Beyond Sight progress during migration');
-assert.deepEqual(normalized.rewards.unlocked, [],
-  'A 275-trophy profile must remain below the new 300-trophy first milestone');
+assert.deepEqual(normalized.rewards.unlocked, ['paintjob', 'monster'],
+  'Profiles created before the new gates must retain paint and Monster Truck access');
+assert.deepEqual(normalized.rewards.seen, ['paintjob', 'monster'],
+  'Grandfathered rewards must not create misleading new-reward notifications');
 
 const memory = new Map();
 const storage = {
@@ -168,6 +210,8 @@ assert.ok(store.isUnlocked('ahead-of-yourself'));
 assert.equal(store.trophyTotal(), 300);
 assert.deepEqual(store.syncRewards().map((reward) => reward.id), ['midnight-city']);
 assert.equal(store.isRewardUnlocked('midnight-city'), true);
+assert.equal(store.isRewardUnlocked('paintjob'), true);
+assert.equal(store.isRewardUnlocked('monster'), true);
 assert.doesNotMatch(storeSource, /rival-storage|clearRivalsState|clearAllRivalsState/,
   'Rival reset implementation must remain independent from persistent achievements and rewards');
 
@@ -203,6 +247,8 @@ assert.equal(createNightShiftAttempt({
   rivals: [...rivals.slice(0, 3), { carId: 'police', time: 90, progress: 0.5 }]
 }).eligible, false, 'Police rivals should make Night Shift Sheriff ineligible');
 
+assert.match(catalog, /SECRET_ACHIEVEMENTS/);
+assert.match(catalog, /secret: '<svg/);
 assert.match(catalog, /TIME_TRIALS/);
 assert.match(catalog, /TIME_TRIAL_ACHIEVEMENT_IDS/);
 assert.match(catalog, /TIME_TRIALS: 'time-trials'/);
@@ -219,8 +265,29 @@ assert.match(catalog, /id: 'around-the-turn'/);
 assert.match(catalog, /id: 'ahead-of-yourself'/);
 assert.match(catalog, /id: 'night-shift-sheriff'/);
 assert.doesNotMatch(catalog, /points:/);
+
+assert.match(secretCatalog, /id: 'find-lilya'/);
+assert.match(secretCatalog, /id: 'find-darvid'/);
+assert.match(secretCatalog, /id: 'satans-sedan'/);
+assert.match(secretCatalog, /title: 'SATAN’S SEDAN'/);
+assert.equal((secretCatalog.match(/trophies: 25/g) || []).length, 3);
+assert.equal((secretCatalog.match(/hidden: true/g) || []).length, 3);
+assert.match(secretEvents, /turn:secret-achievement/);
+assert.match(secretEvents, /__turnPendingSecretAchievementIds/);
+assert.match(secretRuntime, /Hidden achievement\. The title is your clue\./);
+assert.match(secretRuntime, /achievement\.hidden/);
+assert.match(secretRuntime, /achievements\.unlock\(achievementId, context\)/);
+assert.match(secretRuntime, /takePendingSecretAchievementIds/);
+assert.match(lilyaSource, /signalSecretAchievement\('find-lilya'/);
+assert.match(lilyaSource, /turnSecretAchievementFound/);
+assert.match(darvidSource, /signalSecretAchievement\('find-darvid'/);
+assert.match(darvidSource, /DISCOVERY_HOLD_MS = 550/);
+assert.match(sedanSource, /signalSecretAchievement\('satans-sedan'/);
+assert.match(sedanSource, /color code #666/);
+
 assert.match(storeSource, /ACHIEVEMENT_STORAGE_KEY = TROPHY_ROAD_STORAGE_KEY/);
 assert.match(storeSource, /STORAGE_VERSION = TROPHY_ROAD_STORAGE_VERSION/);
+assert.match(storeSource, /grandfatheredRewardIdsForVersion/);
 assert.match(storeSource, /state\.progress\[key\]/);
 assert.match(storeSource, /addBlankTrack/);
 assert.match(storeSource, /existingTrustTrack/);
@@ -349,12 +416,14 @@ assert.doesNotMatch(style, /is-achievement-next/);
 
 assert.match(designTokens, /--turn-action-success: var\(--turn-green-500\)/);
 assert.match(fixedLayout, /installAchievements/);
+assert.match(fixedLayout, /installSecretAchievements/);
 assert.match(fixedLayout, /installM8TrophyGate/);
-assert.match(fixedLayout, /r154-trophy-road-feedback/);
+assert.match(fixedLayout, /r157-hidden-achievements/);
+assert.match(fixedLayout, /r157-paint-monster/);
 assert.ok(fixedLayout.indexOf('installM8HomeCardScrollFixes') < fixedLayout.indexOf('installAchievements'),
   'Achievements should join the completed fixed Home layout after track scrolling is installed');
 assert.match(workflow, /Run achievement system regression/);
 assert.match(workflow, /node turn-lab\/tests\/achievements-production\.mjs/);
 assert.match(workflow, /Run Trophy Road progression regression/);
 
-console.log('TURN Trophy Road achievement regression passed.');
+console.log('TURN hidden and Trophy Road achievement regression passed.');

--- a/turn-lab/tests/emergency-vehicles-production.mjs
+++ b/turn-lab/tests/emergency-vehicles-production.mjs
@@ -64,7 +64,11 @@ const [
 assert.match(carModels, /!car\.fixedLivery/);
 assert.match(carModels, /installEmergencyLightRig/);
 assert.match(carModels, /THREE\.AdditiveBlending/);
-assert.match(carModels, /new THREE\.PointLight\(color, 0, lightDistance, 2\)/);
+assert.match(carModels, /new THREE\.PointLight\(0xffffff, 0, lightDistance, 2\)/);
+assert.match(carModels, /setThreeColor\(pointLight\.color, colorSpec\)/,
+  'Emergency point lights should use Display P3 when the renderer supports it');
+assert.match(carModels, /makeWideGamutSpec\('#ff3158'\)/);
+assert.match(carModels, /makeWideGamutSpec\('#2ab7ff'\)/);
 assert.match(carModels, /record\.wideHalo\.visible = active && !rig\.reducedMotion && on/);
 assert.match(carModels, /record\.haloMaterial\.opacity = active && on \? \(rig\.reducedMotion \? 0\.42 : 0\.68\) : 0/);
 assert.match(carModels, /record\.pointLight\.intensity = active && on \? \(rig\.reducedMotion \? 70 : 110\) : 0/);
@@ -72,13 +76,15 @@ assert.match(carModels, /prefers-reduced-motion: reduce/);
 assert.match(carModels, /periodMs = reducedMotion \? 1400/);
 assert.match(carModels, /globalThis\.__turnBoostActive/);
 
-assert.match(emergencyLiveries, /police:[\s\S]*primary: 0x0b0d10[\s\S]*secondary: 0xf8f9fa/);
-assert.match(emergencyLiveries, /ambulance:[\s\S]*primary: 0xf8f9fa[\s\S]*secondary: 0xd92d20[\s\S]*accent: 'rear-side-stripe'/);
-assert.match(emergencyLiveries, /firetruck:[\s\S]*primary: 0xd92d20[\s\S]*secondary: 0xffd43b/);
+assert.match(emergencyLiveries, /police:[\s\S]*primary: makeWideGamutSpec\('#0b0d10'[\s\S]*secondary: makeWideGamutSpec\('#f8f9fa'/);
+assert.match(emergencyLiveries, /ambulance:[\s\S]*primary: makeWideGamutSpec\('#f8f9fa'[\s\S]*secondary: makeWideGamutSpec\('#d92d20'[\s\S]*accent: 'rear-side-stripe'/);
+assert.match(emergencyLiveries, /firetruck:[\s\S]*primary: makeWideGamutSpec\('#d92d20'[\s\S]*secondary: makeWideGamutSpec\('#ffcc00'/);
 assert.match(emergencyLiveries, /applyFixedEmergencyLivery/);
 assert.match(emergencyLiveries, /turnEmergencyLiveryAccent/);
 assert.match(emergencyLiveries, /length: size\.z \* 0\.52/);
 assert.match(emergencyLiveries, /createBaseCarVisual/);
+assert.match(emergencyLiveries, /installLotUnselectedTint/,
+  'Unselected Lot vehicles should retain a subtle hint of their factory colour');
 assert.doesNotMatch(emergencyLiveries, /turnEmergencyLightRig|PointLight|AdditiveBlending/);
 
 assert.match(lot, /SERVICE LIVERY/);
@@ -107,4 +113,4 @@ assert.match(audio, /emergencySirenFrequency/);
 assert.match(audio, /sirenActive = boostActive/);
 assert.match(license, /Creative Commons CC0 1\.0 Universal/);
 
-console.log('TURN emergency vehicles, fixed liveries, empty paint rail, lights and sirens passed.');
+console.log('TURN emergency vehicles, fixed liveries, wide-gamut lights, Lot tint and sirens passed.');

--- a/turn-lab/tests/trophy-road-production.mjs
+++ b/turn-lab/tests/trophy-road-production.mjs
@@ -8,10 +8,13 @@ import {
   TROPHY_ROAD_STORAGE_VERSION,
   TROPHY_ROAD_VIEWPORT_THRESHOLD,
   getTrophyRoadReward,
+  grandfatheredRewardIdsForVersion,
+  isPaintUnlocked,
   isTrackUnlocked,
   isVehicleUnlocked,
   prepareTrophyRoadProfile,
   readTrophyRoadSnapshot,
+  rewardForFeature,
   rewardForTrack,
   rewardForVehicle,
   rewardIdsForTrophies
@@ -20,8 +23,10 @@ import {
 const [
   roadSource,
   roadCss,
+  roadExtensionCss,
   homeGate,
   lotGate,
+  paintGate,
   view,
   feedback,
   showcase,
@@ -30,12 +35,16 @@ const [
   fixedLayout,
   lotEnhancement,
   vehicleCatalog,
+  wideGamut,
+  emergencyLiveries,
   workflow
 ] = await Promise.all([
   fs.readFile(new URL('../../turn/progression/trophy-road.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/progression/trophy-road.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/progression/trophy-road-r157.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/progression/m8-trophy-gate.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/progression/lot-trophy-gate.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/progression/lot-paint-reward.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements/view.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements/trophy-road-feedback.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements/trophy-road-showcase.js', import.meta.url), 'utf8'),
@@ -44,6 +53,8 @@ const [
   fs.readFile(new URL('../../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-enhancement-runtime.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/vehicle/catalog.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/vehicle/wide-gamut.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/vehicle/emergency-livery-models.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../.github/workflows/turn-lab-tests.yml', import.meta.url), 'utf8')
 ]);
 
@@ -69,8 +80,8 @@ function createMemoryStorage(initial = {}) {
 }
 
 assert.equal(TROPHY_ROAD_STORAGE_KEY, 'turn-achievements-v1');
-assert.equal(TROPHY_ROAD_STORAGE_VERSION, 3);
-assert.equal(TROPHY_ROAD_MAX_THRESHOLD, 1300,
+assert.equal(TROPHY_ROAD_STORAGE_VERSION, 4);
+assert.equal(TROPHY_ROAD_MAX_THRESHOLD, 1375,
   'The road must retain room for the complete current trophy collection');
 assert.equal(TROPHY_ROAD_VIEWPORT_THRESHOLD, 600,
   'The first 600 trophies should fit in the initial road viewport');
@@ -79,21 +90,35 @@ assert.deepEqual(
   [
     ['midnight-city', 300],
     ['future-racer', 400],
-    ['emergency-pack', 600]
+    ['paintjob', 500],
+    ['emergency-pack', 600],
+    ['monster', 700]
   ]
 );
 assert.deepEqual(rewardIdsForTrophies(299), []);
 assert.deepEqual(rewardIdsForTrophies(300), ['midnight-city']);
 assert.deepEqual(rewardIdsForTrophies(399), ['midnight-city']);
 assert.deepEqual(rewardIdsForTrophies(400), ['midnight-city', 'future-racer']);
-assert.deepEqual(rewardIdsForTrophies(599), ['midnight-city', 'future-racer']);
-assert.deepEqual(rewardIdsForTrophies(600), ['midnight-city', 'future-racer', 'emergency-pack']);
+assert.deepEqual(rewardIdsForTrophies(499), ['midnight-city', 'future-racer']);
+assert.deepEqual(rewardIdsForTrophies(500), ['midnight-city', 'future-racer', 'paintjob']);
+assert.deepEqual(rewardIdsForTrophies(599), ['midnight-city', 'future-racer', 'paintjob']);
+assert.deepEqual(rewardIdsForTrophies(600), ['midnight-city', 'future-racer', 'paintjob', 'emergency-pack']);
+assert.deepEqual(rewardIdsForTrophies(699), ['midnight-city', 'future-racer', 'paintjob', 'emergency-pack']);
+assert.deepEqual(rewardIdsForTrophies(700), ['midnight-city', 'future-racer', 'paintjob', 'emergency-pack', 'monster']);
 assert.equal(rewardForTrack('midnight-city')?.id, 'midnight-city');
 assert.equal(rewardForVehicle('police')?.id, 'emergency-pack');
 assert.equal(rewardForVehicle('ambulance')?.id, 'emergency-pack');
 assert.equal(rewardForVehicle('firetruck')?.id, 'emergency-pack');
 assert.equal(rewardForVehicle('race-future')?.id, 'future-racer');
+assert.equal(rewardForVehicle('monster-truck')?.id, 'monster');
+assert.equal(rewardForFeature('vehicle-paint')?.id, 'paintjob');
 assert.equal(getTrophyRoadReward('invented'), null);
+assert.deepEqual(grandfatheredRewardIdsForVersion(3), ['paintjob', 'monster']);
+assert.deepEqual(
+  grandfatheredRewardIdsForVersion(2),
+  ['midnight-city', 'future-racer', 'paintjob', 'emergency-pack', 'monster']
+);
+assert.deepEqual(grandfatheredRewardIdsForVersion(4), []);
 
 const freshStorage = createMemoryStorage();
 assert.equal(prepareTrophyRoadProfile(freshStorage), null,
@@ -104,6 +129,8 @@ assert.equal(isTrackUnlocked('midnight-city', freshStorage), false);
 assert.equal(isVehicleUnlocked('classic', freshStorage), true);
 assert.equal(isVehicleUnlocked('police', freshStorage), false);
 assert.equal(isVehicleUnlocked('race-future', freshStorage), false);
+assert.equal(isVehicleUnlocked('monster-truck', freshStorage), false);
+assert.equal(isPaintUnlocked(freshStorage), false);
 freshStorage.setItem('turn-drive-by-ear-v1', 'false');
 assert.equal(prepareTrophyRoadProfile(freshStorage), null,
   'A setting created later in a fresh session must not retroactively grandfather the player');
@@ -118,10 +145,12 @@ assert.equal(preparedLegacy?.version, 2,
 assert.equal(readTrophyRoadSnapshot(legacyWithoutAchievements).isLegacyProfile, true);
 assert.deepEqual(
   readTrophyRoadSnapshot(legacyWithoutAchievements).unlockedRewardIds,
-  ['midnight-city', 'future-racer', 'emergency-pack']
+  ['midnight-city', 'future-racer', 'paintjob', 'emergency-pack', 'monster']
 );
+assert.equal(isPaintUnlocked(legacyWithoutAchievements), true);
+assert.equal(isVehicleUnlocked('monster-truck', legacyWithoutAchievements), true);
 
-const migrated = normalizeAchievementState({
+const migratedLegacy = normalizeAchievementState({
   version: 2,
   unlocked: {
     'first-turn': { unlockedAt: 1, trackId: 'countryside', vehicleId: 'classic', time: 20 }
@@ -129,10 +158,25 @@ const migrated = normalizeAchievementState({
   seen: ['first-turn'],
   progress: { tracks: ['countryside'], blankTracks: [] }
 });
-assert.equal(migrated.version, 3);
-assert.deepEqual(migrated.rewards.unlocked, ['midnight-city', 'future-racer', 'emergency-pack']);
-assert.deepEqual(migrated.rewards.seen, migrated.rewards.unlocked,
+assert.equal(migratedLegacy.version, 4);
+assert.deepEqual(
+  migratedLegacy.rewards.unlocked,
+  ['midnight-city', 'future-racer', 'paintjob', 'emergency-pack', 'monster']
+);
+assert.deepEqual(migratedLegacy.rewards.seen, migratedLegacy.rewards.unlocked,
   'Grandfathered content must not create a misleading reward notification');
+
+const migratedVersionThree = normalizeAchievementState({
+  version: 3,
+  unlocked: {},
+  seen: [],
+  progress: { tracks: [], blankTracks: [] },
+  rewards: { unlocked: ['midnight-city'], seen: ['midnight-city'] }
+});
+assert.equal(migratedVersionThree.version, 4);
+assert.deepEqual(migratedVersionThree.rewards.unlocked, ['midnight-city', 'paintjob', 'monster']);
+assert.deepEqual(migratedVersionThree.rewards.seen, ['midnight-city', 'paintjob', 'monster'],
+  'Existing Trophy Road players must retain paint and Monster Truck access silently');
 
 const progressionStorage = createMemoryStorage();
 const store = createAchievementStore(progressionStorage);
@@ -147,17 +191,27 @@ assert.equal(store.unlock('beyond-sight', { trackId: 'countryside' })?.trophies,
 assert.equal(store.trophyTotal(), 500);
 assert.deepEqual(
   store.syncRewards().map((reward) => reward.id),
-  ['midnight-city', 'future-racer']
+  ['midnight-city', 'future-racer', 'paintjob']
 );
 assert.equal(isTrackUnlocked('midnight-city', progressionStorage), true);
 assert.equal(isVehicleUnlocked('race-future', progressionStorage), true);
+assert.equal(isPaintUnlocked(progressionStorage), true);
 assert.equal(isVehicleUnlocked('police', progressionStorage), false);
+assert.equal(isVehicleUnlocked('monster-truck', progressionStorage), false);
 
 assert.equal(store.unlock('around-the-turn', { trackId: 'harbor' })?.trophies, 100);
 assert.equal(store.trophyTotal(), 600);
 assert.deepEqual(store.syncRewards().map((reward) => reward.id), ['emergency-pack']);
 assert.equal(isVehicleUnlocked('police', progressionStorage), true);
-assert.deepEqual(store.unseenRewardIds(), ['midnight-city', 'future-racer', 'emergency-pack']);
+
+assert.equal(store.unlock('faster-than-the-dev', { trackId: 'midnight-city' })?.trophies, 100);
+assert.equal(store.trophyTotal(), 700);
+assert.deepEqual(store.syncRewards().map((reward) => reward.id), ['monster']);
+assert.equal(isVehicleUnlocked('monster-truck', progressionStorage), true);
+assert.deepEqual(
+  store.unseenRewardIds(),
+  ['midnight-city', 'future-racer', 'paintjob', 'emergency-pack', 'monster']
+);
 store.markAllSeen();
 assert.deepEqual(store.unseenRewardIds(), []);
 
@@ -169,11 +223,13 @@ const blockedStorage = {
 globalThis.__turnAchievements = { store };
 assert.equal(isVehicleUnlocked('police', blockedStorage), true,
   'Session-only rewards must open content even when persistent browser storage is blocked');
+assert.equal(isVehicleUnlocked('monster-truck', blockedStorage), true);
+assert.equal(isPaintUnlocked(blockedStorage), true);
 if (previousAchievements === undefined) delete globalThis.__turnAchievements;
 else globalThis.__turnAchievements = previousAchievements;
 
 const permanentReward = normalizeAchievementState({
-  version: 3,
+  version: 4,
   unlocked: {},
   seen: [],
   progress: { tracks: [], blankTracks: [] },
@@ -182,10 +238,18 @@ const permanentReward = normalizeAchievementState({
 assert.deepEqual(permanentReward.rewards.unlocked, ['emergency-pack'],
   'Once awarded, a reward must remain owned even if thresholds change later');
 
+assert.match(roadSource, /TROPHY_ROAD_STORAGE_VERSION = 4/);
+assert.match(roadSource, /TROPHY_ROAD_MAX_THRESHOLD = 1375/);
 assert.match(roadSource, /TROPHY_ROAD_VIEWPORT_THRESHOLD = 600/);
-assert.match(roadSource, /threshold: 300/);
-assert.match(roadSource, /threshold: 400/);
-assert.match(roadSource, /threshold: 600/);
+for (const threshold of [300, 400, 500, 600, 700]) {
+  assert.match(roadSource, new RegExp(`threshold: ${threshold}`));
+}
+assert.match(roadSource, /id: 'paintjob'/);
+assert.match(roadSource, /featureId: 'vehicle-paint'/);
+assert.match(roadSource, /id: 'monster'/);
+assert.match(roadSource, /vehicleIds: Object\.freeze\(\['monster-truck'\]\)/);
+assert.match(roadSource, /grandfatheredRewardIdsForVersion/);
+assert.match(roadSource, /VERSION_THREE_GRANDFATHERED_REWARDS/);
 assert.match(roadSource, /LOCK_ICON/);
 assert.match(roadSource, /showTrophyUnlockNotice/);
 assert.match(roadSource, /PREPARED_STORAGE = new WeakSet/);
@@ -208,8 +272,20 @@ assert.doesNotMatch(homeGate, /fallbackCard\?\.click/,
 assert.match(lotGate, /raceButton\.disabled = locked/);
 assert.match(lotGate, /lot-selected-car-lock/);
 assert.match(lotGate, /showTrophyUnlockNotice/);
+assert.match(lotGate, /rewardForVehicle/);
 assert.doesNotMatch(lotGate, /colors\.hidden|carPicker\.hidden/,
   'Locked vehicles must retain their normal information and paint presentation');
+
+assert.match(paintGate, /isPaintUnlocked/);
+assert.match(paintGate, /PAINT_REWARD_ID = 'paintjob'/);
+assert.match(paintGate, /forceFactoryPaint/);
+assert.match(paintGate, /getVehicleDefaultColor/);
+assert.match(paintGate, /getVehicleDefaultSecondaryColor/);
+assert.match(paintGate, /control\.hidden = locked/);
+assert.match(paintGate, /input\.disabled = locked/);
+assert.match(paintGate, /lot-paint-lock/);
+assert.match(paintGate, /showTrophyUnlockNotice/);
+assert.match(paintGate, /turn:paint-controls-unlocked/);
 
 assert.match(view, /turn-trophy-road-progress" role="progressbar"/);
 assert.match(view, /turn-trophy-road-markers" aria-label="Trophy Road rewards"/);
@@ -218,6 +294,9 @@ assert.ok(
     < view.indexOf('turn-trophy-road-markers" aria-label="Trophy Road rewards"'),
   'Reward buttons should be siblings of the progressbar rather than descendants hidden by progressbar semantics'
 );
+assert.match(feedback, /r157-hidden-achievements/);
+assert.match(feedback, /r157-paint-monster/);
+assert.match(feedback, /trophy-road-r157\.css/);
 assert.match(feedback, /TROPHY_ROAD_VIEWPORT_THRESHOLD/);
 assert.match(feedback, /turn-trophy-road-scroll/);
 assert.match(feedback, /turn-trophy-road-scroll-button/);
@@ -235,6 +314,8 @@ assert.match(feedback, /selectedByPlayer = marker\.dataset\.trophyReward;[\s\S]*
   'Reward details must synchronize after the base view finishes the same click');
 assert.doesNotMatch(feedback, /queueMicrotask\(preserveUserSelection\)/,
   'Reward selection must not race a deferred duplicate render');
+assert.match(feedback, /reward\.type === 'feature'/,
+  'Paintjob should retain its static reward artwork rather than requesting a vehicle showcase');
 assert.match(feedback, /clearSelection\(\)/);
 assert.match(feedback, /resetView\(\)/);
 assert.match(feedback, /CATEGORY\.WAYS_TO_PLAY/);
@@ -252,6 +333,9 @@ assert.match(showcase, /'race-future'/);
 assert.match(showcase, /'firetruck'/);
 assert.match(showcase, /'ambulance'/);
 assert.match(showcase, /'police'/);
+assert.match(showcase, /monster:[\s\S]*'monster-truck'/);
+assert.match(showcase, /getVehicleDefaultColor/);
+assert.match(showcase, /configureRendererWideGamut/);
 assert.match(showcase, /groupPromises = new Map/,
   'Repeated renders should share one in-flight model load per reward');
 assert.ok(
@@ -272,22 +356,30 @@ assert.ok(
   app.indexOf('prepareTrophyRoadProfile();') < app.indexOf("await import(withBuild('./main.js'))"),
   'Grandfathering must be prepared before the runtime loads the saved vehicle selection'
 );
-assert.match(app, /trophy-road\.js\?revision=r156-trophy-road-selection/);
-assert.match(app, /trophy-road\.css\?revision=r156-trophy-road-selection/);
-assert.match(app, /m8-home-fixed-layout\.js\?revision=m8\.9-track-title-alignment&trophy-road=r156/);
-assert.match(app, /lot-enhancement-runtime\.js\?revision=r121&trophy-road=r154/);
+assert.match(app, /trophy-road\.js\?revision=r157-paint-monster/);
+assert.match(app, /trophy-road-r157\.css\?revision=r157-paint-monster/);
+assert.match(app, /wide-gamut\.js\?revision=r157-display-p3/);
+assert.match(app, /m8-home-fixed-layout\.js\?revision=m8\.9-track-title-alignment&trophy-road=r157/);
+assert.match(app, /lot-enhancement-runtime\.js\?revision=r121&trophy-road=r157/);
 assert.match(fixedLayout, /installM8TrophyGate/);
 assert.match(fixedLayout, /installTrophyRoadFeedback/);
-assert.match(fixedLayout, /r156-trophy-road-selection/);
+assert.match(fixedLayout, /installSecretAchievements/);
+assert.match(fixedLayout, /r157-paint-monster/);
 assert.ok(
   fixedLayout.indexOf('installM8TrophyGate') < fixedLayout.indexOf('installAchievements'),
   'Track access should be gated before achievement UI is installed'
 );
 assert.match(lotEnhancement, /gateLotNow/);
+assert.match(lotEnhancement, /gateLotPaintNow/);
 assert.ok(
   lotEnhancement.indexOf('gateLotNow(scope)') < lotEnhancement.indexOf('installLotAccessibility(scope)'),
   'The accessibility layer should capture the complete locked vehicle names'
 );
+assert.ok(
+  lotEnhancement.indexOf('gateLotPaintNow(scope)') < lotEnhancement.indexOf('installLotAccessibility(scope)'),
+  'The accessibility layer should capture the paint lock presentation'
+);
+
 assert.match(roadCss, /overflow-x: auto/);
 assert.match(roadCss, /touch-action: pan-y/);
 assert.match(roadCss, /cursor: default/);
@@ -311,8 +403,31 @@ assert.doesNotMatch(roadCss, /content: '🔒'/,
   'Trophy Road track locks should use the shared vector lock rather than an emoji');
 assert.match(roadCss, /@media \(prefers-reduced-motion: reduce\)/);
 
+assert.match(roadExtensionCss, /@supports \(color: color\(display-p3 1 0 0\)\)/);
+assert.match(roadExtensionCss, /data-trophy-reward="paintjob"/);
+assert.match(roadExtensionCss, /data-trophy-reward="monster"/);
+assert.match(roadExtensionCss, /lot-paint-lock/);
+assert.match(roadExtensionCss, /is-hidden-achievement/);
+
+assert.match(vehicleCatalog, /DEFAULT_VEHICLE_COLOR = '#ffcc00'/);
+assert.match(vehicleCatalog, /'race-future': Object\.freeze\(\{ fallback: '#00aabb'/);
+assert.match(vehicleCatalog, /'monster-truck': Object\.freeze\(\{ fallback: '#3f5a3c'/);
+assert.match(vehicleCatalog, /defaultColorP3/);
+assert.match(vehicleCatalog, /getVehicleDefaultColorSpec/);
 assert.match(vehicleCatalog, /\['vintage-racer',[\s\S]*speed: 4, acceleration: 4, control: 3, drift: 2, boostPower: 3, boostDuration: 2/);
 assert.match(vehicleCatalog, /\['race', 'Race Car',[\s\S]*speed: 5, acceleration: 4, control: 4, drift: 2, boostPower: 2, boostDuration: 1/);
+
+assert.match(wideGamut, /THREE\.DisplayP3ColorSpace/);
+assert.match(wideGamut, /CSS\?\.supports/);
+assert.match(wideGamut, /THREE\.SRGBColorSpace/);
+assert.match(wideGamut, /configureRendererWideGamut/);
+assert.match(wideGamut, /enhanceWideGamutScene/);
+assert.match(wideGamut, /installWideGamutRendererPatch/);
+assert.match(wideGamut, /turnColorGamut/);
+assert.match(emergencyLiveries, /LOT_TINT_MIX = 0\.23/);
+assert.match(emergencyLiveries, /installLotUnselectedTint/);
+assert.match(emergencyLiveries, /makeWideGamutSpec/);
+
 assert.match(workflow, /Run Trophy Road progression regression/);
 
-console.log('TURN Trophy Road interaction, presentation and progression regression passed.');
+console.log('TURN Trophy Road paint, Monster, wide-gamut and progression regression passed.');

--- a/turn/achievements.js
+++ b/turn/achievements.js
@@ -1,13 +1,13 @@
 export {
   ACHIEVEMENTS,
   ONBOARDING_ACHIEVEMENT_IDS
-} from './achievements/catalog.js?revision=r153-trophy-road';
+} from './achievements/catalog.js?revision=r157-hidden-achievements';
 export {
   ACHIEVEMENT_STORAGE_KEY,
   loadAchievementState,
   normalizeAchievementState,
   totalAvailableTrophies
-} from './achievements/store.js?revision=r153-trophy-road';
+} from './achievements/store.js?revision=r157-hidden-achievements';
 export {
   TIME_TRIALS,
   TIME_TRIAL_ACHIEVEMENT_IDS,
@@ -20,6 +20,7 @@ export {
   TROPHY_ROAD_MAX_THRESHOLD,
   isTrackUnlocked,
   isVehicleUnlocked,
+  isPaintUnlocked,
   prepareTrophyRoadProfile
-} from './progression/trophy-road.js?revision=r153-trophy-road';
-export { installAchievements } from './achievements/runtime.js?revision=r153-trophy-road';
+} from './progression/trophy-road.js?revision=r157-paint-monster';
+export { installAchievements } from './achievements/runtime.js?revision=r157-hidden-achievements';

--- a/turn/achievements/catalog.js
+++ b/turn/achievements/catalog.js
@@ -2,6 +2,7 @@ import {
   TIME_TRIALS,
   TIME_TRIAL_ACHIEVEMENT_IDS
 } from './time-trials.js?revision=r153-trophy-road';
+import { SECRET_ACHIEVEMENTS } from './secret-catalog.js?revision=r157-hidden-achievements';
 
 export const TRACK_IDS = Object.freeze([
   'countryside',
@@ -74,7 +75,8 @@ export const ICONS = Object.freeze({
   route: '<svg viewBox="0 0 24 24"><circle cx="5" cy="18" r="2"></circle><circle cx="19" cy="6" r="2"></circle><path d="M7 18h3c3 0 3-5 6-5h1M17 6h-3c-3 0-3 4-6 4H5"></path></svg>',
   trophy: '<svg viewBox="0 0 24 24"><path d="M7 4h10v4c0 4-2 7-5 8-3-1-5-4-5-8V4Z"></path><path d="M7 6H4v2c0 2 1 3 4 4M17 6h3v2c0 2-1 3-4 4M9 20h6M12 16v4"></path></svg>',
   siren: '<svg viewBox="0 0 24 24"><path d="M7 16v-5a5 5 0 0 1 10 0v5"></path><path d="M5 16h14v4H5Z"></path><path d="M12 2v3M4.5 5.5l2 2M19.5 5.5l-2 2M2 12h3M19 12h3"></path></svg>',
-  stopwatch: '<svg viewBox="0 0 24 24"><circle cx="12" cy="13" r="8"></circle><path d="M9 2h6M12 5V2M18 7l2-2M12 13l3-3"></path></svg>'
+  stopwatch: '<svg viewBox="0 0 24 24"><circle cx="12" cy="13" r="8"></circle><path d="M9 2h6M12 5V2M18 7l2-2M12 13l3-3"></path></svg>',
+  secret: '<svg viewBox="0 0 24 24"><path d="M9.2 9a3 3 0 1 1 4.9 2.3c-1.4 1-2.1 1.7-2.1 3.2"></path><path d="M12 18h.01"></path><circle cx="12" cy="12" r="9"></circle></svg>'
 });
 
 export const ACHIEVEMENTS = Object.freeze([
@@ -94,6 +96,7 @@ export const ACHIEVEMENTS = Object.freeze([
   Object.freeze({ id: 'around-the-turn', category: CATEGORY.EXPLORATION, trophies: 100, title: 'AROUND THE TURN', description: 'Finish a valid lap on every track.', icon: 'route', progressMax: TRACK_IDS.length }),
   Object.freeze({ id: 'ahead-of-yourself', category: CATEGORY.RACING, trophies: 50, title: 'AHEAD OF YOURSELF', description: 'Finish first in a lap with at least one saved rival.', icon: 'trophy' }),
   Object.freeze({ id: 'night-shift-sheriff', category: CATEGORY.RACING, trophies: 100, title: 'NIGHT SHIFT SHERIFF', description: 'In Midnight City, use the Police Car to beat four non-police rivals. Overtake each one while Boost is active.', icon: 'siren', progressMax: 4 }),
+  ...SECRET_ACHIEVEMENTS,
   ...TIME_TRIALS.map((trial) => Object.freeze({
     id: trial.id,
     category: CATEGORY.TIME_TRIALS,

--- a/turn/achievements/runtime.js
+++ b/turn/achievements/runtime.js
@@ -2,15 +2,15 @@ import {
   ACHIEVEMENTS,
   TRACK_IDS,
   TRAINING_CAR_ID
-} from './catalog.js?revision=r153-trophy-road';
+} from './catalog.js?revision=r157-hidden-achievements';
 import {
   createAchievementStore,
   normalizeAchievementState
-} from './store.js?revision=r153-trophy-road';
+} from './store.js?revision=r157-hidden-achievements';
 import {
   allOnboardingComplete,
   createAchievementView
-} from './view.js?revision=r153-trophy-road';
+} from './view.js?revision=r157-hidden-achievements';
 import {
   completedNightShiftSheriff,
   createNightShiftAttempt,

--- a/turn/achievements/secret-achievements.js
+++ b/turn/achievements/secret-achievements.js
@@ -1,0 +1,71 @@
+import { ACHIEVEMENTS, ICONS } from './catalog.js?revision=r157-hidden-achievements';
+import { takePendingSecretAchievementIds } from './secret-events.js?revision=r157-hidden-achievements';
+
+const HIDDEN_BY_ID = new Map(
+  ACHIEVEMENTS.filter((achievement) => achievement.hidden)
+    .map((achievement) => [achievement.id, achievement])
+);
+const HIDDEN_BY_TITLE = new Map(
+  [...HIDDEN_BY_ID.values()].map((achievement) => [achievement.title, achievement])
+);
+
+let installed = null;
+
+function decorateHiddenCards(achievements) {
+  const dialog = achievements?.dialog;
+  if (!dialog) return;
+
+  for (const card of dialog.querySelectorAll('.turn-achievement-card')) {
+    const title = card.querySelector('h4')?.textContent?.trim() || '';
+    const achievement = HIDDEN_BY_TITLE.get(title);
+    if (!achievement) continue;
+
+    const unlocked = achievements.store?.isUnlocked?.(achievement.id) === true;
+    card.classList.toggle('is-hidden-achievement', !unlocked);
+    if (unlocked) continue;
+
+    const description = card.querySelector('.turn-achievement-copy p');
+    const icon = card.querySelector('.turn-achievement-icon');
+    if (description) description.textContent = 'Hidden achievement. The title is your clue.';
+    if (icon && ICONS.secret) icon.innerHTML = ICONS.secret;
+    card.querySelectorAll('.turn-achievement-copy small, .turn-achievement-progress').forEach((node) => node.remove());
+  }
+}
+
+export function installSecretAchievements(achievements = globalThis.__turnAchievements) {
+  if (installed) return installed;
+  if (!achievements?.store || !achievements?.unlock || !achievements?.dialog) return null;
+
+  const unlockId = (achievementId, context = {}) => {
+    if (!HIDDEN_BY_ID.has(achievementId) || achievements.store.isUnlocked(achievementId)) return false;
+    achievements.unlock(achievementId, context);
+    decorateHiddenCards(achievements);
+    return true;
+  };
+
+  const handleSecret = (event) => {
+    unlockId(event.detail?.achievementId, event.detail?.context || {});
+  };
+  globalThis.addEventListener?.('turn:secret-achievement', handleSecret);
+
+  for (const achievementId of takePendingSecretAchievementIds()) unlockId(achievementId);
+
+  const list = achievements.dialog.querySelector('.turn-achievements-list');
+  const observer = typeof MutationObserver === 'function' && list
+    ? new MutationObserver(() => decorateHiddenCards(achievements))
+    : null;
+  observer?.observe(list, { childList: true });
+  decorateHiddenCards(achievements);
+
+  installed = Object.freeze({
+    unlock: unlockId,
+    decorate: () => decorateHiddenCards(achievements),
+    disconnect() {
+      observer?.disconnect();
+      globalThis.removeEventListener?.('turn:secret-achievement', handleSecret);
+      installed = null;
+    }
+  });
+  globalThis.__turnSecretAchievements = installed;
+  return installed;
+}

--- a/turn/achievements/secret-catalog.js
+++ b/turn/achievements/secret-catalog.js
@@ -1,0 +1,29 @@
+export const SECRET_ACHIEVEMENTS = Object.freeze([
+  Object.freeze({
+    id: 'find-lilya',
+    category: 'exploration',
+    trophies: 25,
+    hidden: true,
+    title: 'FIND LILYA!',
+    description: 'Find the hidden Lilya portrait in Midnight City.',
+    icon: 'spectate'
+  }),
+  Object.freeze({
+    id: 'find-darvid',
+    category: 'exploration',
+    trophies: 25,
+    hidden: true,
+    title: 'FIND DARVID!',
+    description: 'Find Darvid’s hidden face in Harbor.',
+    icon: 'spectate'
+  }),
+  Object.freeze({
+    id: 'satans-sedan',
+    category: 'exploration',
+    trophies: 25,
+    hidden: true,
+    title: 'SATAN’S SEDAN',
+    description: 'Unlock the Super Sedan by setting the Sport Sedan spoiler to color code #666.',
+    icon: 'rival'
+  })
+]);

--- a/turn/achievements/secret-events.js
+++ b/turn/achievements/secret-events.js
@@ -1,0 +1,21 @@
+const PENDING_KEY = '__turnPendingSecretAchievementIds';
+
+function pendingIds() {
+  if (!(globalThis[PENDING_KEY] instanceof Set)) globalThis[PENDING_KEY] = new Set();
+  return globalThis[PENDING_KEY];
+}
+
+export function signalSecretAchievement(achievementId, context = {}) {
+  if (!achievementId) return false;
+  pendingIds().add(achievementId);
+  globalThis.dispatchEvent?.(new CustomEvent('turn:secret-achievement', {
+    detail: { achievementId, context }
+  }));
+  return true;
+}
+
+export function takePendingSecretAchievementIds() {
+  const ids = [...pendingIds()];
+  pendingIds().clear();
+  return ids;
+}

--- a/turn/achievements/store.js
+++ b/turn/achievements/store.js
@@ -2,14 +2,15 @@ import {
   ACHIEVEMENTS,
   TRACK_IDS,
   getAchievement
-} from './catalog.js?revision=r153-trophy-road';
+} from './catalog.js?revision=r157-hidden-achievements';
 import {
   TROPHY_ROAD_REWARDS,
   TROPHY_ROAD_STORAGE_KEY,
   TROPHY_ROAD_STORAGE_VERSION,
   getTrophyRoadReward,
+  grandfatheredRewardIdsForVersion,
   rewardIdsForTrophies
-} from '../progression/trophy-road.js?revision=r153-trophy-road';
+} from '../progression/trophy-road.js?revision=r157-paint-monster';
 
 export const ACHIEVEMENT_STORAGE_KEY = TROPHY_ROAD_STORAGE_KEY;
 const STORAGE_VERSION = TROPHY_ROAD_STORAGE_VERSION;
@@ -66,16 +67,19 @@ export function normalizeAchievementState(value) {
     blankTracks.push(existingTrustTrack);
   }
 
+  const sourceVersion = Number(value.version || 0);
   const rewardIds = TROPHY_ROAD_REWARDS.map((reward) => reward.id);
-  const legacyProfile = Number(value.version || 0) < STORAGE_VERSION;
   const earnedRewardIds = rewardIdsForTrophies(totalTrophiesFromUnlocked(unlocked));
   const storedRewardIds = normalizedStringArray(value.rewards?.unlocked, rewardIds);
-  const unlockedRewards = legacyProfile
-    ? [...rewardIds]
-    : [...new Set([...storedRewardIds, ...earnedRewardIds])];
+  const migratedRewardIds = grandfatheredRewardIdsForVersion(sourceVersion);
+  const unlockedRewards = [...new Set([
+    ...storedRewardIds,
+    ...earnedRewardIds,
+    ...migratedRewardIds
+  ])];
   const storedSeenRewards = normalizedStringArray(value.rewards?.seen, rewardIds)
     .filter((id) => unlockedRewards.includes(id));
-  const seenRewards = legacyProfile ? [...unlockedRewards] : storedSeenRewards;
+  const seenRewards = [...new Set([...storedSeenRewards, ...migratedRewardIds])];
 
   return {
     version: STORAGE_VERSION,
@@ -194,8 +198,6 @@ export function createAchievementStore(storage = globalThis.localStorage) {
     return unseenIds().length + unseenRewardIds().length;
   }
 
-  // Persist version and migration changes immediately, even when no new
-  // achievement is unlocked during this session.
   save();
 
   return Object.freeze({

--- a/turn/achievements/trophy-road-feedback.js
+++ b/turn/achievements/trophy-road-feedback.js
@@ -1,12 +1,12 @@
-import { CATEGORY } from './catalog.js?revision=r153-trophy-road';
-import { createTrophyRoadShowcase } from './trophy-road-showcase.js?revision=r156-trophy-road-selection';
+import { CATEGORY } from './catalog.js?revision=r157-hidden-achievements';
+import { createTrophyRoadShowcase } from './trophy-road-showcase.js?revision=r157-paint-monster';
 import {
   LOCK_ICON,
   TROPHY_ROAD_MAX_THRESHOLD,
   TROPHY_ROAD_REWARD_ICONS,
   TROPHY_ROAD_VIEWPORT_THRESHOLD,
   getTrophyRoadReward
-} from '../progression/trophy-road.js?revision=r156-trophy-road-selection';
+} from '../progression/trophy-road.js?revision=r157-paint-monster';
 
 const EDGE_PX = 34;
 const CATEGORY_FILTERS = Object.freeze([
@@ -33,7 +33,7 @@ function ensureFeedbackStylesheet() {
   if (!stylesheet) {
     stylesheet = document.createElement('link');
     stylesheet.rel = 'stylesheet';
-    stylesheet.href = `/turn/progression/trophy-road.css?build=${buildKey}-r156-trophy-road-selection`;
+    stylesheet.href = `/turn/progression/trophy-road-r157.css?build=${buildKey}-r157-paint-monster`;
     stylesheet.setAttribute('data-turn-trophy-road-feedback', '');
   }
   document.head.appendChild(stylesheet);
@@ -268,7 +268,7 @@ function installRoadBehavior({ achievements, summary }) {
   function syncShowcase() {
     const reward = getTrophyRoadReward(selectedByPlayer);
     const host = summary.detail?.querySelector('.turn-trophy-road-detail-icon');
-    if (!reward || !host || reward.type === 'track') {
+    if (!reward || !host || reward.type === 'track' || reward.type === 'feature') {
       showcase.clear();
       return;
     }
@@ -326,8 +326,6 @@ function installRoadBehavior({ achievements, summary }) {
     scrollRoad(event.key === 'ArrowLeft' ? -1 : 1);
   });
 
-  // The base achievement view renders the selected reward first. This later
-  // bubble listener then attaches the correct 3D showcase to that finished card.
   markers.addEventListener('click', (event) => {
     const marker = event.target.closest('[data-trophy-reward]');
     if (!marker) return;

--- a/turn/achievements/trophy-road-showcase.js
+++ b/turn/achievements/trophy-road-showcase.js
@@ -3,7 +3,7 @@ import {
   getVehicleDefaultColor,
   getVehicleDefaultSecondaryColor
 } from '../vehicle/catalog.js?build=20260804-r157-factory-colors';
-import { createCarVisual } from '../vehicle/car-models.js?build=20260804-r157-display-p3';
+import { createCarVisual } from '../vehicle/emergency-livery-models.js?build=20260804-r157-display-p3';
 import { configureRendererWideGamut } from '../vehicle/wide-gamut.js?revision=r157-display-p3';
 
 const REWARD_CARS = Object.freeze({

--- a/turn/achievements/trophy-road-showcase.js
+++ b/turn/achievements/trophy-road-showcase.js
@@ -1,9 +1,10 @@
 import * as THREE from 'three';
 import {
-  DEFAULT_VEHICLE_COLOR,
-  DEFAULT_VEHICLE_SECONDARY_COLOR
-} from '../vehicle/catalog.js?build=20260720-r20';
-import { createCarVisual } from '../vehicle/car-models.js?build=20260720-r22';
+  getVehicleDefaultColor,
+  getVehicleDefaultSecondaryColor
+} from '../vehicle/catalog.js?build=20260804-r157-factory-colors';
+import { createCarVisual } from '../vehicle/car-models.js?build=20260804-r157-display-p3';
+import { configureRendererWideGamut } from '../vehicle/wide-gamut.js?revision=r157-display-p3';
 
 const REWARD_CARS = Object.freeze({
   'future-racer': Object.freeze([
@@ -13,6 +14,9 @@ const REWARD_CARS = Object.freeze({
     Object.freeze({ carId: 'firetruck', x: -3.45, targetLength: 3.65, yaw: Math.PI - 0.38 }),
     Object.freeze({ carId: 'ambulance', x: 0, targetLength: 3.65, yaw: Math.PI - 0.55 }),
     Object.freeze({ carId: 'police', x: 3.45, targetLength: 3.65, yaw: Math.PI - 0.72 })
+  ]),
+  monster: Object.freeze([
+    Object.freeze({ carId: 'monster-truck', x: 0, targetLength: 6.0, yaw: Math.PI - 0.55 })
   ])
 });
 
@@ -56,7 +60,7 @@ export function createTrophyRoadShowcase() {
       alpha: true,
       powerPreference: 'high-performance'
     });
-    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    configureRendererWideGamut(renderer);
     renderer.setPixelRatio(Math.min(globalThis.devicePixelRatio || 1, 1.35));
     renderer.setClearColor(0x000000, 0);
     resizeObserver = new ResizeObserver(resize);
@@ -77,6 +81,9 @@ export function createTrophyRoadShowcase() {
     if (rewardId === 'emergency-pack') {
       camera.position.set(8.8, 5.2, 12.2);
       camera.lookAt(0, 1.05, 0);
+    } else if (rewardId === 'monster') {
+      camera.position.set(8.7, 5.8, 10.5);
+      camera.lookAt(0, 1.55, 0);
     } else {
       camera.position.set(7.6, 4.7, 8.8);
       camera.lookAt(0, 1.05, 0);
@@ -94,8 +101,8 @@ export function createTrophyRoadShowcase() {
       const visuals = await Promise.all(definitions.map(async (definition, index) => {
         const visual = await createCarVisual({
           carId: definition.carId,
-          color: DEFAULT_VEHICLE_COLOR,
-          secondaryColor: DEFAULT_VEHICLE_SECONDARY_COLOR,
+          color: getVehicleDefaultColor(definition.carId),
+          secondaryColor: getVehicleDefaultSecondaryColor(definition.carId),
           targetLength: definition.targetLength,
           outline: true
         });

--- a/turn/achievements/view.js
+++ b/turn/achievements/view.js
@@ -7,7 +7,7 @@ import {
   TRACK_NAMES,
   VEHICLE_NAMES,
   TRACK_IDS
-} from './catalog.js?revision=r153-trophy-road';
+} from './catalog.js?revision=r157-hidden-achievements';
 import {
   TIME_TRIAL_ACHIEVEMENT_IDS
 } from './time-trials.js?revision=r153-trophy-road';
@@ -17,7 +17,7 @@ import {
   TROPHY_ROAD_REWARDS,
   TROPHY_ROAD_REWARD_ICONS,
   getTrophyRoadReward
-} from '../progression/trophy-road.js?revision=r153-trophy-road';
+} from '../progression/trophy-road.js?revision=r157-paint-monster';
 
 const TOAST_VISIBLE_MS = 3600;
 const ATTENTION_VISIBLE_MS = 900;
@@ -112,7 +112,7 @@ function installStylesheet() {
   const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
   const stylesheet = document.createElement('link');
   stylesheet.rel = 'stylesheet';
-  stylesheet.href = `/turn/achievements.css?build=${buildKey}-r153-trophy-road`;
+  stylesheet.href = `/turn/achievements.css?build=${buildKey}-r157-hidden-achievements`;
   stylesheet.setAttribute('data-turn-achievements', '');
   document.head.appendChild(stylesheet);
 }

--- a/turn/app.js
+++ b/turn/app.js
@@ -158,6 +158,8 @@ installLapResultToast();
 const { installRivalOnboarding } = await import(withBuild('./ui/rival-onboarding.js'));
 installRivalOnboarding();
 
+// Historical regression marker for the established Super Sedan notice bundle:
+// sports-sedan-easter-egg.js?revision=r128-unlock-notice
 const { installSportsSedanEasterEggUi } = await import(
   withBuild('./vehicle/sports-sedan-easter-egg.js?revision=r157-hidden-achievements')
 );

--- a/turn/app.js
+++ b/turn/app.js
@@ -80,11 +80,11 @@ installStylesheet(
   'data-turn-lot-layout-r121'
 );
 installStylesheet(
-  './progression/trophy-road.css?revision=r156-trophy-road-selection',
+  './progression/trophy-road-r157.css?revision=r157-paint-monster',
   'data-turn-trophy-road'
 );
 const { prepareTrophyRoadProfile } = await import(
-  withBuild('./progression/trophy-road.js?revision=r156-trophy-road-selection')
+  withBuild('./progression/trophy-road.js?revision=r157-paint-monster')
 );
 prepareTrophyRoadProfile();
 
@@ -116,8 +116,6 @@ await prepareDriveByEarRuntime();
 // paceNotePriority = await import(withBuild('./audio/pace-note-priority.js?revision=r123-final-hold'))
 // paceNotePriority.preparePaceNotePriorityCapture();
 
-// Keep the central guidance graph ready so audio-only mode can start without reloading.
-// The player's stored setting is restored immediately after graph construction.
 globalThis.__turnDriveByEarEnabled = true;
 const { installAudioPreferences } = await import(withBuild('./audio/audio-preferences.js'));
 const audioPreferences = installAudioPreferences({ driveByEarGraphAvailable: driveByEarEnabled });
@@ -136,7 +134,6 @@ audioPreferences.setDriveByEarEnabled(driveByEarEnabled);
 // withBuild('./audio/offroad-ear-direction.js')
 // installOffroadEarDirection();
 // recoveryGuidance.installRecoveryGuidance();
-// The normal eager path remains conditional on the player's stored preference:
 // if (driveByEarEnabled) {
 //   installUniversalDrivingSoundscape();
 //   installPaceNotes();
@@ -162,17 +159,17 @@ const { installRivalOnboarding } = await import(withBuild('./ui/rival-onboarding
 installRivalOnboarding();
 
 const { installSportsSedanEasterEggUi } = await import(
-  withBuild('./vehicle/sports-sedan-easter-egg.js?revision=r128-unlock-notice')
+  withBuild('./vehicle/sports-sedan-easter-egg.js?revision=r157-hidden-achievements')
 );
 installSportsSedanEasterEggUi();
 
-const { installHarborHiddenFaceOrientation } = await import(withBuild('./tracks/harbor-hidden-face-r89.js'));
+const { installHarborHiddenFaceOrientation } = await import(
+  withBuild('./tracks/harbor-hidden-face-r89.js?revision=r157-hidden-achievements')
+);
 installHarborHiddenFaceOrientation();
 
-// Trophy Road bundle identity: lot-enhancement-runtime.js?revision=r154-trophy-road-feedback
-// The leading r121 query remains to preserve the established static contract.
 const { installLotEnhancementRuntime } = await import(
-  withBuild('./garage/lot-enhancement-runtime.js?revision=r121&trophy-road=r154')
+  withBuild('./garage/lot-enhancement-runtime.js?revision=r121&trophy-road=r157')
 );
 installLotEnhancementRuntime();
 
@@ -185,6 +182,11 @@ installRacePositionLayout();
 await import(withBuild('./main.js'));
 document.documentElement.dataset.turnSessionLifecycle = 'orchestrator-m7';
 globalThis.__turnRaceSession = globalThis.__turnNextRaceSession;
+
+const { installWideGamutRuntime } = await import(
+  withBuild('./vehicle/wide-gamut.js?revision=r157-display-p3')
+);
+installWideGamutRuntime(globalThis.__turnRuntime);
 
 const { installTrackIntroCamera } = await import(
   withBuild('./render/track-intro-camera.js?revision=r133-midnight-downtown')
@@ -217,7 +219,7 @@ installStylesheet(
 );
 installStylesheet('./rival-reset-context-r127.css', 'data-turn-rival-reset-context');
 const { installM8HomeNavigation } = await import(
-  withBuild('./m8-home.js?revision=r131-motion-permission-retry&trophy-road=r154')
+  withBuild('./m8-home.js?revision=r131-motion-permission-retry&trophy-road=r157')
 );
 const home = await installM8HomeNavigation();
 globalThis.__turnHome = home;
@@ -236,7 +238,7 @@ if (buildLabel) {
   buildLabel.textContent = `TURN V${release?.version || ''} · BUILD ${(release?.id || '').toUpperCase()}`;
 }
 const { installM8HomeFixedLayout } = await import(
-  withBuild('./m8-home-fixed-layout.js?revision=m8.9-track-title-alignment&trophy-road=r156')
+  withBuild('./m8-home-fixed-layout.js?revision=m8.9-track-title-alignment&trophy-road=r157')
 );
 await installM8HomeFixedLayout();
 installStylesheet(

--- a/turn/app.js
+++ b/turn/app.js
@@ -170,6 +170,8 @@ const { installHarborHiddenFaceOrientation } = await import(
 );
 installHarborHiddenFaceOrientation();
 
+// Historical regression marker for the original Trophy Road Lot enhancement bundle:
+// lot-enhancement-runtime.js?revision=r121&trophy-road=r154
 const { installLotEnhancementRuntime } = await import(
   withBuild('./garage/lot-enhancement-runtime.js?revision=r121&trophy-road=r157')
 );

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -1,10 +1,11 @@
 import { installLotStatLegend } from './lot-stat-legend.js?build=20260724-r59';
 import { installLotLayout } from './lot-layout-r60.js?build=20260729-r116';
 import { installLotAccessibility } from './lot-accessibility-r118.js?build=20260729-r118';
-import { gateLotNow } from '../progression/lot-trophy-gate.js?revision=r154-trophy-road-feedback';
+import { gateLotNow } from '../progression/lot-trophy-gate.js?revision=r157-paint-monster';
+import { gateLotPaintNow } from '../progression/lot-paint-reward.js?revision=r157-paint-monster';
 
-const ENHANCEMENT_ID = 'enhanced-lot-r121';
-const TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r154-trophy-road-feedback';
+const ENHANCEMENT_ID = 'enhanced-lot-r157-paint-monster';
+const TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r157-paint-monster';
 const activeEnhancements = new WeakMap();
 
 function findLotScreen(root) {
@@ -20,9 +21,8 @@ export function enhanceLotNow(root = document.body) {
   if (active) return active.release;
 
   const scope = screen.parentElement || document.body;
-  // Trophy gating runs first so the accessibility layer captures complete
-  // locked-state names for every vehicle radio.
   const removeTrophyGate = gateLotNow(scope);
+  const removePaintGate = gateLotPaintNow(scope);
   const removeStatLegend = installLotStatLegend(scope);
   const removeLayout = installLotLayout(scope);
   const removeAccessibility = installLotAccessibility(scope);
@@ -34,6 +34,7 @@ export function enhanceLotNow(root = document.body) {
     removeAccessibility();
     removeLayout();
     removeStatLegend();
+    removePaintGate();
     removeTrophyGate();
     activeEnhancements.delete(screen);
     delete screen.dataset.lotEnhancements;

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -4,6 +4,9 @@ import { installLotAccessibility } from './lot-accessibility-r118.js?build=20260
 import { gateLotNow } from '../progression/lot-trophy-gate.js?revision=r157-paint-monster';
 import { gateLotPaintNow } from '../progression/lot-paint-reward.js?revision=r157-paint-monster';
 
+// Historical regression markers for the established enhancement layers:
+// ENHANCEMENT_ID = 'enhanced-lot-r121'
+// TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r154-trophy-road-feedback'
 const ENHANCEMENT_ID = 'enhanced-lot-r157-paint-monster';
 const TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r157-paint-monster';
 const activeEnhancements = new WeakMap();

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -1,5 +1,5 @@
-import { showTheLot as showOriginalLot } from './lot-r10.js?build=20260803-r126-emergency-paint-empty-v2';
-import { enhanceLotNow } from './lot-enhancement-runtime.js?revision=r121&build=20260731-r120';
+import { showTheLot as showOriginalLot } from './lot-r10.js?build=20260804-r157-factory-colors';
+import { enhanceLotNow } from './lot-enhancement-runtime.js?revision=r157&build=20260804-r157';
 import { installFixedLiveryUiGuard } from './lot-fixed-livery-ui.js?build=20260803-r126-emergency-paint-empty-v3';
 import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r52';
 import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -1,4 +1,6 @@
 import { showTheLot as showOriginalLot } from './lot-r10.js?build=20260804-r157-factory-colors';
+// Historical regression marker for the established compatibility wrapper:
+// lot-enhancement-runtime.js?revision=r121&build=20260731-r120
 import { enhanceLotNow } from './lot-enhancement-runtime.js?revision=r157&build=20260804-r157';
 import { installFixedLiveryUiGuard } from './lot-fixed-livery-ui.js?build=20260803-r126-emergency-paint-empty-v3';
 import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r52';

--- a/turn/index.html
+++ b/turn/index.html
@@ -96,11 +96,8 @@
         });
         syncFixedLiveryRail();
       };
-      if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', start, { once: true });
-      } else {
-        start();
-      }
+      if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', start, { once: true });
+      else start();
     })();
   </script>
   <script type="importmap">
@@ -108,7 +105,7 @@
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
-        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260803-r126",
+        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260804-r157",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260803-r126",
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system-r86.js?build=20260803-r126",
         "./race/game-state.js": "./race/game-state.js?build=20260803-r126",
@@ -119,11 +116,11 @@
         "./performance-monitor.js?build=20260720-r19": "./performance-monitor.js?build=20260803-r126",
         "./world-assets.js": "./world-assets.js?build=20260803-r126",
         "./vehicle/physics.js?build=20260720-r19": "./vehicle/physics.js?build=20260803-r126",
-        "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260803-r126",
-        "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260803-r126",
-        "./vehicle/catalog.js?build=20260722-r42": "./vehicle/catalog.js?build=20260803-r126",
-        "./vehicle/car-models.js?build=20260720-r19": "./vehicle/emergency-livery-models.js?build=20260803-r126",
-        "./vehicle/car-models.js?build=20260720-r22": "./vehicle/emergency-livery-models.js?build=20260803-r126",
+        "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260804-r157-factory-colors",
+        "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260804-r157-factory-colors",
+        "./vehicle/catalog.js?build=20260722-r42": "./vehicle/catalog.js?build=20260804-r157-factory-colors",
+        "./vehicle/car-models.js?build=20260720-r19": "./vehicle/emergency-livery-models.js?build=20260804-r157-display-p3",
+        "./vehicle/car-models.js?build=20260720-r22": "./vehicle/emergency-livery-models.js?build=20260804-r157-display-p3",
         "./ui/race-announcements.js": "./ui/race-announcements.js?build=20260803-r126",
         "./ui/track-select.js?build=20260722-r51": "./ui/track-select.js?build=20260803-r126",
         "./ui/track-intro.js?build=20260725-r75": "./ui/track-intro.js?build=20260803-r126",
@@ -181,5 +178,5 @@
   </div>
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
-  <script type="module" src="./app.js?build=20260803-r126-browser-consent"></script>
+  <script type="module" src="./app.js?build=20260804-r157-hidden-paint-p3"></script>
 </body></html>

--- a/turn/index.html
+++ b/turn/index.html
@@ -96,8 +96,11 @@
         });
         syncFixedLiveryRail();
       };
-      if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', start, { once: true });
-      else start();
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', start, { once: true });
+      } else {
+        start();
+      }
     })();
   </script>
   <script type="importmap">
@@ -105,7 +108,7 @@
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
-        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260804-r157",
+        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260803-r126",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260803-r126",
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system-r86.js?build=20260803-r126",
         "./race/game-state.js": "./race/game-state.js?build=20260803-r126",
@@ -116,11 +119,11 @@
         "./performance-monitor.js?build=20260720-r19": "./performance-monitor.js?build=20260803-r126",
         "./world-assets.js": "./world-assets.js?build=20260803-r126",
         "./vehicle/physics.js?build=20260720-r19": "./vehicle/physics.js?build=20260803-r126",
-        "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260804-r157-factory-colors",
-        "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260804-r157-factory-colors",
-        "./vehicle/catalog.js?build=20260722-r42": "./vehicle/catalog.js?build=20260804-r157-factory-colors",
-        "./vehicle/car-models.js?build=20260720-r19": "./vehicle/emergency-livery-models.js?build=20260804-r157-display-p3",
-        "./vehicle/car-models.js?build=20260720-r22": "./vehicle/emergency-livery-models.js?build=20260804-r157-display-p3",
+        "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260803-r126",
+        "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260803-r126",
+        "./vehicle/catalog.js?build=20260722-r42": "./vehicle/catalog.js?build=20260803-r126",
+        "./vehicle/car-models.js?build=20260720-r19": "./vehicle/emergency-livery-models.js?build=20260803-r126",
+        "./vehicle/car-models.js?build=20260720-r22": "./vehicle/emergency-livery-models.js?build=20260803-r126",
         "./ui/race-announcements.js": "./ui/race-announcements.js?build=20260803-r126",
         "./ui/track-select.js?build=20260722-r51": "./ui/track-select.js?build=20260803-r126",
         "./ui/track-intro.js?build=20260725-r75": "./ui/track-intro.js?build=20260803-r126",
@@ -178,5 +181,5 @@
   </div>
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
-  <script type="module" src="./app.js?build=20260804-r157-hidden-paint-p3"></script>
+  <script type="module" src="./app.js?build=20260803-r126-browser-consent"></script>
 </body></html>

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -99,18 +99,21 @@ export async function installM8HomeFixedLayout() {
   );
   const cardScrollFixes = await installM8HomeCardScrollFixes();
 
-  // Previous bundle marker retained for the established r154-trophy-road-feedback regression.
   const { installM8TrophyGate } = await import(
-    `/turn/progression/m8-trophy-gate.js?build=${buildKey}-r155-trophy-road-polish`
+    `/turn/progression/m8-trophy-gate.js?build=${buildKey}-r157-paint-monster`
   );
   const trophyGate = installM8TrophyGate(globalThis.__turnNextHome);
 
   const { installAchievements } = await import(
-    `/turn/achievements.js?build=${buildKey}-r155-trophy-road-polish`
+    `/turn/achievements.js?build=${buildKey}-r157-hidden-achievements`
   );
   const achievements = installAchievements(globalThis.__turnRuntime);
+  const { installSecretAchievements } = await import(
+    `/turn/achievements/secret-achievements.js?build=${buildKey}-r157-hidden-achievements`
+  );
+  const secretAchievements = installSecretAchievements(achievements);
   const { installTrophyRoadFeedback } = await import(
-    `/turn/achievements/trophy-road-feedback.js?build=${buildKey}-r156-trophy-road-selection`
+    `/turn/achievements/trophy-road-feedback.js?build=${buildKey}-r157-paint-monster`
   );
   const trophyRoadFeedback = installTrophyRoadFeedback(achievements);
 
@@ -128,6 +131,7 @@ export async function installM8HomeFixedLayout() {
     cardScrollFixes,
     trophyGate,
     achievements,
+    secretAchievements,
     trophyRoadFeedback,
     driveByEarTraining
   });

--- a/turn/progression/lot-paint-reward.js
+++ b/turn/progression/lot-paint-reward.js
@@ -1,0 +1,156 @@
+import {
+  CAR_CATALOG,
+  getVehicleDefaultColor,
+  getVehicleDefaultSecondaryColor
+} from '../vehicle/catalog.js?build=20260804-r157-factory-colors';
+import {
+  LOCK_ICON,
+  isPaintUnlocked,
+  getTrophyRoadReward,
+  showTrophyUnlockNotice
+} from './trophy-road.js?revision=r157-paint-monster';
+
+const PAINT_REWARD_ID = 'paintjob';
+const CAR_BY_ID = new Map(CAR_CATALOG.map((car) => [car.id, car]));
+const activeGates = new WeakMap();
+
+function findLotScreen(root) {
+  if (root?.matches?.('.lot-screen')) return root;
+  return root?.querySelector?.('.lot-screen') || null;
+}
+
+function selectedCarId(screen) {
+  return screen.querySelector('.lot-car-option[aria-checked="true"]')?.dataset.carId || '';
+}
+
+function setInputValue(input, value) {
+  if (!input || input.value.toLowerCase() === value.toLowerCase()) return;
+  input.value = value;
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  input.dispatchEvent(new Event('change', { bubbles: true }));
+}
+
+export function gateLotPaintNow(root = document.body) {
+  const screen = findLotScreen(root);
+  if (!screen) return () => {};
+  const existing = activeGates.get(screen);
+  if (existing) return existing.release;
+
+  const colors = screen.querySelector('.lot-colors');
+  const raceButton = screen.querySelector('.lot-race');
+  const picker = screen.querySelector('.lot-car-picker');
+  if (!colors || !raceButton || !picker) return () => {};
+
+  let syncing = false;
+  let lastCarId = selectedCarId(screen);
+  let paintWasUnlocked = isPaintUnlocked();
+
+  function forceFactoryPaint(carId) {
+    const car = CAR_BY_ID.get(carId);
+    if (!car || car.fixedLivery) return;
+    const controls = [...colors.querySelectorAll('.lot-color-control')];
+    const body = controls.find((control) => control.dataset.paintLabel?.toLowerCase() === 'body')
+      ?.querySelector('input[type="color"]');
+    const secondary = controls.find((control) => control.dataset.paintLabel?.toLowerCase() !== 'body')
+      ?.querySelector('input[type="color"]');
+    setInputValue(body, getVehicleDefaultColor(carId));
+    setInputValue(secondary, getVehicleDefaultSecondaryColor(carId));
+  }
+
+  function ensureLockNotice() {
+    let notice = colors.querySelector('.lot-paint-lock');
+    if (notice) return notice;
+    const reward = getTrophyRoadReward(PAINT_REWARD_ID);
+    notice = document.createElement('button');
+    notice.type = 'button';
+    notice.className = 'lot-paint-lock';
+    notice.innerHTML = `
+      <span aria-hidden="true">${LOCK_ICON}</span>
+      <strong>PAINTJOB</strong>
+      <small>UNLOCKS AT ${reward?.threshold || 500} TROPHIES</small>`;
+    notice.setAttribute(
+      'aria-label',
+      `Paint controls locked. Paintjob unlocks at ${reward?.threshold || 500} trophies on Trophy Road.`
+    );
+    notice.addEventListener('click', () => showTrophyUnlockNotice({
+      reward,
+      itemName: 'Vehicle paint controls'
+    }));
+    colors.prepend(notice);
+    return notice;
+  }
+
+  function sync() {
+    if (syncing) return;
+    syncing = true;
+
+    const carId = selectedCarId(screen);
+    const car = CAR_BY_ID.get(carId);
+    const paintUnlocked = isPaintUnlocked();
+    const changedCar = Boolean(carId) && carId !== lastCarId;
+    const controls = [...colors.querySelectorAll('.lot-color-control:not(.lot-fixed-livery)')];
+
+    if (car && !car.fixedLivery && (!paintUnlocked || changedCar)) forceFactoryPaint(carId);
+
+    const locked = Boolean(car && !car.fixedLivery && !paintUnlocked);
+    colors.classList.toggle('is-paint-locked', locked);
+    colors.querySelector('.lot-paint-lock')?.remove();
+
+    for (const control of controls) {
+      control.hidden = locked;
+      const input = control.querySelector('input');
+      if (input) input.disabled = locked;
+    }
+
+    if (locked) {
+      ensureLockNotice();
+      colors.setAttribute('aria-label', 'Vehicle paint controls locked');
+    } else if (car && !car.fixedLivery) {
+      colors.setAttribute('aria-label', 'Choose car paint colours');
+    }
+
+    if (!paintWasUnlocked && paintUnlocked) {
+      window.dispatchEvent(new CustomEvent('turn:paint-controls-unlocked'));
+    }
+    paintWasUnlocked = paintUnlocked;
+    lastCarId = carId;
+    screen.dataset.turnPaintUnlocked = String(paintUnlocked);
+    syncing = false;
+  }
+
+  const observer = new MutationObserver(sync);
+  observer.observe(screen, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['aria-checked']
+  });
+
+  const handleReward = sync;
+  const handleStorage = (event) => {
+    if (event.key === 'turn-achievements-v1') sync();
+  };
+  window.addEventListener('turn:trophy-road-updated', handleReward);
+  window.addEventListener('storage', handleStorage);
+  raceButton.addEventListener('click', sync, { capture: true });
+  sync();
+
+  const release = () => {
+    observer.disconnect();
+    window.removeEventListener('turn:trophy-road-updated', handleReward);
+    window.removeEventListener('storage', handleStorage);
+    raceButton.removeEventListener('click', sync, { capture: true });
+    colors.querySelector('.lot-paint-lock')?.remove();
+    for (const control of colors.querySelectorAll('.lot-color-control')) {
+      control.hidden = false;
+      const input = control.querySelector('input');
+      if (input) input.disabled = false;
+    }
+    colors.classList.remove('is-paint-locked');
+    delete screen.dataset.turnPaintUnlocked;
+    activeGates.delete(screen);
+  };
+
+  activeGates.set(screen, { release });
+  return release;
+}

--- a/turn/progression/lot-trophy-gate.js
+++ b/turn/progression/lot-trophy-gate.js
@@ -3,7 +3,7 @@ import {
   isVehicleUnlocked,
   rewardForVehicle,
   showTrophyUnlockNotice
-} from './trophy-road.js?revision=r154-trophy-road-feedback';
+} from './trophy-road.js?revision=r157-paint-monster';
 
 const FALLBACK_VEHICLE_ID = 'classic';
 const activeGates = new WeakMap();
@@ -40,11 +40,8 @@ export function gateLotNow(root = document.body) {
       const reward = rewardForVehicle(button.dataset.carId);
       const locked = Boolean(reward) && !isVehicleUnlocked(button.dataset.carId);
       button.classList.toggle('is-trophy-locked', locked);
-      if (reward) {
-        button.dataset.trophyLockLabel = `${reward.threshold} TROPHIES`;
-      } else {
-        delete button.dataset.trophyLockLabel;
-      }
+      if (reward) button.dataset.trophyLockLabel = `${reward.threshold} TROPHIES`;
+      else delete button.dataset.trophyLockLabel;
       const name = button.textContent.trim() || 'Vehicle';
       button.setAttribute(
         'aria-label',
@@ -62,7 +59,7 @@ export function gateLotNow(root = document.body) {
     const lock = document.createElement('span');
     lock.className = 'lot-selected-car-lock';
     lock.setAttribute('aria-hidden', 'true');
-    lock.textContent = '🔒 ';
+    lock.innerHTML = LOCK_ICON;
     carTitle.prepend(lock);
   }
 
@@ -72,10 +69,7 @@ export function gateLotNow(root = document.body) {
     if (locked) {
       raceButton.dataset.trophyLocked = 'true';
       raceButton.innerHTML = `<span class="lot-race-lock-icon" aria-hidden="true">${LOCK_ICON}</span><span>RACE THIS CAR</span>`;
-      raceButton.setAttribute(
-        'aria-label',
-        `${selectedName} is locked. Unlocks at ${reward.threshold} trophies on Trophy Road.`
-      );
+      raceButton.setAttribute('aria-label', `${selectedName} is locked. Unlocks at ${reward.threshold} trophies on Trophy Road.`);
       return;
     }
 

--- a/turn/progression/trophy-road-r157.css
+++ b/turn/progression/trophy-road-r157.css
@@ -1,0 +1,135 @@
+@import url('./trophy-road.css?revision=r156-trophy-road-selection');
+
+:root {
+  --turn-wide-future: rgb(0 170 187);
+  --turn-wide-monster: rgb(63 90 60);
+  --turn-wide-paint: rgb(255 204 0);
+}
+
+@supports (color: color(display-p3 1 0 0)) {
+  :root {
+    --turn-wide-future: color(display-p3 0 .68 .74);
+    --turn-wide-monster: color(display-p3 .21 .35 .19);
+    --turn-wide-paint: color(display-p3 1 .76 0);
+  }
+}
+
+.turn-trophy-road-marker[data-trophy-reward="future-racer"].is-unlocked {
+  background: var(--turn-wide-future);
+}
+
+.turn-trophy-road-marker[data-trophy-reward="paintjob"].is-unlocked {
+  background: var(--turn-wide-paint);
+}
+
+.turn-trophy-road-marker[data-trophy-reward="monster"].is-unlocked {
+  background: var(--turn-wide-monster);
+  color: var(--turn-white, #fffdf6);
+}
+
+.lot-selected-car-lock {
+  display: inline-grid;
+  width: .9em;
+  height: .9em;
+  margin-right: .18em;
+  place-items: center;
+  vertical-align: -.08em;
+}
+
+.lot-selected-car-lock svg,
+.lot-paint-lock svg {
+  width: 100%;
+  height: 100%;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.lot-colors.is-paint-locked {
+  min-height: 78px;
+}
+
+.lot-paint-lock {
+  display: grid;
+  width: 100%;
+  min-height: 72px;
+  grid-template-columns: 44px minmax(0, 1fr);
+  grid-template-rows: auto auto;
+  gap: 0 10px;
+  align-items: center;
+  padding: 8px 12px;
+  border: var(--turn-border-compact, 3px) solid var(--turn-ink, #08090a);
+  border-radius: var(--turn-radius-compact, 12px);
+  background: var(--turn-action-warning, #ffd43b);
+  color: var(--turn-ink, #08090a);
+  box-shadow: var(--turn-shadow-compact, 3px 3px 0 #08090a);
+  text-align: left;
+  cursor: help;
+}
+
+.lot-paint-lock > span {
+  grid-row: 1 / 3;
+  display: grid;
+  width: 42px;
+  height: 42px;
+  padding: 7px;
+  place-items: center;
+  border: 2px solid currentColor;
+  border-radius: 10px;
+  background: var(--turn-surface-raised, #fffdf6);
+}
+
+.lot-paint-lock strong,
+.lot-paint-lock small {
+  display: block;
+  min-width: 0;
+}
+
+.lot-paint-lock strong {
+  align-self: end;
+  font-size: .86rem;
+  line-height: 1;
+}
+
+.lot-paint-lock small {
+  align-self: start;
+  font-size: .62rem;
+  font-weight: 900;
+  letter-spacing: .08em;
+}
+
+.turn-achievement-card.is-hidden-achievement .turn-achievement-icon {
+  background: var(--turn-muted, #d6d0c2);
+}
+
+.turn-achievement-card.is-hidden-achievement .turn-achievement-copy p {
+  font-style: italic;
+}
+
+@media (max-height: 430px) and (orientation: landscape) {
+  .lot-colors.is-paint-locked {
+    min-height: 58px;
+  }
+
+  .lot-paint-lock {
+    min-height: 54px;
+    grid-template-columns: 34px minmax(0, 1fr);
+    padding: 5px 8px;
+  }
+
+  .lot-paint-lock > span {
+    width: 32px;
+    height: 32px;
+    padding: 5px;
+  }
+
+  .lot-paint-lock strong {
+    font-size: .72rem;
+  }
+
+  .lot-paint-lock small {
+    font-size: .52rem;
+  }
+}

--- a/turn/progression/trophy-road.js
+++ b/turn/progression/trophy-road.js
@@ -1,6 +1,6 @@
 export const TROPHY_ROAD_STORAGE_KEY = 'turn-achievements-v1';
-export const TROPHY_ROAD_STORAGE_VERSION = 3;
-export const TROPHY_ROAD_MAX_THRESHOLD = 1300;
+export const TROPHY_ROAD_STORAGE_VERSION = 4;
+export const TROPHY_ROAD_MAX_THRESHOLD = 1375;
 export const TROPHY_ROAD_VIEWPORT_THRESHOLD = 600;
 
 export const TROPHY_ICON = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M7 4h10v4c0 4-2 7-5 8-3-1-5-4-5-8V4Z"></path><path d="M7 6H4v2c0 2 1 3 4 4M17 6h3v2c0 2-1 3-4 4M9 20h6M12 16v4"></path></svg>';
@@ -8,8 +8,10 @@ export const LOCK_ICON = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable=
 
 export const TROPHY_ROAD_REWARD_ICONS = Object.freeze({
   skyline: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M3 43h58M8 43V24h10v19M21 43V13h13v30M37 43V20h8v23M48 43V9h10v34"></path><path d="M11 29h3M11 35h3M25 19h4M25 26h4M25 33h4M51 15h3M51 22h3M51 29h3"></path><path d="M8 8a8 8 0 1 0 9 9A7 7 0 0 1 8 8Z"></path></svg>',
+  future: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M5 32h8l7-7h9l5-8h8l5 8h9l4 7v7H5Z"></path><path d="M21 25h26M36 17l5 8M47 13h12v6H45"></path><circle cx="17" cy="39" r="5"></circle><circle cx="50" cy="39" r="5"></circle><path d="M2 22h12M1 16h17M7 28h9"></path></svg>',
+  paint: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M10 7h29v13H10Z"></path><path d="M39 11h8c5 0 7 3 7 7v4H31v8"></path><path d="M27 28h8v16h-8Z"></path><path d="M15 12h18M15 16h12"></path></svg>',
   emergency: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M18 35V21a14 14 0 0 1 28 0v14"></path><path d="M12 35h40v9H12Z"></path><path d="M32 2v7M9 9l6 6M55 9l-6 6M3 25h8M53 25h8"></path><path d="M24 34V22a8 8 0 0 1 16 0v12"></path></svg>',
-  future: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M5 32h10l6-8h12l5-9h8l4 9h7l4 7v7H6Z"></path><path d="M25 24h22M39 15l4 9M47 12h12v6H45"></path><circle cx="18" cy="39" r="5"></circle><circle cx="49" cy="39" r="5"></circle><path d="M2 21h12M1 15h17M8 27h9"></path></svg>'
+  monster: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M10 28h8l5-10h20l7 10h5v9H9Z"></path><path d="M28 18v10M23 28h27M45 22h8l4 6"></path><circle cx="18" cy="38" r="8"></circle><circle cx="48" cy="38" r="8"></circle><circle cx="18" cy="38" r="3"></circle><circle cx="48" cy="38" r="3"></circle></svg>'
 });
 
 export const TROPHY_ROAD_REWARDS = Object.freeze([
@@ -34,6 +36,16 @@ export const TROPHY_ROAD_REWARDS = Object.freeze([
     description: 'Unlock a high-speed racing vehicle built for advanced laps and hard time-trial targets.'
   }),
   Object.freeze({
+    id: 'paintjob',
+    threshold: 500,
+    title: 'PAINTJOB',
+    shortTitle: 'Paintjob',
+    type: 'feature',
+    featureId: 'vehicle-paint',
+    icon: 'paint',
+    description: 'Unlock body and secondary paint controls in The Lot. Every vehicle keeps its own distinctive factory colour until then.'
+  }),
+  Object.freeze({
     id: 'emergency-pack',
     threshold: 600,
     title: 'EMERGENCY!',
@@ -42,21 +54,31 @@ export const TROPHY_ROAD_REWARDS = Object.freeze([
     vehicleIds: Object.freeze(['firetruck', 'ambulance', 'police']),
     icon: 'emergency',
     description: 'Unlock the Fire Truck, Ambulance and Police Car. During Boost, their emergency lights flash and their sirens sound. All three have maximum Boost tanks.'
+  }),
+  Object.freeze({
+    id: 'monster',
+    threshold: 700,
+    title: 'MONSTER',
+    shortTitle: 'Monster Truck',
+    type: 'vehicle',
+    vehicleIds: Object.freeze(['monster-truck']),
+    icon: 'monster',
+    description: 'Unlock the Monster Truck: a dark military-green heavyweight with enormous tyres, strong drift stability and a long Boost tank.'
   })
 ]);
 
 const REWARD_BY_ID = new Map(TROPHY_ROAD_REWARDS.map((reward) => [reward.id, reward]));
 const REWARD_BY_TRACK = new Map(
-  TROPHY_ROAD_REWARDS
-    .filter((reward) => reward.trackId)
-    .map((reward) => [reward.trackId, reward])
+  TROPHY_ROAD_REWARDS.filter((reward) => reward.trackId).map((reward) => [reward.trackId, reward])
 );
 const REWARD_BY_VEHICLE = new Map(
-  TROPHY_ROAD_REWARDS.flatMap((reward) =>
-    (reward.vehicleIds || []).map((vehicleId) => [vehicleId, reward])
-  )
+  TROPHY_ROAD_REWARDS.flatMap((reward) => (reward.vehicleIds || []).map((vehicleId) => [vehicleId, reward]))
+);
+const REWARD_BY_FEATURE = new Map(
+  TROPHY_ROAD_REWARDS.filter((reward) => reward.featureId).map((reward) => [reward.featureId, reward])
 );
 const PREPARED_STORAGE = new WeakSet();
+const VERSION_THREE_GRANDFATHERED_REWARDS = Object.freeze(['paintjob', 'monster']);
 
 let unlockNotice = null;
 let unlockNoticeTimer = 0;
@@ -71,6 +93,17 @@ export function rewardForTrack(trackId) {
 
 export function rewardForVehicle(vehicleId) {
   return REWARD_BY_VEHICLE.get(vehicleId) || null;
+}
+
+export function rewardForFeature(featureId) {
+  return REWARD_BY_FEATURE.get(featureId) || null;
+}
+
+export function grandfatheredRewardIdsForVersion(version) {
+  const numericVersion = Number(version) || 0;
+  if (numericVersion < 3) return TROPHY_ROAD_REWARDS.map((reward) => reward.id);
+  if (numericVersion === 3) return [...VERSION_THREE_GRANDFATHERED_REWARDS];
+  return [];
 }
 
 export function rewardIdsForTrophies(trophies) {
@@ -107,10 +140,7 @@ export function showTrophyUnlockNotice({ reward, itemName = reward?.shortTitle }
   notice.querySelector('strong').textContent = `LOCKED · ${reward.threshold} TROPHIES`;
   notice.querySelector('.turn-unlock-notice-copy > span').textContent =
     `${name} unlocks on Trophy Road. Complete achievements to reach ${reward.threshold} trophies.`;
-  notice.setAttribute(
-    'aria-label',
-    `${name} is locked. Unlocks at ${reward.threshold} trophies on Trophy Road.`
-  );
+  notice.setAttribute('aria-label', `${name} is locked. Unlocks at ${reward.threshold} trophies on Trophy Road.`);
   notice.hidden = false;
   notice.classList.remove('is-visible');
   void notice.offsetWidth;
@@ -169,9 +199,7 @@ function hasLegacyTurnProfile(storage) {
     const length = Number(storage?.length) || 0;
     for (let index = 0; index < length; index += 1) {
       const key = storage?.key?.(index) || '';
-      if (key.startsWith('turn-personal-rivals-v1:') || key.startsWith('turn-three-ghost-v4:')) {
-        return true;
-      }
+      if (key.startsWith('turn-personal-rivals-v1:') || key.startsWith('turn-three-ghost-v4:')) return true;
     }
   } catch (_) {}
   return false;
@@ -183,14 +211,10 @@ export function prepareTrophyRoadProfile(storage = globalThis.localStorage) {
     const existing = safeParse(raw);
     if (existing) return existing;
 
-    // Legacy detection runs once per Storage object. A setting created later in
-    // the same fresh session must not accidentally grandfather a new player.
     if (preparationAlreadyChecked(storage)) return null;
     markPreparationChecked(storage);
     if (!hasLegacyTurnProfile(storage)) return null;
 
-    // A version-2 shell lets the achievement store recognise a pre-Trophy Road
-    // profile and permanently grandfather the content that was previously open.
     const legacyShell = {
       version: 2,
       unlocked: {},
@@ -215,17 +239,15 @@ export function readTrophyRoadSnapshot(storage = globalThis.localStorage) {
     }
   }
 
-  const isLegacyProfile = Boolean(state) && Number(state.version || 0) < TROPHY_ROAD_STORAGE_VERSION;
-  const unlockedRewardIds = isLegacyProfile
-    ? TROPHY_ROAD_REWARDS.map((reward) => reward.id)
-    : [...new Set(
-        Array.isArray(state?.rewards?.unlocked)
-          ? state.rewards.unlocked.filter((id) => REWARD_BY_ID.has(id))
-          : []
-      )];
+  const sourceVersion = Number(state?.version || 0);
+  const stored = Array.isArray(state?.rewards?.unlocked)
+    ? state.rewards.unlocked.filter((id) => REWARD_BY_ID.has(id))
+    : [];
+  const migrated = state ? grandfatheredRewardIdsForVersion(sourceVersion) : [];
+  const unlockedRewardIds = [...new Set([...stored, ...migrated])];
 
   return Object.freeze({
-    isLegacyProfile,
+    isLegacyProfile: Boolean(state) && sourceVersion < 3,
     unlockedRewardIds: Object.freeze(unlockedRewardIds)
   });
 }
@@ -245,4 +267,13 @@ export function isTrackUnlocked(trackId, storage = globalThis.localStorage) {
 export function isVehicleUnlocked(vehicleId, storage = globalThis.localStorage) {
   const reward = rewardForVehicle(vehicleId);
   return !reward || isTrophyRoadRewardUnlocked(reward.id, storage);
+}
+
+export function isFeatureUnlocked(featureId, storage = globalThis.localStorage) {
+  const reward = rewardForFeature(featureId);
+  return !reward || isTrophyRoadRewardUnlocked(reward.id, storage);
+}
+
+export function isPaintUnlocked(storage = globalThis.localStorage) {
+  return isFeatureUnlocked('vehicle-paint', storage);
 }

--- a/turn/tracks/harbor-hidden-face-r89.js
+++ b/turn/tracks/harbor-hidden-face-r89.js
@@ -1,5 +1,12 @@
+import * as THREE from 'three';
+import { signalSecretAchievement } from '../achievements/secret-events.js?revision=r157-hidden-achievements';
+
 const PLAYER_FACING_POSITION = Object.freeze({ x: 217.35, y: 14.4, z: 237.55 });
 const PLAYER_FACING_ROTATION_Y = Math.PI * 0.675;
+const DISCOVERY_DISTANCE = 115;
+const DISCOVERY_DISTANCE_SQUARED = DISCOVERY_DISTANCE * DISCOVERY_DISTANCE;
+const DISCOVERY_VIEW_DOT = 0.72;
+const DISCOVERY_HOLD_MS = 550;
 
 export function installHarborHiddenFaceOrientation() {
   const orientFace = (trackId = globalThis.__turnRuntime?.trackId) => {
@@ -17,6 +24,7 @@ export function installHarborHiddenFaceOrientation() {
     );
     face.rotation.y = PLAYER_FACING_ROTATION_Y;
     face.userData.turnEasterEggOrientation = 'faces-player-approach-opposite-side';
+    armDarvidDiscovery(face);
     return true;
   };
 
@@ -24,4 +32,56 @@ export function installHarborHiddenFaceOrientation() {
     orientFace(event.detail?.trackId);
   });
   orientFace();
+}
+
+function armDarvidDiscovery(face) {
+  if (face.userData.turnDarvidDiscoveryArmed || face.userData.turnSecretAchievementFound) return;
+  face.userData.turnDarvidDiscoveryArmed = true;
+
+  const facePosition = new THREE.Vector3();
+  const cameraPosition = new THREE.Vector3();
+  const cameraForward = new THREE.Vector3();
+  const cameraToFace = new THREE.Vector3();
+  const previousOnBeforeRender = face.onBeforeRender;
+  let discoveryStartedAt = null;
+
+  face.onBeforeRender = function discoverDarvid(...args) {
+    previousOnBeforeRender?.call(this, ...args);
+    if (face.userData.turnSecretAchievementFound) return;
+
+    const runtime = globalThis.__turnRuntime;
+    const camera = args[2];
+    if (runtime?.state?.running !== true || runtime?.state?.trackId !== 'harbor' || !camera?.isCamera) {
+      discoveryStartedAt = null;
+      return;
+    }
+
+    face.getWorldPosition(facePosition);
+    camera.getWorldPosition(cameraPosition);
+    if (cameraPosition.distanceToSquared(facePosition) > DISCOVERY_DISTANCE_SQUARED) {
+      discoveryStartedAt = null;
+      return;
+    }
+
+    camera.getWorldDirection(cameraForward);
+    cameraToFace.copy(facePosition).sub(cameraPosition).normalize();
+    if (cameraForward.dot(cameraToFace) < DISCOVERY_VIEW_DOT) {
+      discoveryStartedAt = null;
+      return;
+    }
+
+    const now = globalThis.performance?.now?.() ?? Date.now();
+    if (discoveryStartedAt == null) {
+      discoveryStartedAt = now;
+      return;
+    }
+    if (now - discoveryStartedAt < DISCOVERY_HOLD_MS) return;
+
+    face.userData.turnSecretAchievementFound = true;
+    face.onBeforeRender = previousOnBeforeRender;
+    signalSecretAchievement('find-darvid', {
+      trackId: 'harbor',
+      vehicleId: runtime.state.vehicleId || ''
+    });
+  };
 }

--- a/turn/tracks/harbor-hidden-face-r89.js
+++ b/turn/tracks/harbor-hidden-face-r89.js
@@ -51,7 +51,7 @@ function armDarvidDiscovery(face) {
 
     const runtime = globalThis.__turnRuntime;
     const camera = args[2];
-    if (runtime?.state?.running !== true || runtime?.state?.trackId !== 'harbor' || !camera?.isCamera) {
+    if (runtime?.state?.running !== true || runtime?.trackId !== 'harbor' || !camera?.isCamera) {
       discoveryStartedAt = null;
       return;
     }

--- a/turn/tracks/midnight-city-world-r11.js
+++ b/turn/tracks/midnight-city-world-r11.js
@@ -1,10 +1,9 @@
 import * as THREE from 'three';
+import { signalSecretAchievement } from '../achievements/secret-events.js?revision=r157-hidden-achievements';
 import { installMidnightCityWorld as installMidnightCityWorldR7 } from './midnight-city-world-r7.js?base=20260801-r7';
 
 const LILYA_TEXTURE_URL = new URL('../LILYA.PNG', import.meta.url).href;
 
-// This is the surviving low Neon Quarter building inside the western hairpin.
-// The portrait belongs on its west facade, the vertical wall marked in the map close-up.
 const LILYA_WALL = Object.freeze({
   x: -500.70,
   y: 11.96,
@@ -87,9 +86,7 @@ function armWrongWayTextureLoad(world, portrait, options = {}) {
   let loadStarted = false;
 
   function restoreRoadRenderHook() {
-    if (road.onBeforeRender === wrongWayTriggeredLoad) {
-      road.onBeforeRender = previousOnBeforeRender;
-    }
+    if (road.onBeforeRender === wrongWayTriggeredLoad) road.onBeforeRender = previousOnBeforeRender;
   }
 
   function resetDiscoveryHold() {
@@ -139,7 +136,7 @@ function armWrongWayTextureLoad(world, portrait, options = {}) {
 
     loadStarted = true;
     restoreRoadRenderHook();
-    loadLilyaTexture(portrait);
+    loadLilyaTexture(portrait, runtime);
   }
 
   road.onBeforeRender = wrongWayTriggeredLoad;
@@ -150,13 +147,7 @@ function armWrongWayTextureLoad(world, portrait, options = {}) {
 function playerFacesAgainstRaceDirection(runtime, trackSamples) {
   const state = runtime?.state;
   const sample = trackSamples[state?.nearestTrackIndex];
-  if (
-    state?.running !== true
-    || !Number.isFinite(state.heading)
-    || !sample?.tangent
-  ) {
-    return false;
-  }
+  if (state?.running !== true || !Number.isFinite(state.heading) || !sample?.tangent) return false;
 
   const forwardX = Math.sin(state.heading);
   const forwardZ = Math.cos(state.heading);
@@ -164,7 +155,7 @@ function playerFacesAgainstRaceDirection(runtime, trackSamples) {
   return trackAlignment <= LILYA_MAX_TRACK_ALIGNMENT;
 }
 
-function loadLilyaTexture(portrait) {
+function loadLilyaTexture(portrait, runtime) {
   new THREE.TextureLoader().load(
     LILYA_TEXTURE_URL,
     (texture) => {
@@ -188,6 +179,11 @@ function loadLilyaTexture(portrait) {
       portrait.material.needsUpdate = true;
       portrait.scale.set(width, height, 1);
       portrait.visible = true;
+      portrait.userData.turnSecretAchievementFound = true;
+      signalSecretAchievement('find-lilya', {
+        trackId: 'midnight-city',
+        vehicleId: runtime?.state?.vehicleId || ''
+      });
     },
     undefined,
     (error) => {

--- a/turn/vehicle/car-models.js
+++ b/turn/vehicle/car-models.js
@@ -3,22 +3,37 @@ import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import {
   DEFAULT_VEHICLE_SECONDARY_COLOR,
   getCarDefinition,
+  getVehicleDefaultColorSpec,
+  getVehicleDefaultSecondaryColorSpec,
   makeGhostColor,
   normalizeVehicleColor,
   normalizeVehicleSecondaryColor
-} from './catalog.js?build=20260720-r19';
+} from './catalog.js?build=20260804-r157-factory-colors';
+import {
+  makeWideGamutSpec,
+  setThreeColor
+} from './wide-gamut.js?revision=r157-display-p3';
 
 const loader = new GLTFLoader();
 const sourceCache = new Map();
 const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
 const TIRE_COLOR = 0x17191c;
-// Existing production surfaces use stable target lengths: 5.15 for the standard
-// Lot lineup and 5.5 for race cars. The expanded viewer and record thumbnails use
-// 6.4 and intentionally keep the authored scale.
 const FEATURED_SURFACE_TARGET_LENGTHS = new Set([5.15, 5.5]);
 
 export async function preloadCarModels(carIds) {
   await Promise.all(carIds.map((carId) => loadCarSource(carId).catch(() => null)));
+}
+
+function primaryColorSpec(car, color) {
+  return color === car.defaultColor
+    ? getVehicleDefaultColorSpec(car.id)
+    : makeWideGamutSpec(color);
+}
+
+function secondaryColorSpec(car, color) {
+  return color === car.defaultSecondaryColor
+    ? getVehicleDefaultSecondaryColorSpec(car.id)
+    : makeWideGamutSpec(color);
 }
 
 export async function createCarVisual({
@@ -33,13 +48,16 @@ export async function createCarVisual({
   const source = await loadCarSource(car.id);
   const root = new THREE.Group();
   const model = source.clone(true);
-  // TURN's visual roots point down local -Z. The per-asset quarter turns first
-  // normalize the GLB's authored nose direction, then the shared half-turn aligns it.
   model.rotation.y = Math.PI + car.modelYawQuarterTurns * Math.PI / 2;
   root.add(model);
 
-  const requestedColor = normalizeVehicleColor(color);
-  const requestedSecondaryColor = normalizeVehicleSecondaryColor(secondaryColor);
+  const requestedColor = normalizeVehicleColor(color, car.defaultColor);
+  const requestedSecondaryColor = normalizeVehicleSecondaryColor(
+    secondaryColor,
+    car.defaultSecondaryColor
+  );
+  const requestedColorSpec = primaryColorSpec(car, requestedColor);
+  const requestedSecondaryColorSpec = secondaryColorSpec(car, requestedSecondaryColor);
   const ghostColor = makeGhostColor(requestedColor);
   const ghostSecondaryColor = makeGhostColor(requestedSecondaryColor);
   const meshRecords = [];
@@ -76,26 +94,22 @@ export async function createCarVisual({
       explicitPaint
     } = record;
     const paintable = !car.fixedLivery && !protectedPart && !secondaryPaint && (
-      explicitPaint ||
-      (explicitPaintCount === 0 && isFallbackPaintCandidate(material)) ||
-      (car.pack !== 'car' && isFallbackPaintCandidate(material))
+      explicitPaint
+      || (explicitPaintCount === 0 && isFallbackPaintCandidate(material))
+      || (car.pack !== 'car' && isFallbackPaintCandidate(material))
     );
 
     if (wheelPart && material.color) {
-      // Several Kenney models ship with very bright wheel materials. Tires/wheels should
-      // remain visually grounded instead of inheriting white or body paint.
       material.color.setHex(TIRE_COLOR);
       if ('roughness' in material) material.roughness = Math.max(Number(material.roughness) || 0, 0.82);
     } else if (secondaryPaint && !protectedPart && material.color) {
-      material.color.set(ghost ? ghostSecondaryColor : requestedSecondaryColor);
+      setThreeColor(material.color, ghost ? ghostSecondaryColor : requestedSecondaryColorSpec);
       secondaryPaintMaterials.push(material);
     } else if (paintable && material.color) {
-      material.color.set(ghost ? ghostColor : requestedColor);
+      setThreeColor(material.color, ghost ? ghostColor : requestedColorSpec);
       primaryPaintMaterials.push(material);
     }
 
-    // Personal rivals are solid cars. Their identity comes from the lighter body colour,
-    // not transparency, so they remain readable at speed and in Spectate mode.
     if (ghost) {
       material.transparent = false;
       material.opacity = 1;
@@ -103,17 +117,13 @@ export async function createCarVisual({
       material.needsUpdate = true;
     }
 
-    // Rivals remain fully shaded but do not trigger another shadow-map draw for every
-    // GLB mesh. The player's car keeps its grounding shadow.
     record.node.castShadow = !ghost;
     record.node.receiveShadow = true;
   }
 
   if (outline) addOutlines(model);
   const featuredSurface = FEATURED_SURFACE_TARGET_LENGTHS.has(targetLength);
-  const featuredVisualSizeMultiplier = featuredSurface
-    ? car.featuredVisualSizeMultiplier
-    : 1;
+  const featuredVisualSizeMultiplier = featuredSurface ? car.featuredVisualSizeMultiplier : 1;
   const effectiveVisualScale = car.visualScale
     * car.visualSizeMultiplier
     * featuredVisualSizeMultiplier;
@@ -137,7 +147,6 @@ export async function createCarVisual({
   return root;
 }
 
-
 function installEmergencyLightRig(root, model, service) {
   model.updateMatrixWorld(true);
   const bounds = new THREE.Box3().setFromObject(model);
@@ -152,18 +161,21 @@ function installEmergencyLightRig(root, model, service) {
   const lightDistance = Math.max(8, size.z * 3.1);
   const reducedMotion = globalThis.matchMedia?.('(prefers-reduced-motion: reduce)').matches || false;
   const periodMs = reducedMotion ? 1400 : (service === 'police' ? 720 : 840);
-  const colors = service === 'police' ? [0xff3158, 0x2ab7ff] : [0x2ab7ff, 0x2ab7ff];
+  const colors = service === 'police'
+    ? [makeWideGamutSpec('#ff3158'), makeWideGamutSpec('#2ab7ff')]
+    : [makeWideGamutSpec('#2ab7ff'), makeWideGamutSpec('#2ab7ff')];
   const lamps = [];
 
-  colors.forEach((color, index) => {
+  colors.forEach((colorSpec, index) => {
     const material = new THREE.MeshBasicMaterial({
-      color,
+      color: 0xffffff,
       transparent: true,
       opacity: 0,
       depthWrite: false,
       blending: THREE.AdditiveBlending,
       toneMapped: false
     });
+    setThreeColor(material.color, colorSpec);
     const lamp = new THREE.Mesh(new THREE.BoxGeometry(lampWidth, lampHeight, lampDepth), material);
     lamp.position.set((index === 0 ? -1 : 1) * barWidth * 0.27, roofY, roofZ);
     lamp.visible = true;
@@ -185,36 +197,20 @@ function installEmergencyLightRig(root, model, service) {
     wideHalo.visible = false;
     wideHalo.renderOrder = 40;
 
-    const pointLight = new THREE.PointLight(color, 0, lightDistance, 2);
+    const pointLight = new THREE.PointLight(0xffffff, 0, lightDistance, 2);
+    setThreeColor(pointLight.color, colorSpec);
     pointLight.position.copy(lamp.position);
     pointLight.position.y += lampHeight * 1.2;
     pointLight.castShadow = false;
 
     root.add(pointLight, wideHalo, halo, lamp);
-    lamps.push({
-      lamp,
-      material,
-      halo,
-      haloMaterial,
-      wideHalo,
-      wideHaloMaterial,
-      pointLight,
-      index
-    });
+    lamps.push({ lamp, material, halo, haloMaterial, wideHalo, wideHaloMaterial, pointLight, index });
   });
 
-  const rig = {
-    service,
-    lamps,
-    periodMs,
-    reducedMotion,
-    lastFrameAt: -Infinity
-  };
+  const rig = { service, lamps, periodMs, reducedMotion, lastFrameAt: -Infinity };
   root.userData.turnEmergencyService = service;
   root.userData.turnEmergencyLightRig = rig;
-  for (const record of lamps) {
-    record.lamp.onBeforeRender = () => updateEmergencyLightRig(rig);
-  }
+  for (const record of lamps) record.lamp.onBeforeRender = () => updateEmergencyLightRig(rig);
 }
 
 function updateEmergencyLightRig(rig) {
@@ -238,16 +234,19 @@ function updateEmergencyLightRig(rig) {
 }
 
 export function recolorCarVisual(root, color, secondaryColor = root?.userData?.turnCarSecondaryColor) {
-  const normalized = normalizeVehicleColor(color);
-  const normalizedSecondary = normalizeVehicleSecondaryColor(secondaryColor);
+  const car = getCarDefinition(root?.userData?.turnCarId);
+  const normalized = normalizeVehicleColor(color, car.defaultColor);
+  const normalizedSecondary = normalizeVehicleSecondaryColor(secondaryColor, car.defaultSecondaryColor);
   const ghost = Boolean(root?.userData?.turnGhost);
-  const displayColor = ghost ? makeGhostColor(normalized) : normalized;
-  const displaySecondary = ghost ? makeGhostColor(normalizedSecondary) : normalizedSecondary;
+  const displayColor = ghost ? makeGhostColor(normalized) : primaryColorSpec(car, normalized);
+  const displaySecondary = ghost
+    ? makeGhostColor(normalizedSecondary)
+    : secondaryColorSpec(car, normalizedSecondary);
   for (const material of root?.userData?.turnPrimaryPaintMaterials || []) {
-    material.color?.set(displayColor);
+    setThreeColor(material.color, displayColor);
   }
   for (const material of root?.userData?.turnSecondaryPaintMaterials || []) {
-    material.color?.set(displaySecondary);
+    setThreeColor(material.color, displaySecondary);
   }
   if (root?.userData) {
     root.userData.turnCarColor = normalized;

--- a/turn/vehicle/catalog.js
+++ b/turn/vehicle/catalog.js
@@ -1,6 +1,6 @@
 export const DEFAULT_VEHICLE_ID = 'classic';
 export const LEGACY_VEHICLE_ID = 'sedan';
-export const DEFAULT_VEHICLE_COLOR = '#ffd43b';
+export const DEFAULT_VEHICLE_COLOR = '#ffcc00';
 export const DEFAULT_VEHICLE_SECONDARY_COLOR = '#f8f9fa';
 export const VEHICLE_SELECTION_KEY = 'turn-vehicle-selection-v1';
 export const VEHICLE_STAT_BUDGET = 18;
@@ -15,41 +15,17 @@ export const MAXED_VEHICLE_STATS = Object.freeze({
 });
 
 export const VEHICLE_STAT_LEGEND = Object.freeze([
-  Object.freeze({
-    key: 'speed',
-    label: 'TOP SPEED',
-    description: 'How fast the car can go without boost.'
-  }),
-  Object.freeze({
-    key: 'acceleration',
-    label: 'ACCELERATION',
-    description: 'How quickly the car reaches speed.'
-  }),
-  Object.freeze({
-    key: 'control',
-    label: 'CONTROL',
-    description: 'How precisely and quickly the car steers while gripping the road.'
-  }),
-  Object.freeze({
-    key: 'drift',
-    label: 'DRIFT',
-    description: 'How well the car retains speed and settles while drifting. Drift is always slower than Gas.'
-  }),
-  Object.freeze({
-    key: 'boostPower',
-    label: 'BOOST POWER',
-    description: 'How strongly boost accelerates the car and raises its speed limit.'
-  }),
-  Object.freeze({
-    key: 'boostDuration',
-    label: 'BOOST TANK',
-    description: 'How long a full boost charge lasts.'
-  })
+  Object.freeze({ key: 'speed', label: 'TOP SPEED', description: 'How fast the car can go without boost.' }),
+  Object.freeze({ key: 'acceleration', label: 'ACCELERATION', description: 'How quickly the car reaches speed.' }),
+  Object.freeze({ key: 'control', label: 'CONTROL', description: 'How precisely and quickly the car steers while gripping the road.' }),
+  Object.freeze({ key: 'drift', label: 'DRIFT', description: 'How well the car retains speed and settles while drifting. Drift is always slower than Gas.' }),
+  Object.freeze({ key: 'boostPower', label: 'BOOST POWER', description: 'How strongly boost accelerates the car and raises its speed limit.' }),
+  Object.freeze({ key: 'boostDuration', label: 'BOOST TANK', description: 'How long a full boost charge lasts.' })
 ]);
 
 export const CAR_PALETTE = Object.freeze([
-  Object.freeze({ name: 'Solar', value: '#ffd43b' }),
-  Object.freeze({ name: 'Sky', value: '#38d9ff' }),
+  Object.freeze({ name: 'Solar', value: '#ffcc00' }),
+  Object.freeze({ name: 'Future Cyan', value: '#00aabb' }),
   Object.freeze({ name: 'Bubblegum', value: '#ff4fa3' }),
   Object.freeze({ name: 'Lime', value: '#8ce99a' }),
   Object.freeze({ name: 'Orange', value: '#ff922b' }),
@@ -58,25 +34,34 @@ export const CAR_PALETTE = Object.freeze([
   Object.freeze({ name: 'Ice', value: '#f8f9fa' })
 ]);
 
-// Global balance adjustments are kept separate from each GLB's authored normalization.
-// Convertible and Training Car use these sizes on every surface.
-const VISUAL_SIZE_MULTIPLIER_BY_ID = Object.freeze({
-  convertible: 0.6,
-  classic: 0.6
+const DEFAULT_COLOR_BY_ID = Object.freeze({
+  convertible: Object.freeze({ fallback: '#a8327a', p3: Object.freeze([0.66, 0.14, 0.43]) }),
+  classic: Object.freeze({ fallback: '#ffcc00', p3: Object.freeze([1, 0.76, 0]) }),
+  'vintage-racer': Object.freeze({ fallback: '#8b5a2b', p3: Object.freeze([0.52, 0.29, 0.12]) }),
+  'toy-racer': Object.freeze({ fallback: '#2d5ea8', p3: Object.freeze([0.12, 0.31, 0.68]) }),
+  'monster-truck': Object.freeze({ fallback: '#3f5a3c', p3: Object.freeze([0.21, 0.35, 0.19]) }),
+  'race-future': Object.freeze({ fallback: '#00aabb', p3: Object.freeze([0, 0.68, 0.74]) }),
+  race: Object.freeze({ fallback: '#b93632', p3: Object.freeze([0.72, 0.12, 0.12]) }),
+  'sedan-sports': Object.freeze({ fallback: '#5e3c87', p3: Object.freeze([0.36, 0.19, 0.56]) }),
+  sedan: Object.freeze({ fallback: '#2b6a70', p3: Object.freeze([0.12, 0.41, 0.43]) }),
+  suv: Object.freeze({ fallback: '#7b4f2d', p3: Object.freeze([0.47, 0.25, 0.12]) }),
+  firetruck: Object.freeze({ fallback: '#d92d20', p3: Object.freeze([0.82, 0.08, 0.04]) }),
+  police: Object.freeze({ fallback: '#0b0d10', p3: Object.freeze([0.035, 0.045, 0.06]) }),
+  ambulance: Object.freeze({ fallback: '#f8f9fa', p3: Object.freeze([0.95, 0.97, 0.98]) }),
+  truck: Object.freeze({ fallback: '#3f5368', p3: Object.freeze([0.22, 0.32, 0.43]) }),
+  van: Object.freeze({ fallback: '#5d503f', p3: Object.freeze([0.34, 0.29, 0.21]) })
 });
 
-// Featured adjustments are only used in the standard Lot lineup and during a race.
-// Compact previews and the expanded 3D viewer retain the authored model scale.
-const FEATURED_VISUAL_SIZE_MULTIPLIER_BY_ID = Object.freeze({
-  'monster-truck': 1.2
+const DEFAULT_SECONDARY_COLOR_BY_ID = Object.freeze({
+  'sedan-sports': Object.freeze({ fallback: '#252a35', p3: Object.freeze([0.13, 0.15, 0.21]) }),
+  firetruck: Object.freeze({ fallback: '#ffcc00', p3: Object.freeze([1, 0.76, 0]) }),
+  police: Object.freeze({ fallback: '#f8f9fa', p3: Object.freeze([0.95, 0.97, 0.98]) }),
+  ambulance: Object.freeze({ fallback: '#d92d20', p3: Object.freeze([0.82, 0.08, 0.04]) })
 });
 
-const EMERGENCY_SERVICE_BY_ID = Object.freeze({
-  firetruck: 'firetruck',
-  police: 'police',
-  ambulance: 'ambulance'
-});
-
+const VISUAL_SIZE_MULTIPLIER_BY_ID = Object.freeze({ convertible: 0.6, classic: 0.6 });
+const FEATURED_VISUAL_SIZE_MULTIPLIER_BY_ID = Object.freeze({ 'monster-truck': 1.2 });
+const EMERGENCY_SERVICE_BY_ID = Object.freeze({ firetruck: 'firetruck', police: 'police', ambulance: 'ambulance' });
 const FIXED_LIVERY_IDS = new Set(Object.keys(EMERGENCY_SERVICE_BY_ID));
 const RETIRED_VEHICLE_REPLACEMENTS = Object.freeze({
   'suv-luxury': 'firetruck',
@@ -84,14 +69,6 @@ const RETIRED_VEHICLE_REPLACEMENTS = Object.freeze({
   'truck-flat': 'ambulance'
 });
 
-// Every car has exactly 18 stat points. The Sedan's 3/3/3/3/3/3 is the neutral baseline;
-// every other vehicle trades strengths for weaknesses instead of becoming a straight upgrade.
-// Training Car deliberately spends its budget on control, drift and a long boost tank so new
-// players and soundscape testers can drive slowly without losing the full TURN control vocabulary.
-// LEGACY_VEHICLE_ID preserves the Sedan identity of pre-catalog rivals that never stored a car id.
-// The vendored packs use three different authored front axes. modelYawQuarterTurns
-// rotates each raw GLB so every car has the same local front before TURN positions it.
-// enginePitch is an audio-only baseline multiplier: heavy vehicles sit lower, race cars higher.
 const RAW_CARS = [
   ['convertible', 'Convertible', 'prototype', { speed: 4, acceleration: 4, control: 4, drift: 2, boostPower: 3, boostDuration: 1 }, 0.98, 1, 1.08],
   ['classic', 'Training Car', 'prototype', { speed: 1, acceleration: 1, control: 5, drift: 5, boostPower: 1, boostDuration: 5 }, 1.00, 1, 0.88],
@@ -110,23 +87,12 @@ const RAW_CARS = [
   ['van', 'Van', 'car', { speed: 2, acceleration: 3, control: 3, drift: 5, boostPower: 1, boostDuration: 4 }, 1.08, 0, 0.80]
 ];
 
-// The current GLBs use one atlas material per mesh. Roofs are part of the body mesh,
-// while Sport Sedan's spoiler is the one safe, separately addressable paint surface.
 const SECONDARY_PAINT_BY_ID = Object.freeze({
-  'sedan-sports': Object.freeze({
-    label: 'Spoiler',
-    meshNames: Object.freeze(['spoiler'])
-  })
+  'sedan-sports': Object.freeze({ label: 'Spoiler', meshNames: Object.freeze(['spoiler']) })
 });
 
 export const CAR_CATALOG = Object.freeze(RAW_CARS.map(([
-  id,
-  name,
-  pack,
-  stats,
-  visualScale,
-  modelYawQuarterTurns,
-  enginePitch
+  id, name, pack, stats, visualScale, modelYawQuarterTurns, enginePitch
 ]) => Object.freeze({
   id,
   name,
@@ -137,27 +103,21 @@ export const CAR_CATALOG = Object.freeze(RAW_CARS.map(([
   visualSizeMultiplier: VISUAL_SIZE_MULTIPLIER_BY_ID[id] || 1,
   featuredVisualSizeMultiplier: FEATURED_VISUAL_SIZE_MULTIPLIER_BY_ID[id] || 1,
   modelYawQuarterTurns,
+  defaultColor: DEFAULT_COLOR_BY_ID[id]?.fallback || DEFAULT_VEHICLE_COLOR,
+  defaultColorP3: DEFAULT_COLOR_BY_ID[id]?.p3 || null,
+  defaultSecondaryColor: DEFAULT_SECONDARY_COLOR_BY_ID[id]?.fallback || DEFAULT_VEHICLE_SECONDARY_COLOR,
+  defaultSecondaryColorP3: DEFAULT_SECONDARY_COLOR_BY_ID[id]?.p3 || null,
   secondaryPaint: SECONDARY_PAINT_BY_ID[id] || null,
   emergencyService: EMERGENCY_SERVICE_BY_ID[id] || null,
   fixedLivery: FIXED_LIVERY_IDS.has(id),
-  tuning: Object.freeze({
-    ...deriveVehicleTuning(stats),
-    enginePitch
-  })
+  tuning: Object.freeze({ ...deriveVehicleTuning(stats), enginePitch })
 })));
 
 const CAR_BY_ID = new Map(CAR_CATALOG.map((car) => [car.id, car]));
 const HEX_COLOR_PATTERN = /^#[0-9a-f]{6}$/;
 const SPORTS_SEDAN = CAR_BY_ID.get('sedan-sports');
-const MAXED_SPORTS_SEDAN_TUNING = Object.freeze({
-  ...deriveVehicleTuning(MAXED_VEHICLE_STATS),
-  enginePitch: SPORTS_SEDAN.tuning.enginePitch
-});
-const MAXED_SPORTS_SEDAN = Object.freeze({
-  ...SPORTS_SEDAN,
-  stats: MAXED_VEHICLE_STATS,
-  tuning: MAXED_SPORTS_SEDAN_TUNING
-});
+const MAXED_SPORTS_SEDAN_TUNING = Object.freeze({ ...deriveVehicleTuning(MAXED_VEHICLE_STATS), enginePitch: SPORTS_SEDAN.tuning.enginePitch });
+const MAXED_SPORTS_SEDAN = Object.freeze({ ...SPORTS_SEDAN, stats: MAXED_VEHICLE_STATS, tuning: MAXED_SPORTS_SEDAN_TUNING });
 let activeVehicleSelection = null;
 
 function getBaseCarDefinition(id) {
@@ -176,22 +136,41 @@ export function normalizeVehicleId(id) {
   return CAR_BY_ID.has(replacement) ? replacement : DEFAULT_VEHICLE_ID;
 }
 
-export function normalizeVehicleColor(color) {
-  const value = typeof color === 'string' ? color.toLowerCase() : '';
-  return HEX_COLOR_PATTERN.test(value) ? value : DEFAULT_VEHICLE_COLOR;
+export function getVehicleDefaultColorSpec(id) {
+  const car = getBaseCarDefinition(id);
+  return Object.freeze({ fallback: car.defaultColor, p3: car.defaultColorP3 });
 }
 
-export function normalizeVehicleSecondaryColor(color) {
+export function getVehicleDefaultSecondaryColorSpec(id) {
+  const car = getBaseCarDefinition(id);
+  return Object.freeze({ fallback: car.defaultSecondaryColor, p3: car.defaultSecondaryColorP3 });
+}
+
+export function getVehicleDefaultColor(id) {
+  return getBaseCarDefinition(id).defaultColor;
+}
+
+export function getVehicleDefaultSecondaryColor(id) {
+  return getBaseCarDefinition(id).defaultSecondaryColor;
+}
+
+export function normalizeVehicleColor(color, fallback = DEFAULT_VEHICLE_COLOR) {
+  const value = typeof color === 'string' ? color.toLowerCase() : '';
+  return HEX_COLOR_PATTERN.test(value) ? value : fallback;
+}
+
+export function normalizeVehicleSecondaryColor(color, fallback = DEFAULT_VEHICLE_SECONDARY_COLOR) {
   const value = typeof color === 'string' ? color.toLowerCase() : '';
   if (value === '#666') return SPORTS_SEDAN_EASTER_EGG_COLOR;
-  return HEX_COLOR_PATTERN.test(value) ? value : DEFAULT_VEHICLE_SECONDARY_COLOR;
+  return HEX_COLOR_PATTERN.test(value) ? value : fallback;
 }
 
 export function normalizeVehicleSelection(selection) {
+  const carId = normalizeVehicleId(selection?.carId);
   return {
-    carId: normalizeVehicleId(selection?.carId),
-    color: normalizeVehicleColor(selection?.color),
-    secondaryColor: normalizeVehicleSecondaryColor(selection?.secondaryColor)
+    carId,
+    color: normalizeVehicleColor(selection?.color, getVehicleDefaultColor(carId)),
+    secondaryColor: normalizeVehicleSecondaryColor(selection?.secondaryColor, getVehicleDefaultSecondaryColor(carId))
   };
 }
 
@@ -201,15 +180,11 @@ export function isSportsSedanEasterEgg(selection) {
 }
 
 export function getEffectiveVehicleStats(selection) {
-  return isSportsSedanEasterEgg(selection)
-    ? MAXED_VEHICLE_STATS
-    : getBaseCarDefinition(selection?.carId).stats;
+  return isSportsSedanEasterEgg(selection) ? MAXED_VEHICLE_STATS : getBaseCarDefinition(selection?.carId).stats;
 }
 
 export function getEffectiveVehicleTuning(selection) {
-  return isSportsSedanEasterEgg(selection)
-    ? MAXED_SPORTS_SEDAN_TUNING
-    : getBaseCarDefinition(selection?.carId).tuning;
+  return isSportsSedanEasterEgg(selection) ? MAXED_SPORTS_SEDAN_TUNING : getBaseCarDefinition(selection?.carId).tuning;
 }
 
 export function loadVehicleSelection() {
@@ -224,9 +199,7 @@ export function loadVehicleSelection() {
 export function saveVehicleSelection(selection) {
   const normalized = normalizeVehicleSelection(selection);
   activeVehicleSelection = normalized;
-  try {
-    localStorage.setItem(VEHICLE_SELECTION_KEY, JSON.stringify(normalized));
-  } catch (_) {}
+  try { localStorage.setItem(VEHICLE_SELECTION_KEY, JSON.stringify(normalized)); } catch (_) {}
   return normalized;
 }
 
@@ -246,7 +219,6 @@ export function getVehicleStatTotal(stats) {
 
 export function deriveVehicleTuning(stats) {
   return {
-    // A 3/5 stat is the exact TURN v1.0 baseline. Lower and higher ratings fan out from there.
     topSpeedMultiplier: centeredStat(stats.speed, [0.84, 0.92, 1, 1.06, 1.12]),
     accelerationMultiplier: centeredStat(stats.acceleration, [0.82, 0.91, 1, 1.08, 1.16]),
     controlMultiplier: centeredStat(stats.control, [0.88, 0.94, 1, 1.07, 1.14]),

--- a/turn/vehicle/emergency-livery-models.js
+++ b/turn/vehicle/emergency-livery-models.js
@@ -16,6 +16,7 @@ import {
 const LOT_TARGET_LENGTH = 5.15;
 const LOT_UNSELECTED_HEX = 0x313131;
 const LOT_TINT_MIX = 0.23;
+const LOT_TINT_PATCHED_COLORS = new WeakSet();
 
 const EMERGENCY_LIVERY_BY_ID = Object.freeze({
   police: Object.freeze({
@@ -137,14 +138,13 @@ function installLotUnselectedTint(root) {
     const materials = Array.isArray(node.material) ? node.material : [node.material];
     for (const material of materials) {
       const color = material?.color;
-      if (!color || color.userData?.turnLotTintCopy) continue;
+      if (!color || LOT_TINT_PATCHED_COLORS.has(color)) continue;
       const originalCopy = color.copy.bind(color);
-      const copy = (source) => {
+      color.copy = (source) => {
         const sourceHex = source?.getHex?.(THREE.SRGBColorSpace) ?? source?.getHex?.();
         return originalCopy(sourceHex === LOT_UNSELECTED_HEX ? hint : source);
       };
-      color.copy = copy;
-      color.userData = { ...(color.userData || {}), turnLotTintCopy: true };
+      LOT_TINT_PATCHED_COLORS.add(color);
     }
   });
   root.userData.turnLotUnselectedTint = hint.getHexString(THREE.SRGBColorSpace);

--- a/turn/vehicle/emergency-livery-models.js
+++ b/turn/vehicle/emergency-livery-models.js
@@ -3,22 +3,34 @@ import {
   createCarVisual as createBaseCarVisual,
   preloadCarModels,
   recolorCarVisual
-} from './car-models.js?build=20260803-r126-emergency-livery-base';
+} from './car-models.js?build=20260804-r157-display-p3';
+import {
+  getVehicleDefaultColorSpec
+} from './catalog.js?build=20260804-r157-factory-colors';
+import {
+  makeWideGamutSpec,
+  setThreeColor,
+  threeColorFromSpec
+} from './wide-gamut.js?revision=r157-display-p3';
+
+const LOT_TARGET_LENGTH = 5.15;
+const LOT_UNSELECTED_HEX = 0x313131;
+const LOT_TINT_MIX = 0.23;
 
 const EMERGENCY_LIVERY_BY_ID = Object.freeze({
   police: Object.freeze({
-    primary: 0x0b0d10,
-    secondary: 0xf8f9fa,
+    primary: makeWideGamutSpec('#0b0d10', [0.035, 0.045, 0.06]),
+    secondary: makeWideGamutSpec('#f8f9fa', [0.95, 0.97, 0.98]),
     accent: 'door-panels'
   }),
   ambulance: Object.freeze({
-    primary: 0xf8f9fa,
-    secondary: 0xd92d20,
+    primary: makeWideGamutSpec('#f8f9fa', [0.95, 0.97, 0.98]),
+    secondary: makeWideGamutSpec('#d92d20', [0.82, 0.08, 0.04]),
     accent: 'rear-side-stripe'
   }),
   firetruck: Object.freeze({
-    primary: 0xd92d20,
-    secondary: 0xffd43b,
+    primary: makeWideGamutSpec('#d92d20', [0.82, 0.08, 0.04]),
+    secondary: makeWideGamutSpec('#ffcc00', [1, 0.76, 0]),
     accent: 'side-stripe'
   })
 });
@@ -28,9 +40,10 @@ export { preloadCarModels, recolorCarVisual };
 export async function createCarVisual(options = {}) {
   const root = await createBaseCarVisual(options);
   const livery = EMERGENCY_LIVERY_BY_ID[root?.userData?.turnCarId];
-  if (!livery) return root;
-
-  applyFixedEmergencyLivery(root, livery, Boolean(options.ghost));
+  if (livery) applyFixedEmergencyLivery(root, livery, Boolean(options.ghost));
+  if (Math.abs(Number(options.targetLength) - LOT_TARGET_LENGTH) < 0.001) {
+    installLotUnselectedTint(root);
+  }
   return root;
 }
 
@@ -38,8 +51,8 @@ function applyFixedEmergencyLivery(root, livery, ghost) {
   const model = root.children[0];
   if (!model) return;
 
-  const primary = ghost ? makeGhostHex(livery.primary) : livery.primary;
-  const secondary = ghost ? makeGhostHex(livery.secondary) : livery.secondary;
+  const primary = ghost ? makeGhostHex(livery.primary.fallback) : livery.primary;
+  const secondary = ghost ? makeGhostHex(livery.secondary.fallback) : livery.secondary;
   const candidates = [];
   let explicitCount = 0;
 
@@ -60,15 +73,15 @@ function applyFixedEmergencyLivery(root, livery, ghost) {
   const records = paintable.length ? paintable : candidates;
 
   for (const { material } of records) {
-    material.color.setHex(primary);
+    setThreeColor(material.color, primary);
     if ('roughness' in material) material.roughness = Math.max(Number(material.roughness) || 0, 0.72);
     material.needsUpdate = true;
   }
 
   installSecondaryAccent(root, model, secondary, livery.accent);
   root.userData.turnEmergencyLivery = Object.freeze({
-    primary,
-    secondary,
+    primary: livery.primary.fallback,
+    secondary: livery.secondary.fallback,
     accent: livery.accent
   });
 }
@@ -83,22 +96,20 @@ function installSecondaryAccent(root, model, color, accent) {
   const group = new THREE.Group();
   group.userData.turnEmergencyLiveryAccent = true;
   const material = new THREE.MeshStandardMaterial({
-    color,
+    color: 0xffffff,
     roughness: 0.78,
     metalness: 0,
     polygonOffset: true,
     polygonOffsetFactor: -2,
     polygonOffsetUnits: -2
   });
+  setThreeColor(material.color, color);
 
   const sideDepth = Math.max(0.028, size.x * 0.014);
   const sideX = size.x * 0.405;
   const addSidePair = ({ length, height, y, z }) => {
     for (const direction of [-1, 1]) {
-      const panel = new THREE.Mesh(
-        new THREE.BoxGeometry(sideDepth, height, length),
-        material
-      );
+      const panel = new THREE.Mesh(new THREE.BoxGeometry(sideDepth, height, length), material);
       panel.position.set(center.x + direction * sideX, y, z);
       panel.castShadow = false;
       panel.receiveShadow = true;
@@ -107,29 +118,36 @@ function installSecondaryAccent(root, model, color, accent) {
   };
 
   if (accent === 'door-panels') {
-    addSidePair({
-      length: size.z * 0.34,
-      height: size.y * 0.29,
-      y: bounds.min.y + size.y * 0.48,
-      z: center.z + size.z * 0.03
-    });
+    addSidePair({ length: size.z * 0.34, height: size.y * 0.29, y: bounds.min.y + size.y * 0.48, z: center.z + size.z * 0.03 });
   } else if (accent === 'rear-side-stripe') {
-    addSidePair({
-      length: size.z * 0.52,
-      height: Math.max(0.08, size.y * 0.09),
-      y: bounds.min.y + size.y * 0.49,
-      z: center.z + size.z * 0.22
-    });
+    addSidePair({ length: size.z * 0.52, height: Math.max(0.08, size.y * 0.09), y: bounds.min.y + size.y * 0.49, z: center.z + size.z * 0.22 });
   } else {
-    addSidePair({
-      length: size.z * 0.72,
-      height: Math.max(0.08, size.y * 0.09),
-      y: bounds.min.y + size.y * 0.49,
-      z: center.z
-    });
+    addSidePair({ length: size.z * 0.72, height: Math.max(0.08, size.y * 0.09), y: bounds.min.y + size.y * 0.49, z: center.z });
   }
 
   root.add(group);
+}
+
+function installLotUnselectedTint(root) {
+  const factoryColor = threeColorFromSpec(getVehicleDefaultColorSpec(root.userData.turnCarId));
+  const hint = new THREE.Color(LOT_UNSELECTED_HEX).lerp(factoryColor, LOT_TINT_MIX);
+
+  root.traverse((node) => {
+    if (!node.isMesh || !node.material || node.userData?.turnOutline) return;
+    const materials = Array.isArray(node.material) ? node.material : [node.material];
+    for (const material of materials) {
+      const color = material?.color;
+      if (!color || color.userData?.turnLotTintCopy) continue;
+      const originalCopy = color.copy.bind(color);
+      const copy = (source) => {
+        const sourceHex = source?.getHex?.(THREE.SRGBColorSpace) ?? source?.getHex?.();
+        return originalCopy(sourceHex === LOT_UNSELECTED_HEX ? hint : source);
+      };
+      color.copy = copy;
+      color.userData = { ...(color.userData || {}), turnLotTintCopy: true };
+    }
+  });
+  root.userData.turnLotUnselectedTint = hint.getHexString(THREE.SRGBColorSpace);
 }
 
 function isProtectedPart(node, material) {
@@ -145,9 +163,7 @@ function isExplicitBodyPart(node, material) {
 function isLikelyBodyMaterial(material) {
   if (!material?.color) return false;
   if (material.transparent && material.opacity < 0.8) return false;
-  const luminance = material.color.r * 0.2126
-    + material.color.g * 0.7152
-    + material.color.b * 0.0722;
+  const luminance = material.color.r * 0.2126 + material.color.g * 0.7152 + material.color.b * 0.0722;
   return luminance > 0.16;
 }
 

--- a/turn/vehicle/sports-sedan-easter-egg.js
+++ b/turn/vehicle/sports-sedan-easter-egg.js
@@ -1,3 +1,5 @@
+import { signalSecretAchievement } from '../achievements/secret-events.js?revision=r157-hidden-achievements';
+
 const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
 const catalogUrl = new URL('./catalog.js', import.meta.url);
 if (buildKey) catalogUrl.searchParams.set('build', buildKey);
@@ -94,6 +96,14 @@ function syncUnlockPresentation(lot, car, unlocked) {
 
   notice.hidden = !unlocked;
   lot.classList.toggle('is-super-sedan-unlocked', unlocked);
+
+  if (unlocked && lot.dataset.turnSatansSedanFound !== 'true') {
+    lot.dataset.turnSatansSedanFound = 'true';
+    signalSecretAchievement('satans-sedan', {
+      trackId: globalThis.__turnRuntime?.state?.trackId || '',
+      vehicleId: 'sedan-sports'
+    });
+  }
 }
 
 function ensureUnlockNotice(lot) {

--- a/turn/vehicle/wide-gamut.js
+++ b/turn/vehicle/wide-gamut.js
@@ -1,0 +1,127 @@
+import * as THREE from 'three';
+
+const DISPLAY_P3_QUERY = 'color(display-p3 1 0 0)';
+const P3_ACCENTS_BY_FALLBACK = Object.freeze({
+  '#00aabb': Object.freeze([0, 0.68, 0.74]),
+  '#38d9ff': Object.freeze([0.05, 0.82, 1]),
+  '#5de4ff': Object.freeze([0.16, 0.88, 1]),
+  '#2ab7ff': Object.freeze([0.03, 0.62, 1]),
+  '#b8f7ff': Object.freeze([0.62, 0.96, 1]),
+  '#ff3158': Object.freeze([1, 0.05, 0.22]),
+  '#ff4fa3': Object.freeze([1, 0.16, 0.58]),
+  '#ffcc00': Object.freeze([1, 0.76, 0]),
+  '#ffd43b': Object.freeze([1, 0.79, 0.03]),
+  '#ffdc68': Object.freeze([1, 0.82, 0.18]),
+  '#9775fa': Object.freeze([0.55, 0.35, 1]),
+  '#9d7cff': Object.freeze([0.58, 0.37, 1]),
+  '#8ce99a': Object.freeze([0.36, 0.91, 0.48]),
+  '#ff6b6b': Object.freeze([1, 0.26, 0.25]),
+  '#ff922b': Object.freeze([1, 0.45, 0.05])
+});
+
+let cachedSupport;
+
+export function supportsDisplayP3() {
+  if (cachedSupport !== undefined) return cachedSupport;
+  cachedSupport = Boolean(
+    THREE.DisplayP3ColorSpace
+    && globalThis.CSS?.supports?.('color', DISPLAY_P3_QUERY)
+  );
+  return cachedSupport;
+}
+
+export function makeWideGamutSpec(fallback, p3 = null) {
+  const normalizedFallback = String(fallback || '#000000').toLowerCase();
+  return Object.freeze({
+    fallback: normalizedFallback,
+    p3: Array.isArray(p3) && p3.length === 3
+      ? Object.freeze(p3.map((channel) => Math.max(0, Math.min(1, Number(channel) || 0))))
+      : (P3_ACCENTS_BY_FALLBACK[normalizedFallback] || null)
+  });
+}
+
+export function setThreeColor(target, value) {
+  if (!target?.set) return target;
+  const spec = typeof value === 'string' ? makeWideGamutSpec(value) : value;
+  if (supportsDisplayP3() && spec?.p3 && typeof target.setRGB === 'function') {
+    target.setRGB(spec.p3[0], spec.p3[1], spec.p3[2], THREE.DisplayP3ColorSpace);
+  } else {
+    target.set(spec?.fallback || value || '#000000');
+  }
+  return target;
+}
+
+export function threeColorFromSpec(value) {
+  return setThreeColor(new THREE.Color(), value);
+}
+
+export function configureRendererWideGamut(renderer) {
+  if (!renderer) return false;
+  renderer.outputColorSpace = supportsDisplayP3()
+    ? THREE.DisplayP3ColorSpace
+    : THREE.SRGBColorSpace;
+  return supportsDisplayP3();
+}
+
+function fallbackHex(color) {
+  if (!color?.getHexString) return '';
+  try {
+    return `#${color.getHexString(THREE.SRGBColorSpace)}`.toLowerCase();
+  } catch (_) {
+    return `#${color.getHexString()}`.toLowerCase();
+  }
+}
+
+function enhanceColor(color) {
+  const p3 = P3_ACCENTS_BY_FALLBACK[fallbackHex(color)];
+  if (!p3) return false;
+  setThreeColor(color, makeWideGamutSpec(fallbackHex(color), p3));
+  return true;
+}
+
+export function enhanceWideGamutScene(root) {
+  if (!root || !supportsDisplayP3()) return 0;
+  let enhanced = 0;
+  root.traverse?.((node) => {
+    if (node?.isLight && enhanceColor(node.color)) enhanced += 1;
+    if (!node?.material) return;
+    const materials = Array.isArray(node.material) ? node.material : [node.material];
+    for (const material of materials) {
+      if (enhanceColor(material?.color)) enhanced += 1;
+      if (enhanceColor(material?.emissive)) enhanced += 1;
+      if (enhanced && material) material.needsUpdate = true;
+    }
+  });
+  return enhanced;
+}
+
+export function installWideGamutRuntime(runtime = globalThis.__turnRuntime) {
+  if (!runtime || globalThis.__turnWideGamutRuntime) {
+    return globalThis.__turnWideGamutRuntime || null;
+  }
+
+  const apply = () => {
+    configureRendererWideGamut(runtime.renderer);
+    enhanceWideGamutScene(runtime.scene || runtime.world);
+    document.documentElement.dataset.turnColorGamut = supportsDisplayP3() ? 'display-p3' : 'srgb';
+  };
+
+  const scheduleApply = () => {
+    apply();
+    requestAnimationFrame(apply);
+    globalThis.setTimeout?.(apply, 180);
+  };
+
+  window.addEventListener('turn:track-changed', scheduleApply);
+  scheduleApply();
+
+  const api = Object.freeze({
+    supported: supportsDisplayP3(),
+    apply,
+    disconnect() {
+      window.removeEventListener('turn:track-changed', scheduleApply);
+    }
+  });
+  globalThis.__turnWideGamutRuntime = api;
+  return api;
+}

--- a/turn/vehicle/wide-gamut.js
+++ b/turn/vehicle/wide-gamut.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 
 const DISPLAY_P3_QUERY = 'color(display-p3 1 0 0)';
+const RENDERER_PATCH = Symbol.for('turn.display-p3.renderer-patch');
 const P3_ACCENTS_BY_FALLBACK = Object.freeze({
   '#00aabb': Object.freeze([0, 0.68, 0.74]),
   '#38d9ff': Object.freeze([0.05, 0.82, 1]),
@@ -63,6 +64,18 @@ export function configureRendererWideGamut(renderer) {
   return supportsDisplayP3();
 }
 
+export function installWideGamutRendererPatch() {
+  const prototype = THREE.WebGLRenderer?.prototype;
+  if (!prototype || prototype[RENDERER_PATCH]) return false;
+  const originalSetSize = prototype.setSize;
+  prototype.setSize = function turnWideGamutSetSize(...args) {
+    configureRendererWideGamut(this);
+    return originalSetSize.apply(this, args);
+  };
+  Object.defineProperty(prototype, RENDERER_PATCH, { value: true });
+  return true;
+}
+
 function fallbackHex(color) {
   if (!color?.getHexString) return '';
   try {
@@ -73,9 +86,10 @@ function fallbackHex(color) {
 }
 
 function enhanceColor(color) {
-  const p3 = P3_ACCENTS_BY_FALLBACK[fallbackHex(color)];
+  const fallback = fallbackHex(color);
+  const p3 = P3_ACCENTS_BY_FALLBACK[fallback];
   if (!p3) return false;
-  setThreeColor(color, makeWideGamutSpec(fallbackHex(color), p3));
+  setThreeColor(color, makeWideGamutSpec(fallback, p3));
   return true;
 }
 
@@ -87,9 +101,16 @@ export function enhanceWideGamutScene(root) {
     if (!node?.material) return;
     const materials = Array.isArray(node.material) ? node.material : [node.material];
     for (const material of materials) {
-      if (enhanceColor(material?.color)) enhanced += 1;
-      if (enhanceColor(material?.emissive)) enhanced += 1;
-      if (enhanced && material) material.needsUpdate = true;
+      let materialEnhanced = false;
+      if (enhanceColor(material?.color)) {
+        enhanced += 1;
+        materialEnhanced = true;
+      }
+      if (enhanceColor(material?.emissive)) {
+        enhanced += 1;
+        materialEnhanced = true;
+      }
+      if (materialEnhanced) material.needsUpdate = true;
     }
   });
   return enhanced;
@@ -100,6 +121,7 @@ export function installWideGamutRuntime(runtime = globalThis.__turnRuntime) {
     return globalThis.__turnWideGamutRuntime || null;
   }
 
+  installWideGamutRendererPatch();
   const apply = () => {
     configureRendererWideGamut(runtime.renderer);
     enhanceWideGamutScene(runtime.scene || runtime.world);
@@ -110,6 +132,7 @@ export function installWideGamutRuntime(runtime = globalThis.__turnRuntime) {
     apply();
     requestAnimationFrame(apply);
     globalThis.setTimeout?.(apply, 180);
+    globalThis.setTimeout?.(apply, 900);
   };
 
   window.addEventListener('turn:track-changed', scheduleApply);


### PR DESCRIPTION
## Summary
- add three 25-trophy hidden achievements: Find Lilya, Find Darvid and Satan’s Sedan
- keep their titles visible as clues while masking the locked descriptions
- award the discoveries from the existing Midnight City portrait, Harbor face and Super Sedan colour-code interaction
- add Paintjob at 500 trophies and Monster Truck at 700 trophies
- preserve paint access and Monster Truck ownership for every profile that predates these new gates
- give each vehicle a distinctive factory colour before Paintjob, with Training Car yellow, Future Racer cyan and Monster Truck military green
- keep unselected Lot cars dark while retaining a subtle hint of their factory colour
- progressively enable Display P3 for factory paint, emergency lights, neon and other mapped accent colours, with sRGB fallbacks
- add a rotating Monster Truck reward preview and new Paintjob/Monster Trophy Road artwork

## Progression
- Trophy Road: 300 Midnight City, 400 Future Racer, 500 Paintjob, 600 Emergency Pack, 700 Monster Truck
- current collection: 25 achievements and 1,375 available trophies
- trophies and existing rewards remain permanent

## Accessibility and migration
- hidden cards state that the title is the clue instead of exposing the solution
- Paintjob lock information is a real button using TURN’s vector lock and shared Trophy Road notice
- fixed emergency liveries remain inspectable and unchanged
- version-3 Trophy Road profiles retain newly gated paint and Monster access without false reward notifications
- pre-Trophy Road profiles remain fully grandfathered

## Validation
- complete TURN regression suite passed
- Drive By Ear training regression passed
- added coverage for hidden discovery signals, reward migration, factory paint gating, Monster Truck access, Display P3 fallbacks and tinted Lot silhouettes