### PR TITLE
Add guided onboarding and varied POSTAL shifts

### DIFF
--- a/.github/workflows/postal-game-tests.yml
+++ b/.github/workflows/postal-game-tests.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Check JavaScript syntax
         run: node --check postal/main.mjs && node --check postal/world.mjs && node --check postal/sim.mjs && node --check postal/sw.js
       - name: Test the shift simulation
-        run: node --test postal/tests/sim.test.mjs
+        run: node --test postal/tests/*.test.mjs

--- a/postal/README.md
+++ b/postal/README.md
@@ -1,37 +1,34 @@
-# POSTAL visual game slice
+# POSTAL portrait game campaign
 
-POSTAL is a mobile-portrait parcel-network management game set in Sweden. This directory contains a polished, playable shift rather than the earlier interaction prototype.
+POSTAL is a mobile-portrait parcel-network management game set in Sweden. The current playable build contains a guided first shift followed by four distinct operations rather than one unexplained scenario.
 
-## Playable shift
+## Shift campaign
 
-The 18:20 northbound Express flow is at risk in Sundsvall. The player can:
+1. **First rounds — guided terminal shift.** Read the blue Express lane, move spare crew, inspect the scanner, watch six promises and send the morning van. Instruction steps do not run a deadline.
+2. **Northbound promises — systems shift.** Protect a departure, investigate a misrouted parcel, correlate matching failures, repair the routing rule and verify the later flow.
+3. **Snow over E4 — network shift.** Inspect three depots, allocate one spare truck, choose between the restricted coast road and the inland route, then run the weather window.
+4. **Scanner fever — triage shift.** Diagnose a jam, order three parcel groups by their promises, choose repair or manual bypass and clear the live queue. Parcel groups change on replays.
+5. **Priority parcel — investigation shift.** Read a temperature-controlled parcel's event trail, infer its location, choose a recovery connection and follow it to delivery. Evidence changes on replays.
 
-1. read the animated parcel flow and protect the departure;
-2. rebalance crew or accept the downstream cost of holding the truck;
-3. trace an Express parcel that entered the Standard lane;
-4. light up matching parcels and identify the shared routing signature;
-5. correct the rule order;
-6. verify twelve later parcels in live flow;
-7. dispatch the truck and receive a graded shift report.
+Completing the first shift opens the full shift board. Completion, best results and replay variants are stored locally in the browser.
 
-The shift is pausable, supports 1× and 2× time, and takes roughly five minutes on a first playthrough.
+## Presentation and feedback
 
-## Presentation
-
-- A fixed isometric 3D terminal, regional diorama and parcel-inspection scene replace the former CSS-drawn map and explanatory card stack.
-- The world uses small CC0 Kenney assets vendored under `assets/`; see [`assets/ATTRIBUTION.md`](./assets/ATTRIBUTION.md).
-- The required three.js modules are vendored locally, so the game world does not depend on a third-party CDN at runtime.
-- Consequential detail stays available on demand through the structured Shift details dialog.
-- The interface is portrait-first and remains usable on narrow and short phone viewports.
+- Fixed isometric 3D terminal, regional and parcel scenes use small CC0 Kenney assets vendored under `assets/`; see [`assets/ATTRIBUTION.md`](./assets/ATTRIBUTION.md).
+- The required three.js modules are vendored locally, so the game does not depend on a third-party CDN at runtime.
+- Snow, scanner congestion, live routing, crew movement, parcel flow and recovery progress are shown in the miniature worlds.
+- Interface feedback uses a quiet family of short, low-volume triangle tones synthesized by the Web Audio API. The previous sharp sample cues are no longer played.
+- Consequential detail remains available on demand through a scenario-specific structured Shift details dialog.
 
 ## Accessibility
 
 - Every consequential canvas state is repeated in semantic HTML.
-- Projected world hotspots are real buttons with accessible names.
-- Colour is paired with labels, shapes and patterns.
-- Opening detailed information pauses the simulation and restores the previous running state on close.
-- The game responds to reduced-motion preferences and pauses when the page becomes hidden.
-- Full play does not depend on precise canvas picking; every required action is also exposed as a large HTML control.
+- Projected world hotspots are real buttons with accessible names, and each required object action has a large HTML alternative.
+- Colour is paired with labels, shapes, values and patterns.
+- The first shift introduces one action at a time and does not start time while explaining it.
+- Opening detailed information pauses live simulation and restores the previous running state on close.
+- Reduced-motion preferences remove camera sweeps, pulsing and non-essential animation.
+- A no-WebGL fallback keeps every shift playable through the command deck and structured details.
 
 ## Local run and checks
 
@@ -40,4 +37,6 @@ Serve the repository root over HTTP and open `/postal/`.
 ```sh
 python -m http.server 4173
 node --test postal/tests/sim.test.mjs
+node --check postal/main.mjs
+node --check postal/world.mjs
 ```

--- a/postal/assets/ATTRIBUTION.md
+++ b/postal/assets/ATTRIBUTION.md
@@ -5,7 +5,7 @@ POSTAL includes selected assets from the following Kenney packs:
 - [**Factory Kit 3.0**](https://kenney.nl/assets/factory-kit) — conveyors, parcels, scanners, machinery, structures and Oopi operators.
 - [**City Builder Starter Kit**](https://github.com/KenneyNL/City-Builder-Kit) — roads, buildings and trees.
 - [**Car Kit 3.1**](https://kenney.nl/assets/car-kit) — the northbound truck, shared from TURN's existing vendored assets.
-- [**UI Audio 1.0**](https://kenney.nl/assets/ui-audio) — interface and game-feedback sounds.
+- [**UI Audio 1.0**](https://kenney.nl/assets/ui-audio) — CC0 samples retained from the first visual prototype. The current build does not play these files; its short, warm feedback tones are synthesized locally with the Web Audio API.
 
 All selected assets are released under [Creative Commons CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/). Attribution is not required. POSTAL credits Kenney because the work gives the game much of its character.
 

--- a/postal/index.html
+++ b/postal/index.html
@@ -9,7 +9,7 @@
   <meta name="format-detection" content="telephone=no">
   <meta name="description" content="POSTAL is a portrait-friendly parcel network management game set in Sweden.">
   <title>POSTAL — Every package has a promise</title>
-  <link rel="stylesheet" href="./styles.css?build=20260805-visual-game-r1">
+  <link rel="stylesheet" href="./styles.css?build=20260805-campaign-r3">
   <script type="importmap">
     {
       "imports": {
@@ -45,26 +45,26 @@
       </div>
 
       <div class="shift-line">
-        <span class="shift-place">SUNDSVALL · SHIFT 3</span>
-        <span class="shift-clock" id="clock">17:42</span>
+        <span class="shift-place" id="shiftPlace">SUNDSVALL · FIRST SHIFT</span>
+        <span class="shift-clock" id="clock">08:05</span>
         <span class="shift-state" id="shiftState">READY</span>
       </div>
 
       <section class="metrics" aria-label="Network performance">
         <div class="metric metric--service" id="serviceMetric">
-          <span class="metric-icon" aria-hidden="true">✓</span>
-          <span class="metric-label">On time</span>
-          <strong id="serviceValue">91%</strong>
+          <span class="metric-icon" id="serviceIcon" aria-hidden="true">✓</span>
+          <span class="metric-label" id="serviceLabel">On time</span>
+          <strong id="serviceValue">98%</strong>
         </div>
         <div class="metric metric--backlog" id="backlogMetric">
-          <span class="metric-icon" aria-hidden="true">▦</span>
-          <span class="metric-label">In flow</span>
-          <strong id="backlogValue">84</strong>
+          <span class="metric-icon" id="backlogIcon" aria-hidden="true">▦</span>
+          <span class="metric-label" id="backlogLabel">In flow</span>
+          <strong id="backlogValue">6</strong>
         </div>
         <div class="metric metric--risk" id="riskMetric" data-level="warning">
-          <span class="metric-icon" aria-hidden="true">!</span>
-          <span class="metric-label">At risk</span>
-          <strong id="riskValue">18</strong>
+          <span class="metric-icon" id="riskIcon" aria-hidden="true">!</span>
+          <span class="metric-label" id="riskLabel">At risk</span>
+          <strong id="riskValue">0</strong>
         </div>
       </section>
     </header>
@@ -84,18 +84,18 @@
         <strong id="sceneTitle">Sundsvall</strong>
       </div>
 
-      <div class="mission-pill" id="missionPill" aria-live="polite">
+      <div class="mission-pill" id="missionPill">
         <span class="mission-symbol" aria-hidden="true">↗</span>
         <span>
-          <small id="missionLabel">NORTHBOUND EXPRESS</small>
-          <strong id="missionTime">DEPARTS 18:20 · 38 MIN</strong>
+          <small id="missionLabel">FIRST ROUNDS</small>
+          <strong id="missionTime">4 SHORT TASKS · NO PRESSURE</strong>
         </span>
       </div>
 
       <div class="hotspot-layer" id="hotspotLayer" aria-label="Interactive locations in the current scene"></div>
 
       <p class="sr-only" id="sceneSummary">
-        Sundsvall terminal. Express lane A is overloaded. Eighteen northbound parcels are at risk before the 18:20 departure.
+        Sundsvall terminal. The guided first shift begins with the blue Express lane.
       </p>
     </main>
 
@@ -103,12 +103,12 @@
       <div class="deck-grabber" aria-hidden="true"></div>
       <div class="command-content" id="commandContent">
         <div class="command-copy">
-          <span class="command-kicker">SHIFT BRIEF</span>
-          <h1 id="commandTitle">The northbound run needs you.</h1>
-          <p id="commandText">Watch the parcel flow, protect the departure and find out why blue Express parcels keep reaching the yellow lane.</p>
+          <span class="command-kicker">FIRST SHIFT · GUIDED</span>
+          <h1 id="commandTitle">Meet the parcel flow.</h1>
+          <p id="commandText">Four small actions introduce the terminal. Nothing moves until you are ready.</p>
         </div>
         <div class="command-actions" id="commandActions">
-          <button class="game-button game-button--primary" id="deckStartButton" type="button">Start shift</button>
+          <button class="game-button game-button--primary" id="deckStartButton" type="button">Start first shift</button>
         </div>
       </div>
     </section>
@@ -135,7 +135,7 @@
     <div class="welcome-card">
       <div class="welcome-logo" aria-hidden="true">
         <span class="welcome-box"><i></i></span>
-        <span class="welcome-word">POSTAL</span>
+        <span class="welcome-word" id="welcomeTitle">POSTAL</span>
       </div>
       <p class="welcome-tagline">Every package has a promise.</p>
       <div class="brief-card">
@@ -146,29 +146,42 @@
           <span class="brief-line"></span>
           <span class="brief-node"></span>
         </div>
-        <span class="brief-label">TONIGHT'S CHALLENGE</span>
-        <strong>Save the 18:20 northbound express.</strong>
-        <span>Sundsvall → Härnösand · about 5 minutes</span>
+        <span class="brief-label">FIRST SHIFT · GUIDED</span>
+        <strong>Learn the terminal one action at a time.</strong>
+        <span>Four short tasks · no clock pressure</span>
       </div>
-      <button class="game-button game-button--primary welcome-start" id="startButton" type="button">Start the shift</button>
-      <p class="welcome-note">Best played in portrait with sound on. The shift can be paused at any time.</p>
+      <button class="game-button game-button--primary welcome-start" id="startButton" type="button">Start first shift</button>
+      <p class="welcome-note">After this, four different shifts open: systems, network routing, queue triage and parcel investigation.</p>
+    </div>
+  </section>
+
+  <section class="campaign-screen" id="campaignScreen" aria-labelledby="campaignTitle" hidden>
+    <div class="campaign-scrim" aria-hidden="true"></div>
+    <div class="campaign-panel">
+      <header class="campaign-head">
+        <div>
+          <span class="command-kicker">SUNDSVALL REGION</span>
+          <h2 id="campaignTitle">Choose your next shift</h2>
+          <p id="campaignProgress">Four operations are open.</p>
+        </div>
+        <div class="campaign-stamp" id="campaignStamp" aria-hidden="true">1/5</div>
+      </header>
+      <div class="shift-list" id="shiftList"></div>
+      <p class="campaign-note">Each shift uses a different kind of play. Scanner and parcel details change when replayed.</p>
     </div>
   </section>
 
   <section class="result-screen" id="resultScreen" aria-labelledby="resultTitle" hidden>
     <div class="result-rays" aria-hidden="true"></div>
     <div class="result-card">
-      <span class="result-kicker">SHIFT COMPLETE</span>
+      <span class="result-kicker" id="resultKicker">SHIFT COMPLETE</span>
       <div class="result-grade" id="resultGrade" aria-label="Grade A">A</div>
       <h2 id="resultTitle">Promises kept.</h2>
       <p id="resultSummary">The northbound truck left on time and the recurring routing error is gone.</p>
-      <div class="result-stats" aria-label="Shift results">
-        <div><span>Saved</span><strong id="resultSaved">18</strong></div>
-        <div><span>On time</span><strong id="resultOnTime">98%</strong></div>
-        <div><span>Score</span><strong id="resultScore">1,240</strong></div>
-      </div>
+      <div class="result-stats" id="resultStats" aria-label="Shift results"></div>
       <div class="result-medals" id="resultMedals" aria-label="Shift achievements"></div>
-      <button class="game-button game-button--primary" id="replayButton" type="button">Play the shift again</button>
+      <button class="game-button game-button--primary" id="nextShiftButton" type="button">Choose next shift</button>
+      <button class="game-button game-button--quiet" id="replayButton" type="button">Replay this shift</button>
       <button class="text-button" id="resultDetailsButton" type="button" aria-haspopup="dialog">See the shift report</button>
     </div>
   </section>
@@ -185,36 +198,12 @@
     <div class="dialog-scroll">
       <p class="dialog-intro" id="detailsIntro">The northbound Express lane is the highest-consequence issue in the network.</p>
 
-      <dl class="detail-metrics">
-        <div><dt>Time</dt><dd id="detailTime">17:42</dd></div>
-        <div><dt>On time</dt><dd id="detailService">91%</dd></div>
-        <div><dt>At risk</dt><dd id="detailRisk">18 parcels</dd></div>
-        <div><dt>Departure</dt><dd id="detailDeparture">18:20</dd></div>
-      </dl>
-
-      <section class="dialog-section" aria-labelledby="laneTableTitle">
-        <h3 id="laneTableTitle">Terminal lanes</h3>
-        <div class="table-wrap">
-          <table>
-            <thead><tr><th scope="col">Lane</th><th scope="col">Load</th><th scope="col">Crew</th><th scope="col">State</th></tr></thead>
-            <tbody>
-              <tr><th scope="row">Inbound scan</th><td>48%</td><td>2</td><td>Stable</td></tr>
-              <tr><th scope="row">Express A</th><td id="detailExpressLoad">92%</td><td id="detailExpressCrew">4</td><td id="detailExpressState">Overloaded</td></tr>
-              <tr><th scope="row">Standard B</th><td id="detailStandardLoad">43%</td><td id="detailStandardCrew">6</td><td id="detailStandardState">Spare capacity</td></tr>
-              <tr><th scope="row">Outbound</th><td>61%</td><td>2</td><td>Stable</td></tr>
-            </tbody>
-          </table>
-        </div>
-      </section>
-
-      <section class="dialog-section" aria-labelledby="caseDetailTitle">
-        <h3 id="caseDetailTitle">Selected parcel</h3>
-        <p id="detailCase">No parcel selected. Blue floor markers identify Express service; yellow markers identify Standard service.</p>
-      </section>
+      <dl class="detail-metrics" id="detailMetrics"></dl>
+      <div id="detailScenario"></div>
 
       <details class="help-disclosure">
         <summary>How to play</summary>
-        <p>Tap highlighted objects in the 3D world or use the large action buttons below it. Pause whenever you need more time. Terminal, Network and Parcel views always expose the same shift state.</p>
+        <p>Tap highlighted objects in the miniature world or use the matching large action below it. The first shift introduces one action at a time. Later shifts let you pause, inspect and choose between trade-offs.</p>
       </details>
 
       <details class="help-disclosure">
@@ -224,7 +213,7 @@
 
       <details class="help-disclosure">
         <summary>Credits</summary>
-        <p>3D models and interface sounds are from Kenney asset packs under CC0. POSTAL is an original fictional game and does not reproduce any real operator network.</p>
+        <p>3D models are from Kenney asset packs under CC0. The warm interface tones are synthesized in the browser. POSTAL is an original fictional game and does not reproduce any real operator network.</p>
       </details>
     </div>
   </dialog>
@@ -232,6 +221,6 @@
   <div class="toast" id="toast" role="status" aria-live="polite" hidden></div>
   <div class="sr-only" id="assertiveLive" aria-live="assertive" aria-atomic="true"></div>
 
-  <script type="module" src="./main.mjs?build=20260805-visual-game-r1"></script>
+  <script type="module" src="./main.mjs?build=20260805-campaign-r3"></script>
 </body>
 </html>

--- a/postal/main.mjs
+++ b/postal/main.mjs
@@ -1,4 +1,10 @@
-import { ShiftSimulation, VERIFY_TARGET, formatClock } from './sim.mjs';
+import {
+  SHIFT_CATALOG,
+  ShiftSimulation,
+  VERIFY_TARGET,
+  formatClock,
+  getShiftDefinition
+} from './sim.mjs';
 import { PostalWorld } from './world.mjs';
 
 const $ = (selector) => document.querySelector(selector);
@@ -9,8 +15,13 @@ const ui = {
   welcome: $('#welcomeScreen'),
   start: $('#startButton'),
   deckStart: $('#deckStartButton'),
+  campaign: $('#campaignScreen'),
+  campaignProgress: $('#campaignProgress'),
+  campaignStamp: $('#campaignStamp'),
+  shiftList: $('#shiftList'),
   result: $('#resultScreen'),
   replay: $('#replayButton'),
+  nextShift: $('#nextShiftButton'),
   resultDetails: $('#resultDetailsButton'),
   pause: $('#pauseButton'),
   speed: $('#speedButton'),
@@ -18,10 +29,17 @@ const ui = {
   details: $('#detailsButton'),
   detailsDialog: $('#detailsDialog'),
   detailsClose: $('#detailsCloseButton'),
+  shiftPlace: $('#shiftPlace'),
   clock: $('#clock'),
   shiftState: $('#shiftState'),
+  serviceLabel: $('#serviceLabel'),
+  serviceIcon: $('#serviceIcon'),
   serviceValue: $('#serviceValue'),
+  backlogLabel: $('#backlogLabel'),
+  backlogIcon: $('#backlogIcon'),
   backlogValue: $('#backlogValue'),
+  riskLabel: $('#riskLabel'),
+  riskIcon: $('#riskIcon'),
   riskValue: $('#riskValue'),
   serviceMetric: $('#serviceMetric'),
   riskMetric: $('#riskMetric'),
@@ -38,44 +56,68 @@ const ui = {
   worldCanvas: $('#worldCanvas'),
   toast: $('#toast'),
   live: $('#assertiveLive'),
-  caseAlert: $('#caseAlert')
+  caseAlert: $('#caseAlert'),
+  detailMetrics: $('#detailMetrics'),
+  detailScenario: $('#detailScenario')
 };
 
 class GameAudio {
   constructor() {
     this.enabled = true;
-    this.unlocked = false;
-    this.sounds = {
-      click: new Audio('./assets/audio/click1.ogg'),
-      select: new Audio('./assets/audio/click3.ogg'),
-      staff: new Audio('./assets/audio/switch7.ogg'),
-      reveal: new Audio('./assets/audio/switch19.ogg'),
-      success: new Audio('./assets/audio/switch28.ogg'),
-      dispatch: new Audio('./assets/audio/switch3.ogg')
-    };
-    Object.values(this.sounds).forEach((audio) => {
-      audio.preload = 'auto';
-      audio.volume = 0.42;
-    });
-    this.sounds.success.volume = 0.6;
+    this.context = null;
+    this.master = null;
   }
 
   unlock() {
-    this.unlocked = true;
-    const click = this.sounds.click;
-    click.volume = 0;
-    click.play().then(() => {
-      click.pause();
-      click.currentTime = 0;
-      click.volume = 0.42;
-    }).catch(() => {});
+    if (!this.context) {
+      const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+      if (!AudioContextClass) return;
+      this.context = new AudioContextClass();
+      this.master = this.context.createGain();
+      this.master.gain.value = 0.72;
+      this.master.connect(this.context.destination);
+    }
+    if (this.context.state === 'suspended') this.context.resume().catch(() => {});
   }
 
   play(name) {
-    if (!this.enabled || !this.unlocked || !this.sounds[name]) return;
-    const audio = this.sounds[name];
-    audio.currentTime = 0;
-    audio.play().catch(() => {});
+    if (!this.enabled) return;
+    this.unlock();
+    if (!this.context || !this.master) return;
+
+    const patterns = {
+      click: [[232, 0, 0.075, 0.014]],
+      select: [[294, 0, 0.095, 0.018]],
+      inspect: [[262, 0, 0.09, 0.017], [330, 0.055, 0.11, 0.014]],
+      staff: [[247, 0, 0.1, 0.018], [311, 0.065, 0.12, 0.016]],
+      reveal: [[294, 0, 0.11, 0.018], [370, 0.075, 0.13, 0.016]],
+      repair: [[277, 0, 0.1, 0.017], [349, 0.07, 0.13, 0.017]],
+      success: [[330, 0, 0.11, 0.019], [415, 0.085, 0.14, 0.017]],
+      dispatch: [[247, 0, 0.11, 0.018], [330, 0.075, 0.13, 0.018], [392, 0.15, 0.16, 0.016]]
+    };
+    const pattern = patterns[name] || patterns.click;
+    const now = this.context.currentTime;
+    pattern.forEach(([frequency, delay, duration, level]) => this.tone(frequency, now + delay, duration, level));
+  }
+
+  tone(frequency, start, duration, level) {
+    const oscillator = this.context.createOscillator();
+    const gain = this.context.createGain();
+    const filter = this.context.createBiquadFilter();
+    oscillator.type = 'triangle';
+    oscillator.frequency.setValueAtTime(frequency, start);
+    oscillator.detune.setValueAtTime(-5, start);
+    filter.type = 'lowpass';
+    filter.frequency.setValueAtTime(920, start);
+    filter.Q.value = 0.45;
+    gain.gain.setValueAtTime(0.0001, start);
+    gain.gain.exponentialRampToValueAtTime(level, start + 0.012);
+    gain.gain.exponentialRampToValueAtTime(0.0001, start + duration);
+    oscillator.connect(filter);
+    filter.connect(gain);
+    gain.connect(this.master);
+    oscillator.start(start);
+    oscillator.stop(start + duration + 0.02);
   }
 
   toggle() {
@@ -84,23 +126,49 @@ class GameAudio {
   }
 }
 
+const CAMPAIGN_KEY = 'postal-campaign-v3';
+
+function loadCampaign() {
+  try {
+    const saved = JSON.parse(localStorage.getItem(CAMPAIGN_KEY) || 'null');
+    if (saved?.version === 3) {
+      return {
+        version: 3,
+        completed: saved.completed || {},
+        plays: saved.plays || {},
+        bestScores: saved.bestScores || {}
+      };
+    }
+  } catch {}
+  return { version: 3, completed: {}, plays: {}, bestScores: {} };
+}
+
+function saveCampaign() {
+  try {
+    localStorage.setItem(CAMPAIGN_KEY, JSON.stringify(campaign));
+  } catch {}
+}
+
 const audio = new GameAudio();
-let currentScene = 'terminal';
-let worldReady = false;
+const campaign = loadCampaign();
+let activeShift = getShiftDefinition('first-rounds');
+let simulation = new ShiftSimulation(handleSimulationChange, activeShift.id);
+let currentScene = activeShift.startScene;
 let commandRenderKey = '';
 let toastTimer = 0;
 let wasRunningBeforeDialog = false;
 let resultTimer = 0;
+let shiftResultRecorded = false;
 
-const simulation = new ShiftSimulation(handleSimulationChange);
 const world = new PostalWorld(ui.worldCanvas, ui.hotspotLayer, {
   onReady: () => {
-    worldReady = true;
     ui.loading.hidden = true;
+    world.setState(simulation.snapshot());
+    world.setMode(currentScene, true);
   },
   onHotspot: handleHotspot,
   onError: () => {
-    ui.loading.innerHTML = '<span aria-hidden="true">!</span><span>3D view unavailable. The complete shift remains playable below.</span>';
+    ui.loading.innerHTML = '<span aria-hidden="true">!</span><span>3D view unavailable. Every shift remains playable with the controls below.</span>';
     ui.loading.setAttribute('role', 'alert');
   }
 });
@@ -113,12 +181,12 @@ function announce(message, assertive = false) {
     ui.live.textContent = '';
     window.setTimeout(() => { ui.live.textContent = message; }, 20);
   }
-  toastTimer = window.setTimeout(() => { ui.toast.hidden = true; }, 3000);
+  toastTimer = window.setTimeout(() => { ui.toast.hidden = true; }, 2600);
 }
 
 function handleSimulationChange(state, event) {
   renderShift(state);
-  world.setState(state);
+  world?.setState(state);
   if (!event || event.type === 'tick' || event.type === 'reset') return;
 
   const soundByEvent = {
@@ -126,28 +194,42 @@ function handleSimulationChange(state, event) {
     pause: 'click',
     resume: 'click',
     speed: 'click',
+    inspect: 'inspect',
     staff: 'staff',
     hold: 'select',
-    package: 'select',
+    package: 'inspect',
     signature: 'reveal',
+    triage: 'select',
+    allocate: 'staff',
+    route: 'reveal',
+    deduce: 'reveal',
+    repair: 'repair',
     rule: 'success',
     verified: 'success',
     complete: 'dispatch'
   };
-  audio.play(soundByEvent[event.type]);
+  audio.play(soundByEvent[event.type] || 'click');
 
-  const assertive = ['staff', 'package', 'signature', 'rule', 'verified', 'complete'].includes(event.type);
+  const assertive = ['staff', 'package', 'signature', 'allocate', 'deduce', 'repair', 'rule', 'verified', 'complete'].includes(event.type);
   if (event.message && event.type !== 'complete') announce(event.message, assertive);
 
-  if (event.type === 'package') switchScene('case', true);
+  if (state.shiftId === 'northbound' && event.type === 'package') switchScene('case', true);
+  if (state.shiftId === 'priority-parcel' && event.type === 'deduce') switchScene('network', true);
   if (event.type === 'signature') ui.caseAlert.hidden = true;
   if (event.type === 'complete') {
     ui.toast.hidden = true;
     ui.live.textContent = '';
     window.setTimeout(() => { ui.live.textContent = event.message; }, 20);
     window.clearTimeout(resultTimer);
-    resultTimer = window.setTimeout(() => showResult(state.outcome), 1250);
+    resultTimer = window.setTimeout(() => showResult(state.outcome, state), 900);
   }
+}
+
+function configureHud(shift) {
+  ui.shiftPlace.textContent = shift.shiftLabel;
+  [ui.serviceLabel.textContent, ui.backlogLabel.textContent, ui.riskLabel.textContent] = shift.metricLabels;
+  [ui.serviceIcon.textContent, ui.backlogIcon.textContent, ui.riskIcon.textContent] = shift.metricIcons;
+  ui.gameShell.dataset.shift = shift.id;
 }
 
 function renderShift(state) {
@@ -163,271 +245,498 @@ function renderShift(state) {
   ui.pause.firstElementChild.textContent = shiftIsPaused ? '▶' : 'Ⅱ';
   ui.speed.textContent = `${state.speed}×`;
   ui.speed.setAttribute('aria-label', `Simulation speed, ${state.speed === 1 ? 'normal' : 'double'}`);
+  ui.pause.disabled = !state.canRun || state.completed;
+  ui.speed.disabled = !state.canRun || state.completed;
 
-  const minutesLeft = Math.max(0, Math.ceil(state.departure - state.time));
-  ui.missionTime.textContent = state.completed
-    ? `DEPARTED ${formatClock(state.departure)}`
-    : state.time < state.departure
-      ? `DEPARTS ${formatClock(state.departure)} · ${minutesLeft} MIN`
-      : `${Math.floor(state.time - state.departure) + 1} MIN LATE`;
-  ui.missionLabel.textContent = state.ruleFixed ? 'NORTHBOUND · FLOW CORRECTED' : 'NORTHBOUND EXPRESS';
-  ui.missionPill.dataset.state = state.ruleFixed ? 'good' : state.risk >= 20 || state.time >= state.departure ? 'danger' : 'warning';
+  const mission = missionFor(state);
+  ui.missionLabel.textContent = mission.label;
+  ui.missionTime.textContent = mission.value;
+  ui.missionPill.dataset.state = mission.state;
 
-  ui.riskMetric.dataset.level = state.risk <= 4 ? 'good' : state.risk >= 20 ? 'danger' : 'warning';
+  ui.riskMetric.dataset.level = state.risk <= 2 ? 'good' : state.risk >= 18 ? 'danger' : 'warning';
   ui.serviceMetric.dataset.level = state.onTime >= 96 ? 'good' : 'warning';
 
-  ui.pause.disabled = !state.started || state.completed;
-  ui.speed.disabled = !state.started || state.completed;
   $$('.scene-tab').forEach((button) => {
-    if (!state.started || state.completed) {
-      button.disabled = true;
-    } else if (button.dataset.scene === 'case') {
-      button.disabled = !state.packageSelected;
-    } else {
-      button.disabled = false;
-    }
+    button.disabled = !state.started || state.completed || !state.availableScenes.includes(button.dataset.scene);
   });
+  ui.caseAlert.hidden = !(state.shiftId === 'northbound' && !state.packageSelected && state.stage === 'investigate');
 
-  ui.caseAlert.hidden = state.packageSelected || state.stage !== 'investigate';
-  updateStructuredDetails(state);
+  if (ui.detailsDialog.open) updateStructuredDetails(state);
   updateSceneSummary(state);
 
-  const nextKey = [state.stage, state.paused, state.verified, state.staffMoved, state.truckHeld, state.ruleFixed].join(':');
+  const nextKey = [
+    state.shiftId,
+    state.stage,
+    state.paused,
+    state.verified,
+    state.staffMoved,
+    state.truckHeld,
+    state.ruleFixed,
+    state.inspectedDepots.join(','),
+    state.allocation,
+    state.routeChoice,
+    state.delivered,
+    state.triageOrder.join(','),
+    state.scannerFixed,
+    state.scannerBypassed,
+    state.processed,
+    state.clueChoice,
+    state.recoveryChoice,
+    Math.floor(state.deliveryProgress / 5)
+  ].join(':');
   if (nextKey !== commandRenderKey) {
     commandRenderKey = nextKey;
     renderCommand(state);
   }
 }
 
+function missionFor(state) {
+  if (state.shiftId === 'first-rounds') {
+    const missions = {
+      brief: ['FIRST ROUNDS', '4 SHORT TASKS · NO PRESSURE', 'warning'],
+      tour: ['STEP 1 OF 4', 'READ EXPRESS A', 'warning'],
+      'coach-move': ['STEP 2 OF 4', 'MOVE THE SPARE CREW', 'warning'],
+      'coach-scan': ['STEP 3 OF 4', 'CHECK THE SCANNER', 'warning'],
+      'coach-run': ['STEP 4 OF 4', 'START THE FLOW', 'warning'],
+      'coach-watch': ['PROMISES MOVING', `${state.verified} / 6 CORRECT`, 'good'],
+      dispatch: ['MORNING VAN', 'READY TO SEND', 'good'],
+      complete: ['FIRST SHIFT', 'COMPLETE', 'good']
+    };
+    const [label, value, missionState] = missions[state.stage] || missions.brief;
+    return { label, value, state: missionState };
+  }
+
+  if (state.shiftId === 'northbound') {
+    const minutesLeft = Math.max(0, Math.ceil(state.departure - state.time));
+    return {
+      label: state.ruleFixed ? 'NORTHBOUND · FLOW CORRECTED' : 'NORTHBOUND EXPRESS',
+      value: state.completed
+        ? `DEPARTED ${formatClock(state.departure)}`
+        : state.time < state.departure
+          ? `DEPARTS ${formatClock(state.departure)} · ${minutesLeft} MIN`
+          : `${Math.floor(state.time - state.departure) + 1} MIN LATE`,
+      state: state.ruleFixed ? 'good' : state.risk >= 20 || state.time >= state.departure ? 'danger' : 'warning'
+    };
+  }
+
+  if (state.shiftId === 'snow-window') {
+    const missions = {
+      brief: ['WEATHER WINDOW', 'SNOW ARRIVES 06:30'],
+      'weather-scan': ['READ THE NETWORK', `${state.inspectedDepots.length} / 3 DEPOTS CHECKED`],
+      'weather-allocate': ['ONE SPARE TRUCK', 'CHOOSE THE PROMISES'],
+      'weather-route': ['E4 RESTRICTED', 'CHOOSE THE ROAD'],
+      'weather-run': [`${String(state.allocation || '').toUpperCase()} RUN`, `${state.delivered} / ${state.deliveryTarget} DELIVERED`],
+      dispatch: ['WEATHER RUN', 'ARRIVED'],
+      complete: ['WEATHER WINDOW', 'CLOSED']
+    };
+    const [label, value] = missions[state.stage] || missions.brief;
+    return { label, value, state: state.stage === 'dispatch' || state.completed ? 'good' : 'warning' };
+  }
+
+  if (state.shiftId === 'scanner-fever') {
+    const missions = {
+      brief: ['SCANNER 2', 'QUEUE BUILDING'],
+      'jam-diagnose': ['SCANNER STOPPED', 'FIND THE BLOCKAGE'],
+      'jam-triage': ['MANUAL RELEASE', `${state.triageOrder.length} / 3 GROUPS ORDERED`],
+      'jam-repair': ['QUEUE ORDERED', 'CHOOSE RECOVERY'],
+      'jam-run': [state.scannerFixed ? 'SCANNER RESTORED' : 'MANUAL BYPASS', `${state.processed} / 31 PROCESSED`],
+      dispatch: ['OUTBOUND FLOW', 'CLEAR'],
+      complete: ['SCANNER SHIFT', 'COMPLETE']
+    };
+    const [label, value] = missions[state.stage] || missions.brief;
+    return { label, value, state: state.stage === 'dispatch' || state.completed ? 'good' : 'danger' };
+  }
+
+  const missions = {
+    brief: ['PRIORITY PARCEL', 'DELIVER BY 21:10'],
+    'case-inspect': ['COLD CHAIN', 'OPEN THE SCAN TRAIL'],
+    'case-clue': ['THREE EVENTS', 'FIND THE PARCEL'],
+    'case-plan': ['PARCEL SECURED', 'CHOOSE RECOVERY'],
+    'case-run': ['RECOVERY LIVE', `${Math.round(state.deliveryProgress)}% TO RECIPIENT`],
+    dispatch: ['DELIVERY', 'CONFIRM RECEIPT'],
+    complete: ['COLD CHAIN', 'INTACT']
+  };
+  const [label, value] = missions[state.stage] || missions.brief;
+  return { label, value, state: state.stage === 'dispatch' || state.completed ? 'good' : 'warning' };
+}
+
 function renderCommand(state) {
-  const templates = {
-    brief: () => `
+  const command = commandFor(state);
+  ui.commandContent.dataset.layout = command.layout || 'standard';
+  ui.commandContent.innerHTML = command.html;
+  ui.commandContent.querySelectorAll('[data-action]').forEach((button) => {
+    button.addEventListener('click', () => handleAction(button.dataset.action, button.dataset.value || null));
+  });
+}
+
+function commandFor(state) {
+  if (state.shiftId === 'first-rounds') return onboardingCommand(state);
+  if (state.shiftId === 'northbound') return northboundCommand(state);
+  if (state.shiftId === 'snow-window') return snowCommand(state);
+  if (state.shiftId === 'scanner-fever') return scannerCommand(state);
+  return priorityCommand(state);
+}
+
+function shell(kicker, title, body, actions, layout = 'standard') {
+  return {
+    layout,
+    html: `
       <div class="command-copy">
-        <span class="command-kicker">SHIFT BRIEF</span>
-        <h1 id="commandTitle">The northbound run needs you.</h1>
-        <p>Watch the parcel flow, protect the departure and find out why blue Express parcels keep reaching the yellow lane.</p>
+        <span class="command-kicker">${kicker}</span>
+        <h1 id="commandTitle">${title}</h1>
+        ${body ? `<p>${body}</p>` : ''}
       </div>
-      <div class="command-actions">
-        <button class="game-button game-button--primary" type="button" data-action="start">Start shift</button>
-      </div>`,
-    protect: () => `
-      <div class="command-copy">
-        <span class="command-kicker">LIVE · EXPRESS A</span>
-        <h1 id="commandTitle">The blue lane is filling fast.</h1>
-        <p>Standard B has spare crew. Rebalance now, or buy three minutes by holding the truck and reduce the next transfer margin.</p>
-      </div>
-      <div class="command-actions">
-        <button class="game-button game-button--blue" type="button" data-action="move-staff">Move 2 crew</button>
-        <button class="game-button game-button--quiet" type="button" data-action="hold-truck">Hold truck · 3 min</button>
-      </div>`,
-    investigate: () => `
-      <div class="command-copy">
-        <span class="command-kicker">ANOMALY · STANDARD B</span>
-        <h1 id="commandTitle">A blue parcel is in the yellow lane.</h1>
-        <p>The queue is recovering, but this Express parcel took the same wrong turn as eleven earlier parcels.</p>
-      </div>
-      <div class="command-actions">
-        <button class="game-button game-button--orange" type="button" data-action="trace-package">Trace the flashing parcel</button>
-        ${state.staffMoved ? '' : '<button class="game-button game-button--quiet" type="button" data-action="move-staff">Also move 2 crew</button>'}
-      </div>`,
-    compare: () => `
-      <div class="command-copy">
+      <div class="command-actions">${actions}</div>`
+  };
+}
+
+function onboardingCommand(state) {
+  const commands = {
+    brief: () => shell('FIRST SHIFT · GUIDED', 'Meet the parcel flow.', 'Four small actions introduce the terminal. Nothing moves until you are ready.', '<button class="game-button game-button--primary" type="button" data-action="start">Start first shift</button>'),
+    tour: () => shell('STEP 1 · READ', 'Blue leaves first.', 'Express parcels use blue rings and carry the shortest promises. Tap the glowing blue lane.', '<button class="game-button game-button--blue" type="button" data-action="inspect-express">Inspect Express A</button>'),
+    'coach-move': () => shell('STEP 2 · BALANCE', 'Move help where it matters.', 'The yellow lane has spare operators. Move two of them to the blue lane.', '<button class="game-button game-button--blue" type="button" data-action="move-staff">Move 2 crew</button>'),
+    'coach-scan': () => shell('STEP 3 · FOLLOW', 'Find the promise reader.', 'The scanner reads the label before the belts divide. Tap the highlighted machine.', '<button class="game-button game-button--orange" type="button" data-action="inspect-scanner">Inspect scanner</button>'),
+    'coach-run': () => shell('STEP 4 · WATCH', 'Let six parcels through.', 'Start the belt and watch the rings: blue to Express, yellow to Standard.', '<button class="game-button game-button--green" type="button" data-action="resume">Start parcel flow</button>'),
+    'coach-watch': () => shell('FLOW LIVE', 'Watch the promises move.', 'The belts will pause when six parcels have reached the correct lane.', progressAction(state.verified, 6, 'CORRECT')),
+    dispatch: () => shell('MORNING VAN READY', 'Send your first departure.', 'The flow is balanced and every parcel is aboard.', '<button class="game-button game-button--green" type="button" data-action="dispatch">Send morning van</button>'),
+    complete: () => shell('FIRST SHIFT COMPLETE', 'The shift board is open.', 'Four different kinds of work are ready.', '<button class="game-button game-button--green" type="button" disabled>On the roster</button>')
+  };
+  return (commands[state.stage] || commands.brief)();
+}
+
+function northboundCommand(state) {
+  const commands = {
+    brief: () => shell('SHIFT BRIEF', 'The northbound run needs you.', 'Protect the departure, then find why blue Express parcels reach the yellow lane.', '<button class="game-button game-button--primary" type="button" data-action="start">Start shift</button>'),
+    protect: () => shell('LIVE · EXPRESS A', 'The blue lane is filling fast.', 'Standard B has spare crew. Rebalance now, or buy three minutes by holding the truck and spend transfer margin.', `
+      <button class="game-button game-button--blue" type="button" data-action="move-staff">Move 2 crew</button>
+      <button class="game-button game-button--quiet" type="button" data-action="hold-truck">Hold truck · 3 min</button>`),
+    investigate: () => shell('ANOMALY · STANDARD B', 'A blue parcel is in the yellow lane.', 'The queue is recovering, but this Express parcel took the same wrong turn as eleven earlier parcels.', `
+      <button class="game-button game-button--orange" type="button" data-action="trace-package">Trace flashing parcel</button>
+      ${state.staffMoved ? '' : '<button class="game-button game-button--quiet" type="button" data-action="move-staff">Also move 2 crew</button>'}`),
+    compare: () => ({
+      layout: 'standard',
+      html: `<div class="command-copy">
         <span class="command-kicker">PARCEL · SE-0428-771</span>
         <h1 id="commandTitle">Where did its journey diverge?</h1>
         <div class="route-comparison" aria-label="Planned and actual route">
           <div class="route-row"><strong>Planned</strong> Scan → <span>Express A</span> → 18:20</div>
           <div class="route-row route-row--wrong"><strong>Actual</strong> Scan → <span>Standard B</span> → correction</div>
-        </div>
-      </div>
-      <div class="command-actions">
-        <button class="game-button game-button--blue" type="button" data-action="find-similar">Light up matching parcels</button>
-      </div>`,
-    rule: () => `
-      <div class="command-copy">
-        <span class="command-kicker">ROOT CAUSE · 12 MATCHES</span>
-        <h1 id="commandTitle">The fallback rule runs first.</h1>
-        <p>All matches are north-zone Express parcels scanned after 17:30. Put the service promise ahead of the fallback.</p>
-      </div>
-      <div class="command-actions rule-stack" aria-label="Current routing rule order">
-        <div class="rule-card"><span class="rule-order">1</span><span>North zone after 17:30</span></div>
-        <button class="rule-card" type="button" data-action="fix-rule"><span class="rule-order">↑</span><span>Move <strong>Express service</strong> to first</span></button>
-      </div>`,
-    verify: () => `
-      <div class="command-copy">
-        <span class="command-kicker">VERIFY THE FIX</span>
-        <h1 id="commandTitle">Watch the next twelve parcels.</h1>
-        <p>${state.paused ? 'The shift paused after the rule change. Resume and make sure new parcels take the blue lane.' : 'New matching parcels are entering the scanner. No wrong turns so far.'}</p>
-      </div>
-      <div class="command-actions">
-        <div class="mini-progress" aria-label="${state.verified} of ${VERIFY_TARGET} parcels verified">
-          <div class="mini-progress-track"><span style="width:${(state.verified / VERIFY_TARGET) * 100}%"></span></div>
-          <span class="mini-progress-label">${state.verified} / ${VERIFY_TARGET} CORRECT</span>
-        </div>
-        ${state.paused
-          ? '<button class="game-button game-button--green" type="button" data-action="resume">Resume flow</button>'
-          : '<button class="game-button game-button--blue" type="button" data-action="speed-up">Run at 2×</button>'}
-      </div>`,
-    dispatch: () => `
-      <div class="command-copy">
-        <span class="command-kicker">DEPARTURE READY</span>
-        <h1 id="commandTitle">The flow is clean.</h1>
-        <p>Twelve new parcels followed the corrected rule. Send the northbound truck and close the shift.</p>
-      </div>
-      <div class="command-actions">
-        <button class="game-button game-button--green" type="button" data-action="dispatch">Send northbound</button>
-      </div>`,
-    complete: () => `
-      <div class="command-copy">
-        <span class="command-kicker">SHIFT COMPLETE</span>
-        <h1 id="commandTitle">Northbound is on its way.</h1>
-        <p>The shift report is ready.</p>
-      </div>
-      <div class="command-actions"><button class="game-button game-button--green" type="button" disabled>Promises kept</button></div>`
+        </div></div>
+        <div class="command-actions"><button class="game-button game-button--blue" type="button" data-action="find-similar">Light up matching parcels</button></div>`
+    }),
+    rule: () => ({
+      layout: 'standard',
+      html: `<div class="command-copy"><span class="command-kicker">ROOT CAUSE · 12 MATCHES</span><h1 id="commandTitle">The fallback rule runs first.</h1><p>All matches are north-zone Express parcels scanned after 17:30.</p></div>
+        <div class="command-actions rule-stack" aria-label="Current routing rule order">
+          <div class="rule-card"><span class="rule-order">1</span><span>North zone after 17:30</span></div>
+          <button class="rule-card" type="button" data-action="fix-rule"><span class="rule-order">↑</span><span>Move <strong>Express service</strong> first</span></button>
+        </div>`
+    }),
+    verify: () => shell('VERIFY THE FIX', 'Watch the next twelve parcels.', state.paused ? 'Resume the flow and make sure new parcels take the blue lane.' : 'No wrong turns so far.', `
+      ${progressAction(state.verified, VERIFY_TARGET, 'CORRECT')}
+      ${state.paused
+        ? '<button class="game-button game-button--green" type="button" data-action="resume">Resume flow</button>'
+        : '<button class="game-button game-button--blue" type="button" data-action="speed-up">Run at 2×</button>'}`),
+    dispatch: () => shell('DEPARTURE READY', 'The flow is clean.', 'Twelve later parcels followed the corrected rule. Send the northbound truck.', '<button class="game-button game-button--green" type="button" data-action="dispatch">Send northbound</button>'),
+    complete: () => shell('SHIFT COMPLETE', 'Northbound is on its way.', 'The shift report is ready.', '<button class="game-button game-button--green" type="button" disabled>Promises kept</button>')
   };
-
-  ui.commandContent.innerHTML = (templates[state.stage] || templates.brief)();
-  ui.commandContent.querySelectorAll('[data-action]').forEach((button) => {
-    button.addEventListener('click', () => handleAction(button.dataset.action));
-  });
+  return (commands[state.stage] || commands.brief)();
 }
 
-function handleAction(action) {
-  audio.play('click');
-  switch (action) {
-    case 'start':
-      beginShift();
-      break;
-    case 'move-staff':
-      simulation.moveStaff();
-      break;
-    case 'hold-truck':
-      simulation.holdTruck();
-      break;
-    case 'trace-package':
-      simulation.selectPackage();
-      break;
-    case 'find-similar':
-      simulation.findSimilar();
-      break;
-    case 'fix-rule':
-      simulation.fixRule();
-      break;
-    case 'resume':
-      simulation.setPaused(false);
-      break;
-    case 'speed-up':
-      simulation.setSpeed(2);
-      break;
-    case 'dispatch':
-      simulation.completeShift();
-      break;
+function snowCommand(state) {
+  if (state.stage === 'brief') return shell('NETWORK SHIFT', 'Snow is closing the coast road.', 'One spare truck must protect the most important promises before 06:30.', '<button class="game-button game-button--primary" type="button" data-action="start">Open network</button>');
+  if (state.stage === 'weather-scan') {
+    const depots = ['harnosand', 'timra', 'matfors'];
+    const next = depots.find((depot) => !state.inspectedDepots.includes(depot));
+    const labels = { harnosand: 'Härnösand', timra: 'Timrå', matfors: 'Matfors' };
+    return shell('READ THE NETWORK', 'Check all three depots.', 'Tap the places in the miniature network. The large button provides the same inspection.', `<button class="game-button game-button--blue" type="button" data-action="inspect-depot" data-value="${next}">Check ${labels[next]}</button>`);
   }
+  if (state.stage === 'weather-allocate') {
+    return shell('ONE SPARE TRUCK', 'Which promises move first?', 'Härnösand has 14 urgent parcels. Timrå has 26 standard; Matfors has 9 next-day.', `
+      <div class="choice-grid choice-grid--three">
+        <button class="choice-card" type="button" data-action="allocate-truck" data-value="harnosand"><strong>Härnösand</strong><span>14 · urgent</span></button>
+        <button class="choice-card" type="button" data-action="allocate-truck" data-value="timra"><strong>Timrå</strong><span>26 · standard</span></button>
+        <button class="choice-card" type="button" data-action="allocate-truck" data-value="matfors"><strong>Matfors</strong><span>9 · next day</span></button>
+      </div>`, 'wide');
+  }
+  if (state.stage === 'weather-route') {
+    return shell('ROAD DECISION', 'Choose the road north.', 'The coast road is shorter but restricted. The inland road via Matfors is longer and open.', `
+      <div class="choice-grid">
+        <button class="choice-card" type="button" data-action="choose-route" data-value="coast"><strong>Coast road</strong><span>Fast · snow risk</span></button>
+        <button class="choice-card choice-card--blue" type="button" data-action="choose-route" data-value="inland"><strong>Via Matfors</strong><span>Longer · open</span></button>
+      </div>`, 'wide');
+  }
+  if (state.stage === 'weather-run') return shell('CONVOY READY', 'Run through the weather window.', state.paused ? 'Start the truck. Its route is visible across the miniature network.' : 'The assigned load is moving.', `
+    ${progressAction(state.delivered, state.deliveryTarget, 'DELIVERED')}
+    ${state.paused ? '<button class="game-button game-button--green" type="button" data-action="resume">Start convoy</button>' : '<button class="game-button game-button--blue" type="button" data-action="speed-up">Run at 2×</button>'}`);
+  if (state.stage === 'dispatch') return shell('ARRIVAL CONFIRMED', 'Close the weather run.', 'The assigned parcels are inside the depot before the road closes.', '<button class="game-button game-button--green" type="button" data-action="dispatch">Close weather shift</button>');
+  return shell('WEATHER SHIFT COMPLETE', 'The network adapted.', 'The shift report is ready.', '<button class="game-button game-button--green" type="button" disabled>Route complete</button>');
+}
+
+function scannerCommand(state) {
+  if (state.stage === 'brief') return shell('TERMINAL SHIFT', 'Scanner 2 has stopped.', 'Diagnose the jam, decide what moves first and recover the queue.', '<button class="game-button game-button--primary" type="button" data-action="start">Start terminal shift</button>');
+  if (state.stage === 'jam-diagnose') return shell('FLOW STOPPED', 'Find the blockage.', 'Parcels are bunching before Scanner 2. Tap the highlighted scanner.', '<button class="game-button game-button--orange" type="button" data-action="inspect-scanner">Inspect Scanner 2</button>');
+  if (state.stage === 'jam-triage') {
+    const choices = state.triageQueue.map((parcel) => {
+      const position = state.triageOrder.indexOf(parcel.id);
+      return `<button class="parcel-choice" data-tone="${parcel.tone}" type="button" data-action="prioritize" data-value="${parcel.id}" ${position >= 0 ? 'disabled' : ''}>
+        <span class="parcel-choice-box" aria-hidden="true">□</span><strong>${parcel.label}</strong><span>${position >= 0 ? `Released #${position + 1}` : parcel.promise}</span>
+      </button>`;
+    }).join('');
+    return shell('MANUAL RELEASE', 'Which promise goes first?', 'Tap the three waiting groups in the order you want to release them.', `<div class="parcel-priority-grid">${choices}</div>`, 'wide');
+  }
+  if (state.stage === 'jam-repair') return shell('QUEUE ORDERED', 'Repair or bypass?', 'Repair restores accuracy but takes longer. Manual bypass moves now and leaves more handling risk.', `
+    <div class="choice-grid">
+      <button class="choice-card choice-card--blue" type="button" data-action="repair-scanner"><strong>Clear + calibrate</strong><span>Restore 98% accuracy</span></button>
+      <button class="choice-card" type="button" data-action="bypass-scanner"><strong>Manual bypass</strong><span>Move now · more risk</span></button>
+    </div>`, 'wide');
+  if (state.stage === 'jam-run') return shell(state.scannerFixed ? 'SCANNER RESTORED' : 'MANUAL BYPASS', 'Clear the waiting queue.', state.paused ? 'Start the recovered flow and watch the parcels pass the scanner.' : 'The queue is shrinking.', `
+    ${progressAction(state.processed, 31, 'PROCESSED')}
+    ${state.paused ? '<button class="game-button game-button--green" type="button" data-action="resume">Start recovered flow</button>' : '<button class="game-button game-button--blue" type="button" data-action="speed-up">Run at 2×</button>'}`);
+  if (state.stage === 'dispatch') return shell('OUTBOUND CLEAR', 'Release the departures.', 'Every waiting parcel has passed the recovery point.', '<button class="game-button game-button--green" type="button" data-action="dispatch">Close terminal shift</button>');
+  return shell('QUEUE CLEARED', 'The line is moving.', 'The shift report is ready.', '<button class="game-button game-button--green" type="button" disabled>Flow restored</button>');
+}
+
+function priorityCommand(state) {
+  if (state.stage === 'brief') return shell('INVESTIGATION SHIFT', 'One cold-chain promise is missing.', 'Use its scans to find it, then choose a recovery that can still make 21:10.', '<button class="game-button game-button--primary" type="button" data-action="start">Open parcel case</button>');
+  if (state.stage === 'case-inspect') return shell(`PARCEL · ${state.caseData.parcelId}`, 'Open the scan trail.', 'The temperature is safe now, but the delivery window is shrinking.', '<button class="game-button game-button--orange" type="button" data-action="inspect-case">Inspect parcel history</button>');
+  if (state.stage === 'case-clue') {
+    const evidence = state.caseData.evidence.map((item) => `<li>${item}</li>`).join('');
+    const locations = state.caseData.locations.map((location) => `<button class="choice-card" type="button" data-action="choose-location" data-value="${location.id}"><strong>${location.label}</strong><span>Search here</span></button>`).join('');
+    return {
+      layout: 'wide',
+      html: `<div class="command-copy"><span class="command-kicker">SCAN TRAIL</span><h1 id="commandTitle">Where is the parcel?</h1><ol class="evidence-list">${evidence}</ol></div><div class="command-actions"><div class="choice-grid choice-grid--three">${locations}</div></div>`
+    };
+  }
+  if (state.stage === 'case-plan') return shell('PARCEL SECURED', 'Choose the final connection.', 'Direct courier protects the cold chain. A held linehaul is efficient but tight; scheduled transfer misses the original margin.', `
+    <div class="choice-grid choice-grid--three">
+      <button class="choice-card choice-card--blue" type="button" data-action="choose-recovery" data-value="courier"><strong>Courier</strong><span>22 min · direct</span></button>
+      <button class="choice-card" type="button" data-action="choose-recovery" data-value="linehaul"><strong>Hold linehaul</strong><span>31 min · tight</span></button>
+      <button class="choice-card" type="button" data-action="choose-recovery" data-value="scheduled"><strong>Scheduled</strong><span>48 min · late risk</span></button>
+    </div>`, 'wide');
+  if (state.stage === 'case-run') return shell('RECOVERY READY', 'Follow it to the recipient.', state.paused ? 'Start the chosen connection. The regional view shows its progress.' : 'Temperature and route are stable.', `
+    ${progressAction(Math.round(state.deliveryProgress), 100, 'TO RECIPIENT')}
+    ${state.paused ? '<button class="game-button game-button--green" type="button" data-action="resume">Start recovery</button>' : '<button class="game-button game-button--blue" type="button" data-action="speed-up">Run at 2×</button>'}`);
+  if (state.stage === 'dispatch') return shell('RECIPIENT CONFIRMED', 'Complete the handoff.', 'The parcel arrived with its cold chain intact.', '<button class="game-button game-button--green" type="button" data-action="dispatch">Confirm delivery</button>');
+  return shell('DELIVERY COMPLETE', 'Cold chain intact.', 'The shift report is ready.', '<button class="game-button game-button--green" type="button" disabled>Promise kept</button>');
+}
+
+function progressAction(value, target, label) {
+  return `<div class="mini-progress" aria-label="${value} of ${target} ${label.toLowerCase()}">
+    <div class="mini-progress-track"><span style="width:${Math.min(100, (value / Math.max(1, target)) * 100)}%"></span></div>
+    <span class="mini-progress-label">${value} / ${target} ${label}</span>
+  </div>`;
+}
+
+function handleAction(action, value = null) {
+  if (action === 'start') {
+    beginShift();
+    return;
+  }
+  const performed = simulation.perform(action, value);
+  if (!performed) audio.play('click');
+}
+
+function prepareShift(shiftId) {
+  activeShift = getShiftDefinition(shiftId);
+  const variant = campaign.plays[activeShift.id] || 0;
+  simulation = new ShiftSimulation(handleSimulationChange, activeShift.id, { variant });
+  shiftResultRecorded = false;
+  commandRenderKey = '';
+  currentScene = activeShift.startScene;
+  configureHud(activeShift);
+  renderShift(simulation.snapshot());
+  world.setState(simulation.snapshot());
+  switchScene(activeShift.startScene, false, true);
 }
 
 function beginShift() {
   if (simulation.state.started) return;
   audio.unlock();
-  audio.play('select');
   ui.welcome.hidden = true;
+  ui.campaign.hidden = true;
+  ui.result.hidden = true;
   ui.gameShell.inert = false;
   simulation.start();
-  switchScene('terminal', false);
+  switchScene(activeShift.startScene, false, true);
   ui.commandDeck.focus({ preventScroll: true });
 }
 
-function handleHotspot(id) {
-  audio.play('select');
-  const state = simulation.snapshot();
-  switch (id) {
-    case 'parcel':
-      simulation.selectPackage();
-      break;
-    case 'case-package':
-      if (!state.signatureFound) announce('The label says Express to Härnösand. Its event history shows a turn into Standard B at 17:32.');
-      break;
-    case 'case-similar':
-      announce('Twelve matching parcels: Express, north zone, scanned after 17:30.');
-      break;
-    case 'express-lane':
-      announce(`Express A: ${Math.round(state.expressLoad)} percent load with ${state.expressCrew} crew. ${state.ruleFixed ? 'Flow is correct.' : 'Blue service markers belong here.'}`);
-      break;
-    case 'standard-lane':
-      announce(`Standard B: ${Math.round(state.standardLoad)} percent load with ${state.standardCrew} crew. ${state.packageSelected ? 'The selected Express parcel should not be here.' : 'Spare capacity is available.'}`);
-      break;
-    case 'truck':
-      announce(`Northbound truck departs ${formatClock(state.departure)}. ${Math.max(0, Math.ceil(state.departure - state.time))} minutes remain.`);
-      break;
-    case 'network-sundsvall':
-      switchScene('terminal', false);
-      announce('Sundsvall terminal selected. This is the source of the northbound pressure.');
-      break;
-    case 'network-harnosand':
-      announce('Härnösand is waiting for the northbound Express connection. Eighteen parcel promises depend on it.');
-      break;
-    case 'network-timra':
-      announce('Timrå depot is stable.');
-      break;
-    case 'network-matfors':
-      announce('Matfors depot is stable.');
-      break;
-  }
+function depotFromHotspot(id) {
+  return {
+    'network-harnosand': 'harnosand',
+    'network-timra': 'timra',
+    'network-matfors': 'matfors'
+  }[id];
 }
 
-function switchScene(scene, focusDeck = false) {
+function handleHotspot(id) {
+  const state = simulation.snapshot();
+
+  if (state.shiftId === 'first-rounds') {
+    if (id === 'express-lane' && state.stage === 'tour') simulation.perform('inspect-express');
+    else if (id === 'scanner' && state.stage === 'coach-scan') simulation.perform('inspect-scanner');
+    else if (id === 'truck' && state.stage === 'dispatch') simulation.perform('dispatch');
+    else inspectTerminalHotspot(id, state);
+    return;
+  }
+
+  if (state.shiftId === 'northbound') {
+    if (id === 'parcel') simulation.perform('trace-package');
+    else if (id === 'case-package') announce('The label says Express to Härnösand. Its history turns into Standard B at 17:32.');
+    else if (id === 'case-similar') announce('Twelve matches: Express, north zone, scanned after 17:30.');
+    else if (id === 'network-sundsvall') {
+      switchScene('terminal');
+      announce('Sundsvall is the source of the northbound pressure.');
+    } else if (id === 'network-harnosand') announce('Härnösand is waiting for the Express connection.');
+    else if (id === 'network-timra') announce('Timrå depot is stable.');
+    else if (id === 'network-matfors') announce('Matfors depot is stable.');
+    else inspectTerminalHotspot(id, state);
+    return;
+  }
+
+  if (state.shiftId === 'snow-window') {
+    const depot = depotFromHotspot(id);
+    if (depot && state.stage === 'weather-scan') simulation.perform('inspect-depot', depot);
+    else if (id === 'network-sundsvall') announce('One spare truck is ready in Sundsvall.');
+    else if (id === 'network-harnosand') announce('Härnösand: 14 urgent parcels, including blood samples.');
+    else if (id === 'network-timra') announce('Timrå: 26 standard parcels with later promises.');
+    else if (id === 'network-matfors') announce('Matfors: 9 next-day parcels and the open inland road.');
+    return;
+  }
+
+  if (state.shiftId === 'scanner-fever') {
+    if (id === 'scanner' && state.stage === 'jam-diagnose') simulation.perform('inspect-scanner');
+    else if (id === 'parcel') announce('Three promise groups are blocked before Scanner 2.');
+    else inspectTerminalHotspot(id, state);
+    return;
+  }
+
+  if (id === 'case-package' && state.stage === 'case-inspect') simulation.perform('inspect-case');
+  else if (id === 'case-package') announce(`${state.caseData.parcelId}. Temperature is stable and the scan evidence is open below.`);
+  else if (id.startsWith('network-')) announce('The recovery connection is visible in the regional network.');
+}
+
+function inspectTerminalHotspot(id, state) {
+  audio.play('select');
+  if (id === 'express-lane') announce(`Express A: ${Math.round(state.expressLoad)} percent load with ${state.expressCrew} crew.`);
+  if (id === 'standard-lane') announce(`Standard B: ${Math.round(state.standardLoad)} percent load with ${state.standardCrew} crew.`);
+  if (id === 'scanner') announce(state.scannerFixed ? 'Scanner 2 is calibrated and running.' : 'The scanner reads each parcel promise before the belts divide.');
+  if (id === 'truck') announce(`Departure is scheduled for ${formatClock(state.departure)}.`);
+}
+
+function switchScene(scene, focusDeck = false, force = false) {
+  const state = simulation.snapshot();
+  if (!force && state.started && !state.availableScenes.includes(scene)) return;
   currentScene = scene;
   world.setMode(scene);
-  const labels = {
-    terminal: ['LIVE TERMINAL', 'Sundsvall'],
-    network: ['REGIONAL NETWORK', 'Mid Sweden'],
-    case: ['PARCEL TRACE', 'SE-0428-771']
+  const parcelId = state.caseData?.parcelId || 'SE-0428-771';
+  const sceneLabels = {
+    terminal: state.shiftId === 'scanner-fever' ? ['LIVE TERMINAL', 'Scanner hall'] : ['LIVE TERMINAL', 'Sundsvall'],
+    network: state.shiftId === 'snow-window' ? ['WEATHER NETWORK', 'Mid Sweden'] : ['REGIONAL NETWORK', 'Mid Sweden'],
+    case: ['PARCEL TRACE', parcelId]
   };
-  [ui.sceneEyebrow.textContent, ui.sceneTitle.textContent] = labels[scene];
+  [ui.sceneEyebrow.textContent, ui.sceneTitle.textContent] = sceneLabels[scene];
   $$('.scene-tab').forEach((button) => {
     if (button.dataset.scene === scene) button.setAttribute('aria-current', 'page');
     else button.removeAttribute('aria-current');
   });
-  updateSceneSummary(simulation.snapshot());
+  updateSceneSummary(state);
   if (focusDeck) window.setTimeout(() => ui.commandDeck.focus({ preventScroll: true }), 80);
 }
 
 function updateSceneSummary(state) {
-  const summaries = {
-    terminal: `Sundsvall terminal. Express lane A is at ${Math.round(state.expressLoad)} percent load with ${state.expressCrew} crew. Standard lane B is at ${Math.round(state.standardLoad)} percent with ${state.standardCrew} crew. ${state.ruleFixed ? 'The routing rule has been corrected.' : 'Express parcels scanned after 17:30 can be misrouted to Standard B.'}`,
-    network: `Regional network. Sundsvall to Härnösand is the highest-consequence route, with ${Math.round(state.risk)} parcels at risk. Timrå and Matfors are stable.`,
-    case: state.packageSelected
-      ? `Parcel SE-0428-771. Planned route: inbound scan, Express A, 18:20 northbound. Actual route: inbound scan, Standard B, manual correction, Express A. ${state.signatureFound ? 'Twelve similar parcels share the same rule signature.' : ''}`
-      : 'No parcel is selected.'
-  };
-  ui.sceneSummary.textContent = summaries[currentScene];
+  let summary = '';
+  if (currentScene === 'terminal') {
+    if (state.shiftId === 'scanner-fever') {
+      summary = `Sundsvall scanner hall. Scanner 2 is ${state.scannerFixed ? 'repaired' : state.scannerBypassed ? 'bypassed' : 'stopped'}. ${state.backlog} parcels remain in the queue.`;
+    } else {
+      summary = `Sundsvall terminal. Express A is at ${Math.round(state.expressLoad)} percent with ${state.expressCrew} crew. Standard B is at ${Math.round(state.standardLoad)} percent with ${state.standardCrew} crew.`;
+    }
+  } else if (currentScene === 'network') {
+    summary = state.shiftId === 'snow-window'
+      ? `Regional snow network. Härnösand has 14 urgent parcels, Timrå 26 standard parcels and Matfors 9 next-day parcels. ${state.routeChoice === 'inland' ? 'The selected truck is using the open inland route.' : 'The coast road is restricted.'}`
+      : `Regional network. ${Math.round(state.risk)} promises are at risk. Sundsvall, Härnösand, Timrå and Matfors are available as structured locations.`;
+  } else {
+    summary = state.shiftId === 'priority-parcel'
+      ? `Priority parcel ${state.caseData.parcelId}. ${state.caseData.evidence.join('. ')}.`
+      : state.packageSelected
+        ? `Parcel SE-0428-771. Planned for Express A, but routed to Standard B. ${state.signatureFound ? 'Twelve parcels share the same rule signature.' : ''}`
+        : 'No parcel is selected.';
+  }
+  ui.sceneSummary.textContent = summary;
+}
+
+function detailMetric(label, value) {
+  return `<div><dt>${label}</dt><dd>${value}</dd></div>`;
 }
 
 function updateStructuredDetails(state) {
-  $('#detailTime').textContent = formatClock(state.time);
-  $('#detailService').textContent = `${Math.round(state.onTime)}%`;
-  $('#detailRisk').textContent = `${Math.round(state.risk)} parcels`;
-  $('#detailDeparture').textContent = formatClock(state.departure);
-  $('#detailExpressLoad').textContent = `${Math.round(state.expressLoad)}%`;
-  $('#detailExpressCrew').textContent = state.expressCrew;
-  $('#detailExpressState').textContent = state.ruleFixed ? 'Recovering · correct flow' : state.staffMoved ? 'Recovering · routing fault remains' : 'Overloaded';
-  $('#detailStandardLoad').textContent = `${Math.round(state.standardLoad)}%`;
-  $('#detailStandardCrew').textContent = state.standardCrew;
-  $('#detailStandardState').textContent = state.staffMoved ? 'Adequate' : 'Spare capacity';
-  $('#detailsIntro').textContent = state.completed
-    ? state.outcome.summary
-    : state.ruleFixed
-      ? `The Express rule is corrected. ${state.verified} of ${VERIFY_TARGET} new matching parcels have been verified.`
-      : 'The Sundsvall to Härnösand Express connection is the highest-consequence issue in the network.';
-  $('#detailCase').textContent = !state.packageSelected
-    ? 'No parcel selected. Blue floor markers identify Express service; yellow markers identify Standard service.'
-    : state.signatureFound
-      ? 'SE-0428-771 is one of twelve Express parcels for the north zone scanned after 17:30. The fallback rule was evaluated before the Express service rule.'
-      : 'SE-0428-771 was planned for Express A and the 18:20 northbound departure. At 17:32 it entered Standard B, then required a six-minute manual correction.';
+  $('#detailsTitle').textContent = `${activeShift.title} details`;
+  const labels = activeShift.metricLabels;
+  ui.detailMetrics.innerHTML = [
+    detailMetric('Time', formatClock(state.time)),
+    detailMetric(labels[0], `${Math.round(state.onTime)}%`),
+    detailMetric(labels[1], Math.round(state.backlog)),
+    detailMetric(labels[2], Math.round(state.risk))
+  ].join('');
+
+  if (state.shiftId === 'first-rounds') {
+    $('#detailsIntro').textContent = state.completed ? state.outcome.summary : 'The guided shift introduces one consequential control at a time and does not run a deadline during instruction.';
+    ui.detailScenario.innerHTML = `<section class="dialog-section"><h3>First-shift progress</h3><ol class="detail-checklist">
+      <li data-done="${state.laneInspected}">Read the Express lane</li>
+      <li data-done="${state.staffMoved}">Move spare crew</li>
+      <li data-done="${state.scannerInspected}">Inspect the scanner</li>
+      <li data-done="${state.verified >= 6}">Verify six parcels</li>
+    </ol></section>`;
+    return;
+  }
+
+  if (state.shiftId === 'northbound') {
+    $('#detailsIntro').textContent = state.completed
+      ? state.outcome.summary
+      : state.ruleFixed
+        ? `The Express rule is corrected. ${state.verified} of ${VERIFY_TARGET} later parcels have been verified.`
+        : 'The Sundsvall to Härnösand Express connection is the highest-consequence issue.';
+    ui.detailScenario.innerHTML = `<section class="dialog-section"><h3>Terminal lanes</h3><div class="table-wrap"><table>
+      <thead><tr><th scope="col">Lane</th><th scope="col">Load</th><th scope="col">Crew</th><th scope="col">State</th></tr></thead>
+      <tbody><tr><th scope="row">Express A</th><td>${Math.round(state.expressLoad)}%</td><td>${state.expressCrew}</td><td>${state.ruleFixed ? 'Correct flow' : state.staffMoved ? 'Recovering' : 'Overloaded'}</td></tr>
+      <tr><th scope="row">Standard B</th><td>${Math.round(state.standardLoad)}%</td><td>${state.standardCrew}</td><td>${state.staffMoved ? 'Adequate' : 'Spare capacity'}</td></tr></tbody>
+    </table></div></section><section class="dialog-section"><h3>Selected parcel</h3><p>${state.packageSelected ? 'SE-0428-771 was planned for Express A. At 17:32 it entered Standard B and required manual correction.' : 'No parcel selected.'}</p></section>`;
+    return;
+  }
+
+  if (state.shiftId === 'snow-window') {
+    $('#detailsIntro').textContent = state.completed ? state.outcome.summary : 'Snow restricts the coast road at 06:30. One spare truck can cover one departure group.';
+    const checked = (id) => state.inspectedDepots.includes(id) ? 'Checked' : 'Not checked';
+    ui.detailScenario.innerHTML = `<section class="dialog-section"><h3>Depot demand</h3><div class="table-wrap"><table>
+      <thead><tr><th scope="col">Depot</th><th scope="col">Waiting</th><th scope="col">Promise</th><th scope="col">Read</th></tr></thead>
+      <tbody><tr><th scope="row">Härnösand</th><td>14</td><td>Urgent · 07:00</td><td>${checked('harnosand')}</td></tr>
+      <tr><th scope="row">Timrå</th><td>26</td><td>Standard</td><td>${checked('timra')}</td></tr>
+      <tr><th scope="row">Matfors</th><td>9</td><td>Next day</td><td>${checked('matfors')}</td></tr></tbody>
+    </table></div><p><strong>Allocation:</strong> ${state.allocation || 'Not chosen'}. <strong>Route:</strong> ${state.routeChoice || 'Not chosen'}.</p></section>`;
+    return;
+  }
+
+  if (state.shiftId === 'scanner-fever') {
+    $('#detailsIntro').textContent = state.completed ? state.outcome.summary : 'A crushed label blocks Scanner 2. Manual release order affects which promises retain their margin.';
+    ui.detailScenario.innerHTML = `<section class="dialog-section"><h3>Waiting promise groups</h3><div class="table-wrap"><table>
+      <thead><tr><th scope="col">Group</th><th scope="col">Promise</th><th scope="col">Release</th></tr></thead><tbody>
+      ${state.triageQueue.map((parcel) => `<tr><th scope="row">${parcel.label}</th><td>${parcel.promise}</td><td>${state.triageOrder.includes(parcel.id) ? `#${state.triageOrder.indexOf(parcel.id) + 1}` : 'Waiting'}</td></tr>`).join('')}
+      </tbody></table></div><p><strong>Recovery:</strong> ${state.scannerFixed ? 'Scanner repaired and calibrated' : state.scannerBypassed ? 'Manual bypass' : 'Not chosen'}.</p></section>`;
+    return;
+  }
+
+  $('#detailsIntro').textContent = state.completed ? state.outcome.summary : `Temperature-controlled parcel ${state.caseData.parcelId} must arrive by ${formatClock(state.departure)}.`;
+  ui.detailScenario.innerHTML = `<section class="dialog-section"><h3>Scan evidence</h3><ol class="detail-checklist">${state.caseData.evidence.map((item) => `<li>${item}</li>`).join('')}</ol>
+    <p><strong>Chosen location:</strong> ${state.clueChoice || 'Not chosen'}. <strong>Recovery:</strong> ${state.recoveryChoice || 'Not chosen'}.</p></section>`;
 }
 
 function openDetails() {
   const state = simulation.snapshot();
-  wasRunningBeforeDialog = state.started && !state.paused && !state.completed;
+  wasRunningBeforeDialog = state.canRun && !state.paused && !state.completed;
   if (wasRunningBeforeDialog) simulation.setPaused(true);
+  updateStructuredDetails(simulation.snapshot());
   ui.detailsDialog.showModal();
 }
 
@@ -437,23 +746,68 @@ function closeDetails() {
   wasRunningBeforeDialog = false;
 }
 
-function showResult(outcome) {
-  if (!outcome) return;
-  $('#resultGrade').textContent = outcome.grade;
-  $('#resultGrade').setAttribute('aria-label', `Grade ${outcome.grade}`);
-  $('#resultSummary').textContent = outcome.summary;
-  $('#resultSaved').textContent = outcome.saved;
-  $('#resultOnTime').textContent = `${outcome.onTime}%`;
-  $('#resultScore').textContent = outcome.score.toLocaleString('en-SE');
-  $('#resultMedals').innerHTML = outcome.medals
-    .map((medal) => `<span class="result-medal"><span aria-hidden="true">${medal.icon}</span>${medal.label}</span>`)
-    .join('');
-  ui.result.hidden = false;
-  ui.gameShell.inert = true;
-  ui.replay.focus({ preventScroll: true });
+function recordResult(outcome, state) {
+  if (shiftResultRecorded) return;
+  shiftResultRecorded = true;
+  campaign.completed[state.shiftId] = { grade: outcome.grade, score: outcome.score };
+  campaign.plays[state.shiftId] = (campaign.plays[state.shiftId] || 0) + 1;
+  campaign.bestScores[state.shiftId] = Math.max(campaign.bestScores[state.shiftId] || 0, outcome.score || 0);
+  saveCampaign();
 }
 
-ui.start.addEventListener('click', beginShift);
+function showResult(outcome, state) {
+  if (!outcome) return;
+  recordResult(outcome, state);
+  $('#resultKicker').textContent = outcome.kicker;
+  $('#resultGrade').textContent = outcome.grade;
+  $('#resultGrade').setAttribute('aria-label', outcome.gradeLabel);
+  $('#resultTitle').textContent = outcome.title;
+  $('#resultSummary').textContent = outcome.summary;
+  $('#resultStats').innerHTML = outcome.stats.map((stat) => `<div><span>${stat.label}</span><strong>${stat.value}</strong></div>`).join('');
+  $('#resultMedals').innerHTML = outcome.medals.map((medal) => `<span class="result-medal"><span aria-hidden="true">${medal.icon}</span>${medal.label}</span>`).join('');
+  ui.nextShift.textContent = state.shiftId === 'first-rounds' ? 'Open shift board' : 'Choose next shift';
+  ui.result.hidden = false;
+  ui.gameShell.inert = true;
+  ui.nextShift.focus({ preventScroll: true });
+}
+
+function renderCampaign() {
+  const completedCount = SHIFT_CATALOG.filter((shift) => campaign.completed[shift.id]).length;
+  ui.campaignProgress.textContent = completedCount === SHIFT_CATALOG.length
+    ? 'All five shifts completed. Replay conditions still vary.'
+    : `${SHIFT_CATALOG.length - completedCount} shifts remain · ${completedCount} completed`;
+  ui.campaignStamp.textContent = `${completedCount}/${SHIFT_CATALOG.length}`;
+  ui.shiftList.innerHTML = SHIFT_CATALOG.map((shift) => {
+    const completion = campaign.completed[shift.id];
+    const plays = campaign.plays[shift.id] || 0;
+    return `<button class="shift-card" data-shift-id="${shift.id}" data-tone="${shift.tone}" type="button">
+      <span class="shift-card-number" aria-hidden="true">${shift.number}</span>
+      <span class="shift-card-copy"><span class="shift-card-kind">${shift.kind} · ${shift.duration}</span><strong>${shift.title}</strong><span>${shift.description}</span><small>${shift.mechanic}${plays > 1 ? ` · ${plays} runs` : ''}</small></span>
+      <span class="shift-card-state">${completion ? `<strong>${completion.grade}</strong><span>Replay</span>` : '<strong>→</strong><span>Open</span>'}</span>
+    </button>`;
+  }).join('');
+  ui.shiftList.querySelectorAll('[data-shift-id]').forEach((button) => {
+    button.addEventListener('click', () => {
+      prepareShift(button.dataset.shiftId);
+      beginShift();
+    });
+  });
+}
+
+function openCampaign() {
+  window.clearTimeout(resultTimer);
+  ui.welcome.hidden = true;
+  ui.result.hidden = true;
+  ui.campaign.hidden = false;
+  ui.gameShell.inert = true;
+  renderCampaign();
+  window.setTimeout(() => ui.shiftList.querySelector('button')?.focus({ preventScroll: true }), 80);
+}
+
+ui.start.addEventListener('click', () => {
+  prepareShift('first-rounds');
+  beginShift();
+});
 ui.deckStart.addEventListener('click', beginShift);
 ui.pause.addEventListener('click', () => simulation.togglePaused());
 ui.speed.addEventListener('click', () => simulation.setSpeed(simulation.state.speed === 1 ? 2 : 1));
@@ -473,7 +827,12 @@ ui.detailsDialog.addEventListener('cancel', (event) => {
   event.preventDefault();
   closeDetails();
 });
-ui.replay.addEventListener('click', () => location.reload());
+ui.nextShift.addEventListener('click', openCampaign);
+ui.replay.addEventListener('click', () => {
+  ui.result.hidden = true;
+  prepareShift(activeShift.id);
+  beginShift();
+});
 
 $$('.scene-tab').forEach((button) => {
   button.addEventListener('click', () => {
@@ -489,20 +848,37 @@ document.addEventListener('keydown', (event) => {
   if (event.key.toLowerCase() === 'p') simulation.togglePaused();
   if (event.key === '1') switchScene('terminal');
   if (event.key === '2') switchScene('network');
-  if (event.key === '3' && simulation.state.packageSelected) switchScene('case');
+  if (event.key === '3') switchScene('case');
 });
 
 document.addEventListener('visibilitychange', () => {
-  if (document.hidden && simulation.state.started && !simulation.state.paused && !simulation.state.completed) {
-    simulation.setPaused(true);
-  }
+  const state = simulation.snapshot();
+  if (document.hidden && state.canRun && !state.paused && !state.completed) simulation.setPaused(true);
 });
 
 window.setInterval(() => simulation.tick(0.1), 100);
-ui.gameShell.inert = true;
+configureHud(activeShift);
 renderShift(simulation.snapshot());
-switchScene('terminal', false);
-window.setTimeout(() => ui.start.focus({ preventScroll: true }), 120);
+switchScene(activeShift.startScene, false, true);
+ui.gameShell.inert = true;
+
+if (campaign.completed['first-rounds']) {
+  ui.welcome.hidden = true;
+  openCampaign();
+} else {
+  ui.campaign.hidden = true;
+  window.setTimeout(() => ui.start.focus({ preventScroll: true }), 120);
+}
+
+window.__POSTAL_GAME__ = {
+  getState: () => simulation.snapshot(),
+  getCampaign: () => JSON.parse(JSON.stringify(campaign)),
+  startShift: (shiftId) => {
+    prepareShift(shiftId);
+    beginShift();
+  },
+  act: (action, value = null) => simulation.perform(action, value)
+};
 
 if ('serviceWorker' in navigator && location.protocol === 'https:') {
   navigator.serviceWorker.register('./sw.js').catch(() => {});

--- a/postal/sim.mjs
+++ b/postal/sim.mjs
@@ -2,7 +2,153 @@ export const INITIAL_TIME = 17 * 60 + 42;
 export const BASE_DEPARTURE = 18 * 60 + 20;
 export const VERIFY_TARGET = 12;
 
+const ONBOARDING_VERIFY_TARGET = 6;
 const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
+export const SHIFT_CATALOG = Object.freeze([
+  {
+    id: 'first-rounds',
+    number: 1,
+    title: 'First rounds',
+    place: 'Sundsvall terminal',
+    shiftLabel: 'SUNDSVALL · FIRST SHIFT',
+    kind: 'Guided shift',
+    duration: '2 min',
+    mechanic: 'Watch · Move · Scan · Send',
+    description: 'Meet the parcel flow one action at a time. There is no clock pressure.',
+    startScene: 'terminal',
+    tone: 'yellow',
+    startTime: 8 * 60 + 5,
+    departure: 8 * 60 + 20,
+    metricLabels: ['On time', 'In flow', 'At risk'],
+    metricIcons: ['✓', '▦', '!']
+  },
+  {
+    id: 'northbound',
+    number: 2,
+    title: 'Northbound promises',
+    place: 'Sundsvall → Härnösand',
+    shiftLabel: 'SUNDSVALL · SHIFT 2',
+    kind: 'Systems shift',
+    duration: '5 min',
+    mechanic: 'Capacity · Investigation · Rules',
+    description: 'Protect a departure, trace a wrong turn and repair the system behind it.',
+    startScene: 'terminal',
+    tone: 'blue',
+    startTime: INITIAL_TIME,
+    departure: BASE_DEPARTURE,
+    metricLabels: ['On time', 'In flow', 'At risk'],
+    metricIcons: ['✓', '▦', '!']
+  },
+  {
+    id: 'snow-window',
+    number: 3,
+    title: 'Snow over E4',
+    place: 'Mid Sweden network',
+    shiftLabel: 'REGION MID · SHIFT 3',
+    kind: 'Network shift',
+    duration: '4 min',
+    mechanic: 'Read demand · Allocate · Reroute',
+    description: 'One spare truck, three depots and a closing weather window. Choose what moves.',
+    startScene: 'network',
+    tone: 'purple',
+    startTime: 5 * 60 + 48,
+    departure: 6 * 60 + 30,
+    metricLabels: ['Coverage', 'Waiting', 'At risk'],
+    metricIcons: ['⌁', '▰', '!']
+  },
+  {
+    id: 'scanner-fever',
+    number: 4,
+    title: 'Scanner fever',
+    place: 'Sundsvall terminal',
+    shiftLabel: 'SUNDSVALL · SHIFT 4',
+    kind: 'Triage shift',
+    duration: '4 min',
+    mechanic: 'Diagnose · Prioritise · Recover',
+    description: 'A scanner has stopped. Order the waiting promises, then choose how to recover.',
+    startScene: 'terminal',
+    tone: 'orange',
+    startTime: 14 * 60 + 6,
+    departure: 14 * 60 + 40,
+    metricLabels: ['Accuracy', 'Queue', 'At risk'],
+    metricIcons: ['◆', '▦', '!']
+  },
+  {
+    id: 'priority-parcel',
+    number: 5,
+    title: 'Priority parcel',
+    place: 'Regional recovery',
+    shiftLabel: 'REGION MID · SHIFT 5',
+    kind: 'Investigation shift',
+    duration: '4 min',
+    mechanic: 'Trace · Deduce · Recover',
+    description: 'Find a temperature-controlled parcel from its scan trail and get it moving.',
+    startScene: 'case',
+    tone: 'pink',
+    startTime: 20 * 60 + 32,
+    departure: 21 * 60 + 10,
+    metricLabels: ['Cold chain', 'Min left', 'At risk'],
+    metricIcons: ['◇', '◷', '!']
+  }
+]);
+
+const SHIFT_BY_ID = new Map(SHIFT_CATALOG.map((shift) => [shift.id, shift]));
+
+const TRIAGE_VARIANTS = Object.freeze([
+  [
+    { id: 'medicine', label: 'Chilled medicine', promise: '28 min', priority: 1, tone: 'pink' },
+    { id: 'express', label: 'Express documents', promise: '51 min', priority: 2, tone: 'blue' },
+    { id: 'economy', label: 'Economy returns', promise: 'Tomorrow', priority: 3, tone: 'yellow' }
+  ],
+  [
+    { id: 'flight', label: 'Airport connection', promise: '19 min', priority: 1, tone: 'blue' },
+    { id: 'sample', label: 'Laboratory sample', promise: '44 min', priority: 2, tone: 'pink' },
+    { id: 'returns', label: 'Shop returns', promise: 'Tomorrow', priority: 3, tone: 'yellow' }
+  ],
+  [
+    { id: 'parts', label: 'Repair parts', promise: '24 min', priority: 1, tone: 'orange' },
+    { id: 'signed', label: 'Signed delivery', promise: '63 min', priority: 2, tone: 'blue' },
+    { id: 'catalogue', label: 'Catalogues', promise: '2 days', priority: 3, tone: 'yellow' }
+  ]
+]);
+
+const CASE_VARIANTS = Object.freeze([
+  {
+    parcelId: 'SE-8841-204',
+    correctLocation: 'dock-3',
+    evidence: ['Inbound scan · 20:11', 'No outbound confirmation', 'Handheld ping · Dock 3 · 20:18'],
+    locations: [
+      { id: 'dock-3', label: 'Dock 3' },
+      { id: 'truck-7', label: 'Truck 7' },
+      { id: 'timra', label: 'Timrå depot' }
+    ]
+  },
+  {
+    parcelId: 'SE-2930-117',
+    correctLocation: 'timra',
+    evidence: ['Sundsvall outbound · 20:05', 'Timrå arrival group · 20:21', 'No final cage scan'],
+    locations: [
+      { id: 'cage-4', label: 'Sundsvall cage 4' },
+      { id: 'timra', label: 'Timrå inbound' },
+      { id: 'truck-7', label: 'Truck 7' }
+    ]
+  },
+  {
+    parcelId: 'SE-7105-663',
+    correctLocation: 'truck-7',
+    evidence: ['Dock 3 scan · 20:09', 'Truck 7 load list · matched', 'No Härnösand arrival scan'],
+    locations: [
+      { id: 'truck-7', label: 'Truck 7' },
+      { id: 'harnosand', label: 'Härnösand depot' },
+      { id: 'dock-3', label: 'Dock 3' }
+    ]
+  }
+]);
+
+export function getShiftDefinition(id = 'first-rounds') {
+  return SHIFT_BY_ID.get(id) || SHIFT_BY_ID.get('first-rounds');
+}
 
 export function formatClock(totalMinutes) {
   const rounded = Math.floor(totalMinutes);
@@ -14,22 +160,30 @@ export function formatClock(totalMinutes) {
 export function getStage(state) {
   if (state.completed) return 'complete';
   if (!state.started) return 'brief';
-  if (!state.staffMoved && !state.truckHeld) return 'protect';
-  if (!state.packageSelected) return 'investigate';
-  if (!state.signatureFound) return 'compare';
-  if (!state.ruleFixed) return 'rule';
-  if (state.verified < VERIFY_TARGET) return 'verify';
-  return 'dispatch';
+  return state.stage;
 }
 
-export function createInitialState() {
+function baseState(shiftId, variant) {
+  const shift = getShiftDefinition(shiftId);
   return {
+    shiftId: shift.id,
+    variant,
     started: false,
     completed: false,
     paused: true,
     speed: 1,
-    time: INITIAL_TIME,
-    departure: BASE_DEPARTURE,
+    stage: 'brief',
+    time: shift.startTime,
+    departure: shift.departure,
+    onTime: 100,
+    backlog: 0,
+    risk: 0,
+    score: 400,
+    saved: 0,
+    lateMinutes: 0,
+    lastMinute: Math.floor(shift.startTime),
+    outcome: null,
+    events: [],
     staffMoved: false,
     truckHeld: false,
     packageSelected: false,
@@ -38,152 +192,619 @@ export function createInitialState() {
     verified: 0,
     expressCrew: 4,
     standardCrew: 6,
-    expressLoad: 92,
-    standardLoad: 43,
-    backlog: 84,
-    risk: 18,
-    onTime: 91,
+    expressLoad: 62,
+    standardLoad: 42,
     downstreamMargin: 10,
-    lateMinutes: 0,
-    saved: 0,
-    score: 600,
-    lastMinute: Math.floor(INITIAL_TIME),
-    outcome: null,
-    events: []
+    laneInspected: false,
+    scannerInspected: false,
+    inspectedDepots: [],
+    allocation: null,
+    routeChoice: null,
+    delivered: 0,
+    deliveryTarget: 0,
+    triageQueue: [],
+    triageOrder: [],
+    triageMistakes: 0,
+    scannerFixed: false,
+    scannerBypassed: false,
+    processed: 0,
+    caseData: null,
+    clueChoice: null,
+    locationCorrect: false,
+    recoveryChoice: null,
+    deliveryProgress: 0
+  };
+}
+
+export function createInitialState(shiftId = 'first-rounds', variant = 0) {
+  const normalizedVariant = Math.max(0, Math.floor(variant || 0));
+  const state = baseState(shiftId, normalizedVariant);
+
+  switch (state.shiftId) {
+    case 'first-rounds':
+      Object.assign(state, {
+        onTime: 98,
+        backlog: 6,
+        risk: 0,
+        score: 300,
+        expressCrew: 2,
+        standardCrew: 4,
+        expressLoad: 54,
+        standardLoad: 31
+      });
+      break;
+    case 'northbound':
+      Object.assign(state, {
+        onTime: 91,
+        backlog: 84,
+        risk: 18,
+        score: 600,
+        expressLoad: 92,
+        standardLoad: 43
+      });
+      break;
+    case 'snow-window':
+      Object.assign(state, {
+        onTime: 72,
+        backlog: 49,
+        risk: 23,
+        score: 520
+      });
+      break;
+    case 'scanner-fever':
+      Object.assign(state, {
+        onTime: 96,
+        backlog: 31,
+        risk: 7,
+        score: 500,
+        expressLoad: 84,
+        standardLoad: 69,
+        triageQueue: TRIAGE_VARIANTS[normalizedVariant % TRIAGE_VARIANTS.length].map((parcel) => ({ ...parcel }))
+      });
+      break;
+    case 'priority-parcel':
+      Object.assign(state, {
+        onTime: 100,
+        backlog: 38,
+        risk: 1,
+        score: 480,
+        packageSelected: false,
+        caseData: {
+          ...CASE_VARIANTS[normalizedVariant % CASE_VARIANTS.length],
+          evidence: [...CASE_VARIANTS[normalizedVariant % CASE_VARIANTS.length].evidence],
+          locations: CASE_VARIANTS[normalizedVariant % CASE_VARIANTS.length].locations.map((location) => ({ ...location }))
+        }
+      });
+      break;
+  }
+
+  return state;
+}
+
+function canRun(state) {
+  if (!state.started || state.completed) return false;
+  if (state.shiftId === 'northbound') return !['compare', 'rule', 'dispatch'].includes(state.stage);
+  return ['coach-watch', 'weather-run', 'jam-run', 'case-run'].includes(state.stage);
+}
+
+function activeHotspots(state) {
+  const stage = getStage(state);
+  switch (state.shiftId) {
+    case 'first-rounds':
+      if (stage === 'tour') return ['express-lane'];
+      if (stage === 'coach-move') return ['express-lane', 'standard-lane'];
+      if (stage === 'coach-scan') return ['scanner'];
+      if (stage === 'coach-watch') return ['express-lane', 'truck'];
+      if (stage === 'dispatch') return ['truck'];
+      return [];
+    case 'northbound': {
+      const network = ['network-sundsvall', 'network-harnosand', 'network-timra', 'network-matfors'];
+      if (stage === 'protect') return ['express-lane', 'standard-lane', 'truck', ...network];
+      if (stage === 'investigate') return ['parcel', 'express-lane', 'standard-lane', 'truck', ...network];
+      if (stage === 'compare') return ['case-package'];
+      if (stage === 'rule') return ['case-package', 'case-similar'];
+      if (stage === 'verify') return ['express-lane', 'standard-lane', 'truck', ...network];
+      if (stage === 'dispatch') return ['truck', ...network];
+      return [];
+    }
+    case 'snow-window':
+      return ['network-sundsvall', 'network-harnosand', 'network-timra', 'network-matfors'];
+    case 'scanner-fever':
+      if (stage === 'jam-diagnose') return ['scanner', 'parcel'];
+      if (stage === 'jam-triage' || stage === 'jam-repair') return ['scanner', 'parcel', 'express-lane', 'standard-lane'];
+      if (stage === 'jam-run' || stage === 'dispatch') return ['scanner', 'express-lane', 'standard-lane', 'truck'];
+      return [];
+    case 'priority-parcel':
+      if (stage === 'case-inspect' || stage === 'case-clue') return ['case-package'];
+      if (stage === 'case-plan' || stage === 'case-run' || stage === 'dispatch') {
+        return ['case-package', 'network-sundsvall', 'network-harnosand', 'network-timra', 'network-matfors'];
+      }
+      return [];
+    default:
+      return [];
+  }
+}
+
+function availableScenes(state) {
+  switch (state.shiftId) {
+    case 'first-rounds':
+    case 'scanner-fever':
+      return ['terminal'];
+    case 'snow-window':
+      return ['network'];
+    case 'priority-parcel':
+      return state.stage === 'case-inspect' || state.stage === 'case-clue' ? ['case'] : ['case', 'network'];
+    case 'northbound':
+      return state.packageSelected ? ['terminal', 'network', 'case'] : ['terminal', 'network'];
+    default:
+      return ['terminal'];
+  }
+}
+
+function hotspotPresentation(state) {
+  if (state.shiftId === 'first-rounds') {
+    return {
+      labels: { 'express-lane': '1 · Express A', 'standard-lane': 'Standard B', scanner: '3 · Scanner', truck: '4 · Send van' },
+      icons: { 'express-lane': '1', scanner: '3', truck: '4' }
+    };
+  }
+  if (state.shiftId === 'scanner-fever') {
+    return {
+      labels: { scanner: state.scannerFixed ? 'Scanner restored' : 'Scanner 2 · stopped', parcel: 'Blocked parcels' },
+      tones: { scanner: state.scannerFixed ? 'good' : 'danger', parcel: 'danger' },
+      icons: { scanner: state.scannerFixed ? '✓' : '!', parcel: '▦' }
+    };
+  }
+  if (state.shiftId === 'snow-window') {
+    return {
+      labels: {
+        'network-harnosand': 'Härnösand · 14 urgent',
+        'network-timra': 'Timrå · 26 waiting',
+        'network-matfors': 'Matfors · 9 waiting',
+        'network-sundsvall': 'Spare truck'
+      },
+      tones: {
+        'network-harnosand': state.allocation === 'harnosand' ? 'good' : 'danger',
+        'network-timra': state.allocation === 'timra' ? 'good' : 'yellow',
+        'network-matfors': state.routeChoice === 'inland' ? 'blue' : 'yellow'
+      }
+    };
+  }
+  if (state.shiftId === 'priority-parcel') {
+    return {
+      labels: {
+        'case-package': state.caseData?.parcelId || 'Priority parcel',
+        'network-sundsvall': 'Sundsvall',
+        'network-harnosand': 'Härnösand',
+        'network-timra': 'Timrå',
+        'network-matfors': 'Matfors'
+      },
+      tones: { 'case-package': state.locationCorrect ? 'good' : 'danger' }
+    };
+  }
+  return {
+    labels: {},
+    tones: {
+      parcel: state.ruleFixed ? 'good' : 'danger',
+      'network-harnosand': state.ruleFixed ? 'good' : 'danger'
+    },
+    icons: { 'network-harnosand': state.ruleFixed ? '✓' : '!' }
   };
 }
 
 export class ShiftSimulation {
-  constructor(onChange = () => {}) {
-    this.state = createInitialState();
+  constructor(onChange = () => {}, shiftId = 'first-rounds', options = {}) {
+    this.shiftId = getShiftDefinition(shiftId).id;
+    this.variant = Math.max(0, Math.floor(options.variant || 0));
+    this.state = createInitialState(this.shiftId, this.variant);
     this.onChange = onChange;
-    this.verificationAccumulator = 0;
+    this.progressAccumulator = 0;
   }
 
-  emit(type, message = '') {
-    const event = { type, message, at: formatClock(this.state.time) };
-    this.state.events = [...this.state.events.slice(-11), event];
+  emit(type, message = '', data = {}) {
+    const event = { type, message, data, at: formatClock(this.state.time) };
+    this.state.events = [...this.state.events.slice(-15), event];
     this.onChange(this.snapshot(), event);
     return event;
   }
 
   snapshot() {
-    return { ...this.state, events: [...this.state.events], stage: getStage(this.state) };
+    const presentation = hotspotPresentation(this.state);
+    return {
+      ...this.state,
+      events: [...this.state.events],
+      inspectedDepots: [...this.state.inspectedDepots],
+      triageQueue: this.state.triageQueue.map((parcel) => ({ ...parcel })),
+      triageOrder: [...this.state.triageOrder],
+      caseData: this.state.caseData ? {
+        ...this.state.caseData,
+        evidence: [...this.state.caseData.evidence],
+        locations: this.state.caseData.locations.map((location) => ({ ...location }))
+      } : null,
+      stage: getStage(this.state),
+      canRun: canRun(this.state),
+      activeHotspots: activeHotspots(this.state),
+      availableScenes: availableScenes(this.state),
+      hotspotLabels: presentation.labels || {},
+      hotspotTones: presentation.tones || {},
+      hotspotIcons: presentation.icons || {}
+    };
   }
 
   start() {
-    if (this.state.started) return;
+    if (this.state.started) return false;
     this.state.started = true;
-    this.state.paused = false;
     this.state.score += 40;
-    this.emit('start', 'Shift started. Northbound Express departs at 18:20.');
+    const starts = {
+      'first-rounds': ['tour', true, 'First shift started. Begin with the blue Express lane.'],
+      northbound: ['protect', false, 'Northbound Express departs at 18:20.'],
+      'snow-window': ['weather-scan', true, 'Snow shift started. Inspect all three depots before assigning the spare truck.'],
+      'scanner-fever': ['jam-diagnose', true, 'Scanner 2 has stopped. Inspect the machine and the blocked flow.'],
+      'priority-parcel': ['case-inspect', true, 'Priority recovery started. Inspect the temperature-controlled parcel trail.']
+    };
+    const [stage, paused, message] = starts[this.state.shiftId];
+    this.state.stage = stage;
+    this.state.paused = paused;
+    this.emit('start', message);
+    return true;
   }
 
   setPaused(paused) {
-    if (!this.state.started || this.state.completed) return;
+    if (!canRun(this.state)) return false;
     this.state.paused = Boolean(paused);
     this.emit(paused ? 'pause' : 'resume', paused ? 'Shift paused.' : `Shift running at ${this.state.speed} times speed.`);
+    return true;
   }
 
   togglePaused() {
-    this.setPaused(!this.state.paused);
+    return this.setPaused(!this.state.paused);
   }
 
   setSpeed(speed) {
-    if (!this.state.started || this.state.completed) return;
+    if (!canRun(this.state)) return false;
     this.state.speed = speed === 2 ? 2 : 1;
     this.state.paused = false;
     this.emit('speed', `Shift running at ${this.state.speed} times speed.`);
+    return true;
+  }
+
+  perform(action, value = null) {
+    if (!this.state.started || this.state.completed) return false;
+    switch (this.state.shiftId) {
+      case 'first-rounds':
+        return this.performOnboarding(action);
+      case 'northbound':
+        return this.performNorthbound(action);
+      case 'snow-window':
+        return this.performSnow(action, value);
+      case 'scanner-fever':
+        return this.performScanner(action, value);
+      case 'priority-parcel':
+        return this.performPriority(action, value);
+      default:
+        return false;
+    }
+  }
+
+  performOnboarding(action) {
+    if (action === 'inspect-express' && this.state.stage === 'tour') {
+      this.state.laneInspected = true;
+      this.state.stage = 'coach-move';
+      this.state.score += 60;
+      this.emit('inspect', 'Express A carries the promises that leave first. Now give it the spare crew.');
+      return true;
+    }
+    if (action === 'move-staff' && this.state.stage === 'coach-move') {
+      this.state.staffMoved = true;
+      this.state.expressCrew = 4;
+      this.state.standardCrew = 2;
+      this.state.expressLoad = 38;
+      this.state.standardLoad = 44;
+      this.state.stage = 'coach-scan';
+      this.state.score += 90;
+      this.emit('staff', 'Two operators moved to Express A. The blue lane is clearing.');
+      return true;
+    }
+    if (action === 'inspect-scanner' && this.state.stage === 'coach-scan') {
+      this.state.scannerInspected = true;
+      this.state.stage = 'coach-run';
+      this.state.score += 60;
+      this.emit('inspect', 'The scanner reads each promise and sends the parcel to its lane. The flow is ready.');
+      return true;
+    }
+    if (action === 'resume' && this.state.stage === 'coach-run') {
+      this.state.stage = 'coach-watch';
+      this.state.paused = false;
+      this.emit('resume', 'Flow running. Watch six parcels reach the correct lane.');
+      return true;
+    }
+    if (action === 'dispatch' && this.state.stage === 'dispatch') return this.finishShift();
+    return false;
+  }
+
+  performNorthbound(action) {
+    if (action === 'move-staff' && !this.state.staffMoved && ['protect', 'investigate'].includes(this.state.stage)) {
+      this.state.staffMoved = true;
+      this.state.expressCrew = 6;
+      this.state.standardCrew = 4;
+      this.state.expressLoad = 68;
+      this.state.standardLoad = 57;
+      this.state.risk = Math.max(9, this.state.risk - 9);
+      this.state.backlog = Math.max(70, this.state.backlog - 13);
+      this.state.onTime = Math.max(this.state.onTime, 94);
+      this.state.stage = 'investigate';
+      this.state.score += 180;
+      this.emit('staff', 'Two operators moved to Express A. The immediate departure risk is falling.');
+      return true;
+    }
+    if (action === 'hold-truck' && this.state.stage === 'protect' && !this.state.truckHeld) {
+      this.state.truckHeld = true;
+      this.state.departure += 3;
+      this.state.downstreamMargin -= 3;
+      this.state.risk = Math.max(12, this.state.risk - 4);
+      this.state.score -= 60;
+      this.state.stage = 'investigate';
+      this.emit('hold', 'Truck held for three minutes. Current parcels gain time; the transfer loses margin.');
+      return true;
+    }
+    if (action === 'trace-package' && this.state.stage === 'investigate' && !this.state.packageSelected) {
+      this.state.packageSelected = true;
+      this.state.paused = true;
+      this.state.stage = 'compare';
+      this.state.score += 70;
+      this.emit('package', 'Parcel SE-0428-771 selected. The shift paused for inspection.');
+      return true;
+    }
+    if (action === 'find-similar' && this.state.stage === 'compare' && !this.state.signatureFound) {
+      this.state.signatureFound = true;
+      this.state.stage = 'rule';
+      this.state.score += 120;
+      this.emit('signature', 'Twelve matching Express parcels share the same after-17:30 fallback rule.');
+      return true;
+    }
+    if (action === 'fix-rule' && this.state.stage === 'rule' && !this.state.ruleFixed) {
+      this.state.ruleFixed = true;
+      this.state.paused = true;
+      this.state.stage = 'verify';
+      this.state.score += 300;
+      this.state.onTime = Math.max(this.state.onTime, 96);
+      this.emit('rule', 'Express service now takes priority over the north-zone fallback. Run the flow to verify it.');
+      return true;
+    }
+    if (action === 'resume' && this.state.stage === 'verify') return this.setPaused(false);
+    if (action === 'speed-up' && this.state.stage === 'verify') return this.setSpeed(2);
+    if (action === 'dispatch' && this.state.stage === 'dispatch') return this.finishShift();
+    return false;
+  }
+
+  performSnow(action, value) {
+    if (action === 'inspect-depot' && this.state.stage === 'weather-scan') {
+      if (!['harnosand', 'timra', 'matfors'].includes(value) || this.state.inspectedDepots.includes(value)) return false;
+      this.state.inspectedDepots = [...this.state.inspectedDepots, value];
+      const messages = {
+        harnosand: 'Härnösand: 14 urgent parcels, including blood samples due at 07:00.',
+        timra: 'Timrå: 26 standard parcels. Their promises allow a later departure.',
+        matfors: 'Matfors: 9 next-day parcels and the open inland road north.'
+      };
+      this.state.score += 35;
+      if (this.state.inspectedDepots.length === 3) this.state.stage = 'weather-allocate';
+      this.emit('inspect', messages[value]);
+      return true;
+    }
+    if (action === 'allocate-truck' && this.state.stage === 'weather-allocate') {
+      if (!['harnosand', 'timra', 'matfors'].includes(value)) return false;
+      this.state.allocation = value;
+      this.state.deliveryTarget = { harnosand: 14, timra: 26, matfors: 9 }[value];
+      this.state.risk = value === 'harnosand' ? 9 : 20;
+      this.state.score += value === 'harnosand' ? 220 : 70;
+      this.state.stage = 'weather-route';
+      this.emit('allocate', `The spare truck is assigned to ${value === 'harnosand' ? 'Härnösand' : value === 'timra' ? 'Timrå' : 'Matfors'}. Choose its road.`);
+      return true;
+    }
+    if (action === 'choose-route' && this.state.stage === 'weather-route') {
+      if (!['coast', 'inland'].includes(value)) return false;
+      this.state.routeChoice = value;
+      this.state.stage = 'weather-run';
+      this.state.paused = true;
+      this.state.risk += value === 'coast' ? 5 : -4;
+      this.state.score += value === 'inland' ? 180 : 40;
+      this.emit('route', value === 'inland'
+        ? 'The truck will detour inland via Matfors. Longer, but open and reliable.'
+        : 'The truck will test the snowy coast road. It is shorter, but delay risk remains.');
+      return true;
+    }
+    if (action === 'resume' && this.state.stage === 'weather-run') return this.setPaused(false);
+    if (action === 'speed-up' && this.state.stage === 'weather-run') return this.setSpeed(2);
+    if (action === 'dispatch' && this.state.stage === 'dispatch') return this.finishShift();
+    return false;
+  }
+
+  performScanner(action, value) {
+    if (action === 'inspect-scanner' && this.state.stage === 'jam-diagnose') {
+      this.state.scannerInspected = true;
+      this.state.stage = 'jam-triage';
+      this.state.score += 75;
+      this.emit('inspect', 'A crushed label is blocking Scanner 2. Three promise groups are waiting for manual release.');
+      return true;
+    }
+    if (action === 'prioritize' && this.state.stage === 'jam-triage') {
+      const parcel = this.state.triageQueue.find((item) => item.id === value);
+      if (!parcel || this.state.triageOrder.includes(value)) return false;
+      const expected = [...this.state.triageQueue].sort((a, b) => a.priority - b.priority)[this.state.triageOrder.length];
+      this.state.triageOrder = [...this.state.triageOrder, value];
+      if (expected.id === value) {
+        this.state.score += 70;
+      } else {
+        this.state.triageMistakes += 1;
+        this.state.risk += 2;
+        this.state.score -= 25;
+      }
+      if (this.state.triageOrder.length === this.state.triageQueue.length) this.state.stage = 'jam-repair';
+      this.emit('triage', `${parcel.label} released ${this.state.triageOrder.length} of ${this.state.triageQueue.length}.`);
+      return true;
+    }
+    if (action === 'repair-scanner' && this.state.stage === 'jam-repair') {
+      this.state.scannerFixed = true;
+      this.state.stage = 'jam-run';
+      this.state.paused = true;
+      this.state.risk = Math.max(2, this.state.risk - 5);
+      this.state.onTime = Math.max(97, this.state.onTime);
+      this.state.score += 230;
+      this.emit('repair', 'Crushed label cleared and Scanner 2 calibrated. Run the queue through it.');
+      return true;
+    }
+    if (action === 'bypass-scanner' && this.state.stage === 'jam-repair') {
+      this.state.scannerBypassed = true;
+      this.state.stage = 'jam-run';
+      this.state.paused = true;
+      this.state.risk += 4;
+      this.state.onTime = 91;
+      this.state.score += 60;
+      this.emit('repair', 'The queue is moving through manual scan. It is faster now, but less accurate.');
+      return true;
+    }
+    if (action === 'resume' && this.state.stage === 'jam-run') return this.setPaused(false);
+    if (action === 'speed-up' && this.state.stage === 'jam-run') return this.setSpeed(2);
+    if (action === 'dispatch' && this.state.stage === 'dispatch') return this.finishShift();
+    return false;
+  }
+
+  performPriority(action, value) {
+    if (action === 'inspect-case' && this.state.stage === 'case-inspect' && !this.state.packageSelected) {
+      this.state.packageSelected = true;
+      this.state.stage = 'case-clue';
+      this.state.score += 80;
+      this.emit('package', `${this.state.caseData.parcelId} scan trail opened. Three events narrow down its location.`);
+      return true;
+    }
+    if (action === 'choose-location' && this.state.stage === 'case-clue') {
+      if (!this.state.caseData.locations.some((location) => location.id === value)) return false;
+      this.state.clueChoice = value;
+      this.state.locationCorrect = value === this.state.caseData.correctLocation;
+      this.state.stage = 'case-plan';
+      this.state.score += this.state.locationCorrect ? 220 : 55;
+      this.state.risk += this.state.locationCorrect ? 0 : 2;
+      this.emit('deduce', this.state.locationCorrect
+        ? 'The scan trail fits. The parcel has been found and secured.'
+        : 'The team searched there first, then followed the handheld scan to the parcel. Time was lost.');
+      return true;
+    }
+    if (action === 'choose-recovery' && this.state.stage === 'case-plan') {
+      if (!['courier', 'linehaul', 'scheduled'].includes(value)) return false;
+      this.state.recoveryChoice = value;
+      this.state.stage = 'case-run';
+      this.state.paused = true;
+      this.state.score += value === 'courier' ? 190 : value === 'linehaul' ? 90 : 20;
+      if (value === 'scheduled') this.state.risk += 3;
+      this.emit('route', {
+        courier: 'A direct courier has the parcel and active temperature control.',
+        linehaul: 'The linehaul is held for the handoff. It can make the promise with little margin.',
+        scheduled: 'The parcel joins the scheduled transfer. Its delivery promise is now at risk.'
+      }[value]);
+      return true;
+    }
+    if (action === 'resume' && this.state.stage === 'case-run') return this.setPaused(false);
+    if (action === 'speed-up' && this.state.stage === 'case-run') return this.setSpeed(2);
+    if (action === 'dispatch' && this.state.stage === 'dispatch') return this.finishShift();
+    return false;
   }
 
   moveStaff() {
-    if (this.state.staffMoved || this.state.completed) return false;
-    this.state.staffMoved = true;
-    this.state.expressCrew = 6;
-    this.state.standardCrew = 4;
-    this.state.expressLoad = 68;
-    this.state.standardLoad = 57;
-    this.state.risk = Math.max(9, this.state.risk - 9);
-    this.state.backlog = Math.max(70, this.state.backlog - 13);
-    this.state.onTime = Math.max(this.state.onTime, 94);
-    this.state.score += 180;
-    this.emit('staff', 'Two operators moved to Express A. The immediate departure risk is falling.');
-    return true;
+    return this.perform('move-staff');
   }
 
   holdTruck() {
-    if (this.state.truckHeld || this.state.completed) return false;
-    this.state.truckHeld = true;
-    this.state.departure += 3;
-    this.state.downstreamMargin -= 3;
-    this.state.risk = Math.max(12, this.state.risk - 4);
-    this.state.score -= 60;
-    this.emit('hold', 'Northbound truck held for three minutes. Current parcels gain time; the Härnösand transfer loses margin.');
-    return true;
+    return this.perform('hold-truck');
   }
 
   selectPackage() {
-    if (!this.state.started || this.state.completed) return false;
-    this.state.packageSelected = true;
-    this.state.paused = true;
-    this.state.score += 70;
-    this.emit('package', 'Parcel SE-0428-771 selected. The shift paused for inspection.');
-    return true;
+    return this.perform(this.state.shiftId === 'priority-parcel' ? 'inspect-case' : 'trace-package');
   }
 
   findSimilar() {
-    if (!this.state.packageSelected || this.state.signatureFound || this.state.completed) return false;
-    this.state.signatureFound = true;
-    this.state.score += 120;
-    this.emit('signature', 'Twelve matching Express parcels share the same after-17:30 fallback rule.');
-    return true;
+    return this.perform('find-similar');
   }
 
   fixRule() {
-    if (!this.state.signatureFound || this.state.ruleFixed || this.state.completed) return false;
-    this.state.ruleFixed = true;
-    this.state.paused = true;
-    this.state.score += 300;
-    this.state.onTime = Math.max(this.state.onTime, 96);
-    this.emit('rule', 'Express service now takes priority over the north-zone fallback. Run the flow to verify the change.');
-    return true;
+    return this.perform('fix-rule');
+  }
+
+  completeShift() {
+    return this.perform('dispatch');
   }
 
   tick(realSeconds) {
-    if (!this.state.started || this.state.paused || this.state.completed) return;
+    if (!this.state.started || this.state.paused || this.state.completed || !canRun(this.state)) return;
     const gameMinutes = Math.max(0, realSeconds) * this.state.speed * 0.24;
     this.state.time += gameMinutes;
 
+    switch (this.state.shiftId) {
+      case 'first-rounds':
+        this.tickOnboarding(gameMinutes);
+        break;
+      case 'northbound':
+        this.tickNorthbound(gameMinutes);
+        break;
+      case 'snow-window':
+        this.tickSnow(gameMinutes);
+        break;
+      case 'scanner-fever':
+        this.tickScanner(gameMinutes);
+        break;
+      case 'priority-parcel':
+        this.tickPriority(gameMinutes);
+        break;
+    }
+
+    this.onChange(this.snapshot(), { type: 'tick' });
+  }
+
+  tickOnboarding(gameMinutes) {
+    this.progressAccumulator += gameMinutes;
+    while (this.progressAccumulator >= 0.62 && this.state.verified < ONBOARDING_VERIFY_TARGET) {
+      this.progressAccumulator -= 0.62;
+      this.state.verified += 1;
+      this.state.backlog = Math.max(0, ONBOARDING_VERIFY_TARGET - this.state.verified);
+      this.state.score += 12;
+    }
+    if (this.state.verified === ONBOARDING_VERIFY_TARGET && this.state.stage === 'coach-watch') {
+      this.state.stage = 'dispatch';
+      this.state.paused = true;
+      this.emit('verified', 'Six promises reached the right lane. The morning van is ready.');
+    }
+  }
+
+  tickNorthbound(gameMinutes) {
     if (this.state.ruleFixed) {
-      this.verificationAccumulator += gameMinutes;
-      while (this.verificationAccumulator >= 0.72 && this.state.verified < VERIFY_TARGET) {
-        this.verificationAccumulator -= 0.72;
+      this.progressAccumulator += gameMinutes;
+      while (this.progressAccumulator >= 0.72 && this.state.verified < VERIFY_TARGET) {
+        this.progressAccumulator -= 0.72;
         this.state.verified += 1;
         this.state.risk = Math.max(2, this.state.risk - (this.state.verified % 3 === 0 ? 1 : 0));
         this.state.backlog = Math.max(52, this.state.backlog - 1);
         this.state.score += 8;
-        if (this.state.verified === VERIFY_TARGET) {
-          this.state.onTime = Math.max(this.state.onTime, this.state.staffMoved ? 98 : 95);
-          this.emit('verified', 'Twelve new matching parcels reached Express A correctly. The recurring failure has stopped.');
-        }
+      }
+      if (this.state.verified === VERIFY_TARGET && this.state.stage === 'verify') {
+        this.state.onTime = Math.max(this.state.onTime, this.state.staffMoved ? 98 : 95);
+        this.state.stage = 'dispatch';
+        this.state.paused = true;
+        this.emit('verified', 'Twelve later parcels reached Express A correctly. The recurring failure has stopped.');
       }
     }
 
     const minute = Math.floor(this.state.time);
     while (this.state.lastMinute < minute) {
       this.state.lastMinute += 1;
-      this.stepMinute();
+      this.stepNorthboundMinute();
     }
 
     if (this.state.time >= this.state.departure && this.state.verified < VERIFY_TARGET) {
       this.state.lateMinutes = Math.floor(this.state.time - this.state.departure) + 1;
       this.state.onTime = clamp(this.state.onTime - 0.18 * gameMinutes, 72, 100);
     }
-
-    this.onChange(this.snapshot(), { type: 'tick' });
   }
 
-  stepMinute() {
+  stepNorthboundMinute() {
     if (!this.state.staffMoved) {
       this.state.expressLoad = clamp(this.state.expressLoad + 0.55, 0, 100);
       this.state.backlog = clamp(this.state.backlog + 1, 0, 999);
@@ -198,18 +819,86 @@ export class ShiftSimulation {
     }
   }
 
-  completeShift() {
-    if (this.state.completed || this.state.verified < VERIFY_TARGET) return false;
+  tickSnow(gameMinutes) {
+    const reliability = this.state.routeChoice === 'inland' ? 1 : 0.62;
+    this.progressAccumulator += gameMinutes * reliability;
+    while (this.progressAccumulator >= 0.62 && this.state.delivered < this.state.deliveryTarget) {
+      this.progressAccumulator -= 0.62;
+      this.state.delivered += 1;
+      this.state.backlog = Math.max(0, this.state.backlog - 1);
+      if (this.state.delivered % 3 === 0) this.state.risk = Math.max(this.state.allocation === 'harnosand' ? 2 : 9, this.state.risk - 1);
+      this.state.score += 9;
+    }
+    this.state.onTime = clamp(72 + (this.state.delivered / Math.max(1, this.state.deliveryTarget)) * 26, 0, 99);
+    if (this.state.delivered === this.state.deliveryTarget && this.state.stage === 'weather-run') {
+      this.state.stage = 'dispatch';
+      this.state.paused = true;
+      this.emit('verified', 'The assigned parcels reached their depot. The weather window is closing behind the truck.');
+    }
+  }
+
+  tickScanner(gameMinutes) {
+    const rate = this.state.scannerFixed ? 1 : 0.72;
+    this.progressAccumulator += gameMinutes * rate;
+    while (this.progressAccumulator >= 0.45 && this.state.processed < 31) {
+      this.progressAccumulator -= 0.45;
+      this.state.processed += 1;
+      this.state.backlog = Math.max(0, 31 - this.state.processed);
+      if (this.state.processed % 5 === 0) this.state.risk = Math.max(this.state.scannerFixed ? 1 : 4, this.state.risk - 1);
+      this.state.score += this.state.scannerFixed ? 8 : 4;
+    }
+    if (this.state.processed === 31 && this.state.stage === 'jam-run') {
+      this.state.stage = 'dispatch';
+      this.state.paused = true;
+      this.emit('verified', 'The full queue has cleared. Scanner accuracy is stable.');
+    }
+  }
+
+  tickPriority(gameMinutes) {
+    const rate = { courier: 4.8, linehaul: 3.4, scheduled: 2.35 }[this.state.recoveryChoice] || 0;
+    this.state.deliveryProgress = clamp(this.state.deliveryProgress + gameMinutes * rate, 0, 100);
+    this.state.backlog = Math.max(0, Math.ceil(this.state.departure - this.state.time));
+    if (this.state.time > this.state.departure) {
+      this.state.risk = Math.max(2, this.state.risk + gameMinutes * 0.12);
+      this.state.onTime = clamp(this.state.onTime - gameMinutes * 0.5, 70, 100);
+    }
+    if (this.state.deliveryProgress >= 100 && this.state.stage === 'case-run') {
+      this.state.deliveryProgress = 100;
+      this.state.stage = 'dispatch';
+      this.state.paused = true;
+      this.emit('verified', 'The recipient has the parcel. Temperature remained inside the safe range.');
+    }
+  }
+
+  finishShift() {
+    if (this.state.completed || this.state.stage !== 'dispatch') return false;
     this.state.completed = true;
     this.state.paused = true;
-    this.state.time = Math.max(this.state.time, this.state.departure);
     this.state.lateMinutes = Math.max(0, Math.floor(this.state.time - this.state.departure));
-    this.state.saved = Math.max(12, 18 - this.state.lateMinutes * 2);
-    this.state.risk = Math.max(0, 18 - this.state.saved);
-    this.state.backlog = Math.max(48, this.state.backlog - 8);
-    this.state.onTime = clamp(this.state.onTime - this.state.lateMinutes * 2, 0, 99);
-    if (!this.state.truckHeld) this.state.score += 120;
-    if (this.state.lateMinutes === 0) this.state.score += 140;
+
+    if (this.state.shiftId === 'northbound') {
+      this.state.time = Math.max(this.state.time, this.state.departure);
+      this.state.saved = Math.max(12, 18 - this.state.lateMinutes * 2);
+      this.state.risk = Math.max(0, 18 - this.state.saved);
+      this.state.backlog = Math.max(48, this.state.backlog - 8);
+      this.state.onTime = clamp(this.state.onTime - this.state.lateMinutes * 2, 0, 99);
+      if (!this.state.truckHeld) this.state.score += 120;
+      if (this.state.lateMinutes === 0) this.state.score += 140;
+    } else if (this.state.shiftId === 'first-rounds') {
+      this.state.saved = ONBOARDING_VERIFY_TARGET;
+      this.state.onTime = 100;
+      this.state.score += 120;
+    } else if (this.state.shiftId === 'snow-window') {
+      this.state.saved = this.state.delivered;
+      if (this.state.allocation === 'harnosand') this.state.score += 120;
+    } else if (this.state.shiftId === 'scanner-fever') {
+      this.state.saved = this.state.processed;
+      if (this.state.scannerFixed) this.state.score += 100;
+    } else if (this.state.shiftId === 'priority-parcel') {
+      this.state.saved = 1;
+      this.state.onTime = this.state.recoveryChoice === 'courier' ? 100 : this.state.recoveryChoice === 'linehaul' ? 96 : 86;
+    }
+
     this.state.score = Math.max(0, Math.round(this.state.score));
     this.state.outcome = createOutcome(this.state);
     this.emit('complete', this.state.outcome.summary);
@@ -217,28 +906,127 @@ export class ShiftSimulation {
   }
 
   reset() {
-    this.state = createInitialState();
-    this.verificationAccumulator = 0;
+    this.state = createInitialState(this.shiftId, this.variant);
+    this.progressAccumulator = 0;
     this.emit('reset', 'Shift reset.');
   }
 }
 
 export function createOutcome(state) {
-  const cleanFix = state.ruleFixed && state.staffMoved;
-  const onTime = state.lateMinutes === 0;
-  const grade = cleanFix && onTime && !state.truckHeld ? 'A+' : cleanFix && onTime ? 'A' : onTime ? 'B' : 'C';
-  const medals = [];
-  if (state.staffMoved) medals.push({ icon: '↔', label: 'Crew whisperer' });
-  if (state.ruleFixed) medals.push({ icon: '◆', label: 'Root cause found' });
-  if (!state.truckHeld) medals.push({ icon: '↗', label: 'Clean departure' });
+  if (state.shiftId === 'first-rounds') {
+    return {
+      grade: '✓',
+      gradeLabel: 'Training complete',
+      kicker: 'FIRST SHIFT COMPLETE',
+      title: 'You are on the roster.',
+      summary: 'You read the flow, moved the team, checked the scanner and sent the van. Four very different shifts are now open.',
+      medals: [
+        { icon: '1', label: 'First shift' },
+        { icon: '↗', label: 'Promises moving' }
+      ],
+      stats: [
+        { label: 'Parcels', value: '6 / 6' },
+        { label: 'On time', value: '100%' },
+        { label: 'Score', value: state.score.toLocaleString('en-SE') }
+      ],
+      score: state.score
+    };
+  }
+
+  if (state.shiftId === 'northbound') {
+    const cleanFix = state.ruleFixed && state.staffMoved;
+    const onTime = state.lateMinutes === 0;
+    const grade = cleanFix && onTime && !state.truckHeld ? 'A+' : cleanFix && onTime ? 'A' : onTime ? 'B' : 'C';
+    const medals = [];
+    if (state.staffMoved) medals.push({ icon: '↔', label: 'Crew whisperer' });
+    if (state.ruleFixed) medals.push({ icon: '◆', label: 'Root cause found' });
+    if (!state.truckHeld) medals.push({ icon: '↗', label: 'Clean departure' });
+    return {
+      grade,
+      gradeLabel: `Grade ${grade}`,
+      kicker: 'SHIFT COMPLETE',
+      title: 'Promises kept.',
+      summary: onTime
+        ? 'The northbound truck left on time and the recurring routing error is gone.'
+        : `The error is gone. The truck left ${state.lateMinutes} minutes late, with recovery already under way.`,
+      medals,
+      stats: [
+        { label: 'Saved', value: String(state.saved) },
+        { label: 'On time', value: `${Math.round(state.onTime)}%` },
+        { label: 'Score', value: state.score.toLocaleString('en-SE') }
+      ],
+      score: state.score
+    };
+  }
+
+  if (state.shiftId === 'snow-window') {
+    const urgentFirst = state.allocation === 'harnosand';
+    const reliableRoute = state.routeChoice === 'inland';
+    const grade = urgentFirst && reliableRoute ? 'A+' : urgentFirst || reliableRoute ? 'A' : 'B';
+    return {
+      grade,
+      gradeLabel: `Grade ${grade}`,
+      kicker: 'WEATHER WINDOW CLOSED',
+      title: urgentFirst ? 'The urgent load got through.' : 'The network adapted.',
+      summary: urgentFirst
+        ? 'The spare truck protected the most time-sensitive promises before the snow closed in.'
+        : 'The assigned route moved, but the urgent Härnösand promises needed a second recovery plan.',
+      medals: [
+        reliableRoute ? { icon: '⌁', label: 'Inland navigator' } : { icon: '❄', label: 'Snow runner' },
+        urgentFirst ? { icon: '◇', label: 'Urgent first' } : { icon: '▰', label: 'Capacity moved' }
+      ],
+      stats: [
+        { label: 'Delivered', value: String(state.delivered) },
+        { label: 'Coverage', value: `${Math.round(state.onTime)}%` },
+        { label: 'Score', value: state.score.toLocaleString('en-SE') }
+      ],
+      score: state.score
+    };
+  }
+
+  if (state.shiftId === 'scanner-fever') {
+    const grade = state.scannerFixed && state.triageMistakes === 0 ? 'A+' : state.scannerFixed ? 'A' : state.triageMistakes <= 1 ? 'B' : 'C';
+    return {
+      grade,
+      gradeLabel: `Grade ${grade}`,
+      kicker: 'QUEUE CLEARED',
+      title: state.scannerFixed ? 'Scanner 2 is healthy.' : 'Manual flow held the line.',
+      summary: state.scannerFixed
+        ? 'The right promises moved first, the obstruction is gone and automated accuracy is restored.'
+        : 'The queue moved, but the next shift still needs to repair and recalibrate the scanner.',
+      medals: [
+        state.triageMistakes === 0 ? { icon: '1', label: 'Perfect priority' } : { icon: '▦', label: 'Queue cleared' },
+        state.scannerFixed ? { icon: '◆', label: 'Clean repair' } : { icon: '↔', label: 'Manual recovery' }
+      ],
+      stats: [
+        { label: 'Processed', value: String(state.processed) },
+        { label: 'Accuracy', value: `${Math.round(state.onTime)}%` },
+        { label: 'Score', value: state.score.toLocaleString('en-SE') }
+      ],
+      score: state.score
+    };
+  }
+
+  const correctFind = state.locationCorrect;
+  const direct = state.recoveryChoice === 'courier';
+  const grade = correctFind && direct ? 'A+' : correctFind || direct ? 'A' : state.recoveryChoice === 'linehaul' ? 'B' : 'C';
   return {
     grade,
-    medals,
-    summary: onTime
-      ? 'The northbound truck left on time and the recurring routing error is gone.'
-      : `The routing error is gone. The truck left ${state.lateMinutes} minutes late, with the next shift set up to recover.`,
-    saved: state.saved,
-    onTime: Math.round(state.onTime),
+    gradeLabel: `Grade ${grade}`,
+    kicker: 'DELIVERY CONFIRMED',
+    title: 'Cold chain intact.',
+    summary: correctFind && direct
+      ? 'The scan trail led straight to the parcel and a direct courier protected every minute of its promise.'
+      : 'The parcel arrived safely. The recovery took a detour, but its temperature stayed inside range.',
+    medals: [
+      correctFind ? { icon: '◇', label: 'Sharp detective' } : { icon: '□', label: 'Parcel recovered' },
+      direct ? { icon: '↗', label: 'Direct handoff' } : { icon: '⌁', label: 'Connection made' }
+    ],
+    stats: [
+      { label: 'Delivered', value: '1 / 1' },
+      { label: 'Cold chain', value: `${Math.round(state.onTime)}%` },
+      { label: 'Score', value: state.score.toLocaleString('en-SE') }
+    ],
     score: state.score
   };
 }

--- a/postal/styles.css
+++ b/postal/styles.css
@@ -523,6 +523,18 @@ button[disabled] {
   background: #fff1a6;
 }
 
+.world-hotspot[data-tone="orange"] {
+  background: #ffe1c6;
+}
+
+.world-hotspot[data-tone="pink"] {
+  background: #ffd5e8;
+}
+
+.world-hotspot[data-tone="purple"] {
+  background: #ded9ff;
+}
+
 .world-hotspot[data-tone="danger"] {
   background: #ffd5ca;
   animation: hotspot-pop 850ms ease-in-out infinite alternate;
@@ -574,6 +586,17 @@ button[disabled] {
   gap: 12px;
   align-items: center;
   min-height: 128px;
+}
+
+.command-content[data-layout="wide"] {
+  grid-template-columns: 1fr;
+  gap: 8px;
+  min-height: 190px;
+  align-content: center;
+}
+
+.command-content[data-layout="wide"] .command-copy p {
+  -webkit-line-clamp: 2;
 }
 
 .command-copy {
@@ -748,6 +771,121 @@ button[disabled] {
   font-weight: 1000;
 }
 
+.choice-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 7px;
+}
+
+.choice-grid--three {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.choice-card {
+  display: grid;
+  min-width: 0;
+  min-height: 58px;
+  align-content: center;
+  gap: 3px;
+  padding: 7px 6px;
+  border: 2px solid var(--ink);
+  border-radius: 11px;
+  background: var(--paper-bright);
+  box-shadow: 2px 2px 0 var(--ink);
+  text-align: center;
+}
+
+.choice-card--blue {
+  background: #d8f5ff;
+}
+
+.choice-card strong {
+  overflow-wrap: anywhere;
+  font-size: clamp(0.65rem, 2.7vw, 0.78rem);
+  line-height: 1.05;
+}
+
+.choice-card span {
+  color: #46424c;
+  font-size: clamp(0.52rem, 2.25vw, 0.64rem);
+  font-weight: 800;
+  line-height: 1.05;
+}
+
+.choice-card:active,
+.parcel-choice:not([disabled]):active {
+  transform: translate(2px, 2px);
+  box-shadow: none;
+}
+
+.parcel-priority-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 7px;
+}
+
+.parcel-choice {
+  display: grid;
+  min-width: 0;
+  min-height: 72px;
+  place-items: center;
+  gap: 2px;
+  padding: 6px 4px;
+  border: 2px solid var(--ink);
+  border-radius: 11px;
+  background: var(--paper-bright);
+  box-shadow: 2px 2px 0 var(--ink);
+  text-align: center;
+}
+
+.parcel-choice[data-tone="pink"] {
+  background: #ffd9e9;
+}
+
+.parcel-choice[data-tone="blue"] {
+  background: #d8f5ff;
+}
+
+.parcel-choice[data-tone="orange"] {
+  background: #ffe1c6;
+}
+
+.parcel-choice[data-tone="yellow"] {
+  background: #fff1a6;
+}
+
+.parcel-choice[disabled] {
+  background: #d6f0dc;
+  opacity: 0.7;
+  box-shadow: none;
+}
+
+.parcel-choice-box {
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.parcel-choice strong {
+  overflow-wrap: anywhere;
+  font-size: clamp(0.58rem, 2.4vw, 0.7rem);
+  line-height: 1;
+}
+
+.parcel-choice span:last-child {
+  font-size: clamp(0.5rem, 2.1vw, 0.6rem);
+  font-weight: 850;
+}
+
+.evidence-list {
+  display: grid;
+  gap: 2px;
+  margin: 6px 0 0;
+  padding-left: 19px;
+  font-size: clamp(0.6rem, 2.6vw, 0.72rem);
+  font-weight: 750;
+  line-height: 1.18;
+}
+
 .scene-nav {
   position: relative;
   z-index: 35;
@@ -801,7 +939,8 @@ button[disabled] {
 }
 
 .welcome,
-.result-screen {
+.result-screen,
+.campaign-screen {
   position: fixed;
   z-index: 200;
   inset: 0;
@@ -812,7 +951,8 @@ button[disabled] {
 }
 
 .welcome[hidden],
-.result-screen[hidden] {
+.result-screen[hidden],
+.campaign-screen[hidden] {
   display: none;
 }
 
@@ -979,6 +1119,185 @@ button[disabled] {
   font-size: 0.65rem;
   font-weight: 720;
   line-height: 1.3;
+  text-align: center;
+}
+
+.campaign-screen {
+  align-items: end;
+  background: transparent;
+}
+
+.campaign-scrim {
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(to bottom, rgb(23 22 46 / 0.3), rgb(23 22 46 / 0.86) 54%, rgb(23 22 46 / 0.98)),
+    radial-gradient(circle at 50% 20%, transparent, rgb(23 22 46 / 0.55));
+  backdrop-filter: blur(2px) saturate(1.15);
+}
+
+.campaign-panel {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  width: calc(100% - 20px);
+  max-width: 520px;
+  max-height: calc(100dvh - max(36px, var(--safe-top)));
+  justify-self: center;
+  gap: 10px;
+  padding: 16px 13px calc(12px + var(--safe-bottom));
+  overflow: hidden;
+  border: 3px solid var(--ink);
+  border-bottom: 0;
+  border-radius: 24px 24px 0 0;
+  background:
+    linear-gradient(rgb(16 19 26 / 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(16 19 26 / 0.035) 1px, transparent 1px),
+    var(--paper);
+  background-size: 20px 20px;
+  box-shadow: 7px -7px 0 rgb(16 19 26 / 0.32);
+}
+
+.campaign-head {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+}
+
+.campaign-head h2 {
+  margin: 0;
+  font-size: clamp(1.45rem, 7vw, 2rem);
+  line-height: 0.95;
+  letter-spacing: -0.035em;
+}
+
+.campaign-head p {
+  margin: 5px 0 0;
+  font-size: 0.68rem;
+  font-weight: 750;
+}
+
+.campaign-stamp {
+  display: grid;
+  width: 58px;
+  height: 58px;
+  place-items: center;
+  border: 3px solid var(--ink);
+  border-radius: 18px;
+  background: var(--yellow);
+  font-size: 1rem;
+  font-weight: 1000;
+  box-shadow: 3px 3px 0 var(--ink);
+  transform: rotate(3deg);
+}
+
+.shift-list {
+  display: grid;
+  gap: 8px;
+  min-height: 0;
+  padding: 2px 4px 5px 2px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-color: var(--purple) transparent;
+}
+
+.shift-card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 9px;
+  align-items: center;
+  min-height: 96px;
+  padding: 9px;
+  border: 3px solid var(--ink);
+  border-radius: 15px;
+  background: var(--paper-bright);
+  box-shadow: var(--shadow-small);
+  text-align: left;
+}
+
+.shift-card[data-tone="yellow"] { background: #fff3b5; }
+.shift-card[data-tone="blue"] { background: #d8f5ff; }
+.shift-card[data-tone="purple"] { background: #ded9ff; }
+.shift-card[data-tone="orange"] { background: #ffe1c6; }
+.shift-card[data-tone="pink"] { background: #ffd9e9; }
+
+.shift-card:active {
+  transform: translate(3px, 3px);
+  box-shadow: none;
+}
+
+.shift-card-number {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  border: 2px solid var(--ink);
+  border-radius: 11px;
+  background: var(--paper-bright);
+  font-size: 1rem;
+  font-weight: 1000;
+}
+
+.shift-card-copy {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.shift-card-kind,
+.shift-card-copy small {
+  font-size: 0.54rem;
+  font-weight: 900;
+  letter-spacing: 0.035em;
+  text-transform: uppercase;
+}
+
+.shift-card-copy strong {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.shift-card-copy > span:not(.shift-card-kind) {
+  display: -webkit-box;
+  overflow: hidden;
+  font-size: 0.65rem;
+  font-weight: 690;
+  line-height: 1.18;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.shift-card-copy small {
+  margin-top: 2px;
+  color: #4a4551;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.shift-card-state {
+  display: grid;
+  justify-items: center;
+  gap: 1px;
+  min-width: 40px;
+}
+
+.shift-card-state strong {
+  font-size: 1.05rem;
+}
+
+.shift-card-state span {
+  font-size: 0.5rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.campaign-note {
+  margin: 0 4px;
+  font-size: 0.59rem;
+  font-weight: 720;
+  line-height: 1.25;
   text-align: center;
 }
 
@@ -1265,6 +1584,34 @@ tbody tr:last-child td {
   line-height: 1.4;
 }
 
+.detail-checklist {
+  display: grid;
+  gap: 5px;
+  margin: 9px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.detail-checklist li {
+  position: relative;
+  padding-left: 24px;
+  font-size: 0.76rem;
+  font-weight: 720;
+  line-height: 1.3;
+}
+
+.detail-checklist li::before {
+  content: "○";
+  position: absolute;
+  left: 2px;
+  font-weight: 1000;
+}
+
+.detail-checklist li[data-done="true"]::before {
+  content: "✓";
+  color: var(--green-deep);
+}
+
 .toast {
   position: fixed;
   z-index: 400;
@@ -1380,6 +1727,10 @@ tbody tr:last-child td {
     min-height: 113px;
   }
 
+  .command-content[data-layout="wide"] {
+    min-height: 166px;
+  }
+
   .command-copy p {
     -webkit-line-clamp: 2;
   }
@@ -1404,6 +1755,41 @@ tbody tr:last-child td {
 
   .toast {
     bottom: calc(202px + var(--safe-bottom));
+  }
+
+  .result-card {
+    gap: 6px;
+    padding: 12px;
+  }
+
+  .result-grade {
+    width: 64px;
+    height: 64px;
+    border-radius: 20px;
+    font-size: 2rem;
+    box-shadow: 4px 4px 0 var(--ink);
+  }
+
+  .result-card h2 {
+    font-size: 1.45rem;
+  }
+
+  .result-medals {
+    gap: 4px;
+  }
+
+  .result-card .game-button {
+    min-height: 44px;
+  }
+
+  .campaign-panel {
+    gap: 7px;
+    padding-top: 11px;
+  }
+
+  .shift-card {
+    min-height: 84px;
+    padding-block: 7px;
   }
 }
 

--- a/postal/sw.js
+++ b/postal/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'postal-visual-game-20260805-r2';
+const CACHE_NAME = 'postal-campaign-20260805-r3';
 const CORE_ASSETS = [
   './',
   './index.html',

--- a/postal/tests/sim.test.mjs
+++ b/postal/tests/sim.test.mjs
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   BASE_DEPARTURE,
+  SHIFT_CATALOG,
   ShiftSimulation,
   VERIFY_TARGET,
   createInitialState,
@@ -9,16 +10,47 @@ import {
   getStage
 } from '../sim.mjs';
 
-test('starts with the researched Sundsvall incident state', () => {
-  const state = createInitialState();
+test('campaign exposes five shifts with four different post-training play styles', () => {
+  assert.equal(SHIFT_CATALOG.length, 5);
+  assert.equal(SHIFT_CATALOG[0].id, 'first-rounds');
+  assert.deepEqual(
+    SHIFT_CATALOG.slice(1).map((shift) => shift.kind),
+    ['Systems shift', 'Network shift', 'Triage shift', 'Investigation shift']
+  );
+});
+
+test('first shift teaches one safe action at a time before running flow', () => {
+  const sim = new ShiftSimulation();
+  assert.equal(getStage(sim.snapshot()), 'brief');
+  sim.start();
+  assert.equal(sim.snapshot().stage, 'tour');
+  assert.equal(sim.snapshot().paused, true);
+  assert.deepEqual(sim.snapshot().activeHotspots, ['express-lane']);
+
+  assert.equal(sim.perform('inspect-express'), true);
+  assert.equal(sim.snapshot().stage, 'coach-move');
+  assert.equal(sim.perform('move-staff'), true);
+  assert.equal(sim.snapshot().stage, 'coach-scan');
+  assert.equal(sim.perform('inspect-scanner'), true);
+  assert.equal(sim.snapshot().stage, 'coach-run');
+  assert.equal(sim.perform('resume'), true);
+  sim.tick(60);
+  assert.equal(sim.snapshot().stage, 'dispatch');
+  assert.equal(sim.completeShift(), true);
+  assert.equal(sim.snapshot().outcome.grade, '✓');
+  assert.match(sim.snapshot().outcome.summary, /four very different shifts/i);
+});
+
+test('northbound starts with the researched Sundsvall incident state', () => {
+  const state = createInitialState('northbound');
   assert.equal(formatClock(state.time), '17:42');
   assert.equal(formatClock(state.departure), '18:20');
   assert.equal(state.risk, 18);
   assert.equal(getStage(state), 'brief');
 });
 
-test('moving crew protects the departure without hiding the root cause', () => {
-  const sim = new ShiftSimulation();
+test('moving crew protects northbound without hiding the root cause', () => {
+  const sim = new ShiftSimulation(() => {}, 'northbound');
   sim.start();
   assert.equal(sim.moveStaff(), true);
   const state = sim.snapshot();
@@ -30,7 +62,7 @@ test('moving crew protects the departure without hiding the root cause', () => {
 });
 
 test('holding the truck buys three minutes and spends downstream margin', () => {
-  const sim = new ShiftSimulation();
+  const sim = new ShiftSimulation(() => {}, 'northbound');
   sim.start();
   sim.holdTruck();
   const state = sim.snapshot();
@@ -39,22 +71,18 @@ test('holding the truck buys three minutes and spends downstream margin', () => 
   assert.equal(state.truckHeld, true);
 });
 
-test('package investigation pauses time and exposes the rule correction sequence', () => {
-  const sim = new ShiftSimulation();
+test('parcel selection cannot be repeated for extra score', () => {
+  const sim = new ShiftSimulation(() => {}, 'northbound');
   sim.start();
   sim.moveStaff();
-  sim.selectPackage();
-  assert.equal(sim.snapshot().paused, true);
-  assert.equal(sim.snapshot().stage, 'compare');
-  sim.findSimilar();
-  assert.equal(sim.snapshot().stage, 'rule');
-  sim.fixRule();
-  assert.equal(sim.snapshot().stage, 'verify');
-  assert.equal(sim.snapshot().ruleFixed, true);
+  assert.equal(sim.selectPackage(), true);
+  const score = sim.snapshot().score;
+  assert.equal(sim.selectPackage(), false);
+  assert.equal(sim.snapshot().score, score);
 });
 
-test('verification only progresses while the corrected flow is running', () => {
-  const sim = new ShiftSimulation();
+test('northbound verification only progresses while corrected flow runs', () => {
+  const sim = new ShiftSimulation(() => {}, 'northbound');
   sim.start();
   sim.moveStaff();
   sim.selectPackage();
@@ -68,8 +96,8 @@ test('verification only progresses while the corrected flow is running', () => {
   assert.equal(sim.snapshot().stage, 'dispatch');
 });
 
-test('a clean root-cause fix can finish with an A plus result', () => {
-  const sim = new ShiftSimulation();
+test('clean northbound root-cause fix earns A plus', () => {
+  const sim = new ShiftSimulation(() => {}, 'northbound');
   sim.start();
   sim.moveStaff();
   sim.selectPackage();
@@ -78,16 +106,70 @@ test('a clean root-cause fix can finish with an A plus result', () => {
   sim.setPaused(false);
   sim.tick(60);
   assert.equal(sim.completeShift(), true);
-  const state = sim.snapshot();
-  assert.equal(state.completed, true);
-  assert.equal(state.outcome.grade, 'A+');
-  assert.ok(state.outcome.medals.some((medal) => medal.label === 'Root cause found'));
+  assert.equal(sim.snapshot().outcome.grade, 'A+');
 });
 
-test('cannot dispatch before twelve corrected parcels are verified', () => {
-  const sim = new ShiftSimulation();
+test('snow shift requires reading depots, then rewards urgent inland routing', () => {
+  const sim = new ShiftSimulation(() => {}, 'snow-window');
   sim.start();
-  sim.moveStaff();
-  assert.equal(sim.completeShift(), false);
-  assert.equal(sim.snapshot().completed, false);
+  assert.equal(sim.snapshot().stage, 'weather-scan');
+  assert.equal(sim.perform('inspect-depot', 'harnosand'), true);
+  assert.equal(sim.perform('inspect-depot', 'timra'), true);
+  assert.equal(sim.perform('inspect-depot', 'matfors'), true);
+  assert.equal(sim.snapshot().stage, 'weather-allocate');
+  assert.equal(sim.perform('allocate-truck', 'harnosand'), true);
+  assert.equal(sim.perform('choose-route', 'inland'), true);
+  assert.equal(sim.perform('resume'), true);
+  sim.tick(60);
+  assert.equal(sim.snapshot().delivered, 14);
+  assert.equal(sim.snapshot().stage, 'dispatch');
+  sim.completeShift();
+  assert.equal(sim.snapshot().outcome.grade, 'A+');
+});
+
+test('scanner shift changes its triage groups on replay variants', () => {
+  const first = createInitialState('scanner-fever', 0).triageQueue.map((parcel) => parcel.id);
+  const replay = createInitialState('scanner-fever', 1).triageQueue.map((parcel) => parcel.id);
+  assert.notDeepEqual(first, replay);
+});
+
+test('scanner shift supports promise ordering, repair and live recovery', () => {
+  const sim = new ShiftSimulation(() => {}, 'scanner-fever');
+  sim.start();
+  sim.perform('inspect-scanner');
+  const ordered = [...sim.snapshot().triageQueue].sort((a, b) => a.priority - b.priority);
+  ordered.forEach((parcel) => assert.equal(sim.perform('prioritize', parcel.id), true));
+  assert.equal(sim.snapshot().triageMistakes, 0);
+  assert.equal(sim.perform('repair-scanner'), true);
+  assert.equal(sim.perform('resume'), true);
+  sim.tick(60);
+  assert.equal(sim.snapshot().processed, 31);
+  assert.equal(sim.snapshot().stage, 'dispatch');
+  sim.completeShift();
+  assert.equal(sim.snapshot().outcome.grade, 'A+');
+});
+
+test('priority parcel shift turns evidence into a recovery choice', () => {
+  const sim = new ShiftSimulation(() => {}, 'priority-parcel');
+  sim.start();
+  assert.equal(sim.selectPackage(), true);
+  const correctLocation = sim.snapshot().caseData.correctLocation;
+  assert.equal(sim.perform('choose-location', correctLocation), true);
+  assert.equal(sim.snapshot().locationCorrect, true);
+  assert.equal(sim.perform('choose-recovery', 'courier'), true);
+  assert.equal(sim.perform('resume'), true);
+  sim.tick(90);
+  assert.equal(sim.snapshot().deliveryProgress, 100);
+  assert.equal(sim.snapshot().stage, 'dispatch');
+  sim.completeShift();
+  assert.equal(sim.snapshot().outcome.grade, 'A+');
+});
+
+test('no shift can be closed before its live objective is ready', () => {
+  for (const shift of SHIFT_CATALOG) {
+    const sim = new ShiftSimulation(() => {}, shift.id);
+    sim.start();
+    assert.equal(sim.completeShift(), false, shift.id);
+    assert.equal(sim.snapshot().completed, false, shift.id);
+  }
 });

--- a/postal/tests/ui-contract.test.mjs
+++ b/postal/tests/ui-contract.test.mjs
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const root = new URL('../', import.meta.url);
+const [html, main, world, styles] = await Promise.all([
+  readFile(new URL('index.html', root), 'utf8'),
+  readFile(new URL('main.mjs', root), 'utf8'),
+  readFile(new URL('world.mjs', root), 'utf8'),
+  readFile(new URL('styles.css', root), 'utf8')
+]);
+
+test('every JavaScript ID selector has a matching unique HTML element', () => {
+  const htmlIds = [...html.matchAll(/\sid="([^"]+)"/g)].map((match) => match[1]);
+  const duplicateIds = htmlIds.filter((id, index) => htmlIds.indexOf(id) !== index);
+  assert.deepEqual(duplicateIds, []);
+
+  const selectorIds = [...main.matchAll(/\$\('#([^']+)'\)/g)].map((match) => match[1]);
+  const missing = [...new Set(selectorIds)].filter((id) => !htmlIds.includes(id));
+  assert.deepEqual(missing, []);
+
+  const labelledByIds = [...html.matchAll(/aria-labelledby="([^"]+)"/g)]
+    .flatMap((match) => match[1].split(/\s+/));
+  assert.deepEqual([...new Set(labelledByIds)].filter((id) => !htmlIds.includes(id)), []);
+});
+
+test('fresh-player and campaign overlays have named controls and real hidden states', () => {
+  assert.match(html, /id="welcomeScreen" aria-labelledby="welcomeTitle"/);
+  assert.match(html, /id="startButton"[^>]*>Start first shift</);
+  assert.match(html, /id="campaignScreen" aria-labelledby="campaignTitle" hidden/);
+  assert.match(html, /id="shiftList"/);
+  assert.match(styles, /\.campaign-screen\[hidden\]/);
+  assert.match(main, /if \(campaign\.completed\['first-rounds'\]\)/);
+});
+
+test('runtime no longer plays the sharp sample files', () => {
+  assert.doesNotMatch(main, /new Audio\s*\(/);
+  assert.doesNotMatch(main, /assets\/audio/);
+  assert.match(main, /oscillator\.type = 'triangle'/);
+  assert.match(main, /filter\.type = 'lowpass'/);
+  assert.match(main, /\[392, 0\.15, 0\.16, 0\.016\]/);
+});
+
+test('no-WebGL mode is guarded before scene groups are dereferenced', () => {
+  const setModeStart = world.indexOf('setMode(mode, immediate = false)');
+  const guard = world.indexOf('if (!this.camera || !this.terminalGroup', setModeStart);
+  const dereference = world.indexOf("this.terminalGroup.visible = mode === 'terminal'", setModeStart);
+  assert.ok(setModeStart > 0);
+  assert.ok(guard > setModeStart);
+  assert.ok(dereference > guard);
+  assert.match(main, /Every shift remains playable with the controls below|complete shift remains playable below/i);
+});
+
+test('all required world actions retain large HTML alternatives', () => {
+  for (const action of [
+    'inspect-express',
+    'move-staff',
+    'inspect-scanner',
+    'inspect-depot',
+    'allocate-truck',
+    'choose-route',
+    'prioritize',
+    'repair-scanner',
+    'inspect-case',
+    'choose-location',
+    'choose-recovery',
+    'dispatch'
+  ]) {
+    assert.match(main, new RegExp(`data-action=\\"${action}\\"`), action);
+  }
+});
+
+test('portrait command deck has compact and expanded layouts', () => {
+  assert.match(styles, /\.command-content\[data-layout="wide"\]/);
+  assert.match(styles, /@media \(max-height: 700px\)[\s\S]*\.command-content\[data-layout="wide"\]/);
+  assert.match(styles, /\.choice-grid--three/);
+  assert.match(styles, /\.parcel-priority-grid/);
+});

--- a/postal/world.mjs
+++ b/postal/world.mjs
@@ -124,6 +124,7 @@ export class PostalWorld {
     this.runningVisualTime = 0;
     this.cameraBlend = 1;
     this.state = {
+      shiftId: 'first-rounds',
       started: false,
       paused: true,
       stage: 'brief',
@@ -132,10 +133,15 @@ export class PostalWorld {
       ruleFixed: false,
       verified: 0,
       completed: false,
-      speed: 1
+      speed: 1,
+      activeHotspots: [],
+      hotspotLabels: {},
+      hotspotTones: {},
+      hotspotIcons: {}
     };
     this.interactiveRoots = [];
     this.hotspots = new Map();
+    this.hotspotStateKey = '';
     this.packages = [];
     this.operators = [];
     this.networkTrucks = [];
@@ -384,6 +390,18 @@ export class PostalWorld {
     group.add(warningRoot);
     this.warningRoot = warningRoot;
 
+    const scannerWarningRoot = new THREE.Group();
+    scannerWarningRoot.position.set(-2.85, 1.62, 0.75);
+    const scannerWarningRing = new THREE.Mesh(
+      new THREE.TorusGeometry(0.48, 0.075, 8, 28),
+      material(0xff9a55, { emissive: 0xff665e, emissiveIntensity: 1.25 })
+    );
+    scannerWarningRing.rotation.x = Math.PI / 2;
+    scannerWarningRoot.add(scannerWarningRing);
+    scannerWarningRoot.visible = false;
+    group.add(scannerWarningRoot);
+    this.scannerWarningRoot = scannerWarningRoot;
+
     this.createOperators(group);
     this.createPackages(group);
 
@@ -400,11 +418,13 @@ export class PostalWorld {
     group.add(standardHit);
     this.markInteractive(standardHit, 'standard-lane');
     this.markInteractive(this.truck, 'truck');
+    this.markInteractive(this.scanner, 'scanner');
 
     this.registerHotspot('express-lane', 'Express A', '↗', 'blue', group, new THREE.Vector3(3.1, 1.45, -1.4));
     this.registerHotspot('standard-lane', 'Standard B', '→', 'yellow', group, new THREE.Vector3(3.1, 1.3, 2.35));
     this.registerHotspot('truck', '18:20 truck', '▰', 'yellow', group, new THREE.Vector3(5.3, 1.75, -1.75));
     this.registerHotspot('parcel', 'Trace parcel', '!', 'danger', group, new THREE.Vector3(2.75, 1.3, 2.35));
+    this.registerHotspot('scanner', 'Scanner 2', '◆', 'orange', group, new THREE.Vector3(-2.85, 2.05, 0.75));
   }
 
   addLaneMarker(parent, z, color, name) {
@@ -543,12 +563,30 @@ export class PostalWorld {
       new THREE.Vector3(0, 0.16, -3.25)
     ];
     const routeCurve = new THREE.CatmullRomCurve3(routePoints);
+    this.networkPrimaryCurve = routeCurve;
     const route = new THREE.Mesh(
       new THREE.TubeGeometry(routeCurve, 40, 0.085, 8, false),
       material(0xff665e, { emissive: 0xff4c44, emissiveIntensity: 1.2 })
     );
     group.add(route);
     this.networkRiskRoute = route;
+
+    const altRoutePoints = [
+      new THREE.Vector3(0, 0.19, 3.1),
+      new THREE.Vector3(-2.2, 0.19, 2.05),
+      new THREE.Vector3(-4.0, 0.19, 1.65),
+      new THREE.Vector3(-2.8, 0.19, -1.2),
+      new THREE.Vector3(0, 0.19, -3.25)
+    ];
+    const altRouteCurve = new THREE.CatmullRomCurve3(altRoutePoints, false, 'centripetal', 0.35);
+    const altRoute = new THREE.Mesh(
+      new THREE.TubeGeometry(altRouteCurve, 58, 0.075, 8, false),
+      material(0x38c7f3, { emissive: 0x1589bb, emissiveIntensity: 0.7, opacity: 0.92 })
+    );
+    altRoute.visible = false;
+    group.add(altRoute);
+    this.networkAltCurve = altRouteCurve;
+    this.networkAltRoute = altRoute;
 
     for (let index = 0; index < 2; index += 1) {
       const truck = this.makeAsset('truck', { targetSize: 0.72 });
@@ -558,6 +596,22 @@ export class PostalWorld {
       group.add(truck);
       this.networkTrucks.push(truck);
     }
+
+    const snowGeometry = new THREE.BufferGeometry();
+    const snowPositions = new Float32Array(90 * 3);
+    for (let index = 0; index < 90; index += 1) {
+      snowPositions[index * 3] = -7 + seeded(index + 130) * 14;
+      snowPositions[index * 3 + 1] = 0.6 + seeded(index + 170) * 8;
+      snowPositions[index * 3 + 2] = -5 + seeded(index + 210) * 10;
+    }
+    snowGeometry.setAttribute('position', new THREE.BufferAttribute(snowPositions, 3));
+    const snow = new THREE.Points(
+      snowGeometry,
+      new THREE.PointsMaterial({ color: 0xfffdf5, size: 0.095, transparent: true, opacity: 0.82, depthWrite: false })
+    );
+    snow.visible = false;
+    group.add(snow);
+    this.networkSnow = snow;
 
     const riskRing = new THREE.Mesh(
       new THREE.RingGeometry(0.78, 1.04, 28),
@@ -665,12 +719,13 @@ export class PostalWorld {
     button.innerHTML = `<span class="world-hotspot-icon" aria-hidden="true">${icon}</span><span>${label}</span>`;
     button.addEventListener('click', () => this.callbacks.onHotspot?.(id));
     this.hotspotLayer.append(button);
-    this.hotspots.set(id, { id, anchor, button, group, tone });
+    this.hotspots.set(id, { id, anchor, button, group, tone, label, icon });
     return anchor;
   }
 
   setMode(mode, immediate = false) {
     if (!CAMERA_PRESETS[mode]) return;
+    if (!this.camera || !this.terminalGroup || !this.networkGroup || !this.caseGroup) return;
     this.mode = mode;
     this.terminalGroup.visible = mode === 'terminal';
     this.networkGroup.visible = mode === 'network';
@@ -695,32 +750,34 @@ export class PostalWorld {
     if (!previous.signatureFound && this.state.signatureFound) {
       this.matchRevealStartedAt = this.elapsed;
     }
-    if (previous.staffMoved !== this.state.staffMoved || previous.ruleFixed !== this.state.ruleFixed || previous.stage !== this.state.stage) {
+    const nextHotspotStateKey = JSON.stringify([
+      this.state.started,
+      this.state.completed,
+      this.state.activeHotspots,
+      this.state.hotspotLabels,
+      this.state.hotspotTones,
+      this.state.hotspotIcons
+    ]);
+    if (nextHotspotStateKey !== this.hotspotStateKey) {
+      this.hotspotStateKey = nextHotspotStateKey;
       this.updateHotspotVisibility();
     }
   }
 
   updateHotspotVisibility() {
+    const activeHotspots = new Set(this.state.activeHotspots || []);
     for (const [id, hotspot] of this.hotspots) {
-      let visible = hotspot.group.visible && this.state.started && !this.state.completed;
-      if (id === 'parcel') visible &&= ['investigate', 'compare', 'rule'].includes(this.state.stage);
-      if (id === 'case-similar') visible &&= this.state.signatureFound;
-      if (id === 'case-package') visible &&= this.state.packageSelected;
-      if (id === 'express-lane' || id === 'standard-lane' || id === 'truck') visible &&= this.mode === 'terminal';
-      if (id.startsWith('network-')) visible &&= this.mode === 'network';
+      const visible = hotspot.group.visible
+        && this.state.started
+        && !this.state.completed
+        && activeHotspots.has(id);
       hotspot.button.dataset.visible = String(visible);
       hotspot.button.tabIndex = visible ? 0 : -1;
       hotspot.button.hidden = !visible;
-
-      if ((id === 'parcel' || id === 'network-harnosand') && this.state.ruleFixed) {
-        hotspot.button.dataset.tone = 'good';
-      } else {
-        hotspot.button.dataset.tone = hotspot.tone;
-      }
-
-      if (id === 'network-harnosand') {
-        hotspot.button.querySelector('.world-hotspot-icon').textContent = this.state.ruleFixed ? '✓' : '!';
-      }
+      hotspot.button.dataset.tone = this.state.hotspotTones?.[id] || hotspot.tone;
+      hotspot.button.querySelector('.world-hotspot-icon').textContent = this.state.hotspotIcons?.[id] || hotspot.icon;
+      hotspot.button.querySelector('span:last-child').textContent = this.state.hotspotLabels?.[id] || hotspot.label;
+      hotspot.button.setAttribute('aria-label', this.state.hotspotLabels?.[id] || hotspot.label);
     }
   }
 
@@ -766,9 +823,15 @@ export class PostalWorld {
       const data = parcel.userData;
       const cycle = (flowTime * data.speed + data.offset) % 1;
       const onInput = cycle < 0.34;
-      const localT = onInput ? cycle / 0.34 : (cycle - 0.34) / 0.66;
+      let localT = onInput ? cycle / 0.34 : (cycle - 0.34) / 0.66;
       const intendedExpress = data.service === 'express';
-      const usesWrongLane = data.misrouted && !this.state.ruleFixed;
+      const usesWrongLane = this.state.shiftId === 'northbound' && data.misrouted && !this.state.ruleFixed;
+      const scannerBlocked = this.state.shiftId === 'scanner-fever'
+        && !this.state.scannerFixed
+        && !this.state.scannerBypassed;
+      if (scannerBlocked && onInput && localT > 0.58) {
+        localT = 0.58 + (localT - 0.58) * 0.035;
+      }
       const route = intendedExpress && !usesWrongLane ? this.expressCurve : this.standardCurve;
       let routeT = localT;
       if (usesWrongLane && !this.state.staffMoved && routeT > 0.72) routeT = 0.72 + (routeT - 0.72) * 0.08;
@@ -791,12 +854,24 @@ export class PostalWorld {
     });
 
     if (this.warningRoot) {
-      const warningVisible = !this.state.ruleFixed;
+      const warningVisible = this.state.shiftId === 'northbound' && !this.state.ruleFixed;
       this.warningRoot.visible = warningVisible;
       if (!REDUCED_MOTION) {
         const pulse = 1 + Math.sin(this.elapsed * 5) * 0.12;
         this.warningRoot.scale.setScalar(pulse);
         this.warningRoot.rotation.y += delta * 0.9;
+      }
+    }
+
+    if (this.scannerWarningRoot) {
+      const scannerWarningVisible = this.state.shiftId === 'scanner-fever'
+        && !this.state.scannerFixed
+        && !this.state.scannerBypassed;
+      this.scannerWarningRoot.visible = scannerWarningVisible;
+      if (scannerWarningVisible && !REDUCED_MOTION) {
+        const pulse = 1 + Math.sin(this.elapsed * 4.2) * 0.1;
+        this.scannerWarningRoot.scale.setScalar(pulse);
+        this.scannerWarningRoot.rotation.y += delta * 0.65;
       }
     }
 
@@ -808,27 +883,51 @@ export class PostalWorld {
 
   updateNetwork(delta) {
     if (!this.networkGroup) return;
+    const snowShift = this.state.shiftId === 'snow-window';
+    const useInland = snowShift && this.state.routeChoice === 'inland';
     this.networkTrucks.forEach((truck, index) => {
       const t = (this.runningVisualTime * 0.035 + truck.userData.offset) % 1;
-      const position = truck.userData.curve.getPointAt(t);
-      const tangent = truck.userData.curve.getTangentAt(t);
+      const activeCurve = useInland ? this.networkAltCurve : this.networkPrimaryCurve || truck.userData.curve;
+      const position = activeCurve.getPointAt(t);
+      const tangent = activeCurve.getTangentAt(t);
       truck.position.copy(position);
       truck.rotation.y = Math.atan2(tangent.x, tangent.z) + Math.PI;
       if (!REDUCED_MOTION) truck.position.y += Math.sin(this.elapsed * 4 + index) * 0.015;
     });
     if (this.networkRiskRoute) {
-      const fixed = this.state.ruleFixed;
-      this.networkRiskRoute.material.color.setHex(fixed ? 0x79e29f : 0xff665e);
-      this.networkRiskRoute.material.emissive.setHex(fixed ? 0x249a60 : 0xff4c44);
-      this.networkRiskRoute.material.emissiveIntensity = fixed ? 0.55 : 1.2;
+      const safe = this.state.ruleFixed || (snowShift && this.state.routeChoice === 'coast' && this.state.stage === 'dispatch');
+      this.networkRiskRoute.material.color.setHex(safe ? 0x79e29f : snowShift ? 0xff9a55 : 0xff665e);
+      this.networkRiskRoute.material.emissive.setHex(safe ? 0x249a60 : 0xff4c44);
+      this.networkRiskRoute.material.emissiveIntensity = safe ? 0.55 : 1.2;
+    }
+    if (this.networkAltRoute) {
+      this.networkAltRoute.visible = snowShift
+        && (this.state.stage === 'weather-route' || this.state.routeChoice === 'inland' || this.state.stage === 'dispatch');
+      this.networkAltRoute.material.color.setHex(useInland ? 0x79e29f : 0x38c7f3);
+      this.networkAltRoute.material.emissive.setHex(useInland ? 0x249a60 : 0x1589bb);
+      this.networkAltRoute.material.emissiveIntensity = useInland ? 0.9 : 0.5;
     }
     if (this.networkRiskRing) {
-      const fixed = this.state.ruleFixed;
+      const fixed = this.state.ruleFixed || (snowShift && this.state.stage === 'dispatch');
       this.networkRiskRing.material.color.setHex(fixed ? 0x79e29f : 0xff665e);
       if (!REDUCED_MOTION) {
         const pulse = 1 + Math.sin(this.elapsed * 3.8) * 0.1;
         this.networkRiskRing.scale.setScalar(pulse);
         this.networkRiskRing.rotation.z += delta * 0.25;
+      }
+    }
+    if (this.networkSnow) {
+      this.networkSnow.visible = snowShift;
+      if (snowShift && !REDUCED_MOTION) {
+        const positions = this.networkSnow.geometry.attributes.position;
+        for (let index = 0; index < positions.count; index += 1) {
+          let y = positions.getY(index) - delta * (0.85 + (index % 5) * 0.08);
+          if (y < 0.25) y = 7.5 + (index % 7) * 0.15;
+          positions.setY(index, y);
+          positions.setX(index, positions.getX(index) + delta * 0.08);
+          if (positions.getX(index) > 7.2) positions.setX(index, -7.2);
+        }
+        positions.needsUpdate = true;
       }
     }
   }
@@ -859,6 +958,7 @@ export class PostalWorld {
   }
 
   updateHotspotPositions() {
+    if (!this.camera) return;
     const width = this.canvas.clientWidth;
     const height = this.canvas.clientHeight;
     if (!width || !height) return;


### PR DESCRIPTION
## What changed

- replaces the unexplained “Shift 3” opening with **First rounds**, a four-step guided shift that introduces the Express lane, crew movement, scanner, live parcel flow, and dispatch without running a deadline during instruction
- adds a persistent portrait **shift board** with five total shifts and clear completion/replay state
- keeps the original northbound root-cause scenario as a deeper systems shift
- adds three genuinely different post-training operations:
  - **Snow over E4** — inspect depot demand, allocate one spare truck, choose coast or inland routing, and run a visible snow convoy
  - **Scanner fever** — diagnose a jam, order promise groups by deadline, choose repair or manual bypass, and clear the live queue
  - **Priority parcel** — interpret a changing scan trail, infer a parcel location, choose a recovery connection, and follow delivery
- varies scanner groups and parcel evidence on replays and persists completions, play counts, and best scores locally
- replaces the sharp Kenney sample cues with short, low-volume, low-pass triangle tones synthesized in-browser
- adds snow, an inland route, scanner congestion and scanner highlighting to the asset-led 3D worlds
- makes the structured details dialog scenario-specific and preserves large HTML alternatives for every required world action
- fixes both review issues from #329: repeat parcel score inflation and the no-WebGL scene dereference

## Why

A first-time player was dropped into a complex incident without knowing where to look, while the UI claimed it was Shift 3 even though no other shifts existed. This pass gives the game a safe first success, makes the larger game visible immediately, and ensures the follow-up play changes the player’s activity rather than merely changing copy.

## Player impact

Fresh players now always begin with one highlighted action at a time. Completing that shift opens four operations spanning systems management, route allocation, queue triage, and evidence-based parcel recovery. Returning players land on the shift board and can replay any operation.

## Verification

- `node --test postal/tests/*.test.mjs` — 19 passing
- `node --check postal/main.mjs postal/world.mjs postal/sim.mjs postal/sw.js` (run individually)
- `git diff --check`
- served the complete local bundle and verified HTML, CSS, modules, Three runtime, representative factory/city/vehicle models all return HTTP 200
- verified the published branch tree is byte-identical to local tree `eb8826fa41bc90806b2cc395308f0aedb21cecd8`
- UI contracts cover unique/named HTML relationships, all required action alternatives, procedural-audio constraints, compact/expanded portrait layouts, and no-WebGL fallback ordering