### PR TITLE
Build standalone YOUR TURN recipient app

### DIFF
--- a/.github/workflows/turn-challenge-tests.yml
+++ b/.github/workflows/turn-challenge-tests.yml
@@ -7,14 +7,18 @@ on:
       - main
     paths:
       - 'turn-next/**'
+      - 'yourturn/**'
       - 'turn-tests/challenge-*.mjs'
+      - 'turn-tests/yourturn-production.mjs'
       - '.github/workflows/turn-challenge-tests.yml'
   push:
     branches:
       - main
     paths:
       - 'turn-next/**'
+      - 'yourturn/**'
       - 'turn-tests/challenge-*.mjs'
+      - 'turn-tests/yourturn-production.mjs'
       - '.github/workflows/turn-challenge-tests.yml'
 
 permissions:
@@ -33,13 +37,16 @@ jobs:
           node-version: '24'
 
       - name: Syntax-check challenge modules
-        run: find turn-next -maxdepth 1 -type f -name 'challenge-*.js' -print0 | xargs -0 -n1 node --check
+        run: find turn-next yourturn -maxdepth 1 -type f -name '*.js' -print0 | xargs -0 -n1 node --check
 
       - name: Run Race My Ghost contract
         run: node turn-tests/challenge-mode-production.mjs
 
       - name: Run challenge dialog state-safety regression
         run: node turn-tests/challenge-dialog-state-production.mjs
+
+      - name: Run YOUR TURN recipient contract
+        run: node turn-tests/yourturn-production.mjs
 
       - name: Verify TURN NEXT parity wrapper
         run: node turn-next/scripts/build-parity-app.mjs --check

