### PR TITLE
Add SHARE YOUR TURN to production TURN

### DIFF
--- a/.github/workflows/turn-challenge-tests.yml
+++ b/.github/workflows/turn-challenge-tests.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - 'turn-next/**'
       - 'yourturn/**'
+      - 'turn/social/**'
+      - 'turn/race/rival-storage.js'
+      - 'turn/render/covered-rendering.js'
+      - 'turn/m8-home-fixed-layout.js'
       - 'turn-tests/challenge-*.mjs'
       - 'turn-tests/yourturn-*.mjs'
       - '.github/workflows/turn-challenge-tests.yml'
@@ -17,6 +21,10 @@ on:
     paths:
       - 'turn-next/**'
       - 'yourturn/**'
+      - 'turn/social/**'
+      - 'turn/race/rival-storage.js'
+      - 'turn/render/covered-rendering.js'
+      - 'turn/m8-home-fixed-layout.js'
       - 'turn-tests/challenge-*.mjs'
       - 'turn-tests/yourturn-*.mjs'
       - '.github/workflows/turn-challenge-tests.yml'
@@ -37,7 +45,9 @@ jobs:
           node-version: '24'
 
       - name: Syntax-check challenge modules
-        run: find turn-next yourturn -maxdepth 1 -type f -name '*.js' -print0 | xargs -0 -n1 node --check
+        run: |
+          find turn-next yourturn -maxdepth 1 -type f -name '*.js' -print0 | xargs -0 -n1 node --check
+          find turn/social -maxdepth 1 -type f -name '*.js' -print0 | xargs -0 -n1 node --check
 
       - name: Run Race My Ghost contract
         run: node turn-tests/challenge-mode-production.mjs
@@ -47,6 +57,9 @@ jobs:
 
       - name: Run YOUR TURN recipient contract
         run: node turn-tests/yourturn-production.mjs
+
+      - name: Run TURN to YOUR TURN sharing contract
+        run: node turn-tests/yourturn-turn-sharing-production.mjs
 
       - name: Run YOUR TURN start-grid and social-preview regression
         run: node turn-tests/yourturn-start-grid-production.mjs

--- a/.github/workflows/turn-challenge-tests.yml
+++ b/.github/workflows/turn-challenge-tests.yml
@@ -8,10 +8,10 @@ on:
     paths:
       - 'turn-next/**'
       - 'yourturn/**'
+      - 'turn/index.html'
       - 'turn/social/**'
       - 'turn/race/rival-storage.js'
       - 'turn/render/covered-rendering.js'
-      - 'turn/m8-home-fixed-layout.js'
       - 'turn-tests/challenge-*.mjs'
       - 'turn-tests/yourturn-*.mjs'
       - '.github/workflows/turn-challenge-tests.yml'
@@ -21,10 +21,10 @@ on:
     paths:
       - 'turn-next/**'
       - 'yourturn/**'
+      - 'turn/index.html'
       - 'turn/social/**'
       - 'turn/race/rival-storage.js'
       - 'turn/render/covered-rendering.js'
-      - 'turn/m8-home-fixed-layout.js'
       - 'turn-tests/challenge-*.mjs'
       - 'turn-tests/yourturn-*.mjs'
       - '.github/workflows/turn-challenge-tests.yml'

--- a/turn-tests/covered-rendering-production.mjs
+++ b/turn-tests/covered-rendering-production.mjs
@@ -22,8 +22,10 @@ assert.ok(
 );
 
 assert.match(guard, /THREE\.WebGLRenderer\.prototype/, 'The guard must cover the renderer loop at its shared registration boundary');
-assert.match(guard, /TRACK_SELECTOR_CLASS = 'turn-track-select-open'/, 'Only the fully covering track selector should add this new pause condition');
-assert.match(guard, /document\.body\?\.classList\.contains\(TRACK_SELECTOR_CLASS\)/, 'Covered frames must be detected from the selector lifecycle class');
+assert.match(guard, /PAUSE_CLASSES[\s\S]*turn-track-select-open[\s\S]*turn-runtime-paused/,
+  'The renderer guard must support both track selection and deliberate modal pauses');
+assert.match(guard, /PAUSE_CLASSES\.some\(\(className\) => document\.body\?\.classList\.contains\(className\)\)/,
+  'Covered frames must be detected from the declared pause lifecycle classes');
 assert.match(guard, /stats\.skippedFrames \+= 1/, 'Skipped covered frames must remain measurable through diagnostics');
 assert.match(guard, /callback\.call\(renderer, time, frame\)/, 'Visible frames must preserve the original renderer callback context and arguments');
 assert.match(guard, /typeof callback !== 'function'/, 'Removing an animation loop must still delegate directly to Three.js');
