### PR TITLE
Finish Bella’s eye size, placement and coat

### DIFF
--- a/turn/render/world.js
+++ b/turn/render/world.js
@@ -10,12 +10,13 @@ function moduleUrl(relativePath) {
 }
 
 async function loadWorldModules() {
-  const [beauty, art, identity, intensity, bella] = await Promise.all([
+  const [beauty, art, identity, intensity, bella, bellaFinal] = await Promise.all([
     import(moduleUrl('../world-beauty.js')),
     import(moduleUrl('../world-art-pass.js')),
     import(moduleUrl('../track-identity.js')),
     import(moduleUrl('../section-intensity.js')),
-    import(moduleUrl('../tracks/countryside-bella-r166.js?revision=r168-bella-markings-eyes-foliage-r169-facing-palette-r170-eye-placement-r171-cute-eyes'))
+    import(moduleUrl('../tracks/countryside-bella-r166.js?revision=r168-bella-markings-eyes-foliage-r169-facing-palette-r170-eye-placement-r171-cute-eyes-r172-final-tune')),
+    import(moduleUrl('../tracks/countryside-bella-final-r172.js?revision=r172-final-tune'))
   ]);
 
   return {
@@ -23,7 +24,8 @@ async function loadWorldModules() {
     installArtPass: art.installArtPass,
     installTrackIdentity: identity.installTrackIdentity,
     installSectionIntensity: intensity.installSectionIntensity,
-    installCountrysideBella: bella.installCountrysideBella
+    installCountrysideBella: bella.installCountrysideBella,
+    applyBellaFinalVisuals: bellaFinal.applyBellaFinalVisuals
   };
 }
 
@@ -96,7 +98,8 @@ async function install(runtime) {
       installArtPass,
       installTrackIdentity,
       installSectionIntensity,
-      installCountrysideBella
+      installCountrysideBella,
+      applyBellaFinalVisuals
     } = await loadWorldModules();
 
     // Compatibility helper retained from the previous world tuning layer.
@@ -114,9 +117,11 @@ async function install(runtime) {
 
     installTrackIdentity({ world, samples: worldSamples, trackWidth });
     installSectionIntensity({ world, samples: worldSamples, trackWidth });
-    installCountrysideBella({ world, samples: worldSamples, trackWidth, runtime }).catch((error) => {
-      console.warn('TURN: Bella discovery failed, keeping the rest of Countryside.', error);
-    });
+    installCountrysideBella({ world, samples: worldSamples, trackWidth, runtime })
+      .then(applyBellaFinalVisuals)
+      .catch((error) => {
+        console.warn('TURN: Bella discovery failed, keeping the rest of Countryside.', error);
+      });
 
     const beautyBaselineChildren = new Set(world.children);
     installWorldBeauty({ world, scene, samples: worldSamples, trackWidth, sun, hemi })

--- a/turn/tracks/countryside-bella-final-r172.js
+++ b/turn/tracks/countryside-bella-final-r172.js
@@ -6,6 +6,26 @@ const SEAL_BROWN = new THREE.Color(0x382c1f);
 const FINAL_EYE_HEIGHT_RATIO = 0.5;
 const FINAL_EYE_SCALE = 1.1;
 
+function getCatLocalBounds(cat, eyes) {
+  cat.updateMatrixWorld(true);
+  const bounds = new THREE.Box3().makeEmpty();
+  const meshBounds = new THREE.Box3();
+  const worldToCat = cat.matrixWorld.clone().invert();
+  const meshToCat = new THREE.Matrix4();
+
+  cat.traverse((node) => {
+    if (!node.isMesh || eyes.includes(node) || !node.geometry) return;
+    if (!node.geometry.boundingBox) node.geometry.computeBoundingBox();
+    if (!node.geometry.boundingBox) return;
+
+    meshToCat.multiplyMatrices(worldToCat, node.matrixWorld);
+    meshBounds.copy(node.geometry.boundingBox).applyMatrix4(meshToCat);
+    bounds.union(meshBounds);
+  });
+
+  return bounds;
+}
+
 function remapCoatVertexColors(cat, eyes) {
   const coatVector = SEAL_BROWN.clone().sub(PREVIOUS_CREAM);
   const coatLengthSquared = Math.max(coatVector.lengthSq(), Number.EPSILON);
@@ -49,11 +69,7 @@ export function applyBellaFinalVisuals(root) {
     if (node.isMesh && node.name?.startsWith('Bella eye')) eyes.push(node);
   });
 
-  for (const eye of eyes) eye.visible = false;
-  cat.updateMatrixWorld(true);
-  const bounds = new THREE.Box3().setFromObject(cat);
-  for (const eye of eyes) eye.visible = true;
-
+  const bounds = getCatLocalBounds(cat, eyes);
   if (!bounds.isEmpty()) {
     const size = bounds.getSize(new THREE.Vector3());
     const eyeY = bounds.min.y + size.y * FINAL_EYE_HEIGHT_RATIO;

--- a/turn/tracks/countryside-bella-final-r172.js
+++ b/turn/tracks/countryside-bella-final-r172.js
@@ -1,0 +1,76 @@
+import * as THREE from 'three';
+
+const PREVIOUS_CREAM = new THREE.Color(0xf4eada);
+const FINAL_CREAM = new THREE.Color(0xfff8ec);
+const SEAL_BROWN = new THREE.Color(0x382c1f);
+const FINAL_EYE_HEIGHT_RATIO = 0.5;
+const FINAL_EYE_SCALE = 1.1;
+
+function remapCoatVertexColors(cat, eyes) {
+  const coatVector = SEAL_BROWN.clone().sub(PREVIOUS_CREAM);
+  const coatLengthSquared = Math.max(coatVector.lengthSq(), Number.EPSILON);
+  const source = new THREE.Color();
+  const remapped = new THREE.Color();
+  const offset = new THREE.Color();
+
+  cat.traverse((node) => {
+    if (!node.isMesh || eyes.includes(node)) return;
+
+    const colors = node.geometry?.attributes?.color;
+    if (colors && node.material?.vertexColors) {
+      for (let index = 0; index < colors.count; index += 1) {
+        source.fromBufferAttribute(colors, index);
+        offset.copy(source).sub(PREVIOUS_CREAM);
+        const darkMix = THREE.MathUtils.clamp(offset.dot(coatVector) / coatLengthSquared, 0, 1);
+        remapped.copy(FINAL_CREAM).lerp(SEAL_BROWN, darkMix);
+        colors.setXYZ(index, remapped.r, remapped.g, remapped.b);
+      }
+      colors.needsUpdate = true;
+      return;
+    }
+
+    const materials = Array.isArray(node.material) ? node.material : [node.material];
+    for (const material of materials) {
+      if (!material?.color) continue;
+      if (material.color.distanceTo(PREVIOUS_CREAM) < 0.02) {
+        material.color.copy(FINAL_CREAM);
+        material.needsUpdate = true;
+      }
+    }
+  });
+}
+
+export function applyBellaFinalVisuals(root) {
+  const cat = root?.userData?.turnBellaFocus;
+  if (!cat) return root;
+
+  const eyes = [];
+  cat.traverse((node) => {
+    if (node.isMesh && node.name?.startsWith('Bella eye')) eyes.push(node);
+  });
+
+  for (const eye of eyes) eye.visible = false;
+  cat.updateMatrixWorld(true);
+  const bounds = new THREE.Box3().setFromObject(cat);
+  for (const eye of eyes) eye.visible = true;
+
+  if (!bounds.isEmpty()) {
+    const size = bounds.getSize(new THREE.Vector3());
+    const eyeY = bounds.min.y + size.y * FINAL_EYE_HEIGHT_RATIO;
+    for (const eye of eyes) {
+      eye.position.y = eyeY;
+      eye.scale.multiplyScalar(FINAL_EYE_SCALE);
+    }
+  }
+
+  remapCoatVertexColors(cat, eyes);
+
+  root.userData.turnBellaFinalVisuals = Object.freeze({
+    cream: '#FFF8EC',
+    eyeHeight: '50% of model height',
+    eyeScale: '10% larger than r171',
+    preserved: '#382C1F markings, #44CCFF irises, spacing, foliage and rescue behavior'
+  });
+
+  return root;
+}


### PR DESCRIPTION
## Summary
- move Bella’s eye centres from 53% to 50% of model height
- enlarge both eyes by another 10%
- lighten the cream body and paws from `#F4EADA` to `#FFF8EC`
- preserve the existing 17% eye spacing, exact `#44CCFF` irises, black-centre gradient, `#382C1F` markings, green foliage and rescue behavior
- calculate the final eye position in Bella-local coordinates so the existing model scale and tree placement cannot distort the adjustment
- refresh the Bella module cache identity

## Validation
- TURN regression workflow
- syntax and lint checks
- existing achievement, world and release architecture checks
