### PR TITLE
Fix black footer when TURN launches in landscape

### DIFF
--- a/turn-next/index.html
+++ b/turn-next/index.html
@@ -37,6 +37,18 @@
       cacheKey: '20260805-r160'
     });
   </script>
+  <style id="turn-landscape-launch-containment-r178">
+    html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; }
+    body { position: fixed; inset: 0; min-width: 0; min-height: 0; }
+    .install-gate, .rotate-panel, .m8-home.m8-home-fixed-layout {
+      position: fixed !important;
+      inset: 0 !important;
+      width: auto !important;
+      height: auto !important;
+      min-width: 0 !important;
+      min-height: 0 !important;
+    }
+  </style>
   <script src="/turn-next/storage-bootstrap.js?source=20260805-r160"></script>
   <link rel="icon" href="./TURNicon.PNG?icon=20260803-profile-512" type="image/png" sizes="512x512">
   <link rel="apple-touch-icon" href="./TURNicon.PNG?icon=20260803-profile-512" sizes="512x512">
@@ -140,7 +152,7 @@
   <div class="hud" id="hud" hidden><div class="topbar"><div class="stats"><div class="chip">speed<strong><span id="speed">0</span> km/h</strong></div><div class="chip">lap<strong id="lap">1</strong></div><div class="chip">time<strong id="lapTime">0:00.000</strong></div><div class="chip">best<strong id="bestTime">--:--.---</strong></div></div><div class="map-wrap"><canvas id="map" width="300" height="210" aria-label="Track map"></canvas></div></div><div class="message" id="message" role="status"></div><div class="tilt-drive" aria-hidden="true"><span><b>brake</b><b>gas</b></span><div class="tilt-track"><i class="tilt-needle" id="tiltNeedle"></i></div><small class="tilt-value" id="tiltValue">neutral</small></div></div>
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
-  <script type="module" src="./startup-viewport-r177.js?revision=r177-cold-start-rotation-crop"></script>
+  <script type="module" src="./startup-viewport-r177.js?revision=r178-landscape-first-containment"></script>
   <script type="module" src="/turn-next/app.js?source=20260805-r160-browser-consent-r166-bella-records"></script>
   <script type="module" src="./ui/about-history-bootstrap.js?revision=r164-design-navigation"></script>
 </body></html>

--- a/turn-tests/startup-and-unread-production.mjs
+++ b/turn-tests/startup-and-unread-production.mjs
@@ -21,10 +21,13 @@ assert.match(index, /TURN v1\.5\.1 · Build 2026\.08\.05-r160/);
 assert.match(index, /app\.js\?build=20260805-r160-browser-consent-r176-bella-road-derived-zone/);
 assert.match(index, /countryside-bella-rescue-hotfix-r176\.js\?revision=r176-video-proven-rescue/,
   'The canonical startup document must replace cached Bella rescue behavior independently');
-assert.match(index, /startup-viewport-r177\.js\?revision=r177-cold-start-rotation-crop/);
+assert.match(index, /startup-viewport-r177\.js\?revision=r178-landscape-first-containment/);
+assert.match(index, /id="turn-landscape-launch-containment-r178"/,
+  'The full-screen containment fix must exist in the startup document before modules execute');
 assert.match(nextIndex, /TURN NEXT · Source TURN v1\.5\.1 · Build 2026\.08\.05-r160/);
 assert.match(nextIndex, /turn-next\/app\.js\?source=20260805-r160-browser-consent-r166-bella-records/);
-assert.match(nextIndex, /startup-viewport-r177\.js\?revision=r177-cold-start-rotation-crop/);
+assert.match(nextIndex, /startup-viewport-r177\.js\?revision=r178-landscape-first-containment/);
+assert.match(nextIndex, /id="turn-landscape-launch-containment-r178"/);
 
 assert.match(app, /function installStartupCover\(\)/);
 assert.match(app, /copy\.textContent = 'Loading TURN'/);