--- a/turn-lab/tests/bella-rescue-production.mjs
+++ b/turn-lab/tests/bella-rescue-production.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
 const [
+  releaseSource,
   behavior,
   bootstrap,
   secretEvents,
@@ -11,6 +12,7 @@ const [
   homeLayout,
   index
 ] = await Promise.all([
+  fs.readFile(new URL('../../turn/release.json', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/tracks/countryside-bella-rescue-r173.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/tracks/countryside-bella-rescue-hotfix-r176.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements/secret-events.js', import.meta.url), 'utf8'),
@@ -20,6 +22,8 @@ const [
   fs.readFile(new URL('../../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8')
 ]);
+
+const release = JSON.parse(releaseSource);
 
 assert.match(behavior, /SAVE_BELLA_ID = 'save-bella'/);
 assert.match(behavior, /REQUIRED_VEHICLE_ID = 'firetruck'/);
@@ -97,9 +101,13 @@ assert.match(bootstrap, /turnBellaRescueBehaviorInstalled = false/);
 assert.match(bootstrap, /installBellaRescueBehavior\(\{ root, runtime \}\)/);
 assert.match(bootstrap, /turnBellaRescueBootstrap = 'r176-road-derived-zone'/,
   'The production bootstrap must dispose and replace any rescue timer installed by a cached world module');
-assert.match(index, /app\.js\?build=20260805-r160-browser-consent-r176-bella-road-derived-zone/,
-  'The top-level app URL must change so Safari cannot retain the old dependency graph');
+assert.match(index, new RegExp(`app\\.js\\?build=${escapeRegex(release.cacheKey)}-browser-consent-r176-bella-road-derived-zone`),
+  'The top-level app URL must use the canonical release cache key so Safari cannot retain an old dependency graph');
 assert.match(index, /countryside-bella-rescue-hotfix-r176\.js\?revision=r176-video-proven-rescue/,
   'The current rescue replacement must be loaded independently from the cached world graph');
 
 console.log('TURN Bella video-proven road-derived rescue, siren input, ground transition and cache replacement regression passed.');
+
+function escapeRegex(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/turn-tests/about-history-production.mjs
+++ b/turn-tests/about-history-production.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
 const [
+  releaseSource,
   productionEntry,
   nextEntry,
   bootstrapEntry,
@@ -14,6 +15,7 @@ const [
   designReference,
   designNavigation
 ] = await Promise.all([
+  fs.readFile(new URL('../turn/release.json', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-next/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/ui/about-history-bootstrap.js', import.meta.url), 'utf8'),
@@ -26,6 +28,8 @@ const [
   fs.readFile(new URL('../turn/design-dialogs.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/design-navigation.css', import.meta.url), 'utf8')
 ]);
+
+const release = JSON.parse(releaseSource);
 
 assert.match(productionEntry, /about-history-bootstrap-r165\.js\?build=20260806-r161-r167-changelog-order/,
   'The public website must load the newest-first browser-aware About implementation directly');
@@ -105,8 +109,12 @@ assert.match(content, /18–19 July 2026/);
 assert.match(content, /Current stabilization/);
 assert.match(content, /18 July 2026/);
 assert.match(content, /5 August/);
-assert.match(content, /TURN 1\.5\.1/);
-assert.match(content, /2026\.08\.05-r160/);
+assert.match(content, /TURN 1\.5\.1/,
+  'History must retain the previous 1.5.1 milestone');
+assert.match(content, new RegExp(`TURN ${escapeRegex(release.version)}`),
+  'History must name the canonical current release');
+assert.match(content, new RegExp(escapeRegex(release.id)),
+  'History must name the canonical current build');
 assert.match(content, /one oh one/);
 assert.match(content, /28 achievements and 1,700 available trophies/);
 assert.match(content, /SAVE BELLA!/);
@@ -168,3 +176,7 @@ assert.match(designNavigation, /\.section-nav\.design-section-nav/);
 assert.match(designNavigation, /prefers-reduced-motion: reduce/);
 
 console.log('TURN website About, history, dialog system and design-system navigation regression passed.');
+
+function escapeRegex(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/turn-tests/design-system-production.mjs
+++ b/turn-tests/design-system-production.mjs
@@ -212,15 +212,14 @@ assert.match(design, /aria-label="Design system sections"/);
 assert.match(design, /@media \(prefers-reduced-motion: reduce\)/);
 
 const releaseDefinition = JSON.parse(release);
-assert.deepEqual(releaseDefinition, {
-  version: '1.5.1',
-  id: '2026.08.05-r160',
-  cacheKey: '20260805-r160'
-});
-assert.match(index, /TURN v1\.5\.1 · Build 2026\.08\.05-r160/);
-assert.match(index, /version: '1\.5\.1'/);
-assert.match(index, /id: '2026\.08\.05-r160'/);
-assert.match(index, /cacheKey: '20260805-r160'/);
+assert.match(index, new RegExp(`TURN v${escapeRegex(releaseDefinition.version)} · Build ${escapeRegex(releaseDefinition.id)}`));
+assert.match(index, new RegExp(`version: '${escapeRegex(releaseDefinition.version)}'`));
+assert.match(index, new RegExp(`id: '${escapeRegex(releaseDefinition.id)}'`));
+assert.match(index, new RegExp(`cacheKey: '${escapeRegex(releaseDefinition.cacheKey)}'`));
 assert.match(design, /TURN V\d+\.\d+\.\d+ · BUILD \d{4}\.\d{2}\.\d{2}-R\d+/);
 
 console.log('TURN primitive palette, semantic mappings, compatibility aliases and component reference passed.');
+
+function escapeRegex(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/turn-tests/startup-and-unread-production.mjs
+++ b/turn-tests/startup-and-unread-production.mjs
@@ -11,17 +11,16 @@ const [releaseSource, index, nextIndex, app, fixedLayout, unreadMarkers] = await
 ]);
 
 const release = JSON.parse(releaseSource);
-assert.deepEqual(release, {
-  version: '1.5.1',
-  id: '2026.08.05-r160',
-  cacheKey: '20260805-r160'
-});
-assert.match(index, /TURN v1\.5\.1 · Build 2026\.08\.05-r160/);
-assert.match(index, /app\.js\?build=20260805-r160-browser-consent-r176-bella-road-derived-zone/);
+const escapedVersion = escapeRegex(release.version);
+const escapedId = escapeRegex(release.id);
+const escapedCacheKey = escapeRegex(release.cacheKey);
+
+assert.match(index, new RegExp(`TURN v${escapedVersion} · Build ${escapedId}`));
+assert.match(index, new RegExp(`app\\.js\\?build=${escapedCacheKey}-browser-consent-r176-bella-road-derived-zone`));
 assert.match(index, /countryside-bella-rescue-hotfix-r176\.js\?revision=r176-video-proven-rescue/,
   'The canonical startup document must replace cached Bella rescue behavior independently');
-assert.match(nextIndex, /TURN NEXT · Source TURN v1\.5\.1 · Build 2026\.08\.05-r160/);
-assert.match(nextIndex, /turn-next\/app\.js\?source=20260805-r160-browser-consent-r166-bella-records/);
+assert.match(nextIndex, new RegExp(`TURN NEXT · Source TURN v${escapedVersion} · Build ${escapedId}`));
+assert.match(nextIndex, new RegExp(`turn-next\\/app\\.js\\?source=${escapedCacheKey}-browser-consent-r166-bella-records`));
 
 assert.match(app, /function installStartupCover\(\)/);
 assert.match(app, /copy\.textContent = 'Loading TURN'/);
@@ -49,4 +48,8 @@ assert.match(unreadMarkers, /Newly unlocked achievement\./);
 assert.match(unreadMarkers, /new MutationObserver\(queueDecoration\)/);
 assert.match(unreadMarkers, /listObserver\.observe\(list, \{ childList: true \}\)/);
 
-console.log('TURN 1.5.1 startup cover, refreshed Bella graph, fixed Home viewport, spoken training labels and unread achievement markers passed.');
+console.log(`TURN ${release.version} startup cover, refreshed Bella graph, fixed Home viewport, spoken training labels and unread achievement markers passed.`);
+
+function escapeRegex(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/turn-tests/yourturn-production.mjs
+++ b/turn-tests/yourturn-production.mjs
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import {
+  challengeFromLap,
+  decodeChallenge,
+  encodeChallenge,
+  makeChallengeUrl,
+  makeMockChallengeUrl
+} from '../yourturn/protocol.js';
+
+const [
+  indexSource,
+  appSource,
+  sessionSource,
+  sceneSource,
+  uiSource,
+  cssSource,
+  storageSource,
+  mockSource,
+  productionApp
+] = await Promise.all([
+  fs.readFile(new URL('../yourturn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/app.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/session.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/scene.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/ui.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/yourturn.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/storage-bootstrap.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/mock-challenges.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8')
+]);
+
+assert.match(indexSource, /<title>YOUR TURN<\/title>/);
+assert.match(indexSource, /\/yourturn\/storage-bootstrap\.js/);
+assert.match(indexSource, /\/yourturn\/app\.js/);
+assert.match(indexSource, /id="yourTurnPauseButton"/);
+assert.match(indexSource, /id="yourTurnRotate"/);
+assert.match(indexSource, /ROTATE YOUR DEVICE TO LANDSCAPE/);
+assert.doesNotMatch(indexSource, /manifest|install-gate/i,
+  'YOUR TURN must remain a browser-first challenge app rather than a PWA install gate');
+
+assert.match(appSource, /await import\(withBuild\('\/turn\/main\.js'\)\)/,
+  'YOUR TURN must reuse the canonical TURN race runtime');
+assert.doesNotMatch(appSource, /\/turn\/app\.js|m8-home|installM8HomeNavigation/,
+  'YOUR TURN must not bootstrap the full TURN Home application');
+assert.match(appSource, /installAnimationPauseBridge/);
+assert.match(appSource, /nativeSetAnimationLoop\.call\(renderer, null\)/,
+  'Pause must stop the rendering/physics loop rather than merely reducing motion');
+assert.match(appSource, /installScreenBlanking/,
+  'The non-visual screen blanking affordance must remain available');
+assert.match(appSource, /installRaceSpeech/,
+  'Screen-reader race announcements must be included');
+
+assert.match(sessionSource, /prepareMotionAccess\(\)/,
+  'Accept must request motion steering first');
+assert.ok(
+  sessionSource.indexOf('prepareMotionAccess()') < sessionSource.indexOf('awaitLandscapeAndStart()'),
+  'Motion permission must happen before the landscape transition'
+);
+assert.match(sessionSource, /ui\.showRotate\(\)/);
+assert.match(sessionSource, /prepareManualAccess\(\)/,
+  'On-screen steering must remain an explicit fallback');
+assert.match(sessionSource, /label: 'TRY LATER'/);
+assert.match(sessionSource, /globalThis\.location\.href = '\/turn\/'/);
+assert.match(sessionSource, /label: 'ABOUT TURN'/);
+assert.match(sessionSource, /label: 'GET FULL TURN'/);
+assert.match(sessionSource, /label: 'PAUSE'|titleText: 'PAUSED'/);
+assert.match(sessionSource, /navigator\.share/);
+assert.match(sessionSource, /navigator\.clipboard/);
+assert.doesNotMatch(sessionSource, /ghost/i,
+  'YOUR TURN recipient copy and challenge layer must describe the challenger’s car, not a ghost');
+
+assert.match(uiSource, /YOUR TURN/);
+assert.match(uiSource, /rotate your phone like a steering wheel/i);
+assert.match(uiSource, /spatial audio/i);
+assert.match(uiSource, /screen-reader and non-visual play/i);
+assert.match(uiSource, /visually-hidden/);
+assert.doesNotMatch(uiSource, /ghost/i);
+
+assert.match(sceneSource, /PREVIEW_START_DELAY_MS = 650/,
+  'Opponent preview movement must not begin as an uncanny instant imitation');
+assert.match(sceneSource, /STAGED_IMITATION_DELAY_MS = 650/);
+assert.match(sceneSource, /prefers-reduced-motion/);
+
+assert.match(cssSource, /background: rgb\(255 248 232 \/ 0\.9\)/,
+  'Portrait invitation card must be slightly translucent so the challenger car remains perceptible');
+assert.match(cssSource, /\.yourturn-pause-button[\s\S]*#ff9b66/,
+  'The explicit Pause control must use the navigation/back orange');
+assert.match(cssSource, /@media \(orientation: portrait\)/);
+assert.match(cssSource, /@media \(max-height: 560px\) and \(orientation: landscape\)/,
+  'Small in-app browser viewports need a dedicated compact landscape layout');
+
+assert.match(storageSource, /const LOCAL_PREFIX = 'yourturn:';/);
+assert.match(storageSource, /turn production TURN records|TURN records/i);
+assert.match(mockSource, /'sol-countryside-r1'/);
+assert.match(mockSource, /time: 13\.5/);
+
+assert.match(productionApp, /installM8HomeNavigation\(\)/,
+  'Production TURN remains the full application and is not replaced by YOUR TURN');
+
+const frames = Array.from({ length: 900 }, (_, index) => ({
+  t: 42 * index / 899,
+  x: index * 0.08,
+  z: index * 0.04,
+  h: index * 0.001,
+  s: 0,
+  d: 0,
+  p: index / 899
+}));
+const challenge = challengeFromLap({
+  challengerName: 'Erik',
+  trackId: 'countryside',
+  trackRevision: 'countryside',
+  trackName: 'Countryside',
+  lap: {
+    time: 42,
+    carId: 'sedan-sports',
+    carColor: '#ff4fa3',
+    carSecondaryColor: '#252a35',
+    frames
+  }
+});
+assert.ok(challenge.frames.length <= 450);
+const encoded = await encodeChallenge(challenge);
+const decoded = await decodeChallenge(encoded);
+assert.equal(decoded.challengerName, 'Erik');
+assert.equal(decoded.trackId, 'countryside');
+assert.equal(decoded.time, 42);
+assert.match(makeChallengeUrl(encoded), /^https:\/\/enkel\.design\/yourturn\/#challenge=/);
+assert.equal(
+  makeMockChallengeUrl('sol-countryside-r1'),
+  'https://enkel.design/yourturn/?challenge=sol-countryside-r1'
+);
+
+console.log('YOUR TURN standalone recipient, motion-first flow, pause, accessibility and protocol regression passed.');

--- a/yourturn/app.js
+++ b/yourturn/app.js
@@ -1,0 +1,150 @@
+import * as THREE from 'three';
+import { createYourTurnUi, escapeHtml } from '/yourturn/ui.js?revision=r1';
+import { createYourTurnSession, readYourTurnRequest } from '/yourturn/session.js?revision=r1';
+
+if (globalThis.__YOUR_TURN_STORAGE_READY__ === false) {
+  throw new Error('YOUR TURN storage isolation failed before startup.');
+}
+
+const animation = installAnimationPauseBridge(THREE);
+const release = await loadTurnRelease();
+globalThis.__TURN_BUILD__ = Object.freeze(release);
+document.documentElement.dataset.yourTurnRuntime = 'recipient-r1';
+
+function withBuild(path) {
+  const url = new URL(path, globalThis.location?.href || 'https://enkel.design/yourturn/');
+  if (release.cacheKey) url.searchParams.set('build', `${release.cacheKey}-yourturn-r1`);
+  return url.href;
+}
+
+const { createWebPlatform } = await import(withBuild('/turn/platform/web-platform.js'));
+const { installTurnPlatform } = await import(withBuild('/turn/platform/platform-context.js'));
+const { installMotionLifecycleBridge } = await import(withBuild('/turn/motion-lifecycle-bridge.js'));
+const { installDisplayLifecycleBridge } = await import(withBuild('/turn/display-lifecycle-bridge.js'));
+const webPlatform = createWebPlatform();
+installTurnPlatform(webPlatform);
+globalThis.__turnMotionLifecycle = installMotionLifecycleBridge({ platform: webPlatform });
+globalThis.__turnDisplayLifecycle = installDisplayLifecycleBridge({ platform: webPlatform });
+
+document.documentElement.dataset.turnPlatform = 'web-adapter';
+
+const { installPerformanceProfile } = await import(withBuild('/turn/performance-profile.js'));
+installPerformanceProfile();
+const { installCoveredRenderingGuard } = await import(withBuild('/turn/render/covered-rendering.js'));
+installCoveredRenderingGuard();
+
+const { installDriveByEarSetting } = await import(withBuild('/turn/ui/drive-by-ear-setting.js'));
+const driveByEarEnabled = installDriveByEarSetting();
+const {
+  prepareDriveByEarRuntime,
+  ensureDriveByEarRuntime
+} = await import(withBuild('/turn/audio/drive-by-ear-runtime.js?revision=r143-temporary-audio-only'));
+await prepareDriveByEarRuntime();
+globalThis.__turnDriveByEarEnabled = driveByEarEnabled !== false;
+
+const { installAudioPreferences } = await import(withBuild('/turn/audio/audio-preferences.js'));
+const audioPreferences = installAudioPreferences({ driveByEarGraphAvailable: driveByEarEnabled });
+const { installTurnAudio } = await import(withBuild('/turn/audio/audio-system.js'));
+installTurnAudio();
+audioPreferences.setDriveByEarEnabled(driveByEarEnabled !== false);
+
+globalThis.__turnEnsureDriveByEarRuntime = ensureDriveByEarRuntime;
+if (driveByEarEnabled !== false) await ensureDriveByEarRuntime();
+const { installAudioPreferenceRuntime } = await import(withBuild('/turn/audio/audio-preference-runtime.js'));
+installAudioPreferenceRuntime();
+
+const { installSteeringLimitWarning } = await import(withBuild('/turn/ui/steering-limit-warning.js'));
+installSteeringLimitWarning();
+
+await import(withBuild('/turn/input/analog-gas.js'));
+await import(withBuild('/turn/ui/gameplay-controls.js'));
+const { installRaceSpeech } = await import(withBuild('/turn/ui/race-speech.js'));
+installRaceSpeech();
+const { installRacePositionLayout } = await import(withBuild('/turn/ui/race-position-layout.js'));
+installRacePositionLayout();
+const { installLapResultToast } = await import(withBuild('/turn/ui/lap-result-toast.js'));
+installLapResultToast();
+
+await import(withBuild('/turn/main.js'));
+const runtime = globalThis.__turnRuntime;
+const raceSession = globalThis.__turnNextRaceSession;
+if (!runtime || !raceSession) throw new Error('TURN racing runtime did not become available.');
+
+globalThis.__turnRaceSession = raceSession;
+const { installWideGamutRuntime } = await import(withBuild('/turn/vehicle/wide-gamut.js?revision=r157-display-p3'));
+installWideGamutRuntime(runtime);
+await import(withBuild('/turn/render/world.js?revision=r175-bella-broad-rear-zone'));
+
+const { installScreenBlanking } = await import(withBuild('/turn/ui/screen-blanking.js?revision=r143-temporary-dbe-position'));
+installScreenBlanking(runtime);
+
+const ui = createYourTurnUi();
+const request = readYourTurnRequest();
+const session = createYourTurnSession({ runtime, raceSession, ui, animation, request });
+globalThis.__yourTurnSession = session;
+
+try {
+  await session.launch();
+} catch (error) {
+  console.error('YOUR TURN could not open the challenge.', error);
+  document.body.classList.add('yourturn-active');
+  ui.hideRaceChrome();
+  ui.hideRotate();
+  ui.showModal({
+    titleText: 'CHALLENGE UNAVAILABLE',
+    copyHtml: escapeHtml(error instanceof Error ? error.message : 'This challenge could not be opened.'),
+    className: 'error',
+    actionList: [
+      { label: 'TRY A MOCK CHALLENGE', primary: true, action: () => { globalThis.location.href = '/yourturn/'; } },
+      { label: 'OPEN TURN', navigation: true, action: () => { globalThis.location.href = '/turn/'; } }
+    ]
+  });
+}
+
+async function loadTurnRelease() {
+  try {
+    const response = await fetch('/turn/release.json', { cache: 'no-store' });
+    if (!response.ok) throw new Error(`TURN release metadata returned ${response.status}.`);
+    const value = await response.json();
+    if (!value?.version || !value?.id || !value?.cacheKey) throw new Error('TURN release metadata is incomplete.');
+    return value;
+  } catch (error) {
+    console.warn('YOUR TURN: using bundled TURN release fallback.', error);
+    return {
+      version: '1.5.2',
+      id: '2026.08.06-r161',
+      cacheKey: '20260806-r161'
+    };
+  }
+}
+
+function installAnimationPauseBridge(three) {
+  const prototype = three.WebGLRenderer.prototype;
+  const nativeSetAnimationLoop = prototype.setAnimationLoop;
+  let renderer = null;
+  let loop = null;
+  let paused = false;
+
+  prototype.setAnimationLoop = function setAnimationLoop(callback) {
+    renderer = this;
+    if (typeof callback === 'function') loop = callback;
+    if (callback === null) loop = null;
+    return nativeSetAnimationLoop.call(this, paused ? null : callback);
+  };
+
+  return Object.freeze({
+    pause() {
+      paused = true;
+      if (renderer) nativeSetAnimationLoop.call(renderer, null);
+    },
+    resume() {
+      if (!paused && renderer && loop) {
+        nativeSetAnimationLoop.call(renderer, loop);
+        return;
+      }
+      paused = false;
+      if (renderer && loop) nativeSetAnimationLoop.call(renderer, loop);
+    },
+    isPaused: () => paused
+  });
+}

--- a/yourturn/app.js
+++ b/yourturn/app.js
@@ -25,7 +25,6 @@ const webPlatform = createWebPlatform();
 installTurnPlatform(webPlatform);
 globalThis.__turnMotionLifecycle = installMotionLifecycleBridge({ platform: webPlatform });
 globalThis.__turnDisplayLifecycle = installDisplayLifecycleBridge({ platform: webPlatform });
-
 document.documentElement.dataset.turnPlatform = 'web-adapter';
 
 const { installPerformanceProfile } = await import(withBuild('/turn/performance-profile.js'));
@@ -82,6 +81,7 @@ const ui = createYourTurnUi();
 const request = readYourTurnRequest();
 const session = createYourTurnSession({ runtime, raceSession, ui, animation, request });
 globalThis.__yourTurnSession = session;
+document.querySelector('#yourTurnLoading')?.setAttribute('hidden', '');
 
 try {
   await session.launch();

--- a/yourturn/index.html
+++ b/yourturn/index.html
@@ -1,0 +1,130 @@
+<!doctype html>
+<html lang="en" data-turn-deployment="yourturn">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="theme-color" content="#38d9ff">
+  <meta name="application-name" content="YOUR TURN">
+  <meta name="description" content="A YOUR TURN racing challenge, powered by TURN.">
+  <link rel="canonical" href="https://enkel.design/yourturn/">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="YOUR TURN">
+  <meta property="og:title" content="YOUR TURN — a TURN challenge">
+  <meta property="og:description" content="Someone challenged you. Your turn.">
+  <meta property="og:url" content="https://enkel.design/yourturn/">
+  <meta property="og:image" content="https://enkel.design/turn/turn-og-r58.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="YOUR TURN — a TURN challenge">
+  <meta name="twitter:description" content="Someone challenged you. Your turn.">
+  <meta name="twitter:image" content="https://enkel.design/turn/turn-og-r58.jpg">
+  <title>YOUR TURN</title>
+  <link rel="icon" href="/turn/TURNicon.PNG?icon=20260803-profile-512" type="image/png">
+
+  <link rel="stylesheet" href="/turn/styles.css?source=yourturn-r1">
+  <link rel="stylesheet" href="/turn/vertical-drive.css?source=yourturn-r1">
+  <link rel="stylesheet" href="/turn/hud-tuning.css?source=yourturn-r1">
+  <link rel="stylesheet" href="/turn/gameplay-features.css?source=yourturn-r1">
+  <link rel="stylesheet" href="/turn/gameplay-v2.css?source=yourturn-r1">
+  <link rel="stylesheet" href="/turn/position-hud-r83.css?source=yourturn-r1">
+  <link rel="stylesheet" href="/turn/drive-pad.css?source=yourturn-r1">
+  <link rel="stylesheet" href="/turn/manual-steering.css?source=yourturn-r1">
+  <link rel="stylesheet" href="/turn/steering-limit-warning.css?source=yourturn-r1">
+  <link rel="stylesheet" href="/turn/lap-result-toast.css?source=yourturn-r1">
+  <link rel="stylesheet" href="/turn/r104-polish.css?source=yourturn-r1">
+  <link rel="stylesheet" href="/yourturn/yourturn.css?revision=r1">
+
+  <script src="/yourturn/storage-bootstrap.js?revision=r1"></script>
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
+        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/"
+      }
+    }
+  </script>
+</head>
+<body class="yourturn">
+  <div id="game" aria-label="YOUR TURN racing challenge"></div>
+
+  <section class="panel" id="intro" hidden aria-hidden="true">
+    <button id="motionButton" type="button" hidden></button>
+    <button id="manualButton" type="button" hidden></button>
+    <p id="status" role="status" hidden></p>
+  </section>
+
+  <div class="hud" id="hud" hidden>
+    <div class="topbar">
+      <div class="stats">
+        <div class="chip speed-chip">speed<strong><span id="speed">0</span> km/h</strong></div>
+        <div class="chip lap-chip">lap<strong id="lap">1</strong></div>
+        <div class="chip time-chip">time<strong id="lapTime">0:00.000</strong></div>
+        <div class="chip best-chip">best<strong id="bestTime">--:--.---</strong></div>
+        <div class="chip yourturn-target-chip" id="yourTurnTargetChip" hidden>
+          <span>YOUR TURN</span>
+          <strong>BEAT <b id="yourTurnTargetOpponent"></b> · <span id="yourTurnTargetTime"></span></strong>
+        </div>
+      </div>
+      <div class="map-wrap"><canvas id="map" width="300" height="210" aria-label="Track map"></canvas></div>
+    </div>
+    <div class="message" id="message" role="status"></div>
+    <div class="tilt-drive" aria-hidden="true">
+      <span><b>brake</b><b>gas</b></span>
+      <div class="tilt-track"><i class="tilt-needle" id="tiltNeedle"></i></div>
+      <small class="tilt-value" id="tiltValue">neutral</small>
+    </div>
+  </div>
+
+  <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden>
+    <span class="manual-steer-knob" aria-hidden="true"></span>
+  </div>
+
+  <div class="controls" id="controls" hidden>
+    <div class="utility-group">
+      <button class="utility yourturn-pause-button" id="yourTurnPauseButton" type="button" hidden>PAUSE</button>
+      <button class="utility" id="calibrateButton" type="button">Recalibrate</button>
+      <button class="utility" id="resetButton" type="button">Restart Lap</button>
+    </div>
+    <div class="pedals">
+      <button class="pedal brake" id="brakeButton" type="button">Brake</button>
+      <button class="pedal gas" id="gasButton" type="button">Gas</button>
+    </div>
+  </div>
+
+  <section class="yourturn-rotate" id="yourTurnRotate" aria-labelledby="yourTurnRotateTitle" hidden>
+    <div class="yourturn-rotate-card">
+      <div class="yourturn-phone" aria-hidden="true"></div>
+      <strong id="yourTurnRotateTitle" tabindex="-1">ROTATE YOUR DEVICE TO LANDSCAPE</strong>
+      <p>Keep the phone comfortably level. The race will start when you turn it.</p>
+    </div>
+  </section>
+
+  <dialog class="yourturn-dialog" id="yourTurnDialog" aria-labelledby="yourTurnTitle">
+    <article class="yourturn-card">
+      <header class="yourturn-card-head">
+        <img src="/turn/TURNicon.PNG?icon=20260803-profile-512" alt="" aria-hidden="true">
+        <div>
+          <span class="yourturn-kicker">YOUR TURN</span>
+          <h1 id="yourTurnTitle"></h1>
+        </div>
+      </header>
+      <div class="yourturn-details"></div>
+      <p class="yourturn-copy"></p>
+      <div class="yourturn-extra"></div>
+      <label class="yourturn-name-field" hidden>
+        <span>Your name in the reply</span>
+        <input type="text" maxlength="24" autocomplete="nickname">
+      </label>
+      <p class="yourturn-dialog-status" role="status" aria-live="polite"></p>
+      <div class="yourturn-actions"></div>
+    </article>
+  </dialog>
+
+  <div class="yourturn-loading" id="yourTurnLoading" role="status" aria-live="polite">
+    <img src="/turn/TURNicon.PNG?icon=20260803-profile-512" alt="">
+    <strong>YOUR TURN</strong>
+    <span>Loading challenge…</span>
+  </div>
+
+  <script type="module" src="/yourturn/app.js?revision=r1"></script>
+</body>
+</html>

--- a/yourturn/mock-challenges.js
+++ b/yourturn/mock-challenges.js
@@ -1,0 +1,36 @@
+export const MOCK_CHALLENGES = Object.freeze({
+  'sol-countryside-r1': Object.freeze({
+    id: 'sol-countryside-r1',
+    challengerName: 'SOL',
+    trackId: 'countryside',
+    time: 13.5,
+    carId: 'sedan-sports',
+    carColor: '#ff4fa3',
+    carSecondaryColor: '#252a35',
+    label: 'SOL · Countryside · 0:13.500'
+  }),
+  'sol-countryside-friendly': Object.freeze({
+    id: 'sol-countryside-friendly',
+    challengerName: 'SOL',
+    trackId: 'countryside',
+    time: 18.75,
+    carId: 'sedan-sports',
+    carColor: '#ff4fa3',
+    carSecondaryColor: '#252a35',
+    label: 'SOL · Countryside · 0:18.750'
+  }),
+  'alex-countryside-r1': Object.freeze({
+    id: 'alex-countryside-r1',
+    challengerName: 'ALEX',
+    trackId: 'countryside',
+    time: 16.25,
+    carId: 'sedan',
+    carColor: '#38d9ff',
+    carSecondaryColor: '#fff8e8',
+    label: 'ALEX · Countryside · 0:16.250'
+  })
+});
+
+export function getMockChallenge(id) {
+  return MOCK_CHALLENGES[String(id || '')] || null;
+}

--- a/yourturn/protocol.js
+++ b/yourturn/protocol.js
@@ -1,0 +1,336 @@
+const CHALLENGE_SCHEMA_VERSION = 1;
+const WIRE_VERSION = 1;
+const HASH_KEY = 'challenge';
+const MAX_NAME_LENGTH = 24;
+const MAX_FRAMES = 450;
+const MIN_FRAMES = 21;
+const TIME_SCALE = 1000;
+const POSITION_SCALE = 100;
+const HEADING_SCALE = 10000;
+const CONTROL_SCALE = 1000;
+const PROGRESS_SCALE = 1000000;
+
+export function formatChallengeTime(seconds) {
+  if (!Number.isFinite(seconds)) return '--:--.---';
+  const minutes = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60).toString().padStart(2, '0');
+  const ms = Math.floor((seconds % 1) * 1000).toString().padStart(3, '0');
+  return `${minutes}:${secs}.${ms}`;
+}
+
+export function normalizeChallengeName(value, fallback = 'A TURN PLAYER') {
+  const clean = String(value || '')
+    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, MAX_NAME_LENGTH);
+  return clean || fallback;
+}
+
+export function challengeFromLap({
+  challengerName,
+  trackId,
+  trackRevision,
+  trackName,
+  lap,
+  replyTo = null
+}) {
+  const time = Number(lap?.time);
+  const frames = downsampleFrames(lap?.frames);
+  if (!Number.isFinite(time) || time <= 5 || frames.length < MIN_FRAMES) {
+    throw new Error('YOUR TURN can only share a complete valid lap.');
+  }
+
+  return normalizeChallenge({
+    v: CHALLENGE_SCHEMA_VERSION,
+    challengerName,
+    trackId,
+    trackRevision,
+    trackName,
+    time,
+    carId: lap.carId,
+    carColor: lap.carColor,
+    carSecondaryColor: lap.carSecondaryColor,
+    frames,
+    replyTo
+  });
+}
+
+export function normalizeChallenge(value) {
+  const source = value && typeof value === 'object' ? value : {};
+  const time = Number(source.time);
+  const frames = downsampleFrames(source.frames);
+  const trackId = String(source.trackId || '').trim();
+  const carId = String(source.carId || '').trim();
+
+  if (Number(source.v) !== CHALLENGE_SCHEMA_VERSION) {
+    throw new Error('This challenge uses an unsupported replay version.');
+  }
+  if (!trackId || !carId || !Number.isFinite(time) || time <= 5 || frames.length < MIN_FRAMES) {
+    throw new Error('This challenge is incomplete or damaged.');
+  }
+
+  return Object.freeze({
+    v: CHALLENGE_SCHEMA_VERSION,
+    challengerName: normalizeChallengeName(source.challengerName),
+    trackId,
+    trackRevision: String(source.trackRevision || ''),
+    trackName: String(source.trackName || '').trim(),
+    time,
+    carId,
+    carColor: normalizeHex(source.carColor, '#ffcc00'),
+    carSecondaryColor: normalizeHex(source.carSecondaryColor, '#f8f9fa'),
+    frames,
+    replyTo: normalizeReply(source.replyTo)
+  });
+}
+
+export async function encodeChallenge(challenge) {
+  const normalized = normalizeChallenge(challenge);
+  const json = JSON.stringify(toWireChallenge(normalized));
+  const bytes = new TextEncoder().encode(json);
+
+  if (typeof CompressionStream === 'function') {
+    try {
+      const compressed = await streamBytes(bytes, new CompressionStream('gzip'));
+      return `gz.${bytesToBase64Url(compressed)}`;
+    } catch (_) {}
+  }
+
+  return `raw.${bytesToBase64Url(bytes)}`;
+}
+
+export async function decodeChallenge(encoded) {
+  const value = String(encoded || '').trim();
+  const separator = value.indexOf('.');
+  if (separator <= 0) throw new Error('This challenge link is incomplete.');
+
+  const encoding = value.slice(0, separator);
+  let bytes = base64UrlToBytes(value.slice(separator + 1));
+
+  if (encoding === 'gz') {
+    if (typeof DecompressionStream !== 'function') {
+      throw new Error('This browser cannot unpack this challenge. Open the link in a current Safari, Chrome, Edge or Firefox.');
+    }
+    bytes = await streamBytes(bytes, new DecompressionStream('gzip'));
+  } else if (encoding !== 'raw') {
+    throw new Error('This challenge link uses an unknown encoding.');
+  }
+
+  const parsed = JSON.parse(new TextDecoder().decode(bytes));
+  return normalizeChallenge(parsed?.w === WIRE_VERSION ? fromWireChallenge(parsed) : parsed);
+}
+
+export function encodedChallengeFromLocation(locationRef = globalThis.location) {
+  const hash = String(locationRef?.hash || '').replace(/^#/, '');
+  return new URLSearchParams(hash).get(HASH_KEY) || '';
+}
+
+export function makeChallengeUrl(encoded, {
+  baseUrl = 'https://enkel.design/yourturn/',
+  reply = '',
+  responder = ''
+} = {}) {
+  const url = new URL(baseUrl);
+  if (reply) url.searchParams.set('reply', reply);
+  if (responder) url.searchParams.set('responder', normalizeChallengeName(responder));
+  const params = new URLSearchParams();
+  params.set(HASH_KEY, encoded);
+  url.hash = params.toString();
+  return url.href;
+}
+
+export function makeMockChallengeUrl(challengeId, {
+  baseUrl = 'https://enkel.design/yourturn/',
+  reply = '',
+  responder = ''
+} = {}) {
+  const url = new URL(baseUrl);
+  url.searchParams.set('challenge', String(challengeId || ''));
+  if (reply) url.searchParams.set('reply', reply);
+  if (responder) url.searchParams.set('responder', normalizeChallengeName(responder));
+  return url.href;
+}
+
+function toWireChallenge(challenge) {
+  let previous = null;
+  const frames = challenge.frames.map((frame) => {
+    const current = [
+      quantize(frame.t, TIME_SCALE),
+      quantize(frame.x, POSITION_SCALE),
+      quantize(frame.z, POSITION_SCALE),
+      quantize(frame.h, HEADING_SCALE),
+      quantize(frame.s, CONTROL_SCALE),
+      quantize(frame.d, CONTROL_SCALE),
+      quantize(frame.p ?? 0, PROGRESS_SCALE)
+    ];
+    const row = previous
+      ? [
+        current[0] - previous[0],
+        current[1] - previous[1],
+        current[2] - previous[2],
+        current[3],
+        current[4],
+        current[5],
+        current[6] - previous[6]
+      ]
+      : current;
+    previous = current;
+    return row;
+  });
+
+  return {
+    w: WIRE_VERSION,
+    v: challenge.v,
+    n: challenge.challengerName,
+    ti: challenge.trackId,
+    tr: challenge.trackRevision,
+    tn: challenge.trackName,
+    tm: quantize(challenge.time, TIME_SCALE),
+    c: challenge.carId,
+    pc: challenge.carColor,
+    sc: challenge.carSecondaryColor,
+    f: frames,
+    r: challenge.replyTo ? [
+      challenge.replyTo.kind === 'win' ? 'w' : 'g',
+      challenge.replyTo.opponent,
+      Number.isFinite(challenge.replyTo.previousTime)
+        ? quantize(challenge.replyTo.previousTime, TIME_SCALE)
+        : null
+    ] : null
+  };
+}
+
+function fromWireChallenge(wire) {
+  let previous = null;
+  const frames = Array.isArray(wire.f) ? wire.f.map((row, index) => {
+    if (!Array.isArray(row) || row.length < 7) return null;
+    const current = index === 0
+      ? row.map((value) => integer(value))
+      : [
+        previous[0] + integer(row[0]),
+        previous[1] + integer(row[1]),
+        previous[2] + integer(row[2]),
+        integer(row[3]),
+        integer(row[4]),
+        integer(row[5]),
+        previous[6] + integer(row[6])
+      ];
+    previous = current;
+    return {
+      t: current[0] / TIME_SCALE,
+      x: current[1] / POSITION_SCALE,
+      z: current[2] / POSITION_SCALE,
+      h: current[3] / HEADING_SCALE,
+      s: current[4] / CONTROL_SCALE,
+      d: current[5] / CONTROL_SCALE,
+      p: current[6] / PROGRESS_SCALE
+    };
+  }).filter(Boolean) : [];
+
+  const reply = Array.isArray(wire.r) ? {
+    kind: wire.r[0] === 'w' ? 'win' : wire.r[0] === 'g' ? 'give-up' : '',
+    opponent: wire.r[1],
+    previousTime: wire.r[2] == null ? null : integer(wire.r[2]) / TIME_SCALE
+  } : null;
+
+  return {
+    v: wire.v,
+    challengerName: wire.n,
+    trackId: wire.ti,
+    trackRevision: wire.tr,
+    trackName: wire.tn,
+    time: integer(wire.tm) / TIME_SCALE,
+    carId: wire.c,
+    carColor: wire.pc,
+    carSecondaryColor: wire.sc,
+    frames,
+    replyTo: reply
+  };
+}
+
+function normalizeFrames(frames, { limit = MAX_FRAMES } = {}) {
+  if (!Array.isArray(frames)) return [];
+  const source = Number.isFinite(limit) ? frames.slice(0, limit) : frames;
+  return source
+    .map((frame) => ({
+      t: finite(frame?.t),
+      x: finite(frame?.x),
+      z: finite(frame?.z),
+      h: finite(frame?.h),
+      s: finite(frame?.s),
+      d: finite(frame?.d),
+      p: Number.isFinite(Number(frame?.p)) ? Number(frame.p) : null
+    }))
+    .filter((frame) => Number.isFinite(frame.t)
+      && Number.isFinite(frame.x)
+      && Number.isFinite(frame.z)
+      && Number.isFinite(frame.h))
+    .sort((a, b) => a.t - b.t);
+}
+
+function downsampleFrames(frames) {
+  const normalized = normalizeFrames(frames, { limit: Infinity });
+  if (normalized.length <= MAX_FRAMES) return normalized;
+  const stride = Math.ceil(normalized.length / MAX_FRAMES);
+  const sampled = normalized.filter((_, index) => index % stride === 0);
+  const last = normalized.at(-1);
+  if (last && sampled.at(-1) !== last) {
+    if (sampled.length >= MAX_FRAMES) sampled[MAX_FRAMES - 1] = last;
+    else sampled.push(last);
+  }
+  return sampled;
+}
+
+function normalizeReply(reply) {
+  if (!reply || typeof reply !== 'object') return null;
+  const kind = reply.kind === 'win' ? 'win' : reply.kind === 'give-up' ? 'give-up' : '';
+  if (!kind) return null;
+  return Object.freeze({
+    kind,
+    opponent: normalizeChallengeName(reply.opponent, 'THE CHALLENGER'),
+    previousTime: Number.isFinite(Number(reply.previousTime)) ? Number(reply.previousTime) : null
+  });
+}
+
+function normalizeHex(value, fallback) {
+  const clean = String(value || '').toLowerCase();
+  return /^#[0-9a-f]{6}$/.test(clean) ? clean : fallback;
+}
+
+function quantize(value, scale) {
+  return Math.round(finite(value) * scale);
+}
+
+function integer(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? Math.round(number) : 0;
+}
+
+function finite(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+async function streamBytes(bytes, stream) {
+  const bufferPromise = new Response(stream.readable).arrayBuffer();
+  const writer = stream.writable.getWriter();
+  await writer.write(bytes);
+  await writer.close();
+  return new Uint8Array(await bufferPromise);
+}
+
+function bytesToBase64Url(bytes) {
+  let binary = '';
+  for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000));
+  }
+  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/g, '');
+}
+
+function base64UrlToBytes(value) {
+  const base64 = value.replaceAll('-', '+').replaceAll('_', '/');
+  const padded = base64 + '='.repeat((4 - base64.length % 4) % 4);
+  const binary = atob(padded);
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+}

--- a/yourturn/scene.js
+++ b/yourturn/scene.js
@@ -1,0 +1,152 @@
+import * as THREE from 'three';
+import { replayFrameAt } from '/turn/race/replay-system.js';
+import { trackPitch, trackSurfaceY } from '/turn/tracks/elevation.js?build=20260725-r67';
+
+const PREVIEW_CAMERA_DISTANCE = 18;
+const PREVIEW_CAMERA_HEIGHT = 8.4;
+const PREVIEW_START_DELAY_MS = 650;
+const STAGED_IMITATION_DELAY_MS = 650;
+
+export function createChallengeScene({ runtime, challengeLap, onRaceStarted }) {
+  let phase = 'preview';
+  let previewStartedAt = performance.now();
+  const stagedHistory = [];
+  const reduceMotion = globalThis.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
+
+  function setPhase(nextPhase) {
+    phase = nextPhase;
+    if (nextPhase === 'preview' || nextPhase === 'reply' || nextPhase === 'result') {
+      previewStartedAt = performance.now();
+    }
+    if (nextPhase !== 'staged') stagedHistory.length = 0;
+  }
+
+  function update(dt) {
+    if (phase === 'preview' || phase === 'reply' || phase === 'result') {
+      renderPreview(runtime, challengeLap, previewStartedAt, dt, reduceMotion);
+      return true;
+    }
+    if (phase === 'staged') {
+      if (runtime.state.lapActive) {
+        phase = 'racing';
+        stagedHistory.length = 0;
+        onRaceStarted?.();
+        return false;
+      }
+      renderStage(runtime, dt, stagedHistory, reduceMotion);
+      return true;
+    }
+    return false;
+  }
+
+  runtime.setSceneOverride(update);
+  return Object.freeze({ setPhase, getPhase: () => phase });
+}
+
+function renderPreview(runtime, challengeLap, previewStartedAt, dt, reduceMotion) {
+  const sinceOpenMs = performance.now() - previewStartedAt;
+  const elapsed = reduceMotion
+    ? Math.min(challengeLap.time * 0.18, 1.2)
+    : Math.max(0, sinceOpenMs - PREVIEW_START_DELAY_MS) / 1000;
+  const replayTime = challengeLap.time > 0 ? elapsed % challengeLap.time : elapsed;
+  const frame = replayFrameAt(challengeLap, replayTime);
+  const opponentCar = runtime.competitorCars[0];
+  runtime.playerCar.visible = false;
+  hideOtherCompetitors(runtime, 0);
+  if (!frame || !opponentCar) return;
+
+  placeReplayCar(runtime, opponentCar, frame, dt);
+  const focus = new THREE.Vector3(frame.x, replaySurfaceY(runtime, frame), frame.z);
+  const forward = new THREE.Vector3(Math.sin(frame.h), 0, Math.cos(frame.h));
+  const desiredCamera = focus.clone().addScaledVector(forward, -PREVIEW_CAMERA_DISTANCE);
+  desiredCamera.y += PREVIEW_CAMERA_HEIGHT;
+  runtime.cameraPosition.lerp(desiredCamera, 1 - Math.exp(-dt * 7.2));
+  runtime.camera.position.copy(runtime.cameraPosition);
+
+  const desiredTarget = focus.clone().addScaledVector(forward, 12.5);
+  desiredTarget.y += 1.9;
+  runtime.cameraTarget.lerp(desiredTarget, 1 - Math.exp(-dt * 9));
+  runtime.camera.up.set(0, 1, 0);
+  runtime.camera.lookAt(runtime.cameraTarget);
+  runtime.camera.fov = THREE.MathUtils.lerp(runtime.camera.fov, 70, Math.min(1, dt * 6));
+  runtime.camera.updateProjectionMatrix();
+}
+
+function renderStage(runtime, dt, stagedHistory, reduceMotion) {
+  const { state, playerCar, competitorCars } = runtime;
+  const opponentCar = competitorCars[0];
+  playerCar.visible = true;
+  playerCar.position.copy(state.position);
+  const playerSample = runtime.findNearestTrack(state.position).sample;
+  playerCar.position.y = trackSurfaceY(playerSample);
+  playerCar.rotation.x = trackPitch(playerSample);
+  playerCar.rotation.y = state.heading + Math.PI;
+  playerCar.rotation.z = 0;
+  runtime.animateWheels(playerCar, state.steering, state.speed, dt);
+
+  const now = performance.now();
+  if (!reduceMotion) {
+    const last = stagedHistory.at(-1);
+    if (!last || now - last.at >= 40) {
+      stagedHistory.push({ at: now, heading: state.heading, steering: state.steering });
+    }
+    while (stagedHistory.length > 2 && stagedHistory[1].at < now - 1600) stagedHistory.shift();
+  }
+  const delayed = reduceMotion
+    ? { heading: state.heading, steering: 0 }
+    : delayedStageSample(stagedHistory, now - STAGED_IMITATION_DELAY_MS) || { heading: state.heading, steering: 0 };
+
+  hideOtherCompetitors(runtime, 0);
+  if (opponentCar) {
+    const right = new THREE.Vector3(Math.cos(state.heading), 0, -Math.sin(state.heading));
+    opponentCar.visible = true;
+    opponentCar.position.copy(state.position).addScaledVector(right, 4.1);
+    opponentCar.position.y = playerCar.position.y;
+    opponentCar.rotation.x = playerCar.rotation.x;
+    opponentCar.rotation.y = delayed.heading + Math.PI;
+    opponentCar.rotation.z = -delayed.steering * 0.03;
+    runtime.animateWheels(opponentCar, delayed.steering, 0, dt);
+  }
+
+  const forward = new THREE.Vector3(Math.sin(state.heading), 0, Math.cos(state.heading));
+  const focus = state.position.clone();
+  focus.y = playerCar.position.y;
+  const desiredCamera = focus.clone().addScaledVector(forward, -17.5);
+  desiredCamera.y += 8.2;
+  runtime.cameraPosition.lerp(desiredCamera, 1 - Math.exp(-dt * 9));
+  runtime.camera.position.copy(runtime.cameraPosition);
+  const desiredTarget = focus.clone().addScaledVector(forward, 12);
+  desiredTarget.y += 2;
+  runtime.cameraTarget.lerp(desiredTarget, 1 - Math.exp(-dt * 10));
+  runtime.camera.up.set(0, 1, 0);
+  runtime.camera.lookAt(runtime.cameraTarget);
+}
+
+function delayedStageSample(history, targetTime) {
+  let candidate = null;
+  for (const sample of history) {
+    if (sample.at > targetTime) break;
+    candidate = sample;
+  }
+  return candidate;
+}
+
+function placeReplayCar(runtime, car, frame, dt) {
+  const sample = runtime.findNearestTrack(frame).sample;
+  car.visible = true;
+  car.position.set(frame.x, trackSurfaceY(sample), frame.z);
+  car.rotation.x = trackPitch(sample);
+  car.rotation.y = frame.h + Math.PI;
+  car.rotation.z = -frame.s * 0.03;
+  runtime.animateWheels(car, frame.s, 45, dt);
+}
+
+function replaySurfaceY(runtime, frame) {
+  return trackSurfaceY(runtime.findNearestTrack(frame).sample);
+}
+
+function hideOtherCompetitors(runtime, keepIndex) {
+  for (let index = 0; index < runtime.competitorCars.length; index += 1) {
+    if (index !== keepIndex) runtime.competitorCars[index].visible = false;
+  }
+}

--- a/yourturn/session.js
+++ b/yourturn/session.js
@@ -1,0 +1,610 @@
+import * as THREE from 'three';
+import { GAME_MODE } from '/turn/race/game-state.js';
+import { syncPrimaryRivalState } from '/turn/race/rival-storage.js?build=20260720-r19';
+import { activateTrack } from '/turn/tracks/track-manager.js?source=20260729-r118-m8';
+import { getTrackDefinition } from '/turn/tracks/catalog.js?source=20260729-r118-m8';
+import { getTrackStorageRevision } from '/turn/tracks/definitions.js';
+import { getCarDefinition } from '/turn/vehicle/catalog.js?build=20260720-r19';
+import {
+  challengeFromLap,
+  decodeChallenge,
+  encodeChallenge,
+  encodedChallengeFromLocation,
+  formatChallengeTime,
+  makeChallengeUrl,
+  makeMockChallengeUrl,
+  normalizeChallenge,
+  normalizeChallengeName
+} from '/yourturn/protocol.js?revision=r1';
+import { getMockChallenge, MOCK_CHALLENGES } from '/yourturn/mock-challenges.js?revision=r1';
+import { createChallengeScene } from '/yourturn/scene.js?revision=r1';
+import { aboutTurnHtml, escapeHtml, newcomerAssistiveText } from '/yourturn/ui.js?revision=r1';
+
+export function readYourTurnRequest(locationRef = globalThis.location) {
+  const query = new URLSearchParams(locationRef?.search || '');
+  const mockId = query.get('challenge') || '';
+  const encoded = encodedChallengeFromLocation(locationRef);
+  return Object.freeze({
+    mockId,
+    encoded,
+    reply: query.get('reply') === 'give-up' ? 'give-up' : '',
+    responder: normalizeChallengeName(query.get('responder'), 'A TURN PLAYER'),
+    hasChallenge: Boolean(mockId || encoded)
+  });
+}
+
+export function createYourTurnSession({ runtime, raceSession, ui, animation, request }) {
+  const state = {
+    active: false,
+    accepted: false,
+    authorizing: false,
+    phase: 'idle',
+    challenge: null,
+    challengeLap: null,
+    winningLap: null,
+    scene: null,
+    pendingAccess: null,
+    paused: false,
+    backgroundPaused: false
+  };
+
+  ui.bindPause(() => pauseRace('Paused by player.'));
+  window.addEventListener('turn:lap-result', handleLapResult);
+  window.addEventListener('turn:ui-state-change', handleUiState);
+  document.addEventListener('visibilitychange', handleVisibility);
+  window.addEventListener('pagehide', stopDrivingInputs, { capture: true });
+
+  async function launch() {
+    if (!request.hasChallenge) {
+      state.active = true;
+      document.body.classList.add('yourturn-active', 'yourturn-preview');
+      showMockPicker();
+      return;
+    }
+
+    const challenge = await resolveChallenge();
+    state.active = true;
+    state.challenge = challenge;
+    state.challengeLap = challengeToLap(challenge);
+
+    await raceSession.selectVehicle(challengeVehicle(challenge));
+    useChallengeAsOnlyOpponent();
+    document.body.classList.add('yourturn-active', 'yourturn-preview');
+
+    runtime.state.running = true;
+    runtime.state.lastFrame = performance.now();
+    runtime.state.touchGas = false;
+    runtime.state.touchBrake = false;
+    runtime.state.velocity.set(0, 0, 0);
+    runtime.setGameMode(GAME_MODE.STAGED);
+    runtime.playerCar.visible = false;
+
+    state.scene = createChallengeScene({
+      runtime,
+      challengeLap: state.challengeLap,
+      onRaceStarted() {
+        state.phase = 'racing';
+      }
+    });
+    state.phase = request.reply ? 'reply' : 'preview';
+    state.scene.setPhase(state.phase);
+    ui.setTarget({
+      opponent: challenge.challengerName,
+      time: formatChallengeTime(challenge.time)
+    });
+
+    if (request.reply === 'give-up') showReceivedGiveUp();
+    else showInvitation();
+  }
+
+  async function resolveChallenge() {
+    if (request.mockId) {
+      const definition = getMockChallenge(request.mockId);
+      if (!definition) throw new Error('This mock challenge does not exist.');
+      await activateTrack(definition.trackId, runtime);
+      return materializeMockChallenge(definition);
+    }
+
+    const challenge = await decodeChallenge(request.encoded);
+    await activateTrack(challenge.trackId, runtime);
+    const currentRevision = getTrackStorageRevision(challenge.trackId);
+    if (challenge.trackRevision && challenge.trackRevision !== currentRevision) {
+      throw new Error('This challenge was recorded on an older version of the track.');
+    }
+    return challenge;
+  }
+
+  function materializeMockChallenge(definition) {
+    const frames = runtime.samples.map((sample, index, samples) => {
+      const denominator = Math.max(1, samples.length - 1);
+      const previous = samples[(index - 2 + samples.length) % samples.length];
+      const next = samples[(index + 2) % samples.length];
+      const previousHeading = Math.atan2(previous.tangent.x, previous.tangent.z);
+      const nextHeading = Math.atan2(next.tangent.x, next.tangent.z);
+      const steering = normalizeAngle(nextHeading - previousHeading) * 3.2;
+      return {
+        t: definition.time * index / denominator,
+        x: sample.point.x,
+        z: sample.point.z,
+        h: Math.atan2(sample.tangent.x, sample.tangent.z),
+        s: THREE.MathUtils.clamp(steering, -1, 1),
+        d: Math.min(1, Math.abs(steering) * 0.75),
+        p: index / denominator
+      };
+    });
+    const track = getTrackDefinition(definition.trackId);
+    return normalizeChallenge({
+      v: 1,
+      challengerName: definition.challengerName,
+      trackId: definition.trackId,
+      trackRevision: getTrackStorageRevision(definition.trackId),
+      trackName: track.name,
+      time: definition.time,
+      carId: definition.carId,
+      carColor: definition.carColor,
+      carSecondaryColor: definition.carSecondaryColor,
+      frames
+    });
+  }
+
+  function showInvitation() {
+    const challenge = state.challenge;
+    const track = getTrackDefinition(challenge.trackId);
+    const car = getCarDefinition(challenge.carId);
+    state.phase = 'preview';
+    state.scene?.setPhase('preview');
+    ui.hideRaceChrome();
+    ui.showModal({
+      titleText: `${challenge.challengerName} CHALLENGES YOU`,
+      detailsHtml: `
+        <strong>${escapeHtml(track.name.toUpperCase())}</strong>
+        <span>${escapeHtml(car.name)} · ${formatChallengeTime(challenge.time)}</span>`,
+      copyHtml: `Beat ${escapeHtml(challenge.challengerName)}’s car. Race as many laps as you need.`,
+      extraHtml: newcomerAssistiveText(challenge.challengerName),
+      className: 'invitation',
+      actionList: [
+        { label: 'ACCEPT CHALLENGE', primary: true, action: () => void acceptWithMotion() },
+        { label: 'TRY LATER', navigation: true, action: openFullTurn },
+        { label: 'GIVE UP', destructive: true, action: showGiveUpConfirm },
+        { label: 'ABOUT TURN', kind: 'quiet', action: () => showAbout(showInvitation) }
+      ]
+    });
+  }
+
+  async function acceptWithMotion() {
+    if (state.authorizing) return;
+    state.authorizing = true;
+    ui.setStatus('Requesting motion access…');
+    try {
+      state.pendingAccess = await raceSession.prepareMotionAccess();
+      state.authorizing = false;
+      await awaitLandscapeAndStart();
+    } catch (error) {
+      state.authorizing = false;
+      showMotionProblem(error);
+    }
+  }
+
+  function showMotionProblem(error) {
+    const message = error instanceof Error ? error.message : 'Motion steering could not be enabled.';
+    ui.showModal({
+      titleText: 'MOTION STEERING NEEDED',
+      copyHtml: `${escapeHtml(message)} TURN is designed around rotating the phone like a steering wheel.`,
+      extraHtml: '<p class="yourturn-small-note">If this browser cannot provide motion access, on-screen steering is available as a fallback.</p>',
+      className: 'motion-error',
+      actionList: [
+        { label: 'TRY MOTION AGAIN', primary: true, action: () => void acceptWithMotion() },
+        { label: 'USE ON-SCREEN STEERING', action: () => void acceptWithManual() },
+        { label: 'TRY LATER', navigation: true, action: openFullTurn },
+        { label: 'ABOUT TURN', kind: 'quiet', action: () => showAbout(showMotionProblem.bind(null, error)) }
+      ]
+    });
+  }
+
+  async function acceptWithManual() {
+    state.pendingAccess = raceSession.prepareManualAccess();
+    await awaitLandscapeAndStart();
+  }
+
+  async function awaitLandscapeAndStart() {
+    ui.closeModal();
+    ui.showRotate();
+    if (isLandscape()) {
+      await nextPaint();
+      return startAcceptedRace();
+    }
+
+    await new Promise((resolve) => {
+      let settled = false;
+      const check = () => {
+        if (settled || !isLandscape()) return;
+        settled = true;
+        window.removeEventListener('resize', check);
+        window.removeEventListener('orientationchange', check);
+        resolve();
+      };
+      window.addEventListener('resize', check, { passive: true });
+      window.addEventListener('orientationchange', check, { passive: true });
+    });
+    return startAcceptedRace();
+  }
+
+  async function startAcceptedRace() {
+    state.accepted = true;
+    state.paused = false;
+    ui.hideRotate();
+    document.body.classList.remove('yourturn-preview');
+    document.body.classList.add('yourturn-racing');
+    state.phase = 'staged';
+    state.scene.setPhase('staged');
+    useChallengeAsOnlyOpponent();
+
+    document.querySelector('#resetButton')?.click();
+    useChallengeAsOnlyOpponent();
+    const access = state.pendingAccess || raceSession.prepareManualAccess();
+    await raceSession.startGame(access.fullscreenPromise);
+    runtime.setGameMode(GAME_MODE.STAGED);
+    runtime.state.velocity.set(0, 0, 0);
+    stopDrivingInputs();
+    const message = document.querySelector('#message');
+    message?.classList.remove('show');
+    if (message) message.textContent = '';
+    ui.showRaceChrome();
+    animation.resume();
+  }
+
+  function handleLapResult(event) {
+    if (!state.active || !state.accepted || state.phase === 'result' || state.paused) return;
+    const time = Number(event.detail?.time);
+    const recording = runtime.state.recording;
+    if (!Number.isFinite(time) || !Array.isArray(recording) || recording.length < 21) return;
+    const candidate = {
+      time,
+      hitAt: Date.now(),
+      carId: state.challenge.carId,
+      carColor: state.challenge.carColor,
+      carSecondaryColor: state.challenge.carSecondaryColor,
+      frames: recording.map((frame) => ({ ...frame }))
+    };
+    queueMicrotask(() => finishAttempt(candidate));
+  }
+
+  function finishAttempt(candidate) {
+    useChallengeAsOnlyOpponent();
+    if (candidate.time < state.challenge.time) {
+      state.winningLap = candidate;
+      state.phase = 'result';
+      stopRaceForModal('result');
+      showWin(candidate);
+      return;
+    }
+    state.phase = runtime.state.lapActive ? 'racing' : 'staged';
+    state.scene.setPhase(state.phase);
+  }
+
+  function showWin(candidate) {
+    const difference = state.challenge.time - candidate.time;
+    ui.showModal({
+      titleText: `YOU BEAT ${state.challenge.challengerName}`,
+      detailsHtml: `
+        <strong>${formatChallengeTime(candidate.time)}</strong>
+        <span>${difference.toFixed(3)} seconds ahead</span>`,
+      copyHtml: 'Send your winning lap back as a new YOUR TURN challenge.',
+      requestName: true,
+      className: 'result',
+      actionList: [
+        { label: 'SHARE YOUR TURN', primary: true, action: () => void shareWinningReply() },
+        { label: 'RACE AGAIN', action: raceAgain },
+        { label: 'GET FULL TURN', navigation: true, action: openFullTurn },
+        { label: 'ABOUT TURN', kind: 'quiet', action: () => showAbout(() => showWin(candidate)) }
+      ]
+    });
+  }
+
+  async function shareWinningReply() {
+    const responder = ui.playerName();
+    const replyChallenge = challengeFromLap({
+      challengerName: responder,
+      trackId: state.challenge.trackId,
+      trackRevision: getTrackStorageRevision(state.challenge.trackId),
+      trackName: getTrackDefinition(state.challenge.trackId).name,
+      lap: state.winningLap,
+      replyTo: {
+        kind: 'win',
+        opponent: state.challenge.challengerName,
+        previousTime: state.challenge.time
+      }
+    });
+    const encoded = await encodeChallenge(replyChallenge);
+    const url = makeChallengeUrl(encoded);
+    return shareUrl({
+      title: `${responder} sends you YOUR TURN`,
+      text: `${responder} beat ${state.challenge.challengerName} with ${formatChallengeTime(state.winningLap.time)}. Your turn.`,
+      url,
+      success: 'Your challenge is ready to send.'
+    });
+  }
+
+  function showGiveUpConfirm() {
+    const wasAccepted = state.accepted;
+    if (wasAccepted) stopRaceForModal('reply');
+    ui.showModal({
+      titleText: 'GIVE UP?',
+      detailsHtml: `<strong>${escapeHtml(state.challenge.challengerName)} WINS</strong><span>Target ${formatChallengeTime(state.challenge.time)}</span>`,
+      copyHtml: `You can keep racing ${escapeHtml(state.challenge.challengerName)}’s car for as many laps as you want.`,
+      className: 'give-up',
+      actionList: [
+        { label: 'KEEP RACING', primary: true, action: wasAccepted ? raceAgain : showInvitation },
+        { label: 'YES, GIVE UP', destructive: true, action: finishGiveUp }
+      ]
+    });
+  }
+
+  function finishGiveUp() {
+    state.phase = 'reply';
+    state.scene?.setPhase('reply');
+    ui.showModal({
+      titleText: `${state.challenge.challengerName} WINS`,
+      detailsHtml: `<strong>${formatChallengeTime(state.challenge.time)}</strong><span>Challenge held</span>`,
+      copyHtml: 'Send the result back, try again, or open the full TURN game.',
+      requestName: true,
+      className: 'result',
+      actionList: [
+        { label: 'SHARE RESULT', primary: true, action: () => void shareGiveUpReply() },
+        { label: 'TRY AGAIN', action: state.accepted ? raceAgain : showInvitation },
+        { label: 'GET FULL TURN', navigation: true, action: openFullTurn },
+        { label: 'ABOUT TURN', kind: 'quiet', action: () => showAbout(finishGiveUp) }
+      ]
+    });
+  }
+
+  async function shareGiveUpReply() {
+    const responder = ui.playerName();
+    const url = request.mockId
+      ? makeMockChallengeUrl(request.mockId, { reply: 'give-up', responder })
+      : makeChallengeUrl(request.encoded, { reply: 'give-up', responder });
+    return shareUrl({
+      title: `${responder} answered your YOUR TURN challenge`,
+      text: `${responder} gave up. ${state.challenge.challengerName} wins this round.`,
+      url,
+      success: 'Result ready to send.'
+    });
+  }
+
+  function showReceivedGiveUp() {
+    ui.showModal({
+      titleText: `${request.responder} GAVE UP`,
+      detailsHtml: `<strong>YOU WIN</strong><span>${formatChallengeTime(state.challenge.time)} held the lead</span>`,
+      copyHtml: `Your car beat ${escapeHtml(request.responder)}.`,
+      className: 'result',
+      actionList: [
+        { label: 'RACE THIS CHALLENGE', primary: true, action: () => void acceptWithMotion() },
+        { label: 'GET FULL TURN', navigation: true, action: openFullTurn },
+        { label: 'ABOUT TURN', kind: 'quiet', action: () => showAbout(showReceivedGiveUp) }
+      ]
+    });
+  }
+
+  function pauseRace(reason = 'Race paused.') {
+    if (!state.accepted || state.paused || !['racing', 'staged'].includes(state.phase)) return;
+    state.paused = true;
+    stopDrivingInputs();
+    animation.pause();
+    ui.showModal({
+      titleText: 'PAUSED',
+      copyHtml: escapeHtml(reason),
+      className: 'paused',
+      actionList: [
+        { label: 'RESUME', primary: true, action: resumeRace },
+        { label: 'RESTART LAP', action: restartFromPause },
+        { label: 'GIVE UP', destructive: true, action: showGiveUpConfirm },
+        { label: 'ABOUT TURN', kind: 'quiet', action: () => showAbout(() => pauseRaceView(reason)) }
+      ]
+    });
+  }
+
+  function pauseRaceView(reason) {
+    ui.showModal({
+      titleText: 'PAUSED',
+      copyHtml: escapeHtml(reason),
+      className: 'paused',
+      actionList: [
+        { label: 'RESUME', primary: true, action: resumeRace },
+        { label: 'RESTART LAP', action: restartFromPause },
+        { label: 'GIVE UP', destructive: true, action: showGiveUpConfirm },
+        { label: 'ABOUT TURN', kind: 'quiet', action: () => showAbout(() => pauseRaceView(reason)) }
+      ]
+    });
+  }
+
+  function resumeRace() {
+    ui.closeModal();
+    state.paused = false;
+    state.backgroundPaused = false;
+    runtime.state.lastFrame = performance.now();
+    animation.resume();
+    ui.showRaceChrome();
+  }
+
+  function restartFromPause() {
+    document.querySelector('#resetButton')?.click();
+    useChallengeAsOnlyOpponent();
+    state.phase = 'staged';
+    state.scene.setPhase('staged');
+    resumeRace();
+  }
+
+  function raceAgain() {
+    ui.closeModal();
+    state.winningLap = null;
+    state.paused = false;
+    document.body.classList.remove('yourturn-preview');
+    document.body.classList.add('yourturn-racing');
+    useChallengeAsOnlyOpponent();
+    showRaceUi(runtime.state.sensorMode);
+    document.querySelector('#resetButton')?.click();
+    useChallengeAsOnlyOpponent();
+    state.phase = 'staged';
+    state.scene.setPhase('staged');
+    runtime.state.lastFrame = performance.now();
+    animation.resume();
+    ui.showRaceChrome();
+  }
+
+  function stopRaceForModal(scenePhase) {
+    runtime.setGameMode(GAME_MODE.STAGED);
+    runtime.state.velocity.set(0, 0, 0);
+    stopDrivingInputs();
+    useChallengeAsOnlyOpponent();
+    state.scene?.setPhase(scenePhase);
+    hideRaceUi();
+    ui.hideRaceChrome();
+    document.body.classList.remove('yourturn-racing');
+    document.body.classList.add('yourturn-preview');
+    state.paused = false;
+    runtime.state.running = true;
+    runtime.state.lastFrame = performance.now();
+    animation.resume();
+  }
+
+  function showAbout(returnAction) {
+    ui.showModal({
+      titleText: 'ABOUT TURN',
+      extraHtml: aboutTurnHtml(),
+      className: 'about',
+      actionList: [
+        { label: 'BACK', primary: true, action: returnAction },
+        { label: 'GET FULL TURN', navigation: true, action: openFullTurn }
+      ]
+    });
+  }
+
+  function showMockPicker() {
+    const buttons = Object.values(MOCK_CHALLENGES).map((mock) => ({
+      label: mock.label,
+      action: () => { globalThis.location.href = makeMockChallengeUrl(mock.id); }
+    }));
+    ui.showModal({
+      titleText: 'TEST CHALLENGES',
+      copyHtml: 'Choose a stable mock link while the recipient experience is under development.',
+      className: 'picker',
+      actionList: [
+        ...buttons,
+        { label: 'ABOUT TURN', kind: 'quiet', action: () => showAbout(showMockPicker) }
+      ]
+    });
+  }
+
+  function handleUiState(event) {
+    if (!state.active || !state.accepted) return;
+    if (event.detail?.reason === 'race-reset') {
+      state.phase = 'staged';
+      state.scene?.setPhase('staged');
+      useChallengeAsOnlyOpponent();
+    }
+  }
+
+  function handleVisibility() {
+    if (!state.accepted) return;
+    if (document.hidden && !state.paused && ['racing', 'staged'].includes(state.phase)) {
+      state.paused = true;
+      state.backgroundPaused = true;
+      stopDrivingInputs();
+      animation.pause();
+      return;
+    }
+    if (!document.hidden && state.backgroundPaused) {
+      state.backgroundPaused = false;
+      pauseRaceView('Race paused while YOUR TURN was in the background.');
+    }
+  }
+
+  function useChallengeAsOnlyOpponent() {
+    runtime.state.competitorLaps = state.challengeLap ? [state.challengeLap] : [];
+    syncPrimaryRivalState(runtime.state);
+    runtime.syncCompetitorVisuals?.();
+    runtime.setRacePosition?.(null, state.challengeLap ? 2 : 1);
+  }
+
+  function stopDrivingInputs() {
+    runtime.state.touchGas = false;
+    runtime.state.touchBrake = false;
+    runtime.state.manualSteering = 0;
+    globalThis.__turnAnalogGas = 0;
+    globalThis.__turnBoostActive = false;
+    globalThis.__turnDriftHeld = false;
+  }
+
+  async function shareUrl({ title, text, url, success }) {
+    try {
+      if (navigator.share) {
+        await navigator.share({ title, text, url });
+        ui.setStatus(success);
+        return true;
+      }
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(url);
+        ui.setStatus('Link copied.');
+        return true;
+      }
+    } catch (error) {
+      if (error?.name === 'AbortError') return false;
+    }
+    ui.setStatus(url);
+    return false;
+  }
+
+  function openFullTurn() {
+    globalThis.location.href = '/turn/';
+  }
+
+  return Object.freeze({ launch, getState: () => state });
+}
+
+function challengeToLap(challenge) {
+  return {
+    time: challenge.time,
+    hitAt: null,
+    challengeId: 'yourturn-opponent',
+    challengerName: challenge.challengerName,
+    carId: challenge.carId,
+    carColor: challenge.carColor,
+    carSecondaryColor: challenge.carSecondaryColor,
+    frames: challenge.frames.map((frame) => ({ ...frame }))
+  };
+}
+
+function challengeVehicle(challenge) {
+  return {
+    carId: challenge.carId,
+    color: challenge.carColor,
+    secondaryColor: challenge.carSecondaryColor
+  };
+}
+
+function showRaceUi(sensorMode) {
+  document.querySelector('#hud')?.removeAttribute('hidden');
+  document.querySelector('#controls')?.removeAttribute('hidden');
+  if (!sensorMode) document.querySelector('#manualSteer')?.removeAttribute('hidden');
+}
+
+function hideRaceUi() {
+  document.querySelector('#hud')?.setAttribute('hidden', '');
+  document.querySelector('#controls')?.setAttribute('hidden', '');
+  document.querySelector('#manualSteer')?.setAttribute('hidden', '');
+}
+
+function isLandscape() {
+  return globalThis.matchMedia?.('(orientation: landscape)').matches
+    || globalThis.innerWidth > globalThis.innerHeight;
+}
+
+function nextPaint() {
+  return new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+}
+
+function normalizeAngle(angle) {
+  while (angle > Math.PI) angle -= Math.PI * 2;
+  while (angle < -Math.PI) angle += Math.PI * 2;
+  return angle;
+}

--- a/yourturn/storage-bootstrap.js
+++ b/yourturn/storage-bootstrap.js
@@ -1,0 +1,93 @@
+(() => {
+  const LOCAL_PREFIX = 'yourturn:';
+  const SESSION_PREFIX = 'yourturn-session:';
+  const PATCH_MARKER = Symbol.for('yourturn.storage.patch');
+
+  function fail(error) {
+    console.error('YOUR TURN: isolated storage could not be established.', error);
+    globalThis.__YOUR_TURN_STORAGE_READY__ = false;
+    const render = () => {
+      if (!document.body) return;
+      document.body.innerHTML = `
+        <main style="min-height:100vh;display:grid;place-items:center;padding:24px;background:#08090a;color:#fff8e8;font:700 18px/1.45 system-ui,sans-serif">
+          <section role="alert" style="max-width:42rem;border:4px solid #ff7f50;border-radius:20px;padding:24px;background:#241611">
+            <h1 style="margin:0 0 12px;font-size:1.5rem">YOUR TURN could not start</h1>
+            <p style="margin:0">This browser would not allow a separate challenge save area. The race was stopped before it could touch your TURN records.</p>
+          </section>
+        </main>`;
+    };
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', render, { once: true });
+    else render();
+  }
+
+  try {
+    const localStorageRef = window.localStorage;
+    const sessionStorageRef = window.sessionStorage;
+    const proto = Storage.prototype;
+    if (proto[PATCH_MARKER]) throw new Error('YOUR TURN storage bootstrap was installed more than once.');
+
+    const native = Object.freeze({
+      getItem: proto.getItem,
+      setItem: proto.setItem,
+      removeItem: proto.removeItem,
+      clear: proto.clear,
+      key: proto.key
+    });
+
+    function prefixFor(storage) {
+      if (storage === localStorageRef) return LOCAL_PREFIX;
+      if (storage === sessionStorageRef) return SESSION_PREFIX;
+      return '';
+    }
+
+    function scopedKeys(storage, prefix) {
+      const keys = [];
+      for (let index = 0; index < storage.length; index += 1) {
+        const key = native.key.call(storage, index);
+        if (key?.startsWith(prefix)) keys.push(key);
+      }
+      return keys;
+    }
+
+    proto.getItem = function getItem(key) {
+      const prefix = prefixFor(this);
+      return native.getItem.call(this, prefix ? prefix + String(key) : key);
+    };
+    proto.setItem = function setItem(key, value) {
+      const prefix = prefixFor(this);
+      return native.setItem.call(this, prefix ? prefix + String(key) : key, value);
+    };
+    proto.removeItem = function removeItem(key) {
+      const prefix = prefixFor(this);
+      return native.removeItem.call(this, prefix ? prefix + String(key) : key);
+    };
+    proto.clear = function clear() {
+      const prefix = prefixFor(this);
+      if (!prefix) return native.clear.call(this);
+      for (const key of scopedKeys(this, prefix)) native.removeItem.call(this, key);
+    };
+    proto.key = function key(index) {
+      const prefix = prefixFor(this);
+      if (!prefix) return native.key.call(this, index);
+      return scopedKeys(this, prefix)[index]?.slice(prefix.length) ?? null;
+    };
+
+    Object.defineProperty(proto, PATCH_MARKER, {
+      value: true,
+      configurable: false,
+      enumerable: false,
+      writable: false
+    });
+
+    globalThis.__TURN_DEPLOYMENT__ = Object.freeze({
+      id: 'yourturn',
+      label: 'YOUR TURN',
+      production: false,
+      storageNamespace: LOCAL_PREFIX,
+      sessionStorageNamespace: SESSION_PREFIX
+    });
+    globalThis.__YOUR_TURN_STORAGE_READY__ = true;
+  } catch (error) {
+    fail(error);
+  }
+})();

--- a/yourturn/ui.js
+++ b/yourturn/ui.js
@@ -1,0 +1,169 @@
+import { normalizeChallengeName } from '/yourturn/protocol.js?revision=r1';
+
+const PLAYER_NAME_KEY = 'yourturn-player-name-v1';
+
+export function createYourTurnUi() {
+  const dialog = document.querySelector('#yourTurnDialog');
+  const card = dialog?.querySelector('.yourturn-card');
+  const kicker = dialog?.querySelector('.yourturn-kicker');
+  const title = dialog?.querySelector('#yourTurnTitle');
+  const details = dialog?.querySelector('.yourturn-details');
+  const copy = dialog?.querySelector('.yourturn-copy');
+  const extra = dialog?.querySelector('.yourturn-extra');
+  const actions = dialog?.querySelector('.yourturn-actions');
+  const status = dialog?.querySelector('.yourturn-dialog-status');
+  const nameField = dialog?.querySelector('.yourturn-name-field');
+  const rotate = document.querySelector('#yourTurnRotate');
+  const targetChip = document.querySelector('#yourTurnTargetChip');
+  const targetOpponent = document.querySelector('#yourTurnTargetOpponent');
+  const targetTime = document.querySelector('#yourTurnTargetTime');
+  const pauseButton = document.querySelector('#yourTurnPauseButton');
+
+  if (!dialog || !card || !kicker || !title || !details || !copy || !extra || !actions || !status
+      || !nameField || !rotate || !targetChip || !targetOpponent || !targetTime || !pauseButton) {
+    throw new Error('YOUR TURN could not find its complete interface.');
+  }
+
+  dialog.addEventListener('cancel', (event) => {
+    if (document.body.classList.contains('yourturn-active')) event.preventDefault();
+  });
+
+  function showModal({
+    kickerText = 'YOUR TURN',
+    titleText,
+    detailsHtml = '',
+    copyHtml = '',
+    extraHtml = '',
+    actionList = [],
+    requestName = false,
+    className = ''
+  }) {
+    kicker.textContent = kickerText;
+    title.textContent = titleText;
+    details.innerHTML = detailsHtml;
+    details.hidden = !detailsHtml;
+    copy.innerHTML = copyHtml;
+    copy.hidden = !copyHtml;
+    extra.innerHTML = extraHtml;
+    extra.hidden = !extraHtml;
+    status.textContent = '';
+    card.dataset.view = className;
+
+    nameField.hidden = !requestName;
+    if (requestName) nameField.querySelector('input').value = loadPlayerName();
+
+    actions.replaceChildren();
+    for (const action of actionList) {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = action.label;
+      if (action.kind) button.dataset.kind = action.kind;
+      if (action.primary) button.classList.add('is-primary');
+      if (action.destructive) button.classList.add('is-destructive');
+      if (action.navigation) button.classList.add('is-navigation');
+      button.addEventListener('click', action.action);
+      actions.appendChild(button);
+    }
+
+    if (typeof dialog.showModal === 'function' && !dialog.open) dialog.showModal();
+    else dialog.setAttribute('open', '');
+    actions.querySelector('.is-primary, button')?.focus();
+  }
+
+  function closeModal() {
+    if (typeof dialog.close === 'function' && dialog.open) dialog.close();
+    else dialog.removeAttribute('open');
+  }
+
+  function setStatus(message) {
+    status.textContent = String(message || '');
+  }
+
+  function playerName() {
+    const input = nameField.querySelector('input');
+    const name = normalizeChallengeName(input?.value);
+    try {
+      localStorage.setItem(PLAYER_NAME_KEY, name);
+    } catch (_) {}
+    if (input) input.value = name;
+    return name;
+  }
+
+  function setTarget({ opponent, time }) {
+    targetOpponent.textContent = opponent;
+    targetTime.textContent = time;
+  }
+
+  function showRaceChrome() {
+    targetChip.hidden = false;
+    pauseButton.hidden = false;
+    document.body.classList.add('yourturn-racing');
+  }
+
+  function hideRaceChrome() {
+    targetChip.hidden = true;
+    pauseButton.hidden = true;
+    document.body.classList.remove('yourturn-racing');
+  }
+
+  function showRotate() {
+    rotate.hidden = false;
+    document.body.classList.add('yourturn-awaiting-landscape');
+    rotate.querySelector('strong')?.focus?.();
+  }
+
+  function hideRotate() {
+    rotate.hidden = true;
+    document.body.classList.remove('yourturn-awaiting-landscape');
+  }
+
+  function bindPause(handler) {
+    pauseButton.addEventListener('click', handler);
+  }
+
+  return Object.freeze({
+    showModal,
+    closeModal,
+    setStatus,
+    playerName,
+    setTarget,
+    showRaceChrome,
+    hideRaceChrome,
+    showRotate,
+    hideRotate,
+    bindPause
+  });
+}
+
+export function aboutTurnHtml() {
+  return `
+    <div class="yourturn-about-copy">
+      <p><strong>TURN</strong> is a racing game built around one unusual control: rotate your phone like a steering wheel.</p>
+      <p>Gas, Drift and Boost are on screen. Drive By Ear turns the racing line, upcoming corners, grip and nearby cars into spatial sound.</p>
+      <p>TURN is designed for screen-reader and non-visual play as well as visual play. Headphones give the clearest left/right audio information.</p>
+    </div>`;
+}
+
+export function newcomerAssistiveText(challengerName) {
+  return `
+    <span class="visually-hidden">
+      New to TURN: ${escapeHtml(challengerName)} has sent you a racing challenge. TURN is normally steered by rotating your phone like a steering wheel. The race includes spatial audio guidance and supports screen readers. After you accept, your browser may ask for motion access, then you will be asked to rotate the phone to landscape.
+    </span>`;
+}
+
+export function escapeHtml(value) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function loadPlayerName() {
+  try {
+    return normalizeChallengeName(localStorage.getItem(PLAYER_NAME_KEY));
+  } catch (_) {
+    return 'A TURN PLAYER';
+  }
+}

--- a/yourturn/yourturn.css
+++ b/yourturn/yourturn.css
@@ -1,0 +1,512 @@
+html[data-turn-deployment="yourturn"],
+html[data-turn-deployment="yourturn"] body {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  margin: 0;
+  overflow: hidden;
+  background: #08090a;
+}
+
+html[data-turn-deployment="yourturn"] body {
+  position: fixed;
+  inset: 0;
+  width: auto;
+  height: auto;
+  min-width: 0;
+  min-height: 0;
+}
+
+html[data-turn-deployment="yourturn"] #game {
+  position: fixed;
+  inset: 0;
+  width: auto;
+  height: auto;
+  min-width: 0;
+  min-height: 0;
+}
+
+html[data-turn-deployment="yourturn"] #intro {
+  display: none !important;
+}
+
+.yourturn-loading {
+  position: fixed;
+  z-index: 7000;
+  inset: 0;
+  display: grid;
+  place-content: center;
+  justify-items: center;
+  gap: 10px;
+  padding: 24px;
+  background: #38d9ff;
+  color: #08090a;
+  text-align: center;
+  font: 900 1rem/1.1 system-ui, sans-serif;
+  letter-spacing: 0.04em;
+}
+
+.yourturn-loading[hidden] {
+  display: none;
+}
+
+.yourturn-loading img {
+  width: min(28vw, 132px);
+  border: 4px solid #08090a;
+  border-radius: 22px;
+  box-shadow: 8px 8px 0 #08090a;
+}
+
+.yourturn-loading strong {
+  margin-top: 8px;
+  font-size: clamp(1.8rem, 7vw, 4rem);
+  letter-spacing: -0.04em;
+}
+
+.yourturn-loading span {
+  font-size: 0.9rem;
+}
+
+.yourturn-dialog {
+  width: 100%;
+  max-width: none;
+  height: 100%;
+  max-height: none;
+  margin: 0;
+  padding:
+    max(16px, env(safe-area-inset-top))
+    max(16px, env(safe-area-inset-right))
+    max(18px, env(safe-area-inset-bottom))
+    max(16px, env(safe-area-inset-left));
+  border: 0;
+  background: transparent;
+  color: #08090a;
+  place-items: center;
+  overflow: auto;
+}
+
+.yourturn-dialog[open] {
+  display: grid;
+}
+
+.yourturn-dialog::backdrop {
+  background: rgb(8 9 10 / 0.18);
+  backdrop-filter: blur(1.5px);
+}
+
+.yourturn-card {
+  box-sizing: border-box;
+  width: min(720px, 92vw);
+  max-height: calc(100dvh - 32px);
+  overflow: auto;
+  padding: clamp(18px, 3vw, 30px);
+  border: 5px solid #08090a;
+  border-radius: 26px;
+  background: rgb(255 248 232 / 0.93);
+  box-shadow: 12px 12px 0 rgb(8 9 10 / 0.96);
+  text-align: left;
+  -webkit-overflow-scrolling: touch;
+}
+
+.yourturn-card-head {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: start;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.yourturn-card-head img {
+  width: clamp(48px, 7vw, 72px);
+  aspect-ratio: 1;
+  border: 3px solid #08090a;
+  border-radius: 14px;
+  box-shadow: 4px 4px 0 #08090a;
+}
+
+.yourturn-kicker {
+  display: block;
+  margin-bottom: 5px;
+  color: #6b3fa0;
+  font-size: clamp(0.72rem, 1.5vw, 0.95rem);
+  font-weight: 1000;
+  letter-spacing: 0.14em;
+}
+
+.yourturn-card h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 4.6rem);
+  line-height: 0.86;
+  letter-spacing: -0.06em;
+  overflow-wrap: anywhere;
+}
+
+.yourturn-details {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px 16px;
+  margin: 0 0 14px;
+  padding: 12px 15px;
+  border: 4px solid #08090a;
+  border-radius: 16px;
+  background: #ffd43b;
+}
+
+.yourturn-details[hidden],
+.yourturn-copy[hidden],
+.yourturn-extra[hidden],
+.yourturn-name-field[hidden] {
+  display: none;
+}
+
+.yourturn-details strong {
+  font-size: clamp(1.25rem, 3vw, 2rem);
+  line-height: 1;
+}
+
+.yourturn-details span {
+  font-size: clamp(0.95rem, 2vw, 1.25rem);
+  font-weight: 800;
+}
+
+.yourturn-copy {
+  margin: 0 0 16px;
+  font-size: clamp(1rem, 2.2vw, 1.25rem);
+  font-weight: 760;
+  line-height: 1.28;
+}
+
+.yourturn-extra {
+  margin: 0 0 14px;
+}
+
+.yourturn-small-note,
+.yourturn-about-copy p {
+  margin: 0 0 10px;
+  font-size: clamp(0.92rem, 1.8vw, 1.08rem);
+  line-height: 1.35;
+}
+
+.yourturn-about-copy p:last-child {
+  margin-bottom: 0;
+}
+
+.yourturn-name-field {
+  display: grid;
+  gap: 7px;
+  margin: 0 0 14px;
+  font-weight: 850;
+}
+
+.yourturn-name-field input {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 48px;
+  padding: 9px 12px;
+  border: 3px solid #08090a;
+  border-radius: 12px;
+  background: #fff;
+  color: #08090a;
+  font: inherit;
+  font-size: 1.05rem;
+  font-weight: 900;
+  user-select: text;
+  -webkit-user-select: text;
+  touch-action: manipulation;
+}
+
+.yourturn-dialog-status {
+  min-height: 1.2em;
+  margin: 0 0 10px;
+  font-size: 0.9rem;
+  font-weight: 750;
+  overflow-wrap: anywhere;
+}
+
+.yourturn-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.yourturn-actions button {
+  min-height: 48px;
+  padding: 10px 16px;
+  border: 4px solid #08090a;
+  border-radius: 14px;
+  background: #fff8e8;
+  color: #08090a;
+  box-shadow: 5px 5px 0 #08090a;
+  font: inherit;
+  font-weight: 1000;
+  letter-spacing: 0.015em;
+  touch-action: manipulation;
+}
+
+.yourturn-actions button.is-primary {
+  background: #8ce99a;
+}
+
+.yourturn-actions button.is-navigation {
+  background: #ff9b66;
+}
+
+.yourturn-actions button.is-destructive {
+  background: #ffb4ab;
+}
+
+.yourturn-actions button[data-kind="quiet"] {
+  border-width: 0 0 3px;
+  border-radius: 0;
+  padding-inline: 4px;
+  background: transparent;
+  box-shadow: none;
+}
+
+.yourturn-actions button:focus-visible,
+.yourturn-name-field input:focus-visible,
+.yourturn-pause-button:focus-visible {
+  outline: 4px solid #38d9ff;
+  outline-offset: 4px;
+}
+
+.yourturn-card[data-view="paused"] {
+  width: min(520px, 90vw);
+}
+
+.yourturn-card[data-view="error"] {
+  border-color: #ff7f50;
+}
+
+.yourturn-rotate {
+  position: fixed;
+  z-index: 6000;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding:
+    max(20px, env(safe-area-inset-top))
+    max(20px, env(safe-area-inset-right))
+    max(20px, env(safe-area-inset-bottom))
+    max(20px, env(safe-area-inset-left));
+  background: #38d9ff;
+  color: #08090a;
+}
+
+.yourturn-rotate[hidden] {
+  display: none;
+}
+
+.yourturn-rotate-card {
+  display: grid;
+  justify-items: center;
+  gap: 16px;
+  width: min(560px, 92vw);
+  padding: clamp(22px, 5vw, 40px);
+  border: 5px solid #08090a;
+  border-radius: 28px;
+  background: #fff8e8;
+  box-shadow: 12px 12px 0 #08090a;
+  text-align: center;
+}
+
+.yourturn-rotate-card strong {
+  font-size: clamp(1.45rem, 5vw, 2.7rem);
+  line-height: 0.95;
+  letter-spacing: -0.035em;
+}
+
+.yourturn-rotate-card p {
+  margin: 0;
+  max-width: 34ch;
+  font-weight: 750;
+  line-height: 1.3;
+}
+
+.yourturn-phone {
+  width: 72px;
+  height: 118px;
+  border: 6px solid #08090a;
+  border-radius: 16px;
+  background: #ffd43b;
+  transform: rotate(90deg);
+}
+
+.yourturn-target-chip {
+  min-width: clamp(170px, 22vw, 280px);
+  background: #fff8e8 !important;
+}
+
+.yourturn-target-chip > span {
+  display: block;
+  color: #6b3fa0;
+  font-size: 0.62rem;
+  font-weight: 1000;
+  letter-spacing: 0.1em;
+}
+
+.yourturn-target-chip strong {
+  display: block;
+  white-space: nowrap;
+}
+
+body.yourturn-racing .lap-chip,
+body.yourturn-racing .best-chip {
+  display: none !important;
+}
+
+.yourturn-pause-button {
+  background: #ff9b66 !important;
+  color: #08090a !important;
+}
+
+body.yourturn-racing #resetButton {
+  background: #fff8e8;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0 0 0 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+@media (orientation: portrait) {
+  .yourturn-dialog {
+    place-items: end center;
+    padding-bottom: max(24px, env(safe-area-inset-bottom));
+  }
+
+  .yourturn-card {
+    width: min(92vw, 620px);
+    max-height: min(68dvh, 720px);
+    background: rgb(255 248 232 / 0.9);
+  }
+
+  .yourturn-card h1 {
+    font-size: clamp(2rem, 9vw, 3.7rem);
+  }
+
+  .yourturn-card-head img {
+    width: 52px;
+  }
+
+  .yourturn-actions button {
+    flex: 1 1 42%;
+  }
+
+  .yourturn-actions button.is-primary {
+    flex-basis: 58%;
+  }
+}
+
+@media (max-height: 560px) and (orientation: landscape) {
+  .yourturn-dialog {
+    padding: 10px max(12px, env(safe-area-inset-right)) 12px max(12px, env(safe-area-inset-left));
+  }
+
+  .yourturn-card {
+    width: min(820px, 94vw);
+    max-height: calc(100dvh - 22px);
+    padding: 15px 18px;
+    border-width: 4px;
+    box-shadow: 8px 8px 0 rgb(8 9 10 / 0.96);
+  }
+
+  .yourturn-card-head {
+    grid-template-columns: 44px minmax(0, 1fr);
+    gap: 10px;
+    margin-bottom: 10px;
+  }
+
+  .yourturn-card-head img {
+    width: 42px;
+    border-width: 2px;
+  }
+
+  .yourturn-card h1 {
+    font-size: clamp(1.7rem, 5.2vw, 3.2rem);
+  }
+
+  .yourturn-details {
+    margin-bottom: 9px;
+    padding: 8px 11px;
+    border-width: 3px;
+  }
+
+  .yourturn-copy {
+    margin-bottom: 9px;
+    font-size: 0.95rem;
+  }
+
+  .yourturn-extra {
+    margin-bottom: 8px;
+  }
+
+  .yourturn-name-field {
+    margin-bottom: 8px;
+  }
+
+  .yourturn-name-field input {
+    min-height: 40px;
+    padding-block: 6px;
+  }
+
+  .yourturn-dialog-status {
+    margin-bottom: 5px;
+  }
+
+  .yourturn-actions {
+    gap: 8px;
+  }
+
+  .yourturn-actions button {
+    min-height: 40px;
+    padding: 7px 11px;
+    border-width: 3px;
+    box-shadow: 3px 3px 0 #08090a;
+    font-size: 0.86rem;
+  }
+
+  body.yourturn-racing .map-wrap {
+    display: none !important;
+  }
+
+  body.yourturn-racing .topbar {
+    justify-content: flex-start;
+  }
+
+  body.yourturn-racing .stats {
+    max-width: calc(100vw - max(14px, env(safe-area-inset-left)) - max(14px, env(safe-area-inset-right)));
+  }
+
+  .yourturn-target-chip {
+    min-width: 150px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .yourturn-dialog::backdrop {
+    backdrop-filter: none;
+  }
+
+  .yourturn-phone {
+    transform: rotate(90deg);
+  }
+
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.001ms !important;
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
## Product boundary
Build `/yourturn` as a small browser-first challenge app parallel to TURN's `RACE`, without changing production `turn/**` or replacing TURN Home.

## Recipient flow
- portrait invitation with YOUR TURN branding and the challenger’s actual name
- slightly translucent invitation so the challenger’s car remains perceptible behind it
- `ACCEPT CHALLENGE` requests device-motion access first
- after permission, show a dedicated `ROTATE YOUR DEVICE TO LANDSCAPE` transition before starting the race
- device rotation is the default; on-screen steering appears only as an explicit fallback when motion is unavailable/denied
- `TRY LATER` opens full TURN in the browser
- `ABOUT TURN` provides a concise onboarding including Drive By Ear, screen-reader and non-visual play

## Race experience
- reuse canonical TURN `main.js`, tracks, vehicles, audio, Drive By Ear, screen-reader race speech, controls and screen blanking
- no TURN Home, track chooser, Lot, achievements or Trophy Road bootstrap
- explicit orange `PAUSE` control that freezes the actual render/physics loop, plus automatic safe pause when the browser is backgrounded
- opponent staging imitation is delayed by 650 ms; preview movement also starts after a short delay
- `prefers-reduced-motion` keeps the preview static, but Pause remains available independently
- all visible recipient copy says the challenger’s car / YOUR TURN; no “ghost” terminology

## Result flow
- win and give-up screens can share a reply link from `/yourturn`
- after win or give-up, offer `GET FULL TURN`
- mock challenge links are included for development; TURN challenge creation remains untouched for now

## Compatibility and isolation
- browser route only: no PWA manifest or install gate
- feature-detect native share/clipboard/fullscreen/motion with fallbacks
- separate `yourturn:` local/session storage namespace so challenge testing cannot alter production TURN records or selected car

## Test links after merge
- `/yourturn/?challenge=sol-countryside-r1`
- `/yourturn/?challenge=sol-countryside-friendly`
- `/yourturn/?challenge=alex-countryside-r1`
- `/yourturn/` provides a mock-picker when no challenge is supplied

## Validation
- focused YOUR TURN regression contract added
- focused challenge workflow extended to syntax-check and run `/yourturn`
- focused challenge regression: green
- complete TURN regression suite: green
- while running the previously dormant full suite, four pre-existing release-stale assertions were found in startup, history, design-system and Bella regression coverage; those test assertions now follow canonical `turn/release.json` instead of hard-coding 1.5.1/r160
- production `turn/**` code is unchanged
