### PR TITLE
Limit hidden admin unlock to rewards

### DIFF
--- a/turn-lab/tests/admin-unlock-production.mjs
+++ b/turn-lab/tests/admin-unlock-production.mjs
@@ -4,9 +4,8 @@ import {
   ADMIN_UNLOCK_SEQUENCE,
   advanceAdminUnlockSequence,
   completeAdminUnlockFromLot,
-  createAdminUnlockedState
+  createAdminRewardState
 } from '../../turn/testing/admin-unlock-sequence.js';
-import { ACHIEVEMENTS, TRACK_IDS } from '../../turn/achievements/catalog.js';
 import { TROPHY_ROAD_REWARDS } from '../../turn/progression/trophy-road.js';
 
 const [source, indexSource] = await Promise.all([
@@ -61,6 +60,7 @@ const explicitConvertibleIndex = advanceAdminUnlockSequence(
 assert.equal(completeAdminUnlockFromLot(explicitConvertibleIndex, 'convertible').completed, true,
   'Selecting Convertible after entering The Lot must also complete');
 
+const rewardIds = TROPHY_ROAD_REWARDS.map(({ id }) => id);
 const existing = {
   version: 4,
   unlocked: {
@@ -71,46 +71,90 @@ const existing = {
       time: 18
     }
   },
-  seen: [],
+  seen: ['first-turn'],
   progress: { tracks: ['countryside'], blankTracks: [] },
   rewards: { unlocked: [], seen: [] }
 };
-const unlocked = createAdminUnlockedState(existing, 456);
-const achievementIds = ACHIEVEMENTS.map(({ id }) => id);
-const rewardIds = TROPHY_ROAD_REWARDS.map(({ id }) => id);
+const preserved = createAdminRewardState(existing).snapshot;
+assert.deepEqual(Object.keys(preserved.unlocked), ['first-turn'],
+  'The admin sequence must not create achievement records');
+assert.deepEqual(preserved.seen, ['first-turn']);
+assert.deepEqual(preserved.progress.tracks, ['countryside']);
+assert.deepEqual(preserved.progress.blankTracks, []);
+assert.deepEqual(preserved.rewards.unlocked, rewardIds);
+assert.deepEqual(preserved.rewards.seen, rewardIds);
+assert.equal(preserved.unlocked['first-turn'].unlockedAt, 123,
+  'Real achievement history must be preserved');
 
-assert.deepEqual(Object.keys(unlocked.unlocked).sort(), [...achievementIds].sort());
-assert.deepEqual(unlocked.seen, achievementIds);
-assert.deepEqual(unlocked.progress.tracks, TRACK_IDS);
-assert.deepEqual(unlocked.progress.blankTracks, TRACK_IDS);
-assert.deepEqual(unlocked.rewards.unlocked, rewardIds);
-assert.deepEqual(unlocked.rewards.seen, rewardIds);
-assert.equal(unlocked.unlocked['first-turn'].unlockedAt, 123,
-  'Existing achievement history must be preserved');
-assert.equal(unlocked.unlocked['save-bella'].unlockedAt, 456);
+const cleanProfile = createAdminRewardState(null).snapshot;
+assert.deepEqual(cleanProfile.unlocked, {},
+  'A new testing profile must receive rewards without any achievements');
+assert.deepEqual(cleanProfile.seen, []);
+assert.deepEqual(cleanProfile.rewards.unlocked, rewardIds);
+
+const allTracks = ['countryside', 'airport', 'cliffside', 'harbor', 'midnight-city'];
+const legacyAdminProfile = {
+  version: 4,
+  unlocked: {
+    'first-turn': {
+      unlockedAt: 123,
+      trackId: 'countryside',
+      vehicleId: 'classic',
+      time: 18
+    },
+    'save-bella': {
+      unlockedAt: 456,
+      trackId: '',
+      vehicleId: '',
+      time: null
+    },
+    'beyond-sight': {
+      unlockedAt: 456,
+      trackId: '',
+      vehicleId: '',
+      time: null
+    }
+  },
+  seen: ['first-turn', 'save-bella', 'beyond-sight'],
+  progress: { tracks: allTracks, blankTracks: allTracks },
+  rewards: { unlocked: rewardIds, seen: rewardIds }
+};
+const repaired = createAdminRewardState(legacyAdminProfile, 458);
+assert.equal(repaired.repairedLegacyAdminState, true);
+assert.deepEqual(Object.keys(repaired.snapshot.unlocked), ['first-turn'],
+  'Re-running the corrected sequence must remove achievements fabricated by the old admin path');
+assert.deepEqual(repaired.snapshot.seen, ['first-turn']);
+assert.deepEqual(repaired.snapshot.progress.tracks, []);
+assert.deepEqual(repaired.snapshot.progress.blankTracks, []);
+assert.deepEqual(repaired.snapshot.rewards.unlocked, rewardIds);
+assert.equal(repaired.snapshot.unlocked['save-bella'], undefined,
+  'SAVE BELLA! must remain available for real rescue testing');
 
 assert.match(source, /target\.closest\('\.m8-track-continue'\)/,
   'The Home RACE action must be the separator that opens The Lot');
 assert.match(source, /aria-checked="true"/,
   'The final action must detect a Convertible that was already selected on Lot entry');
 assert.match(source, /completeAdminUnlockFromLot\(sequenceIndex, selectedVehicleId\)/);
+assert.match(source, /unlockRewardsForTesting\(storage\)/);
+assert.match(source, /snapshot\.rewards\.unlocked = \[\.\.\.rewardIds\]/);
+assert.match(source, /resetLegacyChallengeProgress\(storage\)/,
+  'The corrected path must clear challenge progress polluted by the old all-achievement unlock');
+assert.doesNotMatch(source, /ACHIEVEMENTS|TRACK_IDS/,
+  'The admin module must not enumerate achievements or fake all-track progress');
+assert.doesNotMatch(source, /turn:achievements-updated|turn:trophy-road-updated|turn:secret-achievement/,
+  'The admin path must not emit achievement or reward events');
 assert.match(source, /documentRef\.addEventListener\('click', handleClick, true\)/);
 assert.match(source, /event\.preventDefault\(\)/);
 assert.match(source, /event\.stopImmediatePropagation\(\)/);
 assert.match(source, /globalThis\.setTimeout\?\.\(reload, 0\)/,
-  'The final action must reload so all pre-rendered gates rebuild unlocked');
-assert.match(source, /CHALLENGE_PROGRESS_STORAGE_KEY/);
-assert.match(source, /armyTracks: \[\.\.\.TRACK_IDS\]/);
-assert.match(source, /cleanTracks: \[\.\.\.TRACK_IDS\]/);
-assert.doesNotMatch(source, /turn:achievements-updated|turn:trophy-road-updated|turn:secret-achievement/,
-  'The admin path must not emit achievement or reward events');
+  'The final action must reload so all pre-rendered reward gates rebuild unlocked');
 assert.match(source, /installAdminUnlockSequence\(\);\s*$/,
   'The isolated production module must install itself');
 assert.match(indexSource,
-  /<script type="module" src="\.\/testing\/admin-unlock-sequence\.js\?revision=r175-admin-unlock"><\/script>/,
-  'The production entry must publish the corrected recognizer with a fresh cache identity');
+  /<script type="module" src="\.\/testing\/admin-unlock-sequence\.js\?revision=r176-admin-rewards"><\/script>/,
+  'The production entry must publish the rewards-only recognizer with a fresh cache identity');
 assert.match(indexSource,
   /src="\.\/live-steering-setting\.js\?build=20260805-r160-live-steering"/,
   'The hidden recognizer must not disturb the canonical steering entry');
 
-console.log('TURN hidden admin unlock sequence regression passed.');
+console.log('TURN rewards-only admin unlock regression passed.');

--- a/turn/index.html
+++ b/turn/index.html
@@ -183,6 +183,6 @@
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
   <script type="module" src="./ui/about-history-bootstrap-r165.js?revision=r165-browser-about"></script>
-  <script type="module" src="./testing/admin-unlock-sequence.js?revision=r175-admin-unlock"></script>
+  <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
   <script type="module" src="./app.js?build=20260805-r160-browser-consent-r166-bella-records"></script>
 </body></html>

--- a/turn/testing/admin-unlock-sequence.js
+++ b/turn/testing/admin-unlock-sequence.js
@@ -1,8 +1,4 @@
 import {
-  ACHIEVEMENTS,
-  TRACK_IDS
-} from '../achievements/catalog.js?revision=r166-bella-records';
-import {
   ACHIEVEMENT_STORAGE_KEY,
   normalizeAchievementState
 } from '../achievements/store.js?revision=r166-bella-records';
@@ -30,7 +26,9 @@ export const ADMIN_UNLOCK_SEQUENCE = Object.freeze([
 
 const INSTALL_FLAG = '__turnAdminUnlockSequenceInstalled';
 const ADMIN_UNLOCK_MARKER = 'turn-admin-unlock-v1';
+const ADMIN_REWARD_PROFILE_VERSION = 2;
 const FINAL_VEHICLE_ID = 'convertible';
+const LEGACY_TIMESTAMP_TOLERANCE_MS = 5000;
 
 function parseStoredState(storage) {
   try {
@@ -41,27 +39,61 @@ function parseStoredState(storage) {
   }
 }
 
-export function createAdminUnlockedState(existing, timestamp = Date.now()) {
-  const state = normalizeAchievementState(existing);
-  const achievementIds = ACHIEVEMENTS.map((achievement) => achievement.id);
-  const rewardIds = TROPHY_ROAD_REWARDS.map((reward) => reward.id);
+function readLegacyAdminTimestamp(storage) {
+  try {
+    const raw = storage?.getItem?.(ADMIN_UNLOCK_MARKER);
+    if (!raw) return null;
 
-  for (const achievementId of achievementIds) {
-    if (state.unlocked[achievementId]) continue;
-    state.unlocked[achievementId] = {
-      unlockedAt: timestamp,
-      trackId: '',
-      vehicleId: '',
-      time: null
-    };
+    const numeric = Number(raw);
+    if (Number.isFinite(numeric)) return numeric;
+
+    const marker = JSON.parse(raw);
+    if (Number(marker?.version) >= ADMIN_REWARD_PROFILE_VERSION) return null;
+    const timestamp = Number(marker?.activatedAt);
+    return Number.isFinite(timestamp) ? timestamp : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function isLegacyAdminAchievementRecord(record, legacyAdminTimestamp) {
+  if (!Number.isFinite(Number(legacyAdminTimestamp))) return false;
+  const unlockedAt = Number(record?.unlockedAt);
+  const time = record?.time;
+  return Number.isFinite(unlockedAt)
+    && Math.abs(unlockedAt - Number(legacyAdminTimestamp)) <= LEGACY_TIMESTAMP_TOLERANCE_MS
+    && record?.trackId === ''
+    && record?.vehicleId === ''
+    && (time == null || Number(time) === 0);
+}
+
+export function createAdminRewardState(existing, legacyAdminTimestamp = null) {
+  const snapshot = normalizeAchievementState(existing);
+  const rewardIds = TROPHY_ROAD_REWARDS.map((reward) => reward.id);
+  let removedLegacyAchievements = false;
+
+  for (const [achievementId, record] of Object.entries(snapshot.unlocked)) {
+    if (!isLegacyAdminAchievementRecord(record, legacyAdminTimestamp)) continue;
+    delete snapshot.unlocked[achievementId];
+    removedLegacyAchievements = true;
   }
 
-  state.seen = [...achievementIds];
-  state.progress.tracks = [...TRACK_IDS];
-  state.progress.blankTracks = [...TRACK_IDS];
-  state.rewards.unlocked = [...rewardIds];
-  state.rewards.seen = [...rewardIds];
-  return state;
+  if (removedLegacyAchievements) {
+    snapshot.seen = snapshot.seen.filter((achievementId) => Boolean(snapshot.unlocked[achievementId]));
+    // The previous admin implementation overwrote these collections with all tracks.
+    // Their earlier values cannot be recovered, so reset them rather than leaving
+    // achievement progress falsely complete.
+    snapshot.progress.tracks = [];
+    snapshot.progress.blankTracks = [];
+  }
+
+  snapshot.rewards.unlocked = [...rewardIds];
+  snapshot.rewards.seen = [...rewardIds];
+
+  return Object.freeze({
+    snapshot,
+    repairedLegacyAdminState: removedLegacyAchievements
+  });
 }
 
 export function advanceAdminUnlockSequence(currentIndex, token) {
@@ -110,32 +142,47 @@ function copyStateIntoLiveStore(snapshot) {
   };
 }
 
-function copyChallengeProgressIntoLiveRuntime(progress) {
-  const liveProgress = globalThis.__turnAchievementChallengeExpansion?.progress;
-  if (!liveProgress) return;
-  liveProgress.armyTracks = [...progress.armyTracks];
-  liveProgress.cleanTracks = [...progress.cleanTracks];
-}
-
-export function unlockEverythingForTesting(storage = globalThis.localStorage) {
-  const snapshot = createAdminUnlockedState(parseStoredState(storage));
-  const challengeProgress = {
-    armyTracks: [...TRACK_IDS],
-    cleanTracks: [...TRACK_IDS]
-  };
-
+function resetLegacyChallengeProgress(storage) {
+  const progress = { armyTracks: [], cleanTracks: [] };
   try {
-    storage?.setItem?.(ACHIEVEMENT_STORAGE_KEY, JSON.stringify(snapshot));
-    storage?.setItem?.(CHALLENGE_PROGRESS_STORAGE_KEY, JSON.stringify(challengeProgress));
-    storage?.setItem?.(ADMIN_UNLOCK_MARKER, String(Date.now()));
+    storage?.setItem?.(CHALLENGE_PROGRESS_STORAGE_KEY, JSON.stringify(progress));
   } catch (_) {
     return false;
   }
 
+  const liveProgress = globalThis.__turnAchievementChallengeExpansion?.progress;
+  if (liveProgress) {
+    liveProgress.armyTracks = [];
+    liveProgress.cleanTracks = [];
+  }
+  return true;
+}
+
+export function unlockRewardsForTesting(storage = globalThis.localStorage) {
+  const legacyAdminTimestamp = readLegacyAdminTimestamp(storage);
+  const { snapshot, repairedLegacyAdminState } = createAdminRewardState(
+    parseStoredState(storage),
+    legacyAdminTimestamp
+  );
+  const marker = {
+    version: ADMIN_REWARD_PROFILE_VERSION,
+    activatedAt: Date.now(),
+    rewardsOnly: true
+  };
+
+  try {
+    storage?.setItem?.(ACHIEVEMENT_STORAGE_KEY, JSON.stringify(snapshot));
+    storage?.setItem?.(ADMIN_UNLOCK_MARKER, JSON.stringify(marker));
+  } catch (_) {
+    return false;
+  }
+
+  if (repairedLegacyAdminState) resetLegacyChallengeProgress(storage);
   copyStateIntoLiveStore(snapshot);
-  copyChallengeProgressIntoLiveRuntime(challengeProgress);
-  document.documentElement.dataset.turnAdminUnlocked = 'true';
-  console.info('TURN: hidden test profile unlocked.');
+  if (globalThis.document?.documentElement) {
+    globalThis.document.documentElement.dataset.turnAdminRewardsUnlocked = 'true';
+  }
+  console.info('TURN: hidden test rewards unlocked.');
   return true;
 }
 
@@ -211,10 +258,10 @@ export function installAdminUnlockSequence({
     const selectedVehicleId = selectedVehicleFromLot(lotScreen, rememberedVehicleId);
     const result = completeAdminUnlockFromLot(sequenceIndex, selectedVehicleId);
     resetSequence();
-    if (!result.completed || !unlockEverythingForTesting(storage)) return;
+    if (!result.completed || !unlockRewardsForTesting(storage)) return;
 
     // The current Home and Lot were rendered from the pre-unlock snapshot. Stop this
-    // race launch and reload once so every gate rebuilds from the silent test profile.
+    // race launch and reload once so every reward gate rebuilds from the test profile.
     event.preventDefault();
     event.stopImmediatePropagation();
     globalThis.setTimeout?.(reload, 0);


### PR DESCRIPTION
## Summary
- change the hidden testing sequence from a full-profile unlock to a rewards-only unlock
- unlock every Trophy Road reward, including the Fire Truck, without creating achievement records or completing achievement progress
- preserve genuine achievements and existing legitimate progress
- repair profiles affected by the previous admin implementation by removing only its timestamped synthetic achievement batch
- clear the all-track challenge progress that the previous admin path falsely completed
- keep all rewards marked as seen so no reward notifications appear
- retain the existing sequence and Convertible handling
- publish the correction under a fresh module revision for Safari cache safety

## SAVE BELLA! testing
After this change, the Fire Truck is available while `SAVE BELLA!` remains locked until Bella is actually rescued. Rerunning the sequence once also repairs a profile polluted by the previous full-achievement admin unlock.

## Validation
- dedicated rewards-only admin regression
- complete TURN regression suite
