### PR TITLE
Add private TURN usage statistics and privacy disclosure

### DIFF
--- a/.github/workflows/turn-challenge-tests.yml
+++ b/.github/workflows/turn-challenge-tests.yml
@@ -10,10 +10,16 @@ on:
       - 'yourturn/**'
       - 'turn/index.html'
       - 'turn/social/**'
+      - 'turn/telemetry/**'
+      - 'turn/content/about-turn.js'
+      - 'turn/about-privacy.css'
+      - 'turn/stats/**'
       - 'turn/race/rival-storage.js'
       - 'turn/render/covered-rendering.js'
+      - 'workers/turn-challenges/**'
       - 'turn-tests/challenge-*.mjs'
       - 'turn-tests/yourturn-*.mjs'
+      - 'turn-tests/telemetry-production.mjs'
       - '.github/workflows/turn-challenge-tests.yml'
   push:
     branches:
@@ -23,10 +29,16 @@ on:
       - 'yourturn/**'
       - 'turn/index.html'
       - 'turn/social/**'
+      - 'turn/telemetry/**'
+      - 'turn/content/about-turn.js'
+      - 'turn/about-privacy.css'
+      - 'turn/stats/**'
       - 'turn/race/rival-storage.js'
       - 'turn/render/covered-rendering.js'
+      - 'workers/turn-challenges/**'
       - 'turn-tests/challenge-*.mjs'
       - 'turn-tests/yourturn-*.mjs'
+      - 'turn-tests/telemetry-production.mjs'
       - '.github/workflows/turn-challenge-tests.yml'
 
 permissions:
@@ -47,7 +59,7 @@ jobs:
       - name: Syntax-check challenge modules
         run: |
           find turn-next yourturn -maxdepth 1 -type f -name '*.js' -print0 | xargs -0 -n1 node --check
-          find turn/social -maxdepth 1 -type f -name '*.js' -print0 | xargs -0 -n1 node --check
+          find turn/social turn/telemetry turn/stats -type f -name '*.js' -print0 | xargs -0 -n1 node --check
 
       - name: Run Race My Ghost contract
         run: node turn-tests/challenge-mode-production.mjs
@@ -66,6 +78,9 @@ jobs:
 
       - name: Run YOUR TURN start-grid and social-preview regression
         run: node turn-tests/yourturn-start-grid-production.mjs
+
+      - name: Run private telemetry and privacy contract
+        run: node turn-tests/telemetry-production.mjs
 
       - name: Verify TURN NEXT parity wrapper
         run: node turn-next/scripts/build-parity-app.mjs --check

