### PR TITLE
Recover installed TURN from the cached broken app shell

### DIFF
--- a/turn-lab/tests/app-icon-production.mjs
+++ b/turn-lab/tests/app-icon-production.mjs
@@ -12,6 +12,7 @@ const index = fs.readFileSync(path.join(turnRoot, 'index.html'), 'utf8');
 const nextIndex = fs.readFileSync(path.join(turnNextRoot, 'index.html'), 'utf8');
 const homeSource = fs.readFileSync(path.join(turnRoot, 'm8-home.js'), 'utf8');
 const orientationGuard = fs.readFileSync(path.join(turnRoot, 'orientation-guard.css'), 'utf8');
+const shellRecovery = fs.readFileSync(path.join(turnRoot, 'motion-safe-zone.js'), 'utf8');
 const release = JSON.parse(fs.readFileSync(path.join(turnRoot, 'release.json'), 'utf8'));
 const manifest = JSON.parse(fs.readFileSync(path.join(turnRoot, 'site.webmanifest'), 'utf8'));
 const nextManifest = JSON.parse(fs.readFileSync(path.join(turnNextRoot, 'site.webmanifest'), 'utf8'));
@@ -43,10 +44,30 @@ const expectedIcons = [
 ];
 assert.deepEqual(manifest.icons, expectedIcons);
 assert.deepEqual(nextManifest.icons, expectedIcons);
+assert.equal(manifest.id, '/turn/', 'The production manifest identity must remain stable while its launch URL is versioned');
+assert.equal(nextManifest.id, '/turn-next/', 'TURN NEXT must retain its independent stable manifest identity');
+assert.equal(manifest.start_url, '/turn/?shell=20260806-r179');
+assert.equal(nextManifest.start_url, '/turn-next/?shell=20260806-r179');
+assert.equal(manifest.scope, '/turn/');
+assert.equal(nextManifest.scope, '/turn-next/');
 assert.equal(manifest.background_color, '#08090a');
 assert.equal(manifest.theme_color, '#08090a');
 assert.equal(nextManifest.background_color, '#08090a');
 assert.equal(nextManifest.theme_color, '#08090a');
