### PR TITLE
Stage the full YOUR TURN field side by side

### DIFF
--- a/.github/workflows/turn-challenge-tests.yml
+++ b/.github/workflows/turn-challenge-tests.yml
@@ -9,7 +9,7 @@ on:
       - 'turn-next/**'
       - 'yourturn/**'
       - 'turn-tests/challenge-*.mjs'
-      - 'turn-tests/yourturn-production.mjs'
+      - 'turn-tests/yourturn-*.mjs'
       - '.github/workflows/turn-challenge-tests.yml'
   push:
     branches:
@@ -18,7 +18,7 @@ on:
       - 'turn-next/**'
       - 'yourturn/**'
       - 'turn-tests/challenge-*.mjs'
-      - 'turn-tests/yourturn-production.mjs'
+      - 'turn-tests/yourturn-*.mjs'
       - '.github/workflows/turn-challenge-tests.yml'
 
 permissions:
@@ -47,6 +47,9 @@ jobs:
 
       - name: Run YOUR TURN recipient contract
         run: node turn-tests/yourturn-production.mjs
+
+      - name: Run YOUR TURN start-grid and social-preview regression
+        run: node turn-tests/yourturn-start-grid-production.mjs
 
       - name: Verify TURN NEXT parity wrapper
         run: node turn-next/scripts/build-parity-app.mjs --check

--- a/turn-tests/yourturn-start-grid-production.mjs
+++ b/turn-tests/yourturn-start-grid-production.mjs
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import {
+  challengeFromLap,
+  challengeWithLap,
+  decodeChallenge,
+  encodeChallenge,
+  makeChallengeUrl
+} from '../yourturn/protocol.js';
+
+const [indexSource, sceneSource, labelsSource, bootstrapSource, colorsSource, cssSource, uiSource, mockSource] = await Promise.all([
+  fs.readFile(new URL('../yourturn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/scene.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/racer-labels.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/racer-labels-bootstrap.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/racer-colors.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/growing-challenge.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/ui.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/mock-challenges.js', import.meta.url), 'utf8')
+]);
+
+assert.match(sceneSource, /rivalCount > 1/);
+assert.match(sceneSource, /const totalCars = rivalCount \+ 1/);
+assert.match(sceneSource, /const playerSlot = Math\.floor\(\(totalCars - 1\) \/ 2\)/,
+  'The player belongs in the middle or left-middle start slot');
+assert.match(sceneSource, /for \(let index = 0; index < competitorCars\.length; index \+= 1\)/,
+  'Every rival car must be explicitly staged in a multi-car start row');
+assert.match(bootstrapSource, /state\.challengeLaps\.length > 1[^\n]*state\.challengeLap = null/,
+  'The single-rival smart start-line adapter must stand down for multi-car rows');
+
+assert.match(labelsSource, /\( YOU \)/);
+assert.match(labelsSource, /ownRacer\?\.order \|\| state\?\.challenge\?\.nextOrder/);
+assert.match(colorsSource, /'#ffd1e6'[\s\S]*'#bdeeff'[\s\S]*'#c8f5d0'[\s\S]*'#fff0a8'[\s\S]*'#ffd0ae'/);
+assert.match(colorsSource, /lap\.carColor = colorForOrder/);
+assert.match(colorsSource, /raceSession\.selectVehicle/,
+  'The recipient car must use the same order color as the YOU plate');
+assert.match(cssSource, /text-transform: uppercase/);
+assert.match(cssSource, /yourturn-order-1[\s\S]*#ffd1e6/);
+assert.match(cssSource, /yourturn-order-5[\s\S]*#ffd0ae/);
+assert.match(cssSource, /yourturn-player-label[\s\S]*font-weight: 1000/);
+
+assert.match(indexSource, /placeholder="WRITE YOUR NAME HERE"/);
+assert.match(cssSource, /input::placeholder[\s\S]*#666/,
+  'The share-name placeholder must use the middle-grey design token value');
+assert.match(uiSource, /nameInput\.value = ''/,
+  'Opening a share result must show a real placeholder instead of editable fake placeholder text');
+assert.match(mockSource, /'erik-full-field-r1'/);
+assert.match(mockSource, /challengerName: 'ERIK'/);
+
+assert.match(indexSource, /property="og:image"/);
+assert.match(indexSource, /property="og:image:secure_url"/);
+assert.match(indexSource, /property="og:image:width" content="1200"/);
+assert.match(indexSource, /property="og:image:height" content="630"/);
+assert.match(indexSource, /name="twitter:card" content="summary_large_image"/);
+assert.match(indexSource, /rel="image_src"/);
+
+const lap = (time, offset = 0) => ({
+  time,
+  carId: 'sedan-sports',
+  carColor: '#ffffff',
+  carSecondaryColor: '#252a35',
+  frames: Array.from({ length: 900 }, (_, index) => ({
+    t: time * index / 899,
+    x: index * 0.08 + offset,
+    z: index * 0.04,
+    h: index * 0.001,
+    s: Math.sin(index / 40) * 0.2,
+    d: 0,
+    p: index / 899
+  }))
+});
+
+let chain = challengeFromLap({
+  challengerName: 'ERIK',
+  racerId: 'r-erik',
+  chainId: 'yt-grid-order',
+  trackId: 'countryside',
+  trackRevision: 'countryside',
+  trackName: 'Countryside',
+  lap: lap(15.4)
+});
+chain = challengeWithLap({ challenge: chain, racerId: 'r-arvid', racerName: 'ARVID', lap: lap(14.9, 0.2) });
+chain = challengeWithLap({ challenge: chain, racerId: 'r-kerstin', racerName: 'KERSTIN', lap: lap(16.1, -0.2) });
+chain = challengeWithLap({ challenge: chain, racerId: 'r-sol', racerName: 'SOL', lap: lap(15.8, 0.4) });
+
+assert.equal(chain.racers.find((racer) => racer.id === 'r-erik').order, 1,
+  'First challenger stays pink even if someone later becomes faster');
+assert.equal(chain.racers.find((racer) => racer.id === 'r-arvid').order, 2);
+assert.equal(chain.racers.find((racer) => racer.id === 'r-kerstin').order, 3);
+assert.equal(chain.racers.find((racer) => racer.id === 'r-sol').order, 4);
+assert.equal(chain.nextOrder, 5, 'The next recipient gets the fifth/orange identity color');
+
+const encoded = await encodeChallenge(chain);
+const decoded = await decodeChallenge(encoded);
+assert.deepEqual(
+  decoded.racers.map(({ id, order }) => [id, order]),
+  chain.racers.map(({ id, order }) => [id, order]),
+  'Join order must survive a real challenge-link round trip'
+);
+const url = makeChallengeUrl(encoded);
+assert.ok(url.length < 8000, `A four-rival query URL must stay below common request-line limits for reliable OG previews; got ${url.length}`);
+
+console.log('YOUR TURN full start grid, ordered colors, name entry and social-preview regression passed.');

--- a/yourturn/growing-challenge.css
+++ b/yourturn/growing-challenge.css
@@ -10,6 +10,10 @@
   background: #ff9b66;
 }
 
+.yourturn-card h1 {
+  text-transform: uppercase;
+}
+
 .yourturn-racer-summary {
   display: flex;
   flex-wrap: wrap;

--- a/yourturn/growing-challenge.css
+++ b/yourturn/growing-challenge.css
@@ -31,11 +31,12 @@
 }
 
 .yourturn-racer-summary > span[data-leader="true"] {
-  background: #ffd43b;
+  box-shadow: 0 0 0 3px #ffd43b, 3px 3px 0 3px #08090a;
 }
 
 .yourturn-racer-summary b {
-  font-weight: 1000;
+  font-weight: 900;
+  text-transform: uppercase;
 }
 
 .yourturn-racer-summary small {
@@ -59,16 +60,48 @@
   padding: 4px 8px;
   border: 2px solid #08090a;
   border-radius: 999px;
-  background: rgb(255 248 232 / 0.92);
+  background: rgb(255 248 232 / 0.94);
   color: #08090a;
   box-shadow: 2px 2px 0 #08090a;
   font-size: clamp(0.64rem, 1.3vw, 0.82rem);
-  font-weight: 1000;
+  font-weight: 900;
   line-height: 1;
+  text-transform: uppercase;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   will-change: transform;
+}
+
+.yourturn-racer-label.yourturn-order-1,
+.yourturn-racer-summary > span.yourturn-order-1 {
+  background: #ffd1e6;
+}
+
+.yourturn-racer-label.yourturn-order-2,
+.yourturn-racer-summary > span.yourturn-order-2 {
+  background: #bdeeff;
+}
+
+.yourturn-racer-label.yourturn-order-3,
+.yourturn-racer-summary > span.yourturn-order-3 {
+  background: #c8f5d0;
+}
+
+.yourturn-racer-label.yourturn-order-4,
+.yourturn-racer-summary > span.yourturn-order-4 {
+  background: #fff0a8;
+}
+
+.yourturn-racer-label.yourturn-order-5,
+.yourturn-racer-summary > span.yourturn-order-5 {
+  background: #ffd0ae;
+}
+
+.yourturn-player-label {
+  border-width: 3px;
+  font-weight: 1000;
+  letter-spacing: 0.025em;
 }
 
 .yourturn-racer-label[hidden] {
@@ -77,6 +110,20 @@
 
 .yourturn-dialog[open] ~ .yourturn-racer-labels .yourturn-racer-label {
   opacity: 0.72;
+}
+
+.yourturn-name-field input {
+  text-transform: uppercase;
+}
+
+.yourturn-name-field input::placeholder {
+  color: #666;
+  opacity: 1;
+  text-transform: uppercase;
+}
+
+#yourTurnTargetOpponent {
+  text-transform: uppercase;
 }
 
 @media (max-height: 560px) and (orientation: landscape) {
@@ -99,5 +146,9 @@
     padding: 3px 6px;
     border-width: 2px;
     font-size: 0.65rem;
+  }
+
+  .yourturn-player-label {
+    border-width: 3px;
   }
 }

