### PR TITLE
Use short Cloudflare links for YOUR TURN challenges

### DIFF
--- a/.github/workflows/turn-challenge-tests.yml
+++ b/.github/workflows/turn-challenge-tests.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Run TURN to YOUR TURN sharing contract
         run: node turn-tests/yourturn-turn-sharing-production.mjs
 
+      - name: Run YOUR TURN short-link transport regression
+        run: node turn-tests/yourturn-short-links-production.mjs
+
       - name: Run YOUR TURN start-grid and social-preview regression
         run: node turn-tests/yourturn-start-grid-production.mjs
 

--- a/turn-tests/yourturn-production.mjs
+++ b/turn-tests/yourturn-production.mjs
@@ -48,8 +48,8 @@ assert.match(indexSource, /\/yourturn\/storage-bootstrap\.js/);
 assert.match(indexSource, /\/yourturn\/app\.js\?revision=r6/);
 assert.match(indexSource, /growing-challenge\.css/);
 assert.match(indexSource, /racer-labels-bootstrap\.js/);
-assert.match(indexSource, /session\.js\?revision=r3[^\n]*session\.js\?revision=r6/,
-  'The page must cache-bust the new growing-challenge session even though app.js stays canonical');
+assert.match(indexSource, /session\.js\?revision=r3[^\n]*session\.js\?revision=r7/,
+  'The page must cache-bust the short-link growing-challenge session even though app.js stays canonical');
 assert.match(indexSource, /Your name in the challenge/);
 assert.match(indexSource, /id="yourTurnChallengeButton"[\s\S]*>THE CHALLENGE<\/button>/);
 assert.match(indexSource, /Press Gas, Drift or Boost to start the race\./);