+
+assert.match(shellRecovery, /PWA_SHELL_REVISION = '20260806-r179'/);
+assert.match(shellRecovery, /#turn-landscape-launch-containment-r178/,
+  'A cached PR #351 document must have its harmful inline containment rule removed immediately');
+assert.match(shellRecovery, /manifest\.href = `\$\{manifestPath\}\?shell=\$\{PWA_SHELL_REVISION\}`/,
+  'The active document must retarget its manifest to a versioned URL');
+assert.match(shellRecovery, /if \(isStandalone\)/,
+  'Only installed standalone contexts may perform the document-shell handoff');
+assert.match(shellRecovery, /sessionStorage\.getItem\(PWA_REDIRECT_GUARD\)/);
+assert.match(shellRecovery, /launchUrl\.searchParams\.set\('shell', PWA_SHELL_REVISION\)/);
+assert.match(shellRecovery, /window\.location\.replace\(launchUrl\.href\)/,
+  'The standalone handoff must request a genuinely new same-origin document without adding browser history');
+assert.match(shellRecovery, /return;[\s\S]*const SAFE_ZONE_DEGREES = 24/,
+  'No game bootstrap may continue in the stale document after navigation begins');
 
 const icon = fs.readFileSync(path.join(turnRoot, 'TURNicon.PNG'));
 assert.deepEqual(
@@ -67,4 +88,4 @@ assert.equal(
   'All icon surfaces must remain tied to the exact current user-supplied TURNicon.PNG blob'
 );
 
-console.log(`TURN ${release.id} supplied app icon, favicon, bookmarks, install onboarding and Home branding passed.`);
+console.log(`TURN ${release.id} supplied app icon, versioned standalone shell recovery and Home branding passed.`);

--- a/turn-next/site.webmanifest
+++ b/turn-next/site.webmanifest
@@ -3,7 +3,7 @@
   "name": "TURN NEXT",
   "short_name": "TURN NEXT",
   "description": "The isolated architecture test runtime for TURN.",
-  "start_url": "/turn-next/",
+  "start_url": "/turn-next/?shell=20260806-r179",
   "scope": "/turn-next/",
   "display": "fullscreen",
   "orientation": "landscape",

--- a/turn/motion-safe-zone.js
+++ b/turn/motion-safe-zone.js
@@ -1,4 +1,48 @@
 (() => {
+  const PWA_SHELL_REVISION = '20260806-r179';
+  const PWA_REDIRECT_GUARD = `turn-pwa-shell-${PWA_SHELL_REVISION}`;
+  const isStandalone =
+    window.matchMedia('(display-mode: standalone)').matches ||
+    window.matchMedia('(display-mode: fullscreen)').matches ||
+    navigator.standalone === true;
+  const isNextDeployment = document.documentElement.dataset.turnDeployment === 'next';
+  const manifestPath = isNextDeployment
+    ? '/turn-next/site.webmanifest'
+    : '/turn/site.webmanifest';
+
+  // PR #351's document shell can remain in iOS's installed-web-app cache even after
+  // Safari has fetched the reverted production page. Remove its inline containment
+  // rule immediately if an older standalone shell executes this refreshed bootstrap.
+  document.querySelector('#turn-landscape-launch-containment-r178')?.remove();
+
+  const manifest = document.querySelector('link[rel="manifest"]');
+  if (manifest) {
+    manifest.href = `${manifestPath}?shell=${PWA_SHELL_REVISION}`;
+  }
+
+  if (isStandalone) {
+    const launchUrl = new URL(window.location.href);
+    const currentRevision = launchUrl.searchParams.get('shell');
+    let alreadyRedirected = false;
+    try {
+      alreadyRedirected = sessionStorage.getItem(PWA_REDIRECT_GUARD) === '1';
+    } catch (_) {}
+
+    if (currentRevision !== PWA_SHELL_REVISION && !alreadyRedirected) {
+      try {
+        sessionStorage.setItem(PWA_REDIRECT_GUARD, '1');
+      } catch (_) {}
+      launchUrl.searchParams.set('shell', PWA_SHELL_REVISION);
+      globalThis.__turnPwaShellRecovery = Object.freeze({
+        revision: PWA_SHELL_REVISION,
+        from: window.location.href,
+        to: launchUrl.href
+      });
+      window.location.replace(launchUrl.href);
+      return;
+    }
+  }
+
   const SAFE_ZONE_DEGREES = 24;
 
   globalThis.__TURN_MOTION_SAFE_ZONE__ = Object.freeze({
@@ -13,5 +57,6 @@
   });
 
   document.documentElement.dataset.turnMotionSafeZone = String(SAFE_ZONE_DEGREES);
+  document.documentElement.dataset.turnPwaShell = PWA_SHELL_REVISION;
   console.info(`TURN: motion safe zone configured at ±${SAFE_ZONE_DEGREES}°.`);
 })();

--- a/turn/motion-safe-zone.js
+++ b/turn/motion-safe-zone.js
@@ -34,6 +34,7 @@
       try {
         globalThis.sessionStorage.setItem(PWA_REDIRECT_GUARD, '1');
       } catch (_) {}
+      // Only the query changes: origin, path, manifest ID, scope and local storage stay intact.
       launchUrl.searchParams.set('shell', PWA_SHELL_REVISION);
       globalThis.__turnPwaShellRecovery = Object.freeze({
         revision: PWA_SHELL_REVISION,

--- a/turn/motion-safe-zone.js
+++ b/turn/motion-safe-zone.js
@@ -4,7 +4,7 @@
   const isStandalone =
     window.matchMedia('(display-mode: standalone)').matches ||
     window.matchMedia('(display-mode: fullscreen)').matches ||
-    navigator.standalone === true;
+    globalThis.navigator.standalone === true;
   const isNextDeployment = document.documentElement.dataset.turnDeployment === 'next';
   const manifestPath = isNextDeployment
     ? '/turn-next/site.webmanifest'
@@ -27,12 +27,12 @@
     const currentRevision = launchUrl.searchParams.get('shell');
     let alreadyRedirected = false;
     try {
-      alreadyRedirected = sessionStorage.getItem(PWA_REDIRECT_GUARD) === '1';
+      alreadyRedirected = globalThis.sessionStorage.getItem(PWA_REDIRECT_GUARD) === '1';
     } catch (_) {}
 
     if (currentRevision !== PWA_SHELL_REVISION && !alreadyRedirected) {
       try {
-        sessionStorage.setItem(PWA_REDIRECT_GUARD, '1');
+        globalThis.sessionStorage.setItem(PWA_REDIRECT_GUARD, '1');
       } catch (_) {}
       launchUrl.searchParams.set('shell', PWA_SHELL_REVISION);
       globalThis.__turnPwaShellRecovery = Object.freeze({

--- a/turn/motion-safe-zone.js
+++ b/turn/motion-safe-zone.js
@@ -10,6 +10,8 @@
     ? '/turn-next/site.webmanifest'
     : '/turn/site.webmanifest';
 
+  // This synchronous script runs before orientation and game startup. Keep the PWA
+  // document-shell recovery above the normal motion safe-zone configuration.
   // PR #351's document shell can remain in iOS's installed-web-app cache even after
   // Safari has fetched the reverted production page. Remove its inline containment
   // rule immediately if an older standalone shell executes this refreshed bootstrap.

--- a/turn/site.webmanifest
+++ b/turn/site.webmanifest
@@ -3,7 +3,7 @@
   "name": "TURN",
   "short_name": "TURN",
   "description": "A motion-controlled arcade drift racer where you race your own best laps.",
-  "start_url": "/turn/",
+  "start_url": "/turn/?shell=20260806-r179",
   "scope": "/turn/",
   "display": "fullscreen",
   "orientation": "landscape",


### PR DESCRIPTION
## Diagnosis
Safari loads the reverted PR #350 document correctly, while the installed Home Screen app continues to render PR #351’s split/clipped shell. This isolates the remaining failure to iOS standalone document/manifest caching rather than the current responsive CSS.

## Changes
- keep the stable manifest IDs and storage scopes
- version TURN’s standalone `start_url` as `/turn/?shell=20260806-r179`
- version TURN NEXT independently as `/turn-next/?shell=20260806-r179`
- retarget the active manifest link to the same shell revision during early synchronous bootstrap
- when running standalone from an older URL, perform one same-origin `location.replace()` before game initialization
- guard the redirect with session storage to prevent loops
- immediately remove PR #351’s cached `turn-landscape-launch-containment-r178` inline style if an old document shell reaches the refreshed bootstrap
- leave normal Safari/browser launches unchanged
- preserve localStorage, achievements and settings because the path, origin, manifest ID and scope do not change

## Scope
No viewport, layout, renderer, cold-start preload or iPad crop code is changed.

## Validation
The PWA branding regression now checks stable IDs/scopes, versioned start URLs, standalone-only navigation, loop prevention, stale-style removal and that game bootstrap stops in the old document once navigation begins.