### PR TITLE
Fix Trophy Road first-tap details and add 1000 TBA marker

### DIFF
--- a/turn-lab/tests/achievements-production.mjs
+++ b/turn-lab/tests/achievements-production.mjs
@@ -122,8 +122,14 @@ for (const id of ['find-lilya', 'find-darvid', 'satans-sedan']) {
   assert.equal(achievement?.trophies, 25, `${id} should award 25 trophies`);
   assert.equal(achievement?.category, 'exploration');
 }
-assert.equal(ACHIEVEMENTS.find((item) => item.id === 'find-lilya')?.title, 'FIND LILYA!');
-assert.equal(ACHIEVEMENTS.find((item) => item.id === 'find-darvid')?.title, 'FIND DARVID!');
+assert.equal(
+  ACHIEVEMENTS.find((item) => item.id === 'find-lilya')?.title,
+  'FIND LILYA AFTER MIDNIGHT!'
+);
+assert.equal(
+  ACHIEVEMENTS.find((item) => item.id === 'find-darvid')?.title,
+  'FIND DARVID AT THE HARBOR!'
+);
 assert.equal(ACHIEVEMENTS.find((item) => item.id === 'satans-sedan')?.title, 'SATAN’S SEDAN');
 
 assert.deepEqual(
@@ -269,6 +275,8 @@ assert.doesNotMatch(catalog, /points:/);
 assert.match(secretCatalog, /id: 'find-lilya'/);
 assert.match(secretCatalog, /id: 'find-darvid'/);
 assert.match(secretCatalog, /id: 'satans-sedan'/);
+assert.match(secretCatalog, /title: 'FIND LILYA AFTER MIDNIGHT!'/);
+assert.match(secretCatalog, /title: 'FIND DARVID AT THE HARBOR!'/);
 assert.match(secretCatalog, /title: 'SATAN’S SEDAN'/);
 assert.equal((secretCatalog.match(/trophies: 25/g) || []).length, 3);
 assert.equal((secretCatalog.match(/hidden: true/g) || []).length, 3);

--- a/turn-lab/tests/trophy-road-production.mjs
+++ b/turn-lab/tests/trophy-road-production.mjs
@@ -310,10 +310,16 @@ assert.doesNotMatch(feedback, /pointerdown|pointermove|setPointerCapture/,
 assert.match(feedback, /createTrophyRoadShowcase/);
 assert.match(feedback, /TROPHY_ROAD_REWARD_ICONS/);
 assert.match(feedback, /selectedByPlayer = ''/);
-assert.match(feedback, /selectedByPlayer = marker\.dataset\.trophyReward;[\s\S]*preserveUserSelection\(\);/,
-  'Reward details must synchronize after the base view finishes the same click');
+assert.match(feedback, /selectedByPlayer = markerSelectionId\(marker\)/);
+assert.match(feedback, /\{ capture: true \}\)/,
+  'Reward selection must be captured before the base view replaces nested SVG event targets');
+assert.match(feedback, /The base view rebuilds every reward button/);
 assert.doesNotMatch(feedback, /queueMicrotask\(preserveUserSelection\)/,
   'Reward selection must not race a deferred duplicate render');
+assert.match(feedback, /TBA_MILESTONE[\s\S]*threshold: 1000/);
+assert.match(feedback, /data-trophy-placeholder/);
+assert.match(feedback, /renderTbaDetail/);
+assert.match(feedback, /Future Trophy Road reward is reserved here|future Trophy Road reward is reserved here/);
 assert.match(feedback, /reward\.type === 'feature'/,
   'Paintjob should retain its static reward artwork rather than requesting a vehicle showcase');
 assert.match(feedback, /clearSelection\(\)/);
@@ -430,4 +436,4 @@ assert.match(emergencyLiveries, /makeWideGamutSpec/);
 
 assert.match(workflow, /Run Trophy Road progression regression/);
 
-console.log('TURN Trophy Road paint, Monster, wide-gamut and progression regression passed.');
+console.log('TURN Trophy Road first-tap, TBA, paint, Monster and wide-gamut regression passed.');

--- a/turn/achievements/secret-catalog.js
+++ b/turn/achievements/secret-catalog.js
@@ -4,7 +4,7 @@ export const SECRET_ACHIEVEMENTS = Object.freeze([
     category: 'exploration',
     trophies: 25,
     hidden: true,
-    title: 'FIND LILYA!',
+    title: 'FIND LILYA AFTER MIDNIGHT!',
     description: 'Find the hidden Lilya portrait in Midnight City.',
     icon: 'spectate'
   }),
@@ -13,7 +13,7 @@ export const SECRET_ACHIEVEMENTS = Object.freeze([
     category: 'exploration',
     trophies: 25,
     hidden: true,
-    title: 'FIND DARVID!',
+    title: 'FIND DARVID AT THE HARBOR!',
     description: 'Find Darvid’s hidden face in Harbor.',
     icon: 'spectate'
   }),

--- a/turn/achievements/trophy-road-feedback.js
+++ b/turn/achievements/trophy-road-feedback.js
@@ -9,6 +9,13 @@ import {
 } from '../progression/trophy-road.js?revision=r157-paint-monster';
 
 const EDGE_PX = 34;
+const TBA_MILESTONE = Object.freeze({
+  id: 'tba-1000',
+  threshold: 1000,
+  title: 'TBA',
+  description: 'A future Trophy Road reward is reserved here. Details to be announced.'
+});
+const TBA_ICON = '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><circle cx="32" cy="24" r="18"></circle><path d="M24 18c1-6 15-7 16 0 1 5-7 6-8 11M32 36h.01"></path></svg>';
 const CATEGORY_FILTERS = Object.freeze([
   Object.freeze({ id: CATEGORY.ONBOARDING, label: 'GETTING STARTED' }),
   Object.freeze({ id: CATEGORY.WAYS_TO_PLAY, label: 'WAYS TO PLAY' }),
@@ -212,6 +219,40 @@ function installRoadBehavior({ achievements, summary }) {
   let selectedByPlayer = '';
   let geometryFrame = 0;
 
+  function markerSelectionId(marker) {
+    return marker?.dataset?.trophyReward || marker?.dataset?.trophyPlaceholder || '';
+  }
+
+  function ensureTbaMarker() {
+    let marker = markers.querySelector(`[data-trophy-placeholder="${TBA_MILESTONE.id}"]`);
+    if (marker) return marker;
+
+    marker = document.createElement('button');
+    marker.type = 'button';
+    marker.className = 'turn-trophy-road-marker is-locked is-tba';
+    marker.dataset.trophyPlaceholder = TBA_MILESTONE.id;
+    marker.dataset.trophyThreshold = String(TBA_MILESTONE.threshold);
+    marker.setAttribute('aria-pressed', 'false');
+    marker.setAttribute(
+      'aria-label',
+      `${TBA_MILESTONE.title}. ${TBA_MILESTONE.threshold} trophies. Future reward details to be announced.`
+    );
+    marker.innerHTML = `<span class="turn-trophy-road-marker-icon" aria-hidden="true">${TBA_ICON}</span><b>${TBA_MILESTONE.threshold}</b>`;
+    markers.appendChild(marker);
+    return marker;
+  }
+
+  function renderTbaDetail() {
+    if (!summary.detail) return;
+    summary.detail.innerHTML = `
+      <div class="turn-trophy-road-detail-icon" aria-hidden="true">${TBA_ICON}</div>
+      <div>
+        <span>${TBA_MILESTONE.threshold} TROPHIES · TBA</span>
+        <h3>${TBA_MILESTONE.title}</h3>
+        <p>${TBA_MILESTONE.description}</p>
+      </div>`;
+  }
+
   function updateScrollButtons() {
     const maximum = Math.max(0, summary.scroll.scrollWidth - summary.scroll.clientWidth);
     const atStart = summary.scroll.scrollLeft <= 1;
@@ -232,12 +273,13 @@ function installRoadBehavior({ achievements, summary }) {
       const contentWidth = Math.ceil(contentRoadWidth + EDGE_PX * 2);
       summary.content.style.width = `${contentWidth}px`;
 
-      for (const marker of markers.querySelectorAll('[data-trophy-reward]')) {
+      for (const marker of markers.querySelectorAll('[data-trophy-reward], [data-trophy-placeholder]')) {
         const reward = getTrophyRoadReward(marker.dataset.trophyReward);
-        if (!reward) continue;
+        const threshold = reward?.threshold ?? Number(marker.dataset.trophyThreshold);
+        if (!Number.isFinite(threshold)) continue;
         marker.style.setProperty(
           '--turn-trophy-road-position',
-          `${EDGE_PX + (reward.threshold / TROPHY_ROAD_MAX_THRESHOLD) * contentRoadWidth}px`
+          `${EDGE_PX + (threshold / TROPHY_ROAD_MAX_THRESHOLD) * contentRoadWidth}px`
         );
       }
       updateScrollButtons();
@@ -246,6 +288,7 @@ function installRoadBehavior({ achievements, summary }) {
   }
 
   function decorateMarkers() {
+    ensureTbaMarker();
     for (const marker of markers.querySelectorAll('[data-trophy-reward]')) {
       const reward = getTrophyRoadReward(marker.dataset.trophyReward);
       const icon = marker.querySelector('span');
@@ -268,7 +311,13 @@ function installRoadBehavior({ achievements, summary }) {
   function syncShowcase() {
     const reward = getTrophyRoadReward(selectedByPlayer);
     const host = summary.detail?.querySelector('.turn-trophy-road-detail-icon');
-    if (!reward || !host || reward.type === 'track' || reward.type === 'feature') {
+    if (
+      selectedByPlayer === TBA_MILESTONE.id
+      || !reward
+      || !host
+      || reward.type === 'track'
+      || reward.type === 'feature'
+    ) {
       showcase.clear();
       return;
     }
@@ -280,7 +329,7 @@ function installRoadBehavior({ achievements, summary }) {
   function clearSelection() {
     selectedByPlayer = '';
     showcase.clear();
-    for (const marker of markers.querySelectorAll('[data-trophy-reward]')) {
+    for (const marker of markers.querySelectorAll('[data-trophy-reward], [data-trophy-placeholder]')) {
       marker.classList.remove('is-selected');
       marker.setAttribute('aria-pressed', 'false');
     }
@@ -298,11 +347,12 @@ function installRoadBehavior({ achievements, summary }) {
       clearSelection();
       return;
     }
-    for (const marker of markers.querySelectorAll('[data-trophy-reward]')) {
-      const selected = marker.dataset.trophyReward === selectedByPlayer;
+    for (const marker of markers.querySelectorAll('[data-trophy-reward], [data-trophy-placeholder]')) {
+      const selected = markerSelectionId(marker) === selectedByPlayer;
       marker.classList.toggle('is-selected', selected);
       marker.setAttribute('aria-pressed', String(selected));
     }
+    if (selectedByPlayer === TBA_MILESTONE.id) renderTbaDetail();
     if (summary.detail) summary.detail.hidden = false;
     if (summary.help) summary.help.hidden = true;
     syncShowcase();
@@ -326,12 +376,15 @@ function installRoadBehavior({ achievements, summary }) {
     scrollRoad(event.key === 'ArrowLeft' ? -1 : 1);
   });
 
+  // The base view rebuilds every reward button during its bubble-phase click handler.
+  // Capture the connected marker first so nested SVG taps cannot lose their selection
+  // when WebKit detaches the original event target before this enhancement can read it.
   markers.addEventListener('click', (event) => {
-    const marker = event.target.closest('[data-trophy-reward]');
+    const marker = event.target.closest('[data-trophy-reward], [data-trophy-placeholder]');
     if (!marker) return;
-    selectedByPlayer = marker.dataset.trophyReward;
-    preserveUserSelection();
-  });
+    selectedByPlayer = markerSelectionId(marker);
+    if (marker.dataset.trophyPlaceholder) preserveUserSelection();
+  }, { capture: true });
 
   const markerObserver = new MutationObserver(preserveUserSelection);
   markerObserver.observe(markers, { childList: true });


### PR DESCRIPTION
## Summary
- capture Trophy Road marker selection before the base view replaces the tapped SVG/button subtree
- keep reward details synchronized on the first tap instead of requiring a second tap
- add a presentation-only TBA milestone at 1000 trophies without introducing or unlocking new content
- give the Lilya and Darvid hidden achievements actual location clues in their titles

## Cause
The base achievement view rebuilds all Trophy Road marker buttons during its bubble-phase click handler. On iOS/WebKit, taps landing on nested SVG content can leave the later enhancement listener reading a detached event target. The mutation observer then sees no retained selection and clears the freshly rendered detail card. A second tap often lands on the rebuilt button and succeeds.

The fix records the connected marker in the capture phase, before the base view mutates the marker subtree. The existing mutation observer can then safely restore the selected state and model/static artwork after the render.

## Validation
- complete TURN regression suite passed
- source regression covers capture-phase selection and the 1000-trophy placeholder
- hidden achievement regression covers the new clue titles