### PR TITLE
Pronounce Drive By Ear 101 as one oh one

### DIFF
--- a/turn-tests/startup-and-unread-production.mjs
+++ b/turn-tests/startup-and-unread-production.mjs
@@ -36,6 +36,10 @@ assert.ok(
 assert.match(fixedLayout, /achievements\/unread-markers\.js\?build=\$\{buildKey\}-r159-unread-cards/);
 assert.match(fixedLayout, /installAchievementUnreadMarkers\(achievements\)/);
 assert.match(fixedLayout, /achievementUnreadMarkers,/);
+assert.match(fixedLayout, /function installDriveByEarSpokenLabels\(training\)/);
+assert.match(fixedLayout, /const spokenName = 'Drive By Ear one oh one'/);
+assert.match(fixedLayout, /homeButton\?\.setAttribute\('aria-label', spokenName\)/);
+assert.match(fixedLayout, /installDriveByEarSpokenLabels\(driveByEarTraining\)/);
 assert.match(unreadMarkers, /new Set\(achievements\.store\.unseenIds\(\)\)/);
 assert.match(unreadMarkers, /addEventListener\('click', captureBeforeOpen, \{ capture: true \}\)/);
 assert.match(unreadMarkers, /turn-achievement-unread-dot/);
@@ -43,4 +47,4 @@ assert.match(unreadMarkers, /Newly unlocked achievement\./);
 assert.match(unreadMarkers, /new MutationObserver\(queueDecoration\)/);
 assert.match(unreadMarkers, /listObserver\.observe\(list, \{ childList: true \}\)/);
 
-console.log('TURN 1.5.1 startup cover, fixed Home viewport and unread achievement markers passed.');
+console.log('TURN 1.5.1 startup cover, fixed Home viewport, spoken training labels and unread achievement markers passed.');

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -31,6 +31,26 @@ function spokenTrackName(rawName) {
     .replace(/(^|\s)\p{L}/gu, (character) => character.toLocaleUpperCase('en'));
 }
 
+function installDriveByEarSpokenLabels(training) {
+  const spokenName = 'Drive By Ear one oh one';
+  training.entryPoints?.homeButton?.setAttribute('aria-label', spokenName);
+  training.entryPoints?.howCallout
+    ?.querySelector('[data-turn-dbe-training-entry]')
+    ?.setAttribute('aria-label', `Start ${spokenName}`);
+  training.entryPoints?.settingsCallout
+    ?.querySelector('[data-turn-dbe-training-entry]')
+    ?.setAttribute('aria-label', `Try ${spokenName}`);
+  training.introDialog
+    ?.querySelector('#turnDbeTrainingTitle')
+    ?.setAttribute('aria-label', spokenName);
+  training.introDialog
+    ?.querySelector('[data-training-cancel]')
+    ?.setAttribute('aria-label', `Close ${spokenName}`);
+  training.partDialog
+    ?.querySelector('[data-training-leave]')
+    ?.setAttribute('aria-label', `Leave ${spokenName}`);
+}
+
 export async function installM8HomeFixedLayout() {
   installStylesheet();
   const home = await waitForHome();
@@ -125,6 +145,7 @@ export async function installM8HomeFixedLayout() {
     `/turn/training/drive-by-ear-training.js?build=${buildKey}-r151-dbe-training-device-fixes`
   );
   const driveByEarTraining = await installDriveByEarTraining(globalThis.__turnRuntime);
+  installDriveByEarSpokenLabels(driveByEarTraining);
 
   globalThis.__turnHomeLayout = Object.freeze({
     id: LAYOUT_ID,


### PR DESCRIPTION
## Summary
- add explicit accessible names so screen readers pronounce **Drive By Ear 101** as **Drive By Ear one oh one**
- apply the pronunciation to the Home entry point, How to Play and Settings entry points, the training dialog title, and its close/leave controls
- keep the visible `101` wording unchanged
- add regression coverage for the spoken label helper

## Accessibility
This changes only the accessible names. Sighted copy and visual layout remain unchanged.