### PR TITLE
Harden TURN NEXT Race My Ghost follow-up

### DIFF
--- a/.github/workflows/turn-challenge-tests.yml
+++ b/.github/workflows/turn-challenge-tests.yml
@@ -1,0 +1,45 @@
+name: TURN challenge regression
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'turn-next/**'
+      - 'turn-tests/challenge-*.mjs'
+      - '.github/workflows/turn-challenge-tests.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'turn-next/**'
+      - 'turn-tests/challenge-*.mjs'
+      - '.github/workflows/turn-challenge-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  challenge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Syntax-check challenge modules
+        run: find turn-next -maxdepth 1 -type f -name 'challenge-*.js' -print0 | xargs -0 -n1 node --check
+
+      - name: Run Race My Ghost contract
+        run: node turn-tests/challenge-mode-production.mjs
+
+      - name: Run challenge dialog state-safety regression
+        run: node turn-tests/challenge-dialog-state-production.mjs
+
+      - name: Verify TURN NEXT parity wrapper
+        run: node turn-next/scripts/build-parity-app.mjs --check

--- a/turn-next/challenge-ui.js
+++ b/turn-next/challenge-ui.js
@@ -28,6 +28,9 @@ export function createChallengeUi() {
         <div class="turn-challenge-actions"></div>
       </article>`;
     document.body.appendChild(modal);
+    modal.addEventListener('cancel', (event) => {
+      if (document.body.classList.contains('turn-challenge-active')) event.preventDefault();
+    });
     return modal;
   }
 

--- a/turn-tests/challenge-dialog-state-production.mjs
+++ b/turn-tests/challenge-dialog-state-production.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const [uiSource, sessionSource, sharingSource] = await Promise.all([
+  fs.readFile(new URL('../turn-next/challenge-ui.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn-next/challenge-session.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn-next/challenge-sharing.js', import.meta.url), 'utf8')
+]);
+
+assert.match(
+  uiSource,
+  /modal\.addEventListener\('cancel',[\s\S]*turn-challenge-active[\s\S]*event\.preventDefault\(\)/,
+  'Escape must not dismiss a state-critical modal while a ghost challenge is active'
+);
+
+assert.ok(
+  sessionSource.indexOf("document.body.classList.add('turn-challenge-active', 'turn-challenge-preview')")
+    < sessionSource.indexOf('showChallengeModal();'),
+  'The challenge must become state-protected before its invitation dialog is shown'
+);
+
+assert.match(
+  sharingSource,
+  /title: 'CHALLENGE A FRIEND'/,
+  'Ordinary share dialogs must continue to use the same dialog UI outside active challenge state'
+);
+
+console.log('TURN NEXT challenge dialog state-safety regression passed.');


### PR DESCRIPTION
## Why
PR #359 merged the Race My Ghost prototype, but its Codex review did not run because the review quota was exhausted, and GitHub did not create a TURN regression workflow run for that PR.

A manual review found one concrete state-safety issue: native `<dialog>` can be dismissed with Escape. During an active challenge that can close the invitation/result/give-up modal while Home and race controls are intentionally hidden, leaving the challenge in an inaccessible intermediate state.

## Changes
- prevent native dialog cancellation only while `turn-challenge-active` is present
- keep ordinary non-challenge share dialogs dismissible with Escape
- add a focused regression for the dialog state boundary
- add a focused TURN challenge GitHub Actions workflow with `workflow_dispatch`, PR, and main-push triggers
- run the existing Race My Ghost contract and TURN NEXT parity wrapper in that workflow

## Scope
TURN NEXT and tests/workflow only. Production `turn/**` is unchanged.