--- a/turn-tests/yourturn-short-links-production.mjs
+++ b/turn-tests/yourturn-short-links-production.mjs
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import {
+  CHALLENGE_SNAPSHOT_ID_PATTERN,
+  CHALLENGE_STORE_BASE_URL,
+  loadChallengeSnapshot,
+  makeSelfContainedChallengeUrl,
+  makeShareableChallengeUrl,
+  makeSnapshotChallengeUrl,
+  saveChallengeSnapshot,
+  snapshotIdFromLocation
+} from '../yourturn/challenge-store.js';
+
+const SNAPSHOT_ID = '01abcdeghjkm';
+const PAYLOAD = 'raw.QUJDREVGRw';
+
+assert.equal(CHALLENGE_STORE_BASE_URL, 'https://turn-challenges.erik-jansson-ux.workers.dev');
+assert.ok(CHALLENGE_SNAPSHOT_ID_PATTERN.test(SNAPSHOT_ID));
+assert.equal(
+  snapshotIdFromLocation({ search: `?c=${SNAPSHOT_ID}` }),
+  SNAPSHOT_ID,
+  'Short c= links must be recognized as immutable snapshot IDs'
+);
+assert.equal(
+  snapshotIdFromLocation({ search: '?c=gz.not-a-short-id' }),
+  '',
+  'Legacy self-contained c= payloads must not be mistaken for snapshot IDs'
+);
+
+assert.equal(
+  makeSnapshotChallengeUrl(SNAPSHOT_ID),
+  `https://enkel.design/yourturn/?c=${SNAPSHOT_ID}`,
+  'The public short link must remain on enkel.design and contain no replay payload'
+);
+const fallbackUrl = makeSelfContainedChallengeUrl(PAYLOAD);
+assert.match(fallbackUrl, /^https:\/\/enkel\.design\/yourturn\/\?share=1#challenge=raw\./);
+assert.ok(fallbackUrl.length > makeSnapshotChallengeUrl(SNAPSHOT_ID).length,
+  'The self-contained URL remains available as a longer fallback');
+
+let savedRequest = null;
+const saveFetch = async (url, init) => {
+  savedRequest = { url, init };
+  return new Response(JSON.stringify({ id: SNAPSHOT_ID, created: true }), {
+    status: 201,
+    headers: { 'Content-Type': 'application/json' }
+  });
+};
+assert.equal(
+  await saveChallengeSnapshot(PAYLOAD, { fetchImpl: saveFetch, timeoutMs: 1000 }),
+  SNAPSHOT_ID
+);
+assert.equal(savedRequest.url, `${CHALLENGE_STORE_BASE_URL}/v1/challenges`);
+assert.equal(savedRequest.init.method, 'POST');
+assert.equal(savedRequest.init.credentials, 'omit');
+assert.deepEqual(JSON.parse(savedRequest.init.body), { payload: PAYLOAD });
+
+let loadedRequest = null;
+const loadFetch = async (url, init) => {
+  loadedRequest = { url, init };
+  return new Response(JSON.stringify({ id: SNAPSHOT_ID, payload: PAYLOAD }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' }
+  });
+};
+assert.equal(
+  await loadChallengeSnapshot(SNAPSHOT_ID, { fetchImpl: loadFetch, timeoutMs: 1000 }),
+  PAYLOAD
+);
+assert.equal(loadedRequest.url, `${CHALLENGE_STORE_BASE_URL}/v1/challenges/${SNAPSHOT_ID}`);
+assert.equal(loadedRequest.init.method, 'GET');
+
+const shortPrepared = await makeShareableChallengeUrl(PAYLOAD, {
+  fetchImpl: saveFetch,
+  timeoutMs: 1000
+});
+assert.equal(shortPrepared.usedSnapshot, true);
+assert.equal(shortPrepared.snapshotId, SNAPSHOT_ID);
+assert.equal(shortPrepared.url, `https://enkel.design/yourturn/?c=${SNAPSHOT_ID}`);
+assert.equal(shortPrepared.fallbackUrl, fallbackUrl);
+
+const fallbackPrepared = await makeShareableChallengeUrl(PAYLOAD, {
+  fetchImpl: async () => { throw new TypeError('offline'); },
+  timeoutMs: 1000
+});
+assert.equal(fallbackPrepared.usedSnapshot, false);
+assert.equal(fallbackPrepared.url, fallbackUrl,
+  'A failed Worker write must fall back to the existing self-contained challenge link');
+assert.ok(fallbackPrepared.error instanceof Error);
+
+const [sessionSource, turnShareSource, turnIndex, yourTurnIndex] = await Promise.all([
+  fs.readFile(new URL('../yourturn/session.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/social/your-turn-share.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/index.html', import.meta.url), 'utf8')
+]);
+
+assert.match(sessionSource, /snapshotIdFromLocation/);
+assert.match(sessionSource, /request\.snapshotId[\s\S]*loadChallengeSnapshot\(request\.snapshotId\)/,
+  'YOUR TURN must resolve short IDs through the snapshot service before decoding the challenge');
+assert.match(sessionSource, /makeShareableChallengeUrl\(encoded\)/,
+  'Growing YOUR TURN shares must prefer the short snapshot transport');
+assert.doesNotMatch(sessionSource, /const url = makeChallengeUrl\(encoded\)/,
+  'YOUR TURN must no longer make the long fragment its primary share URL');
+
+assert.match(turnShareSource, /makeShareableChallengeUrl/,
+  'TURN-created seeds must use the same short-link transport');
+assert.match(turnShareSource, /Preparing challenge link…/,
+  'The composer should announce the short-link preparation delay');
+assert.match(turnIndex, /your-turn-share-bootstrap\.js\?revision=r2/,
+  'TURN must cache-bust the short-link sharing bootstrap');
+assert.match(yourTurnIndex, /session\.js\?revision=r3[^\n]*session\.js\?revision=r7/,
+  'YOUR TURN must cache-bust the session that understands short IDs');
+
+console.log('TURN and YOUR TURN short snapshot links, readback and self-contained fallback regression passed.');

--- a/turn-tests/yourturn-short-links-production.mjs
+++ b/turn-tests/yourturn-short-links-production.mjs
@@ -40,7 +40,7 @@ assert.ok(fallbackUrl.length > makeSnapshotChallengeUrl(SNAPSHOT_ID).length,
 let savedRequest = null;
 const saveFetch = async (url, init) => {
   savedRequest = { url, init };
-  return new Response(JSON.stringify({ id: SNAPSHOT_ID, created: true }), {
+  return new globalThis.Response(JSON.stringify({ id: SNAPSHOT_ID, created: true }), {
     status: 201,
     headers: { 'Content-Type': 'application/json' }
   });
@@ -57,7 +57,7 @@ assert.deepEqual(JSON.parse(savedRequest.init.body), { payload: PAYLOAD });
 let loadedRequest = null;
 const loadFetch = async (url, init) => {
   loadedRequest = { url, init };
-  return new Response(JSON.stringify({ id: SNAPSHOT_ID, payload: PAYLOAD }), {
+  return new globalThis.Response(JSON.stringify({ id: SNAPSHOT_ID, payload: PAYLOAD }), {
     status: 200,
     headers: { 'Content-Type': 'application/json' }
   });

--- a/turn-tests/yourturn-turn-sharing-production.mjs
+++ b/turn-tests/yourturn-turn-sharing-production.mjs
@@ -12,7 +12,8 @@ const [
   fixedHome,
   coveredRendering,
   yourTurnIndex,
-  yourTurnUi
+  yourTurnUi,
+  challengeStore
 ] = await Promise.all([
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/social/your-turn-share-bootstrap.js', import.meta.url), 'utf8'),
@@ -24,11 +25,14 @@ const [
   fs.readFile(new URL('../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/render/covered-rendering.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../yourturn/index.html', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../yourturn/ui.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../yourturn/ui.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/challenge-store.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(turnIndex, /\.\/social\/your-turn-share-bootstrap\.js\?revision=r1/,
-  'Production TURN must load the social sharing bootstrap with an explicit cache identity');
+assert.match(turnIndex, /\.\/social\/your-turn-share-bootstrap\.js\?revision=r2/,
+  'Production TURN must load the short-link sharing bootstrap with a fresh cache identity');
+assert.match(shareBootstrap, /your-turn-share\.js\?revision=r2/,
+  'The bootstrap must load the short-link sharing implementation');
 assert.match(shareBootstrap, /globalThis\.__turnHomeLayout\?\.home/,
   'Sharing must wait until all existing fixed-Home enhancements have completed');
 assert.match(shareBootstrap, /installYourTurnShare\(\{ home \}\)/);
@@ -46,11 +50,18 @@ assert.match(rivalStorage, /historical summary-only fallback[\s\S]*oldGhost\?\.b
 
 assert.match(shareSource, /challengeFromLap/);
 assert.match(shareSource, /encodeChallenge/);
-assert.match(shareSource, /makeChallengeUrl/);
+assert.match(shareSource, /makeShareableChallengeUrl/,
+  'TURN seed creation must prefer the short immutable snapshot transport');
+assert.doesNotMatch(shareSource, /makeChallengeUrl/,
+  'TURN should not directly construct the old long URL anymore');
+assert.match(challengeStore, /turn-challenges\.erik-jansson-ux\.workers\.dev/,
+  'The short-link transport must target the deployed Worker');
+assert.match(challengeStore, /makeSelfContainedChallengeUrl/,
+  'The current self-contained challenge URL must remain as the automatic fallback');
 assert.match(shareSource, /getTrackStorageRevision/,
   'Seed challenges must carry the current track revision');
 assert.match(shareSource, /racerId: profile\.id/,
-  'TURN-created seeds must carry the social racer ID in the link payload');
+  'TURN-created seeds must carry the social racer ID in the challenge payload');
 assert.match(shareSource, /SHARE YOUR TURN/);
 assert.match(shareSource, /WRITE YOUR NAME HERE/);
 assert.match(shareSource, /normalizeChallengeName\(input\.value, ''\)/,
@@ -112,4 +123,4 @@ assert.match(yourTurnUi, /adoptSocialRacerIdentity\(\{ id: existing\.id, name: t
 assert.match(yourTurnUi, /challenge\.racers\.some\(\(racer\) => racer\.id === sessionState\.racerId\)/,
   'A recognized racer ID must bypass unnecessary identity confirmation');
 
-console.log('TURN → YOUR TURN seed sharing, remembered names and returning-racer claim regression passed.');
+console.log('TURN → YOUR TURN seed sharing, short transport, remembered names and returning-racer claim regression passed.');

--- a/turn/index.html
+++ b/turn/index.html
@@ -186,6 +186,6 @@
   <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260806-r161-r168-shared-about-credits"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
   <script type="module" src="./app.js?build=20260806-r161-browser-consent-r176-bella-road-derived-zone"></script>
-  <script type="module" src="./social/your-turn-share-bootstrap.js?revision=r1"></script>
+  <script type="module" src="./social/your-turn-share-bootstrap.js?revision=r2"></script>
   <script type="module" src="./tracks/countryside-bella-rescue-hotfix-r176.js?revision=r176-video-proven-rescue"></script>
 </body></html>

--- a/turn/social/your-turn-share-bootstrap.js
+++ b/turn/social/your-turn-share-bootstrap.js
@@ -1,4 +1,4 @@
-import { installYourTurnShare } from './your-turn-share.js?revision=r1';
+import { installYourTurnShare } from './your-turn-share.js?revision=r2';
 
 let started = false;
 

--- a/turn/social/your-turn-share.js
+++ b/turn/social/your-turn-share.js
@@ -6,9 +6,9 @@ import {
   challengeFromLap,
   encodeChallenge,
   formatChallengeTime,
-  makeChallengeUrl,
   normalizeChallengeName
 } from '/yourturn/protocol-social.js?revision=r1';
+import { makeShareableChallengeUrl } from '/yourturn/challenge-store.js?revision=r1';
 import {
   loadSocialRacerProfile,
   saveSocialRacerName
@@ -247,7 +247,10 @@ export async function installYourTurnShare({ home = document.querySelector('.m8-
         lap: activeLap
       });
       const encoded = await encodeChallenge(challenge);
-      const url = makeChallengeUrl(encoded);
+      status.textContent = 'Preparing challenge link…';
+      const prepared = await makeShareableChallengeUrl(encoded);
+      const url = prepared.url;
+      status.textContent = '';
       const shareData = {
         title: `${racerName} sends you YOUR TURN`,
         text: `${racerName} challenges you on ${track?.name || activeTrackId} with ${formatChallengeTime(activeLap.time)}. Your turn.`,
@@ -266,7 +269,9 @@ export async function installYourTurnShare({ home = document.querySelector('.m8-
 
       if (navigator.clipboard?.writeText) {
         await navigator.clipboard.writeText(url);
-        status.textContent = 'Challenge link copied.';
+        status.textContent = prepared.usedSnapshot
+          ? 'Short challenge link copied.'
+          : 'Challenge link copied.';
         return;
       }
 
@@ -364,7 +369,7 @@ export async function installYourTurnShare({ home = document.querySelector('.m8-
   });
   globalThis[INSTALL_FLAG] = api;
   globalThis.__turnYourTurnShare = api;
-  document.documentElement.dataset.turnYourTurnShare = 'r1';
+  document.documentElement.dataset.turnYourTurnShare = 'r2';
   return api;
 }
 

--- a/yourturn/challenge-store.js
+++ b/yourturn/challenge-store.js
@@ -1,5 +1,3 @@
-import { makeChallengeUrl } from '/yourturn/protocol-social.js?revision=r1';
-
 export const CHALLENGE_STORE_BASE_URL = 'https://turn-challenges.erik-jansson-ux.workers.dev';
 export const CHALLENGE_SNAPSHOT_ID_PATTERN = /^[0123456789abcdefghjkmnpqrstvwxyz]{12}$/;
 
@@ -24,9 +22,29 @@ export function makeSnapshotChallengeUrl(snapshotId, {
   url.searchParams.delete('share');
   if (reply) url.searchParams.set('reply', String(reply));
   else url.searchParams.delete('reply');
-  if (responder) url.searchParams.set('responder', String(responder).trim());
+  if (responder) url.searchParams.set('responder', normalizeResponder(responder));
   else url.searchParams.delete('responder');
   url.hash = '';
+  return url.href;
+}
+
+export function makeSelfContainedChallengeUrl(encoded, {
+  baseUrl = DEFAULT_PUBLIC_BASE_URL,
+  reply = '',
+  responder = ''
+} = {}) {
+  const payload = normalizeEncodedPayload(encoded);
+  const url = new URL(baseUrl);
+  url.searchParams.delete('c');
+  url.searchParams.set('share', '1');
+  if (reply) url.searchParams.set('reply', String(reply));
+  else url.searchParams.delete('reply');
+  if (responder) url.searchParams.set('responder', normalizeResponder(responder));
+  else url.searchParams.delete('responder');
+
+  const fragment = new URLSearchParams();
+  fragment.set('challenge', payload);
+  url.hash = fragment.toString();
   return url.href;
 }
 
@@ -95,7 +113,7 @@ export async function makeShareableChallengeUrl(encoded, {
   timeoutMs = DEFAULT_TIMEOUT_MS
 } = {}) {
   const payload = normalizeEncodedPayload(encoded);
-  const fallbackUrl = makeChallengeUrl(payload, { baseUrl, reply, responder });
+  const fallbackUrl = makeSelfContainedChallengeUrl(payload, { baseUrl, reply, responder });
 
   try {
     const snapshotId = await saveChallengeSnapshot(payload, {
@@ -132,6 +150,14 @@ function normalizeEncodedPayload(value) {
     throw new Error('YOUR TURN challenge data is incomplete or damaged.');
   }
   return payload;
+}
+
+function normalizeResponder(value) {
+  return String(value || '')
+    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 24);
 }
 
 function stripTrailingSlash(value) {

--- a/yourturn/challenge-store.js
+++ b/yourturn/challenge-store.js
@@ -1,0 +1,163 @@
+import { makeChallengeUrl } from '/yourturn/protocol-social.js?revision=r1';
+
+export const CHALLENGE_STORE_BASE_URL = 'https://turn-challenges.erik-jansson-ux.workers.dev';
+export const CHALLENGE_SNAPSHOT_ID_PATTERN = /^[0123456789abcdefghjkmnpqrstvwxyz]{12}$/;
+
+const DEFAULT_TIMEOUT_MS = 3500;
+const DEFAULT_PUBLIC_BASE_URL = 'https://enkel.design/yourturn/';
+
+export function snapshotIdFromLocation(locationRef = globalThis.location) {
+  const query = new URLSearchParams(locationRef?.search || '');
+  return normalizeSnapshotId(query.get('c'));
+}
+
+export function makeSnapshotChallengeUrl(snapshotId, {
+  baseUrl = DEFAULT_PUBLIC_BASE_URL,
+  reply = '',
+  responder = ''
+} = {}) {
+  const id = normalizeSnapshotId(snapshotId);
+  if (!id) throw new Error('YOUR TURN received an invalid short challenge ID.');
+
+  const url = new URL(baseUrl);
+  url.searchParams.set('c', id);
+  url.searchParams.delete('share');
+  if (reply) url.searchParams.set('reply', String(reply));
+  else url.searchParams.delete('reply');
+  if (responder) url.searchParams.set('responder', String(responder).trim());
+  else url.searchParams.delete('responder');
+  url.hash = '';
+  return url.href;
+}
+
+export async function saveChallengeSnapshot(encoded, {
+  fetchImpl = globalThis.fetch,
+  serviceBaseUrl = CHALLENGE_STORE_BASE_URL,
+  timeoutMs = DEFAULT_TIMEOUT_MS
+} = {}) {
+  const payload = normalizeEncodedPayload(encoded);
+  if (typeof fetchImpl !== 'function') throw new Error('Challenge storage is unavailable in this browser.');
+
+  const response = await fetchWithTimeout(`${stripTrailingSlash(serviceBaseUrl)}/v1/challenges`, {
+    method: 'POST',
+    mode: 'cors',
+    credentials: 'omit',
+    cache: 'no-store',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    },
+    body: JSON.stringify({ payload })
+  }, { fetchImpl, timeoutMs });
+
+  const body = await readJsonResponse(response);
+  if (!response?.ok) {
+    throw new Error(body?.message || `Challenge storage returned ${response?.status || 'an error'}.`);
+  }
+
+  const id = normalizeSnapshotId(body?.id);
+  if (!id) throw new Error('Challenge storage returned an invalid short ID.');
+  return id;
+}
+
+export async function loadChallengeSnapshot(snapshotId, {
+  fetchImpl = globalThis.fetch,
+  serviceBaseUrl = CHALLENGE_STORE_BASE_URL,
+  timeoutMs = DEFAULT_TIMEOUT_MS
+} = {}) {
+  const id = normalizeSnapshotId(snapshotId);
+  if (!id) throw new Error('This short challenge link is incomplete.');
+  if (typeof fetchImpl !== 'function') throw new Error('This browser cannot load short YOUR TURN links.');
+
+  const response = await fetchWithTimeout(`${stripTrailingSlash(serviceBaseUrl)}/v1/challenges/${id}`, {
+    method: 'GET',
+    mode: 'cors',
+    credentials: 'omit',
+    cache: 'default',
+    headers: { 'Accept': 'application/json' }
+  }, { fetchImpl, timeoutMs });
+
+  const body = await readJsonResponse(response);
+  if (!response?.ok) {
+    if (response?.status === 404) throw new Error('This YOUR TURN challenge could not be found.');
+    throw new Error(body?.message || `The challenge service returned ${response?.status || 'an error'}.`);
+  }
+
+  return normalizeEncodedPayload(body?.payload);
+}
+
+export async function makeShareableChallengeUrl(encoded, {
+  baseUrl = DEFAULT_PUBLIC_BASE_URL,
+  reply = '',
+  responder = '',
+  fetchImpl = globalThis.fetch,
+  serviceBaseUrl = CHALLENGE_STORE_BASE_URL,
+  timeoutMs = DEFAULT_TIMEOUT_MS
+} = {}) {
+  const payload = normalizeEncodedPayload(encoded);
+  const fallbackUrl = makeChallengeUrl(payload, { baseUrl, reply, responder });
+
+  try {
+    const snapshotId = await saveChallengeSnapshot(payload, {
+      fetchImpl,
+      serviceBaseUrl,
+      timeoutMs
+    });
+    return Object.freeze({
+      url: makeSnapshotChallengeUrl(snapshotId, { baseUrl, reply, responder }),
+      snapshotId,
+      usedSnapshot: true,
+      fallbackUrl,
+      error: null
+    });
+  } catch (error) {
+    return Object.freeze({
+      url: fallbackUrl,
+      snapshotId: '',
+      usedSnapshot: false,
+      fallbackUrl,
+      error: error instanceof Error ? error : new Error('Short challenge storage failed.')
+    });
+  }
+}
+
+function normalizeSnapshotId(value) {
+  const id = String(value || '').trim().toLowerCase();
+  return CHALLENGE_SNAPSHOT_ID_PATTERN.test(id) ? id : '';
+}
+
+function normalizeEncodedPayload(value) {
+  const payload = String(value || '').trim();
+  if (!/^(?:gz|raw)\.[A-Za-z0-9_-]+$/.test(payload)) {
+    throw new Error('YOUR TURN challenge data is incomplete or damaged.');
+  }
+  return payload;
+}
+
+function stripTrailingSlash(value) {
+  return String(value || '').replace(/\/+$/g, '');
+}
+
+async function readJsonResponse(response) {
+  try {
+    return await response.json();
+  } catch (_) {
+    return null;
+  }
+}
+
+async function fetchWithTimeout(url, init, { fetchImpl, timeoutMs }) {
+  const duration = Math.max(250, Number(timeoutMs) || DEFAULT_TIMEOUT_MS);
+  if (typeof AbortController !== 'function') return fetchImpl(url, init);
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), duration);
+  try {
+    return await fetchImpl(url, { ...init, signal: controller.signal });
+  } catch (error) {
+    if (error?.name === 'AbortError') throw new Error('Challenge storage took too long to respond.');
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/yourturn/index.html
+++ b/yourturn/index.html
@@ -51,7 +51,7 @@
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
-        "/yourturn/session.js?revision=r3": "/yourturn/session.js?revision=r6",
+        "/yourturn/session.js?revision=r3": "/yourturn/session.js?revision=r7",
         "/yourturn/ui.js?revision=r3": "/yourturn/ui.js?revision=r10",
         "/yourturn/protocol.js?revision=r3": "/yourturn/protocol-social.js?revision=r1",
         "/yourturn/scene.js?revision=r1": "/yourturn/scene.js?revision=r7"

--- a/yourturn/session.js
+++ b/yourturn/session.js
@@ -14,11 +14,15 @@ import {
   encodeChallenge,
   encodedChallengeFromLocation,
   formatChallengeTime,
-  makeChallengeUrl,
   makeMockChallengeUrl,
   normalizeChallenge,
   normalizeChallengeName
 } from '/yourturn/protocol.js?revision=r3';
+import {
+  loadChallengeSnapshot,
+  makeShareableChallengeUrl,
+  snapshotIdFromLocation
+} from '/yourturn/challenge-store.js?revision=r1';
 import { getMockChallenge, MOCK_CHALLENGES } from '/yourturn/mock-challenges.js?revision=r1';
 import { createChallengeScene } from '/yourturn/scene.js?revision=r1';
 import { aboutTurnHtml, escapeHtml, newcomerAssistiveText } from '/yourturn/ui.js?revision=r3';
@@ -28,14 +32,16 @@ const RACER_ID_KEY = 'yourturn-racer-id-v1';
 export function readYourTurnRequest(locationRef = globalThis.location) {
   const query = new URLSearchParams(locationRef?.search || '');
   const mockId = query.get('challenge') || '';
-  const encoded = encodedChallengeFromLocation(locationRef);
+  const snapshotId = snapshotIdFromLocation(locationRef);
+  const encoded = snapshotId ? '' : encodedChallengeFromLocation(locationRef);
   return Object.freeze({
     mockId,
+    snapshotId,
     encoded,
     // Kept only so already-shared r5 give-up links remain understandable.
     reply: query.get('reply') === 'give-up' ? 'give-up' : '',
     responder: normalizeChallengeName(query.get('responder'), 'A TURN PLAYER'),
-    hasChallenge: Boolean(mockId || encoded)
+    hasChallenge: Boolean(mockId || snapshotId || encoded)
   });
 }
 
@@ -124,7 +130,10 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
       return materializeMockChallenge(definition);
     }
 
-    const challenge = await decodeChallenge(request.encoded);
+    const encoded = request.snapshotId
+      ? await loadChallengeSnapshot(request.snapshotId)
+      : request.encoded;
+    const challenge = await decodeChallenge(encoded);
     await activateTrack(challenge.trackId, runtime);
     const currentRevision = getTrackStorageRevision(challenge.trackId);
     if (challenge.trackRevision && challenge.trackRevision !== currentRevision) {
@@ -414,7 +423,10 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
       lap: candidate
     });
     const encoded = await encodeChallenge(nextChallenge);
-    const url = makeChallengeUrl(encoded);
+    ui.setStatus('Preparing challenge link…');
+    const prepared = await makeShareableChallengeUrl(encoded);
+    const url = prepared.url;
+    ui.setStatus('');
     const leader = challengeLeader(nextChallenge);
     const text = nextChallenge.racers.length === 1
       ? `${racerName} challenges you with ${formatChallengeTime(candidate.time)}. Your turn.`
@@ -429,7 +441,10 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
 
   async function shareExistingChallenge() {
     const encoded = await encodeChallenge(state.challenge);
-    const url = makeChallengeUrl(encoded);
+    ui.setStatus('Preparing challenge link…');
+    const prepared = await makeShareableChallengeUrl(encoded);
+    const url = prepared.url;
+    ui.setStatus('');
     const leader = challengeLeader(state.challenge);
     return shareUrl({
       title: 'YOUR TURN — a TURN challenge',


### PR DESCRIPTION
## What changes
- TURN-created YOUR TURN seeds now try to store the existing encoded challenge document in the deployed `turn-challenges` Worker and share a short `https://enkel.design/yourturn/?c=<12-char-id>` URL
- growing shares and pass-through shares inside YOUR TURN use the same short transport
- YOUR TURN recognizes a short `c=` snapshot ID, fetches the immutable payload from the Worker, then decodes/runs the exact existing challenge protocol
- legacy query-encoded links, current `?share=1#challenge=...` links and mock links remain readable

## Failure behavior
- storing a snapshot is deliberately best-effort with a 3.5 s ceiling
- if the Worker write fails or times out, sharing automatically falls back to the current self-contained `?share=1#challenge=...` URL
- no gameplay, replay format, chain identity, racer identity or four-racer cap changes

## Deployed service
Uses the already health-checked Worker at `https://turn-challenges.erik-jansson-ux.workers.dev` with its live D1 binding.

## QA
Final head `304f8280a1002e96347b7f0a76f6e2c79cf03e07` is green:
- TURN challenge regression #45 — passed, including the new short-link transport test
- TURN regression suite #1010 — passed all production checks
- TURN admin unlock regression #42 — passed

The new executable transport regression covers POST, GET, exact short URL shape, short-ID parsing, legacy `c=` discrimination, and automatic long-link fallback.

The intent is specifically to fix the growing-link/iMessage problem without making Cloudflare a hard dependency for creating a challenge.