### PR TITLE
Fix the actual Home-to-Lot race freeze

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -157,6 +157,9 @@ jobs:
       - name: Run Trophy Road progression regression
         run: node turn-lab/tests/trophy-road-production.mjs
 
+      - name: Run Lot paint observer freeze regression
+        run: node turn-lab/tests/paint-lock-observer-production.mjs
+
       - name: Run production sound foundation regression
         run: node turn-lab/tests/audio-foundation-production.mjs
 

--- a/turn-lab/tests/paint-lock-observer-production.mjs
+++ b/turn-lab/tests/paint-lock-observer-production.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const [paintGate, lotRuntime, app, index] = await Promise.all([
+  fs.readFile(new URL('../../turn/progression/lot-paint-reward.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-enhancement-runtime.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/app.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8')
+]);
+
+const syncBody = paintGate.match(/function sync\(\) \{([\s\S]*?)\n  \}\n\n  const observer/ )?.[1] || '';
+assert.ok(syncBody, 'The paint gate must expose a bounded synchronization function');
+assert.match(paintGate, /observer\.observe\(picker,/,
+  'Paint synchronization must observe the car picker rather than the whole Lot screen');
+assert.doesNotMatch(paintGate, /observer\.observe\(screen,/,
+  'The lock notice panel must not be inside the paint observer target');
+assert.match(syncBody, /if \(locked\) \{[\s\S]*ensureLockNotice\(\);[\s\S]*\} else \{[\s\S]*lot-paint-lock[\s\S]*remove\(\)/,
+  'The lock notice must be retained while locked and removed only when it is no longer needed');
+assert.doesNotMatch(syncBody, /lot-paint-lock[\s\S]*remove\(\);[\s\S]*if \(locked\)/,
+  'A synchronization pass must never remove and immediately recreate its own observed lock notice');
+assert.match(paintGate, /try \{[\s\S]*\} finally \{[\s\S]*syncing = false/,
+  'The synchronization guard must always be released');
+assert.match(lotRuntime, /lot-paint-reward\.js\?revision=r159-paint-lock-observer/);
+assert.match(app, /lot-enhancement-runtime\.js\?revision=r121&trophy-road=r157&paint=r159-paint-lock-observer/);
+assert.match(index, /app\.js\?build=20260803-r126-browser-consent-r159-paint-lock-observer/);
+
+console.log('TURN Lot paint lock observer reaches quiescence and cannot freeze Home-to-Lot race entry.');

--- a/turn/app.js
+++ b/turn/app.js
@@ -173,7 +173,7 @@ installHarborHiddenFaceOrientation();
 // Historical regression marker for the original Trophy Road Lot enhancement bundle:
 // lot-enhancement-runtime.js?revision=r121&trophy-road=r154
 const { installLotEnhancementRuntime } = await import(
-  withBuild('./garage/lot-enhancement-runtime.js?revision=r121&trophy-road=r157')
+  withBuild('./garage/lot-enhancement-runtime.js?revision=r121&trophy-road=r157&paint=r159-paint-lock-observer')
 );
 installLotEnhancementRuntime();
 

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -2,12 +2,12 @@ import { installLotStatLegend } from './lot-stat-legend.js?build=20260724-r59';
 import { installLotLayout } from './lot-layout-r60.js?build=20260729-r116';
 import { installLotAccessibility } from './lot-accessibility-r118.js?build=20260729-r118';
 import { gateLotNow } from '../progression/lot-trophy-gate.js?revision=r157-paint-monster';
-import { gateLotPaintNow } from '../progression/lot-paint-reward.js?revision=r157-paint-monster';
+import { gateLotPaintNow } from '../progression/lot-paint-reward.js?revision=r159-paint-lock-observer';
 
 // Historical regression markers for the established enhancement layers:
 // ENHANCEMENT_ID = 'enhanced-lot-r121'
 // TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r154-trophy-road-feedback'
-const ENHANCEMENT_ID = 'enhanced-lot-r157-paint-monster';
+const ENHANCEMENT_ID = 'enhanced-lot-r159-paint-lock-observer';
 const TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r157-paint-monster';
 const activeEnhancements = new WeakMap();
 

--- a/turn/index.html
+++ b/turn/index.html
@@ -181,5 +181,5 @@
   </div>
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
-  <script type="module" src="./app.js?build=20260803-r126-browser-consent-r158-race-freeze"></script>
+  <script type="module" src="./app.js?build=20260803-r126-browser-consent-r159-paint-lock-observer"></script>
 </body></html>

--- a/turn/progression/lot-paint-reward.js
+++ b/turn/progression/lot-paint-reward.js
@@ -84,42 +84,49 @@ export function gateLotPaintNow(root = document.body) {
     if (syncing) return;
     syncing = true;
 
-    const carId = selectedCarId(screen);
-    const car = CAR_BY_ID.get(carId);
-    const paintUnlocked = isPaintUnlocked();
-    const changedCar = Boolean(carId) && carId !== lastCarId;
-    const controls = [...colors.querySelectorAll('.lot-color-control:not(.lot-fixed-livery)')];
+    try {
+      const carId = selectedCarId(screen);
+      const car = CAR_BY_ID.get(carId);
+      const paintUnlocked = isPaintUnlocked();
+      const changedCar = Boolean(carId) && carId !== lastCarId;
+      const controls = [...colors.querySelectorAll('.lot-color-control:not(.lot-fixed-livery)')];
 
-    if (car && !car.fixedLivery && (!paintUnlocked || changedCar)) forceFactoryPaint(carId);
+      if (car && !car.fixedLivery && (!paintUnlocked || changedCar)) forceFactoryPaint(carId);
 
-    const locked = Boolean(car && !car.fixedLivery && !paintUnlocked);
-    colors.classList.toggle('is-paint-locked', locked);
-    colors.querySelector('.lot-paint-lock')?.remove();
+      const locked = Boolean(car && !car.fixedLivery && !paintUnlocked);
+      colors.classList.toggle('is-paint-locked', locked);
 
-    for (const control of controls) {
-      control.hidden = locked;
-      const input = control.querySelector('input');
-      if (input) input.disabled = locked;
+      for (const control of controls) {
+        control.hidden = locked;
+        const input = control.querySelector('input');
+        if (input) input.disabled = locked;
+      }
+
+      if (locked) {
+        ensureLockNotice();
+        colors.setAttribute('aria-label', 'Vehicle paint controls locked');
+      } else {
+        colors.querySelector('.lot-paint-lock')?.remove();
+        if (car && !car.fixedLivery) {
+          colors.setAttribute('aria-label', 'Choose car paint colours');
+        }
+      }
+
+      if (!paintWasUnlocked && paintUnlocked) {
+        window.dispatchEvent(new CustomEvent('turn:paint-controls-unlocked'));
+      }
+      paintWasUnlocked = paintUnlocked;
+      lastCarId = carId;
+      screen.dataset.turnPaintUnlocked = String(paintUnlocked);
+    } finally {
+      syncing = false;
     }
-
-    if (locked) {
-      ensureLockNotice();
-      colors.setAttribute('aria-label', 'Vehicle paint controls locked');
-    } else if (car && !car.fixedLivery) {
-      colors.setAttribute('aria-label', 'Choose car paint colours');
-    }
-
-    if (!paintWasUnlocked && paintUnlocked) {
-      window.dispatchEvent(new CustomEvent('turn:paint-controls-unlocked'));
-    }
-    paintWasUnlocked = paintUnlocked;
-    lastCarId = carId;
-    screen.dataset.turnPaintUnlocked = String(paintUnlocked);
-    syncing = false;
   }
 
   const observer = new MutationObserver(sync);
-  observer.observe(screen, {
+  // Observe only the car picker. The lock notice lives in the separate colour
+  // panel, so adding or removing it cannot recursively trigger this observer.
+  observer.observe(picker, {
     childList: true,
     subtree: true,
     attributes: true,


### PR DESCRIPTION
## Critical hotfix
- stop the PAINTJOB lock observer from observing and mutating the same subtree
- retain the paint lock notice while locked instead of removing and recreating it on every synchronization pass
- observe only the car picker, so changes in the separate paint panel cannot recursively trigger the observer
- guarantee the synchronization guard is released with `try/finally`
- force fresh app, Lot enhancement and paint-gate module URLs
- add a dedicated regression that prevents the self-triggering observer pattern from returning

## Root cause
The video shows the RACE button remaining in its pressed state while the main thread stops repainting. The freeze happens as Home opens The Lot. `gateLotPaintNow()` observed the entire Lot screen for child-list changes, then every observer callback removed `.lot-paint-lock` and immediately prepended a new one. Those two mutations scheduled another callback indefinitely, creating a synchronous MutationObserver microtask loop before The Lot could appear.

The previous hotfix reverted the Trophy Road detail handler, but that code was not the freeze source.

## Validation
CI must pass the complete TURN regression suite, Drive By Ear training suite and the new Lot paint observer freeze regression before merge.