### PR TITLE
Fix stale TURN version metadata cache

### DIFF
--- a/turn/index.html
+++ b/turn/index.html
@@ -183,7 +183,7 @@
   </div>
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
-  <script type="module" src="./ui/about-history-bootstrap-r165.js?revision=r165-browser-about"></script>
+  <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260806-r161-release-meta"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
   <script type="module" src="./app.js?build=20260806-r161-browser-consent-r176-bella-road-derived-zone"></script>
   <script type="module" src="./tracks/countryside-bella-rescue-hotfix-r176.js?revision=r176-video-proven-rescue"></script>

--- a/turn/ui/about-history-bootstrap-r165.js
+++ b/turn/ui/about-history-bootstrap-r165.js
@@ -2,7 +2,7 @@ import {
   CHANGELOG,
   CURRENT_RELEASE,
   DEVELOPMENT_HISTORY
-} from '../content/about-history.js?revision=r163-modal-system';
+} from '../content/about-history.js?build=20260806-r161';
 
 const REVISION = 'r165-browser-about';
 const INSTALL_NOTE =


### PR DESCRIPTION
## Cause
The 1.5.2 release metadata was correctly merged, but the in-game History/Changelog loader still imported `about-history.js` using the old fixed `r163-modal-system` cache URL. Installed/browser caches could therefore keep serving the 1.5.1 metadata.

## Fix
- cache-bust the History/Changelog bootstrap from `turn/index.html`
- load `about-history.js` with the current `20260806-r161` build key

## Scope
Two URL-string changes only. No gameplay, styling, assets, progression, physics, controls or other runtime behavior changed.