### PR TITLE
Make POSTAL resources interactive and keep shifts running

### DIFF
--- a/.github/workflows/postal-game-tests.yml
+++ b/.github/workflows/postal-game-tests.yml
@@ -23,6 +23,6 @@ jobs:
         with:
           node-version: 22
       - name: Check JavaScript syntax
-        run: node --check postal/main.mjs && node --check postal/world.mjs && node --check postal/sim.mjs && node --check postal/sw.js
+        run: node --check postal/main.mjs && node --check postal/world.mjs && node --check postal/sim.mjs && node --check postal/management-sim.mjs && node --check postal/management-ui.mjs && node --check postal/sw.js
       - name: Test the shift simulation
         run: node --test postal/tests/*.test.mjs

--- a/postal/index.html
+++ b/postal/index.html
@@ -10,6 +10,7 @@
   <meta name="description" content="POSTAL is a portrait-friendly real-time parcel network game set in Sweden.">
   <title>POSTAL — Every package has a promise</title>
   <link rel="stylesheet" href="./styles.css?build=20260805-live-r4">
+  <link rel="stylesheet" href="./management.css?build=20260806-management-r1">
   <script type="importmap">
     {
       "imports": {
@@ -164,7 +165,7 @@
         <span>Town → region · no deadline</span>
       </div>
       <button class="game-button game-button--primary welcome-start" id="startButton" type="button">Start first shift</button>
-      <p class="welcome-note">After training, shifts run continuously. Watch the miniature network and act before promises expire.</p>
+      <p class="welcome-note">After training, shifts run continuously. Plan teams and trucks, watch the miniature network and act before promises expire.</p>
     </div>
   </section>
 
@@ -180,7 +181,7 @@
         <div class="campaign-stamp" id="campaignStamp" aria-hidden="true">1/5</div>
       </header>
       <div class="shift-list" id="shiftList"></div>
-      <p class="campaign-note">Each shift adds pressure and another live level. Replays vary carrier and arrival order.</p>
+      <p class="campaign-note">Each shift adds pressure and another live level. Replays vary carrier and arrival order. After a report, keep operating for endless waves.</p>
     </div>
   </section>
 
@@ -215,7 +216,7 @@
 
       <details class="help-disclosure">
         <summary>How to play</summary>
-        <p>Select a waiting parcel batch, then tap the lane, depot or hub printed on its marker. Blue arrows use Express A; yellow squares use Standard B. Occupied teams and vehicles take the next routed batch automatically. Switch levels when their badges appear.</p>
+        <p>Select a waiting parcel batch, then tap the lane, depot or hub printed on its marker. Blue arrows use Express A; yellow squares use Standard B. Use Plan teams, Plan trucks or Plan linehauls to move resources toward specific work: a matching assignment completes faster. Trucks in the regional and national miniature can also be tapped directly. Switch levels when their badges appear.</p>
       </details>
 
       <details class="help-disclosure">
@@ -240,5 +241,6 @@
   <div class="sr-only" id="assertiveLive" aria-live="assertive" aria-atomic="true"></div>
 
   <script type="module" src="./main.mjs?build=20260805-live-r4"></script>
+  <script type="module" src="./management-ui.mjs?build=20260806-management-r1"></script>
 </body>
 </html>

--- a/postal/management-sim.mjs
+++ b/postal/management-sim.mjs
@@ -1,0 +1,261 @@
+import { ShiftSimulation } from './sim.mjs';
+
+const PATCH_FLAG = Symbol.for('postal.resourceManagementPatch');
+
+export const RESOURCE_TARGETS = Object.freeze({
+  terminal: Object.freeze([
+    ['any', 'Flexible'],
+    ['express-lane', 'Express A'],
+    ['standard-lane', 'Standard B']
+  ]),
+  network: Object.freeze([
+    ['any', 'Any regional route'],
+    ['network-harnosand', 'Härnösand'],
+    ['network-timra', 'Timrå'],
+    ['network-matfors', 'Matfors'],
+    ['network-sundsvall', 'National gate']
+  ]),
+  sweden: Object.freeze([
+    ['any', 'Any national route'],
+    ['sweden-stockholm', 'Stockholm'],
+    ['sweden-gothenburg', 'Gothenburg']
+  ])
+});
+
+const RESOURCE_PREFIX = Object.freeze({ terminal: 'T', network: 'R', sweden: 'S' });
+const RESOURCE_KIND = Object.freeze({ terminal: 'team', network: 'truck', sweden: 'linehaul' });
+const RESOURCE_NAME = Object.freeze({ terminal: 'Sort team', network: 'Regional truck', sweden: 'Linehaul' });
+
+function assignmentLabel(level, assignment) {
+  return RESOURCE_TARGETS[level]?.find(([id]) => id === assignment)?.[1] || 'Flexible';
+}
+
+function ensureResources(simulation) {
+  if (Array.isArray(simulation.state.resources)) return simulation.state.resources;
+  const resources = [];
+  for (const level of ['terminal', 'network', 'sweden']) {
+    const count = simulation.state.capacity[level] || 0;
+    for (let index = 0; index < count; index += 1) {
+      const shortId = `${RESOURCE_PREFIX[level]}${index + 1}`;
+      resources.push({
+        id: shortId,
+        hotspotId: `resource-${shortId}`,
+        level,
+        kind: RESOURCE_KIND[level],
+        name: `${RESOURCE_NAME[level]} ${index + 1}`,
+        assignment: 'any'
+      });
+    }
+  }
+  simulation.state.resources = resources;
+  simulation.state.overtime = false;
+  simulation.state.overtimeWave = 0;
+  simulation.state.nextOvertimeWaveAt = null;
+  simulation.state.lastOutcome = null;
+  return resources;
+}
+
+function resourceBusyJob(simulation, resourceId) {
+  return simulation.state.jobs.find((job) => job.status === 'processing' && job.resourceId === resourceId) || null;
+}
+
+function chooseResource(simulation, job) {
+  const busy = new Set(simulation.state.jobs
+    .filter((item) => item.status === 'processing' && item.resourceId)
+    .map((item) => item.resourceId));
+  const available = ensureResources(simulation)
+    .filter((resource) => resource.level === job.stage && !busy.has(resource.id));
+  return available.find((resource) => resource.assignment === job.target)
+    || available.find((resource) => resource.assignment === 'any')
+    || available[0]
+    || null;
+}
+
+function buildOvertimeJob(simulation, template, index, scheduledAt) {
+  const wave = simulation.state.overtimeWave;
+  const path = [...template.path];
+  const originalPromise = Math.max(
+    32,
+    Math.min(110, Number(template.deadline - template.scheduledAt) || simulation.shift.promiseSeconds || 60)
+  );
+  const pressure = Math.min(12, wave * 1.5);
+  const deadline = scheduledAt + Math.max(28, originalPromise - pressure);
+  const serial = String(simulation.state.jobs.length + index + 1).padStart(3, '0');
+  return {
+    ...template,
+    id: `${template.carrierCode}-OT${wave}-${serial}`,
+    path,
+    pathIndex: 0,
+    stage: path[0],
+    target: '',
+    scheduledAt,
+    arrivedAt: null,
+    deadline,
+    status: 'scheduled',
+    startedAt: null,
+    completesAt: null,
+    queueOrder: null,
+    deliveredAt: null,
+    late: false,
+    missed: false,
+    resourceId: null,
+    history: []
+  };
+}
+
+function addOvertimeWave(simulation, count = 0) {
+  const baseCount = Math.max(1, simulation.shift.jobs || simulation.state.jobs.length);
+  const templates = simulation.state.jobs.slice(0, baseCount);
+  if (!templates.length) return 0;
+  simulation.state.overtimeWave += 1;
+  const totalResources = Object.values(simulation.state.capacity).reduce((sum, value) => sum + value, 0);
+  const waveSize = count || Math.max(6, Math.min(12, totalResources * 2));
+  const spacing = Math.max(3.2, (simulation.shift.spawnEvery || 5) * 0.82);
+  const firstArrival = simulation.state.elapsed + 1.25;
+  const jobs = Array.from({ length: waveSize }, (_, index) => {
+    const templateIndex = (index + simulation.state.overtimeWave * 3 + simulation.variant) % templates.length;
+    return buildOvertimeJob(simulation, templates[templateIndex], index, firstArrival + index * spacing);
+  });
+  simulation.state.jobs.push(...jobs);
+  simulation.state.nextOvertimeWaveAt = jobs.at(-1).scheduledAt + Math.max(7, spacing * 1.5);
+  return jobs.length;
+}
+
+function continueOperations(simulation) {
+  ensureResources(simulation);
+  if (!simulation.state.completed || simulation.shiftId === 'first-rounds') return false;
+  simulation.state.lastOutcome = simulation.state.outcome;
+  simulation.state.outcome = null;
+  simulation.state.completed = false;
+  simulation.state.paused = false;
+  simulation.state.stage = 'overtime';
+  simulation.state.overtime = true;
+  simulation.state.selectedJobId = null;
+  addOvertimeWave(simulation);
+  simulation.emit('resume', 'Shift report closed. Live overtime continues.');
+  return true;
+}
+
+function cycleResource(simulation, resourceId) {
+  const resource = ensureResources(simulation).find((item) => item.id === resourceId || item.hotspotId === resourceId);
+  if (!resource || simulation.shiftId === 'first-rounds' || !simulation.state.started || simulation.state.completed) return false;
+  const options = RESOURCE_TARGETS[resource.level] || RESOURCE_TARGETS.terminal;
+  const currentIndex = Math.max(0, options.findIndex(([id]) => id === resource.assignment));
+  resource.assignment = options[(currentIndex + 1) % options.length][0];
+  const busyJob = resourceBusyJob(simulation, resource.id);
+  const timing = busyJob ? ' after its current run' : '';
+  simulation.emit(
+    'plan',
+    `${resource.name} assigned to ${assignmentLabel(resource.level, resource.assignment)}${timing}.`,
+    { resourceId: resource.id, level: resource.level, assignment: resource.assignment }
+  );
+  return true;
+}
+
+function resourceSnapshot(simulation) {
+  return ensureResources(simulation).map((resource) => {
+    const job = resourceBusyJob(simulation, resource.id);
+    return {
+      ...resource,
+      assignmentLabel: assignmentLabel(resource.level, resource.assignment),
+      busy: Boolean(job),
+      busyJobId: job?.id || null,
+      busyCarrierCode: job?.carrierCode || null,
+      busyTarget: job?.target || null
+    };
+  });
+}
+
+function installPatch() {
+  const prototype = ShiftSimulation.prototype;
+  if (prototype[PATCH_FLAG]) return;
+  Object.defineProperty(prototype, PATCH_FLAG, { value: true });
+
+  const originalSnapshot = prototype.snapshot;
+  const originalPerform = prototype.perform;
+  const originalStartProcessing = prototype.startProcessing;
+  const originalProcessingDuration = prototype.processingDuration;
+  const originalShouldFinish = prototype.shouldFinish;
+  const originalEnforceHardStop = prototype.enforceHardStop;
+  const originalTick = prototype.tick;
+  const originalReset = prototype.reset;
+
+  prototype.snapshot = function snapshotWithResources() {
+    ensureResources(this);
+    const snapshot = originalSnapshot.call(this);
+    const resources = resourceSnapshot(this);
+    const activeResourceHotspots = snapshot.started && !snapshot.completed && snapshot.shiftId !== 'first-rounds'
+      ? resources.filter((resource) => resource.level !== 'terminal').map((resource) => resource.hotspotId)
+      : [];
+    const hotspotLabels = { ...snapshot.hotspotLabels };
+    const hotspotTones = { ...snapshot.hotspotTones };
+    const hotspotIcons = { ...snapshot.hotspotIcons };
+    for (const resource of resources) {
+      hotspotLabels[resource.hotspotId] = `${resource.id} · ${resource.assignmentLabel}${resource.busy ? ` · ${resource.busyCarrierCode}` : ' · ready'}`;
+      hotspotTones[resource.hotspotId] = resource.busy ? 'orange' : 'good';
+      hotspotIcons[resource.hotspotId] = '▰';
+    }
+    return {
+      ...snapshot,
+      overtime: Boolean(this.state.overtime),
+      overtimeWave: this.state.overtimeWave || 0,
+      resources,
+      activeHotspots: [...new Set([...snapshot.activeHotspots, ...activeResourceHotspots])],
+      hotspotLabels,
+      hotspotTones,
+      hotspotIcons
+    };
+  };
+
+  prototype.perform = function performWithManagement(action, value = null) {
+    ensureResources(this);
+    if (action === 'cycle-resource') return cycleResource(this, value);
+    if (action === 'continue-operations') return continueOperations(this);
+    return originalPerform.call(this, action, value);
+  };
+
+  prototype.startProcessing = function startProcessingWithResource(job) {
+    ensureResources(this);
+    const resource = chooseResource(this, job);
+    job.resourceId = resource?.id || null;
+    return originalStartProcessing.call(this, job);
+  };
+
+  prototype.processingDuration = function processingDurationWithPlan(job) {
+    const base = originalProcessingDuration.call(this, job);
+    const resource = ensureResources(this).find((item) => item.id === job.resourceId);
+    if (!resource || resource.assignment === 'any') return base;
+    return base * (resource.assignment === job.target ? 0.78 : 1.22);
+  };
+
+  prototype.shouldFinish = function shouldFinishWithOvertime() {
+    if (this.state.overtime) return false;
+    return originalShouldFinish.call(this);
+  };
+
+  prototype.enforceHardStop = function enforceHardStopWithOvertime() {
+    if (this.state.overtime) return;
+    return originalEnforceHardStop.call(this);
+  };
+
+  prototype.tick = function tickWithOvertime(realSeconds) {
+    ensureResources(this);
+    const result = originalTick.call(this, realSeconds);
+    if (this.state.overtime && !this.state.completed) {
+      const unresolved = this.state.jobs.filter((job) => ['scheduled', 'waiting', 'queued', 'processing'].includes(job.status)).length;
+      if (unresolved <= 2 && this.state.elapsed >= (this.state.nextOvertimeWaveAt || 0)) {
+        addOvertimeWave(this);
+        this.onChange(this.snapshot(), { type: 'tick' });
+      }
+    }
+    return result;
+  };
+
+  prototype.reset = function resetWithResources() {
+    const result = originalReset.call(this);
+    ensureResources(this);
+    return result;
+  };
+}
+
+installPatch();

--- a/postal/management-ui.mjs
+++ b/postal/management-ui.mjs
@@ -1,0 +1,229 @@
+import './management-sim.mjs';
+import { PostalWorld } from './world.mjs';
+
+const WORLD_PATCH = Symbol.for('postal.resourceWorldPatch');
+
+function dispatchResource(resourceId) {
+  document.dispatchEvent(new CustomEvent('postal-resource-activate', { detail: { resourceId } }));
+}
+
+function wrapWorldHotspotCallback(world) {
+  if (world.__postalResourceCallbackWrapped) return;
+  world.__postalResourceCallbackWrapped = true;
+  const original = world.callbacks.onHotspot;
+  world.callbacks.onHotspot = (id) => {
+    if (String(id).startsWith('resource-')) {
+      dispatchResource(String(id).replace('resource-', ''));
+      return;
+    }
+    original?.(id);
+  };
+}
+
+function ensureTruckHotspots(world, level, trucks, prefix, group, label) {
+  if (!trucks?.length || !group) return;
+  wrapWorldHotspotCallback(world);
+  const resourceCount = (world.state.resources || []).filter((resource) => resource.level === level).length;
+  trucks.slice(0, resourceCount).forEach((truck, index) => {
+    const shortId = `${prefix}${index + 1}`;
+    const hotspotId = `resource-${shortId}`;
+    if (!truck.userData.postalResourceHotspot) {
+      truck.userData.postalResourceHotspot = hotspotId;
+      world.markInteractive(truck, hotspotId);
+      world.registerHotspot(hotspotId, `${label} ${shortId}`, '▰', 'good', group, truck.position.clone());
+      world.hotspotStateKey = '';
+      world.updateHotspotVisibility();
+    }
+    const hotspot = world.hotspots.get(hotspotId);
+    if (hotspot) {
+      hotspot.anchor.position.copy(truck.position);
+      hotspot.anchor.position.y += 1.05;
+    }
+    truck.visible = world.state.started && !world.state.completed && world.state.shiftId !== 'first-rounds';
+  });
+}
+
+function patchWorld() {
+  const prototype = PostalWorld.prototype;
+  if (prototype[WORLD_PATCH]) return;
+  Object.defineProperty(prototype, WORLD_PATCH, { value: true });
+  const originalNetwork = prototype.updateNetwork;
+  const originalSweden = prototype.updateSweden;
+
+  prototype.updateNetwork = function updateNetworkWithInteractiveTrucks(delta) {
+    originalNetwork.call(this, delta);
+    ensureTruckHotspots(this, 'network', this.networkTrucks, 'R', this.networkGroup, 'Regional truck');
+  };
+
+  prototype.updateSweden = function updateSwedenWithInteractiveLinehauls(delta) {
+    originalSweden.call(this, delta);
+    ensureTruckHotspots(this, 'sweden', this.swedenTrucks, 'S', this.swedenGroup, 'Linehaul');
+  };
+}
+
+patchWorld();
+
+const $ = (selector) => document.querySelector(selector);
+let plannerOpen = false;
+let plannerKey = '';
+
+function announce(message) {
+  const live = $('#politeLive');
+  if (!live) return;
+  live.textContent = '';
+  window.setTimeout(() => { live.textContent = message; }, 20);
+}
+
+function currentLevel() {
+  return $('.scene-tab[aria-current="page"]')?.dataset.scene || 'terminal';
+}
+
+function planLabel(level) {
+  if (level === 'terminal') return 'Plan teams';
+  if (level === 'network') return 'Plan trucks';
+  return 'Plan linehauls';
+}
+
+function resourceIcon(resource) {
+  return resource.level === 'terminal' ? '●' : '▰';
+}
+
+function installUi() {
+  const game = window.__POSTAL_GAME__;
+  if (!game) {
+    window.setTimeout(installUi, 40);
+    return;
+  }
+
+  const operationLayer = $('#operationLayer');
+  const operationHead = operationLayer?.querySelector('.operation-head');
+  const parcelRack = $('#parcelRack');
+  const result = $('#resultScreen');
+  const nextShift = $('#nextShiftButton');
+  const hudControls = $('.hud-controls');
+  if (!operationLayer || !operationHead || !parcelRack || !result || !nextShift || !hudControls) return;
+
+  const planToggle = document.createElement('button');
+  planToggle.type = 'button';
+  planToggle.className = 'resource-plan-toggle';
+  planToggle.id = 'resourcePlanToggle';
+  planToggle.setAttribute('aria-expanded', 'false');
+  planToggle.setAttribute('aria-controls', 'resourcePlanner');
+  planToggle.textContent = 'Plan resources';
+  operationHead.append(planToggle);
+
+  const planner = document.createElement('section');
+  planner.className = 'resource-planner';
+  planner.id = 'resourcePlanner';
+  planner.setAttribute('aria-label', 'Resource assignments');
+  planner.hidden = true;
+  parcelRack.before(planner);
+
+  const boardButton = document.createElement('button');
+  boardButton.type = 'button';
+  boardButton.className = 'icon-button management-board-button';
+  boardButton.id = 'shiftBoardButton';
+  boardButton.setAttribute('aria-label', 'Open shift board');
+  boardButton.innerHTML = '<span aria-hidden="true">↩</span>';
+  hudControls.insertBefore(boardButton, $('#detailsButton'));
+
+  const continueButton = document.createElement('button');
+  continueButton.type = 'button';
+  continueButton.className = 'game-button game-button--primary';
+  continueButton.id = 'continueOperationsButton';
+  continueButton.textContent = 'Keep operating';
+  nextShift.before(continueButton);
+
+  function syncResultActions() {
+    if (result.hidden) return;
+    const state = game.getState();
+    const liveShift = state.shiftId !== 'first-rounds';
+    continueButton.hidden = !liveShift;
+    nextShift.textContent = state.shiftId === 'first-rounds' ? 'Open shift board' : 'Choose another shift';
+    nextShift.classList.toggle('game-button--primary', !liveShift);
+    nextShift.classList.toggle('game-button--quiet', liveShift);
+  }
+
+  function renderPlanner(force = false) {
+    const state = game.getState();
+    const level = currentLevel();
+    const resources = (state.resources || []).filter((resource) => resource.level === level);
+    const available = state.started && !state.completed && state.shiftId !== 'first-rounds' && resources.length > 0;
+    planToggle.hidden = !available;
+    boardButton.hidden = !state.started;
+    if (!available) plannerOpen = false;
+    planToggle.textContent = planLabel(level);
+    planToggle.setAttribute('aria-expanded', String(plannerOpen && available));
+    planner.hidden = !plannerOpen || !available;
+
+    const key = JSON.stringify([level, plannerOpen, resources]);
+    if (!force && key === plannerKey) return;
+    plannerKey = key;
+    if (planner.hidden) {
+      planner.innerHTML = '';
+      return;
+    }
+
+    planner.innerHTML = `<div class="resource-planner-head"><div><span>LIVE RESOURCE PLAN</span><strong>${planLabel(level).replace('Plan ', '')}</strong></div><p>Tap a resource to move it to the next lane or route. Matching work runs faster.</p></div><div class="resource-roster">${resources.map((resource) => {
+      const status = resource.busy ? `${resource.busyCarrierCode} moving` : 'Ready';
+      const aria = `${resource.name}. Assigned to ${resource.assignmentLabel}. ${status}. Tap to change assignment.`;
+      return `<button class="resource-card" type="button" data-resource-id="${resource.id}" data-busy="${resource.busy}" aria-label="${aria}">
+        <span class="resource-card-icon" aria-hidden="true">${resourceIcon(resource)}</span>
+        <span class="resource-card-copy"><strong>${resource.id}</strong><span>${resource.assignmentLabel}</span><small>${status}</small></span>
+        <span class="resource-card-cycle" aria-hidden="true">↻</span>
+      </button>`;
+    }).join('')}</div>`;
+
+    planner.querySelectorAll('[data-resource-id]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const before = game.getState().resources.find((resource) => resource.id === button.dataset.resourceId);
+        if (!game.act('cycle-resource', button.dataset.resourceId)) return;
+        const after = game.getState().resources.find((resource) => resource.id === button.dataset.resourceId);
+        announce(`${after.name} moved from ${before.assignmentLabel} to ${after.assignmentLabel}.`);
+        renderPlanner(true);
+      });
+    });
+  }
+
+  planToggle.addEventListener('click', () => {
+    plannerOpen = !plannerOpen;
+    renderPlanner(true);
+    if (plannerOpen) planner.querySelector('button')?.focus({ preventScroll: true });
+  });
+
+  boardButton.addEventListener('click', () => {
+    const state = game.getState();
+    if (state.canRun && !state.paused && !state.completed) $('#pauseButton')?.click();
+    nextShift.click();
+  });
+
+  continueButton.addEventListener('click', () => {
+    if (!game.act('continue-operations')) return;
+    result.hidden = true;
+    $('#gameShell').inert = false;
+    plannerOpen = true;
+    renderPlanner(true);
+    announce('Shift report closed. The network is still live and a new wave is arriving.');
+    window.setTimeout(() => planToggle.focus({ preventScroll: true }), 40);
+  });
+
+  document.addEventListener('postal-resource-activate', (event) => {
+    const resourceId = event.detail?.resourceId;
+    if (!resourceId || !game.act('cycle-resource', resourceId)) return;
+    plannerOpen = true;
+    renderPlanner(true);
+    const resource = game.getState().resources.find((item) => item.id === resourceId);
+    announce(`${resource.name} assigned to ${resource.assignmentLabel}.`);
+  });
+
+  const resultObserver = new MutationObserver(syncResultActions);
+  resultObserver.observe(result, { attributes: true, attributeFilter: ['hidden'] });
+  document.querySelectorAll('.scene-tab').forEach((button) => button.addEventListener('click', () => renderPlanner(true)));
+  window.setInterval(() => {
+    renderPlanner();
+    syncResultActions();
+  }, 200);
+  renderPlanner(true);
+}
+
+installUi();

--- a/postal/management.css
+++ b/postal/management.css
@@ -1,0 +1,186 @@
+.operation-head {
+  flex-wrap: wrap;
+}
+
+.resource-plan-toggle {
+  min-height: 36px;
+  margin-left: auto;
+  padding: 6px 10px;
+  border: 2px solid var(--ink);
+  border-radius: 999px;
+  background: var(--blue);
+  box-shadow: 2px 2px 0 var(--ink);
+  font-size: 0.7rem;
+  font-weight: 950;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.resource-plan-toggle[aria-expanded="true"] {
+  background: var(--yellow);
+  box-shadow: 1px 1px 0 var(--ink);
+  transform: translate(1px, 1px);
+}
+
+.resource-planner {
+  margin: 8px 0 5px;
+  padding: 9px;
+  border: 2px solid var(--ink);
+  border-radius: var(--radius-small);
+  background: rgb(255 253 245 / 0.96);
+  box-shadow: var(--shadow-small);
+}
+
+.resource-planner[hidden],
+.resource-plan-toggle[hidden],
+.management-board-button[hidden],
+#continueOperationsButton[hidden] {
+  display: none;
+}
+
+.resource-planner-head {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 7px;
+}
+
+.resource-planner-head div {
+  display: grid;
+  gap: 1px;
+}
+
+.resource-planner-head span,
+.resource-planner-head p {
+  margin: 0;
+  font-size: 0.62rem;
+  font-weight: 850;
+  line-height: 1.15;
+}
+
+.resource-planner-head span {
+  color: var(--purple);
+  letter-spacing: 0.08em;
+}
+
+.resource-planner-head strong {
+  font-size: 0.88rem;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.resource-planner-head p {
+  max-width: 190px;
+  color: rgb(16 19 26 / 0.72);
+  text-align: right;
+}
+
+.resource-roster {
+  display: flex;
+  gap: 7px;
+  overflow-x: auto;
+  padding: 1px 1px 4px;
+  scrollbar-width: thin;
+}
+
+.resource-card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  min-width: 154px;
+  min-height: 54px;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 8px;
+  border: 2px solid var(--ink);
+  border-radius: 11px;
+  background: var(--paper-bright);
+  box-shadow: 2px 2px 0 var(--ink);
+  text-align: left;
+}
+
+.resource-card[data-busy="true"] {
+  background: color-mix(in srgb, var(--orange) 28%, var(--paper-bright));
+}
+
+.resource-card:active {
+  box-shadow: none;
+  transform: translate(2px, 2px);
+}
+
+.resource-card-icon {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  border: 2px solid var(--ink);
+  border-radius: 8px;
+  background: var(--yellow);
+  font-size: 0.9rem;
+}
+
+.resource-card-copy {
+  display: grid;
+  min-width: 0;
+  gap: 1px;
+}
+
+.resource-card-copy strong,
+.resource-card-copy span,
+.resource-card-copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.resource-card-copy strong {
+  font-size: 0.78rem;
+}
+
+.resource-card-copy span {
+  font-size: 0.72rem;
+  font-weight: 900;
+}
+
+.resource-card-copy small {
+  color: rgb(16 19 26 / 0.68);
+  font-size: 0.62rem;
+  font-weight: 800;
+}
+
+.resource-card-cycle {
+  font-size: 1.1rem;
+  font-weight: 950;
+}
+
+.management-board-button span {
+  font-size: 1.1rem;
+}
+
+.result-card #continueOperationsButton {
+  width: 100%;
+}
+
+@media (max-height: 700px) {
+  .resource-planner {
+    margin-top: 5px;
+    padding: 6px;
+  }
+
+  .resource-planner-head p {
+    display: none;
+  }
+
+  .resource-card {
+    min-width: 138px;
+    min-height: 46px;
+    padding: 5px 7px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .resource-plan-toggle,
+  .resource-card {
+    transition: none;
+  }
+}

--- a/postal/sw.js
+++ b/postal/sw.js
@@ -1,11 +1,14 @@
-const CACHE_NAME = 'postal-live-20260805-r4';
+const CACHE_NAME = 'postal-live-20260806-r5';
 const CORE_ASSETS = [
   './',
   './index.html',
   './styles.css',
+  './management.css',
   './main.mjs',
   './sim.mjs',
   './world.mjs',
+  './management-sim.mjs',
+  './management-ui.mjs',
   './vendor/three.module.min.js',
   './vendor/three.core.min.js',
   './vendor/addons/loaders/GLTFLoader.js',

--- a/postal/tests/management.test.mjs
+++ b/postal/tests/management.test.mjs
@@ -1,0 +1,107 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import '../management-sim.mjs';
+import { SHIFT_CATALOG, ShiftSimulation } from '../sim.mjs';
+
+function routeEveryWaitingBatch(simulation) {
+  const state = simulation.snapshot();
+  for (const incident of state.incidents.filter((item) => item.active)) {
+    simulation.perform('resolve-incident', incident.target);
+  }
+  for (const job of simulation.snapshot().jobs.filter((item) => item.status === 'waiting')) {
+    assert.equal(simulation.perform('select-job', job.id), true, `select ${job.id}`);
+    assert.equal(simulation.perform('route-selected', job.target), true, `route ${job.id}`);
+  }
+}
+
+function finishShift(shiftId) {
+  const simulation = new ShiftSimulation(() => {}, shiftId);
+  simulation.start();
+  for (let step = 0; step < 5000 && !simulation.snapshot().completed; step += 1) {
+    routeEveryWaitingBatch(simulation);
+    simulation.tick(0.25);
+  }
+  return simulation;
+}
+
+function assignResourceTo(simulation, resourceId, target) {
+  for (let step = 0; step < 8; step += 1) {
+    const resource = simulation.snapshot().resources.find((item) => item.id === resourceId);
+    if (resource.assignment === target) return resource;
+    assert.equal(simulation.perform('cycle-resource', resourceId), true);
+  }
+  assert.fail(`${resourceId} could not be assigned to ${target}`);
+}
+
+test('live shifts expose assignable teams, regional trucks and national linehauls', () => {
+  const simulation = new ShiftSimulation(() => {}, 'sweden-night');
+  simulation.start();
+  const state = simulation.snapshot();
+  assert.deepEqual(state.resources.map((resource) => resource.id), ['T1', 'T2', 'R1', 'R2', 'S1', 'S2']);
+  assert.ok(state.activeHotspots.includes('resource-R1'));
+  assert.ok(state.activeHotspots.includes('resource-S1'));
+  assert.equal(state.resources.find((resource) => resource.id === 'R1').assignmentLabel, 'Any regional route');
+});
+
+test('matching a team to the selected lane gives that team the batch and completes it faster', () => {
+  const planned = new ShiftSimulation(() => {}, 'town-rush');
+  planned.start();
+  planned.tick(1.5);
+  const plannedJob = planned.snapshot().jobs.find((job) => job.status === 'waiting');
+  assert.ok(plannedJob);
+  assignResourceTo(planned, 'T1', plannedJob.target);
+  planned.perform('select-job', plannedJob.id);
+  planned.perform('route-selected', plannedJob.target);
+  const plannedProcessing = planned.snapshot().jobs.find((job) => job.id === plannedJob.id);
+
+  const flexible = new ShiftSimulation(() => {}, 'town-rush');
+  flexible.start();
+  flexible.tick(1.5);
+  const flexibleJob = flexible.snapshot().jobs.find((job) => job.id === plannedJob.id);
+  flexible.perform('select-job', flexibleJob.id);
+  flexible.perform('route-selected', flexibleJob.target);
+  const flexibleProcessing = flexible.snapshot().jobs.find((job) => job.id === flexibleJob.id);
+
+  assert.equal(plannedProcessing.resourceId, 'T1');
+  assert.equal(planned.snapshot().resources.find((resource) => resource.id === 'T1').busy, true);
+  assert.ok(
+    plannedProcessing.completesAt - plannedProcessing.startedAt < flexibleProcessing.completesAt - flexibleProcessing.startedAt,
+    'planned matching work should be faster than a flexible assignment'
+  );
+});
+
+test('a completed live shift can close its report and continue into recurring overtime waves', () => {
+  const simulation = finishShift('town-rush');
+  const completed = simulation.snapshot();
+  assert.equal(completed.completed, true);
+  assert.equal(completed.jobs.length, SHIFT_CATALOG.find((shift) => shift.id === 'town-rush').jobs);
+
+  assert.equal(simulation.perform('continue-operations'), true);
+  let state = simulation.snapshot();
+  assert.equal(state.completed, false);
+  assert.equal(state.paused, false);
+  assert.equal(state.stage, 'overtime');
+  assert.equal(state.overtime, true);
+  assert.ok(state.jobs.length > completed.jobs.length);
+  assert.ok(state.jobs.some((job) => job.status === 'scheduled'));
+
+  simulation.tick(500);
+  state = simulation.snapshot();
+  assert.equal(state.completed, false);
+  assert.equal(state.overtime, true);
+  assert.ok(state.overtimeWave >= 2);
+});
+
+test('the calm first shift remains a bounded tutorial rather than endless overtime', () => {
+  const simulation = new ShiftSimulation(() => {}, 'first-rounds');
+  simulation.start();
+  simulation.perform('select-job', 'TRAINING-01');
+  simulation.perform('route-selected', 'express-lane');
+  simulation.tick(12);
+  simulation.perform('visit-level', 'network');
+  simulation.perform('select-job', 'TRAINING-01');
+  simulation.perform('route-selected', 'network-harnosand');
+  simulation.tick(20);
+  assert.equal(simulation.snapshot().completed, true);
+  assert.equal(simulation.perform('continue-operations'), false);
+});

--- a/postal/tests/ui-contract.test.mjs
+++ b/postal/tests/ui-contract.test.mjs
@@ -3,13 +3,16 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 
 const root = new URL('../', import.meta.url);
-const [html, main, sim, world, styles, worker] = await Promise.all([
+const [html, main, sim, world, styles, worker, managementSim, managementUi, managementStyles] = await Promise.all([
   readFile(new URL('index.html', root), 'utf8'),
   readFile(new URL('main.mjs', root), 'utf8'),
   readFile(new URL('sim.mjs', root), 'utf8'),
   readFile(new URL('world.mjs', root), 'utf8'),
   readFile(new URL('styles.css', root), 'utf8'),
-  readFile(new URL('sw.js', root), 'utf8')
+  readFile(new URL('sw.js', root), 'utf8'),
+  readFile(new URL('management-sim.mjs', root), 'utf8'),
+  readFile(new URL('management-ui.mjs', root), 'utf8'),
+  readFile(new URL('management.css', root), 'utf8')
 ]);
 
 test('every JavaScript ID selector has a matching unique HTML element', () => {
@@ -69,6 +72,33 @@ test('fresh-player onboarding remains guided while the live command deck has no 
   assert.match(styles, /\.command-content\[data-layout="live"\]/);
 });
 
+test('teams and vehicles have a compact semantic planner and matching assignments affect work', () => {
+  assert.match(managementUi, /resource-plan-toggle/);
+  assert.match(managementUi, /data-resource-id/);
+  assert.match(managementUi, /Tap a resource to move it to the next lane or route/);
+  assert.match(managementStyles, /\.resource-roster[\s\S]*overflow-x: auto/);
+  assert.match(managementStyles, /\.resource-card\[data-busy="true"\]/);
+  assert.match(managementSim, /processingDurationWithPlan/);
+  assert.match(managementSim, /resource\.assignment === job\.target \? 0\.78 : 1\.22/);
+});
+
+test('regional and national trucks are direct canvas interactions with semantic alternatives', () => {
+  assert.match(managementUi, /ensureTruckHotspots/);
+  assert.match(managementUi, /world\.markInteractive\(truck, hotspotId\)/);
+  assert.match(managementUi, /world\.registerHotspot\(hotspotId/);
+  assert.match(managementUi, /postal-resource-activate/);
+  assert.match(managementSim, /resource-R1|`resource-\$\{shortId\}`/);
+});
+
+test('completed live shifts can close the report and continue into recurring overtime', () => {
+  assert.match(managementUi, /continueOperationsButton/);
+  assert.match(managementUi, /Keep operating/);
+  assert.match(managementSim, /continue-operations/);
+  assert.match(managementSim, /state\.overtime = true/);
+  assert.match(managementSim, /addOvertimeWave/);
+  assert.match(html, /After a report, keep operating for endless waves/);
+});
+
 test('runtime uses only short low-pass synthesized feedback', () => {
   assert.doesNotMatch(main, /new Audio\s*\(/);
   assert.doesNotMatch(main, /assets\/audio/);
@@ -121,9 +151,14 @@ test('portrait live controls are compact, horizontally scrollable and status-ind
   assert.match(styles, /\.parcel-deadline\[data-late="true"\]/);
   assert.match(styles, /\.game-shell\[data-play-mode="live"\] \.command-deck/);
   assert.match(styles, /@media \(max-height: 700px\)[\s\S]*data-play-mode="live"/);
+  assert.match(managementStyles, /@media \(max-height: 700px\)/);
 });
 
-test('new build markers bypass the previous campaign service worker cache', () => {
+test('new build markers and offline assets bypass the previous live cache', () => {
   assert.match(html, /build=20260805-live-r4/);
-  assert.match(worker, /postal-live-20260805-r4/);
+  assert.match(html, /build=20260806-management-r1/);
+  assert.match(worker, /postal-live-20260806-r5/);
+  assert.match(worker, /management-sim\.mjs/);
+  assert.match(worker, /management-ui\.mjs/);
+  assert.match(worker, /management\.css/);
 });


### PR DESCRIPTION
## What changed

- Adds a compact live resource planner for town teams, regional trucks, and national linehauls.
- Assignments now affect processing speed: matching a team or vehicle to its lane or route completes work faster.
- Makes the moving regional and national trucks directly tappable in the 3D scenes, with equivalent semantic controls below the scene.
- Adds a **Keep operating** action after live-shift reports. It closes the report, resumes the same operation, and schedules recurring overtime waves instead of leaving the game frozen.
- Adds an always-available shift-board control during play.
- Updates onboarding/help copy, offline caching, simulation tests, UI contract tests, and CI syntax coverage.

## Why

The five shifts teach the game well, but completion previously behaved like a hard stop. Trucks were visual rather than operational, and the player could not plan how limited teams and vehicles were used. This pass turns those pieces into actual ongoing management decisions.

## Validation

- New simulation tests cover resource rosters, matching-assignment speed effects, endless overtime, and bounded onboarding.
- UI contract tests cover semantic planner controls, direct 3D truck interaction, continuous-play actions, and offline assets.
- GitHub Actions checks syntax for all POSTAL modules and runs the complete POSTAL test suite.