### PR TITLE
Turn POSTAL into live national operations

### DIFF
--- a/postal/README.md
+++ b/postal/README.md
@@ -1,34 +1,42 @@
-# POSTAL portrait game campaign
+# POSTAL live operations game
 
-POSTAL is a mobile-portrait parcel-network management game set in Sweden. The current playable build contains a guided first shift followed by four distinct operations rather than one unexplained scenario.
+POSTAL is a mobile-portrait, pausable real-time parcel-network game set in Sweden. Its interaction loop is inspired by the immediacy of time-management games: read the live scene, select a waiting parcel batch, tap its marked physical destination, and keep limited teams and vehicles moving before promises expire.
 
 ## Shift campaign
 
-1. **First rounds — guided terminal shift.** Read the blue Express lane, move spare crew, inspect the scanner, watch six promises and send the morning van. Instruction steps do not run a deadline.
-2. **Northbound promises — systems shift.** Protect a departure, investigate a misrouted parcel, correlate matching failures, repair the routing rule and verify the later flow.
-3. **Snow over E4 — network shift.** Inspect three depots, allocate one spare truck, choose between the restricted coast road and the inland route, then run the weather window.
-4. **Scanner fever — triage shift.** Diagnose a jam, order three parcel groups by their promises, choose repair or manual bypass and clear the live queue. Parcel groups change on replays.
-5. **Priority parcel — investigation shift.** Read a temperature-controlled parcel's event trail, infer its location, choose a recovery connection and follow it to delivery. Evidence changes on replays.
+1. **First rounds — calm practice.** One DLH batch teaches the core select-and-route interaction from Sundsvall's town terminal to Härnösand. The clock is stopped and the consequential action happens in the miniature world, not in a duplicate instruction button.
+2. **After-work rush — town.** NordPost, DLH, Brang and USP vans feed two sorting lanes in real time. Two teams must absorb the arriving work while a scanner disruption can stall the floor.
+3. **Region pulse — town + region.** Sundsvall sorting continues while Timrå, Härnösand, Matfors and the national gate compete for two regional trucks. Snow can close the direct route until the player opens the inland detour.
+4. **Sweden by night — town + region + Sweden.** Stockholm and Gothenburg become live national hubs while the lower levels continue operating. A blocked national dock creates another simultaneous concern.
+5. **Friday surge — peak network.** More batches, faster arrivals, all four carriers, all three levels and three timed disruptions. Replay variants alter carrier and destination order.
 
-Completing the first shift opens the full shift board. Completion, best results and replay variants are stored locally in the browser.
+Shifts unlock in order so each new level is learned through play. Completion, best results and replay variants are stored locally. Existing campaign players retain their completed first shift and begin with the redesigned live operation.
+
+## Live interaction model
+
+- Parcel batches are semantic HTML buttons over the 3D operation scene. Each combines carrier, destination, promise countdown, service shape and processing state.
+- Selecting a waiting batch exposes its route mark. Tapping the corresponding lane, depot or national hub immediately commits a team or vehicle.
+- Busy capacity creates an automatic first-in queue. Wrong destinations cost score and promise margin but leave the batch selected for correction.
+- Batches can progress through Town, Region and Sweden. Advanced schedules also inject partner work directly at higher levels so several levels demand attention at once.
+- Level badges report unattended batches and disruptions without interrupting play.
+- On-time deliveries build a score combo. Late or missed work breaks it; shifts close automatically after all arriving work is resolved.
 
 ## Presentation and feedback
 
-- Fixed isometric 3D terminal, regional and parcel scenes use small CC0 Kenney assets vendored under `assets/`; see [`assets/ATTRIBUTION.md`](./assets/ATTRIBUTION.md).
+- Fixed isometric 3D terminal, regional diorama and national Sweden board use small CC0 Kenney assets vendored under `assets/`; see [`assets/ATTRIBUTION.md`](./assets/ATTRIBUTION.md).
+- The national board contains interactive Sundsvall, Stockholm and Gothenburg hubs, animated routes and moving linehaul vehicles.
 - The required three.js modules are vendored locally, so the game does not depend on a third-party CDN at runtime.
-- Snow, scanner congestion, live routing, crew movement, parcel flow and recovery progress are shown in the miniature worlds.
-- Interface feedback uses a quiet family of short, low-volume triangle tones synthesized by the Web Audio API. The previous sharp sample cues are no longer played.
-- Consequential detail remains available on demand through a scenario-specific structured Shift details dialog.
+- Interface feedback uses a quiet family of very short, low-volume triangle tones synthesized through a low-pass filter.
+- Consequential detail remains available on demand through a structured live-network dialog; opening it pauses play.
 
 ## Accessibility
 
 - Every consequential canvas state is repeated in semantic HTML.
-- Projected world hotspots are real buttons with accessible names, and each required object action has a large HTML alternative.
-- Colour is paired with labels, shapes, values and patterns.
-- The first shift introduces one action at a time and does not start time while explaining it.
-- Opening detailed information pauses live simulation and restores the previous running state on close.
+- Projected world hotspots are real buttons with accessible names. Parcel markers pair carrier colour with codes, express/standard colour with shapes, and urgency with numeric countdowns.
+- The first shift introduces the input grammar without running a deadline; later shifts remove the coaching copy.
+- Town, Region and Sweden badges expose waiting counts and disruptions to assistive technology.
 - Reduced-motion preferences remove camera sweeps, pulsing and non-essential animation.
-- A no-WebGL fallback keeps every shift playable through the command deck and structured details.
+- A no-WebGL fallback preserves the parcel controls, destinations, level navigation and structured details.
 
 ## Local run and checks
 
@@ -36,7 +44,7 @@ Serve the repository root over HTTP and open `/postal/`.
 
 ```sh
 python -m http.server 4173
-node --test postal/tests/sim.test.mjs
+node --test postal/tests/*.test.mjs
 node --check postal/main.mjs
 node --check postal/world.mjs
 ```

--- a/postal/index.html
+++ b/postal/index.html
@@ -7,9 +7,9 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="format-detection" content="telephone=no">
-  <meta name="description" content="POSTAL is a portrait-friendly parcel network management game set in Sweden.">
+  <meta name="description" content="POSTAL is a portrait-friendly real-time parcel network game set in Sweden.">
   <title>POSTAL — Every package has a promise</title>
