### PR TITLE
Grow YOUR TURN into a multi-player challenge chain

### DIFF
--- a/turn-tests/yourturn-production.mjs
+++ b/turn-tests/yourturn-production.mjs
@@ -1,12 +1,16 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import {
+  MAX_CHALLENGE_RACERS,
   challengeFromLap,
+  challengeLeader,
+  challengeWithLap,
   decodeChallenge,
   encodeChallenge,
   encodedChallengeFromLocation,
   makeChallengeUrl,
-  makeMockChallengeUrl
+  makeMockChallengeUrl,
+  normalizeChallenge
 } from '../yourturn/protocol.js';
 
 const [
@@ -16,8 +20,10 @@ const [
   sceneSource,
   uiSource,
   cssSource,
+  growingCssSource,
+  labelsSource,
+  labelBootstrapSource,
   nonVisualSource,
-  nonVisualCssSource,
   storageSource,
   mockSource,
   productionApp
@@ -28,8 +34,10 @@ const [
   fs.readFile(new URL('../yourturn/scene.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../yourturn/ui.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../yourturn/yourturn.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/growing-challenge.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/racer-labels.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/racer-labels-bootstrap.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../yourturn/nonvisual.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../yourturn/nonvisual.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../yourturn/storage-bootstrap.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../yourturn/mock-challenges.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8')
@@ -37,21 +45,16 @@ const [
 
 assert.match(indexSource, /<title>YOUR TURN<\/title>/);
 assert.match(indexSource, /\/yourturn\/storage-bootstrap\.js/);
-assert.match(indexSource, /\/yourturn\/app\.js\?revision=r4/);
-assert.match(indexSource, /\/yourturn\/nonvisual\.css\?revision=r1/);
-assert.match(indexSource, /\/yourturn\/nonvisual\.js\?revision=r1/);
-assert.match(indexSource, /id="yourTurnChallengeButton"[\s\S]*>THE CHALLENGE<\/button>/,
-  'The in-race return point must read as the challenge hub, not as a verb or a Pause command');
-assert.match(indexSource, /id="yourTurnMotionToggle"[\s\S]*aria-label="Pause background motion"/,
-  'Invitation and result motion need an explicit pause/play control');
-assert.match(indexSource, /<rect x="6"[\s\S]*<rect x="14"/,
-  'The initial modal Pause icon must be vector artwork rather than an emoji glyph');
-assert.match(indexSource, /id="yourTurnRotate"/);
-assert.match(indexSource, /ROTATE YOUR DEVICE TO LANDSCAPE/);
-assert.match(indexSource, /The race starts when you cross the starting line\./,
-  'The landscape transition must explain that timing starts at the physical start line');
+assert.match(indexSource, /\/yourturn\/app\.js\?revision=r6/);
+assert.match(indexSource, /growing-challenge\.css/);
+assert.match(indexSource, /racer-labels-bootstrap\.js/);
+assert.match(indexSource, /session\.js\?revision=r3[^\n]*session\.js\?revision=r6/,
+  'The page must cache-bust the new growing-challenge session even though app.js stays canonical');
+assert.match(indexSource, /Your name in the challenge/);
+assert.match(indexSource, /id="yourTurnChallengeButton"[\s\S]*>THE CHALLENGE<\/button>/);
+assert.match(indexSource, /The race starts when you cross the starting line\./);
 assert.doesNotMatch(indexSource, /manifest|install-gate/i,
-  'YOUR TURN must remain a browser-first challenge app rather than a PWA install gate');
+  'YOUR TURN remains browser-first rather than a PWA install gate');
 
 assert.match(appSource, /await import\(withBuild\('\/turn\/main\.js'\)\)/,
   'YOUR TURN must reuse the canonical TURN race runtime');
@@ -59,179 +62,150 @@ assert.doesNotMatch(appSource, /\/turn\/app\.js|m8-home|installM8HomeNavigation/
   'YOUR TURN must not bootstrap the full TURN Home application');
 assert.match(appSource, /installHardPauseController/);
 assert.match(appSource, /classList\.add\('turn-lot-open', 'yourturn-runtime-paused'\)/,
-  'YOUR TURN pause must use TURN’s canonical hard-occlusion path so physics and rendering both stop');
-assert.match(appSource, /state\.lapStartedAt \+= pausedFor/,
-  'Time spent in THE CHALLENGE menu must not count against an active lap');
-assert.doesNotMatch(appSource, /WebGLRenderer\.prototype|installAnimationPauseBridge/,
-  'Do not rely on prototype interception for Three.js animation pause; renderer methods may be instance-owned');
-assert.ok(
-  appSource.indexOf("await import(withBuild('/turn/main.js'))")
-    < appSource.indexOf('globalThis.__turnMotionLifecycle?.uninstall?.()'),
-  'YOUR TURN must restore native multi-listener motion semantics after canonical TURN startup'
-);
-assert.match(appSource, /single devicemotion[\s\S]*multi-listener semantics/,
-  'The steering subscription collision must remain documented next to the compatibility fix');
-assert.match(appSource, /FINAL_MOTION_CENTER_DELAY_MS = 320/,
-  'Final centering must happen after TURN’s early startup-center window, not during the orientation transition');
-assert.match(appSource, /animation\.deferResumeUntil\(silentlyCenterAfterLandscape\(runtime\)\)/,
-  'The race runtime must stay hard-paused until final landscape centering finishes');
-assert.match(appSource, /waitForSettledLandscape/);
-assert.match(appSource, /waitForFreshMotionSamples\(FINAL_MOTION_SAMPLE_COUNT, 600\)/,
-  'Final centering must use fresh post-rotation motion data');
-assert.match(appSource, /state\.neutralRoll = state\.targetRoll[\s\S]*state\.steeringEngaged = false/,
-  'The final landscape center must silently reset steering state');
-assert.match(appSource, /PLAYER_START_LANE_OFFSET = 4\.1/,
-  'Recipient and challenger need a stable side-by-side pre-start formation');
+  'THE CHALLENGE modal must hard-pause physics and replay movement');
+assert.match(appSource, /FINAL_MOTION_CENTER_DELAY_MS = 320/);
 assert.match(appSource, /installStartLineFormationAdapter/);
-assert.match(appSource, /formation\.rivalDistance = Math\.min\(formation\.rivalDistance, playerDistance\)/,
-  'The challenger may advance toward the line but must never follow a player who backs away');
-assert.match(appSource, /challengeLap\.frames\[0\]/,
-  'The staged challenger must converge on the exact recorded t=0 start pose');
-assert.match(appSource, /aheadIndex === 0 && Number\.isFinite\(startFrame\?\.x\)/,
-  'The pre-start path must interpolate into the exact recorded start position rather than snap there');
-assert.match(appSource, /installScreenBlanking/,
-  'The non-visual screen blanking affordance must remain available');
-assert.match(appSource, /installRaceSpeech/,
-  'Screen-reader race announcements must be included');
+assert.match(appSource, /formation\.rivalDistance = Math\.min\(formation\.rivalDistance, playerDistance\)/);
+assert.match(appSource, /installScreenBlanking/);
+assert.match(appSource, /installRaceSpeech/);
 
-assert.match(nonVisualSource, /document\.querySelector\('\.reset-rivals-button'\)\?\.remove\(\)/,
-  'YOUR TURN must remove Reset Rivals because its only rival is the challenger');
-assert.match(nonVisualSource, /BLANK SCREEN MODE[\s\S]*DRIVE BY EAR/,
-  'Blank screen must open a short Drive By Ear introduction before hiding visuals');
-assert.match(nonVisualSource, /turns the racing line, upcoming corners, grip, recovery and nearby cars into spatial sound/i);
-assert.match(nonVisualSource, /supports complete non-visual gameplay and works with screen readers/i);
-assert.match(nonVisualSource, /full TURN game also includes Drive By Ear 101 training/i,
-  'Recipient guidance should point to training in full TURN without adding a training action here');
-assert.doesNotMatch(nonVisualSource, /TRY TRAINING/i,
-  'YOUR TURN should explain training availability without adding a training button');
-assert.match(nonVisualSource, /id="yourTurnDbeBalance" type="range" min="0" max="100"/,
-  'The Drive By Ear introduction needs the sound-balance slider');
-assert.match(nonVisualSource, /audioPreferences\.setBalance\?\.\(value \/ 100\)/,
-  'The balance slider must use TURN’s actual audio preference API');
-assert.match(nonVisualSource, /event\.stopImmediatePropagation\(\)/,
-  'The recipient dialog must replace the canonical two-tap blank-screen confirmation');
-assert.match(nonVisualSource, /blankButton\.click\(\);[\s\S]*blankButton\.click\(\);/,
-  'After informed confirmation, reuse TURN’s canonical screen-blanking state machine');
-assert.match(nonVisualSource, /classList\.add\('turn-lot-open', 'yourturn-runtime-paused', 'yourturn-nonvisual-info-open'\)/,
-  'The non-visual information dialog must hard-pause background gameplay while it is being read');
-assert.match(nonVisualSource, /state\.lapStartedAt \+= pausedFor/,
-  'Opening the non-visual information dialog must not add time to an active lap');
-assert.match(nonVisualCssSource, /\.yourturn-dbe-balance/);
-assert.match(nonVisualCssSource, /input\[type="range"\]/);
-assert.match(nonVisualCssSource, /@media \(max-height: 560px\) and \(orientation: landscape\)/,
-  'The non-visual dialog must stay usable in compact in-app-browser landscape viewports');
-
-assert.match(sessionSource, /prepareMotionAccess\(\)/,
-  'Accept must request motion steering first');
-assert.ok(
-  sessionSource.indexOf('prepareMotionAccess()') < sessionSource.indexOf('awaitLandscapeAndStart()'),
-  'Motion permission must happen before the landscape transition'
-);
-assert.match(sessionSource, /ui\.showRotate\(\)/);
-assert.match(sessionSource, /centerMotionAfterLandscape\(\)/,
-  'Landscape entry keeps its immediate center while r4 adds a final post-settle center before movement');
-assert.match(sessionSource, /runtime\.state\.neutralRoll = runtime\.state\.targetRoll/);
-assert.match(sessionSource, /prepareManualAccess\(\)/,
-  'On-screen steering must remain an explicit fallback');
-assert.match(sessionSource, /label: 'TRY LATER'/);
-assert.match(sessionSource, /globalThis\.location\.href = '\/turn\/'/);
-assert.match(sessionSource, /label: 'ABOUT TURN'/);
-assert.match(sessionSource, /label: 'GET FULL TURN'/);
-assert.match(sessionSource, /titleText: 'CHALLENGE'/);
-assert.match(sessionSource, /label: 'GIVE UP'/,
-  'Challenge menu must keep the route back to Give Up visible');
-assert.match(sessionSource, /ambientPaused/);
-assert.match(sessionSource, /toggleAmbientMotion/);
-assert.match(sessionSource, /if \(state\.ambientPaused\) animation\.pause\(\)/,
-  'A start-screen background pause preference must carry through to the result scene');
+assert.match(sessionSource, /challengeLaps: \[\]/,
+  'A challenge session must support a field of replay cars');
+assert.match(sessionSource, /state\.challenge\.racers\.map\(racerToLap\)/,
+  'Every racer in the bundle must become a canonical TURN replay lap');
+assert.match(sessionSource, /runtime\.state\.competitorLaps = state\.challengeLaps/,
+  'The growing challenge field must feed TURN’s canonical rival runtime');
+assert.match(sessionSource, /challengeWithLap\(/,
+  'Sharing a run must merge it into the existing challenge instead of replacing the challenge');
+assert.match(sessionSource, /state\.racerId:|racerId: loadOrCreateRacerId\(\)/,
+  'A browser participant needs a stable racer identity so their later best can replace their earlier car');
+assert.match(sessionSource, /if \(!state\.bestRun \|\| candidate\.time < state\.bestRun\.time\) state\.bestRun = candidate/,
+  'A player can share their best attempt even without taking the overall lead');
+assert.match(sessionSource, /label: 'SHARE'/);
+assert.match(sessionSource, /label: 'SHARE YOUR TURN'/);
+assert.doesNotMatch(sessionSource, /label: 'GIVE UP'|label: 'YES, GIVE UP'/,
+  'The active framework must use neutral sharing instead of Give Up');
+assert.match(sessionSource, /label: 'GET THE GAME', game: true/);
+assert.match(sessionSource, /label: 'BACK', back: true/);
+assert.match(sessionSource, /racerSummaryHtml/);
+assert.match(sessionSource, /players challenge you|PLAYERS CHALLENGE YOU/i);
 assert.match(sessionSource, /navigator\.share/);
 assert.match(sessionSource, /navigator\.clipboard/);
 assert.doesNotMatch(sessionSource, /ghost/i,
-  'YOUR TURN recipient copy and challenge layer must describe the challenger’s car, not a ghost');
+  'Recipient-facing YOUR TURN challenge code describes people and cars, not ghosts');
 
-assert.match(uiSource, /YOUR TURN/);
-assert.match(uiSource, /bindMotionToggle/);
-assert.match(uiSource, /Play background motion/);
-assert.match(uiSource, /Pause background motion/);
-assert.match(uiSource, /const PAUSE_ICON[\s\S]*<rect[\s\S]*<rect/,
-  'Pause must use two SVG bars');
-assert.match(uiSource, /const PLAY_ICON[\s\S]*<path/,
-  'Play must use matching SVG artwork');
-assert.doesNotMatch(uiSource, /⏸|▶/,
-  'Motion control artwork must not depend on platform emoji glyphs');
-assert.match(uiSource, /rotate your phone like a steering wheel/i);
-assert.match(uiSource, /spatial audio/i);
-assert.match(uiSource, /screen-reader and non-visual play/i);
-assert.match(uiSource, /visually-hidden/);
-assert.doesNotMatch(uiSource, /ghost/i);
+assert.match(uiSource, /action\.share/);
+assert.match(uiSource, /action\.game/);
+assert.match(uiSource, /action\.back/);
+assert.match(uiSource, /is-share/);
+assert.match(uiSource, /is-game/);
+assert.match(uiSource, /is-back/);
+assert.match(uiSource, /const PAUSE_ICON[\s\S]*<rect[\s\S]*<rect/);
+assert.match(uiSource, /const PLAY_ICON[\s\S]*<path/);
+assert.doesNotMatch(uiSource, /⏸|▶/);
 
-assert.match(sceneSource, /PREVIEW_START_DELAY_MS = 650/,
-  'Opponent preview movement must not begin as an uncanny instant imitation');
+assert.match(growingCssSource, /\.is-share[\s\S]*#ff4fa3/,
+  'Share is the pink CTA');
+assert.match(growingCssSource, /\.is-game[\s\S]*#38d9ff/,
+  'Get the Game uses blue rather than navigation orange');
+assert.match(growingCssSource, /\.is-back[\s\S]*#ff9b66/,
+  'Back remains the design-system orange');
+assert.match(growingCssSource, /\.yourturn-racer-summary/);
+assert.match(growingCssSource, /\.yourturn-racer-label/);
+assert.match(labelsSource, /lap\.challengerName/,
+  'Visual replay labels must use the player name carried by each racer lap');
+assert.match(labelsSource, /runtime\.competitorCars/);
+assert.match(labelBootstrapSource, /installRacerLabels/);
+assert.match(labelBootstrapSource, /carId = state\.challenge\.carId/,
+  'All social racers must retain the challenge car identity');
+
+assert.match(sceneSource, /PREVIEW_START_DELAY_MS = 650/);
 assert.match(sceneSource, /STAGED_IMITATION_DELAY_MS = 650/);
 assert.match(sceneSource, /prefers-reduced-motion/);
-
-assert.match(cssSource, /background: rgb\(255 248 232 \/ 0\.9\)/,
-  'Portrait invitation card must be slightly translucent so the challenger car remains perceptible');
-assert.match(cssSource, /\.yourturn-challenge-button[\s\S]*#ff9b66/,
-  'The challenge-menu control must use the navigation/back orange');
-assert.match(cssSource, /\.yourturn-motion-toggle[\s\S]*border-radius: 50%[\s\S]*background: #ff9b66/,
-  'The modal pause/play control must be round and use the navigation/back orange');
-assert.match(cssSource, /@media \(orientation: portrait\)/);
-assert.match(cssSource, /@media \(max-height: 560px\) and \(orientation: landscape\)/,
-  'Small in-app browser viewports need a dedicated compact landscape layout');
-
+assert.match(cssSource, /background: rgb\(255 248 232 \/ 0\.9\)/);
+assert.match(nonVisualSource, /Drive By Ear 101 training/);
+assert.match(nonVisualSource, /yourTurnDbeBalance/);
+assert.match(nonVisualSource, /removeRivalResetUi/);
 assert.match(storageSource, /const LOCAL_PREFIX = 'yourturn:';/);
-assert.match(storageSource, /turn production TURN records|TURN records/i);
 assert.match(mockSource, /'sol-countryside-r1'/);
-assert.match(mockSource, /time: 13\.5/);
-
 assert.match(productionApp, /installM8HomeNavigation\(\)/,
   'Production TURN remains the full application and is not replaced by YOUR TURN');
 
-const frames = Array.from({ length: 900 }, (_, index) => ({
-  t: 42 * index / 899,
-  x: index * 0.08,
-  z: index * 0.04,
-  h: index * 0.001,
-  s: 0,
-  d: 0,
-  p: index / 899
-}));
-const challenge = challengeFromLap({
-  challengerName: 'Erik',
+assert.equal(MAX_CHALLENGE_RACERS, 4);
+
+const lap = (time, offset = 0) => ({
+  time,
+  carId: 'sedan-sports',
+  carColor: '#ff4fa3',
+  carSecondaryColor: '#252a35',
+  frames: Array.from({ length: 900 }, (_, index) => ({
+    t: time * index / 899,
+    x: index * 0.08 + offset,
+    z: index * 0.04,
+    h: index * 0.001,
+    s: Math.sin(index / 40) * 0.2,
+    d: 0,
+    p: index / 899
+  }))
+});
+
+let chain = challengeFromLap({
+  challengerName: 'ARVID',
+  racerId: 'r-arvid',
+  chainId: 'yt-family-chain',
   trackId: 'countryside',
   trackRevision: 'countryside',
   trackName: 'Countryside',
-  lap: {
-    time: 42,
-    carId: 'sedan-sports',
-    carColor: '#ff4fa3',
-    carSecondaryColor: '#252a35',
-    frames
-  }
+  lap: lap(15.8)
 });
-assert.ok(challenge.frames.length <= 180);
-const encoded = await encodeChallenge(challenge);
-const decoded = await decodeChallenge(encoded);
-assert.equal(decoded.challengerName, 'Erik');
-assert.equal(decoded.trackId, 'countryside');
-assert.equal(decoded.time, 42);
-const challengeUrl = makeChallengeUrl(encoded);
-assert.match(challengeUrl, /^https:\/\/enkel\.design\/yourturn\/\?c=/,
-  'New challenge replies must use a query-carried URL so social preview crawlers receive the challenge URL');
-assert.equal(
-  encodedChallengeFromLocation(new URL(challengeUrl)),
-  encoded,
-  'Query-carried challenge URLs must decode normally'
-);
-assert.equal(
-  encodedChallengeFromLocation(new URL(`https://enkel.design/yourturn/#challenge=${encoded}`)),
-  encoded,
-  'Previously shared hash-carried challenge links must remain valid'
-);
-assert.equal(
-  makeMockChallengeUrl('sol-countryside-r1'),
-  'https://enkel.design/yourturn/?challenge=sol-countryside-r1'
-);
+assert.equal(chain.racers.length, 1);
+assert.equal(challengeLeader(chain).name, 'ARVID');
+assert.ok(chain.racers[0].frames.length <= 120);
 
-console.log('YOUR TURN non-visual onboarding, balance control, rival reset removal and recipient regression passed.');
+chain = challengeWithLap({ challenge: chain, racerId: 'r-erik', racerName: 'ERIK', lap: lap(15.5, 0.3) });
+chain = challengeWithLap({ challenge: chain, racerId: 'r-kerstin', racerName: 'KERSTIN', lap: lap(16.1, -0.25) });
+assert.deepEqual(chain.racers.map((racer) => racer.name), ['ERIK', 'ARVID', 'KERSTIN']);
+
+chain = challengeWithLap({ challenge: chain, racerId: 'r-erik', racerName: 'ERIK', lap: lap(15.2, 0.15) });
+assert.equal(chain.racers.filter((racer) => racer.id === 'r-erik').length, 1,
+  'A returning player must keep exactly one car in the challenge');
+assert.equal(chain.racers.find((racer) => racer.id === 'r-erik').time, 15.2,
+  'A better repeat lap must replace that player’s older car');
+
+chain = challengeWithLap({ challenge: chain, racerId: 'r-d', racerName: 'D', lap: lap(17.2, 0.5) });
+chain = challengeWithLap({ challenge: chain, racerId: 'r-e', racerName: 'E', lap: lap(18.4, -0.5) });
+assert.equal(chain.racers.length, 4, 'Self-contained links are capped at four rival cars');
+assert.ok(chain.racers.some((racer) => racer.id === 'r-e'), 'The newest contributor must survive the four-car cap');
+assert.equal(chain.chainId, 'yt-family-chain', 'The social challenge identity must survive every share');
+
+const encoded = await encodeChallenge(chain);
+const decoded = await decodeChallenge(encoded);
+assert.equal(decoded.racers.length, 4);
+assert.deepEqual(decoded.racers.map((racer) => racer.id), chain.racers.map((racer) => racer.id));
+assert.equal(decoded.chainId, chain.chainId);
+assert.ok(encoded.length < 18000, `Four-car challenge link payload should stay practical; got ${encoded.length} characters`);
+
+const challengeUrl = makeChallengeUrl(encoded);
+assert.match(challengeUrl, /^https:\/\/enkel\.design\/yourturn\/\?c=/);
+assert.equal(encodedChallengeFromLocation(new URL(challengeUrl)), encoded);
+assert.equal(encodedChallengeFromLocation(new URL(`https://enkel.design/yourturn/#challenge=${encoded}`)), encoded,
+  'Previously shared hash-carried challenge links remain readable');
+assert.equal(makeMockChallengeUrl('sol-countryside-r1'), 'https://enkel.design/yourturn/?challenge=sol-countryside-r1');
+
+const legacy = normalizeChallenge({
+  v: 1,
+  challengerName: 'SOL',
+  trackId: 'countryside',
+  trackRevision: 'countryside',
+  trackName: 'Countryside',
+  time: 18.75,
+  carId: 'sedan-sports',
+  carColor: '#ff4fa3',
+  carSecondaryColor: '#252a35',
+  frames: lap(18.75).frames
+});
+assert.equal(legacy.v, 2);
+assert.equal(legacy.racers.length, 1, 'Old one-car links must transparently upgrade into a challenge field');
+assert.equal(legacy.racers[0].name, 'SOL');
+
+console.log('YOUR TURN growing four-car social challenge, named racers, share CTA and compatibility regression passed.');

--- a/turn-tests/yourturn-production.mjs
+++ b/turn-tests/yourturn-production.mjs
@@ -71,16 +71,18 @@ assert.match(appSource, /installRaceSpeech/);
 
 assert.match(sessionSource, /challengeLaps: \[\]/,
   'A challenge session must support a field of replay cars');
-assert.match(sessionSource, /state\.challenge\.racers\.map\(racerToLap\)/,
-  'Every racer in the bundle must become a canonical TURN replay lap');
+assert.match(sessionSource, /state\.challenge\.racers\.map\(\(racer\) => racerToLap\(racer, state\.challenge\)\)/,
+  'Every racer in the bundle must become a canonical TURN replay lap with challenge car identity');
 assert.match(sessionSource, /runtime\.state\.competitorLaps = state\.challengeLaps/,
   'The growing challenge field must feed TURN’s canonical rival runtime');
 assert.match(sessionSource, /challengeWithLap\(/,
   'Sharing a run must merge it into the existing challenge instead of replacing the challenge');
-assert.match(sessionSource, /state\.racerId:|racerId: loadOrCreateRacerId\(\)/,
+assert.match(sessionSource, /racerId: loadOrCreateRacerId\(\)/,
   'A browser participant needs a stable racer identity so their later best can replace their earlier car');
 assert.match(sessionSource, /if \(!state\.bestRun \|\| candidate\.time < state\.bestRun\.time\) state\.bestRun = candidate/,
   'A player can share their best attempt even without taking the overall lead');
+assert.match(sessionSource, /previousSelf && previousSelf\.time <= candidate\.time/,
+  'A returning racer must keep their earlier faster car when the current attempt is slower');
 assert.match(sessionSource, /label: 'SHARE'/);
 assert.match(sessionSource, /label: 'SHARE YOUR TURN'/);
 assert.doesNotMatch(sessionSource, /label: 'GIVE UP'|label: 'YES, GIVE UP'/,
@@ -88,7 +90,9 @@ assert.doesNotMatch(sessionSource, /label: 'GIVE UP'|label: 'YES, GIVE UP'/,
 assert.match(sessionSource, /label: 'GET THE GAME', game: true/);
 assert.match(sessionSource, /label: 'BACK', back: true/);
 assert.match(sessionSource, /racerSummaryHtml/);
-assert.match(sessionSource, /players challenge you|PLAYERS CHALLENGE YOU/i);
+assert.match(sessionSource, /PLAYERS CHALLENGE YOU/);
+assert.match(sessionSource, /state\.ambientPaused = true/,
+  'Moving from the hard-paused challenge menu to share/result must keep background motion paused');
 assert.match(sessionSource, /navigator\.share/);
 assert.match(sessionSource, /navigator\.clipboard/);
 assert.doesNotMatch(sessionSource, /ghost/i,
@@ -116,8 +120,8 @@ assert.match(labelsSource, /lap\.challengerName/,
   'Visual replay labels must use the player name carried by each racer lap');
 assert.match(labelsSource, /runtime\.competitorCars/);
 assert.match(labelBootstrapSource, /installRacerLabels/);
-assert.match(labelBootstrapSource, /carId = state\.challenge\.carId/,
-  'All social racers must retain the challenge car identity');
+assert.match(sessionSource, /carId: challenge\.carId[\s\S]*carColor: challenge\.carColor[\s\S]*carSecondaryColor: challenge\.carSecondaryColor/,
+  'Every social racer lap must carry the shared challenge car identity');
 
 assert.match(sceneSource, /PREVIEW_START_DELAY_MS = 650/);
 assert.match(sceneSource, /STAGED_IMITATION_DELAY_MS = 650/);
@@ -128,6 +132,8 @@ assert.match(nonVisualSource, /yourTurnDbeBalance/);
 assert.match(nonVisualSource, /removeRivalResetUi/);
 assert.match(storageSource, /const LOCAL_PREFIX = 'yourturn:';/);
 assert.match(mockSource, /'sol-countryside-r1'/);
+assert.match(mockSource, /'friends-countryside-r1'/,
+  'A deterministic named three-car fixture must be available for phone testing');
 assert.match(productionApp, /installM8HomeNavigation\(\)/,
   'Production TURN remains the full application and is not replaced by YOUR TURN');
 
@@ -191,6 +197,7 @@ assert.equal(encodedChallengeFromLocation(new URL(challengeUrl)), encoded);
 assert.equal(encodedChallengeFromLocation(new URL(`https://enkel.design/yourturn/#challenge=${encoded}`)), encoded,
   'Previously shared hash-carried challenge links remain readable');
 assert.equal(makeMockChallengeUrl('sol-countryside-r1'), 'https://enkel.design/yourturn/?challenge=sol-countryside-r1');
+assert.equal(makeMockChallengeUrl('friends-countryside-r1'), 'https://enkel.design/yourturn/?challenge=friends-countryside-r1');
 
 const legacy = normalizeChallenge({
   v: 1,

--- a/yourturn/growing-challenge.css
+++ b/yourturn/growing-challenge.css
@@ -1,0 +1,103 @@
+.yourturn-actions button.is-share {
+  background: #ff4fa3;
+}
+
+.yourturn-actions button.is-game {
+  background: #38d9ff;
+}
+
+.yourturn-actions button.is-back {
+  background: #ff9b66;
+}
+
+.yourturn-racer-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-top: 4px;
+}
+
+.yourturn-racer-summary > span {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 7px;
+  padding: 6px 9px;
+  border: 3px solid #08090a;
+  border-radius: 999px;
+  background: #fff8e8;
+  box-shadow: 3px 3px 0 #08090a;
+  font-size: 0.82rem;
+  line-height: 1;
+}
+
+.yourturn-racer-summary > span[data-leader="true"] {
+  background: #ffd43b;
+}
+
+.yourturn-racer-summary b {
+  font-weight: 1000;
+}
+
+.yourturn-racer-summary small {
+  font-size: 0.75rem;
+  font-weight: 850;
+}
+
+.yourturn-racer-labels {
+  position: fixed;
+  z-index: 850;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.yourturn-racer-label {
+  position: absolute;
+  top: 0;
+  left: 0;
+  max-width: 150px;
+  padding: 4px 8px;
+  border: 2px solid #08090a;
+  border-radius: 999px;
+  background: rgb(255 248 232 / 0.92);
+  color: #08090a;
+  box-shadow: 2px 2px 0 #08090a;
+  font-size: clamp(0.64rem, 1.3vw, 0.82rem);
+  font-weight: 1000;
+  line-height: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  will-change: transform;
+}
+
+.yourturn-racer-label[hidden] {
+  display: none;
+}
+
+.yourturn-dialog[open] ~ .yourturn-racer-labels .yourturn-racer-label {
+  opacity: 0.72;
+}
+
+@media (max-height: 560px) and (orientation: landscape) {
+  .yourturn-racer-summary {
+    gap: 5px;
+  }
+
+  .yourturn-racer-summary > span {
+    padding: 4px 7px;
+    border-width: 2px;
+    box-shadow: 2px 2px 0 #08090a;
+    font-size: 0.72rem;
+  }
+
+  .yourturn-racer-summary small {
+    font-size: 0.66rem;
+  }
+
+  .yourturn-racer-label {
+    padding: 3px 6px;
+    border-width: 2px;
+    font-size: 0.65rem;
+  }
+}

--- a/yourturn/index.html
+++ b/yourturn/index.html
@@ -33,13 +33,16 @@
   <link rel="stylesheet" href="/turn/r104-polish.css?source=yourturn-r4">
   <link rel="stylesheet" href="/yourturn/yourturn.css?revision=r3">
   <link rel="stylesheet" href="/yourturn/nonvisual.css?revision=r1">
+  <link rel="stylesheet" href="/yourturn/growing-challenge.css?revision=r1">
 
   <script src="/yourturn/storage-bootstrap.js?revision=r1"></script>
   <script type="importmap">
     {
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
-        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/"
+        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
+        "/yourturn/session.js?revision=r3": "/yourturn/session.js?revision=r6",
+        "/yourturn/ui.js?revision=r3": "/yourturn/ui.js?revision=r6"
       }
     }
   </script>
@@ -118,8 +121,8 @@
       <p class="yourturn-copy"></p>
       <div class="yourturn-extra"></div>
       <label class="yourturn-name-field" hidden>
-        <span>Your name in the reply</span>
-        <input type="text" maxlength="24" autocomplete="nickname">
+        <span>Your name in the challenge</span>
+        <input type="text" maxlength="24" autocomplete="nickname" placeholder="YOUR NAME">
       </label>
       <p class="yourturn-dialog-status" role="status" aria-live="polite"></p>
       <div class="yourturn-actions"></div>
@@ -132,7 +135,8 @@
     <span>Loading challenge…</span>
   </div>
 
-  <script type="module" src="/yourturn/app.js?revision=r4"></script>
+  <script type="module" src="/yourturn/app.js?revision=r6"></script>
   <script type="module" src="/yourturn/nonvisual.js?revision=r1"></script>
+  <script type="module" src="/yourturn/racer-labels-bootstrap.js?revision=r1"></script>
 </body>
 </html>

--- a/yourturn/mock-challenges.js
+++ b/yourturn/mock-challenges.js
@@ -28,6 +28,21 @@ export const MOCK_CHALLENGES = Object.freeze({
     carColor: '#38d9ff',
     carSecondaryColor: '#fff8e8',
     label: 'ALEX · Countryside · 0:16.250'
+  }),
+  'friends-countryside-r1': Object.freeze({
+    id: 'friends-countryside-r1',
+    challengerName: 'ARVID',
+    trackId: 'countryside',
+    time: 15.4,
+    carId: 'sedan-sports',
+    carColor: '#ff4fa3',
+    carSecondaryColor: '#252a35',
+    racers: Object.freeze([
+      Object.freeze({ id: 'mock-arvid', name: 'ARVID', time: 15.4, laneOffset: 0 }),
+      Object.freeze({ id: 'mock-erik', name: 'ERIK', time: 16.1, laneOffset: 1.15 }),
+      Object.freeze({ id: 'mock-kerstin', name: 'KERSTIN', time: 17.05, laneOffset: -1.15 })
+    ]),
+    label: 'ARVID + ERIK + KERSTIN · 3 cars'
   })
 });
 

--- a/yourturn/mock-challenges.js
+++ b/yourturn/mock-challenges.js
@@ -28,21 +28,6 @@ export const MOCK_CHALLENGES = Object.freeze({
     carColor: '#38d9ff',
     carSecondaryColor: '#fff8e8',
     label: 'ALEX · Countryside · 0:16.250'
-  }),
-  'friends-countryside-r1': Object.freeze({
-    id: 'friends-countryside-r1',
-    challengerName: 'ARVID',
-    trackId: 'countryside',
-    time: 15.4,
-    carId: 'sedan-sports',
-    carColor: '#ff4fa3',
-    carSecondaryColor: '#252a35',
-    racers: Object.freeze([
-      Object.freeze({ id: 'mock-arvid', name: 'ARVID', time: 15.4, laneOffset: 0 }),
-      Object.freeze({ id: 'mock-erik', name: 'ERIK', time: 16.1, laneOffset: 1.2 }),
-      Object.freeze({ id: 'mock-kerstin', name: 'KERSTIN', time: 17.05, laneOffset: -1.2 })
-    ]),
-    label: 'ARVID + ERIK + KERSTIN · 3 cars'
   })
 });
 

--- a/yourturn/mock-challenges.js
+++ b/yourturn/mock-challenges.js
@@ -28,6 +28,21 @@ export const MOCK_CHALLENGES = Object.freeze({
     carColor: '#38d9ff',
     carSecondaryColor: '#fff8e8',
     label: 'ALEX · Countryside · 0:16.250'
+  }),
+  'friends-countryside-r1': Object.freeze({
+    id: 'friends-countryside-r1',
+    challengerName: 'ARVID',
+    trackId: 'countryside',
+    time: 15.4,
+    carId: 'sedan-sports',
+    carColor: '#ff4fa3',
+    carSecondaryColor: '#252a35',
+    racers: Object.freeze([
+      Object.freeze({ id: 'mock-arvid', name: 'ARVID', time: 15.4, laneOffset: 0 }),
+      Object.freeze({ id: 'mock-erik', name: 'ERIK', time: 16.1, laneOffset: 1.2 }),
+      Object.freeze({ id: 'mock-kerstin', name: 'KERSTIN', time: 17.05, laneOffset: -1.2 })
+    ]),
+    label: 'ARVID + ERIK + KERSTIN · 3 cars'
   })
 });
 

--- a/yourturn/protocol.js
+++ b/yourturn/protocol.js
@@ -1,9 +1,12 @@
-const CHALLENGE_SCHEMA_VERSION = 1;
-const WIRE_VERSION = 1;
+const CHALLENGE_SCHEMA_VERSION = 2;
+const LEGACY_SCHEMA_VERSION = 1;
+const WIRE_VERSION = 2;
+const LEGACY_WIRE_VERSION = 1;
 const HASH_KEY = 'challenge';
 const QUERY_KEY = 'c';
 const MAX_NAME_LENGTH = 24;
-const MAX_FRAMES = 180;
+export const MAX_CHALLENGE_RACERS = 4;
+const MAX_FRAMES = 120;
 const MIN_FRAMES = 21;
 const TIME_SCALE = 1000;
 const POSITION_SCALE = 100;
@@ -28,60 +31,139 @@ export function normalizeChallengeName(value, fallback = 'A TURN PLAYER') {
   return clean || fallback;
 }
 
+export function createRacerId(prefix = 'r') {
+  const random = globalThis.crypto?.randomUUID?.()
+    || `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 12)}`;
+  return normalizeRacerId(`${prefix}-${random}`);
+}
+
+export function createChallengeChainId() {
+  return createRacerId('yt');
+}
+
 export function challengeFromLap({
   challengerName,
+  racerId,
+  chainId,
   trackId,
   trackRevision,
   trackName,
   lap,
   replyTo = null
 }) {
-  const time = Number(lap?.time);
-  const frames = downsampleFrames(lap?.frames);
-  if (!Number.isFinite(time) || time <= 5 || frames.length < MIN_FRAMES) {
-    throw new Error('YOUR TURN can only share a complete valid lap.');
-  }
+  const racer = racerFromLap({
+    racerId: racerId || createRacerId(),
+    racerName: challengerName,
+    lap
+  });
 
   return normalizeChallenge({
     v: CHALLENGE_SCHEMA_VERSION,
-    challengerName,
+    chainId: chainId || createChallengeChainId(),
+    sharedBy: racer.id,
     trackId,
     trackRevision,
     trackName,
-    time,
-    carId: lap.carId,
-    carColor: lap.carColor,
-    carSecondaryColor: lap.carSecondaryColor,
-    frames,
+    carId: lap?.carId,
+    carColor: lap?.carColor,
+    carSecondaryColor: lap?.carSecondaryColor,
+    racers: [racer],
     replyTo
   });
 }
 
+export function challengeWithLap({ challenge, racerId, racerName, lap }) {
+  const current = normalizeChallenge(challenge);
+  const candidate = racerFromLap({ racerId, racerName, lap });
+  const existing = current.racers.find((racer) => racer.id === candidate.id);
+  const merged = current.racers.filter((racer) => racer.id !== candidate.id);
+
+  // Returning players keep a single car in the bundle. A slower repeat never
+  // overwrites their better earlier run; a new personal best replaces it.
+  merged.push(existing && existing.time <= candidate.time ? existing : candidate);
+
+  // The link is intentionally self-contained and capped at TURN's four-rival
+  // visual/runtime limit. A new contributor is always retained; the remaining
+  // slots are the quickest other cars in the chain.
+  const selected = merged
+    .sort((a, b) => a.time - b.time)
+    .filter((racer, index, racers) => {
+      if (racer.id === candidate.id) return true;
+      const contributorIndex = racers.findIndex((item) => item.id === candidate.id);
+      const beforeContributor = racers.slice(0, contributorIndex).filter((item) => item.id !== candidate.id);
+      const afterContributor = racers.slice(contributorIndex + 1).filter((item) => item.id !== candidate.id);
+      const others = [...beforeContributor, ...afterContributor].sort((a, b) => a.time - b.time);
+      return others.slice(0, MAX_CHALLENGE_RACERS - 1).some((item) => item.id === racer.id);
+    })
+    .sort((a, b) => a.time - b.time)
+    .slice(0, MAX_CHALLENGE_RACERS);
+
+  if (!selected.some((racer) => racer.id === candidate.id)) {
+    selected[MAX_CHALLENGE_RACERS - 1] = existing && existing.time <= candidate.time ? existing : candidate;
+    selected.sort((a, b) => a.time - b.time);
+  }
+
+  return normalizeChallenge({
+    ...current,
+    v: CHALLENGE_SCHEMA_VERSION,
+    sharedBy: candidate.id,
+    racers: selected,
+    replyTo: null
+  });
+}
+
+export function challengeLeader(challenge) {
+  return normalizeChallenge(challenge).racers[0];
+}
+
+export function challengeSender(challenge) {
+  const normalized = normalizeChallenge(challenge);
+  return normalized.racers.find((racer) => racer.id === normalized.sharedBy) || normalized.racers[0];
+}
+
 export function normalizeChallenge(value) {
   const source = value && typeof value === 'object' ? value : {};
-  const time = Number(source.time);
-  const frames = downsampleFrames(source.frames);
-  const trackId = String(source.trackId || '').trim();
-  const carId = String(source.carId || '').trim();
-
-  if (Number(source.v) !== CHALLENGE_SCHEMA_VERSION) {
+  const sourceVersion = Number(source.v);
+  if (sourceVersion !== CHALLENGE_SCHEMA_VERSION && sourceVersion !== LEGACY_SCHEMA_VERSION) {
     throw new Error('This challenge uses an unsupported replay version.');
   }
-  if (!trackId || !carId || !Number.isFinite(time) || time <= 5 || frames.length < MIN_FRAMES) {
+
+  const trackId = String(source.trackId || '').trim();
+  const carId = String(source.carId || '').trim();
+  const rawRacers = Array.isArray(source.racers) && source.racers.length
+    ? source.racers
+    : [legacyRacerFromChallenge(source)];
+  const racers = rawRacers
+    .map((racer, index) => normalizeRacer(racer, index))
+    .filter(Boolean)
+    .sort((a, b) => a.time - b.time)
+    .slice(0, MAX_CHALLENGE_RACERS);
+
+  if (!trackId || !carId || racers.length === 0) {
     throw new Error('This challenge is incomplete or damaged.');
   }
 
+  const leader = racers[0];
+  const sharedByCandidate = normalizeRacerId(source.sharedBy || source.senderId || leader.id, leader.id);
+  const sharedBy = racers.some((racer) => racer.id === sharedByCandidate) ? sharedByCandidate : leader.id;
+  const chainId = normalizeRacerId(source.chainId, legacyChainId(source, leader));
+
   return Object.freeze({
     v: CHALLENGE_SCHEMA_VERSION,
-    challengerName: normalizeChallengeName(source.challengerName),
+    chainId,
+    sharedBy,
     trackId,
     trackRevision: String(source.trackRevision || ''),
     trackName: String(source.trackName || '').trim(),
-    time,
     carId,
     carColor: normalizeHex(source.carColor, '#ffcc00'),
     carSecondaryColor: normalizeHex(source.carSecondaryColor, '#f8f9fa'),
-    frames,
+    racers: Object.freeze(racers),
+    // Leader aliases preserve the simple single-rival interface used by preview
+    // and backwards-compatible callers while the challenge itself is now a field.
+    challengerName: leader.name,
+    time: leader.time,
+    frames: leader.frames,
     replyTo: normalizeReply(source.replyTo)
   });
 }
@@ -119,7 +201,9 @@ export async function decodeChallenge(encoded) {
   }
 
   const parsed = JSON.parse(new TextDecoder().decode(bytes));
-  return normalizeChallenge(parsed?.w === WIRE_VERSION ? fromWireChallenge(parsed) : parsed);
+  if (parsed?.w === WIRE_VERSION) return normalizeChallenge(fromWireChallengeV2(parsed));
+  if (parsed?.w === LEGACY_WIRE_VERSION) return normalizeChallenge(fromWireChallengeV1(parsed));
+  return normalizeChallenge(parsed);
 }
 
 export function encodedChallengeFromLocation(locationRef = globalThis.location) {
@@ -154,9 +238,108 @@ export function makeMockChallengeUrl(challengeId, {
   return url.href;
 }
 
+function racerFromLap({ racerId, racerName, lap }) {
+  const time = Number(lap?.time);
+  const frames = downsampleFrames(lap?.frames);
+  if (!Number.isFinite(time) || time <= 5 || frames.length < MIN_FRAMES) {
+    throw new Error('YOUR TURN can only share a complete valid lap.');
+  }
+  return normalizeRacer({
+    id: racerId || createRacerId(),
+    name: racerName,
+    time,
+    frames
+  }, 0);
+}
+
+function normalizeRacer(value, index) {
+  const source = value && typeof value === 'object' ? value : {};
+  const time = Number(source.time);
+  const frames = downsampleFrames(source.frames);
+  if (!Number.isFinite(time) || time <= 5 || frames.length < MIN_FRAMES) return null;
+  const name = normalizeChallengeName(source.name || source.challengerName);
+  const id = normalizeRacerId(source.id || source.racerId, legacyRacerId(name, time, frames, index));
+  return Object.freeze({ id, name, time, frames });
+}
+
+function legacyRacerFromChallenge(source) {
+  return {
+    id: source.racerId,
+    name: source.challengerName,
+    time: source.time,
+    frames: source.frames
+  };
+}
+
 function toWireChallenge(challenge) {
+  return {
+    w: WIRE_VERSION,
+    v: challenge.v,
+    id: challenge.chainId,
+    s: challenge.sharedBy,
+    ti: challenge.trackId,
+    tr: challenge.trackRevision,
+    tn: challenge.trackName,
+    c: challenge.carId,
+    pc: challenge.carColor,
+    sc: challenge.carSecondaryColor,
+    rs: challenge.racers.map((racer) => [
+      racer.id,
+      racer.name,
+      quantize(racer.time, TIME_SCALE),
+      encodeFrames(racer.frames)
+    ]),
+    r: challenge.replyTo ? [
+      challenge.replyTo.kind === 'win' ? 'w' : 'g',
+      challenge.replyTo.opponent,
+      Number.isFinite(challenge.replyTo.previousTime)
+        ? quantize(challenge.replyTo.previousTime, TIME_SCALE)
+        : null
+    ] : null
+  };
+}
+
+function fromWireChallengeV2(wire) {
+  const racers = Array.isArray(wire.rs) ? wire.rs.map((row) => ({
+    id: row?.[0],
+    name: row?.[1],
+    time: integer(row?.[2]) / TIME_SCALE,
+    frames: decodeFrames(row?.[3])
+  })) : [];
+  return {
+    v: CHALLENGE_SCHEMA_VERSION,
+    chainId: wire.id,
+    sharedBy: wire.s,
+    trackId: wire.ti,
+    trackRevision: wire.tr,
+    trackName: wire.tn,
+    carId: wire.c,
+    carColor: wire.pc,
+    carSecondaryColor: wire.sc,
+    racers,
+    replyTo: decodeReply(wire.r)
+  };
+}
+
+function fromWireChallengeV1(wire) {
+  return {
+    v: LEGACY_SCHEMA_VERSION,
+    challengerName: wire.n,
+    trackId: wire.ti,
+    trackRevision: wire.tr,
+    trackName: wire.tn,
+    time: integer(wire.tm) / TIME_SCALE,
+    carId: wire.c,
+    carColor: wire.pc,
+    carSecondaryColor: wire.sc,
+    frames: decodeFrames(wire.f),
+    replyTo: decodeReply(wire.r)
+  };
+}
+
+function encodeFrames(frames) {
   let previous = null;
-  const frames = challenge.frames.map((frame) => {
+  return frames.map((frame) => {
     const current = [
       quantize(frame.t, TIME_SCALE),
       quantize(frame.x, POSITION_SCALE),
@@ -180,32 +363,11 @@ function toWireChallenge(challenge) {
     previous = current;
     return row;
   });
-
-  return {
-    w: WIRE_VERSION,
-    v: challenge.v,
-    n: challenge.challengerName,
-    ti: challenge.trackId,
-    tr: challenge.trackRevision,
-    tn: challenge.trackName,
-    tm: quantize(challenge.time, TIME_SCALE),
-    c: challenge.carId,
-    pc: challenge.carColor,
-    sc: challenge.carSecondaryColor,
-    f: frames,
-    r: challenge.replyTo ? [
-      challenge.replyTo.kind === 'win' ? 'w' : 'g',
-      challenge.replyTo.opponent,
-      Number.isFinite(challenge.replyTo.previousTime)
-        ? quantize(challenge.replyTo.previousTime, TIME_SCALE)
-        : null
-    ] : null
-  };
 }
 
-function fromWireChallenge(wire) {
+function decodeFrames(rows) {
   let previous = null;
-  const frames = Array.isArray(wire.f) ? wire.f.map((row, index) => {
+  return Array.isArray(rows) ? rows.map((row, index) => {
     if (!Array.isArray(row) || row.length < 7) return null;
     const current = index === 0
       ? row.map((value) => integer(value))
@@ -229,26 +391,14 @@ function fromWireChallenge(wire) {
       p: current[6] / PROGRESS_SCALE
     };
   }).filter(Boolean) : [];
+}
 
-  const reply = Array.isArray(wire.r) ? {
-    kind: wire.r[0] === 'w' ? 'win' : wire.r[0] === 'g' ? 'give-up' : '',
-    opponent: wire.r[1],
-    previousTime: wire.r[2] == null ? null : integer(wire.r[2]) / TIME_SCALE
+function decodeReply(row) {
+  return Array.isArray(row) ? {
+    kind: row[0] === 'w' ? 'win' : row[0] === 'g' ? 'give-up' : '',
+    opponent: row[1],
+    previousTime: row[2] == null ? null : integer(row[2]) / TIME_SCALE
   } : null;
-
-  return {
-    v: wire.v,
-    challengerName: wire.n,
-    trackId: wire.ti,
-    trackRevision: wire.tr,
-    trackName: wire.tn,
-    time: integer(wire.tm) / TIME_SCALE,
-    carId: wire.c,
-    carColor: wire.pc,
-    carSecondaryColor: wire.sc,
-    frames,
-    replyTo: reply
-  };
 }
 
 function normalizeFrames(frames, { limit = MAX_FRAMES } = {}) {
@@ -293,6 +443,37 @@ function normalizeReply(reply) {
     opponent: normalizeChallengeName(reply.opponent, 'THE CHALLENGER'),
     previousTime: Number.isFinite(Number(reply.previousTime)) ? Number(reply.previousTime) : null
   });
+}
+
+function normalizeRacerId(value, fallback = '') {
+  const clean = String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, '')
+    .slice(0, 64);
+  if (clean) return clean;
+  const fallbackClean = String(fallback || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, '')
+    .slice(0, 64);
+  return fallbackClean || 'r-unknown';
+}
+
+function legacyRacerId(name, time, frames, index = 0) {
+  const first = frames[0] || {};
+  return `legacy-${simpleHash(`${name}|${time.toFixed(3)}|${finite(first.x)}|${finite(first.z)}|${index}`)}`;
+}
+
+function legacyChainId(source, leader) {
+  return `yt-legacy-${simpleHash(`${source.trackId || ''}|${source.trackRevision || ''}|${leader.id}`)}`;
+}
+
+function simpleHash(value) {
+  let hash = 2166136261;
+  for (const character of String(value)) {
+    hash ^= character.charCodeAt(0);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
 }
 
 function normalizeHex(value, fallback) {

--- a/yourturn/racer-labels-bootstrap.js
+++ b/yourturn/racer-labels-bootstrap.js
@@ -6,27 +6,12 @@ function bootstrap(attempt = 0) {
   const runtime = globalThis.__turnRuntime;
   const session = globalThis.__yourTurnSession;
   if (runtime && session) {
+    // Labels are a presentation layer only. Session owns the canonical challenge
+    // replay field and its vehicle identity; this bootstrap never mutates race state.
     installRacerLabels(runtime, () => session.getState());
-    syncChallengeCarIdentity(runtime, session);
     return;
   }
   if (attempt < FRAME_LIMIT) requestAnimationFrame(() => bootstrap(attempt + 1));
-}
-
-function syncChallengeCarIdentity(runtime, session, attempt = 0) {
-  const state = session.getState();
-  if (!state.challenge || !state.challengeLaps?.length) {
-    if (attempt < FRAME_LIMIT) requestAnimationFrame(() => syncChallengeCarIdentity(runtime, session, attempt + 1));
-    return;
-  }
-
-  for (const lap of state.challengeLaps) {
-    lap.carId = state.challenge.carId;
-    lap.carColor = state.challenge.carColor;
-    lap.carSecondaryColor = state.challenge.carSecondaryColor;
-  }
-  runtime.state.competitorLaps = state.challengeLaps;
-  runtime.syncCompetitorVisuals?.();
 }
 
 bootstrap();

--- a/yourturn/racer-labels-bootstrap.js
+++ b/yourturn/racer-labels-bootstrap.js
@@ -7,9 +7,26 @@ function bootstrap(attempt = 0) {
   const session = globalThis.__yourTurnSession;
   if (runtime && session) {
     installRacerLabels(runtime, () => session.getState());
+    syncChallengeCarIdentity(runtime, session);
     return;
   }
   if (attempt < FRAME_LIMIT) requestAnimationFrame(() => bootstrap(attempt + 1));
+}
+
+function syncChallengeCarIdentity(runtime, session, attempt = 0) {
+  const state = session.getState();
+  if (!state.challenge || !state.challengeLaps?.length) {
+    if (attempt < FRAME_LIMIT) requestAnimationFrame(() => syncChallengeCarIdentity(runtime, session, attempt + 1));
+    return;
+  }
+
+  for (const lap of state.challengeLaps) {
+    lap.carId = state.challenge.carId;
+    lap.carColor = state.challenge.carColor;
+    lap.carSecondaryColor = state.challenge.carSecondaryColor;
+  }
+  runtime.state.competitorLaps = state.challengeLaps;
+  runtime.syncCompetitorVisuals?.();
 }
 
 bootstrap();

--- a/yourturn/racer-labels-bootstrap.js
+++ b/yourturn/racer-labels-bootstrap.js
@@ -1,0 +1,15 @@
+import { installRacerLabels } from '/yourturn/racer-labels.js?revision=r1';
+
+const FRAME_LIMIT = 240;
+
+function bootstrap(attempt = 0) {
+  const runtime = globalThis.__turnRuntime;
+  const session = globalThis.__yourTurnSession;
+  if (runtime && session) {
+    installRacerLabels(runtime, () => session.getState());
+    return;
+  }
+  if (attempt < FRAME_LIMIT) requestAnimationFrame(() => bootstrap(attempt + 1));
+}
+
+bootstrap();

--- a/yourturn/racer-labels.js
+++ b/yourturn/racer-labels.js
@@ -1,0 +1,71 @@
+import * as THREE from 'three';
+
+const LABEL_HEIGHT = 2.8;
+
+export function installRacerLabels(runtime, getSessionState) {
+  if (!runtime?.camera || runtime.__yourTurnRacerLabelsInstalled) return null;
+  runtime.__yourTurnRacerLabelsInstalled = true;
+
+  const root = document.createElement('div');
+  root.className = 'yourturn-racer-labels';
+  root.setAttribute('aria-hidden', 'true');
+  document.body.appendChild(root);
+
+  let labels = [];
+  let signature = '';
+  const point = new THREE.Vector3();
+
+  function syncLabels(laps) {
+    const nextSignature = laps.map((lap) => `${lap.racerId}:${lap.challengerName}`).join('|');
+    if (nextSignature === signature) return;
+    signature = nextSignature;
+    root.replaceChildren();
+    labels = laps.map((lap) => {
+      const label = document.createElement('span');
+      label.className = 'yourturn-racer-label';
+      label.textContent = lap.challengerName || 'TURN PLAYER';
+      root.appendChild(label);
+      return label;
+    });
+  }
+
+  function frame() {
+    const state = getSessionState?.();
+    const laps = state?.challengeLaps || [];
+    syncLabels(laps);
+    const visible = Boolean(state?.active)
+      && !document.documentElement.classList.contains('turn-screen-blanked');
+
+    for (let index = 0; index < labels.length; index += 1) {
+      const label = labels[index];
+      const car = runtime.competitorCars?.[index];
+      if (!visible || !car?.visible) {
+        label.hidden = true;
+        continue;
+      }
+
+      point.copy(car.position);
+      point.y += LABEL_HEIGHT;
+      point.project(runtime.camera);
+      if (!Number.isFinite(point.x) || !Number.isFinite(point.y) || point.z < -1 || point.z > 1) {
+        label.hidden = true;
+        continue;
+      }
+
+      const x = (point.x * 0.5 + 0.5) * globalThis.innerWidth;
+      const y = (-point.y * 0.5 + 0.5) * globalThis.innerHeight;
+      if (x < -80 || x > globalThis.innerWidth + 80 || y < -60 || y > globalThis.innerHeight + 60) {
+        label.hidden = true;
+        continue;
+      }
+
+      label.hidden = false;
+      label.style.transform = `translate3d(${x}px, ${y}px, 0) translate(-50%, -100%)`;
+    }
+
+    requestAnimationFrame(frame);
+  }
+
+  requestAnimationFrame(frame);
+  return root;
+}

--- a/yourturn/session.js
+++ b/yourturn/session.js
@@ -6,7 +6,10 @@ import { getTrackDefinition } from '/turn/tracks/catalog.js?source=20260729-r118
 import { getTrackStorageRevision } from '/turn/tracks/definitions.js';
 import { getCarDefinition } from '/turn/vehicle/catalog.js?build=20260720-r19';
 import {
-  challengeFromLap,
+  challengeLeader,
+  challengeSender,
+  challengeWithLap,
+  createRacerId,
   decodeChallenge,
   encodeChallenge,
   encodedChallengeFromLocation,
@@ -15,10 +18,12 @@ import {
   makeMockChallengeUrl,
   normalizeChallenge,
   normalizeChallengeName
-} from '/yourturn/protocol.js?revision=r2';
+} from '/yourturn/protocol.js?revision=r3';
 import { getMockChallenge, MOCK_CHALLENGES } from '/yourturn/mock-challenges.js?revision=r1';
 import { createChallengeScene } from '/yourturn/scene.js?revision=r1';
-import { aboutTurnHtml, escapeHtml, newcomerAssistiveText } from '/yourturn/ui.js?revision=r2';
+import { aboutTurnHtml, escapeHtml, newcomerAssistiveText } from '/yourturn/ui.js?revision=r3';
+
+const RACER_ID_KEY = 'yourturn-racer-id-v1';
 
 export function readYourTurnRequest(locationRef = globalThis.location) {
   const query = new URLSearchParams(locationRef?.search || '');
@@ -27,6 +32,7 @@ export function readYourTurnRequest(locationRef = globalThis.location) {
   return Object.freeze({
     mockId,
     encoded,
+    // Kept only so already-shared r5 give-up links remain understandable.
     reply: query.get('reply') === 'give-up' ? 'give-up' : '',
     responder: normalizeChallengeName(query.get('responder'), 'A TURN PLAYER'),
     hasChallenge: Boolean(mockId || encoded)
@@ -41,12 +47,15 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
     phase: 'idle',
     challenge: null,
     challengeLap: null,
+    challengeLaps: [],
+    bestRun: null,
     winningLap: null,
     scene: null,
     pendingAccess: null,
     paused: false,
     backgroundPaused: false,
-    ambientPaused: false
+    ambientPaused: false,
+    racerId: loadOrCreateRacerId()
   };
 
   ui.bindChallengeMenu(() => openChallengeMenu('Race paused.'));
@@ -67,11 +76,10 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
 
     const challenge = await resolveChallenge();
     state.active = true;
-    state.challenge = challenge;
-    state.challengeLap = challengeToLap(challenge);
+    setChallenge(challenge);
 
     await raceSession.selectVehicle(challengeVehicle(challenge));
-    useChallengeAsOnlyOpponent();
+    useChallengeField();
     document.body.classList.add('yourturn-active', 'yourturn-preview');
 
     runtime.state.running = true;
@@ -91,13 +99,21 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
     });
     state.phase = request.reply ? 'reply' : 'preview';
     state.scene.setPhase(state.phase);
-    ui.setTarget({
-      opponent: challenge.challengerName,
-      time: formatChallengeTime(challenge.time)
-    });
+    syncTarget();
 
-    if (request.reply === 'give-up') showReceivedGiveUp();
+    if (request.reply === 'give-up') showReceivedLegacyGiveUp();
     else showInvitation();
+  }
+
+  function setChallenge(challenge) {
+    state.challenge = normalizeChallenge(challenge);
+    state.challengeLaps = state.challenge.racers.map(racerToLap);
+    state.challengeLap = state.challengeLaps[0] || null;
+  }
+
+  function syncTarget() {
+    const leader = challengeLeader(state.challenge);
+    ui.setTarget({ opponent: leader.name, time: formatChallengeTime(leader.time) });
   }
 
   async function resolveChallenge() {
@@ -160,21 +176,26 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
     const challenge = state.challenge;
     const track = getTrackDefinition(challenge.trackId);
     const car = getCarDefinition(challenge.carId);
+    const leader = challengeLeader(challenge);
+    const sender = challengeSender(challenge);
+    const count = challenge.racers.length;
     state.phase = 'preview';
     state.scene?.setPhase('preview');
     ui.hideRaceChrome();
     showSessionModal({
-      titleText: `${challenge.challengerName} CHALLENGES YOU`,
+      titleText: count === 1 ? `${sender.name} CHALLENGES YOU` : `${count} PLAYERS CHALLENGE YOU`,
       detailsHtml: `
         <strong>${escapeHtml(track.name.toUpperCase())}</strong>
-        <span>${escapeHtml(car.name)} · ${formatChallengeTime(challenge.time)}</span>`,
-      copyHtml: `Beat ${escapeHtml(challenge.challengerName)}’s car. Race as many laps as you need.`,
-      extraHtml: newcomerAssistiveText(challenge.challengerName),
+        <span>${escapeHtml(car.name)} · fastest ${escapeHtml(leader.name)} ${formatChallengeTime(leader.time)}</span>`,
+      copyHtml: count === 1
+        ? `Beat ${escapeHtml(leader.name)}’s car, or add your best lap and share the challenge on.`
+        : `Race ${escapeHtml(joinRacerNames(challenge.racers))}. Beat ${escapeHtml(leader.name)} to take the lead, or add your best lap and share the challenge on.`,
+      extraHtml: `${racerSummaryHtml(challenge)}${newcomerAssistiveText(sender.name)}`,
       className: 'invitation',
       actionList: [
         { label: 'ACCEPT CHALLENGE', primary: true, action: () => void acceptWithMotion() },
         { label: 'TRY LATER', navigation: true, action: openFullTurn },
-        { label: 'GIVE UP', destructive: true, action: showGiveUpConfirm },
+        { label: 'SHARE', share: true, action: () => void shareExistingChallenge() },
         { label: 'ABOUT TURN', kind: 'quiet', action: () => showAbout(showInvitation) }
       ]
     });
@@ -247,10 +268,10 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
     document.body.classList.add('yourturn-racing');
     state.phase = 'staged';
     state.scene.setPhase('staged');
-    useChallengeAsOnlyOpponent();
+    useChallengeField();
 
     document.querySelector('#resetButton')?.click();
-    useChallengeAsOnlyOpponent();
+    useChallengeField();
     const access = state.pendingAccess || raceSession.prepareManualAccess();
     await centerMotionAfterLandscape();
     await raceSession.startGame(access.fullscreenPromise);
@@ -313,117 +334,103 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
   }
 
   function finishAttempt(candidate) {
-    useChallengeAsOnlyOpponent();
-    if (candidate.time < state.challenge.time) {
+    useChallengeField();
+    if (!state.bestRun || candidate.time < state.bestRun.time) state.bestRun = candidate;
+    const leader = challengeLeader(state.challenge);
+    if (candidate.time < leader.time) {
       state.winningLap = candidate;
       state.phase = 'result';
       stopRaceForModal('result');
-      showWin(candidate);
+      showShareResult(candidate);
       return;
     }
     state.phase = runtime.state.lapActive ? 'racing' : 'staged';
     state.scene.setPhase(state.phase);
   }
 
-  function showWin(candidate) {
-    const difference = state.challenge.time - candidate.time;
+  function showShareResult(candidate = state.bestRun) {
+    if (!candidate) {
+      showNoLapYet();
+      return;
+    }
+    const leader = challengeLeader(state.challenge);
+    const ahead = leader.time - candidate.time;
+    const won = ahead > 0;
     showSessionModal({
-      titleText: `YOU BEAT ${state.challenge.challengerName}`,
+      titleText: won ? `YOU BEAT ${leader.name}` : 'YOUR BEST LAP',
       detailsHtml: `
         <strong>${formatChallengeTime(candidate.time)}</strong>
-        <span>${difference.toFixed(3)} seconds ahead</span>`,
-      copyHtml: 'Send your winning lap back as a new YOUR TURN challenge.',
+        <span>${won ? `${ahead.toFixed(3)} seconds ahead` : `${Math.abs(ahead).toFixed(3)} seconds behind ${escapeHtml(leader.name)}`}</span>`,
+      copyHtml: 'Add your car to this challenge and send it on. If you are already in the challenge, only your faster run is kept.',
       requestName: true,
       className: 'result',
       actionList: [
-        { label: 'SHARE YOUR TURN', primary: true, action: () => void shareWinningReply() },
+        { label: 'SHARE YOUR TURN', share: true, action: () => void shareContribution(candidate) },
         { label: 'RACE AGAIN', action: raceAgain },
-        { label: 'GET FULL TURN', navigation: true, action: openFullTurn },
-        { label: 'ABOUT TURN', kind: 'quiet', action: () => showAbout(() => showWin(candidate)) }
+        { label: 'GET THE GAME', game: true, action: openFullTurn },
+        { label: 'ABOUT TURN', kind: 'quiet', action: () => showAbout(() => showShareResult(candidate)) }
       ]
     });
   }
 
-  async function shareWinningReply() {
-    const responder = ui.playerName();
-    const replyChallenge = challengeFromLap({
-      challengerName: responder,
-      trackId: state.challenge.trackId,
-      trackRevision: getTrackStorageRevision(state.challenge.trackId),
-      trackName: getTrackDefinition(state.challenge.trackId).name,
-      lap: state.winningLap,
-      replyTo: {
-        kind: 'win',
-        opponent: state.challenge.challengerName,
-        previousTime: state.challenge.time
-      }
+  function showNoLapYet() {
+    showSessionModal({
+      titleText: 'NO LAP YET',
+      copyHtml: 'Finish a valid lap to add your own car to this challenge. You can also pass the current challenge on unchanged.',
+      className: 'share-empty',
+      actionList: [
+        { label: 'KEEP RACING', primary: true, action: resumeRace },
+        { label: 'SHARE ORIGINAL', share: true, action: () => void shareExistingChallenge() },
+        { label: 'ABOUT TURN', kind: 'quiet', action: () => showAbout(showNoLapYet) }
+      ]
     });
-    const encoded = await encodeChallenge(replyChallenge);
+  }
+
+  async function shareContribution(candidate) {
+    const racerName = ui.playerName();
+    const nextChallenge = challengeWithLap({
+      challenge: state.challenge,
+      racerId: state.racerId,
+      racerName,
+      lap: candidate
+    });
+    const encoded = await encodeChallenge(nextChallenge);
     const url = makeChallengeUrl(encoded);
+    const leader = challengeLeader(nextChallenge);
+    const text = nextChallenge.racers.length === 1
+      ? `${racerName} challenges you with ${formatChallengeTime(candidate.time)}. Your turn.`
+      : `${racerName} joined a ${nextChallenge.racers.length}-car YOUR TURN challenge. Fastest: ${leader.name} ${formatChallengeTime(leader.time)}. Your turn.`;
     return shareUrl({
-      title: `${responder} sends you YOUR TURN`,
-      text: `${responder} beat ${state.challenge.challengerName} with ${formatChallengeTime(state.winningLap.time)}. Your turn.`,
+      title: `${racerName} sends you YOUR TURN`,
+      text,
       url,
-      success: 'Your challenge is ready to send.'
+      success: 'Your growing challenge is ready to send.'
     });
   }
 
-  function showGiveUpConfirm() {
-    const wasAccepted = state.accepted;
-    if (wasAccepted) stopRaceForModal('reply');
-    showSessionModal({
-      titleText: 'GIVE UP?',
-      detailsHtml: `<strong>${escapeHtml(state.challenge.challengerName)} WINS</strong><span>Target ${formatChallengeTime(state.challenge.time)}</span>`,
-      copyHtml: `You can keep racing ${escapeHtml(state.challenge.challengerName)}’s car for as many laps as you want.`,
-      className: 'give-up',
-      actionList: [
-        { label: 'KEEP RACING', primary: true, action: wasAccepted ? raceAgain : showInvitation },
-        { label: 'YES, GIVE UP', destructive: true, action: finishGiveUp }
-      ]
-    });
-  }
-
-  function finishGiveUp() {
-    state.phase = 'reply';
-    state.scene?.setPhase('reply');
-    showSessionModal({
-      titleText: `${state.challenge.challengerName} WINS`,
-      detailsHtml: `<strong>${formatChallengeTime(state.challenge.time)}</strong><span>Challenge held</span>`,
-      copyHtml: 'Send the result back, try again, or open the full TURN game.',
-      requestName: true,
-      className: 'result',
-      actionList: [
-        { label: 'SHARE RESULT', primary: true, action: () => void shareGiveUpReply() },
-        { label: 'TRY AGAIN', action: state.accepted ? raceAgain : showInvitation },
-        { label: 'GET FULL TURN', navigation: true, action: openFullTurn },
-        { label: 'ABOUT TURN', kind: 'quiet', action: () => showAbout(finishGiveUp) }
-      ]
-    });
-  }
-
-  async function shareGiveUpReply() {
-    const responder = ui.playerName();
-    const url = request.mockId
-      ? makeMockChallengeUrl(request.mockId, { reply: 'give-up', responder })
-      : makeChallengeUrl(request.encoded, { reply: 'give-up', responder });
+  async function shareExistingChallenge() {
+    const encoded = await encodeChallenge(state.challenge);
+    const url = makeChallengeUrl(encoded);
+    const leader = challengeLeader(state.challenge);
     return shareUrl({
-      title: `${responder} answered your YOUR TURN challenge`,
-      text: `${responder} gave up. ${state.challenge.challengerName} wins this round.`,
+      title: 'YOUR TURN — a TURN challenge',
+      text: `Race ${state.challenge.racers.length === 1 ? leader.name : `${state.challenge.racers.length} players`}. Fastest: ${leader.name} ${formatChallengeTime(leader.time)}. Your turn.`,
       url,
-      success: 'Result ready to send.'
+      success: 'Challenge ready to send.'
     });
   }
 
-  function showReceivedGiveUp() {
+  function showReceivedLegacyGiveUp() {
     showSessionModal({
-      titleText: `${request.responder} GAVE UP`,
-      detailsHtml: `<strong>YOU WIN</strong><span>${formatChallengeTime(state.challenge.time)} held the lead</span>`,
-      copyHtml: `Your car beat ${escapeHtml(request.responder)}.`,
+      titleText: `${request.responder} PASSED IT ON`,
+      detailsHtml: `<strong>YOUR TURN</strong><span>${formatChallengeTime(challengeLeader(state.challenge).time)} is still the time to beat</span>`,
+      copyHtml: 'This is an older challenge reply. You can race it or send the challenge on.',
       className: 'result',
       actionList: [
         { label: 'RACE THIS CHALLENGE', primary: true, action: () => void acceptWithMotion() },
-        { label: 'GET FULL TURN', navigation: true, action: openFullTurn },
-        { label: 'ABOUT TURN', kind: 'quiet', action: () => showAbout(showReceivedGiveUp) }
+        { label: 'SHARE', share: true, action: () => void shareExistingChallenge() },
+        { label: 'GET THE GAME', game: true, action: openFullTurn },
+        { label: 'ABOUT TURN', kind: 'quiet', action: () => showAbout(showReceivedLegacyGiveUp) }
       ]
     });
   }
@@ -438,16 +445,34 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
 
   function showChallengeMenuView(reason) {
     showSessionModal({
-      titleText: 'CHALLENGE',
-      copyHtml: escapeHtml(reason),
+      titleText: 'THE CHALLENGE',
+      copyHtml: state.bestRun
+        ? `Your best lap so far is ${formatChallengeTime(state.bestRun.time)}. Keep racing or add it to the challenge and share.`
+        : escapeHtml(reason),
+      extraHtml: racerSummaryHtml(state.challenge),
       className: 'paused',
       actionList: [
         { label: 'RESUME', primary: true, action: resumeRace },
         { label: 'RESTART LAP', action: restartFromPause },
-        { label: 'GIVE UP', destructive: true, action: showGiveUpConfirm },
+        { label: 'SHARE', share: true, action: shareFromChallengeMenu },
         { label: 'ABOUT TURN', kind: 'quiet', action: () => showAbout(() => showChallengeMenuView(reason)) }
       ]
     });
+  }
+
+  function shareFromChallengeMenu() {
+    if (!state.bestRun) {
+      showNoLapYet();
+      return;
+    }
+    state.phase = 'result';
+    state.scene?.setPhase('result');
+    hideRaceUi();
+    ui.hideRaceChrome();
+    document.body.classList.remove('yourturn-racing');
+    document.body.classList.add('yourturn-preview');
+    state.paused = false;
+    showShareResult(state.bestRun);
   }
 
   function resumeRace() {
@@ -456,12 +481,13 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
     state.backgroundPaused = false;
     runtime.state.lastFrame = performance.now();
     animation.resume();
+    showRaceUi(runtime.state.sensorMode);
     ui.showRaceChrome();
   }
 
   function restartFromPause() {
     document.querySelector('#resetButton')?.click();
-    useChallengeAsOnlyOpponent();
+    useChallengeField();
     state.phase = 'staged';
     state.scene.setPhase('staged');
     resumeRace();
@@ -473,10 +499,10 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
     state.paused = false;
     document.body.classList.remove('yourturn-preview');
     document.body.classList.add('yourturn-racing');
-    useChallengeAsOnlyOpponent();
+    useChallengeField();
     showRaceUi(runtime.state.sensorMode);
     document.querySelector('#resetButton')?.click();
-    useChallengeAsOnlyOpponent();
+    useChallengeField();
     state.phase = 'staged';
     state.scene.setPhase('staged');
     runtime.state.lastFrame = performance.now();
@@ -488,7 +514,7 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
     runtime.setGameMode(GAME_MODE.STAGED);
     runtime.state.velocity.set(0, 0, 0);
     stopDrivingInputs();
-    useChallengeAsOnlyOpponent();
+    useChallengeField();
     state.scene?.setPhase(scenePhase);
     hideRaceUi();
     ui.hideRaceChrome();
@@ -519,8 +545,8 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
       extraHtml: aboutTurnHtml(),
       className: 'about',
       actionList: [
-        { label: 'BACK', primary: true, action: returnAction },
-        { label: 'GET FULL TURN', navigation: true, action: openFullTurn }
+        { label: 'BACK', back: true, action: returnAction },
+        { label: 'GET THE GAME', game: true, action: openFullTurn }
       ]
     });
   }
@@ -546,7 +572,7 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
     if (event.detail?.reason === 'race-reset') {
       state.phase = 'staged';
       state.scene?.setPhase('staged');
-      useChallengeAsOnlyOpponent();
+      useChallengeField();
     }
   }
 
@@ -565,11 +591,11 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
     }
   }
 
-  function useChallengeAsOnlyOpponent() {
-    runtime.state.competitorLaps = state.challengeLap ? [state.challengeLap] : [];
+  function useChallengeField() {
+    runtime.state.competitorLaps = state.challengeLaps.map((lap) => ({ ...lap, frames: lap.frames.map((frame) => ({ ...frame })) }));
     syncPrimaryRivalState(runtime.state);
     runtime.syncCompetitorVisuals?.();
-    runtime.setRacePosition?.(null, state.challengeLap ? 2 : 1);
+    runtime.setRacePosition?.(null, state.challengeLaps.length + 1);
   }
 
   function stopDrivingInputs() {
@@ -607,16 +633,15 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
   return Object.freeze({ launch, getState: () => state });
 }
 
-function challengeToLap(challenge) {
+function racerToLap(racer) {
   return {
-    time: challenge.time,
+    time: racer.time,
     hitAt: null,
-    challengeId: 'yourturn-opponent',
-    challengerName: challenge.challengerName,
-    carId: challenge.carId,
-    carColor: challenge.carColor,
-    carSecondaryColor: challenge.carSecondaryColor,
-    frames: challenge.frames.map((frame) => ({ ...frame }))
+    challengeId: `yourturn-${racer.id}`,
+    racerId: racer.id,
+    challengerName: racer.name,
+    carId: null,
+    frames: racer.frames.map((frame) => ({ ...frame }))
   };
 }
 
@@ -626,6 +651,34 @@ function challengeVehicle(challenge) {
     color: challenge.carColor,
     secondaryColor: challenge.carSecondaryColor
   };
+}
+
+function racerSummaryHtml(challenge) {
+  if (!challenge?.racers?.length) return '';
+  return `<div class="yourturn-racer-summary" aria-label="Cars in this challenge">${challenge.racers.map((racer, index) => `
+    <span${index === 0 ? ' data-leader="true"' : ''}>
+      <b>${escapeHtml(racer.name)}</b>
+      <small>${formatChallengeTime(racer.time)}</small>
+    </span>`).join('')}</div>`;
+}
+
+function joinRacerNames(racers) {
+  const names = racers.map((racer) => racer.name);
+  if (names.length <= 1) return names[0] || '';
+  if (names.length === 2) return `${names[0]} and ${names[1]}`;
+  return `${names.slice(0, -1).join(', ')} and ${names.at(-1)}`;
+}
+
+function loadOrCreateRacerId() {
+  try {
+    const existing = localStorage.getItem(RACER_ID_KEY);
+    if (existing) return existing;
+    const created = createRacerId();
+    localStorage.setItem(RACER_ID_KEY, created);
+    return created;
+  } catch (_) {
+    return createRacerId();
+  }
 }
 
 function showRaceUi(sensorMode) {

--- a/yourturn/session.js
+++ b/yourturn/session.js
@@ -107,7 +107,7 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
 
   function setChallenge(challenge) {
     state.challenge = normalizeChallenge(challenge);
-    state.challengeLaps = state.challenge.racers.map(racerToLap);
+    state.challengeLaps = state.challenge.racers.map((racer) => racerToLap(racer, state.challenge));
     state.challengeLap = state.challengeLaps[0] || null;
   }
 
@@ -134,35 +134,50 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
   }
 
   function materializeMockChallenge(definition) {
-    const frames = runtime.samples.map((sample, index, samples) => {
-      const denominator = Math.max(1, samples.length - 1);
-      const previous = samples[(index - 2 + samples.length) % samples.length];
-      const next = samples[(index + 2) % samples.length];
-      const previousHeading = Math.atan2(previous.tangent.x, previous.tangent.z);
-      const nextHeading = Math.atan2(next.tangent.x, next.tangent.z);
-      const steering = normalizeAngle(nextHeading - previousHeading) * 3.2;
-      return {
-        t: definition.time * index / denominator,
-        x: sample.point.x,
-        z: sample.point.z,
-        h: Math.atan2(sample.tangent.x, sample.tangent.z),
-        s: THREE.MathUtils.clamp(steering, -1, 1),
-        d: Math.min(1, Math.abs(steering) * 0.75),
-        p: index / denominator
-      };
-    });
+    const mockRacers = Array.isArray(definition.racers) && definition.racers.length
+      ? definition.racers
+      : [{
+        id: `mock-${definition.id}`,
+        name: definition.challengerName,
+        time: definition.time,
+        laneOffset: 0
+      }];
+    const racers = mockRacers.map((racer) => ({
+      id: racer.id,
+      name: racer.name,
+      time: racer.time,
+      frames: runtime.samples.map((sample, index, samples) => {
+        const denominator = Math.max(1, samples.length - 1);
+        const previous = samples[(index - 2 + samples.length) % samples.length];
+        const next = samples[(index + 2) % samples.length];
+        const previousHeading = Math.atan2(previous.tangent.x, previous.tangent.z);
+        const nextHeading = Math.atan2(next.tangent.x, next.tangent.z);
+        const steering = normalizeAngle(nextHeading - previousHeading) * 3.2;
+        const normal = sample.normal || new THREE.Vector3(-sample.tangent.z, 0, sample.tangent.x).normalize();
+        const laneOffset = Number(racer.laneOffset) || 0;
+        return {
+          t: racer.time * index / denominator,
+          x: sample.point.x + normal.x * laneOffset,
+          z: sample.point.z + normal.z * laneOffset,
+          h: Math.atan2(sample.tangent.x, sample.tangent.z),
+          s: THREE.MathUtils.clamp(steering, -1, 1),
+          d: Math.min(1, Math.abs(steering) * 0.75),
+          p: index / denominator
+        };
+      })
+    }));
     const track = getTrackDefinition(definition.trackId);
     return normalizeChallenge({
-      v: 1,
-      challengerName: definition.challengerName,
+      v: 2,
+      chainId: `yt-mock-${definition.id}`,
+      sharedBy: racers[0].id,
       trackId: definition.trackId,
       trackRevision: getTrackStorageRevision(definition.trackId),
       trackName: track.name,
-      time: definition.time,
       carId: definition.carId,
       carColor: definition.carColor,
       carSecondaryColor: definition.carSecondaryColor,
-      frames
+      racers
     });
   }
 
@@ -356,12 +371,16 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
     const leader = challengeLeader(state.challenge);
     const ahead = leader.time - candidate.time;
     const won = ahead > 0;
+    const previousSelf = state.challenge.racers.find((racer) => racer.id === state.racerId);
+    const keepingPrevious = previousSelf && previousSelf.time <= candidate.time;
     showSessionModal({
       titleText: won ? `YOU BEAT ${leader.name}` : 'YOUR BEST LAP',
       detailsHtml: `
         <strong>${formatChallengeTime(candidate.time)}</strong>
         <span>${won ? `${ahead.toFixed(3)} seconds ahead` : `${Math.abs(ahead).toFixed(3)} seconds behind ${escapeHtml(leader.name)}`}</span>`,
-      copyHtml: 'Add your car to this challenge and send it on. If you are already in the challenge, only your faster run is kept.',
+      copyHtml: keepingPrevious
+        ? `Your earlier ${formatChallengeTime(previousSelf.time)} car is still faster, so that run will stay in the challenge when you share.`
+        : 'Add your car to this challenge and send it on. If you are already in the challenge, this faster run replaces your earlier car.',
       requestName: true,
       className: 'result',
       actionList: [
@@ -471,7 +490,11 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
     ui.hideRaceChrome();
     document.body.classList.remove('yourturn-racing');
     document.body.classList.add('yourturn-preview');
+    // Opening THE CHALLENGE deliberately hard-paused the race. Carry that paused
+    // state into the result preview so the top-right control truthfully shows Play.
+    state.ambientPaused = true;
     state.paused = false;
+    ui.setMotionPaused(true);
     showShareResult(state.bestRun);
   }
 
@@ -592,7 +615,10 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
   }
 
   function useChallengeField() {
-    runtime.state.competitorLaps = state.challengeLaps.map((lap) => ({ ...lap, frames: lap.frames.map((frame) => ({ ...frame })) }));
+    runtime.state.competitorLaps = state.challengeLaps.map((lap) => ({
+      ...lap,
+      frames: lap.frames.map((frame) => ({ ...frame }))
+    }));
     syncPrimaryRivalState(runtime.state);
     runtime.syncCompetitorVisuals?.();
     runtime.setRacePosition?.(null, state.challengeLaps.length + 1);
@@ -633,14 +659,16 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
   return Object.freeze({ launch, getState: () => state });
 }
 
-function racerToLap(racer) {
+function racerToLap(racer, challenge) {
   return {
     time: racer.time,
     hitAt: null,
     challengeId: `yourturn-${racer.id}`,
     racerId: racer.id,
     challengerName: racer.name,
-    carId: null,
+    carId: challenge.carId,
+    carColor: challenge.carColor,
+    carSecondaryColor: challenge.carSecondaryColor,
     frames: racer.frames.map((frame) => ({ ...frame }))
   };
 }

--- a/yourturn/ui.js
+++ b/yourturn/ui.js
@@ -1,4 +1,4 @@
-import { normalizeChallengeName } from '/yourturn/protocol.js?revision=r2';
+import { normalizeChallengeName } from '/yourturn/protocol.js?revision=r3';
 
 const PLAYER_NAME_KEY = 'yourturn-player-name-v1';
 const PAUSE_ICON = `
@@ -73,13 +73,16 @@ export function createYourTurnUi() {
       if (action.primary) button.classList.add('is-primary');
       if (action.destructive) button.classList.add('is-destructive');
       if (action.navigation) button.classList.add('is-navigation');
+      if (action.share) button.classList.add('is-share');
+      if (action.game) button.classList.add('is-game');
+      if (action.back) button.classList.add('is-back');
       button.addEventListener('click', action.action);
       actions.appendChild(button);
     }
 
     if (typeof dialog.showModal === 'function' && !dialog.open) dialog.showModal();
     else dialog.setAttribute('open', '');
-    actions.querySelector('.is-primary, button')?.focus();
+    actions.querySelector('.is-primary, .is-share, button')?.focus();
   }
 
   function closeModal() {
@@ -189,6 +192,6 @@ function loadPlayerName() {
   try {
     return normalizeChallengeName(localStorage.getItem(PLAYER_NAME_KEY));
   } catch (_) {
-    return 'A TURN PLAYER';
+    return 'YOUR NAME';
   }
 }


### PR DESCRIPTION
## What changed
- changes YOUR TURN from one challenger replay to a self-contained challenge field with up to four named racer cars
- every shared valid run carries a stable racer ID + typed display name; returning players replace their own earlier car only when they improve it
- keeps a stable challenge-chain ID across shares as a future seam for server-backed/imported challenges without requiring that architecture now
- allows a player to SHARE their best valid run even if they did not beat the fastest car; active GIVE UP actions are removed
- carries the existing field forward on every share, capped at TURN’s canonical four-rival limit while always retaining the newest contributor
- shows player names above the replay cars and a named/time summary in challenge dialogs
- makes SHARE / SHARE YOUR TURN the pink CTA, GET THE GAME blue, and ABOUT → BACK orange
- preserves old single-car challenge links by transparently upgrading them to a one-racer field
- keeps production `/turn/**` untouched

## Future continuity
The bundle now has durable `chainId` and per-player `racerId` identities. That does not yet import the challenge into installed TURN, but it avoids designing this iteration around disposable one-to-one replies and leaves a clean identity boundary for that next step.

## Testing
The focused YOUR TURN contract now exercises A → B → C → B replacement, four-car capping, old-link compatibility, encoded link size, named-car labels and semantic action colors.