### PR TITLE
Improve YOUR TURN non-visual entry

### DIFF
--- a/turn-tests/yourturn-production.mjs
+++ b/turn-tests/yourturn-production.mjs
@@ -16,6 +16,8 @@ const [
   sceneSource,
   uiSource,
   cssSource,
+  nonVisualSource,
+  nonVisualCssSource,
   storageSource,
   mockSource,
   productionApp
@@ -26,6 +28,8 @@ const [
   fs.readFile(new URL('../yourturn/scene.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../yourturn/ui.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../yourturn/yourturn.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/nonvisual.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/nonvisual.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../yourturn/storage-bootstrap.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../yourturn/mock-challenges.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8')
@@ -34,6 +38,8 @@ const [
 assert.match(indexSource, /<title>YOUR TURN<\/title>/);
 assert.match(indexSource, /\/yourturn\/storage-bootstrap\.js/);
 assert.match(indexSource, /\/yourturn\/app\.js\?revision=r4/);
+assert.match(indexSource, /\/yourturn\/nonvisual\.css\?revision=r1/);
+assert.match(indexSource, /\/yourturn\/nonvisual\.js\?revision=r1/);
 assert.match(indexSource, /id="yourTurnChallengeButton"[\s\S]*>THE CHALLENGE<\/button>/,
   'The in-race return point must read as the challenge hub, not as a verb or a Pause command');
 assert.match(indexSource, /id="yourTurnMotionToggle"[\s\S]*aria-label="Pause background motion"/,
@@ -87,6 +93,33 @@ assert.match(appSource, /installScreenBlanking/,
   'The non-visual screen blanking affordance must remain available');
 assert.match(appSource, /installRaceSpeech/,
   'Screen-reader race announcements must be included');
+
+assert.match(nonVisualSource, /document\.querySelector\('\.reset-rivals-button'\)\?\.remove\(\)/,
+  'YOUR TURN must remove Reset Rivals because its only rival is the challenger');
+assert.match(nonVisualSource, /BLANK SCREEN MODE[\s\S]*DRIVE BY EAR/,
+  'Blank screen must open a short Drive By Ear introduction before hiding visuals');
+assert.match(nonVisualSource, /turns the racing line, upcoming corners, grip, recovery and nearby cars into spatial sound/i);
+assert.match(nonVisualSource, /supports complete non-visual gameplay and works with screen readers/i);
+assert.match(nonVisualSource, /full TURN game also includes Drive By Ear 101 training/i,
+  'Recipient guidance should point to training in full TURN without adding a training action here');
+assert.doesNotMatch(nonVisualSource, /TRY TRAINING/i,
+  'YOUR TURN should explain training availability without adding a training button');
+assert.match(nonVisualSource, /id="yourTurnDbeBalance" type="range" min="0" max="100"/,
+  'The Drive By Ear introduction needs the sound-balance slider');
+assert.match(nonVisualSource, /audioPreferences\.setBalance\?\.\(value \/ 100\)/,
+  'The balance slider must use TURN’s actual audio preference API');
+assert.match(nonVisualSource, /event\.stopImmediatePropagation\(\)/,
+  'The recipient dialog must replace the canonical two-tap blank-screen confirmation');
+assert.match(nonVisualSource, /blankButton\.click\(\);[\s\S]*blankButton\.click\(\);/,
+  'After informed confirmation, reuse TURN’s canonical screen-blanking state machine');
+assert.match(nonVisualSource, /classList\.add\('turn-lot-open', 'yourturn-runtime-paused', 'yourturn-nonvisual-info-open'\)/,
+  'The non-visual information dialog must hard-pause background gameplay while it is being read');
+assert.match(nonVisualSource, /state\.lapStartedAt \+= pausedFor/,
+  'Opening the non-visual information dialog must not add time to an active lap');
+assert.match(nonVisualCssSource, /\.yourturn-dbe-balance/);
+assert.match(nonVisualCssSource, /input\[type="range"\]/);
+assert.match(nonVisualCssSource, /@media \(max-height: 560px\) and \(orientation: landscape\)/,
+  'The non-visual dialog must stay usable in compact in-app-browser landscape viewports');
 
 assert.match(sessionSource, /prepareMotionAccess\(\)/,
   'Accept must request motion steering first');
@@ -201,4 +234,4 @@ assert.equal(
   'https://enkel.design/yourturn/?challenge=sol-countryside-r1'
 );
 
-console.log('YOUR TURN final centering, seamless start formation, hard pause, vector controls and social-link regression passed.');
+console.log('YOUR TURN non-visual onboarding, balance control, rival reset removal and recipient regression passed.');

--- a/yourturn/index.html
+++ b/yourturn/index.html
@@ -32,6 +32,7 @@
   <link rel="stylesheet" href="/turn/lap-result-toast.css?source=yourturn-r4">
   <link rel="stylesheet" href="/turn/r104-polish.css?source=yourturn-r4">
   <link rel="stylesheet" href="/yourturn/yourturn.css?revision=r3">
+  <link rel="stylesheet" href="/yourturn/nonvisual.css?revision=r1">
 
   <script src="/yourturn/storage-bootstrap.js?revision=r1"></script>
   <script type="importmap">
@@ -132,5 +133,6 @@
   </div>
 
   <script type="module" src="/yourturn/app.js?revision=r4"></script>
+  <script type="module" src="/yourturn/nonvisual.js?revision=r1"></script>
 </body>
 </html>

--- a/yourturn/nonvisual.css
+++ b/yourturn/nonvisual.css
@@ -1,0 +1,115 @@
+.yourturn-nonvisual-card {
+  width: min(760px, 92vw);
+}
+
+.yourturn-nonvisual-copy {
+  display: grid;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.yourturn-nonvisual-copy p,
+.yourturn-dbe-balance p {
+  margin: 0;
+  font-size: clamp(0.95rem, 2vw, 1.12rem);
+  font-weight: 760;
+  line-height: 1.35;
+}
+
+.yourturn-dbe-balance {
+  display: grid;
+  gap: 10px;
+  margin: 0 0 18px;
+  padding: 14px 16px;
+  border: 4px solid #08090a;
+  border-radius: 16px;
+  background: #fff8e8;
+}
+
+.yourturn-dbe-balance h2 {
+  margin: 0;
+  font-size: clamp(1rem, 2.2vw, 1.35rem);
+  line-height: 1;
+  letter-spacing: 0.06em;
+}
+
+.yourturn-dbe-balance input[type="range"] {
+  width: 100%;
+  min-height: 36px;
+  accent-color: #6b3fa0;
+  touch-action: manipulation;
+}
+
+.yourturn-dbe-balance input[type="range"]:focus-visible {
+  outline: 4px solid #38d9ff;
+  outline-offset: 3px;
+}
+
+.yourturn-dbe-balance-labels {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  font-size: 0.78rem;
+  font-weight: 900;
+}
+
+.yourturn-dbe-balance output {
+  justify-self: center;
+  min-width: 9ch;
+  padding: 5px 10px;
+  border: 2px solid #08090a;
+  border-radius: 999px;
+  background: #ffd43b;
+  font-size: 0.8rem;
+  font-weight: 900;
+  text-align: center;
+}
+
+@media (max-height: 560px) and (orientation: landscape) {
+  .yourturn-nonvisual-card {
+    width: min(900px, 94vw);
+  }
+
+  .yourturn-nonvisual-copy {
+    gap: 6px;
+    margin-bottom: 9px;
+  }
+
+  .yourturn-nonvisual-copy p,
+  .yourturn-dbe-balance p {
+    font-size: 0.84rem;
+    line-height: 1.25;
+  }
+
+  .yourturn-dbe-balance {
+    grid-template-columns: minmax(0, 1fr) minmax(220px, 0.9fr);
+    align-items: center;
+    gap: 5px 14px;
+    margin-bottom: 9px;
+    padding: 8px 11px;
+    border-width: 3px;
+  }
+
+  .yourturn-dbe-balance h2,
+  .yourturn-dbe-balance p {
+    grid-column: 1;
+  }
+
+  .yourturn-dbe-balance input,
+  .yourturn-dbe-balance-labels,
+  .yourturn-dbe-balance output {
+    grid-column: 2;
+  }
+
+  .yourturn-dbe-balance input {
+    grid-row: 1;
+  }
+
+  .yourturn-dbe-balance-labels {
+    grid-row: 2;
+  }
+
+  .yourturn-dbe-balance output {
+    grid-row: 3;
+  }
+}

--- a/yourturn/nonvisual.js
+++ b/yourturn/nonvisual.js
@@ -1,0 +1,153 @@
+const BLANKING_ACTIVATION_TIMEOUT_MS = 1800;
+
+export function installYourTurnNonVisualIntro({
+  screenBlanking,
+  animation,
+  audioPreferences
+} = {}) {
+  const blankButton = screenBlanking?.button;
+  if (!blankButton || !animation || !audioPreferences) return null;
+
+  const dialog = createDialog();
+  const balanceSlider = dialog.querySelector('#yourTurnDbeBalance');
+  const balanceOutput = dialog.querySelector('#yourTurnDbeBalanceValue');
+  const blankAction = dialog.querySelector('[data-yourturn-blank-screen]');
+  const backAction = dialog.querySelector('[data-yourturn-nonvisual-back]');
+  let bypassBlankButtonIntro = false;
+  let resumeAfterDialog = false;
+
+  function balanceLabel(value) {
+    if (value < 45) return `${100 - value}% other sounds`;
+    if (value > 55) return `${value}% Drive By Ear`;
+    return 'Balanced';
+  }
+
+  function syncBalance() {
+    const settings = audioPreferences.getSettings?.() || { balance: 0.5 };
+    const stored = Number(settings.balance);
+    const percent = Math.round((Number.isFinite(stored) ? stored : 0.5) * 100);
+    balanceSlider.value = String(percent);
+    balanceOutput.value = balanceLabel(percent);
+    balanceOutput.textContent = balanceOutput.value;
+  }
+
+  function openDialog() {
+    syncBalance();
+    resumeAfterDialog = !animation.isPaused();
+    animation.pause();
+    if (typeof dialog.showModal === 'function' && !dialog.open) dialog.showModal();
+    else dialog.setAttribute('open', '');
+    blankAction.focus();
+  }
+
+  function closeDialog({ resume = true } = {}) {
+    if (typeof dialog.close === 'function' && dialog.open) dialog.close();
+    else dialog.removeAttribute('open');
+    if (resume && resumeAfterDialog) animation.resume();
+    resumeAfterDialog = false;
+    if (!blankButton.hidden) blankButton.focus({ preventScroll: true });
+  }
+
+  async function activateBlankScreen() {
+    const shouldResume = resumeAfterDialog;
+    closeDialog({ resume: false });
+
+    // Reuse TURN's tested screen-blanking state machine. The recipient-facing
+    // information dialog replaces its two-tap confirmation, so advance IDLE → ARMED
+    // → ACTIVE internally without showing the intermediate toast to the player.
+    bypassBlankButtonIntro = true;
+    try {
+      blankButton.click();
+      blankButton.click();
+    } finally {
+      bypassBlankButtonIntro = false;
+    }
+
+    await waitForBlankingAttempt(blankButton);
+    if (shouldResume) animation.resume();
+    resumeAfterDialog = false;
+  }
+
+  blankButton.addEventListener('click', (event) => {
+    if (bypassBlankButtonIntro || blankButton.dataset.state === 'active') return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    openDialog();
+  }, { capture: true });
+
+  balanceSlider.addEventListener('input', () => {
+    const value = Number(balanceSlider.value);
+    audioPreferences.setBalance?.(value / 100);
+    balanceOutput.value = balanceLabel(value);
+    balanceOutput.textContent = balanceOutput.value;
+  });
+
+  blankAction.addEventListener('click', () => void activateBlankScreen());
+  backAction.addEventListener('click', () => closeDialog());
+  dialog.addEventListener('cancel', (event) => {
+    event.preventDefault();
+    closeDialog();
+  });
+
+  document.body.appendChild(dialog);
+  return Object.freeze({ dialog, blankButton });
+}
+
+function createDialog() {
+  const dialog = document.createElement('dialog');
+  dialog.className = 'yourturn-dialog yourturn-nonvisual-dialog';
+  dialog.setAttribute('aria-labelledby', 'yourTurnNonVisualTitle');
+  dialog.innerHTML = `
+    <article class="yourturn-card yourturn-nonvisual-card" data-view="nonvisual">
+      <header class="yourturn-card-head">
+        <img src="/turn/TURNicon.PNG?icon=20260803-profile-512" alt="" aria-hidden="true">
+        <div>
+          <span class="yourturn-kicker">BLANK SCREEN MODE</span>
+          <h1 id="yourTurnNonVisualTitle">DRIVE BY EAR</h1>
+        </div>
+      </header>
+
+      <div class="yourturn-nonvisual-copy">
+        <p>Blank screen mode hides the visuals while the race and controls keep running. Drive By Ear turns the racing line, upcoming corners, grip, recovery and nearby cars into spatial sound.</p>
+        <p>TURN supports complete non-visual gameplay and works with screen readers. Headphones give the clearest left and right guidance. The full TURN game also includes Drive By Ear 101 training if you want to learn the sound system step by step.</p>
+      </div>
+
+      <section class="yourturn-dbe-balance" aria-labelledby="yourTurnDbeBalanceTitle">
+        <h2 id="yourTurnDbeBalanceTitle">SOUND BALANCE</h2>
+        <p>Keep the middle for TURN's intended mix, or favour the car and world sounds or Drive By Ear guidance.</p>
+        <input id="yourTurnDbeBalance" type="range" min="0" max="100" step="1" value="50" aria-describedby="yourTurnDbeBalanceValue">
+        <div class="yourturn-dbe-balance-labels" aria-hidden="true">
+          <span>Other sounds</span>
+          <span>Drive By Ear</span>
+        </div>
+        <output id="yourTurnDbeBalanceValue" for="yourTurnDbeBalance">Balanced</output>
+      </section>
+
+      <div class="yourturn-actions">
+        <button type="button" class="is-primary" data-yourturn-blank-screen>BLANK SCREEN</button>
+        <button type="button" class="is-navigation" data-yourturn-nonvisual-back>BACK</button>
+      </div>
+    </article>`;
+  return dialog;
+}
+
+function waitForBlankingAttempt(button) {
+  if (button.dataset.state === 'active' || button.dataset.state === 'idle') {
+    return Promise.resolve(button.dataset.state);
+  }
+
+  return new Promise((resolve) => {
+    let timer = 0;
+    const observer = new MutationObserver(() => {
+      if (button.dataset.state !== 'active' && button.dataset.state !== 'idle') return;
+      observer.disconnect();
+      window.clearTimeout(timer);
+      resolve(button.dataset.state);
+    });
+    observer.observe(button, { attributes: true, attributeFilter: ['data-state'] });
+    timer = window.setTimeout(() => {
+      observer.disconnect();
+      resolve(button.dataset.state || 'unknown');
+    }, BLANKING_ACTIVATION_TIMEOUT_MS);
+  });
+}

--- a/yourturn/nonvisual.js
+++ b/yourturn/nonvisual.js
@@ -1,12 +1,16 @@
 const BLANKING_ACTIVATION_TIMEOUT_MS = 1800;
+const BOOTSTRAP_FRAME_LIMIT = 180;
 
 export function installYourTurnNonVisualIntro({
-  screenBlanking,
-  animation,
-  audioPreferences
+  blankButton = document.querySelector('.turn-screen-blank-control'),
+  audioPreferences = globalThis.__turnAudioPreferences,
+  runtime = globalThis.__turnRuntime
 } = {}) {
-  const blankButton = screenBlanking?.button;
-  if (!blankButton || !animation || !audioPreferences) return null;
+  if (!blankButton || !audioPreferences || !runtime) return null;
+  if (blankButton.dataset.yourTurnNonVisualIntro === 'true') return null;
+  blankButton.dataset.yourTurnNonVisualIntro = 'true';
+
+  removeRivalResetUi();
 
   const dialog = createDialog();
   const balanceSlider = dialog.querySelector('#yourTurnDbeBalance');
@@ -14,7 +18,8 @@ export function installYourTurnNonVisualIntro({
   const blankAction = dialog.querySelector('[data-yourturn-blank-screen]');
   const backAction = dialog.querySelector('[data-yourturn-nonvisual-back]');
   let bypassBlankButtonIntro = false;
-  let resumeAfterDialog = false;
+  let pausedForDialog = false;
+  let pausedAt = 0;
 
   function balanceLabel(value) {
     if (value < 45) return `${100 - value}% other sounds`;
@@ -31,10 +36,31 @@ export function installYourTurnNonVisualIntro({
     balanceOutput.textContent = balanceOutput.value;
   }
 
+  function pauseRaceForDialog() {
+    pausedForDialog = !document.body.classList.contains('turn-lot-open');
+    if (!pausedForDialog) return;
+    pausedAt = performance.now();
+    document.body.classList.add('turn-lot-open', 'yourturn-runtime-paused', 'yourturn-nonvisual-info-open');
+    globalThis.__turnAudio?.silence?.();
+  }
+
+  function resumeRaceFromDialog() {
+    if (!pausedForDialog) return;
+    const now = performance.now();
+    const state = runtime.state;
+    const pausedFor = Math.max(0, now - pausedAt);
+    if (state?.lapActive && Number.isFinite(state.lapStartedAt)) {
+      state.lapStartedAt += pausedFor;
+    }
+    if (state) state.lastFrame = now;
+    document.body.classList.remove('turn-lot-open', 'yourturn-runtime-paused', 'yourturn-nonvisual-info-open');
+    pausedForDialog = false;
+    pausedAt = 0;
+  }
+
   function openDialog() {
     syncBalance();
-    resumeAfterDialog = !animation.isPaused();
-    animation.pause();
+    pauseRaceForDialog();
     if (typeof dialog.showModal === 'function' && !dialog.open) dialog.showModal();
     else dialog.setAttribute('open', '');
     blankAction.focus();
@@ -43,18 +69,15 @@ export function installYourTurnNonVisualIntro({
   function closeDialog({ resume = true } = {}) {
     if (typeof dialog.close === 'function' && dialog.open) dialog.close();
     else dialog.removeAttribute('open');
-    if (resume && resumeAfterDialog) animation.resume();
-    resumeAfterDialog = false;
+    if (resume) resumeRaceFromDialog();
     if (!blankButton.hidden) blankButton.focus({ preventScroll: true });
   }
 
   async function activateBlankScreen() {
-    const shouldResume = resumeAfterDialog;
     closeDialog({ resume: false });
 
-    // Reuse TURN's tested screen-blanking state machine. The recipient-facing
-    // information dialog replaces its two-tap confirmation, so advance IDLE → ARMED
-    // → ACTIVE internally without showing the intermediate toast to the player.
+    // Reuse TURN's tested screen-blanking state machine. This information dialog
+    // replaces its two-tap confirmation, so advance IDLE → ARMED → ACTIVE internally.
     bypassBlankButtonIntro = true;
     try {
       blankButton.click();
@@ -64,8 +87,7 @@ export function installYourTurnNonVisualIntro({
     }
 
     await waitForBlankingAttempt(blankButton);
-    if (shouldResume) animation.resume();
-    resumeAfterDialog = false;
+    resumeRaceFromDialog();
   }
 
   blankButton.addEventListener('click', (event) => {
@@ -131,6 +153,12 @@ function createDialog() {
   return dialog;
 }
 
+function removeRivalResetUi() {
+  document.querySelector('.reset-rivals-button')?.remove();
+  document.querySelector('.nuke-dialog')?.remove();
+  document.querySelector('.nuke-effect')?.remove();
+}
+
 function waitForBlankingAttempt(button) {
   if (button.dataset.state === 'active' || button.dataset.state === 'idle') {
     return Promise.resolve(button.dataset.state);
@@ -150,4 +178,26 @@ function waitForBlankingAttempt(button) {
       resolve(button.dataset.state || 'unknown');
     }, BLANKING_ACTIVATION_TIMEOUT_MS);
   });
+}
+
+function bootstrap(attempt = 0) {
+  removeRivalResetUi();
+  const blankButton = document.querySelector('.turn-screen-blank-control');
+  const audioPreferences = globalThis.__turnAudioPreferences;
+  const runtime = globalThis.__turnRuntime;
+
+  if (blankButton && audioPreferences && runtime) {
+    installYourTurnNonVisualIntro({ blankButton, audioPreferences, runtime });
+    return;
+  }
+
+  if (attempt < BOOTSTRAP_FRAME_LIMIT) {
+    requestAnimationFrame(() => bootstrap(attempt + 1));
+  }
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => bootstrap(), { once: true });
+} else {
+  bootstrap();
 }


### PR DESCRIPTION
## What changed
- removes `RESET RIVALS` from YOUR TURN so the recipient cannot delete the challenger
- replaces the blank-screen control's terse two-tap confirmation with a short recipient-facing Drive By Ear dialog
- explains what Drive By Ear does, that TURN supports complete non-visual gameplay and screen readers, and that Drive By Ear 101 training is available in the full game
- adds the real TURN sound-balance slider to that dialog using the existing audio preference API
- keeps the race hard-paused while the information dialog is being read, then resumes when the user backs out or activates blank-screen mode
- reuses TURN's canonical screen-blanking state machine after the user chooses BLANK SCREEN; no separate blank-screen implementation is introduced
- adds compact landscape styling for in-app browsers and regression coverage

## Scope
Only `/yourturn/**` plus the focused YOUR TURN regression test. Production `/turn/**` remains untouched.