### PR TITLE
Use black links in YOUR TURN About

### DIFF
--- a/yourturn/about-links.css
+++ b/yourturn/about-links.css
@@ -1,0 +1,4 @@
+html[data-turn-deployment="yourturn"] .yourturn-card[data-view="about"] a,
+html[data-turn-deployment="yourturn"] .yourturn-card[data-view="about"] a:visited {
+  color: #08090a;
+}

--- a/yourturn/index.html
+++ b/yourturn/index.html
@@ -43,6 +43,7 @@
   <link rel="stylesheet" href="/yourturn/yourturn.css?revision=r3">
   <link rel="stylesheet" href="/yourturn/nonvisual.css?revision=r1">
   <link rel="stylesheet" href="/yourturn/growing-challenge.css?revision=r2">
+  <link rel="stylesheet" href="/yourturn/about-links.css?revision=r1">
 
   <script src="/yourturn/storage-bootstrap.js?revision=r1"></script>
   <script type="importmap">


### PR DESCRIPTION
## What changed
- makes links in the YOUR TURN About modal black, including visited links
- scopes the override to the About view only
- leaves TURN and gameplay behavior unchanged

## Why
The inherited link color was too light against the cream About surface and did not meet the intended contrast/design treatment.