### PR TITLE
Hotfix race freeze after Trophy Road marker update

### DIFF
--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -146,7 +146,7 @@ const releaseTarget = (filePath) => `${filePath}?build=${release.cacheKey}`;
 assert.match(index, new RegExp(`TURN v${release.version.replaceAll('.', '\\.')} · Build ${release.id.replaceAll('.', '\\.')}`));
 assert.match(index, new RegExp(`\\.\\/garage\\/lot-r10\\.css\\?build=${release.cacheKey}`));
 assert.match(index, new RegExp(`\\.\\/track-intro\\.css\\?build=${release.cacheKey}`));
-assert.match(index, new RegExp(`src="\\.\\/app\\.js\\?build=${release.cacheKey}-browser-consent"`));
+assert.match(index, new RegExp(`src="\\.\\/app\\.js\\?build=${release.cacheKey}-browser-consent(?:-[^"]+)?"`));
 assert.equal(imports['./garage/lot-r10.js?build=20260720-r19'], releaseTarget('./garage/lot-track-select.js'));
 assert.equal(imports['./ui/track-intro.js?build=20260725-r75'], releaseTarget('./ui/track-intro.js'));
 assert.equal(imports['./race/lap-system.js?build=20260720-r19'], releaseTarget('./race/lap-system-r86.js'));

--- a/turn-lab/tests/trophy-road-production.mjs
+++ b/turn-lab/tests/trophy-road-production.mjs
@@ -310,16 +310,10 @@ assert.doesNotMatch(feedback, /pointerdown|pointermove|setPointerCapture/,
 assert.match(feedback, /createTrophyRoadShowcase/);
 assert.match(feedback, /TROPHY_ROAD_REWARD_ICONS/);
 assert.match(feedback, /selectedByPlayer = ''/);
-assert.match(feedback, /selectedByPlayer = markerSelectionId\(marker\)/);
-assert.match(feedback, /\{ capture: true \}\)/,
-  'Reward selection must be captured before the base view replaces nested SVG event targets');
-assert.match(feedback, /The base view rebuilds every reward button/);
+assert.match(feedback, /selectedByPlayer = marker\.dataset\.trophyReward;[\s\S]*preserveUserSelection\(\);/,
+  'Reward details must synchronize after the base view finishes the same click');
 assert.doesNotMatch(feedback, /queueMicrotask\(preserveUserSelection\)/,
   'Reward selection must not race a deferred duplicate render');
-assert.match(feedback, /TBA_MILESTONE[\s\S]*threshold: 1000/);
-assert.match(feedback, /data-trophy-placeholder/);
-assert.match(feedback, /renderTbaDetail/);
-assert.match(feedback, /Future Trophy Road reward is reserved here|future Trophy Road reward is reserved here/);
 assert.match(feedback, /reward\.type === 'feature'/,
   'Paintjob should retain its static reward artwork rather than requesting a vehicle showcase');
 assert.match(feedback, /clearSelection\(\)/);
@@ -436,4 +430,4 @@ assert.match(emergencyLiveries, /makeWideGamutSpec/);
 
 assert.match(workflow, /Run Trophy Road progression regression/);
 
-console.log('TURN Trophy Road first-tap, TBA, paint, Monster and wide-gamut regression passed.');
+console.log('TURN Trophy Road paint, Monster, wide-gamut and progression regression passed.');

--- a/turn-tests/turn-next-entry-production.mjs
+++ b/turn-tests/turn-next-entry-production.mjs
@@ -65,7 +65,10 @@ assert.equal(release.cacheKey, release.id.replaceAll('.', ''));
 
 assert.match(productionIndex, new RegExp(`TURN v${release.version.replaceAll('.', '\\.')} · Build ${release.id.replaceAll('.', '\\.')}`));
 assert.match(productionIndex, /<meta name="theme-color" content="#08090a">/);
-assert.match(productionIndex, new RegExp(`src="\\.\\/app\\.js\\?build=${release.cacheKey}-browser-consent"`));
+assert.match(
+  productionIndex,
+  new RegExp(`src="\\.\\/app\\.js\\?build=${release.cacheKey}-browser-consent(?:-[^"]+)?"`)
+);
 assert.match(productionIndex, new RegExp(`src="\\.\\/install-gate\\.js\\?build=${release.cacheKey}-social-browser"`));
 assert.match(productionIndex, new RegExp(`href="\\.\\/install-gate\\.css\\?build=${release.cacheKey}-social-browser"`));
 assert.match(productionIndex, new RegExp(`href="\\.\\/orientation-guard\\.css\\?build=${release.cacheKey}-home-portrait"`));

--- a/turn/achievements/trophy-road-feedback.js
+++ b/turn/achievements/trophy-road-feedback.js
@@ -9,13 +9,6 @@ import {
 } from '../progression/trophy-road.js?revision=r157-paint-monster';
 
 const EDGE_PX = 34;
