### PR TITLE
Respect the usable iOS standalone viewport

### DIFF
--- a/turn-next/index.html
+++ b/turn-next/index.html
@@ -4,7 +4,7 @@
   <base href="/turn/">
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no, shrink-to-fit=no">
-  <meta name="theme-color" content="#38d9ff">
+  <meta name="theme-color" content="#08090a">
   <meta name="application-name" content="TURN NEXT">
   <meta name="robots" content="noindex,nofollow">
   <meta name="description" content="TURN NEXT is the isolated test channel for TURN.">
@@ -40,7 +40,7 @@
   <script src="/turn-next/storage-bootstrap.js?source=20260805-r160"></script>
   <link rel="icon" href="./TURNicon.PNG?icon=20260803-profile-512" type="image/png" sizes="512x512">
   <link rel="apple-touch-icon" href="./TURNicon.PNG?icon=20260803-profile-512" sizes="512x512">
-  <link rel="manifest" href="/turn-next/site.webmanifest?source=20260805-r160-icon-20260803-profile-512-m8.5-r181-usable-pwa-viewport">
+  <link rel="manifest" href="/turn-next/site.webmanifest?source=20260805-r160-icon-20260803-profile-512-m8.5">
   <link rel="stylesheet" href="./styles.css?build=20260805-r160">
   <link rel="stylesheet" href="./vertical-drive.css?build=20260805-r160">
   <link rel="stylesheet" href="./hud-tuning.css?build=20260805-r160">

--- a/turn-next/index.html
+++ b/turn-next/index.html
@@ -3,8 +3,8 @@
 <html lang="en" data-turn-deployment="next"><head>
   <base href="/turn/">
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no">
-  <meta name="theme-color" content="#08090a">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no, shrink-to-fit=no">
+  <meta name="theme-color" content="#38d9ff">
   <meta name="application-name" content="TURN NEXT">
   <meta name="robots" content="noindex,nofollow">
   <meta name="description" content="TURN NEXT is the isolated test channel for TURN.">
@@ -40,7 +40,7 @@
   <script src="/turn-next/storage-bootstrap.js?source=20260805-r160"></script>
   <link rel="icon" href="./TURNicon.PNG?icon=20260803-profile-512" type="image/png" sizes="512x512">
   <link rel="apple-touch-icon" href="./TURNicon.PNG?icon=20260803-profile-512" sizes="512x512">
-  <link rel="manifest" href="/turn-next/site.webmanifest?source=20260805-r160-icon-20260803-profile-512-m8.5">
+  <link rel="manifest" href="/turn-next/site.webmanifest?source=20260805-r160-icon-20260803-profile-512-m8.5-r181-usable-pwa-viewport">
   <link rel="stylesheet" href="./styles.css?build=20260805-r160">
   <link rel="stylesheet" href="./vertical-drive.css?build=20260805-r160">
   <link rel="stylesheet" href="./hud-tuning.css?build=20260805-r160">
@@ -69,6 +69,7 @@
   <link rel="stylesheet" href="/turn-next/identity.css?source=20260805-r160-m8.5-logo">
   <script defer src="/turn-next/identity.js?source=20260805-r160-m8.5-logo"></script>
   <script src="./install-gate.js?build=20260805-r160-social-browser"></script>
+  <script src="./pwa-usable-viewport-r181.js?revision=r181-usable-web-layer"></script>
   <script src="./motion-safe-zone.js?build=20260805-r160"></script>
   <script src="./orientation-compat.js?build=20260805-r160"></script>
   <script src="./live-steering-setting.js?build=20260805-r160-live-steering"></script>

--- a/turn-next/site.webmanifest
+++ b/turn-next/site.webmanifest
@@ -5,10 +5,11 @@
   "description": "The isolated architecture test runtime for TURN.",
   "start_url": "/turn-next/",
   "scope": "/turn-next/",
-  "display": "fullscreen",
+  "display": "standalone",
+  "display_override": ["standalone"],
   "orientation": "landscape",