--- a/yourturn/index.html
+++ b/yourturn/index.html
@@ -5,18 +5,27 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#38d9ff">
   <meta name="application-name" content="YOUR TURN">
+  <meta name="apple-mobile-web-app-title" content="YOUR TURN">
   <meta name="description" content="A YOUR TURN racing challenge, powered by TURN.">
   <link rel="canonical" href="https://enkel.design/yourturn/">
+  <link rel="image_src" href="https://enkel.design/turn/turn-og-r58.jpg">
   <meta property="og:type" content="website">
+  <meta property="og:locale" content="en_US">
   <meta property="og:site_name" content="YOUR TURN">
   <meta property="og:title" content="YOUR TURN — a TURN challenge">
   <meta property="og:description" content="Someone challenged you. Your turn.">
   <meta property="og:url" content="https://enkel.design/yourturn/">
   <meta property="og:image" content="https://enkel.design/turn/turn-og-r58.jpg">
+  <meta property="og:image:secure_url" content="https://enkel.design/turn/turn-og-r58.jpg">
+  <meta property="og:image:type" content="image/jpeg">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:alt" content="YOUR TURN — a TURN racing challenge">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="YOUR TURN — a TURN challenge">
   <meta name="twitter:description" content="Someone challenged you. Your turn.">
   <meta name="twitter:image" content="https://enkel.design/turn/turn-og-r58.jpg">
