### PR TITLE
Fix YOUR TURN hard pause and motion steering

### DIFF
--- a/turn-tests/yourturn-production.mjs
+++ b/turn-tests/yourturn-production.mjs
@@ -33,11 +33,13 @@ const [
 
 assert.match(indexSource, /<title>YOUR TURN<\/title>/);
 assert.match(indexSource, /\/yourturn\/storage-bootstrap\.js/);
-assert.match(indexSource, /\/yourturn\/app\.js\?revision=r2/);
-assert.match(indexSource, /id="yourTurnChallengeButton"[\s\S]*>CHALLENGE<\/button>/,
-  'The in-race return point must be a challenge menu, not merely a Pause label');
+assert.match(indexSource, /\/yourturn\/app\.js\?revision=r3/);
+assert.match(indexSource, /id="yourTurnChallengeButton"[\s\S]*>THE CHALLENGE<\/button>/,
+  'The in-race return point must read as the challenge hub, not as a verb or a Pause command');
 assert.match(indexSource, /id="yourTurnMotionToggle"[\s\S]*aria-label="Pause background motion"/,
   'Invitation and result motion need an explicit pause/play control');
+assert.match(indexSource, /<rect x="6"[\s\S]*<rect x="14"/,
+  'The initial modal Pause icon must be vector artwork rather than an emoji glyph');
 assert.match(indexSource, /id="yourTurnRotate"/);
 assert.match(indexSource, /ROTATE YOUR DEVICE TO LANDSCAPE/);
 assert.doesNotMatch(indexSource, /manifest|install-gate/i,
@@ -47,13 +49,20 @@ assert.match(appSource, /await import\(withBuild\('\/turn\/main\.js'\)\)/,
   'YOUR TURN must reuse the canonical TURN race runtime');
 assert.doesNotMatch(appSource, /\/turn\/app\.js|m8-home|installM8HomeNavigation/,
   'YOUR TURN must not bootstrap the full TURN Home application');
-assert.match(appSource, /installAnimationPauseBridge/);
+assert.match(appSource, /installHardPauseController/);
+assert.match(appSource, /classList\.add\('turn-lot-open', 'yourturn-runtime-paused'\)/,
+  'YOUR TURN pause must use TURN’s canonical hard-occlusion path so physics and rendering both stop');
+assert.match(appSource, /state\.lapStartedAt \+= pausedFor/,
+  'Time spent in THE CHALLENGE menu must not count against an active lap');
+assert.doesNotMatch(appSource, /WebGLRenderer\.prototype|installAnimationPauseBridge/,
+  'Do not rely on prototype interception for Three.js animation pause; renderer methods may be instance-owned');
 assert.ok(
-  appSource.indexOf('installCoveredRenderingGuard();') < appSource.indexOf('installAnimationPauseBridge(THREE)'),
-  'YOUR TURN pause must wrap the final renderer loop after TURN covered-rendering composition'
+  appSource.indexOf("await import(withBuild('/turn/main.js'))")
+    < appSource.indexOf('globalThis.__turnMotionLifecycle?.uninstall?.()'),
+  'YOUR TURN must restore native multi-listener motion semantics after canonical TURN startup'
 );
-assert.match(appSource, /downstreamSetAnimationLoop\.call\(renderer, null\)/,
-  'Pause must stop the actual rendering and physics loop');
+assert.match(appSource, /single devicemotion[\s\S]*multi-listener semantics/,
+  'The steering subscription collision must remain documented next to the compatibility fix');
 assert.match(appSource, /installScreenBlanking/,
   'The non-visual screen blanking affordance must remain available');
 assert.match(appSource, /installRaceSpeech/,
@@ -91,6 +100,12 @@ assert.match(uiSource, /YOUR TURN/);
 assert.match(uiSource, /bindMotionToggle/);
 assert.match(uiSource, /Play background motion/);
 assert.match(uiSource, /Pause background motion/);
+assert.match(uiSource, /const PAUSE_ICON[\s\S]*<rect[\s\S]*<rect/,
+  'Pause must use two SVG bars');
+assert.match(uiSource, /const PLAY_ICON[\s\S]*<path/,
+  'Play must use matching SVG artwork');
+assert.doesNotMatch(uiSource, /⏸|▶/,
+  'Motion control artwork must not depend on platform emoji glyphs');
 assert.match(uiSource, /rotate your phone like a steering wheel/i);
 assert.match(uiSource, /spatial audio/i);
 assert.match(uiSource, /screen-reader and non-visual play/i);
@@ -166,4 +181,4 @@ assert.equal(
   'https://enkel.design/yourturn/?challenge=sol-countryside-r1'
 );
 
-console.log('YOUR TURN recipient motion controls, challenge menu, fresh calibration, social links and protocol regression passed.');
+console.log('YOUR TURN hard pause, steering subscription, vector motion controls, challenge menu and social-link regression passed.');

--- a/yourturn/app.js
+++ b/yourturn/app.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
-import { createYourTurnUi, escapeHtml } from '/yourturn/ui.js?revision=r2';
-import { createYourTurnSession, readYourTurnRequest } from '/yourturn/session.js?revision=r2';
+import { createYourTurnUi, escapeHtml } from '/yourturn/ui.js?revision=r3';
+import { createYourTurnSession, readYourTurnRequest } from '/yourturn/session.js?revision=r3';
 
 if (globalThis.__YOUR_TURN_STORAGE_READY__ === false) {
   throw new Error('YOUR TURN storage isolation failed before startup.');
@@ -8,11 +8,11 @@ if (globalThis.__YOUR_TURN_STORAGE_READY__ === false) {
 
 const release = await loadTurnRelease();
 globalThis.__TURN_BUILD__ = Object.freeze(release);
-document.documentElement.dataset.yourTurnRuntime = 'recipient-r2';
+document.documentElement.dataset.yourTurnRuntime = 'recipient-r3';
 
 function withBuild(path) {
   const url = new URL(path, globalThis.location?.href || 'https://enkel.design/yourturn/');
-  if (release.cacheKey) url.searchParams.set('build', `${release.cacheKey}-yourturn-r2`);
+  if (release.cacheKey) url.searchParams.set('build', `${release.cacheKey}-yourturn-r3`);
   return url.href;
 }
 
@@ -30,7 +30,7 @@ const { installPerformanceProfile } = await import(withBuild('/turn/performance-
 installPerformanceProfile();
 const { installCoveredRenderingGuard } = await import(withBuild('/turn/render/covered-rendering.js'));
 installCoveredRenderingGuard();
-const animation = installAnimationPauseBridge(THREE);
+const animation = installHardPauseController();
 
 const { installDriveByEarSetting } = await import(withBuild('/turn/ui/drive-by-ear-setting.js'));
 const driveByEarEnabled = installDriveByEarSetting();
@@ -68,6 +68,12 @@ await import(withBuild('/turn/main.js'));
 const runtime = globalThis.__turnRuntime;
 const raceSession = globalThis.__turnNextRaceSession;
 if (!runtime || !raceSession) throw new Error('TURN racing runtime did not become available.');
+
+// TURN's production lifecycle bridge intentionally owns a single devicemotion
+// subscription. YOUR TURN also samples motion briefly after the portrait → landscape
+// transition before centering. Restore normal browser multi-listener semantics here so
+// that sampling cannot replace the racing listener (which caused steering to disappear).
+globalThis.__turnMotionLifecycle?.uninstall?.();
 
 globalThis.__turnRaceSession = raceSession;
 const { installWideGamutRuntime } = await import(withBuild('/turn/vehicle/wide-gamut.js?revision=r157-display-p3'));
@@ -118,31 +124,40 @@ async function loadTurnRelease() {
   }
 }
 
-function installAnimationPauseBridge(three) {
-  const prototype = three.WebGLRenderer.prototype;
-  const downstreamSetAnimationLoop = prototype.setAnimationLoop;
-  let renderer = null;
-  let loop = null;
+function installHardPauseController() {
   let paused = false;
-
-  prototype.setAnimationLoop = function setAnimationLoop(callback) {
-    renderer = this;
-    if (typeof callback === 'function') loop = callback;
-    if (callback === null && !paused) loop = null;
-    return downstreamSetAnimationLoop.call(this, paused ? null : callback);
-  };
+  let pausedAt = 0;
 
   return Object.freeze({
     pause() {
       if (paused) return;
       paused = true;
-      if (renderer) downstreamSetAnimationLoop.call(renderer, null);
+      pausedAt = performance.now();
+
+      // The canonical TURN loop already has a hard occlusion path for The Lot.
+      // YOUR TURN has no Lot UI, so reusing that class gives us a tested frame-level
+      // stop: no physics, replay movement or rendering advances behind our modal.
+      document.body.classList.add('turn-lot-open', 'yourturn-runtime-paused');
+      globalThis.__turnAudio?.silence?.();
     },
+
     resume() {
       if (!paused) return;
+      const now = performance.now();
+      const state = globalThis.__turnRuntime?.state;
+      const pausedFor = Math.max(0, now - pausedAt);
+
+      // A menu pause must not count against an active lap.
+      if (state?.lapActive && Number.isFinite(state.lapStartedAt)) {
+        state.lapStartedAt += pausedFor;
+      }
+      if (state) state.lastFrame = now;
+
+      document.body.classList.remove('turn-lot-open', 'yourturn-runtime-paused');
       paused = false;
-      if (renderer && loop) downstreamSetAnimationLoop.call(renderer, loop);
+      pausedAt = 0;
     },
+
     isPaused: () => paused
   });
 }

--- a/yourturn/index.html
+++ b/yourturn/index.html
@@ -20,18 +20,18 @@
   <title>YOUR TURN</title>
   <link rel="icon" href="/turn/TURNicon.PNG?icon=20260803-profile-512" type="image/png">
 
-  <link rel="stylesheet" href="/turn/styles.css?source=yourturn-r2">
-  <link rel="stylesheet" href="/turn/vertical-drive.css?source=yourturn-r2">
-  <link rel="stylesheet" href="/turn/hud-tuning.css?source=yourturn-r2">
-  <link rel="stylesheet" href="/turn/gameplay-features.css?source=yourturn-r2">
-  <link rel="stylesheet" href="/turn/gameplay-v2.css?source=yourturn-r2">
-  <link rel="stylesheet" href="/turn/position-hud-r83.css?source=yourturn-r2">
-  <link rel="stylesheet" href="/turn/drive-pad.css?source=yourturn-r2">
-  <link rel="stylesheet" href="/turn/manual-steering.css?source=yourturn-r2">
-  <link rel="stylesheet" href="/turn/steering-limit-warning.css?source=yourturn-r2">
-  <link rel="stylesheet" href="/turn/lap-result-toast.css?source=yourturn-r2">
-  <link rel="stylesheet" href="/turn/r104-polish.css?source=yourturn-r2">
-  <link rel="stylesheet" href="/yourturn/yourturn.css?revision=r2">
+  <link rel="stylesheet" href="/turn/styles.css?source=yourturn-r3">
+  <link rel="stylesheet" href="/turn/vertical-drive.css?source=yourturn-r3">
+  <link rel="stylesheet" href="/turn/hud-tuning.css?source=yourturn-r3">
+  <link rel="stylesheet" href="/turn/gameplay-features.css?source=yourturn-r3">
+  <link rel="stylesheet" href="/turn/gameplay-v2.css?source=yourturn-r3">
+  <link rel="stylesheet" href="/turn/position-hud-r83.css?source=yourturn-r3">
+  <link rel="stylesheet" href="/turn/drive-pad.css?source=yourturn-r3">
+  <link rel="stylesheet" href="/turn/manual-steering.css?source=yourturn-r3">
+  <link rel="stylesheet" href="/turn/steering-limit-warning.css?source=yourturn-r3">
+  <link rel="stylesheet" href="/turn/lap-result-toast.css?source=yourturn-r3">
+  <link rel="stylesheet" href="/turn/r104-polish.css?source=yourturn-r3">
+  <link rel="stylesheet" href="/yourturn/yourturn.css?revision=r3">
 
   <script src="/yourturn/storage-bootstrap.js?revision=r1"></script>
   <script type="importmap">
@@ -80,7 +80,7 @@
 
   <div class="controls" id="controls" hidden>
     <div class="utility-group">
-      <button class="utility yourturn-challenge-button" id="yourTurnChallengeButton" type="button" hidden aria-label="Open challenge menu">CHALLENGE</button>
+      <button class="utility yourturn-challenge-button" id="yourTurnChallengeButton" type="button" hidden aria-label="Open the challenge">THE CHALLENGE</button>
       <button class="utility" id="calibrateButton" type="button">Recalibrate</button>
       <button class="utility" id="resetButton" type="button">Restart Lap</button>
     </div>
@@ -100,7 +100,12 @@
 
   <dialog class="yourturn-dialog" id="yourTurnDialog" aria-labelledby="yourTurnTitle">
     <article class="yourturn-card">
-      <button class="yourturn-motion-toggle" id="yourTurnMotionToggle" type="button" hidden aria-label="Pause background motion" aria-pressed="false" title="Pause background motion">⏸</button>
+      <button class="yourturn-motion-toggle" id="yourTurnMotionToggle" type="button" hidden aria-label="Pause background motion" aria-pressed="false" title="Pause background motion">
+        <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
+          <rect x="6" y="5" width="4" height="14" rx="1"></rect>
+          <rect x="14" y="5" width="4" height="14" rx="1"></rect>
+        </svg>
+      </button>
       <header class="yourturn-card-head">
         <img src="/turn/TURNicon.PNG?icon=20260803-profile-512" alt="" aria-hidden="true">
         <div>
@@ -126,6 +131,6 @@
     <span>Loading challenge…</span>
   </div>
 
-  <script type="module" src="/yourturn/app.js?revision=r2"></script>
+  <script type="module" src="/yourturn/app.js?revision=r3"></script>
 </body>
 </html>

--- a/yourturn/ui.js
+++ b/yourturn/ui.js
@@ -1,6 +1,15 @@
 import { normalizeChallengeName } from '/yourturn/protocol.js?revision=r2';
 
 const PLAYER_NAME_KEY = 'yourturn-player-name-v1';
+const PAUSE_ICON = `
+  <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
+    <rect x="6" y="5" width="4" height="14" rx="1"></rect>
+    <rect x="14" y="5" width="4" height="14" rx="1"></rect>
+  </svg>`;
+const PLAY_ICON = `
+  <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
+    <path d="M8 5.5v13l10-6.5z"></path>
+  </svg>`;
 
 export function createYourTurnUi() {
   const dialog = document.querySelector('#yourTurnDialog');
@@ -129,7 +138,7 @@ export function createYourTurnUi() {
   }
 
   function setMotionPaused(paused) {
-    motionToggle.textContent = paused ? '▶' : '⏸';
+    motionToggle.innerHTML = paused ? PLAY_ICON : PAUSE_ICON;
     motionToggle.setAttribute('aria-label', paused ? 'Play background motion' : 'Pause background motion');
     motionToggle.setAttribute('aria-pressed', String(Boolean(paused)));
     motionToggle.title = paused ? 'Play background motion' : 'Pause background motion';


### PR DESCRIPTION
## What changed
- fixes the r2 steering regression: YOUR TURN now restores normal browser multi-listener `devicemotion` behavior after canonical TURN startup, so the post-rotation centering sample can no longer replace the actual racing motion listener
- keeps the working `ACCEPT → motion permission → rotate to landscape` flow unchanged
- replaces the ineffective Three.js prototype pause interception with TURN’s existing hard runtime occlusion path; modal pause and THE CHALLENGE now stop physics, replay movement and rendering rather than merely stopping acceleration
- excludes time spent in THE CHALLENGE from an active lap
- renames the in-race button from `CHALLENGE` to `THE CHALLENGE`
- uses matching inline SVG artwork for both modal Pause (two rectangles) and Play instead of platform emoji glyphs
- bumps YOUR TURN client references to r3 to avoid stale mobile/in-app-browser code

## Root causes
1. TURN’s production motion lifecycle bridge intentionally supports one active `devicemotion` subscriber. r2 added a temporary landscape-centering subscriber; that replaced the racing subscriber and was then removed, leaving no steering at all.
2. r2 tried to pause by intercepting `THREE.WebGLRenderer.prototype.setAnimationLoop`. The live renderer does not reliably route its loop through that prototype interception, so the UI said paused while the canonical game loop kept advancing.

## Scope
Only `/yourturn/**` and its focused regression test change. Production `/turn/**` remains untouched.

## Validation
The regression contract now explicitly checks the motion-subscription fix, TURN hard-occlusion pause path, active-lap time compensation, `THE CHALLENGE` wording, and SVG pause/play controls.