### PR TITLE
Fix hidden admin unlock flow through The Lot

### DIFF
--- a/turn-lab/tests/admin-unlock-production.mjs
+++ b/turn-lab/tests/admin-unlock-production.mjs
@@ -91,7 +91,7 @@ assert.equal(unlocked.unlocked['save-bella'].unlockedAt, 456);
 
 assert.match(source, /target\.closest\('\.m8-track-continue'\)/,
   'The Home RACE action must be the separator that opens The Lot');
-assert.match(source, /aria-checked=\\"true\\"/,
+assert.match(source, /aria-checked="true"/,
   'The final action must detect a Convertible that was already selected on Lot entry');
 assert.match(source, /completeAdminUnlockFromLot\(sequenceIndex, selectedVehicleId\)/);
 assert.match(source, /documentRef\.addEventListener\('click', handleClick, true\)/);

--- a/turn-lab/tests/admin-unlock-production.mjs
+++ b/turn-lab/tests/admin-unlock-production.mjs
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises';
 import {
   ADMIN_UNLOCK_SEQUENCE,
   advanceAdminUnlockSequence,
+  completeAdminUnlockFromLot,
   createAdminUnlockedState
 } from '../../turn/testing/admin-unlock-sequence.js';
 import { ACHIEVEMENTS, TRACK_IDS } from '../../turn/achievements/catalog.js';
@@ -23,12 +24,17 @@ assert.deepEqual(ADMIN_UNLOCK_SEQUENCE, [
   'track:airport',
   'track:cliffside',
   'track:harbor',
-  'vehicle:race',
+  'action:race',
   'vehicle:convertible',
   'action:race-this-car'
 ]);
 
 let index = 0;
+for (const irrelevant of ['action:race-this-car', 'track:harbor', 'vehicle:convertible']) {
+  index = advanceAdminUnlockSequence(index, irrelevant).nextIndex;
+  assert.equal(index, 0, 'Activity before the first Countryside selection must not matter');
+}
+
 for (let step = 0; step < ADMIN_UNLOCK_SEQUENCE.length; step += 1) {
   const result = advanceAdminUnlockSequence(index, ADMIN_UNLOCK_SEQUENCE[step]);
   assert.equal(result.completed, step === ADMIN_UNLOCK_SEQUENCE.length - 1);
@@ -38,6 +44,22 @@ assert.equal(index, 0, 'The recognizer must reset after a completed sequence');
 assert.equal(advanceAdminUnlockSequence(4, 'track:harbor').nextIndex, 0);
 assert.equal(advanceAdminUnlockSequence(4, 'track:countryside').nextIndex, 1,
   'A mismatch matching the first token should immediately restart the sequence');
+
+let lotEntryIndex = 0;
+for (const token of ADMIN_UNLOCK_SEQUENCE.slice(0, 10)) {
+  lotEntryIndex = advanceAdminUnlockSequence(lotEntryIndex, token).nextIndex;
+}
+assert.equal(ADMIN_UNLOCK_SEQUENCE[lotEntryIndex], 'vehicle:convertible');
+assert.equal(completeAdminUnlockFromLot(lotEntryIndex, 'convertible').completed, true,
+  'Convertible already selected on Lot entry must complete without another vehicle click');
+assert.equal(completeAdminUnlockFromLot(lotEntryIndex, 'classic').completed, false,
+  'RACE THIS CAR must not complete while another vehicle is selected');
+const explicitConvertibleIndex = advanceAdminUnlockSequence(
+  lotEntryIndex,
+  'vehicle:convertible'
+).nextIndex;
+assert.equal(completeAdminUnlockFromLot(explicitConvertibleIndex, 'convertible').completed, true,
+  'Selecting Convertible after entering The Lot must also complete');
 
 const existing = {
   version: 4,
@@ -67,6 +89,11 @@ assert.equal(unlocked.unlocked['first-turn'].unlockedAt, 123,
   'Existing achievement history must be preserved');
 assert.equal(unlocked.unlocked['save-bella'].unlockedAt, 456);
 
+assert.match(source, /target\.closest\('\.m8-track-continue'\)/,
+  'The Home RACE action must be the separator that opens The Lot');
+assert.match(source, /aria-checked=\\"true\\"/,
+  'The final action must detect a Convertible that was already selected on Lot entry');
+assert.match(source, /completeAdminUnlockFromLot\(sequenceIndex, selectedVehicleId\)/);
 assert.match(source, /documentRef\.addEventListener\('click', handleClick, true\)/);
 assert.match(source, /event\.preventDefault\(\)/);
 assert.match(source, /event\.stopImmediatePropagation\(\)/);
@@ -80,8 +107,8 @@ assert.doesNotMatch(source, /turn:achievements-updated|turn:trophy-road-updated|
 assert.match(source, /installAdminUnlockSequence\(\);\s*$/,
   'The isolated production module must install itself');
 assert.match(indexSource,
-  /<script type="module" src="\.\/testing\/admin-unlock-sequence\.js\?revision=r174-admin-unlock"><\/script>/,
-  'The production entry must publish the hidden recognizer with its own cache identity');
+  /<script type="module" src="\.\/testing\/admin-unlock-sequence\.js\?revision=r175-admin-unlock"><\/script>/,
+  'The production entry must publish the corrected recognizer with a fresh cache identity');
 assert.match(indexSource,
   /src="\.\/live-steering-setting\.js\?build=20260805-r160-live-steering"/,
   'The hidden recognizer must not disturb the canonical steering entry');

--- a/turn/index.html
+++ b/turn/index.html
@@ -183,6 +183,6 @@
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
   <script type="module" src="./ui/about-history-bootstrap-r165.js?revision=r165-browser-about"></script>
-  <script type="module" src="./testing/admin-unlock-sequence.js?revision=r174-admin-unlock"></script>
+  <script type="module" src="./testing/admin-unlock-sequence.js?revision=r175-admin-unlock"></script>
   <script type="module" src="./app.js?build=20260805-r160-browser-consent-r166-bella-records"></script>
 </body></html>

--- a/turn/testing/admin-unlock-sequence.js
+++ b/turn/testing/admin-unlock-sequence.js
@@ -23,13 +23,14 @@ export const ADMIN_UNLOCK_SEQUENCE = Object.freeze([
   'track:airport',
   'track:cliffside',
   'track:harbor',
-  'vehicle:race',
+  'action:race',
   'vehicle:convertible',
   'action:race-this-car'
 ]);
 
 const INSTALL_FLAG = '__turnAdminUnlockSequenceInstalled';
 const ADMIN_UNLOCK_MARKER = 'turn-admin-unlock-v1';
+const FINAL_VEHICLE_ID = 'convertible';
 
 function parseStoredState(storage) {
   try {
@@ -81,6 +82,18 @@ export function advanceAdminUnlockSequence(currentIndex, token) {
   });
 }
 
+export function completeAdminUnlockFromLot(currentIndex, selectedVehicleId) {
+  if (selectedVehicleId !== FINAL_VEHICLE_ID) {
+    return Object.freeze({ nextIndex: 0, completed: false });
+  }
+
+  let index = currentIndex;
+  if (ADMIN_UNLOCK_SEQUENCE[index] === `vehicle:${FINAL_VEHICLE_ID}`) {
+    index = advanceAdminUnlockSequence(index, `vehicle:${FINAL_VEHICLE_ID}`).nextIndex;
+  }
+  return advanceAdminUnlockSequence(index, 'action:race-this-car');
+}
+
 function copyStateIntoLiveStore(snapshot) {
   const liveState = globalThis.__turnAchievements?.store?.state;
   if (!liveState) return;
@@ -126,18 +139,18 @@ export function unlockEverythingForTesting(storage = globalThis.localStorage) {
   return true;
 }
 
-function tokenFromClick(event) {
-  const target = event.target;
-  if (!(target instanceof Element)) return '';
-
+function homeTokenFromClick(target) {
   const track = target.closest('.track-card[data-track-id]:not([disabled])');
   if (track) return `track:${track.dataset.trackId || ''}`;
-
-  const vehicle = target.closest('.lot-car-option[data-car-id]');
-  if (vehicle) return `vehicle:${vehicle.dataset.carId || ''}`;
-
-  if (target.closest('.lot-race')) return 'action:race-this-car';
+  if (target.closest('.m8-track-continue')) return 'action:race';
   return '';
+}
+
+function selectedVehicleFromLot(lotScreen, rememberedVehicleId = '') {
+  if (rememberedVehicleId) return rememberedVehicleId;
+  return lotScreen
+    ?.querySelector('.lot-car-option[data-car-id][aria-checked="true"]')
+    ?.dataset.carId || '';
 }
 
 export function installAdminUnlockSequence({
@@ -149,20 +162,59 @@ export function installAdminUnlockSequence({
   if (globalThis[INSTALL_FLAG]) return globalThis[INSTALL_FLAG];
 
   let sequenceIndex = 0;
+  let lotArmed = false;
+  let rememberedVehicleId = '';
+
+  function resetSequence() {
+    sequenceIndex = 0;
+    lotArmed = false;
+    rememberedVehicleId = '';
+  }
 
   const handleClick = (event) => {
-    const token = tokenFromClick(event);
-    if (!token) return;
+    const target = event.target;
+    if (!(target instanceof Element)) return;
 
-    const result = advanceAdminUnlockSequence(sequenceIndex, token);
-    sequenceIndex = result.nextIndex;
-    if (!result.completed) return;
+    const homeToken = homeTokenFromClick(target);
+    if (homeToken) {
+      const result = advanceAdminUnlockSequence(sequenceIndex, homeToken);
+      sequenceIndex = result.nextIndex;
+      lotArmed = homeToken === 'action:race'
+        && ADMIN_UNLOCK_SEQUENCE[sequenceIndex] === `vehicle:${FINAL_VEHICLE_ID}`;
+      if (!lotArmed) rememberedVehicleId = '';
+      return;
+    }
 
-    if (!unlockEverythingForTesting(storage)) return;
+    if (!lotArmed) return;
+    const lotScreen = target.closest('.lot-screen');
+    if (!lotScreen) return;
 
-    // The existing Home and Lot were rendered from the pre-unlock snapshot. Stop the
-    // normal race action and reload once so every track, vehicle and paint control is
-    // rebuilt from the complete test profile without emitting achievement events.
+    const vehicle = target.closest('.lot-car-option[data-car-id]');
+    if (vehicle) {
+      rememberedVehicleId = vehicle.dataset.carId || '';
+      if (rememberedVehicleId === FINAL_VEHICLE_ID
+          && ADMIN_UNLOCK_SEQUENCE[sequenceIndex] === `vehicle:${FINAL_VEHICLE_ID}`) {
+        sequenceIndex = advanceAdminUnlockSequence(
+          sequenceIndex,
+          `vehicle:${FINAL_VEHICLE_ID}`
+        ).nextIndex;
+      }
+      return;
+    }
+
+    if (target.closest('.lot-back')) {
+      resetSequence();
+      return;
+    }
+
+    if (!target.closest('.lot-race')) return;
+    const selectedVehicleId = selectedVehicleFromLot(lotScreen, rememberedVehicleId);
+    const result = completeAdminUnlockFromLot(sequenceIndex, selectedVehicleId);
+    resetSequence();
+    if (!result.completed || !unlockEverythingForTesting(storage)) return;
+
+    // The current Home and Lot were rendered from the pre-unlock snapshot. Stop this
+    // race launch and reload once so every gate rebuilds from the silent test profile.
     event.preventDefault();
     event.stopImmediatePropagation();
     globalThis.setTimeout?.(reload, 0);


### PR DESCRIPTION
## Summary
- replace the mistaken Race Car selection token with the actual Home `RACE` action that opens The Lot
- make the sequence begin cleanly on the first Countryside selection regardless of earlier clicks
- allow Convertible to be either already selected when The Lot opens or selected afterward
- require Convertible to be the active vehicle when `RACE THIS CAR` is pressed
- retain silent full-profile restoration without achievement or reward events
- publish the corrected recognizer under a fresh cache identity

## Exact flow
1. Countryside
2. Airport
3. Countryside
4. Airport
5. Cliffside
6. Countryside
7. Airport
8. Cliffside
9. Harbor
10. RACE — opens The Lot
11. Ensure Convertible is selected; no extra click is required if it is already selected
12. RACE THIS CAR

## Validation
- dedicated admin-unlock regression covers irrelevant prior clicks, preselected Convertible, selecting Convertible after entry and rejection of other vehicles
- full TURN regression suite
