### PR TITLE
Show newest TURN changelog entries first

### DIFF
--- a/turn-tests/about-history-production.mjs
+++ b/turn-tests/about-history-production.mjs
@@ -27,8 +27,8 @@ const [
   fs.readFile(new URL('../turn/design-navigation.css', import.meta.url), 'utf8')
 ]);
 
-assert.match(productionEntry, /about-history-bootstrap-r165\.js\?revision=r165-browser-about/,
-  'The public website must load the browser-aware About implementation directly');
+assert.match(productionEntry, /about-history-bootstrap-r165\.js\?build=20260806-r161-r167-changelog-order/,
+  'The public website must load the newest-first browser-aware About implementation directly');
 assert.ok(
   productionEntry.indexOf('about-history-bootstrap-r165.js') < productionEntry.indexOf('./app.js?build='),
   'Website About must load before the game module waits for explicit browser launch'
@@ -45,6 +45,8 @@ assert.match(productionEntry, /id="installTurnButton"[\s\S]*id="installNote"[\s\
 assert.match(productionEntry, /Install TURN as a home screen web app for the best fullscreen experience\. You can also play here, but it is not recommended\./);
 
 assert.match(bootstrap, /CHANGELOG[\s\S]*CURRENT_RELEASE[\s\S]*DEVELOPMENT_HISTORY/);
+assert.match(bootstrap, /return \[\.\.\.CHANGELOG\]\.reverse\(\)\.map\(/,
+  'The changelog must render newest entries first without mutating its source data');
 assert.match(bootstrap, /const INSTALL_NOTE[\s\S]*Install TURN as a home screen web app for the best fullscreen experience\. You can also play here, but it is not recommended\./);
 assert.match(bootstrap, /function installWebsiteAbout\(\)/);
 assert.match(bootstrap, /id = 'installAboutButton'/);

--- a/turn/index.html
+++ b/turn/index.html
@@ -183,7 +183,7 @@
   </div>
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
-  <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260806-r161-release-meta"></script>
+  <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260806-r161-r167-changelog-order"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
   <script type="module" src="./app.js?build=20260806-r161-browser-consent-r176-bella-road-derived-zone"></script>
   <script type="module" src="./tracks/countryside-bella-rescue-hotfix-r176.js?revision=r176-video-proven-rescue"></script>

--- a/turn/ui/about-history-bootstrap-r165.js
+++ b/turn/ui/about-history-bootstrap-r165.js
@@ -68,7 +68,7 @@ function historyMarkup() {
 }
 
 function changelogMarkup() {
-  return CHANGELOG.map((release) => `
+  return [...CHANGELOG].reverse().map((release) => `
     <article class="turn-changelog-release">
       <time>${escapeMarkup(release.date)}</time>
       <h3>${escapeMarkup(release.entries[0]?.[0] || release.date)}</h3>


### PR DESCRIPTION
## What changed
- render the changelog newest-first while preserving the source history order
- refresh the production module cache key so installed/browser copies receive the change
- add a regression assertion for newest-first rendering

## Scope
No gameplay, styling, assets, progression, physics, controls, audio, tracks, or release metadata changed.