### PR TITLE
Add in-game history and normative dialog system

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Run inclusive Home feedback and attribution regression
         run: node turn-tests/home-feedback-production.mjs
 
+      - name: Run About history and dialog-system regression
+        run: node turn-tests/about-history-production.mjs
+
       - name: Run TURN design-system specimen regression
         run: node turn-tests/design-system-production.mjs
 

--- a/turn-next/index.html
+++ b/turn-next/index.html
@@ -141,4 +141,5 @@
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
   <script type="module" src="/turn-next/app.js?source=20260805-r160-browser-consent"></script>
+  <script type="module" src="./ui/about-history-bootstrap.js?revision=r163-modal-system"></script>
 </body></html>

--- a/turn-tests/about-history-production.mjs
+++ b/turn-tests/about-history-production.mjs
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const [
+  productionEntry,
+  nextEntry,
+  bootstrap,
+  content,
+  dialogCss,
+  historyCss,
+  designReference
+] = await Promise.all([
+  fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn-next/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/ui/about-history-bootstrap.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/content/about-history.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/dialog-system-r163.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/about-history-r163.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/design-dialogs.html', import.meta.url), 'utf8')
+]);
+
+for (const entry of [productionEntry, nextEntry]) {
+  assert.match(entry, /about-history-bootstrap\.js\?revision=r163-modal-system/,
+    'Production and TURN NEXT must load the same canonical About history enhancement');
+}
+
+assert.match(bootstrap, /CHANGELOG[\s\S]*CURRENT_RELEASE[\s\S]*DEVELOPMENT_HISTORY/);
+assert.match(bootstrap, /className = 'm8-dialog turn-dialog turn-dialog--reader turn-history-dialog'/);
+assert.match(bootstrap, /aria-labelledby', 'turnHistoryTitle'/);
+assert.match(bootstrap, /role="tablist" aria-label="TURN history sections"/);
+assert.match(bootstrap, /role="tab"[\s\S]*aria-selected="true"[\s\S]*aria-controls="turnHistoryDevelopmentPanel"/);
+assert.match(bootstrap, /role="tabpanel"[\s\S]*aria-labelledby="turnHistoryDevelopmentTab"/);
+assert.match(bootstrap, /event\.key === 'ArrowRight'/);
+assert.match(bootstrap, /event\.key === 'ArrowLeft'/);
+assert.match(bootstrap, /event\.key === 'Home'/);
+assert.match(bootstrap, /event\.key === 'End'/);
+assert.match(bootstrap, /aboutDialog\.close\(\)/,
+  'The source About dialog must close before the history dialog opens; modal dialogs must not stack');
+assert.match(bootstrap, /aboutDialog\.showModal\(\)/,
+  'Closing the reader should restore the source About dialog');
+assert.match(bootstrap, /historyButton\.focus\(\{ preventScroll: true \}\)/,
+  'Focus should return to the History and Changelog action inside the restored About dialog');
+assert.match(bootstrap, /HISTORY &amp; CHANGELOG/);
+assert.match(bootstrap, /href="\/turn\/design-dialogs\.html"/);
+assert.match(bootstrap, />DESIGN SYSTEM<\/a>/);
+assert.match(bootstrap, /installStylesheet\('\.\.\/dialog-system-r163\.css/);
+assert.match(bootstrap, /installStylesheet\('\.\.\/about-history-r163\.css/);
+assert.doesNotMatch(bootstrap, /setInterval|@keyframes|animation:/,
+  'History and dialog behaviour must not add timing loops or decorative animation');
+
+const historyEntries = (content.match(/period:/g) || []).length;
+const changelogDays = (content.match(/date:/g) || []).length;
+assert.ok(historyEntries >= 10, `Expected at least ten development-history periods, found ${historyEntries}`);
+assert.ok(changelogDays >= 18, `Expected at least eighteen changelog dates, found ${changelogDays}`);
+assert.match(content, /18–19 July 2026/);
+assert.match(content, /Current stabilization/);
+assert.match(content, /18 July 2026/);
+assert.match(content, /5 August/);
+assert.match(content, /TURN 1\.5\.1/);
+assert.match(content, /2026\.08\.05-r160/);
+assert.match(content, /one oh one/);
+assert.match(content, /25 achievements and 1,375 available trophies/);
+assert.match(content, /Paintjob MutationObserver/);
+
+for (const size of ['compact', 'standard', 'wide', 'reader']) {
+  assert.match(dialogCss, new RegExp(`\\.turn-dialog--${size}`),
+    `Dialog system must define the ${size} size`);
+}
+assert.match(dialogCss, /\.turn-dialog__surface/);
+assert.match(dialogCss, /\.turn-dialog__header/);
+assert.match(dialogCss, /\.turn-dialog__body/);
+assert.match(dialogCss, /\.turn-dialog__actions/);
+assert.match(dialogCss, /overscroll-behavior: contain/);
+assert.match(dialogCss, /scrollbar-gutter: stable/);
+assert.match(dialogCss, /prefers-reduced-motion: reduce/);
+
+assert.match(historyCss, /\.turn-history-card[\s\S]*overflow: hidden !important/,
+  'The reader shell must stay fixed while its body owns scrolling');
+assert.match(historyCss, /\.turn-history-panel[\s\S]*overflow-y: auto/);
+assert.match(historyCss, /\.m8-about-summary[\s\S]*font-size: 0\.8rem !important/,
+  'About supporting copy must be compact enough for short landscape viewports');
+assert.match(historyCss, /\.m8-about-actions[\s\S]*grid-template-columns/);
+
+assert.match(designReference, /TURN DIALOGS/);
+assert.match(designReference, /Standardize the shell, not the content/);
+assert.match(designReference, /Production dialog inventory/);
+assert.match(designReference, /About TURN/);
+assert.match(designReference, /Development history &amp; changelog/);
+assert.match(designReference, /Drive By Ear 101 introduction/);
+assert.match(designReference, /Motion access denied/);
+assert.match(designReference, /In-race audio settings/);
+assert.match(designReference, /Compact[\s\S]*Standard[\s\S]*Wide[\s\S]*Reader/);
+assert.match(designReference, /Do not stack modal dialogs/);
+assert.match(designReference, /href="\.\/design\.html"/,
+  'The dialog reference must remain connected to the main design system');
+
+console.log('TURN About history, changelog and normative dialog-system regression passed.');

--- a/turn/about-history-r163.css
+++ b/turn/about-history-r163.css
@@ -1,0 +1,301 @@
+.m8-about-dialog {
+  --turn-dialog-inline-size: min(660px, calc(100vw - 32px));
+}
+
+.m8-about-card {
+  overscroll-behavior-y: contain;
+  scrollbar-gutter: stable;
+}
+
+.m8-about-content {
+  max-width: 62ch;
+}
+
+.m8-about-content p {
+  margin: 0;
+}
+
+.m8-about-content p + p {
+  margin-top: 9px;
+}
+
+.m8-about-lead {
+  font-size: clamp(1.02rem, 1.8vw, 1.2rem) !important;
+  font-weight: 900;
+  line-height: 1.34 !important;
+}
+
+.m8-about-summary,
+.m8-about-credits {
+  font-size: 0.8rem !important;
+  line-height: 1.4 !important;
+}
+
+.m8-about-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.m8-about-history,
+.m8-about-design-system {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: 10px 15px;
+  border: 4px solid var(--m8-ink);
+  border-radius: 999px;
+  color: var(--m8-ink);
+  box-shadow: 5px 5px 0 var(--m8-ink);
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 950;
+  line-height: 1.05;
+  letter-spacing: 0.035em;
+  text-align: center;
+  text-decoration: none;
+}
+
+.m8-about-history {
+  background: var(--m8-yellow);
+}
+
+.m8-about-design-system {
+  background: var(--m8-blue);
+}
+
+.m8-about-history:hover,
+.m8-about-design-system:hover {
+  transform: translateY(-2px);
+}
+
+.m8-about-history:active,
+.m8-about-design-system:active {
+  transform: translate(4px, 4px);
+  box-shadow: 1px 1px 0 var(--m8-ink);
+}
+
+.m8-about-content a:not(.m8-about-design-system) {
+  color: inherit;
+  font-weight: 900;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 0.18em;
+}
+
+.turn-history-dialog {
+  --turn-dialog-inline-size: calc(100vw - 24px);
+  --turn-dialog-block-size: calc(100vh - 24px);
+  --turn-dialog-block-size: calc(100dvh - 24px);
+  --turn-dialog-padding: clamp(14px, 2vw, 24px);
+}
+
+.turn-history-card {
+  height: var(--turn-dialog-block-size);
+  overflow: hidden !important;
+}
+
+.turn-history-head {
+  margin-bottom: 12px !important;
+}
+
+.turn-history-head h2 {
+  font-size: clamp(1.8rem, 4.7vw, 3.7rem);
+}
+
+.turn-history-release {
+  margin: 4px 0 0;
+  font-size: 0.72rem;
+  font-weight: 900;
+  line-height: 1.3;
+}
+
+.turn-history-shell {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.turn-history-tabs {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 8px;
+  padding: 0 4px 10px;
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.turn-history-tabs button {
+  flex: 0 0 auto;
+  min-height: 44px;
+  padding: 8px 15px;
+  border: 4px solid var(--m8-ink);
+  border-radius: 999px;
+  background: var(--m8-cream);
+  box-shadow: 4px 4px 0 var(--m8-ink);
+  font: inherit;
+  font-size: clamp(0.74rem, 1.3vw, 0.94rem);
+  font-weight: 950;
+  letter-spacing: 0.035em;
+}
+
+.turn-history-tabs button[aria-selected='true'] {
+  background: var(--m8-yellow);
+}
+
+.turn-history-tabs button:active {
+  transform: translate(3px, 3px) !important;
+  box-shadow: 1px 1px 0 var(--m8-ink) !important;
+}
+
+.turn-history-panels {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+  border: 4px solid var(--m8-ink);
+  border-radius: 20px;
+  background: rgb(255 255 255 / 0.78);
+  box-shadow: 5px 5px 0 var(--m8-ink);
+}
+
+.turn-history-panel {
+  height: 100%;
+  overflow-y: auto;
+  overscroll-behavior-y: contain;
+  scrollbar-gutter: stable;
+  -webkit-overflow-scrolling: touch;
+  padding: clamp(14px, 2.4vw, 26px);
+}
+
+.turn-history-panel[hidden] {
+  display: none;
+}
+
+.turn-history-intro {
+  max-width: 74ch;
+  margin: 0 0 20px;
+  font-size: clamp(0.88rem, 1.35vw, 1rem);
+  line-height: 1.48;
+}
+
+.turn-history-entry,
+.turn-changelog-release {
+  position: relative;
+  max-width: 82ch;
+  padding: 0 0 22px 22px;
+  border-left: 4px solid var(--m8-ink);
+}
+
+.turn-history-entry:last-child,
+.turn-changelog-release:last-child {
+  padding-bottom: 2px;
+}
+
+.turn-history-entry::before,
+.turn-changelog-release::before {
+  content: '';
+  position: absolute;
+  top: 3px;
+  left: -10px;
+  width: 14px;
+  height: 14px;
+  border: 3px solid var(--m8-ink);
+  border-radius: 50%;
+  background: var(--m8-pink);
+}
+
+.turn-history-entry > span,
+.turn-changelog-release > time {
+  display: block;
+  margin-bottom: 3px;
+  font-size: 0.68rem;
+  font-weight: 950;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.turn-history-entry h3,
+.turn-changelog-release h3 {
+  margin: 0 0 8px;
+  font-size: clamp(1.05rem, 2vw, 1.45rem);
+  line-height: 1.08;
+}
+
+.turn-history-entry p {
+  margin: 0;
+  font-size: clamp(0.82rem, 1.2vw, 0.94rem);
+  line-height: 1.46;
+}
+
+.turn-history-entry p + p {
+  margin-top: 7px;
+}
+
+.turn-history-entry ul,
+.turn-changelog-release ul {
+  margin: 10px 0 0;
+  padding-left: 20px;
+}
+
+.turn-history-entry li,
+.turn-changelog-release li {
+  margin-top: 5px;
+  font-size: clamp(0.79rem, 1.16vw, 0.91rem);
+  line-height: 1.38;
+}
+
+.turn-changelog-release h3 {
+  margin-bottom: 5px;
+}
+
+.turn-changelog-release strong {
+  font-weight: 950;
+}
+
+@media (max-height: 560px) and (orientation: landscape) {
+  .turn-history-dialog {
+    --turn-dialog-inline-size: calc(100vw - 10px);
+    --turn-dialog-block-size: calc(100vh - 10px);
+    --turn-dialog-block-size: calc(100dvh - 10px);
+    --turn-dialog-padding: 12px 16px max(12px, env(safe-area-inset-bottom));
+  }
+
+  .turn-history-head {
+    margin-bottom: 8px !important;
+  }
+
+  .turn-history-tabs {
+    padding-bottom: 7px;
+  }
+
+  .turn-history-tabs button {
+    min-height: 38px;
+    padding-block: 6px;
+  }
+
+  .turn-history-panel {
+    padding: 14px 18px;
+  }
+}
+
+@media (max-width: 680px) and (orientation: portrait) {
+  .m8-about-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .turn-history-dialog {
+    --turn-dialog-inline-size: calc(100vw - 16px);
+    --turn-dialog-block-size: calc(100vh - 16px);
+    --turn-dialog-block-size: calc(100dvh - 16px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .m8-about-history,
+  .m8-about-design-system,
+  .turn-history-tabs button {
+    transition: none !important;
+  }
+}

--- a/turn/content/about-history.js
+++ b/turn/content/about-history.js
@@ -1,0 +1,285 @@
+export const DEVELOPMENT_HISTORY = Object.freeze([
+  {
+    period: '18–19 July 2026',
+    title: 'From sensor experiment to modular racer',
+    paragraphs: [
+      'TURN began as a mobile prototype built around one unusual idea: hold a phone or tablet in landscape and rotate it like a steering wheel.',
+      'The first day established the Three.js road, motion steering, touch driving, drift-oriented physics, lap timing, saved rivals and PWA installation. TURN LAB then split the fast prototype into explicit race, input, physics, rendering, replay, track and interface modules before the verified R7 runtime replaced production.'
+    ],
+    milestones: [
+      'Sensor-steered prototype and Three.js world',
+      'Mobile HUD, touch controls and personal rival recordings',
+      'Protected TURN LAB refactor and R7 production baseline'
+    ]
+  },
+  {
+    period: '19–22 July',
+    title: 'The Lot and dependable racing',
+    paragraphs: [
+      'TURN became a small racing game rather than a single-car experiment. The Lot introduced fifteen vehicles, a rotating 3D viewer, paint and an eighteen-point stat budget built around trade-offs.',
+      'The same period made racing trustworthy: ordered swept checkpoints, a physical start and finish line, brake-before-reverse behaviour, clearer lap results, restart handling and systematic model-orientation corrections.'
+    ],
+    milestones: [
+      'Fifteen-car garage with balanced attributes',
+      'Unified thumb-operated drive surface',
+      'Reliable checkpoints, lap validity and result presentation'
+    ]
+  },
+  {
+    period: '22–25 July',
+    title: 'One course becomes a track platform',
+    paragraphs: [
+      'Countryside gained Airport, then Cliffside and Harbor. Each track exposed another hard-coded assumption and pushed the runtime toward a generic registry for identity, storage, atmosphere, collision, elevation and activation.',
+      'Track cards evolved into postcards with best times and the actual record-setting car. World containment, scenery colliders, elevation-aware presentation and event-driven rendering work prepared the game for continued expansion.'
+    ],
+    milestones: [
+      'Airport, elevated Cliffside and Harbor',
+      'Track-scoped records and generic runtime registry',
+      'World collision, elevation and performance architecture'
+    ]
+  },
+  {
+    period: '26–28 July',
+    title: 'Drive By Ear becomes a driving language',
+    paragraphs: [
+      'Engine and tyre feedback expanded into Drive By Ear: spatial guidance designed to help every player and, together with a screen reader, support complete non-visual play.',
+      'Early separate cues were consolidated into a layered hierarchy with an organic steering ribbon, off-road recovery, wrong-way priority, directional rivals and hand-authored pace notes. Device recordings repeatedly corrected channel direction, recovery meaning, speech priority and rare note loss.'
+    ],
+    milestones: [
+      'All-track pace notes and central audio mixer',
+      'One consistent steer-toward-the-sound rule',
+      'Delivery-critical route guidance and screen-reader race speech'
+    ]
+  },
+  {
+    period: '28–31 July',
+    title: 'TURN NEXT validates the platform refactor',
+    paragraphs: [
+      'TURN NEXT was created as an isolated PWA with separate storage, then used to stage motion, display and race-session architecture without putting production records at risk.',
+      'A whole-screen orientation-freeze experiment was rejected after physical iOS testing. The accepted web solution became a truthful ±24° operating envelope with directional, non-flashing visual feedback plus audio, haptics and first-per-side screen-reader announcements.',
+      'The M5–M8 programme also replaced the old startup loop with Home → track → The Lot → introduction → race.'
+    ],
+    milestones: [
+      'Platform-owned motion and display lifecycle',
+      'Validated 24° steering and horizon safe zone',
+      'Home, consolidated Settings and central session orchestration'
+    ]
+  },
+  {
+    period: '29 July–2 August',
+    title: 'Accessibility becomes structural',
+    paragraphs: [
+      'Accessibility work changed information architecture and interaction rather than merely adding labels. The Lot became a keyboard-friendly radio group with complete car descriptions, human-readable paint colours and deliberate heading navigation.',
+      'VoiceOver testing invalidated two plausible ARIA techniques, so TURN replaced them with real hidden summary text and selected-first DOM ordering. Dialog focus return, installation guidance, motion-denial recovery, external-keyboard controls and non-visual instructions were hardened in the same period.'
+    ],
+    milestones: [
+      'Complete keyboard and assistive-technology car selection',
+      'Composed lap speech and managed position announcements',
+      'Browser-aware installation and truthful device support'
+    ]
+  },
+  {
+    period: '31 July–2 August',
+    title: 'Midnight City and a living design system',
+    paragraphs: [
+      'Midnight City became TURN’s fifth and longest track. Its first boulevard layout was rebuilt into distinct districts with parks, skyline, neon lore, a cinematic introduction and a deliberately hidden LILYA portrait.',
+      'The longer 1,080-sample route exposed a progress-normalisation defect that moved pace notes to two-thirds of their intended positions. Geometry-backed direction tests and sample-aware timing now protect the track.',
+      'A living design-system reference and shared semantic tokens established stable colour, control, form, disclosure, radius, border and shadow rules without flattening track personality.'
+    ],
+    milestones: [
+      'Five-track game with a long night-city course',
+      'Geometry-backed Midnight City pace-note validation',
+      'Production semantic tokens and design reference'
+    ]
+  },
+  {
+    period: '3 August',
+    title: 'Emergency vehicles and blank-screen play',
+    paragraphs: [
+      'Fire Truck, Police Car and Ambulance replaced three garage vehicles. Fixed service liveries, large Boost tanks, flashing lights and vehicle-specific procedural sirens made Boost part of each vehicle’s identity.',
+      'Blank-screen mode then covered the visual game with true black while retaining controls, tilt steering, audio and assistive-technology access. Drive By Ear can be enabled temporarily for that session without overwriting the player’s preference.'
+    ],
+    milestones: [
+      'Three fixed-livery emergency vehicles',
+      'Boost-controlled lights and sirens',
+      'Audio-only play with temporary Drive By Ear activation'
+    ]
+  },
+  {
+    period: '3–5 August',
+    title: 'Achievements become Trophy Road',
+    paragraphs: [
+      'An offline-first achievement collection grew from onboarding challenges into non-visual play, developer time trials, Police Car challenges and hidden discoveries.',
+      'Points became permanent trophies. Trophy Road now unlocks Midnight City, Future Racer, Paintjob, the Emergency Pack and Monster Truck while grandfathering existing profiles.',
+      'A serious Home-to-Lot freeze was eventually traced to a Paintjob MutationObserver that repeatedly changed the subtree it watched. The fix narrowed ownership and added a regression for the self-triggering pattern.'
+    ],
+    milestones: [
+      '25 achievements and 1,375 available trophies',
+      'Persistent content rewards and legacy-player migration',
+      'Critical observer-loop diagnosis and prevention'
+    ]
+  },
+  {
+    period: '4–5 August',
+    title: 'Current stabilization',
+    paragraphs: [
+      'TURN 1.5.0 added a branded loading cover, stable iOS Home sizing, compact Paintjob locking and new-achievement markers.',
+      'TURN 1.5.1 corrected Trophy Road’s initial reward card, transitions between 3D and line-art previews and the Paintjob lower rail. Later main-branch hotfixes colour the locked swatch from the selected car and dismiss stale vehicle-lock messaging.',
+      'The game is now in a refinement and hardening phase: five tracks, fifteen garage slots, local rivals, a mature non-visual audio system, assistive-technology navigation and persistent progression.'
+    ],
+    milestones: [
+      'Canonical release: TURN 1.5.1 · 2026.08.05-r160',
+      'Post-r160 Paintjob and lock-toast fixes',
+      'Sixty-plus production regression gates plus DBE training tests'
+    ]
+  }
+]);
+
+export const CHANGELOG = Object.freeze([
+  {
+    date: '18 July 2026',
+    entries: [
+      ['Prototype', 'Sensor steering, Three.js road and world, touch driving, lap timing, saved rivals and first PWA work.']
+    ]
+  },
+  {
+    date: '19 July',
+    entries: [
+      ['R7', 'Verified modular TURN LAB runtime promoted to production.'],
+      ['1.0.1 r8', 'Correct manual steering and visible on-screen steering.'],
+      ['1.1.0–1.1.3 r9–r12', 'The Lot, fifteen cars, viewer, balanced stats and ordered checkpoints.'],
+      ['1.2.0–1.2.1 r13–r14', 'Continuous Gas/Drift/Boost pad, Brake · Reverse and Boost rearming.']
+    ]
+  },
+  {
+    date: '20 July',
+    entries: [
+      ['1.3.0 r15', 'State-aware race menu.'],
+      ['1.4.0 r16 — reverted', 'Ability Zones and nitrous removed after device testing.'],
+      ['1.3.1–1.3.9 r17–r25', 'Performance, orientation, paint, outlines and repeated Lot simplification.']
+    ]
+  },
+  {
+    date: '21 July',
+    entries: [
+      ['1.3.10–1.3.15 r26–r31', 'Procedural audio, vehicle sound identity and stronger landscape handling.'],
+      ['1.3.16–1.3.21 r32–r38', 'Lap-result toast, swept gates, invalid-lap state and physical start/finish ownership.'],
+      ['1.4.0 r37 — reverted', 'Audio redesign rolled back after real-device regressions.']
+    ]
+  },
+  {
+    date: '22 July',
+    entries: [
+      ['1.3.22–1.3.29 r39–r46', 'Rival onboarding, immediate invalid-lap feedback, mobile performance and new icon package.'],
+      ['1.5.0–1.6.2 r47–r52', 'Airport, track selection, track-scoped records and forgiving hairpin run-off.']
+    ]
+  },
+  {
+    date: '23–24 July',
+    entries: [
+      ['1.7.0 r53', 'World containment and reusable scenery collision.'],
+      ['1.7.1–1.7.6 r62–r67', 'Release source of truth, generic track registry, covered-render pause, event-driven rivals, skid ring buffer and elevation foundation.']
+    ]
+  },
+  {
+    date: '25 July',
+    entries: [
+      ['1.8.0–1.8.6 r68–r74', 'Cliffside, forgiving shoulders and iOS/iPad viewport coverage.'],
+      ['1.9.0–1.9.4 r75–r79', 'Track introductions, Cliffside highlands and track postcard identities.'],
+      ['1.10.0–1.10.5 r80–r85', 'Harbor, free roaming, top-HUD position and LAP VOID wording.']
+    ]
+  },
+  {
+    date: '26 July',
+    entries: [
+      ['1.11.0–1.11.3 r86–r89', 'Super Sedan secret and hidden Harbor face.'],
+      ['1.12.0 r90', 'Brake/Reverse joins the continuous four-zone drive surface.'],
+      ['1.13.0–1.15.0 r91–r95', 'Universal soundscape, Sound Guide, race speech and first Airport pace notes.']
+    ]
+  },
+  {
+    date: '27 July',
+    entries: [
+      ['1.16.0–1.17.0 r96–r97', 'Pace notes on every track and a true Drive By Ear off path.'],
+      ['1.18.0–1.22.0 r98–r103', 'RAD prototype, Training Car, unified Trajectory Slider, pure-pursuit recovery and organic hum.'],
+      ['r104', 'Audio controls, sound balance, Spectate rank and race-UI polish.']
+    ]
+  },
+  {
+    date: '28 July',
+    entries: [
+      ['1.23.1–1.23.6 r105–r110', 'Recovery direction, speech priority, exact lap wording and delivery-critical pace notes.'],
+      ['TURN NEXT M1–M4.2', 'Isolated staging, platform contract, rejected orientation freeze, accepted 24° safe zone and non-flashing inertial warning.']
+    ]
+  },
+  {
+    date: '29 July',
+    entries: [
+      ['1.24.0 r111', 'Validated 24° steering/horizon envelope promoted to production.'],
+      ['1.24.1–1.24.2 r112–r113', 'Expanded Drive By Ear guide and screen-reader compatibility explanation.'],
+      ['1.24.3–1.24.7 r114–r118', 'Accessible Lot navigation, unified 3D/paint panel and VoiceOver-correct selected-car structure.']
+    ]
+  },
+  {
+    date: '30 July',
+    entries: [
+      ['1.24.8 r119 — reverted', 'Generated icon suite rolled back after visual review.'],
+      ['TURN NEXT M5–M7', 'Platform motion/display lifecycle and central race-session orchestration.']
+    ]
+  },
+  {
+    date: '31 July',
+    entries: [
+      ['TURN NEXT M8', 'Track chooser becomes Home; native iOS scrolling, fixed layout and retired legacy startup screen.'],
+      ['1.25.0 r120', 'M5–M8 promoted to production; Home → track → The Lot → race.'],
+      ['Post-r120 fixes', 'Restore enhanced Lot, keep race action visible and make installation guidance browser-aware.'],
+      ['Midnight City', 'First long night-track implementation.']
+    ]
+  },
+  {
+    date: '1 August',
+    entries: [
+      ['Midnight City rebuild', 'District route, parks, skyline, cinematic intro and deliberate hidden LILYA discovery.'],
+      ['Pace-note corrections', 'Mirrored directions fixed and 1,080/720 progress distortion removed.'],
+      ['1.3.0 r121', 'Human-facing version line reset from 1.25.0 for clearer reading.'],
+      ['r122 and hotfixes', 'Record-car thumbnails, canonical player marker, expanded help and contextual rival reset.'],
+      ['Accessibility', 'External-keyboard route, desktop support gate and motion-denial recovery.']
+    ]
+  },
+  {
+    date: '2 August',
+    entries: [
+      ['1.3.1–1.3.2 r123–r124', 'Semantic difficulty, form-control and disclosure design system.'],
+      ['Design/brand fixes', 'Profile-aligned icon, complete palette reference and vehicle-size balancing.']
+    ]
+  },
+  {
+    date: '3 August',
+    entries: [
+      ['1.4.0 r125 and r126', 'Emergency vehicles, fixed liveries, lights and sirens.'],
+      ['Blank screen', 'True-black audio-only play with temporary Drive By Ear activation.'],
+      ['Achievements', 'Onboarding, non-visual, Police and developer time-trial challenges.'],
+      ['Trophy Road', 'Permanent trophies, reward gates, hidden achievements and existing-player migration.'],
+      ['Critical hotfixes', 'Race-freeze investigation and actual Paintjob observer-loop correction.']
+    ]
+  },
+  {
+    date: '4 August',
+    entries: [
+      ['1.5.0 r159', 'Branded loading cover, stable iOS Home surface, compact Paintjob lock and unread achievement dots.']
+    ]
+  },
+  {
+    date: '5 August',
+    entries: [
+      ['1.5.1 r160', 'Trophy Road initial-card and preview-transition fixes; Paintjob lower rail.'],
+      ['Post-r160', 'Car-coloured Paintjob lock, contrast-safe icon, stale vehicle-lock toast dismissal and “one oh one” screen-reader pronunciation for Drive By Ear 101.']
+    ]
+  }
+]);
+
+export const CURRENT_RELEASE = Object.freeze({
+  version: '1.5.1',
+  build: '2026.08.05-r160',
+  note: 'The repository also contains post-r160 fixes documented in the final changelog entry.'
+});

--- a/turn/design-dialogs.html
+++ b/turn/design-dialogs.html
@@ -1,0 +1,322 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light">
+  <meta name="robots" content="noindex">
+  <title>TURN Design System — Dialogs</title>
+  <link rel="stylesheet" href="./design-tokens.css?revision=r141-form-disclosure">
+  <link rel="stylesheet" href="./design-semantic.css?revision=r141-form-disclosure">
+  <link rel="stylesheet" href="./m8-home.css?revision=r163-dialog-reference">
+  <link rel="stylesheet" href="./dialog-system-r163.css?revision=r163-modal-pattern">
+  <style>
+    :root {
+      font-family: Inter, ui-rounded, system-ui, sans-serif;
+      color-scheme: light;
+      --m8-ink: var(--turn-ink);
+      --m8-cream: var(--turn-paper);
+      --m8-pink: var(--turn-pink-500);
+      --m8-blue: var(--turn-blue-500);
+      --m8-yellow: var(--turn-yellow-400);
+    }
+
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; background: var(--turn-ink); }
+    body { margin: 0; background: var(--turn-ink); color: var(--turn-paper); font-weight: 780; line-height: 1.48; }
+    a, button { color: inherit; font: inherit; }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    a:focus-visible, button:focus-visible { outline: 5px solid var(--turn-form-control-focus); outline-offset: 4px; }
+
+    .hero {
+      padding: clamp(40px, 8vw, 96px) max(22px, calc((100vw - 1120px) / 2));
+      background: linear-gradient(145deg, var(--turn-blue-500), var(--turn-green-500));
+      color: var(--turn-ink);
+    }
+
+    .hero-nav { display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 28px; }
+    .hero-nav a {
+      padding: 8px 13px;
+      border: 3px solid var(--turn-ink);
+      border-radius: var(--turn-radius-pill);
+      background: var(--turn-paper);
+      box-shadow: var(--turn-shadow-compact);
+      font-size: .78rem;
+      font-weight: 950;
+      text-decoration: none;
+    }
+
+    .eyebrow {
+      display: inline-block;
+      padding: 7px 11px;
+      border: 3px solid var(--turn-ink);
+      border-radius: var(--turn-radius-pill);
+      background: var(--turn-yellow-400);
+      box-shadow: var(--turn-shadow-compact);
+      font-size: .72rem;
+      font-weight: 950;
+      letter-spacing: .15em;
+      text-transform: uppercase;
+    }
+
+    h1 { max-width: 9ch; margin: 20px 0 14px; font-size: clamp(3.7rem, 11vw, 7rem); line-height: .78; letter-spacing: -.075em; }
+    .hero p { max-width: 68rem; margin: 0; font-size: clamp(1rem, 2vw, 1.3rem); }
+
+    .section-nav {
+      position: sticky;
+      z-index: 20;
+      top: 0;
+      display: flex;
+      gap: 8px;
+      overflow-x: auto;
+      padding: 10px max(18px, calc((100vw - 1120px) / 2));
+      border-block: 4px solid var(--turn-ink);
+      background: rgb(255 248 232 / .97);
+      color: var(--turn-ink);
+    }
+
+    .section-nav a { flex: 0 0 auto; padding: 8px 12px; border-radius: var(--turn-radius-pill); text-decoration: none; }
+    .section-nav a:hover { background: var(--turn-yellow-400); }
+    main { width: min(1120px, 100%); margin: auto; padding: 70px 22px 110px; }
+    section { scroll-margin-top: 78px; margin-top: 90px; }
+    section:first-child { margin-top: 0; }
+    .kicker { font-size: .72rem; font-weight: 950; letter-spacing: .15em; text-transform: uppercase; }
+    .section-head { display: grid; grid-template-columns: minmax(0, 1fr) minmax(260px, .55fr); gap: 28px; align-items: end; margin-bottom: 26px; }
+    .section-head h2 { margin: 7px 0 0; font-size: clamp(2.2rem, 5vw, 4rem); line-height: .9; letter-spacing: -.055em; }
+    .section-head p { margin: 0; color: rgb(255 248 232 / .78); }
+
+    .card,
+    .table-wrap,
+    .specimen {
+      border: 4px solid var(--turn-ink);
+      border-radius: var(--turn-radius-default);
+      background: var(--turn-paper);
+      color: var(--turn-ink);
+      box-shadow: var(--turn-shadow-default);
+    }
+
+    .grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 16px; }
+    .card { padding: 20px; }
+    .card h3 { margin: 7px 0 8px; }
+    .card p { margin: 0; }
+    .table-wrap { overflow-x: auto; }
+    table { width: 100%; min-width: 760px; border-collapse: collapse; text-align: left; }
+    th, td { padding: 13px 15px; border-bottom: 2px solid var(--turn-ink); vertical-align: top; }
+    th { background: var(--turn-yellow-400); font-size: .7rem; letter-spacing: .12em; text-transform: uppercase; }
+    tr:last-child td { border-bottom: 0; }
+    .status { display: inline-block; padding: 3px 8px; border: 2px solid var(--turn-ink); border-radius: var(--turn-radius-pill); font-size: .68rem; font-weight: 950; white-space: nowrap; }
+    .status.current { background: var(--turn-green-200); }
+    .status.special { background: var(--turn-blue-200); }
+    .status.migrate { background: var(--turn-yellow-200); }
+
+    .anatomy { display: grid; gap: 12px; margin: 0; padding: 0; list-style: none; counter-reset: anatomy; }
+    .anatomy li { counter-increment: anatomy; display: grid; grid-template-columns: 42px minmax(0, 1fr); gap: 13px; align-items: start; padding: 16px; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-default); background: var(--turn-paper); color: var(--turn-ink); box-shadow: var(--turn-shadow-compact); }
+    .anatomy li::before { content: counter(anatomy); display: grid; place-items: center; width: 38px; height: 38px; border: 3px solid var(--turn-ink); border-radius: 50%; background: var(--turn-pink-200); font-weight: 950; }
+    .anatomy strong, .anatomy span { display: block; }
+    .anatomy span { margin-top: 3px; font-size: .9rem; }
+
+    .sizes { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 14px; }
+    .size-card { min-width: 0; padding: 18px; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-default); background: var(--turn-paper); color: var(--turn-ink); box-shadow: var(--turn-shadow-compact); }
+    .size-card span { display: block; font-size: .7rem; font-weight: 950; letter-spacing: .12em; text-transform: uppercase; }
+    .size-card h3 { margin: 5px 0 8px; }
+    .size-card p { margin: 0; font-size: .88rem; }
+
+    .rules { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
+    .rules article { padding: 19px; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-default); background: var(--turn-paper); color: var(--turn-ink); box-shadow: var(--turn-shadow-compact); }
+    .rules h3 { margin: 0 0 8px; }
+    .rules ul { margin: 0; padding-left: 20px; }
+    .rules li + li { margin-top: 7px; }
+
+    .specimen { padding: 24px; }
+    .demo-stage { display: grid; place-items: center; min-height: 240px; padding: 24px; border: 4px dashed var(--turn-ink); border-radius: var(--turn-radius-default); background: var(--turn-blue-200); }
+    .demo-open { min-height: 52px; padding: 10px 18px; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-pill); background: var(--turn-pink-500); color: var(--turn-ink); box-shadow: var(--turn-shadow-default); font-weight: 950; }
+    .demo-open:active, .m8-dialog button:active { transform: translate(5px, 5px); box-shadow: 1px 1px 0 var(--turn-ink); }
+    .demo-body p { max-width: 58ch; margin: 0; line-height: 1.5; }
+    .demo-actions { margin-top: 18px; }
+    .demo-actions button { min-height: 46px; padding: 9px 16px; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-pill); background: var(--turn-yellow-400); color: var(--turn-ink); box-shadow: var(--turn-shadow-compact); font-weight: 950; }
+
+    .code-block { overflow-x: auto; padding: 18px; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-default); background: #151719; color: var(--turn-paper); box-shadow: var(--turn-shadow-default); }
+    .code-block pre { margin: 0; font-size: .82rem; line-height: 1.55; }
+    footer { padding: 38px 22px; border-top: 4px solid var(--turn-ink); background: var(--turn-yellow-600); color: var(--turn-ink); text-align: center; }
+
+    @media (max-width: 900px) {
+      .grid, .sizes { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .section-head { grid-template-columns: 1fr; }
+    }
+
+    @media (max-width: 620px) {
+      .grid, .sizes, .rules { grid-template-columns: 1fr; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      html { scroll-behavior: auto; }
+      *, *::before, *::after { transition: none !important; }
+    }
+  </style>
+</head>
+<body>
+  <header class="hero">
+    <nav class="hero-nav" aria-label="Design system navigation">
+      <a href="./design.html">← Main design system</a>
+      <a href="./">Open TURN</a>
+    </nav>
+    <span class="eyebrow">Normative component pattern</span>
+    <h1>TURN DIALOGS</h1>
+    <p>One interaction model and one visual anatomy, with deliberate size variants for short decisions, settings, rich tools and long-form reading.</p>
+  </header>
+
+  <nav class="section-nav" aria-label="Dialog design sections">
+    <a href="#principles">Principles</a>
+    <a href="#inventory">Inventory</a>
+    <a href="#anatomy">Anatomy</a>
+    <a href="#sizes">Sizes</a>
+    <a href="#behaviour">Behaviour</a>
+    <a href="#specimen">Specimen</a>
+  </nav>
+
+  <main>
+    <section id="principles">
+      <div class="section-head">
+        <div><span class="kicker">01 · Decision</span><h2>Standardize the shell, not the content.</h2></div>
+        <p>TURN dialogs should feel related and behave predictably. A Trophy Road tool, a denial alert and a long history reader do not need the same dimensions or internal layout.</p>
+      </div>
+      <div class="grid">
+        <article class="card"><span class="kicker">Structure</span><h3>Native dialog</h3><p>Use <code>&lt;dialog&gt;</code>, an accessible name, one visible heading and a real close control.</p></article>
+        <article class="card"><span class="kicker">Ownership</span><h3>One scroll surface</h3><p>The shell remains stable. Long content scrolls inside the body rather than moving the close control away.</p></article>
+        <article class="card"><span class="kicker">Variation</span><h3>Named sizes</h3><p>Choose compact, standard, wide or reader. Avoid one-off pixel widths tied to a single feature.</p></article>
+      </div>
+    </section>
+
+    <section id="inventory">
+      <div class="section-head">
+        <div><span class="kicker">02 · Production audit</span><h2>Current modal landscape.</h2></div>
+        <p>The audit covers production Home, race, progression, training and platform dialogs. Installation guidance remains an onboarding overlay outside this in-game pattern.</p>
+      </div>
+      <div class="table-wrap" tabindex="0" role="region" aria-label="Production dialog inventory">
+        <table>
+          <thead><tr><th>Dialog</th><th>Recommended size</th><th>Status</th><th>Notes</th></tr></thead>
+          <tbody>
+            <tr><td>About TURN</td><td>Compact</td><td><span class="status current">Normative</span></td><td>Short overview, credits, history and design-system actions.</td></tr>
+            <tr><td>Development history &amp; changelog</td><td>Reader</td><td><span class="status current">Normative</span></td><td>Nearly full screen; stable header, tabs and one internal reading surface.</td></tr>
+            <tr><td>Give Feedback</td><td>Standard</td><td><span class="status current">Normative shell</span></td><td>Compact body and action row.</td></tr>
+            <tr><td>How to Play</td><td>Wide</td><td><span class="status current">Normative shell</span></td><td>Card grid needs horizontal room.</td></tr>
+            <tr><td>Home Settings</td><td>Wide</td><td><span class="status current">Normative shell</span></td><td>Two-column form becomes one column in portrait.</td></tr>
+            <tr><td>Achievements / Trophy Road</td><td>Wide or Reader</td><td><span class="status special">Specialized body</span></td><td>Uses the common shell; owns filtering, preview and list layout.</td></tr>
+            <tr><td>Drive By Ear 101 introduction</td><td>Wide</td><td><span class="status special">Specialized focus</span></td><td>Top-preserving focus and delayed WebKit scroll correction are intentional.</td></tr>
+            <tr><td>Drive By Ear 101 part complete</td><td>Wide</td><td><span class="status current">Normative shell</span></td><td>Short instructional content plus navigation actions.</td></tr>
+            <tr><td>Motion access denied</td><td>Compact alert</td><td><span class="status migrate">Migration candidate</span></td><td>Keep the direct acknowledgement flow; align visual anatomy when next touched.</td></tr>
+            <tr><td>In-race audio settings</td><td>Standard</td><td><span class="status migrate">Migration candidate</span></td><td>Legacy visual shell; content semantics remain valid.</td></tr>
+            <tr><td>Reset-rivals confirmation</td><td>Inline confirmation</td><td><span class="status special">Not a modal</span></td><td>Keep the confirmation inside Settings; avoid a dialog on top of a dialog.</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section id="anatomy">
+      <div class="section-head">
+        <div><span class="kicker">03 · Anatomy</span><h2>A stable frame around changing content.</h2></div>
+        <p>Class names describe responsibility. Feature classes may extend the body but should not redefine the complete shell.</p>
+      </div>
+      <ol class="anatomy">
+        <li><div><strong><code>.turn-dialog</code></strong><span>The native dialog element. Owns viewport bounds, backdrop and size variant.</span></div></li>
+        <li><div><strong><code>.turn-dialog__surface</code></strong><span>The bordered TURN card. Owns padding, radius, hard shadow and overflow boundary.</span></div></li>
+        <li><div><strong><code>.turn-dialog__header</code></strong><span>Eyebrow, h2 and close button. Remains visible in reader dialogs.</span></div></li>
+        <li><div><strong><code>.turn-dialog__body</code></strong><span>The sole scroll owner when content exceeds the available block size.</span></div></li>
+        <li><div><strong><code>.turn-dialog__actions</code></strong><span>Optional grouped actions. Use buttons for commands and links for navigation.</span></div></li>
+      </ol>
+    </section>
+
+    <section id="sizes">
+      <div class="section-head">
+        <div><span class="kicker">04 · Size scale</span><h2>Four named choices.</h2></div>
+        <p>Choose the smallest size that supports the content without cramped controls, excessive wrapping or unnecessary empty space.</p>
+      </div>
+      <div class="sizes">
+        <article class="size-card"><span>Compact</span><h3>≈ 660 px</h3><p>About, alerts and short explanations.</p></article>
+        <article class="size-card"><span>Standard</span><h3>≈ 760 px</h3><p>Feedback, simple settings and focused tasks.</p></article>
+        <article class="size-card"><span>Wide</span><h3>≈ 1040 px</h3><p>Card grids, complex settings, training and progression.</p></article>
+        <article class="size-card"><span>Reader</span><h3>Near full screen</h3><p>Long documents, tabs and dense lists where stable navigation matters.</p></article>
+      </div>
+    </section>
+
+    <section id="behaviour">
+      <div class="section-head">
+        <div><span class="kicker">05 · Behaviour</span><h2>Predictable focus and dismissal.</h2></div>
+        <p>Visual consistency without consistent keyboard, screen-reader and scroll behaviour is not a component system.</p>
+      </div>
+      <div class="rules">
+        <article><h3>Opening</h3><ul><li>Record the invoking control.</li><li>Reset the intended scroll surface to the top.</li><li>Focus the close control unless feature testing proves another target is better.</li><li>Use <code>preventScroll</code> when available.</li></ul></article>
+        <article><h3>Closing</h3><ul><li>Close button and backdrop dismiss ordinary dialogs.</li><li>Escape uses native dialog behaviour.</li><li>Return focus to the invoking control.</li><li>Do not return focus to an element inside a dialog that is now closed.</li></ul></article>
+        <article><h3>Long content</h3><ul><li>Keep header and tab controls outside the scrolling body.</li><li>Use one internal scroll owner.</li><li>Contain overscroll to avoid moving the game beneath the dialog.</li><li>Do not shrink body text below a comfortable reading size merely to fit more.</li></ul></article>
+        <article><h3>Dialog transitions</h3><ul><li>Do not stack modal dialogs.</li><li>Close the source, open the destination, then restore the source when appropriate.</li><li>Tabs belong inside one dialog when they describe parallel views of the same object.</li><li>Use a separate dialog when the task changes substantially.</li></ul></article>
+      </div>
+    </section>
+
+    <section id="specimen">
+      <div class="section-head">
+        <div><span class="kicker">06 · Interactive specimen</span><h2>The standard shell.</h2></div>
+        <p>This specimen uses the production dialog stylesheet rather than a visual imitation.</p>
+      </div>
+      <div class="specimen">
+        <div class="demo-stage">
+          <button class="demo-open" type="button" aria-haspopup="dialog">OPEN DIALOG SPECIMEN</button>
+        </div>
+      </div>
+      <div class="code-block" style="margin-top:22px" tabindex="0" role="region" aria-label="Dialog markup example">
+<pre><code>&lt;dialog class="m8-dialog turn-dialog turn-dialog--standard" aria-labelledby="exampleTitle"&gt;
+  &lt;article class="m8-dialog-card turn-dialog__surface"&gt;
+    &lt;header class="m8-dialog-head turn-dialog__header"&gt;
+      &lt;div&gt;&lt;span&gt;EYEBROW&lt;/span&gt;&lt;h2 id="exampleTitle"&gt;TITLE&lt;/h2&gt;&lt;/div&gt;
+      &lt;button type="button" data-dialog-close aria-label="Close title"&gt;×&lt;/button&gt;
+    &lt;/header&gt;
+    &lt;div class="turn-dialog__body"&gt;…&lt;/div&gt;
+    &lt;div class="turn-dialog__actions"&gt;…&lt;/div&gt;
+  &lt;/article&gt;
+&lt;/dialog&gt;</code></pre>
+      </div>
+    </section>
+  </main>
+
+  <dialog class="m8-dialog turn-dialog turn-dialog--standard" aria-labelledby="dialogSpecimenTitle">
+    <article class="m8-dialog-card turn-dialog__surface">
+      <header class="m8-dialog-head turn-dialog__header">
+        <div><span>NORMATIVE EXAMPLE</span><h2 id="dialogSpecimenTitle">DIALOG TITLE</h2></div>
+        <button type="button" data-dialog-close aria-label="Close dialog specimen">×</button>
+      </header>
+      <div class="turn-dialog__body demo-body">
+        <p>The shell owns the backdrop, boundaries, padding, title and close control. Feature content owns only what happens inside this body.</p>
+      </div>
+      <div class="turn-dialog__actions demo-actions">
+        <button type="button" data-dialog-close>DONE</button>
+      </div>
+    </article>
+  </dialog>
+
+  <footer>TURN design system · Dialog pattern · August 2026</footer>
+
+  <script>
+    const trigger = document.querySelector('.demo-open');
+    const dialog = document.querySelector('dialog');
+    const closeButtons = dialog.querySelectorAll('[data-dialog-close]');
+    const open = () => {
+      dialog.__returnFocus = trigger;
+      if (typeof dialog.showModal === 'function') dialog.showModal();
+      else dialog.setAttribute('open', '');
+      dialog.querySelector('.m8-dialog-head [data-dialog-close]')?.focus();
+    };
+    const close = () => {
+      if (typeof dialog.close === 'function' && dialog.open) dialog.close();
+      else {
+        dialog.removeAttribute('open');
+        dialog.__returnFocus?.focus();
+      }
+    };
+    trigger.addEventListener('click', open);
+    closeButtons.forEach((button) => button.addEventListener('click', close));
+    dialog.addEventListener('click', (event) => {
+      if (event.target === dialog) close();
+    });
+    dialog.addEventListener('close', () => dialog.__returnFocus?.focus());
+  </script>
+</body>
+</html>

--- a/turn/dialog-system-r163.css
+++ b/turn/dialog-system-r163.css
@@ -1,0 +1,152 @@
+/*
+ * TURN dialog system
+ *
+ * Normative anatomy:
+ * dialog.turn-dialog
+ *   article.turn-dialog__surface
+ *     header.turn-dialog__header
+ *     .turn-dialog__body
+ *     .turn-dialog__actions (optional)
+ *
+ * Size is a content decision, not an ad-hoc width:
+ * compact · standard · wide · reader
+ */
+
+:where(.m8-dialog) {
+  --turn-dialog-inline-size: min(1040px, calc(100vw - 32px));
+  --turn-dialog-block-size: calc(100vh - 32px);
+  --turn-dialog-block-size: calc(100dvh - 32px);
+  --turn-dialog-padding: clamp(18px, 3vw, 34px);
+  --turn-dialog-radius: var(--turn-radius-hero, 30px);
+  --turn-dialog-border: var(--turn-border-strong, 6px);
+  --turn-dialog-shadow: var(--turn-shadow-hero, 12px 12px 0 var(--turn-ink, #08090a));
+  width: var(--turn-dialog-inline-size);
+  max-width: none;
+  max-height: none;
+}
+
+:where(.m8-dialog-card) {
+  box-sizing: border-box;
+  max-height: var(--turn-dialog-block-size);
+  padding: var(--turn-dialog-padding);
+  border-width: var(--turn-dialog-border);
+  border-radius: var(--turn-dialog-radius);
+  box-shadow: var(--turn-dialog-shadow);
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+}
+
+.turn-dialog--compact {
+  --turn-dialog-inline-size: min(660px, calc(100vw - 32px));
+}
+
+.turn-dialog--standard {
+  --turn-dialog-inline-size: min(760px, calc(100vw - 32px));
+}
+
+.turn-dialog--wide {
+  --turn-dialog-inline-size: min(1040px, calc(100vw - 32px));
+}
+
+.turn-dialog--reader {
+  --turn-dialog-inline-size: calc(100vw - 24px);
+  --turn-dialog-block-size: calc(100vh - 24px);
+  --turn-dialog-block-size: calc(100dvh - 24px);
+  --turn-dialog-padding: clamp(16px, 2.4vw, 28px);
+}
+
+.turn-dialog__surface {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.turn-dialog__header {
+  flex: 0 0 auto;
+}
+
+.turn-dialog__body {
+  min-height: 0;
+  overflow: auto;
+  overscroll-behavior-y: contain;
+  scrollbar-gutter: stable;
+  -webkit-overflow-scrolling: touch;
+}
+
+.turn-dialog__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.turn-dialog--reader .turn-dialog__surface {
+  height: var(--turn-dialog-block-size);
+  overflow: hidden;
+}
+
+.turn-dialog--reader .turn-dialog__header {
+  margin-bottom: clamp(12px, 2vh, 20px);
+}
+
+.turn-dialog--reader .turn-dialog__body {
+  flex: 1 1 auto;
+}
+
+/* Existing production dialogs mapped to the normative size scale. */
+.m8-about-dialog,
+.turn-motion-denied-dialog {
+  --turn-dialog-inline-size: min(660px, calc(100vw - 32px));
+}
+
+.m8-feedback-dialog,
+.audio-settings-dialog {
+  --turn-dialog-inline-size: min(760px, calc(100vw - 32px));
+}
+
+.m8-how-dialog,
+.m8-settings-dialog,
+.turn-achievements-dialog,
+.turn-dbe-training-intro-dialog,
+.turn-dbe-training-part-dialog {
+  --turn-dialog-inline-size: min(1040px, calc(100vw - 32px));
+}
+
+@media (max-height: 560px) and (orientation: landscape) {
+  :where(.m8-dialog) {
+    --turn-dialog-block-size: calc(100vh - 16px);
+    --turn-dialog-block-size: calc(100dvh - 16px);
+    --turn-dialog-padding: 16px 20px max(16px, env(safe-area-inset-bottom));
+  }
+
+  .turn-dialog--reader {
+    --turn-dialog-inline-size: calc(100vw - 12px);
+    --turn-dialog-block-size: calc(100vh - 12px);
+    --turn-dialog-block-size: calc(100dvh - 12px);
+  }
+
+  :where(.m8-dialog-head h2) {
+    font-size: clamp(1.65rem, 5vw, 2.8rem);
+  }
+
+  :where(.m8-dialog-head > button) {
+    width: 46px;
+    height: 46px;
+  }
+}
+
+@media (max-width: 760px) and (orientation: portrait) {
+  :where(.m8-dialog) {
+    --turn-dialog-inline-size: calc(100vw - 20px);
+    --turn-dialog-block-size: calc(100vh - 20px);
+    --turn-dialog-block-size: calc(100dvh - 20px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .turn-dialog,
+  .turn-dialog * {
+    scroll-behavior: auto !important;
+    transition: none !important;
+  }
+}

--- a/turn/dialog-system-r163.css
+++ b/turn/dialog-system-r163.css
@@ -20,6 +20,10 @@
   --turn-dialog-radius: var(--turn-radius-hero, 30px);
   --turn-dialog-border: var(--turn-border-strong, 6px);
   --turn-dialog-shadow: var(--turn-shadow-hero, 12px 12px 0 var(--turn-ink, #08090a));
+}
+
+/* The compound selector deliberately outranks the older .m8-dialog width. */
+.m8-dialog.turn-dialog {
   width: var(--turn-dialog-inline-size);
   max-width: none;
   max-height: none;
@@ -27,13 +31,17 @@
 
 :where(.m8-dialog-card) {
   box-sizing: border-box;
-  max-height: var(--turn-dialog-block-size);
   padding: var(--turn-dialog-padding);
   border-width: var(--turn-dialog-border);
   border-radius: var(--turn-dialog-radius);
   box-shadow: var(--turn-dialog-shadow);
   overscroll-behavior: contain;
   scrollbar-gutter: stable;
+}
+
+/* Likewise, the normative surface owns the block-size contract. */
+.m8-dialog-card.turn-dialog__surface {
+  max-height: var(--turn-dialog-block-size);
 }
 
 .turn-dialog--compact {

--- a/turn/index.html
+++ b/turn/index.html
@@ -182,4 +182,5 @@
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
   <script type="module" src="./app.js?build=20260805-r160-browser-consent-r162-dismiss-unlocked-car-toast"></script>
+  <script type="module" src="./ui/about-history-bootstrap.js?revision=r163-modal-system"></script>
 </body></html>

--- a/turn/ui/about-history-bootstrap.js
+++ b/turn/ui/about-history-bootstrap.js
@@ -250,17 +250,19 @@ function waitForAbout() {
   if (existing) return Promise.resolve(existing);
 
   return new Promise((resolve) => {
-    let attempts = 0;
+    let settled = false;
     const check = () => {
+      if (settled) return;
       const about = findAboutApi();
-      if (about) {
-        resolve(about);
-        return;
-      }
-      attempts += 1;
-      if (attempts < 600) requestAnimationFrame(check);
-      else throw new Error('TURN history could not find About TURN.');
+      if (!about) return;
+      settled = true;
+      resolve(about);
     };
+
+    // Home readiness is the stable lifecycle boundary. The one animation-frame
+    // check closes the tiny race where About was installed between the initial
+    // lookup and this listener being registered. No polling runs while a player
+    // remains on installation onboarding.
     document.addEventListener('turn:home-ready', check, { once: true });
     requestAnimationFrame(check);
   });

--- a/turn/ui/about-history-bootstrap.js
+++ b/turn/ui/about-history-bootstrap.js
@@ -1,0 +1,297 @@
+import {
+  CHANGELOG,
+  CURRENT_RELEASE,
+  DEVELOPMENT_HISTORY
+} from '../content/about-history.js?revision=r163-modal-system';
+
+const REVISION = 'r163-modal-system';
+let installed = false;
+
+function withBuild(path) {
+  const url = new URL(path, import.meta.url);
+  const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
+  if (buildKey) url.searchParams.set('build', `${buildKey}-${REVISION}`);
+  return url.href;
+}
+
+function installStylesheet(path, dataAttribute) {
+  if (document.querySelector(`link[${dataAttribute}]`)) return;
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = withBuild(path);
+  link.setAttribute(dataAttribute, '');
+  document.head.appendChild(link);
+}
+
+function openDialog(dialog, trigger) {
+  dialog.__turnReturnFocus = trigger;
+  const card = dialog.querySelector('.m8-dialog-card');
+  if (card) card.scrollTop = 0;
+  if (typeof dialog.showModal === 'function') dialog.showModal();
+  else dialog.setAttribute('open', '');
+  try {
+    dialog.querySelector('[data-dialog-close]')?.focus({ preventScroll: true });
+  } catch (_) {
+    dialog.querySelector('[data-dialog-close]')?.focus?.();
+  }
+}
+
+function closeDialog(dialog) {
+  if (typeof dialog.close === 'function' && dialog.open) {
+    dialog.close();
+    return;
+  }
+  dialog.removeAttribute('open');
+  dialog.dispatchEvent(new Event('turn-dialog-fallback-close'));
+}
+
+function escapeMarkup(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}
+
+function historyMarkup() {
+  return DEVELOPMENT_HISTORY.map((entry) => `
+    <article class="turn-history-entry">
+      <span>${escapeMarkup(entry.period)}</span>
+      <h3>${escapeMarkup(entry.title)}</h3>
+      ${entry.paragraphs.map((paragraph) => `<p>${escapeMarkup(paragraph)}</p>`).join('')}
+      <ul>${entry.milestones.map((milestone) => `<li>${escapeMarkup(milestone)}</li>`).join('')}</ul>
+    </article>`).join('');
+}
+
+function changelogMarkup() {
+  return CHANGELOG.map((release) => `
+    <article class="turn-changelog-release">
+      <time>${escapeMarkup(release.date)}</time>
+      <h3>${escapeMarkup(release.entries[0]?.[0] || release.date)}</h3>
+      <ul>${release.entries.map(([version, description]) => `
+        <li><strong>${escapeMarkup(version)}:</strong> ${escapeMarkup(description)}</li>`).join('')}
+      </ul>
+    </article>`).join('');
+}
+
+function createHistoryDialog() {
+  const dialog = document.createElement('dialog');
+  dialog.className = 'm8-dialog turn-dialog turn-dialog--reader turn-history-dialog';
+  dialog.setAttribute('aria-labelledby', 'turnHistoryTitle');
+  dialog.innerHTML = `
+    <article class="m8-dialog-card turn-dialog__surface turn-history-card">
+      <header class="m8-dialog-head turn-dialog__header turn-history-head">
+        <div>
+          <span>FROM FIRST PROTOTYPE TO TODAY</span>
+          <h2 id="turnHistoryTitle">TURN HISTORY</h2>
+          <p class="turn-history-release">V${escapeMarkup(CURRENT_RELEASE.version)} · BUILD ${escapeMarkup(CURRENT_RELEASE.build.toUpperCase())}</p>
+        </div>
+        <button type="button" data-dialog-close aria-label="Close TURN history">×</button>
+      </header>
+
+      <div class="turn-history-shell">
+        <div class="turn-history-tabs" role="tablist" aria-label="TURN history sections">
+          <button
+            id="turnHistoryDevelopmentTab"
+            type="button"
+            role="tab"
+            aria-selected="true"
+            aria-controls="turnHistoryDevelopmentPanel"
+            tabindex="0"
+            data-history-tab="development"
+          >DEVELOPMENT HISTORY</button>
+          <button
+            id="turnHistoryChangelogTab"
+            type="button"
+            role="tab"
+            aria-selected="false"
+            aria-controls="turnHistoryChangelogPanel"
+            tabindex="-1"
+            data-history-tab="changelog"
+          >CHANGELOG</button>
+        </div>
+
+        <div class="turn-history-panels turn-dialog__body">
+          <section
+            id="turnHistoryDevelopmentPanel"
+            class="turn-history-panel"
+            role="tabpanel"
+            aria-labelledby="turnHistoryDevelopmentTab"
+            tabindex="0"
+            data-history-panel="development"
+          >
+            <p class="turn-history-intro">TURN grew from a one-day sensor experiment into a five-track racing PWA with personal rivals, a fifteen-car garage, Drive By Ear, assistive-technology support and Trophy Road progression. This is the development story rather than a raw list of commits.</p>
+            ${historyMarkup()}
+          </section>
+
+          <section
+            id="turnHistoryChangelogPanel"
+            class="turn-history-panel"
+            role="tabpanel"
+            aria-labelledby="turnHistoryChangelogTab"
+            tabindex="0"
+            data-history-panel="changelog"
+            hidden
+          >
+            <p class="turn-history-intro">Meaningful player-facing, accessibility, architecture, performance and content changes are consolidated by date. Reverted experiments remain visible because they explain the product decisions that followed.</p>
+            ${changelogMarkup()}
+          </section>
+        </div>
+      </div>
+    </article>`;
+  document.body.appendChild(dialog);
+  return dialog;
+}
+
+function installTabs(dialog) {
+  const tabs = [...dialog.querySelectorAll('[role="tab"]')];
+  const panels = [...dialog.querySelectorAll('[role="tabpanel"]')];
+
+  function selectTab(tab, { focus = false } = {}) {
+    const selected = tab?.dataset.historyTab;
+    if (!selected) return;
+    for (const candidate of tabs) {
+      const active = candidate === tab;
+      candidate.setAttribute('aria-selected', String(active));
+      candidate.tabIndex = active ? 0 : -1;
+    }
+    for (const panel of panels) {
+      panel.hidden = panel.dataset.historyPanel !== selected;
+    }
+    if (focus) tab.focus();
+  }
+
+  for (const tab of tabs) {
+    tab.addEventListener('click', () => selectTab(tab));
+    tab.addEventListener('keydown', (event) => {
+      const currentIndex = tabs.indexOf(tab);
+      let nextIndex = currentIndex;
+      if (event.key === 'ArrowRight') nextIndex = (currentIndex + 1) % tabs.length;
+      else if (event.key === 'ArrowLeft') nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+      else if (event.key === 'Home') nextIndex = 0;
+      else if (event.key === 'End') nextIndex = tabs.length - 1;
+      else return;
+      event.preventDefault();
+      selectTab(tabs[nextIndex], { focus: true });
+    });
+  }
+
+  return Object.freeze({ select: (name) => {
+    const tab = tabs.find((candidate) => candidate.dataset.historyTab === name) || tabs[0];
+    selectTab(tab);
+  }});
+}
+
+function compactAboutDialog(aboutDialog, historyDialog, tabs) {
+  aboutDialog.classList.add('turn-dialog', 'turn-dialog--compact');
+  aboutDialog.querySelector('.m8-about-card')?.classList.add('turn-dialog__surface');
+  aboutDialog.querySelector('.m8-dialog-head')?.classList.add('turn-dialog__header');
+
+  const content = aboutDialog.querySelector('.m8-about-content');
+  if (!content) throw new Error('TURN history could not find the About content.');
+
+  content.classList.add('turn-dialog__body');
+  content.innerHTML = `
+    <p class="m8-about-lead">TURN is a racing game about tilt steering, personal rivals and learning to drive by ear.</p>
+    <p class="m8-about-summary">Built through inclusive and universal design so players can use sight, sound, touch, motion, a keyboard or assistive technology.</p>
+    <p class="m8-about-credits">© 2026 <a href="https://enkel.design/" target="_blank" rel="noreferrer">enkel.design</a>. Created by Erik Jansson, aided by OpenAI Codex. Drive By Ear™ is inspired by <a href="https://ceal.cs.columbia.edu/rad/" target="_blank" rel="noreferrer">RAD – Racing Auditory Display</a>.</p>
+    <div class="m8-about-actions turn-dialog__actions">
+      <button class="m8-about-history" type="button" aria-haspopup="dialog">HISTORY &amp; CHANGELOG</button>
+      <a class="m8-about-design-system" href="/turn/design-dialogs.html" target="_blank" rel="noreferrer">DESIGN SYSTEM</a>
+    </div>`;
+
+  const historyButton = content.querySelector('.m8-about-history');
+  let reopenAbout = false;
+
+  function showHistory() {
+    tabs.select('development');
+    reopenAbout = aboutDialog.open || aboutDialog.hasAttribute('open');
+    if (reopenAbout) {
+      aboutDialog.__turnReturnFocus = null;
+      if (typeof aboutDialog.close === 'function' && aboutDialog.open) aboutDialog.close();
+      else aboutDialog.removeAttribute('open');
+    }
+    openDialog(historyDialog, historyButton);
+  }
+
+  function restoreAbout() {
+    if (!reopenAbout) {
+      historyDialog.__turnReturnFocus?.focus?.();
+      return;
+    }
+    reopenAbout = false;
+    if (typeof aboutDialog.showModal === 'function') aboutDialog.showModal();
+    else aboutDialog.setAttribute('open', '');
+    try {
+      historyButton.focus({ preventScroll: true });
+    } catch (_) {
+      historyButton.focus();
+    }
+  }
+
+  historyButton.addEventListener('click', showHistory);
+  historyDialog.querySelector('[data-dialog-close]')?.addEventListener('click', () => closeDialog(historyDialog));
+  historyDialog.addEventListener('click', (event) => {
+    if (event.target === historyDialog) closeDialog(historyDialog);
+  });
+  historyDialog.addEventListener('close', restoreAbout);
+  historyDialog.addEventListener('turn-dialog-fallback-close', restoreAbout);
+
+  return historyButton;
+}
+
+function findAboutApi() {
+  const about = globalThis.__turnHomeFeedback?.about;
+  return about?.dialog?.isConnected ? about : null;
+}
+
+function waitForAbout() {
+  const existing = findAboutApi();
+  if (existing) return Promise.resolve(existing);
+
+  return new Promise((resolve) => {
+    let attempts = 0;
+    const check = () => {
+      const about = findAboutApi();
+      if (about) {
+        resolve(about);
+        return;
+      }
+      attempts += 1;
+      if (attempts < 600) requestAnimationFrame(check);
+      else throw new Error('TURN history could not find About TURN.');
+    };
+    document.addEventListener('turn:home-ready', check, { once: true });
+    requestAnimationFrame(check);
+  });
+}
+
+export async function installAboutHistory() {
+  if (installed) return globalThis.__turnAboutHistory;
+
+  installStylesheet('../dialog-system-r163.css?revision=r163-modal-pattern', 'data-turn-dialog-system');
+  installStylesheet('../about-history-r163.css?revision=r163-history-reader', 'data-turn-about-history');
+
+  const about = await waitForAbout();
+  const historyDialog = createHistoryDialog();
+  const tabs = installTabs(historyDialog);
+  const trigger = compactAboutDialog(about.dialog, historyDialog, tabs);
+
+  installed = true;
+  globalThis.__turnAboutHistory = Object.freeze({
+    version: REVISION,
+    dialog: historyDialog,
+    trigger,
+    open: (section = 'development') => {
+      tabs.select(section);
+      trigger.click();
+    },
+    close: () => closeDialog(historyDialog)
+  });
+  document.documentElement.dataset.turnDialogSystem = REVISION;
+  return globalThis.__turnAboutHistory;
+}
+
+installAboutHistory().catch((error) => {
+  console.error('TURN: About history enhancement failed.', error);
+});


### PR DESCRIPTION
## What changed

- keeps About TURN compact while adding a **History & Changelog** action
- adds one near-full-screen reader with accessible **Development history** and **Changelog** tabs
- stores the long-form content separately from the interface code
- adds a direct About link to the TURN dialog design-system reference
- defines compact, standard, wide and reader dialog variants
- audits current production dialogs and records intentional special cases and migration candidates
- loads the enhancement in both TURN and TURN NEXT without changing the public 1.5.1/r160 release identity
- adds a dedicated production regression and includes it in the normal TURN CI workflow

## Interaction decisions

- one tabbed reader rather than two separate long-form dialogs
- no stacked modal dialogs: About closes before the reader opens, then is restored on exit
- reader header and tabs remain stable while one internal body owns scrolling
- keyboard tabs support Left/Right, Home and End
- focus returns to the History & Changelog action inside the restored About dialog

## Validation

- branch is based on current `main` (`b24dfa6`)
- no release metadata or generated TURN NEXT runtime files changed
- GitHub Actions regression suite is configured to syntax-check, lint and run the new `about-history-production.mjs` contract