+  <meta name="twitter:image:alt" content="YOUR TURN — a TURN racing challenge">
   <title>YOUR TURN</title>
   <link rel="icon" href="/turn/TURNicon.PNG?icon=20260803-profile-512" type="image/png">
 
@@ -33,7 +42,7 @@
   <link rel="stylesheet" href="/turn/r104-polish.css?source=yourturn-r4">
   <link rel="stylesheet" href="/yourturn/yourturn.css?revision=r3">
   <link rel="stylesheet" href="/yourturn/nonvisual.css?revision=r1">
-  <link rel="stylesheet" href="/yourturn/growing-challenge.css?revision=r1">
+  <link rel="stylesheet" href="/yourturn/growing-challenge.css?revision=r2">
 
   <script src="/yourturn/storage-bootstrap.js?revision=r1"></script>
   <script type="importmap">
@@ -42,7 +51,9 @@
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/yourturn/session.js?revision=r3": "/yourturn/session.js?revision=r6",
-        "/yourturn/ui.js?revision=r3": "/yourturn/ui.js?revision=r6"
+        "/yourturn/ui.js?revision=r3": "/yourturn/ui.js?revision=r7",
+        "/yourturn/protocol.js?revision=r3": "/yourturn/protocol.js?revision=r7",
+        "/yourturn/scene.js?revision=r1": "/yourturn/scene.js?revision=r7"
       }
     }
   </script>
@@ -122,7 +133,7 @@
       <div class="yourturn-extra"></div>
       <label class="yourturn-name-field" hidden>
         <span>Your name in the challenge</span>
-        <input type="text" maxlength="24" autocomplete="nickname" placeholder="YOUR NAME">
+        <input type="text" maxlength="24" autocomplete="nickname" placeholder="WRITE YOUR NAME HERE">
       </label>
       <p class="yourturn-dialog-status" role="status" aria-live="polite"></p>
       <div class="yourturn-actions"></div>
@@ -137,6 +148,7 @@
 
   <script type="module" src="/yourturn/app.js?revision=r6"></script>
   <script type="module" src="/yourturn/nonvisual.js?revision=r1"></script>
-  <script type="module" src="/yourturn/racer-labels-bootstrap.js?revision=r1"></script>
+  <script type="module" src="/yourturn/racer-labels-bootstrap.js?revision=r2"></script>
+  <script type="module" src="/yourturn/racer-colors.js?revision=r1"></script>
 </body>
 </html>

--- a/yourturn/mock-challenges.js
+++ b/yourturn/mock-challenges.js
@@ -43,6 +43,22 @@ export const MOCK_CHALLENGES = Object.freeze({
       Object.freeze({ id: 'mock-kerstin', name: 'KERSTIN', time: 17.05, laneOffset: -1.15 })
     ]),
     label: 'ARVID + ERIK + KERSTIN · 3 cars'
+  }),
+  'erik-full-field-r1': Object.freeze({
+    id: 'erik-full-field-r1',
+    challengerName: 'ERIK',
+    trackId: 'countryside',
+    time: 15.4,
+    carId: 'sedan-sports',
+    carColor: '#ffd1e6',
+    carSecondaryColor: '#252a35',
+    racers: Object.freeze([
+      Object.freeze({ id: 'mock-erik-first', name: 'ERIK', time: 15.4, laneOffset: 0 }),
+      Object.freeze({ id: 'mock-arvid-second', name: 'ARVID', time: 16.0, laneOffset: 0.85 }),
+      Object.freeze({ id: 'mock-kerstin-third', name: 'KERSTIN', time: 16.7, laneOffset: -0.85 }),
+      Object.freeze({ id: 'mock-sol-fourth', name: 'SOL', time: 17.4, laneOffset: 1.55 })
+    ]),
+    label: 'ERIK FIRST · 4 rivals + YOU'
   })
 });
 