-  "background_color": "#08090a",
-  "theme_color": "#08090a",
+  "background_color": "#38d9ff",
+  "theme_color": "#38d9ff",
   "icons": [
     {
       "src": "/turn/TURNicon.PNG?icon=20260803-profile-512",

--- a/turn-next/site.webmanifest
+++ b/turn-next/site.webmanifest
@@ -8,8 +8,8 @@
   "display": "standalone",
   "display_override": ["standalone"],
   "orientation": "landscape",
-  "background_color": "#38d9ff",
-  "theme_color": "#38d9ff",
+  "background_color": "#08090a",
+  "theme_color": "#08090a",
   "icons": [
     {
       "src": "/turn/TURNicon.PNG?icon=20260803-profile-512",

--- a/turn-next/site.webmanifest
+++ b/turn-next/site.webmanifest
@@ -8,8 +8,8 @@
   "display": "standalone",
   "display_override": ["standalone"],
   "orientation": "landscape",
-  "background_color": "#08090a",
-  "theme_color": "#08090a",
+  "background_color": "#38d9ff",
+  "theme_color": "#38d9ff",
   "icons": [
     {
       "src": "/turn/TURNicon.PNG?icon=20260803-profile-512",

--- a/turn-tests/.pwa-viewport-check-trigger
+++ b/turn-tests/.pwa-viewport-check-trigger
@@ -1,1 +1,0 @@
-temporary workflow trigger

--- a/turn-tests/.pwa-viewport-check-trigger
+++ b/turn-tests/.pwa-viewport-check-trigger
@@ -1,0 +1,1 @@
+temporary workflow trigger

--- a/turn-tests/viewport-coverage-production.mjs
+++ b/turn-tests/viewport-coverage-production.mjs
@@ -1,117 +1,92 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [index, releaseSource, main, styles] = await Promise.all([
+const [
+  index,
+  nextIndex,
+  releaseSource,
+  main,
+  styles,
+  usableViewport,
+  productionManifestSource,
+  nextManifestSource
+] = await Promise.all([
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn-next/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/release.json', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/main.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/styles.css', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/styles.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/pwa-usable-viewport-r181.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/site.webmanifest', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn-next/site.webmanifest', import.meta.url), 'utf8')
 ]);
 
 const release = JSON.parse(releaseSource);
-const blockStart = main.indexOf('function isStandaloneDisplayMode()');
-const blockEnd = main.indexOf('\nconst initialViewport = getViewportSize();');
-assert.ok(blockStart >= 0 && blockEnd > blockStart, 'Production must expose one standalone-aware viewport measurement boundary');
-const viewportBlock = main.slice(blockStart, blockEnd);
+const productionManifest = JSON.parse(productionManifestSource);
+const nextManifest = JSON.parse(nextManifestSource);
 
-assert.match(viewportBlock, /window\.visualViewport/, 'TURN must still observe the live visual viewport');
-assert.match(viewportBlock, /window\.innerWidth/, 'Width must include the layout viewport');
-assert.match(viewportBlock, /window\.innerHeight/, 'Height must include the layout viewport');
-assert.match(viewportBlock, /root\.clientWidth/, 'Width must include the document viewport as an iOS rotation fallback');
-assert.match(viewportBlock, /root\.clientHeight/, 'Height must include the document viewport as an iOS rotation fallback');
-assert.match(viewportBlock, /screen\.width/, 'Installed TURN must be able to recover the complete physical screen width');
-assert.match(viewportBlock, /screen\.height/, 'Installed TURN must be able to recover the complete physical screen height');
-assert.match(viewportBlock, /navigator\.standalone === true/, 'iOS Home Screen mode must activate complete screen coverage');
-assert.match(viewportBlock, /display-mode: standalone/, 'Standards-based standalone mode must activate complete screen coverage');
-assert.match(viewportBlock, /display-mode: fullscreen/, 'Fullscreen mode must activate complete screen coverage');
-assert.doesNotMatch(viewportBlock, /viewport\?\.height \|\| window\.innerHeight/, 'A temporarily short visual viewport must never expose the cyan page background');
-
-const createViewportFunctions = new Function(
-  'window',
-  'document',
-  'navigator',
-  'screen',
-  `${viewportBlock}\nreturn { getViewportSize, getStandaloneScreenSize, isStandaloneDisplayMode };`
+assert.match(
+  index,
+  /<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no, shrink-to-fit=no">/,
+  'Production must explicitly disable legacy virtual-viewport shrinking'
 );
+assert.match(index, /pwa-usable-viewport-r181\.js\?revision=r181-usable-web-layer/);
+assert.ok(
+  index.indexOf('install-gate.js') < index.indexOf('pwa-usable-viewport-r181.js'),
+  'Standalone detection must run before the usable-viewport boundary'
+);
+assert.ok(
+  index.indexOf('pwa-usable-viewport-r181.js') < index.indexOf('app.js?build='),
+  'The PWA boundary must be installed before main.js can publish physical-screen dimensions'
+);
+assert.match(nextIndex, /pwa-usable-viewport-r181\.js\?revision=r181-usable-web-layer/);
 
-function measure({
-  standalone = false,
-  fullscreen = false,
-  navigatorStandalone = false,
-  viewportWidth = 1080,
-  viewportHeight = 778,
-  innerWidth = viewportWidth,
-  innerHeight = viewportHeight,
-  clientWidth = viewportWidth,
-  clientHeight = viewportHeight,
-  screenWidth = 810,
-  screenHeight = 1080
-} = {}) {
-  const windowMock = {
-    visualViewport: { width: viewportWidth, height: viewportHeight },
-    innerWidth,
-    innerHeight,
-    matchMedia(query) {
-      return {
-        matches: query.includes('standalone') ? standalone : query.includes('fullscreen') ? fullscreen : false
-      };
-    }
-  };
-  const documentMock = {
-    documentElement: {
-      clientWidth,
-      clientHeight,
-      classList: {
-        contains(name) {
-          return name === 'turn-standalone' && standalone;
-        }
-      }
-    }
-  };
-  const navigatorMock = { standalone: navigatorStandalone };
-  const screenMock = {
-    width: screenWidth,
-    height: screenHeight,
-    availWidth: screenWidth,
-    availHeight: screenHeight
-  };
-  return createViewportFunctions(windowMock, documentMock, navigatorMock, screenMock).getViewportSize();
+for (const manifest of [productionManifest, nextManifest]) {
+  assert.equal(manifest.display, 'standalone', 'iOS must use the stable standalone presentation mode');
+  assert.deepEqual(manifest.display_override, ['standalone']);
+  assert.equal(manifest.orientation, 'landscape');
 }
 
-assert.deepEqual(
-  measure({ standalone: true }),
-  { width: 1080, height: 810 },
-  'Installed iPad TURN must cover the full 1080×810 screen even when WebKit reports only 1080×778'
-);
-assert.deepEqual(
-  measure({ standalone: false }),
-  { width: 1080, height: 778 },
-  'Normal browser play must remain inside the browser viewport rather than extending below its chrome'
-);
-assert.deepEqual(
-  measure({ fullscreen: true }),
-  { width: 1080, height: 810 },
-  'Fullscreen display mode must receive the same complete-screen coverage as the installed app'
-);
-assert.deepEqual(
-  measure({ navigatorStandalone: true }),
-  { width: 1080, height: 810 },
-  'Legacy iOS navigator.standalone mode must receive complete-screen coverage'
-);
-assert.deepEqual(
-  measure({
-    standalone: true,
-    viewportWidth: 778,
-    viewportHeight: 1080,
-    screenWidth: 810,
-    screenHeight: 1080
-  }),
-  { width: 810, height: 1080 },
-  'Portrait mode must map the screen short side to width and long side to height'
+assert.match(main, /screen\.width/);
+assert.match(main, /screen\.height/,
+  'The compatibility boundary must explicitly neutralize the legacy physical-screen sizing path');
+assert.match(styles, /min-height: 100lvh/,
+  'The compatibility boundary must override the legacy large-viewport minimum in installed mode');
+
+assert.match(usableViewport, /if \(!isStandalone\) return;/,
+  'Ordinary Safari must remain on the established browser layout path');
+assert.match(usableViewport, /--app-width: 100dvw !important/);
+assert.match(usableViewport, /--app-height: 100dvh !important/);
+assert.match(usableViewport, /min-width: 0 !important/);
+assert.match(usableViewport, /min-height: 0 !important/,
+  'The installed app must not be forced to the physical large viewport');
+assert.match(usableViewport, /const gameRect = game\?\.getBoundingClientRect\(\)/);
+assert.match(usableViewport, /Number\(root\.clientWidth\)/);
+assert.match(usableViewport, /Number\(root\.clientHeight\)/);
+assert.match(usableViewport, /camera\.aspect = width \/ height/);
+assert.match(usableViewport, /nativeSetSize\(width, height, false\)/);
+assert.match(usableViewport, /renderer\.setSize = function useUsableViewportInsteadOfPhysicalScreen/,
+  'Later main.js resize events must not reapply physical-screen dimensions');
+assert.match(usableViewport, /SETTLE_DELAYS_MS = Object\.freeze\(\[0, 80, 240, 650, 1200\]\)/,
+  'The installed web layer must be sampled as iOS finishes launch and rotation');
+assert.match(usableViewport, /__turnPwaViewportDiagnostics/,
+  'Device reports must expose actual usable, visual and physical dimensions for follow-up diagnosis');
+
+const sizeStart = usableViewport.indexOf('function usableViewportSize()');
+const sizeEnd = usableViewport.indexOf('\n  function publishDiagnostics', sizeStart);
+assert.ok(sizeStart >= 0 && sizeEnd > sizeStart, 'The usable viewport measurement must remain independently testable');
+const sizeBlock = usableViewport.slice(sizeStart, sizeEnd);
+assert.doesNotMatch(sizeBlock, /screen\./,
+  'Physical screen dimensions must never participate in app or renderer sizing');
+assert.doesNotMatch(sizeBlock, /100lvh|100lvw/,
+  'Large viewport units must never participate in the installed app measurement');
+assert.match(sizeBlock, /game\?\.getBoundingClientRect/);
+assert.match(sizeBlock, /root\.clientWidth/);
+assert.match(sizeBlock, /root\.clientHeight/);
+
+assert.match(
+  index,
+  new RegExp(`TURN v${release.version.replaceAll('.', '\\.')} · Build ${release.id.replaceAll('.', '\\.')}`)
 );
 
-assert.match(styles, /body \{[\s\S]*min-width: 100vw;[\s\S]*min-height: 100vh;/, 'The app surface must cover the complete layout viewport between resize events');
-assert.match(styles, /@supports \(height: 100lvh\) \{[\s\S]*body \{[\s\S]*min-height: 100lvh;/, 'Modern WebKit must retain the stable large viewport coverage floor');
-assert.match(index, new RegExp(`TURN v${release.version.replaceAll('.', '\\.')} · Build ${release.id.replaceAll('.', '\\.')}`), 'The viewport fix must ship through the current release identity');
-
-console.log(`TURN ${release.id} full standalone iPad screen coverage passed.`);
+console.log(`TURN ${release.id} usable iOS standalone viewport boundary passed.`);

--- a/turn/index.html
+++ b/turn/index.html
@@ -2,8 +2,8 @@
 <!-- TURN 2026.08.05-r160 release identity -->
 <html lang="en"><head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no">
-  <meta name="theme-color" content="#08090a">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no, shrink-to-fit=no">
+  <meta name="theme-color" content="#38d9ff">
   <meta name="application-name" content="TURN">
   <meta name="description" content="TURN is a motion-controlled arcade drift racer. Tilt your device to steer, drift and boost through short tracks, then race your own best laps.">
   <link rel="canonical" href="https://enkel.design/turn/">
@@ -37,7 +37,7 @@
   </script>
   <link rel="icon" href="./TURNicon.PNG?icon=20260803-profile-512" type="image/png" sizes="512x512">
   <link rel="apple-touch-icon" href="./TURNicon.PNG?icon=20260803-profile-512" sizes="512x512">
-  <link rel="manifest" href="./site.webmanifest?build=20260805-r160-icon-20260803-profile-512">
+  <link rel="manifest" href="./site.webmanifest?build=20260805-r160-icon-20260803-profile-512-r181-usable-pwa-viewport">
   <link rel="stylesheet" href="./styles.css?build=20260805-r160">
   <link rel="stylesheet" href="./vertical-drive.css?build=20260805-r160">
   <link rel="stylesheet" href="./hud-tuning.css?build=20260805-r160">
@@ -65,6 +65,7 @@
   <link rel="stylesheet" href="./garage/lot-layout-r60.css?build=20260805-r160">
   <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260805-r160-menu-font-v3">
   <script src="./install-gate.js?build=20260805-r160-social-browser"></script>
+  <script src="./pwa-usable-viewport-r181.js?revision=r181-usable-web-layer"></script>
   <script src="./motion-safe-zone.js?build=20260805-r160"></script>
   <script src="./orientation-compat.js?build=20260805-r160"></script>
   <script src="./live-steering-setting.js?build=20260805-r160-live-steering"></script>

--- a/turn/index.html
+++ b/turn/index.html
@@ -3,7 +3,7 @@
 <html lang="en"><head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no, shrink-to-fit=no">
-  <meta name="theme-color" content="#38d9ff">
+  <meta name="theme-color" content="#08090a">
   <meta name="application-name" content="TURN">
   <meta name="description" content="TURN is a motion-controlled arcade drift racer. Tilt your device to steer, drift and boost through short tracks, then race your own best laps.">
   <link rel="canonical" href="https://enkel.design/turn/">
@@ -37,7 +37,7 @@
   </script>
   <link rel="icon" href="./TURNicon.PNG?icon=20260803-profile-512" type="image/png" sizes="512x512">
   <link rel="apple-touch-icon" href="./TURNicon.PNG?icon=20260803-profile-512" sizes="512x512">
-  <link rel="manifest" href="./site.webmanifest?build=20260805-r160-icon-20260803-profile-512-r181-usable-pwa-viewport">
+  <link rel="manifest" href="./site.webmanifest?build=20260805-r160-icon-20260803-profile-512">
   <link rel="stylesheet" href="./styles.css?build=20260805-r160">
   <link rel="stylesheet" href="./vertical-drive.css?build=20260805-r160">
   <link rel="stylesheet" href="./hud-tuning.css?build=20260805-r160">

--- a/turn/pwa-usable-viewport-r181.js
+++ b/turn/pwa-usable-viewport-r181.js
@@ -87,7 +87,6 @@
     const camera = runtime.camera;
     const canvas = renderer.domElement;
     const nativeSetSize = renderer.setSize.bind(renderer);
-    let applying = false;
     let animationFrame = 0;
     let settleTimers = [];
 
@@ -96,10 +95,7 @@
       const { width, height } = usableViewportSize();
       camera.aspect = width / height;
       camera.updateProjectionMatrix();
-
-      applying = true;
       nativeSetSize(width, height, false);
-      applying = false;
 
       canvas.style.setProperty('width', '100%', 'important');
       canvas.style.setProperty('height', '100%', 'important');
@@ -119,7 +115,6 @@
     }
 
     renderer.setSize = function useUsableViewportInsteadOfPhysicalScreen() {
-      if (applying) return nativeSetSize(...arguments);
       queueSync();
       return renderer;
     };

--- a/turn/pwa-usable-viewport-r181.js
+++ b/turn/pwa-usable-viewport-r181.js
@@ -1,0 +1,145 @@
+(() => {
+  const isStandalone =
+    document.documentElement.classList.contains('turn-standalone') ||
+    window.matchMedia?.('(display-mode: standalone)').matches ||
+    window.matchMedia?.('(display-mode: fullscreen)').matches ||
+    navigator.standalone === true;
+
+  if (!isStandalone) return;
+
+  const ROOT_CLASS = 'turn-pwa-usable-viewport-r181';
+  const STYLE_ID = 'turn-pwa-usable-viewport-r181-style';
+  const SETTLE_DELAYS_MS = Object.freeze([0, 80, 240, 650, 1200]);
+  const root = document.documentElement;
+  root.classList.add(ROOT_CLASS);
+
+  if (!document.querySelector(`#${STYLE_ID}`)) {
+    const style = document.createElement('style');
+    style.id = STYLE_ID;
+    style.textContent = `
+      html.${ROOT_CLASS} {
+        --app-width: 100vw !important;
+        --app-height: 100vh !important;
+      }
+      @supports (width: 100dvw) and (height: 100dvh) {
+        html.${ROOT_CLASS} {
+          --app-width: 100dvw !important;
+          --app-height: 100dvh !important;
+        }
+      }
+      html.${ROOT_CLASS},
+      html.${ROOT_CLASS} body {
+        min-width: 0 !important;
+        min-height: 0 !important;
+        overflow: hidden !important;
+        background: #38d9ff !important;
+      }
+      html.${ROOT_CLASS} body {
+        width: var(--app-width) !important;
+        height: var(--app-height) !important;
+      }
+    `;
+    document.head.appendChild(style);
+  }
+
+  function usableViewportSize() {
+    const game = document.querySelector('#game');
+    const gameRect = game?.getBoundingClientRect();
+    const width = Number(gameRect?.width)
+      || Number(root.clientWidth)
+      || Number(window.innerWidth)
+      || 1;
+    const height = Number(gameRect?.height)
+      || Number(root.clientHeight)
+      || Number(window.innerHeight)
+      || 1;
+    return {
+      width: Math.max(1, Math.round(width)),
+      height: Math.max(1, Math.round(height))
+    };
+  }
+
+  function publishDiagnostics(width, height) {
+    const viewport = window.visualViewport;
+    const snapshot = Object.freeze({
+      strategy: 'usable-web-layer',
+      width,
+      height,
+      innerWidth: Number(window.innerWidth) || 0,
+      innerHeight: Number(window.innerHeight) || 0,
+      clientWidth: Number(root.clientWidth) || 0,
+      clientHeight: Number(root.clientHeight) || 0,
+      visualWidth: Number(viewport?.width) || 0,
+      visualHeight: Number(viewport?.height) || 0,
+      screenWidth: Number(screen.width) || 0,
+      screenHeight: Number(screen.height) || 0
+    });
+    globalThis.__turnPwaViewportDiagnostics = snapshot;
+    root.dataset.turnPwaViewport = `${width}x${height}`;
+    root.dataset.turnPwaViewportStrategy = snapshot.strategy;
+  }
+
+  function installRuntimeBoundary(runtime) {
+    if (!runtime?.renderer || !runtime?.camera || runtime.__turnUsableViewportR181Installed) return false;
+    runtime.__turnUsableViewportR181Installed = true;
+
+    const renderer = runtime.renderer;
+    const camera = runtime.camera;
+    const canvas = renderer.domElement;
+    const nativeSetSize = renderer.setSize.bind(renderer);
+    let applying = false;
+    let animationFrame = 0;
+    let settleTimers = [];
+
+    function syncNow() {
+      animationFrame = 0;
+      const { width, height } = usableViewportSize();
+      camera.aspect = width / height;
+      camera.updateProjectionMatrix();
+
+      applying = true;
+      nativeSetSize(width, height, false);
+      applying = false;
+
+      canvas.style.setProperty('width', '100%', 'important');
+      canvas.style.setProperty('height', '100%', 'important');
+      publishDiagnostics(width, height);
+    }
+
+    function queueSync() {
+      if (animationFrame) cancelAnimationFrame(animationFrame);
+      animationFrame = requestAnimationFrame(() => {
+        animationFrame = requestAnimationFrame(syncNow);
+      });
+    }
+
+    function settle() {
+      for (const timer of settleTimers) window.clearTimeout(timer);
+      settleTimers = SETTLE_DELAYS_MS.map((delay) => window.setTimeout(queueSync, delay));
+    }
+
+    renderer.setSize = function useUsableViewportInsteadOfPhysicalScreen() {
+      if (applying) return nativeSetSize(...arguments);
+      queueSync();
+      return renderer;
+    };
+
+    for (const eventName of ['resize', 'orientationchange', 'pageshow', 'focus']) {
+      window.addEventListener(eventName, settle, { passive: true });
+    }
+    window.visualViewport?.addEventListener('resize', settle, { passive: true });
+    screen.orientation?.addEventListener?.('change', settle, { passive: true });
+    document.addEventListener('visibilitychange', () => {
+      if (!document.hidden) settle();
+    }, { passive: true });
+
+    settle();
+    return true;
+  }
+
+  if (!installRuntimeBoundary(globalThis.__turnRuntime)) {
+    window.addEventListener('turn:runtime-ready', (event) => {
+      installRuntimeBoundary(event.detail || globalThis.__turnRuntime);
+    }, { once: true });
+  }
+})();

--- a/turn/site.webmanifest
+++ b/turn/site.webmanifest
@@ -5,10 +5,11 @@
   "description": "A motion-controlled arcade drift racer where you race your own best laps.",
   "start_url": "/turn/",
   "scope": "/turn/",
-  "display": "fullscreen",
+  "display": "standalone",
+  "display_override": ["standalone"],
   "orientation": "landscape",
-  "background_color": "#08090a",
-  "theme_color": "#08090a",
+  "background_color": "#38d9ff",
+  "theme_color": "#38d9ff",
   "icons": [
     {
       "src": "/turn/TURNicon.PNG?icon=20260803-profile-512",

--- a/turn/site.webmanifest
+++ b/turn/site.webmanifest
@@ -8,8 +8,8 @@
   "display": "standalone",
   "display_override": ["standalone"],
   "orientation": "landscape",
-  "background_color": "#38d9ff",
-  "theme_color": "#38d9ff",
+  "background_color": "#08090a",
+  "theme_color": "#08090a",
   "icons": [
     {
       "src": "/turn/TURNicon.PNG?icon=20260803-profile-512",

--- a/turn/site.webmanifest
+++ b/turn/site.webmanifest
@@ -8,8 +8,8 @@
   "display": "standalone",
   "display_override": ["standalone"],
   "orientation": "landscape",
-  "background_color": "#08090a",
-  "theme_color": "#08090a",
+  "background_color": "#38d9ff",
+  "theme_color": "#38d9ff",
   "icons": [
     {
       "src": "/turn/TURNicon.PNG?icon=20260803-profile-512",


### PR DESCRIPTION
## Device-proven problem
TURN is correct in Safari but the installed iOS Home Screen app can render into a smaller web layer, leaving a black system-owned area and clipping the bottom of Home. Reinstalling and restoring the exact PR #349 tree did not change the result, ruling out a stale shell or the later startup experiment.

## Root cause
The PR #349 runtime still deliberately expands installed TURN from the actual web viewport to `screen.width` / `screen.height`, writes those physical dimensions into `--app-width` / `--app-height`, and combines them with a `100lvh` minimum. Current iOS WebKit can expose a standalone web layer smaller than the physical display, so TURN lays out the CTA into space the page cannot reach.

This matches reopened WebKit bug 301994. Its iOS 26.5.2 report describes `screen.height` being larger than `innerHeight`, `100dvh` and `clientHeight`, with the remaining strip drawn by the system and unreachable by DOM.

## Fix
- use `standalone` rather than `fullscreen` as the manifest presentation mode
- install one synchronous boundary before the game runtime, only in installed mode
- override the legacy physical-screen CSS variables with `100dvw` / `100dvh`
- neutralize the `100lvh` and physical-screen minimums in installed mode
- set the launch-time document background to TURN cyan so the system-owned strip does not present as a black footer after relaunch
- size WebGL from the actual `#game` bounding rectangle / document client viewport
- intercept later `renderer.setSize()` calls so legacy resize events cannot restore physical-screen dimensions
- resample through 1.2 seconds after launch, rotation, focus and visibility restoration
- expose `__turnPwaViewportDiagnostics` for future device reports
- leave ordinary Safari unchanged
- mirror the contract in TURN NEXT

## Validation
- new production regression rejects physical `screen.*` and `100lvh` as installed-app sizing inputs
- direct syntax check passed
- targeted runtime harness passed:
  - browser/Safari mode installs no override
  - simulated physical `852×393` / usable `852×330` PWA renders at `852×330`
  - a later legacy `renderer.setSize(852, 393)` request is rejected and remains `852×330`

GitHub Actions has not created a workflow run for the PR despite several normal synchronize events.