### PR TITLE
Add Cloudflare Worker for short YOUR TURN challenges

### DIFF
--- a/.github/workflows/turn-challenge-worker-tests.yml
+++ b/.github/workflows/turn-challenge-worker-tests.yml
@@ -1,0 +1,43 @@
+name: TURN challenge Worker
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'workers/turn-challenges/**'
+      - '.github/workflows/turn-challenge-worker-tests.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'workers/turn-challenges/**'
+      - '.github/workflows/turn-challenge-worker-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  worker:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: workers/turn-challenges
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Install Worker tooling
+        run: npm install --ignore-scripts
+
+      - name: Run Worker contract tests
+        run: npm run check
+
+      - name: Validate Cloudflare bundle
+        run: npx wrangler deploy --dry-run --outdir .wrangler-dry-run

--- a/workers/turn-challenges/README.md
+++ b/workers/turn-challenges/README.md
@@ -1,0 +1,75 @@
+# TURN challenge snapshot Worker
+
+This is the deliberately small server component for short YOUR TURN links.
+
+It does one thing: store an immutable encoded YOUR TURN challenge snapshot behind a short opaque ID and return that same snapshot later.
+
+TURN and YOUR TURN are **not connected to this Worker yet**. Until the frontend integration lands, production sharing keeps using the existing self-contained challenge links.
+
+## API
+
+- `GET /health` — deployment/binding health check.
+- `POST /v1/challenges` — accepts `{ "payload": "gz.…" }` from `https://enkel.design`, validates the YOUR TURN v2 wire payload, stores it, and returns a 12-character ID.
+- `GET /v1/challenges/:id` — returns the immutable encoded challenge snapshot.
+
+There is intentionally no update, delete, account, session, leaderboard, or synchronization API. Two people who grow the same seed still create two independent challenge branches.
+
+## Storage and safety boundaries
+
+- D1 binding: `DB`.
+- The table is created lazily with `CREATE TABLE IF NOT EXISTS` so first deployment does not require a separate migration step.
+- Exact duplicate payloads reuse the same snapshot ID; different challenge generations get different immutable snapshots.
+- Browser writes are accepted only with an `Origin` of `https://enkel.design` (or `https://www.enkel.design`). This is a browser-origin guard, not an authentication system.
+- Request and decompressed-payload limits protect the tiny store from accidental oversized writes.
+- The Worker decompresses and structurally validates the current YOUR TURN v2 wire format before storing anything.
+
+## Cloudflare dashboard setup
+
+Cloudflare Workers Builds can deploy this project directly from the existing `enkeldesign/webb` repository.
+
+1. Open **Workers & Pages** → **Create application** → **Import a repository**.
+2. Connect the GitHub account and choose `enkeldesign/webb`.
+3. Worker/project name: **`turn-challenges`**. This must match `wrangler.jsonc`.
+4. Production branch: **`main`**.
+5. Root directory: **`workers/turn-challenges`**.
+6. Leave the optional build command empty.
+7. Leave the deploy command at its default: **`npx wrangler deploy`**.
+8. Save and deploy.
+
+The Wrangler config declares a draft D1 binding with only `"binding": "DB"`. Wrangler 4.45+ supports automatic resource provisioning for D1 and should create/link the database during deployment.
+
+If Cloudflare's automatic D1 provisioning does not complete, do not improvise another architecture. Create one D1 database in the dashboard and bind it to the Worker as variable **`DB`**, then redeploy. No schema SQL needs to be entered manually because the Worker initializes its one table lazily.
+
+After deployment, open the generated `*.workers.dev/health` endpoint. A ready deployment returns JSON containing:
+
+```json
+{
+  "ok": true,
+  "service": "turn-challenges",
+  "version": 1,
+  "databaseBound": true
+}
+```
+
+Give the resulting public Worker base URL to the TURN frontend integration, for example:
+
+```text
+https://turn-challenges.<account-subdomain>.workers.dev
+```
+
+The Worker URL is public configuration, not a secret.
+
+## Local checks
+
+Requires Node 24+ for the same web-platform primitives used by the Worker tests.
+
+```sh
+npm test
+```
+
+Wrangler is only required for local Cloudflare development/deployment:
+
+```sh
+npm install
+npm run dev
+```

--- a/workers/turn-challenges/package.json
+++ b/workers/turn-challenges/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "turn-challenges-worker",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "check": "node --check src/index.js && node --test test/*.test.js",
+    "test": "node --test test/*.test.js",
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "wrangler": "^4.45.0"
+  }
+}

--- a/workers/turn-challenges/src/index.js
+++ b/workers/turn-challenges/src/index.js
@@ -1,0 +1,389 @@
+const API_VERSION = 1;
+const MAX_REQUEST_BYTES = 64 * 1024;
+const MAX_ENCODED_BYTES = 48 * 1024;
+const MAX_DECODED_BYTES = 256 * 1024;
+const MAX_RACERS = 4;
+const MIN_FRAMES = 21;
+const MAX_FRAMES = 120;
+const ID_LENGTH = 12;
+const ID_ALPHABET = '0123456789abcdefghjkmnpqrstvwxyz';
+const ID_PATTERN = /^[0123456789abcdefghjkmnpqrstvwxyz]{12}$/;
+const ALLOWED_WRITE_ORIGINS = new Set([
+  'https://enkel.design',
+  'https://www.enkel.design'
+]);
+
+const initializedDatabases = new WeakSet();
+
+class ApiError extends Error {
+  constructor(status, code, message) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export default {
+  fetch(request, env) {
+    return handleRequest(request, env);
+  }
+};
+
+export async function handleRequest(request, env = {}) {
+  try {
+    const url = new URL(request.url);
+    const path = url.pathname.replace(/\/+$/, '') || '/';
+
+    if (request.method === 'OPTIONS') {
+      return new Response(null, {
+        status: 204,
+        headers: corsHeaders(request)
+      });
+    }
+
+    if (path === '/' && request.method === 'GET') {
+      return jsonResponse({
+        service: 'turn-challenges',
+        version: API_VERSION,
+        purpose: 'Immutable YOUR TURN challenge snapshots'
+      }, 200, request);
+    }
+
+    if (path === '/health' && request.method === 'GET') {
+      return jsonResponse({
+        ok: true,
+        service: 'turn-challenges',
+        version: API_VERSION,
+        databaseBound: Boolean(env.DB)
+      }, 200, request, { 'Cache-Control': 'no-store' });
+    }
+
+    if (path === '/v1/challenges' && request.method === 'POST') {
+      requireAllowedWriteOrigin(request);
+      requireJsonRequest(request);
+      const bodyText = await readTextWithLimit(request, MAX_REQUEST_BYTES);
+      let body;
+      try {
+        body = JSON.parse(bodyText);
+      } catch (_) {
+        throw new ApiError(400, 'invalid_json', 'Request body must be valid JSON.');
+      }
+
+      const payload = typeof body?.payload === 'string' ? body.payload.trim() : '';
+      await validateEncodedChallenge(payload);
+      const saved = await saveSnapshot(env.DB, payload);
+      return jsonResponse({
+        id: saved.id,
+        created: saved.created,
+        createdAt: saved.createdAt
+      }, saved.created ? 201 : 200, request, {
+        'Cache-Control': 'no-store'
+      });
+    }
+
+    const challengeMatch = path.match(/^\/v1\/challenges\/([0123456789abcdefghjkmnpqrstvwxyz]{12})$/);
+    if (challengeMatch && request.method === 'GET') {
+      const snapshot = await loadSnapshot(env.DB, challengeMatch[1]);
+      if (!snapshot) {
+        throw new ApiError(404, 'challenge_not_found', 'Challenge not found.');
+      }
+      return jsonResponse({
+        id: challengeMatch[1],
+        payload: snapshot.payload,
+        createdAt: snapshot.createdAt
+      }, 200, request, {
+        'Cache-Control': 'public, max-age=31536000, immutable'
+      });
+    }
+
+    if (path === '/v1/challenges' || path.startsWith('/v1/challenges/')) {
+      throw new ApiError(405, 'method_not_allowed', 'This challenge endpoint does not support that method.');
+    }
+
+    throw new ApiError(404, 'not_found', 'Endpoint not found.');
+  } catch (error) {
+    if (error instanceof ApiError) {
+      return jsonResponse({ error: error.code, message: error.message }, error.status, request, {
+        'Cache-Control': 'no-store'
+      });
+    }
+    console.error('TURN challenge Worker error', error);
+    return jsonResponse({
+      error: 'internal_error',
+      message: 'The challenge service could not complete the request.'
+    }, 500, request, { 'Cache-Control': 'no-store' });
+  }
+}
+
+export async function validateEncodedChallenge(payload) {
+  if (!payload) {
+    throw new ApiError(422, 'invalid_challenge', 'A challenge payload is required.');
+  }
+  if (byteLength(payload) > MAX_ENCODED_BYTES) {
+    throw new ApiError(413, 'challenge_too_large', 'Challenge payload is too large.');
+  }
+
+  const separator = payload.indexOf('.');
+  if (separator <= 0) {
+    throw new ApiError(422, 'invalid_challenge', 'Challenge payload has no supported encoding.');
+  }
+
+  const encoding = payload.slice(0, separator);
+  if (encoding !== 'gz' && encoding !== 'raw') {
+    throw new ApiError(422, 'invalid_challenge', 'Challenge payload uses an unsupported encoding.');
+  }
+
+  let bytes;
+  try {
+    bytes = base64UrlToBytes(payload.slice(separator + 1));
+  } catch (_) {
+    throw new ApiError(422, 'invalid_challenge', 'Challenge payload is not valid base64url data.');
+  }
+
+  if (encoding === 'gz') {
+    try {
+      bytes = await decompressGzipWithLimit(bytes, MAX_DECODED_BYTES);
+    } catch (error) {
+      if (error instanceof ApiError) throw error;
+      throw new ApiError(422, 'invalid_challenge', 'Challenge payload could not be decompressed.');
+    }
+  } else if (bytes.byteLength > MAX_DECODED_BYTES) {
+    throw new ApiError(413, 'challenge_too_large', 'Decoded challenge payload is too large.');
+  }
+
+  let wire;
+  try {
+    wire = JSON.parse(new TextDecoder().decode(bytes));
+  } catch (_) {
+    throw new ApiError(422, 'invalid_challenge', 'Challenge payload does not contain valid JSON.');
+  }
+
+  if (!isValidWireV2(wire)) {
+    throw new ApiError(422, 'invalid_challenge', 'Challenge payload is not a valid YOUR TURN v2 challenge.');
+  }
+  return true;
+}
+
+async function saveSnapshot(db, payload) {
+  await ensureSchema(db);
+  const hash = await sha256Hex(payload);
+  const existing = await db
+    .prepare('SELECT id, created_at FROM challenges WHERE payload_sha256 = ?1 LIMIT 1')
+    .bind(hash)
+    .first();
+  if (existing?.id) {
+    return {
+      id: String(existing.id),
+      createdAt: Number(existing.created_at) || 0,
+      created: false
+    };
+  }
+
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const id = createSnapshotId();
+    const createdAt = Date.now();
+    try {
+      await db
+        .prepare('INSERT INTO challenges (id, payload, payload_sha256, created_at) VALUES (?1, ?2, ?3, ?4)')
+        .bind(id, payload, hash, createdAt)
+        .run();
+      return { id, createdAt, created: true };
+    } catch (_) {
+      const duplicate = await db
+        .prepare('SELECT id, created_at FROM challenges WHERE payload_sha256 = ?1 LIMIT 1')
+        .bind(hash)
+        .first();
+      if (duplicate?.id) {
+        return {
+          id: String(duplicate.id),
+          createdAt: Number(duplicate.created_at) || 0,
+          created: false
+        };
+      }
+    }
+  }
+
+  throw new ApiError(503, 'id_generation_failed', 'Could not allocate a challenge ID. Try sharing again.');
+}
+
+async function loadSnapshot(db, id) {
+  if (!ID_PATTERN.test(id)) return null;
+  await ensureSchema(db);
+  const row = await db
+    .prepare('SELECT payload, created_at FROM challenges WHERE id = ?1 LIMIT 1')
+    .bind(id)
+    .first();
+  if (!row?.payload) return null;
+  return {
+    payload: String(row.payload),
+    createdAt: Number(row.created_at) || 0
+  };
+}
+
+async function ensureSchema(db) {
+  if (!db || typeof db.prepare !== 'function') {
+    throw new ApiError(503, 'database_unavailable', 'Challenge storage is not connected yet.');
+  }
+  if (initializedDatabases.has(db)) return;
+  await db.prepare(`
+    CREATE TABLE IF NOT EXISTS challenges (
+      id TEXT PRIMARY KEY NOT NULL,
+      payload TEXT NOT NULL,
+      payload_sha256 TEXT NOT NULL UNIQUE,
+      created_at INTEGER NOT NULL
+    )
+  `).run();
+  initializedDatabases.add(db);
+}
+
+function requireAllowedWriteOrigin(request) {
+  const origin = request.headers.get('Origin') || '';
+  if (!ALLOWED_WRITE_ORIGINS.has(origin)) {
+    throw new ApiError(403, 'origin_not_allowed', 'Challenge creation is only accepted from TURN on enkel.design.');
+  }
+}
+
+function requireJsonRequest(request) {
+  const contentType = request.headers.get('Content-Type') || '';
+  if (!contentType.toLowerCase().startsWith('application/json')) {
+    throw new ApiError(415, 'unsupported_media_type', 'Challenge creation requires application/json.');
+  }
+}
+
+function isValidWireV2(wire) {
+  if (!wire || typeof wire !== 'object' || Array.isArray(wire)) return false;
+  if (wire.w !== 2 || wire.v !== 2) return false;
+  if (!validIdentifier(wire.id, 64) || !validIdentifier(wire.s, 64)) return false;
+  if (!validText(wire.ti, 64) || !validText(wire.c, 64)) return false;
+  if (!Number.isInteger(wire.o) || wire.o < 2 || wire.o > 1000) return false;
+  if (!Array.isArray(wire.rs) || wire.rs.length < 1 || wire.rs.length > MAX_RACERS) return false;
+  if (!wire.rs.every(isValidRacerRow)) return false;
+  const racerIds = new Set(wire.rs.map((row) => row[0]));
+  if (!racerIds.has(wire.s)) return false;
+  if (wire.pc != null && !validHex(wire.pc)) return false;
+  if (wire.sc != null && !validHex(wire.sc)) return false;
+  return true;
+}
+
+function isValidRacerRow(row) {
+  if (!Array.isArray(row) || row.length < 5) return false;
+  const [id, name, timeMs, frames, order] = row;
+  if (!validIdentifier(id, 64)) return false;
+  if (!validText(name, 24)) return false;
+  if (!Number.isInteger(timeMs) || timeMs <= 5000 || timeMs > 3_600_000) return false;
+  if (!Number.isInteger(order) || order < 1 || order > 999) return false;
+  if (!Array.isArray(frames) || frames.length < MIN_FRAMES || frames.length > MAX_FRAMES) return false;
+  return frames.every((frame) => (
+    Array.isArray(frame)
+    && frame.length >= 7
+    && frame.slice(0, 7).every((value) => Number.isInteger(value) && Number.isSafeInteger(value))
+  ));
+}
+
+function validIdentifier(value, maxLength) {
+  return typeof value === 'string'
+    && value.length >= 1
+    && value.length <= maxLength
+    && /^[a-z0-9_-]+$/.test(value);
+}
+
+function validText(value, maxLength) {
+  return typeof value === 'string'
+    && value.trim().length >= 1
+    && value.length <= maxLength
+    && !/[\u0000-\u001f\u007f]/.test(value);
+}
+
+function validHex(value) {
+  return typeof value === 'string' && /^#[0-9a-fA-F]{6}$/.test(value);
+}
+
+function createSnapshotId() {
+  const bytes = new Uint8Array(ID_LENGTH);
+  crypto.getRandomValues(bytes);
+  let id = '';
+  for (const byte of bytes) id += ID_ALPHABET[byte & 31];
+  return id;
+}
+
+async function sha256Hex(value) {
+  const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value)));
+  return [...digest].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+async function readTextWithLimit(request, limit) {
+  const declaredLength = Number(request.headers.get('Content-Length'));
+  if (Number.isFinite(declaredLength) && declaredLength > limit) {
+    throw new ApiError(413, 'request_too_large', 'Request body is too large.');
+  }
+  if (!request.body) return '';
+  const bytes = await readStreamWithLimit(request.body, limit, 'request_too_large', 'Request body is too large.');
+  return new TextDecoder().decode(bytes);
+}
+
+async function decompressGzipWithLimit(bytes, limit) {
+  const source = new Response(bytes).body;
+  if (!source) throw new Error('No decompression source stream.');
+  const decompressed = source.pipeThrough(new DecompressionStream('gzip'));
+  return readStreamWithLimit(decompressed, limit, 'challenge_too_large', 'Decoded challenge payload is too large.');
+}
+
+async function readStreamWithLimit(stream, limit, code, message) {
+  const reader = stream.getReader();
+  const chunks = [];
+  let total = 0;
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > limit) {
+      await reader.cancel();
+      throw new ApiError(413, code, message);
+    }
+    chunks.push(value);
+  }
+  const output = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return output;
+}
+
+function base64UrlToBytes(value) {
+  if (!value || !/^[A-Za-z0-9_-]+$/.test(value)) throw new Error('Invalid base64url.');
+  const base64 = value.replaceAll('-', '+').replaceAll('_', '/');
+  const padded = base64 + '='.repeat((4 - base64.length % 4) % 4);
+  const binary = atob(padded);
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+}
+
+function byteLength(value) {
+  return new TextEncoder().encode(String(value)).byteLength;
+}
+
+function corsHeaders(request) {
+  const origin = request.headers.get('Origin') || '';
+  const allowOrigin = ALLOWED_WRITE_ORIGINS.has(origin) ? origin : '*';
+  return {
+    'Access-Control-Allow-Origin': allowOrigin,
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Max-Age': '86400',
+    'Vary': 'Origin'
+  };
+}
+
+function jsonResponse(value, status, request, extraHeaders = {}) {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: {
+      ...corsHeaders(request),
+      'Content-Type': 'application/json; charset=utf-8',
+      'X-Content-Type-Options': 'nosniff',
+      ...extraHeaders
+    }
+  });
+}

--- a/workers/turn-challenges/test/worker.test.js
+++ b/workers/turn-challenges/test/worker.test.js
@@ -1,0 +1,179 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { handleRequest, validateEncodedChallenge } from '../src/index.js';
+
+const ORIGIN = 'https://enkel.design';
+
+class FakeD1 {
+  constructor() {
+    this.rows = new Map();
+    this.byHash = new Map();
+  }
+
+  prepare(sql) {
+    return new FakeStatement(this, sql);
+  }
+}
+
+class FakeStatement {
+  constructor(db, sql) {
+    this.db = db;
+    this.sql = sql.replace(/\s+/g, ' ').trim();
+    this.values = [];
+  }
+
+  bind(...values) {
+    this.values = values;
+    return this;
+  }
+
+  async run() {
+    if (this.sql.startsWith('CREATE TABLE IF NOT EXISTS challenges')) {
+      return { success: true, meta: { changes: 0 } };
+    }
+    if (this.sql.startsWith('INSERT INTO challenges')) {
+      const [id, payload, hash, createdAt] = this.values;
+      if (this.db.rows.has(id) || this.db.byHash.has(hash)) {
+        throw new Error('UNIQUE constraint failed');
+      }
+      const row = { id, payload, payload_sha256: hash, created_at: createdAt };
+      this.db.rows.set(id, row);
+      this.db.byHash.set(hash, row);
+      return { success: true, meta: { changes: 1 } };
+    }
+    throw new Error(`Unexpected D1 run query: ${this.sql}`);
+  }
+
+  async first() {
+    if (this.sql.includes('WHERE payload_sha256 = ?1')) {
+      return this.db.byHash.get(this.values[0]) || null;
+    }
+    if (this.sql.includes('WHERE id = ?1')) {
+      return this.db.rows.get(this.values[0]) || null;
+    }
+    throw new Error(`Unexpected D1 first query: ${this.sql}`);
+  }
+}
+
+function wireChallenge() {
+  const frames = Array.from({ length: 21 }, (_, index) => [
+    index === 0 ? 0 : 800,
+    index === 0 ? 0 : 8,
+    index === 0 ? 0 : 4,
+    index * 10,
+    0,
+    0,
+    index === 0 ? 0 : 50_000
+  ]);
+  return {
+    w: 2,
+    v: 2,
+    id: 'yt-family-chain',
+    s: 'r-erik',
+    o: 2,
+    ti: 'countryside',
+    tr: 'countryside',
+    tn: 'Countryside',
+    c: 'training-car',
+    pc: '#ffcc00',
+    sc: '#f8f9fa',
+    rs: [['r-erik', 'ERIK', 16_388, frames, 1]],
+    r: null
+  };
+}
+
+function rawPayload(wire = wireChallenge()) {
+  return `raw.${Buffer.from(JSON.stringify(wire)).toString('base64url')}`;
+}
+
+async function gzipPayload(wire = wireChallenge()) {
+  const bytes = new TextEncoder().encode(JSON.stringify(wire));
+  const compressed = await new Response(
+    new Response(bytes).body.pipeThrough(new CompressionStream('gzip'))
+  ).arrayBuffer();
+  return `gz.${Buffer.from(compressed).toString('base64url')}`;
+}
+
+function postRequest(payload, { origin = ORIGIN } = {}) {
+  return new Request('https://turn-challenges.example/v1/challenges', {
+    method: 'POST',
+    headers: {
+      Origin: origin,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ payload })
+  });
+}
+
+const db = new FakeD1();
+
+await test('accepts current raw and gzip YOUR TURN v2 payloads', async () => {
+  await assert.doesNotReject(() => validateEncodedChallenge(rawPayload()));
+  await assert.doesNotReject(async () => validateEncodedChallenge(await gzipPayload()));
+});
+
+await test('stores an immutable snapshot and returns a short opaque ID', async () => {
+  const payload = rawPayload();
+  const response = await handleRequest(postRequest(payload), { DB: db });
+  assert.equal(response.status, 201);
+  const body = await response.json();
+  assert.match(body.id, /^[0123456789abcdefghjkmnpqrstvwxyz]{12}$/);
+  assert.equal(body.created, true);
+
+  const read = await handleRequest(
+    new Request(`https://turn-challenges.example/v1/challenges/${body.id}`, {
+      headers: { Origin: ORIGIN }
+    }),
+    { DB: db }
+  );
+  assert.equal(read.status, 200);
+  assert.match(read.headers.get('cache-control'), /immutable/);
+  const snapshot = await read.json();
+  assert.equal(snapshot.payload, payload);
+});
+
+await test('deduplicates the exact same immutable snapshot', async () => {
+  const payload = await gzipPayload();
+  const first = await handleRequest(postRequest(payload), { DB: db });
+  assert.equal(first.status, 201);
+  const firstBody = await first.json();
+
+  const second = await handleRequest(postRequest(payload), { DB: db });
+  assert.equal(second.status, 200);
+  const secondBody = await second.json();
+  assert.equal(secondBody.id, firstBody.id);
+  assert.equal(secondBody.created, false);
+});
+
+await test('rejects browser writes from outside enkel.design', async () => {
+  const response = await handleRequest(postRequest(rawPayload(), { origin: 'https://example.com' }), { DB: db });
+  assert.equal(response.status, 403);
+  assert.equal((await response.json()).error, 'origin_not_allowed');
+});
+
+await test('rejects damaged or structurally invalid challenges', async () => {
+  const damaged = wireChallenge();
+  damaged.rs[0][3] = damaged.rs[0][3].slice(0, 4);
+  const response = await handleRequest(postRequest(rawPayload(damaged)), { DB: db });
+  assert.equal(response.status, 422);
+  assert.equal((await response.json()).error, 'invalid_challenge');
+});
+
+await test('does not expose mutation endpoints for stored snapshots', async () => {
+  const response = await handleRequest(new Request(
+    'https://turn-challenges.example/v1/challenges/0123456789ab',
+    { method: 'PUT', headers: { Origin: ORIGIN } }
+  ), { DB: db });
+  assert.equal(response.status, 405);
+});
+
+await test('health endpoint reports whether D1 is bound without mutating it', async () => {
+  const response = await handleRequest(new Request('https://turn-challenges.example/health'), { DB: db });
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    ok: true,
+    service: 'turn-challenges',
+    version: 1,
+    databaseBound: true
+  });
+});

--- a/workers/turn-challenges/wrangler.jsonc
+++ b/workers/turn-challenges/wrangler.jsonc
@@ -1,0 +1,15 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "turn-challenges",
+  "main": "src/index.js",
+  "compatibility_date": "2026-08-08",
+  "workers_dev": true,
+  "observability": {
+    "enabled": true
+  },
+  "d1_databases": [
+    {
+      "binding": "DB"
+    }
+  ]
+}


### PR DESCRIPTION
## Scope
Adds the isolated Cloudflare backend project for short YOUR TURN challenge links. Production TURN and YOUR TURN are not connected to it in this PR.

## Worker
- immutable challenge snapshot API: POST `/v1/challenges`, GET `/v1/challenges/:id`
- 12-character opaque snapshot IDs
- exact duplicate snapshots reuse the same ID
- D1 storage with lazy one-table initialization, so no manual schema step is required
- current YOUR TURN v2 payloads are decompressed and structurally validated before storage
- request/decompression size limits and an `enkel.design` browser-origin guard
- immutable GET responses are cacheable

## Cloudflare setup
- monorepo project root: `workers/turn-challenges`
- Worker name: `turn-challenges`
- Wrangler 4.45+ draft D1 binding uses Cloudflare automatic resource provisioning
- README contains the exact dashboard import settings and the manual D1-binding fallback if beta provisioning does not complete

## QA
Adds a dedicated GitHub Actions workflow that installs the Worker tooling, runs the contract tests, syntax-checks the source, and asks Wrangler to produce a dry-run bundle/config validation.

The next step after this PR is green/merged is to connect `enkeldesign/webb` from Cloudflare Workers Builds. Only after the deployed `/health` endpoint reports `databaseBound: true` should TURN/YOUR TURN be changed to prefer short snapshot IDs, with the existing self-contained URL retained as fallback.