### PR TITLE
Separate POSTAL action, planning and package investigation

### DIFF
--- a/postal/index.html
+++ b/postal/index.html
@@ -10,7 +10,7 @@
   <meta name="description" content="POSTAL is a portrait-friendly real-time parcel network game set in Sweden.">
   <title>POSTAL — Every package has a promise</title>
   <link rel="stylesheet" href="./styles.css?build=20260805-live-r4">
-  <link rel="stylesheet" href="./management.css?build=20260806-management-r1">
+  <link rel="stylesheet" href="./management.css?build=20260806-management-r2">
   <script type="importmap">
     {
       "imports": {
@@ -21,7 +21,7 @@
   </script>
 </head>
 <body>
-  <a class="skip-link" href="#operationLayer">Skip to live parcels</a>
+  <a class="skip-link" href="#operationLayer">Skip to live packages</a>
 
   <div class="game-shell" id="gameShell" data-play-mode="guided">
     <header class="hud" aria-label="Shift status and controls">
@@ -32,16 +32,10 @@
         </div>
 
         <div class="hud-controls">
-          <button class="icon-button" id="pauseButton" type="button" aria-pressed="false" aria-label="Pause shift" disabled>
-            <span aria-hidden="true">Ⅱ</span>
-          </button>
+          <button class="icon-button" id="pauseButton" type="button" aria-pressed="false" aria-label="Pause shift" disabled><span aria-hidden="true">Ⅱ</span></button>
           <button class="speed-button" id="speedButton" type="button" aria-label="Simulation speed, normal" disabled>1×</button>
-          <button class="icon-button" id="soundButton" type="button" aria-pressed="true" aria-label="Mute sound">
-            <span aria-hidden="true">♪</span>
-          </button>
-          <button class="icon-button" id="detailsButton" type="button" aria-haspopup="dialog" aria-label="Open detailed shift information">
-            <span aria-hidden="true">i</span>
-          </button>
+          <button class="icon-button" id="soundButton" type="button" aria-pressed="true" aria-label="Mute sound"><span aria-hidden="true">♪</span></button>
+          <button class="icon-button" id="detailsButton" type="button" aria-haspopup="dialog" aria-label="Open detailed shift information"><span aria-hidden="true">i</span></button>
         </div>
       </div>
 
@@ -52,21 +46,9 @@
       </div>
 
       <section class="metrics" aria-label="Network performance">
-        <div class="metric metric--service" id="serviceMetric">
-          <span class="metric-icon" id="serviceIcon" aria-hidden="true">✓</span>
-          <span class="metric-label" id="serviceLabel">On time</span>
-          <strong id="serviceValue">100%</strong>
-        </div>
-        <div class="metric metric--backlog" id="backlogMetric">
-          <span class="metric-icon" id="backlogIcon" aria-hidden="true">▦</span>
-          <span class="metric-label" id="backlogLabel">Waiting</span>
-          <strong id="backlogValue">0</strong>
-        </div>
-        <div class="metric metric--risk" id="riskMetric" data-level="good">
-          <span class="metric-icon" id="riskIcon" aria-hidden="true">×</span>
-          <span class="metric-label" id="riskLabel">Combo</span>
-          <strong id="riskValue">0×</strong>
-        </div>
+        <div class="metric metric--service" id="serviceMetric"><span class="metric-icon" id="serviceIcon" aria-hidden="true">✓</span><span class="metric-label" id="serviceLabel">On time</span><strong id="serviceValue">100%</strong></div>
+        <div class="metric metric--backlog" id="backlogMetric"><span class="metric-icon" id="backlogIcon" aria-hidden="true">▦</span><span class="metric-label" id="backlogLabel">Waiting</span><strong id="backlogValue">0</strong></div>
+        <div class="metric metric--risk" id="riskMetric" data-level="good"><span class="metric-icon" id="riskIcon" aria-hidden="true">×</span><span class="metric-label" id="riskLabel">Combo</span><strong id="riskValue">0×</strong></div>
       </section>
     </header>
 
@@ -74,173 +56,57 @@
       <canvas id="worldCanvas" aria-hidden="true"></canvas>
       <div class="world-vignette" aria-hidden="true"></div>
       <div class="world-grid" aria-hidden="true"></div>
-
-      <div class="loading-card" id="loadingCard" role="status">
-        <span class="loading-parcel" aria-hidden="true"></span>
-        <span>Opening the network…</span>
-      </div>
-
-      <div class="scene-heading" aria-hidden="true">
-        <span id="sceneEyebrow">LIVE TOWN</span>
-        <strong id="sceneTitle">Sundsvall</strong>
-      </div>
-
-      <div class="mission-pill" id="missionPill" data-state="warning">
-        <span class="mission-symbol" aria-hidden="true">↗</span>
-        <span>
-          <small id="missionLabel">FIRST ROUNDS</small>
-          <strong id="missionTime">NO PRESSURE</strong>
-        </span>
-      </div>
-
+      <div class="loading-card" id="loadingCard" role="status"><span class="loading-parcel" aria-hidden="true"></span><span>Opening the network…</span></div>
+      <div class="scene-heading" aria-hidden="true"><span id="sceneEyebrow">LIVE DEPOT</span><strong id="sceneTitle">Sundsvall</strong></div>
+      <div class="mission-pill" id="missionPill" data-state="warning"><span class="mission-symbol" aria-hidden="true">↗</span><span><small id="missionLabel">FIRST ROUNDS</small><strong id="missionTime">NO PRESSURE</strong></span></div>
       <div class="hotspot-layer" id="hotspotLayer" aria-label="Interactive destinations in the current scene"></div>
 
       <section class="operation-layer" id="operationLayer" aria-labelledby="workQueueTitle" hidden>
         <div class="operation-head">
-          <div>
-            <span class="operation-level" id="operationLevel">TOWN FLOOR</span>
-            <strong id="workQueueTitle">Waiting batches</strong>
-          </div>
+          <div><span class="operation-level" id="operationLevel">DEPOT FLOOR</span><strong id="workQueueTitle">Waiting batches</strong></div>
           <span class="resource-chip" id="resourceChip">0 / 1 busy</span>
         </div>
-        <div class="parcel-rack" id="parcelRack" role="group" aria-label="Waiting and moving parcel batches"></div>
+        <div class="parcel-rack" id="parcelRack" role="group" aria-label="Waiting and moving package batches"></div>
         <div class="fallback-targets" id="fallbackTargets" aria-label="Destinations in this level" hidden></div>
         <p class="operation-empty" id="operationEmpty">All clear here.</p>
       </section>
-
-      <p class="sr-only" id="sceneSummary">Sundsvall terminal. No live work has started.</p>
+      <p class="sr-only" id="sceneSummary">Sundsvall depot. No live work has started.</p>
     </main>
 
     <section class="command-deck" id="commandDeck" aria-labelledby="commandTitle" tabindex="-1">
       <div class="deck-grabber" aria-hidden="true"></div>
-      <div class="command-content" id="commandContent">
-        <div class="command-copy">
-          <span class="command-kicker">FIRST SHIFT · GUIDED</span>
-          <h1 id="commandTitle">Learn the live route.</h1>
-          <p>Select a parcel batch, then tap its marked destination in the miniature world.</p>
-        </div>
-        <div class="command-actions">
-          <button class="game-button game-button--primary" id="deckStartButton" type="button">Start first shift</button>
-        </div>
-      </div>
+      <div class="command-content" id="commandContent"><div class="command-copy"><span class="command-kicker">FIRST SHIFT · GUIDED</span><h1 id="commandTitle">Learn the live route.</h1><p>Select a package batch, then tap its marked destination in the miniature world.</p></div><div class="command-actions"><button class="game-button game-button--primary" id="deckStartButton" type="button">Start first shift</button></div></div>
     </section>
 
     <nav class="scene-nav" aria-label="Network levels">
-      <button class="scene-tab" type="button" data-scene="terminal" aria-current="page" disabled>
-        <span class="scene-tab-icon" aria-hidden="true">▦</span>
-        <span>Town</span>
-        <span class="tab-count" id="terminalAlert" aria-label="No waiting town batches" hidden>0</span>
-      </button>
-      <button class="scene-tab" type="button" data-scene="network" disabled>
-        <span class="scene-tab-icon" aria-hidden="true">⌁</span>
-        <span>Region</span>
-        <span class="tab-count" id="networkAlert" aria-label="No waiting regional batches" hidden>0</span>
-      </button>
-      <button class="scene-tab" type="button" data-scene="sweden" disabled>
-        <span class="scene-tab-icon" aria-hidden="true">◆</span>
-        <span>Sweden</span>
-        <span class="tab-count" id="swedenAlert" aria-label="No waiting national batches" hidden>0</span>
-      </button>
+      <button class="scene-tab" type="button" data-scene="terminal" aria-current="page" disabled><span class="scene-tab-icon" aria-hidden="true">▦</span><span>Depot</span><span class="tab-count" id="terminalAlert" aria-label="No waiting depot batches" hidden>0</span></button>
+      <button class="scene-tab" type="button" data-scene="network" disabled><span class="scene-tab-icon" aria-hidden="true">⌁</span><span>Region</span><span class="tab-count" id="networkAlert" aria-label="No waiting regional batches" hidden>0</span></button>
+      <button class="scene-tab" type="button" data-scene="sweden" disabled><span class="scene-tab-icon" aria-hidden="true">◆</span><span>Sweden</span><span class="tab-count" id="swedenAlert" aria-label="No waiting national batches" hidden>0</span></button>
     </nav>
   </div>
 
   <section class="welcome" id="welcomeScreen" aria-labelledby="welcomeTitle">
     <div class="welcome-scrim" aria-hidden="true"></div>
     <div class="welcome-card">
-      <div class="welcome-logo" aria-hidden="true">
-        <span class="welcome-box"><i></i></span>
-        <span class="welcome-word" id="welcomeTitle">POSTAL</span>
-      </div>
+      <div class="welcome-logo" aria-hidden="true"><span class="welcome-box"><i></i></span><span class="welcome-word" id="welcomeTitle">POSTAL</span></div>
       <p class="welcome-tagline">Every package has a promise.</p>
-      <div class="brief-card">
-        <div class="brief-route" aria-hidden="true">
-          <span class="brief-node brief-node--start"></span>
-          <span class="brief-line"></span>
-          <span class="brief-truck">▰</span>
-          <span class="brief-line"></span>
-          <span class="brief-node"></span>
-        </div>
-        <span class="brief-label">FIRST SHIFT · CALM PRACTICE</span>
-        <strong>Learn one route. Then you are in charge.</strong>
-        <span>Town → region · no deadline</span>
-      </div>
+      <div class="brief-card"><div class="brief-route" aria-hidden="true"><span class="brief-node brief-node--start"></span><span class="brief-line"></span><span class="brief-truck">▰</span><span class="brief-line"></span><span class="brief-node"></span></div><span class="brief-label">FIRST SHIFT · CALM PRACTICE</span><strong>Learn one route. Then you are in charge.</strong><span>Depot → region · no deadline</span></div>
       <button class="game-button game-button--primary welcome-start" id="startButton" type="button">Start first shift</button>
-      <p class="welcome-note">After training, shifts run continuously. Plan teams and trucks, watch the miniature network and act before promises expire.</p>
+      <p class="welcome-note">After training, shifts run continuously. Plan teams and trucks, inspect suspicious packages and act before packages become late.</p>
     </div>
   </section>
 
-  <section class="campaign-screen" id="campaignScreen" aria-labelledby="campaignTitle" hidden>
-    <div class="campaign-scrim" aria-hidden="true"></div>
-    <div class="campaign-panel">
-      <header class="campaign-head">
-        <div>
-          <span class="command-kicker">POSTAL OPERATIONS</span>
-          <h2 id="campaignTitle">Choose a shift</h2>
-          <p id="campaignProgress">The next operation is open.</p>
-        </div>
-        <div class="campaign-stamp" id="campaignStamp" aria-hidden="true">1/5</div>
-      </header>
-      <div class="shift-list" id="shiftList"></div>
-      <p class="campaign-note">Each shift adds pressure and another live level. Replays vary carrier and arrival order. After a report, keep operating for endless waves.</p>
-    </div>
-  </section>
+  <section class="campaign-screen" id="campaignScreen" aria-labelledby="campaignTitle" hidden><div class="campaign-scrim" aria-hidden="true"></div><div class="campaign-panel"><header class="campaign-head"><div><span class="command-kicker">POSTAL OPERATIONS</span><h2 id="campaignTitle">Choose a shift</h2><p id="campaignProgress">The next operation is open.</p></div><div class="campaign-stamp" id="campaignStamp" aria-hidden="true">1/5</div></header><div class="shift-list" id="shiftList"></div><p class="campaign-note">Each shift adds pressure and another live level. Replays vary carrier and arrival order. After a report, keep operating for endless waves.</p></div></section>
 
-  <section class="result-screen" id="resultScreen" aria-labelledby="resultTitle" hidden>
-    <div class="result-rays" aria-hidden="true"></div>
-    <div class="result-card">
-      <span class="result-kicker" id="resultKicker">SHIFT COMPLETE</span>
-      <div class="result-grade" id="resultGrade" aria-label="Grade A">A</div>
-      <h2 id="resultTitle">Promises kept.</h2>
-      <p id="resultSummary">The live network cleared.</p>
-      <div class="result-stats" id="resultStats" aria-label="Shift results"></div>
-      <div class="result-medals" id="resultMedals" aria-label="Shift achievements"></div>
-      <button class="game-button game-button--primary" id="nextShiftButton" type="button">Choose next shift</button>
-      <button class="game-button game-button--quiet" id="replayButton" type="button">Replay this shift</button>
-      <button class="text-button" id="resultDetailsButton" type="button" aria-haspopup="dialog">See the shift report</button>
-    </div>
-  </section>
+  <section class="result-screen" id="resultScreen" aria-labelledby="resultTitle" hidden><div class="result-rays" aria-hidden="true"></div><div class="result-card"><span class="result-kicker" id="resultKicker">SHIFT COMPLETE</span><div class="result-grade" id="resultGrade" aria-label="Grade A">A</div><h2 id="resultTitle">Packages delivered.</h2><p id="resultSummary">The live network cleared.</p><div class="result-stats" id="resultStats" aria-label="Shift results"></div><div class="result-medals" id="resultMedals" aria-label="Shift achievements"></div><button class="game-button game-button--primary" id="nextShiftButton" type="button">Choose next shift</button><button class="game-button game-button--quiet" id="replayButton" type="button">Replay this shift</button><button class="text-button" id="resultDetailsButton" type="button" aria-haspopup="dialog">See the shift report</button></div></section>
 
-  <dialog class="details-dialog" id="detailsDialog" aria-labelledby="detailsTitle">
-    <div class="dialog-head">
-      <div>
-        <span class="command-kicker">STRUCTURED VIEW</span>
-        <h2 id="detailsTitle">Live network details</h2>
-      </div>
-      <button class="dialog-close" id="detailsCloseButton" type="button" aria-label="Close shift details">×</button>
-    </div>
-
-    <div class="dialog-scroll">
-      <p class="dialog-intro" id="detailsIntro">The same live network information in a sortable text view.</p>
-      <dl class="detail-metrics" id="detailMetrics"></dl>
-      <div id="detailScenario"></div>
-
-      <details class="help-disclosure">
-        <summary>How to play</summary>
-        <p>Select a waiting parcel batch, then tap the lane, depot or hub printed on its marker. Blue arrows use Express A; yellow squares use Standard B. Use Plan teams, Plan trucks or Plan linehauls to move resources toward specific work: a matching assignment completes faster. Trucks in the regional and national miniature can also be tapped directly. Switch levels when their badges appear.</p>
-      </details>
-
-      <details class="help-disclosure">
-        <summary>Carriers</summary>
-        <p>NordPost brings steady mixed volume. DLH carries short express promises. Brang arrives in quick local bursts. USP brings larger national batches. They are fictional operators created for POSTAL.</p>
-      </details>
-
-      <details class="help-disclosure">
-        <summary>Accessibility and motion</summary>
-        <p>All consequential canvas information is repeated in semantic controls and this structured view. Colour is paired with codes, shapes and labels. Opening this dialog pauses the shift. Reduced-motion preferences remove camera sweeps and non-essential animation.</p>
-      </details>
-
-      <details class="help-disclosure">
-        <summary>Credits</summary>
-        <p>3D models are from Kenney asset packs under CC0. Interface tones are synthesized in the browser. POSTAL is an original fictional game and does not reproduce any real operator network.</p>
-      </details>
-    </div>
-  </dialog>
+  <dialog class="details-dialog" id="detailsDialog" aria-labelledby="detailsTitle"><div class="dialog-head"><div><span class="command-kicker">STRUCTURED VIEW</span><h2 id="detailsTitle">Live network details</h2></div><button class="dialog-close" id="detailsCloseButton" type="button" aria-label="Close shift details">×</button></div><div class="dialog-scroll"><p class="dialog-intro" id="detailsIntro">The same live network information in a sortable text view.</p><dl class="detail-metrics" id="detailMetrics"></dl><div id="detailScenario"></div><details class="help-disclosure"><summary>How to play</summary><p>Select a waiting package batch, then tap the lane, depot or hub printed on its marker. Use the resource planner to assign teams and vehicles. Suspicious packages can be opened for individual investigation.</p></details><details class="help-disclosure"><summary>Carriers</summary><p>NordPost brings steady mixed volume. DLH carries short express deadlines. Brang arrives in quick local bursts. USP brings larger national batches. They are fictional operators created for POSTAL.</p></details><details class="help-disclosure"><summary>Accessibility and motion</summary><p>All consequential canvas information is repeated in semantic controls and this structured view. Colour is paired with codes, shapes and labels. Opening this dialog pauses the shift. Reduced-motion preferences remove camera sweeps and non-essential animation.</p></details><details class="help-disclosure"><summary>Credits</summary><p>3D models are from Kenney asset packs under CC0. Interface tones are synthesized in the browser. POSTAL is an original fictional game and does not reproduce any real operator network.</p></details></div></dialog>
 
   <div class="toast" id="toast" role="status" aria-live="polite" hidden></div>
   <div class="sr-only" id="politeLive" aria-live="polite" aria-atomic="true"></div>
   <div class="sr-only" id="assertiveLive" aria-live="assertive" aria-atomic="true"></div>
 
-  <script type="module" src="./main.mjs?build=20260805-live-r4"></script>
-  <script type="module" src="./management-ui.mjs?build=20260806-management-r1"></script>
+  <script type="module" src="./main.mjs?build=20260806-layout-r1"></script>
+  <script type="module" src="./management-ui.mjs?build=20260806-management-r2"></script>
 </body>
 </html>

--- a/postal/management-ui.mjs
+++ b/postal/management-ui.mjs
@@ -66,6 +66,9 @@ patchWorld();
 const $ = (selector) => document.querySelector(selector);
 let plannerOpen = false;
 let plannerKey = '';
+let investigationJobId = null;
+let investigationPreviousLevel = 'terminal';
+let investigationWasRunning = false;
 
 function announce(message) {
   const live = $('#politeLive');
@@ -88,6 +91,12 @@ function resourceIcon(resource) {
   return resource.level === 'terminal' ? '●' : '▰';
 }
 
+function suspiciousJob(state) {
+  return state.jobs
+    .filter((job) => ['waiting', 'queued'].includes(job.status))
+    .sort((a, b) => (a.deadline - state.elapsed) - (b.deadline - state.elapsed))[0] || null;
+}
+
 function installUi() {
   const game = window.__POSTAL_GAME__;
   if (!game) {
@@ -97,11 +106,11 @@ function installUi() {
 
   const operationLayer = $('#operationLayer');
   const operationHead = operationLayer?.querySelector('.operation-head');
-  const parcelRack = $('#parcelRack');
   const result = $('#resultScreen');
   const nextShift = $('#nextShiftButton');
   const hudControls = $('.hud-controls');
-  if (!operationLayer || !operationHead || !parcelRack || !result || !nextShift || !hudControls) return;
+  const gameShell = $('#gameShell');
+  if (!operationLayer || !operationHead || !result || !nextShift || !hudControls || !gameShell) return;
 
   const planToggle = document.createElement('button');
   planToggle.type = 'button';
@@ -117,7 +126,29 @@ function installUi() {
   planner.id = 'resourcePlanner';
   planner.setAttribute('aria-label', 'Resource assignments');
   planner.hidden = true;
-  parcelRack.before(planner);
+  document.body.append(planner);
+
+  const communicationRail = document.createElement('section');
+  communicationRail.className = 'communication-rail';
+  communicationRail.id = 'communicationRail';
+  communicationRail.setAttribute('aria-label', 'Operations communication');
+  communicationRail.innerHTML = '<span class="communication-rail-label">OPERATIONS</span><strong id="communicationRailText">Select a package batch to begin.</strong>';
+  gameShell.append(communicationRail);
+
+  const investigateButton = document.createElement('button');
+  investigateButton.type = 'button';
+  investigateButton.className = 'investigate-button';
+  investigateButton.id = 'investigatePackageButton';
+  investigateButton.textContent = 'Inspect package';
+  communicationRail.append(investigateButton);
+
+  const investigation = document.createElement('section');
+  investigation.className = 'package-investigation';
+  investigation.id = 'packageInvestigation';
+  investigation.hidden = true;
+  investigation.setAttribute('aria-labelledby', 'investigationTitle');
+  investigation.innerHTML = '<div class="investigation-head"><div><span>PACKAGE INVESTIGATION</span><strong id="investigationTitle">Trace package</strong></div><button type="button" class="investigation-close" id="investigationClose" aria-label="Close package investigation">×</button></div><div class="investigation-body" id="investigationBody"></div>';
+  document.body.append(investigation);
 
   const boardButton = document.createElement('button');
   boardButton.type = 'button';
@@ -134,8 +165,18 @@ function installUi() {
   continueButton.textContent = 'Keep operating';
   nextShift.before(continueButton);
 
+  function closePlanner({ restoreFocus = false } = {}) {
+    plannerOpen = false;
+    planner.hidden = true;
+    planner.innerHTML = '';
+    planToggle.setAttribute('aria-expanded', 'false');
+    if (restoreFocus) planToggle.focus({ preventScroll: true });
+  }
+
   function syncResultActions() {
     if (result.hidden) return;
+    closePlanner();
+    closeInvestigation();
     const state = game.getState();
     const liveShift = state.shiftId !== 'first-rounds';
     continueButton.hidden = !liveShift;
@@ -151,7 +192,7 @@ function installUi() {
     const available = state.started && !state.completed && state.shiftId !== 'first-rounds' && resources.length > 0;
     planToggle.hidden = !available;
     boardButton.hidden = !state.started;
-    if (!available) plannerOpen = false;
+    if (!available) closePlanner();
     planToggle.textContent = planLabel(level);
     planToggle.setAttribute('aria-expanded', String(plannerOpen && available));
     planner.hidden = !plannerOpen || !available;
@@ -159,21 +200,15 @@ function installUi() {
     const key = JSON.stringify([level, plannerOpen, resources]);
     if (!force && key === plannerKey) return;
     plannerKey = key;
-    if (planner.hidden) {
-      planner.innerHTML = '';
-      return;
-    }
+    if (planner.hidden) return;
 
-    planner.innerHTML = `<div class="resource-planner-head"><div><span>LIVE RESOURCE PLAN</span><strong>${planLabel(level).replace('Plan ', '')}</strong></div><p>Tap a resource to move it to the next lane or route. Matching work runs faster.</p></div><div class="resource-roster">${resources.map((resource) => {
+    planner.innerHTML = `<div class="resource-planner-head"><div><span>LIVE RESOURCE PLAN</span><strong>${planLabel(level).replace('Plan ', '')}</strong></div><button type="button" class="planner-close" aria-label="Close resource planner">×</button></div><p class="resource-planner-help">Tap a resource to move it to the next lane or route. Matching work runs faster.</p><div class="resource-roster">${resources.map((resource) => {
       const status = resource.busy ? `${resource.busyCarrierCode} moving` : 'Ready';
       const aria = `${resource.name}. Assigned to ${resource.assignmentLabel}. ${status}. Tap to change assignment.`;
-      return `<button class="resource-card" type="button" data-resource-id="${resource.id}" data-busy="${resource.busy}" aria-label="${aria}">
-        <span class="resource-card-icon" aria-hidden="true">${resourceIcon(resource)}</span>
-        <span class="resource-card-copy"><strong>${resource.id}</strong><span>${resource.assignmentLabel}</span><small>${status}</small></span>
-        <span class="resource-card-cycle" aria-hidden="true">↻</span>
-      </button>`;
+      return `<button class="resource-card" type="button" data-resource-id="${resource.id}" data-busy="${resource.busy}" aria-label="${aria}"><span class="resource-card-icon" aria-hidden="true">${resourceIcon(resource)}</span><span class="resource-card-copy"><strong>${resource.id}</strong><span>${resource.assignmentLabel}</span><small>${status}</small></span><span class="resource-card-cycle" aria-hidden="true">↻</span></button>`;
     }).join('')}</div>`;
 
+    planner.querySelector('.planner-close')?.addEventListener('click', () => closePlanner({ restoreFocus: true }));
     planner.querySelectorAll('[data-resource-id]').forEach((button) => {
       button.addEventListener('click', () => {
         const before = game.getState().resources.find((resource) => resource.id === button.dataset.resourceId);
@@ -185,6 +220,81 @@ function installUi() {
     });
   }
 
+  function renderCommunication() {
+    const state = game.getState();
+    const selected = state.selectedJob;
+    const incident = state.incidents.find((item) => item.active);
+    const atRisk = state.jobs.filter((job) => ['waiting', 'queued'].includes(job.status) && job.deadline - state.elapsed <= 14).length;
+    const text = selected
+      ? `${selected.carrierCode} package batch selected for ${selected.destinationName}.`
+      : incident
+        ? `${incident.label} needs attention in ${incident.level === 'terminal' ? 'Depot' : incident.level === 'network' ? 'Region' : 'Sweden'}.`
+        : atRisk
+          ? `${atRisk} package batch${atRisk === 1 ? '' : 'es'} close to deadline.`
+          : state.overtime
+            ? `Overtime wave ${state.overtimeWave}. ${state.backlog} package batches active.`
+            : `${state.backlog} package batches active across the network.`;
+    $('#communicationRailText').textContent = text;
+    const suspect = suspiciousJob(state);
+    investigateButton.hidden = !suspect || state.shiftId === 'first-rounds' || state.completed;
+    investigateButton.dataset.jobId = suspect?.id || '';
+  }
+
+  function renderInvestigation() {
+    const state = game.getState();
+    const job = state.jobs.find((item) => item.id === investigationJobId);
+    if (!job) {
+      closeInvestigation();
+      return;
+    }
+    const history = job.history.length ? job.history : [`${job.carrierCode} package entered ${job.stage}.`];
+    const issue = job.deadline - state.elapsed <= 10
+      ? 'The package is close to its deadline.'
+      : job.status === 'queued'
+        ? 'The package is waiting behind other work.'
+        : 'The route history needs verification.';
+    $('#investigationTitle').textContent = `${job.id} · ${job.destinationCode}`;
+    $('#investigationBody').innerHTML = `<div class="investigation-summary"><span class="investigation-package" aria-hidden="true">□</span><div><strong>${job.carrierName} package</strong><span>${job.units} parcels · ${job.destinationName}</span><small>${issue}</small></div></div><ol class="investigation-history">${history.map((entry) => `<li>${entry}</li>`).join('')}</ol><div class="investigation-evidence"><span>Evidence</span><ul><li>Carrier label: ${job.carrierCode}</li><li>Destination code: ${job.destinationCode}</li><li>Current route mark: ${job.target || 'not assigned'}</li></ul></div><button type="button" class="game-button game-button--primary" id="investigationCorrect">Prioritise correct route</button>`;
+    $('#investigationCorrect')?.addEventListener('click', () => {
+      closeInvestigation();
+      if (job.status === 'waiting') game.act('select-job', job.id);
+      announce(`${job.id} selected. Send it to ${job.target || job.destinationName}.`);
+    });
+  }
+
+  function openInvestigation(jobId) {
+    const state = game.getState();
+    const job = state.jobs.find((item) => item.id === jobId);
+    if (!job) return;
+    closePlanner();
+    investigationJobId = job.id;
+    investigationPreviousLevel = currentLevel();
+    investigationWasRunning = state.canRun && !state.paused && !state.completed;
+    if (investigationWasRunning) $('#pauseButton')?.click();
+    investigation.hidden = false;
+    gameShell.dataset.investigating = 'true';
+    document.querySelectorAll('.scene-tab').forEach((button) => { button.disabled = true; });
+    const world = window.__POSTAL_WORLD__;
+    world?.setMode?.('case');
+    renderInvestigation();
+    $('#investigationClose')?.focus({ preventScroll: true });
+  }
+
+  function closeInvestigation() {
+    if (investigation.hidden) return;
+    investigation.hidden = true;
+    investigationJobId = null;
+    delete gameShell.dataset.investigating;
+    const world = window.__POSTAL_WORLD__;
+    world?.setMode?.(investigationPreviousLevel);
+    const state = game.getState();
+    document.querySelectorAll('.scene-tab').forEach((button) => {
+      button.disabled = !state.started || state.completed || !state.availableScenes.includes(button.dataset.scene);
+    });
+    if (investigationWasRunning && state.paused && !state.completed) $('#pauseButton')?.click();
+    investigationWasRunning = false;
+  }
+
   planToggle.addEventListener('click', () => {
     plannerOpen = !plannerOpen;
     renderPlanner(true);
@@ -192,6 +302,8 @@ function installUi() {
   });
 
   boardButton.addEventListener('click', () => {
+    closePlanner();
+    closeInvestigation();
     const state = game.getState();
     if (state.canRun && !state.paused && !state.completed) $('#pauseButton')?.click();
     nextShift.click();
@@ -200,30 +312,43 @@ function installUi() {
   continueButton.addEventListener('click', () => {
     if (!game.act('continue-operations')) return;
     result.hidden = true;
-    $('#gameShell').inert = false;
-    plannerOpen = true;
-    renderPlanner(true);
-    announce('Shift report closed. The network is still live and a new wave is arriving.');
+    gameShell.inert = false;
+    closePlanner();
+    announce('Shift report closed. The network is still live and a new package wave is arriving.');
     window.setTimeout(() => planToggle.focus({ preventScroll: true }), 40);
   });
+
+  investigateButton.addEventListener('click', () => openInvestigation(investigateButton.dataset.jobId));
+  $('#investigationClose')?.addEventListener('click', closeInvestigation);
 
   document.addEventListener('postal-resource-activate', (event) => {
     const resourceId = event.detail?.resourceId;
     if (!resourceId || !game.act('cycle-resource', resourceId)) return;
-    plannerOpen = true;
-    renderPlanner(true);
+    closePlanner();
     const resource = game.getState().resources.find((item) => item.id === resourceId);
     announce(`${resource.name} assigned to ${resource.assignmentLabel}.`);
   });
 
+  document.addEventListener('keydown', (event) => {
+    if (event.key !== 'Escape') return;
+    if (!investigation.hidden) closeInvestigation();
+    else if (plannerOpen) closePlanner({ restoreFocus: true });
+  });
+
   const resultObserver = new MutationObserver(syncResultActions);
   resultObserver.observe(result, { attributes: true, attributeFilter: ['hidden'] });
-  document.querySelectorAll('.scene-tab').forEach((button) => button.addEventListener('click', () => renderPlanner(true)));
+  document.querySelectorAll('.scene-tab').forEach((button) => button.addEventListener('click', () => {
+    closePlanner();
+    renderPlanner(true);
+  }));
   window.setInterval(() => {
     renderPlanner();
+    renderCommunication();
+    if (!investigation.hidden) renderInvestigation();
     syncResultActions();
   }, 200);
   renderPlanner(true);
+  renderCommunication();
 }
 
 installUi();

--- a/postal/management.css
+++ b/postal/management.css
@@ -2,18 +2,22 @@
   flex-wrap: wrap;
 }
 
-.resource-plan-toggle {
-  min-height: 36px;
-  margin-left: auto;
+.resource-plan-toggle,
+.investigate-button {
+  min-height: 34px;
   padding: 6px 10px;
   border: 2px solid var(--ink);
   border-radius: 999px;
-  background: var(--blue);
   box-shadow: 2px 2px 0 var(--ink);
-  font-size: 0.7rem;
+  font-size: 0.68rem;
   font-weight: 950;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
+}
+
+.resource-plan-toggle {
+  margin-left: auto;
+  background: var(--blue);
 }
 
 .resource-plan-toggle[aria-expanded="true"] {
@@ -22,76 +26,100 @@
   transform: translate(1px, 1px);
 }
 
-.resource-planner {
-  margin: 8px 0 5px;
-  padding: 9px;
-  border: 2px solid var(--ink);
-  border-radius: var(--radius-small);
-  background: rgb(255 253 245 / 0.96);
-  box-shadow: var(--shadow-small);
+.resource-planner,
+.package-investigation {
+  position: fixed;
+  z-index: 260;
+  right: max(10px, calc((100vw - 620px) / 2 + 10px));
+  bottom: calc(76px + var(--safe-bottom));
+  left: max(10px, calc((100vw - 620px) / 2 + 10px));
+  max-height: min(54dvh, 430px);
+  overflow: auto;
+  padding: 12px;
+  border: 3px solid var(--ink);
+  border-radius: 18px;
+  background: var(--paper-bright);
+  box-shadow: 6px 6px 0 var(--ink);
 }
 
 .resource-planner[hidden],
 .resource-plan-toggle[hidden],
 .management-board-button[hidden],
-#continueOperationsButton[hidden] {
+#continueOperationsButton[hidden],
+.package-investigation[hidden],
+.investigate-button[hidden] {
   display: none;
 }
 
-.resource-planner-head {
+.resource-planner-head,
+.investigation-head {
   display: flex;
   align-items: start;
   justify-content: space-between;
   gap: 10px;
-  margin-bottom: 7px;
 }
 
-.resource-planner-head div {
+.resource-planner-head div,
+.investigation-head div {
   display: grid;
-  gap: 1px;
+  gap: 2px;
 }
 
 .resource-planner-head span,
-.resource-planner-head p {
-  margin: 0;
-  font-size: 0.62rem;
-  font-weight: 850;
-  line-height: 1.15;
-}
-
-.resource-planner-head span {
+.investigation-head span,
+.communication-rail-label {
   color: var(--purple);
+  font-size: 0.62rem;
+  font-weight: 900;
   letter-spacing: 0.08em;
 }
 
-.resource-planner-head strong {
-  font-size: 0.88rem;
-  line-height: 1;
+.resource-planner-head strong,
+.investigation-head strong {
+  font-size: 0.95rem;
+  line-height: 1.05;
   text-transform: uppercase;
 }
 
-.resource-planner-head p {
-  max-width: 190px;
+.planner-close,
+.investigation-close {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 2px solid var(--ink);
+  border-radius: 50%;
+  background: var(--orange);
+  box-shadow: 2px 2px 0 var(--ink);
+  font-size: 1.25rem;
+  font-weight: 1000;
+}
+
+.resource-planner-help {
+  margin: 8px 0;
   color: rgb(16 19 26 / 0.72);
-  text-align: right;
+  font-size: 0.72rem;
+  font-weight: 800;
+  line-height: 1.25;
 }
 
 .resource-roster {
   display: flex;
-  gap: 7px;
+  gap: 8px;
   overflow-x: auto;
-  padding: 1px 1px 4px;
+  padding: 1px 1px 5px;
   scrollbar-width: thin;
 }
 
 .resource-card {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
-  min-width: 154px;
-  min-height: 54px;
+  min-width: 160px;
+  min-height: 58px;
   align-items: center;
   gap: 7px;
-  padding: 7px 8px;
+  padding: 8px;
   border: 2px solid var(--ink);
   border-radius: 11px;
   background: var(--paper-bright);
@@ -161,26 +189,155 @@
   width: 100%;
 }
 
-@media (max-height: 700px) {
-  .resource-planner {
-    margin-top: 5px;
-    padding: 6px;
-  }
+.communication-rail {
+  position: relative;
+  z-index: 34;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 3px 8px;
+  min-height: 50px;
+  padding: 7px 10px;
+  border-top: 3px solid var(--ink);
+  background: var(--paper);
+}
 
-  .resource-planner-head p {
-    display: none;
+.communication-rail-label {
+  grid-column: 1;
+}
+
+.communication-rail strong {
+  grid-column: 1;
+  overflow: hidden;
+  font-size: 0.72rem;
+  line-height: 1.15;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.investigate-button {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  background: var(--yellow);
+}
+
+.game-shell[data-play-mode="live"] .command-deck {
+  display: none;
+}
+
+.game-shell[data-play-mode="live"] {
+  grid-template-rows: auto minmax(0, 1fr) auto auto;
+}
+
+.package-investigation {
+  display: grid;
+  gap: 10px;
+}
+
+.investigation-body {
+  display: grid;
+  gap: 10px;
+}
+
+.investigation-summary {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 10px;
+  padding: 10px;
+  border: 2px solid var(--ink);
+  border-radius: 12px;
+  background: #d8f5ff;
+}
+
+.investigation-package {
+  display: grid;
+  width: 54px;
+  height: 54px;
+  place-items: center;
+  border: 2px solid var(--ink);
+  border-radius: 12px;
+  background: var(--yellow);
+  font-size: 1.6rem;
+}
+
+.investigation-summary div {
+  display: grid;
+  gap: 2px;
+}
+
+.investigation-summary strong {
+  font-size: 0.9rem;
+}
+
+.investigation-summary span,
+.investigation-summary small,
+.investigation-history,
+.investigation-evidence {
+  font-size: 0.72rem;
+  font-weight: 800;
+  line-height: 1.25;
+}
+
+.investigation-history {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 22px;
+}
+
+.investigation-evidence {
+  padding: 9px 10px;
+  border: 2px solid var(--ink);
+  border-radius: 12px;
+  background: var(--paper);
+}
+
+.investigation-evidence > span {
+  color: var(--purple);
+  font-weight: 950;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.investigation-evidence ul {
+  margin: 6px 0 0;
+  padding-left: 18px;
+}
+
+.toast {
+  top: auto !important;
+  right: max(12px, calc((100vw - 620px) / 2 + 12px)) !important;
+  bottom: calc(136px + var(--safe-bottom)) !important;
+  left: auto !important;
+  max-width: min(78vw, 330px);
+  pointer-events: none;
+}
+
+@media (max-height: 700px) {
+  .resource-planner,
+  .package-investigation {
+    bottom: calc(69px + var(--safe-bottom));
+    max-height: 48dvh;
+    padding: 9px;
   }
 
   .resource-card {
-    min-width: 138px;
-    min-height: 46px;
-    padding: 5px 7px;
+    min-width: 140px;
+    min-height: 48px;
+    padding: 6px 7px;
+  }
+
+  .communication-rail {
+    min-height: 44px;
+    padding-block: 5px;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .resource-plan-toggle,
-  .resource-card {
+  .resource-card,
+  .investigate-button {
     transition: none;
   }
 }

--- a/postal/sw.js
+++ b/postal/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'postal-live-20260806-r5';
+const CACHE_NAME = 'postal-live-20260806-r6';
 const CORE_ASSETS = [
   './',
   './index.html',
@@ -37,7 +37,6 @@ self.addEventListener('fetch', (event) => {
   event.respondWith(
     caches.match(event.request).then((cached) => {
       if (cached) return cached;
-
       return fetch(event.request).then((response) => {
         if (response.ok || response.type === 'opaque') {
           const copy = response.clone();

--- a/postal/tests/ui-contract.test.mjs
+++ b/postal/tests/ui-contract.test.mjs
@@ -19,146 +19,84 @@ test('every JavaScript ID selector has a matching unique HTML element', () => {
   const htmlIds = [...html.matchAll(/\sid="([^"]+)"/g)].map((match) => match[1]);
   const duplicateIds = htmlIds.filter((id, index) => htmlIds.indexOf(id) !== index);
   assert.deepEqual(duplicateIds, []);
-
   const selectorIds = [...main.matchAll(/\$\('#([^']+)'\)/g)].map((match) => match[1]);
   const missing = [...new Set(selectorIds)].filter((id) => !htmlIds.includes(id));
   assert.deepEqual(missing, []);
-
-  const labelledByIds = [...html.matchAll(/aria-labelledby="([^"]+)"/g)]
-    .flatMap((match) => match[1].split(/\s+/));
-  assert.deepEqual([...new Set(labelledByIds)].filter((id) => !htmlIds.includes(id)), []);
 });
 
-test('the primary game navigation exposes town, region and Sweden as live levels', () => {
-  assert.match(html, /data-scene="terminal"[\s\S]*?<span>Town<\/span>/);
+test('the primary navigation exposes depot, region and Sweden', () => {
+  assert.match(html, /data-scene="terminal"[\s\S]*?<span>Depot<\/span>/);
   assert.match(html, /data-scene="network"[\s\S]*?<span>Region<\/span>/);
   assert.match(html, /data-scene="sweden"[\s\S]*?<span>Sweden<\/span>/);
-  assert.match(html, /id="terminalAlert"/);
-  assert.match(html, /id="networkAlert"/);
-  assert.match(html, /id="swedenAlert"/);
-  assert.doesNotMatch(html, /data-scene="case"/);
+  assert.match(html, /DEPOT FLOOR/);
+  assert.doesNotMatch(html, /TOWN FLOOR/);
 });
 
-test('post-training play uses live parcel objects and scene destinations rather than answer prompts', () => {
-  assert.match(html, /id="operationLayer" aria-labelledby="workQueueTitle"/);
-  assert.match(main, /class="parcel-batch"/);
-  assert.match(main, /data-action is intentionally absent|simulation\.perform\('select-job'/);
-  assert.match(main, /simulation\.perform\('route-selected'/);
-  assert.doesNotMatch(main, /Which promises|Choose the road|Repair or bypass|Where is the parcel/);
-  assert.doesNotMatch(main, /allocate-truck|choose-recovery|find-similar|fix-rule/);
+test('live play keeps package language while the slogan retains promise', () => {
+  assert.match(html, /Every package has a promise/);
+  assert.match(html, /Waiting and moving package batches/);
+  assert.match(html, /before packages become late/);
+  assert.doesNotMatch(html, /act before promises expire/);
+  assert.doesNotMatch(html, /short express promises/);
 });
 
-test('the national miniature includes Stockholm, Gothenburg and asset-led hubs', () => {
-  assert.match(world, /buildSweden\(\)/);
-  assert.match(world, /sweden-stockholm/);
-  assert.match(world, /Stockholm hub/);
-  assert.match(world, /sweden-gothenburg/);
-  assert.match(world, /Gothenburg hub/);
-  assert.match(world, /placeAsset\(group, 'roadIntersection'/);
-  assert.match(world, /this\.swedenTrucks/);
-});
-
-test('NordPost, DLH, Brang and USP are represented as fictional live carriers', () => {
-  for (const carrier of ['NordPost', 'DLH', 'Brang', 'USP']) assert.match(sim, new RegExp(carrier));
-  assert.match(html, /They are fictional operators created for POSTAL/);
-  assert.match(main, /carrier-legend/);
-});
-
-test('fresh-player onboarding remains guided while the live command deck has no action buttons', () => {
-  assert.match(html, /FIRST SHIFT · CALM PRACTICE/);
-  assert.match(main, /onboardingCommand/);
-  assert.match(main, /The action happens there, not in this box/);
-  assert.match(main, /if \(state\.shiftId === 'first-rounds'\) return onboardingCommand/);
-  assert.match(styles, /\.command-content\[data-layout="live"\]/);
-});
-
-test('teams and vehicles have a compact semantic planner and matching assignments affect work', () => {
-  assert.match(managementUi, /resource-plan-toggle/);
-  assert.match(managementUi, /data-resource-id/);
-  assert.match(managementUi, /Tap a resource to move it to the next lane or route/);
-  assert.match(managementStyles, /\.resource-roster[\s\S]*overflow-x: auto/);
-  assert.match(managementStyles, /\.resource-card\[data-busy="true"\]/);
+test('teams and vehicles have a dismissible semantic planner', () => {
+  assert.match(managementUi, /class=\"planner-close\"/);
+  assert.match(managementUi, /function closePlanner/);
+  assert.match(managementUi, /event\.key !== 'Escape'/);
+  assert.match(managementUi, /closePlanner\(\{ restoreFocus: true \}\)/);
+  assert.match(managementStyles, /\.resource-planner[\s\S]*position: fixed/);
   assert.match(managementSim, /processingDurationWithPlan/);
-  assert.match(managementSim, /resource\.assignment === job\.target \? 0\.78 : 1\.22/);
 });
 
-test('regional and national trucks are direct canvas interactions with semantic alternatives', () => {
+test('communication is separated from the 3D action area', () => {
+  assert.match(managementUi, /communication-rail/);
+  assert.match(managementUi, /renderCommunication/);
+  assert.match(managementStyles, /\.communication-rail/);
+  assert.match(managementStyles, /game-shell\[data-play-mode="live"\] \.command-deck[\s\S]*display: none/);
+  assert.match(managementStyles, /\.toast[\s\S]*pointer-events: none/);
+});
+
+test('individual package investigation uses the existing 3D case scene', () => {
+  assert.match(managementUi, /package-investigation/);
+  assert.match(managementUi, /Inspect package/);
+  assert.match(managementUi, /world\?\.setMode\?\.\('case'\)/);
+  assert.match(managementUi, /investigation-history/);
+  assert.match(managementUi, /Prioritise correct route/);
+  assert.match(world, /buildCase\(\)/);
+  assert.match(world, /CAMERA_PRESETS[\s\S]*case:/);
+});
+
+test('regional and national trucks remain direct interactions', () => {
   assert.match(managementUi, /ensureTruckHotspots/);
   assert.match(managementUi, /world\.markInteractive\(truck, hotspotId\)/);
-  assert.match(managementUi, /world\.registerHotspot\(hotspotId/);
   assert.match(managementUi, /postal-resource-activate/);
-  assert.match(managementSim, /resource-R1|`resource-\$\{shortId\}`/);
 });
 
-test('completed live shifts can close the report and continue into recurring overtime', () => {
+test('completed live shifts can continue into recurring overtime', () => {
   assert.match(managementUi, /continueOperationsButton/);
   assert.match(managementUi, /Keep operating/);
   assert.match(managementSim, /continue-operations/);
   assert.match(managementSim, /state\.overtime = true/);
   assert.match(managementSim, /addOvertimeWave/);
-  assert.match(html, /After a report, keep operating for endless waves/);
 });
 
-test('runtime uses only short low-pass synthesized feedback', () => {
+test('runtime uses short low-pass synthesized feedback', () => {
   assert.doesNotMatch(main, /new Audio\s*\(/);
-  assert.doesNotMatch(main, /assets\/audio/);
   assert.match(main, /oscillator\.type = 'triangle'/);
   assert.match(main, /filter\.type = 'lowpass'/);
-  assert.match(main, /filter\.frequency\.setValueAtTime\(860/);
-  assert.match(main, /master\.gain\.value = 0\.5/);
 });
 
-test('no-WebGL mode is guarded before all scene groups are dereferenced', () => {
-  const setModeStart = world.indexOf('setMode(mode, immediate = false)');
-  const guard = world.indexOf('if (!this.camera || !this.terminalGroup', setModeStart);
-  const national = world.indexOf("this.swedenGroup.visible = mode === 'sweden'", setModeStart);
-  assert.ok(setModeStart > 0);
-  assert.ok(guard > setModeStart);
-  assert.ok(national > guard);
+test('no-WebGL mode preserves semantic controls', () => {
   assert.match(main, /All live batches and destinations remain usable in the controls/);
   assert.match(html, /id="fallbackTargets" aria-label="Destinations in this level" hidden/);
   assert.match(main, /function renderFallbackTargets\(state\)/);
-  assert.match(main, /data-fallback-target/);
-  assert.match(styles, /\.fallback-targets button/);
 });
 
-test('direct canvas destinations retain projected semantic button alternatives', () => {
-  for (const hotspot of [
-    'express-lane',
-    'standard-lane',
-    'network-sundsvall',
-    'network-harnosand',
-    'network-timra',
-    'network-matfors',
-    'sweden-sundsvall',
-    'sweden-stockholm',
-    'sweden-gothenburg',
-    'scanner',
-    'network-detour',
-    'sweden-relief'
-  ]) {
-    assert.match(world, new RegExp(`registerHotspot\\('${hotspot}'`), hotspot);
-  }
-  assert.match(world, /button\.type = 'button'/);
-  assert.match(world, /button\.setAttribute\('aria-label'/);
-});
-
-test('portrait live controls are compact, horizontally scrollable and status-independent', () => {
-  assert.match(styles, /\.operation-layer/);
-  assert.match(styles, /\.parcel-rack[\s\S]*overflow-x: auto/);
-  assert.match(styles, /\.parcel-batch\[aria-pressed="true"\]/);
-  assert.match(styles, /\.parcel-cube\[data-service="express"\]/);
-  assert.match(styles, /\.parcel-deadline\[data-late="true"\]/);
-  assert.match(styles, /\.game-shell\[data-play-mode="live"\] \.command-deck/);
-  assert.match(styles, /@media \(max-height: 700px\)[\s\S]*data-play-mode="live"/);
-  assert.match(managementStyles, /@media \(max-height: 700px\)/);
-});
-
-test('new build markers and offline assets bypass the previous live cache', () => {
-  assert.match(html, /build=20260805-live-r4/);
-  assert.match(html, /build=20260806-management-r1/);
-  assert.match(worker, /postal-live-20260806-r5/);
-  assert.match(worker, /management-sim\.mjs/);
+test('new build markers and offline assets bypass the previous cache', () => {
+  assert.match(html, /build=20260806-layout-r1/);
+  assert.match(html, /build=20260806-management-r2/);
+  assert.match(worker, /postal-live-20260806-r6/);
   assert.match(worker, /management-ui\.mjs/);
   assert.match(worker, /management\.css/);
 });


### PR DESCRIPTION
## What changed

- Replaces the sticky embedded resource planner with a dismissible bottom drawer, including explicit close and Escape handling.
- Separates routine communication from the 3D action area using a compact operations rail; live shifts no longer keep the large command deck visible.
- Repositions transient toast feedback so it does not cover the main interaction area.
- Renames Town/Town floor to Depot/Depot floor in the visible interface.
- Uses package-focused language in gameplay copy while retaining “Every package has a promise” as the slogan.
- Restores individual package detective work: suspicious active packages can be inspected in the existing 3D package-case scene, with route history, evidence and a corrective prioritisation action.
- Keeps direct truck interaction, resource planning and endless overtime intact.
- Refreshes offline cache and UI contract coverage.

## Validation

GitHub Actions checks syntax for all POSTAL modules and runs the POSTAL test suite. The PR will only be merged after those checks pass.