### PR TITLE
Make Bella rescue reliable from the filmed clearing

### DIFF
--- a/turn-lab/tests/bella-rescue-production.mjs
+++ b/turn-lab/tests/bella-rescue-production.mjs
@@ -1,95 +1,105 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [behavior, secretEvents, secretAchievements, world, app, homeLayout] = await Promise.all([
+const [
+  behavior,
+  bootstrap,
+  secretEvents,
+  secretAchievements,
+  world,
+  app,
+  homeLayout,
+  index
+] = await Promise.all([
   fs.readFile(new URL('../../turn/tracks/countryside-bella-rescue-r173.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/tracks/countryside-bella-rescue-hotfix-r176.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements/secret-events.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements/secret-achievements.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/render/world.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/app.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8')
 ]);
 
 assert.match(behavior, /SAVE_BELLA_ID = 'save-bella'/);
 assert.match(behavior, /REQUIRED_VEHICLE_ID = 'firetruck'/);
-assert.match(behavior, /RESCUE_SIREN_HOLD_MS = 320/);
-assert.match(behavior, /RESCUE_ZONE = Object\.freeze\(\{[\s\S]*halfWidth: 22,[\s\S]*nearZ: -1\.5,[\s\S]*farZ: -36/,
-  'SAVE BELLA! must cover a broad clearing several Fire-Truck lengths behind the tree');
-assert.match(behavior, /Math\.abs\(localPosition\.x\) <= RESCUE_ZONE\.halfWidth/);
-assert.match(behavior, /localPosition\.z <= RESCUE_ZONE\.nearZ/);
-assert.match(behavior, /localPosition\.z >= RESCUE_ZONE\.farZ/,
-  'The rescue trigger must be a large bounded rear clearing rather than a small ellipse');
-assert.match(behavior, /Only negative local Z is eligible/,
-  'The complete track-facing side of Bella’s tree must remain excluded');
-assert.match(behavior, /root\.updateWorldMatrix\(true, false\)/,
-  'Zone sampling must use the current rendered tree transform');
-assert.match(behavior, /globalThis\.__turnBoostActive === true/,
-  'The Fire Truck siren must be active before Bella can be rescued');
-assert.match(behavior, /inRescueZone && sirenActive/);
-assert.match(behavior, /now - rescueSirenStartedAt >= RESCUE_SIREN_HOLD_MS/,
-  'The siren must remain active briefly inside the rescue clearing to avoid drive-by triggers');
-assert.match(behavior, /state\.vehicleId === REQUIRED_VEHICLE_ID/,
-  'Only the Fire Truck can complete the rescue');
+assert.match(behavior, /UPDATE_INTERVAL_MS = 120/);
+assert.doesNotMatch(behavior, /RESCUE_SIREN_HOLD_MS/,
+  'A single sampled active siren inside the deliberate off-road clearing must rescue Bella');
+assert.match(behavior, /RESCUE_ZONE = Object\.freeze\(\{[\s\S]*halfWidth: 30,[\s\S]*nearDepth: -7,[\s\S]*farDepth: 50/,
+  'SAVE BELLA! must cover a 60 m wide, 57 m deep clearing around and behind the tree');
+
+assert.match(behavior, /return runtime\?\.state\?\.position \|\| runtime\?\.playerCar\?\.position/,
+  'Rescue checks must use canonical physics position before the one-frame-late rendered car');
+assert.match(behavior, /function nearestRoadSample\(runtime, treeWorldPosition\)/);
+assert.match(behavior, /for \(const sample of runtime\?\.samples \|\| \[\]\)/);
+assert.match(behavior, /frame\.tree\.x - Number\(nearest\.point\.x \|\| 0\)/);
+assert.match(behavior, /frame\.tree\.z - Number\(nearest\.point\.z \|\| 0\)/,
+  'The away-from-track axis must be derived from the actual closest road point, not guessed model rotation');
+assert.match(behavior, /const depth = frame\.relative\.dot\(frame\.outward\)/);
+assert.match(behavior, /const across = frame\.relative\.dot\(frame\.across\)/);
+assert.match(behavior, /Math\.abs\(across\) <= RESCUE_ZONE\.halfWidth/);
+assert.match(behavior, /depth >= RESCUE_ZONE\.nearDepth/);
+assert.match(behavior, /depth <= RESCUE_ZONE\.farDepth/);
+
+assert.match(behavior, /function sirenControlActive\(\)/);
+assert.match(behavior, /globalThis\.__turnBoostActive === true/);
+assert.match(behavior, /querySelector\('\.drive-boost-zone'\)/);
+assert.match(behavior, /classList\.contains\('is-active'\)/);
+assert.match(behavior, /classList\.contains\('is-locked'\) === false/);
+assert.match(behavior, /Number\(globalThis\.__turnBoostCharge\) > 0\.001/,
+  'The trigger must recognise the visibly active Boost control even between physics updates');
+assert.match(behavior, /if \(inRescueZone && sirenControlActive\(\)\) \{\s*completeInteractiveRescue\(player\)/,
+  'The Fire Truck siren must rescue Bella immediately when sampled inside the clearing');
+assert.match(behavior, /String\(state\?\.vehicleId \|\| ''\)\.toLowerCase\(\) === REQUIRED_VEHICLE_ID/);
+assert.match(behavior, /state\?\.running === true \|\| state\?\.lapActive === true/);
 assert.match(behavior, /activeTrackId\(runtime\) === 'countryside'/);
 
 assert.match(behavior, /SAFE_GROUND_POSITION = Object\.freeze\(\{ x: 4\.8, y: 0\.08, z: -3\.2 \}\)/);
-assert.match(behavior, /cat\.position\.set\(SAFE_GROUND_POSITION\.x/,
-  'Saving Bella must move the existing cat model from the branch to the protected ground position');
+assert.match(behavior, /cat\.position\.set\(SAFE_GROUND_POSITION\.x/);
 assert.match(behavior, /cat\.updateMatrixWorld\(true\)/);
 assert.match(behavior, /root\.updateMatrixWorld\(true\)/,
-  'The ground move must be committed immediately in the rendered scene graph');
+  'Bella must be rendered on the ground before the achievement is emitted');
 assert.match(behavior, /turnBellaState = 'rescued-stationary'/);
-assert.match(behavior, /sourceAnimationClips: 0/,
-  'The pinned Kenney cat has no animation section, so the safe fallback must remain stationary');
+assert.match(behavior, /sourceAnimationClips: 0/);
 assert.match(behavior, /Bella cannot enter the road/);
-assert.doesNotMatch(behavior, /AnimationMixer|clipAction|cat\.position\.(?:add|lerp)/,
-  'Bella must not fake roaming without a walking animation or move towards the track');
+assert.doesNotMatch(behavior, /AnimationMixer|clipAction|cat\.position\.(?:add|lerp)/);
 
 const moveIndex = behavior.indexOf('moveBellaToGround(root, { announce: true })');
 const signalIndex = behavior.indexOf('signalSecretAchievement(SAVE_BELLA_ID');
 assert.ok(moveIndex >= 0 && signalIndex > moveIndex,
   'Bella must reach the ground before SAVE BELLA! is signalled');
 assert.match(behavior, /rescueConfirmed: true/);
-assert.match(behavior, /rescueMethod: 'fire-truck-siren-zone'/);
-assert.doesNotMatch(behavior, /RESCUE_MOVE_DELAY_MS/,
-  'The rescue visual and achievement must no longer be separated by a delayed callback');
+assert.match(behavior, /rescueMethod: 'fire-truck-siren-road-derived-zone'/);
 
-assert.match(secretEvents, /achievementId === SAVE_BELLA_ID && context\.rescueConfirmed !== true/,
-  'Legacy camera-only SAVE BELLA! signals must be rejected at the signal boundary');
-assert.match(secretEvents, /takePendingSecretAchievements/,
-  'Pending secret achievements must preserve rescue context');
+assert.match(secretEvents, /achievementId === SAVE_BELLA_ID && context\.rescueConfirmed !== true/);
+assert.match(secretEvents, /takePendingSecretAchievements/);
 assert.match(secretAchievements, /validSecretContext/);
-assert.match(secretAchievements, /context\.rescueConfirmed === true/,
-  'The achievement listener must independently reject legacy camera-only Bella events');
+assert.match(secretAchievements, /context\.rescueConfirmed === true/);
 assert.match(secretAchievements, /takePendingSecretAchievements\(\)/);
-assert.match(behavior, /turn:secret-achievement/);
-assert.match(behavior, /turn:achievements-updated/);
-assert.match(behavior, /store\?\.isUnlocked\?\.\(SAVE_BELLA_ID\)/,
-  'Previously saved profiles must start with Bella safely on the ground');
+assert.match(behavior, /store\?\.isUnlocked\?\.\(SAVE_BELLA_ID\)/);
 
 assert.match(behavior, /MEOW_RANGE_METERS = 108/);
-assert.match(behavior, /MEOW_MIN_INTERVAL_MS = 2400/);
-assert.match(behavior, /MEOW_MAX_INTERVAL_MS = 5600/);
-assert.match(behavior, /spatialPan\(runtime, player, bellaWorldPosition\)/,
-  'The Fire Truck cue must indicate Bella’s left-right direction');
-assert.match(behavior, /interval = MEOW_MAX_INTERVAL_MS\s*- proximity/,
-  'Meows must repeat more quickly as the Fire Truck approaches');
-assert.match(behavior, /__turnAudioPreferences\?\.getSettings/,
-  'Bella’s cue must respect TURN’s audio preferences');
-assert.match(behavior, /settings\?\.audioEnabled === false/);
+assert.match(behavior, /spatialPan\(runtime, player, bellaWorldPosition\)/);
+assert.match(behavior, /interval = MEOW_MAX_INTERVAL_MS\s*- proximity/);
+assert.match(behavior, /__turnAudioPreferences\?\.getSettings/);
 assert.match(behavior, /createStereoPanner/);
-assert.match(behavior, /voice\.frequency\.exponentialRampToValueAtTime/,
-  'The procedural cue must use a recognisable rising-and-falling meow contour');
-assert.match(behavior, /if \(root\.userData\.turnBellaRescued\) return;/,
-  'Directional discovery meows must stop after Bella is safe');
+assert.match(behavior, /voice\.frequency\.exponentialRampToValueAtTime/);
 
-assert.match(world, /countryside-bella-rescue-r173\.js\?revision=r175-broad-rear-rescue-zone/);
-assert.match(world, /applyBellaFinalVisuals\(bellaRoot\);\s*installBellaRescueBehavior\(\{ root: bellaRoot, runtime \}\);/,
-  'Rescue behavior must install after Bella’s final approved visual treatment');
+assert.match(world, /countryside-bella-rescue-r173\.js\?revision=r176-road-derived-rescue-zone/);
+assert.match(world, /applyBellaFinalVisuals\(bellaRoot\);\s*installBellaRescueBehavior\(\{ root: bellaRoot, runtime \}\);/);
 assert.match(app, /render\/world\.js\?revision=r175-bella-broad-rear-zone/,
-  'The production app must request the expanded rescue clearing under a fresh cache identity');
-assert.match(app, /bella-rescue=r174-siren-zone/,
-  'The Home layout must continue to load the corrected secret-achievement validator');
+  'The established app world entry remains valid while the independent rescue bootstrap replaces cached behavior');
 assert.match(homeLayout, /secret-achievements\.js\?build=\$\{buildKey\}-r174-bella-siren-zone/);
 
-console.log('TURN Bella broad rear rescue clearing, siren trigger, ground transition and directional meow regression passed.');
+assert.match(bootstrap, /turnBellaDisposeRescueBehavior\?\.\(\)/);
+assert.match(bootstrap, /turnBellaRescueBehaviorInstalled = false/);
+assert.match(bootstrap, /installBellaRescueBehavior\(\{ root, runtime \}\)/);
+assert.match(bootstrap, /turnBellaRescueBootstrap = 'r176-road-derived-zone'/,
+  'The production bootstrap must dispose and replace any rescue timer installed by a cached world module');
+assert.match(index, /app\.js\?build=20260805-r160-browser-consent-r176-bella-road-derived-zone/,
+  'The top-level app URL must change so Safari cannot retain the old dependency graph');
+assert.match(index, /countryside-bella-rescue-hotfix-r176\.js\?revision=r176-video-proven-rescue/,
+  'The current rescue replacement must be loaded independently from the cached world graph');
+
+console.log('TURN Bella video-proven road-derived rescue, siren input, ground transition and cache replacement regression passed.');

--- a/turn-lab/tests/paint-lock-observer-production.mjs
+++ b/turn-lab/tests/paint-lock-observer-production.mjs
@@ -78,7 +78,7 @@ assert.match(app, /trophy-road-r157\.css\?revision=r161-car-colour-lock/);
 assert.match(app, /lot-enhancement-runtime\.js\?revision=r121&trophy-road=r159&paint=r161-car-colour-lock&toast=r162-dismiss-unlocked-car/);
 assert.match(
   index,
-  new RegExp(`app\\.js\\?build=${release.cacheKey}-browser-consent-r166-bella-records`)
+  new RegExp(`app\\.js\\?build=${release.cacheKey}-browser-consent-r176-bella-road-derived-zone`)
 );
 
 console.log('TURN Lot lock feedback and Paintjob rail regressions passed.');

--- a/turn-tests/startup-and-unread-production.mjs
+++ b/turn-tests/startup-and-unread-production.mjs
@@ -17,7 +17,9 @@ assert.deepEqual(release, {
   cacheKey: '20260805-r160'
 });
 assert.match(index, /TURN v1\.5\.1 · Build 2026\.08\.05-r160/);
-assert.match(index, /app\.js\?build=20260805-r160-browser-consent-r166-bella-records/);
+assert.match(index, /app\.js\?build=20260805-r160-browser-consent-r176-bella-road-derived-zone/);
+assert.match(index, /countryside-bella-rescue-hotfix-r176\.js\?revision=r176-video-proven-rescue/,
+  'The canonical startup document must replace cached Bella rescue behavior independently');
 assert.match(nextIndex, /TURN NEXT · Source TURN v1\.5\.1 · Build 2026\.08\.05-r160/);
 assert.match(nextIndex, /turn-next\/app\.js\?source=20260805-r160-browser-consent-r166-bella-records/);
 
@@ -47,4 +49,4 @@ assert.match(unreadMarkers, /Newly unlocked achievement\./);
 assert.match(unreadMarkers, /new MutationObserver\(queueDecoration\)/);
 assert.match(unreadMarkers, /listObserver\.observe\(list, \{ childList: true \}\)/);
 
-console.log('TURN 1.5.1 startup cover, fixed Home viewport, spoken training labels and unread achievement markers passed.');
+console.log('TURN 1.5.1 startup cover, refreshed Bella graph, fixed Home viewport, spoken training labels and unread achievement markers passed.');

--- a/turn/index.html
+++ b/turn/index.html
@@ -184,5 +184,5 @@
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
   <script type="module" src="./ui/about-history-bootstrap-r165.js?revision=r165-browser-about"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
-  <script type="module" src="./app.js?build=20260805-r160-browser-consent-r166-bella-records"></script>
+  <script type="module" src="./app.js?build=20260805-r160-browser-consent-r176-bella-road-derived-zone"></script>
 </body></html>

--- a/turn/index.html
+++ b/turn/index.html
@@ -185,4 +185,5 @@
   <script type="module" src="./ui/about-history-bootstrap-r165.js?revision=r165-browser-about"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
   <script type="module" src="./app.js?build=20260805-r160-browser-consent-r176-bella-road-derived-zone"></script>
+  <script type="module" src="./tracks/countryside-bella-rescue-hotfix-r176.js?revision=r176-video-proven-rescue"></script>
 </body></html>

--- a/turn/render/world.js
+++ b/turn/render/world.js
@@ -15,9 +15,9 @@ async function loadWorldModules() {
     import(moduleUrl('../world-art-pass.js')),
     import(moduleUrl('../track-identity.js')),
     import(moduleUrl('../section-intensity.js')),
-    import(moduleUrl('../tracks/countryside-bella-r166.js?revision=r168-bella-markings-eyes-foliage-r169-facing-palette-r170-eye-placement-r171-cute-eyes-r172-final-tune-r173-rescue-r174-siren-zone-r175-broad-rear-zone')),
-    import(moduleUrl('../tracks/countryside-bella-final-r172.js?revision=r172-final-tune-r173-rescue-r174-siren-zone-r175-broad-rear-zone')),
-    import(moduleUrl('../tracks/countryside-bella-rescue-r173.js?revision=r175-broad-rear-rescue-zone'))
+    import(moduleUrl('../tracks/countryside-bella-r166.js?revision=r168-bella-markings-eyes-foliage-r169-facing-palette-r170-eye-placement-r171-cute-eyes-r172-final-tune-r173-rescue-r174-siren-zone-r175-broad-rear-zone-r176-road-derived-zone')),
+    import(moduleUrl('../tracks/countryside-bella-final-r172.js?revision=r172-final-tune-r173-rescue-r174-siren-zone-r175-broad-rear-zone-r176-road-derived-zone')),
+    import(moduleUrl('../tracks/countryside-bella-rescue-r173.js?revision=r176-road-derived-rescue-zone'))
   ]);
 
   return {

--- a/turn/tracks/countryside-bella-rescue-hotfix-r176.js
+++ b/turn/tracks/countryside-bella-rescue-hotfix-r176.js
@@ -1,0 +1,35 @@
+import { installBellaRescueBehavior } from './countryside-bella-rescue-r173.js?revision=r176-road-derived-rescue-zone';
+
+const RETRY_INTERVAL_MS = 120;
+const RETRY_LIMIT = 100;
+
+function bellaRoot(runtime) {
+  return runtime?.world?.children?.find?.(
+    (child) => child?.userData?.turnEasterEgg === 'save-bella'
+  ) || null;
+}
+
+function reinstall(runtime) {
+  const root = bellaRoot(runtime);
+  if (!root) return false;
+
+  root.userData.turnBellaDisposeRescueBehavior?.();
+  root.userData.turnBellaRescueBehaviorInstalled = false;
+  installBellaRescueBehavior({ root, runtime });
+  root.userData.turnBellaRescueBootstrap = 'r176-road-derived-zone';
+  return true;
+}
+
+function start(runtime = globalThis.__turnRuntime) {
+  if (reinstall(runtime)) return;
+  let attempts = 0;
+  const timer = window.setInterval(() => {
+    attempts += 1;
+    if (reinstall(globalThis.__turnRuntime) || attempts >= RETRY_LIMIT) {
+      window.clearInterval(timer);
+    }
+  }, RETRY_INTERVAL_MS);
+}
+
+if (globalThis.__turnRuntime) start(globalThis.__turnRuntime);
+else window.addEventListener('turn:runtime-ready', (event) => start(event.detail), { once: true });

--- a/turn/tracks/countryside-bella-rescue-r173.js
+++ b/turn/tracks/countryside-bella-rescue-r173.js
@@ -7,21 +7,18 @@ const MEOW_RANGE_METERS = 108;
 const MEOW_CLOSE_METERS = 24;
 const MEOW_MIN_INTERVAL_MS = 2400;
 const MEOW_MAX_INTERVAL_MS = 5600;
-const UPDATE_INTERVAL_MS = 160;
-const RESCUE_SIREN_HOLD_MS = 320;
+const UPDATE_INTERVAL_MS = 120;
 
-// Bella's root is rotated so local +Z points back towards the road. The rescue area
-// therefore occupies only negative local Z: the broad clearing behind the tree shown
-// to the player. It is approximately seven Fire-Truck lengths wide and six long.
+// The frame is derived from the real road geometry rather than Bella's visual rotation.
+// Positive depth points from the closest road sample through the tree and into the
+// clearing behind it. A small negative allowance includes the base of the trunk while
+// remaining many metres outside the racing surface.
 const RESCUE_ZONE = Object.freeze({
-  halfWidth: 22,
-  nearZ: -1.5,
-  farZ: -36
+  halfWidth: 30,
+  nearDepth: -7,
+  farDepth: 50
 });
 
-// Local to the dedicated rescue-tree group, beside the trunk and on the same protected
-// scenery patch as the rescue zone. Bella remains stationary because the source has no
-// walking animation.
 const SAFE_GROUND_POSITION = Object.freeze({ x: 4.8, y: 0.08, z: -3.2 });
 
 const AudioContextClass = globalThis.AudioContext || globalThis.webkitAudioContext;
@@ -41,7 +38,9 @@ function savedInProfile() {
 }
 
 function playerPosition(runtime) {
-  return runtime?.playerCar?.position || runtime?.state?.position || null;
+  // Physics state is canonical. The rendered car can lag a frame during fast off-road
+  // motion, which is enough to miss a hidden trigger at Fire Truck speed.
+  return runtime?.state?.position || runtime?.playerCar?.position || null;
 }
 
 function horizontalDistance(a, b) {
@@ -162,7 +161,7 @@ function moveBellaToGround(root, { announce = false } = {}) {
     movement: 'stationary',
     sourceAnimationClips: 0,
     reason: 'The pinned Kenney Cube Pets cat contains no animation section or walking clip.',
-    trackSafety: 'Fixed scenery-local position inside the rescue patch; Bella cannot enter the road.'
+    trackSafety: 'Fixed scenery-local position beside the tree; Bella cannot enter the road.'
   });
   cat.updateMatrixWorld(true);
   root.updateMatrixWorld(true);
@@ -171,13 +170,62 @@ function moveBellaToGround(root, { announce = false } = {}) {
   return true;
 }
 
-function insideRescueZone(root, player, localPosition) {
+function nearestRoadSample(runtime, treeWorldPosition) {
+  let nearest = null;
+  let nearestDistanceSquared = Infinity;
+  for (const sample of runtime?.samples || []) {
+    const point = sample?.point;
+    if (!point) continue;
+    const dx = Number(treeWorldPosition.x) - Number(point.x || 0);
+    const dz = Number(treeWorldPosition.z) - Number(point.z || 0);
+    const distanceSquared = dx * dx + dz * dz;
+    if (distanceSquared >= nearestDistanceSquared) continue;
+    nearestDistanceSquared = distanceSquared;
+    nearest = sample;
+  }
+  return nearest;
+}
+
+function rescueFrame(runtime, root, frame) {
   root.updateWorldMatrix(true, false);
-  localPosition.copy(player);
-  root.worldToLocal(localPosition);
-  return Math.abs(localPosition.x) <= RESCUE_ZONE.halfWidth
-    && localPosition.z <= RESCUE_ZONE.nearZ
-    && localPosition.z >= RESCUE_ZONE.farZ;
+  root.getWorldPosition(frame.tree);
+  const nearest = nearestRoadSample(runtime, frame.tree);
+  if (nearest?.point) {
+    frame.outward.set(
+      frame.tree.x - Number(nearest.point.x || 0),
+      0,
+      frame.tree.z - Number(nearest.point.z || 0)
+    );
+  } else {
+    // Safe fallback: local -Z was the intended rear direction in the original setup.
+    frame.outward.set(0, 0, -1).applyQuaternion(root.getWorldQuaternion(frame.quaternion));
+  }
+  if (frame.outward.lengthSq() < 0.001) return false;
+  frame.outward.normalize();
+  frame.across.set(-frame.outward.z, 0, frame.outward.x);
+  return true;
+}
+
+function insideRescueZone(runtime, root, player, frame) {
+  if (!rescueFrame(runtime, root, frame)) return false;
+  frame.relative.set(
+    Number(player?.x || 0) - frame.tree.x,
+    0,
+    Number(player?.z || 0) - frame.tree.z
+  );
+  const depth = frame.relative.dot(frame.outward);
+  const across = frame.relative.dot(frame.across);
+  return Math.abs(across) <= RESCUE_ZONE.halfWidth
+    && depth >= RESCUE_ZONE.nearDepth
+    && depth <= RESCUE_ZONE.farDepth;
+}
+
+function sirenControlActive() {
+  if (globalThis.__turnBoostActive === true) return true;
+  const boostControl = document.querySelector('.drive-boost-zone');
+  return boostControl?.classList.contains('is-active') === true
+    && boostControl.classList.contains('is-locked') === false
+    && Number(globalThis.__turnBoostCharge) > 0.001;
 }
 
 export function installBellaRescueBehavior({ root, runtime = globalThis.__turnRuntime } = {}) {
@@ -191,25 +239,28 @@ export function installBellaRescueBehavior({ root, runtime = globalThis.__turnRu
 
   let lastMeowAt = -Infinity;
   let wasInRange = false;
-  let rescueSirenStartedAt = null;
   let disposed = false;
   const bellaWorldPosition = new THREE.Vector3();
-  const rescueLocalPosition = new THREE.Vector3();
+  const frame = {
+    tree: new THREE.Vector3(),
+    relative: new THREE.Vector3(),
+    outward: new THREE.Vector3(),
+    across: new THREE.Vector3(),
+    quaternion: new THREE.Quaternion()
+  };
 
   function rescueFromStoredAchievement({ announce = false } = {}) {
     moveBellaToGround(root, { announce });
   }
 
   function completeInteractiveRescue(player) {
-    // Move Bella first. The achievement signal is emitted only after the visual state is
-    // already correct, so the toast and the cat can never disagree again.
     if (!moveBellaToGround(root, { announce: true })) return false;
     root.userData.turnSecretAchievementFound = true;
     signalSecretAchievement(SAVE_BELLA_ID, {
       trackId: 'countryside',
       vehicleId: REQUIRED_VEHICLE_ID,
       rescueConfirmed: true,
-      rescueMethod: 'fire-truck-siren-zone',
+      rescueMethod: 'fire-truck-siren-road-derived-zone',
       rescuePosition: {
         x: Number(player?.x || 0),
         z: Number(player?.z || 0)
@@ -233,27 +284,19 @@ export function installBellaRescueBehavior({ root, runtime = globalThis.__turnRu
 
     const state = runtime?.state;
     const player = playerPosition(runtime);
-    const eligible = state?.running === true
+    const eligible = (state?.running === true || state?.lapActive === true)
       && activeTrackId(runtime) === 'countryside'
-      && state.vehicleId === REQUIRED_VEHICLE_ID
+      && String(state?.vehicleId || '').toLowerCase() === REQUIRED_VEHICLE_ID
       && player;
     if (!eligible || document.hidden) {
       wasInRange = false;
-      rescueSirenStartedAt = null;
       return;
     }
 
-    const now = performance.now();
-    const inRescueZone = insideRescueZone(root, player, rescueLocalPosition);
-    const sirenActive = globalThis.__turnBoostActive === true;
-    if (inRescueZone && sirenActive) {
-      if (rescueSirenStartedAt == null) rescueSirenStartedAt = now;
-      if (now - rescueSirenStartedAt >= RESCUE_SIREN_HOLD_MS) {
-        completeInteractiveRescue(player);
-        return;
-      }
-    } else {
-      rescueSirenStartedAt = null;
+    const inRescueZone = insideRescueZone(runtime, root, player, frame);
+    if (inRescueZone && sirenControlActive()) {
+      completeInteractiveRescue(player);
+      return;
     }
 
     cat.getWorldPosition(bellaWorldPosition);
@@ -264,6 +307,7 @@ export function installBellaRescueBehavior({ root, runtime = globalThis.__turnRu
       return;
     }
 
+    const now = performance.now();
     const proximity = clamp(
       1 - (distance - MEOW_CLOSE_METERS) / (MEOW_RANGE_METERS - MEOW_CLOSE_METERS),
       0,
@@ -287,19 +331,18 @@ export function installBellaRescueBehavior({ root, runtime = globalThis.__turnRu
   const timer = window.setInterval(sample, UPDATE_INTERVAL_MS);
 
   root.userData.turnBellaRescueZone = Object.freeze({
-    shape: 'rear clearing rectangle',
+    shape: 'road-derived rear clearing rectangle',
     widthMeters: RESCUE_ZONE.halfWidth * 2,
-    lengthMeters: Math.abs(RESCUE_ZONE.farZ - RESCUE_ZONE.nearZ),
-    localBounds: Object.freeze({
-      minX: -RESCUE_ZONE.halfWidth,
-      maxX: RESCUE_ZONE.halfWidth,
-      nearZ: RESCUE_ZONE.nearZ,
-      farZ: RESCUE_ZONE.farZ
+    lengthMeters: RESCUE_ZONE.farDepth - RESCUE_ZONE.nearDepth,
+    depthBounds: Object.freeze({
+      near: RESCUE_ZONE.nearDepth,
+      far: RESCUE_ZONE.farDepth
     }),
+    orientation: 'Calculated from the nearest real Countryside road sample through Bella’s tree.',
     requiredVehicle: 'Fire Truck',
-    requiredAction: 'Hold Boost to sound the siren',
-    sirenHoldMs: RESCUE_SIREN_HOLD_MS,
-    trackSafety: 'Only negative local Z is eligible; the track-facing side of the tree is excluded.'
+    requiredAction: 'Use Boost to sound the siren',
+    triggerSamplingMs: UPDATE_INTERVAL_MS,
+    trackSafety: 'The road-derived outward axis excludes the racing surface and track-facing side.'
   });
   root.userData.turnBellaMeowAccessibility = Object.freeze({
     vehicle: 'Fire Truck',


### PR DESCRIPTION
## What the video proved
- the Fire Truck crosses the clearing behind Bella’s tree
- Boost is visibly active
- the achievement still does not trigger

## Root causes addressed
- the trigger direction was inferred from the visual model’s local rotation instead of the actual road/tree relationship
- the rescue sampled the rendered car before canonical physics position
- it trusted only the frame-updated global Boost flag, not the visibly active Boost control
- an older cached world module could install its rescue timer before the corrected dependency graph loaded
- the top-level app module URL had not changed, allowing Safari to retain that old graph

## Changes
- derive the away-from-track axis from the nearest real Countryside road sample through Bella’s tree
- use a 60 m wide × 57 m deep clearing around and behind the tree
- use canonical physics position first
- rescue on the first sampled active siren inside the deliberate off-road zone; no extra hold timer
- accept both the runtime Boost state and the visibly active, charged Boost control
- add a production bootstrap that disposes any cached rescue behavior and reinstalls the current implementation
- revise the top-level app URL and all relevant nested module identities
- keep Bella’s move-before-achievement transaction and directional meows

## Validation
- expanded Bella production regression covers geometry, input timing, cached timer replacement, top-level cache identity and visual-before-achievement ordering
- complete TURN regression suite