### PR TITLE
Use each car colour for the locked Paintjob swatch

### DIFF
--- a/turn-lab/tests/paint-lock-observer-production.mjs
+++ b/turn-lab/tests/paint-lock-observer-production.mjs
@@ -17,8 +17,8 @@ assert.match(paintGate, /observer\.observe\(picker,/,
   'Paint synchronization must observe the car picker rather than the whole Lot screen');
 assert.doesNotMatch(paintGate, /observer\.observe\(screen,/,
   'The lock presentation must not be inside the paint observer target');
-assert.match(syncBody, /setLockedInteraction\(locked\)/,
-  'Paint synchronization must retain or remove the compact rail according to the current state');
+assert.match(syncBody, /setLockedInteraction\(locked, carId\)/,
+  'Paint synchronization must retain the compact rail and recolour its lock for the current car');
 assert.doesNotMatch(syncBody, /lot-paint-lock[\s\S]*remove\(\);[\s\S]*if \(locked\)/,
   'A synchronization pass must never remove and immediately recreate its own lock icon');
 assert.match(paintGate, /try \{[\s\S]*\} finally \{[\s\S]*syncing = false/,
@@ -30,7 +30,16 @@ assert.match(paintGate, /colors\.addEventListener\('keydown', handleLockedAreaKe
 assert.match(paintGate, /colors\.setAttribute\('role', 'button'\)/);
 assert.match(paintGate, /colors\.tabIndex = 0/);
 assert.match(paintGate, /lot-paint-lock-copy/);
-assert.match(paintGate, /<strong>Paintjob<\/strong><i>•<\/i><b>LOCKED<\/b>/);
+assert.match(paintGate, /<strong>PAINTJOB<\/strong>/);
+assert.doesNotMatch(paintGate, /<i>•<\/i>|<b>LOCKED<\/b>/,
+  'Visible lock-status copy must not crowd out the Paintjob label');
+assert.match(paintGate, /function contrastingInk\(hexColor\)/);
+assert.match(paintGate, /luminance > 0\.36 \? '#08090a' : '#fffdf6'/,
+  'The lock glyph must switch between dark and light ink according to the car colour');
+assert.match(paintGate, /--lot-paint-lock-background/);
+assert.match(paintGate, /--lot-paint-lock-foreground/);
+assert.match(paintGate, /getVehicleDefaultColor\(carId\)/,
+  'The locked swatch must represent the selected car factory colour');
 assert.doesNotMatch(paintGate, /document\.createElement\('button'\)[\s\S]*lot-paint-lock/,
   'The compact lock must not create a nested oversized button');
 assert.match(paintCss, /\.lot-colors\.is-paint-locked[\s\S]*min-height: 54px/);
@@ -48,12 +57,17 @@ const paintLockRule = paintCss.match(/\.lot-paint-lock\s*\{([\s\S]*?)\}/)?.[1] |
 assert.ok(paintLockRule, 'The compact paint lock must have its own CSS rule');
 assert.match(paintLockRule, /width: 36px/);
 assert.match(paintLockRule, /height: 36px/);
+assert.match(paintLockRule, /background: var\(--lot-paint-lock-background/);
+assert.match(paintLockRule, /color: var\(--lot-paint-lock-foreground/);
+assert.match(paintLockRule, /border: 2px solid var\(--turn-ink/,
+  'The swatch keeps the TURN black outline even when the lock glyph needs white contrast');
 assert.doesNotMatch(paintLockRule, /width: 100%/);
-assert.match(lotRuntime, /lot-paint-reward\.js\?revision=r160-bottom-paint-rail/);
-assert.match(app, /lot-enhancement-runtime\.js\?revision=r121&trophy-road=r159&paint=r159-paint-lock-observer/);
+assert.match(lotRuntime, /lot-paint-reward\.js\?revision=r161-car-colour-lock/);
+assert.match(app, /trophy-road-r157\.css\?revision=r161-car-colour-lock/);
+assert.match(app, /lot-enhancement-runtime\.js\?revision=r121&trophy-road=r159&paint=r161-car-colour-lock/);
 assert.match(
   index,
   new RegExp(`app\\.js\\?build=${release.cacheKey}-browser-consent-r160-reward-detail-paint-rail`)
 );
 
-console.log('TURN locked Paintjob rail remains compact, explainable, below the viewer and free from observer loops.');
+console.log('TURN Paintjob rail shows the full label and a contrast-safe factory-colour lock swatch.');

--- a/turn-lab/tests/paint-lock-observer-production.mjs
+++ b/turn-lab/tests/paint-lock-observer-production.mjs
@@ -67,7 +67,7 @@ assert.match(app, /trophy-road-r157\.css\?revision=r161-car-colour-lock/);
 assert.match(app, /lot-enhancement-runtime\.js\?revision=r121&trophy-road=r159&paint=r161-car-colour-lock/);
 assert.match(
   index,
-  new RegExp(`app\\.js\\?build=${release.cacheKey}-browser-consent-r160-reward-detail-paint-rail`)
+  new RegExp(`app\\.js\\?build=${release.cacheKey}-browser-consent-r161-paint-lock-colour`)
 );
 
 console.log('TURN Paintjob rail shows the full label and a contrast-safe factory-colour lock swatch.');

--- a/turn-lab/tests/paint-lock-observer-production.mjs
+++ b/turn-lab/tests/paint-lock-observer-production.mjs
@@ -34,8 +34,8 @@ assert.match(paintGate, /<strong>PAINTJOB<\/strong>/);
 assert.doesNotMatch(paintGate, /<i>•<\/i>|<b>LOCKED<\/b>/,
   'Visible lock-status copy must not crowd out the Paintjob label');
 assert.match(paintGate, /function contrastingInk\(hexColor\)/);
-assert.match(paintGate, /luminance > 0\.36 \? '#08090a' : '#fffdf6'/,
-  'The lock glyph must switch between dark and light ink according to the car colour');
+assert.match(paintGate, /luminance > 0\.18 \? '#08090a' : '#fffdf6'/,
+  'The lock glyph must use whichever TURN ink gives the stronger colour contrast');
 assert.match(paintGate, /--lot-paint-lock-background/);
 assert.match(paintGate, /--lot-paint-lock-foreground/);
 assert.match(paintGate, /getVehicleDefaultColor\(carId\)/,

--- a/turn-tests/startup-and-unread-production.mjs
+++ b/turn-tests/startup-and-unread-production.mjs
@@ -17,7 +17,7 @@ assert.deepEqual(release, {
   cacheKey: '20260805-r160'
 });
 assert.match(index, /TURN v1\.5\.1 · Build 2026\.08\.05-r160/);
-assert.match(index, /app\.js\?build=20260805-r160-browser-consent-r160-reward-detail-paint-rail/);
+assert.match(index, /app\.js\?build=20260805-r160-browser-consent-r161-paint-lock-colour/);
 assert.match(nextIndex, /TURN NEXT · Source TURN v1\.5\.1 · Build 2026\.08\.05-r160/);
 assert.match(nextIndex, /turn-next\/app\.js\?source=20260805-r160-browser-consent/);
 

--- a/turn/app.js
+++ b/turn/app.js
@@ -172,7 +172,7 @@ installStylesheet(
   'data-turn-lot-layout-r121'
 );
 installStylesheet(
-  './progression/trophy-road-r157.css?revision=r157-paint-monster',
+  './progression/trophy-road-r157.css?revision=r161-car-colour-lock',
   'data-turn-trophy-road'
 );
 const { prepareTrophyRoadProfile } = await import(
@@ -266,7 +266,7 @@ installHarborHiddenFaceOrientation();
 // lot-enhancement-runtime.js?revision=r121&trophy-road=r154
 // lot-enhancement-runtime.js?revision=r121&trophy-road=r157
 const { installLotEnhancementRuntime } = await import(
-  withBuild('./garage/lot-enhancement-runtime.js?revision=r121&trophy-road=r159&paint=r159-paint-lock-observer')
+  withBuild('./garage/lot-enhancement-runtime.js?revision=r121&trophy-road=r159&paint=r161-car-colour-lock')
 );
 installLotEnhancementRuntime();
 

--- a/turn/app.js
+++ b/turn/app.js
@@ -171,6 +171,8 @@ installStylesheet(
   './garage/lot-layout-r60.css?revision=r121-viewer-r122-fit-r128-super-sedan-notice-r129-race-button-fit',
   'data-turn-lot-layout-r121'
 );
+// Historical stylesheet bundle marker retained for the Trophy Road regression contract:
+// trophy-road-r157.css?revision=r157-paint-monster
 installStylesheet(
   './progression/trophy-road-r157.css?revision=r161-car-colour-lock',
   'data-turn-trophy-road'

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -2,12 +2,12 @@ import { installLotStatLegend } from './lot-stat-legend.js?build=20260724-r59';
 import { installLotLayout } from './lot-layout-r60.js?build=20260729-r116';
 import { installLotAccessibility } from './lot-accessibility-r118.js?build=20260729-r118';
 import { gateLotNow } from '../progression/lot-trophy-gate.js?revision=r157-paint-monster';
-import { gateLotPaintNow } from '../progression/lot-paint-reward.js?revision=r160-bottom-paint-rail';
+import { gateLotPaintNow } from '../progression/lot-paint-reward.js?revision=r161-car-colour-lock';
 
 // Historical regression markers for the established enhancement layers:
 // ENHANCEMENT_ID = 'enhanced-lot-r121'
 // TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r154-trophy-road-feedback'
-const ENHANCEMENT_ID = 'enhanced-lot-r160-bottom-paint-rail';
+const ENHANCEMENT_ID = 'enhanced-lot-r161-car-colour-lock';
 const TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r157-paint-monster';
 const activeEnhancements = new WeakMap();
 

--- a/turn/index.html
+++ b/turn/index.html
@@ -181,5 +181,5 @@
   </div>
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
-  <script type="module" src="./app.js?build=20260805-r160-browser-consent-r160-reward-detail-paint-rail"></script>
+  <script type="module" src="./app.js?build=20260805-r160-browser-consent-r161-paint-lock-colour"></script>
 </body></html>

--- a/turn/progression/lot-paint-reward.js
+++ b/turn/progression/lot-paint-reward.js
@@ -30,6 +30,19 @@ function setInputValue(input, value) {
   input.dispatchEvent(new Event('change', { bubbles: true }));
 }
 
+function contrastingInk(hexColor) {
+  const match = /^#([0-9a-f]{6})$/i.exec(hexColor || '');
+  if (!match) return '#08090a';
+  const channels = [0, 2, 4].map((offset) => Number.parseInt(match[1].slice(offset, offset + 2), 16) / 255);
+  const linear = channels.map((channel) => (
+    channel <= 0.04045
+      ? channel / 12.92
+      : ((channel + 0.055) / 1.055) ** 2.4
+  ));
+  const luminance = linear[0] * 0.2126 + linear[1] * 0.7152 + linear[2] * 0.0722;
+  return luminance > 0.36 ? '#08090a' : '#fffdf6';
+}
+
 export function gateLotPaintNow(root = document.body) {
   const screen = findLotScreen(root);
   if (!screen) return () => {};
@@ -76,19 +89,27 @@ export function gateLotPaintNow(root = document.body) {
     label = document.createElement('span');
     label.className = 'lot-paint-lock-copy';
     label.setAttribute('aria-hidden', 'true');
-    label.innerHTML = '<strong>Paintjob</strong><i>•</i><b>LOCKED</b>';
+    label.innerHTML = '<strong>PAINTJOB</strong>';
     colors.prepend(label);
     return label;
   }
 
-  function ensureLockIcon() {
+  function applyLockColour(icon, carId) {
+    const bodyColour = getVehicleDefaultColor(carId);
+    icon.style.setProperty('--lot-paint-lock-background', bodyColour);
+    icon.style.setProperty('--lot-paint-lock-foreground', contrastingInk(bodyColour));
+  }
+
+  function ensureLockIcon(carId) {
     let icon = colors.querySelector('.lot-paint-lock');
-    if (icon) return icon;
-    icon = document.createElement('span');
-    icon.className = 'lot-paint-lock';
-    icon.setAttribute('aria-hidden', 'true');
-    icon.innerHTML = LOCK_ICON;
-    colors.append(icon);
+    if (!icon) {
+      icon = document.createElement('span');
+      icon.className = 'lot-paint-lock';
+      icon.setAttribute('aria-hidden', 'true');
+      icon.innerHTML = LOCK_ICON;
+      colors.append(icon);
+    }
+    applyLockColour(icon, carId);
     return icon;
   }
 
@@ -97,7 +118,7 @@ export function gateLotPaintNow(root = document.body) {
     colors.querySelector('.lot-paint-lock')?.remove();
   }
 
-  function setLockedInteraction(locked) {
+  function setLockedInteraction(locked, carId) {
     if (locked) {
       const threshold = reward()?.threshold || 500;
       colors.setAttribute('role', 'button');
@@ -107,7 +128,7 @@ export function gateLotPaintNow(root = document.body) {
         `Paintjob locked. Vehicle paint controls unlock at ${threshold} trophies on Trophy Road.`
       );
       ensureLockLabel();
-      ensureLockIcon();
+      ensureLockIcon(carId);
       return;
     }
 
@@ -140,7 +161,7 @@ export function gateLotPaintNow(root = document.body) {
         if (input) input.disabled = locked;
       }
 
-      setLockedInteraction(locked);
+      setLockedInteraction(locked, carId);
       if (!locked && car && !car.fixedLivery) {
         colors.setAttribute('aria-label', 'Choose car paint colours');
       }

--- a/turn/progression/lot-paint-reward.js
+++ b/turn/progression/lot-paint-reward.js
@@ -40,7 +40,7 @@ function contrastingInk(hexColor) {
       : ((channel + 0.055) / 1.055) ** 2.4
   ));
   const luminance = linear[0] * 0.2126 + linear[1] * 0.7152 + linear[2] * 0.0722;
-  return luminance > 0.36 ? '#08090a' : '#fffdf6';
+  return luminance > 0.18 ? '#08090a' : '#fffdf6';
 }
 
 export function gateLotPaintNow(root = document.body) {

--- a/turn/progression/trophy-road-r157.css
+++ b/turn/progression/trophy-road-r157.css
@@ -83,10 +83,8 @@
 }
 
 .lot-paint-lock-copy {
-  display: flex;
+  display: block;
   min-width: 0;
-  align-items: baseline;
-  gap: .34em;
   overflow: hidden;
   font-size: clamp(.72rem, 1.7vw, 1rem);
   line-height: 1;
@@ -94,21 +92,11 @@
 }
 
 .lot-paint-lock-copy strong {
+  display: block;
   overflow: hidden;
   font-size: 1em;
   font-weight: 900;
   text-overflow: ellipsis;
-}
-
-.lot-paint-lock-copy i {
-  font-style: normal;
-  font-weight: 950;
-}
-
-.lot-paint-lock-copy b {
-  font-size: .78em;
-  font-weight: 950;
-  letter-spacing: .06em;
 }
 
 .lot-paint-lock {
@@ -118,10 +106,11 @@
   box-sizing: border-box;
   padding: 7px;
   place-items: center;
-  border: 2px solid currentColor;
+  border: 2px solid var(--turn-ink, #08090a);
   border-radius: 10px;
-  background: var(--turn-action-warning, #ffd43b);
+  background: var(--lot-paint-lock-background, var(--turn-action-warning, #ffd43b));
   box-shadow: 3px 3px 0 var(--turn-ink, #08090a);
+  color: var(--lot-paint-lock-foreground, var(--turn-ink, #08090a));
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- keep the full **PAINTJOB** label visible and remove the redundant visual “• LOCKED” copy
- colour the lock swatch with the selected car’s factory body colour
- automatically use black or warm-white lock artwork according to relative luminance, while retaining TURN’s black outline and shadow
- update the swatch immediately when the player selects another car
- force fresh production CSS and module URLs and extend the Paintjob regression coverage

## Accessibility
The rail remains one keyboard- and touch-operable control. Its accessible name still explains that Paintjob is locked and gives the Trophy Road requirement; only the redundant visible lock-status copy is removed.

## Validation
- complete 62-step TURN regression suite passed
- dedicated Paintjob rail regression covers the full label, car-colour updates, contrast-safe lock artwork, bottom-rail placement and observer-loop protection