### PR TITLE
Add hidden full-profile admin unlock sequence

### DIFF
--- a/.github/workflows/turn-admin-unlock-test.yml
+++ b/.github/workflows/turn-admin-unlock-test.yml
@@ -7,7 +7,6 @@ on:
     paths:
       - 'turn/index.html'
       - 'turn/testing/admin-unlock-sequence.js'
-      - 'turn/live-steering-setting.js'
       - 'turn/achievements/**'
       - 'turn/progression/**'
       - 'turn-lab/tests/admin-unlock-production.mjs'
@@ -18,7 +17,6 @@ on:
     paths:
       - 'turn/index.html'
       - 'turn/testing/admin-unlock-sequence.js'
-      - 'turn/live-steering-setting.js'
       - 'turn/achievements/**'
       - 'turn/progression/**'
       - 'turn-lab/tests/admin-unlock-production.mjs'

--- a/.github/workflows/turn-admin-unlock-test.yml
+++ b/.github/workflows/turn-admin-unlock-test.yml
@@ -1,0 +1,41 @@
+name: TURN admin unlock regression
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'turn/testing/admin-unlock-sequence.js'
+      - 'turn/live-steering-setting.js'
+      - 'turn/achievements/**'
+      - 'turn/progression/**'
+      - 'turn-lab/tests/admin-unlock-production.mjs'
+      - '.github/workflows/turn-admin-unlock-test.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'turn/testing/admin-unlock-sequence.js'
+      - 'turn/live-steering-setting.js'
+      - 'turn/achievements/**'
+      - 'turn/progression/**'
+      - 'turn-lab/tests/admin-unlock-production.mjs'
+      - '.github/workflows/turn-admin-unlock-test.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  admin-unlock:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Run hidden admin unlock regression
+        run: node turn-lab/tests/admin-unlock-production.mjs

--- a/.github/workflows/turn-admin-unlock-test.yml
+++ b/.github/workflows/turn-admin-unlock-test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     paths:
+      - 'turn/index.html'
       - 'turn/testing/admin-unlock-sequence.js'
       - 'turn/live-steering-setting.js'
       - 'turn/achievements/**'
@@ -15,6 +16,7 @@ on:
     branches:
       - main
     paths:
+      - 'turn/index.html'
       - 'turn/testing/admin-unlock-sequence.js'
       - 'turn/live-steering-setting.js'
       - 'turn/achievements/**'