-  <link rel="stylesheet" href="./styles.css?build=20260805-campaign-r3">
+  <link rel="stylesheet" href="./styles.css?build=20260805-live-r4">
   <script type="importmap">
     {
       "imports": {
@@ -20,9 +20,9 @@
   </script>
 </head>
 <body>
-  <a class="skip-link" href="#commandDeck">Skip to shift controls</a>
+  <a class="skip-link" href="#operationLayer">Skip to live parcels</a>
 
-  <div class="game-shell" id="gameShell">
+  <div class="game-shell" id="gameShell" data-play-mode="guided">
     <header class="hud" aria-label="Shift status and controls">
       <div class="hud-topline">
         <div class="brand" aria-label="POSTAL">
@@ -54,17 +54,17 @@
         <div class="metric metric--service" id="serviceMetric">
           <span class="metric-icon" id="serviceIcon" aria-hidden="true">✓</span>
           <span class="metric-label" id="serviceLabel">On time</span>
-          <strong id="serviceValue">98%</strong>
+          <strong id="serviceValue">100%</strong>
         </div>
         <div class="metric metric--backlog" id="backlogMetric">
           <span class="metric-icon" id="backlogIcon" aria-hidden="true">▦</span>
-          <span class="metric-label" id="backlogLabel">In flow</span>
-          <strong id="backlogValue">6</strong>
+          <span class="metric-label" id="backlogLabel">Waiting</span>
+          <strong id="backlogValue">0</strong>
         </div>
-        <div class="metric metric--risk" id="riskMetric" data-level="warning">
-          <span class="metric-icon" id="riskIcon" aria-hidden="true">!</span>
-          <span class="metric-label" id="riskLabel">At risk</span>
-          <strong id="riskValue">0</strong>
+        <div class="metric metric--risk" id="riskMetric" data-level="good">
+          <span class="metric-icon" id="riskIcon" aria-hidden="true">×</span>
+          <span class="metric-label" id="riskLabel">Combo</span>
+          <strong id="riskValue">0×</strong>
         </div>
       </section>
     </header>
@@ -76,27 +76,38 @@
 
       <div class="loading-card" id="loadingCard" role="status">
         <span class="loading-parcel" aria-hidden="true"></span>
-        <span>Opening Sundsvall terminal…</span>
+        <span>Opening the network…</span>
       </div>
 
       <div class="scene-heading" aria-hidden="true">
-        <span id="sceneEyebrow">LIVE TERMINAL</span>
+        <span id="sceneEyebrow">LIVE TOWN</span>
         <strong id="sceneTitle">Sundsvall</strong>
       </div>
 
-      <div class="mission-pill" id="missionPill">
+      <div class="mission-pill" id="missionPill" data-state="warning">
         <span class="mission-symbol" aria-hidden="true">↗</span>
         <span>
           <small id="missionLabel">FIRST ROUNDS</small>
-          <strong id="missionTime">4 SHORT TASKS · NO PRESSURE</strong>
+          <strong id="missionTime">NO PRESSURE</strong>
         </span>
       </div>
 
-      <div class="hotspot-layer" id="hotspotLayer" aria-label="Interactive locations in the current scene"></div>
+      <div class="hotspot-layer" id="hotspotLayer" aria-label="Interactive destinations in the current scene"></div>
 
-      <p class="sr-only" id="sceneSummary">
-        Sundsvall terminal. The guided first shift begins with the blue Express lane.
-      </p>
+      <section class="operation-layer" id="operationLayer" aria-labelledby="workQueueTitle" hidden>
+        <div class="operation-head">
+          <div>
+            <span class="operation-level" id="operationLevel">TOWN FLOOR</span>
+            <strong id="workQueueTitle">Waiting batches</strong>
+          </div>
+          <span class="resource-chip" id="resourceChip">0 / 1 busy</span>
+        </div>
+        <div class="parcel-rack" id="parcelRack" role="group" aria-label="Waiting and moving parcel batches"></div>
+        <div class="fallback-targets" id="fallbackTargets" aria-label="Destinations in this level" hidden></div>
+        <p class="operation-empty" id="operationEmpty">All clear here.</p>
+      </section>
+
+      <p class="sr-only" id="sceneSummary">Sundsvall terminal. No live work has started.</p>
     </main>
 
     <section class="command-deck" id="commandDeck" aria-labelledby="commandTitle" tabindex="-1">
@@ -104,28 +115,30 @@
       <div class="command-content" id="commandContent">
         <div class="command-copy">
           <span class="command-kicker">FIRST SHIFT · GUIDED</span>
-          <h1 id="commandTitle">Meet the parcel flow.</h1>
-          <p id="commandText">Four small actions introduce the terminal. Nothing moves until you are ready.</p>
+          <h1 id="commandTitle">Learn the live route.</h1>
+          <p>Select a parcel batch, then tap its marked destination in the miniature world.</p>
         </div>
-        <div class="command-actions" id="commandActions">
+        <div class="command-actions">
           <button class="game-button game-button--primary" id="deckStartButton" type="button">Start first shift</button>
         </div>
       </div>
     </section>
 
-    <nav class="scene-nav" aria-label="Game views">
+    <nav class="scene-nav" aria-label="Network levels">
       <button class="scene-tab" type="button" data-scene="terminal" aria-current="page" disabled>
         <span class="scene-tab-icon" aria-hidden="true">▦</span>
-        <span>Terminal</span>
+        <span>Town</span>
+        <span class="tab-count" id="terminalAlert" aria-label="No waiting town batches" hidden>0</span>
       </button>
       <button class="scene-tab" type="button" data-scene="network" disabled>
         <span class="scene-tab-icon" aria-hidden="true">⌁</span>
-        <span>Network</span>
+        <span>Region</span>
+        <span class="tab-count" id="networkAlert" aria-label="No waiting regional batches" hidden>0</span>
       </button>
-      <button class="scene-tab" type="button" data-scene="case" disabled>
-        <span class="scene-tab-icon" aria-hidden="true">□</span>
-        <span>Parcel</span>
-        <span class="tab-alert" id="caseAlert" aria-label="New parcel case" hidden></span>
+      <button class="scene-tab" type="button" data-scene="sweden" disabled>
+        <span class="scene-tab-icon" aria-hidden="true">◆</span>
+        <span>Sweden</span>
+        <span class="tab-count" id="swedenAlert" aria-label="No waiting national batches" hidden>0</span>
       </button>
     </nav>
   </div>
@@ -146,12 +159,12 @@
           <span class="brief-line"></span>
           <span class="brief-node"></span>
         </div>
-        <span class="brief-label">FIRST SHIFT · GUIDED</span>
-        <strong>Learn the terminal one action at a time.</strong>
-        <span>Four short tasks · no clock pressure</span>
+        <span class="brief-label">FIRST SHIFT · CALM PRACTICE</span>
+        <strong>Learn one route. Then you are in charge.</strong>
+        <span>Town → region · no deadline</span>
       </div>
       <button class="game-button game-button--primary welcome-start" id="startButton" type="button">Start first shift</button>
-      <p class="welcome-note">After this, four different shifts open: systems, network routing, queue triage and parcel investigation.</p>
+      <p class="welcome-note">After training, shifts run continuously. Watch the miniature network and act before promises expire.</p>
     </div>
   </section>
 
@@ -160,14 +173,14 @@
     <div class="campaign-panel">
       <header class="campaign-head">
         <div>
-          <span class="command-kicker">SUNDSVALL REGION</span>
-          <h2 id="campaignTitle">Choose your next shift</h2>
-          <p id="campaignProgress">Four operations are open.</p>
+          <span class="command-kicker">POSTAL OPERATIONS</span>
+          <h2 id="campaignTitle">Choose a shift</h2>
+          <p id="campaignProgress">The next operation is open.</p>
         </div>
         <div class="campaign-stamp" id="campaignStamp" aria-hidden="true">1/5</div>
       </header>
       <div class="shift-list" id="shiftList"></div>
-      <p class="campaign-note">Each shift uses a different kind of play. Scanner and parcel details change when replayed.</p>
+      <p class="campaign-note">Each shift adds pressure and another live level. Replays vary carrier and arrival order.</p>
     </div>
   </section>
 
@@ -177,7 +190,7 @@
       <span class="result-kicker" id="resultKicker">SHIFT COMPLETE</span>
       <div class="result-grade" id="resultGrade" aria-label="Grade A">A</div>
       <h2 id="resultTitle">Promises kept.</h2>
-      <p id="resultSummary">The northbound truck left on time and the recurring routing error is gone.</p>
+      <p id="resultSummary">The live network cleared.</p>
       <div class="result-stats" id="resultStats" aria-label="Shift results"></div>
       <div class="result-medals" id="resultMedals" aria-label="Shift achievements"></div>
       <button class="game-button game-button--primary" id="nextShiftButton" type="button">Choose next shift</button>
@@ -190,37 +203,42 @@
     <div class="dialog-head">
       <div>
         <span class="command-kicker">STRUCTURED VIEW</span>
-        <h2 id="detailsTitle">Shift details</h2>
+        <h2 id="detailsTitle">Live network details</h2>
       </div>
       <button class="dialog-close" id="detailsCloseButton" type="button" aria-label="Close shift details">×</button>
     </div>
 
     <div class="dialog-scroll">
-      <p class="dialog-intro" id="detailsIntro">The northbound Express lane is the highest-consequence issue in the network.</p>
-
+      <p class="dialog-intro" id="detailsIntro">The same live network information in a sortable text view.</p>
       <dl class="detail-metrics" id="detailMetrics"></dl>
       <div id="detailScenario"></div>
 
       <details class="help-disclosure">
         <summary>How to play</summary>
-        <p>Tap highlighted objects in the miniature world or use the matching large action below it. The first shift introduces one action at a time. Later shifts let you pause, inspect and choose between trade-offs.</p>
+        <p>Select a waiting parcel batch, then tap the lane, depot or hub printed on its marker. Blue arrows use Express A; yellow squares use Standard B. Occupied teams and vehicles take the next routed batch automatically. Switch levels when their badges appear.</p>
+      </details>
+
+      <details class="help-disclosure">
+        <summary>Carriers</summary>
+        <p>NordPost brings steady mixed volume. DLH carries short express promises. Brang arrives in quick local bursts. USP brings larger national batches. They are fictional operators created for POSTAL.</p>
       </details>
 
       <details class="help-disclosure">
         <summary>Accessibility and motion</summary>
-        <p>All consequential game information is repeated in this structured view and announced to assistive technology. Colour is paired with labels, shapes and patterns. Reduced-motion preferences remove camera sweeps and non-essential animation.</p>
+        <p>All consequential canvas information is repeated in semantic controls and this structured view. Colour is paired with codes, shapes and labels. Opening this dialog pauses the shift. Reduced-motion preferences remove camera sweeps and non-essential animation.</p>
       </details>
 
       <details class="help-disclosure">
         <summary>Credits</summary>
-        <p>3D models are from Kenney asset packs under CC0. The warm interface tones are synthesized in the browser. POSTAL is an original fictional game and does not reproduce any real operator network.</p>
+        <p>3D models are from Kenney asset packs under CC0. Interface tones are synthesized in the browser. POSTAL is an original fictional game and does not reproduce any real operator network.</p>
       </details>
     </div>
   </dialog>
 
   <div class="toast" id="toast" role="status" aria-live="polite" hidden></div>
+  <div class="sr-only" id="politeLive" aria-live="polite" aria-atomic="true"></div>
   <div class="sr-only" id="assertiveLive" aria-live="assertive" aria-atomic="true"></div>
 
-  <script type="module" src="./main.mjs?build=20260805-campaign-r3"></script>
+  <script type="module" src="./main.mjs?build=20260805-live-r4"></script>
 </body>
 </html>

--- a/postal/main.mjs
+++ b/postal/main.mjs
@@ -1,8 +1,9 @@
 import {
+  LEVEL_LABELS,
   SHIFT_CATALOG,
   ShiftSimulation,
-  VERIFY_TARGET,
   formatClock,
+  formatSeconds,
   getShiftDefinition
 } from './sim.mjs';
 import { PostalWorld } from './world.mjs';
@@ -32,14 +33,8 @@ const ui = {
   shiftPlace: $('#shiftPlace'),
   clock: $('#clock'),
   shiftState: $('#shiftState'),
-  serviceLabel: $('#serviceLabel'),
-  serviceIcon: $('#serviceIcon'),
   serviceValue: $('#serviceValue'),
-  backlogLabel: $('#backlogLabel'),
-  backlogIcon: $('#backlogIcon'),
   backlogValue: $('#backlogValue'),
-  riskLabel: $('#riskLabel'),
-  riskIcon: $('#riskIcon'),
   riskValue: $('#riskValue'),
   serviceMetric: $('#serviceMetric'),
   riskMetric: $('#riskMetric'),
@@ -54,12 +49,39 @@ const ui = {
   loading: $('#loadingCard'),
   hotspotLayer: $('#hotspotLayer'),
   worldCanvas: $('#worldCanvas'),
+  operationLayer: $('#operationLayer'),
+  operationLevel: $('#operationLevel'),
+  parcelRack: $('#parcelRack'),
+  fallbackTargets: $('#fallbackTargets'),
+  operationEmpty: $('#operationEmpty'),
+  resourceChip: $('#resourceChip'),
+  terminalAlert: $('#terminalAlert'),
+  networkAlert: $('#networkAlert'),
+  swedenAlert: $('#swedenAlert'),
   toast: $('#toast'),
+  politeLive: $('#politeLive'),
   live: $('#assertiveLive'),
-  caseAlert: $('#caseAlert'),
   detailMetrics: $('#detailMetrics'),
   detailScenario: $('#detailScenario')
 };
+
+const TARGET_LABELS = Object.freeze({
+  'express-lane': 'Express A',
+  'standard-lane': 'Standard B',
+  'network-sundsvall': 'National gate',
+  'network-harnosand': 'Härnösand',
+  'network-timra': 'Timrå',
+  'network-matfors': 'Matfors',
+  'sweden-sundsvall': 'Sundsvall hub',
+  'sweden-stockholm': 'Stockholm hub',
+  'sweden-gothenburg': 'Gothenburg hub'
+});
+
+const SCENE_PRESENTATION = Object.freeze({
+  terminal: { eyebrow: 'LIVE TOWN', title: 'Sundsvall', operation: 'TOWN FLOOR', resource: 'sort teams' },
+  network: { eyebrow: 'REGIONAL ROUTES', title: 'Mid Sweden', operation: 'REGIONAL DEPOTS', resource: 'trucks' },
+  sweden: { eyebrow: 'NATIONAL NETWORK', title: 'Sweden', operation: 'NATIONAL HUBS', resource: 'linehauls' }
+});
 
 class GameAudio {
   constructor() {
@@ -74,7 +96,7 @@ class GameAudio {
       if (!AudioContextClass) return;
       this.context = new AudioContextClass();
       this.master = this.context.createGain();
-      this.master.gain.value = 0.72;
+      this.master.gain.value = 0.5;
       this.master.connect(this.context.destination);
     }
     if (this.context.state === 'suspended') this.context.resume().catch(() => {});
@@ -84,20 +106,21 @@ class GameAudio {
     if (!this.enabled) return;
     this.unlock();
     if (!this.context || !this.master) return;
-
     const patterns = {
-      click: [[232, 0, 0.075, 0.014]],
-      select: [[294, 0, 0.095, 0.018]],
-      inspect: [[262, 0, 0.09, 0.017], [330, 0.055, 0.11, 0.014]],
-      staff: [[247, 0, 0.1, 0.018], [311, 0.065, 0.12, 0.016]],
-      reveal: [[294, 0, 0.11, 0.018], [370, 0.075, 0.13, 0.016]],
-      repair: [[277, 0, 0.1, 0.017], [349, 0.07, 0.13, 0.017]],
-      success: [[330, 0, 0.11, 0.019], [415, 0.085, 0.14, 0.017]],
-      dispatch: [[247, 0, 0.11, 0.018], [330, 0.075, 0.13, 0.018], [392, 0.15, 0.16, 0.016]]
+      click: [[220, 0, 0.065, 0.012]],
+      select: [[277, 0, 0.08, 0.014]],
+      work: [[247, 0, 0.075, 0.013], [311, 0.05, 0.09, 0.011]],
+      arrival: [[262, 0, 0.07, 0.01]],
+      handoff: [[277, 0, 0.08, 0.011], [349, 0.055, 0.095, 0.01]],
+      delivered: [[294, 0, 0.09, 0.013], [370, 0.065, 0.11, 0.012]],
+      warning: [[196, 0, 0.1, 0.014]],
+      repair: [[247, 0, 0.085, 0.013], [330, 0.06, 0.11, 0.012]],
+      complete: [[247, 0, 0.1, 0.014], [330, 0.075, 0.13, 0.013], [392, 0.15, 0.16, 0.012]]
     };
-    const pattern = patterns[name] || patterns.click;
     const now = this.context.currentTime;
-    pattern.forEach(([frequency, delay, duration, level]) => this.tone(frequency, now + delay, duration, level));
+    for (const [frequency, delay, duration, level] of patterns[name] || patterns.click) {
+      this.tone(frequency, now + delay, duration, level);
+    }
   }
 
   tone(frequency, start, duration, level) {
@@ -108,8 +131,8 @@ class GameAudio {
     oscillator.frequency.setValueAtTime(frequency, start);
     oscillator.detune.setValueAtTime(-5, start);
     filter.type = 'lowpass';
-    filter.frequency.setValueAtTime(920, start);
-    filter.Q.value = 0.45;
+    filter.frequency.setValueAtTime(860, start);
+    filter.Q.value = 0.4;
     gain.gain.setValueAtTime(0.0001, start);
     gain.gain.exponentialRampToValueAtTime(level, start + 0.012);
     gain.gain.exponentialRampToValueAtTime(0.0001, start + duration);
@@ -126,21 +149,34 @@ class GameAudio {
   }
 }
 
-const CAMPAIGN_KEY = 'postal-campaign-v3';
+const CAMPAIGN_KEY = 'postal-campaign-v4';
+const LEGACY_CAMPAIGN_KEY = 'postal-campaign-v3';
+
+function emptyCampaign() {
+  return { version: 4, completed: {}, plays: {}, bestScores: {} };
+}
 
 function loadCampaign() {
   try {
     const saved = JSON.parse(localStorage.getItem(CAMPAIGN_KEY) || 'null');
-    if (saved?.version === 3) {
+    if (saved?.version === 4) {
       return {
-        version: 3,
+        version: 4,
         completed: saved.completed || {},
         plays: saved.plays || {},
         bestScores: saved.bestScores || {}
       };
     }
+    const legacy = JSON.parse(localStorage.getItem(LEGACY_CAMPAIGN_KEY) || 'null');
+    if (legacy?.completed?.['first-rounds']) {
+      const migrated = emptyCampaign();
+      migrated.completed['first-rounds'] = legacy.completed['first-rounds'];
+      migrated.plays['first-rounds'] = legacy.plays?.['first-rounds'] || 1;
+      migrated.bestScores['first-rounds'] = legacy.bestScores?.['first-rounds'] || 300;
+      return migrated;
+    }
   } catch {}
-  return { version: 3, completed: {}, plays: {}, bestScores: {} };
+  return emptyCampaign();
 }
 
 function saveCampaign() {
@@ -155,10 +191,12 @@ let activeShift = getShiftDefinition('first-rounds');
 let simulation = new ShiftSimulation(handleSimulationChange, activeShift.id);
 let currentScene = activeShift.startScene;
 let commandRenderKey = '';
+let operationRenderKey = '';
 let toastTimer = 0;
 let wasRunningBeforeDialog = false;
 let resultTimer = 0;
 let shiftResultRecorded = false;
+let worldUnavailable = false;
 
 const world = new PostalWorld(ui.worldCanvas, ui.hotspotLayer, {
   onReady: () => {
@@ -168,12 +206,14 @@ const world = new PostalWorld(ui.worldCanvas, ui.hotspotLayer, {
   },
   onHotspot: handleHotspot,
   onError: () => {
-    ui.loading.innerHTML = '<span aria-hidden="true">!</span><span>3D view unavailable. Every shift remains playable with the controls below.</span>';
+    worldUnavailable = true;
+    ui.gameShell.dataset.worldUnavailable = 'true';
+    ui.loading.innerHTML = '<span aria-hidden="true">!</span><span>3D view unavailable. All live batches and destinations remain usable in the controls.</span>';
     ui.loading.setAttribute('role', 'alert');
   }
 });
 
-function announce(message, assertive = false) {
+function announce(message, assertive = false, duration = 2100) {
   window.clearTimeout(toastTimer);
   ui.toast.textContent = message;
   ui.toast.hidden = false;
@@ -181,7 +221,7 @@ function announce(message, assertive = false) {
     ui.live.textContent = '';
     window.setTimeout(() => { ui.live.textContent = message; }, 20);
   }
-  toastTimer = window.setTimeout(() => { ui.toast.hidden = true; }, 2600);
+  toastTimer = window.setTimeout(() => { ui.toast.hidden = true; }, duration);
 }
 
 function handleSimulationChange(state, event) {
@@ -194,98 +234,91 @@ function handleSimulationChange(state, event) {
     pause: 'click',
     resume: 'click',
     speed: 'click',
-    inspect: 'inspect',
-    staff: 'staff',
-    hold: 'select',
-    package: 'inspect',
-    signature: 'reveal',
-    triage: 'select',
-    allocate: 'staff',
-    route: 'reveal',
-    deduce: 'reveal',
+    select: 'select',
+    deselect: 'click',
+    work: 'work',
+    queue: 'click',
+    arrival: 'arrival',
+    handoff: 'handoff',
+    delivered: 'delivered',
     repair: 'repair',
-    rule: 'success',
-    verified: 'success',
-    complete: 'dispatch'
+    coach: 'handoff',
+    incident: 'warning',
+    warning: 'warning',
+    missed: 'warning',
+    mistake: 'warning',
+    late: 'warning',
+    complete: 'complete'
   };
   audio.play(soundByEvent[event.type] || 'click');
 
-  const assertive = ['staff', 'package', 'signature', 'allocate', 'deduce', 'repair', 'rule', 'verified', 'complete'].includes(event.type);
-  if (event.message && event.type !== 'complete') announce(event.message, assertive);
+  if (['select', 'deselect', 'work', 'queue', 'arrival', 'handoff', 'delivered'].includes(event.type)) {
+    ui.politeLive.textContent = '';
+    window.setTimeout(() => { ui.politeLive.textContent = event.message; }, 20);
+  }
 
-  if (state.shiftId === 'northbound' && event.type === 'package') switchScene('case', true);
-  if (state.shiftId === 'priority-parcel' && event.type === 'deduce') switchScene('network', true);
-  if (event.type === 'signature') ui.caseAlert.hidden = true;
+  if (['incident', 'missed', 'mistake'].includes(event.type)) announce(event.message, true, 2500);
+  else if (['coach', 'repair', 'late'].includes(event.type)) announce(event.message, false, 2200);
+
   if (event.type === 'complete') {
     ui.toast.hidden = true;
     ui.live.textContent = '';
     window.setTimeout(() => { ui.live.textContent = event.message; }, 20);
     window.clearTimeout(resultTimer);
-    resultTimer = window.setTimeout(() => showResult(state.outcome, state), 900);
+    resultTimer = window.setTimeout(() => showResult(state.outcome, state), 850);
   }
 }
 
 function configureHud(shift) {
   ui.shiftPlace.textContent = shift.shiftLabel;
-  [ui.serviceLabel.textContent, ui.backlogLabel.textContent, ui.riskLabel.textContent] = shift.metricLabels;
-  [ui.serviceIcon.textContent, ui.backlogIcon.textContent, ui.riskIcon.textContent] = shift.metricIcons;
   ui.gameShell.dataset.shift = shift.id;
+  ui.gameShell.dataset.playMode = shift.id === 'first-rounds' ? 'guided' : 'live';
 }
 
 function renderShift(state) {
-  const shiftIsPaused = state.started && state.paused;
   ui.clock.textContent = formatClock(state.time);
   ui.serviceValue.textContent = `${Math.round(state.onTime)}%`;
   ui.backlogValue.textContent = Math.round(state.backlog);
-  ui.riskValue.textContent = Math.round(state.risk);
+  ui.riskValue.textContent = `${state.combo}×`;
   ui.shiftState.textContent = !state.started ? 'READY' : state.completed ? 'COMPLETE' : state.paused ? 'PAUSED' : `${state.speed}× LIVE`;
   ui.shiftState.dataset.paused = String(state.paused);
-  ui.pause.setAttribute('aria-pressed', String(shiftIsPaused));
-  ui.pause.setAttribute('aria-label', shiftIsPaused ? 'Resume shift' : 'Pause shift');
-  ui.pause.firstElementChild.textContent = shiftIsPaused ? '▶' : 'Ⅱ';
+  ui.pause.setAttribute('aria-pressed', String(state.started && state.paused));
+  ui.pause.setAttribute('aria-label', state.paused ? 'Resume shift' : 'Pause shift');
+  ui.pause.firstElementChild.textContent = state.paused ? '▶' : 'Ⅱ';
   ui.speed.textContent = `${state.speed}×`;
   ui.speed.setAttribute('aria-label', `Simulation speed, ${state.speed === 1 ? 'normal' : 'double'}`);
   ui.pause.disabled = !state.canRun || state.completed;
   ui.speed.disabled = !state.canRun || state.completed;
+  ui.serviceMetric.dataset.level = state.onTime >= 90 ? 'good' : state.onTime >= 75 ? 'warning' : 'danger';
+  ui.riskMetric.dataset.level = state.combo >= 5 ? 'good' : state.risk ? 'warning' : 'good';
 
   const mission = missionFor(state);
   ui.missionLabel.textContent = mission.label;
   ui.missionTime.textContent = mission.value;
   ui.missionPill.dataset.state = mission.state;
 
-  ui.riskMetric.dataset.level = state.risk <= 2 ? 'good' : state.risk >= 18 ? 'danger' : 'warning';
-  ui.serviceMetric.dataset.level = state.onTime >= 96 ? 'good' : 'warning';
-
-  $$('.scene-tab').forEach((button) => {
+  for (const button of $$('.scene-tab')) {
     button.disabled = !state.started || state.completed || !state.availableScenes.includes(button.dataset.scene);
-  });
-  ui.caseAlert.hidden = !(state.shiftId === 'northbound' && !state.packageSelected && state.stage === 'investigate');
+    button.setAttribute('aria-current', button.dataset.scene === currentScene ? 'page' : 'false');
+  }
+  renderLevelBadges(state);
 
+  ui.operationLayer.hidden = !state.started || state.completed;
+  if (!ui.operationLayer.hidden) renderOperations(state);
   if (ui.detailsDialog.open) updateStructuredDetails(state);
   updateSceneSummary(state);
 
-  const nextKey = [
+  const commandKey = [
     state.shiftId,
     state.stage,
-    state.paused,
-    state.verified,
-    state.staffMoved,
-    state.truckHeld,
-    state.ruleFixed,
-    state.inspectedDepots.join(','),
-    state.allocation,
-    state.routeChoice,
-    state.delivered,
-    state.triageOrder.join(','),
-    state.scannerFixed,
-    state.scannerBypassed,
-    state.processed,
-    state.clueChoice,
-    state.recoveryChoice,
-    Math.floor(state.deliveryProgress / 5)
+    state.selectedJobId,
+    currentScene,
+    state.resourceStatus[currentScene]?.busy,
+    state.resourceStatus[currentScene]?.waiting,
+    state.incidents.filter((incident) => incident.active).map((incident) => incident.id).join(',')
   ].join(':');
-  if (nextKey !== commandRenderKey) {
-    commandRenderKey = nextKey;
+  if (commandKey !== commandRenderKey) {
+    commandRenderKey = commandKey;
     renderCommand(state);
   }
 }
@@ -293,71 +326,134 @@ function renderShift(state) {
 function missionFor(state) {
   if (state.shiftId === 'first-rounds') {
     const missions = {
-      brief: ['FIRST ROUNDS', '4 SHORT TASKS · NO PRESSURE', 'warning'],
-      tour: ['STEP 1 OF 4', 'READ EXPRESS A', 'warning'],
-      'coach-move': ['STEP 2 OF 4', 'MOVE THE SPARE CREW', 'warning'],
-      'coach-scan': ['STEP 3 OF 4', 'CHECK THE SCANNER', 'warning'],
-      'coach-run': ['STEP 4 OF 4', 'START THE FLOW', 'warning'],
-      'coach-watch': ['PROMISES MOVING', `${state.verified} / 6 CORRECT`, 'good'],
-      dispatch: ['MORNING VAN', 'READY TO SEND', 'good'],
+      brief: ['FIRST ROUNDS', 'NO PRESSURE', 'warning'],
+      'coach-select': ['STEP 1', 'SELECT THE DLH BATCH', 'warning'],
+      'coach-town-target': ['STEP 2', 'TAP EXPRESS A', 'warning'],
+      'coach-town-run': ['TOWN SORT', 'MOVING', 'good'],
+      'coach-open-region': ['STEP 3', 'OPEN REGION', 'warning'],
+      'coach-region-select': ['STEP 4', 'SELECT THE BATCH', 'warning'],
+      'coach-region-target': ['STEP 5', 'TAP HÄRNÖSAND', 'warning'],
+      'coach-region-run': ['REGIONAL RUN', 'MOVING', 'good'],
       complete: ['FIRST SHIFT', 'COMPLETE', 'good']
     };
     const [label, value, missionState] = missions[state.stage] || missions.brief;
     return { label, value, state: missionState };
   }
 
-  if (state.shiftId === 'northbound') {
-    const minutesLeft = Math.max(0, Math.ceil(state.departure - state.time));
+  if (state.arrivalsComplete) {
     return {
-      label: state.ruleFixed ? 'NORTHBOUND · FLOW CORRECTED' : 'NORTHBOUND EXPRESS',
-      value: state.completed
-        ? `DEPARTED ${formatClock(state.departure)}`
-        : state.time < state.departure
-          ? `DEPARTS ${formatClock(state.departure)} · ${minutesLeft} MIN`
-          : `${Math.floor(state.time - state.departure) + 1} MIN LATE`,
-      state: state.ruleFixed ? 'good' : state.risk >= 20 || state.time >= state.departure ? 'danger' : 'warning'
+      label: state.backlog ? 'CLEAR THE NETWORK' : 'SHIFT CLEAR',
+      value: state.backlog ? `${state.backlog} BATCH${state.backlog === 1 ? '' : 'ES'} LEFT` : 'ALL PROMISES RESOLVED',
+      state: state.risk ? 'danger' : 'good'
     };
   }
-
-  if (state.shiftId === 'snow-window') {
-    const missions = {
-      brief: ['WEATHER WINDOW', 'SNOW ARRIVES 06:30'],
-      'weather-scan': ['READ THE NETWORK', `${state.inspectedDepots.length} / 3 DEPOTS CHECKED`],
-      'weather-allocate': ['ONE SPARE TRUCK', 'CHOOSE THE PROMISES'],
-      'weather-route': ['E4 RESTRICTED', 'CHOOSE THE ROAD'],
-      'weather-run': [`${String(state.allocation || '').toUpperCase()} RUN`, `${state.delivered} / ${state.deliveryTarget} DELIVERED`],
-      dispatch: ['WEATHER RUN', 'ARRIVED'],
-      complete: ['WEATHER WINDOW', 'CLOSED']
-    };
-    const [label, value] = missions[state.stage] || missions.brief;
-    return { label, value, state: state.stage === 'dispatch' || state.completed ? 'good' : 'warning' };
-  }
-
-  if (state.shiftId === 'scanner-fever') {
-    const missions = {
-      brief: ['SCANNER 2', 'QUEUE BUILDING'],
-      'jam-diagnose': ['SCANNER STOPPED', 'FIND THE BLOCKAGE'],
-      'jam-triage': ['MANUAL RELEASE', `${state.triageOrder.length} / 3 GROUPS ORDERED`],
-      'jam-repair': ['QUEUE ORDERED', 'CHOOSE RECOVERY'],
-      'jam-run': [state.scannerFixed ? 'SCANNER RESTORED' : 'MANUAL BYPASS', `${state.processed} / 31 PROCESSED`],
-      dispatch: ['OUTBOUND FLOW', 'CLEAR'],
-      complete: ['SCANNER SHIFT', 'COMPLETE']
-    };
-    const [label, value] = missions[state.stage] || missions.brief;
-    return { label, value, state: state.stage === 'dispatch' || state.completed ? 'good' : 'danger' };
-  }
-
-  const missions = {
-    brief: ['PRIORITY PARCEL', 'DELIVER BY 21:10'],
-    'case-inspect': ['COLD CHAIN', 'OPEN THE SCAN TRAIL'],
-    'case-clue': ['THREE EVENTS', 'FIND THE PARCEL'],
-    'case-plan': ['PARCEL SECURED', 'CHOOSE RECOVERY'],
-    'case-run': ['RECOVERY LIVE', `${Math.round(state.deliveryProgress)}% TO RECIPIENT`],
-    dispatch: ['DELIVERY', 'CONFIRM RECEIPT'],
-    complete: ['COLD CHAIN', 'INTACT']
+  return {
+    label: 'LIVE ARRIVALS',
+    value: `${formatSeconds(state.remainingSeconds)} · ${state.delivered} DELIVERED`,
+    state: state.risk >= 4 ? 'danger' : state.risk ? 'warning' : 'good'
   };
-  const [label, value] = missions[state.stage] || missions.brief;
-  return { label, value, state: state.stage === 'dispatch' || state.completed ? 'good' : 'warning' };
+}
+
+function renderLevelBadges(state) {
+  const badgeByLevel = {
+    terminal: ui.terminalAlert,
+    network: ui.networkAlert,
+    sweden: ui.swedenAlert
+  };
+  for (const [level, badge] of Object.entries(badgeByLevel)) {
+    const incidentCount = state.incidents.filter((incident) => incident.active && incident.level === level).length;
+    const count = (state.levelCounts[level] || 0) + incidentCount;
+    badge.hidden = count === 0;
+    badge.textContent = count > 9 ? '9+' : String(count);
+    badge.dataset.danger = String(incidentCount > 0);
+    badge.setAttribute('aria-label', count
+      ? `${count} ${LEVEL_LABELS[level].toLowerCase()} items need attention${incidentCount ? ', including a disruption' : ''}`
+      : `No ${LEVEL_LABELS[level].toLowerCase()} items need attention`);
+  }
+}
+
+function renderOperations(state) {
+  const presentation = SCENE_PRESENTATION[currentScene];
+  const resource = state.resourceStatus[currentScene] || { busy: 0, capacity: 0 };
+  ui.operationLevel.textContent = presentation.operation;
+  ui.resourceChip.textContent = `${resource.busy} / ${resource.capacity} ${presentation.resource}`;
+
+  const visibleJobs = state.jobs
+    .filter((job) => job.stage === currentScene && ['waiting', 'queued', 'processing'].includes(job.status))
+    .sort((a, b) => {
+      const order = { waiting: 0, queued: 1, processing: 2 };
+      return order[a.status] - order[b.status] || a.deadline - b.deadline;
+    });
+  const key = visibleJobs.map((job) => `${job.id}:${job.status}:${job.target}`).join('|') + `:${state.selectedJobId}`;
+  if (key !== operationRenderKey) {
+    operationRenderKey = key;
+    ui.parcelRack.innerHTML = visibleJobs.map((job) => parcelButton(job, state)).join('');
+    ui.parcelRack.querySelectorAll('[data-job-id]').forEach((button) => {
+      button.addEventListener('click', () => simulation.perform('select-job', button.dataset.jobId));
+    });
+  }
+  ui.operationEmpty.hidden = visibleJobs.length > 0;
+  ui.parcelRack.hidden = visibleJobs.length === 0;
+  updateOperationTimes(state);
+  renderFallbackTargets(state);
+}
+
+function renderFallbackTargets(state) {
+  if (!worldUnavailable) {
+    ui.fallbackTargets.hidden = true;
+    ui.fallbackTargets.innerHTML = '';
+    return;
+  }
+  const belongsHere = (id) => currentScene === 'network'
+    ? id.startsWith('network-')
+    : currentScene === 'sweden'
+      ? id.startsWith('sweden-')
+      : !id.startsWith('network-') && !id.startsWith('sweden-');
+  const targets = state.activeHotspots.filter(belongsHere);
+  ui.fallbackTargets.hidden = targets.length === 0;
+  ui.fallbackTargets.innerHTML = targets.map((id) => `<button type="button" data-fallback-target="${id}" data-tone="${state.hotspotTones[id] || 'yellow'}">${state.hotspotLabels[id] || TARGET_LABELS[id] || id}</button>`).join('');
+  ui.fallbackTargets.querySelectorAll('[data-fallback-target]').forEach((button) => {
+    button.addEventListener('click', () => handleHotspot(button.dataset.fallbackTarget));
+  });
+}
+
+function parcelButton(job, state) {
+  const selected = state.selectedJobId === job.id;
+  const routeMark = job.stage === 'terminal'
+    ? job.service === 'express' ? 'A ↗' : 'B ■'
+    : job.target === 'network-sundsvall' ? 'NAT' : job.destinationCode;
+  const statusLabel = job.status === 'processing' ? 'MOVING' : job.status === 'queued' ? 'QUEUED' : routeMark;
+  const noDeadline = state.shiftId === 'first-rounds';
+  const timeLeft = noDeadline ? 'NO LIMIT' : formatSeconds(job.deadline - state.elapsed);
+  const disabled = job.status !== 'waiting';
+  const aria = `${job.carrierName}, ${job.units} parcels for ${job.destinationName}. ${TARGET_LABELS[job.target] || routeMark}. ${noDeadline ? 'No deadline' : `${timeLeft} remaining`}. ${job.status}.`;
+  return `<button class="parcel-batch" type="button" data-job-id="${job.id}" data-tone="${job.carrierTone}" data-status="${job.status}" aria-pressed="${selected}" aria-label="${aria}" ${disabled ? 'disabled' : ''}>
+    <span class="carrier-code">${job.carrierCode}</span>
+    <span class="parcel-cube" data-service="${job.service}" aria-hidden="true"><i></i></span>
+    <span class="parcel-route"><strong>${statusLabel}</strong><small>${job.destinationCode}</small></span>
+    <span class="parcel-deadline" data-late="${job.deadline <= state.elapsed}">${timeLeft}</span>
+    <span class="parcel-progress" aria-hidden="true"><i></i></span>
+  </button>`;
+}
+
+function updateOperationTimes(state) {
+  ui.parcelRack.querySelectorAll('[data-job-id]').forEach((button) => {
+    const job = state.jobs.find((item) => item.id === button.dataset.jobId);
+    if (!job) return;
+    const noDeadline = state.shiftId === 'first-rounds';
+    const remaining = job.deadline - state.elapsed;
+    const deadline = button.querySelector('.parcel-deadline');
+    deadline.textContent = noDeadline ? 'NO LIMIT' : formatSeconds(remaining);
+    deadline.dataset.late = String(!noDeadline && remaining <= 0);
+    button.setAttribute('aria-label', `${job.carrierName}, ${job.units} parcels for ${job.destinationName}. ${TARGET_LABELS[job.target] || job.destinationCode}. ${noDeadline ? 'No deadline' : `${formatSeconds(remaining)} remaining`}. ${job.status}.`);
+    const progress = button.querySelector('.parcel-progress i');
+    if (job.status === 'processing' && job.completesAt > job.startedAt) {
+      const value = ((state.elapsed - job.startedAt) / (job.completesAt - job.startedAt)) * 100;
+      progress.style.width = `${Math.max(0, Math.min(100, value))}%`;
+    } else {
+      progress.style.width = job.status === 'queued' ? '12%' : '0%';
+    }
+  });
 }
 
 function renderCommand(state) {
@@ -369,302 +465,125 @@ function renderCommand(state) {
   });
 }
 
-function commandFor(state) {
-  if (state.shiftId === 'first-rounds') return onboardingCommand(state);
-  if (state.shiftId === 'northbound') return northboundCommand(state);
-  if (state.shiftId === 'snow-window') return snowCommand(state);
-  if (state.shiftId === 'scanner-fever') return scannerCommand(state);
-  return priorityCommand(state);
-}
-
-function shell(kicker, title, body, actions, layout = 'standard') {
+function shell(kicker, title, body, actions = '', layout = 'standard') {
   return {
     layout,
-    html: `
-      <div class="command-copy">
-        <span class="command-kicker">${kicker}</span>
-        <h1 id="commandTitle">${title}</h1>
-        ${body ? `<p>${body}</p>` : ''}
-      </div>
-      <div class="command-actions">${actions}</div>`
+    html: `<div class="command-copy"><span class="command-kicker">${kicker}</span><h1 id="commandTitle">${title}</h1>${body ? `<p>${body}</p>` : ''}</div>${actions ? `<div class="command-actions">${actions}</div>` : ''}`
   };
+}
+
+function commandFor(state) {
+  if (state.shiftId === 'first-rounds') return onboardingCommand(state);
+  const selected = state.selectedJob;
+  const currentIncident = state.incidents.find((incident) => incident.active && incident.level === currentScene);
+  if (selected) {
+    return shell(
+      `${selected.carrierName.toUpperCase()} · ${selected.units} PARCEL${selected.units === 1 ? '' : 'S'} · ${selected.stage === 'terminal' ? (selected.service === 'express' ? 'EXPRESS ↗' : 'STANDARD ■') : LEVEL_LABELS[selected.stage].toUpperCase()}`,
+      `${selected.destinationName} · ${formatSeconds(selected.deadline - state.elapsed)}`,
+      `Route mark: ${TARGET_LABELS[selected.target] || selected.destinationCode}.`,
+      '',
+      'live'
+    );
+  }
+  const resource = state.resourceStatus[currentScene] || { busy: 0, capacity: 0, waiting: 0 };
+  const incident = currentIncident ? `<span class="live-alert"><span aria-hidden="true">!</span>${currentIncident.label}</span>` : '';
+  return shell(
+    `${SCENE_PRESENTATION[currentScene].operation} · LIVE`,
+    `${resource.waiting} waiting · ${resource.busy}/${resource.capacity} busy`,
+    '',
+    `${incident}<div class="carrier-legend" aria-label="Active partner carriers"><span data-tone="yellow">NP</span><span data-tone="red">DLH</span><span data-tone="green">B</span><span data-tone="blue">USP</span></div>`,
+    'live'
+  );
 }
 
 function onboardingCommand(state) {
   const commands = {
-    brief: () => shell('FIRST SHIFT · GUIDED', 'Meet the parcel flow.', 'Four small actions introduce the terminal. Nothing moves until you are ready.', '<button class="game-button game-button--primary" type="button" data-action="start">Start first shift</button>'),
-    tour: () => shell('STEP 1 · READ', 'Blue leaves first.', 'Express parcels use blue rings and carry the shortest promises. Tap the glowing blue lane.', '<button class="game-button game-button--blue" type="button" data-action="inspect-express">Inspect Express A</button>'),
-    'coach-move': () => shell('STEP 2 · BALANCE', 'Move help where it matters.', 'The yellow lane has spare operators. Move two of them to the blue lane.', '<button class="game-button game-button--blue" type="button" data-action="move-staff">Move 2 crew</button>'),
-    'coach-scan': () => shell('STEP 3 · FOLLOW', 'Find the promise reader.', 'The scanner reads the label before the belts divide. Tap the highlighted machine.', '<button class="game-button game-button--orange" type="button" data-action="inspect-scanner">Inspect scanner</button>'),
-    'coach-run': () => shell('STEP 4 · WATCH', 'Let six parcels through.', 'Start the belt and watch the rings: blue to Express, yellow to Standard.', '<button class="game-button game-button--green" type="button" data-action="resume">Start parcel flow</button>'),
-    'coach-watch': () => shell('FLOW LIVE', 'Watch the promises move.', 'The belts will pause when six parcels have reached the correct lane.', progressAction(state.verified, 6, 'CORRECT')),
-    dispatch: () => shell('MORNING VAN READY', 'Send your first departure.', 'The flow is balanced and every parcel is aboard.', '<button class="game-button game-button--green" type="button" data-action="dispatch">Send morning van</button>'),
-    complete: () => shell('FIRST SHIFT COMPLETE', 'The shift board is open.', 'Four different kinds of work are ready.', '<button class="game-button game-button--green" type="button" disabled>On the roster</button>')
+    brief: () => shell('FIRST SHIFT · GUIDED', 'Learn the live route.', 'Select a parcel batch, then tap its marked destination in the miniature world.', '<button class="game-button game-button--primary" type="button" data-action="start">Start first shift</button>'),
+    'coach-select': () => shell('STEP 1 · SELECT', 'Take the waiting DLH batch.', 'Tap the parcel card on the town floor. Its blue arrow is the route mark.'),
+    'coach-town-target': () => shell('STEP 2 · SORT', 'Blue arrow means Express A.', 'Tap Express A in the miniature terminal. The action happens there, not in this box.'),
+    'coach-town-run': () => shell('TOWN SORT · LIVE', 'The sort team is occupied.', 'When the batch reaches the regional gate, the Region badge will light up.'),
+    'coach-open-region': () => shell('STEP 3 · FOLLOW', 'Work is waiting in Region.', 'Open the level with the red badge.'),
+    'coach-region-select': () => shell('STEP 4 · SELECT', 'Take the DLH batch again.', 'It is now waiting for a regional truck.'),
+    'coach-region-target': () => shell('STEP 5 · ROUTE', 'The label says Härnösand.', 'Tap Härnösand in the miniature region.'),
+    'coach-region-run': () => shell('REGIONAL RUN · LIVE', 'The truck is on the road.', 'The first promise completes on arrival.'),
+    complete: () => shell('FIRST SHIFT COMPLETE', 'You are in charge now.', 'Live operations continue without prompts.')
   };
   return (commands[state.stage] || commands.brief)();
-}
-
-function northboundCommand(state) {
-  const commands = {
-    brief: () => shell('SHIFT BRIEF', 'The northbound run needs you.', 'Protect the departure, then find why blue Express parcels reach the yellow lane.', '<button class="game-button game-button--primary" type="button" data-action="start">Start shift</button>'),
-    protect: () => shell('LIVE · EXPRESS A', 'The blue lane is filling fast.', 'Standard B has spare crew. Rebalance now, or buy three minutes by holding the truck and spend transfer margin.', `
-      <button class="game-button game-button--blue" type="button" data-action="move-staff">Move 2 crew</button>
-      <button class="game-button game-button--quiet" type="button" data-action="hold-truck">Hold truck · 3 min</button>`),
-    investigate: () => shell('ANOMALY · STANDARD B', 'A blue parcel is in the yellow lane.', 'The queue is recovering, but this Express parcel took the same wrong turn as eleven earlier parcels.', `
-      <button class="game-button game-button--orange" type="button" data-action="trace-package">Trace flashing parcel</button>
-      ${state.staffMoved ? '' : '<button class="game-button game-button--quiet" type="button" data-action="move-staff">Also move 2 crew</button>'}`),
-    compare: () => ({
-      layout: 'standard',
-      html: `<div class="command-copy">
-        <span class="command-kicker">PARCEL · SE-0428-771</span>
-        <h1 id="commandTitle">Where did its journey diverge?</h1>
-        <div class="route-comparison" aria-label="Planned and actual route">
-          <div class="route-row"><strong>Planned</strong> Scan → <span>Express A</span> → 18:20</div>
-          <div class="route-row route-row--wrong"><strong>Actual</strong> Scan → <span>Standard B</span> → correction</div>
-        </div></div>
-        <div class="command-actions"><button class="game-button game-button--blue" type="button" data-action="find-similar">Light up matching parcels</button></div>`
-    }),
-    rule: () => ({
-      layout: 'standard',
-      html: `<div class="command-copy"><span class="command-kicker">ROOT CAUSE · 12 MATCHES</span><h1 id="commandTitle">The fallback rule runs first.</h1><p>All matches are north-zone Express parcels scanned after 17:30.</p></div>
-        <div class="command-actions rule-stack" aria-label="Current routing rule order">
-          <div class="rule-card"><span class="rule-order">1</span><span>North zone after 17:30</span></div>
-          <button class="rule-card" type="button" data-action="fix-rule"><span class="rule-order">↑</span><span>Move <strong>Express service</strong> first</span></button>
-        </div>`
-    }),
-    verify: () => shell('VERIFY THE FIX', 'Watch the next twelve parcels.', state.paused ? 'Resume the flow and make sure new parcels take the blue lane.' : 'No wrong turns so far.', `
-      ${progressAction(state.verified, VERIFY_TARGET, 'CORRECT')}
-      ${state.paused
-        ? '<button class="game-button game-button--green" type="button" data-action="resume">Resume flow</button>'
-        : '<button class="game-button game-button--blue" type="button" data-action="speed-up">Run at 2×</button>'}`),
-    dispatch: () => shell('DEPARTURE READY', 'The flow is clean.', 'Twelve later parcels followed the corrected rule. Send the northbound truck.', '<button class="game-button game-button--green" type="button" data-action="dispatch">Send northbound</button>'),
-    complete: () => shell('SHIFT COMPLETE', 'Northbound is on its way.', 'The shift report is ready.', '<button class="game-button game-button--green" type="button" disabled>Promises kept</button>')
-  };
-  return (commands[state.stage] || commands.brief)();
-}
-
-function snowCommand(state) {
-  if (state.stage === 'brief') return shell('NETWORK SHIFT', 'Snow is closing the coast road.', 'One spare truck must protect the most important promises before 06:30.', '<button class="game-button game-button--primary" type="button" data-action="start">Open network</button>');
-  if (state.stage === 'weather-scan') {
-    const depots = ['harnosand', 'timra', 'matfors'];
-    const next = depots.find((depot) => !state.inspectedDepots.includes(depot));
-    const labels = { harnosand: 'Härnösand', timra: 'Timrå', matfors: 'Matfors' };
-    return shell('READ THE NETWORK', 'Check all three depots.', 'Tap the places in the miniature network. The large button provides the same inspection.', `<button class="game-button game-button--blue" type="button" data-action="inspect-depot" data-value="${next}">Check ${labels[next]}</button>`);
-  }
-  if (state.stage === 'weather-allocate') {
-    return shell('ONE SPARE TRUCK', 'Which promises move first?', 'Härnösand has 14 urgent parcels. Timrå has 26 standard; Matfors has 9 next-day.', `
-      <div class="choice-grid choice-grid--three">
-        <button class="choice-card" type="button" data-action="allocate-truck" data-value="harnosand"><strong>Härnösand</strong><span>14 · urgent</span></button>
-        <button class="choice-card" type="button" data-action="allocate-truck" data-value="timra"><strong>Timrå</strong><span>26 · standard</span></button>
-        <button class="choice-card" type="button" data-action="allocate-truck" data-value="matfors"><strong>Matfors</strong><span>9 · next day</span></button>
-      </div>`, 'wide');
-  }
-  if (state.stage === 'weather-route') {
-    return shell('ROAD DECISION', 'Choose the road north.', 'The coast road is shorter but restricted. The inland road via Matfors is longer and open.', `
-      <div class="choice-grid">
-        <button class="choice-card" type="button" data-action="choose-route" data-value="coast"><strong>Coast road</strong><span>Fast · snow risk</span></button>
-        <button class="choice-card choice-card--blue" type="button" data-action="choose-route" data-value="inland"><strong>Via Matfors</strong><span>Longer · open</span></button>
-      </div>`, 'wide');
-  }
-  if (state.stage === 'weather-run') return shell('CONVOY READY', 'Run through the weather window.', state.paused ? 'Start the truck. Its route is visible across the miniature network.' : 'The assigned load is moving.', `
-    ${progressAction(state.delivered, state.deliveryTarget, 'DELIVERED')}
-    ${state.paused ? '<button class="game-button game-button--green" type="button" data-action="resume">Start convoy</button>' : '<button class="game-button game-button--blue" type="button" data-action="speed-up">Run at 2×</button>'}`);
-  if (state.stage === 'dispatch') return shell('ARRIVAL CONFIRMED', 'Close the weather run.', 'The assigned parcels are inside the depot before the road closes.', '<button class="game-button game-button--green" type="button" data-action="dispatch">Close weather shift</button>');
-  return shell('WEATHER SHIFT COMPLETE', 'The network adapted.', 'The shift report is ready.', '<button class="game-button game-button--green" type="button" disabled>Route complete</button>');
-}
-
-function scannerCommand(state) {
-  if (state.stage === 'brief') return shell('TERMINAL SHIFT', 'Scanner 2 has stopped.', 'Diagnose the jam, decide what moves first and recover the queue.', '<button class="game-button game-button--primary" type="button" data-action="start">Start terminal shift</button>');
-  if (state.stage === 'jam-diagnose') return shell('FLOW STOPPED', 'Find the blockage.', 'Parcels are bunching before Scanner 2. Tap the highlighted scanner.', '<button class="game-button game-button--orange" type="button" data-action="inspect-scanner">Inspect Scanner 2</button>');
-  if (state.stage === 'jam-triage') {
-    const choices = state.triageQueue.map((parcel) => {
-      const position = state.triageOrder.indexOf(parcel.id);
-      return `<button class="parcel-choice" data-tone="${parcel.tone}" type="button" data-action="prioritize" data-value="${parcel.id}" ${position >= 0 ? 'disabled' : ''}>
-        <span class="parcel-choice-box" aria-hidden="true">□</span><strong>${parcel.label}</strong><span>${position >= 0 ? `Released #${position + 1}` : parcel.promise}</span>
-      </button>`;
-    }).join('');
-    return shell('MANUAL RELEASE', 'Which promise goes first?', 'Tap the three waiting groups in the order you want to release them.', `<div class="parcel-priority-grid">${choices}</div>`, 'wide');
-  }
-  if (state.stage === 'jam-repair') return shell('QUEUE ORDERED', 'Repair or bypass?', 'Repair restores accuracy but takes longer. Manual bypass moves now and leaves more handling risk.', `
-    <div class="choice-grid">
-      <button class="choice-card choice-card--blue" type="button" data-action="repair-scanner"><strong>Clear + calibrate</strong><span>Restore 98% accuracy</span></button>
-      <button class="choice-card" type="button" data-action="bypass-scanner"><strong>Manual bypass</strong><span>Move now · more risk</span></button>
-    </div>`, 'wide');
-  if (state.stage === 'jam-run') return shell(state.scannerFixed ? 'SCANNER RESTORED' : 'MANUAL BYPASS', 'Clear the waiting queue.', state.paused ? 'Start the recovered flow and watch the parcels pass the scanner.' : 'The queue is shrinking.', `
-    ${progressAction(state.processed, 31, 'PROCESSED')}
-    ${state.paused ? '<button class="game-button game-button--green" type="button" data-action="resume">Start recovered flow</button>' : '<button class="game-button game-button--blue" type="button" data-action="speed-up">Run at 2×</button>'}`);
-  if (state.stage === 'dispatch') return shell('OUTBOUND CLEAR', 'Release the departures.', 'Every waiting parcel has passed the recovery point.', '<button class="game-button game-button--green" type="button" data-action="dispatch">Close terminal shift</button>');
-  return shell('QUEUE CLEARED', 'The line is moving.', 'The shift report is ready.', '<button class="game-button game-button--green" type="button" disabled>Flow restored</button>');
-}
-
-function priorityCommand(state) {
-  if (state.stage === 'brief') return shell('INVESTIGATION SHIFT', 'One cold-chain promise is missing.', 'Use its scans to find it, then choose a recovery that can still make 21:10.', '<button class="game-button game-button--primary" type="button" data-action="start">Open parcel case</button>');
-  if (state.stage === 'case-inspect') return shell(`PARCEL · ${state.caseData.parcelId}`, 'Open the scan trail.', 'The temperature is safe now, but the delivery window is shrinking.', '<button class="game-button game-button--orange" type="button" data-action="inspect-case">Inspect parcel history</button>');
-  if (state.stage === 'case-clue') {
-    const evidence = state.caseData.evidence.map((item) => `<li>${item}</li>`).join('');
-    const locations = state.caseData.locations.map((location) => `<button class="choice-card" type="button" data-action="choose-location" data-value="${location.id}"><strong>${location.label}</strong><span>Search here</span></button>`).join('');
-    return {
-      layout: 'wide',
-      html: `<div class="command-copy"><span class="command-kicker">SCAN TRAIL</span><h1 id="commandTitle">Where is the parcel?</h1><ol class="evidence-list">${evidence}</ol></div><div class="command-actions"><div class="choice-grid choice-grid--three">${locations}</div></div>`
-    };
-  }
-  if (state.stage === 'case-plan') return shell('PARCEL SECURED', 'Choose the final connection.', 'Direct courier protects the cold chain. A held linehaul is efficient but tight; scheduled transfer misses the original margin.', `
-    <div class="choice-grid choice-grid--three">
-      <button class="choice-card choice-card--blue" type="button" data-action="choose-recovery" data-value="courier"><strong>Courier</strong><span>22 min · direct</span></button>
-      <button class="choice-card" type="button" data-action="choose-recovery" data-value="linehaul"><strong>Hold linehaul</strong><span>31 min · tight</span></button>
-      <button class="choice-card" type="button" data-action="choose-recovery" data-value="scheduled"><strong>Scheduled</strong><span>48 min · late risk</span></button>
-    </div>`, 'wide');
-  if (state.stage === 'case-run') return shell('RECOVERY READY', 'Follow it to the recipient.', state.paused ? 'Start the chosen connection. The regional view shows its progress.' : 'Temperature and route are stable.', `
-    ${progressAction(Math.round(state.deliveryProgress), 100, 'TO RECIPIENT')}
-    ${state.paused ? '<button class="game-button game-button--green" type="button" data-action="resume">Start recovery</button>' : '<button class="game-button game-button--blue" type="button" data-action="speed-up">Run at 2×</button>'}`);
-  if (state.stage === 'dispatch') return shell('RECIPIENT CONFIRMED', 'Complete the handoff.', 'The parcel arrived with its cold chain intact.', '<button class="game-button game-button--green" type="button" data-action="dispatch">Confirm delivery</button>');
-  return shell('DELIVERY COMPLETE', 'Cold chain intact.', 'The shift report is ready.', '<button class="game-button game-button--green" type="button" disabled>Promise kept</button>');
-}
-
-function progressAction(value, target, label) {
-  return `<div class="mini-progress" aria-label="${value} of ${target} ${label.toLowerCase()}">
-    <div class="mini-progress-track"><span style="width:${Math.min(100, (value / Math.max(1, target)) * 100)}%"></span></div>
-    <span class="mini-progress-label">${value} / ${target} ${label}</span>
-  </div>`;
 }
 
 function handleAction(action, value = null) {
+  audio.unlock();
   if (action === 'start') {
     beginShift();
     return;
   }
-  const performed = simulation.perform(action, value);
-  if (!performed) audio.play('click');
+  simulation.perform(action, value);
 }
 
 function prepareShift(shiftId) {
   activeShift = getShiftDefinition(shiftId);
   const variant = campaign.plays[activeShift.id] || 0;
   simulation = new ShiftSimulation(handleSimulationChange, activeShift.id, { variant });
-  shiftResultRecorded = false;
-  commandRenderKey = '';
   currentScene = activeShift.startScene;
+  commandRenderKey = '';
+  operationRenderKey = '';
+  shiftResultRecorded = false;
   configureHud(activeShift);
   renderShift(simulation.snapshot());
-  world.setState(simulation.snapshot());
-  switchScene(activeShift.startScene, false, true);
+  switchScene(currentScene, false, true);
 }
 
 function beginShift() {
-  if (simulation.state.started) return;
   audio.unlock();
   ui.welcome.hidden = true;
   ui.campaign.hidden = true;
   ui.result.hidden = true;
   ui.gameShell.inert = false;
-  simulation.start();
-  switchScene(activeShift.startScene, false, true);
-  ui.commandDeck.focus({ preventScroll: true });
-}
-
-function depotFromHotspot(id) {
-  return {
-    'network-harnosand': 'harnosand',
-    'network-timra': 'timra',
-    'network-matfors': 'matfors'
-  }[id];
+  if (!simulation.state.started) simulation.start();
+  ui.operationLayer.hidden = false;
+  window.setTimeout(() => {
+    const firstBatch = ui.parcelRack.querySelector('button:not([disabled])');
+    (firstBatch || ui.commandDeck).focus({ preventScroll: true });
+  }, 80);
 }
 
 function handleHotspot(id) {
   const state = simulation.snapshot();
-
-  if (state.shiftId === 'first-rounds') {
-    if (id === 'express-lane' && state.stage === 'tour') simulation.perform('inspect-express');
-    else if (id === 'scanner' && state.stage === 'coach-scan') simulation.perform('inspect-scanner');
-    else if (id === 'truck' && state.stage === 'dispatch') simulation.perform('dispatch');
-    else inspectTerminalHotspot(id, state);
+  const incident = state.incidents.find((item) => item.active && item.target === id);
+  if (incident) {
+    simulation.perform('resolve-incident', id);
     return;
   }
-
-  if (state.shiftId === 'northbound') {
-    if (id === 'parcel') simulation.perform('trace-package');
-    else if (id === 'case-package') announce('The label says Express to Härnösand. Its history turns into Standard B at 17:32.');
-    else if (id === 'case-similar') announce('Twelve matches: Express, north zone, scanned after 17:30.');
-    else if (id === 'network-sundsvall') {
-      switchScene('terminal');
-      announce('Sundsvall is the source of the northbound pressure.');
-    } else if (id === 'network-harnosand') announce('Härnösand is waiting for the Express connection.');
-    else if (id === 'network-timra') announce('Timrå depot is stable.');
-    else if (id === 'network-matfors') announce('Matfors depot is stable.');
-    else inspectTerminalHotspot(id, state);
+  if (state.selectedJobId) {
+    simulation.perform('route-selected', id);
     return;
   }
-
-  if (state.shiftId === 'snow-window') {
-    const depot = depotFromHotspot(id);
-    if (depot && state.stage === 'weather-scan') simulation.perform('inspect-depot', depot);
-    else if (id === 'network-sundsvall') announce('One spare truck is ready in Sundsvall.');
-    else if (id === 'network-harnosand') announce('Härnösand: 14 urgent parcels, including blood samples.');
-    else if (id === 'network-timra') announce('Timrå: 26 standard parcels with later promises.');
-    else if (id === 'network-matfors') announce('Matfors: 9 next-day parcels and the open inland road.');
-    return;
-  }
-
-  if (state.shiftId === 'scanner-fever') {
-    if (id === 'scanner' && state.stage === 'jam-diagnose') simulation.perform('inspect-scanner');
-    else if (id === 'parcel') announce('Three promise groups are blocked before Scanner 2.');
-    else inspectTerminalHotspot(id, state);
-    return;
-  }
-
-  if (id === 'case-package' && state.stage === 'case-inspect') simulation.perform('inspect-case');
-  else if (id === 'case-package') announce(`${state.caseData.parcelId}. Temperature is stable and the scan evidence is open below.`);
-  else if (id.startsWith('network-')) announce('The recovery connection is visible in the regional network.');
-}
-
-function inspectTerminalHotspot(id, state) {
-  audio.play('select');
-  if (id === 'express-lane') announce(`Express A: ${Math.round(state.expressLoad)} percent load with ${state.expressCrew} crew.`);
-  if (id === 'standard-lane') announce(`Standard B: ${Math.round(state.standardLoad)} percent load with ${state.standardCrew} crew.`);
-  if (id === 'scanner') announce(state.scannerFixed ? 'Scanner 2 is calibrated and running.' : 'The scanner reads each parcel promise before the belts divide.');
-  if (id === 'truck') announce(`Departure is scheduled for ${formatClock(state.departure)}.`);
+  const status = state.targetStatus[id];
+  if (status) announce(`${status.label}: ${status.processing} moving, ${status.queued} queued.`);
 }
 
 function switchScene(scene, focusDeck = false, force = false) {
   const state = simulation.snapshot();
-  if (!force && state.started && !state.availableScenes.includes(scene)) return;
+  if (!force && !state.availableScenes.includes(scene)) return;
   currentScene = scene;
-  world.setMode(scene);
-  const parcelId = state.caseData?.parcelId || 'SE-0428-771';
-  const sceneLabels = {
-    terminal: state.shiftId === 'scanner-fever' ? ['LIVE TERMINAL', 'Scanner hall'] : ['LIVE TERMINAL', 'Sundsvall'],
-    network: state.shiftId === 'snow-window' ? ['WEATHER NETWORK', 'Mid Sweden'] : ['REGIONAL NETWORK', 'Mid Sweden'],
-    case: ['PARCEL TRACE', parcelId]
-  };
-  [ui.sceneEyebrow.textContent, ui.sceneTitle.textContent] = sceneLabels[scene];
-  $$('.scene-tab').forEach((button) => {
-    if (button.dataset.scene === scene) button.setAttribute('aria-current', 'page');
-    else button.removeAttribute('aria-current');
-  });
-  updateSceneSummary(state);
+  simulation.perform('visit-level', scene);
+  world.setMode(scene, force);
+  const presentation = SCENE_PRESENTATION[scene];
+  ui.sceneEyebrow.textContent = presentation.eyebrow;
+  ui.sceneTitle.textContent = presentation.title;
+  $$('.scene-tab').forEach((button) => button.setAttribute('aria-current', button.dataset.scene === scene ? 'page' : 'false'));
+  operationRenderKey = '';
+  commandRenderKey = '';
+  renderShift(simulation.snapshot());
   if (focusDeck) window.setTimeout(() => ui.commandDeck.focus({ preventScroll: true }), 80);
 }
 
 function updateSceneSummary(state) {
-  let summary = '';
-  if (currentScene === 'terminal') {
-    if (state.shiftId === 'scanner-fever') {
-      summary = `Sundsvall scanner hall. Scanner 2 is ${state.scannerFixed ? 'repaired' : state.scannerBypassed ? 'bypassed' : 'stopped'}. ${state.backlog} parcels remain in the queue.`;
-    } else {
-      summary = `Sundsvall terminal. Express A is at ${Math.round(state.expressLoad)} percent with ${state.expressCrew} crew. Standard B is at ${Math.round(state.standardLoad)} percent with ${state.standardCrew} crew.`;
-    }
-  } else if (currentScene === 'network') {
-    summary = state.shiftId === 'snow-window'
-      ? `Regional snow network. Härnösand has 14 urgent parcels, Timrå 26 standard parcels and Matfors 9 next-day parcels. ${state.routeChoice === 'inland' ? 'The selected truck is using the open inland route.' : 'The coast road is restricted.'}`
-      : `Regional network. ${Math.round(state.risk)} promises are at risk. Sundsvall, Härnösand, Timrå and Matfors are available as structured locations.`;
-  } else {
-    summary = state.shiftId === 'priority-parcel'
-      ? `Priority parcel ${state.caseData.parcelId}. ${state.caseData.evidence.join('. ')}.`
-      : state.packageSelected
-        ? `Parcel SE-0428-771. Planned for Express A, but routed to Standard B. ${state.signatureFound ? 'Twelve parcels share the same rule signature.' : ''}`
-        : 'No parcel is selected.';
-  }
-  ui.sceneSummary.textContent = summary;
+  const jobs = state.jobs.filter((job) => job.stage === currentScene && ['waiting', 'queued', 'processing'].includes(job.status));
+  const waiting = jobs.filter((job) => job.status === 'waiting').length;
+  const moving = jobs.filter((job) => job.status === 'processing').length;
+  const incidents = state.incidents.filter((incident) => incident.active && incident.level === currentScene).map((incident) => incident.label);
+  ui.sceneSummary.textContent = `${SCENE_PRESENTATION[currentScene].title}. ${waiting} batches waiting and ${moving} moving.${incidents.length ? ` Attention: ${incidents.join(', ')}.` : ''}`;
 }
 
 function detailMetric(label, value) {
@@ -672,64 +591,29 @@ function detailMetric(label, value) {
 }
 
 function updateStructuredDetails(state) {
-  $('#detailsTitle').textContent = `${activeShift.title} details`;
-  const labels = activeShift.metricLabels;
   ui.detailMetrics.innerHTML = [
-    detailMetric('Time', formatClock(state.time)),
-    detailMetric(labels[0], `${Math.round(state.onTime)}%`),
-    detailMetric(labels[1], Math.round(state.backlog)),
-    detailMetric(labels[2], Math.round(state.risk))
+    detailMetric('On time', `${state.onTime}%`),
+    detailMetric('Waiting or moving', state.backlog),
+    detailMetric('Current combo', `${state.combo}×`),
+    detailMetric('Score', Math.round(state.score))
   ].join('');
+  $('#detailsIntro').textContent = state.completed
+    ? state.outcome.summary
+    : `${activeShift.title}: ${state.delivered} batches delivered, ${state.risk} items currently at risk.`;
 
-  if (state.shiftId === 'first-rounds') {
-    $('#detailsIntro').textContent = state.completed ? state.outcome.summary : 'The guided shift introduces one consequential control at a time and does not run a deadline during instruction.';
-    ui.detailScenario.innerHTML = `<section class="dialog-section"><h3>First-shift progress</h3><ol class="detail-checklist">
-      <li data-done="${state.laneInspected}">Read the Express lane</li>
-      <li data-done="${state.staffMoved}">Move spare crew</li>
-      <li data-done="${state.scannerInspected}">Inspect the scanner</li>
-      <li data-done="${state.verified >= 6}">Verify six parcels</li>
-    </ol></section>`;
-    return;
-  }
+  const unresolved = state.jobs
+    .filter((job) => !['scheduled', 'delivered', 'missed'].includes(job.status))
+    .sort((a, b) => a.deadline - b.deadline);
+  const jobRows = unresolved.length
+    ? unresolved.map((job) => `<tr><th scope="row">${job.carrierCode} ${job.id.split('-').at(-1)}</th><td>${LEVEL_LABELS[job.stage]}</td><td>${job.destinationCode}</td><td>${formatSeconds(job.deadline - state.elapsed)}</td><td>${job.status}</td></tr>`).join('')
+    : '<tr><td colspan="5">No active batches.</td></tr>';
+  const incidents = state.incidents.length
+    ? `<section class="dialog-section"><h3>Disruptions</h3><ul class="detail-checklist">${state.incidents.map((incident) => `<li data-done="${incident.resolved}">${incident.label} · ${incident.resolved ? 'cleared' : incident.active ? 'active' : 'not yet active'}</li>`).join('')}</ul></section>`
+    : '';
 
-  if (state.shiftId === 'northbound') {
-    $('#detailsIntro').textContent = state.completed
-      ? state.outcome.summary
-      : state.ruleFixed
-        ? `The Express rule is corrected. ${state.verified} of ${VERIFY_TARGET} later parcels have been verified.`
-        : 'The Sundsvall to Härnösand Express connection is the highest-consequence issue.';
-    ui.detailScenario.innerHTML = `<section class="dialog-section"><h3>Terminal lanes</h3><div class="table-wrap"><table>
-      <thead><tr><th scope="col">Lane</th><th scope="col">Load</th><th scope="col">Crew</th><th scope="col">State</th></tr></thead>
-      <tbody><tr><th scope="row">Express A</th><td>${Math.round(state.expressLoad)}%</td><td>${state.expressCrew}</td><td>${state.ruleFixed ? 'Correct flow' : state.staffMoved ? 'Recovering' : 'Overloaded'}</td></tr>
-      <tr><th scope="row">Standard B</th><td>${Math.round(state.standardLoad)}%</td><td>${state.standardCrew}</td><td>${state.staffMoved ? 'Adequate' : 'Spare capacity'}</td></tr></tbody>
-    </table></div></section><section class="dialog-section"><h3>Selected parcel</h3><p>${state.packageSelected ? 'SE-0428-771 was planned for Express A. At 17:32 it entered Standard B and required manual correction.' : 'No parcel selected.'}</p></section>`;
-    return;
-  }
-
-  if (state.shiftId === 'snow-window') {
-    $('#detailsIntro').textContent = state.completed ? state.outcome.summary : 'Snow restricts the coast road at 06:30. One spare truck can cover one departure group.';
-    const checked = (id) => state.inspectedDepots.includes(id) ? 'Checked' : 'Not checked';
-    ui.detailScenario.innerHTML = `<section class="dialog-section"><h3>Depot demand</h3><div class="table-wrap"><table>
-      <thead><tr><th scope="col">Depot</th><th scope="col">Waiting</th><th scope="col">Promise</th><th scope="col">Read</th></tr></thead>
-      <tbody><tr><th scope="row">Härnösand</th><td>14</td><td>Urgent · 07:00</td><td>${checked('harnosand')}</td></tr>
-      <tr><th scope="row">Timrå</th><td>26</td><td>Standard</td><td>${checked('timra')}</td></tr>
-      <tr><th scope="row">Matfors</th><td>9</td><td>Next day</td><td>${checked('matfors')}</td></tr></tbody>
-    </table></div><p><strong>Allocation:</strong> ${state.allocation || 'Not chosen'}. <strong>Route:</strong> ${state.routeChoice || 'Not chosen'}.</p></section>`;
-    return;
-  }
-
-  if (state.shiftId === 'scanner-fever') {
-    $('#detailsIntro').textContent = state.completed ? state.outcome.summary : 'A crushed label blocks Scanner 2. Manual release order affects which promises retain their margin.';
-    ui.detailScenario.innerHTML = `<section class="dialog-section"><h3>Waiting promise groups</h3><div class="table-wrap"><table>
-      <thead><tr><th scope="col">Group</th><th scope="col">Promise</th><th scope="col">Release</th></tr></thead><tbody>
-      ${state.triageQueue.map((parcel) => `<tr><th scope="row">${parcel.label}</th><td>${parcel.promise}</td><td>${state.triageOrder.includes(parcel.id) ? `#${state.triageOrder.indexOf(parcel.id) + 1}` : 'Waiting'}</td></tr>`).join('')}
-      </tbody></table></div><p><strong>Recovery:</strong> ${state.scannerFixed ? 'Scanner repaired and calibrated' : state.scannerBypassed ? 'Manual bypass' : 'Not chosen'}.</p></section>`;
-    return;
-  }
-
-  $('#detailsIntro').textContent = state.completed ? state.outcome.summary : `Temperature-controlled parcel ${state.caseData.parcelId} must arrive by ${formatClock(state.departure)}.`;
-  ui.detailScenario.innerHTML = `<section class="dialog-section"><h3>Scan evidence</h3><ol class="detail-checklist">${state.caseData.evidence.map((item) => `<li>${item}</li>`).join('')}</ol>
-    <p><strong>Chosen location:</strong> ${state.clueChoice || 'Not chosen'}. <strong>Recovery:</strong> ${state.recoveryChoice || 'Not chosen'}.</p></section>`;
+  ui.detailScenario.innerHTML = `<section class="dialog-section"><h3>Live batches</h3><div class="table-wrap"><table>
+    <thead><tr><th scope="col">Batch</th><th scope="col">Level</th><th scope="col">To</th><th scope="col">Promise</th><th scope="col">State</th></tr></thead>
+    <tbody>${jobRows}</tbody></table></div></section>${incidents}`;
 }
 
 function openDetails() {
@@ -765,28 +649,34 @@ function showResult(outcome, state) {
   $('#resultSummary').textContent = outcome.summary;
   $('#resultStats').innerHTML = outcome.stats.map((stat) => `<div><span>${stat.label}</span><strong>${stat.value}</strong></div>`).join('');
   $('#resultMedals').innerHTML = outcome.medals.map((medal) => `<span class="result-medal"><span aria-hidden="true">${medal.icon}</span>${medal.label}</span>`).join('');
-  ui.nextShift.textContent = state.shiftId === 'first-rounds' ? 'Open shift board' : 'Choose next shift';
+  ui.nextShift.textContent = state.shiftId === 'first-rounds' ? 'Open shift board' : 'Back to shift board';
   ui.result.hidden = false;
   ui.gameShell.inert = true;
   ui.nextShift.focus({ preventScroll: true });
 }
 
+function shiftUnlocked(index) {
+  return index === 0 || Boolean(campaign.completed[SHIFT_CATALOG[index - 1].id]);
+}
+
 function renderCampaign() {
   const completedCount = SHIFT_CATALOG.filter((shift) => campaign.completed[shift.id]).length;
+  const nextIndex = SHIFT_CATALOG.findIndex((shift) => !campaign.completed[shift.id]);
   ui.campaignProgress.textContent = completedCount === SHIFT_CATALOG.length
-    ? 'All five shifts completed. Replay conditions still vary.'
-    : `${SHIFT_CATALOG.length - completedCount} shifts remain · ${completedCount} completed`;
+    ? 'Every shift cleared. Peak conditions vary on replay.'
+    : `${completedCount} cleared · shift ${nextIndex + 1} is next`;
   ui.campaignStamp.textContent = `${completedCount}/${SHIFT_CATALOG.length}`;
-  ui.shiftList.innerHTML = SHIFT_CATALOG.map((shift) => {
+  ui.shiftList.innerHTML = SHIFT_CATALOG.map((shift, index) => {
     const completion = campaign.completed[shift.id];
     const plays = campaign.plays[shift.id] || 0;
-    return `<button class="shift-card" data-shift-id="${shift.id}" data-tone="${shift.tone}" type="button">
+    const unlocked = shiftUnlocked(index);
+    return `<button class="shift-card" data-shift-id="${shift.id}" data-tone="${shift.tone}" type="button" ${unlocked ? '' : 'disabled'}>
       <span class="shift-card-number" aria-hidden="true">${shift.number}</span>
       <span class="shift-card-copy"><span class="shift-card-kind">${shift.kind} · ${shift.duration}</span><strong>${shift.title}</strong><span>${shift.description}</span><small>${shift.mechanic}${plays > 1 ? ` · ${plays} runs` : ''}</small></span>
-      <span class="shift-card-state">${completion ? `<strong>${completion.grade}</strong><span>Replay</span>` : '<strong>→</strong><span>Open</span>'}</span>
+      <span class="shift-card-state">${completion ? `<strong>${completion.grade}</strong><span>Replay</span>` : unlocked ? '<strong>→</strong><span>Play</span>' : '<strong>×</strong><span>Locked</span>'}</span>
     </button>`;
   }).join('');
-  ui.shiftList.querySelectorAll('[data-shift-id]').forEach((button) => {
+  ui.shiftList.querySelectorAll('[data-shift-id]:not([disabled])').forEach((button) => {
     button.addEventListener('click', () => {
       prepareShift(button.dataset.shiftId);
       beginShift();
@@ -801,7 +691,11 @@ function openCampaign() {
   ui.campaign.hidden = false;
   ui.gameShell.inert = true;
   renderCampaign();
-  window.setTimeout(() => ui.shiftList.querySelector('button')?.focus({ preventScroll: true }), 80);
+  window.setTimeout(() => {
+    const nextShift = SHIFT_CATALOG.find((shift, index) => shiftUnlocked(index) && !campaign.completed[shift.id]);
+    const next = nextShift ? ui.shiftList.querySelector(`[data-shift-id="${nextShift.id}"]`) : null;
+    (next || ui.shiftList.querySelector('button:not([disabled])'))?.focus({ preventScroll: true });
+  }, 80);
 }
 
 ui.start.addEventListener('click', () => {
@@ -838,7 +732,7 @@ $$('.scene-tab').forEach((button) => {
   button.addEventListener('click', () => {
     if (button.disabled) return;
     audio.play('click');
-    switchScene(button.dataset.scene, false);
+    switchScene(button.dataset.scene);
   });
 });
 
@@ -848,7 +742,7 @@ document.addEventListener('keydown', (event) => {
   if (event.key.toLowerCase() === 'p') simulation.togglePaused();
   if (event.key === '1') switchScene('terminal');
   if (event.key === '2') switchScene('network');
-  if (event.key === '3') switchScene('case');
+  if (event.key === '3') switchScene('sweden');
 });
 
 document.addEventListener('visibilitychange', () => {
@@ -877,7 +771,9 @@ window.__POSTAL_GAME__ = {
     prepareShift(shiftId);
     beginShift();
   },
-  act: (action, value = null) => simulation.perform(action, value)
+  act: (action, value = null) => simulation.perform(action, value),
+  showLevel: (level) => switchScene(level),
+  tick: (seconds) => simulation.tick(seconds)
 };
 
 if ('serviceWorker' in navigator && location.protocol === 'https:') {

--- a/postal/sim.mjs
+++ b/postal/sim.mjs
@@ -1,9 +1,62 @@
 export const INITIAL_TIME = 17 * 60 + 42;
-export const BASE_DEPARTURE = 18 * 60 + 20;
-export const VERIFY_TARGET = 12;
 
-const ONBOARDING_VERIFY_TARGET = 6;
-const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+export const LEVELS = Object.freeze(['terminal', 'network', 'sweden']);
+
+export const LEVEL_LABELS = Object.freeze({
+  terminal: 'Town',
+  network: 'Region',
+  sweden: 'Sweden'
+});
+
+export const CARRIERS = Object.freeze({
+  nordpost: {
+    id: 'nordpost',
+    name: 'NordPost',
+    code: 'NP',
+    tone: 'yellow',
+    defaultService: 'standard',
+    units: [3, 4, 2, 5],
+    promiseAdjust: 5
+  },
+  dlh: {
+    id: 'dlh',
+    name: 'DLH',
+    code: 'DLH',
+    tone: 'red',
+    defaultService: 'express',
+    units: [1, 2, 1, 3],
+    promiseAdjust: -6
+  },
+  brang: {
+    id: 'brang',
+    name: 'Brang',
+    code: 'B',
+    tone: 'green',
+    defaultService: 'standard',
+    units: [1, 2, 2, 1],
+    promiseAdjust: -2
+  },
+  usp: {
+    id: 'usp',
+    name: 'USP',
+    code: 'USP',
+    tone: 'blue',
+    defaultService: 'express',
+    units: [4, 3, 5, 3],
+    promiseAdjust: 7
+  }
+});
+
+const DESTINATIONS = Object.freeze({
+  north: { id: 'north', code: 'NORTH', name: 'Sundsvall north', path: ['terminal'] },
+  centre: { id: 'centre', code: 'CENTRE', name: 'Sundsvall centre', path: ['terminal'] },
+  harbour: { id: 'harbour', code: 'HARBOUR', name: 'Sundsvall harbour', path: ['terminal'] },
+  harnosand: { id: 'harnosand', code: 'HND', name: 'Härnösand', path: ['terminal', 'network'] },
+  timra: { id: 'timra', code: 'TMR', name: 'Timrå', path: ['terminal', 'network'] },
+  matfors: { id: 'matfors', code: 'MTF', name: 'Matfors', path: ['terminal', 'network'] },
+  stockholm: { id: 'stockholm', code: 'STH', name: 'Stockholm', path: ['terminal', 'network', 'sweden'] },
+  gothenburg: { id: 'gothenburg', code: 'GBG', name: 'Gothenburg', path: ['terminal', 'network', 'sweden'] }
+});
 
 export const SHIFT_CATALOG = Object.freeze([
   {
@@ -14,137 +67,148 @@ export const SHIFT_CATALOG = Object.freeze([
     shiftLabel: 'SUNDSVALL · FIRST SHIFT',
     kind: 'Guided shift',
     duration: '2 min',
-    mechanic: 'Watch · Move · Scan · Send',
-    description: 'Meet the parcel flow one action at a time. There is no clock pressure.',
+    mechanic: 'Select · Sort · Route',
+    description: 'Learn the live controls without a deadline.',
     startScene: 'terminal',
     tone: 'yellow',
     startTime: 8 * 60 + 5,
-    departure: 8 * 60 + 20,
-    metricLabels: ['On time', 'In flow', 'At risk'],
-    metricIcons: ['✓', '▦', '!']
+    activeLevels: ['terminal', 'network'],
+    capacity: { terminal: 1, network: 1, sweden: 0 },
+    durationSeconds: 999,
+    promiseSeconds: 999,
+    jobs: 1,
+    spawnEvery: 999,
+    carriers: ['dlh'],
+    destinations: ['harnosand'],
+    incidents: []
   },
   {
-    id: 'northbound',
+    id: 'town-rush',
     number: 2,
-    title: 'Northbound promises',
-    place: 'Sundsvall → Härnösand',
+    title: 'After-work rush',
+    place: 'Sundsvall',
     shiftLabel: 'SUNDSVALL · SHIFT 2',
-    kind: 'Systems shift',
-    duration: '5 min',
-    mechanic: 'Capacity · Investigation · Rules',
-    description: 'Protect a departure, trace a wrong turn and repair the system behind it.',
+    kind: 'Town rush',
+    duration: '2–3 min',
+    mechanic: 'Two lanes · Four carriers',
+    description: 'Keep both sorting lanes moving as partner vans arrive.',
     startScene: 'terminal',
     tone: 'blue',
     startTime: INITIAL_TIME,
-    departure: BASE_DEPARTURE,
-    metricLabels: ['On time', 'In flow', 'At risk'],
-    metricIcons: ['✓', '▦', '!']
+    activeLevels: ['terminal'],
+    capacity: { terminal: 2, network: 0, sweden: 0 },
+    durationSeconds: 78,
+    promiseSeconds: 30,
+    jobs: 15,
+    spawnEvery: 5,
+    carriers: ['nordpost', 'dlh', 'brang', 'usp'],
+    destinations: ['north', 'centre', 'harbour'],
+    incidents: [{ id: 'scanner-1', type: 'scanner-jam', level: 'terminal', target: 'scanner', at: 38 }]
   },
   {
-    id: 'snow-window',
+    id: 'region-pulse',
     number: 3,
-    title: 'Snow over E4',
-    place: 'Mid Sweden network',
-    shiftLabel: 'REGION MID · SHIFT 3',
-    kind: 'Network shift',
-    duration: '4 min',
-    mechanic: 'Read demand · Allocate · Reroute',
-    description: 'One spare truck, three depots and a closing weather window. Choose what moves.',
-    startScene: 'network',
+    title: 'Region pulse',
+    place: 'Mid Sweden',
+    shiftLabel: 'MID SWEDEN · SHIFT 3',
+    kind: 'Town + region',
+    duration: '3 min',
+    mechanic: 'Sort teams · Route trucks',
+    description: 'Sort in Sundsvall while three regional depots call for trucks.',
+    startScene: 'terminal',
     tone: 'purple',
     startTime: 5 * 60 + 48,
-    departure: 6 * 60 + 30,
-    metricLabels: ['Coverage', 'Waiting', 'At risk'],
-    metricIcons: ['⌁', '▰', '!']
+    activeLevels: ['terminal', 'network'],
+    capacity: { terminal: 2, network: 2, sweden: 0 },
+    durationSeconds: 108,
+    promiseSeconds: 50,
+    jobs: 20,
+    spawnEvery: 5.1,
+    carriers: ['nordpost', 'dlh', 'brang', 'usp'],
+    destinations: ['harnosand', 'timra', 'matfors', 'harnosand', 'timra'],
+    directHigherEvery: 5,
+    incidents: [{ id: 'snow-1', type: 'snow-route', level: 'network', target: 'network-detour', at: 52 }]
   },
   {
-    id: 'scanner-fever',
+    id: 'sweden-night',
     number: 4,
-    title: 'Scanner fever',
-    place: 'Sundsvall terminal',
-    shiftLabel: 'SUNDSVALL · SHIFT 4',
-    kind: 'Triage shift',
-    duration: '4 min',
-    mechanic: 'Diagnose · Prioritise · Recover',
-    description: 'A scanner has stopped. Order the waiting promises, then choose how to recover.',
-    startScene: 'terminal',
+    title: 'Sweden by night',
+    place: 'National network',
+    shiftLabel: 'SWEDEN · SHIFT 4',
+    kind: 'National shift',
+    duration: '3–4 min',
+    mechanic: 'Town · Region · Sweden',
+    description: 'Feed Stockholm and Gothenburg while local work keeps arriving.',
+    startScene: 'sweden',
     tone: 'orange',
-    startTime: 14 * 60 + 6,
-    departure: 14 * 60 + 40,
-    metricLabels: ['Accuracy', 'Queue', 'At risk'],
-    metricIcons: ['◆', '▦', '!']
+    startTime: 21 * 60 + 5,
+    activeLevels: ['terminal', 'network', 'sweden'],
+    capacity: { terminal: 2, network: 2, sweden: 2 },
+    durationSeconds: 138,
+    promiseSeconds: 68,
+    jobs: 25,
+    spawnEvery: 5.15,
+    carriers: ['usp', 'nordpost', 'dlh', 'brang'],
+    destinations: ['stockholm', 'gothenburg', 'timra', 'stockholm', 'harnosand', 'gothenburg'],
+    directHigherEvery: 4,
+    incidents: [
+      { id: 'scanner-2', type: 'scanner-jam', level: 'terminal', target: 'scanner', at: 47 },
+      { id: 'dock-1', type: 'hub-gridlock', level: 'sweden', target: 'sweden-relief', at: 82 }
+    ]
   },
   {
-    id: 'priority-parcel',
+    id: 'friday-surge',
     number: 5,
-    title: 'Priority parcel',
-    place: 'Regional recovery',
-    shiftLabel: 'REGION MID · SHIFT 5',
-    kind: 'Investigation shift',
+    title: 'Friday surge',
+    place: 'National network',
+    shiftLabel: 'SWEDEN · FRIDAY SURGE',
+    kind: 'Peak shift',
     duration: '4 min',
-    mechanic: 'Trace · Deduce · Recover',
-    description: 'Find a temperature-controlled parcel from its scan trail and get it moving.',
-    startScene: 'case',
+    mechanic: 'All levels · Live disruptions',
+    description: 'Everything is open, everything is arriving, and every second matters.',
+    startScene: 'terminal',
     tone: 'pink',
-    startTime: 20 * 60 + 32,
-    departure: 21 * 60 + 10,
-    metricLabels: ['Cold chain', 'Min left', 'At risk'],
-    metricIcons: ['◇', '◷', '!']
+    startTime: 16 * 60 + 12,
+    activeLevels: ['terminal', 'network', 'sweden'],
+    capacity: { terminal: 2, network: 2, sweden: 2 },
+    durationSeconds: 168,
+    promiseSeconds: 62,
+    jobs: 32,
+    spawnEvery: 4.75,
+    carriers: ['nordpost', 'dlh', 'brang', 'usp'],
+    destinations: ['stockholm', 'harnosand', 'gothenburg', 'timra', 'centre', 'stockholm', 'matfors', 'gothenburg'],
+    directHigherEvery: 3,
+    incidents: [
+      { id: 'scanner-3', type: 'scanner-jam', level: 'terminal', target: 'scanner', at: 34 },
+      { id: 'snow-2', type: 'snow-route', level: 'network', target: 'network-detour', at: 73 },
+      { id: 'dock-2', type: 'hub-gridlock', level: 'sweden', target: 'sweden-relief', at: 112 }
+    ]
   }
 ]);
 
 const SHIFT_BY_ID = new Map(SHIFT_CATALOG.map((shift) => [shift.id, shift]));
+const TARGET_LABELS = Object.freeze({
+  'express-lane': 'Express A',
+  'standard-lane': 'Standard B',
+  'network-sundsvall': 'National gate',
+  'network-harnosand': 'Härnösand',
+  'network-timra': 'Timrå',
+  'network-matfors': 'Matfors',
+  'sweden-sundsvall': 'Sundsvall',
+  'sweden-stockholm': 'Stockholm',
+  'sweden-gothenburg': 'Gothenburg',
+  scanner: 'Scanner 2',
+  'network-detour': 'Inland road',
+  'sweden-relief': 'Relief dock'
+});
 
-const TRIAGE_VARIANTS = Object.freeze([
-  [
-    { id: 'medicine', label: 'Chilled medicine', promise: '28 min', priority: 1, tone: 'pink' },
-    { id: 'express', label: 'Express documents', promise: '51 min', priority: 2, tone: 'blue' },
-    { id: 'economy', label: 'Economy returns', promise: 'Tomorrow', priority: 3, tone: 'yellow' }
-  ],
-  [
-    { id: 'flight', label: 'Airport connection', promise: '19 min', priority: 1, tone: 'blue' },
-    { id: 'sample', label: 'Laboratory sample', promise: '44 min', priority: 2, tone: 'pink' },
-    { id: 'returns', label: 'Shop returns', promise: 'Tomorrow', priority: 3, tone: 'yellow' }
-  ],
-  [
-    { id: 'parts', label: 'Repair parts', promise: '24 min', priority: 1, tone: 'orange' },
-    { id: 'signed', label: 'Signed delivery', promise: '63 min', priority: 2, tone: 'blue' },
-    { id: 'catalogue', label: 'Catalogues', promise: '2 days', priority: 3, tone: 'yellow' }
-  ]
-]);
+const INCIDENT_LABELS = Object.freeze({
+  'scanner-jam': 'Scanner jam',
+  'snow-route': 'Snow on E4',
+  'hub-gridlock': 'National dock blocked'
+});
 
-const CASE_VARIANTS = Object.freeze([
-  {
-    parcelId: 'SE-8841-204',
-    correctLocation: 'dock-3',
-    evidence: ['Inbound scan · 20:11', 'No outbound confirmation', 'Handheld ping · Dock 3 · 20:18'],
-    locations: [
-      { id: 'dock-3', label: 'Dock 3' },
-      { id: 'truck-7', label: 'Truck 7' },
-      { id: 'timra', label: 'Timrå depot' }
-    ]
-  },
-  {
-    parcelId: 'SE-2930-117',
-    correctLocation: 'timra',
-    evidence: ['Sundsvall outbound · 20:05', 'Timrå arrival group · 20:21', 'No final cage scan'],
-    locations: [
-      { id: 'cage-4', label: 'Sundsvall cage 4' },
-      { id: 'timra', label: 'Timrå inbound' },
-      { id: 'truck-7', label: 'Truck 7' }
-    ]
-  },
-  {
-    parcelId: 'SE-7105-663',
-    correctLocation: 'truck-7',
-    evidence: ['Dock 3 scan · 20:09', 'Truck 7 load list · matched', 'No Härnösand arrival scan'],
-    locations: [
-      { id: 'truck-7', label: 'Truck 7' },
-      { id: 'harnosand', label: 'Härnösand depot' },
-      { id: 'dock-3', label: 'Dock 3' }
-    ]
-  }
-]);
+const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
 
 export function getShiftDefinition(id = 'first-rounds') {
   return SHIFT_BY_ID.get(id) || SHIFT_BY_ID.get('first-rounds');
@@ -157,302 +221,305 @@ export function formatClock(totalMinutes) {
   return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
 }
 
+export function formatSeconds(totalSeconds) {
+  const seconds = Math.max(0, Math.ceil(totalSeconds));
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}:${String(seconds % 60).padStart(2, '0')}`;
+}
+
 export function getStage(state) {
   if (state.completed) return 'complete';
   if (!state.started) return 'brief';
   return state.stage;
 }
 
-function baseState(shiftId, variant) {
+function destinationFor(id) {
+  return DESTINATIONS[id] || DESTINATIONS.centre;
+}
+
+function targetForJob(job, level = job.stage) {
+  if (level === 'terminal') return job.service === 'express' ? 'express-lane' : 'standard-lane';
+  if (level === 'network') {
+    return ['harnosand', 'timra', 'matfors'].includes(job.destinationId)
+      ? `network-${job.destinationId}`
+      : 'network-sundsvall';
+  }
+  if (level === 'sweden') return `sweden-${job.destinationId}`;
+  return '';
+}
+
+function buildJobs(shift, variant) {
+  const jobs = [];
+  for (let index = 0; index < shift.jobs; index += 1) {
+    const carrierId = shift.carriers[(index + variant) % shift.carriers.length];
+    const carrier = CARRIERS[carrierId];
+    const destinationStep = shift.destinations.length % 2 === 0 ? shift.destinations.length - 1 : 2;
+    const destinationId = shift.destinations[(index * destinationStep + variant) % shift.destinations.length];
+    const destination = destinationFor(destinationId);
+    let path = destination.path.filter((level) => shift.activeLevels.includes(level));
+    let directLevel = 0;
+    if (shift.directHigherEvery && index > 1 && (index + variant + 1) % shift.directHigherEvery === 0) {
+      directLevel = Math.min(path.length - 1, 1 + ((index + variant) % Math.max(1, path.length - 1)));
+    }
+    path = path.slice(directLevel);
+    const units = carrier.units[(index + variant * 2) % carrier.units.length];
+    const jitter = ((index * 17 + variant * 11) % 7) * 0.16;
+    const at = shift.id === 'first-rounds' ? 0 : 1.25 + index * shift.spawnEvery + jitter;
+    const service = index % 7 === 5
+      ? (carrier.defaultService === 'express' ? 'standard' : 'express')
+      : carrier.defaultService;
+    const promise = shift.promiseSeconds + carrier.promiseAdjust + path.length * 10 - units * 0.6;
+
+    jobs.push({
+      id: shift.id === 'first-rounds' ? 'TRAINING-01' : `${carrier.code}-${String(index + 1).padStart(2, '0')}`,
+      carrierId,
+      carrierName: carrier.name,
+      carrierCode: carrier.code,
+      carrierTone: carrier.tone,
+      destinationId,
+      destinationName: destination.name,
+      destinationCode: destination.code,
+      service,
+      units,
+      path,
+      pathIndex: 0,
+      stage: path[0],
+      target: '',
+      scheduledAt: at,
+      arrivedAt: null,
+      deadline: at + promise,
+      status: 'scheduled',
+      startedAt: null,
+      completesAt: null,
+      queueOrder: null,
+      deliveredAt: null,
+      late: false,
+      missed: false,
+      history: []
+    });
+  }
+  return jobs;
+}
+
+function buildIncidents(shift) {
+  return shift.incidents.map((incident) => ({
+    ...incident,
+    label: INCIDENT_LABELS[incident.type],
+    active: false,
+    resolved: false,
+    triggeredAt: null,
+    resolvedAt: null
+  }));
+}
+
+export function createInitialState(shiftId = 'first-rounds', variant = 0) {
   const shift = getShiftDefinition(shiftId);
+  const normalizedVariant = Math.max(0, Math.floor(variant || 0));
   return {
     shiftId: shift.id,
-    variant,
+    variant: normalizedVariant,
     started: false,
     completed: false,
     paused: true,
     speed: 1,
     stage: 'brief',
+    elapsed: 0,
     time: shift.startTime,
-    departure: shift.departure,
+    durationSeconds: shift.durationSeconds,
+    selectedJobId: null,
+    jobs: buildJobs(shift, normalizedVariant),
+    incidents: buildIncidents(shift),
+    capacity: { ...shift.capacity },
+    queueSequence: 0,
+    delivered: 0,
+    onTimeDelivered: 0,
+    missed: 0,
+    mistakes: 0,
+    combo: 0,
+    bestCombo: 0,
+    score: shift.id === 'first-rounds' ? 300 : 0,
     onTime: 100,
     backlog: 0,
     risk: 0,
-    score: 400,
-    saved: 0,
-    lateMinutes: 0,
-    lastMinute: Math.floor(shift.startTime),
     outcome: null,
-    events: [],
-    staffMoved: false,
-    truckHeld: false,
-    packageSelected: false,
-    signatureFound: false,
-    ruleFixed: false,
-    verified: 0,
-    expressCrew: 4,
-    standardCrew: 6,
-    expressLoad: 62,
-    standardLoad: 42,
-    downstreamMargin: 10,
-    laneInspected: false,
-    scannerInspected: false,
-    inspectedDepots: [],
-    allocation: null,
-    routeChoice: null,
-    delivered: 0,
-    deliveryTarget: 0,
-    triageQueue: [],
-    triageOrder: [],
-    triageMistakes: 0,
-    scannerFixed: false,
-    scannerBypassed: false,
-    processed: 0,
-    caseData: null,
-    clueChoice: null,
-    locationCorrect: false,
-    recoveryChoice: null,
-    deliveryProgress: 0
+    events: []
   };
 }
 
-export function createInitialState(shiftId = 'first-rounds', variant = 0) {
-  const normalizedVariant = Math.max(0, Math.floor(variant || 0));
-  const state = baseState(shiftId, normalizedVariant);
-
-  switch (state.shiftId) {
-    case 'first-rounds':
-      Object.assign(state, {
-        onTime: 98,
-        backlog: 6,
-        risk: 0,
-        score: 300,
-        expressCrew: 2,
-        standardCrew: 4,
-        expressLoad: 54,
-        standardLoad: 31
-      });
-      break;
-    case 'northbound':
-      Object.assign(state, {
-        onTime: 91,
-        backlog: 84,
-        risk: 18,
-        score: 600,
-        expressLoad: 92,
-        standardLoad: 43
-      });
-      break;
-    case 'snow-window':
-      Object.assign(state, {
-        onTime: 72,
-        backlog: 49,
-        risk: 23,
-        score: 520
-      });
-      break;
-    case 'scanner-fever':
-      Object.assign(state, {
-        onTime: 96,
-        backlog: 31,
-        risk: 7,
-        score: 500,
-        expressLoad: 84,
-        standardLoad: 69,
-        triageQueue: TRIAGE_VARIANTS[normalizedVariant % TRIAGE_VARIANTS.length].map((parcel) => ({ ...parcel }))
-      });
-      break;
-    case 'priority-parcel':
-      Object.assign(state, {
-        onTime: 100,
-        backlog: 38,
-        risk: 1,
-        score: 480,
-        packageSelected: false,
-        caseData: {
-          ...CASE_VARIANTS[normalizedVariant % CASE_VARIANTS.length],
-          evidence: [...CASE_VARIANTS[normalizedVariant % CASE_VARIANTS.length].evidence],
-          locations: CASE_VARIANTS[normalizedVariant % CASE_VARIANTS.length].locations.map((location) => ({ ...location }))
-        }
-      });
-      break;
-  }
-
-  return state;
+function cloneJob(job) {
+  return { ...job, path: [...job.path], history: [...job.history] };
 }
 
-function canRun(state) {
+function activeJobs(state) {
+  return state.jobs.filter((job) => !['scheduled', 'delivered', 'missed'].includes(job.status));
+}
+
+function busyAtLevel(state, level) {
+  return state.jobs.filter((job) => job.stage === level && job.status === 'processing').length;
+}
+
+function waitingAtLevel(state, level) {
+  return state.jobs.filter((job) => job.stage === level && ['waiting', 'queued'].includes(job.status)).length;
+}
+
+function canControlTime(state) {
   if (!state.started || state.completed) return false;
-  if (state.shiftId === 'northbound') return !['compare', 'rule', 'dispatch'].includes(state.stage);
-  return ['coach-watch', 'weather-run', 'jam-run', 'case-run'].includes(state.stage);
-}
-
-function activeHotspots(state) {
-  const stage = getStage(state);
-  switch (state.shiftId) {
-    case 'first-rounds':
-      if (stage === 'tour') return ['express-lane'];
-      if (stage === 'coach-move') return ['express-lane', 'standard-lane'];
-      if (stage === 'coach-scan') return ['scanner'];
-      if (stage === 'coach-watch') return ['express-lane', 'truck'];
-      if (stage === 'dispatch') return ['truck'];
-      return [];
-    case 'northbound': {
-      const network = ['network-sundsvall', 'network-harnosand', 'network-timra', 'network-matfors'];
-      if (stage === 'protect') return ['express-lane', 'standard-lane', 'truck', ...network];
-      if (stage === 'investigate') return ['parcel', 'express-lane', 'standard-lane', 'truck', ...network];
-      if (stage === 'compare') return ['case-package'];
-      if (stage === 'rule') return ['case-package', 'case-similar'];
-      if (stage === 'verify') return ['express-lane', 'standard-lane', 'truck', ...network];
-      if (stage === 'dispatch') return ['truck', ...network];
-      return [];
-    }
-    case 'snow-window':
-      return ['network-sundsvall', 'network-harnosand', 'network-timra', 'network-matfors'];
-    case 'scanner-fever':
-      if (stage === 'jam-diagnose') return ['scanner', 'parcel'];
-      if (stage === 'jam-triage' || stage === 'jam-repair') return ['scanner', 'parcel', 'express-lane', 'standard-lane'];
-      if (stage === 'jam-run' || stage === 'dispatch') return ['scanner', 'express-lane', 'standard-lane', 'truck'];
-      return [];
-    case 'priority-parcel':
-      if (stage === 'case-inspect' || stage === 'case-clue') return ['case-package'];
-      if (stage === 'case-plan' || stage === 'case-run' || stage === 'dispatch') {
-        return ['case-package', 'network-sundsvall', 'network-harnosand', 'network-timra', 'network-matfors'];
-      }
-      return [];
-    default:
-      return [];
-  }
+  if (state.shiftId !== 'first-rounds') return true;
+  return ['coach-town-run', 'coach-region-run'].includes(state.stage);
 }
 
 function availableScenes(state) {
-  switch (state.shiftId) {
-    case 'first-rounds':
-    case 'scanner-fever':
-      return ['terminal'];
-    case 'snow-window':
-      return ['network'];
-    case 'priority-parcel':
-      return state.stage === 'case-inspect' || state.stage === 'case-clue' ? ['case'] : ['case', 'network'];
-    case 'northbound':
-      return state.packageSelected ? ['terminal', 'network', 'case'] : ['terminal', 'network'];
-    default:
-      return ['terminal'];
+  const shift = getShiftDefinition(state.shiftId);
+  if (state.shiftId !== 'first-rounds') return [...shift.activeLevels];
+  if (['coach-open-region', 'coach-region-select', 'coach-region-target', 'coach-region-run', 'complete'].includes(getStage(state))) {
+    return ['terminal', 'network'];
   }
+  return ['terminal'];
+}
+
+function liveTargetIds(state) {
+  const ids = [];
+  const scenes = availableScenes(state);
+  if (scenes.includes('terminal')) ids.push('express-lane', 'standard-lane');
+  if (scenes.includes('network')) ids.push('network-sundsvall', 'network-harnosand', 'network-timra', 'network-matfors');
+  if (scenes.includes('sweden')) ids.push('sweden-sundsvall', 'sweden-stockholm', 'sweden-gothenburg');
+  return ids;
+}
+
+function activeHotspots(state) {
+  if (!state.started || state.completed) return [];
+  if (state.shiftId === 'first-rounds') {
+    if (state.stage === 'coach-town-target') return ['express-lane'];
+    if (state.stage === 'coach-region-target') return ['network-harnosand'];
+    return [];
+  }
+  return [
+    ...liveTargetIds(state),
+    ...state.incidents.filter((incident) => incident.active).map((incident) => incident.target)
+  ];
 }
 
 function hotspotPresentation(state) {
-  if (state.shiftId === 'first-rounds') {
-    return {
-      labels: { 'express-lane': '1 · Express A', 'standard-lane': 'Standard B', scanner: '3 · Scanner', truck: '4 · Send van' },
-      icons: { 'express-lane': '1', scanner: '3', truck: '4' }
-    };
-  }
-  if (state.shiftId === 'scanner-fever') {
-    return {
-      labels: { scanner: state.scannerFixed ? 'Scanner restored' : 'Scanner 2 · stopped', parcel: 'Blocked parcels' },
-      tones: { scanner: state.scannerFixed ? 'good' : 'danger', parcel: 'danger' },
-      icons: { scanner: state.scannerFixed ? '✓' : '!', parcel: '▦' }
-    };
-  }
-  if (state.shiftId === 'snow-window') {
-    return {
-      labels: {
-        'network-harnosand': 'Härnösand · 14 urgent',
-        'network-timra': 'Timrå · 26 waiting',
-        'network-matfors': 'Matfors · 9 waiting',
-        'network-sundsvall': 'Spare truck'
-      },
-      tones: {
-        'network-harnosand': state.allocation === 'harnosand' ? 'good' : 'danger',
-        'network-timra': state.allocation === 'timra' ? 'good' : 'yellow',
-        'network-matfors': state.routeChoice === 'inland' ? 'blue' : 'yellow'
-      }
-    };
-  }
-  if (state.shiftId === 'priority-parcel') {
-    return {
-      labels: {
-        'case-package': state.caseData?.parcelId || 'Priority parcel',
-        'network-sundsvall': 'Sundsvall',
-        'network-harnosand': 'Härnösand',
-        'network-timra': 'Timrå',
-        'network-matfors': 'Matfors'
-      },
-      tones: { 'case-package': state.locationCorrect ? 'good' : 'danger' }
-    };
-  }
-  return {
-    labels: {},
-    tones: {
-      parcel: state.ruleFixed ? 'good' : 'danger',
-      'network-harnosand': state.ruleFixed ? 'good' : 'danger'
-    },
-    icons: { 'network-harnosand': state.ruleFixed ? '✓' : '!' }
+  const labels = {};
+  const tones = {
+    'express-lane': 'blue',
+    'standard-lane': 'yellow',
+    'network-sundsvall': 'purple',
+    'network-harnosand': 'blue',
+    'network-timra': 'yellow',
+    'network-matfors': 'green',
+    'sweden-sundsvall': 'yellow',
+    'sweden-stockholm': 'blue',
+    'sweden-gothenburg': 'green'
   };
+  const icons = {};
+  const targetStatus = {};
+
+  for (const id of liveTargetIds(state)) {
+    const level = id.startsWith('network-') ? 'network' : id.startsWith('sweden-') ? 'sweden' : 'terminal';
+    const processing = state.jobs.filter((job) => job.target === id && job.status === 'processing').length;
+    const queued = state.jobs.filter((job) => job.target === id && job.status === 'queued').length;
+    const load = processing + queued;
+    labels[id] = load ? `${TARGET_LABELS[id]} · ${load}` : TARGET_LABELS[id];
+    icons[id] = processing ? '●' : queued ? '◷' : id.includes('lane') ? (id.startsWith('express') ? '↗' : '■') : '○';
+    targetStatus[id] = { level, processing, queued, label: TARGET_LABELS[id] };
+  }
+
+  for (const incident of state.incidents.filter((item) => item.active)) {
+    labels[incident.target] = incident.type === 'scanner-jam'
+      ? 'Clear scanner jam'
+      : incident.type === 'snow-route'
+        ? 'Open inland detour'
+        : 'Open relief dock';
+    tones[incident.target] = 'danger';
+    icons[incident.target] = '!';
+  }
+
+  return { labels, tones, icons, targetStatus };
+}
+
+function recalculate(state) {
+  const active = activeJobs(state);
+  state.delivered = state.jobs.filter((job) => job.status === 'delivered').length;
+  state.onTimeDelivered = state.jobs.filter((job) => job.status === 'delivered' && !job.late).length;
+  state.missed = state.jobs.filter((job) => job.status === 'missed').length;
+  state.backlog = active.length;
+  const resolved = state.delivered + state.missed;
+  state.onTime = resolved ? Math.round((state.onTimeDelivered / resolved) * 100) : 100;
+  const dueSoon = active.filter((job) => job.deadline - state.elapsed <= 12).length;
+  const activeIncidents = state.incidents.filter((incident) => incident.active).length;
+  state.risk = dueSoon + state.missed + activeIncidents * 2;
 }
 
 export class ShiftSimulation {
   constructor(onChange = () => {}, shiftId = 'first-rounds', options = {}) {
-    this.shiftId = getShiftDefinition(shiftId).id;
+    this.shift = getShiftDefinition(shiftId);
+    this.shiftId = this.shift.id;
     this.variant = Math.max(0, Math.floor(options.variant || 0));
     this.state = createInitialState(this.shiftId, this.variant);
     this.onChange = onChange;
-    this.progressAccumulator = 0;
   }
 
   emit(type, message = '', data = {}) {
+    recalculate(this.state);
     const event = { type, message, data, at: formatClock(this.state.time) };
-    this.state.events = [...this.state.events.slice(-15), event];
+    this.state.events = [...this.state.events.slice(-20), event];
     this.onChange(this.snapshot(), event);
     return event;
   }
 
   snapshot() {
+    recalculate(this.state);
     const presentation = hotspotPresentation(this.state);
+    const levelCounts = Object.fromEntries(LEVELS.map((level) => [level, waitingAtLevel(this.state, level)]));
+    const resourceStatus = Object.fromEntries(LEVELS.map((level) => [level, {
+      capacity: this.state.capacity[level] || 0,
+      busy: busyAtLevel(this.state, level),
+      waiting: waitingAtLevel(this.state, level)
+    }]));
+    const selectedJob = this.state.jobs.find((job) => job.id === this.state.selectedJobId) || null;
     return {
       ...this.state,
+      jobs: this.state.jobs.map(cloneJob),
+      incidents: this.state.incidents.map((incident) => ({ ...incident })),
+      capacity: { ...this.state.capacity },
       events: [...this.state.events],
-      inspectedDepots: [...this.state.inspectedDepots],
-      triageQueue: this.state.triageQueue.map((parcel) => ({ ...parcel })),
-      triageOrder: [...this.state.triageOrder],
-      caseData: this.state.caseData ? {
-        ...this.state.caseData,
-        evidence: [...this.state.caseData.evidence],
-        locations: this.state.caseData.locations.map((location) => ({ ...location }))
-      } : null,
       stage: getStage(this.state),
-      canRun: canRun(this.state),
+      canRun: canControlTime(this.state),
       activeHotspots: activeHotspots(this.state),
       availableScenes: availableScenes(this.state),
-      hotspotLabels: presentation.labels || {},
-      hotspotTones: presentation.tones || {},
-      hotspotIcons: presentation.icons || {}
+      hotspotLabels: presentation.labels,
+      hotspotTones: presentation.tones,
+      hotspotIcons: presentation.icons,
+      targetStatus: presentation.targetStatus,
+      levelCounts,
+      resourceStatus,
+      selectedJob: selectedJob ? cloneJob(selectedJob) : null,
+      remainingSeconds: Math.max(0, this.shift.durationSeconds - this.state.elapsed),
+      arrivalsComplete: this.state.jobs.every((job) => job.status !== 'scheduled')
     };
   }
 
   start() {
     if (this.state.started) return false;
     this.state.started = true;
-    this.state.score += 40;
-    const starts = {
-      'first-rounds': ['tour', true, 'First shift started. Begin with the blue Express lane.'],
-      northbound: ['protect', false, 'Northbound Express departs at 18:20.'],
-      'snow-window': ['weather-scan', true, 'Snow shift started. Inspect all three depots before assigning the spare truck.'],
-      'scanner-fever': ['jam-diagnose', true, 'Scanner 2 has stopped. Inspect the machine and the blocked flow.'],
-      'priority-parcel': ['case-inspect', true, 'Priority recovery started. Inspect the temperature-controlled parcel trail.']
-    };
-    const [stage, paused, message] = starts[this.state.shiftId];
-    this.state.stage = stage;
-    this.state.paused = paused;
-    this.emit('start', message);
+    this.spawnArrivals();
+    if (this.shiftId === 'first-rounds') {
+      this.state.stage = 'coach-select';
+      this.state.paused = true;
+      this.emit('start', 'First shift started. Select the waiting DLH parcel.');
+    } else {
+      this.state.stage = 'live';
+      this.state.paused = false;
+      this.emit('start', `${this.shift.title} is live.`);
+    }
     return true;
   }
 
   setPaused(paused) {
-    if (!canRun(this.state)) return false;
+    if (!canControlTime(this.state)) return false;
     this.state.paused = Boolean(paused);
-    this.emit(paused ? 'pause' : 'resume', paused ? 'Shift paused.' : `Shift running at ${this.state.speed} times speed.`);
+    this.emit(paused ? 'pause' : 'resume', paused ? 'Shift paused.' : `Live at ${this.state.speed} times speed.`);
     return true;
   }
 
@@ -461,445 +528,260 @@ export class ShiftSimulation {
   }
 
   setSpeed(speed) {
-    if (!canRun(this.state)) return false;
+    if (!canControlTime(this.state)) return false;
     this.state.speed = speed === 2 ? 2 : 1;
     this.state.paused = false;
-    this.emit('speed', `Shift running at ${this.state.speed} times speed.`);
+    this.emit('speed', `Live at ${this.state.speed} times speed.`);
     return true;
   }
 
   perform(action, value = null) {
     if (!this.state.started || this.state.completed) return false;
-    switch (this.state.shiftId) {
-      case 'first-rounds':
-        return this.performOnboarding(action);
-      case 'northbound':
-        return this.performNorthbound(action);
-      case 'snow-window':
-        return this.performSnow(action, value);
-      case 'scanner-fever':
-        return this.performScanner(action, value);
-      case 'priority-parcel':
-        return this.performPriority(action, value);
-      default:
-        return false;
-    }
+    if (action === 'select-job') return this.selectJob(value);
+    if (action === 'route-selected') return this.routeSelected(value);
+    if (action === 'resolve-incident') return this.resolveIncident(value);
+    if (action === 'visit-level') return this.visitLevel(value);
+    return false;
   }
 
-  performOnboarding(action) {
-    if (action === 'inspect-express' && this.state.stage === 'tour') {
-      this.state.laneInspected = true;
-      this.state.stage = 'coach-move';
-      this.state.score += 60;
-      this.emit('inspect', 'Express A carries the promises that leave first. Now give it the spare crew.');
+  selectJob(jobId) {
+    const job = this.state.jobs.find((item) => item.id === jobId);
+    if (!job || job.status !== 'waiting') return false;
+    this.state.selectedJobId = job.id;
+    if (this.shiftId === 'first-rounds') {
+      if (this.state.stage === 'coach-select' && job.stage === 'terminal') this.state.stage = 'coach-town-target';
+      else if (this.state.stage === 'coach-region-select' && job.stage === 'network') this.state.stage = 'coach-region-target';
+      else return false;
+    }
+    this.emit('select', `${job.carrierName} batch selected: ${job.destinationName}, ${job.units} parcels.`, { jobId });
+    return true;
+  }
+
+  routeSelected(target) {
+    const job = this.state.jobs.find((item) => item.id === this.state.selectedJobId);
+    if (!job || job.status !== 'waiting') return false;
+    const expected = targetForJob(job);
+    if (target !== expected) {
+      if (this.shiftId === 'first-rounds') return false;
+      this.state.mistakes += 1;
+      this.state.combo = 0;
+      this.state.score = Math.max(0, this.state.score - 35);
+      job.deadline -= 2;
+      this.emit('mistake', `${job.carrierCode} is marked for ${TARGET_LABELS[expected]}.`, { jobId: job.id, expected });
       return true;
     }
-    if (action === 'move-staff' && this.state.stage === 'coach-move') {
-      this.state.staffMoved = true;
-      this.state.expressCrew = 4;
-      this.state.standardCrew = 2;
-      this.state.expressLoad = 38;
-      this.state.standardLoad = 44;
-      this.state.stage = 'coach-scan';
-      this.state.score += 90;
-      this.emit('staff', 'Two operators moved to Express A. The blue lane is clearing.');
-      return true;
+
+    this.state.selectedJobId = null;
+    job.target = target;
+    job.queueOrder = ++this.state.queueSequence;
+    if (busyAtLevel(this.state, job.stage) < (this.state.capacity[job.stage] || 0)) {
+      this.startProcessing(job);
+    } else {
+      job.status = 'queued';
+      job.history.push(`${formatClock(this.state.time)} · queued for ${TARGET_LABELS[target]}`);
+      this.emit('queue', `${job.carrierCode} queued for ${TARGET_LABELS[target]}.`, { jobId: job.id, level: job.stage });
     }
-    if (action === 'inspect-scanner' && this.state.stage === 'coach-scan') {
-      this.state.scannerInspected = true;
-      this.state.stage = 'coach-run';
-      this.state.score += 60;
-      this.emit('inspect', 'The scanner reads each promise and sends the parcel to its lane. The flow is ready.');
-      return true;
-    }
-    if (action === 'resume' && this.state.stage === 'coach-run') {
-      this.state.stage = 'coach-watch';
+
+    if (this.shiftId === 'first-rounds') {
+      this.state.stage = job.stage === 'terminal' ? 'coach-town-run' : 'coach-region-run';
       this.state.paused = false;
-      this.emit('resume', 'Flow running. Watch six parcels reach the correct lane.');
-      return true;
     }
-    if (action === 'dispatch' && this.state.stage === 'dispatch') return this.finishShift();
-    return false;
+    return true;
   }
 
-  performNorthbound(action) {
-    if (action === 'move-staff' && !this.state.staffMoved && ['protect', 'investigate'].includes(this.state.stage)) {
-      this.state.staffMoved = true;
-      this.state.expressCrew = 6;
-      this.state.standardCrew = 4;
-      this.state.expressLoad = 68;
-      this.state.standardLoad = 57;
-      this.state.risk = Math.max(9, this.state.risk - 9);
-      this.state.backlog = Math.max(70, this.state.backlog - 13);
-      this.state.onTime = Math.max(this.state.onTime, 94);
-      this.state.stage = 'investigate';
-      this.state.score += 180;
-      this.emit('staff', 'Two operators moved to Express A. The immediate departure risk is falling.');
-      return true;
-    }
-    if (action === 'hold-truck' && this.state.stage === 'protect' && !this.state.truckHeld) {
-      this.state.truckHeld = true;
-      this.state.departure += 3;
-      this.state.downstreamMargin -= 3;
-      this.state.risk = Math.max(12, this.state.risk - 4);
-      this.state.score -= 60;
-      this.state.stage = 'investigate';
-      this.emit('hold', 'Truck held for three minutes. Current parcels gain time; the transfer loses margin.');
-      return true;
-    }
-    if (action === 'trace-package' && this.state.stage === 'investigate' && !this.state.packageSelected) {
-      this.state.packageSelected = true;
-      this.state.paused = true;
-      this.state.stage = 'compare';
-      this.state.score += 70;
-      this.emit('package', 'Parcel SE-0428-771 selected. The shift paused for inspection.');
-      return true;
-    }
-    if (action === 'find-similar' && this.state.stage === 'compare' && !this.state.signatureFound) {
-      this.state.signatureFound = true;
-      this.state.stage = 'rule';
-      this.state.score += 120;
-      this.emit('signature', 'Twelve matching Express parcels share the same after-17:30 fallback rule.');
-      return true;
-    }
-    if (action === 'fix-rule' && this.state.stage === 'rule' && !this.state.ruleFixed) {
-      this.state.ruleFixed = true;
-      this.state.paused = true;
-      this.state.stage = 'verify';
-      this.state.score += 300;
-      this.state.onTime = Math.max(this.state.onTime, 96);
-      this.emit('rule', 'Express service now takes priority over the north-zone fallback. Run the flow to verify it.');
-      return true;
-    }
-    if (action === 'resume' && this.state.stage === 'verify') return this.setPaused(false);
-    if (action === 'speed-up' && this.state.stage === 'verify') return this.setSpeed(2);
-    if (action === 'dispatch' && this.state.stage === 'dispatch') return this.finishShift();
-    return false;
+  startProcessing(job) {
+    job.status = 'processing';
+    job.startedAt = this.state.elapsed;
+    job.completesAt = this.state.elapsed + this.processingDuration(job);
+    job.history.push(`${formatClock(this.state.time)} · ${TARGET_LABELS[job.target]} started`);
+    this.emit('work', `${TARGET_LABELS[job.target]} started ${job.carrierCode}.`, { jobId: job.id, level: job.stage });
   }
 
-  performSnow(action, value) {
-    if (action === 'inspect-depot' && this.state.stage === 'weather-scan') {
-      if (!['harnosand', 'timra', 'matfors'].includes(value) || this.state.inspectedDepots.includes(value)) return false;
-      this.state.inspectedDepots = [...this.state.inspectedDepots, value];
-      const messages = {
-        harnosand: 'Härnösand: 14 urgent parcels, including blood samples due at 07:00.',
-        timra: 'Timrå: 26 standard parcels. Their promises allow a later departure.',
-        matfors: 'Matfors: 9 next-day parcels and the open inland road north.'
-      };
-      this.state.score += 35;
-      if (this.state.inspectedDepots.length === 3) this.state.stage = 'weather-allocate';
-      this.emit('inspect', messages[value]);
-      return true;
-    }
-    if (action === 'allocate-truck' && this.state.stage === 'weather-allocate') {
-      if (!['harnosand', 'timra', 'matfors'].includes(value)) return false;
-      this.state.allocation = value;
-      this.state.deliveryTarget = { harnosand: 14, timra: 26, matfors: 9 }[value];
-      this.state.risk = value === 'harnosand' ? 9 : 20;
-      this.state.score += value === 'harnosand' ? 220 : 70;
-      this.state.stage = 'weather-route';
-      this.emit('allocate', `The spare truck is assigned to ${value === 'harnosand' ? 'Härnösand' : value === 'timra' ? 'Timrå' : 'Matfors'}. Choose its road.`);
-      return true;
-    }
-    if (action === 'choose-route' && this.state.stage === 'weather-route') {
-      if (!['coast', 'inland'].includes(value)) return false;
-      this.state.routeChoice = value;
-      this.state.stage = 'weather-run';
-      this.state.paused = true;
-      this.state.risk += value === 'coast' ? 5 : -4;
-      this.state.score += value === 'inland' ? 180 : 40;
-      this.emit('route', value === 'inland'
-        ? 'The truck will detour inland via Matfors. Longer, but open and reliable.'
-        : 'The truck will test the snowy coast road. It is shorter, but delay risk remains.');
-      return true;
-    }
-    if (action === 'resume' && this.state.stage === 'weather-run') return this.setPaused(false);
-    if (action === 'speed-up' && this.state.stage === 'weather-run') return this.setSpeed(2);
-    if (action === 'dispatch' && this.state.stage === 'dispatch') return this.finishShift();
-    return false;
+  processingDuration(job) {
+    const base = { terminal: 5.2, network: 8.4, sweden: 10.8 }[job.stage] || 6;
+    const unitFactor = 1 + Math.max(0, job.units - 1) * 0.12;
+    const incident = this.state.incidents.find((item) => item.active && item.level === job.stage);
+    const incidentFactor = incident
+      ? incident.type === 'scanner-jam' ? 1.75 : incident.type === 'snow-route' ? 1.55 : 1.65
+      : 1;
+    return base * unitFactor * incidentFactor;
   }
 
-  performScanner(action, value) {
-    if (action === 'inspect-scanner' && this.state.stage === 'jam-diagnose') {
-      this.state.scannerInspected = true;
-      this.state.stage = 'jam-triage';
-      this.state.score += 75;
-      this.emit('inspect', 'A crushed label is blocking Scanner 2. Three promise groups are waiting for manual release.');
-      return true;
+  resolveIncident(target) {
+    const incident = this.state.incidents.find((item) => item.active && item.target === target);
+    if (!incident) return false;
+    incident.active = false;
+    incident.resolved = true;
+    incident.resolvedAt = this.state.elapsed;
+    this.state.score += 90;
+    for (const job of this.state.jobs.filter((item) => item.status === 'processing' && item.stage === incident.level)) {
+      const remaining = Math.max(0.5, job.completesAt - this.state.elapsed);
+      job.completesAt = this.state.elapsed + remaining * 0.72;
     }
-    if (action === 'prioritize' && this.state.stage === 'jam-triage') {
-      const parcel = this.state.triageQueue.find((item) => item.id === value);
-      if (!parcel || this.state.triageOrder.includes(value)) return false;
-      const expected = [...this.state.triageQueue].sort((a, b) => a.priority - b.priority)[this.state.triageOrder.length];
-      this.state.triageOrder = [...this.state.triageOrder, value];
-      if (expected.id === value) {
-        this.state.score += 70;
+    this.emit('repair', `${incident.label} cleared.`, { incidentId: incident.id, level: incident.level });
+    return true;
+  }
+
+  visitLevel(level) {
+    if (!availableScenes(this.state).includes(level)) return false;
+    const selected = this.state.jobs.find((job) => job.id === this.state.selectedJobId);
+    if (selected && selected.stage !== level) {
+      this.state.selectedJobId = null;
+      this.emit('deselect', `Selection cleared. ${selected.carrierCode} remains in ${LEVEL_LABELS[selected.stage]}.`);
+    }
+    if (this.shiftId === 'first-rounds' && this.state.stage === 'coach-open-region' && level === 'network') {
+      this.state.stage = 'coach-region-select';
+      this.emit('coach', 'Regional view open. Select the DLH batch waiting for Härnösand.');
+    }
+    return true;
+  }
+
+  spawnArrivals() {
+    let spawned = 0;
+    for (const job of this.state.jobs) {
+      if (job.status !== 'scheduled' || job.scheduledAt > this.state.elapsed) continue;
+      job.status = 'waiting';
+      job.arrivedAt = this.state.elapsed;
+      job.target = targetForJob(job);
+      job.history.push(`${formatClock(this.state.time)} · arrived at ${LEVEL_LABELS[job.stage]}`);
+      spawned += 1;
+    }
+    if (spawned && this.shiftId !== 'first-rounds') {
+      this.emit('arrival', `${spawned} new ${spawned === 1 ? 'batch' : 'batches'} arrived.`, { count: spawned });
+    }
+  }
+
+  triggerIncidents() {
+    for (const incident of this.state.incidents) {
+      if (incident.resolved || incident.active || incident.at > this.state.elapsed) continue;
+      incident.active = true;
+      incident.triggeredAt = this.state.elapsed;
+      this.emit('incident', `${incident.label} needs attention in ${LEVEL_LABELS[incident.level]}.`, {
+        incidentId: incident.id,
+        level: incident.level
+      });
+    }
+  }
+
+  completeProcessing() {
+    const completed = this.state.jobs
+      .filter((job) => job.status === 'processing' && job.completesAt <= this.state.elapsed)
+      .sort((a, b) => a.completesAt - b.completesAt);
+    for (const job of completed) this.advanceJob(job);
+    for (const level of LEVELS) this.startQueued(level);
+  }
+
+  advanceJob(job) {
+    job.pathIndex += 1;
+    job.startedAt = null;
+    job.completesAt = null;
+    job.queueOrder = null;
+    job.target = '';
+
+    if (job.pathIndex < job.path.length) {
+      job.stage = job.path[job.pathIndex];
+      job.status = 'waiting';
+      job.arrivedAt = this.state.elapsed;
+      job.target = targetForJob(job);
+      job.history.push(`${formatClock(this.state.time)} · ready in ${LEVEL_LABELS[job.stage]}`);
+      if (this.shiftId === 'first-rounds') {
+        this.state.stage = 'coach-open-region';
+        this.state.paused = true;
+        this.emit('coach', 'The town sort is complete. Open Region to finish the route.');
       } else {
-        this.state.triageMistakes += 1;
-        this.state.risk += 2;
-        this.state.score -= 25;
+        this.emit('handoff', `${job.carrierCode} reached ${LEVEL_LABELS[job.stage]}.`, { jobId: job.id, level: job.stage });
       }
-      if (this.state.triageOrder.length === this.state.triageQueue.length) this.state.stage = 'jam-repair';
-      this.emit('triage', `${parcel.label} released ${this.state.triageOrder.length} of ${this.state.triageQueue.length}.`);
-      return true;
+      return;
     }
-    if (action === 'repair-scanner' && this.state.stage === 'jam-repair') {
-      this.state.scannerFixed = true;
-      this.state.stage = 'jam-run';
-      this.state.paused = true;
-      this.state.risk = Math.max(2, this.state.risk - 5);
-      this.state.onTime = Math.max(97, this.state.onTime);
-      this.state.score += 230;
-      this.emit('repair', 'Crushed label cleared and Scanner 2 calibrated. Run the queue through it.');
-      return true;
+
+    job.status = 'delivered';
+    job.deliveredAt = this.state.elapsed;
+    job.late = job.deliveredAt > job.deadline;
+    job.history.push(`${formatClock(this.state.time)} · delivered${job.late ? ' late' : ' on time'}`);
+    if (job.late) {
+      this.state.combo = 0;
+      this.state.score = Math.max(0, this.state.score - 20);
+    } else {
+      this.state.combo += 1;
+      this.state.bestCombo = Math.max(this.state.bestCombo, this.state.combo);
+      const margin = Math.max(0, job.deadline - job.deliveredAt);
+      this.state.score += Math.round(90 + margin * 3 + Math.min(this.state.combo, 8) * 14);
     }
-    if (action === 'bypass-scanner' && this.state.stage === 'jam-repair') {
-      this.state.scannerBypassed = true;
-      this.state.stage = 'jam-run';
-      this.state.paused = true;
-      this.state.risk += 4;
-      this.state.onTime = 91;
-      this.state.score += 60;
-      this.emit('repair', 'The queue is moving through manual scan. It is faster now, but less accurate.');
-      return true;
+
+    if (this.shiftId === 'first-rounds') {
+      this.finishShift(true);
+    } else {
+      this.emit(job.late ? 'late' : 'delivered', `${job.carrierCode} reached ${job.destinationName}${job.late ? ' late' : ' on time'}.`, { jobId: job.id });
     }
-    if (action === 'resume' && this.state.stage === 'jam-run') return this.setPaused(false);
-    if (action === 'speed-up' && this.state.stage === 'jam-run') return this.setSpeed(2);
-    if (action === 'dispatch' && this.state.stage === 'dispatch') return this.finishShift();
-    return false;
   }
 
-  performPriority(action, value) {
-    if (action === 'inspect-case' && this.state.stage === 'case-inspect' && !this.state.packageSelected) {
-      this.state.packageSelected = true;
-      this.state.stage = 'case-clue';
-      this.state.score += 80;
-      this.emit('package', `${this.state.caseData.parcelId} scan trail opened. Three events narrow down its location.`);
-      return true;
+  startQueued(level) {
+    const capacity = this.state.capacity[level] || 0;
+    while (busyAtLevel(this.state, level) < capacity) {
+      const next = this.state.jobs
+        .filter((job) => job.stage === level && job.status === 'queued')
+        .sort((a, b) => a.queueOrder - b.queueOrder)[0];
+      if (!next) break;
+      this.startProcessing(next);
     }
-    if (action === 'choose-location' && this.state.stage === 'case-clue') {
-      if (!this.state.caseData.locations.some((location) => location.id === value)) return false;
-      this.state.clueChoice = value;
-      this.state.locationCorrect = value === this.state.caseData.correctLocation;
-      this.state.stage = 'case-plan';
-      this.state.score += this.state.locationCorrect ? 220 : 55;
-      this.state.risk += this.state.locationCorrect ? 0 : 2;
-      this.emit('deduce', this.state.locationCorrect
-        ? 'The scan trail fits. The parcel has been found and secured.'
-        : 'The team searched there first, then followed the handheld scan to the parcel. Time was lost.');
-      return true;
+  }
+
+  expirePromises() {
+    for (const job of activeJobs(this.state)) {
+      if (!job.late && this.state.elapsed > job.deadline) {
+        job.late = true;
+        this.state.combo = 0;
+        this.emit('warning', `${job.carrierCode} to ${job.destinationCode} is now late.`, { jobId: job.id, level: job.stage });
+      }
+      if (job.status === 'waiting' && this.state.elapsed > job.deadline + 28) {
+        job.status = 'missed';
+        job.missed = true;
+        if (this.state.selectedJobId === job.id) this.state.selectedJobId = null;
+        this.state.score = Math.max(0, this.state.score - 70);
+        this.emit('missed', `${job.carrierCode} collection left without its batch.`, { jobId: job.id, level: job.stage });
+      }
     }
-    if (action === 'choose-recovery' && this.state.stage === 'case-plan') {
-      if (!['courier', 'linehaul', 'scheduled'].includes(value)) return false;
-      this.state.recoveryChoice = value;
-      this.state.stage = 'case-run';
-      this.state.paused = true;
-      this.state.score += value === 'courier' ? 190 : value === 'linehaul' ? 90 : 20;
-      if (value === 'scheduled') this.state.risk += 3;
-      this.emit('route', {
-        courier: 'A direct courier has the parcel and active temperature control.',
-        linehaul: 'The linehaul is held for the handoff. It can make the promise with little margin.',
-        scheduled: 'The parcel joins the scheduled transfer. Its delivery promise is now at risk.'
-      }[value]);
-      return true;
+  }
+
+  shouldFinish() {
+    if (this.shiftId === 'first-rounds') return false;
+    const noFuture = this.state.jobs.every((job) => job.status !== 'scheduled');
+    const noActive = this.state.jobs.every((job) => ['delivered', 'missed'].includes(job.status));
+    return noFuture && noActive;
+  }
+
+  enforceHardStop() {
+    if (this.state.elapsed < this.shift.durationSeconds + 48) return;
+    for (const job of activeJobs(this.state)) {
+      job.status = 'missed';
+      job.missed = true;
     }
-    if (action === 'resume' && this.state.stage === 'case-run') return this.setPaused(false);
-    if (action === 'speed-up' && this.state.stage === 'case-run') return this.setSpeed(2);
-    if (action === 'dispatch' && this.state.stage === 'dispatch') return this.finishShift();
-    return false;
-  }
-
-  moveStaff() {
-    return this.perform('move-staff');
-  }
-
-  holdTruck() {
-    return this.perform('hold-truck');
-  }
-
-  selectPackage() {
-    return this.perform(this.state.shiftId === 'priority-parcel' ? 'inspect-case' : 'trace-package');
-  }
-
-  findSimilar() {
-    return this.perform('find-similar');
-  }
-
-  fixRule() {
-    return this.perform('fix-rule');
-  }
-
-  completeShift() {
-    return this.perform('dispatch');
   }
 
   tick(realSeconds) {
-    if (!this.state.started || this.state.paused || this.state.completed || !canRun(this.state)) return;
-    const gameMinutes = Math.max(0, realSeconds) * this.state.speed * 0.24;
-    this.state.time += gameMinutes;
-
-    switch (this.state.shiftId) {
-      case 'first-rounds':
-        this.tickOnboarding(gameMinutes);
-        break;
-      case 'northbound':
-        this.tickNorthbound(gameMinutes);
-        break;
-      case 'snow-window':
-        this.tickSnow(gameMinutes);
-        break;
-      case 'scanner-fever':
-        this.tickScanner(gameMinutes);
-        break;
-      case 'priority-parcel':
-        this.tickPriority(gameMinutes);
-        break;
+    if (!this.state.started || this.state.paused || this.state.completed || !canControlTime(this.state)) return;
+    let remaining = Math.max(0, realSeconds) * this.state.speed;
+    while (remaining > 0 && !this.state.completed && !this.state.paused) {
+      const step = Math.min(0.25, remaining);
+      remaining -= step;
+      this.state.elapsed += step;
+      this.state.time = this.shift.startTime + this.state.elapsed * 0.42;
+      this.spawnArrivals();
+      this.triggerIncidents();
+      this.completeProcessing();
+      this.expirePromises();
+      this.enforceHardStop();
+      if (this.shouldFinish()) this.finishShift(true);
     }
-
-    this.onChange(this.snapshot(), { type: 'tick' });
+    if (!this.state.completed) this.onChange(this.snapshot(), { type: 'tick' });
   }
 
-  tickOnboarding(gameMinutes) {
-    this.progressAccumulator += gameMinutes;
-    while (this.progressAccumulator >= 0.62 && this.state.verified < ONBOARDING_VERIFY_TARGET) {
-      this.progressAccumulator -= 0.62;
-      this.state.verified += 1;
-      this.state.backlog = Math.max(0, ONBOARDING_VERIFY_TARGET - this.state.verified);
-      this.state.score += 12;
-    }
-    if (this.state.verified === ONBOARDING_VERIFY_TARGET && this.state.stage === 'coach-watch') {
-      this.state.stage = 'dispatch';
-      this.state.paused = true;
-      this.emit('verified', 'Six promises reached the right lane. The morning van is ready.');
-    }
-  }
-
-  tickNorthbound(gameMinutes) {
-    if (this.state.ruleFixed) {
-      this.progressAccumulator += gameMinutes;
-      while (this.progressAccumulator >= 0.72 && this.state.verified < VERIFY_TARGET) {
-        this.progressAccumulator -= 0.72;
-        this.state.verified += 1;
-        this.state.risk = Math.max(2, this.state.risk - (this.state.verified % 3 === 0 ? 1 : 0));
-        this.state.backlog = Math.max(52, this.state.backlog - 1);
-        this.state.score += 8;
-      }
-      if (this.state.verified === VERIFY_TARGET && this.state.stage === 'verify') {
-        this.state.onTime = Math.max(this.state.onTime, this.state.staffMoved ? 98 : 95);
-        this.state.stage = 'dispatch';
-        this.state.paused = true;
-        this.emit('verified', 'Twelve later parcels reached Express A correctly. The recurring failure has stopped.');
-      }
-    }
-
-    const minute = Math.floor(this.state.time);
-    while (this.state.lastMinute < minute) {
-      this.state.lastMinute += 1;
-      this.stepNorthboundMinute();
-    }
-
-    if (this.state.time >= this.state.departure && this.state.verified < VERIFY_TARGET) {
-      this.state.lateMinutes = Math.floor(this.state.time - this.state.departure) + 1;
-      this.state.onTime = clamp(this.state.onTime - 0.18 * gameMinutes, 72, 100);
-    }
-  }
-
-  stepNorthboundMinute() {
-    if (!this.state.staffMoved) {
-      this.state.expressLoad = clamp(this.state.expressLoad + 0.55, 0, 100);
-      this.state.backlog = clamp(this.state.backlog + 1, 0, 999);
-      if (!this.state.ruleFixed && this.state.lastMinute % 3 === 0) {
-        this.state.risk = clamp(this.state.risk + 1, 0, 99);
-        this.state.onTime = clamp(this.state.onTime - 0.2, 0, 100);
-      }
-    } else {
-      this.state.expressLoad = clamp(this.state.expressLoad - 0.38, 42, 100);
-      if (this.state.lastMinute % 2 === 0) this.state.backlog = Math.max(52, this.state.backlog - 1);
-      if (this.state.ruleFixed && this.state.lastMinute % 2 === 0) this.state.risk = Math.max(2, this.state.risk - 1);
-    }
-  }
-
-  tickSnow(gameMinutes) {
-    const reliability = this.state.routeChoice === 'inland' ? 1 : 0.62;
-    this.progressAccumulator += gameMinutes * reliability;
-    while (this.progressAccumulator >= 0.62 && this.state.delivered < this.state.deliveryTarget) {
-      this.progressAccumulator -= 0.62;
-      this.state.delivered += 1;
-      this.state.backlog = Math.max(0, this.state.backlog - 1);
-      if (this.state.delivered % 3 === 0) this.state.risk = Math.max(this.state.allocation === 'harnosand' ? 2 : 9, this.state.risk - 1);
-      this.state.score += 9;
-    }
-    this.state.onTime = clamp(72 + (this.state.delivered / Math.max(1, this.state.deliveryTarget)) * 26, 0, 99);
-    if (this.state.delivered === this.state.deliveryTarget && this.state.stage === 'weather-run') {
-      this.state.stage = 'dispatch';
-      this.state.paused = true;
-      this.emit('verified', 'The assigned parcels reached their depot. The weather window is closing behind the truck.');
-    }
-  }
-
-  tickScanner(gameMinutes) {
-    const rate = this.state.scannerFixed ? 1 : 0.72;
-    this.progressAccumulator += gameMinutes * rate;
-    while (this.progressAccumulator >= 0.45 && this.state.processed < 31) {
-      this.progressAccumulator -= 0.45;
-      this.state.processed += 1;
-      this.state.backlog = Math.max(0, 31 - this.state.processed);
-      if (this.state.processed % 5 === 0) this.state.risk = Math.max(this.state.scannerFixed ? 1 : 4, this.state.risk - 1);
-      this.state.score += this.state.scannerFixed ? 8 : 4;
-    }
-    if (this.state.processed === 31 && this.state.stage === 'jam-run') {
-      this.state.stage = 'dispatch';
-      this.state.paused = true;
-      this.emit('verified', 'The full queue has cleared. Scanner accuracy is stable.');
-    }
-  }
-
-  tickPriority(gameMinutes) {
-    const rate = { courier: 4.8, linehaul: 3.4, scheduled: 2.35 }[this.state.recoveryChoice] || 0;
-    this.state.deliveryProgress = clamp(this.state.deliveryProgress + gameMinutes * rate, 0, 100);
-    this.state.backlog = Math.max(0, Math.ceil(this.state.departure - this.state.time));
-    if (this.state.time > this.state.departure) {
-      this.state.risk = Math.max(2, this.state.risk + gameMinutes * 0.12);
-      this.state.onTime = clamp(this.state.onTime - gameMinutes * 0.5, 70, 100);
-    }
-    if (this.state.deliveryProgress >= 100 && this.state.stage === 'case-run') {
-      this.state.deliveryProgress = 100;
-      this.state.stage = 'dispatch';
-      this.state.paused = true;
-      this.emit('verified', 'The recipient has the parcel. Temperature remained inside the safe range.');
-    }
-  }
-
-  finishShift() {
-    if (this.state.completed || this.state.stage !== 'dispatch') return false;
+  finishShift(force = false) {
+    if (this.state.completed || (!force && !this.shouldFinish())) return false;
     this.state.completed = true;
     this.state.paused = true;
-    this.state.lateMinutes = Math.max(0, Math.floor(this.state.time - this.state.departure));
-
-    if (this.state.shiftId === 'northbound') {
-      this.state.time = Math.max(this.state.time, this.state.departure);
-      this.state.saved = Math.max(12, 18 - this.state.lateMinutes * 2);
-      this.state.risk = Math.max(0, 18 - this.state.saved);
-      this.state.backlog = Math.max(48, this.state.backlog - 8);
-      this.state.onTime = clamp(this.state.onTime - this.state.lateMinutes * 2, 0, 99);
-      if (!this.state.truckHeld) this.state.score += 120;
-      if (this.state.lateMinutes === 0) this.state.score += 140;
-    } else if (this.state.shiftId === 'first-rounds') {
-      this.state.saved = ONBOARDING_VERIFY_TARGET;
-      this.state.onTime = 100;
-      this.state.score += 120;
-    } else if (this.state.shiftId === 'snow-window') {
-      this.state.saved = this.state.delivered;
-      if (this.state.allocation === 'harnosand') this.state.score += 120;
-    } else if (this.state.shiftId === 'scanner-fever') {
-      this.state.saved = this.state.processed;
-      if (this.state.scannerFixed) this.state.score += 100;
-    } else if (this.state.shiftId === 'priority-parcel') {
-      this.state.saved = 1;
-      this.state.onTime = this.state.recoveryChoice === 'courier' ? 100 : this.state.recoveryChoice === 'linehaul' ? 96 : 86;
-    }
-
-    this.state.score = Math.max(0, Math.round(this.state.score));
+    this.state.stage = 'complete';
+    recalculate(this.state);
     this.state.outcome = createOutcome(this.state);
     this.emit('complete', this.state.outcome.summary);
     return true;
@@ -907,126 +789,60 @@ export class ShiftSimulation {
 
   reset() {
     this.state = createInitialState(this.shiftId, this.variant);
-    this.progressAccumulator = 0;
-    this.emit('reset', 'Shift reset.');
+    this.emit('reset');
   }
 }
 
 export function createOutcome(state) {
   if (state.shiftId === 'first-rounds') {
     return {
+      kicker: 'FIRST SHIFT COMPLETE',
       grade: '✓',
       gradeLabel: 'Training complete',
-      kicker: 'FIRST SHIFT COMPLETE',
-      title: 'You are on the roster.',
-      summary: 'You read the flow, moved the team, checked the scanner and sent the van. Four very different shifts are now open.',
-      medals: [
-        { icon: '1', label: 'First shift' },
-        { icon: '↗', label: 'Promises moving' }
-      ],
+      title: 'You have the route.',
+      summary: 'Select the batch, tap its marked destination, and keep an eye on every level. The live shifts are open.',
+      score: state.score,
       stats: [
-        { label: 'Parcels', value: '6 / 6' },
-        { label: 'On time', value: '100%' },
-        { label: 'Score', value: state.score.toLocaleString('en-SE') }
+        { label: 'Town sort', value: 'Done' },
+        { label: 'Regional route', value: 'Done' },
+        { label: 'Pressure', value: 'None' }
       ],
-      score: state.score
+      medals: [{ icon: '↗', label: 'Ready for live work' }]
     };
   }
 
-  if (state.shiftId === 'northbound') {
-    const cleanFix = state.ruleFixed && state.staffMoved;
-    const onTime = state.lateMinutes === 0;
-    const grade = cleanFix && onTime && !state.truckHeld ? 'A+' : cleanFix && onTime ? 'A' : onTime ? 'B' : 'C';
-    const medals = [];
-    if (state.staffMoved) medals.push({ icon: '↔', label: 'Crew whisperer' });
-    if (state.ruleFixed) medals.push({ icon: '◆', label: 'Root cause found' });
-    if (!state.truckHeld) medals.push({ icon: '↗', label: 'Clean departure' });
-    return {
-      grade,
-      gradeLabel: `Grade ${grade}`,
-      kicker: 'SHIFT COMPLETE',
-      title: 'Promises kept.',
-      summary: onTime
-        ? 'The northbound truck left on time and the recurring routing error is gone.'
-        : `The error is gone. The truck left ${state.lateMinutes} minutes late, with recovery already under way.`,
-      medals,
-      stats: [
-        { label: 'Saved', value: String(state.saved) },
-        { label: 'On time', value: `${Math.round(state.onTime)}%` },
-        { label: 'Score', value: state.score.toLocaleString('en-SE') }
-      ],
-      score: state.score
-    };
-  }
+  recalculate(state);
+  const totalResolved = state.delivered + state.missed;
+  const service = totalResolved ? Math.round((state.onTimeDelivered / totalResolved) * 100) : 0;
+  const grade = service >= 94 && state.missed === 0 && state.mistakes <= 1
+    ? 'A+'
+    : service >= 86 && state.missed <= 1
+      ? 'A'
+      : service >= 74
+        ? 'B'
+        : service >= 60
+          ? 'C'
+          : 'D';
+  const title = grade === 'A+' ? 'The network sang.' : grade === 'A' ? 'Promises kept.' : grade === 'B' ? 'A solid recovery.' : 'The backlog bit back.';
+  const summary = `${state.onTimeDelivered} of ${totalResolved} batches made their promise across the live network.`;
+  const medals = [];
+  if (state.missed === 0) medals.push({ icon: '✓', label: 'Nothing left behind' });
+  if (state.mistakes === 0 && state.delivered > 0 && state.missed === 0) medals.push({ icon: '◆', label: 'Perfect sorting' });
+  if (state.bestCombo >= 6) medals.push({ icon: '×', label: `${state.bestCombo} flow combo` });
+  if (state.incidents.length && state.incidents.every((incident) => incident.resolved)) medals.push({ icon: '!', label: 'Every disruption cleared' });
 
-  if (state.shiftId === 'snow-window') {
-    const urgentFirst = state.allocation === 'harnosand';
-    const reliableRoute = state.routeChoice === 'inland';
-    const grade = urgentFirst && reliableRoute ? 'A+' : urgentFirst || reliableRoute ? 'A' : 'B';
-    return {
-      grade,
-      gradeLabel: `Grade ${grade}`,
-      kicker: 'WEATHER WINDOW CLOSED',
-      title: urgentFirst ? 'The urgent load got through.' : 'The network adapted.',
-      summary: urgentFirst
-        ? 'The spare truck protected the most time-sensitive promises before the snow closed in.'
-        : 'The assigned route moved, but the urgent Härnösand promises needed a second recovery plan.',
-      medals: [
-        reliableRoute ? { icon: '⌁', label: 'Inland navigator' } : { icon: '❄', label: 'Snow runner' },
-        urgentFirst ? { icon: '◇', label: 'Urgent first' } : { icon: '▰', label: 'Capacity moved' }
-      ],
-      stats: [
-        { label: 'Delivered', value: String(state.delivered) },
-        { label: 'Coverage', value: `${Math.round(state.onTime)}%` },
-        { label: 'Score', value: state.score.toLocaleString('en-SE') }
-      ],
-      score: state.score
-    };
-  }
-
-  if (state.shiftId === 'scanner-fever') {
-    const grade = state.scannerFixed && state.triageMistakes === 0 ? 'A+' : state.scannerFixed ? 'A' : state.triageMistakes <= 1 ? 'B' : 'C';
-    return {
-      grade,
-      gradeLabel: `Grade ${grade}`,
-      kicker: 'QUEUE CLEARED',
-      title: state.scannerFixed ? 'Scanner 2 is healthy.' : 'Manual flow held the line.',
-      summary: state.scannerFixed
-        ? 'The right promises moved first, the obstruction is gone and automated accuracy is restored.'
-        : 'The queue moved, but the next shift still needs to repair and recalibrate the scanner.',
-      medals: [
-        state.triageMistakes === 0 ? { icon: '1', label: 'Perfect priority' } : { icon: '▦', label: 'Queue cleared' },
-        state.scannerFixed ? { icon: '◆', label: 'Clean repair' } : { icon: '↔', label: 'Manual recovery' }
-      ],
-      stats: [
-        { label: 'Processed', value: String(state.processed) },
-        { label: 'Accuracy', value: `${Math.round(state.onTime)}%` },
-        { label: 'Score', value: state.score.toLocaleString('en-SE') }
-      ],
-      score: state.score
-    };
-  }
-
-  const correctFind = state.locationCorrect;
-  const direct = state.recoveryChoice === 'courier';
-  const grade = correctFind && direct ? 'A+' : correctFind || direct ? 'A' : state.recoveryChoice === 'linehaul' ? 'B' : 'C';
   return {
+    kicker: 'SHIFT COMPLETE',
     grade,
     gradeLabel: `Grade ${grade}`,
-    kicker: 'DELIVERY CONFIRMED',
-    title: 'Cold chain intact.',
-    summary: correctFind && direct
-      ? 'The scan trail led straight to the parcel and a direct courier protected every minute of its promise.'
-      : 'The parcel arrived safely. The recovery took a detour, but its temperature stayed inside range.',
-    medals: [
-      correctFind ? { icon: '◇', label: 'Sharp detective' } : { icon: '□', label: 'Parcel recovered' },
-      direct ? { icon: '↗', label: 'Direct handoff' } : { icon: '⌁', label: 'Connection made' }
-    ],
+    title,
+    summary,
+    score: Math.round(state.score),
     stats: [
-      { label: 'Delivered', value: '1 / 1' },
-      { label: 'Cold chain', value: `${Math.round(state.onTime)}%` },
-      { label: 'Score', value: state.score.toLocaleString('en-SE') }
+      { label: 'On time', value: `${service}%` },
+      { label: 'Delivered', value: state.delivered },
+      { label: 'Best combo', value: `${state.bestCombo}×` }
     ],
-    score: state.score
+    medals: medals.length ? medals : [{ icon: '↗', label: 'Shift completed' }]
   };
 }

--- a/postal/styles.css
+++ b/postal/styles.css
@@ -1853,3 +1853,388 @@ tbody tr:last-child td {
     forced-color-adjust: none;
   }
 }
+
+/* Live operations — the parcel batches are the game controls. */
+.operation-layer {
+  position: absolute;
+  z-index: 12;
+  right: 8px;
+  bottom: 8px;
+  left: 8px;
+  display: grid;
+  gap: 5px;
+  pointer-events: none;
+}
+
+.operation-layer[hidden],
+.operation-empty[hidden],
+.parcel-rack[hidden],
+.fallback-targets[hidden] {
+  display: none;
+}
+
+.operation-head {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 8px;
+  color: white;
+  filter: drop-shadow(0 2px 0 rgb(16 19 26 / 0.9));
+}
+
+.operation-head > div {
+  display: grid;
+}
+
+.operation-level {
+  font-size: 0.5rem;
+  font-weight: 1000;
+  letter-spacing: 0.12em;
+}
+
+.operation-head strong {
+  font-size: 0.8rem;
+  line-height: 1;
+}
+
+.resource-chip {
+  padding: 4px 7px;
+  border: 2px solid var(--ink);
+  border-radius: 999px;
+  background: rgb(255 248 232 / 0.95);
+  color: var(--ink);
+  font-size: 0.55rem;
+  font-weight: 950;
+  filter: none;
+  box-shadow: 2px 2px 0 var(--ink);
+}
+
+.parcel-rack {
+  display: flex;
+  gap: 7px;
+  min-width: 0;
+  padding: 2px 4px 5px 1px;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  scroll-snap-type: x proximity;
+  scrollbar-color: var(--yellow) rgb(16 19 26 / 0.4);
+  pointer-events: auto;
+}
+
+.parcel-batch {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-rows: auto 1fr auto;
+  width: 94px;
+  min-width: 94px;
+  height: 88px;
+  padding: 5px 6px 8px;
+  overflow: hidden;
+  border: 2px solid var(--ink);
+  border-radius: 12px;
+  background: var(--paper-bright);
+  box-shadow: 3px 3px 0 var(--ink);
+  scroll-snap-align: start;
+  text-align: left;
+}
+
+.parcel-batch::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  height: 7px;
+  border-bottom: 2px solid var(--ink);
+  background: var(--yellow);
+}
+
+.parcel-batch[data-tone="red"]::before { background: var(--red); }
+.parcel-batch[data-tone="green"]::before { background: var(--green); }
+.parcel-batch[data-tone="blue"]::before { background: var(--blue); }
+
+.parcel-batch[aria-pressed="true"] {
+  background: #e9e4ff;
+  outline: 4px solid var(--yellow);
+  outline-offset: -5px;
+  transform: translateY(-3px);
+}
+
+.parcel-batch[data-status="queued"] {
+  background: #fff1b8;
+}
+
+.parcel-batch[data-status="processing"] {
+  background: #d7f4df;
+}
+
+.parcel-batch[disabled] {
+  opacity: 0.92;
+  cursor: default;
+}
+
+.carrier-code {
+  z-index: 1;
+  grid-column: 1 / -1;
+  margin-top: 5px;
+  font-size: 0.5rem;
+  font-weight: 1000;
+  letter-spacing: 0.05em;
+}
+
+.parcel-cube {
+  position: relative;
+  display: block;
+  width: 28px;
+  height: 25px;
+  align-self: center;
+  border: 2px solid var(--ink);
+  border-radius: 4px;
+  background: var(--yellow);
+  box-shadow: 2px 2px 0 rgb(16 19 26 / 0.28);
+}
+
+.parcel-cube::before {
+  content: "";
+  position: absolute;
+  top: -2px;
+  left: 8px;
+  width: 7px;
+  height: 25px;
+  border-inline: 1px solid var(--ink);
+  background: var(--paper-bright);
+}
+
+.parcel-cube i {
+  position: absolute;
+  z-index: 1;
+  right: 2px;
+  bottom: 3px;
+  width: 7px;
+  height: 5px;
+  border: 1px solid var(--ink);
+  background: var(--paper-bright);
+}
+
+.parcel-cube[data-service="express"] {
+  background: var(--blue);
+}
+
+.parcel-route {
+  display: grid;
+  min-width: 0;
+  align-self: center;
+  justify-items: end;
+}
+
+.parcel-route strong {
+  font-size: 0.68rem;
+  font-weight: 1000;
+  line-height: 1;
+}
+
+.parcel-route small {
+  max-width: 48px;
+  overflow: hidden;
+  font-size: 0.48rem;
+  font-weight: 900;
+  text-overflow: ellipsis;
+}
+
+.parcel-deadline {
+  grid-column: 1 / -1;
+  justify-self: end;
+  font-size: 0.58rem;
+  font-weight: 1000;
+  font-variant-numeric: tabular-nums;
+}
+
+.parcel-deadline[data-late="true"] {
+  padding-inline: 3px;
+  background: var(--red);
+}
+
+.parcel-progress {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 5px;
+  border-top: 1px solid var(--ink);
+  background: var(--paper-dim);
+}
+
+.parcel-progress i {
+  display: block;
+  width: 0;
+  height: 100%;
+  background: var(--green-deep);
+  transition: width 120ms linear;
+}
+
+.operation-empty {
+  width: fit-content;
+  margin: 0;
+  padding: 7px 10px;
+  border: 2px solid var(--ink);
+  border-radius: 999px;
+  background: rgb(121 226 159 / 0.94);
+  font-size: 0.65rem;
+  font-weight: 950;
+  box-shadow: 2px 2px 0 var(--ink);
+  pointer-events: none;
+}
+
+.fallback-targets {
+  display: flex;
+  gap: 6px;
+  min-width: 0;
+  padding: 2px 3px 5px 1px;
+  overflow-x: auto;
+  pointer-events: auto;
+}
+
+.fallback-targets button {
+  min-width: max-content;
+  min-height: 44px;
+  padding: 7px 10px;
+  border: 2px solid var(--ink);
+  border-radius: 999px;
+  background: var(--paper-bright);
+  font-size: 0.62rem;
+  font-weight: 1000;
+  box-shadow: 2px 2px 0 var(--ink);
+}
+
+.fallback-targets button[data-tone="blue"] { background: #d6f5ff; }
+.fallback-targets button[data-tone="yellow"] { background: #fff1a6; }
+.fallback-targets button[data-tone="green"],
+.fallback-targets button[data-tone="good"] { background: #cdf6d9; }
+.fallback-targets button[data-tone="danger"] { background: #ffd5ca; }
+
+.tab-count {
+  position: absolute;
+  top: 3px;
+  right: 11%;
+  display: grid;
+  min-width: 20px;
+  height: 20px;
+  place-items: center;
+  padding-inline: 3px;
+  border: 2px solid var(--ink);
+  border-radius: 999px;
+  background: var(--yellow);
+  font-size: 0.52rem;
+  font-weight: 1000;
+  line-height: 1;
+}
+
+.tab-count[hidden] {
+  display: none;
+}
+
+.tab-count[data-danger="true"] {
+  background: var(--red);
+  animation: beacon-pulse 800ms ease-in-out infinite alternate;
+}
+
+.game-shell[data-play-mode="live"] .command-deck {
+  min-height: 88px;
+  padding-block: 10px 8px;
+}
+
+.command-content[data-layout="live"] {
+  grid-template-columns: minmax(0, 1fr) auto;
+  min-height: 65px;
+  gap: 10px;
+}
+
+.command-content[data-layout="live"] .command-copy h1 {
+  font-size: clamp(0.92rem, 4vw, 1.14rem);
+}
+
+.command-content[data-layout="live"] .command-copy p {
+  margin-top: 3px;
+  font-size: 0.68rem;
+  -webkit-line-clamp: 1;
+}
+
+.command-content[data-layout="live"] .command-actions {
+  min-width: 82px;
+  justify-items: end;
+}
+
+.carrier-legend {
+  display: grid;
+  grid-template-columns: repeat(2, 33px);
+  gap: 4px;
+}
+
+.carrier-legend span {
+  display: grid;
+  height: 25px;
+  place-items: center;
+  border: 2px solid var(--ink);
+  border-radius: 7px;
+  background: var(--yellow);
+  font-size: 0.48rem;
+  font-weight: 1000;
+}
+
+.carrier-legend span[data-tone="red"] { background: var(--red); }
+.carrier-legend span[data-tone="green"] { background: var(--green); }
+.carrier-legend span[data-tone="blue"] { background: var(--blue); }
+
+.live-alert {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 7px;
+  border: 2px solid var(--ink);
+  border-radius: 9px;
+  background: #ffd5ca;
+  font-size: 0.58rem;
+  font-weight: 1000;
+}
+
+.live-alert > span {
+  display: grid;
+  width: 21px;
+  height: 21px;
+  place-items: center;
+  border: 2px solid var(--ink);
+  border-radius: 50%;
+  background: var(--red);
+}
+
+.shift-card[disabled] {
+  opacity: 0.56;
+  filter: grayscale(0.5);
+  box-shadow: none;
+}
+
+@media (max-height: 700px) {
+  .game-shell[data-play-mode="live"] .command-deck {
+    min-height: 76px;
+    padding-block: 7px 6px;
+  }
+
+  .command-content[data-layout="live"] {
+    min-height: 58px;
+  }
+
+  .parcel-batch {
+    width: 88px;
+    min-width: 88px;
+    height: 80px;
+  }
+}
+
+@media (forced-colors: active) {
+  .parcel-batch,
+  .resource-chip,
+  .tab-count {
+    forced-color-adjust: none;
+  }
+}

--- a/postal/sw.js
+++ b/postal/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'postal-campaign-20260805-r3';
+const CACHE_NAME = 'postal-live-20260805-r4';
 const CORE_ASSETS = [
   './',
   './index.html',

--- a/postal/tests/sim.test.mjs
+++ b/postal/tests/sim.test.mjs
@@ -1,175 +1,231 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  BASE_DEPARTURE,
+  CARRIERS,
   SHIFT_CATALOG,
   ShiftSimulation,
-  VERIFY_TARGET,
   createInitialState,
   formatClock,
   getStage
 } from '../sim.mjs';
 
-test('campaign exposes five shifts with four different post-training play styles', () => {
+function routeEveryWaitingBatch(sim) {
+  const state = sim.snapshot();
+  for (const incident of state.incidents.filter((item) => item.active)) {
+    sim.perform('resolve-incident', incident.target);
+  }
+  for (const job of sim.snapshot().jobs.filter((item) => item.status === 'waiting')) {
+    assert.equal(sim.perform('select-job', job.id), true, `select ${job.id}`);
+    assert.equal(sim.perform('route-selected', job.target), true, `route ${job.id} to ${job.target}`);
+  }
+}
+
+function finishPerfectly(shiftId) {
+  const sim = new ShiftSimulation(() => {}, shiftId);
+  sim.start();
+  for (let step = 0; step < 4000 && !sim.snapshot().completed; step += 1) {
+    routeEveryWaitingBatch(sim);
+    sim.tick(0.25);
+  }
+  return sim;
+}
+
+test('campaign difficulty expands from guided town play to all three live levels', () => {
   assert.equal(SHIFT_CATALOG.length, 5);
   assert.equal(SHIFT_CATALOG[0].id, 'first-rounds');
-  assert.deepEqual(
-    SHIFT_CATALOG.slice(1).map((shift) => shift.kind),
-    ['Systems shift', 'Network shift', 'Triage shift', 'Investigation shift']
-  );
+  assert.deepEqual(SHIFT_CATALOG[1].activeLevels, ['terminal']);
+  assert.deepEqual(SHIFT_CATALOG[2].activeLevels, ['terminal', 'network']);
+  assert.deepEqual(SHIFT_CATALOG[3].activeLevels, ['terminal', 'network', 'sweden']);
+  assert.deepEqual(SHIFT_CATALOG[4].activeLevels, ['terminal', 'network', 'sweden']);
+  assert.ok(SHIFT_CATALOG[1].jobs < SHIFT_CATALOG[2].jobs);
+  assert.ok(SHIFT_CATALOG[2].jobs < SHIFT_CATALOG[4].jobs);
 });
 
-test('first shift teaches one safe action at a time before running flow', () => {
+test('all four fictional partner carriers participate in live work', () => {
+  assert.deepEqual(Object.values(CARRIERS).map((carrier) => carrier.name), ['NordPost', 'DLH', 'Brang', 'USP']);
+  const liveCarrierIds = new Set(createInitialState('friday-surge').jobs.map((job) => job.carrierId));
+  assert.deepEqual([...liveCarrierIds].sort(), ['brang', 'dlh', 'nordpost', 'usp']);
+  const nationalDestinations = new Set(createInitialState('sweden-night').jobs.map((job) => job.destinationId));
+  assert.ok(nationalDestinations.has('stockholm'));
+  assert.ok(nationalDestinations.has('gothenburg'));
+});
+
+test('first shift teaches selection and world routing without deadline pressure', () => {
   const sim = new ShiftSimulation();
   assert.equal(getStage(sim.snapshot()), 'brief');
   sim.start();
-  assert.equal(sim.snapshot().stage, 'tour');
+  assert.equal(sim.snapshot().stage, 'coach-select');
   assert.equal(sim.snapshot().paused, true);
+  assert.equal(sim.snapshot().jobs[0].status, 'waiting');
+
+  assert.equal(sim.perform('select-job', 'TRAINING-01'), true);
+  assert.equal(sim.snapshot().stage, 'coach-town-target');
   assert.deepEqual(sim.snapshot().activeHotspots, ['express-lane']);
+  assert.equal(sim.perform('route-selected', 'express-lane'), true);
+  assert.equal(sim.snapshot().stage, 'coach-town-run');
+  sim.tick(12);
 
-  assert.equal(sim.perform('inspect-express'), true);
-  assert.equal(sim.snapshot().stage, 'coach-move');
-  assert.equal(sim.perform('move-staff'), true);
-  assert.equal(sim.snapshot().stage, 'coach-scan');
-  assert.equal(sim.perform('inspect-scanner'), true);
-  assert.equal(sim.snapshot().stage, 'coach-run');
-  assert.equal(sim.perform('resume'), true);
-  sim.tick(60);
-  assert.equal(sim.snapshot().stage, 'dispatch');
-  assert.equal(sim.completeShift(), true);
+  assert.equal(sim.snapshot().stage, 'coach-open-region');
+  assert.equal(sim.snapshot().paused, true);
+  assert.deepEqual(sim.snapshot().availableScenes, ['terminal', 'network']);
+  assert.equal(sim.perform('visit-level', 'network'), true);
+  assert.equal(sim.snapshot().stage, 'coach-region-select');
+  assert.equal(sim.perform('select-job', 'TRAINING-01'), true);
+  assert.equal(sim.perform('route-selected', 'network-harnosand'), true);
+  sim.tick(20);
+  assert.equal(sim.snapshot().completed, true);
   assert.equal(sim.snapshot().outcome.grade, '✓');
-  assert.match(sim.snapshot().outcome.summary, /four very different shifts/i);
 });
 
-test('northbound starts with the researched Sundsvall incident state', () => {
-  const state = createInitialState('northbound');
-  assert.equal(formatClock(state.time), '17:42');
-  assert.equal(formatClock(state.departure), '18:20');
-  assert.equal(state.risk, 18);
-  assert.equal(getStage(state), 'brief');
+test('live shifts begin in real time with no question stage', () => {
+  for (const shift of SHIFT_CATALOG.slice(1)) {
+    const sim = new ShiftSimulation(() => {}, shift.id);
+    sim.start();
+    assert.equal(sim.snapshot().stage, 'live', shift.id);
+    assert.equal(sim.snapshot().paused, false, shift.id);
+    assert.ok(sim.snapshot().availableScenes.length >= 1, shift.id);
+  }
 });
 
-test('moving crew protects northbound without hiding the root cause', () => {
-  const sim = new ShiftSimulation(() => {}, 'northbound');
+test('a batch is selected, routed through its scene target and occupies capacity', () => {
+  const sim = new ShiftSimulation(() => {}, 'town-rush');
   sim.start();
-  assert.equal(sim.moveStaff(), true);
-  const state = sim.snapshot();
-  assert.equal(state.expressCrew, 6);
-  assert.equal(state.standardCrew, 4);
-  assert.equal(state.risk, 9);
-  assert.equal(state.ruleFixed, false);
-  assert.equal(state.stage, 'investigate');
+  sim.tick(1.5);
+  const job = sim.snapshot().jobs.find((item) => item.status === 'waiting');
+  assert.ok(job);
+  assert.equal(sim.perform('select-job', job.id), true);
+  assert.equal(sim.snapshot().selectedJobId, job.id);
+  assert.equal(sim.perform('route-selected', job.target), true);
+  assert.equal(sim.snapshot().selectedJobId, null);
+  assert.equal(sim.snapshot().jobs.find((item) => item.id === job.id).status, 'processing');
+  assert.equal(sim.snapshot().resourceStatus.terminal.busy, 1);
 });
 
-test('holding the truck buys three minutes and spends downstream margin', () => {
-  const sim = new ShiftSimulation(() => {}, 'northbound');
+test('a wrong physical destination costs score and time but leaves the batch selected', () => {
+  const sim = new ShiftSimulation(() => {}, 'town-rush');
   sim.start();
-  sim.holdTruck();
-  const state = sim.snapshot();
-  assert.equal(state.departure, BASE_DEPARTURE + 3);
-  assert.equal(state.downstreamMargin, 7);
-  assert.equal(state.truckHeld, true);
-});
-
-test('parcel selection cannot be repeated for extra score', () => {
-  const sim = new ShiftSimulation(() => {}, 'northbound');
-  sim.start();
-  sim.moveStaff();
-  assert.equal(sim.selectPackage(), true);
+  sim.tick(1.5);
+  const job = sim.snapshot().jobs.find((item) => item.status === 'waiting');
+  sim.perform('select-job', job.id);
   const score = sim.snapshot().score;
-  assert.equal(sim.selectPackage(), false);
-  assert.equal(sim.snapshot().score, score);
+  const deadline = job.deadline;
+  const wrong = job.target === 'express-lane' ? 'standard-lane' : 'express-lane';
+  assert.equal(sim.perform('route-selected', wrong), true);
+  const state = sim.snapshot();
+  assert.equal(state.mistakes, 1);
+  assert.equal(state.selectedJobId, job.id);
+  assert.ok(state.score <= score);
+  assert.equal(state.jobs.find((item) => item.id === job.id).deadline, deadline - 2);
 });
 
-test('northbound verification only progresses while corrected flow runs', () => {
-  const sim = new ShiftSimulation(() => {}, 'northbound');
+test('switching levels clears a batch from the previous level', () => {
+  const sim = new ShiftSimulation(() => {}, 'sweden-night');
   sim.start();
-  sim.moveStaff();
-  sim.selectPackage();
-  sim.findSimilar();
-  sim.fixRule();
-  sim.tick(30);
-  assert.equal(sim.snapshot().verified, 0);
-  sim.setPaused(false);
-  sim.tick(60);
-  assert.equal(sim.snapshot().verified, VERIFY_TARGET);
-  assert.equal(sim.snapshot().stage, 'dispatch');
+  sim.tick(2);
+  const job = sim.snapshot().jobs.find((item) => item.stage === 'terminal' && item.status === 'waiting');
+  sim.perform('select-job', job.id);
+  assert.equal(sim.snapshot().selectedJobId, job.id);
+  sim.perform('visit-level', 'sweden');
+  assert.equal(sim.snapshot().selectedJobId, null);
+  assert.equal(sim.snapshot().jobs.find((item) => item.id === job.id).status, 'waiting');
 });
 
-test('clean northbound root-cause fix earns A plus', () => {
-  const sim = new ShiftSimulation(() => {}, 'northbound');
+test('scarce teams create a real queue instead of a prompted choice', () => {
+  const sim = new ShiftSimulation(() => {}, 'town-rush');
   sim.start();
-  sim.moveStaff();
-  sim.selectPackage();
-  sim.findSimilar();
-  sim.fixRule();
-  sim.setPaused(false);
-  sim.tick(60);
-  assert.equal(sim.completeShift(), true);
-  assert.equal(sim.snapshot().outcome.grade, 'A+');
+  sim.tick(13);
+  const waiting = sim.snapshot().jobs.filter((job) => job.status === 'waiting').slice(0, 3);
+  assert.equal(waiting.length, 3);
+  for (const job of waiting) {
+    sim.perform('select-job', job.id);
+    sim.perform('route-selected', job.target);
+  }
+  const state = sim.snapshot();
+  assert.equal(state.resourceStatus.terminal.busy, 2);
+  assert.equal(state.jobs.filter((job) => job.status === 'queued').length, 1);
 });
 
-test('snow shift requires reading depots, then rewards urgent inland routing', () => {
-  const sim = new ShiftSimulation(() => {}, 'snow-window');
+test('one national batch visibly progresses through town, region and Sweden', () => {
+  const sim = new ShiftSimulation(() => {}, 'sweden-night');
   sim.start();
-  assert.equal(sim.snapshot().stage, 'weather-scan');
-  assert.equal(sim.perform('inspect-depot', 'harnosand'), true);
-  assert.equal(sim.perform('inspect-depot', 'timra'), true);
-  assert.equal(sim.perform('inspect-depot', 'matfors'), true);
-  assert.equal(sim.snapshot().stage, 'weather-allocate');
-  assert.equal(sim.perform('allocate-truck', 'harnosand'), true);
-  assert.equal(sim.perform('choose-route', 'inland'), true);
-  assert.equal(sim.perform('resume'), true);
-  sim.tick(60);
-  assert.equal(sim.snapshot().delivered, 14);
-  assert.equal(sim.snapshot().stage, 'dispatch');
-  sim.completeShift();
-  assert.equal(sim.snapshot().outcome.grade, 'A+');
+  sim.tick(1.5);
+  let job = sim.snapshot().jobs.find((item) => item.status === 'waiting' && item.path.length === 3);
+  assert.ok(job);
+  assert.equal(job.stage, 'terminal');
+  sim.perform('select-job', job.id);
+  sim.perform('route-selected', job.target);
+  sim.tick(12);
+
+  job = sim.snapshot().jobs.find((item) => item.id === job.id);
+  assert.equal(job.stage, 'network');
+  assert.equal(job.status, 'waiting');
+  sim.perform('select-job', job.id);
+  sim.perform('route-selected', job.target);
+  sim.tick(16);
+
+  job = sim.snapshot().jobs.find((item) => item.id === job.id);
+  assert.equal(job.stage, 'sweden');
+  assert.equal(job.status, 'waiting');
+  assert.match(job.target, /^sweden-(stockholm|gothenburg)$/);
+  sim.perform('select-job', job.id);
+  sim.perform('route-selected', job.target);
+  sim.tick(22);
+  assert.equal(sim.snapshot().jobs.find((item) => item.id === job.id).status, 'delivered');
 });
 
-test('scanner shift changes its triage groups on replay variants', () => {
-  const first = createInitialState('scanner-fever', 0).triageQueue.map((parcel) => parcel.id);
-  const replay = createInitialState('scanner-fever', 1).triageQueue.map((parcel) => parcel.id);
+test('advanced shifts create unattended work on several levels at once', () => {
+  const sim = new ShiftSimulation(() => {}, 'friday-surge');
+  sim.start();
+  sim.tick(34);
+  const state = sim.snapshot();
+  const occupiedLevels = Object.entries(state.levelCounts).filter(([, count]) => count > 0).map(([level]) => level);
+  assert.ok(occupiedLevels.length >= 2, occupiedLevels.join(', '));
+});
+
+test('disruptions appear in real time and are cleared directly in their scene', () => {
+  const sim = new ShiftSimulation(() => {}, 'town-rush');
+  sim.start();
+  sim.tick(39);
+  let state = sim.snapshot();
+  const incident = state.incidents.find((item) => item.type === 'scanner-jam');
+  assert.equal(incident.active, true);
+  assert.ok(state.activeHotspots.includes('scanner'));
+  assert.equal(sim.perform('resolve-incident', 'scanner'), true);
+  state = sim.snapshot();
+  assert.equal(state.incidents.find((item) => item.type === 'scanner-jam').resolved, true);
+  assert.equal(state.incidents.find((item) => item.type === 'scanner-jam').active, false);
+});
+
+test('perfect attention can clear every increasingly difficult live shift', () => {
+  for (const shift of SHIFT_CATALOG.slice(1)) {
+    const sim = finishPerfectly(shift.id);
+    const state = sim.snapshot();
+    assert.equal(state.completed, true, shift.id);
+    assert.equal(state.delivered, shift.jobs, shift.id);
+    assert.equal(state.missed, 0, shift.id);
+    assert.equal(state.outcome.grade, 'A+', shift.id);
+  }
+});
+
+test('ignoring the town floor creates missed promises and still ends the shift', () => {
+  const sim = new ShiftSimulation(() => {}, 'town-rush');
+  sim.start();
+  sim.tick(160);
+  const state = sim.snapshot();
+  assert.equal(state.completed, true);
+  assert.ok(state.missed > 0);
+  assert.ok(state.onTime < 100);
+  assert.notEqual(state.outcome.grade, 'A+');
+  assert.ok(!state.outcome.medals.some((medal) => medal.label === 'Perfect sorting'));
+});
+
+test('replays vary carrier and destination order without changing the rules', () => {
+  const first = createInitialState('friday-surge', 0).jobs.slice(0, 6).map((job) => `${job.carrierId}:${job.destinationId}`);
+  const replay = createInitialState('friday-surge', 1).jobs.slice(0, 6).map((job) => `${job.carrierId}:${job.destinationId}`);
   assert.notDeepEqual(first, replay);
 });
 
-test('scanner shift supports promise ordering, repair and live recovery', () => {
-  const sim = new ShiftSimulation(() => {}, 'scanner-fever');
-  sim.start();
-  sim.perform('inspect-scanner');
-  const ordered = [...sim.snapshot().triageQueue].sort((a, b) => a.priority - b.priority);
-  ordered.forEach((parcel) => assert.equal(sim.perform('prioritize', parcel.id), true));
-  assert.equal(sim.snapshot().triageMistakes, 0);
-  assert.equal(sim.perform('repair-scanner'), true);
-  assert.equal(sim.perform('resume'), true);
-  sim.tick(60);
-  assert.equal(sim.snapshot().processed, 31);
-  assert.equal(sim.snapshot().stage, 'dispatch');
-  sim.completeShift();
-  assert.equal(sim.snapshot().outcome.grade, 'A+');
-});
-
-test('priority parcel shift turns evidence into a recovery choice', () => {
-  const sim = new ShiftSimulation(() => {}, 'priority-parcel');
-  sim.start();
-  assert.equal(sim.selectPackage(), true);
-  const correctLocation = sim.snapshot().caseData.correctLocation;
-  assert.equal(sim.perform('choose-location', correctLocation), true);
-  assert.equal(sim.snapshot().locationCorrect, true);
-  assert.equal(sim.perform('choose-recovery', 'courier'), true);
-  assert.equal(sim.perform('resume'), true);
-  sim.tick(90);
-  assert.equal(sim.snapshot().deliveryProgress, 100);
-  assert.equal(sim.snapshot().stage, 'dispatch');
-  sim.completeShift();
-  assert.equal(sim.snapshot().outcome.grade, 'A+');
-});
-
-test('no shift can be closed before its live objective is ready', () => {
-  for (const shift of SHIFT_CATALOG) {
-    const sim = new ShiftSimulation(() => {}, shift.id);
-    sim.start();
-    assert.equal(sim.completeShift(), false, shift.id);
-    assert.equal(sim.snapshot().completed, false, shift.id);
-  }
+test('clock and stage helpers remain deterministic', () => {
+  assert.equal(formatClock(17 * 60 + 42), '17:42');
+  assert.equal(getStage(createInitialState('town-rush')), 'brief');
 });

--- a/postal/tests/ui-contract.test.mjs
+++ b/postal/tests/ui-contract.test.mjs
@@ -3,11 +3,13 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 
 const root = new URL('../', import.meta.url);
-const [html, main, world, styles] = await Promise.all([
+const [html, main, sim, world, styles, worker] = await Promise.all([
   readFile(new URL('index.html', root), 'utf8'),
   readFile(new URL('main.mjs', root), 'utf8'),
+  readFile(new URL('sim.mjs', root), 'utf8'),
   readFile(new URL('world.mjs', root), 'utf8'),
-  readFile(new URL('styles.css', root), 'utf8')
+  readFile(new URL('styles.css', root), 'utf8'),
+  readFile(new URL('sw.js', root), 'utf8')
 ]);
 
 test('every JavaScript ID selector has a matching unique HTML element', () => {
@@ -24,55 +26,104 @@ test('every JavaScript ID selector has a matching unique HTML element', () => {
   assert.deepEqual([...new Set(labelledByIds)].filter((id) => !htmlIds.includes(id)), []);
 });
 
-test('fresh-player and campaign overlays have named controls and real hidden states', () => {
-  assert.match(html, /id="welcomeScreen" aria-labelledby="welcomeTitle"/);
-  assert.match(html, /id="startButton"[^>]*>Start first shift</);
-  assert.match(html, /id="campaignScreen" aria-labelledby="campaignTitle" hidden/);
-  assert.match(html, /id="shiftList"/);
-  assert.match(styles, /\.campaign-screen\[hidden\]/);
-  assert.match(main, /if \(campaign\.completed\['first-rounds'\]\)/);
+test('the primary game navigation exposes town, region and Sweden as live levels', () => {
+  assert.match(html, /data-scene="terminal"[\s\S]*?<span>Town<\/span>/);
+  assert.match(html, /data-scene="network"[\s\S]*?<span>Region<\/span>/);
+  assert.match(html, /data-scene="sweden"[\s\S]*?<span>Sweden<\/span>/);
+  assert.match(html, /id="terminalAlert"/);
+  assert.match(html, /id="networkAlert"/);
+  assert.match(html, /id="swedenAlert"/);
+  assert.doesNotMatch(html, /data-scene="case"/);
 });
 
-test('runtime no longer plays the sharp sample files', () => {
+test('post-training play uses live parcel objects and scene destinations rather than answer prompts', () => {
+  assert.match(html, /id="operationLayer" aria-labelledby="workQueueTitle"/);
+  assert.match(main, /class="parcel-batch"/);
+  assert.match(main, /data-action is intentionally absent|simulation\.perform\('select-job'/);
+  assert.match(main, /simulation\.perform\('route-selected'/);
+  assert.doesNotMatch(main, /Which promises|Choose the road|Repair or bypass|Where is the parcel/);
+  assert.doesNotMatch(main, /allocate-truck|choose-recovery|find-similar|fix-rule/);
+});
+
+test('the national miniature includes Stockholm, Gothenburg and asset-led hubs', () => {
+  assert.match(world, /buildSweden\(\)/);
+  assert.match(world, /sweden-stockholm/);
+  assert.match(world, /Stockholm hub/);
+  assert.match(world, /sweden-gothenburg/);
+  assert.match(world, /Gothenburg hub/);
+  assert.match(world, /placeAsset\(group, 'roadIntersection'/);
+  assert.match(world, /this\.swedenTrucks/);
+});
+
+test('NordPost, DLH, Brang and USP are represented as fictional live carriers', () => {
+  for (const carrier of ['NordPost', 'DLH', 'Brang', 'USP']) assert.match(sim, new RegExp(carrier));
+  assert.match(html, /They are fictional operators created for POSTAL/);
+  assert.match(main, /carrier-legend/);
+});
+
+test('fresh-player onboarding remains guided while the live command deck has no action buttons', () => {
+  assert.match(html, /FIRST SHIFT · CALM PRACTICE/);
+  assert.match(main, /onboardingCommand/);
+  assert.match(main, /The action happens there, not in this box/);
+  assert.match(main, /if \(state\.shiftId === 'first-rounds'\) return onboardingCommand/);
+  assert.match(styles, /\.command-content\[data-layout="live"\]/);
+});
+
+test('runtime uses only short low-pass synthesized feedback', () => {
   assert.doesNotMatch(main, /new Audio\s*\(/);
   assert.doesNotMatch(main, /assets\/audio/);
   assert.match(main, /oscillator\.type = 'triangle'/);
   assert.match(main, /filter\.type = 'lowpass'/);
-  assert.match(main, /\[392, 0\.15, 0\.16, 0\.016\]/);
+  assert.match(main, /filter\.frequency\.setValueAtTime\(860/);
+  assert.match(main, /master\.gain\.value = 0\.5/);
 });
 
-test('no-WebGL mode is guarded before scene groups are dereferenced', () => {
+test('no-WebGL mode is guarded before all scene groups are dereferenced', () => {
   const setModeStart = world.indexOf('setMode(mode, immediate = false)');
   const guard = world.indexOf('if (!this.camera || !this.terminalGroup', setModeStart);
-  const dereference = world.indexOf("this.terminalGroup.visible = mode === 'terminal'", setModeStart);
+  const national = world.indexOf("this.swedenGroup.visible = mode === 'sweden'", setModeStart);
   assert.ok(setModeStart > 0);
   assert.ok(guard > setModeStart);
-  assert.ok(dereference > guard);
-  assert.match(main, /Every shift remains playable with the controls below|complete shift remains playable below/i);
+  assert.ok(national > guard);
+  assert.match(main, /All live batches and destinations remain usable in the controls/);
+  assert.match(html, /id="fallbackTargets" aria-label="Destinations in this level" hidden/);
+  assert.match(main, /function renderFallbackTargets\(state\)/);
+  assert.match(main, /data-fallback-target/);
+  assert.match(styles, /\.fallback-targets button/);
 });
 
-test('all required world actions retain large HTML alternatives', () => {
-  for (const action of [
-    'inspect-express',
-    'move-staff',
-    'inspect-scanner',
-    'inspect-depot',
-    'allocate-truck',
-    'choose-route',
-    'prioritize',
-    'repair-scanner',
-    'inspect-case',
-    'choose-location',
-    'choose-recovery',
-    'dispatch'
+test('direct canvas destinations retain projected semantic button alternatives', () => {
+  for (const hotspot of [
+    'express-lane',
+    'standard-lane',
+    'network-sundsvall',
+    'network-harnosand',
+    'network-timra',
+    'network-matfors',
+    'sweden-sundsvall',
+    'sweden-stockholm',
+    'sweden-gothenburg',
+    'scanner',
+    'network-detour',
+    'sweden-relief'
   ]) {
-    assert.match(main, new RegExp(`data-action=\\"${action}\\"`), action);
+    assert.match(world, new RegExp(`registerHotspot\\('${hotspot}'`), hotspot);
   }
+  assert.match(world, /button\.type = 'button'/);
+  assert.match(world, /button\.setAttribute\('aria-label'/);
 });
 
-test('portrait command deck has compact and expanded layouts', () => {
-  assert.match(styles, /\.command-content\[data-layout="wide"\]/);
-  assert.match(styles, /@media \(max-height: 700px\)[\s\S]*\.command-content\[data-layout="wide"\]/);
-  assert.match(styles, /\.choice-grid--three/);
-  assert.match(styles, /\.parcel-priority-grid/);
+test('portrait live controls are compact, horizontally scrollable and status-independent', () => {
+  assert.match(styles, /\.operation-layer/);
+  assert.match(styles, /\.parcel-rack[\s\S]*overflow-x: auto/);
+  assert.match(styles, /\.parcel-batch\[aria-pressed="true"\]/);
+  assert.match(styles, /\.parcel-cube\[data-service="express"\]/);
+  assert.match(styles, /\.parcel-deadline\[data-late="true"\]/);
+  assert.match(styles, /\.game-shell\[data-play-mode="live"\] \.command-deck/);
+  assert.match(styles, /@media \(max-height: 700px\)[\s\S]*data-play-mode="live"/);
+});
+
+test('new build markers bypass the previous campaign service worker cache', () => {
+  assert.match(html, /build=20260805-live-r4/);
+  assert.match(worker, /postal-live-20260805-r4/);
 });

--- a/postal/world.mjs
+++ b/postal/world.mjs
@@ -56,6 +56,11 @@ const CAMERA_PRESETS = Object.freeze({
     target: new THREE.Vector3(0, 0, 0),
     fov: 39
   },
+  sweden: {
+    position: new THREE.Vector3(10.8, 17.8, 15.8),
+    target: new THREE.Vector3(0, 0, 0.25),
+    fov: 39
+  },
   case: {
     position: new THREE.Vector3(7.5, 7.4, 10.5),
     target: new THREE.Vector3(0, 1.15, 0),
@@ -134,6 +139,10 @@ export class PostalWorld {
       verified: 0,
       completed: false,
       speed: 1,
+      jobs: [],
+      incidents: [],
+      levelCounts: { terminal: 0, network: 0, sweden: 0 },
+      resourceStatus: {},
       activeHotspots: [],
       hotspotLabels: {},
       hotspotTones: {},
@@ -145,6 +154,9 @@ export class PostalWorld {
     this.packages = [];
     this.operators = [];
     this.networkTrucks = [];
+    this.swedenTrucks = [];
+    this.swedenCurves = {};
+    this.swedenHubRings = {};
     this.caseBoxes = [];
     this.matchRevealStartedAt = null;
     this.lastFrameTime = performance.now();
@@ -208,10 +220,13 @@ export class PostalWorld {
     this.terminalGroup.name = 'Sundsvall terminal';
     this.networkGroup = new THREE.Group();
     this.networkGroup.name = 'Regional network';
+    this.swedenGroup = new THREE.Group();
+    this.swedenGroup.name = 'Sweden network';
     this.caseGroup = new THREE.Group();
     this.caseGroup.name = 'Parcel case';
-    this.scene.add(this.terminalGroup, this.networkGroup, this.caseGroup);
+    this.scene.add(this.terminalGroup, this.networkGroup, this.swedenGroup, this.caseGroup);
     this.networkGroup.visible = false;
+    this.swedenGroup.visible = false;
     this.caseGroup.visible = false;
 
     this.resizeObserver = new ResizeObserver(() => this.resize());
@@ -258,6 +273,7 @@ export class PostalWorld {
 
     this.buildTerminal();
     this.buildNetwork();
+    this.buildSweden();
     this.buildCase();
     this.setMode('terminal', true);
     this.callbacks.onReady?.();
@@ -631,6 +647,110 @@ export class PostalWorld {
     this.registerHotspot('network-harnosand', 'Härnösand', '!', 'danger', group, new THREE.Vector3(0, 2.25, -3.45));
     this.registerHotspot('network-timra', 'Timrå', '✓', 'good', group, new THREE.Vector3(4.0, 1.75, 1.75));
     this.registerHotspot('network-matfors', 'Matfors', '✓', 'good', group, new THREE.Vector3(-4.1, 1.7, 1.65));
+    this.registerHotspot('network-detour', 'Open inland detour', '!', 'danger', group, new THREE.Vector3(-2.8, 1.05, -0.65));
+  }
+
+  buildSweden() {
+    const group = this.swedenGroup;
+    const ocean = addPrimitiveBox(group, [14.4, 0.5, 11.2], [0, -0.38, 0.2], 0x2f8eae);
+    ocean.material.roughness = 0.65;
+
+    const landPieces = [
+      [[3.1, 0.34, 3.7], [1.05, -0.06, -3.25], 0.10],
+      [[4.4, 0.34, 3.25], [0.35, -0.04, -0.55], -0.08],
+      [[5.2, 0.34, 3.5], [-0.45, -0.02, 2.3], 0.12],
+      [[2.4, 0.3, 1.7], [-2.65, 0, 3.2], -0.18]
+    ];
+    landPieces.forEach(([size, position, rotation]) => {
+      const piece = addPrimitiveBox(group, size, position, 0x86ba78, rotation);
+      piece.material.roughness = 1;
+    });
+
+    for (let index = 0; index < 22; index += 1) {
+      const north = index < 8;
+      const x = (north ? 0.25 : -0.25) + (seeded(index + 310) - 0.5) * (north ? 2.3 : 4.5);
+      const z = north ? -4.25 + seeded(index + 340) * 3.2 : -0.7 + seeded(index + 340) * 5.2;
+      this.placeAsset(group, index % 4 === 0 ? 'tallTrees' : 'trees', [x, 0.04, z], {
+        targetHeight: 0.55 + seeded(index + 370) * 0.55,
+        rotationY: seeded(index + 400) * Math.PI * 2,
+        castShadow: index % 3 === 0
+      });
+    }
+
+    const hubs = {
+      sundsvall: { position: [1.1, 0.03, -2.5], building: 'garage', height: 1.45, tone: 0xffd43b },
+      stockholm: { position: [1.05, 0.03, 1.15], building: 'buildingC', height: 1.75, tone: 0x38c7f3 },
+      gothenburg: { position: [-2.55, 0.03, 2.5], building: 'buildingB', height: 1.6, tone: 0x79e29f }
+    };
+
+    for (const [id, hub] of Object.entries(hubs)) {
+      const road = this.placeAsset(group, 'roadIntersection', [hub.position[0], -0.03, hub.position[2]], {
+        targetSize: 1.7,
+        rotationY: id === 'gothenburg' ? Math.PI / 2 : 0,
+        castShadow: false
+      });
+      const building = this.placeAsset(group, hub.building, hub.position, {
+        targetHeight: hub.height,
+        rotationY: id === 'gothenburg' ? Math.PI / 2 : Math.PI
+      });
+      const ring = new THREE.Mesh(
+        new THREE.RingGeometry(0.72, 0.94, 28),
+        new THREE.MeshBasicMaterial({ color: hub.tone, transparent: true, opacity: 0.72, side: THREE.DoubleSide })
+      );
+      ring.rotation.x = -Math.PI / 2;
+      ring.position.set(hub.position[0], 0.08, hub.position[2]);
+      group.add(ring);
+      this.swedenHubRings[id] = ring;
+      this.markInteractive(road, `sweden-${id}`);
+      this.markInteractive(building, `sweden-${id}`);
+    }
+
+    const sundsvallPoint = new THREE.Vector3(1.1, 0.18, -2.5);
+    const stockholmPoint = new THREE.Vector3(1.05, 0.18, 1.15);
+    const gothenburgPoint = new THREE.Vector3(-2.55, 0.18, 2.5);
+    const stockholmCurve = new THREE.CatmullRomCurve3([
+      sundsvallPoint,
+      new THREE.Vector3(1.65, 0.18, -0.7),
+      stockholmPoint
+    ], false, 'centripetal', 0.35);
+    const gothenburgCurve = new THREE.CatmullRomCurve3([
+      sundsvallPoint,
+      new THREE.Vector3(-0.15, 0.2, -0.1),
+      new THREE.Vector3(-1.5, 0.2, 1.45),
+      gothenburgPoint
+    ], false, 'centripetal', 0.35);
+    this.swedenCurves.stockholm = stockholmCurve;
+    this.swedenCurves.gothenburg = gothenburgCurve;
+
+    const stockholmRoute = new THREE.Mesh(
+      new THREE.TubeGeometry(stockholmCurve, 48, 0.075, 8, false),
+      material(0x38c7f3, { emissive: 0x1589bb, emissiveIntensity: 0.72 })
+    );
+    const gothenburgRoute = new THREE.Mesh(
+      new THREE.TubeGeometry(gothenburgCurve, 58, 0.075, 8, false),
+      material(0xffd43b, { emissive: 0xf4b62f, emissiveIntensity: 0.65 })
+    );
+    group.add(stockholmRoute, gothenburgRoute);
+    this.swedenRoutes = { stockholm: stockholmRoute, gothenburg: gothenburgRoute };
+
+    for (let index = 0; index < 3; index += 1) {
+      const truck = this.makeAsset('truck', { targetSize: 0.72 });
+      truck.userData.offset = index * 0.31;
+      truck.userData.destination = index % 2 === 0 ? 'stockholm' : 'gothenburg';
+      group.add(truck);
+      this.swedenTrucks.push(truck);
+    }
+
+    const partnerColors = [0xffd43b, 0xff665e, 0x79e29f, 0x38c7f3];
+    partnerColors.forEach((color, index) => {
+      const x = -4.55 + index * 0.72;
+      addPrimitiveBox(group, [0.52, 0.18, 0.75], [x, 0.1, 4.25], color, (index - 1.5) * 0.04);
+    });
+
+    this.registerHotspot('sweden-sundsvall', 'Sundsvall hub', '○', 'yellow', group, new THREE.Vector3(1.35, 2.65, -2.6));
+    this.registerHotspot('sweden-stockholm', 'Stockholm hub', '○', 'blue', group, new THREE.Vector3(1.4, 1.75, 1.1));
+    this.registerHotspot('sweden-gothenburg', 'Gothenburg hub', '○', 'good', group, new THREE.Vector3(-2.8, 2.65, 2.7));
+    this.registerHotspot('sweden-relief', 'Open relief dock', '!', 'danger', group, new THREE.Vector3(-0.3, 1.15, 3.55));
   }
 
   buildCase() {
@@ -725,10 +845,11 @@ export class PostalWorld {
 
   setMode(mode, immediate = false) {
     if (!CAMERA_PRESETS[mode]) return;
-    if (!this.camera || !this.terminalGroup || !this.networkGroup || !this.caseGroup) return;
+    if (!this.camera || !this.terminalGroup || !this.networkGroup || !this.swedenGroup || !this.caseGroup) return;
     this.mode = mode;
     this.terminalGroup.visible = mode === 'terminal';
     this.networkGroup.visible = mode === 'network';
+    this.swedenGroup.visible = mode === 'sweden';
     this.caseGroup.visible = mode === 'case';
     const preset = CAMERA_PRESETS[mode];
     this.cameraDesiredPosition.copy(preset.position);
@@ -803,6 +924,7 @@ export class PostalWorld {
     this.updateCamera(delta);
     this.updateTerminal(delta);
     this.updateNetwork(delta);
+    this.updateSweden(delta);
     this.updateCase(delta);
     this.updateHotspotPositions();
     this.renderer.render(this.scene, this.camera);
@@ -819,16 +941,14 @@ export class PostalWorld {
   updateTerminal(delta) {
     if (!this.terminalGroup) return;
     const flowTime = this.runningVisualTime;
+    const scannerBlocked = this.state.incidents?.some((incident) => incident.active && incident.type === 'scanner-jam');
     this.packages.forEach((parcel, index) => {
       const data = parcel.userData;
       const cycle = (flowTime * data.speed + data.offset) % 1;
       const onInput = cycle < 0.34;
       let localT = onInput ? cycle / 0.34 : (cycle - 0.34) / 0.66;
       const intendedExpress = data.service === 'express';
-      const usesWrongLane = this.state.shiftId === 'northbound' && data.misrouted && !this.state.ruleFixed;
-      const scannerBlocked = this.state.shiftId === 'scanner-fever'
-        && !this.state.scannerFixed
-        && !this.state.scannerBypassed;
+      const usesWrongLane = false;
       if (scannerBlocked && onInput && localT > 0.58) {
         localT = 0.58 + (localT - 0.58) * 0.035;
       }
@@ -845,8 +965,10 @@ export class PostalWorld {
       data.marker.scale.setScalar(usesWrongLane ? 1.2 : 1);
     });
 
+    const expressPressure = (this.state.jobs || []).filter((job) => job.stage === 'terminal' && job.target === 'express-lane' && ['waiting', 'queued', 'processing'].includes(job.status)).length;
+    const standardPressure = (this.state.jobs || []).filter((job) => job.stage === 'terminal' && job.target === 'standard-lane' && ['waiting', 'queued', 'processing'].includes(job.status)).length;
     this.operators.forEach((operator, index) => {
-      const target = this.state.staffMoved && operator.userData.moveToExpress
+      const target = expressPressure > standardPressure && operator.userData.moveToExpress
         ? operator.userData.expressTarget
         : operator.userData.home;
       operator.position.lerp(target, REDUCED_MOTION ? 1 : Math.min(1, delta * 2.4));
@@ -854,7 +976,7 @@ export class PostalWorld {
     });
 
     if (this.warningRoot) {
-      const warningVisible = this.state.shiftId === 'northbound' && !this.state.ruleFixed;
+      const warningVisible = (this.state.levelCounts?.terminal || 0) >= 4 && !scannerBlocked;
       this.warningRoot.visible = warningVisible;
       if (!REDUCED_MOTION) {
         const pulse = 1 + Math.sin(this.elapsed * 5) * 0.12;
@@ -864,9 +986,7 @@ export class PostalWorld {
     }
 
     if (this.scannerWarningRoot) {
-      const scannerWarningVisible = this.state.shiftId === 'scanner-fever'
-        && !this.state.scannerFixed
-        && !this.state.scannerBypassed;
+      const scannerWarningVisible = scannerBlocked;
       this.scannerWarningRoot.visible = scannerWarningVisible;
       if (scannerWarningVisible && !REDUCED_MOTION) {
         const pulse = 1 + Math.sin(this.elapsed * 4.2) * 0.1;
@@ -883,8 +1003,10 @@ export class PostalWorld {
 
   updateNetwork(delta) {
     if (!this.networkGroup) return;
-    const snowShift = this.state.shiftId === 'snow-window';
-    const useInland = snowShift && this.state.routeChoice === 'inland';
+    const snowIncident = this.state.incidents?.find((incident) => incident.type === 'snow-route');
+    const snowActive = Boolean(snowIncident?.active);
+    const useInland = Boolean(snowIncident?.resolved);
+    const regionalBusy = this.state.resourceStatus?.network?.busy || 0;
     this.networkTrucks.forEach((truck, index) => {
       const t = (this.runningVisualTime * 0.035 + truck.userData.offset) % 1;
       const activeCurve = useInland ? this.networkAltCurve : this.networkPrimaryCurve || truck.userData.curve;
@@ -892,24 +1014,24 @@ export class PostalWorld {
       const tangent = activeCurve.getTangentAt(t);
       truck.position.copy(position);
       truck.rotation.y = Math.atan2(tangent.x, tangent.z) + Math.PI;
+      truck.visible = index < Math.max(1, regionalBusy);
       if (!REDUCED_MOTION) truck.position.y += Math.sin(this.elapsed * 4 + index) * 0.015;
     });
     if (this.networkRiskRoute) {
-      const safe = this.state.ruleFixed || (snowShift && this.state.routeChoice === 'coast' && this.state.stage === 'dispatch');
-      this.networkRiskRoute.material.color.setHex(safe ? 0x79e29f : snowShift ? 0xff9a55 : 0xff665e);
+      const safe = !snowActive;
+      this.networkRiskRoute.material.color.setHex(safe ? 0x79e29f : 0xff665e);
       this.networkRiskRoute.material.emissive.setHex(safe ? 0x249a60 : 0xff4c44);
       this.networkRiskRoute.material.emissiveIntensity = safe ? 0.55 : 1.2;
     }
     if (this.networkAltRoute) {
-      this.networkAltRoute.visible = snowShift
-        && (this.state.stage === 'weather-route' || this.state.routeChoice === 'inland' || this.state.stage === 'dispatch');
+      this.networkAltRoute.visible = snowActive || useInland;
       this.networkAltRoute.material.color.setHex(useInland ? 0x79e29f : 0x38c7f3);
       this.networkAltRoute.material.emissive.setHex(useInland ? 0x249a60 : 0x1589bb);
       this.networkAltRoute.material.emissiveIntensity = useInland ? 0.9 : 0.5;
     }
     if (this.networkRiskRing) {
-      const fixed = this.state.ruleFixed || (snowShift && this.state.stage === 'dispatch');
-      this.networkRiskRing.material.color.setHex(fixed ? 0x79e29f : 0xff665e);
+      const regionalPressure = (this.state.levelCounts?.network || 0) > 2;
+      this.networkRiskRing.material.color.setHex(snowActive || regionalPressure ? 0xff665e : 0x79e29f);
       if (!REDUCED_MOTION) {
         const pulse = 1 + Math.sin(this.elapsed * 3.8) * 0.1;
         this.networkRiskRing.scale.setScalar(pulse);
@@ -917,8 +1039,8 @@ export class PostalWorld {
       }
     }
     if (this.networkSnow) {
-      this.networkSnow.visible = snowShift;
-      if (snowShift && !REDUCED_MOTION) {
+      this.networkSnow.visible = snowActive;
+      if (snowActive && !REDUCED_MOTION) {
         const positions = this.networkSnow.geometry.attributes.position;
         for (let index = 0; index < positions.count; index += 1) {
           let y = positions.getY(index) - delta * (0.85 + (index % 5) * 0.08);
@@ -929,6 +1051,42 @@ export class PostalWorld {
         }
         positions.needsUpdate = true;
       }
+    }
+  }
+
+  updateSweden(delta) {
+    if (!this.swedenGroup) return;
+    const processing = (this.state.jobs || []).filter((job) => job.stage === 'sweden' && job.status === 'processing');
+    this.swedenTrucks.forEach((truck, index) => {
+      const job = processing[index];
+      const destination = job?.destinationId === 'gothenburg' ? 'gothenburg' : job?.destinationId === 'stockholm' ? 'stockholm' : truck.userData.destination;
+      const activeCurve = this.swedenCurves[destination] || this.swedenCurves.stockholm;
+      const t = (this.runningVisualTime * 0.028 + truck.userData.offset) % 1;
+      const position = activeCurve.getPointAt(t);
+      const tangent = activeCurve.getTangentAt(t);
+      truck.position.copy(position);
+      truck.rotation.y = Math.atan2(tangent.x, tangent.z) + Math.PI;
+      truck.visible = index < Math.max(1, processing.length);
+      if (!REDUCED_MOTION) truck.position.y += Math.sin(this.elapsed * 3.5 + index) * 0.016;
+    });
+
+    const hubIncident = this.state.incidents?.some((incident) => incident.active && incident.type === 'hub-gridlock');
+    for (const [id, ring] of Object.entries(this.swedenHubRings)) {
+      const waiting = (this.state.jobs || []).filter((job) => job.stage === 'sweden'
+        && ['waiting', 'queued'].includes(job.status)
+        && (job.destinationId === id || id === 'sundsvall' && job.target === 'sweden-sundsvall')).length;
+      const danger = waiting >= 2 || (id === 'stockholm' && hubIncident);
+      ring.material.color.setHex(danger ? 0xff665e : id === 'stockholm' ? 0x38c7f3 : id === 'gothenburg' ? 0x79e29f : 0xffd43b);
+      if (!REDUCED_MOTION) {
+        const pulse = 1 + Math.sin(this.elapsed * (danger ? 4.2 : 2.1) + id.length) * (danger ? 0.12 : 0.045);
+        ring.scale.setScalar(pulse);
+        ring.rotation.z += delta * (danger ? 0.28 : 0.08);
+      }
+    }
+
+    if (this.swedenRoutes) {
+      this.swedenRoutes.stockholm.material.emissiveIntensity = hubIncident ? 1.3 : 0.72;
+      this.swedenRoutes.stockholm.material.color.setHex(hubIncident ? 0xff665e : 0x38c7f3);
     }
   }
 


### PR DESCRIPTION
## What changed

- Replaced the four post-training prompt chains with one continuous real-time operations grammar: select a live batch, then tap its marked lane, depot, or hub.
- Added increasingly difficult Town, Region, and Sweden shifts with simultaneous queues, limited teams/trucks/linehauls, countdowns, score combos, lateness, missed collections, and automatic shift completion.
- Added an interactive national diorama with Sundsvall, Stockholm, and Gothenburg.
- Added NordPost, DLH, Brang, and USP as fictional partner carriers with distinct volume and promise patterns.
- Added direct scene disruptions: scanner jam, snow detour, and national relief dock.
- Kept the first shift as calm onboarding, then removed coaching and duplicate action buttons from live play.
- Added sequential campaign unlocks, v3 progress migration, replay variation, a new offline cache, structured live details, polite assistive announcements, and a no-WebGL destination fallback.

## Why

The campaign had become a sequence of finite-state questions: inspect, choose an obvious answer, confirm, run, and dispatch. That made every shift feel like onboarding. POSTAL is intended to feel like a national parcel-delivery version of a time-management game: easy to read, direct to operate, and increasingly difficult to keep under control in real time.

## Verification

- 26 simulation and UI-contract tests
- JavaScript syntax checks for all four runtime modules
- Full perfect-path simulation for every live shift
- Ignored-work/failure-path verification
- Complete onboarding playthrough in WebGL and no-WebGL modes
- 390×844 and 375×667 portrait renders with no overflow
- Actual UI routing across Town, Region, and Sweden (10 batch actions, zero mistakes)
- No browser, asset, HTTP, or WebGL errors
- Remote tree hash matches the rebased local release tree exactly: `4eba288a3a94670f474cf48e988915cad22052d4`