### PR TITLE
Stabilize YOUR TURN start and social sharing

### DIFF
--- a/turn-tests/yourturn-production.mjs
+++ b/turn-tests/yourturn-production.mjs
@@ -52,7 +52,7 @@ assert.match(indexSource, /session\.js\?revision=r3[^\n]*session\.js\?revision=r
   'The page must cache-bust the new growing-challenge session even though app.js stays canonical');
 assert.match(indexSource, /Your name in the challenge/);
 assert.match(indexSource, /id="yourTurnChallengeButton"[\s\S]*>THE CHALLENGE<\/button>/);
-assert.match(indexSource, /The race starts when you cross the starting line\./);
+assert.match(indexSource, /Press Gas, Drift or Boost to start the race\./);
 assert.doesNotMatch(indexSource, /manifest|install-gate/i,
   'YOUR TURN remains browser-first rather than a PWA install gate');
 

--- a/turn-tests/yourturn-start-grid-production.mjs
+++ b/turn-tests/yourturn-start-grid-production.mjs
@@ -4,32 +4,53 @@ import {
   challengeFromLap,
   challengeWithLap,
   decodeChallenge,
-  encodeChallenge,
-  makeChallengeUrl
+  encodeChallenge
 } from '../yourturn/protocol.js';
 
-const [indexSource, sceneSource, labelsSource, bootstrapSource, colorsSource, cssSource, uiSource, mockSource] = await Promise.all([
+const [
+  indexSource,
+  labelsSource,
+  bootstrapSource,
+  colorsSource,
+  cssSource,
+  uiSource,
+  mockSource,
+  startGateSource,
+  socialProtocolSource
+] = await Promise.all([
   fs.readFile(new URL('../yourturn/index.html', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../yourturn/scene.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../yourturn/racer-labels.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../yourturn/racer-labels-bootstrap.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../yourturn/racer-colors.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../yourturn/growing-challenge.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../yourturn/ui.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../yourturn/mock-challenges.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../yourturn/mock-challenges.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/start-gate.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/protocol-social.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(sceneSource, /rivalCount > 1/);
-assert.match(sceneSource, /const totalCars = rivalCount \+ 1/);
-assert.match(sceneSource, /const playerSlot = Math\.floor\(\(totalCars - 1\) \/ 2\)/,
+assert.match(indexSource, /start-gate\.js\?revision=r1/);
+assert.match(indexSource, /Press Gas, Drift or Boost to start the race\./);
+assert.match(startGateSource, /sessionState\.phase === 'staged'/);
+assert.match(startGateSource, /renderStartGrid/);
+assert.match(startGateSource, /const playerSlot = Math\.floor\(\(totalCars - 1\) \/ 2\)/,
   'The player belongs in the middle or left-middle start slot');
-assert.match(sceneSource, /for \(let index = 0; index < competitorCars\.length; index \+= 1\)/,
-  'Every rival car must be explicitly staged in a multi-car start row');
-assert.match(bootstrapSource, /state\.challengeLaps\.length > 1[^\n]*state\.challengeLap = null/,
-  'The single-rival smart start-line adapter must stand down for multi-car rows');
+assert.match(startGateSource, /runtime\.state\.velocity\.set\(0, 0, 0\)/,
+  'Cars must stand still while waiting for the start input');
+assert.match(startGateSource, /#gasButton, \.drive-drift-zone, \.drive-boost-zone/,
+  'Gas, Drift and Boost are the explicit race-start intents');
+assert.match(startGateSource, /beginTimedLapState/,
+  'The first forward control must start canonical lap timing immediately');
+assert.match(startGateSource, /LAUNCH_BLEND_SECONDS = 0\.9/,
+  'Rivals should merge smoothly from their side-by-side start slots into recorded trajectories');
 
-assert.match(labelsSource, /\( YOU \)/);
+assert.match(labelsSource, /playerLabel\.textContent = 'YOU'/);
+assert.doesNotMatch(labelsSource, /\( YOU \)/);
 assert.match(labelsSource, /ownRacer\?\.order \|\| state\?\.challenge\?\.nextOrder/);
+assert.match(bootstrapSource, /requestAnimationFrame\(bootstrap\)/,
+  'Name-plate bootstrap must keep waiting on slow cold starts');
+assert.doesNotMatch(bootstrapSource, /FRAME_LIMIT/,
+  'Name plates must not silently give up before a slow runtime finishes loading');
 assert.match(colorsSource, /'#ffd1e6'[\s\S]*'#bdeeff'[\s\S]*'#c8f5d0'[\s\S]*'#fff0a8'[\s\S]*'#ffd0ae'/);
 assert.match(colorsSource, /lap\.carColor = colorForOrder/);
 assert.match(colorsSource, /raceSession\.selectVehicle/,
@@ -53,6 +74,12 @@ assert.match(indexSource, /property="og:image:width" content="1200"/);
 assert.match(indexSource, /property="og:image:height" content="630"/);
 assert.match(indexSource, /name="twitter:card" content="summary_large_image"/);
 assert.match(indexSource, /rel="image_src"/);
+assert.match(indexSource, /protocol-social\.js\?revision=r1/,
+  'Runtime sharing must use the OG-stable URL adapter');
+assert.match(socialProtocolSource, /url\.searchParams\.set\('share', '1'\)/);
+assert.match(socialProtocolSource, /fragment\.set\('challenge', String\(encoded \|\| ''\)\)/);
+assert.doesNotMatch(socialProtocolSource, /searchParams\.set\('c', encoded\)/,
+  'Large replay payloads must not be sent to social-preview servers in the query string');
 
 const lap = (time, offset = 0) => ({
   time,
@@ -97,7 +124,7 @@ assert.deepEqual(
   chain.racers.map(({ id, order }) => [id, order]),
   'Join order must survive a real challenge-link round trip'
 );
-const url = makeChallengeUrl(encoded);
-assert.ok(url.length < 8000, `A four-rival query URL must stay below common request-line limits for reliable OG previews; got ${url.length}`);
+assert.ok(encoded.length > 100,
+  'The OG adapter test must use a meaningful self-contained replay payload');
 
-console.log('YOUR TURN full start grid, ordered colors, name entry and social-preview regression passed.');
+console.log('YOUR TURN fixed start gate, reliable labels, ordered colors and OG-stable sharing regression passed.');

--- a/yourturn/index.html
+++ b/yourturn/index.html
@@ -52,7 +52,7 @@
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/yourturn/session.js?revision=r3": "/yourturn/session.js?revision=r6",
         "/yourturn/ui.js?revision=r3": "/yourturn/ui.js?revision=r7",
-        "/yourturn/protocol.js?revision=r3": "/yourturn/protocol.js?revision=r7",
+        "/yourturn/protocol.js?revision=r3": "/yourturn/protocol-social.js?revision=r1",
         "/yourturn/scene.js?revision=r1": "/yourturn/scene.js?revision=r7"
       }
     }
@@ -109,7 +109,7 @@
     <div class="yourturn-rotate-card">
       <div class="yourturn-phone" aria-hidden="true"></div>
       <strong id="yourTurnRotateTitle" tabindex="-1">ROTATE YOUR DEVICE TO LANDSCAPE</strong>
-      <p>The race starts when you cross the starting line.</p>
+      <p>Press Gas, Drift or Boost to start the race.</p>
     </div>
   </section>
 
@@ -148,7 +148,8 @@
 
   <script type="module" src="/yourturn/app.js?revision=r6"></script>
   <script type="module" src="/yourturn/nonvisual.js?revision=r1"></script>
-  <script type="module" src="/yourturn/racer-labels-bootstrap.js?revision=r2"></script>
+  <script type="module" src="/yourturn/racer-labels-bootstrap.js?revision=r3"></script>
   <script type="module" src="/yourturn/racer-colors.js?revision=r1"></script>
+  <script type="module" src="/yourturn/start-gate.js?revision=r1"></script>
 </body>
 </html>

--- a/yourturn/index.html
+++ b/yourturn/index.html
@@ -149,7 +149,7 @@
   <script type="module" src="/yourturn/app.js?revision=r6"></script>
   <script type="module" src="/yourturn/nonvisual.js?revision=r1"></script>
   <script type="module" src="/yourturn/racer-labels-bootstrap.js?revision=r3"></script>
-  <script type="module" src="/yourturn/racer-colors.js?revision=r1"></script>
+  <script type="module" src="/yourturn/racer-colors.js?revision=r2"></script>
   <script type="module" src="/yourturn/start-gate.js?revision=r1"></script>
 </body>
 </html>

--- a/yourturn/protocol-social.js
+++ b/yourturn/protocol-social.js
@@ -1,0 +1,39 @@
+export {
+  MAX_CHALLENGE_RACERS,
+  challengeFromLap,
+  challengeLeader,
+  challengeSender,
+  challengeWithLap,
+  createChallengeChainId,
+  createRacerId,
+  decodeChallenge,
+  encodeChallenge,
+  encodedChallengeFromLocation,
+  formatChallengeTime,
+  makeMockChallengeUrl,
+  normalizeChallenge,
+  normalizeChallengeName
+} from '/yourturn/protocol.js?revision=r7';
+
+import { normalizeChallengeName } from '/yourturn/protocol.js?revision=r7';
+
+// Keep the replay payload in the URL fragment. Social preview crawlers do not send
+// fragments to the server, so every generated challenge presents a short, stable
+// /yourturn/?share=1 URL to Messages and other link-preview services while the
+// recipient browser still receives the complete self-contained challenge.
+export function makeChallengeUrl(encoded, {
+  baseUrl = 'https://enkel.design/yourturn/',
+  reply = '',
+  responder = ''
+} = {}) {
+  const url = new URL(baseUrl);
+  url.searchParams.delete('c');
+  url.searchParams.set('share', '1');
+  if (reply) url.searchParams.set('reply', reply);
+  if (responder) url.searchParams.set('responder', normalizeChallengeName(responder));
+
+  const fragment = new URLSearchParams();
+  fragment.set('challenge', String(encoded || ''));
+  url.hash = fragment.toString();
+  return url.href;
+}

--- a/yourturn/racer-colors.js
+++ b/yourturn/racer-colors.js
@@ -5,7 +5,6 @@ const ORDER_COLORS = Object.freeze([
   '#fff0a8',
   '#ffd0ae'
 ]);
-const FRAME_LIMIT = 240;
 
 function colorForOrder(order) {
   const index = Math.min(ORDER_COLORS.length, Math.max(1, Math.round(Number(order) || 1))) - 1;
@@ -42,20 +41,25 @@ async function applyChallengeColors(runtime, raceSession, session) {
   return true;
 }
 
-function bootstrap(attempt = 0) {
+let applied = false;
+function bootstrap() {
+  if (applied) return;
   const runtime = globalThis.__turnRuntime;
   const raceSession = globalThis.__turnRaceSession || globalThis.__turnNextRaceSession;
   const session = globalThis.__yourTurnSession;
   if (runtime && raceSession && session) {
     const state = session.getState();
     if (state.challenge?.racers?.length) {
+      applied = true;
       void applyChallengeColors(runtime, raceSession, session);
       return;
     }
   }
-  if (attempt < FRAME_LIMIT) requestAnimationFrame(() => bootstrap(attempt + 1));
+  requestAnimationFrame(bootstrap);
 }
 
+window.addEventListener('turn:runtime-ready', bootstrap);
+window.addEventListener('pageshow', bootstrap);
 bootstrap();
 
 export { ORDER_COLORS, colorForOrder };

--- a/yourturn/racer-labels-bootstrap.js
+++ b/yourturn/racer-labels-bootstrap.js
@@ -1,29 +1,19 @@
-import { installRacerLabels } from '/yourturn/racer-labels.js?revision=r2';
+import { installRacerLabels } from '/yourturn/racer-labels.js?revision=r3';
 
-const FRAME_LIMIT = 240;
+let installed = false;
 
-function bootstrap(attempt = 0) {
+function bootstrap() {
+  if (installed) return;
   const runtime = globalThis.__turnRuntime;
   const session = globalThis.__yourTurnSession;
   if (runtime && session) {
     installRacerLabels(runtime, () => session.getState());
-    routeMultiCarStaging(session);
+    installed = true;
     return;
   }
-  if (attempt < FRAME_LIMIT) requestAnimationFrame(() => bootstrap(attempt + 1));
+  requestAnimationFrame(bootstrap);
 }
 
-function routeMultiCarStaging(session, attempt = 0) {
-  const state = session.getState();
-  if (!state.challenge || !state.challengeLaps?.length) {
-    if (attempt < FRAME_LIMIT) requestAnimationFrame(() => routeMultiCarStaging(session, attempt + 1));
-    return;
-  }
-
-  // app.js has a carefully tuned, exact start-line adapter for one rival. With two
-  // or more rivals scene.js owns the whole side-by-side row instead, so this legacy
-  // single-rival alias is intentionally cleared while challengeLaps stays canonical.
-  if (state.challengeLaps.length > 1) state.challengeLap = null;
-}
-
+window.addEventListener('turn:runtime-ready', bootstrap);
+window.addEventListener('pageshow', bootstrap);
 bootstrap();

--- a/yourturn/racer-labels.js
+++ b/yourturn/racer-labels.js
@@ -40,7 +40,7 @@ export function installRacerLabels(runtime, getSessionState) {
 
     playerLabel = document.createElement('span');
     playerLabel.className = `yourturn-racer-label yourturn-player-label yourturn-order-${colorOrder(playerOrder)}`;
-    playerLabel.textContent = '( YOU )';
+    playerLabel.textContent = 'YOU';
     root.appendChild(playerLabel);
   }
 

--- a/yourturn/start-gate.js
+++ b/yourturn/start-gate.js
@@ -1,0 +1,199 @@
+import * as THREE from 'three';
+import { beginTimedLapState } from '/turn/race/lap-system.js';
+import { trackPitch, trackSurfaceY } from '/turn/tracks/elevation.js?build=20260725-r67';
+
+const GRID_SPACING = 3.4;
+const LAUNCH_BLEND_SECONDS = 0.9;
+const START_GATE_GUARD_DISTANCE = 0.75;
+
+bootstrap();
+
+function bootstrap() {
+  const runtime = globalThis.__turnRuntime;
+  const session = globalThis.__yourTurnSession;
+  if (!runtime || !session) {
+    requestAnimationFrame(bootstrap);
+    return;
+  }
+  if (runtime.__yourTurnStartGateInstalled) return;
+  runtime.__yourTurnStartGateInstalled = true;
+  installFixedStartGrid(runtime, session);
+  installStartIntent(runtime, session);
+}
+
+function installFixedStartGrid(runtime, session) {
+  const downstreamRunSceneOverride = runtime.runSceneOverride.bind(runtime);
+
+  runtime.runSceneOverride = (dt) => {
+    const sessionState = session.getState();
+    const staged = sessionState?.accepted
+      && sessionState.phase === 'staged'
+      && !runtime.state.lapActive
+      && document.body.classList.contains('yourturn-racing');
+
+    if (!staged) return downstreamRunSceneOverride(dt);
+
+    renderStartGrid(runtime, sessionState, dt);
+    return true;
+  };
+}
+
+function installStartIntent(runtime, session) {
+  const isForwardControl = (target) => Boolean(target?.closest?.(
+    '#gasButton, .drive-drift-zone, .drive-boost-zone'
+  ));
+
+  const startFromControl = (event) => {
+    if (!isForwardControl(event.target)) return;
+    startRace(runtime, session);
+  };
+
+  document.addEventListener('pointerdown', startFromControl, { capture: true });
+  document.addEventListener('click', startFromControl, { capture: true });
+}
+
+function startRace(runtime, session) {
+  const sessionState = session.getState();
+  if (!sessionState?.accepted || sessionState.phase !== 'staged' || runtime.state.lapActive) return false;
+
+  const layout = startLayout(runtime.state.competitorLaps?.length || 0);
+  prepareRivalLaunchLanes(runtime, layout.rivalOffsets);
+
+  beginTimedLapState({
+    state: runtime.state,
+    samples: runtime.samples,
+    now: performance.now()
+  });
+
+  // beginTimedLapState snapshots the exact start-line position. Give the physical
+  // gate detector a previous point just beyond the line so the first acceleration
+  // does not look like an immediate second crossing and restart the timer.
+  const start = runtime.samples[0];
+  runtime.state.lapPreviousPosition = {
+    x: runtime.state.position.x + start.tangent.x * START_GATE_GUARD_DISTANCE,
+    z: runtime.state.position.z + start.tangent.z * START_GATE_GUARD_DISTANCE
+  };
+
+  window.dispatchEvent(new CustomEvent('turn:ui-state-change', {
+    detail: {
+      reason: 'lap-started',
+      mode: runtime.state.mode,
+      running: runtime.state.running
+    }
+  }));
+  return true;
+}
+
+function renderStartGrid(runtime, sessionState, dt) {
+  const rivalCount = Math.min(
+    sessionState.challengeLaps?.length || 0,
+    runtime.competitorCars?.length || 0
+  );
+  const layout = startLayout(rivalCount);
+  const start = runtime.samples[0];
+  if (!start) return;
+
+  const normal = start.normal || normalFromTangent(start.tangent);
+  const heading = Math.atan2(start.tangent.x, start.tangent.z);
+  const surfaceY = trackSurfaceY(start);
+  const surfacePitch = trackPitch(start);
+
+  runtime.state.position.copy(start.point).addScaledVector(normal, layout.playerOffset);
+  runtime.state.position.y = surfaceY;
+  runtime.state.velocity.set(0, 0, 0);
+  runtime.state.speed = 0;
+  runtime.state.throttle = 0;
+  runtime.state.brake = 0;
+  runtime.state.heading = heading;
+  runtime.state.nearestTrackIndex = 0;
+  runtime.state.trackDistance = Math.abs(layout.playerOffset);
+  runtime.state.progress = 0;
+  runtime.state.lastProgress = 0;
+  runtime.state.lapPreviousPosition = {
+    x: runtime.state.position.x,
+    z: runtime.state.position.z
+  };
+
+  const playerCar = runtime.playerCar;
+  playerCar.visible = true;
+  playerCar.position.copy(runtime.state.position);
+  playerCar.rotation.x = surfacePitch;
+  playerCar.rotation.y = heading + Math.PI;
+  playerCar.rotation.z = 0;
+  runtime.animateWheels(playerCar, runtime.state.steering, 0, dt);
+
+  for (let index = 0; index < runtime.competitorCars.length; index += 1) {
+    const car = runtime.competitorCars[index];
+    if (!car || index >= rivalCount) {
+      if (car) car.visible = false;
+      continue;
+    }
+
+    car.visible = true;
+    car.position.copy(start.point).addScaledVector(normal, layout.rivalOffsets[index] || 0);
+    car.position.y = surfaceY;
+    car.rotation.x = surfacePitch;
+    car.rotation.y = heading + Math.PI;
+    car.rotation.z = 0;
+    runtime.animateWheels(car, 0, 0, dt);
+  }
+
+  renderGridCamera(runtime, start, heading, dt);
+}
+
+function prepareRivalLaunchLanes(runtime, rivalOffsets) {
+  const laps = runtime.state.competitorLaps || [];
+  runtime.state.competitorLaps = laps.map((lap, index) => {
+    const offset = rivalOffsets[index] || 0;
+    if (!offset || !Array.isArray(lap.frames)) return lap;
+
+    return {
+      ...lap,
+      frames: lap.frames.map((frame) => {
+        const fade = THREE.MathUtils.clamp(1 - (Number(frame.t) || 0) / LAUNCH_BLEND_SECONDS, 0, 1);
+        if (fade <= 0) return { ...frame };
+        const sample = runtime.findNearestTrack(frame).sample;
+        const normal = sample.normal || normalFromTangent(sample.tangent);
+        return {
+          ...frame,
+          x: frame.x + normal.x * offset * fade,
+          z: frame.z + normal.z * offset * fade
+        };
+      })
+    };
+  });
+}
+
+function startLayout(rivalCount) {
+  const totalCars = Math.max(1, rivalCount + 1);
+  const playerSlot = Math.floor((totalCars - 1) / 2);
+  const offsets = Array.from(
+    { length: totalCars },
+    (_, index) => (index - (totalCars - 1) / 2) * GRID_SPACING
+  );
+  return {
+    playerOffset: offsets[playerSlot] || 0,
+    rivalOffsets: offsets.filter((_, index) => index !== playerSlot)
+  };
+}
+
+function renderGridCamera(runtime, start, heading, dt) {
+  const forward = new THREE.Vector3(Math.sin(heading), 0, Math.cos(heading));
+  const focus = start.point.clone();
+  focus.y = trackSurfaceY(start);
+
+  const desiredCamera = focus.clone().addScaledVector(forward, -20);
+  desiredCamera.y += 9;
+  runtime.cameraPosition.lerp(desiredCamera, 1 - Math.exp(-dt * 10));
+  runtime.camera.position.copy(runtime.cameraPosition);
+
+  const desiredTarget = focus.clone().addScaledVector(forward, 10);
+  desiredTarget.y += 1.8;
+  runtime.cameraTarget.lerp(desiredTarget, 1 - Math.exp(-dt * 11));
+  runtime.camera.up.set(0, 1, 0);
+  runtime.camera.lookAt(runtime.cameraTarget);
+}
+
+function normalFromTangent(tangent) {
+  return new THREE.Vector3(-tangent.z, 0, tangent.x).normalize();
+}


### PR DESCRIPTION
## What changed
- keeps every car completely stationary on a fixed side-by-side start line before the race
- Gas, Drift or Boost now starts canonical lap timing immediately; Brake does not
- blends rival replay lanes back into their recorded trajectories during the first 0.9s to avoid a start snap
- changes the player plate from `( YOU )` to `YOU`
- makes racer-label bootstrap wait indefinitely for slow cold-start runtimes instead of silently timing out
- routes newly generated challenge links through a short server-visible `?share=1` URL with the self-contained replay in the fragment, so Messages/social crawlers always fetch the same compact OG page
- updates the rotate/start instruction to match the new input-start interaction
- leaves production `/turn/**` untouched

## Compatibility
Old `?c=` and old `#challenge=` links remain readable because decoding still accepts both formats. Mock/seed links remain short query URLs and continue to receive the same static OG metadata.

## QA
Updates the YOUR TURN contracts to cover fixed-grid staging, forward-control start intent, smooth rival launch blending, reliable name-plate bootstrap, `YOU` copy and the OG-safe generated-link adapter.