### PR TITLE
Fix YOUR TURN motion, pause, calibration, and replies

### DIFF
--- a/turn-tests/yourturn-production.mjs
+++ b/turn-tests/yourturn-production.mjs
@@ -4,6 +4,7 @@ import {
   challengeFromLap,
   decodeChallenge,
   encodeChallenge,
+  encodedChallengeFromLocation,
   makeChallengeUrl,
   makeMockChallengeUrl
 } from '../yourturn/protocol.js';
@@ -32,8 +33,11 @@ const [
 
 assert.match(indexSource, /<title>YOUR TURN<\/title>/);
 assert.match(indexSource, /\/yourturn\/storage-bootstrap\.js/);
-assert.match(indexSource, /\/yourturn\/app\.js/);
-assert.match(indexSource, /id="yourTurnPauseButton"/);
+assert.match(indexSource, /\/yourturn\/app\.js\?revision=r2/);
+assert.match(indexSource, /id="yourTurnChallengeButton"[\s\S]*>CHALLENGE<\/button>/,
+  'The in-race return point must be a challenge menu, not merely a Pause label');
+assert.match(indexSource, /id="yourTurnMotionToggle"[\s\S]*aria-label="Pause background motion"/,
+  'Invitation and result motion need an explicit pause/play control');
 assert.match(indexSource, /id="yourTurnRotate"/);
 assert.match(indexSource, /ROTATE YOUR DEVICE TO LANDSCAPE/);
 assert.doesNotMatch(indexSource, /manifest|install-gate/i,
@@ -44,8 +48,12 @@ assert.match(appSource, /await import\(withBuild\('\/turn\/main\.js'\)\)/,
 assert.doesNotMatch(appSource, /\/turn\/app\.js|m8-home|installM8HomeNavigation/,
   'YOUR TURN must not bootstrap the full TURN Home application');
 assert.match(appSource, /installAnimationPauseBridge/);
-assert.match(appSource, /nativeSetAnimationLoop\.call\(renderer, null\)/,
-  'Pause must stop the rendering/physics loop rather than merely reducing motion');
+assert.ok(
+  appSource.indexOf('installCoveredRenderingGuard();') < appSource.indexOf('installAnimationPauseBridge(THREE)'),
+  'YOUR TURN pause must wrap the final renderer loop after TURN covered-rendering composition'
+);
+assert.match(appSource, /downstreamSetAnimationLoop\.call\(renderer, null\)/,
+  'Pause must stop the actual rendering and physics loop');
 assert.match(appSource, /installScreenBlanking/,
   'The non-visual screen blanking affordance must remain available');
 assert.match(appSource, /installRaceSpeech/,
@@ -58,19 +66,31 @@ assert.ok(
   'Motion permission must happen before the landscape transition'
 );
 assert.match(sessionSource, /ui\.showRotate\(\)/);
+assert.match(sessionSource, /centerMotionAfterLandscape\(\)/,
+  'Landscape entry must establish a fresh steering neutral before the race can move');
+assert.match(sessionSource, /runtime\.state\.neutralRoll = runtime\.state\.targetRoll/);
 assert.match(sessionSource, /prepareManualAccess\(\)/,
   'On-screen steering must remain an explicit fallback');
 assert.match(sessionSource, /label: 'TRY LATER'/);
 assert.match(sessionSource, /globalThis\.location\.href = '\/turn\/'/);
 assert.match(sessionSource, /label: 'ABOUT TURN'/);
 assert.match(sessionSource, /label: 'GET FULL TURN'/);
-assert.match(sessionSource, /label: 'PAUSE'|titleText: 'PAUSED'/);
+assert.match(sessionSource, /titleText: 'CHALLENGE'/);
+assert.match(sessionSource, /label: 'GIVE UP'/,
+  'Challenge menu must keep the route back to Give Up visible');
+assert.match(sessionSource, /ambientPaused/);
+assert.match(sessionSource, /toggleAmbientMotion/);
+assert.match(sessionSource, /if \(state\.ambientPaused\) animation\.pause\(\)/,
+  'A start-screen background pause preference must carry through to the result scene');
 assert.match(sessionSource, /navigator\.share/);
 assert.match(sessionSource, /navigator\.clipboard/);
 assert.doesNotMatch(sessionSource, /ghost/i,
   'YOUR TURN recipient copy and challenge layer must describe the challenger’s car, not a ghost');
 
 assert.match(uiSource, /YOUR TURN/);
+assert.match(uiSource, /bindMotionToggle/);
+assert.match(uiSource, /Play background motion/);
+assert.match(uiSource, /Pause background motion/);
 assert.match(uiSource, /rotate your phone like a steering wheel/i);
 assert.match(uiSource, /spatial audio/i);
 assert.match(uiSource, /screen-reader and non-visual play/i);
@@ -84,8 +104,10 @@ assert.match(sceneSource, /prefers-reduced-motion/);
 
 assert.match(cssSource, /background: rgb\(255 248 232 \/ 0\.9\)/,
   'Portrait invitation card must be slightly translucent so the challenger car remains perceptible');
-assert.match(cssSource, /\.yourturn-pause-button[\s\S]*#ff9b66/,
-  'The explicit Pause control must use the navigation/back orange');
+assert.match(cssSource, /\.yourturn-challenge-button[\s\S]*#ff9b66/,
+  'The challenge-menu control must use the navigation/back orange');
+assert.match(cssSource, /\.yourturn-motion-toggle[\s\S]*border-radius: 50%[\s\S]*background: #ff9b66/,
+  'The modal pause/play control must be round and use the navigation/back orange');
 assert.match(cssSource, /@media \(orientation: portrait\)/);
 assert.match(cssSource, /@media \(max-height: 560px\) and \(orientation: landscape\)/,
   'Small in-app browser viewports need a dedicated compact landscape layout');
@@ -120,16 +142,28 @@ const challenge = challengeFromLap({
     frames
   }
 });
-assert.ok(challenge.frames.length <= 450);
+assert.ok(challenge.frames.length <= 180);
 const encoded = await encodeChallenge(challenge);
 const decoded = await decodeChallenge(encoded);
 assert.equal(decoded.challengerName, 'Erik');
 assert.equal(decoded.trackId, 'countryside');
 assert.equal(decoded.time, 42);
-assert.match(makeChallengeUrl(encoded), /^https:\/\/enkel\.design\/yourturn\/#challenge=/);
+const challengeUrl = makeChallengeUrl(encoded);
+assert.match(challengeUrl, /^https:\/\/enkel\.design\/yourturn\/\?c=/,
+  'New challenge replies must use a query-carried URL so social preview crawlers receive the challenge URL');
+assert.equal(
+  encodedChallengeFromLocation(new URL(challengeUrl)),
+  encoded,
+  'Query-carried challenge URLs must decode normally'
+);
+assert.equal(
+  encodedChallengeFromLocation(new URL(`https://enkel.design/yourturn/#challenge=${encoded}`)),
+  encoded,
+  'Previously shared hash-carried challenge links must remain valid'
+);
 assert.equal(
   makeMockChallengeUrl('sol-countryside-r1'),
   'https://enkel.design/yourturn/?challenge=sol-countryside-r1'
 );
 
-console.log('YOUR TURN standalone recipient, motion-first flow, pause, accessibility and protocol regression passed.');
+console.log('YOUR TURN recipient motion controls, challenge menu, fresh calibration, social links and protocol regression passed.');

--- a/yourturn/app.js
+++ b/yourturn/app.js
@@ -1,19 +1,18 @@
 import * as THREE from 'three';
-import { createYourTurnUi, escapeHtml } from '/yourturn/ui.js?revision=r1';
-import { createYourTurnSession, readYourTurnRequest } from '/yourturn/session.js?revision=r1';
+import { createYourTurnUi, escapeHtml } from '/yourturn/ui.js?revision=r2';
+import { createYourTurnSession, readYourTurnRequest } from '/yourturn/session.js?revision=r2';
 
 if (globalThis.__YOUR_TURN_STORAGE_READY__ === false) {
   throw new Error('YOUR TURN storage isolation failed before startup.');
 }
 
-const animation = installAnimationPauseBridge(THREE);
 const release = await loadTurnRelease();
 globalThis.__TURN_BUILD__ = Object.freeze(release);
-document.documentElement.dataset.yourTurnRuntime = 'recipient-r1';
+document.documentElement.dataset.yourTurnRuntime = 'recipient-r2';
 
 function withBuild(path) {
   const url = new URL(path, globalThis.location?.href || 'https://enkel.design/yourturn/');
-  if (release.cacheKey) url.searchParams.set('build', `${release.cacheKey}-yourturn-r1`);
+  if (release.cacheKey) url.searchParams.set('build', `${release.cacheKey}-yourturn-r2`);
   return url.href;
 }
 
@@ -31,6 +30,7 @@ const { installPerformanceProfile } = await import(withBuild('/turn/performance-
 installPerformanceProfile();
 const { installCoveredRenderingGuard } = await import(withBuild('/turn/render/covered-rendering.js'));
 installCoveredRenderingGuard();
+const animation = installAnimationPauseBridge(THREE);
 
 const { installDriveByEarSetting } = await import(withBuild('/turn/ui/drive-by-ear-setting.js'));
 const driveByEarEnabled = installDriveByEarSetting();
@@ -120,7 +120,7 @@ async function loadTurnRelease() {
 
 function installAnimationPauseBridge(three) {
   const prototype = three.WebGLRenderer.prototype;
-  const nativeSetAnimationLoop = prototype.setAnimationLoop;
+  const downstreamSetAnimationLoop = prototype.setAnimationLoop;
   let renderer = null;
   let loop = null;
   let paused = false;
@@ -128,22 +128,20 @@ function installAnimationPauseBridge(three) {
   prototype.setAnimationLoop = function setAnimationLoop(callback) {
     renderer = this;
     if (typeof callback === 'function') loop = callback;
-    if (callback === null) loop = null;
-    return nativeSetAnimationLoop.call(this, paused ? null : callback);
+    if (callback === null && !paused) loop = null;
+    return downstreamSetAnimationLoop.call(this, paused ? null : callback);
   };
 
   return Object.freeze({
     pause() {
+      if (paused) return;
       paused = true;
-      if (renderer) nativeSetAnimationLoop.call(renderer, null);
+      if (renderer) downstreamSetAnimationLoop.call(renderer, null);
     },
     resume() {
-      if (!paused && renderer && loop) {
-        nativeSetAnimationLoop.call(renderer, loop);
-        return;
-      }
+      if (!paused) return;
       paused = false;
-      if (renderer && loop) nativeSetAnimationLoop.call(renderer, loop);
+      if (renderer && loop) downstreamSetAnimationLoop.call(renderer, loop);
     },
     isPaused: () => paused
   });

--- a/yourturn/index.html
+++ b/yourturn/index.html
@@ -20,18 +20,18 @@
   <title>YOUR TURN</title>
   <link rel="icon" href="/turn/TURNicon.PNG?icon=20260803-profile-512" type="image/png">
 
-  <link rel="stylesheet" href="/turn/styles.css?source=yourturn-r1">
-  <link rel="stylesheet" href="/turn/vertical-drive.css?source=yourturn-r1">
-  <link rel="stylesheet" href="/turn/hud-tuning.css?source=yourturn-r1">
-  <link rel="stylesheet" href="/turn/gameplay-features.css?source=yourturn-r1">
-  <link rel="stylesheet" href="/turn/gameplay-v2.css?source=yourturn-r1">
-  <link rel="stylesheet" href="/turn/position-hud-r83.css?source=yourturn-r1">
-  <link rel="stylesheet" href="/turn/drive-pad.css?source=yourturn-r1">
-  <link rel="stylesheet" href="/turn/manual-steering.css?source=yourturn-r1">
-  <link rel="stylesheet" href="/turn/steering-limit-warning.css?source=yourturn-r1">
-  <link rel="stylesheet" href="/turn/lap-result-toast.css?source=yourturn-r1">
-  <link rel="stylesheet" href="/turn/r104-polish.css?source=yourturn-r1">
-  <link rel="stylesheet" href="/yourturn/yourturn.css?revision=r1">
+  <link rel="stylesheet" href="/turn/styles.css?source=yourturn-r2">
+  <link rel="stylesheet" href="/turn/vertical-drive.css?source=yourturn-r2">
+  <link rel="stylesheet" href="/turn/hud-tuning.css?source=yourturn-r2">
+  <link rel="stylesheet" href="/turn/gameplay-features.css?source=yourturn-r2">
+  <link rel="stylesheet" href="/turn/gameplay-v2.css?source=yourturn-r2">
+  <link rel="stylesheet" href="/turn/position-hud-r83.css?source=yourturn-r2">
+  <link rel="stylesheet" href="/turn/drive-pad.css?source=yourturn-r2">
+  <link rel="stylesheet" href="/turn/manual-steering.css?source=yourturn-r2">
+  <link rel="stylesheet" href="/turn/steering-limit-warning.css?source=yourturn-r2">
+  <link rel="stylesheet" href="/turn/lap-result-toast.css?source=yourturn-r2">
+  <link rel="stylesheet" href="/turn/r104-polish.css?source=yourturn-r2">
+  <link rel="stylesheet" href="/yourturn/yourturn.css?revision=r2">
 
   <script src="/yourturn/storage-bootstrap.js?revision=r1"></script>
   <script type="importmap">
@@ -80,7 +80,7 @@
 
   <div class="controls" id="controls" hidden>
     <div class="utility-group">
-      <button class="utility yourturn-pause-button" id="yourTurnPauseButton" type="button" hidden>PAUSE</button>
+      <button class="utility yourturn-challenge-button" id="yourTurnChallengeButton" type="button" hidden aria-label="Open challenge menu">CHALLENGE</button>
       <button class="utility" id="calibrateButton" type="button">Recalibrate</button>
       <button class="utility" id="resetButton" type="button">Restart Lap</button>
     </div>
@@ -100,6 +100,7 @@
 
   <dialog class="yourturn-dialog" id="yourTurnDialog" aria-labelledby="yourTurnTitle">
     <article class="yourturn-card">
+      <button class="yourturn-motion-toggle" id="yourTurnMotionToggle" type="button" hidden aria-label="Pause background motion" aria-pressed="false" title="Pause background motion">⏸</button>
       <header class="yourturn-card-head">
         <img src="/turn/TURNicon.PNG?icon=20260803-profile-512" alt="" aria-hidden="true">
         <div>
@@ -125,6 +126,6 @@
     <span>Loading challenge…</span>
   </div>
 
-  <script type="module" src="/yourturn/app.js?revision=r1"></script>
+  <script type="module" src="/yourturn/app.js?revision=r2"></script>
 </body>
 </html>

--- a/yourturn/protocol.js
+++ b/yourturn/protocol.js
@@ -1,8 +1,9 @@
 const CHALLENGE_SCHEMA_VERSION = 1;
 const WIRE_VERSION = 1;
 const HASH_KEY = 'challenge';
+const QUERY_KEY = 'c';
 const MAX_NAME_LENGTH = 24;
-const MAX_FRAMES = 450;
+const MAX_FRAMES = 180;
 const MIN_FRAMES = 21;
 const TIME_SCALE = 1000;
 const POSITION_SCALE = 100;
@@ -122,6 +123,9 @@ export async function decodeChallenge(encoded) {
 }
 
 export function encodedChallengeFromLocation(locationRef = globalThis.location) {
+  const query = new URLSearchParams(locationRef?.search || '');
+  const queryValue = query.get(QUERY_KEY);
+  if (queryValue) return queryValue;
   const hash = String(locationRef?.hash || '').replace(/^#/, '');
   return new URLSearchParams(hash).get(HASH_KEY) || '';
 }
@@ -132,11 +136,9 @@ export function makeChallengeUrl(encoded, {
   responder = ''
 } = {}) {
   const url = new URL(baseUrl);
+  url.searchParams.set(QUERY_KEY, encoded);
   if (reply) url.searchParams.set('reply', reply);
   if (responder) url.searchParams.set('responder', normalizeChallengeName(responder));
-  const params = new URLSearchParams();
-  params.set(HASH_KEY, encoded);
-  url.hash = params.toString();
   return url.href;
 }
 

--- a/yourturn/session.js
+++ b/yourturn/session.js
@@ -15,10 +15,10 @@ import {
   makeMockChallengeUrl,
   normalizeChallenge,
   normalizeChallengeName
-} from '/yourturn/protocol.js?revision=r1';
+} from '/yourturn/protocol.js?revision=r2';
 import { getMockChallenge, MOCK_CHALLENGES } from '/yourturn/mock-challenges.js?revision=r1';
 import { createChallengeScene } from '/yourturn/scene.js?revision=r1';
-import { aboutTurnHtml, escapeHtml, newcomerAssistiveText } from '/yourturn/ui.js?revision=r1';
+import { aboutTurnHtml, escapeHtml, newcomerAssistiveText } from '/yourturn/ui.js?revision=r2';
 
 export function readYourTurnRequest(locationRef = globalThis.location) {
   const query = new URLSearchParams(locationRef?.search || '');
@@ -45,10 +45,13 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
     scene: null,
     pendingAccess: null,
     paused: false,
-    backgroundPaused: false
+    backgroundPaused: false,
+    ambientPaused: false
   };
 
-  ui.bindPause(() => pauseRace('Paused by player.'));
+  ui.bindChallengeMenu(() => openChallengeMenu('Race paused.'));
+  ui.bindMotionToggle(toggleAmbientMotion);
+  ui.setMotionPaused(false);
   window.addEventListener('turn:lap-result', handleLapResult);
   window.addEventListener('turn:ui-state-change', handleUiState);
   document.addEventListener('visibilitychange', handleVisibility);
@@ -147,6 +150,12 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
     });
   }
 
+  function showSessionModal(config) {
+    const motionControl = Boolean(state.scene && document.body.classList.contains('yourturn-preview'));
+    ui.setMotionPaused(state.ambientPaused);
+    ui.showModal({ ...config, motionControl });
+  }
+
   function showInvitation() {
     const challenge = state.challenge;
     const track = getTrackDefinition(challenge.trackId);
@@ -154,7 +163,7 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
     state.phase = 'preview';
     state.scene?.setPhase('preview');
     ui.hideRaceChrome();
-    ui.showModal({
+    showSessionModal({
       titleText: `${challenge.challengerName} CHALLENGES YOU`,
       detailsHtml: `
         <strong>${escapeHtml(track.name.toUpperCase())}</strong>
@@ -187,7 +196,7 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
 
   function showMotionProblem(error) {
     const message = error instanceof Error ? error.message : 'Motion steering could not be enabled.';
-    ui.showModal({
+    showSessionModal({
       titleText: 'MOTION STEERING NEEDED',
       copyHtml: `${escapeHtml(message)} TURN is designed around rotating the phone like a steering wheel.`,
       extraHtml: '<p class="yourturn-small-note">If this browser cannot provide motion access, on-screen steering is available as a fallback.</p>',
@@ -232,6 +241,7 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
   async function startAcceptedRace() {
     state.accepted = true;
     state.paused = false;
+    animation.pause();
     ui.hideRotate();
     document.body.classList.remove('yourturn-preview');
     document.body.classList.add('yourturn-racing');
@@ -242,6 +252,7 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
     document.querySelector('#resetButton')?.click();
     useChallengeAsOnlyOpponent();
     const access = state.pendingAccess || raceSession.prepareManualAccess();
+    await centerMotionAfterLandscape();
     await raceSession.startGame(access.fullscreenPromise);
     runtime.setGameMode(GAME_MODE.STAGED);
     runtime.state.velocity.set(0, 0, 0);
@@ -249,8 +260,40 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
     const message = document.querySelector('#message');
     message?.classList.remove('show');
     if (message) message.textContent = '';
+    runtime.state.lastFrame = performance.now();
     ui.showRaceChrome();
     animation.resume();
+  }
+
+  async function centerMotionAfterLandscape() {
+    if (!runtime.state.sensorMode) return;
+    await new Promise((resolve) => {
+      let samples = 0;
+      let finished = false;
+      let timer = 0;
+      const finish = () => {
+        if (finished) return;
+        finished = true;
+        window.removeEventListener('devicemotion', onMotion);
+        window.clearTimeout(timer);
+        resolve();
+      };
+      const onMotion = () => {
+        samples += 1;
+        if (samples >= 2) finish();
+      };
+      window.addEventListener('devicemotion', onMotion, { passive: true });
+      timer = window.setTimeout(finish, 320);
+    });
+
+    runtime.state.neutralRoll = runtime.state.targetRoll;
+    runtime.state.horizonRollReference = runtime.state.targetRoll;
+    runtime.state.roll = runtime.state.targetRoll;
+    runtime.state.neutralPitch = runtime.state.targetPitch;
+    runtime.state.pitch = runtime.state.targetPitch;
+    runtime.state.steering = 0;
+    runtime.state.steeringEngaged = false;
+    runtime.state.tiltDrive = 0;
   }
 
   function handleLapResult(event) {
@@ -284,7 +327,7 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
 
   function showWin(candidate) {
     const difference = state.challenge.time - candidate.time;
-    ui.showModal({
+    showSessionModal({
       titleText: `YOU BEAT ${state.challenge.challengerName}`,
       detailsHtml: `
         <strong>${formatChallengeTime(candidate.time)}</strong>
@@ -328,7 +371,7 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
   function showGiveUpConfirm() {
     const wasAccepted = state.accepted;
     if (wasAccepted) stopRaceForModal('reply');
-    ui.showModal({
+    showSessionModal({
       titleText: 'GIVE UP?',
       detailsHtml: `<strong>${escapeHtml(state.challenge.challengerName)} WINS</strong><span>Target ${formatChallengeTime(state.challenge.time)}</span>`,
       copyHtml: `You can keep racing ${escapeHtml(state.challenge.challengerName)}’s car for as many laps as you want.`,
@@ -343,7 +386,7 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
   function finishGiveUp() {
     state.phase = 'reply';
     state.scene?.setPhase('reply');
-    ui.showModal({
+    showSessionModal({
       titleText: `${state.challenge.challengerName} WINS`,
       detailsHtml: `<strong>${formatChallengeTime(state.challenge.time)}</strong><span>Challenge held</span>`,
       copyHtml: 'Send the result back, try again, or open the full TURN game.',
@@ -372,7 +415,7 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
   }
 
   function showReceivedGiveUp() {
-    ui.showModal({
+    showSessionModal({
       titleText: `${request.responder} GAVE UP`,
       detailsHtml: `<strong>YOU WIN</strong><span>${formatChallengeTime(state.challenge.time)} held the lead</span>`,
       copyHtml: `Your car beat ${escapeHtml(request.responder)}.`,
@@ -385,34 +428,24 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
     });
   }
 
-  function pauseRace(reason = 'Race paused.') {
+  function openChallengeMenu(reason = 'Race paused.') {
     if (!state.accepted || state.paused || !['racing', 'staged'].includes(state.phase)) return;
     state.paused = true;
     stopDrivingInputs();
     animation.pause();
-    ui.showModal({
-      titleText: 'PAUSED',
-      copyHtml: escapeHtml(reason),
-      className: 'paused',
-      actionList: [
-        { label: 'RESUME', primary: true, action: resumeRace },
-        { label: 'RESTART LAP', action: restartFromPause },
-        { label: 'GIVE UP', destructive: true, action: showGiveUpConfirm },
-        { label: 'ABOUT TURN', kind: 'quiet', action: () => showAbout(() => pauseRaceView(reason)) }
-      ]
-    });
+    showChallengeMenuView(reason);
   }
 
-  function pauseRaceView(reason) {
-    ui.showModal({
-      titleText: 'PAUSED',
+  function showChallengeMenuView(reason) {
+    showSessionModal({
+      titleText: 'CHALLENGE',
       copyHtml: escapeHtml(reason),
       className: 'paused',
       actionList: [
         { label: 'RESUME', primary: true, action: resumeRace },
         { label: 'RESTART LAP', action: restartFromPause },
         { label: 'GIVE UP', destructive: true, action: showGiveUpConfirm },
-        { label: 'ABOUT TURN', kind: 'quiet', action: () => showAbout(() => pauseRaceView(reason)) }
+        { label: 'ABOUT TURN', kind: 'quiet', action: () => showAbout(() => showChallengeMenuView(reason)) }
       ]
     });
   }
@@ -464,11 +497,24 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
     state.paused = false;
     runtime.state.running = true;
     runtime.state.lastFrame = performance.now();
-    animation.resume();
+    if (state.ambientPaused) animation.pause();
+    else animation.resume();
+  }
+
+  function toggleAmbientMotion() {
+    if (!state.scene || !document.body.classList.contains('yourturn-preview')) return;
+    state.ambientPaused = !state.ambientPaused;
+    if (state.ambientPaused) {
+      animation.pause();
+    } else {
+      runtime.state.lastFrame = performance.now();
+      animation.resume();
+    }
+    ui.setMotionPaused(state.ambientPaused);
   }
 
   function showAbout(returnAction) {
-    ui.showModal({
+    showSessionModal({
       titleText: 'ABOUT TURN',
       extraHtml: aboutTurnHtml(),
       className: 'about',
@@ -484,7 +530,7 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
       label: mock.label,
       action: () => { globalThis.location.href = makeMockChallengeUrl(mock.id); }
     }));
-    ui.showModal({
+    showSessionModal({
       titleText: 'TEST CHALLENGES',
       copyHtml: 'Choose a stable mock link while the recipient experience is under development.',
       className: 'picker',
@@ -515,7 +561,7 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
     }
     if (!document.hidden && state.backgroundPaused) {
       state.backgroundPaused = false;
-      pauseRaceView('Race paused while YOUR TURN was in the background.');
+      showChallengeMenuView('Race paused while YOUR TURN was in the background.');
     }
   }
 

--- a/yourturn/ui.js
+++ b/yourturn/ui.js
@@ -1,4 +1,4 @@
-import { normalizeChallengeName } from '/yourturn/protocol.js?revision=r1';
+import { normalizeChallengeName } from '/yourturn/protocol.js?revision=r2';
 
 const PLAYER_NAME_KEY = 'yourturn-player-name-v1';
 
@@ -13,14 +13,15 @@ export function createYourTurnUi() {
   const actions = dialog?.querySelector('.yourturn-actions');
   const status = dialog?.querySelector('.yourturn-dialog-status');
   const nameField = dialog?.querySelector('.yourturn-name-field');
+  const motionToggle = dialog?.querySelector('#yourTurnMotionToggle');
   const rotate = document.querySelector('#yourTurnRotate');
   const targetChip = document.querySelector('#yourTurnTargetChip');
   const targetOpponent = document.querySelector('#yourTurnTargetOpponent');
   const targetTime = document.querySelector('#yourTurnTargetTime');
-  const pauseButton = document.querySelector('#yourTurnPauseButton');
+  const challengeButton = document.querySelector('#yourTurnChallengeButton');
 
   if (!dialog || !card || !kicker || !title || !details || !copy || !extra || !actions || !status
-      || !nameField || !rotate || !targetChip || !targetOpponent || !targetTime || !pauseButton) {
+      || !nameField || !motionToggle || !rotate || !targetChip || !targetOpponent || !targetTime || !challengeButton) {
     throw new Error('YOUR TURN could not find its complete interface.');
   }
 
@@ -36,7 +37,8 @@ export function createYourTurnUi() {
     extraHtml = '',
     actionList = [],
     requestName = false,
-    className = ''
+    className = '',
+    motionControl = false
   }) {
     kicker.textContent = kickerText;
     title.textContent = titleText;
@@ -48,6 +50,7 @@ export function createYourTurnUi() {
     extra.hidden = !extraHtml;
     status.textContent = '';
     card.dataset.view = className;
+    motionToggle.hidden = !motionControl;
 
     nameField.hidden = !requestName;
     if (requestName) nameField.querySelector('input').value = loadPlayerName();
@@ -96,13 +99,13 @@ export function createYourTurnUi() {
 
   function showRaceChrome() {
     targetChip.hidden = false;
-    pauseButton.hidden = false;
+    challengeButton.hidden = false;
     document.body.classList.add('yourturn-racing');
   }
 
   function hideRaceChrome() {
     targetChip.hidden = true;
-    pauseButton.hidden = true;
+    challengeButton.hidden = true;
     document.body.classList.remove('yourturn-racing');
   }
 
@@ -117,8 +120,19 @@ export function createYourTurnUi() {
     document.body.classList.remove('yourturn-awaiting-landscape');
   }
 
-  function bindPause(handler) {
-    pauseButton.addEventListener('click', handler);
+  function bindChallengeMenu(handler) {
+    challengeButton.addEventListener('click', handler);
+  }
+
+  function bindMotionToggle(handler) {
+    motionToggle.addEventListener('click', handler);
+  }
+
+  function setMotionPaused(paused) {
+    motionToggle.textContent = paused ? '▶' : '⏸';
+    motionToggle.setAttribute('aria-label', paused ? 'Play background motion' : 'Pause background motion');
+    motionToggle.setAttribute('aria-pressed', String(Boolean(paused)));
+    motionToggle.title = paused ? 'Play background motion' : 'Pause background motion';
   }
 
   return Object.freeze({
@@ -131,7 +145,9 @@ export function createYourTurnUi() {
     hideRaceChrome,
     showRotate,
     hideRotate,
-    bindPause
+    bindChallengeMenu,
+    bindMotionToggle,
+    setMotionPaused
   });
 }
 

--- a/yourturn/yourturn.css
+++ b/yourturn/yourturn.css
@@ -96,6 +96,7 @@ html[data-turn-deployment="yourturn"] #intro {
 }
 
 .yourturn-card {
+  position: relative;
   box-sizing: border-box;
   width: min(720px, 92vw);
   max-height: calc(100dvh - 32px);
@@ -109,12 +110,38 @@ html[data-turn-deployment="yourturn"] #intro {
   -webkit-overflow-scrolling: touch;
 }
 
+.yourturn-motion-toggle {
+  position: absolute;
+  z-index: 3;
+  top: 12px;
+  right: 12px;
+  display: grid;
+  width: 52px;
+  height: 52px;
+  min-width: 52px;
+  min-height: 52px;
+  padding: 0;
+  place-items: center;
+  border: 4px solid #08090a;
+  border-radius: 50%;
+  background: #ff9b66;
+  color: #08090a;
+  box-shadow: 4px 4px 0 #08090a;
+  font: 1000 1.2rem/1 system-ui, sans-serif;
+  touch-action: manipulation;
+}
+
+.yourturn-motion-toggle[hidden] {
+  display: none;
+}
+
 .yourturn-card-head {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
   align-items: start;
   gap: 12px;
   margin-bottom: 16px;
+  padding-right: 56px;
 }
 
 .yourturn-card-head img {
@@ -267,7 +294,8 @@ html[data-turn-deployment="yourturn"] #intro {
 
 .yourturn-actions button:focus-visible,
 .yourturn-name-field input:focus-visible,
-.yourturn-pause-button:focus-visible {
+.yourturn-challenge-button:focus-visible,
+.yourturn-motion-toggle:focus-visible {
   outline: 4px solid #38d9ff;
   outline-offset: 4px;
 }
@@ -357,7 +385,7 @@ body.yourturn-racing .best-chip {
   display: none !important;
 }
 
-.yourturn-pause-button {
+.yourturn-challenge-button {
   background: #ff9b66 !important;
   color: #08090a !important;
 }
@@ -420,10 +448,23 @@ body.yourturn-racing #resetButton {
     box-shadow: 8px 8px 0 rgb(8 9 10 / 0.96);
   }
 
+  .yourturn-motion-toggle {
+    top: 8px;
+    right: 8px;
+    width: 42px;
+    height: 42px;
+    min-width: 42px;
+    min-height: 42px;
+    border-width: 3px;
+    box-shadow: 3px 3px 0 #08090a;
+    font-size: 1rem;
+  }
+
   .yourturn-card-head {
     grid-template-columns: 44px minmax(0, 1fr);
     gap: 10px;
     margin-bottom: 10px;
+    padding-right: 46px;
   }
 
   .yourturn-card-head img {


### PR DESCRIPTION
## What changed
- added an explicit round orange pause/play control to invitation/result modal scenes so background car movement can always be stopped independently of `prefers-reduced-motion`
- preserves that ambient-motion choice across the session: if the recipient pauses the opening scene, result scenes start paused too
- renamed the in-race `PAUSE` affordance to `CHALLENGE`; it now acts as the clear route back to the challenge/control modal where Resume, Restart Lap, Give Up, and About TURN live
- fixed the actual race pause composition so it wraps TURN's final renderer loop and freezes physics/rendering instead of only killing driving input
- establishes a fresh motion neutral after the recipient has rotated to landscape, using fresh device-motion samples before racing begins
- new encoded challenge replies use a query-carried `?c=` URL and downsample to at most 180 replay frames for shorter, crawler-visible share URLs; existing `#challenge=` URLs remain supported
- bumped YOUR TURN module/style revision to r2 so mobile/in-app browsers do not retain the previous runtime

## Scope
Only `/yourturn/**` and the focused YOUR TURN regression test are changed. Production `/turn/**` is untouched.

## Validation
The focused workflow covers the challenge menu, modal motion control, final renderer-loop pause composition, landscape calibration, query-carried reply links, backwards-compatible hash links, and the existing recipient contract.