### PR TITLE
Share TURN About copy and credit Kenney

### DIFF
--- a/turn-lab/tests/admin-unlock-production.mjs
+++ b/turn-lab/tests/admin-unlock-production.mjs
@@ -154,7 +154,7 @@ assert.match(indexSource,
   /<script type="module" src="\.\/testing\/admin-unlock-sequence\.js\?revision=r176-admin-rewards"><\/script>/,
   'The production entry must publish the rewards-only recognizer with a fresh cache identity');
 assert.match(indexSource,
-  /src="\.\/live-steering-setting\.js\?build=20260805-r160-live-steering"/,
+  /src="\.\/live-steering-setting\.js\?build=20260806-r161-live-steering"/,
   'The hidden recognizer must not disturb the canonical steering entry');
 
 console.log('TURN rewards-only admin unlock regression passed.');

--- a/turn-tests/about-history-production.mjs
+++ b/turn-tests/about-history-production.mjs
@@ -31,8 +31,8 @@ const [
 
 const release = JSON.parse(releaseSource);
 
-assert.match(productionEntry, /about-history-bootstrap-r165\.js\?build=20260806-r161-r167-changelog-order/,
-  'The public website must load the newest-first browser-aware About implementation directly');
+assert.match(productionEntry, /about-history-bootstrap-r165\.js\?build=20260806-r161-r168-shared-about-credits/,
+  'The public website must load the shared-credit browser-aware About implementation directly');
 assert.ok(
   productionEntry.indexOf('about-history-bootstrap-r165.js') < productionEntry.indexOf('./app.js?build='),
   'Website About must load before the game module waits for explicit browser launch'

--- a/turn/content/about-turn.js
+++ b/turn/content/about-turn.js
@@ -1,0 +1,8 @@
+export function aboutTurnHtml() {
+  return `
+    <div class="turn-about-shared-copy yourturn-about-copy">
+      <p class="m8-about-lead">TURN is a racing game about tilt steering, personal rivals and learning to drive by ear.</p>
+      <p class="m8-about-summary">Built through inclusive and universal design so players can use sight, sound, touch, motion, a keyboard or assistive technology.</p>
+      <p class="m8-about-credits">© 2026 <a href="https://enkel.design/" target="_blank" rel="noreferrer">enkel.design</a>. Created by Erik Jansson, aided by OpenAI Codex. Game assets include <a href="https://kenney.nl" target="_blank" rel="noreferrer">Kenney Game Assets</a>. Drive By Ear™ is inspired by <a href="https://ceal.cs.columbia.edu/rad/" target="_blank" rel="noreferrer">RAD – Racing Auditory Display</a>.</p>
+    </div>`;
+}

--- a/turn/index.html
+++ b/turn/index.html
@@ -183,7 +183,7 @@
   </div>
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
-  <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260806-r161-r167-changelog-order"></script>
+  <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260806-r161-r168-shared-about-credits"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
   <script type="module" src="./app.js?build=20260806-r161-browser-consent-r176-bella-road-derived-zone"></script>
   <script type="module" src="./tracks/countryside-bella-rescue-hotfix-r176.js?revision=r176-video-proven-rescue"></script>

--- a/turn/ui/about-history-bootstrap-r165.js
+++ b/turn/ui/about-history-bootstrap-r165.js
@@ -3,6 +3,7 @@ import {
   CURRENT_RELEASE,
   DEVELOPMENT_HISTORY
 } from '../content/about-history.js?build=20260806-r161';
+import { aboutTurnHtml } from '../content/about-turn.js?revision=r1';
 
 const REVISION = 'r165-browser-about';
 const INSTALL_NOTE =
@@ -199,9 +200,7 @@ function compactAboutDialog(aboutDialog, historyDialog, tabs) {
 
   content.classList.add('turn-dialog__body');
   content.innerHTML = `
-    <p class="m8-about-lead">TURN is a racing game about tilt steering, personal rivals and learning to drive by ear.</p>
-    <p class="m8-about-summary">Built through inclusive and universal design so players can use sight, sound, touch, motion, a keyboard or assistive technology.</p>
-    <p class="m8-about-credits">© 2026 <a href="https://enkel.design/" target="_blank" rel="noreferrer">enkel.design</a>. Created by Erik Jansson, aided by OpenAI Codex. Drive By Ear™ is inspired by <a href="https://ceal.cs.columbia.edu/rad/" target="_blank" rel="noreferrer">RAD – Racing Auditory Display</a>.</p>
+    ${aboutTurnHtml()}
     <div class="m8-about-actions turn-dialog__actions">
       <button class="m8-about-history" type="button" aria-haspopup="dialog">HISTORY &amp; CHANGELOG</button>
       <a class="m8-about-design-system" href="/turn/design.html" target="_blank" rel="noreferrer">DESIGN SYSTEM</a>

--- a/yourturn/index.html
+++ b/yourturn/index.html
@@ -51,7 +51,7 @@
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/yourturn/session.js?revision=r3": "/yourturn/session.js?revision=r6",
-        "/yourturn/ui.js?revision=r3": "/yourturn/ui.js?revision=r7",
+        "/yourturn/ui.js?revision=r3": "/yourturn/ui.js?revision=r8",
         "/yourturn/protocol.js?revision=r3": "/yourturn/protocol-social.js?revision=r1",
         "/yourturn/scene.js?revision=r1": "/yourturn/scene.js?revision=r7"
       }

--- a/yourturn/ui.js
+++ b/yourturn/ui.js
@@ -1,3 +1,4 @@
+import { aboutTurnHtml as sharedAboutTurnHtml } from '/turn/content/about-turn.js?revision=r1';
 import { normalizeChallengeName } from '/yourturn/protocol.js?revision=r3';
 
 const PLAYER_NAME_KEY = 'yourturn-player-name-v1';
@@ -168,12 +169,7 @@ export function createYourTurnUi() {
 }
 
 export function aboutTurnHtml() {
-  return `
-    <div class="yourturn-about-copy">
-      <p><strong>TURN</strong> is a racing game built around one unusual control: rotate your phone like a steering wheel.</p>
-      <p>Gas, Drift and Boost are on screen. Drive By Ear turns the racing line, upcoming corners, grip and nearby cars into spatial sound.</p>
-      <p>TURN is designed for screen-reader and non-visual play as well as visual play. Headphones give the clearest left/right audio information.</p>
-    </div>`;
+  return sharedAboutTurnHtml();
 }
 
 export function newcomerAssistiveText(challengerName) {


### PR DESCRIPTION
## What changed
- adds Kenney Game Assets with a link to https://kenney.nl to the About attribution
- moves the informational About copy into one shared source used by both TURN and YOUR TURN
- keeps each app's context-specific actions intact while making the About text and credits identical
- cache-busts the updated About modules in both public entry points
- does not change racing/gameplay behavior

## QA
- TURN challenge regression: passed
- TURN regression suite: passed
- TURN admin unlock regression: passed

The admin workflow initially exposed a pre-existing stale assertion for the old r160 steering asset while production is already r161; this PR updates that test-only expectation to the current canonical entry.