@@ -41,10 +44,18 @@ assert.ok(
 assert.match(responsiveStartup, /SLOW_LOADING_MESSAGE_DELAY_MS = 1400/,
   'Expectation-setting copy must appear only when startup is genuinely taking time');
 assert.match(responsiveStartup, /note\.textContent = 'This might take a minute\.'/);
-assert.match(responsiveStartup, /note\.hidden = true/);
-assert.match(responsiveStartup, /if \(loading\(\)\) note\.hidden = false/);
-assert.match(responsiveStartup, /document\.addEventListener\('turn:home-ready',[\s\S]*clearExpectation\(\)/,
+assert.match(responsiveStartup, /note\.setAttribute\('aria-live', 'polite'\)/);
+assert.match(responsiveStartup, /const launchStartedAt = performance\.now\(\)/,
+  'The message delay must be based on actual launch elapsed time rather than one mutation callback');
+assert.match(responsiveStartup, /function poll\(\)/);
+assert.match(responsiveStartup, /elapsed >= SLOW_LOADING_MESSAGE_DELAY_MS && loadingCoverIsActive\(\)/);
+assert.match(responsiveStartup, /note\.hidden = false/);
+assert.match(responsiveStartup, /timer = window\.setTimeout\(poll, 100\)/,
+  'A cover that becomes active after the threshold must still receive the message');
+assert.match(responsiveStartup, /document\.addEventListener\('turn:home-ready', stop, \{ once: true \}\)/,
   'The slow-start message must disappear with the loading cover');
+assert.doesNotMatch(responsiveStartup, /new MutationObserver\(syncExpectation\)/,
+  'Slow-start guidance must not depend on the class mutation that was missed on device');
 assert.match(responsiveStartup, /link\.rel = 'modulepreload'/);
 assert.match(responsiveStartup, /'\.\/main\.js'/);
 assert.match(responsiveStartup, /'\.\/render\/world\.js\?revision=r175-bella-broad-rear-zone'/);
@@ -52,7 +63,7 @@ assert.match(responsiveStartup, /'\.\/m8-home\.js\?revision=r131-motion-permissi
 assert.match(responsiveStartup, /'\.\/m8-home-fixed-layout\.js\?revision=m8\.9-track-title-alignment&trophy-road=r159&achievements=r166-bella-records&bella-rescue=r174-siren-zone'/);
 assert.match(responsiveStartup, /three@0\.184\.0\/build\/three\.module\.js/,
   'The large shared Three.js dependency must begin downloading before the sequential app graph reaches main.js');
-assert.match(responsiveStartup, /without[\s\S]*changing initialization order|changing initialization order/,
+assert.match(responsiveStartup, /without running game modules prematurely|keep execution in app\.js's established/,
   'The optimization must preload bytes without executing game modules out of order');
 
 assert.match(fixedLayout, /achievements\/unread-markers\.js\?build=\$\{buildKey\}-r159-unread-cards/);
@@ -69,4 +80,4 @@ assert.match(unreadMarkers, /Newly unlocked achievement\./);
 assert.match(unreadMarkers, /new MutationObserver\(queueDecoration\)/);
 assert.match(unreadMarkers, /listObserver\.observe\(list, \{ childList: true \}\)/);
 
-console.log('TURN 1.5.1 cold-start preload, delayed loading guidance, fixed Home viewport, spoken training labels and unread achievement markers passed.');
+console.log('TURN 1.5.1 cold-start preload, deterministic loading guidance, landscape-first containment, spoken training labels and unread achievement markers passed.');

--- a/turn-tests/viewport-coverage-production.mjs
+++ b/turn-tests/viewport-coverage-production.mjs
@@ -23,37 +23,54 @@ assert.match(viewportBlock, /navigator\.standalone === true/);
 assert.match(viewportBlock, /display-mode: standalone/);
 assert.match(viewportBlock, /display-mode: fullscreen/);
 
-assert.match(index, /startup-viewport-r177\.js\?revision=r177-cold-start-rotation-crop/,
-  'Production TURN must load the independent responsive viewport bootstrap before the canonical app');
+assert.match(index, /startup-viewport-r177\.js\?revision=r178-landscape-first-containment/,
+  'Production TURN must fetch the corrected independent viewport bootstrap');
+assert.ok(
+  index.indexOf('turn-landscape-launch-containment-r178') < index.indexOf('startup-viewport-r177.js'),
+  'The no-footer containment rule must be parsed before any startup module can measure the viewport'
+);
 assert.ok(
   index.indexOf('startup-viewport-r177.js') < index.indexOf('app.js?build='),
   'Viewport containment and startup preloads must begin before the canonical app graph'
 );
-assert.match(nextIndex, /startup-viewport-r177\.js\?revision=r177-cold-start-rotation-crop/,
+assert.match(nextIndex, /startup-viewport-r177\.js\?revision=r178-landscape-first-containment/,
   'TURN NEXT must exercise the same viewport behavior as production');
+assert.match(index, /body \{ position: fixed; inset: 0; min-width: 0; min-height: 0; \}/,
+  'The document body must fill the initial containing block without trusting a startup pixel height');
+assert.match(index, /\.install-gate, \.rotate-panel, \.m8-home\.m8-home-fixed-layout \{[\s\S]*inset: 0 !important;[\s\S]*height: auto !important;/,
+  'Loading, rotation and Home surfaces must independently cover the complete viewport');
 
 assert.match(responsiveViewport, /MIN_RACING_ASPECT = 16 \/ 9/,
   'The 3D racing view must retain at least a 16:9 composition on squarer tablets');
 assert.match(responsiveViewport, /renderAspect = Math\.max\(viewportAspect, MIN_RACING_ASPECT\)/);
 assert.match(responsiveViewport, /nativeSetSize\(fit\.bufferWidth, fit\.bufferHeight, false\)/,
-  'The drawing buffer must no longer write a second, conflicting CSS size');
+  'The drawing buffer must not write a conflicting CSS size');
 assert.match(responsiveViewport, /camera\.aspect = fit\.renderAspect/,
   'The camera and drawing buffer must share one undistorted aspect ratio');
 assert.match(responsiveViewport, /transform: translate\(-50%, -50%\) !important/,
-  'Any overflow must be centred and cropped rather than stretched');
+  'Any 3D overflow must be centred and cropped rather than stretched');
 assert.match(responsiveViewport, /--turn-racing-cover-width/);
 assert.match(responsiveViewport, /--turn-racing-cover-height/);
-assert.match(responsiveViewport, /min-width: 0 !important/);
-assert.match(responsiveViewport, /min-height: 0 !important/,
-  'The late responsive layer must neutralize stale 100vw, 100vh and 100lvh floors after rotation');
-assert.match(responsiveViewport, /ORIENTATION_SETTLE_DELAYS_MS = Object\.freeze\(\[0, 70, 180, 420, 900\]\)/,
-  'iOS rotation must be sampled repeatedly after the first orientation event');
+assert.match(responsiveViewport, /body \{[\s\S]*position: fixed !important;[\s\S]*inset: 0 !important;[\s\S]*width: auto !important;[\s\S]*height: auto !important;/,
+  'The runtime must retain viewport containment instead of replacing it with a stale measured height');
+assert.match(responsiveViewport, /#game,[\s\S]*html body \.install-gate,[\s\S]*html body \.rotate-panel,[\s\S]*html body \.m8-home\.m8-home-fixed-layout[\s\S]*inset: 0 !important;/);
+assert.doesNotMatch(responsiveViewport, /width: var\(--turn-stage-width\) !important|height: var\(--turn-stage-height\) !important/,
+  'Top-level surfaces must never again depend on the launch-time pixel measurement');
+assert.match(responsiveViewport, /ORIENTATION_SETTLE_DELAYS_MS = Object\.freeze\(\[0, 70, 180, 420, 900, 1600\]\)/,
+  'iOS startup and rotation must be sampled beyond the first second');
 assert.match(responsiveViewport, /\['resize', 'orientationchange', 'pageshow', 'focus'\]/);
 assert.match(responsiveViewport, /visualViewport\?\.addEventListener\('resize', scheduleSettledSync/);
 assert.match(responsiveViewport, /screen\.orientation\?\.addEventListener\?\.\('change', scheduleSettledSync/);
 assert.match(responsiveViewport, /dataset\.turnViewportFit = 'crop-not-stretch'/);
-assert.match(responsiveViewport, /standaloneScreenSize\(live\) \|\| live/,
-  'Installed iPad mode must retain complete physical-screen coverage after live orientation has settled');
+assert.match(responsiveViewport, /window\.outerWidth/);
+assert.match(responsiveViewport, /window\.outerHeight/,
+  'Landscape-first launch must consider the outer standalone window when innerHeight is truncated');
+assert.match(responsiveViewport, /width:100lvw;height:100lvh/,
+  'A CSS large-viewport probe must be available when WebKit JavaScript dimensions disagree');
+assert.match(responsiveViewport, /inset:0;width:auto;height:auto/,
+  'A fixed-inset probe must measure the same viewport strategy used by the visible surfaces');
+assert.match(responsiveViewport, /Math\.max\(\.\.\.candidates\.map\(\(size\) => size\.height\)\)/,
+  'The final standalone height must use the largest valid same-orientation candidate, not the first short report');
 
 const fitStart = responsiveViewport.indexOf('function fitRacingSurface(width, height)');
 const fitEnd = responsiveViewport.indexOf('\nfunction applyStageSize', fitStart);
@@ -66,7 +83,7 @@ const ipadFit = fitRacingSurface(1080, 810);
 assert.equal(ipadFit.renderAspect, 16 / 9);
 assert.equal(ipadFit.coverWidth, 1440);
 assert.equal(ipadFit.coverHeight, 810);
-assert.ok(Math.abs(ipadFit.bufferWidth / ipadFit.bufferHeight - 16 / 9) < 0.002);
+assert.equal(ipadFit.bufferWidth / ipadFit.bufferHeight, 16 / 9);
 assert.ok(Math.abs(ipadFit.bufferWidth * ipadFit.bufferHeight - 1080 * 810) < 1800,
   'Cropping must preserve approximately the previous pixel workload on iPad 9');
 assert.notEqual(ipadFit.coverWidth / ipadFit.coverHeight, 1080 / 810,
@@ -78,7 +95,7 @@ assert.equal(iphoneFit.coverWidth, 852);
 assert.equal(iphoneFit.coverHeight, 393);
 
 assert.match(styles, /body \{[\s\S]*min-width: 100vw;[\s\S]*min-height: 100vh;/,
-  'The base stylesheet remains a no-script fallback until the responsive bootstrap takes control');
+  'The base stylesheet remains a no-script fallback; the early inline and runtime layers override it');
 assert.match(index, new RegExp(`TURN v${release.version.replaceAll('.', '\\.')} · Build ${release.id.replaceAll('.', '\\.')}`));
 
-console.log(`TURN ${release.id} settled rotation coverage and crop-not-stretch tablet rendering passed.`);
+console.log(`TURN ${release.id} landscape-first containment and crop-not-stretch tablet rendering passed.`);

--- a/turn/index.html
+++ b/turn/index.html
@@ -35,6 +35,18 @@
       cacheKey: '20260805-r160'
     });
   </script>
+  <style id="turn-landscape-launch-containment-r178">
+    html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; }
+    body { position: fixed; inset: 0; min-width: 0; min-height: 0; }
+    .install-gate, .rotate-panel, .m8-home.m8-home-fixed-layout {
+      position: fixed !important;
+      inset: 0 !important;
+      width: auto !important;
+      height: auto !important;
+      min-width: 0 !important;
+      min-height: 0 !important;
+    }
+  </style>
   <link rel="icon" href="./TURNicon.PNG?icon=20260803-profile-512" type="image/png" sizes="512x512">
   <link rel="apple-touch-icon" href="./TURNicon.PNG?icon=20260803-profile-512" sizes="512x512">
   <link rel="manifest" href="./site.webmanifest?build=20260805-r160-icon-20260803-profile-512">
@@ -184,7 +196,7 @@
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
   <script type="module" src="./ui/about-history-bootstrap-r165.js?revision=r165-browser-about"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
-  <script type="module" src="./startup-viewport-r177.js?revision=r177-cold-start-rotation-crop"></script>
+  <script type="module" src="./startup-viewport-r177.js?revision=r178-landscape-first-containment"></script>
   <script type="module" src="./app.js?build=20260805-r160-browser-consent-r176-bella-road-derived-zone"></script>
   <script type="module" src="./tracks/countryside-bella-rescue-hotfix-r176.js?revision=r176-video-proven-rescue"></script>
 </body></html>

--- a/turn/startup-viewport-r177.js
+++ b/turn/startup-viewport-r177.js
@@ -1,6 +1,6 @@
 const MIN_RACING_ASPECT = 16 / 9;
 const SLOW_LOADING_MESSAGE_DELAY_MS = 1400;
-const ORIENTATION_SETTLE_DELAYS_MS = Object.freeze([0, 70, 180, 420, 900]);
+const ORIENTATION_SETTLE_DELAYS_MS = Object.freeze([0, 70, 180, 420, 900, 1600]);
 const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
 const moduleBase = new URL('/turn/', globalThis.location?.href || 'https://enkel.design/turn/');
 
@@ -21,9 +21,8 @@ function preloadModule(path, { crossOrigin = false } = {}) {
 }
 
 function preloadCriticalStartupGraph() {
-  // These modules sit late in the current sequential startup chain. Starting their
-  // downloads immediately removes much of the first-install network waterfall without
-  // changing initialization order or running game code early.
+  // Start the slow downloads immediately, but keep execution in app.js's established
+  // order. This shortens a fresh install without running game modules prematurely.
   for (const path of [
     './platform/web-platform.js',
     './platform/platform-context.js',
@@ -47,8 +46,6 @@ function installResponsiveViewportStyle() {
   style.id = 'turn-responsive-viewport-r177-style';
   style.textContent = `
     :root {
-      --turn-stage-width: 100vw;
-      --turn-stage-height: 100vh;
       --turn-racing-cover-width: 100vw;
       --turn-racing-cover-height: 100vh;
     }
@@ -58,36 +55,32 @@ function installResponsiveViewportStyle() {
       overflow: hidden !important;
       background: var(--turn-color-cyan, var(--cyan, #38d9ff)) !important;
     }
+    html {
+      width: 100% !important;
+      height: 100% !important;
+    }
     body {
       position: fixed !important;
-      inset: auto !important;
-      top: 0 !important;
-      left: 0 !important;
-      width: var(--turn-stage-width) !important;
-      height: var(--turn-stage-height) !important;
+      inset: 0 !important;
+      width: auto !important;
+      height: auto !important;
+      min-width: 0 !important;
+      min-height: 0 !important;
+    }
+    #game,
+    html body .install-gate,
+    html body .rotate-panel,
+    html body .m8-home.m8-home-fixed-layout {
+      position: fixed !important;
+      inset: 0 !important;
+      width: auto !important;
+      height: auto !important;
       min-width: 0 !important;
       min-height: 0 !important;
     }
     #game {
-      position: fixed !important;
-      inset: auto !important;
-      top: 0 !important;
-      left: 0 !important;
-      width: var(--turn-stage-width) !important;
-      height: var(--turn-stage-height) !important;
       overflow: hidden !important;
       background: var(--turn-color-cyan, var(--cyan, #38d9ff)) !important;
-    }
-    html body .install-gate,
-    html body .m8-home.m8-home-fixed-layout {
-      position: fixed !important;
-      inset: auto !important;
-      top: 0 !important;
-      left: 0 !important;
-      width: var(--turn-stage-width) !important;
-      height: var(--turn-stage-height) !important;
-      min-width: 0 !important;
-      min-height: 0 !important;
     }
     #game canvas {
       position: absolute !important;
@@ -124,40 +117,44 @@ function installSlowLoadingMessage() {
     note = document.createElement('p');
     note.className = 'turn-startup-expectation';
     note.textContent = 'This might take a minute.';
+    note.setAttribute('role', 'status');
+    note.setAttribute('aria-live', 'polite');
     note.hidden = true;
     copy.insertAdjacentElement('afterend', note);
   }
 
+  const launchStartedAt = performance.now();
   let timer = 0;
-  const loading = () => gate.classList.contains('turn-startup-loading')
-    || document.documentElement.classList.contains('turn-startup-pending');
+  let finished = false;
 
-  function clearExpectation() {
+  function loadingCoverIsActive() {
+    return gate.classList.contains('turn-startup-loading')
+      || document.documentElement.classList.contains('turn-startup-pending')
+      || gate.style.display === 'grid';
+  }
+
+  function stop() {
+    finished = true;
     window.clearTimeout(timer);
     timer = 0;
     note.hidden = true;
   }
 
-  function syncExpectation() {
-    if (!loading()) {
-      clearExpectation();
+  function poll() {
+    if (finished || document.documentElement.classList.contains('turn-home-ready')) {
+      stop();
       return;
     }
-    if (timer || !note.hidden) return;
-    timer = window.setTimeout(() => {
-      timer = 0;
-      if (loading()) note.hidden = false;
-    }, SLOW_LOADING_MESSAGE_DELAY_MS);
+
+    const elapsed = performance.now() - launchStartedAt;
+    if (elapsed >= SLOW_LOADING_MESSAGE_DELAY_MS && loadingCoverIsActive()) {
+      note.hidden = false;
+    }
+    timer = window.setTimeout(poll, 100);
   }
 
-  const observer = new MutationObserver(syncExpectation);
-  observer.observe(gate, { attributes: true, attributeFilter: ['class', 'hidden'] });
-  observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
-  document.addEventListener('turn:home-ready', () => {
-    clearExpectation();
-    observer.disconnect();
-  }, { once: true });
-  syncExpectation();
+  document.addEventListener('turn:home-ready', stop, { once: true });
+  timer = window.setTimeout(poll, SLOW_LOADING_MESSAGE_DELAY_MS);
 }
 
 function isStandaloneDisplayMode() {
@@ -169,6 +166,15 @@ function isStandaloneDisplayMode() {
 
 function validSize(width, height) {
   return Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0;
+}
+
+function orientSize(width, height, landscape) {
+  if (!validSize(width, height)) return null;
+  const longSide = Math.max(width, height);
+  const shortSide = Math.min(width, height);
+  return landscape
+    ? { width: longSide, height: shortSide }
+    : { width: shortSide, height: longSide };
 }
 
 function liveViewportSize() {
@@ -187,22 +193,56 @@ function liveViewportSize() {
   };
 }
 
-function standaloneScreenSize(live) {
-  if (!isStandaloneDisplayMode()) return null;
-  const reportedWidth = Math.max(Number(screen.width) || 0, Number(screen.availWidth) || 0);
-  const reportedHeight = Math.max(Number(screen.height) || 0, Number(screen.availHeight) || 0);
-  if (!validSize(reportedWidth, reportedHeight)) return null;
+function viewportIsLandscape(live) {
+  if (window.matchMedia?.('(orientation: landscape)').matches) return true;
+  if (window.matchMedia?.('(orientation: portrait)').matches) return false;
+  const type = String(screen.orientation?.type || '');
+  if (type.startsWith('landscape')) return true;
+  if (type.startsWith('portrait')) return false;
+  const legacyAngle = Math.abs(Number(window.orientation));
+  if (legacyAngle === 90) return true;
+  return live.width >= live.height;
+}
 
-  const longSide = Math.max(reportedWidth, reportedHeight);
-  const shortSide = Math.min(reportedWidth, reportedHeight);
-  return live.width >= live.height
-    ? { width: longSide, height: shortSide }
-    : { width: shortSide, height: longSide };
+function measureCssViewport(cssText) {
+  if (!document.body) return null;
+  const probe = document.createElement('div');
+  probe.setAttribute('aria-hidden', 'true');
+  probe.style.cssText = `${cssText};position:fixed;visibility:hidden;pointer-events:none;z-index:-2147483648;`;
+  document.body.appendChild(probe);
+  const rect = probe.getBoundingClientRect();
+  probe.remove();
+  return validSize(rect.width, rect.height)
+    ? { width: rect.width, height: rect.height }
+    : null;
 }
 
 function targetViewportSize() {
   const live = liveViewportSize();
-  return standaloneScreenSize(live) || live;
+  if (!isStandaloneDisplayMode()) return live;
+
+  const landscape = viewportIsLandscape(live);
+  const candidates = [
+    orientSize(live.width, live.height, landscape),
+    orientSize(Number(screen.width), Number(screen.height), landscape),
+    orientSize(Number(screen.availWidth), Number(screen.availHeight), landscape),
+    orientSize(Number(window.outerWidth), Number(window.outerHeight), landscape),
+    orientSize(
+      measureCssViewport('inset:0;width:auto;height:auto')?.width,
+      measureCssViewport('inset:0;width:auto;height:auto')?.height,
+      landscape
+    ),
+    orientSize(
+      measureCssViewport('inset:auto;left:0;top:0;width:100lvw;height:100lvh')?.width,
+      measureCssViewport('inset:auto;left:0;top:0;width:100lvw;height:100lvh')?.height,
+      landscape
+    )
+  ].filter(Boolean);
+
+  return {
+    width: Math.max(1, Math.round(Math.max(...candidates.map((size) => size.width)))),
+    height: Math.max(1, Math.round(Math.max(...candidates.map((size) => size.height))))
+  };
 }
 
 function fitRacingSurface(width, height) {
@@ -213,9 +253,6 @@ function fitRacingSurface(width, height) {
   let bufferHeight;
 
   if (viewportAspect < MIN_RACING_ASPECT) {
-    // Exact 16:9 integer multiples guarantee that the iPad drawing buffer, camera and
-    // centred CSS cover have the same ratio. The buffer area stays close to the previous
-    // 4:3 workload, so crop-not-stretch does not become a performance regression.
     const aspectUnit = Math.max(1, Math.round(Math.sqrt(viewportArea / (16 * 9))));
     bufferWidth = aspectUnit * 16;
     bufferHeight = aspectUnit * 9;
@@ -246,8 +283,6 @@ function applyStageSize(width, height, fit = null) {
   const rootStyle = root.style;
   rootStyle.setProperty('--app-width', `${width}px`);
   rootStyle.setProperty('--app-height', `${height}px`);
-  rootStyle.setProperty('--turn-stage-width', `${width}px`);
-  rootStyle.setProperty('--turn-stage-height', `${height}px`);
   if (fit) {
     rootStyle.setProperty('--turn-racing-cover-width', `${fit.coverWidth}px`);
     rootStyle.setProperty('--turn-racing-cover-height', `${fit.coverHeight}px`);


### PR DESCRIPTION
## Reproduction confirmed
Launching the installed iOS web app while the device is already in landscape freezes the loading screen and Home at a short startup height. The screenshots show both surfaces ending at the same horizontal line, with the RACE CTA below the fixed-layout fold. Rotating portrait and back supplies a correct viewport and repairs it.

## Root cause
The r177 responsive bootstrap replaced TURN’s earlier fixed-inset containment with a measured pixel height. On landscape-first iOS launches that measurement can be truncated, so the loading cover, body and fixed Home all inherit the same short height.

## Changes
- restore `position: fixed; inset: 0` containment for body, game, loading cover, rotation guard and fixed Home
- never size top-level UI surfaces from a launch-time pixel measurement
- retain measured dimensions only for the 3D renderer and its crop-not-stretch behavior
- expand standalone measurement candidates to include screen, outer window, fixed-inset probe and `100lvh` probe
- keep repeated settling checks through 1.6 seconds
- replace the missed mutation-driven loading message with elapsed-time polling
- show “This might take a minute.” after 1.4 seconds whenever the loading cover is active
- ship the corrected bootstrap under a fresh r178 revision in TURN and TURN NEXT

## Validation
- startup regression covers elapsed-time guidance and cache revision
- viewport regression covers early fixed-inset containment, removal of measured top-level height, fallback viewport candidates and unchanged 16:9 iPad crop
- complete TURN regression suite