### PR TITLE
Expand Bella rescue clearing behind the tree

### DIFF
--- a/turn-lab/tests/bella-rescue-production.mjs
+++ b/turn-lab/tests/bella-rescue-production.mjs
@@ -12,16 +12,22 @@ const [behavior, secretEvents, secretAchievements, world, app, homeLayout] = awa
 
 assert.match(behavior, /SAVE_BELLA_ID = 'save-bella'/);
 assert.match(behavior, /REQUIRED_VEHICLE_ID = 'firetruck'/);
-assert.match(behavior, /RESCUE_SIREN_HOLD_MS = 360/);
-assert.match(behavior, /RESCUE_ZONE = Object\.freeze\(\{[\s\S]*centerX: 0,[\s\S]*centerZ: -5\.5,[\s\S]*radiusX: 12,[\s\S]*radiusZ: 10\.5/,
-  'SAVE BELLA! must use a compact elliptical rescue patch around the off-road tree area');
-assert.match(behavior, /normalizedX \* normalizedX \+ normalizedZ \* normalizedZ <= 1/,
-  'The rescue trigger must be bounded by the configured ellipse rather than broad camera distance');
+assert.match(behavior, /RESCUE_SIREN_HOLD_MS = 320/);
+assert.match(behavior, /RESCUE_ZONE = Object\.freeze\(\{[\s\S]*halfWidth: 22,[\s\S]*nearZ: -1\.5,[\s\S]*farZ: -36/,
+  'SAVE BELLA! must cover a broad clearing several Fire-Truck lengths behind the tree');
+assert.match(behavior, /Math\.abs\(localPosition\.x\) <= RESCUE_ZONE\.halfWidth/);
+assert.match(behavior, /localPosition\.z <= RESCUE_ZONE\.nearZ/);
+assert.match(behavior, /localPosition\.z >= RESCUE_ZONE\.farZ/,
+  'The rescue trigger must be a large bounded rear clearing rather than a small ellipse');
+assert.match(behavior, /Only negative local Z is eligible/,
+  'The complete track-facing side of Bella’s tree must remain excluded');
+assert.match(behavior, /root\.updateWorldMatrix\(true, false\)/,
+  'Zone sampling must use the current rendered tree transform');
 assert.match(behavior, /globalThis\.__turnBoostActive === true/,
   'The Fire Truck siren must be active before Bella can be rescued');
 assert.match(behavior, /inRescueZone && sirenActive/);
 assert.match(behavior, /now - rescueSirenStartedAt >= RESCUE_SIREN_HOLD_MS/,
-  'The siren must remain active briefly inside the rescue patch to avoid drive-by triggers');
+  'The siren must remain active briefly inside the rescue clearing to avoid drive-by triggers');
 assert.match(behavior, /state\.vehicleId === REQUIRED_VEHICLE_ID/,
   'Only the Fire Truck can complete the rescue');
 assert.match(behavior, /activeTrackId\(runtime\) === 'countryside'/);
@@ -77,13 +83,13 @@ assert.match(behavior, /voice\.frequency\.exponentialRampToValueAtTime/,
 assert.match(behavior, /if \(root\.userData\.turnBellaRescued\) return;/,
   'Directional discovery meows must stop after Bella is safe');
 
-assert.match(world, /countryside-bella-rescue-r173\.js\?revision=r174-siren-rescue-zone/);
+assert.match(world, /countryside-bella-rescue-r173\.js\?revision=r175-broad-rear-rescue-zone/);
 assert.match(world, /applyBellaFinalVisuals\(bellaRoot\);\s*installBellaRescueBehavior\(\{ root: bellaRoot, runtime \}\);/,
   'Rescue behavior must install after Bella’s final approved visual treatment');
-assert.match(app, /render\/world\.js\?revision=r174-bella-siren-zone/,
-  'The production app must request the corrected world module under a fresh cache identity');
+assert.match(app, /render\/world\.js\?revision=r175-bella-broad-rear-zone/,
+  'The production app must request the expanded rescue clearing under a fresh cache identity');
 assert.match(app, /bella-rescue=r174-siren-zone/,
-  'The Home layout must also load the corrected secret-achievement validator');
+  'The Home layout must continue to load the corrected secret-achievement validator');
 assert.match(homeLayout, /secret-achievements\.js\?build=\$\{buildKey\}-r174-bella-siren-zone/);
 
-console.log('TURN Bella siren rescue zone, ground transition and directional meow regression passed.');
+console.log('TURN Bella broad rear rescue clearing, siren trigger, ground transition and directional meow regression passed.');

--- a/turn/app.js
+++ b/turn/app.js
@@ -292,10 +292,11 @@ const { installTrackIntroCamera } = await import(
 );
 installTrackIntroCamera();
 
-// Historical Bella world entry retained for the established achievement regression:
+// Historical Bella world entries retained for established achievement regressions:
 // render/world.js?revision=r166-bella-records
+// render/world.js?revision=r174-bella-siren-zone
 await Promise.all([
-  import(withBuild('./render/world.js?revision=r174-bella-siren-zone')),
+  import(withBuild('./render/world.js?revision=r175-bella-broad-rear-zone')),
   import(withBuild('./ui/spectate.js')),
   import(withBuild('./ui/back-to-lot.js'))
 ]);

--- a/turn/render/world.js
+++ b/turn/render/world.js
@@ -15,9 +15,9 @@ async function loadWorldModules() {
     import(moduleUrl('../world-art-pass.js')),
     import(moduleUrl('../track-identity.js')),
     import(moduleUrl('../section-intensity.js')),
-    import(moduleUrl('../tracks/countryside-bella-r166.js?revision=r168-bella-markings-eyes-foliage-r169-facing-palette-r170-eye-placement-r171-cute-eyes-r172-final-tune-r173-rescue-r174-siren-zone')),
-    import(moduleUrl('../tracks/countryside-bella-final-r172.js?revision=r172-final-tune-r173-rescue-r174-siren-zone')),
-    import(moduleUrl('../tracks/countryside-bella-rescue-r173.js?revision=r174-siren-rescue-zone'))
+    import(moduleUrl('../tracks/countryside-bella-r166.js?revision=r168-bella-markings-eyes-foliage-r169-facing-palette-r170-eye-placement-r171-cute-eyes-r172-final-tune-r173-rescue-r174-siren-zone-r175-broad-rear-zone')),
+    import(moduleUrl('../tracks/countryside-bella-final-r172.js?revision=r172-final-tune-r173-rescue-r174-siren-zone-r175-broad-rear-zone')),
+    import(moduleUrl('../tracks/countryside-bella-rescue-r173.js?revision=r175-broad-rear-rescue-zone'))
   ]);
 
   return {

--- a/turn/tracks/countryside-bella-rescue-r173.js
+++ b/turn/tracks/countryside-bella-rescue-r173.js
@@ -8,15 +8,15 @@ const MEOW_CLOSE_METERS = 24;
 const MEOW_MIN_INTERVAL_MS = 2400;
 const MEOW_MAX_INTERVAL_MS = 5600;
 const UPDATE_INTERVAL_MS = 160;
-const RESCUE_SIREN_HOLD_MS = 360;
+const RESCUE_SIREN_HOLD_MS = 320;
 
-// A compact ellipse around the tree on the off-road scenery patch. The rescue tree is
-// more than 40 metres from the road, so this area cannot overlap the racing surface.
+// Bella's root is rotated so local +Z points back towards the road. The rescue area
+// therefore occupies only negative local Z: the broad clearing behind the tree shown
+// to the player. It is approximately seven Fire-Truck lengths wide and six long.
 const RESCUE_ZONE = Object.freeze({
-  centerX: 0,
-  centerZ: -5.5,
-  radiusX: 12,
-  radiusZ: 10.5
+  halfWidth: 22,
+  nearZ: -1.5,
+  farZ: -36
 });
 
 // Local to the dedicated rescue-tree group, beside the trunk and on the same protected
@@ -172,11 +172,12 @@ function moveBellaToGround(root, { announce = false } = {}) {
 }
 
 function insideRescueZone(root, player, localPosition) {
+  root.updateWorldMatrix(true, false);
   localPosition.copy(player);
   root.worldToLocal(localPosition);
-  const normalizedX = (localPosition.x - RESCUE_ZONE.centerX) / RESCUE_ZONE.radiusX;
-  const normalizedZ = (localPosition.z - RESCUE_ZONE.centerZ) / RESCUE_ZONE.radiusZ;
-  return normalizedX * normalizedX + normalizedZ * normalizedZ <= 1;
+  return Math.abs(localPosition.x) <= RESCUE_ZONE.halfWidth
+    && localPosition.z <= RESCUE_ZONE.nearZ
+    && localPosition.z >= RESCUE_ZONE.farZ;
 }
 
 export function installBellaRescueBehavior({ root, runtime = globalThis.__turnRuntime } = {}) {
@@ -286,13 +287,19 @@ export function installBellaRescueBehavior({ root, runtime = globalThis.__turnRu
   const timer = window.setInterval(sample, UPDATE_INTERVAL_MS);
 
   root.userData.turnBellaRescueZone = Object.freeze({
-    shape: 'ellipse',
-    center: Object.freeze({ x: RESCUE_ZONE.centerX, z: RESCUE_ZONE.centerZ }),
-    radii: Object.freeze({ x: RESCUE_ZONE.radiusX, z: RESCUE_ZONE.radiusZ }),
+    shape: 'rear clearing rectangle',
+    widthMeters: RESCUE_ZONE.halfWidth * 2,
+    lengthMeters: Math.abs(RESCUE_ZONE.farZ - RESCUE_ZONE.nearZ),
+    localBounds: Object.freeze({
+      minX: -RESCUE_ZONE.halfWidth,
+      maxX: RESCUE_ZONE.halfWidth,
+      nearZ: RESCUE_ZONE.nearZ,
+      farZ: RESCUE_ZONE.farZ
+    }),
     requiredVehicle: 'Fire Truck',
     requiredAction: 'Hold Boost to sound the siren',
     sirenHoldMs: RESCUE_SIREN_HOLD_MS,
-    trackSafety: 'The ellipse is isolated to the off-road patch around the rescue tree.'
+    trackSafety: 'Only negative local Z is eligible; the track-facing side of the tree is excluded.'
   });
   root.userData.turnBellaMeowAccessibility = Object.freeze({
     vehicle: 'Fire Truck',


### PR DESCRIPTION
## Summary
- replace the undersized 24 m × 21 m ellipse with a 44 m × 34.5 m rear clearing
- make the entire eligible area tree-local and strictly negative-Z, so the track-facing side can never trigger SAVE BELLA!
- cover roughly seven Fire-Truck lengths across and six lengths deep
- refresh the tree world transform before each zone sample
- keep the Fire Truck and active siren requirement, with a slightly shorter 320 ms hold
- retain the move-before-achievement transaction and directional meows
- refresh the world-module cache identity for Safari

## Rescue contract
1. Drive the Fire Truck into the broad clearing behind Bella’s tree, away from the track.
2. Hold Boost so the siren sounds for about one third of a second.
3. Bella moves to the ground first.
4. SAVE BELLA! unlocks.

## Validation
- dedicated Bella broad-clearing regression
- complete TURN regression suite