--- a/turn-lab/tests/admin-unlock-production.mjs
+++ b/turn-lab/tests/admin-unlock-production.mjs
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import {
+  ADMIN_UNLOCK_SEQUENCE,
+  advanceAdminUnlockSequence,
+  createAdminUnlockedState
+} from '../../turn/testing/admin-unlock-sequence.js';
+import { ACHIEVEMENTS, TRACK_IDS } from '../../turn/achievements/catalog.js';
+import { TROPHY_ROAD_REWARDS } from '../../turn/progression/trophy-road.js';
+
+const [source, loaderSource] = await Promise.all([
+  fs.readFile(new URL('../../turn/testing/admin-unlock-sequence.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/live-steering-setting.js', import.meta.url), 'utf8')
+]);
+
+assert.deepEqual(ADMIN_UNLOCK_SEQUENCE, [
+  'track:countryside',
+  'track:airport',
+  'track:countryside',
+  'track:airport',
+  'track:cliffside',
+  'track:countryside',
+  'track:airport',
+  'track:cliffside',
+  'track:harbor',
+  'vehicle:race',
+  'vehicle:convertible',
+  'action:race-this-car'
+]);
+
+let index = 0;
+for (let step = 0; step < ADMIN_UNLOCK_SEQUENCE.length; step += 1) {
+  const result = advanceAdminUnlockSequence(index, ADMIN_UNLOCK_SEQUENCE[step]);
+  assert.equal(result.completed, step === ADMIN_UNLOCK_SEQUENCE.length - 1);
+  index = result.nextIndex;
+}
+assert.equal(index, 0, 'The recognizer must reset after a completed sequence');
+assert.equal(advanceAdminUnlockSequence(4, 'track:harbor').nextIndex, 0);
+assert.equal(advanceAdminUnlockSequence(4, 'track:countryside').nextIndex, 1,
+  'A mismatch matching the first token should immediately restart the sequence');
+
+const existing = {
+  version: 4,
+  unlocked: {
+    'first-turn': {
+      unlockedAt: 123,
+      trackId: 'countryside',
+      vehicleId: 'classic',
+      time: 18
+    }
+  },
+  seen: [],
+  progress: { tracks: ['countryside'], blankTracks: [] },
+  rewards: { unlocked: [], seen: [] }
+};
+const unlocked = createAdminUnlockedState(existing, 456);
+const achievementIds = ACHIEVEMENTS.map(({ id }) => id);
+const rewardIds = TROPHY_ROAD_REWARDS.map(({ id }) => id);
+
+assert.deepEqual(Object.keys(unlocked.unlocked).sort(), [...achievementIds].sort());
+assert.deepEqual(unlocked.seen, achievementIds);
+assert.deepEqual(unlocked.progress.tracks, TRACK_IDS);
+assert.deepEqual(unlocked.progress.blankTracks, TRACK_IDS);
+assert.deepEqual(unlocked.rewards.unlocked, rewardIds);
+assert.deepEqual(unlocked.rewards.seen, rewardIds);
+assert.equal(unlocked.unlocked['first-turn'].unlockedAt, 123,
+  'Existing achievement history must be preserved');
+assert.equal(unlocked.unlocked['save-bella'].unlockedAt, 456);
+
+assert.match(source, /documentRef\.addEventListener\('click', handleClick, true\)/);
+assert.match(source, /event\.preventDefault\(\)/);
+assert.match(source, /event\.stopImmediatePropagation\(\)/);
+assert.match(source, /globalThis\.setTimeout\?\.\(reload, 0\)/,
+  'The final action must reload so all pre-rendered gates rebuild unlocked');
+assert.match(source, /CHALLENGE_PROGRESS_STORAGE_KEY/);
+assert.match(source, /armyTracks: \[\.\.\.TRACK_IDS\]/);
+assert.match(source, /cleanTracks: \[\.\.\.TRACK_IDS\]/);
+assert.doesNotMatch(source, /turn:achievements-updated|turn:trophy-road-updated|turn:secret-achievement/,
+  'The admin path must not emit achievement or reward events');
+assert.match(loaderSource, /admin-unlock-sequence\.js\?revision=r174-admin-unlock/);
+assert.match(loaderSource, /installAdminUnlockSequence\(\)/);
+
+console.log('TURN hidden admin unlock sequence regression passed.');

