### PR TITLE
Unify design-system navigation and protect TURN viewport

### DIFF
--- a/turn-next/index.html
+++ b/turn-next/index.html
@@ -141,5 +141,5 @@
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
   <script type="module" src="/turn-next/app.js?source=20260805-r160-browser-consent"></script>
-  <script type="module" src="./ui/about-history-bootstrap.js?revision=r163-modal-system"></script>
+  <script type="module" src="./ui/about-history-bootstrap.js?revision=r164-design-navigation"></script>
 </body></html>

--- a/turn-tests/about-history-production.mjs
+++ b/turn-tests/about-history-production.mjs
@@ -24,8 +24,8 @@ const [
 ]);
 
 for (const entry of [productionEntry, nextEntry]) {
-  assert.match(entry, /about-history-bootstrap\.js\?revision=r163-modal-system/,
-    'Production and TURN NEXT must load the same canonical About history enhancement');
+  assert.match(entry, /about-history-bootstrap\.js\?revision=r164-design-navigation/,
+    'Production and TURN NEXT must load the same refreshed About history enhancement');
 }
 
 assert.match(bootstrap, /CHANGELOG[\s\S]*CURRENT_RELEASE[\s\S]*DEVELOPMENT_HISTORY/);

--- a/turn-tests/about-history-production.mjs
+++ b/turn-tests/about-history-production.mjs
@@ -8,7 +8,9 @@ const [
   content,
   dialogCss,
   historyCss,
-  designReference
+  designMain,
+  designReference,
+  designNavigation
 ] = await Promise.all([
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-next/index.html', import.meta.url), 'utf8'),
@@ -16,7 +18,9 @@ const [
   fs.readFile(new URL('../turn/content/about-history.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/dialog-system-r163.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/about-history-r163.css', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/design-dialogs.html', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/design.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/design-dialogs.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/design-navigation.css', import.meta.url), 'utf8')
 ]);
 
 for (const entry of [productionEntry, nextEntry]) {
@@ -41,7 +45,8 @@ assert.match(bootstrap, /aboutDialog\.showModal\(\)/,
 assert.match(bootstrap, /historyButton\.focus\(\{ preventScroll: true \}\)/,
   'Focus should return to the History and Changelog action inside the restored About dialog');
 assert.match(bootstrap, /HISTORY &amp; CHANGELOG/);
-assert.match(bootstrap, /href="\/turn\/design-dialogs\.html"/);
+assert.match(bootstrap, /href="\/turn\/design\.html"/,
+  'The About action must open the main TURN design system');
 assert.match(bootstrap, />DESIGN SYSTEM<\/a>/);
 assert.match(bootstrap, /installStylesheet\('\.\.\/dialog-system-r163\.css/);
 assert.match(bootstrap, /installStylesheet\('\.\.\/about-history-r163\.css/);
@@ -94,4 +99,25 @@ assert.match(designReference, /Do not stack modal dialogs/);
 assert.match(designReference, /href="\.\/design\.html"/,
   'The dialog reference must remain connected to the main design system');
 
-console.log('TURN About history, changelog and normative dialog-system regression passed.');
+for (const designPage of [designMain, designReference]) {
+  assert.match(designPage, /href="\.\/design-navigation\.css\?revision=r164-design-navigation"/,
+    'Every design-system page must use the shared navigation pattern');
+  assert.match(designPage, /class="design-page-nav" aria-label="Design system pages"/);
+  assert.match(designPage, />Design system<\/a>[\s\S]*>Dialogs<\/a>[\s\S]*>Open TURN<\/a>/,
+    'Design-system pages must expose the same page navigation in the same order');
+  assert.match(designPage, /href="\/turn\/" target="_blank" rel="noopener noreferrer">Open TURN<\/a>/,
+    'Open TURN must use a fresh browsing context so mobile Safari cannot carry the documentation viewport scale into the game');
+  assert.match(designPage, /class="design-page-scroll" href="#[^"]+"/,
+    'Every design-system hero must visibly indicate that content continues below');
+  assert.match(designPage, /class="section-nav design-section-nav"/,
+    'Every design-system page must use the shared section-navigation treatment');
+}
+
+assert.match(designMain, /href="\.\/design\.html" aria-current="page">Design system<\/a>/);
+assert.match(designReference, /href="\.\/design-dialogs\.html" aria-current="page">Dialogs<\/a>/);
+assert.match(designNavigation, /min-height: 100svh/);
+assert.match(designNavigation, /\.design-page-nav a\[aria-current='page'\]/);
+assert.match(designNavigation, /\.section-nav\.design-section-nav/);
+assert.match(designNavigation, /prefers-reduced-motion: reduce/);
+
+console.log('TURN About history, changelog, dialog system and design-system navigation regression passed.');

--- a/turn/design-dialogs.html
+++ b/turn/design-dialogs.html
@@ -10,10 +10,12 @@
   <link rel="stylesheet" href="./design-semantic.css?revision=r141-form-disclosure">
   <link rel="stylesheet" href="./m8-home.css?revision=r163-dialog-reference">
   <link rel="stylesheet" href="./dialog-system-r163.css?revision=r163-modal-pattern">
+  <link rel="stylesheet" href="./design-navigation.css?revision=r164-design-navigation">
   <style>
     :root {
       font-family: Inter, ui-rounded, system-ui, sans-serif;
       color-scheme: light;
+      --design-page-width: 1120px;
       --m8-ink: var(--turn-ink);
       --m8-cream: var(--turn-paper);
       --m8-pink: var(--turn-pink-500);
@@ -28,22 +30,26 @@
     code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
     a:focus-visible, button:focus-visible { outline: 5px solid var(--turn-form-control-focus); outline-offset: 4px; }
 
+    .skip-link {
+      position: fixed;
+      z-index: 100;
+      top: 12px;
+      left: 12px;
+      padding: 10px 14px;
+      border: 4px solid var(--turn-ink);
+      border-radius: var(--turn-radius-compact);
+      background: var(--turn-yellow-400);
+      color: var(--turn-ink);
+      box-shadow: var(--turn-shadow-default);
+      transform: translateY(-180%);
+    }
+
+    .skip-link:focus { transform: none; }
+
     .hero {
       padding: clamp(40px, 8vw, 96px) max(22px, calc((100vw - 1120px) / 2));
       background: linear-gradient(145deg, var(--turn-blue-500), var(--turn-green-500));
       color: var(--turn-ink);
-    }
-
-    .hero-nav { display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 28px; }
-    .hero-nav a {
-      padding: 8px 13px;
-      border: 3px solid var(--turn-ink);
-      border-radius: var(--turn-radius-pill);
-      background: var(--turn-paper);
-      box-shadow: var(--turn-shadow-compact);
-      font-size: .78rem;
-      font-weight: 950;
-      text-decoration: none;
     }
 
     .eyebrow {
@@ -155,17 +161,25 @@
   </style>
 </head>
 <body>
-  <header class="hero">
-    <nav class="hero-nav" aria-label="Design system navigation">
-      <a href="./design.html">← Main design system</a>
-      <a href="./">Open TURN</a>
-    </nav>
-    <span class="eyebrow">Normative component pattern</span>
-    <h1>TURN DIALOGS</h1>
-    <p>One interaction model and one visual anatomy, with deliberate size variants for short decisions, settings, rich tools and long-form reading.</p>
+  <a class="skip-link" href="#main">Skip to dialog guidance</a>
+
+  <header class="hero design-page-hero">
+    <div class="design-page-shell">
+      <nav class="design-page-nav" aria-label="Design system pages">
+        <a href="./design.html">Design system</a>
+        <a href="./design-dialogs.html" aria-current="page">Dialogs</a>
+        <a href="/turn/" target="_blank" rel="noopener noreferrer">Open TURN</a>
+      </nav>
+      <div class="design-page-hero-content">
+        <span class="eyebrow">Normative component pattern</span>
+        <h1>TURN DIALOGS</h1>
+        <p>One interaction model and one visual anatomy, with deliberate size variants for short decisions, settings, rich tools and long-form reading.</p>
+      </div>
+      <a class="design-page-scroll" href="#dialog-sections"><span aria-hidden="true">↓</span> Explore dialog guidance</a>
+    </div>
   </header>
 
-  <nav class="section-nav" aria-label="Dialog design sections">
+  <nav id="dialog-sections" class="section-nav design-section-nav" aria-label="Dialog design sections">
     <a href="#principles">Principles</a>
     <a href="#inventory">Inventory</a>
     <a href="#anatomy">Anatomy</a>
@@ -174,7 +188,7 @@
     <a href="#specimen">Specimen</a>
   </nav>
 
-  <main>
+  <main id="main">
     <section id="principles">
       <div class="section-head">
         <div><span class="kicker">01 · Decision</span><h2>Standardize the shell, not the content.</h2></div>

--- a/turn/design-navigation.css
+++ b/turn/design-navigation.css
@@ -1,7 +1,6 @@
 /* Shared navigation and hero-continuation pattern for TURN design-system pages. */
 
-.design-page-hero {
-  --design-page-width: 1180px;
+.hero.design-page-hero {
   min-height: 100vh;
   min-height: 100svh;
   display: flex;
@@ -10,7 +9,7 @@
 }
 
 .design-page-shell {
-  width: min(var(--design-page-width), 100%);
+  width: min(var(--design-page-width, 1180px), 100%);
   margin: 0 auto;
   display: flex;
   flex: 1 1 auto;
@@ -93,7 +92,7 @@
   line-height: .8;
 }
 
-.design-section-nav {
+.section-nav.design-section-nav {
   position: sticky;
   z-index: 50;
   top: 0;
@@ -107,20 +106,20 @@
   scrollbar-width: thin;
 }
 
-.design-section-nav a {
+.section-nav.design-section-nav a {
   flex: 0 0 auto;
   padding: 8px 12px;
   border-radius: var(--turn-radius-pill);
   text-decoration: none;
 }
 
-.design-section-nav a:hover,
-.design-section-nav a:focus-visible {
+.section-nav.design-section-nav a:hover,
+.section-nav.design-section-nav a:focus-visible {
   background: var(--turn-yellow-400);
 }
 
 @media (max-height: 620px) and (orientation: landscape) {
-  .design-page-hero {
+  .hero.design-page-hero {
     min-height: auto;
   }
 

--- a/turn/design-navigation.css
+++ b/turn/design-navigation.css
@@ -1,0 +1,152 @@
+/* Shared navigation and hero-continuation pattern for TURN design-system pages. */
+
+.design-page-hero {
+  --design-page-width: 1180px;
+  min-height: 100vh;
+  min-height: 100svh;
+  display: flex;
+  padding-top: clamp(22px, 4vw, 48px) !important;
+  padding-bottom: max(clamp(20px, 3vw, 36px), env(safe-area-inset-bottom)) !important;
+}
+
+.design-page-shell {
+  width: min(var(--design-page-width), 100%);
+  margin: 0 auto;
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.design-page-nav {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 0 0 clamp(22px, 4vh, 36px);
+}
+
+.design-page-nav a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 46px;
+  padding: 8px 14px;
+  border: 3px solid var(--turn-ink);
+  border-radius: var(--turn-radius-pill);
+  background: var(--turn-paper);
+  color: var(--turn-ink);
+  box-shadow: var(--turn-shadow-compact);
+  font-size: clamp(.74rem, 1.25vw, .88rem);
+  font-weight: 950;
+  line-height: 1.1;
+  text-decoration: none;
+}
+
+.design-page-nav a[aria-current='page'] {
+  background: var(--turn-yellow-400);
+}
+
+.design-page-nav a:active,
+.design-page-scroll:active {
+  transform: translate(4px, 4px);
+  box-shadow: 1px 1px 0 var(--turn-ink);
+}
+
+.design-page-hero-content {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.design-page-hero-content > .hero-inner {
+  width: 100%;
+  margin: 0;
+}
+
+.design-page-scroll {
+  display: inline-flex;
+  align-self: center;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  min-height: 46px;
+  margin-top: clamp(20px, 4vh, 38px);
+  padding: 8px 15px;
+  border: 3px solid var(--turn-ink);
+  border-radius: var(--turn-radius-pill);
+  background: var(--turn-yellow-400);
+  color: var(--turn-ink);
+  box-shadow: var(--turn-shadow-compact);
+  font-size: clamp(.72rem, 1.2vw, .84rem);
+  font-weight: 950;
+  letter-spacing: .055em;
+  line-height: 1.1;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.design-page-scroll span {
+  font-size: 1.35em;
+  line-height: .8;
+}
+
+.design-section-nav {
+  position: sticky;
+  z-index: 50;
+  top: 0;
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding: 10px max(18px, calc((100vw - var(--design-page-width, 1180px)) / 2));
+  border-block: 4px solid var(--turn-ink);
+  background: rgb(255 248 232 / .97);
+  color: var(--turn-ink);
+  scrollbar-width: thin;
+}
+
+.design-section-nav a {
+  flex: 0 0 auto;
+  padding: 8px 12px;
+  border-radius: var(--turn-radius-pill);
+  text-decoration: none;
+}
+
+.design-section-nav a:hover,
+.design-section-nav a:focus-visible {
+  background: var(--turn-yellow-400);
+}
+
+@media (max-height: 620px) and (orientation: landscape) {
+  .design-page-hero {
+    min-height: auto;
+  }
+
+  .design-page-hero-content {
+    padding-block: 18px;
+  }
+
+  .design-page-scroll {
+    align-self: flex-start;
+  }
+}
+
+@media (max-width: 620px) {
+  .design-page-nav a {
+    min-height: 44px;
+  }
+
+  .design-page-scroll {
+    align-self: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .design-page-nav a,
+  .design-page-scroll,
+  .design-section-nav a {
+    transition: none !important;
+  }
+}

--- a/turn/design-navigation.css
+++ b/turn/design-navigation.css
@@ -120,15 +120,60 @@
 
 @media (max-height: 620px) and (orientation: landscape) {
   .hero.design-page-hero {
-    min-height: auto;
+    position: relative;
+    height: 100vh;
+    height: 100svh;
+    min-height: 100vh;
+    min-height: 100svh;
+    overflow: hidden;
+    padding-top: max(12px, env(safe-area-inset-top)) !important;
+    padding-bottom: max(52px, calc(env(safe-area-inset-bottom) + 42px)) !important;
+  }
+
+  .design-page-nav {
+    gap: 8px;
+    margin-bottom: 10px;
+  }
+
+  .design-page-nav a {
+    min-height: 38px;
+    padding: 6px 11px;
+    font-size: .7rem;
   }
 
   .design-page-hero-content {
-    padding-block: 18px;
+    justify-content: center;
+    padding: 0;
+  }
+
+  .design-page-hero h1 {
+    margin-block: 10px 8px;
+    font-size: clamp(3rem, 6.8vw, 4.5rem);
+  }
+
+  .design-page-hero p {
+    font-size: clamp(.82rem, 1.55vw, 1rem);
+  }
+
+  .design-page-hero .hero-inner img {
+    width: min(160px, 20vw);
   }
 
   .design-page-scroll {
-    align-self: flex-start;
+    position: absolute;
+    z-index: 2;
+    left: 50%;
+    bottom: max(10px, env(safe-area-inset-bottom));
+    min-height: 38px;
+    margin: 0;
+    padding: 6px 12px;
+    font-size: .68rem;
+    transform: translateX(-50%);
+    white-space: nowrap;
+  }
+
+  .design-page-scroll:active {
+    transform: translate(calc(-50% + 4px), 4px);
   }
 }
 

--- a/turn/design.html
+++ b/turn/design.html
@@ -8,10 +8,12 @@
   <title>TURN Design System</title>
   <link rel="stylesheet" href="./design-tokens.css?revision=r141-form-disclosure">
   <link rel="stylesheet" href="./design-semantic.css?revision=r141-form-disclosure">
+  <link rel="stylesheet" href="./design-navigation.css?revision=r164-design-navigation">
   <style>
     :root {
       font-family: Inter, ui-rounded, system-ui, sans-serif;
       color-scheme: light;
+      --design-page-width: 1180px;
     }
 
     * { box-sizing: border-box; }
@@ -298,18 +300,28 @@
 <body>
   <a class="skip-link" href="#main">Skip to the design system</a>
 
-  <header class="hero">
-    <div class="hero-inner">
-      <div>
-        <span class="eyebrow">Normative production system</span>
-        <h1>TURN DESIGN SYSTEM</h1>
-        <p>A living reference built from TURN’s actual interaction patterns. Standardize the grammar, not the personality.</p>
+  <header class="hero design-page-hero">
+    <div class="design-page-shell">
+      <nav class="design-page-nav" aria-label="Design system pages">
+        <a href="./design.html" aria-current="page">Design system</a>
+        <a href="./design-dialogs.html">Dialogs</a>
+        <a href="/turn/" target="_blank" rel="noopener noreferrer">Open TURN</a>
+      </nav>
+      <div class="design-page-hero-content">
+        <div class="hero-inner">
+          <div>
+            <span class="eyebrow">Normative production system</span>
+            <h1>TURN DESIGN SYSTEM</h1>
+            <p>A living reference built from TURN’s actual interaction patterns. Standardize the grammar, not the personality.</p>
+          </div>
+          <img src="./TURNicon.PNG" alt="TURN app icon">
+        </div>
       </div>
-      <img src="./TURNicon.PNG" alt="TURN app icon">
+      <a class="design-page-scroll" href="#design-sections"><span aria-hidden="true">↓</span> Explore the system</a>
     </div>
   </header>
 
-  <nav class="section-nav" aria-label="Design system sections">
+  <nav id="design-sections" class="section-nav design-section-nav" aria-label="Design system sections">
     <a href="#audit">Audit</a>
     <a href="#colour">Colour</a>
     <a href="#patterns">Patterns</a>

--- a/turn/index.html
+++ b/turn/index.html
@@ -182,5 +182,5 @@
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
   <script type="module" src="./app.js?build=20260805-r160-browser-consent-r162-dismiss-unlocked-car-toast"></script>
-  <script type="module" src="./ui/about-history-bootstrap.js?revision=r163-modal-system"></script>
+  <script type="module" src="./ui/about-history-bootstrap.js?revision=r164-design-navigation"></script>
 </body></html>

--- a/turn/ui/about-history-bootstrap.js
+++ b/turn/ui/about-history-bootstrap.js
@@ -197,7 +197,7 @@ function compactAboutDialog(aboutDialog, historyDialog, tabs) {
     <p class="m8-about-credits">© 2026 <a href="https://enkel.design/" target="_blank" rel="noreferrer">enkel.design</a>. Created by Erik Jansson, aided by OpenAI Codex. Drive By Ear™ is inspired by <a href="https://ceal.cs.columbia.edu/rad/" target="_blank" rel="noreferrer">RAD – Racing Auditory Display</a>.</p>
     <div class="m8-about-actions turn-dialog__actions">
       <button class="m8-about-history" type="button" aria-haspopup="dialog">HISTORY &amp; CHANGELOG</button>
-      <a class="m8-about-design-system" href="/turn/design-dialogs.html" target="_blank" rel="noreferrer">DESIGN SYSTEM</a>
+      <a class="m8-about-design-system" href="/turn/design.html" target="_blank" rel="noreferrer">DESIGN SYSTEM</a>
     </div>`;
 
   const historyButton = content.querySelector('.m8-about-history');


### PR DESCRIPTION
## What changed

- points the in-game **Design system** action to the main TURN design system
- gives both design-system pages the same top-level navigation: **Design system**, **Dialogs**, **Open TURN**
- keeps page-specific section navigation visually consistent through one shared stylesheet
- adds a visible, keyboard-accessible continuation cue at the bottom of each hero
- keeps that cue visible in short landscape viewports
- opens TURN in a fresh browsing context from the documentation pages
- refreshes the About enhancement URL in TURN and TURN NEXT so installed clients receive the updated destination
- extends the existing About/dialog regression to cover navigation parity and the fresh-context launch contract

## Root cause of the flattened race UI

The Dialogs page navigated its existing documentation tab directly into TURN. On mobile Safari, that can retain the scalable documentation page’s visual-viewport state when entering the game page, making the race UI appear horizontally stretched or flattened. The **Open TURN** link now opens a fresh browsing context with `target="_blank"` and `noopener`, so TURN starts with its own viewport contract.

## Validation

- branch based on current `main` (`f403d93`)
- no public release/version change
- no gameplay modules changed
- CI covers shared navigation, active-page state, below-hero cue, About destination, and fresh-context TURN launch