-const TBA_MILESTONE = Object.freeze({
-  id: 'tba-1000',
-  threshold: 1000,
-  title: 'TBA',
-  description: 'A future Trophy Road reward is reserved here. Details to be announced.'
-});
-const TBA_ICON = '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><circle cx="32" cy="24" r="18"></circle><path d="M24 18c1-6 15-7 16 0 1 5-7 6-8 11M32 36h.01"></path></svg>';
 const CATEGORY_FILTERS = Object.freeze([
   Object.freeze({ id: CATEGORY.ONBOARDING, label: 'GETTING STARTED' }),
   Object.freeze({ id: CATEGORY.WAYS_TO_PLAY, label: 'WAYS TO PLAY' }),
@@ -219,40 +212,6 @@ function installRoadBehavior({ achievements, summary }) {
   let selectedByPlayer = '';
   let geometryFrame = 0;
 
-  function markerSelectionId(marker) {
-    return marker?.dataset?.trophyReward || marker?.dataset?.trophyPlaceholder || '';
-  }
-
-  function ensureTbaMarker() {
-    let marker = markers.querySelector(`[data-trophy-placeholder="${TBA_MILESTONE.id}"]`);
-    if (marker) return marker;
-
-    marker = document.createElement('button');
-    marker.type = 'button';
-    marker.className = 'turn-trophy-road-marker is-locked is-tba';
-    marker.dataset.trophyPlaceholder = TBA_MILESTONE.id;
-    marker.dataset.trophyThreshold = String(TBA_MILESTONE.threshold);
-    marker.setAttribute('aria-pressed', 'false');
-    marker.setAttribute(
-      'aria-label',
-      `${TBA_MILESTONE.title}. ${TBA_MILESTONE.threshold} trophies. Future reward details to be announced.`
-    );
-    marker.innerHTML = `<span class="turn-trophy-road-marker-icon" aria-hidden="true">${TBA_ICON}</span><b>${TBA_MILESTONE.threshold}</b>`;
-    markers.appendChild(marker);
-    return marker;
-  }
-
-  function renderTbaDetail() {
-    if (!summary.detail) return;
-    summary.detail.innerHTML = `
-      <div class="turn-trophy-road-detail-icon" aria-hidden="true">${TBA_ICON}</div>
-      <div>
-        <span>${TBA_MILESTONE.threshold} TROPHIES · TBA</span>
-        <h3>${TBA_MILESTONE.title}</h3>
-        <p>${TBA_MILESTONE.description}</p>
-      </div>`;
-  }
-
   function updateScrollButtons() {
     const maximum = Math.max(0, summary.scroll.scrollWidth - summary.scroll.clientWidth);
     const atStart = summary.scroll.scrollLeft <= 1;
@@ -273,13 +232,12 @@ function installRoadBehavior({ achievements, summary }) {
       const contentWidth = Math.ceil(contentRoadWidth + EDGE_PX * 2);
       summary.content.style.width = `${contentWidth}px`;
 
-      for (const marker of markers.querySelectorAll('[data-trophy-reward], [data-trophy-placeholder]')) {
+      for (const marker of markers.querySelectorAll('[data-trophy-reward]')) {
         const reward = getTrophyRoadReward(marker.dataset.trophyReward);
-        const threshold = reward?.threshold ?? Number(marker.dataset.trophyThreshold);
-        if (!Number.isFinite(threshold)) continue;
+        if (!reward) continue;
         marker.style.setProperty(
           '--turn-trophy-road-position',
-          `${EDGE_PX + (threshold / TROPHY_ROAD_MAX_THRESHOLD) * contentRoadWidth}px`
+          `${EDGE_PX + (reward.threshold / TROPHY_ROAD_MAX_THRESHOLD) * contentRoadWidth}px`
         );
       }
       updateScrollButtons();
@@ -288,7 +246,6 @@ function installRoadBehavior({ achievements, summary }) {
   }
 
   function decorateMarkers() {
-    ensureTbaMarker();
     for (const marker of markers.querySelectorAll('[data-trophy-reward]')) {
       const reward = getTrophyRoadReward(marker.dataset.trophyReward);
       const icon = marker.querySelector('span');
@@ -311,13 +268,7 @@ function installRoadBehavior({ achievements, summary }) {
   function syncShowcase() {
     const reward = getTrophyRoadReward(selectedByPlayer);
     const host = summary.detail?.querySelector('.turn-trophy-road-detail-icon');
-    if (
-      selectedByPlayer === TBA_MILESTONE.id
-      || !reward
-      || !host
-      || reward.type === 'track'
-      || reward.type === 'feature'
-    ) {
+    if (!reward || !host || reward.type === 'track' || reward.type === 'feature') {
       showcase.clear();
       return;
     }
@@ -329,7 +280,7 @@ function installRoadBehavior({ achievements, summary }) {
   function clearSelection() {
     selectedByPlayer = '';
     showcase.clear();
-    for (const marker of markers.querySelectorAll('[data-trophy-reward], [data-trophy-placeholder]')) {
+    for (const marker of markers.querySelectorAll('[data-trophy-reward]')) {
       marker.classList.remove('is-selected');
       marker.setAttribute('aria-pressed', 'false');
     }
@@ -347,12 +298,11 @@ function installRoadBehavior({ achievements, summary }) {
       clearSelection();
       return;
     }
-    for (const marker of markers.querySelectorAll('[data-trophy-reward], [data-trophy-placeholder]')) {
-      const selected = markerSelectionId(marker) === selectedByPlayer;
+    for (const marker of markers.querySelectorAll('[data-trophy-reward]')) {
+      const selected = marker.dataset.trophyReward === selectedByPlayer;
       marker.classList.toggle('is-selected', selected);
       marker.setAttribute('aria-pressed', String(selected));
     }
-    if (selectedByPlayer === TBA_MILESTONE.id) renderTbaDetail();
     if (summary.detail) summary.detail.hidden = false;
     if (summary.help) summary.help.hidden = true;
     syncShowcase();
@@ -376,15 +326,12 @@ function installRoadBehavior({ achievements, summary }) {
     scrollRoad(event.key === 'ArrowLeft' ? -1 : 1);
   });
 
-  // The base view rebuilds every reward button during its bubble-phase click handler.
-  // Capture the connected marker first so nested SVG taps cannot lose their selection
-  // when WebKit detaches the original event target before this enhancement can read it.
   markers.addEventListener('click', (event) => {
-    const marker = event.target.closest('[data-trophy-reward], [data-trophy-placeholder]');
+    const marker = event.target.closest('[data-trophy-reward]');
     if (!marker) return;
-    selectedByPlayer = markerSelectionId(marker);
-    if (marker.dataset.trophyPlaceholder) preserveUserSelection();
-  }, { capture: true });
+    selectedByPlayer = marker.dataset.trophyReward;
+    preserveUserSelection();
+  });
 
   const markerObserver = new MutationObserver(preserveUserSelection);
   markerObserver.observe(markers, { childList: true });

--- a/turn/app.js
+++ b/turn/app.js
@@ -242,7 +242,7 @@ if (buildLabel) {
   buildLabel.textContent = `TURN V${release?.version || ''} · BUILD ${(release?.id || '').toUpperCase()}`;
 }
 const { installM8HomeFixedLayout } = await import(
-  withBuild('./m8-home-fixed-layout.js?revision=m8.9-track-title-alignment&trophy-road=r157')
+  withBuild('./m8-home-fixed-layout.js?revision=m8.9-track-title-alignment&trophy-road=r158-race-freeze-hotfix')
 );
 await installM8HomeFixedLayout();
 installStylesheet(

--- a/turn/app.js
+++ b/turn/app.js
@@ -242,7 +242,7 @@ if (buildLabel) {
   buildLabel.textContent = `TURN V${release?.version || ''} · BUILD ${(release?.id || '').toUpperCase()}`;
 }
 const { installM8HomeFixedLayout } = await import(
-  withBuild('./m8-home-fixed-layout.js?revision=m8.9-track-title-alignment&trophy-road=r158-race-freeze-hotfix')
+  withBuild('./m8-home-fixed-layout.js?revision=m8.9-track-title-alignment&trophy-road=r157&hotfix=r158-race-freeze')
 );
 await installM8HomeFixedLayout();
 installStylesheet(

--- a/turn/index.html
+++ b/turn/index.html
@@ -181,5 +181,5 @@
   </div>
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
-  <script type="module" src="./app.js?build=20260803-r126-browser-consent"></script>
+  <script type="module" src="./app.js?build=20260803-r126-browser-consent-r158-race-freeze"></script>
 </body></html>

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -113,7 +113,7 @@ export async function installM8HomeFixedLayout() {
   );
   const secretAchievements = installSecretAchievements(achievements);
   const { installTrophyRoadFeedback } = await import(
-    `/turn/achievements/trophy-road-feedback.js?build=${buildKey}-r157-paint-monster`
+    `/turn/achievements/trophy-road-feedback.js?build=${buildKey}-r158-race-freeze-hotfix`
   );
   const trophyRoadFeedback = installTrophyRoadFeedback(achievements);
 


### PR DESCRIPTION
## Critical hotfix
- revert the Trophy Road marker runtime introduced in #316 to the last known stable implementation
- remove the dynamically injected 1000-trophy TBA marker and capture-phase marker handler from production for now
- retain the improved Lilya and Darvid clue titles
- force new app, Home layout and Trophy Road feedback URLs so installed PWAs do not keep the faulty cached module

## Cause
The regression was isolated to the new Trophy Road feedback runtime from #316. Its dynamically injected marker and capture/mutation synchronization remained active outside the open achievements dialog and interfered with the Home-to-race transition. The hotfix restores the previously tested runtime rather than attempting another complex event-order correction in the critical path.

## Validation
- complete TURN regression suite passed
- Drive By Ear training regression passed
- release and TURN NEXT parity checks passed
- production race, Home navigation, garage, Trophy Road and achievement regressions passed

## Follow-up
The 1000-trophy TBA marker and first-tap fix will be reintroduced separately with a browser-level race-entry regression rather than as a DOM enhancement layered over the base marker renderer.