### PR TITLE
Fix TURN stats Cloudflare deployment

### DIFF
--- a/turn-tests/telemetry-production.mjs
+++ b/turn-tests/telemetry-production.mjs
@@ -36,6 +36,8 @@ assert.match(about, /<summary>PRIVACY &amp; USAGE STATISTICS<\/summary>/);
 assert.match(about, /no analytics cookie and creates no persistent analytics identifier/i);
 assert.match(about, /does not include your name, challenge name, challenge link or ID, replay, driving path, control inputs/i);
 assert.match(about, /private developer dashboard/i);
+assert.match(about, /anonymous daily aggregate statistics in Cloudflare D1/i);
+assert.match(about, /does not keep raw gameplay-event histories/i);
 assert.match(about, /about-privacy\.css\?revision=r1/);
 
 assert.match(privacyCss, /\.turn-about-privacy summary[\s\S]*color: inherit[\s\S]*font: inherit/);
@@ -62,13 +64,12 @@ assert.match(statsJs, /Motion-steered races/);
 assert.match(statsJs, /Drive By Ear races/);
 
 assert.match(workerConfig, /"main": "src\/router\.js"/);
-assert.match(workerConfig, /"analytics_engine_datasets"/);
-assert.match(workerConfig, /"binding": "ANALYTICS"/);
-assert.match(workerConfig, /"dataset": "turn_gameplay"/);
+assert.match(workerConfig, /"d1_databases"/);
+assert.match(workerConfig, /"binding": "DB"/);
+assert.doesNotMatch(workerConfig, /analytics_engine_datasets|"binding": "ANALYTICS"/,
+  'Private stats must deploy using the already-proven D1 binding only');
 assert.match(workerRouter, /handleTelemetryRoute/);
 assert.match(workerTelemetry, /'play_session'[\s\S]*'race_start'[\s\S]*'lap_complete'[\s\S]*'lap_invalid'/);
-assert.match(workerTelemetry, /writeDataPoint/);
-assert.match(workerTelemetry, /const sessionHash = await sha256Hex\(event\.session\)/);
 assert.match(workerTelemetry, /CREATE TABLE IF NOT EXISTS turn_telemetry_daily/);
 assert.doesNotMatch(workerTelemetry, /INSERT INTO turn_telemetry_(?:event|raw|session)|session_hash TEXT|player_id TEXT/i,
   'D1 must keep daily aggregate usage only, not persistent player/session histories');

--- a/turn/content/about-turn.js
+++ b/turn/content/about-turn.js
@@ -25,7 +25,7 @@ export function aboutTurnHtml() {
           <p>The events can include TURN or YOUR TURN, app build, track, car, motion or manual steering, browser or installed web app, Drive By Ear and blank-screen state, valid or void laps and lap time.</p>
           <p>TURN’s analytics payload does not include your name, challenge name, challenge link or ID, replay, driving path, control inputs, advertising identifiers, IP address or precise location. Cloudflare processes normal network request information while carrying the events, but TURN does not add that information to its gameplay statistics.</p>
           <p>TURN sets no analytics cookie and creates no persistent analytics identifier. A random identifier exists only in memory for the current page load so events from that one play session can be grouped; it disappears when the page is closed or reloaded.</p>
-          <p>Raw custom analytics are retained by Cloudflare Analytics Engine for three months. TURN also keeps anonymous daily totals in D1 for longer-term trends in a private developer dashboard. The statistics are not public and are not used for advertising.</p>
+          <p>TURN keeps anonymous daily aggregate statistics in Cloudflare D1 for the private developer dashboard. It does not keep raw gameplay-event histories in that database. The statistics are not public and are not used for advertising.</p>
         </div>
       </details>
     </div>`;

--- a/workers/turn-challenges/README.md
+++ b/workers/turn-challenges/README.md
@@ -19,10 +19,9 @@ There is intentionally no update or delete API for challenge snapshots. Two peop
 
 - `POST /v1/telemetry` — accepts a small batch of allow-listed gameplay events from TURN/YOUR TURN.
 - `GET /v1/stats?days=30` — returns anonymous aggregate statistics to the private dashboard after bearer-key authentication.
-- Analytics Engine binding: `ANALYTICS`, dataset `turn_gameplay`.
-- D1 stores daily aggregate counts only. It does not store player IDs or page-session IDs.
+- D1 stores daily aggregate counts only. It does not store player IDs, page-session IDs or raw gameplay-event histories.
 
-TURN does not create an analytics cookie or persistent analytics identifier. A random page-session identifier exists only in browser memory, is hashed by the Worker before the Analytics Engine write, and is never written to D1. Telemetry starts only after a race actually starts and is event-driven rather than frame-driven.
+TURN does not create an analytics cookie or persistent analytics identifier. A random page-session identifier exists only in browser memory and is never written to D1. Telemetry starts only after a race actually starts and is event-driven rather than frame-driven.
 
 Current event types are deliberately small:
 
@@ -55,7 +54,7 @@ Cloudflare Workers Builds deploys this project directly from `enkeldesign/webb`.
 - Build command: empty
 - Deploy command: `npx wrangler deploy`
 
-The Wrangler config declares D1 as binding `DB` and Analytics Engine as binding `ANALYTICS`. The `turn_gameplay` Analytics Engine dataset is created by Cloudflare when data is first written.
+The Wrangler config declares only the existing D1 binding `DB`. Usage statistics are aggregated directly into D1, which keeps the deployment surface small and avoids making the dashboard depend on a second analytics binding.
 
 After deployment, the public Worker base URL is:
 

--- a/workers/turn-challenges/wrangler.jsonc
+++ b/workers/turn-challenges/wrangler.jsonc
@@ -11,11 +11,5 @@
     {
       "binding": "DB"
     }
-  ],
-  "analytics_engine_datasets": [
-    {
-      "binding": "ANALYTICS",
-      "dataset": "turn_gameplay"
-    }
   ]
 }


### PR DESCRIPTION
## Why
Cloudflare Workers Builds failed the telemetry release in PR #379, leaving production on the previous Worker. The public `/v1/stats` endpoint therefore still returns `not_found`.

The private dashboard does not actually need Workers Analytics Engine to function: all dashboard queries already use anonymous daily aggregates in the existing D1 database. The extra Analytics Engine binding only added deployment surface.

## Fix
- remove the optional `ANALYTICS` binding from Wrangler
- keep the stats API and dashboard on the already-proven D1 binding
- align ABOUT privacy copy and Worker documentation with aggregate-only D1 storage
- keep the existing event-driven, non-persistent telemetry client unchanged
- update regression coverage to require the D1-only deployment contract

## Privacy
D1 keeps anonymous daily aggregates only. It does not store player IDs, session IDs or raw gameplay-event histories.

## Verification
GitHub CI and, crucially, the Cloudflare Workers preview deployment should both pass before merge. The Cloudflare preview is the deployment-path regression test that matters here.