--- a/yourturn/protocol.js
+++ b/yourturn/protocol.js
@@ -54,6 +54,7 @@ export function challengeFromLap({
   const racer = racerFromLap({
     racerId: racerId || createRacerId(),
     racerName: challengerName,
+    challengeOrder: 1,
     lap
   });
 
@@ -61,6 +62,7 @@ export function challengeFromLap({
     v: CHALLENGE_SCHEMA_VERSION,
     chainId: chainId || createChallengeChainId(),
     sharedBy: racer.id,
+    nextOrder: 2,
     trackId,
     trackRevision,
     trackName,
@@ -74,8 +76,15 @@ export function challengeFromLap({
 
 export function challengeWithLap({ challenge, racerId, racerName, lap }) {
   const current = normalizeChallenge(challenge);
-  const candidate = racerFromLap({ racerId, racerName, lap });
-  const existing = current.racers.find((racer) => racer.id === candidate.id);
+  const candidateId = normalizeRacerId(racerId || createRacerId());
+  const existing = current.racers.find((racer) => racer.id === candidateId);
+  const challengeOrder = existing?.order || current.nextOrder;
+  const candidate = racerFromLap({
+    racerId: candidateId,
+    racerName,
+    challengeOrder,
+    lap
+  });
   const merged = current.racers.filter((racer) => racer.id !== candidate.id);
 
   // Returning players keep a single car in the bundle. A slower repeat never
@@ -107,6 +116,7 @@ export function challengeWithLap({ challenge, racerId, racerName, lap }) {
     ...current,
     v: CHALLENGE_SCHEMA_VERSION,
     sharedBy: candidate.id,
+    nextOrder: existing ? current.nextOrder : current.nextOrder + 1,
     racers: selected,
     replyTo: null
   });
@@ -147,11 +157,14 @@ export function normalizeChallenge(value) {
   const sharedByCandidate = normalizeRacerId(source.sharedBy || source.senderId || leader.id, leader.id);
   const sharedBy = racers.some((racer) => racer.id === sharedByCandidate) ? sharedByCandidate : leader.id;
   const chainId = normalizeRacerId(source.chainId, legacyChainId(source, leader));
+  const highestOrder = racers.reduce((highest, racer) => Math.max(highest, racer.order), 0);
+  const nextOrder = Math.max(highestOrder + 1, normalizeRacerOrder(source.nextOrder, highestOrder + 1));
 
   return Object.freeze({
     v: CHALLENGE_SCHEMA_VERSION,
     chainId,
     sharedBy,
+    nextOrder,
     trackId,
     trackRevision: String(source.trackRevision || ''),
     trackName: String(source.trackName || '').trim(),
@@ -238,7 +251,7 @@ export function makeMockChallengeUrl(challengeId, {
   return url.href;
 }
 
-function racerFromLap({ racerId, racerName, lap }) {
+function racerFromLap({ racerId, racerName, challengeOrder = 1, lap }) {
   const time = Number(lap?.time);
   const frames = downsampleFrames(lap?.frames);
   if (!Number.isFinite(time) || time <= 5 || frames.length < MIN_FRAMES) {
@@ -248,6 +261,7 @@ function racerFromLap({ racerId, racerName, lap }) {
     id: racerId || createRacerId(),
     name: racerName,
     time,
+    order: challengeOrder,
     frames
   }, 0);
 }
@@ -259,7 +273,8 @@ function normalizeRacer(value, index) {
   if (!Number.isFinite(time) || time <= 5 || frames.length < MIN_FRAMES) return null;
   const name = normalizeChallengeName(source.name || source.challengerName);
   const id = normalizeRacerId(source.id || source.racerId, legacyRacerId(name, time, frames, index));
-  return Object.freeze({ id, name, time, frames });
+  const order = normalizeRacerOrder(source.order ?? source.challengeOrder, index + 1);
+  return Object.freeze({ id, name, time, order, frames });
 }
 
 function legacyRacerFromChallenge(source) {
@@ -267,6 +282,7 @@ function legacyRacerFromChallenge(source) {
     id: source.racerId,
     name: source.challengerName,
     time: source.time,
+    order: 1,
     frames: source.frames
   };
 }
@@ -277,6 +293,7 @@ function toWireChallenge(challenge) {
     v: challenge.v,
     id: challenge.chainId,
     s: challenge.sharedBy,
+    o: challenge.nextOrder,
     ti: challenge.trackId,
     tr: challenge.trackRevision,
     tn: challenge.trackName,
@@ -287,7 +304,8 @@ function toWireChallenge(challenge) {
       racer.id,
       racer.name,
       quantize(racer.time, TIME_SCALE),
-      encodeFrames(racer.frames)
+      encodeFrames(racer.frames),
+      racer.order
     ]),
     r: challenge.replyTo ? [
       challenge.replyTo.kind === 'win' ? 'w' : 'g',
@@ -304,12 +322,14 @@ function fromWireChallengeV2(wire) {
     id: row?.[0],
     name: row?.[1],
     time: integer(row?.[2]) / TIME_SCALE,
-    frames: decodeFrames(row?.[3])
+    frames: decodeFrames(row?.[3]),
+    order: row?.[4]
   })) : [];
   return {
     v: CHALLENGE_SCHEMA_VERSION,
     chainId: wire.id,
     sharedBy: wire.s,
+    nextOrder: wire.o,
     trackId: wire.ti,
     trackRevision: wire.tr,
     trackName: wire.tn,
@@ -456,6 +476,13 @@ function normalizeRacerId(value, fallback = '') {
     .replace(/[^a-z0-9_-]/g, '')
     .slice(0, 64);
   return fallbackClean || 'r-unknown';
+}
+
+function normalizeRacerOrder(value, fallback = 1) {
+  const order = Math.round(Number(value));
+  if (Number.isFinite(order) && order >= 1 && order <= 999) return order;
+  const fallbackOrder = Math.round(Number(fallback));
+  return Number.isFinite(fallbackOrder) && fallbackOrder >= 1 ? fallbackOrder : 1;
 }
 
 function legacyRacerId(name, time, frames, index = 0) {

--- a/yourturn/racer-colors.js
+++ b/yourturn/racer-colors.js
@@ -1,0 +1,61 @@
+const ORDER_COLORS = Object.freeze([
+  '#ffd1e6',
+  '#bdeeff',
+  '#c8f5d0',
+  '#fff0a8',
+  '#ffd0ae'
+]);
+const FRAME_LIMIT = 240;
+
+function colorForOrder(order) {
+  const index = Math.min(ORDER_COLORS.length, Math.max(1, Math.round(Number(order) || 1))) - 1;
+  return ORDER_COLORS[index];
+}
+
+function racerOrder(state, racerId, fallback = 1) {
+  return state?.challenge?.racers?.find((racer) => racer.id === racerId)?.order || fallback;
+}
+
+function playerOrder(state) {
+  const ownRacer = state?.challenge?.racers?.find((racer) => racer.id === state?.racerId);
+  return ownRacer?.order || state?.challenge?.nextOrder || 1;
+}
+
+async function applyChallengeColors(runtime, raceSession, session) {
+  const state = session.getState();
+  if (!state.challenge || !state.challengeLaps?.length) return false;
+
+  state.challengeLaps.forEach((lap, index) => {
+    lap.carColor = colorForOrder(racerOrder(state, lap.racerId, index + 1));
+  });
+  runtime.state.competitorLaps = state.challengeLaps.map((lap) => ({
+    ...lap,
+    frames: lap.frames.map((frame) => ({ ...frame }))
+  }));
+  runtime.syncCompetitorVisuals?.();
+
+  await raceSession.selectVehicle?.({
+    carId: state.challenge.carId,
+    color: colorForOrder(playerOrder(state)),
+    secondaryColor: state.challenge.carSecondaryColor
+  });
+  return true;
+}
+
+function bootstrap(attempt = 0) {
+  const runtime = globalThis.__turnRuntime;
+  const raceSession = globalThis.__turnRaceSession || globalThis.__turnNextRaceSession;
+  const session = globalThis.__yourTurnSession;
+  if (runtime && raceSession && session) {
+    const state = session.getState();
+    if (state.challenge?.racers?.length) {
+      void applyChallengeColors(runtime, raceSession, session);
+      return;
+    }
+  }
+  if (attempt < FRAME_LIMIT) requestAnimationFrame(() => bootstrap(attempt + 1));
+}
+
+bootstrap();
+
+export { ORDER_COLORS, colorForOrder };

--- a/yourturn/racer-labels-bootstrap.js
+++ b/yourturn/racer-labels-bootstrap.js
@@ -1,4 +1,4 @@
-import { installRacerLabels } from '/yourturn/racer-labels.js?revision=r1';
+import { installRacerLabels } from '/yourturn/racer-labels.js?revision=r2';
 
 const FRAME_LIMIT = 240;
 
@@ -6,12 +6,24 @@ function bootstrap(attempt = 0) {
   const runtime = globalThis.__turnRuntime;
   const session = globalThis.__yourTurnSession;
   if (runtime && session) {
-    // Labels are a presentation layer only. Session owns the canonical challenge
-    // replay field and its vehicle identity; this bootstrap never mutates race state.
     installRacerLabels(runtime, () => session.getState());
+    routeMultiCarStaging(session);
     return;
   }
   if (attempt < FRAME_LIMIT) requestAnimationFrame(() => bootstrap(attempt + 1));
+}
+
+function routeMultiCarStaging(session, attempt = 0) {
+  const state = session.getState();
+  if (!state.challenge || !state.challengeLaps?.length) {
+    if (attempt < FRAME_LIMIT) requestAnimationFrame(() => routeMultiCarStaging(session, attempt + 1));
+    return;
+  }
+
+  // app.js has a carefully tuned, exact start-line adapter for one rival. With two
+  // or more rivals scene.js owns the whole side-by-side row instead, so this legacy
+  // single-rival alias is intentionally cleared while challengeLaps stays canonical.
+  if (state.challengeLaps.length > 1) state.challengeLap = null;
 }
 
 bootstrap();

--- a/yourturn/racer-labels.js
+++ b/yourturn/racer-labels.js
@@ -20,15 +20,18 @@ export function installRacerLabels(runtime, getSessionState) {
 
   function syncLabels(state) {
     const laps = state?.challengeLaps || [];
-    const playerOrder = resolvePlayerOrder(state, laps);
-    const nextSignature = `${laps.map((lap) => `${lap.racerId}:${lap.challengerName}:${lap.challengeOrder}`).join('|')}|you:${playerOrder}`;
+    const playerOrder = resolvePlayerOrder(state);
+    const nextSignature = `${laps.map((lap, index) => {
+      const order = racerOrder(state, lap.racerId, index + 1);
+      return `${lap.racerId}:${lap.challengerName}:${order}`;
+    }).join('|')}|you:${playerOrder}`;
     if (nextSignature === signature) return;
     signature = nextSignature;
     root.replaceChildren();
 
     labels = laps.map((lap, index) => {
       const label = document.createElement('span');
-      const order = lap.challengeOrder || index + 1;
+      const order = racerOrder(state, lap.racerId, index + 1);
       label.className = `yourturn-racer-label yourturn-order-${colorOrder(order)}`;
       label.textContent = lap.challengerName || 'TURN PLAYER';
       root.appendChild(label);
@@ -92,10 +95,13 @@ export function installRacerLabels(runtime, getSessionState) {
   return root;
 }
 
-function resolvePlayerOrder(state, laps) {
-  const ownLap = laps.find((lap) => lap.racerId && lap.racerId === state?.racerId);
-  if (ownLap?.challengeOrder) return ownLap.challengeOrder;
-  return state?.challenge?.nextOrder || Math.min(MAX_ORDER_COLOR, laps.length + 1);
+function racerOrder(state, racerId, fallback) {
+  return state?.challenge?.racers?.find((racer) => racer.id === racerId)?.order || fallback;
+}
+
+function resolvePlayerOrder(state) {
+  const ownRacer = state?.challenge?.racers?.find((racer) => racer.id === state?.racerId);
+  return ownRacer?.order || state?.challenge?.nextOrder || 1;
 }
 
 function colorOrder(order) {

--- a/yourturn/racer-labels.js
+++ b/yourturn/racer-labels.js
@@ -21,14 +21,15 @@ export function installRacerLabels(runtime, getSessionState) {
   function syncLabels(state) {
     const laps = state?.challengeLaps || [];
     const playerOrder = resolvePlayerOrder(state, laps);
-    const nextSignature = `${laps.map((lap, index) => `${lap.racerId}:${lap.challengerName}:${index + 1}`).join('|')}|you:${playerOrder}`;
+    const nextSignature = `${laps.map((lap) => `${lap.racerId}:${lap.challengerName}:${lap.challengeOrder}`).join('|')}|you:${playerOrder}`;
     if (nextSignature === signature) return;
     signature = nextSignature;
     root.replaceChildren();
 
     labels = laps.map((lap, index) => {
       const label = document.createElement('span');
-      label.className = `yourturn-racer-label yourturn-order-${colorOrder(index + 1)}`;
+      const order = lap.challengeOrder || index + 1;
+      label.className = `yourturn-racer-label yourturn-order-${colorOrder(order)}`;
       label.textContent = lap.challengerName || 'TURN PLAYER';
       root.appendChild(label);
       return label;
@@ -92,9 +93,9 @@ export function installRacerLabels(runtime, getSessionState) {
 }
 
 function resolvePlayerOrder(state, laps) {
-  const ownIndex = laps.findIndex((lap) => lap.racerId && lap.racerId === state?.racerId);
-  if (ownIndex >= 0) return ownIndex + 1;
-  return Math.min(MAX_ORDER_COLOR, laps.length + 1);
+  const ownLap = laps.find((lap) => lap.racerId && lap.racerId === state?.racerId);
+  if (ownLap?.challengeOrder) return ownLap.challengeOrder;
+  return state?.challenge?.nextOrder || Math.min(MAX_ORDER_COLOR, laps.length + 1);
 }
 
 function colorOrder(order) {

--- a/yourturn/racer-labels.js
+++ b/yourturn/racer-labels.js
@@ -1,6 +1,8 @@
 import * as THREE from 'three';
 
 const LABEL_HEIGHT = 2.8;
+const PLAYER_LABEL_HEIGHT = 3.05;
+const MAX_ORDER_COLOR = 5;
 
 export function installRacerLabels(runtime, getSessionState) {
   if (!runtime?.camera || runtime.__yourTurnRacerLabelsInstalled) return null;
@@ -12,60 +14,90 @@ export function installRacerLabels(runtime, getSessionState) {
   document.body.appendChild(root);
 
   let labels = [];
+  let playerLabel = null;
   let signature = '';
   const point = new THREE.Vector3();
 
-  function syncLabels(laps) {
-    const nextSignature = laps.map((lap) => `${lap.racerId}:${lap.challengerName}`).join('|');
+  function syncLabels(state) {
+    const laps = state?.challengeLaps || [];
+    const playerOrder = resolvePlayerOrder(state, laps);
+    const nextSignature = `${laps.map((lap, index) => `${lap.racerId}:${lap.challengerName}:${index + 1}`).join('|')}|you:${playerOrder}`;
     if (nextSignature === signature) return;
     signature = nextSignature;
     root.replaceChildren();
-    labels = laps.map((lap) => {
+
+    labels = laps.map((lap, index) => {
       const label = document.createElement('span');
-      label.className = 'yourturn-racer-label';
+      label.className = `yourturn-racer-label yourturn-order-${colorOrder(index + 1)}`;
       label.textContent = lap.challengerName || 'TURN PLAYER';
       root.appendChild(label);
       return label;
     });
+
+    playerLabel = document.createElement('span');
+    playerLabel.className = `yourturn-racer-label yourturn-player-label yourturn-order-${colorOrder(playerOrder)}`;
+    playerLabel.textContent = '( YOU )';
+    root.appendChild(playerLabel);
   }
 
   function frame() {
     const state = getSessionState?.();
     const laps = state?.challengeLaps || [];
-    syncLabels(laps);
+    syncLabels(state);
     const visible = Boolean(state?.active)
       && !document.documentElement.classList.contains('turn-screen-blanked');
 
     for (let index = 0; index < labels.length; index += 1) {
-      const label = labels[index];
-      const car = runtime.competitorCars?.[index];
-      if (!visible || !car?.visible) {
-        label.hidden = true;
-        continue;
-      }
-
-      point.copy(car.position);
-      point.y += LABEL_HEIGHT;
-      point.project(runtime.camera);
-      if (!Number.isFinite(point.x) || !Number.isFinite(point.y) || point.z < -1 || point.z > 1) {
-        label.hidden = true;
-        continue;
-      }
-
-      const x = (point.x * 0.5 + 0.5) * globalThis.innerWidth;
-      const y = (-point.y * 0.5 + 0.5) * globalThis.innerHeight;
-      if (x < -80 || x > globalThis.innerWidth + 80 || y < -60 || y > globalThis.innerHeight + 60) {
-        label.hidden = true;
-        continue;
-      }
-
-      label.hidden = false;
-      label.style.transform = `translate3d(${x}px, ${y}px, 0) translate(-50%, -100%)`;
+      positionLabel(labels[index], runtime.competitorCars?.[index], LABEL_HEIGHT, visible);
     }
+
+    positionLabel(
+      playerLabel,
+      runtime.playerCar,
+      PLAYER_LABEL_HEIGHT,
+      visible && Boolean(state?.accepted)
+    );
 
     requestAnimationFrame(frame);
   }
 
+  function positionLabel(label, car, height, visible) {
+    if (!label) return;
+    if (!visible || !car?.visible) {
+      label.hidden = true;
+      return;
+    }
+
+    point.copy(car.position);
+    point.y += height;
+    point.project(runtime.camera);
+    if (!Number.isFinite(point.x) || !Number.isFinite(point.y) || point.z < -1 || point.z > 1) {
+      label.hidden = true;
+      return;
+    }
+
+    const x = (point.x * 0.5 + 0.5) * globalThis.innerWidth;
+    const y = (-point.y * 0.5 + 0.5) * globalThis.innerHeight;
+    if (x < -80 || x > globalThis.innerWidth + 80 || y < -60 || y > globalThis.innerHeight + 60) {
+      label.hidden = true;
+      return;
+    }
+
+    label.hidden = false;
+    label.style.transform = `translate3d(${x}px, ${y}px, 0) translate(-50%, -100%)`;
+  }
+
   requestAnimationFrame(frame);
   return root;
+}
+
+function resolvePlayerOrder(state, laps) {
+  const ownIndex = laps.findIndex((lap) => lap.racerId && lap.racerId === state?.racerId);
+  if (ownIndex >= 0) return ownIndex + 1;
+  return Math.min(MAX_ORDER_COLOR, laps.length + 1);
+}
+
+function colorOrder(order) {
+  const value = Math.max(1, Math.round(Number(order) || 1));
+  return Math.min(MAX_ORDER_COLOR, value);
 }

--- a/yourturn/scene.js
+++ b/yourturn/scene.js
@@ -6,11 +6,13 @@ const PREVIEW_CAMERA_DISTANCE = 18;
 const PREVIEW_CAMERA_HEIGHT = 8.4;
 const PREVIEW_START_DELAY_MS = 650;
 const STAGED_IMITATION_DELAY_MS = 650;
+const START_GRID_SPACING = 3.4;
 
 export function createChallengeScene({ runtime, challengeLap, onRaceStarted }) {
   let phase = 'preview';
   let previewStartedAt = performance.now();
   const stagedHistory = [];
+  const stagedGrid = createEmptyGrid();
   const reduceMotion = globalThis.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
 
   function setPhase(nextPhase) {
@@ -19,6 +21,7 @@ export function createChallengeScene({ runtime, challengeLap, onRaceStarted }) {
       previewStartedAt = performance.now();
     }
     if (nextPhase !== 'staged') stagedHistory.length = 0;
+    if (nextPhase === 'staged') resetGrid(stagedGrid);
   }
 
   function update(dt) {
@@ -33,7 +36,7 @@ export function createChallengeScene({ runtime, challengeLap, onRaceStarted }) {
         onRaceStarted?.();
         return false;
       }
-      renderStage(runtime, dt, stagedHistory, reduceMotion);
+      renderStage(runtime, dt, stagedHistory, stagedGrid, reduceMotion);
       return true;
     }
     return false;
@@ -72,17 +75,26 @@ function renderPreview(runtime, challengeLap, previewStartedAt, dt, reduceMotion
   runtime.camera.updateProjectionMatrix();
 }
 
-function renderStage(runtime, dt, stagedHistory, reduceMotion) {
+function renderStage(runtime, dt, stagedHistory, stagedGrid, reduceMotion) {
+  const rivalCount = Math.min(
+    runtime.state.competitorLaps?.length || 0,
+    runtime.competitorCars?.length || 0
+  );
+
+  if (rivalCount > 1) {
+    renderMultiRivalGrid(runtime, dt, stagedGrid, rivalCount);
+    renderStageCamera(runtime, dt);
+    return;
+  }
+
+  renderSingleRivalStage(runtime, dt, stagedHistory, reduceMotion);
+  renderStageCamera(runtime, dt);
+}
+
+function renderSingleRivalStage(runtime, dt, stagedHistory, reduceMotion) {
   const { state, playerCar, competitorCars } = runtime;
   const opponentCar = competitorCars[0];
-  playerCar.visible = true;
-  playerCar.position.copy(state.position);
-  const playerSample = runtime.findNearestTrack(state.position).sample;
-  playerCar.position.y = trackSurfaceY(playerSample);
-  playerCar.rotation.x = trackPitch(playerSample);
-  playerCar.rotation.y = state.heading + Math.PI;
-  playerCar.rotation.z = 0;
-  runtime.animateWheels(playerCar, state.steering, state.speed, dt);
+  placePlayerCar(runtime, dt);
 
   const now = performance.now();
   if (!reduceMotion) {
@@ -107,7 +119,79 @@ function renderStage(runtime, dt, stagedHistory, reduceMotion) {
     opponentCar.rotation.z = -delayed.steering * 0.03;
     runtime.animateWheels(opponentCar, delayed.steering, 0, dt);
   }
+}
 
+function renderMultiRivalGrid(runtime, dt, grid, rivalCount) {
+  const { state, samples, competitorCars } = runtime;
+  const totalCars = rivalCount + 1;
+  const playerSlot = Math.floor((totalCars - 1) / 2);
+  const slotOffsets = Array.from(
+    { length: totalCars },
+    (_, index) => (index - (totalCars - 1) / 2) * START_GRID_SPACING
+  );
+
+  if (!grid.playerPlaced) {
+    const nearest = runtime.findNearestTrack(state.position);
+    const normal = nearest.sample.normal || normalFromTangent(nearest.sample.tangent);
+    state.position.addScaledVector(normal, slotOffsets[playerSlot]);
+    const settled = runtime.findNearestTrack(state.position);
+    state.position.y = trackSurfaceY(settled.sample);
+    state.surfacePitch = trackPitch(settled.sample);
+    state.nearestTrackIndex = settled.index;
+    state.trackDistance = settled.distance;
+    state.progress = settled.index / Math.max(1, samples.length);
+    state.lastProgress = state.progress;
+    state.lapPreviousPosition = { x: state.position.x, z: state.position.z };
+    grid.rivalIndex = settled.index;
+    grid.playerPlaced = true;
+  }
+
+  placePlayerCar(runtime, dt);
+
+  const nearest = runtime.findNearestTrack(state.position);
+  if (!Number.isFinite(grid.rivalIndex)) grid.rivalIndex = nearest.index;
+  if (nearest.index >= grid.rivalIndex && nearest.index - grid.rivalIndex < samples.length / 2) {
+    grid.rivalIndex = nearest.index;
+  }
+
+  const rowSample = samples[Math.max(0, Math.min(samples.length - 1, grid.rivalIndex))] || nearest.sample;
+  const rowNormal = rowSample.normal || normalFromTangent(rowSample.tangent);
+  const rowHeading = Math.atan2(rowSample.tangent.x, rowSample.tangent.z);
+  const rivalSlots = slotOffsets.filter((_, index) => index !== playerSlot);
+
+  for (let index = 0; index < competitorCars.length; index += 1) {
+    const car = competitorCars[index];
+    if (!car || index >= rivalCount) {
+      if (car) car.visible = false;
+      continue;
+    }
+
+    const offset = rivalSlots[index] ?? 0;
+    car.visible = true;
+    car.position.copy(rowSample.point).addScaledVector(rowNormal, offset);
+    const surface = runtime.findNearestTrack(car.position).sample;
+    car.position.y = trackSurfaceY(surface);
+    car.rotation.x = trackPitch(surface);
+    car.rotation.y = rowHeading + Math.PI;
+    car.rotation.z = 0;
+    runtime.animateWheels(car, 0, Math.max(0, state.speed), dt);
+  }
+}
+
+function placePlayerCar(runtime, dt) {
+  const { state, playerCar } = runtime;
+  playerCar.visible = true;
+  playerCar.position.copy(state.position);
+  const playerSample = runtime.findNearestTrack(state.position).sample;
+  playerCar.position.y = trackSurfaceY(playerSample);
+  playerCar.rotation.x = trackPitch(playerSample);
+  playerCar.rotation.y = state.heading + Math.PI;
+  playerCar.rotation.z = 0;
+  runtime.animateWheels(playerCar, state.steering, state.speed, dt);
+}
+
+function renderStageCamera(runtime, dt) {
+  const { state, playerCar } = runtime;
   const forward = new THREE.Vector3(Math.sin(state.heading), 0, Math.cos(state.heading));
   const focus = state.position.clone();
   focus.y = playerCar.position.y;
@@ -149,4 +233,17 @@ function hideOtherCompetitors(runtime, keepIndex) {
   for (let index = 0; index < runtime.competitorCars.length; index += 1) {
     if (index !== keepIndex) runtime.competitorCars[index].visible = false;
   }
+}
+
+function normalFromTangent(tangent) {
+  return new THREE.Vector3(-tangent.z, 0, tangent.x).normalize();
+}
+
+function createEmptyGrid() {
+  return { playerPlaced: false, rivalIndex: null };
+}
+
+function resetGrid(grid) {
+  grid.playerPlaced = false;
+  grid.rivalIndex = null;
 }

--- a/yourturn/ui.js
+++ b/yourturn/ui.js
@@ -22,6 +22,7 @@ export function createYourTurnUi() {
   const actions = dialog?.querySelector('.yourturn-actions');
   const status = dialog?.querySelector('.yourturn-dialog-status');
   const nameField = dialog?.querySelector('.yourturn-name-field');
+  const nameInput = nameField?.querySelector('input');
   const motionToggle = dialog?.querySelector('#yourTurnMotionToggle');
   const rotate = document.querySelector('#yourTurnRotate');
   const targetChip = document.querySelector('#yourTurnTargetChip');
@@ -30,7 +31,7 @@ export function createYourTurnUi() {
   const challengeButton = document.querySelector('#yourTurnChallengeButton');
 
   if (!dialog || !card || !kicker || !title || !details || !copy || !extra || !actions || !status
-      || !nameField || !motionToggle || !rotate || !targetChip || !targetOpponent || !targetTime || !challengeButton) {
+      || !nameField || !nameInput || !motionToggle || !rotate || !targetChip || !targetOpponent || !targetTime || !challengeButton) {
     throw new Error('YOUR TURN could not find its complete interface.');
   }
 
@@ -62,7 +63,11 @@ export function createYourTurnUi() {
     motionToggle.hidden = !motionControl;
 
     nameField.hidden = !requestName;
-    if (requestName) nameField.querySelector('input').value = loadPlayerName();
+    if (requestName) {
+      // Names are intentionally entered afresh at each share. A stable anonymous
+      // racer ID handles identity; the visible name remains a deliberate message.
+      nameInput.value = '';
+    }
 
     actions.replaceChildren();
     for (const action of actionList) {
@@ -95,12 +100,11 @@ export function createYourTurnUi() {
   }
 
   function playerName() {
-    const input = nameField.querySelector('input');
-    const name = normalizeChallengeName(input?.value);
+    const name = normalizeChallengeName(nameInput.value);
     try {
       localStorage.setItem(PLAYER_NAME_KEY, name);
     } catch (_) {}
-    if (input) input.value = name;
+    nameInput.value = name;
     return name;
   }
 
@@ -186,12 +190,4 @@ export function escapeHtml(value) {
     .replaceAll('>', '&gt;')
     .replaceAll('"', '&quot;')
     .replaceAll("'", '&#39;');
-}
-
-function loadPlayerName() {
-  try {
-    return normalizeChallengeName(localStorage.getItem(PLAYER_NAME_KEY));
-  } catch (_) {
-    return 'YOUR NAME';
-  }
 }


### PR DESCRIPTION
## What changed
- stages every challenger car beside the recipient before the start line for multi-rival challenges
- keeps the earlier smart one-rival start-line handoff only for single-rival challenges
- places the recipient in the middle / left-middle slot: P R, R P R, R P R R, R R P R R
- gives challenge participants persistent join-order colors: light pink, blue, green, yellow, then orange for the next player
- adds a bold `( YOU )` plate and matches every racer car’s primary color to its name plate
- keeps display names visually uppercase without changing the stored name
- changes the share-name field to the middle-grey `WRITE YOUR NAME HERE` placeholder and starts it empty each time
- adds an ERIK-first four-rival mock so all five color/formation slots can be tested in one run
- strengthens static Open Graph/Twitter image metadata on `/yourturn/` for query and mock challenge links
- preserves production `/turn/**`

## Protocol
Challenge racers now carry a persistent join-order number alongside their stable racer ID. The order survives later faster/slower runs and link round-trips, so colors describe the social chain rather than the leaderboard order.

## QA
Adds a focused start-grid/social-preview contract. It checks the formation rule, all-rival staging, join-order round-tripping, five-color mapping, car/plate color coupling, `( YOU )`, name placeholder behavior, ERIK mock, OG metadata, and an <8 KB four-rival query-URL guard.