### PR TITLE
Move Bella to safety and add Fire Truck meows

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -160,6 +160,9 @@ jobs:
       - name: Run achievement system regression
         run: node turn-lab/tests/achievements-production.mjs
 
+      - name: Run Bella rescue and directional meow regression
+        run: node turn-lab/tests/bella-rescue-production.mjs
+
       - name: Run Trophy Road progression regression
         run: node turn-lab/tests/trophy-road-production.mjs
 

--- a/turn-lab/tests/bella-rescue-production.mjs
+++ b/turn-lab/tests/bella-rescue-production.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const [behavior, world] = await Promise.all([
+  fs.readFile(new URL('../../turn/tracks/countryside-bella-rescue-r173.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/render/world.js', import.meta.url), 'utf8')
+]);
+
+assert.match(behavior, /SAVE_BELLA_ID = 'save-bella'/);
+assert.match(behavior, /REQUIRED_VEHICLE_ID = 'firetruck'/);
+assert.match(behavior, /SAFE_GROUND_POSITION = Object\.freeze\(\{ x: 5\.4, y: 0\.08, z: 2\.2 \}\)/);
+assert.match(behavior, /cat\.position\.set\(SAFE_GROUND_POSITION\.x/,
+  'Saving Bella must move the existing cat model from the branch to the protected ground position');
+assert.match(behavior, /turnBellaState = 'rescued-stationary'/);
+assert.match(behavior, /sourceAnimationClips: 0/,
+  'The pinned Kenney cat has no animation section, so the safe fallback must remain stationary');
+assert.match(behavior, /Bella cannot enter the road/);
+assert.doesNotMatch(behavior, /AnimationMixer|clipAction|cat\.position\.(?:add|lerp)/,
+  'Bella must not fake roaming without a walking animation or move towards the track');
+
+assert.match(behavior, /turn:secret-achievement/);
+assert.match(behavior, /turn:achievements-updated/);
+assert.match(behavior, /store\?\.isUnlocked\?\.\(SAVE_BELLA_ID\)/,
+  'Previously saved profiles must start with Bella safely on the ground');
+assert.match(behavior, /RESCUE_MOVE_DELAY_MS = 80/,
+  'The ground transition should follow the achievement signal rather than precede it');
+
+assert.match(behavior, /MEOW_RANGE_METERS = 108/);
+assert.match(behavior, /MEOW_MIN_INTERVAL_MS = 2400/);
+assert.match(behavior, /MEOW_MAX_INTERVAL_MS = 5600/);
+assert.match(behavior, /spatialPan\(runtime, player, bellaWorldPosition\)/,
+  'The Fire Truck cue must indicate Bella’s left-right direction');
+assert.match(behavior, /interval = MEOW_MAX_INTERVAL_MS\s*- proximity/,
+  'Meows must repeat more quickly as the Fire Truck approaches');
+assert.match(behavior, /state\.vehicleId === REQUIRED_VEHICLE_ID/,
+  'Only the Fire Truck should receive Bella’s discovery cue');
+assert.match(behavior, /activeTrackId\(runtime\) === 'countryside'/);
+assert.match(behavior, /__turnAudioPreferences\?\.getSettings/,
+  'Bella’s cue must respect TURN’s audio preferences');
+assert.match(behavior, /settings\?\.audioEnabled === false/);
+assert.match(behavior, /createStereoPanner/);
+assert.match(behavior, /voice\.frequency\.exponentialRampToValueAtTime/,
+  'The procedural cue must use a recognisable rising-and-falling meow contour');
+assert.match(behavior, /if \(root\.userData\.turnBellaRescued\) return;/,
+  'Directional discovery meows must stop after Bella is safe');
+
+assert.match(world, /countryside-bella-rescue-r173\.js\?revision=r173-ground-and-meow/);
+assert.match(world, /applyBellaFinalVisuals\(bellaRoot\);\s*installBellaRescueBehavior\(\{ root: bellaRoot, runtime \}\);/,
+  'Post-rescue behavior must install after Bella’s final approved visual treatment');
+
+console.log('TURN Bella post-rescue and directional meow regression passed.');

--- a/turn/render/world.js
+++ b/turn/render/world.js
@@ -10,13 +10,14 @@ function moduleUrl(relativePath) {
 }
 
 async function loadWorldModules() {
-  const [beauty, art, identity, intensity, bella, bellaFinal] = await Promise.all([
+  const [beauty, art, identity, intensity, bella, bellaFinal, bellaRescue] = await Promise.all([
     import(moduleUrl('../world-beauty.js')),
     import(moduleUrl('../world-art-pass.js')),
     import(moduleUrl('../track-identity.js')),
     import(moduleUrl('../section-intensity.js')),
-    import(moduleUrl('../tracks/countryside-bella-r166.js?revision=r168-bella-markings-eyes-foliage-r169-facing-palette-r170-eye-placement-r171-cute-eyes-r172-final-tune')),
-    import(moduleUrl('../tracks/countryside-bella-final-r172.js?revision=r172-final-tune'))
+    import(moduleUrl('../tracks/countryside-bella-r166.js?revision=r168-bella-markings-eyes-foliage-r169-facing-palette-r170-eye-placement-r171-cute-eyes-r172-final-tune-r173-rescue')),
+    import(moduleUrl('../tracks/countryside-bella-final-r172.js?revision=r172-final-tune-r173-rescue')),
+    import(moduleUrl('../tracks/countryside-bella-rescue-r173.js?revision=r173-ground-and-meow'))
   ]);
 
   return {
@@ -25,7 +26,8 @@ async function loadWorldModules() {
     installTrackIdentity: identity.installTrackIdentity,
     installSectionIntensity: intensity.installSectionIntensity,
     installCountrysideBella: bella.installCountrysideBella,
-    applyBellaFinalVisuals: bellaFinal.applyBellaFinalVisuals
+    applyBellaFinalVisuals: bellaFinal.applyBellaFinalVisuals,
+    installBellaRescueBehavior: bellaRescue.installBellaRescueBehavior
   };
 }
 
@@ -99,7 +101,8 @@ async function install(runtime) {
       installTrackIdentity,
       installSectionIntensity,
       installCountrysideBella,
-      applyBellaFinalVisuals
+      applyBellaFinalVisuals,
+      installBellaRescueBehavior
     } = await loadWorldModules();
 
     // Compatibility helper retained from the previous world tuning layer.
@@ -118,7 +121,10 @@ async function install(runtime) {
     installTrackIdentity({ world, samples: worldSamples, trackWidth });
     installSectionIntensity({ world, samples: worldSamples, trackWidth });
     installCountrysideBella({ world, samples: worldSamples, trackWidth, runtime })
-      .then(applyBellaFinalVisuals)
+      .then((bellaRoot) => {
+        applyBellaFinalVisuals(bellaRoot);
+        installBellaRescueBehavior({ root: bellaRoot, runtime });
+      })
       .catch((error) => {
         console.warn('TURN: Bella discovery failed, keeping the rest of Countryside.', error);
       });

--- a/turn/tracks/countryside-bella-rescue-r173.js
+++ b/turn/tracks/countryside-bella-rescue-r173.js
@@ -1,0 +1,254 @@
+import * as THREE from 'three';
+
+const SAVE_BELLA_ID = 'save-bella';
+const REQUIRED_VEHICLE_ID = 'firetruck';
+const MEOW_RANGE_METERS = 108;
+const MEOW_CLOSE_METERS = 24;
+const MEOW_MIN_INTERVAL_MS = 2400;
+const MEOW_MAX_INTERVAL_MS = 5600;
+const UPDATE_INTERVAL_MS = 160;
+const RESCUE_MOVE_DELAY_MS = 80;
+
+// Local to the dedicated rescue-tree group. Positive Z remains on the protected
+// scenery side of the tree and the large X offset clears both trunk and branch.
+const SAFE_GROUND_POSITION = Object.freeze({ x: 5.4, y: 0.08, z: 2.2 });
+
+const AudioContextClass = globalThis.AudioContext || globalThis.webkitAudioContext;
+let meowContext = null;
+
+function activeTrackId(runtime) {
+  return String(
+    runtime?.state?.trackId
+    || runtime?.trackId
+    || globalThis.__turnGetTrackId?.()
+    || ''
+  ).toLowerCase();
+}
+
+function savedInProfile() {
+  return globalThis.__turnAchievements?.store?.isUnlocked?.(SAVE_BELLA_ID) === true;
+}
+
+function playerPosition(runtime) {
+  return runtime?.playerCar?.position || runtime?.state?.position || null;
+}
+
+function horizontalDistance(a, b) {
+  return Math.hypot(
+    Number(a?.x || 0) - Number(b?.x || 0),
+    Number(a?.z || 0) - Number(b?.z || 0)
+  );
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, Number(value) || 0));
+}
+
+function spatialPan(runtime, player, target) {
+  const dx = Number(target?.x || 0) - Number(player?.x || 0);
+  const dz = Number(target?.z || 0) - Number(player?.z || 0);
+  const length = Math.hypot(dx, dz);
+  if (length < 0.001) return 0;
+
+  const right = runtime?.getRight?.();
+  if (right) {
+    return clamp((dx / length) * Number(right.x || 0) + (dz / length) * Number(right.z || 0), -1, 1);
+  }
+
+  const heading = Number(runtime?.state?.heading) || 0;
+  return clamp((dx / length) * Math.cos(heading) - (dz / length) * Math.sin(heading), -1, 1);
+}
+
+function otherSoundPreference() {
+  const settings = globalThis.__turnAudioPreferences?.getSettings?.();
+  if (settings?.audioEnabled === false) return 0;
+  const balance = Number.isFinite(Number(settings?.balance)) ? Number(settings.balance) : 0.5;
+  return balance > 0.5 ? clamp((1 - balance) / 0.5, 0, 1) : 1;
+}
+
+function ensureMeowContext() {
+  if (!AudioContextClass) return null;
+  if (!meowContext) {
+    try {
+      meowContext = new AudioContextClass({ latencyHint: 'interactive' });
+    } catch (_) {
+      meowContext = new AudioContextClass();
+    }
+  }
+  if (meowContext.state === 'suspended') void meowContext.resume().catch(() => {});
+  return meowContext;
+}
+
+function unlockMeowContext() {
+  ensureMeowContext();
+}
+
+function scheduleMeow({ pan = 0, intensity = 0.5, rescued = false } = {}) {
+  const preference = otherSoundPreference();
+  const context = ensureMeowContext();
+  if (!context || context.state !== 'running' || preference <= 0.001) return false;
+
+  const now = context.currentTime + 0.012;
+  const level = (0.018 + clamp(intensity, 0, 1) * 0.022) * preference;
+  const duration = rescued ? 0.46 : 0.54;
+  const panner = typeof context.createStereoPanner === 'function'
+    ? context.createStereoPanner()
+    : context.createGain();
+  if (panner.pan) panner.pan.setValueAtTime(clamp(pan, -1, 1), now);
+
+  const gain = context.createGain();
+  gain.gain.setValueAtTime(0.0001, now);
+  gain.gain.exponentialRampToValueAtTime(level, now + 0.035);
+  gain.gain.setValueAtTime(level * 0.86, now + 0.16);
+  gain.gain.exponentialRampToValueAtTime(0.0001, now + duration);
+
+  const voice = context.createOscillator();
+  voice.type = 'sine';
+  voice.frequency.setValueAtTime(rescued ? 570 : 520, now);
+  voice.frequency.exponentialRampToValueAtTime(rescued ? 820 : 760, now + 0.13);
+  voice.frequency.exponentialRampToValueAtTime(rescued ? 490 : 405, now + duration);
+
+  const formant = context.createOscillator();
+  const formantGain = context.createGain();
+  formant.type = 'triangle';
+  formant.frequency.setValueAtTime(rescued ? 1140 : 1040, now);
+  formant.frequency.exponentialRampToValueAtTime(rescued ? 1640 : 1520, now + 0.13);
+  formant.frequency.exponentialRampToValueAtTime(rescued ? 980 : 810, now + duration);
+  formantGain.gain.value = 0.22;
+
+  voice.connect(gain);
+  formant.connect(formantGain);
+  formantGain.connect(gain);
+  gain.connect(panner);
+  panner.connect(context.destination);
+
+  const stopAt = now + duration + 0.03;
+  voice.start(now);
+  formant.start(now);
+  voice.stop(stopAt);
+  formant.stop(stopAt);
+  voice.addEventListener('ended', () => {
+    voice.disconnect();
+    formant.disconnect();
+    formantGain.disconnect();
+    gain.disconnect();
+    panner.disconnect();
+  }, { once: true });
+  return true;
+}
+
+function moveBellaToGround(root, { announce = false } = {}) {
+  if (!root || root.userData.turnBellaRescued) return false;
+  const cat = root.userData.turnBellaFocus;
+  if (!cat) return false;
+
+  cat.position.set(SAFE_GROUND_POSITION.x, SAFE_GROUND_POSITION.y, SAFE_GROUND_POSITION.z);
+  cat.name = 'Bella safe on the ground';
+  cat.userData.turnBellaState = 'rescued-stationary';
+  root.userData.turnBellaRescued = true;
+  root.userData.turnBellaRescueState = Object.freeze({
+    position: 'protected ground beside the rescue tree',
+    movement: 'stationary',
+    sourceAnimationClips: 0,
+    reason: 'The pinned Kenney Cube Pets cat contains no animation section or walking clip.',
+    trackSafety: 'Fixed scenery-local position; Bella cannot enter the road.'
+  });
+
+  if (announce) scheduleMeow({ pan: 0, intensity: 0.72, rescued: true });
+  return true;
+}
+
+export function installBellaRescueBehavior({ root, runtime = globalThis.__turnRuntime } = {}) {
+  if (!root || root.userData.turnBellaRescueBehaviorInstalled) return root || null;
+  const cat = root.userData.turnBellaFocus;
+  if (!cat) return root;
+  root.userData.turnBellaRescueBehaviorInstalled = true;
+
+  document.addEventListener('pointerdown', unlockMeowContext, { capture: true, passive: true });
+  document.addEventListener('keydown', unlockMeowContext, { capture: true });
+
+  let lastMeowAt = -Infinity;
+  let wasInRange = false;
+  let disposed = false;
+  const bellaWorldPosition = new THREE.Vector3();
+
+  function rescue({ announce = false } = {}) {
+    if (root.userData.turnBellaRescued) return;
+    window.setTimeout(() => moveBellaToGround(root, { announce }), RESCUE_MOVE_DELAY_MS);
+  }
+
+  function handleSecretAchievement(event) {
+    if (event.detail?.achievementId === SAVE_BELLA_ID) rescue({ announce: true });
+  }
+
+  function handleAchievementUpdate(event) {
+    if (event.detail?.unlocked?.includes?.(SAVE_BELLA_ID)) rescue({ announce: true });
+  }
+
+  function sample() {
+    if (disposed) return;
+    if (savedInProfile()) rescue();
+    if (root.userData.turnBellaRescued) return;
+
+    const state = runtime?.state;
+    const player = playerPosition(runtime);
+    const eligible = state?.running === true
+      && activeTrackId(runtime) === 'countryside'
+      && state.vehicleId === REQUIRED_VEHICLE_ID
+      && player;
+    if (!eligible || document.hidden) {
+      wasInRange = false;
+      return;
+    }
+
+    cat.getWorldPosition(bellaWorldPosition);
+    const distance = horizontalDistance(player, bellaWorldPosition);
+    const inRange = distance <= MEOW_RANGE_METERS;
+    if (!inRange) {
+      wasInRange = false;
+      return;
+    }
+
+    const now = performance.now();
+    const proximity = clamp(
+      1 - (distance - MEOW_CLOSE_METERS) / (MEOW_RANGE_METERS - MEOW_CLOSE_METERS),
+      0,
+      1
+    );
+    const interval = MEOW_MAX_INTERVAL_MS
+      - proximity * (MEOW_MAX_INTERVAL_MS - MEOW_MIN_INTERVAL_MS);
+    const enteringRange = !wasInRange;
+    wasInRange = true;
+    if (!enteringRange && now - lastMeowAt < interval) return;
+
+    const played = scheduleMeow({
+      pan: spatialPan(runtime, player, bellaWorldPosition),
+      intensity: 0.35 + proximity * 0.65
+    });
+    if (played) lastMeowAt = now;
+  }
+
+  globalThis.addEventListener('turn:secret-achievement', handleSecretAchievement);
+  globalThis.addEventListener('turn:achievements-updated', handleAchievementUpdate);
+  const timer = window.setInterval(sample, UPDATE_INTERVAL_MS);
+
+  root.userData.turnBellaMeowAccessibility = Object.freeze({
+    vehicle: 'Fire Truck',
+    rangeMeters: MEOW_RANGE_METERS,
+    directional: true,
+    cadence: 'Meows repeat more often as the Fire Truck approaches.',
+    availability: 'Other-sounds preference and global audio setting are respected.'
+  });
+  root.userData.turnBellaDisposeRescueBehavior = () => {
+    if (disposed) return;
+    disposed = true;
+    window.clearInterval(timer);
+    globalThis.removeEventListener('turn:secret-achievement', handleSecretAchievement);
+    globalThis.removeEventListener('turn:achievements-updated', handleAchievementUpdate);
+    document.removeEventListener('pointerdown', unlockMeowContext, { capture: true });
+    document.removeEventListener('keydown', unlockMeowContext, { capture: true });
+  };
+
+  sample();
+  return root;
+}


### PR DESCRIPTION
## Summary
- move Bella from the rescue branch to a fixed protected ground position immediately after `SAVE BELLA!` unlocks
- restore the safe ground state on later visits when the achievement is already stored
- keep Bella stationary because the pinned Kenney Cube Pets GLB contains no animation section or walking clip
- add repeated directional meows while an unsaved Bella is nearby and the player is driving the Fire Truck in Countryside
- pan the meow toward Bella and increase its cadence as the Fire Truck approaches
- respect TURN’s global audio setting and other-sounds balance
- stop discovery meows after rescue and play one short confirmation meow when she reaches the ground
- add a permanent regression covering the rescue state, track safety, Fire Truck gate, spatial cue and installation order

## Validation
- TURN regression workflow, now including the Bella rescue and directional meow contract
- syntax and lint checks
- existing achievement, audio, world, Drive By Ear and release architecture checks