--- a/turn-lab/tests/admin-unlock-production.mjs
+++ b/turn-lab/tests/admin-unlock-production.mjs
@@ -8,9 +8,8 @@ import {
 import { ACHIEVEMENTS, TRACK_IDS } from '../../turn/achievements/catalog.js';
 import { TROPHY_ROAD_REWARDS } from '../../turn/progression/trophy-road.js';
 
-const [source, loaderSource, indexSource] = await Promise.all([
+const [source, indexSource] = await Promise.all([
   fs.readFile(new URL('../../turn/testing/admin-unlock-sequence.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/live-steering-setting.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8')
 ]);
 
@@ -78,10 +77,13 @@ assert.match(source, /armyTracks: \[\.\.\.TRACK_IDS\]/);
 assert.match(source, /cleanTracks: \[\.\.\.TRACK_IDS\]/);
 assert.doesNotMatch(source, /turn:achievements-updated|turn:trophy-road-updated|turn:secret-achievement/,
   'The admin path must not emit achievement or reward events');
-assert.match(loaderSource, /admin-unlock-sequence\.js\?revision=r174-admin-unlock/);
-assert.match(loaderSource, /installAdminUnlockSequence\(\)/);
+assert.match(source, /installAdminUnlockSequence\(\);\s*$/,
+  'The isolated production module must install itself');
 assert.match(indexSource,
-  /live-steering-setting\.js\?build=20260805-r160-live-steering-r174-admin-unlock/,
-  'The production entry must publish a fresh loader cache identity');
+  /<script type="module" src="\.\/testing\/admin-unlock-sequence\.js\?revision=r174-admin-unlock"><\/script>/,
+  'The production entry must publish the hidden recognizer with its own cache identity');
+assert.match(indexSource,
+  /src="\.\/live-steering-setting\.js\?build=20260805-r160-live-steering"/,
+  'The hidden recognizer must not disturb the canonical steering entry');
 
 console.log('TURN hidden admin unlock sequence regression passed.');

--- a/turn-lab/tests/admin-unlock-production.mjs
+++ b/turn-lab/tests/admin-unlock-production.mjs
@@ -8,9 +8,10 @@ import {
 import { ACHIEVEMENTS, TRACK_IDS } from '../../turn/achievements/catalog.js';
 import { TROPHY_ROAD_REWARDS } from '../../turn/progression/trophy-road.js';
 
-const [source, loaderSource] = await Promise.all([
+const [source, loaderSource, indexSource] = await Promise.all([
   fs.readFile(new URL('../../turn/testing/admin-unlock-sequence.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/live-steering-setting.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../../turn/live-steering-setting.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8')
 ]);
 
 assert.deepEqual(ADMIN_UNLOCK_SEQUENCE, [
@@ -79,5 +80,8 @@ assert.doesNotMatch(source, /turn:achievements-updated|turn:trophy-road-updated|
   'The admin path must not emit achievement or reward events');
 assert.match(loaderSource, /admin-unlock-sequence\.js\?revision=r174-admin-unlock/);
 assert.match(loaderSource, /installAdminUnlockSequence\(\)/);
+assert.match(indexSource,
+  /live-steering-setting\.js\?build=20260805-r160-live-steering-r174-admin-unlock/,
+  'The production entry must publish a fresh loader cache identity');
 
 console.log('TURN hidden admin unlock sequence regression passed.');

--- a/turn/index.html
+++ b/turn/index.html
@@ -67,7 +67,7 @@
   <script src="./install-gate.js?build=20260805-r160-social-browser"></script>
   <script src="./motion-safe-zone.js?build=20260805-r160"></script>
   <script src="./orientation-compat.js?build=20260805-r160"></script>
-  <script src="./live-steering-setting.js?build=20260805-r160-live-steering-r174-admin-unlock"></script>
+  <script src="./live-steering-setting.js?build=20260805-r160-live-steering"></script>
   <script>
     (() => {
       const emergencyVehicleNames = new Set(['Fire Truck', 'Police Car', 'Ambulance']);
@@ -183,5 +183,6 @@
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
   <script type="module" src="./ui/about-history-bootstrap-r165.js?revision=r165-browser-about"></script>
+  <script type="module" src="./testing/admin-unlock-sequence.js?revision=r174-admin-unlock"></script>
   <script type="module" src="./app.js?build=20260805-r160-browser-consent-r166-bella-records"></script>
 </body></html>

--- a/turn/index.html
+++ b/turn/index.html
@@ -67,7 +67,7 @@
   <script src="./install-gate.js?build=20260805-r160-social-browser"></script>
   <script src="./motion-safe-zone.js?build=20260805-r160"></script>
   <script src="./orientation-compat.js?build=20260805-r160"></script>
-  <script src="./live-steering-setting.js?build=20260805-r160-live-steering"></script>
+  <script src="./live-steering-setting.js?build=20260805-r160-live-steering-r174-admin-unlock"></script>
   <script>
     (() => {
       const emergencyVehicleNames = new Set(['Fire Truck', 'Police Car', 'Ambulance']);

--- a/turn/live-steering-setting.js
+++ b/turn/live-steering-setting.js
@@ -113,4 +113,14 @@
     if (!input?.matches?.('input[name="m8Steering"]:checked')) return;
     void applySteeringModeDuringRace(input);
   });
+
+  const adminModuleUrl = new URL(
+    './testing/admin-unlock-sequence.js?revision=r174-admin-unlock',
+    document.currentScript?.src || globalThis.location?.href
+  );
+  import(adminModuleUrl.href)
+    .then(({ installAdminUnlockSequence }) => installAdminUnlockSequence())
+    .catch((error) => {
+      console.warn('TURN: hidden test-profile sequence could not install.', error);
+    });
 })();

--- a/turn/live-steering-setting.js
+++ b/turn/live-steering-setting.js
@@ -113,14 +113,4 @@
     if (!input?.matches?.('input[name="m8Steering"]:checked')) return;
     void applySteeringModeDuringRace(input);
   });
-
-  const adminModuleUrl = new URL(
-    './testing/admin-unlock-sequence.js?revision=r174-admin-unlock',
-    document.currentScript?.src || globalThis.location?.href
-  );
-  import(adminModuleUrl.href)
-    .then(({ installAdminUnlockSequence }) => installAdminUnlockSequence())
-    .catch((error) => {
-      console.warn('TURN: hidden test-profile sequence could not install.', error);
-    });
 })();

--- a/turn/testing/admin-unlock-sequence.js
+++ b/turn/testing/admin-unlock-sequence.js
@@ -179,3 +179,5 @@ export function installAdminUnlockSequence({
   globalThis[INSTALL_FLAG] = api;
   return api;
 }
+
+installAdminUnlockSequence();

--- a/turn/testing/admin-unlock-sequence.js
+++ b/turn/testing/admin-unlock-sequence.js
@@ -1,0 +1,181 @@
+import {
+  ACHIEVEMENTS,
+  TRACK_IDS
+} from '../achievements/catalog.js?revision=r166-bella-records';
+import {
+  ACHIEVEMENT_STORAGE_KEY,
+  normalizeAchievementState
+} from '../achievements/store.js?revision=r166-bella-records';
+import {
+  TROPHY_ROAD_REWARDS
+} from '../progression/trophy-road.js?revision=r166-bella-records';
+import {
+  CHALLENGE_PROGRESS_STORAGE_KEY
+} from '../achievements/challenge-expansion-r166.js?revision=r166-bella-records';
+
+export const ADMIN_UNLOCK_SEQUENCE = Object.freeze([
+  'track:countryside',
+  'track:airport',
+  'track:countryside',
+  'track:airport',
+  'track:cliffside',
+  'track:countryside',
+  'track:airport',
+  'track:cliffside',
+  'track:harbor',
+  'vehicle:race',
+  'vehicle:convertible',
+  'action:race-this-car'
+]);
+
+const INSTALL_FLAG = '__turnAdminUnlockSequenceInstalled';
+const ADMIN_UNLOCK_MARKER = 'turn-admin-unlock-v1';
+
+function parseStoredState(storage) {
+  try {
+    const raw = storage?.getItem?.(ACHIEVEMENT_STORAGE_KEY);
+    return raw ? JSON.parse(raw) : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+export function createAdminUnlockedState(existing, timestamp = Date.now()) {
+  const state = normalizeAchievementState(existing);
+  const achievementIds = ACHIEVEMENTS.map((achievement) => achievement.id);
+  const rewardIds = TROPHY_ROAD_REWARDS.map((reward) => reward.id);
+
+  for (const achievementId of achievementIds) {
+    if (state.unlocked[achievementId]) continue;
+    state.unlocked[achievementId] = {
+      unlockedAt: timestamp,
+      trackId: '',
+      vehicleId: '',
+      time: null
+    };
+  }
+
+  state.seen = [...achievementIds];
+  state.progress.tracks = [...TRACK_IDS];
+  state.progress.blankTracks = [...TRACK_IDS];
+  state.rewards.unlocked = [...rewardIds];
+  state.rewards.seen = [...rewardIds];
+  return state;
+}
+
+export function advanceAdminUnlockSequence(currentIndex, token) {
+  const index = Number.isInteger(currentIndex) && currentIndex >= 0
+    ? currentIndex
+    : 0;
+  if (token === ADMIN_UNLOCK_SEQUENCE[index]) {
+    const nextIndex = index + 1;
+    return Object.freeze({
+      nextIndex: nextIndex === ADMIN_UNLOCK_SEQUENCE.length ? 0 : nextIndex,
+      completed: nextIndex === ADMIN_UNLOCK_SEQUENCE.length
+    });
+  }
+
+  return Object.freeze({
+    nextIndex: token === ADMIN_UNLOCK_SEQUENCE[0] ? 1 : 0,
+    completed: false
+  });
+}
+
+function copyStateIntoLiveStore(snapshot) {
+  const liveState = globalThis.__turnAchievements?.store?.state;
+  if (!liveState) return;
+  liveState.version = snapshot.version;
+  liveState.unlocked = { ...snapshot.unlocked };
+  liveState.seen = [...snapshot.seen];
+  liveState.progress = {
+    tracks: [...snapshot.progress.tracks],
+    blankTracks: [...snapshot.progress.blankTracks]
+  };
+  liveState.rewards = {
+    unlocked: [...snapshot.rewards.unlocked],
+    seen: [...snapshot.rewards.seen]
+  };
+}
+
+function copyChallengeProgressIntoLiveRuntime(progress) {
+  const liveProgress = globalThis.__turnAchievementChallengeExpansion?.progress;
+  if (!liveProgress) return;
+  liveProgress.armyTracks = [...progress.armyTracks];
+  liveProgress.cleanTracks = [...progress.cleanTracks];
+}
+
+export function unlockEverythingForTesting(storage = globalThis.localStorage) {
+  const snapshot = createAdminUnlockedState(parseStoredState(storage));
+  const challengeProgress = {
+    armyTracks: [...TRACK_IDS],
+    cleanTracks: [...TRACK_IDS]
+  };
+
+  try {
+    storage?.setItem?.(ACHIEVEMENT_STORAGE_KEY, JSON.stringify(snapshot));
+    storage?.setItem?.(CHALLENGE_PROGRESS_STORAGE_KEY, JSON.stringify(challengeProgress));
+    storage?.setItem?.(ADMIN_UNLOCK_MARKER, String(Date.now()));
+  } catch (_) {
+    return false;
+  }
+
+  copyStateIntoLiveStore(snapshot);
+  copyChallengeProgressIntoLiveRuntime(challengeProgress);
+  document.documentElement.dataset.turnAdminUnlocked = 'true';
+  console.info('TURN: hidden test profile unlocked.');
+  return true;
+}
+
+function tokenFromClick(event) {
+  const target = event.target;
+  if (!(target instanceof Element)) return '';
+
+  const track = target.closest('.track-card[data-track-id]:not([disabled])');
+  if (track) return `track:${track.dataset.trackId || ''}`;
+
+  const vehicle = target.closest('.lot-car-option[data-car-id]');
+  if (vehicle) return `vehicle:${vehicle.dataset.carId || ''}`;
+
+  if (target.closest('.lot-race')) return 'action:race-this-car';
+  return '';
+}
+
+export function installAdminUnlockSequence({
+  documentRef = globalThis.document,
+  storage = globalThis.localStorage,
+  reload = () => globalThis.location?.reload?.()
+} = {}) {
+  if (!documentRef?.addEventListener) return null;
+  if (globalThis[INSTALL_FLAG]) return globalThis[INSTALL_FLAG];
+
+  let sequenceIndex = 0;
+
+  const handleClick = (event) => {
+    const token = tokenFromClick(event);
+    if (!token) return;
+
+    const result = advanceAdminUnlockSequence(sequenceIndex, token);
+    sequenceIndex = result.nextIndex;
+    if (!result.completed) return;
+
+    if (!unlockEverythingForTesting(storage)) return;
+
+    // The existing Home and Lot were rendered from the pre-unlock snapshot. Stop the
+    // normal race action and reload once so every track, vehicle and paint control is
+    // rebuilt from the complete test profile without emitting achievement events.
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    globalThis.setTimeout?.(reload, 0);
+  };
+
+  documentRef.addEventListener('click', handleClick, true);
+  const api = Object.freeze({
+    sequence: ADMIN_UNLOCK_SEQUENCE,
+    disconnect() {
+      documentRef.removeEventListener('click', handleClick, true);
+      delete globalThis[INSTALL_FLAG];
+    }
+  });
+  globalThis[INSTALL_FLAG] = api;
+  return api;
+}


### PR DESCRIPTION
## Summary
- add the exact hidden selection sequence requested for restoring a complete test profile
- recognize track choices, Race Car, Convertible and the final `RACE THIS CAR` action through normal accessible button clicks
- silently populate all achievement records, mark every achievement and reward as seen, fill both all-track challenge progress sets and unlock every Trophy Road reward
- write directly to the existing production storage schema without dispatching achievement, Trophy Road or secret-achievement events
- update the live achievement/challenge state before reloading
- consume the final race action and reload once so Home and The Lot rebuild from the unlocked profile rather than their pre-command locked snapshot
- preserve existing achievement timestamps and records where present
- add a targeted CI workflow and regression for the exact sequence, silent state construction and reload contract

## Sequence
1. Countryside
2. Airport
3. Countryside
4. Airport
5. Cliffside
6. Countryside
7. Airport
8. Cliffside
9. Harbor
10. Race Car
11. Convertible
12. Race This Car

## Validation
- full TURN regression suite
- dedicated hidden admin unlock regression
- syntax and lint checks