--- a/turn-tests/telemetry-production.mjs
+++ b/turn-tests/telemetry-production.mjs
@@ -55,8 +55,8 @@ assert.match(statsJs, /location\.hash\.slice\(1\)/,
 assert.match(statsJs, /Authorization: `Bearer \$\{statsKey\}`/);
 assert.doesNotMatch(statsJs, /localStorage|sessionStorage|document\.cookie/i,
   'The private dashboard must not persist its bearer key into browser storage');
-assert.match(statsJs, /mostTrack/);
-assert.match(statsJs, /mostCar/);
+assert.match(statsJs, /renderFavourite\('Track', tracks, races\)/);
+assert.match(statsJs, /renderFavourite\('Car', cars, races\)/);
 assert.match(statsJs, /YOUR TURN play sessions/);
 assert.match(statsJs, /Motion-steered races/);
 assert.match(statsJs, /Drive By Ear races/);

--- a/turn-tests/telemetry-production.mjs
+++ b/turn-tests/telemetry-production.mjs
@@ -1,12 +1,13 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [client, about, privacyCss, statsHtml, statsJs, workerConfig, workerRouter, workerTelemetry] = await Promise.all([
+const [client, about, privacyCss, statsHtml, statsJs, productionIndex, workerConfig, workerRouter, workerTelemetry] = await Promise.all([
   fs.readFile(new URL('../turn/telemetry/client.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/content/about-turn.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/about-privacy.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/stats/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/stats/stats.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../workers/turn-challenges/wrangler.jsonc', import.meta.url), 'utf8'),
   fs.readFile(new URL('../workers/turn-challenges/src/router.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../workers/turn-challenges/src/telemetry.js', import.meta.url), 'utf8')
@@ -47,14 +48,15 @@ assert.match(statsHtml, /<meta name="robots" content="noindex,nofollow,noarchive
 assert.match(statsHtml, /PRIVATE · ENKEL\.DESIGN/);
 assert.match(statsHtml, /PLAY SESSIONS/);
 assert.match(statsHtml, /does not assign a persistent analytics identifier/);
-assert.doesNotMatch(statsHtml, /href=["'][^"']*stats/i,
-  'The private dashboard must not link itself into public game navigation');
+assert.doesNotMatch(productionIndex, /href=["'][^"']*\/turn\/stats|href=["'][^"']*stats\//i,
+  'The private dashboard must not be linked into public TURN navigation');
 assert.match(statsJs, /location\.hash\.slice\(1\)/,
   'The private key must stay in the URL fragment so GitHub Pages never receives it');
 assert.match(statsJs, /Authorization: `Bearer \$\{statsKey\}`/);
 assert.doesNotMatch(statsJs, /localStorage|sessionStorage|document\.cookie/i,
   'The private dashboard must not persist its bearer key into browser storage');
-assert.match(statsJs, /MOST PLAYED|mostTrack|mostCar/);
+assert.match(statsJs, /mostTrack/);
+assert.match(statsJs, /mostCar/);
 assert.match(statsJs, /YOUR TURN play sessions/);
 assert.match(statsJs, /Motion-steered races/);
 assert.match(statsJs, /Drive By Ear races/);

--- a/turn-tests/telemetry-production.mjs
+++ b/turn-tests/telemetry-production.mjs
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const [client, about, privacyCss, statsHtml, statsJs, workerConfig, workerRouter, workerTelemetry] = await Promise.all([
+  fs.readFile(new URL('../turn/telemetry/client.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/content/about-turn.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/about-privacy.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/stats/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/stats/stats.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../workers/turn-challenges/wrangler.jsonc', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../workers/turn-challenges/src/router.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../workers/turn-challenges/src/telemetry.js', import.meta.url), 'utf8')
+]);
+
+assert.match(client, /turn-challenges\.erik-jansson-ux\.workers\.dev\/v1\/telemetry/);
+assert.match(client, /deployment === 'next'/,
+  'TURN NEXT must never pollute production usage statistics');
+assert.match(client, /event\.detail\?\.reason !== 'race-started'/);
+assert.match(client, /queueEvent\('play_session'\)/);
+assert.match(client, /queueEvent\('race_start'\)/);
+assert.match(client, /turn:lap-result/);
+assert.match(client, /queueEvent\('lap_complete'/);
+assert.match(client, /turn:lap-invalid/);
+assert.match(client, /navigator\.sendBeacon/);
+assert.match(client, /keepalive: true/);
+assert.match(client, /credentials: 'omit'/);
+assert.doesNotMatch(client, /localStorage|sessionStorage|document\.cookie|indexedDB/i,
+  'Gameplay telemetry must not create a persistent analytics identifier');
+assert.doesNotMatch(client, /requestAnimationFrame|setInterval|devicemotion|pointermove|mousemove/,
+  'Telemetry must remain event-driven and stay out of the racing/rendering loops');
+
+assert.match(about, /installTurnTelemetry\(\)/);
+assert.match(about, /<details class="turn-about-privacy">/);
+assert.match(about, /<summary>PRIVACY &amp; USAGE STATISTICS<\/summary>/);
+assert.match(about, /no analytics cookie and creates no persistent analytics identifier/i);
+assert.match(about, /does not include your name, challenge name, challenge link or ID, replay, driving path, control inputs/i);
+assert.match(about, /private developer dashboard/i);
+assert.match(about, /about-privacy\.css\?revision=r1/);
+
+assert.match(privacyCss, /\.turn-about-privacy summary[\s\S]*color: inherit[\s\S]*font: inherit/);
+assert.match(privacyCss, /text-decoration: underline/);
+assert.match(privacyCss, /keep the native disclosure marker/i);
+assert.doesNotMatch(privacyCss, /--turn-disclosure-trigger|background:\s*var\(--turn-blue|list-style:\s*none/,
+  'Privacy must stay a quiet native disclosure rather than the salient blue disclosure pattern');
+
+assert.match(statsHtml, /<meta name="robots" content="noindex,nofollow,noarchive">/);
+assert.match(statsHtml, /PRIVATE · ENKEL\.DESIGN/);
+assert.match(statsHtml, /PLAY SESSIONS/);
+assert.match(statsHtml, /does not assign a persistent analytics identifier/);
+assert.doesNotMatch(statsHtml, /href=["'][^"']*stats/i,
+  'The private dashboard must not link itself into public game navigation');
+assert.match(statsJs, /location\.hash\.slice\(1\)/,
+  'The private key must stay in the URL fragment so GitHub Pages never receives it');
+assert.match(statsJs, /Authorization: `Bearer \$\{statsKey\}`/);
+assert.doesNotMatch(statsJs, /localStorage|sessionStorage|document\.cookie/i,
+  'The private dashboard must not persist its bearer key into browser storage');
+assert.match(statsJs, /MOST PLAYED|mostTrack|mostCar/);
+assert.match(statsJs, /YOUR TURN play sessions/);
+assert.match(statsJs, /Motion-steered races/);
+assert.match(statsJs, /Drive By Ear races/);
+
+assert.match(workerConfig, /"main": "src\/router\.js"/);
+assert.match(workerConfig, /"analytics_engine_datasets"/);
+assert.match(workerConfig, /"binding": "ANALYTICS"/);
+assert.match(workerConfig, /"dataset": "turn_gameplay"/);
+assert.match(workerRouter, /handleTelemetryRoute/);
+assert.match(workerTelemetry, /'play_session'[\s\S]*'race_start'[\s\S]*'lap_complete'[\s\S]*'lap_invalid'/);
+assert.match(workerTelemetry, /writeDataPoint/);
+assert.match(workerTelemetry, /const sessionHash = await sha256Hex\(event\.session\)/);
+assert.match(workerTelemetry, /CREATE TABLE IF NOT EXISTS turn_telemetry_daily/);
+assert.doesNotMatch(workerTelemetry, /INSERT INTO turn_telemetry_(?:event|raw|session)|session_hash TEXT|player_id TEXT/i,
+  'D1 must keep daily aggregate usage only, not persistent player/session histories');
+assert.match(workerTelemetry, /Authorization/);
+assert.match(workerTelemetry, /stats_unauthorized/);
+
+console.log('TURN private event-driven telemetry, privacy disclosure and stats dashboard regression passed.');

--- a/turn/about-privacy.css
+++ b/turn/about-privacy.css
@@ -1,0 +1,46 @@
+.turn-about-privacy {
+  margin-top: 10px;
+  color: inherit;
+  font: inherit;
+}
+
+.turn-about-privacy summary {
+  width: fit-content;
+  padding: 2px 0;
+  color: inherit;
+  font: inherit;
+  font-size: 0.8rem;
+  font-weight: 900;
+  line-height: 1.35;
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 0.18em;
+  cursor: pointer;
+}
+
+.turn-about-privacy summary:focus-visible {
+  outline: 4px solid var(--turn-form-control-focus, #38d9ff);
+  outline-offset: 4px;
+  border-radius: 2px;
+}
+
+.turn-about-privacy-copy {
+  max-width: 60ch;
+  margin-top: 8px;
+}
+
+.turn-about-privacy-copy p,
+.yourturn-about-copy .turn-about-privacy-copy p {
+  margin: 0;
+  font-size: 0.78rem !important;
+  font-weight: 760;
+  line-height: 1.42 !important;
+}
+
+.turn-about-privacy-copy p + p,
+.yourturn-about-copy .turn-about-privacy-copy p + p {
+  margin-top: 7px;
+}
+
+/* Intentionally keep the native disclosure marker. Privacy is a quiet text/link
+   disclosure, not TURN's blue informational disclosure component. */

--- a/turn/content/about-turn.js
+++ b/turn/content/about-turn.js
@@ -1,8 +1,22 @@
+import { installTurnTelemetry } from '../telemetry/client.js?revision=r1';
+
+installTurnTelemetry();
+
 export function aboutTurnHtml() {
   return `
     <div class="turn-about-shared-copy yourturn-about-copy">
       <p class="m8-about-lead">TURN is a racing game about tilt steering, personal rivals and learning to drive by ear.</p>
       <p class="m8-about-summary">Built through inclusive and universal design so players can use sight, sound, touch, motion, a keyboard or assistive technology.</p>
       <p class="m8-about-credits">© 2026 <a href="https://enkel.design/" target="_blank" rel="noreferrer">enkel.design</a>. Created by Erik Jansson, aided by OpenAI Codex. Game assets include <a href="https://kenney.nl" target="_blank" rel="noreferrer">Kenney Game Assets</a>. Drive By Ear™ is inspired by <a href="https://ceal.cs.columbia.edu/rad/" target="_blank" rel="noreferrer">RAD – Racing Auditory Display</a>.</p>
+      <details class="turn-about-privacy">
+        <summary>PRIVACY &amp; USAGE STATISTICS</summary>
+        <div class="turn-about-privacy-copy">
+          <p>TURN sends a few anonymous gameplay events to Cloudflare after a race starts so enkel.design can see whether the game is being played, which tracks and cars are used, and where the game may need improvement.</p>
+          <p>The events can include TURN or YOUR TURN, app build, track, car, motion or manual steering, browser or installed web app, Drive By Ear and blank-screen state, valid or void laps and lap time.</p>
+          <p>TURN’s analytics payload does not include your name, challenge name, challenge link or ID, replay, driving path, control inputs, advertising identifiers, IP address or precise location. Cloudflare necessarily handles normal network request information while delivering the service, but TURN does not add that information to its gameplay statistics.</p>
+          <p>TURN sets no analytics cookie and creates no persistent analytics identifier. A random identifier exists only in memory for the current page load so events from that one play session can be grouped; it disappears when the page is closed or reloaded.</p>
+          <p>Raw custom analytics are kept in Cloudflare Analytics Engine for its normal retention period. TURN keeps only anonymous daily totals in D1 for a private developer dashboard. The statistics are not public and are not used for advertising.</p>
+        </div>
+      </details>
     </div>`;
 }

--- a/turn/content/about-turn.js
+++ b/turn/content/about-turn.js
@@ -1,6 +1,16 @@
 import { installTurnTelemetry } from '../telemetry/client.js?revision=r1';
 
 installTurnTelemetry();
+installSharedAboutStyles();
+
+function installSharedAboutStyles() {
+  if (document.querySelector('link[data-turn-about-privacy]')) return;
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = '/turn/about-privacy.css?revision=r1';
+  link.setAttribute('data-turn-about-privacy', '');
+  document.head.appendChild(link);
+}
 
 export function aboutTurnHtml() {
   return `

--- a/turn/content/about-turn.js
+++ b/turn/content/about-turn.js
@@ -23,9 +23,9 @@ export function aboutTurnHtml() {
         <div class="turn-about-privacy-copy">
           <p>TURN sends a few anonymous gameplay events to Cloudflare after a race starts so enkel.design can see whether the game is being played, which tracks and cars are used, and where the game may need improvement.</p>
           <p>The events can include TURN or YOUR TURN, app build, track, car, motion or manual steering, browser or installed web app, Drive By Ear and blank-screen state, valid or void laps and lap time.</p>
-          <p>TURN’s analytics payload does not include your name, challenge name, challenge link or ID, replay, driving path, control inputs, advertising identifiers, IP address or precise location. Cloudflare necessarily handles normal network request information while delivering the service, but TURN does not add that information to its gameplay statistics.</p>
+          <p>TURN’s analytics payload does not include your name, challenge name, challenge link or ID, replay, driving path, control inputs, advertising identifiers, IP address or precise location. Cloudflare processes normal network request information while carrying the events, but TURN does not add that information to its gameplay statistics.</p>
           <p>TURN sets no analytics cookie and creates no persistent analytics identifier. A random identifier exists only in memory for the current page load so events from that one play session can be grouped; it disappears when the page is closed or reloaded.</p>
-          <p>Raw custom analytics are kept in Cloudflare Analytics Engine for its normal retention period. TURN keeps only anonymous daily totals in D1 for a private developer dashboard. The statistics are not public and are not used for advertising.</p>
+          <p>Raw custom analytics are retained by Cloudflare Analytics Engine for three months. TURN also keeps anonymous daily totals in D1 for longer-term trends in a private developer dashboard. The statistics are not public and are not used for advertising.</p>
         </div>
       </details>
     </div>`;

--- a/turn/stats/index.html
+++ b/turn/stats/index.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex,nofollow,noarchive">
+  <meta name="color-scheme" content="light">
+  <title>TURN private usage stats</title>
+  <link rel="icon" href="../TURNicon.PNG" type="image/png">
+  <link rel="stylesheet" href="../design-tokens.css?build=20260808-r162">
+  <link rel="stylesheet" href="./stats.css?revision=r1">
+</head>
+<body>
+  <main class="stats-shell">
+    <header class="stats-hero">
+      <div>
+        <span class="eyebrow">PRIVATE · ENKEL.DESIGN</span>
+        <h1>TURN<br>STATS</h1>
+        <p>Anonymous gameplay usage from TURN and YOUR TURN. Nothing on this page is linked from the game.</p>
+      </div>
+      <img src="../TURNicon.PNG" alt="TURN app icon">
+    </header>
+
+    <section class="stats-access" id="statsAccess" aria-labelledby="statsAccessTitle">
+      <h2 id="statsAccessTitle">PRIVATE DASHBOARD</h2>
+      <p>Open your bookmarked private link, or enter the dashboard key.</p>
+      <form id="statsKeyForm">
+        <label for="statsKey">Dashboard key</label>
+        <div class="key-row">
+          <input id="statsKey" name="statsKey" type="password" autocomplete="off" spellcheck="false" required>
+          <button type="submit">OPEN STATS</button>
+        </div>
+      </form>
+      <p class="status" id="statsAccessStatus" role="status" aria-live="polite"></p>
+    </section>
+
+    <section id="statsDashboard" hidden>
+      <div class="stats-toolbar" aria-label="Statistics period">
+        <div>
+          <span class="toolbar-label">PERIOD</span>
+          <div class="range-tabs" id="rangeTabs">
+            <button type="button" data-days="1">24H</button>
+            <button type="button" data-days="7">7 DAYS</button>
+            <button type="button" data-days="30" aria-pressed="true">30 DAYS</button>
+            <button type="button" data-days="90">90 DAYS</button>
+            <button type="button" data-days="3650">ALL</button>
+          </div>
+        </div>
+        <div class="updated" id="statsUpdated" aria-live="polite"></div>
+      </div>
+
+      <p class="privacy-note"><strong>PLAY SESSIONS</strong> means one page load that actually starts a race. TURN deliberately does not assign a persistent analytics identifier, so this dashboard does not pretend to count unique people.</p>
+
+      <section class="metric-grid" aria-label="Headline statistics">
+        <article class="metric"><span>PLAY SESSIONS</span><strong id="metricSessions">–</strong></article>
+        <article class="metric"><span>RACES STARTED</span><strong id="metricRaces">–</strong></article>
+        <article class="metric"><span>LAPS FINISHED</span><strong id="metricLaps">–</strong></article>
+        <article class="metric"><span>VOID LAPS</span><strong id="metricVoid">–</strong><small id="metricVoidRate"></small></article>
+      </section>
+
+      <section class="favourites-grid">
+        <article class="feature-card most"><span>MOST PLAYED TRACK</span><strong id="mostTrack">–</strong><small id="mostTrackCount"></small></article>
+        <article class="feature-card least"><span>LEAST PLAYED TRACK</span><strong id="leastTrack">–</strong><small id="leastTrackCount"></small></article>
+        <article class="feature-card most"><span>MOST USED CAR</span><strong id="mostCar">–</strong><small id="mostCarCount"></small></article>
+        <article class="feature-card least"><span>LEAST USED CAR</span><strong id="leastCar">–</strong><small id="leastCarCount"></small></article>
+      </section>
+
+      <section class="stats-columns">
+        <article class="panel">
+          <div class="panel-head"><span>RACE STARTS</span><h2>TRACKS</h2></div>
+          <div class="ranking" id="trackRanking"></div>
+        </article>
+        <article class="panel">
+          <div class="panel-head"><span>RACE STARTS</span><h2>CARS</h2></div>
+          <div class="ranking" id="carRanking"></div>
+        </article>
+      </section>
+
+      <section class="stats-columns compact-panels">
+        <article class="panel">
+          <div class="panel-head"><span>HOW TURN IS PLAYED</span><h2>MODES</h2></div>
+          <dl class="breakdown" id="modeBreakdown"></dl>
+        </article>
+        <article class="panel">
+          <div class="panel-head"><span>COMPLETED LAPS</span><h2>AVERAGE TIMES</h2></div>
+          <dl class="breakdown" id="lapTimes"></dl>
+        </article>
+      </section>
+
+      <footer class="stats-footer">
+        <p id="lastActivity">No activity yet.</p>
+        <button id="forgetKey" type="button">FORGET DASHBOARD KEY</button>
+      </footer>
+    </section>
+  </main>
+  <script type="module" src="./stats.js?revision=r1"></script>
+</body>
+</html>

--- a/turn/stats/stats.css
+++ b/turn/stats/stats.css
@@ -1,0 +1,396 @@
+:root {
+  font-family: Inter, ui-rounded, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color-scheme: light;
+  background: var(--turn-ink, #08090a);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  min-width: 0;
+  margin: 0;
+  background: var(--turn-ink, #08090a);
+  color: var(--turn-paper, #fff8e8);
+  font-weight: 800;
+  line-height: 1.35;
+}
+
+button,
+input { font: inherit; }
+
+button { cursor: pointer; }
+
+button:focus-visible,
+input:focus-visible {
+  outline: 5px solid var(--turn-blue-500, #38d9ff);
+  outline-offset: 4px;
+}
+
+.stats-shell {
+  width: min(1120px, 100%);
+  margin: 0 auto;
+  padding: clamp(16px, 3vw, 32px) clamp(16px, 3vw, 28px) 80px;
+}
+
+.stats-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 24px;
+  align-items: center;
+  padding: clamp(24px, 5vw, 54px);
+  border: 5px solid var(--turn-ink, #08090a);
+  border-radius: 28px;
+  background: linear-gradient(145deg, var(--turn-blue-500, #38d9ff), var(--turn-green-500, #8ce99a));
+  color: var(--turn-ink, #08090a);
+  box-shadow: 10px 10px 0 var(--turn-paper, #fff8e8);
+}
+
+.stats-hero h1 {
+  margin: 12px 0 14px;
+  font-size: clamp(3.5rem, 11vw, 7.4rem);
+  line-height: 0.72;
+  letter-spacing: -0.075em;
+}
+
+.stats-hero p {
+  max-width: 58ch;
+  margin: 0;
+  font-size: clamp(0.95rem, 2vw, 1.2rem);
+}
+
+.stats-hero img {
+  width: clamp(86px, 16vw, 170px);
+  border: 5px solid var(--turn-ink, #08090a);
+  border-radius: 24%;
+  background: var(--turn-paper, #fff8e8);
+  box-shadow: 7px 7px 0 var(--turn-ink, #08090a);
+}
+
+.eyebrow,
+.toolbar-label,
+.metric > span,
+.feature-card > span,
+.panel-head > span {
+  font-size: 0.72rem;
+  font-weight: 950;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.eyebrow {
+  display: inline-block;
+  padding: 7px 11px;
+  border: 3px solid var(--turn-ink, #08090a);
+  border-radius: 999px;
+  background: var(--turn-yellow-400, #ffd43b);
+  box-shadow: 4px 4px 0 var(--turn-ink, #08090a);
+}
+
+.stats-access,
+.stats-toolbar,
+.privacy-note,
+.metric,
+.feature-card,
+.panel,
+.stats-footer {
+  border: 4px solid var(--turn-ink, #08090a);
+  color: var(--turn-ink, #08090a);
+  box-shadow: 6px 6px 0 var(--turn-ink, #08090a);
+}
+
+.stats-access {
+  margin-top: 34px;
+  padding: clamp(20px, 4vw, 34px);
+  border-color: var(--turn-paper, #fff8e8);
+  border-radius: 22px;
+  background: var(--turn-paper, #fff8e8);
+  box-shadow: 7px 7px 0 var(--turn-blue-500, #38d9ff);
+}
+
+.stats-access h2 {
+  margin: 0 0 8px;
+  font-size: clamp(1.8rem, 4vw, 3rem);
+  line-height: 0.95;
+}
+
+.stats-access p { margin: 0; }
+.stats-access form { margin-top: 18px; }
+.stats-access label { display: block; margin-bottom: 6px; }
+
+.key-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+}
+
+.key-row input,
+.key-row button,
+.range-tabs button,
+#forgetKey {
+  min-height: 48px;
+  border: 4px solid var(--turn-ink, #08090a);
+  border-radius: 14px;
+  color: var(--turn-ink, #08090a);
+  font-weight: 950;
+}
+
+.key-row input {
+  min-width: 0;
+  padding: 8px 12px;
+  background: #fff;
+}
+
+.key-row button {
+  padding: 8px 16px;
+  background: var(--turn-pink-500, #ff4fa3);
+  box-shadow: 4px 4px 0 var(--turn-ink, #08090a);
+}
+
+.status {
+  min-height: 1.3em;
+  margin-top: 10px !important;
+  font-size: 0.88rem;
+}
+
+#statsDashboard { margin-top: 34px; }
+
+.stats-toolbar {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: end;
+  padding: 16px;
+  border-radius: 18px;
+  background: var(--turn-yellow-600, #ffbd12);
+}
+
+.range-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.range-tabs button {
+  min-height: 42px;
+  padding: 6px 11px;
+  background: var(--turn-paper, #fff8e8);
+  box-shadow: 3px 3px 0 var(--turn-ink, #08090a);
+}
+
+.range-tabs button[aria-pressed="true"] {
+  background: var(--turn-pink-500, #ff4fa3);
+}
+
+.updated {
+  max-width: 30ch;
+  font-size: 0.78rem;
+  text-align: right;
+}
+
+.privacy-note {
+  margin: 20px 0 0;
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: var(--turn-paper, #fff8e8);
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 20px;
+}
+
+.metric {
+  min-width: 0;
+  padding: 18px;
+  border-radius: 18px;
+  background: var(--turn-paper, #fff8e8);
+}
+
+.metric:nth-child(1) { background: var(--turn-pink-100, #ffd1e6); }
+.metric:nth-child(2) { background: var(--turn-blue-100, #bdeeff); }
+.metric:nth-child(3) { background: var(--turn-green-100, #c8f5d0); }
+.metric:nth-child(4) { background: var(--turn-yellow-100, #fff0a8); }
+
+.metric strong {
+  display: block;
+  margin-top: 6px;
+  font-size: clamp(2.2rem, 6vw, 4.4rem);
+  line-height: 0.92;
+  letter-spacing: -0.055em;
+}
+
+.metric small,
+.feature-card small {
+  display: block;
+  margin-top: 7px;
+  font-size: 0.78rem;
+}
+
+.favourites-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 18px;
+}
+
+.feature-card {
+  padding: 18px;
+  border-radius: 18px;
+  background: var(--turn-paper, #fff8e8);
+}
+
+.feature-card.most { background: var(--turn-green-200, #d9f5c2); }
+.feature-card.least { background: var(--turn-orange-100, #ffd0ae); }
+
+.feature-card strong {
+  display: block;
+  margin-top: 7px;
+  font-size: clamp(1.5rem, 4vw, 2.8rem);
+  line-height: 0.95;
+  letter-spacing: -0.04em;
+  text-transform: uppercase;
+}
+
+.stats-columns {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 24px;
+}
+
+.panel {
+  min-width: 0;
+  padding: 20px;
+  border-radius: 22px;
+  background: var(--turn-paper, #fff8e8);
+}
+
+.panel-head {
+  padding-bottom: 12px;
+  border-bottom: 4px solid var(--turn-ink, #08090a);
+}
+
+.panel-head h2 {
+  margin: 2px 0 0;
+  font-size: clamp(1.8rem, 4vw, 3.1rem);
+  line-height: 0.9;
+}
+
+.ranking {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.rank-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+}
+
+.rank-main { min-width: 0; }
+
+.rank-label {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 0.88rem;
+}
+
+.rank-label span:first-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-transform: uppercase;
+}
+
+.rank-bar {
+  height: 12px;
+  margin-top: 4px;
+  overflow: hidden;
+  border: 3px solid var(--turn-ink, #08090a);
+  border-radius: 999px;
+  background: var(--turn-white, #fffdf6);
+}
+
+.rank-bar i {
+  display: block;
+  width: var(--rank-width, 0%);
+  height: 100%;
+  background: var(--turn-pink-500, #ff4fa3);
+}
+
+.rank-row strong {
+  min-width: 3ch;
+  font-size: 1.1rem;
+  text-align: right;
+}
+
+.breakdown {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0;
+  margin: 10px 0 0;
+}
+
+.breakdown dt,
+.breakdown dd {
+  margin: 0;
+  padding: 9px 0;
+  border-bottom: 2px solid var(--turn-ink, #08090a);
+}
+
+.breakdown dt { text-transform: uppercase; }
+.breakdown dd { padding-left: 14px; text-align: right; }
+.breakdown dt:last-of-type,
+.breakdown dd:last-of-type { border-bottom: 0; }
+
+.stats-footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: center;
+  margin-top: 24px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: var(--turn-yellow-600, #ffbd12);
+}
+
+.stats-footer p { margin: 0; font-size: 0.82rem; }
+
+#forgetKey {
+  padding: 7px 12px;
+  background: var(--turn-paper, #fff8e8);
+}
+
+@media (max-width: 820px) {
+  .metric-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .stats-columns { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 620px) {
+  .stats-hero { grid-template-columns: 1fr auto; padding: 22px; }
+  .stats-hero img { width: 88px; }
+  .key-row { grid-template-columns: 1fr; }
+  .stats-toolbar,
+  .stats-footer { align-items: stretch; flex-direction: column; }
+  .updated { max-width: none; text-align: left; }
+  .favourites-grid { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 430px) {
+  .stats-shell { padding-inline: 10px; }
+  .stats-hero { grid-template-columns: 1fr; }
+  .stats-hero img { display: none; }
+  .metric-grid { grid-template-columns: 1fr; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { scroll-behavior: auto !important; }
+}

--- a/turn/stats/stats.js
+++ b/turn/stats/stats.js
@@ -1,0 +1,292 @@
+const STATS_ENDPOINT = 'https://turn-challenges.erik-jansson-ux.workers.dev/v1/stats';
+
+const TRACKS = Object.freeze([
+  ['countryside', 'Countryside'],
+  ['airport', 'Airport'],
+  ['cliffside', 'Cliffside'],
+  ['harbor', 'Harbor'],
+  ['midnight-city', 'Midnight City']
+]);
+
+const CARS = Object.freeze([
+  ['convertible', 'Convertible'],
+  ['classic', 'Training Car'],
+  ['vintage-racer', 'Vintage Racer'],
+  ['toy-racer', 'Toy Racer'],
+  ['monster-truck', 'Monster Truck'],
+  ['race-future', 'Future Racer'],
+  ['race', 'Race Car'],
+  ['sedan-sports', 'Sport Sedan'],
+  ['sedan', 'Sedan'],
+  ['suv', 'SUV'],
+  ['firetruck', 'Fire Truck'],
+  ['police', 'Police Car'],
+  ['ambulance', 'Ambulance'],
+  ['truck', 'Truck'],
+  ['van', 'Van']
+]);
+
+const access = document.querySelector('#statsAccess');
+const dashboard = document.querySelector('#statsDashboard');
+const keyForm = document.querySelector('#statsKeyForm');
+const keyInput = document.querySelector('#statsKey');
+const accessStatus = document.querySelector('#statsAccessStatus');
+const rangeTabs = document.querySelector('#rangeTabs');
+const updated = document.querySelector('#statsUpdated');
+const forgetKey = document.querySelector('#forgetKey');
+
+let statsKey = keyFromFragment();
+let activeDays = 30;
+let requestSequence = 0;
+
+keyForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const key = keyInput.value.trim();
+  if (!key) return;
+  setKey(key);
+  void loadStats(activeDays);
+});
+
+rangeTabs.addEventListener('click', (event) => {
+  const button = event.target.closest('button[data-days]');
+  if (!button) return;
+  const days = Number(button.dataset.days) || 30;
+  activeDays = days;
+  for (const candidate of rangeTabs.querySelectorAll('button[data-days]')) {
+    candidate.setAttribute('aria-pressed', String(candidate === button));
+  }
+  void loadStats(days);
+});
+
+forgetKey.addEventListener('click', () => {
+  statsKey = '';
+  history.replaceState(null, '', `${location.pathname}${location.search}`);
+  dashboard.hidden = true;
+  access.hidden = false;
+  keyInput.value = '';
+  accessStatus.textContent = 'Dashboard key removed from this page.';
+  keyInput.focus();
+});
+
+if (statsKey) void loadStats(activeDays);
+else keyInput.focus();
+
+async function loadStats(days) {
+  if (!statsKey) return;
+  const sequence = ++requestSequence;
+  accessStatus.textContent = 'Loading private statistics…';
+  updated.textContent = 'Loading…';
+
+  try {
+    const response = await fetch(`${STATS_ENDPOINT}?days=${encodeURIComponent(days)}`, {
+      method: 'GET',
+      mode: 'cors',
+      credentials: 'omit',
+      cache: 'no-store',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${statsKey}`
+      }
+    });
+    const body = await response.json().catch(() => null);
+    if (sequence !== requestSequence) return;
+
+    if (response.status === 401) {
+      throw new Error('That dashboard key is not valid.');
+    }
+    if (!response.ok || !body) {
+      throw new Error(body?.message || `Statistics service returned ${response.status}.`);
+    }
+
+    accessStatus.textContent = '';
+    access.hidden = true;
+    dashboard.hidden = false;
+    renderStats(body);
+  } catch (error) {
+    if (sequence !== requestSequence) return;
+    dashboard.hidden = true;
+    access.hidden = false;
+    updated.textContent = '';
+    accessStatus.textContent = error instanceof Error ? error.message : 'TURN statistics could not be loaded.';
+    keyInput.value = statsKey;
+    keyInput.focus();
+  }
+}
+
+function renderStats(stats) {
+  const totals = stats.totals || {};
+  const sessions = Number(totals.playSessions) || 0;
+  const races = Number(totals.races) || 0;
+  const laps = Number(totals.laps) || 0;
+  const voidLaps = Number(totals.voidLaps) || 0;
+  const lapAttempts = laps + voidLaps;
+
+  text('#metricSessions', formatCount(sessions));
+  text('#metricRaces', formatCount(races));
+  text('#metricLaps', formatCount(laps));
+  text('#metricVoid', formatCount(voidLaps));
+  text('#metricVoidRate', lapAttempts ? `${formatPercent(voidLaps / lapAttempts)} of resolved laps` : 'No resolved laps yet');
+
+  const tracks = completeCounts(TRACKS, stats.tracks);
+  const cars = completeCounts(CARS, stats.cars);
+  renderFavourite('Track', tracks, races);
+  renderFavourite('Car', cars, races);
+  renderRanking(document.querySelector('#trackRanking'), tracks);
+  renderRanking(document.querySelector('#carRanking'), cars);
+
+  renderModes(stats);
+  renderLapTimes(stats.lapTimes || []);
+
+  const generatedAt = Number(stats.generatedAt) || Date.now();
+  const range = Number(stats.rangeDays) === 3650 ? 'all recorded time' : `${Number(stats.rangeDays) || 30} days`;
+  updated.textContent = `${range} · refreshed ${formatDateTime(generatedAt)}`;
+
+  const lastAt = Number(stats.lastActivityAt) || 0;
+  text('#lastActivity', lastAt
+    ? `Last recorded gameplay: ${formatDateTime(lastAt)}`
+    : 'No recorded gameplay in this period yet.');
+}
+
+function renderFavourite(kind, rows, raceCount) {
+  const most = rows[0] || null;
+  const least = [...rows].sort((a, b) => a.count - b.count || a.name.localeCompare(b.name))[0] || null;
+  const lower = kind.toLowerCase();
+
+  if (!raceCount || !most) {
+    text(`#most${kind}`, 'No races yet');
+    text(`#least${kind}`, 'No races yet');
+    text(`#most${kind}Count`, '');
+    text(`#least${kind}Count`, '');
+    return;
+  }
+
+  text(`#most${kind}`, most.name);
+  text(`#most${kind}Count`, `${formatCount(most.count)} race${most.count === 1 ? '' : 's'}`);
+  text(`#least${kind}`, least.name);
+  text(`#least${kind}Count`, least.count
+    ? `${formatCount(least.count)} race${least.count === 1 ? '' : 's'}`
+    : `No ${lower} race starts in this period`);
+}
+
+function renderRanking(container, rows) {
+  container.replaceChildren();
+  const maximum = Math.max(1, ...rows.map((row) => row.count));
+  rows.forEach((row, index) => {
+    const item = document.createElement('div');
+    item.className = 'rank-row';
+    const width = row.count ? Math.max(3, row.count / maximum * 100) : 0;
+    item.innerHTML = `
+      <div class="rank-main">
+        <div class="rank-label"><span>${escapeHtml(`${index + 1}. ${row.name}`)}</span></div>
+        <div class="rank-bar" aria-hidden="true"><i style="--rank-width:${width.toFixed(1)}%"></i></div>
+      </div>
+      <strong>${formatCount(row.count)}</strong>`;
+    container.appendChild(item);
+  });
+}
+
+function renderModes(stats) {
+  const rows = [];
+  const surfaces = countMap(stats.surfaces);
+  const steering = countMap(stats.steering);
+  const installed = countMap(stats.installed);
+  const dbe = countMap(stats.driveByEar);
+  const blank = countMap(stats.blankScreen);
+
+  rows.push(['TURN play sessions', surfaces.get('turn') || 0]);
+  rows.push(['YOUR TURN play sessions', surfaces.get('yourturn') || 0]);
+  rows.push(['Motion-steered races', steering.get('motion') || 0]);
+  rows.push(['Manual-steered races', steering.get('manual') || 0]);
+  rows.push(['Installed web-app races', installed.get('1') || 0]);
+  rows.push(['Browser races', installed.get('0') || 0]);
+  rows.push(['Drive By Ear races', dbe.get('1') || 0]);
+  rows.push(['Blank-screen finished laps', blank.get('1') || 0]);
+  renderDefinitionList(document.querySelector('#modeBreakdown'), rows, (value) => formatCount(value));
+}
+
+function renderLapTimes(sourceRows) {
+  const source = new Map(sourceRows.map((row) => [String(row.id), row]));
+  const rows = TRACKS.map(([id, name]) => {
+    const entry = source.get(id);
+    return [name, entry?.count ? Number(entry.average) || 0 : null];
+  });
+  renderDefinitionList(document.querySelector('#lapTimes'), rows, (value) => (
+    Number.isFinite(value) ? formatLapTime(value) : '–'
+  ));
+}
+
+function renderDefinitionList(list, rows, formatter) {
+  list.replaceChildren();
+  for (const [label, value] of rows) {
+    const term = document.createElement('dt');
+    term.textContent = label;
+    const description = document.createElement('dd');
+    description.textContent = formatter(value);
+    list.append(term, description);
+  }
+}
+
+function completeCounts(definitions, sourceRows = []) {
+  const source = countMap(sourceRows);
+  return definitions.map(([id, name]) => ({
+    id,
+    name,
+    count: source.get(id) || 0
+  })).sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+}
+
+function countMap(rows = []) {
+  return new Map(rows.map((row) => [String(row.id), Number(row.count) || 0]));
+}
+
+function setKey(value) {
+  statsKey = String(value || '').trim();
+  if (!statsKey) return;
+  history.replaceState(null, '', `${location.pathname}${location.search}#${encodeURIComponent(statsKey)}`);
+}
+
+function keyFromFragment() {
+  const raw = location.hash.slice(1);
+  if (!raw) return '';
+  try { return decodeURIComponent(raw).trim(); } catch (_) { return raw.trim(); }
+}
+
+function text(selector, value) {
+  const node = document.querySelector(selector);
+  if (node) node.textContent = String(value ?? '');
+}
+
+function formatCount(value) {
+  return new Intl.NumberFormat('en-US').format(Number(value) || 0);
+}
+
+function formatPercent(value) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'percent',
+    maximumFractionDigits: 1
+  }).format(Number(value) || 0);
+}
+
+function formatDateTime(timestamp) {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  }).format(new Date(timestamp));
+}
+
+function formatLapTime(seconds) {
+  const value = Math.max(0, Number(seconds) || 0);
+  const minutes = Math.floor(value / 60);
+  const secs = Math.floor(value % 60).toString().padStart(2, '0');
+  const ms = Math.round((value % 1) * 1000).toString().padStart(3, '0').slice(0, 3);
+  return `${minutes}:${secs}.${ms}`;
+}
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}

--- a/turn/telemetry/client.js
+++ b/turn/telemetry/client.js
@@ -1,0 +1,155 @@
+const TELEMETRY_ENDPOINT = 'https://turn-challenges.erik-jansson-ux.workers.dev/v1/telemetry';
+const CLIENT_VERSION = 1;
+const FLUSH_DELAY_MS = 120;
+const MAX_BATCH = 8;
+
+let installed = false;
+let playSessionSent = false;
+let flushTimer = 0;
+let sessionId = '';
+const queue = [];
+
+export function installTurnTelemetry() {
+  if (installed) return globalThis.__turnTelemetry || null;
+  const deployment = document.documentElement.dataset.turnDeployment || '';
+  if (deployment === 'next') return null;
+
+  installed = true;
+  sessionId = createSessionId();
+
+  const api = Object.freeze({
+    version: CLIENT_VERSION,
+    record: queueEvent,
+    flush: flushQueue,
+    sessionId
+  });
+  globalThis.__turnTelemetry = api;
+
+  window.addEventListener('turn:ui-state-change', (event) => {
+    if (event.detail?.reason !== 'race-started') return;
+    if (!playSessionSent) {
+      playSessionSent = true;
+      queueEvent('play_session');
+    }
+    queueEvent('race_start');
+  });
+
+  window.addEventListener('turn:lap-result', (event) => {
+    queueEvent('lap_complete', {
+      value: Number(event.detail?.time) || 0
+    });
+  });
+
+  window.addEventListener('turn:lap-invalid', (event) => {
+    queueEvent('lap_invalid', {
+      reason: String(event.detail?.reason || '')
+    });
+  });
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') flushQueue();
+  });
+  window.addEventListener('pagehide', flushQueue, { passive: true });
+  return api;
+}
+
+function queueEvent(event, extra = {}) {
+  if (!installed) return false;
+  const runtime = globalThis.__turnRuntime;
+  const state = runtime?.state || {};
+  const audio = globalThis.__turnAudioPreferences?.getSettings?.() || {};
+  const surface = document.documentElement.dataset.turnDeployment === 'yourturn'
+    ? 'yourturn'
+    : 'turn';
+  const payload = {
+    event,
+    session: sessionId,
+    surface,
+    build: globalThis.__TURN_BUILD__?.id || '',
+    trackId: state.trackId || runtime?.trackId || globalThis.__turnGetTrackId?.() || '',
+    carId: state.vehicleId || '',
+    steering: state.sensorMode === true ? 'motion' : state.sensorMode === false ? 'manual' : 'unknown',
+    installed: isInstalledWebApp(),
+    driveByEar: audio.dbeEnabled === true,
+    blank: document.documentElement.classList.contains('turn-screen-blanked'),
+    occurredAt: Date.now(),
+    value: Number(extra.value) || 0,
+    reason: String(extra.reason || '')
+  };
+  queue.push(payload);
+  if (queue.length >= MAX_BATCH) flushQueue();
+  else scheduleFlush();
+  return true;
+}
+
+function scheduleFlush() {
+  if (flushTimer) return;
+  flushTimer = window.setTimeout(() => {
+    flushTimer = 0;
+    flushQueue();
+  }, FLUSH_DELAY_MS);
+}
+
+function flushQueue() {
+  window.clearTimeout(flushTimer);
+  flushTimer = 0;
+  if (!queue.length) return false;
+  const events = queue.splice(0, MAX_BATCH);
+  const body = JSON.stringify({ events });
+
+  if (typeof navigator.sendBeacon === 'function') {
+    try {
+      const sent = navigator.sendBeacon(
+        TELEMETRY_ENDPOINT,
+        new Blob([body], { type: 'text/plain;charset=UTF-8' })
+      );
+      if (sent) {
+        if (queue.length) scheduleFlush();
+        return true;
+      }
+    } catch (_) {}
+  }
+
+  try {
+    void fetch(TELEMETRY_ENDPOINT, {
+      method: 'POST',
+      mode: 'cors',
+      credentials: 'omit',
+      cache: 'no-store',
+      keepalive: true,
+      headers: { 'Content-Type': 'text/plain;charset=UTF-8' },
+      body
+    }).catch(() => {});
+    if (queue.length) scheduleFlush();
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+function isInstalledWebApp() {
+  return document.documentElement.classList.contains('turn-standalone')
+    || navigator.standalone === true
+    || globalThis.matchMedia?.('(display-mode: standalone)').matches === true
+    || globalThis.matchMedia?.('(display-mode: fullscreen)').matches === true;
+}
+
+function createSessionId() {
+  try {
+    if (typeof crypto?.randomUUID === 'function') {
+      return crypto.randomUUID().replaceAll('-', '');
+    }
+  } catch (_) {}
+  try {
+    const bytes = crypto.getRandomValues(new Uint8Array(18));
+    return base64Url(bytes);
+  } catch (_) {
+    return `${Date.now().toString(36)}${Math.random().toString(36).slice(2)}${Math.random().toString(36).slice(2)}`.slice(0, 48);
+  }
+}
+
+function base64Url(bytes) {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/g, '');
+}

--- a/workers/turn-challenges/README.md
+++ b/workers/turn-challenges/README.md
@@ -1,46 +1,69 @@
-# TURN challenge snapshot Worker
+# TURN Cloudflare Worker
 
-This is the deliberately small server component for short YOUR TURN links.
+This is TURN's deliberately small server component. It currently has two jobs:
 
-It does one thing: store an immutable encoded YOUR TURN challenge snapshot behind a short opaque ID and return that same snapshot later.
+1. store immutable YOUR TURN challenge snapshots behind short opaque IDs; and
+2. receive privacy-minimal gameplay events for Erik's private usage dashboard.
 
-TURN and YOUR TURN are **not connected to this Worker yet**. Until the frontend integration lands, production sharing keeps using the existing self-contained challenge links.
+TURN's racing runtime remains local in the browser. The Worker does not simulate races, synchronize players or understand driving physics.
 
-## API
+## Challenge API
 
-- `GET /health` — deployment/binding health check.
+- `GET /health` — deployment/D1 binding health check.
 - `POST /v1/challenges` — accepts `{ "payload": "gz.…" }` from `https://enkel.design`, validates the YOUR TURN v2 wire payload, stores it, and returns a 12-character ID.
 - `GET /v1/challenges/:id` — returns the immutable encoded challenge snapshot.
 
-There is intentionally no update, delete, account, session, leaderboard, or synchronization API. Two people who grow the same seed still create two independent challenge branches.
+There is intentionally no update or delete API for challenge snapshots. Two people who grow the same seed create independent immutable branches.
+
+## Private usage statistics
+
+- `POST /v1/telemetry` — accepts a small batch of allow-listed gameplay events from TURN/YOUR TURN.
+- `GET /v1/stats?days=30` — returns anonymous aggregate statistics to the private dashboard after bearer-key authentication.
+- Analytics Engine binding: `ANALYTICS`, dataset `turn_gameplay`.
+- D1 stores daily aggregate counts only. It does not store player IDs or page-session IDs.
+
+TURN does not create an analytics cookie or persistent analytics identifier. A random page-session identifier exists only in browser memory, is hashed by the Worker before the Analytics Engine write, and is never written to D1. Telemetry starts only after a race actually starts and is event-driven rather than frame-driven.
+
+Current event types are deliberately small:
+
+- `play_session`
+- `race_start`
+- `lap_complete`
+- `lap_invalid`
+
+Dimensions are limited to product surface, build, track, car, steering mode, browser/installed web app, Drive By Ear state, blank-screen state, lap time and invalid-lap reason. Names, challenge IDs/links, replay data, driving paths, control streams and precise location are not part of the analytics payload.
+
+The private dashboard is a static page under `/turn/stats/`. It is `noindex`, unlinked from TURN and protected at the API layer by a bearer key whose plaintext is not committed to the repository.
 
 ## Storage and safety boundaries
 
 - D1 binding: `DB`.
-- The table is created lazily with `CREATE TABLE IF NOT EXISTS` so first deployment does not require a separate migration step.
-- Exact duplicate payloads reuse the same snapshot ID; different challenge generations get different immutable snapshots.
-- Browser writes are accepted only with an `Origin` of `https://enkel.design` (or `https://www.enkel.design`). This is a browser-origin guard, not an authentication system.
-- Request and decompressed-payload limits protect the tiny store from accidental oversized writes.
-- The Worker decompresses and structurally validates the current YOUR TURN v2 wire format before storing anything.
+- Tables are created lazily with `CREATE TABLE IF NOT EXISTS`; deployment does not require a separate migration step.
+- Exact duplicate challenge payloads reuse the same snapshot ID; different challenge generations get different immutable snapshots.
+- Browser writes are accepted only with an `Origin` of `https://enkel.design` (or `https://www.enkel.design`). This is an origin guard, not user authentication.
+- Request and decompressed-payload limits protect the challenge store from accidental oversized writes.
+- The Worker decompresses and structurally validates the current YOUR TURN v2 wire format before storing challenges.
+- The telemetry endpoint accepts only its fixed event schema rather than arbitrary event names or arbitrary user data.
 
-## Cloudflare dashboard setup
+## Cloudflare deployment
 
-Cloudflare Workers Builds can deploy this project directly from the existing `enkeldesign/webb` repository.
+Cloudflare Workers Builds deploys this project directly from `enkeldesign/webb`.
 
-1. Open **Workers & Pages** → **Create application** → **Import a repository**.
-2. Connect the GitHub account and choose `enkeldesign/webb`.
-3. Worker/project name: **`turn-challenges`**. This must match `wrangler.jsonc`.
-4. Production branch: **`main`**.
-5. Root directory: **`workers/turn-challenges`**.
-6. Leave the optional build command empty.
-7. Leave the deploy command at its default: **`npx wrangler deploy`**.
-8. Save and deploy.
+- Worker/project name: `turn-challenges`
+- Production branch: `main`
+- Root directory: `workers/turn-challenges`
+- Build command: empty
+- Deploy command: `npx wrangler deploy`
 
-The Wrangler config declares a draft D1 binding with only `"binding": "DB"`. Wrangler 4.45+ supports automatic resource provisioning for D1 and should create/link the database during deployment.
+The Wrangler config declares D1 as binding `DB` and Analytics Engine as binding `ANALYTICS`. The `turn_gameplay` Analytics Engine dataset is created by Cloudflare when data is first written.
 
-If Cloudflare's automatic D1 provisioning does not complete, do not improvise another architecture. Create one D1 database in the dashboard and bind it to the Worker as variable **`DB`**, then redeploy. No schema SQL needs to be entered manually because the Worker initializes its one table lazily.
+After deployment, the public Worker base URL is:
 
-After deployment, open the generated `*.workers.dev/health` endpoint. A ready deployment returns JSON containing:
+```text
+https://turn-challenges.erik-jansson-ux.workers.dev
+```
+
+A ready `/health` response contains:
 
 ```json
 {
@@ -51,25 +74,17 @@ After deployment, open the generated `*.workers.dev/health` endpoint. A ready de
 }
 ```
 
-Give the resulting public Worker base URL to the TURN frontend integration, for example:
-
-```text
-https://turn-challenges.<account-subdomain>.workers.dev
-```
-
-The Worker URL is public configuration, not a secret.
-
 ## Local checks
 
 Requires Node 24+ for the same web-platform primitives used by the Worker tests.
 
 ```sh
-npm test
+npm install
+npm run check
 ```
 
-Wrangler is only required for local Cloudflare development/deployment:
+For local Cloudflare development:
 
 ```sh
-npm install
 npm run dev
 ```

--- a/workers/turn-challenges/package.json
+++ b/workers/turn-challenges/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "check": "node --check src/index.js && node --test test/*.test.js",
+    "check": "node --check src/index.js && node --check src/router.js && node --check src/telemetry.js && node --test test/*.test.js",
     "test": "node --test test/*.test.js",
     "dev": "wrangler dev",
     "deploy": "wrangler deploy"

--- a/workers/turn-challenges/src/router.js
+++ b/workers/turn-challenges/src/router.js
@@ -1,0 +1,12 @@
+import challengeWorker from './index.js';
+import { handleTelemetryRoute, isTelemetryRoute } from './telemetry.js';
+
+export default {
+  async fetch(request, env, ctx) {
+    const path = new URL(request.url).pathname.replace(/\/+$/, '') || '/';
+    if (isTelemetryRoute(path)) {
+      return handleTelemetryRoute(request, env, ctx);
+    }
+    return challengeWorker.fetch(request, env, ctx);
+  }
+};

--- a/workers/turn-challenges/src/telemetry.js
+++ b/workers/turn-challenges/src/telemetry.js
@@ -1,0 +1,436 @@
+const TELEMETRY_API_VERSION = 1;
+const MAX_BODY_BYTES = 16 * 1024;
+const MAX_EVENTS_PER_REQUEST = 8;
+const STATS_KEY_SHA256 = '18379b62d01eb7c33cf5bc56a9076268425a43eb17797a9bb4129306044c9803';
+const TELEMETRY_EVENTS = new Set([
+  'play_session',
+  'race_start',
+  'lap_complete',
+  'lap_invalid'
+]);
+const ALLOWED_ORIGINS = new Set([
+  'https://enkel.design',
+  'https://www.enkel.design'
+]);
+const initializedDatabases = new WeakSet();
+
+class TelemetryError extends Error {
+  constructor(status, code, message) {
+    super(message);
+    this.name = 'TelemetryError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export function isTelemetryRoute(path) {
+  return path === '/v1/telemetry' || path === '/v1/stats';
+}
+
+export async function handleTelemetryRoute(request, env = {}, ctx = null) {
+  const url = new URL(request.url);
+  const path = url.pathname.replace(/\/+$/, '') || '/';
+
+  try {
+    if (request.method === 'OPTIONS' && isTelemetryRoute(path)) {
+      return new Response(null, { status: 204, headers: corsHeaders(request) });
+    }
+
+    if (path === '/v1/telemetry' && request.method === 'POST') {
+      requireAllowedOrigin(request);
+      const body = await readJsonBody(request);
+      const sourceEvents = Array.isArray(body?.events) ? body.events : [];
+      if (!sourceEvents.length || sourceEvents.length > MAX_EVENTS_PER_REQUEST) {
+        throw new TelemetryError(400, 'invalid_events', `Send between 1 and ${MAX_EVENTS_PER_REQUEST} telemetry events.`);
+      }
+      const events = sourceEvents.map(normalizeTelemetryEvent);
+      const work = recordTelemetryEvents(env, events);
+      if (ctx?.waitUntil) ctx.waitUntil(work);
+      else await work;
+      return jsonResponse({ ok: true, accepted: events.length }, 202, request);
+    }
+
+    if (path === '/v1/stats' && request.method === 'GET') {
+      requireAllowedOrigin(request, { allowMissing: true });
+      await requireStatsKey(request);
+      const days = normalizeDays(url.searchParams.get('days'));
+      const stats = await loadStats(env.DB, days);
+      return jsonResponse(stats, 200, request);
+    }
+
+    if (isTelemetryRoute(path)) {
+      throw new TelemetryError(405, 'method_not_allowed', 'This analytics endpoint does not support that method.');
+    }
+    return null;
+  } catch (error) {
+    if (error instanceof TelemetryError) {
+      return jsonResponse({ error: error.code, message: error.message }, error.status, request);
+    }
+    console.error('TURN telemetry Worker error', error);
+    return jsonResponse({
+      error: 'telemetry_unavailable',
+      message: 'TURN usage statistics are temporarily unavailable.'
+    }, 500, request);
+  }
+}
+
+async function recordTelemetryEvents(env, events) {
+  await ensureTelemetrySchema(env.DB);
+  for (const event of events) {
+    const sessionHash = await sha256Hex(event.session);
+    try {
+      env.ANALYTICS?.writeDataPoint?.({
+        indexes: [sessionHash],
+        blobs: [
+          event.event,
+          event.surface,
+          event.trackId,
+          event.carId,
+          event.steering,
+          event.build,
+          event.reason
+        ],
+        doubles: [
+          event.value,
+          event.installed ? 1 : 0,
+          event.driveByEar ? 1 : 0,
+          event.blank ? 1 : 0
+        ]
+      });
+    } catch (error) {
+      console.warn('TURN telemetry Analytics Engine write failed', error);
+    }
+    await upsertAggregate(env.DB, event);
+  }
+}
+
+async function upsertAggregate(db, event) {
+  const day = new Date(event.occurredAt).toISOString().slice(0, 10);
+  await db.prepare(`
+    INSERT INTO turn_telemetry_daily (
+      day, event, surface, track_id, car_id, steering,
+      installed, drive_by_ear, blank_screen,
+      count, value_sum, last_at
+    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 1, ?10, ?11)
+    ON CONFLICT (
+      day, event, surface, track_id, car_id, steering,
+      installed, drive_by_ear, blank_screen
+    ) DO UPDATE SET
+      count = count + 1,
+      value_sum = value_sum + excluded.value_sum,
+      last_at = MAX(last_at, excluded.last_at)
+  `).bind(
+    day,
+    event.event,
+    event.surface,
+    event.trackId,
+    event.carId,
+    event.steering,
+    event.installed ? 1 : 0,
+    event.driveByEar ? 1 : 0,
+    event.blank ? 1 : 0,
+    event.value,
+    event.occurredAt
+  ).run();
+}
+
+async function loadStats(db, days) {
+  await ensureTelemetrySchema(db);
+  const sinceDay = utcDay(Date.now() - (days - 1) * 86_400_000);
+  const [
+    totalsRows,
+    trackRows,
+    carRows,
+    surfaceRows,
+    steeringRows,
+    installedRows,
+    driveByEarRows,
+    blankRows,
+    lapTimeRows,
+    lastRow
+  ] = await Promise.all([
+    allRows(db.prepare(`
+      SELECT event, SUM(count) AS count, SUM(value_sum) AS value_sum
+      FROM turn_telemetry_daily
+      WHERE day >= ?1
+      GROUP BY event
+    `).bind(sinceDay)),
+    allRows(db.prepare(`
+      SELECT track_id AS id, SUM(count) AS count
+      FROM turn_telemetry_daily
+      WHERE day >= ?1 AND event = 'race_start' AND track_id <> ''
+      GROUP BY track_id ORDER BY count DESC
+    `).bind(sinceDay)),
+    allRows(db.prepare(`
+      SELECT car_id AS id, SUM(count) AS count
+      FROM turn_telemetry_daily
+      WHERE day >= ?1 AND event = 'race_start' AND car_id <> ''
+      GROUP BY car_id ORDER BY count DESC
+    `).bind(sinceDay)),
+    allRows(db.prepare(`
+      SELECT surface AS id, SUM(count) AS count
+      FROM turn_telemetry_daily
+      WHERE day >= ?1 AND event = 'play_session'
+      GROUP BY surface ORDER BY count DESC
+    `).bind(sinceDay)),
+    allRows(db.prepare(`
+      SELECT steering AS id, SUM(count) AS count
+      FROM turn_telemetry_daily
+      WHERE day >= ?1 AND event = 'race_start' AND steering <> ''
+      GROUP BY steering ORDER BY count DESC
+    `).bind(sinceDay)),
+    allRows(db.prepare(`
+      SELECT installed AS id, SUM(count) AS count
+      FROM turn_telemetry_daily
+      WHERE day >= ?1 AND event = 'race_start'
+      GROUP BY installed ORDER BY count DESC
+    `).bind(sinceDay)),
+    allRows(db.prepare(`
+      SELECT drive_by_ear AS id, SUM(count) AS count
+      FROM turn_telemetry_daily
+      WHERE day >= ?1 AND event = 'race_start'
+      GROUP BY drive_by_ear ORDER BY count DESC
+    `).bind(sinceDay)),
+    allRows(db.prepare(`
+      SELECT blank_screen AS id, SUM(count) AS count
+      FROM turn_telemetry_daily
+      WHERE day >= ?1 AND event = 'lap_complete'
+      GROUP BY blank_screen ORDER BY count DESC
+    `).bind(sinceDay)),
+    allRows(db.prepare(`
+      SELECT track_id AS id, SUM(count) AS count, SUM(value_sum) AS value_sum
+      FROM turn_telemetry_daily
+      WHERE day >= ?1 AND event = 'lap_complete' AND track_id <> ''
+      GROUP BY track_id ORDER BY count DESC
+    `).bind(sinceDay)),
+    db.prepare('SELECT MAX(last_at) AS last_at FROM turn_telemetry_daily WHERE day >= ?1').bind(sinceDay).first()
+  ]);
+
+  const totals = Object.fromEntries(totalsRows.map((row) => [
+    String(row.event || ''),
+    Number(row.count) || 0
+  ]));
+  return {
+    version: TELEMETRY_API_VERSION,
+    rangeDays: days,
+    sinceDay,
+    generatedAt: Date.now(),
+    lastActivityAt: Number(lastRow?.last_at) || 0,
+    totals: {
+      playSessions: totals.play_session || 0,
+      races: totals.race_start || 0,
+      laps: totals.lap_complete || 0,
+      voidLaps: totals.lap_invalid || 0
+    },
+    tracks: normalizeCountRows(trackRows),
+    cars: normalizeCountRows(carRows),
+    surfaces: normalizeCountRows(surfaceRows),
+    steering: normalizeCountRows(steeringRows),
+    installed: normalizeCountRows(installedRows),
+    driveByEar: normalizeCountRows(driveByEarRows),
+    blankScreen: normalizeCountRows(blankRows),
+    lapTimes: lapTimeRows.map((row) => ({
+      id: String(row.id || ''),
+      count: Number(row.count) || 0,
+      average: Number(row.count) > 0 ? (Number(row.value_sum) || 0) / Number(row.count) : 0
+    }))
+  };
+}
+
+function normalizeTelemetryEvent(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TelemetryError(400, 'invalid_event', 'Telemetry events must be objects.');
+  }
+  const event = String(value.event || '').trim();
+  if (!TELEMETRY_EVENTS.has(event)) {
+    throw new TelemetryError(400, 'invalid_event', 'Telemetry event type is not supported.');
+  }
+  const session = String(value.session || '').trim();
+  if (!/^[A-Za-z0-9_-]{16,80}$/.test(session)) {
+    throw new TelemetryError(400, 'invalid_session', 'Telemetry session identifier is invalid.');
+  }
+  const surface = value.surface === 'yourturn' ? 'yourturn' : 'turn';
+  return Object.freeze({
+    event,
+    session,
+    surface,
+    build: safeToken(value.build, 48),
+    trackId: safeToken(value.trackId, 48),
+    carId: safeToken(value.carId, 48),
+    steering: ['motion', 'manual', 'unknown'].includes(value.steering) ? value.steering : 'unknown',
+    reason: safeToken(value.reason, 48),
+    installed: Boolean(value.installed),
+    driveByEar: Boolean(value.driveByEar),
+    blank: Boolean(value.blank),
+    value: finiteNumber(value.value, 0, 600),
+    occurredAt: finiteInteger(value.occurredAt, Date.now() - 86_400_000, Date.now() + 300_000, Date.now())
+  });
+}
+
+async function ensureTelemetrySchema(db) {
+  if (!db || typeof db.prepare !== 'function') {
+    throw new TelemetryError(503, 'database_unavailable', 'TURN statistics storage is not connected.');
+  }
+  if (initializedDatabases.has(db)) return;
+  await db.prepare(`
+    CREATE TABLE IF NOT EXISTS turn_telemetry_daily (
+      day TEXT NOT NULL,
+      event TEXT NOT NULL,
+      surface TEXT NOT NULL,
+      track_id TEXT NOT NULL,
+      car_id TEXT NOT NULL,
+      steering TEXT NOT NULL,
+      installed INTEGER NOT NULL,
+      drive_by_ear INTEGER NOT NULL,
+      blank_screen INTEGER NOT NULL,
+      count INTEGER NOT NULL DEFAULT 0,
+      value_sum REAL NOT NULL DEFAULT 0,
+      last_at INTEGER NOT NULL,
+      PRIMARY KEY (
+        day, event, surface, track_id, car_id, steering,
+        installed, drive_by_ear, blank_screen
+      )
+    )
+  `).run();
+  initializedDatabases.add(db);
+}
+
+async function requireStatsKey(request) {
+  const authorization = request.headers.get('Authorization') || '';
+  const key = authorization.startsWith('Bearer ') ? authorization.slice(7).trim() : '';
+  if (!key || key.length > 160) {
+    throw new TelemetryError(401, 'stats_unauthorized', 'A private TURN stats key is required.');
+  }
+  const provided = await sha256Hex(key);
+  if (!constantTimeEqual(provided, STATS_KEY_SHA256)) {
+    throw new TelemetryError(401, 'stats_unauthorized', 'The TURN stats key is not valid.');
+  }
+}
+
+function requireAllowedOrigin(request, { allowMissing = false } = {}) {
+  const origin = request.headers.get('Origin') || '';
+  if (!origin && allowMissing) return;
+  if (!ALLOWED_ORIGINS.has(origin)) {
+    throw new TelemetryError(403, 'origin_not_allowed', 'TURN analytics are only accepted from enkel.design.');
+  }
+}
+
+async function readJsonBody(request) {
+  const text = await readTextWithLimit(request, MAX_BODY_BYTES);
+  try {
+    return JSON.parse(text);
+  } catch (_) {
+    throw new TelemetryError(400, 'invalid_json', 'Analytics payload must be valid JSON.');
+  }
+}
+
+async function readTextWithLimit(request, limit) {
+  const declared = Number(request.headers.get('Content-Length'));
+  if (Number.isFinite(declared) && declared > limit) {
+    throw new TelemetryError(413, 'payload_too_large', 'Analytics payload is too large.');
+  }
+  if (!request.body?.getReader) {
+    const text = await request.text();
+    if (byteLength(text) > limit) throw new TelemetryError(413, 'payload_too_large', 'Analytics payload is too large.');
+    return text;
+  }
+  const reader = request.body.getReader();
+  const chunks = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > limit) {
+      try { await reader.cancel(); } catch (_) {}
+      throw new TelemetryError(413, 'payload_too_large', 'Analytics payload is too large.');
+    }
+    chunks.push(value);
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+async function allRows(statement) {
+  const result = await statement.all();
+  return Array.isArray(result?.results) ? result.results : [];
+}
+
+function normalizeCountRows(rows) {
+  return rows.map((row) => ({ id: String(row.id ?? ''), count: Number(row.count) || 0 }));
+}
+
+function normalizeDays(value) {
+  const days = Math.round(Number(value) || 30);
+  if ([1, 7, 30, 90, 3650].includes(days)) return days;
+  return 30;
+}
+
+function utcDay(timestamp) {
+  return new Date(timestamp).toISOString().slice(0, 10);
+}
+
+function safeToken(value, maxLength) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]/g, '')
+    .slice(0, maxLength);
+}
+
+function finiteNumber(value, min, max) {
+  const number = Number(value);
+  return Number.isFinite(number) ? Math.min(max, Math.max(min, number)) : 0;
+}
+
+function finiteInteger(value, min, max, fallback) {
+  const number = Math.round(Number(value));
+  return Number.isFinite(number) && number >= min && number <= max ? number : fallback;
+}
+
+function constantTimeEqual(a, b) {
+  if (a.length !== b.length) return false;
+  let mismatch = 0;
+  for (let index = 0; index < a.length; index += 1) {
+    mismatch |= a.charCodeAt(index) ^ b.charCodeAt(index);
+  }
+  return mismatch === 0;
+}
+
+async function sha256Hex(value) {
+  const bytes = new TextEncoder().encode(String(value));
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function byteLength(value) {
+  return new TextEncoder().encode(String(value)).byteLength;
+}
+
+function corsHeaders(request) {
+  const origin = request.headers.get('Origin') || '';
+  const allowedOrigin = ALLOWED_ORIGINS.has(origin) ? origin : 'https://enkel.design';
+  return {
+    'Access-Control-Allow-Origin': allowedOrigin,
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+    'Access-Control-Max-Age': '86400',
+    'Vary': 'Origin'
+  };
+}
+
+function jsonResponse(body, status, request) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      ...corsHeaders(request),
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'no-store',
+      'X-Content-Type-Options': 'nosniff'
+    }
+  });
+}

--- a/workers/turn-challenges/test/telemetry.test.js
+++ b/workers/turn-challenges/test/telemetry.test.js
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { handleTelemetryRoute } from '../src/telemetry.js';
+
+const ORIGIN = 'https://enkel.design';
+
+class FakeAnalytics {
+  constructor() {
+    this.points = [];
+  }
+
+  writeDataPoint(point) {
+    this.points.push(structuredClone(point));
+  }
+}
+
+class FakeD1 {
+  constructor() {
+    this.rows = new Map();
+  }
+
+  prepare(sql) {
+    return new FakeStatement(this, sql);
+  }
+}
+
+class FakeStatement {
+  constructor(db, sql) {
+    this.db = db;
+    this.sql = sql.replace(/\s+/g, ' ').trim();
+    this.values = [];
+  }
+
+  bind(...values) {
+    this.values = values;
+    return this;
+  }
+
+  async run() {
+    if (this.sql.startsWith('CREATE TABLE IF NOT EXISTS turn_telemetry_daily')) {
+      return { success: true, meta: { changes: 0 } };
+    }
+    if (this.sql.startsWith('INSERT INTO turn_telemetry_daily')) {
+      const [day, event, surface, trackId, carId, steering, installed, driveByEar, blank, value, lastAt] = this.values;
+      const key = [day, event, surface, trackId, carId, steering, installed, driveByEar, blank].join('|');
+      const existing = this.db.rows.get(key) || { count: 0, value_sum: 0, last_at: 0 };
+      this.db.rows.set(key, {
+        day,
+        event,
+        surface,
+        track_id: trackId,
+        car_id: carId,
+        steering,
+        installed,
+        drive_by_ear: driveByEar,
+        blank_screen: blank,
+        count: existing.count + 1,
+        value_sum: existing.value_sum + value,
+        last_at: Math.max(existing.last_at, lastAt)
+      });
+      return { success: true, meta: { changes: 1 } };
+    }
+    throw new Error(`Unexpected D1 run query: ${this.sql}`);
+  }
+}
+
+function event(overrides = {}) {
+  return {
+    event: 'race_start',
+    session: 'pX1qLd4t3sVfG8jK2mN7rQ',
+    surface: 'turn',
+    build: '2026.08.08-r162',
+    trackId: 'countryside',
+    carId: 'classic',
+    steering: 'motion',
+    installed: true,
+    driveByEar: true,
+    blank: false,
+    occurredAt: Date.now(),
+    value: 0,
+    reason: '',
+    ...overrides
+  };
+}
+
+function post(events, origin = ORIGIN) {
+  return new Request('https://turn-challenges.example/v1/telemetry', {
+    method: 'POST',
+    headers: {
+      Origin: origin,
+      'Content-Type': 'text/plain;charset=UTF-8'
+    },
+    body: JSON.stringify({ events })
+  });
+}
+
+await test('accepts a small gameplay batch and writes aggregate plus Analytics Engine point', async () => {
+  const DB = new FakeD1();
+  const ANALYTICS = new FakeAnalytics();
+  const response = await handleTelemetryRoute(post([
+    event({ event: 'play_session' }),
+    event({ event: 'race_start' }),
+    event({ event: 'lap_complete', value: 16.388 })
+  ]), { DB, ANALYTICS });
+
+  assert.equal(response.status, 202);
+  assert.deepEqual(await response.json(), { ok: true, accepted: 3 });
+  assert.equal(DB.rows.size, 3);
+  assert.equal(ANALYTICS.points.length, 3);
+
+  const point = ANALYTICS.points[1];
+  assert.equal(point.blobs[0], 'race_start');
+  assert.equal(point.blobs[1], 'turn');
+  assert.equal(point.blobs[2], 'countryside');
+  assert.equal(point.blobs[3], 'classic');
+  assert.equal(point.blobs[4], 'motion');
+  assert.match(point.indexes[0], /^[a-f0-9]{64}$/);
+  assert.notEqual(point.indexes[0], event().session, 'The ephemeral page-session ID must be hashed before Analytics Engine');
+  assert.equal(JSON.stringify(point).includes('ERIK'), false);
+  assert.equal(JSON.stringify(point).includes('challenge'), false);
+});
+
+await test('aggregates repeated events without keeping page-session identifiers in D1', async () => {
+  const DB = new FakeD1();
+  const ANALYTICS = new FakeAnalytics();
+  const first = event({ event: 'race_start' });
+  const second = event({ event: 'race_start', session: 'zT8mQ2pR6vN4cK7sL1xF5B' });
+  await handleTelemetryRoute(post([first, second]), { DB, ANALYTICS });
+
+  assert.equal(DB.rows.size, 1);
+  const [row] = DB.rows.values();
+  assert.equal(row.count, 2);
+  assert.equal(Object.hasOwn(row, 'session'), false);
+  assert.equal(Object.hasOwn(row, 'session_hash'), false);
+});
+
+await test('rejects telemetry writes outside enkel.design', async () => {
+  const response = await handleTelemetryRoute(post([event()], 'https://example.com'), {
+    DB: new FakeD1(),
+    ANALYTICS: new FakeAnalytics()
+  });
+  assert.equal(response.status, 403);
+  assert.equal((await response.json()).error, 'origin_not_allowed');
+});
+
+await test('keeps the private stats endpoint closed without a dashboard key', async () => {
+  const response = await handleTelemetryRoute(new Request(
+    'https://turn-challenges.example/v1/stats?days=30',
+    { headers: { Origin: ORIGIN } }
+  ), { DB: new FakeD1() });
+  assert.equal(response.status, 401);
+  assert.equal((await response.json()).error, 'stats_unauthorized');
+});
+
+await test('rejects unsupported telemetry dimensions and event types rather than storing arbitrary data', async () => {
+  const response = await handleTelemetryRoute(post([
+    event({ event: 'player_name', name: 'ERIK', challengeId: 'secret' })
+  ]), { DB: new FakeD1(), ANALYTICS: new FakeAnalytics() });
+  assert.equal(response.status, 400);
+  assert.equal((await response.json()).error, 'invalid_event');
+});

--- a/workers/turn-challenges/wrangler.jsonc
+++ b/workers/turn-challenges/wrangler.jsonc
@@ -1,7 +1,7 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
   "name": "turn-challenges",
-  "main": "src/index.js",
+  "main": "src/router.js",
   "compatibility_date": "2026-08-08",
   "workers_dev": true,
   "observability": {
@@ -10,6 +10,12 @@
   "d1_databases": [
     {
       "binding": "DB"
+    }
+  ],
+  "analytics_engine_datasets": [
+    {
+      "binding": "ANALYTICS",
+      "dataset": "turn_gameplay"
     }
   ]
 }


### PR DESCRIPTION
## Private usage statistics
- add event-driven gameplay telemetry for TURN and YOUR TURN after a race actually starts
- record play sessions, race starts, completed/void laps, track, car, steering mode, installed/browser state, Drive By Ear, blank-screen state and lap time
- keep telemetry out of rendering/physics loops and use `sendBeacon` / keepalive delivery
- add a private, unlinked `/turn/stats/` dashboard with 24h / 7 / 30 / 90 day and all-time views

## Privacy
- no analytics cookies, localStorage identifier or persistent analytics/player ID
- one random page-load session ID exists only in memory and is hashed before Analytics Engine
- no player names, challenge IDs/URLs, replay data, driving paths, control streams, advertising IDs or precise location in the gameplay payload
- D1 stores anonymous daily aggregates only; raw custom analytics use Cloudflare Analytics Engine
- add a shared native `<details>` privacy disclosure to ABOUT TURN, therefore available from TURN and YOUR TURN
- style it deliberately as a quiet link-like disclosure with the native marker, not the salient blue information-disclosure component

## Cloudflare
- keep the existing `turn-challenges` Worker and D1 challenge store
- route telemetry through a small wrapper so challenge handling remains untouched
- bind Analytics Engine dataset `turn_gameplay`; Cloudflare creates the dataset on first write
- protect the aggregate stats API with a private bearer key; only the SHA-256 hash is committed

## Important metric definition
The dashboard reports **PLAY SESSIONS**, meaning a page load that actually starts a race. It deliberately does not claim to count unique people because TURN does not persist an analytics identifier on a player device.

## QA
Final head `1706a5ffb4ab8dad668c74f9bd86d09b5ff3e0ba` is green:
- TURN regression suite **#1020** — passed
- TURN challenge regression **#55** — passed, including the telemetry/privacy production contract
- TURN challenge Worker **#5** — passed
- Worker tests cover 12 contracts total, including privacy-minimal telemetry ingestion and the existing immutable challenge API
- Wrangler 4.120.0 dry-run recognizes both `env.DB` and `env.ANALYTICS (turn_gameplay)`.