### PR TITLE
Fix YOUR TURN About modal scrolling

### DIFF
--- a/.github/workflows/turn-challenge-tests.yml
+++ b/.github/workflows/turn-challenge-tests.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Run YOUR TURN recipient contract
         run: node turn-tests/yourturn-production.mjs
 
+      - name: Run YOUR TURN About modal regression
+        run: node turn-tests/yourturn-about-modal-production.mjs
+
       - name: Run TURN to YOUR TURN sharing contract
         run: node turn-tests/yourturn-turn-sharing-production.mjs
 

--- a/turn-tests/yourturn-about-modal-production.mjs
+++ b/turn-tests/yourturn-about-modal-production.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const [indexSource, sessionSource, aboutCss] = await Promise.all([
+  fs.readFile(new URL('../yourturn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/session.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/about-links.css', import.meta.url), 'utf8')
+]);
+
+assert.match(indexSource, /about-links\.css\?revision=r2/,
+  'YOUR TURN must cache-bust the About modal scrolling fix');
+assert.match(sessionSource, /titleText: 'ABOUT TURN'[\s\S]*className: 'about'[\s\S]*label: 'BACK'[\s\S]*label: 'GET THE GAME'/,
+  'ABOUT TURN keeps its explicit About view and accessible footer actions');
+
+assert.match(aboutCss, /\.yourturn-dialog\s*\{[\s\S]*overflow:\s*hidden/,
+  'The outer dialog must not become a second scroll container');
+assert.match(aboutCss, /\.yourturn-card\[data-view="about"\]\s*\{[\s\S]*display:\s*flex[\s\S]*flex-direction:\s*column[\s\S]*overflow:\s*hidden/,
+  'The About card must contain scrolling instead of scrolling itself');
+assert.match(aboutCss, /\.yourturn-card\[data-view="about"\]\s+\.yourturn-extra\s*\{[\s\S]*min-height:\s*0[\s\S]*overflow-y:\s*auto[\s\S]*overscroll-behavior-y:\s*contain[\s\S]*touch-action:\s*pan-y/,
+  'Only the About content region should scroll normally on touch devices');
+assert.match(aboutCss, /\.yourturn-card\[data-view="about"\]\s+\.yourturn-actions\s*\{[\s\S]*position:\s*relative[\s\S]*z-index:\s*2/,
+  'About footer actions must stay outside the scrolling content and remain interactive');
+
+console.log('YOUR TURN About modal top position, single-scroll behavior and footer access regression passed.');

--- a/yourturn/about-links.css
+++ b/yourturn/about-links.css
@@ -2,3 +2,45 @@ html[data-turn-deployment="yourturn"] .yourturn-card[data-view="about"] a,
 html[data-turn-deployment="yourturn"] .yourturn-card[data-view="about"] a:visited {
   color: #08090a;
 }
+
+/*
+ * ABOUT TURN is deliberately a single-scroll-region modal. The outer <dialog>
+ * and card must not both scroll on iOS: nested scrolling caused the content to
+ * open part-way down, snap while swiping, and leave the visible footer buttons
+ * outside the active touch-scrolling region.
+ */
+html[data-turn-deployment="yourturn"] .yourturn-dialog {
+  overflow: hidden;
+}
+
+html[data-turn-deployment="yourturn"] .yourturn-card[data-view="about"] {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+html[data-turn-deployment="yourturn"] .yourturn-card[data-view="about"] .yourturn-card-head,
+html[data-turn-deployment="yourturn"] .yourturn-card[data-view="about"] .yourturn-name-field,
+html[data-turn-deployment="yourturn"] .yourturn-card[data-view="about"] .yourturn-dialog-status,
+html[data-turn-deployment="yourturn"] .yourturn-card[data-view="about"] .yourturn-actions {
+  flex: 0 0 auto;
+}
+
+html[data-turn-deployment="yourturn"] .yourturn-card[data-view="about"] .yourturn-extra {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior-y: contain;
+  -webkit-overflow-scrolling: touch;
+  touch-action: pan-y;
+  scroll-behavior: auto;
+  scroll-padding-block: 8px;
+}
+
+html[data-turn-deployment="yourturn"] .yourturn-card[data-view="about"] .yourturn-actions {
+  position: relative;
+  z-index: 2;
+  margin-top: 10px;
+  padding-bottom: 2px;
+}

--- a/yourturn/index.html
+++ b/yourturn/index.html
@@ -43,7 +43,7 @@
   <link rel="stylesheet" href="/yourturn/yourturn.css?revision=r3">
   <link rel="stylesheet" href="/yourturn/nonvisual.css?revision=r1">
   <link rel="stylesheet" href="/yourturn/growing-challenge.css?revision=r2">
-  <link rel="stylesheet" href="/yourturn/about-links.css?revision=r1">
+  <link rel="stylesheet" href="/yourturn/about-links.css?revision=r2">
 
   <script src="/yourturn/storage-bootstrap.js?revision=r2"></script>
   <script type="importmap">


### PR DESCRIPTION
## Fix
- make ABOUT TURN use one scroll region instead of nested dialog/card scrolling
- keep the ABOUT header and footer actions outside the scrolling content
- ensure touch scrolling is vertical and contained on iOS
- cache-bust the About-specific stylesheet

## Result
1. ABOUT TURN opens at the top of its content.
2. Scrolling no longer jumps between nested scroll containers.
3. BACK and GET THE GAME remain reachable and interactive while the content scrolls.

## Scope
YOUR TURN only. Production TURN's ABOUT modal is unchanged.

## QA
Adds a focused YOUR TURN About modal regression and runs it in the existing challenge workflow.