### PR TITLE
Dismiss stale vehicle lock toast in The Lot

### DIFF
--- a/turn-lab/tests/paint-lock-observer-production.mjs
+++ b/turn-lab/tests/paint-lock-observer-production.mjs
@@ -1,7 +1,8 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [paintGate, paintCss, lotRuntime, app, index, releaseSource] = await Promise.all([
+const [lotGate, paintGate, paintCss, lotRuntime, app, index, releaseSource] = await Promise.all([
+  fs.readFile(new URL('../../turn/progression/lot-trophy-gate.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/progression/lot-paint-reward.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/progression/trophy-road-r157.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-enhancement-runtime.js', import.meta.url), 'utf8'),
@@ -62,12 +63,22 @@ assert.match(paintLockRule, /color: var\(--lot-paint-lock-foreground/);
 assert.match(paintLockRule, /border: 2px solid var\(--turn-ink/,
   'The swatch keeps the TURN black outline even when the lock glyph needs white contrast');
 assert.doesNotMatch(paintLockRule, /width: 100%/);
+
+assert.match(lotGate, /function dismissVisibleUnlockNotice\(\)/);
+assert.match(lotGate, /\.turn-unlock-notice\.is-visible/);
+assert.match(lotGate, /notice\.classList\.remove\('is-visible'\)/);
+assert.match(lotGate, /if \(lastAnnouncedCarId\) dismissVisibleUnlockNotice\(\)/,
+  'Selecting an available vehicle after a locked one must remove the stale lock notice');
+assert.match(lotGate, /if \(lastAnnouncedCarId\) dismissVisibleUnlockNotice\(\);[\s\S]*raceButton\.classList\.remove/,
+  'Leaving The Lot must not leave a vehicle lock notice behind');
+
+assert.match(lotRuntime, /lot-trophy-gate\.js\?revision=r162-dismiss-unlocked-car-toast/);
 assert.match(lotRuntime, /lot-paint-reward\.js\?revision=r161-car-colour-lock/);
 assert.match(app, /trophy-road-r157\.css\?revision=r161-car-colour-lock/);
-assert.match(app, /lot-enhancement-runtime\.js\?revision=r121&trophy-road=r159&paint=r161-car-colour-lock/);
+assert.match(app, /lot-enhancement-runtime\.js\?revision=r121&trophy-road=r159&paint=r161-car-colour-lock&toast=r162-dismiss-unlocked-car/);
 assert.match(
   index,
-  new RegExp(`app\\.js\\?build=${release.cacheKey}-browser-consent-r161-paint-lock-colour`)
+  new RegExp(`app\\.js\\?build=${release.cacheKey}-browser-consent-r162-dismiss-unlocked-car-toast`)
 );
 
-console.log('TURN Paintjob rail shows the full label and a contrast-safe factory-colour lock swatch.');
+console.log('TURN Lot lock feedback and Paintjob rail regressions passed.');

--- a/turn-tests/startup-and-unread-production.mjs
+++ b/turn-tests/startup-and-unread-production.mjs
@@ -17,7 +17,7 @@ assert.deepEqual(release, {
   cacheKey: '20260805-r160'
 });
 assert.match(index, /TURN v1\.5\.1 · Build 2026\.08\.05-r160/);
-assert.match(index, /app\.js\?build=20260805-r160-browser-consent-r161-paint-lock-colour/);
+assert.match(index, /app\.js\?build=20260805-r160-browser-consent-r162-dismiss-unlocked-car-toast/);
 assert.match(nextIndex, /TURN NEXT · Source TURN v1\.5\.1 · Build 2026\.08\.05-r160/);
 assert.match(nextIndex, /turn-next\/app\.js\?source=20260805-r160-browser-consent/);
 

--- a/turn/app.js
+++ b/turn/app.js
@@ -268,7 +268,7 @@ installHarborHiddenFaceOrientation();
 // lot-enhancement-runtime.js?revision=r121&trophy-road=r154
 // lot-enhancement-runtime.js?revision=r121&trophy-road=r157
 const { installLotEnhancementRuntime } = await import(
-  withBuild('./garage/lot-enhancement-runtime.js?revision=r121&trophy-road=r159&paint=r161-car-colour-lock')
+  withBuild('./garage/lot-enhancement-runtime.js?revision=r121&trophy-road=r159&paint=r161-car-colour-lock&toast=r162-dismiss-unlocked-car')
 );
 installLotEnhancementRuntime();
 

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -1,13 +1,13 @@
 import { installLotStatLegend } from './lot-stat-legend.js?build=20260724-r59';
 import { installLotLayout } from './lot-layout-r60.js?build=20260729-r116';
 import { installLotAccessibility } from './lot-accessibility-r118.js?build=20260729-r118';
-import { gateLotNow } from '../progression/lot-trophy-gate.js?revision=r157-paint-monster';
+import { gateLotNow } from '../progression/lot-trophy-gate.js?revision=r162-dismiss-unlocked-car-toast';
 import { gateLotPaintNow } from '../progression/lot-paint-reward.js?revision=r161-car-colour-lock';
 
 // Historical regression markers for the established enhancement layers:
 // ENHANCEMENT_ID = 'enhanced-lot-r121'
 // TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r154-trophy-road-feedback'
-const ENHANCEMENT_ID = 'enhanced-lot-r161-car-colour-lock';
+const ENHANCEMENT_ID = 'enhanced-lot-r162-dismiss-unlocked-car-toast';
 const TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r157-paint-monster';
 const activeEnhancements = new WeakMap();
 

--- a/turn/index.html
+++ b/turn/index.html
@@ -181,5 +181,5 @@
   </div>
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
-  <script type="module" src="./app.js?build=20260805-r160-browser-consent-r161-paint-lock-colour"></script>
+  <script type="module" src="./app.js?build=20260805-r160-browser-consent-r162-dismiss-unlocked-car-toast"></script>
 </body></html>

--- a/turn/progression/lot-trophy-gate.js
+++ b/turn/progression/lot-trophy-gate.js
@@ -20,6 +20,15 @@ function selectedCarButton(carPicker) {
     || carPicker.querySelector('.lot-car-option');
 }
 
+function dismissVisibleUnlockNotice() {
+  const notice = globalThis.document?.querySelector?.('.turn-unlock-notice.is-visible');
+  if (!notice) return;
+  notice.classList.remove('is-visible');
+  globalThis.setTimeout?.(() => {
+    if (!notice.classList.contains('is-visible')) notice.hidden = true;
+  }, 180);
+}
+
 export function gateLotNow(root = document.body) {
   const screen = findLotScreen(root);
   if (!screen) return () => {};
@@ -106,6 +115,7 @@ export function gateLotNow(root = document.body) {
       lastAnnouncedCarId = selectedId;
       showTrophyUnlockNotice({ reward, itemName: selectedName });
     } else if (!locked) {
+      if (lastAnnouncedCarId) dismissVisibleUnlockNotice();
       lastAnnouncedCarId = '';
     }
     syncing = false;
@@ -129,6 +139,7 @@ export function gateLotNow(root = document.body) {
     observer.disconnect();
     window.removeEventListener('turn:trophy-road-updated', sync);
     window.removeEventListener('storage', handleStorage);
+    if (lastAnnouncedCarId) dismissVisibleUnlockNotice();
     raceButton.classList.remove('is-trophy-locked');
     delete raceButton.dataset.trophyLocked;
     delete screen.dataset.trophyVehicleLocked;


### PR DESCRIPTION
## Summary
- hide the current vehicle lock toast as soon as the player selects an available car
- retain the existing behaviour when moving between locked cars, so each newly selected locked reward still explains its requirement
- also clear a vehicle lock toast when leaving The Lot
- refresh the production module URLs so installed TURN sessions receive the change
- extend regression coverage for the locked-to-available transition

## Accessibility
The toast still appears and announces normally for locked cars. Selecting an available car now removes the obsolete visual status instead of leaving contradictory lock information on screen.

## Validation
- complete 62-step TURN regression suite passed
- dedicated regression verifies the locked-to-available transition and cleanup when leaving The Lot