@@ -36,4 +38,4 @@ assert.match(selector, /document\.body\.classList\.remove\('turn-track-select-op
 assert.match(main, /if \(document\.body\.classList\.contains\('turn-lot-open'\)\) return 'lot'/, 'The existing Lot pause must remain intact');
 assert.match(main, /if \(installGate && !installGate\.hidden\) return 'install gate'/, 'The existing install-gate pause must remain intact');
 
-console.log(`TURN ${release.id} fully covered track-selector rendering guard passed.`);
+console.log(`TURN ${release.id} covered rendering and modal pause guard passed.`);

--- a/turn-tests/yourturn-start-grid-production.mjs
+++ b/turn-tests/yourturn-start-grid-production.mjs
@@ -62,9 +62,11 @@ assert.match(cssSource, /yourturn-player-label[\s\S]*font-weight: 1000/);
 
 assert.match(indexSource, /placeholder="WRITE YOUR NAME HERE"/);
 assert.match(cssSource, /input::placeholder[\s\S]*#666/,
-  'The share-name placeholder must use the middle-grey design token value');
-assert.match(uiSource, /nameInput\.value = ''/,
-  'Opening a share result must show a real placeholder instead of editable fake placeholder text');
+  'The first-share name placeholder must use the middle-grey design token value');
+assert.match(uiSource, /const rememberedName = loadSocialRacerProfile\(\)\.name/,
+  'After a player has named a share, later share composers should use that name as the editable default');
+assert.match(uiSource, /nameInput\.value = nameValue == null \? rememberedName : String\(nameValue\)/,
+  'Explicit identity-recovery flows must still be able to clear or replace the remembered default');
 assert.match(mockSource, /'erik-full-field-r1'/);
 assert.match(mockSource, /challengerName: 'ERIK'/);
 
@@ -127,4 +129,4 @@ assert.deepEqual(
 assert.ok(encoded.length > 100,
   'The OG adapter test must use a meaningful self-contained replay payload');
 
-console.log('YOUR TURN fixed start gate, reliable labels, ordered colors and OG-stable sharing regression passed.');
+console.log('YOUR TURN fixed start gate, reliable labels, ordered colors, remembered names and OG-stable sharing regression passed.');

--- a/turn-tests/yourturn-turn-sharing-production.mjs
+++ b/turn-tests/yourturn-turn-sharing-production.mjs
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
 const [
+  turnIndex,
+  shareBootstrap,
   shareSource,
   shareCss,
   profileSource,
@@ -12,6 +14,8 @@ const [
   yourTurnIndex,
   yourTurnUi
 ] = await Promise.all([
+  fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/social/your-turn-share-bootstrap.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/social/your-turn-share.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/social/your-turn-share.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/social/racer-profile.js', import.meta.url), 'utf8'),
@@ -23,9 +27,13 @@ const [
   fs.readFile(new URL('../yourturn/ui.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(fixedHome, /\/turn\/social\/your-turn-share\.js\?build=\$\{buildKey\}-yourturn-share-r1/,
-  'Production Home must install YOUR TURN sharing after the fixed Home is ready');
-assert.match(fixedHome, /installYourTurnShare\(\{ home \}\)/);
+assert.match(turnIndex, /\.\/social\/your-turn-share-bootstrap\.js\?revision=r1/,
+  'Production TURN must load the social sharing bootstrap with an explicit cache identity');
+assert.match(shareBootstrap, /globalThis\.__turnHomeLayout\?\.home/,
+  'Sharing must wait until all existing fixed-Home enhancements have completed');
+assert.match(shareBootstrap, /installYourTurnShare\(\{ home \}\)/);
+assert.doesNotMatch(fixedHome, /your-turn-share|installYourTurnShare/,
+  'The established fixed Home module stays independent of the new sharing feature');
 
 assert.match(rivalStorage, /export function getStoredBestReplayLap\(/,
   'TURN must expose the actual stored replay, not only the best-time summary');
@@ -33,6 +41,8 @@ assert.match(rivalStorage, /frames: lap\.frames\.map\(\(frame\) => \(\{ \.\.\.fr
   'Shareable replay reads must clone persisted frames');
 assert.match(rivalStorage, /getStoredBestLap[\s\S]*getStoredBestReplayLap/,
   'Existing best-lap summaries must keep using the same canonical record source');
+assert.match(rivalStorage, /historical summary-only fallback[\s\S]*oldGhost\?\.bestTime/,
+  'Very old best-time-only Countryside records must remain visible even when they cannot be shared');
 
 assert.match(shareSource, /challengeFromLap/);
 assert.match(shareSource, /encodeChallenge/);
@@ -47,6 +57,8 @@ assert.match(shareSource, /normalizeChallengeName\(input\.value, ''\)/,
   'TURN share must reject an empty name instead of falling back to an anonymous racer');
 assert.doesNotMatch(shareSource, /A TURN PLAYER/,
   'TURN seed creation must never silently invent an anonymous display name');
+assert.match(shareSource, /input\.value = profile\.name \|\| ''/,
+  'The composer must prefill the last deliberately entered social name');
 assert.match(shareSource, /saveSocialRacerName\(racerName\)/,
   'A successfully entered social name must become the next composer default');
 assert.match(shareSource, /card\?\.classList\.contains\('is-selected'\) && best/,
@@ -56,6 +68,10 @@ assert.match(shareSource, /time < previousBest - PB_EPSILON/,
 assert.match(shareSource, /lap-result-yourturn-share/);
 assert.match(shareSource, /turn-runtime-paused/,
   'Opening the composer during a race must hard-pause the runtime');
+assert.match(shareSource, /state\.lapStartedAt \+= pausedFor/,
+  'Time spent composing or sharing must not count against the automatically started next lap');
+assert.match(shareSource, /__turnAudio\?\.silence\?\.\(\)/,
+  'A hard-paused share composer must not leave the engine/audio state running behind it');
 assert.match(coveredRendering, /turn-runtime-paused/,
   'The renderer guard must honour the sharing modal pause class');
 
@@ -77,6 +93,10 @@ assert.match(profileSource, /adoptSocialRacerIdentity/,
 
 assert.match(storageBootstrap, /__TURN_SHARED_LOCAL_STORAGE__/,
   'YOUR TURN must expose only a deliberate raw local-storage bridge for shared social identity');
+assert.match(storageBootstrap, /effectiveRacerId = sharedRacerId \|\| legacyRacerId \|\| createRacerId\(\)/,
+  'YOUR TURN must establish one shared racer ID before its existing session code initializes');
+assert.match(storageBootstrap, /LEGACY_RACER_NAME_KEY[\s\S]*SHARED_RACER_NAME_KEY/,
+  'Existing YOUR TURN names should migrate into the shared composer default');
 assert.match(storageBootstrap, /storageNamespace: LOCAL_PREFIX/,
   'YOUR TURN gameplay storage remains isolated');
 assert.match(yourTurnIndex, /storage-bootstrap\.js\?revision=r2/);

--- a/turn-tests/yourturn-turn-sharing-production.mjs
+++ b/turn-tests/yourturn-turn-sharing-production.mjs
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const [
+  shareSource,
+  shareCss,
+  profileSource,
+  storageBootstrap,
+  rivalStorage,
+  fixedHome,
+  coveredRendering,
+  yourTurnIndex,
+  yourTurnUi
+] = await Promise.all([
+  fs.readFile(new URL('../turn/social/your-turn-share.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/social/your-turn-share.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/social/racer-profile.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/storage-bootstrap.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/race/rival-storage.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/render/covered-rendering.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/ui.js', import.meta.url), 'utf8')
+]);
+
+assert.match(fixedHome, /\/turn\/social\/your-turn-share\.js\?build=\$\{buildKey\}-yourturn-share-r1/,
+  'Production Home must install YOUR TURN sharing after the fixed Home is ready');
+assert.match(fixedHome, /installYourTurnShare\(\{ home \}\)/);
+
+assert.match(rivalStorage, /export function getStoredBestReplayLap\(/,
+  'TURN must expose the actual stored replay, not only the best-time summary');
+assert.match(rivalStorage, /frames: lap\.frames\.map\(\(frame\) => \(\{ \.\.\.frame \}\)\)/,
+  'Shareable replay reads must clone persisted frames');
+assert.match(rivalStorage, /getStoredBestLap[\s\S]*getStoredBestReplayLap/,
+  'Existing best-lap summaries must keep using the same canonical record source');
+
+assert.match(shareSource, /challengeFromLap/);
+assert.match(shareSource, /encodeChallenge/);
+assert.match(shareSource, /makeChallengeUrl/);
+assert.match(shareSource, /getTrackStorageRevision/,
+  'Seed challenges must carry the current track revision');
+assert.match(shareSource, /racerId: profile\.id/,
+  'TURN-created seeds must carry the social racer ID in the link payload');
+assert.match(shareSource, /SHARE YOUR TURN/);
+assert.match(shareSource, /WRITE YOUR NAME HERE/);
+assert.match(shareSource, /normalizeChallengeName\(input\.value, ''\)/,
+  'TURN share must reject an empty name instead of falling back to an anonymous racer');
+assert.doesNotMatch(shareSource, /A TURN PLAYER/,
+  'TURN seed creation must never silently invent an anonymous display name');
+assert.match(shareSource, /saveSocialRacerName\(racerName\)/,
+  'A successfully entered social name must become the next composer default');
+assert.match(shareSource, /card\?\.classList\.contains\('is-selected'\) && best/,
+  'Only the selected track with a shareable personal best gets the Home share control');
+assert.match(shareSource, /time < previousBest - PB_EPSILON/,
+  'The lap-result share entry must appear only for a new personal best');
+assert.match(shareSource, /lap-result-yourturn-share/);
+assert.match(shareSource, /turn-runtime-paused/,
+  'Opening the composer during a race must hard-pause the runtime');
+assert.match(coveredRendering, /turn-runtime-paused/,
+  'The renderer guard must honour the sharing modal pause class');
+
+assert.match(shareCss, /\.turn-yourturn-track-share/);
+assert.match(shareCss, /\.lap-result-yourturn-share/);
+assert.match(shareCss, /\.turn-yourturn-share-submit[\s\S]*#ff4fa3/,
+  'SHARE YOUR TURN remains the pink CTA');
+assert.match(shareCss, /\.turn-yourturn-share-back[\s\S]*#ff9b66/,
+  'Back remains the navigation orange');
+assert.match(shareCss, /\.turn-yourturn-track-slot[\s\S]*position: relative/,
+  'The separate share button must use a valid sibling wrapper rather than nesting a button inside the track button');
+
+assert.match(profileSource, /turn-social-racer-id-v1/);
+assert.match(profileSource, /turn-social-racer-name-v1/);
+assert.match(profileSource, /__TURN_SHARED_LOCAL_STORAGE__/,
+  'The shared profile must use YOUR TURN raw-storage bridge when present');
+assert.match(profileSource, /adoptSocialRacerIdentity/,
+  'A browser context must be able to adopt a racer ID after explicit human confirmation');
+
+assert.match(storageBootstrap, /__TURN_SHARED_LOCAL_STORAGE__/,
+  'YOUR TURN must expose only a deliberate raw local-storage bridge for shared social identity');
+assert.match(storageBootstrap, /storageNamespace: LOCAL_PREFIX/,
+  'YOUR TURN gameplay storage remains isolated');
+assert.match(yourTurnIndex, /storage-bootstrap\.js\?revision=r2/);
+assert.match(yourTurnIndex, /ui\.js\?revision=r3[^\n]*ui\.js\?revision=r10/);
+
+assert.match(yourTurnUi, /loadSocialRacerProfile\(\)\.name/,
+  'YOUR TURN share composers must prefill the last deliberately entered social name');
+assert.match(yourTurnUi, /IS ALREADY HERE/);
+assert.match(yourTurnUi, /YES, THAT’S ME/);
+assert.match(yourTurnUi, /NO, USE ANOTHER NAME/);
+assert.match(yourTurnUi, /adoptSocialRacerIdentity\(\{ id: existing\.id, name: typedName \}\)/,
+  'Confirming an existing named car must adopt its racer ID before the outgoing share is built');
+assert.match(yourTurnUi, /challenge\.racers\.some\(\(racer\) => racer\.id === sessionState\.racerId\)/,
+  'A recognized racer ID must bypass unnecessary identity confirmation');
+
+console.log('TURN → YOUR TURN seed sharing, remembered names and returning-racer claim regression passed.');

--- a/turn/index.html
+++ b/turn/index.html
@@ -186,5 +186,6 @@
   <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260806-r161-r168-shared-about-credits"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
   <script type="module" src="./app.js?build=20260806-r161-browser-consent-r176-bella-road-derived-zone"></script>
+  <script type="module" src="./social/your-turn-share-bootstrap.js?revision=r1"></script>
   <script type="module" src="./tracks/countryside-bella-rescue-hotfix-r176.js?revision=r176-video-proven-rescue"></script>
 </body></html>

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -154,11 +154,6 @@ export async function installM8HomeFixedLayout() {
   const driveByEarTraining = await installDriveByEarTraining(globalThis.__turnRuntime);
   installDriveByEarSpokenLabels(driveByEarTraining);
 
-  const { installYourTurnShare } = await import(
-    `/turn/social/your-turn-share.js?build=${buildKey}-yourturn-share-r1`
-  );
-  const yourTurnShare = await installYourTurnShare({ home });
-
   globalThis.__turnHomeLayout = Object.freeze({
     id: LAYOUT_ID,
     home,
@@ -172,8 +167,7 @@ export async function installM8HomeFixedLayout() {
     secretAchievements,
     achievementChallengeExpansion,
     trophyRoadFeedback,
-    driveByEarTraining,
-    yourTurnShare
+    driveByEarTraining
   });
   return globalThis.__turnHomeLayout;
 }

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -154,6 +154,11 @@ export async function installM8HomeFixedLayout() {
   const driveByEarTraining = await installDriveByEarTraining(globalThis.__turnRuntime);
   installDriveByEarSpokenLabels(driveByEarTraining);
 
+  const { installYourTurnShare } = await import(
+    `/turn/social/your-turn-share.js?build=${buildKey}-yourturn-share-r1`
+  );
+  const yourTurnShare = await installYourTurnShare({ home });
+
   globalThis.__turnHomeLayout = Object.freeze({
     id: LAYOUT_ID,
     home,
@@ -167,7 +172,8 @@ export async function installM8HomeFixedLayout() {
     secretAchievements,
     achievementChallengeExpansion,
     trophyRoadFeedback,
-    driveByEarTraining
+    driveByEarTraining,
+    yourTurnShare
   });
   return globalThis.__turnHomeLayout;
 }

--- a/turn/race/rival-storage.js
+++ b/turn/race/rival-storage.js
@@ -142,36 +142,52 @@ export function clearAllRivalsState(state, trackIds = []) {
 }
 
 export function getStoredBestLap(trackId = DEFAULT_TRACK_ID) {
+  const bestReplay = getStoredBestReplayLap(trackId);
+  if (!bestReplay) return null;
+  const summary = {
+    time: bestReplay.time,
+    carId: bestReplay.carId
+  };
+  if (bestReplay.carColor) summary.carColor = bestReplay.carColor;
+  if (bestReplay.carSecondaryColor) summary.carSecondaryColor = bestReplay.carSecondaryColor;
+  return summary;
+}
+
+export function getStoredBestReplayLap(trackId = DEFAULT_TRACK_ID) {
   const activeTrackId = normalizeTrackId(trackId);
   try {
     const savedRivals = JSON.parse(localStorage.getItem(rivalKey(activeTrackId)));
     const bestLap = Array.isArray(savedRivals?.laps)
-      ? savedRivals.laps.reduce((best, lap) => {
-        const time = Number(lap?.time);
-        if (!Number.isFinite(time)) return best;
-        if (!best || time < best.time) {
-          const summary = {
-            time,
-            carId: lap?.carId ? normalizeVehicleId(lap.carId) : LEGACY_VEHICLE_ID
-          };
-          if (lap?.carColor) summary.carColor = normalizeVehicleColor(lap.carColor);
-          if (lap?.carSecondaryColor) {
-            summary.carSecondaryColor = normalizeVehicleSecondaryColor(lap.carSecondaryColor);
+      ? savedRivals.laps
+        .filter(isValidLap)
+        .reduce((best, lap) => {
+          const time = Number(lap?.time);
+          if (!best || time < best.time) {
+            return {
+              time,
+              hitAt: lap.hitAt != null && Number.isFinite(Number(lap.hitAt)) ? Number(lap.hitAt) : null,
+              carId: lap?.carId ? normalizeVehicleId(lap.carId) : LEGACY_VEHICLE_ID,
+              carColor: lap?.carColor ? normalizeVehicleColor(lap.carColor) : DEFAULT_VEHICLE_COLOR,
+              carSecondaryColor: normalizeVehicleSecondaryColor(lap?.carSecondaryColor),
+              frames: lap.frames.map((frame) => ({ ...frame }))
+            };
           }
-          return summary;
-        }
-        return best;
-      }, null)
+          return best;
+        }, null)
       : null;
     if (bestLap) return bestLap;
 
     if (activeTrackId === DEFAULT_TRACK_ID) {
       const oldGhost = JSON.parse(localStorage.getItem(ghostKey(activeTrackId)));
       const legacyTime = Number(oldGhost?.bestTime);
-      if (Number.isFinite(legacyTime)) {
+      if (Number.isFinite(legacyTime) && Array.isArray(oldGhost?.frames) && oldGhost.frames.length > 20) {
         return {
           time: legacyTime,
-          carId: LEGACY_VEHICLE_ID
+          hitAt: null,
+          carId: LEGACY_VEHICLE_ID,
+          carColor: DEFAULT_VEHICLE_COLOR,
+          carSecondaryColor: DEFAULT_VEHICLE_SECONDARY_COLOR,
+          frames: oldGhost.frames.map((frame) => ({ ...frame }))
         };
       }
     }

--- a/turn/race/rival-storage.js
+++ b/turn/race/rival-storage.js
@@ -143,14 +143,33 @@ export function clearAllRivalsState(state, trackIds = []) {
 
 export function getStoredBestLap(trackId = DEFAULT_TRACK_ID) {
   const bestReplay = getStoredBestReplayLap(trackId);
-  if (!bestReplay) return null;
-  const summary = {
-    time: bestReplay.time,
-    carId: bestReplay.carId
-  };
-  if (bestReplay.carColor) summary.carColor = bestReplay.carColor;
-  if (bestReplay.carSecondaryColor) summary.carSecondaryColor = bestReplay.carSecondaryColor;
-  return summary;
+  if (bestReplay) {
+    const summary = {
+      time: bestReplay.time,
+      carId: bestReplay.carId
+    };
+    if (bestReplay.carColor) summary.carColor = bestReplay.carColor;
+    if (bestReplay.carSecondaryColor) summary.carSecondaryColor = bestReplay.carSecondaryColor;
+    return summary;
+  }
+
+  // Preserve the historical summary-only fallback. Very old Countryside saves
+  // can contain a best time without enough replay frames to share as YOUR TURN;
+  // Home should still display that record even though no share button is offered.
+  const activeTrackId = normalizeTrackId(trackId);
+  if (activeTrackId === DEFAULT_TRACK_ID) {
+    try {
+      const oldGhost = JSON.parse(localStorage.getItem(ghostKey(activeTrackId)));
+      const legacyTime = Number(oldGhost?.bestTime);
+      if (Number.isFinite(legacyTime)) {
+        return {
+          time: legacyTime,
+          carId: LEGACY_VEHICLE_ID
+        };
+      }
+    } catch (_) {}
+  }
+  return null;
 }
 
 export function getStoredBestReplayLap(trackId = DEFAULT_TRACK_ID) {

--- a/turn/render/covered-rendering.js
+++ b/turn/render/covered-rendering.js
@@ -1,7 +1,10 @@
 import * as THREE from 'three';
 
 const INSTALL_FLAG = Symbol.for('turn.covered-rendering-installed');
-const TRACK_SELECTOR_CLASS = 'turn-track-select-open';
+const PAUSE_CLASSES = Object.freeze([
+  'turn-track-select-open',
+  'turn-runtime-paused'
+]);
 
 export function installCoveredRenderingGuard() {
   const prototype = THREE.WebGLRenderer.prototype;
@@ -20,7 +23,7 @@ export function installCoveredRenderingGuard() {
 
     const renderer = this;
     const guardedCallback = (time, frame) => {
-      if (document.body?.classList.contains(TRACK_SELECTOR_CLASS)) {
+      if (PAUSE_CLASSES.some((className) => document.body?.classList.contains(className))) {
         stats.skippedFrames += 1;
         return;
       }

--- a/turn/social/racer-profile.js
+++ b/turn/social/racer-profile.js
@@ -1,0 +1,77 @@
+const RACER_ID_KEY = 'turn-social-racer-id-v1';
+const RACER_NAME_KEY = 'turn-social-racer-name-v1';
+const MAX_NAME_LENGTH = 24;
+
+function sharedStorage() {
+  const bridged = globalThis.__TURN_SHARED_LOCAL_STORAGE__;
+  if (bridged?.getItem && bridged?.setItem) return bridged;
+  try {
+    return globalThis.localStorage || null;
+  } catch (_) {
+    return null;
+  }
+}
+
+export function normalizeSocialRacerName(value) {
+  return String(value || '')
+    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, MAX_NAME_LENGTH);
+}
+
+export function normalizeSocialRacerId(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, '')
+    .slice(0, 64);
+}
+
+export function createSocialRacerId() {
+  const random = globalThis.crypto?.randomUUID?.()
+    || `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 12)}`;
+  return normalizeSocialRacerId(`r-${random}`);
+}
+
+export function loadSocialRacerProfile() {
+  const storage = sharedStorage();
+  let id = '';
+  let name = '';
+
+  try {
+    id = normalizeSocialRacerId(storage?.getItem?.(RACER_ID_KEY));
+    name = normalizeSocialRacerName(storage?.getItem?.(RACER_NAME_KEY));
+  } catch (_) {}
+
+  if (!id) {
+    id = createSocialRacerId();
+    try {
+      storage?.setItem?.(RACER_ID_KEY, id);
+    } catch (_) {}
+  }
+
+  return Object.freeze({ id, name });
+}
+
+export function saveSocialRacerName(value) {
+  const name = normalizeSocialRacerName(value);
+  if (!name) return '';
+  try {
+    sharedStorage()?.setItem?.(RACER_NAME_KEY, name);
+  } catch (_) {}
+  return name;
+}
+
+export function adoptSocialRacerIdentity({ id, name } = {}) {
+  const racerId = normalizeSocialRacerId(id);
+  const racerName = normalizeSocialRacerName(name);
+  if (!racerId) return loadSocialRacerProfile();
+
+  const storage = sharedStorage();
+  try {
+    storage?.setItem?.(RACER_ID_KEY, racerId);
+    if (racerName) storage?.setItem?.(RACER_NAME_KEY, racerName);
+  } catch (_) {}
+
+  return Object.freeze({ id: racerId, name: racerName });
+}

--- a/turn/social/your-turn-share-bootstrap.js
+++ b/turn/social/your-turn-share-bootstrap.js
@@ -1,21 +1,22 @@
 import { installYourTurnShare } from './your-turn-share.js?revision=r1';
 
-function waitForHome() {
-  const existing = document.querySelector('.m8-home-fixed-layout');
-  if (existing) return Promise.resolve(existing);
+function waitForHomeLayout() {
+  if (globalThis.__turnHomeLayout?.home) return Promise.resolve(globalThis.__turnHomeLayout.home);
 
   return new Promise((resolve) => {
-    const observer = new MutationObserver(() => {
-      const home = document.querySelector('.m8-home-fixed-layout');
-      if (!home) return;
-      observer.disconnect();
-      resolve(home);
-    });
-    observer.observe(document.body, { childList: true, subtree: true, attributes: true, attributeFilter: ['class'] });
+    const check = () => {
+      const home = globalThis.__turnHomeLayout?.home;
+      if (home) {
+        resolve(home);
+        return;
+      }
+      requestAnimationFrame(check);
+    };
+    requestAnimationFrame(check);
   });
 }
 
-waitForHome()
+waitForHomeLayout()
   .then((home) => installYourTurnShare({ home }))
   .catch((error) => {
     console.error('TURN: YOUR TURN sharing could not start.', error);

--- a/turn/social/your-turn-share-bootstrap.js
+++ b/turn/social/your-turn-share-bootstrap.js
@@ -1,0 +1,22 @@
+import { installYourTurnShare } from './your-turn-share.js?revision=r1';
+
+function waitForHome() {
+  const existing = document.querySelector('.m8-home-fixed-layout');
+  if (existing) return Promise.resolve(existing);
+
+  return new Promise((resolve) => {
+    const observer = new MutationObserver(() => {
+      const home = document.querySelector('.m8-home-fixed-layout');
+      if (!home) return;
+      observer.disconnect();
+      resolve(home);
+    });
+    observer.observe(document.body, { childList: true, subtree: true, attributes: true, attributeFilter: ['class'] });
+  });
+}
+
+waitForHome()
+  .then((home) => installYourTurnShare({ home }))
+  .catch((error) => {
+    console.error('TURN: YOUR TURN sharing could not start.', error);
+  });

--- a/turn/social/your-turn-share-bootstrap.js
+++ b/turn/social/your-turn-share-bootstrap.js
@@ -1,23 +1,17 @@
 import { installYourTurnShare } from './your-turn-share.js?revision=r1';
 
-function waitForHomeLayout() {
-  if (globalThis.__turnHomeLayout?.home) return Promise.resolve(globalThis.__turnHomeLayout.home);
+let started = false;
 
-  return new Promise((resolve) => {
-    const check = () => {
-      const home = globalThis.__turnHomeLayout?.home;
-      if (home) {
-        resolve(home);
-        return;
-      }
-      requestAnimationFrame(check);
-    };
-    requestAnimationFrame(check);
+function start() {
+  if (started) return;
+  const home = globalThis.__turnHomeLayout?.home;
+  if (!home) return;
+  started = true;
+  installYourTurnShare({ home }).catch((error) => {
+    started = false;
+    console.error('TURN: YOUR TURN sharing could not start.', error);
   });
 }
 
-waitForHomeLayout()
-  .then((home) => installYourTurnShare({ home }))
-  .catch((error) => {
-    console.error('TURN: YOUR TURN sharing could not start.', error);
-  });
+if (globalThis.__turnHomeLayout?.home) start();
+else document.addEventListener('turn:home-ready', start, { once: true });

--- a/turn/social/your-turn-share.css
+++ b/turn/social/your-turn-share.css
@@ -1,0 +1,296 @@
+.turn-yourturn-track-slot {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+}
+
+.m8-track-rail .turn-yourturn-track-slot {
+  flex: 0 0 clamp(350px, 40vw, 590px);
+  width: clamp(350px, 40vw, 590px);
+  min-height: clamp(220px, 36vh, 400px);
+  scroll-snap-align: start;
+}
+
+.m8-track-rail .turn-yourturn-track-slot > .track-card {
+  width: 100%;
+  height: 100%;
+  min-height: inherit;
+  scroll-snap-align: none;
+}
+
+.m8-home-fixed-layout .m8-track-rail .turn-yourturn-track-slot {
+  width: 100%;
+  min-height: clamp(180px, 27vh, 260px);
+  scroll-snap-align: start;
+}
+
+.m8-home-fixed-layout .m8-track-rail .turn-yourturn-track-slot > .track-card {
+  min-height: inherit;
+}
+
+.turn-yourturn-track-share,
+.lap-result-yourturn-share {
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 4px solid #08090a;
+  border-radius: 50%;
+  background: #fff8e8;
+  color: #08090a;
+  box-shadow: 5px 5px 0 #08090a;
+  touch-action: manipulation;
+}
+
+.turn-yourturn-track-share {
+  position: absolute;
+  z-index: 4;
+  right: 16px;
+  bottom: 16px;
+  width: clamp(46px, 4.6vw, 58px);
+  height: clamp(46px, 4.6vw, 58px);
+}
+
+.turn-yourturn-track-share[hidden],
+.lap-result-yourturn-share[hidden] {
+  display: none !important;
+}
+
+.turn-yourturn-track-share svg,
+.lap-result-yourturn-share svg {
+  width: 58%;
+  height: 58%;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.turn-yourturn-track-share:hover,
+.lap-result-yourturn-share:hover {
+  transform: translateY(-2px);
+}
+
+.turn-yourturn-track-share:active,
+.lap-result-yourturn-share:active {
+  transform: translate(4px, 4px);
+  box-shadow: 1px 1px 0 #08090a;
+}
+
+.turn-yourturn-track-share:focus-visible,
+.lap-result-yourturn-share:focus-visible {
+  outline: 5px solid #38d9ff;
+  outline-offset: 4px;
+}
+
+.lap-result-toast.has-yourturn-share {
+  padding-right: 72px;
+}
+
+.lap-result-yourturn-share {
+  position: absolute;
+  z-index: 2;
+  top: 50%;
+  right: 12px;
+  width: 48px;
+  height: 48px;
+  transform: translateY(-50%);
+  pointer-events: auto;
+  box-shadow: 4px 4px 0 #08090a;
+}
+
+.lap-result-yourturn-share:hover {
+  transform: translateY(calc(-50% - 2px));
+}
+
+.lap-result-yourturn-share:active {
+  transform: translate(4px, calc(-50% + 4px));
+}
+
+.turn-yourturn-share-dialog {
+  width: min(690px, calc(100vw - 28px));
+  max-height: calc(100dvh - 28px);
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: #08090a;
+}
+
+.turn-yourturn-share-dialog::backdrop {
+  background: rgb(8 9 10 / 0.58);
+  backdrop-filter: blur(4px);
+}
+
+.turn-yourturn-share-card {
+  box-sizing: border-box;
+  max-height: calc(100dvh - 28px);
+  overflow: auto;
+  padding: clamp(18px, 3vw, 28px);
+  border: 5px solid #08090a;
+  border-radius: 26px;
+  background: #fff8e8;
+  box-shadow: 10px 10px 0 #08090a;
+}
+
+.turn-yourturn-share-head {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 16px;
+}
+
+.turn-yourturn-share-head span {
+  display: block;
+  margin-bottom: 4px;
+  color: #6b3fa0;
+  font-size: .78rem;
+  font-weight: 1000;
+  letter-spacing: .14em;
+}
+
+.turn-yourturn-share-head h2 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 4rem);
+  line-height: .9;
+  letter-spacing: -.05em;
+}
+
+.turn-yourturn-share-close {
+  flex: 0 0 auto;
+  width: 48px;
+  height: 48px;
+  padding: 0;
+  border: 4px solid #08090a;
+  border-radius: 50%;
+  background: #ff9b66;
+  color: #08090a;
+  box-shadow: 4px 4px 0 #08090a;
+  font: 1000 1.7rem/1 system-ui, sans-serif;
+}
+
+.turn-yourturn-share-details {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px 14px;
+  margin-bottom: 14px;
+  padding: 10px 13px;
+  border: 4px solid #08090a;
+  border-radius: 16px;
+  background: #ffd43b;
+  font-weight: 900;
+}
+
+.turn-yourturn-share-details strong {
+  font-size: clamp(1.2rem, 3vw, 1.8rem);
+}
+
+.turn-yourturn-share-copy {
+  margin: 0 0 16px;
+  font-weight: 750;
+  line-height: 1.3;
+}
+
+.turn-yourturn-share-name {
+  display: grid;
+  gap: 7px;
+  margin-bottom: 10px;
+  font-weight: 900;
+}
+
+.turn-yourturn-share-name input {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 48px;
+  padding: 9px 12px;
+  border: 4px solid #08090a;
+  border-radius: 12px;
+  background: #fff;
+  color: #08090a;
+  font: inherit;
+  font-size: 1.05rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.turn-yourturn-share-name input::placeholder {
+  color: #666;
+  opacity: 1;
+}
+
+.turn-yourturn-share-status {
+  min-height: 1.25em;
+  margin: 0 0 10px;
+  font-size: .86rem;
+  font-weight: 800;
+}
+
+.turn-yourturn-share-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.turn-yourturn-share-actions button {
+  min-height: 48px;
+  padding: 10px 18px;
+  border: 4px solid #08090a;
+  border-radius: 14px;
+  color: #08090a;
+  box-shadow: 5px 5px 0 #08090a;
+  font: inherit;
+  font-weight: 1000;
+}
+
+.turn-yourturn-share-submit {
+  background: #ff4fa3;
+}
+
+.turn-yourturn-share-back {
+  background: #ff9b66;
+}
+
+.turn-yourturn-share-actions button:focus-visible,
+.turn-yourturn-share-close:focus-visible,
+.turn-yourturn-share-name input:focus-visible {
+  outline: 5px solid #38d9ff;
+  outline-offset: 4px;
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+  .turn-yourturn-share-card {
+    padding: 14px 17px;
+    border-width: 4px;
+  }
+
+  .turn-yourturn-share-head {
+    margin-bottom: 9px;
+  }
+
+  .turn-yourturn-share-head h2 {
+    font-size: clamp(1.7rem, 5vw, 2.7rem);
+  }
+
+  .turn-yourturn-share-details,
+  .turn-yourturn-share-copy,
+  .turn-yourturn-share-name {
+    margin-bottom: 8px;
+  }
+
+  .turn-yourturn-share-name input,
+  .turn-yourturn-share-actions button {
+    min-height: 40px;
+  }
+
+  .turn-yourturn-track-share {
+    right: 11px;
+    bottom: 11px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .turn-yourturn-share-dialog::backdrop {
+    backdrop-filter: none;
+  }
+}

--- a/turn/social/your-turn-share.js
+++ b/turn/social/your-turn-share.js
@@ -117,6 +117,7 @@ export async function installYourTurnShare({ home = document.querySelector('.m8-
   let activeTrackId = '';
   let returnFocus = null;
   let pausedRace = false;
+  let pausedAt = 0;
   let sharing = false;
   const knownBestTimes = new Map();
 
@@ -158,14 +159,23 @@ export async function installYourTurnShare({ home = document.querySelector('.m8-
   function pauseForComposer() {
     pausedRace = currentRaceIsVisible();
     if (!pausedRace) return;
+    pausedAt = performance.now();
     document.body.classList.add('turn-runtime-paused');
+    globalThis.__turnAudio?.silence?.();
   }
 
   function resumeAfterComposer() {
     if (!pausedRace) return;
+    const now = performance.now();
+    const pausedFor = Math.max(0, now - pausedAt);
+    const state = runtime?.state;
+    if (state?.lapActive && Number.isFinite(state.lapStartedAt)) {
+      state.lapStartedAt += pausedFor;
+    }
+    if (state) state.lastFrame = now;
     document.body.classList.remove('turn-runtime-paused');
-    if (runtime?.state) runtime.state.lastFrame = performance.now();
     pausedRace = false;
+    pausedAt = 0;
   }
 
   function openComposer(trackId, lap, trigger) {

--- a/turn/social/your-turn-share.js
+++ b/turn/social/your-turn-share.js
@@ -24,12 +24,25 @@ const SHARE_ICON = `
   </svg>`;
 
 function installStylesheet() {
-  if (document.querySelector('link[data-turn-yourturn-share]')) return;
+  const existing = document.querySelector('link[data-turn-yourturn-share]');
+  if (existing?.sheet) return Promise.resolve(existing);
+  if (existing) {
+    return new Promise((resolve, reject) => {
+      existing.addEventListener('load', () => resolve(existing), { once: true });
+      existing.addEventListener('error', () => reject(new Error('TURN YOUR TURN sharing styles could not load.')), { once: true });
+    });
+  }
+
   const link = document.createElement('link');
   link.rel = 'stylesheet';
   link.href = '/turn/social/your-turn-share.css?revision=r1';
   link.setAttribute('data-turn-yourturn-share', '');
+  const ready = new Promise((resolve, reject) => {
+    link.addEventListener('load', () => resolve(link), { once: true });
+    link.addEventListener('error', () => reject(new Error('TURN YOUR TURN sharing styles could not load.')), { once: true });
+  });
   document.head.appendChild(link);
+  return ready;
 }
 
 function formatTrackName(trackId) {
@@ -74,15 +87,13 @@ function wrapTrackCard(card) {
   card.replaceWith(slot);
   slot.appendChild(card);
 
-  if (!card.disabled && !card.classList.contains('is-locked')) {
-    const share = document.createElement('button');
-    share.type = 'button';
-    share.className = 'turn-yourturn-track-share';
-    share.dataset.trackId = card.dataset.trackId || '';
-    share.innerHTML = SHARE_ICON;
-    share.hidden = true;
-    slot.appendChild(share);
-  }
+  const share = document.createElement('button');
+  share.type = 'button';
+  share.className = 'turn-yourturn-track-share';
+  share.dataset.trackId = card.dataset.trackId || '';
+  share.innerHTML = SHARE_ICON;
+  share.hidden = true;
+  slot.appendChild(share);
   return slot;
 }
 
@@ -95,7 +106,7 @@ export async function installYourTurnShare({ home = document.querySelector('.m8-
   if (globalThis[INSTALL_FLAG]) return globalThis[INSTALL_FLAG];
   if (!home) throw new Error('TURN YOUR TURN sharing could not find Home.');
 
-  installStylesheet();
+  await installStylesheet();
   const runtime = globalThis.__turnRuntime;
   const rail = home.querySelector('.m8-track-rail');
   if (!rail) throw new Error('TURN YOUR TURN sharing could not find the track rail.');
@@ -140,7 +151,8 @@ export async function installYourTurnShare({ home = document.querySelector('.m8-
       const trackId = button.dataset.trackId || '';
       const card = button.parentElement?.querySelector('.track-card');
       const best = getStoredBestReplayLap(trackId);
-      button.hidden = !(card?.classList.contains('is-selected') && best);
+      const unavailable = card?.disabled || card?.classList.contains('is-trophy-locked');
+      button.hidden = !(card?.classList.contains('is-selected') && best && !unavailable);
       button.setAttribute(
         'aria-label',
         best
@@ -245,7 +257,7 @@ export async function installYourTurnShare({ home = document.querySelector('.m8-
       if (navigator.share) {
         try {
           await navigator.share(shareData);
-          closeComposer({ restoreFocus: false });
+          closeComposer();
           return;
         } catch (error) {
           if (error?.name === 'AbortError') return;
@@ -301,7 +313,7 @@ export async function installYourTurnShare({ home = document.querySelector('.m8-
     ? new MutationObserver(syncTrackShareButtons)
     : null;
   for (const card of rail.querySelectorAll('.track-card')) {
-    selectionObserver?.observe(card, { attributes: true, attributeFilter: ['class', 'aria-pressed'] });
+    selectionObserver?.observe(card, { attributes: true, attributeFilter: ['class', 'aria-pressed', 'disabled'] });
   }
 
   window.addEventListener('turn:rivals-reset', () => {

--- a/turn/social/your-turn-share.js
+++ b/turn/social/your-turn-share.js
@@ -1,0 +1,356 @@
+import { getStoredBestReplayLap } from '../race/rival-storage.js?build=20260806-r161';
+import { TRACK_CATALOG, getTrackDefinition } from '../tracks/catalog.js?build=20260806-r161';
+import { getTrackStorageRevision } from '../tracks/definitions.js?build=20260806-r161';
+import { getCarDefinition } from '../vehicle/catalog.js?build=20260806-r161';
+import {
+  challengeFromLap,
+  encodeChallenge,
+  formatChallengeTime,
+  makeChallengeUrl,
+  normalizeChallengeName
+} from '/yourturn/protocol-social.js?revision=r1';
+import {
+  loadSocialRacerProfile,
+  saveSocialRacerName
+} from './racer-profile.js?revision=r1';
+
+const INSTALL_FLAG = Symbol.for('turn.yourturn.share.installed');
+const PB_EPSILON = 0.0005;
+const SHARE_ICON = `
+  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+    <path d="M12 15V3"></path>
+    <path d="m7.5 7.5 4.5-4.5 4.5 4.5"></path>
+    <path d="M5 11v8h14v-8"></path>
+  </svg>`;
+
+function installStylesheet() {
+  if (document.querySelector('link[data-turn-yourturn-share]')) return;
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = '/turn/social/your-turn-share.css?revision=r1';
+  link.setAttribute('data-turn-yourturn-share', '');
+  document.head.appendChild(link);
+}
+
+function formatTrackName(trackId) {
+  return getTrackDefinition(trackId)?.name || String(trackId || 'Track');
+}
+
+function createComposer() {
+  const dialog = document.createElement('dialog');
+  dialog.className = 'turn-yourturn-share-dialog';
+  dialog.setAttribute('aria-labelledby', 'turnYourTurnShareTitle');
+  dialog.innerHTML = `
+    <article class="turn-yourturn-share-card">
+      <header class="turn-yourturn-share-head">
+        <div>
+          <span>YOUR TURN</span>
+          <h2 id="turnYourTurnShareTitle">SHARE YOUR TURN</h2>
+        </div>
+        <button class="turn-yourturn-share-close" type="button" aria-label="Close Share Your Turn">×</button>
+      </header>
+      <div class="turn-yourturn-share-details"></div>
+      <p class="turn-yourturn-share-copy">Send your best lap as a challenge. Anyone who races it can add their car and pass the challenge on.</p>
+      <label class="turn-yourturn-share-name">
+        <span>Your name in the challenge</span>
+        <input type="text" maxlength="24" autocomplete="nickname" placeholder="WRITE YOUR NAME HERE" required>
+      </label>
+      <p class="turn-yourturn-share-status" role="status" aria-live="polite"></p>
+      <div class="turn-yourturn-share-actions">
+        <button class="turn-yourturn-share-submit" type="button">SHARE YOUR TURN</button>
+        <button class="turn-yourturn-share-back" type="button">BACK</button>
+      </div>
+    </article>`;
+  document.body.appendChild(dialog);
+  return dialog;
+}
+
+function wrapTrackCard(card) {
+  if (card.parentElement?.classList.contains('turn-yourturn-track-slot')) {
+    return card.parentElement;
+  }
+  const slot = document.createElement('div');
+  slot.className = 'turn-yourturn-track-slot';
+  card.replaceWith(slot);
+  slot.appendChild(card);
+
+  if (!card.disabled && !card.classList.contains('is-locked')) {
+    const share = document.createElement('button');
+    share.type = 'button';
+    share.className = 'turn-yourturn-track-share';
+    share.dataset.trackId = card.dataset.trackId || '';
+    share.innerHTML = SHARE_ICON;
+    share.hidden = true;
+    slot.appendChild(share);
+  }
+  return slot;
+}
+
+function currentRaceIsVisible() {
+  const hud = document.querySelector('#hud');
+  return Boolean(hud && !hud.hidden && !document.body.classList.contains('turn-home-open'));
+}
+
+export async function installYourTurnShare({ home = document.querySelector('.m8-home') } = {}) {
+  if (globalThis[INSTALL_FLAG]) return globalThis[INSTALL_FLAG];
+  if (!home) throw new Error('TURN YOUR TURN sharing could not find Home.');
+
+  installStylesheet();
+  const runtime = globalThis.__turnRuntime;
+  const rail = home.querySelector('.m8-track-rail');
+  if (!rail) throw new Error('TURN YOUR TURN sharing could not find the track rail.');
+
+  for (const card of rail.querySelectorAll('.track-card')) wrapTrackCard(card);
+  globalThis.__turnHomeCardScrollFixes?.syncIndicator?.();
+
+  const dialog = createComposer();
+  const details = dialog.querySelector('.turn-yourturn-share-details');
+  const input = dialog.querySelector('input');
+  const status = dialog.querySelector('.turn-yourturn-share-status');
+  const submit = dialog.querySelector('.turn-yourturn-share-submit');
+  const close = dialog.querySelector('.turn-yourturn-share-close');
+  const back = dialog.querySelector('.turn-yourturn-share-back');
+  const trackButtons = [...rail.querySelectorAll('.turn-yourturn-track-share')];
+  const toast = document.querySelector('.lap-result-toast');
+  let toastShare = null;
+  let activeLap = null;
+  let activeTrackId = '';
+  let returnFocus = null;
+  let pausedRace = false;
+  let sharing = false;
+  const knownBestTimes = new Map();
+
+  for (const track of TRACK_CATALOG) {
+    knownBestTimes.set(track.id, getStoredBestReplayLap(track.id)?.time ?? Infinity);
+  }
+
+  if (toast) {
+    toastShare = document.createElement('button');
+    toastShare.type = 'button';
+    toastShare.className = 'lap-result-yourturn-share';
+    toastShare.innerHTML = SHARE_ICON;
+    toastShare.hidden = true;
+    toastShare.setAttribute('aria-label', 'Share this new personal best as a YOUR TURN challenge');
+    toast.appendChild(toastShare);
+  }
+
+  function syncTrackShareButtons() {
+    for (const button of trackButtons) {
+      const trackId = button.dataset.trackId || '';
+      const card = button.parentElement?.querySelector('.track-card');
+      const best = getStoredBestReplayLap(trackId);
+      button.hidden = !(card?.classList.contains('is-selected') && best);
+      button.setAttribute(
+        'aria-label',
+        best
+          ? `Share your best lap on ${formatTrackName(trackId)} as a YOUR TURN challenge`
+          : `No shareable best lap on ${formatTrackName(trackId)}`
+      );
+    }
+  }
+
+  function setNameValidation(message = '') {
+    status.textContent = message;
+    if (message) input.setAttribute('aria-invalid', 'true');
+    else input.removeAttribute('aria-invalid');
+  }
+
+  function pauseForComposer() {
+    pausedRace = currentRaceIsVisible();
+    if (!pausedRace) return;
+    document.body.classList.add('turn-runtime-paused');
+  }
+
+  function resumeAfterComposer() {
+    if (!pausedRace) return;
+    document.body.classList.remove('turn-runtime-paused');
+    if (runtime?.state) runtime.state.lastFrame = performance.now();
+    pausedRace = false;
+  }
+
+  function openComposer(trackId, lap, trigger) {
+    if (!lap || !Array.isArray(lap.frames) || lap.frames.length < 21) return false;
+    activeTrackId = trackId;
+    activeLap = lap;
+    returnFocus = trigger || null;
+    const track = getTrackDefinition(trackId);
+    const car = getCarDefinition(lap.carId);
+    details.innerHTML = `
+      <strong>${escapeHtml(track?.name?.toUpperCase() || trackId.toUpperCase())}</strong>
+      <span>${escapeHtml(car?.name || 'Car')} · ${formatChallengeTime(lap.time)}</span>`;
+    const profile = loadSocialRacerProfile();
+    input.value = profile.name || '';
+    setNameValidation('');
+    pauseForComposer();
+    if (typeof dialog.showModal === 'function') dialog.showModal();
+    else dialog.setAttribute('open', '');
+    if (input.value) submit.focus();
+    else input.focus();
+    return true;
+  }
+
+  function closeComposer({ restoreFocus = true } = {}) {
+    if (typeof dialog.close === 'function' && dialog.open) dialog.close();
+    else dialog.removeAttribute('open');
+    resumeAfterComposer();
+    if (restoreFocus) returnFocus?.focus?.();
+    activeLap = null;
+    activeTrackId = '';
+    returnFocus = null;
+  }
+
+  async function shareActiveLap() {
+    if (sharing || !activeLap || !activeTrackId) return;
+    const racerName = normalizeChallengeName(input.value, '');
+    if (!racerName) {
+      setNameValidation('Write your name before sharing.');
+      input.focus();
+      return;
+    }
+
+    setNameValidation('');
+    saveSocialRacerName(racerName);
+    input.value = racerName;
+    sharing = true;
+    submit.disabled = true;
+    try {
+      const profile = loadSocialRacerProfile();
+      const track = getTrackDefinition(activeTrackId);
+      const challenge = challengeFromLap({
+        challengerName: racerName,
+        racerId: profile.id,
+        trackId: activeTrackId,
+        trackRevision: getTrackStorageRevision(activeTrackId),
+        trackName: track?.name || activeTrackId,
+        lap: activeLap
+      });
+      const encoded = await encodeChallenge(challenge);
+      const url = makeChallengeUrl(encoded);
+      const shareData = {
+        title: `${racerName} sends you YOUR TURN`,
+        text: `${racerName} challenges you on ${track?.name || activeTrackId} with ${formatChallengeTime(activeLap.time)}. Your turn.`,
+        url
+      };
+
+      if (navigator.share) {
+        try {
+          await navigator.share(shareData);
+          closeComposer({ restoreFocus: false });
+          return;
+        } catch (error) {
+          if (error?.name === 'AbortError') return;
+        }
+      }
+
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(url);
+        status.textContent = 'Challenge link copied.';
+        return;
+      }
+
+      status.textContent = url;
+    } catch (error) {
+      status.textContent = error instanceof Error ? error.message : 'The challenge could not be shared.';
+    } finally {
+      sharing = false;
+      submit.disabled = false;
+    }
+  }
+
+  for (const button of trackButtons) {
+    button.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const trackId = button.dataset.trackId || '';
+      openComposer(trackId, getStoredBestReplayLap(trackId), button);
+    });
+  }
+
+  toastShare?.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const trackId = toastShare.dataset.trackId || runtime?.state?.trackId || 'countryside';
+    openComposer(trackId, getStoredBestReplayLap(trackId), toastShare);
+  });
+
+  submit.addEventListener('click', () => void shareActiveLap());
+  close.addEventListener('click', () => closeComposer());
+  back.addEventListener('click', () => closeComposer());
+  dialog.addEventListener('cancel', (event) => {
+    event.preventDefault();
+    closeComposer();
+  });
+  dialog.addEventListener('click', (event) => {
+    if (event.target === dialog) closeComposer();
+  });
+  input.addEventListener('input', () => {
+    if (normalizeChallengeName(input.value, '')) setNameValidation('');
+  });
+
+  const selectionObserver = typeof MutationObserver === 'function'
+    ? new MutationObserver(syncTrackShareButtons)
+    : null;
+  for (const card of rail.querySelectorAll('.track-card')) {
+    selectionObserver?.observe(card, { attributes: true, attributeFilter: ['class', 'aria-pressed'] });
+  }
+
+  window.addEventListener('turn:rivals-reset', () => {
+    for (const track of TRACK_CATALOG) {
+      knownBestTimes.set(track.id, getStoredBestReplayLap(track.id)?.time ?? Infinity);
+    }
+    syncTrackShareButtons();
+  });
+
+  window.addEventListener('turn:lap-invalid', () => {
+    if (toastShare) toastShare.hidden = true;
+    toast?.classList.remove('has-yourturn-share');
+  });
+
+  window.addEventListener('turn:lap-result', (event) => {
+    const trackId = runtime?.state?.trackId || 'countryside';
+    const time = Number(event.detail?.time);
+    const previousBest = knownBestTimes.get(trackId) ?? Infinity;
+    const currentBest = getStoredBestReplayLap(trackId);
+    const isNewBest = Number.isFinite(time)
+      && time < previousBest - PB_EPSILON
+      && currentBest
+      && Math.abs(currentBest.time - time) <= 0.002;
+    knownBestTimes.set(trackId, currentBest?.time ?? previousBest);
+    syncTrackShareButtons();
+
+    if (!toastShare) return;
+    toastShare.dataset.trackId = trackId;
+    toastShare.hidden = !isNewBest;
+    toast?.classList.toggle('has-yourturn-share', Boolean(isNewBest));
+  });
+
+  window.addEventListener('turn:ui-state-change', (event) => {
+    if (!event.detail?.running || event.detail?.reason === 'race-reset') {
+      if (toastShare) toastShare.hidden = true;
+      toast?.classList.remove('has-yourturn-share');
+    }
+  });
+
+  syncTrackShareButtons();
+
+  const api = Object.freeze({
+    dialog,
+    openForTrack(trackId, trigger = null) {
+      return openComposer(trackId, getStoredBestReplayLap(trackId), trigger);
+    },
+    sync: syncTrackShareButtons
+  });
+  globalThis[INSTALL_FLAG] = api;
+  globalThis.__turnYourTurnShare = api;
+  document.documentElement.dataset.turnYourTurnShare = 'r1';
+  return api;
+}
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}

--- a/yourturn/index.html
+++ b/yourturn/index.html
@@ -45,14 +45,14 @@
   <link rel="stylesheet" href="/yourturn/growing-challenge.css?revision=r2">
   <link rel="stylesheet" href="/yourturn/about-links.css?revision=r1">
 
-  <script src="/yourturn/storage-bootstrap.js?revision=r1"></script>
+  <script src="/yourturn/storage-bootstrap.js?revision=r2"></script>
   <script type="importmap">
     {
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/yourturn/session.js?revision=r3": "/yourturn/session.js?revision=r6",
-        "/yourturn/ui.js?revision=r3": "/yourturn/ui.js?revision=r9",
+        "/yourturn/ui.js?revision=r3": "/yourturn/ui.js?revision=r10",
         "/yourturn/protocol.js?revision=r3": "/yourturn/protocol-social.js?revision=r1",
         "/yourturn/scene.js?revision=r1": "/yourturn/scene.js?revision=r7"
       }

--- a/yourturn/storage-bootstrap.js
+++ b/yourturn/storage-bootstrap.js
@@ -34,6 +34,24 @@
       key: proto.key
     });
 
+    // YOUR TURN isolates gameplay records, but the lightweight social racer
+    // profile intentionally belongs to TURN as a whole. Expose a tiny raw local
+    // storage bridge before patching Storage so /turn and /yourturn can share
+    // that convenience identity when they happen to run in the same browser
+    // storage context. Cross-browser/webview identity still relies on explicit
+    // player confirmation in the challenge UI.
+    globalThis.__TURN_SHARED_LOCAL_STORAGE__ = Object.freeze({
+      getItem(key) {
+        return native.getItem.call(localStorageRef, String(key));
+      },
+      setItem(key, value) {
+        return native.setItem.call(localStorageRef, String(key), String(value));
+      },
+      removeItem(key) {
+        return native.removeItem.call(localStorageRef, String(key));
+      }
+    });
+
     function prefixFor(storage) {
       if (storage === localStorageRef) return LOCAL_PREFIX;
       if (storage === sessionStorageRef) return SESSION_PREFIX;

--- a/yourturn/storage-bootstrap.js
+++ b/yourturn/storage-bootstrap.js
@@ -2,6 +2,10 @@
   const LOCAL_PREFIX = 'yourturn:';
   const SESSION_PREFIX = 'yourturn-session:';
   const PATCH_MARKER = Symbol.for('yourturn.storage.patch');
+  const SHARED_RACER_ID_KEY = 'turn-social-racer-id-v1';
+  const SHARED_RACER_NAME_KEY = 'turn-social-racer-name-v1';
+  const LEGACY_RACER_ID_KEY = `${LOCAL_PREFIX}yourturn-racer-id-v1`;
+  const LEGACY_RACER_NAME_KEY = `${LOCAL_PREFIX}yourturn-player-name-v1`;
 
   function fail(error) {
     console.error('YOUR TURN: isolated storage could not be established.', error);
@@ -33,6 +37,23 @@
       clear: proto.clear,
       key: proto.key
     });
+
+    // Migrate the earlier YOUR TURN-only identity into the shared social profile,
+    // then mirror the shared racer ID back into the old namespaced key so the
+    // existing session code starts with the same identity before any UI is shown.
+    const sharedRacerId = native.getItem.call(localStorageRef, SHARED_RACER_ID_KEY);
+    const legacyRacerId = native.getItem.call(localStorageRef, LEGACY_RACER_ID_KEY);
+    if (!sharedRacerId && legacyRacerId) {
+      native.setItem.call(localStorageRef, SHARED_RACER_ID_KEY, legacyRacerId);
+    } else if (sharedRacerId && sharedRacerId !== legacyRacerId) {
+      native.setItem.call(localStorageRef, LEGACY_RACER_ID_KEY, sharedRacerId);
+    }
+
+    const sharedRacerName = native.getItem.call(localStorageRef, SHARED_RACER_NAME_KEY);
+    const legacyRacerName = native.getItem.call(localStorageRef, LEGACY_RACER_NAME_KEY);
+    if (!sharedRacerName && legacyRacerName) {
+      native.setItem.call(localStorageRef, SHARED_RACER_NAME_KEY, legacyRacerName);
+    }
 
     // YOUR TURN isolates gameplay records, but the lightweight social racer
     // profile intentionally belongs to TURN as a whole. Expose a tiny raw local

--- a/yourturn/storage-bootstrap.js
+++ b/yourturn/storage-bootstrap.js
@@ -24,6 +24,12 @@
     else render();
   }
 
+  function createRacerId() {
+    const random = globalThis.crypto?.randomUUID?.()
+      || `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 12)}`;
+    return `r-${String(random).toLowerCase().replace(/[^a-z0-9_-]/g, '').slice(0, 60)}`;
+  }
+
   try {
     const localStorageRef = window.localStorage;
     const sessionStorageRef = window.sessionStorage;
@@ -38,16 +44,15 @@
       key: proto.key
     });
 
-    // Migrate the earlier YOUR TURN-only identity into the shared social profile,
-    // then mirror the shared racer ID back into the old namespaced key so the
-    // existing session code starts with the same identity before any UI is shown.
+    // Migrate the earlier YOUR TURN-only identity into the shared social profile.
+    // If this browser has never participated before, create the ID here so both
+    // the existing YOUR TURN session code and the new TURN social profile start
+    // with exactly the same racer identity before any UI or replay colours load.
     const sharedRacerId = native.getItem.call(localStorageRef, SHARED_RACER_ID_KEY);
     const legacyRacerId = native.getItem.call(localStorageRef, LEGACY_RACER_ID_KEY);
-    if (!sharedRacerId && legacyRacerId) {
-      native.setItem.call(localStorageRef, SHARED_RACER_ID_KEY, legacyRacerId);
-    } else if (sharedRacerId && sharedRacerId !== legacyRacerId) {
-      native.setItem.call(localStorageRef, LEGACY_RACER_ID_KEY, sharedRacerId);
-    }
+    const effectiveRacerId = sharedRacerId || legacyRacerId || createRacerId();
+    native.setItem.call(localStorageRef, SHARED_RACER_ID_KEY, effectiveRacerId);
+    native.setItem.call(localStorageRef, LEGACY_RACER_ID_KEY, effectiveRacerId);
 
     const sharedRacerName = native.getItem.call(localStorageRef, SHARED_RACER_NAME_KEY);
     const legacyRacerName = native.getItem.call(localStorageRef, LEGACY_RACER_NAME_KEY);

--- a/yourturn/ui.js
+++ b/yourturn/ui.js
@@ -1,9 +1,10 @@
 import { aboutTurnHtml as sharedAboutTurnHtml } from '/turn/content/about-turn.js?revision=r1';
 import {
+  adoptSocialRacerIdentity,
   loadSocialRacerProfile,
   saveSocialRacerName
 } from '/turn/social/racer-profile.js?revision=r1';
-import { normalizeChallengeName } from '/yourturn/protocol.js?revision=r3';
+import { formatChallengeTime, normalizeChallengeName } from '/yourturn/protocol.js?revision=r3';
 
 const NAME_REQUIRED_MESSAGE = 'Write your name before sharing.';
 const PAUSE_ICON = `
@@ -50,19 +51,21 @@ export function createYourTurnUi() {
     if (status.textContent === NAME_REQUIRED_MESSAGE) status.textContent = '';
   });
 
-  function showModal({
-    kickerText = 'YOUR TURN',
-    titleText,
-    detailsHtml = '',
-    copyHtml = '',
-    extraHtml = '',
-    actionList = [],
-    requestName = false,
-    nameValue = null,
-    focusName = false,
-    className = '',
-    motionControl = false
-  }) {
+  function showModal(config) {
+    const {
+      kickerText = 'YOUR TURN',
+      titleText,
+      detailsHtml = '',
+      copyHtml = '',
+      extraHtml = '',
+      actionList = [],
+      requestName = false,
+      nameValue = null,
+      focusName = false,
+      className = '',
+      motionControl = false
+    } = config;
+
     kicker.textContent = kickerText;
     title.textContent = titleText;
     details.innerHTML = detailsHtml;
@@ -96,7 +99,10 @@ export function createYourTurnUi() {
       if (action.game) button.classList.add('is-game');
       if (action.back) button.classList.add('is-back');
       button.addEventListener('click', (event) => {
-        if (requestName && action.share && !validateRequestedName()) return;
+        if (requestName && action.share) {
+          if (!validateRequestedName()) return;
+          if (offerExistingRacerClaim({ action, event, returnConfig: config })) return;
+        }
         action.action(event);
       });
       actions.appendChild(button);
@@ -110,6 +116,56 @@ export function createYourTurnUi() {
     } else {
       actions.querySelector('.is-primary, .is-share, button')?.focus();
     }
+  }
+
+  function offerExistingRacerClaim({ action, event, returnConfig }) {
+    const sessionState = globalThis.__yourTurnSession?.getState?.();
+    const challenge = sessionState?.challenge;
+    if (!sessionState || !challenge?.racers?.length) return false;
+
+    const profile = loadSocialRacerProfile();
+    if (profile.id) sessionState.racerId = profile.id;
+    if (challenge.racers.some((racer) => racer.id === sessionState.racerId)) return false;
+
+    const typedName = normalizeChallengeName(nameInput.value, '');
+    const normalizedTyped = typedName.toLocaleUpperCase('en');
+    const matches = challenge.racers.filter((racer) => (
+      normalizeChallengeName(racer.name, '').toLocaleUpperCase('en') === normalizedTyped
+    ));
+    if (!matches.length) return false;
+
+    if (matches.length > 1) {
+      nameInput.setAttribute('aria-invalid', 'true');
+      status.textContent = `${typedName} is already used by more than one car in this challenge. Use another name.`;
+      nameInput.focus();
+      return true;
+    }
+
+    const existing = matches[0];
+    showModal({
+      titleText: `${existing.name} IS ALREADY HERE`,
+      detailsHtml: `<strong>${formatChallengeTime(existing.time)}</strong><span>Earlier ${escapeHtml(existing.name)} car</span>`,
+      copyHtml: `Is that your earlier car? If it is, this share will update ${escapeHtml(existing.name)} instead of adding a duplicate player.`,
+      className: 'identity-claim',
+      actionList: [
+        {
+          label: 'YES, THAT’S ME',
+          share: true,
+          action: () => {
+            sessionState.racerId = existing.id;
+            adoptSocialRacerIdentity({ id: existing.id, name: typedName });
+            nameInput.value = typedName;
+            action.action(event);
+          }
+        },
+        {
+          label: 'NO, USE ANOTHER NAME',
+          navigation: true,
+          action: () => showModal({ ...returnConfig, nameValue: '', focusName: true })
+        }
+      ]
+    });
+    return true;
   }
 
   function validateRequestedName() {

--- a/yourturn/ui.js
+++ b/yourturn/ui.js
@@ -1,7 +1,10 @@
 import { aboutTurnHtml as sharedAboutTurnHtml } from '/turn/content/about-turn.js?revision=r1';
+import {
+  loadSocialRacerProfile,
+  saveSocialRacerName
+} from '/turn/social/racer-profile.js?revision=r1';
 import { normalizeChallengeName } from '/yourturn/protocol.js?revision=r3';
 
-const PLAYER_NAME_KEY = 'yourturn-player-name-v1';
 const NAME_REQUIRED_MESSAGE = 'Write your name before sharing.';
 const PAUSE_ICON = `
   <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
@@ -55,6 +58,8 @@ export function createYourTurnUi() {
     extraHtml = '',
     actionList = [],
     requestName = false,
+    nameValue = null,
+    focusName = false,
     className = '',
     motionControl = false
   }) {
@@ -74,9 +79,8 @@ export function createYourTurnUi() {
     nameInput.required = requestName;
     nameInput.removeAttribute('aria-invalid');
     if (requestName) {
-      // Names are intentionally entered afresh at each share. A stable anonymous
-      // racer ID handles identity; the visible name remains a deliberate message.
-      nameInput.value = '';
+      const rememberedName = loadSocialRacerProfile().name;
+      nameInput.value = nameValue == null ? rememberedName : String(nameValue);
     }
 
     actions.replaceChildren();
@@ -100,7 +104,12 @@ export function createYourTurnUi() {
 
     if (typeof dialog.showModal === 'function' && !dialog.open) dialog.showModal();
     else dialog.setAttribute('open', '');
-    actions.querySelector('.is-primary, .is-share, button')?.focus();
+
+    if (requestName && (focusName || !nameInput.value)) {
+      nameInput.focus();
+    } else {
+      actions.querySelector('.is-primary, .is-share, button')?.focus();
+    }
   }
 
   function validateRequestedName() {
@@ -129,12 +138,17 @@ export function createYourTurnUi() {
   }
 
   function playerName() {
-    const name = normalizeChallengeName(nameInput.value);
-    try {
-      localStorage.setItem(PLAYER_NAME_KEY, name);
-    } catch (_) {}
+    const name = normalizeChallengeName(nameInput.value, '');
+    if (!name) return '';
+    saveSocialRacerName(name);
     nameInput.value = name;
     return name;
+  }
+
+  function setPlayerNameValue(value, { focus = false } = {}) {
+    nameInput.value = normalizeChallengeName(value, '');
+    nameInput.removeAttribute('aria-invalid');
+    if (focus) nameInput.focus();
   }
 
   function setTarget({ opponent, time }) {
@@ -185,6 +199,7 @@ export function createYourTurnUi() {
     closeModal,
     setStatus,
     playerName,
+    setPlayerNameValue,
     setTarget,
     showRaceChrome,
     hideRaceChrome,


### PR DESCRIPTION
## Product change
- adds a round share action to the selected Home track when that track has a shareable personal-best replay
- adds the same share action to the lap-result toast only when the completed lap is a new personal best
- both entry points open one SHARE YOUR TURN composer rather than adding another permanent in-race utility button
- composer shows track, exact car and time; SHARE YOUR TURN is the pink CTA and BACK is navigation orange
- first share asks for a required name; after a player deliberately enters a name it becomes the editable default for later TURN and YOUR TURN shares
- generated seeds use the existing self-contained YOUR TURN social challenge protocol and contain exactly the player’s actual stored best replay

## Identity model
- introduces a small shared social racer profile: stable racer ID + last display name only
- YOUR TURN keeps its gameplay/local records namespaced and isolated
- when TURN and YOUR TURN happen to share one browser storage context, YOUR TURN migrates its previous local racer identity into the shared profile before the session starts
- no cross-browser identity is assumed: if a returned challenge is opened in another Safari/webview/app context and the typed name already exists in the chain, YOUR TURN explicitly asks whether that earlier car is the player’s
- confirming “YES, THAT’S ME” adopts that racer ID so a better run replaces the earlier car; “NO, USE ANOTHER NAME” returns to name entry

## Race/runtime safety
- exposes the persisted best replay separately from the existing best-time summary; old summary-only Countryside records remain visible but are deliberately not shareable without replay frames
- generalizes the existing covered-rendering guard with a `turn-runtime-paused` lifecycle class
- opening the composer from a live race hard-pauses renderer/physics/replays, silences current audio, and excludes modal/share time from the active lap clock before resuming
- waits for the sharing stylesheet before wrapping Home track cards, so a failed/slow stylesheet cannot momentarily break the established track grid
- preserves existing Home, Lot, race and YOUR TURN gameplay boundaries

## QA
- TURN challenge regression: passed on final head
- TURN regression suite: passed on final head
- TURN admin unlock regression: passed on final head
- adds a focused TURN → YOUR TURN sharing regression covering seed creation, PB-only exposure, required/remembered names, storage isolation/migration, returned-racer confirmation, modal hard pause and UI semantics
- extends the challenge workflow to cover production TURN social sharing files and the production TURN entry point
- updates the existing covered-rendering and YOUR TURN start-grid regressions for the intentional new pause/name behavior

No challenge inbox/import into installed TURN is added in this iteration; the shared racer ID and existing challenge `chainId` are retained specifically so that can be added later without changing the social protocol again.