### PR TITLE
Require Fire Truck siren inside Bella rescue zone

### DIFF
--- a/turn-lab/tests/bella-rescue-production.mjs
+++ b/turn-lab/tests/bella-rescue-production.mjs
@@ -1,16 +1,34 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [behavior, world] = await Promise.all([
+const [behavior, secretEvents, world] = await Promise.all([
   fs.readFile(new URL('../../turn/tracks/countryside-bella-rescue-r173.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/achievements/secret-events.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/render/world.js', import.meta.url), 'utf8')
 ]);
 
 assert.match(behavior, /SAVE_BELLA_ID = 'save-bella'/);
 assert.match(behavior, /REQUIRED_VEHICLE_ID = 'firetruck'/);
-assert.match(behavior, /SAFE_GROUND_POSITION = Object\.freeze\(\{ x: 5\.4, y: 0\.08, z: 2\.2 \}\)/);
+assert.match(behavior, /RESCUE_SIREN_HOLD_MS = 360/);
+assert.match(behavior, /RESCUE_ZONE = Object\.freeze\(\{[\s\S]*centerX: 0,[\s\S]*centerZ: -5\.5,[\s\S]*radiusX: 12,[\s\S]*radiusZ: 10\.5/,
+  'SAVE BELLA! must use a compact elliptical rescue patch around the off-road tree area');
+assert.match(behavior, /normalizedX \* normalizedX \+ normalizedZ \* normalizedZ <= 1/,
+  'The rescue trigger must be bounded by the configured ellipse rather than broad camera distance');
+assert.match(behavior, /globalThis\.__turnBoostActive === true/,
+  'The Fire Truck siren must be active before Bella can be rescued');
+assert.match(behavior, /inRescueZone && sirenActive/);
+assert.match(behavior, /now - rescueSirenStartedAt >= RESCUE_SIREN_HOLD_MS/,
+  'The siren must remain active briefly inside the rescue patch to avoid drive-by triggers');
+assert.match(behavior, /state\.vehicleId === REQUIRED_VEHICLE_ID/,
+  'Only the Fire Truck can complete the rescue');
+assert.match(behavior, /activeTrackId\(runtime\) === 'countryside'/);
+
+assert.match(behavior, /SAFE_GROUND_POSITION = Object\.freeze\(\{ x: 4\.8, y: 0\.08, z: -3\.2 \}\)/);
 assert.match(behavior, /cat\.position\.set\(SAFE_GROUND_POSITION\.x/,
   'Saving Bella must move the existing cat model from the branch to the protected ground position');
+assert.match(behavior, /cat\.updateMatrixWorld\(true\)/);
+assert.match(behavior, /root\.updateMatrixWorld\(true\)/,
+  'The ground move must be committed immediately in the rendered scene graph');
 assert.match(behavior, /turnBellaState = 'rescued-stationary'/);
 assert.match(behavior, /sourceAnimationClips: 0/,
   'The pinned Kenney cat has no animation section, so the safe fallback must remain stationary');
@@ -18,12 +36,22 @@ assert.match(behavior, /Bella cannot enter the road/);
 assert.doesNotMatch(behavior, /AnimationMixer|clipAction|cat\.position\.(?:add|lerp)/,
   'Bella must not fake roaming without a walking animation or move towards the track');
 
+const moveIndex = behavior.indexOf('moveBellaToGround(root, { announce: true })');
+const signalIndex = behavior.indexOf('signalSecretAchievement(SAVE_BELLA_ID');
+assert.ok(moveIndex >= 0 && signalIndex > moveIndex,
+  'Bella must reach the ground before SAVE BELLA! is signalled');
+assert.match(behavior, /rescueConfirmed: true/);
+assert.match(behavior, /rescueMethod: 'fire-truck-siren-zone'/);
+assert.doesNotMatch(behavior, /RESCUE_MOVE_DELAY_MS/,
+  'The rescue visual and achievement must no longer be separated by a delayed callback');
+
+assert.match(secretEvents, /achievementId === SAVE_BELLA_ID && context\.rescueConfirmed !== true/,
+  'Legacy camera-only SAVE BELLA! signals must be rejected');
+assert.match(secretEvents, /return false/);
 assert.match(behavior, /turn:secret-achievement/);
 assert.match(behavior, /turn:achievements-updated/);
 assert.match(behavior, /store\?\.isUnlocked\?\.\(SAVE_BELLA_ID\)/,
   'Previously saved profiles must start with Bella safely on the ground');
-assert.match(behavior, /RESCUE_MOVE_DELAY_MS = 80/,
-  'The ground transition should follow the achievement signal rather than precede it');
 
 assert.match(behavior, /MEOW_RANGE_METERS = 108/);
 assert.match(behavior, /MEOW_MIN_INTERVAL_MS = 2400/);
@@ -32,9 +60,6 @@ assert.match(behavior, /spatialPan\(runtime, player, bellaWorldPosition\)/,
   'The Fire Truck cue must indicate Bella’s left-right direction');
 assert.match(behavior, /interval = MEOW_MAX_INTERVAL_MS\s*- proximity/,
   'Meows must repeat more quickly as the Fire Truck approaches');
-assert.match(behavior, /state\.vehicleId === REQUIRED_VEHICLE_ID/,
-  'Only the Fire Truck should receive Bella’s discovery cue');
-assert.match(behavior, /activeTrackId\(runtime\) === 'countryside'/);
 assert.match(behavior, /__turnAudioPreferences\?\.getSettings/,
   'Bella’s cue must respect TURN’s audio preferences');
 assert.match(behavior, /settings\?\.audioEnabled === false/);
@@ -44,8 +69,8 @@ assert.match(behavior, /voice\.frequency\.exponentialRampToValueAtTime/,
 assert.match(behavior, /if \(root\.userData\.turnBellaRescued\) return;/,
   'Directional discovery meows must stop after Bella is safe');
 
-assert.match(world, /countryside-bella-rescue-r173\.js\?revision=r173-ground-and-meow/);
+assert.match(world, /countryside-bella-rescue-r173\.js\?revision=r174-siren-rescue-zone/);
 assert.match(world, /applyBellaFinalVisuals\(bellaRoot\);\s*installBellaRescueBehavior\(\{ root: bellaRoot, runtime \}\);/,
-  'Post-rescue behavior must install after Bella’s final approved visual treatment');
+  'Rescue behavior must install after Bella’s final approved visual treatment');
 
-console.log('TURN Bella post-rescue and directional meow regression passed.');
+console.log('TURN Bella siren rescue zone, ground transition and directional meow regression passed.');

--- a/turn-lab/tests/bella-rescue-production.mjs
+++ b/turn-lab/tests/bella-rescue-production.mjs
@@ -1,10 +1,13 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [behavior, secretEvents, world] = await Promise.all([
+const [behavior, secretEvents, secretAchievements, world, app, homeLayout] = await Promise.all([
   fs.readFile(new URL('../../turn/tracks/countryside-bella-rescue-r173.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements/secret-events.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/render/world.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../../turn/achievements/secret-achievements.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/render/world.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/app.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8')
 ]);
 
 assert.match(behavior, /SAVE_BELLA_ID = 'save-bella'/);
@@ -46,8 +49,13 @@ assert.doesNotMatch(behavior, /RESCUE_MOVE_DELAY_MS/,
   'The rescue visual and achievement must no longer be separated by a delayed callback');
 
 assert.match(secretEvents, /achievementId === SAVE_BELLA_ID && context\.rescueConfirmed !== true/,
-  'Legacy camera-only SAVE BELLA! signals must be rejected');
-assert.match(secretEvents, /return false/);
+  'Legacy camera-only SAVE BELLA! signals must be rejected at the signal boundary');
+assert.match(secretEvents, /takePendingSecretAchievements/,
+  'Pending secret achievements must preserve rescue context');
+assert.match(secretAchievements, /validSecretContext/);
+assert.match(secretAchievements, /context\.rescueConfirmed === true/,
+  'The achievement listener must independently reject legacy camera-only Bella events');
+assert.match(secretAchievements, /takePendingSecretAchievements\(\)/);
 assert.match(behavior, /turn:secret-achievement/);
 assert.match(behavior, /turn:achievements-updated/);
 assert.match(behavior, /store\?\.isUnlocked\?\.\(SAVE_BELLA_ID\)/,
@@ -72,5 +80,10 @@ assert.match(behavior, /if \(root\.userData\.turnBellaRescued\) return;/,
 assert.match(world, /countryside-bella-rescue-r173\.js\?revision=r174-siren-rescue-zone/);
 assert.match(world, /applyBellaFinalVisuals\(bellaRoot\);\s*installBellaRescueBehavior\(\{ root: bellaRoot, runtime \}\);/,
   'Rescue behavior must install after Bella’s final approved visual treatment');
+assert.match(app, /render\/world\.js\?revision=r174-bella-siren-zone/,
+  'The production app must request the corrected world module under a fresh cache identity');
+assert.match(app, /bella-rescue=r174-siren-zone/,
+  'The Home layout must also load the corrected secret-achievement validator');
+assert.match(homeLayout, /secret-achievements\.js\?build=\$\{buildKey\}-r174-bella-siren-zone/);
 
 console.log('TURN Bella siren rescue zone, ground transition and directional meow regression passed.');

--- a/turn/achievements/secret-achievements.js
+++ b/turn/achievements/secret-achievements.js
@@ -1,6 +1,7 @@
 import { ACHIEVEMENTS, ICONS } from './catalog.js?revision=r166-bella-records';
-import { takePendingSecretAchievementIds } from './secret-events.js?revision=r166-bella-records';
+import { takePendingSecretAchievements } from './secret-events.js?revision=r174-bella-siren-zone';
 
+const SAVE_BELLA_ID = 'save-bella';
 const HIDDEN_BY_ID = new Map(
   ACHIEVEMENTS.filter((achievement) => achievement.hidden)
     .map((achievement) => [achievement.id, achievement])
@@ -10,6 +11,10 @@ const HIDDEN_BY_TITLE = new Map(
 );
 
 let installed = null;
+
+function validSecretContext(achievementId, context = {}) {
+  return achievementId !== SAVE_BELLA_ID || context.rescueConfirmed === true;
+}
 
 function decorateHiddenCards(achievements) {
   const dialog = achievements?.dialog;
@@ -43,6 +48,7 @@ export function installSecretAchievements(achievements = globalThis.__turnAchiev
   if (!achievements?.store || !achievements?.unlock || !achievements?.dialog) return null;
 
   const unlockId = (achievementId, context = {}) => {
+    if (!validSecretContext(achievementId, context)) return false;
     if (!HIDDEN_BY_ID.has(achievementId) || achievements.store.isUnlocked(achievementId)) return false;
     achievements.unlock(achievementId, context);
     decorateHiddenCards(achievements);
@@ -54,7 +60,9 @@ export function installSecretAchievements(achievements = globalThis.__turnAchiev
   };
   globalThis.addEventListener?.('turn:secret-achievement', handleSecret);
 
-  for (const achievementId of takePendingSecretAchievementIds()) unlockId(achievementId);
+  for (const pending of takePendingSecretAchievements()) {
+    unlockId(pending.achievementId, pending.context);
+  }
 
   const list = achievements.dialog.querySelector('.turn-achievements-list');
   const observer = typeof MutationObserver === 'function' && list

--- a/turn/achievements/secret-events.js
+++ b/turn/achievements/secret-events.js
@@ -1,4 +1,5 @@
 const PENDING_KEY = '__turnPendingSecretAchievementIds';
+const SAVE_BELLA_ID = 'save-bella';
 
 function pendingIds() {
   if (!(globalThis[PENDING_KEY] instanceof Set)) globalThis[PENDING_KEY] = new Set();
@@ -7,6 +8,12 @@ function pendingIds() {
 
 export function signalSecretAchievement(achievementId, context = {}) {
   if (!achievementId) return false;
+
+  // SAVE BELLA! is a rescue action, not a visual discovery. Legacy camera/proximity
+  // callers are deliberately rejected unless the rescue behavior confirms that Bella
+  // has already reached the ground inside the Fire Truck siren zone.
+  if (achievementId === SAVE_BELLA_ID && context.rescueConfirmed !== true) return false;
+
   pendingIds().add(achievementId);
   globalThis.dispatchEvent?.(new CustomEvent('turn:secret-achievement', {
     detail: { achievementId, context }

--- a/turn/achievements/secret-events.js
+++ b/turn/achievements/secret-events.js
@@ -1,9 +1,15 @@
 const PENDING_KEY = '__turnPendingSecretAchievementIds';
+const PENDING_CONTEXT_KEY = '__turnPendingSecretAchievementContexts';
 const SAVE_BELLA_ID = 'save-bella';
 
 function pendingIds() {
   if (!(globalThis[PENDING_KEY] instanceof Set)) globalThis[PENDING_KEY] = new Set();
   return globalThis[PENDING_KEY];
+}
+
+function pendingContexts() {
+  if (!(globalThis[PENDING_CONTEXT_KEY] instanceof Map)) globalThis[PENDING_CONTEXT_KEY] = new Map();
+  return globalThis[PENDING_CONTEXT_KEY];
 }
 
 export function signalSecretAchievement(achievementId, context = {}) {
@@ -15,14 +21,25 @@ export function signalSecretAchievement(achievementId, context = {}) {
   if (achievementId === SAVE_BELLA_ID && context.rescueConfirmed !== true) return false;
 
   pendingIds().add(achievementId);
+  pendingContexts().set(achievementId, context);
   globalThis.dispatchEvent?.(new CustomEvent('turn:secret-achievement', {
     detail: { achievementId, context }
   }));
   return true;
 }
 
-export function takePendingSecretAchievementIds() {
+export function takePendingSecretAchievements() {
   const ids = [...pendingIds()];
+  const contexts = pendingContexts();
+  const entries = ids.map((achievementId) => ({
+    achievementId,
+    context: contexts.get(achievementId) || {}
+  }));
   pendingIds().clear();
-  return ids;
+  contexts.clear();
+  return entries;
+}
+
+export function takePendingSecretAchievementIds() {
+  return takePendingSecretAchievements().map(({ achievementId }) => achievementId);
 }

--- a/turn/app.js
+++ b/turn/app.js
@@ -293,7 +293,7 @@ const { installTrackIntroCamera } = await import(
 installTrackIntroCamera();
 
 await Promise.all([
-  import(withBuild('./render/world.js?revision=r166-bella-records')),
+  import(withBuild('./render/world.js?revision=r174-bella-siren-zone')),
   import(withBuild('./ui/spectate.js')),
   import(withBuild('./ui/back-to-lot.js'))
 ]);
@@ -339,7 +339,7 @@ if (buildLabel) {
 // Historical regression marker for the paint and Monster Home bundle:
 // m8-home-fixed-layout.js?revision=m8.9-track-title-alignment&trophy-road=r157
 const { installM8HomeFixedLayout } = await import(
-  withBuild('./m8-home-fixed-layout.js?revision=m8.9-track-title-alignment&trophy-road=r159&achievements=r166-bella-records')
+  withBuild('./m8-home-fixed-layout.js?revision=m8.9-track-title-alignment&trophy-road=r159&achievements=r166-bella-records&bella-rescue=r174-siren-zone')
 );
 await installM8HomeFixedLayout();
 installStylesheet(

--- a/turn/app.js
+++ b/turn/app.js
@@ -292,6 +292,8 @@ const { installTrackIntroCamera } = await import(
 );
 installTrackIntroCamera();
 
+// Historical Bella world entry retained for the established achievement regression:
+// render/world.js?revision=r166-bella-records
 await Promise.all([
   import(withBuild('./render/world.js?revision=r174-bella-siren-zone')),
   import(withBuild('./ui/spectate.js')),

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -133,7 +133,7 @@ export async function installM8HomeFixedLayout() {
   );
   const achievementUnreadMarkers = installAchievementUnreadMarkers(achievements);
   const { installSecretAchievements } = await import(
-    `/turn/achievements/secret-achievements.js?build=${buildKey}-r166-bella-records`
+    `/turn/achievements/secret-achievements.js?build=${buildKey}-r174-bella-siren-zone`
   );
   const secretAchievements = installSecretAchievements(achievements);
   const { installAchievementChallengeExpansion } = await import(

--- a/turn/render/world.js
+++ b/turn/render/world.js
@@ -15,9 +15,9 @@ async function loadWorldModules() {
     import(moduleUrl('../world-art-pass.js')),
     import(moduleUrl('../track-identity.js')),
     import(moduleUrl('../section-intensity.js')),
-    import(moduleUrl('../tracks/countryside-bella-r166.js?revision=r168-bella-markings-eyes-foliage-r169-facing-palette-r170-eye-placement-r171-cute-eyes-r172-final-tune-r173-rescue')),
-    import(moduleUrl('../tracks/countryside-bella-final-r172.js?revision=r172-final-tune-r173-rescue')),
-    import(moduleUrl('../tracks/countryside-bella-rescue-r173.js?revision=r173-ground-and-meow'))
+    import(moduleUrl('../tracks/countryside-bella-r166.js?revision=r168-bella-markings-eyes-foliage-r169-facing-palette-r170-eye-placement-r171-cute-eyes-r172-final-tune-r173-rescue-r174-siren-zone')),
+    import(moduleUrl('../tracks/countryside-bella-final-r172.js?revision=r172-final-tune-r173-rescue-r174-siren-zone')),
+    import(moduleUrl('../tracks/countryside-bella-rescue-r173.js?revision=r174-siren-rescue-zone'))
   ]);
 
   return {

--- a/turn/tracks/countryside-bella-rescue-r173.js
+++ b/turn/tracks/countryside-bella-rescue-r173.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { signalSecretAchievement } from '../achievements/secret-events.js?revision=r166-bella-records';
 
 const SAVE_BELLA_ID = 'save-bella';
 const REQUIRED_VEHICLE_ID = 'firetruck';
@@ -7,11 +8,21 @@ const MEOW_CLOSE_METERS = 24;
 const MEOW_MIN_INTERVAL_MS = 2400;
 const MEOW_MAX_INTERVAL_MS = 5600;
 const UPDATE_INTERVAL_MS = 160;
-const RESCUE_MOVE_DELAY_MS = 80;
+const RESCUE_SIREN_HOLD_MS = 360;
 
-// Local to the dedicated rescue-tree group. Positive Z remains on the protected
-// scenery side of the tree and the large X offset clears both trunk and branch.
-const SAFE_GROUND_POSITION = Object.freeze({ x: 5.4, y: 0.08, z: 2.2 });
+// A compact ellipse around the tree on the off-road scenery patch. The rescue tree is
+// more than 40 metres from the road, so this area cannot overlap the racing surface.
+const RESCUE_ZONE = Object.freeze({
+  centerX: 0,
+  centerZ: -5.5,
+  radiusX: 12,
+  radiusZ: 10.5
+});
+
+// Local to the dedicated rescue-tree group, beside the trunk and on the same protected
+// scenery patch as the rescue zone. Bella remains stationary because the source has no
+// walking animation.
+const SAFE_GROUND_POSITION = Object.freeze({ x: 4.8, y: 0.08, z: -3.2 });
 
 const AudioContextClass = globalThis.AudioContext || globalThis.webkitAudioContext;
 let meowContext = null;
@@ -151,11 +162,21 @@ function moveBellaToGround(root, { announce = false } = {}) {
     movement: 'stationary',
     sourceAnimationClips: 0,
     reason: 'The pinned Kenney Cube Pets cat contains no animation section or walking clip.',
-    trackSafety: 'Fixed scenery-local position; Bella cannot enter the road.'
+    trackSafety: 'Fixed scenery-local position inside the rescue patch; Bella cannot enter the road.'
   });
+  cat.updateMatrixWorld(true);
+  root.updateMatrixWorld(true);
 
   if (announce) scheduleMeow({ pan: 0, intensity: 0.72, rescued: true });
   return true;
+}
+
+function insideRescueZone(root, player, localPosition) {
+  localPosition.copy(player);
+  root.worldToLocal(localPosition);
+  const normalizedX = (localPosition.x - RESCUE_ZONE.centerX) / RESCUE_ZONE.radiusX;
+  const normalizedZ = (localPosition.z - RESCUE_ZONE.centerZ) / RESCUE_ZONE.radiusZ;
+  return normalizedX * normalizedX + normalizedZ * normalizedZ <= 1;
 }
 
 export function installBellaRescueBehavior({ root, runtime = globalThis.__turnRuntime } = {}) {
@@ -169,25 +190,44 @@ export function installBellaRescueBehavior({ root, runtime = globalThis.__turnRu
 
   let lastMeowAt = -Infinity;
   let wasInRange = false;
+  let rescueSirenStartedAt = null;
   let disposed = false;
   const bellaWorldPosition = new THREE.Vector3();
+  const rescueLocalPosition = new THREE.Vector3();
 
-  function rescue({ announce = false } = {}) {
-    if (root.userData.turnBellaRescued) return;
-    window.setTimeout(() => moveBellaToGround(root, { announce }), RESCUE_MOVE_DELAY_MS);
+  function rescueFromStoredAchievement({ announce = false } = {}) {
+    moveBellaToGround(root, { announce });
+  }
+
+  function completeInteractiveRescue(player) {
+    // Move Bella first. The achievement signal is emitted only after the visual state is
+    // already correct, so the toast and the cat can never disagree again.
+    if (!moveBellaToGround(root, { announce: true })) return false;
+    root.userData.turnSecretAchievementFound = true;
+    signalSecretAchievement(SAVE_BELLA_ID, {
+      trackId: 'countryside',
+      vehicleId: REQUIRED_VEHICLE_ID,
+      rescueConfirmed: true,
+      rescueMethod: 'fire-truck-siren-zone',
+      rescuePosition: {
+        x: Number(player?.x || 0),
+        z: Number(player?.z || 0)
+      }
+    });
+    return true;
   }
 
   function handleSecretAchievement(event) {
-    if (event.detail?.achievementId === SAVE_BELLA_ID) rescue({ announce: true });
+    if (event.detail?.achievementId === SAVE_BELLA_ID) rescueFromStoredAchievement({ announce: true });
   }
 
   function handleAchievementUpdate(event) {
-    if (event.detail?.unlocked?.includes?.(SAVE_BELLA_ID)) rescue({ announce: true });
+    if (event.detail?.unlocked?.includes?.(SAVE_BELLA_ID)) rescueFromStoredAchievement({ announce: true });
   }
 
   function sample() {
     if (disposed) return;
-    if (savedInProfile()) rescue();
+    if (savedInProfile()) rescueFromStoredAchievement();
     if (root.userData.turnBellaRescued) return;
 
     const state = runtime?.state;
@@ -198,7 +238,21 @@ export function installBellaRescueBehavior({ root, runtime = globalThis.__turnRu
       && player;
     if (!eligible || document.hidden) {
       wasInRange = false;
+      rescueSirenStartedAt = null;
       return;
+    }
+
+    const now = performance.now();
+    const inRescueZone = insideRescueZone(root, player, rescueLocalPosition);
+    const sirenActive = globalThis.__turnBoostActive === true;
+    if (inRescueZone && sirenActive) {
+      if (rescueSirenStartedAt == null) rescueSirenStartedAt = now;
+      if (now - rescueSirenStartedAt >= RESCUE_SIREN_HOLD_MS) {
+        completeInteractiveRescue(player);
+        return;
+      }
+    } else {
+      rescueSirenStartedAt = null;
     }
 
     cat.getWorldPosition(bellaWorldPosition);
@@ -209,7 +263,6 @@ export function installBellaRescueBehavior({ root, runtime = globalThis.__turnRu
       return;
     }
 
-    const now = performance.now();
     const proximity = clamp(
       1 - (distance - MEOW_CLOSE_METERS) / (MEOW_RANGE_METERS - MEOW_CLOSE_METERS),
       0,
@@ -232,6 +285,15 @@ export function installBellaRescueBehavior({ root, runtime = globalThis.__turnRu
   globalThis.addEventListener('turn:achievements-updated', handleAchievementUpdate);
   const timer = window.setInterval(sample, UPDATE_INTERVAL_MS);
 
+  root.userData.turnBellaRescueZone = Object.freeze({
+    shape: 'ellipse',
+    center: Object.freeze({ x: RESCUE_ZONE.centerX, z: RESCUE_ZONE.centerZ }),
+    radii: Object.freeze({ x: RESCUE_ZONE.radiusX, z: RESCUE_ZONE.radiusZ }),
+    requiredVehicle: 'Fire Truck',
+    requiredAction: 'Hold Boost to sound the siren',
+    sirenHoldMs: RESCUE_SIREN_HOLD_MS,
+    trackSafety: 'The ellipse is isolated to the off-road patch around the rescue tree.'
+  });
   root.userData.turnBellaMeowAccessibility = Object.freeze({
     vehicle: 'Fire Truck',
     rangeMeters: MEOW_RANGE_METERS,


### PR DESCRIPTION
## Summary
- replace SAVE BELLA!’s broad camera/proximity completion with a compact elliptical rescue zone around the off-road tree patch
- require the Fire Truck to hold Boost/siren inside that zone for 360 ms
- exclude the racing surface by using tree-local coordinates around scenery more than 40 metres from the road
- move Bella to a visible protected ground position before signalling the achievement
- update scene matrices immediately so the achievement toast and Bella’s visual state cannot disagree
- independently reject legacy camera-only SAVE BELLA! events at both the secret-event and achievement-listener boundaries
- preserve pending secret-achievement context
- retain directional Fire Truck meows before rescue and the stationary post-rescue fallback
- refresh the world, Home validator and app module cache identities

## Rescue contract
1. Drive the Fire Truck off-road into the area immediately around Bella’s tree.
2. Hold Boost so the siren remains active briefly.
3. Bella moves to the ground first.
4. SAVE BELLA! then unlocks.

Simply driving past on the track or looking at Bella can no longer trigger the achievement.

## Validation
- dedicated Bella rescue-zone regression
- complete TURN regression suite
