### PR TITLE
Add hidden Chromatic Camouflage achievement to TURN 1.6.0

### DIFF
--- a/.github/workflows/turn-chromatic-camouflage.yml
+++ b/.github/workflows/turn-chromatic-camouflage.yml
@@ -1,0 +1,48 @@
+name: TURN Chromatic Camouflage regression
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'turn/index.html'
+      - 'turn/achievements/catalog-chromatic-r183.js'
+      - 'turn/achievements/chromatic-camouflage-r183.js'
+      - 'turn/progression/trophy-road-chromatic-r183.js'
+      - 'turn-lab/tests/chromatic-camouflage-production.mjs'
+      - '.github/workflows/turn-chromatic-camouflage.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'turn/index.html'
+      - 'turn/achievements/catalog-chromatic-r183.js'
+      - 'turn/achievements/chromatic-camouflage-r183.js'
+      - 'turn/progression/trophy-road-chromatic-r183.js'
+      - 'turn-lab/tests/chromatic-camouflage-production.mjs'
+      - '.github/workflows/turn-chromatic-camouflage.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  regression:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Syntax-check Chromatic Camouflage modules
+        run: |
+          node --check turn/achievements/catalog-chromatic-r183.js
+          node --check turn/achievements/chromatic-camouflage-r183.js
+          node --check turn/progression/trophy-road-chromatic-r183.js
+          node --check turn-lab/tests/chromatic-camouflage-production.mjs
+
+      - name: Run Chromatic Camouflage production regression
+        run: node turn-lab/tests/chromatic-camouflage-production.mjs

--- a/turn-lab/tests/chromatic-camouflage-production.mjs
+++ b/turn-lab/tests/chromatic-camouflage-production.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import {
+  ACHIEVEMENTS,
+  TRACK_IDS,
+  getAchievement
+} from '../../turn/achievements/catalog-chromatic-r183.js';
+import {
+  CHROMATIC_CAMOUFLAGE_ID,
+  matchesTrackColor,
+  qualifyingChromaticCamouflage
+} from '../../turn/achievements/chromatic-camouflage-r183.js';
+import { TROPHY_ROAD_MAX_THRESHOLD } from '../../turn/progression/trophy-road-chromatic-r183.js';
+
+const indexSource = await fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8');
+const moduleSource = await fs.readFile(
+  new URL('../../turn/achievements/chromatic-camouflage-r183.js', import.meta.url),
+  'utf8'
+);
+
+const achievement = getAchievement(CHROMATIC_CAMOUFLAGE_ID);
+assert.equal(ACHIEVEMENTS.length, 29,
+  'Production TURN should expose the existing 28 achievements plus Chromatic Camouflage');
+assert.equal(achievement?.title, 'CHROMATIC CAMOUFLAGE');
+assert.equal(achievement?.hidden, true);
+assert.equal(achievement?.category, 'exploration');
+assert.equal(achievement?.trophies, 50);
+assert.equal(
+  achievement?.description,
+  'Set your personal best on every track in a car painted to match that track.'
+);
+assert.equal(
+  ACHIEVEMENTS.reduce((total, item) => total + item.trophies, 0),
+  1750
+);
+assert.equal(TROPHY_ROAD_MAX_THRESHOLD, 1750);
+
+const factoryRoute = Object.freeze({
+  countryside: Object.freeze({ time: 18, carId: 'convertible', carColor: '#a8327a' }),
+  airport: Object.freeze({ time: 21, carId: 'classic', carColor: '#ffcc00' }),
+  harbor: Object.freeze({ time: 35, carId: 'vintage-racer', carColor: '#8b5a2b' }),
+  cliffside: Object.freeze({ time: 24, carId: 'race-future', carColor: '#00aabb' }),
+  'midnight-city': Object.freeze({ time: 70, carId: 'sedan-sports', carColor: '#5e3c87' })
+});
+
+for (const trackId of TRACK_IDS) {
+  assert.equal(matchesTrackColor(trackId, factoryRoute[trackId].carColor), true,
+    `${trackId} should admit its corresponding factory-colour route`);
+}
+
+assert.equal(matchesTrackColor('countryside', '#ff70b4'), true);
+assert.equal(matchesTrackColor('airport', '#ffd84f'), true);
+assert.equal(matchesTrackColor('harbor', '#f28b39'), true);
+assert.equal(matchesTrackColor('cliffside', '#3ccad6'), true);
+assert.equal(matchesTrackColor('midnight-city', '#a785ea'), true);
+
+assert.equal(matchesTrackColor('countryside', '#ffcc00'), false,
+  'A saturated wrong hue must not count');
+assert.equal(matchesTrackColor('airport', '#fafafa'), false,
+  'Near-white paint must not count even when hue is ambiguous');
+assert.equal(matchesTrackColor('midnight-city', '#160b22'), false,
+  'Very dark paint must not count');
+assert.equal(matchesTrackColor('cliffside', '#777777'), false,
+  'Low-chroma grey must not count');
+
+const qualifying = qualifyingChromaticCamouflage((trackId) => factoryRoute[trackId]);
+assert.equal(qualifying?.length, TRACK_IDS.length);
+assert.deepEqual(qualifying?.map(({ trackId }) => trackId), TRACK_IDS);
+
+assert.equal(qualifyingChromaticCamouflage((trackId) => (
+  trackId === 'harbor'
+    ? { ...factoryRoute[trackId], carColor: '#ff4fa3' }
+    : factoryRoute[trackId]
+)), null, 'One wrong-colour personal best must keep the achievement locked');
+
+assert.equal(qualifyingChromaticCamouflage((trackId) => (
+  trackId === 'airport' ? null : factoryRoute[trackId]
+)), null, 'Every canonical production track must have a stored personal best');
+
+assert.match(moduleSource, /minSaturation: 0\.30/);
+assert.match(moduleSource, /minLightness: 0\.28/);
+assert.match(moduleSource, /maxLightness: 0\.85/);
+assert.match(moduleSource, /turn:lap-result/,
+  'The state should be re-evaluated after a record can change');
+
+assert.match(indexSource, /TURN v1\.6\.0 · Build 2026\.08\.08-r162/);
+assert.match(indexSource, /catalog-chromatic-r183\.js/,
+  'Production must route the achievement store and view through the Chromatic catalog');
+assert.match(indexSource, /trophy-road-chromatic-r183\.js/,
+  'Production must expose the expanded 1750-trophy road maximum');
+assert.match(indexSource, /chromatic-camouflage-r183\.js/,
+  'Production must install the hidden achievement evaluator');
+assert.doesNotMatch(indexSource, /airport-runway/,
+  'The TURN NEXT Airport prototype must not enter the production TURN entry point');
+
+console.log('TURN production Chromatic Camouflage achievement regression passed.');

--- a/turn/achievements/catalog-chromatic-r183.js
+++ b/turn/achievements/catalog-chromatic-r183.js
@@ -1,0 +1,32 @@
+import * as base from './catalog.js?revision=r166-chromatic-base';
+
+const CHROMATIC_CAMOUFLAGE = Object.freeze({
+  id: 'chromatic-camouflage',
+  category: base.CATEGORY.EXPLORATION,
+  trophies: 50,
+  hidden: true,
+  title: 'CHROMATIC CAMOUFLAGE',
+  description: 'Set your personal best on every track in a car painted to match that track.',
+  icon: 'secret'
+});
+
+const firstTimeTrialIndex = base.ACHIEVEMENTS.findIndex(
+  (achievement) => achievement.category === base.CATEGORY.TIME_TRIALS
+);
+const insertionIndex = firstTimeTrialIndex >= 0 ? firstTimeTrialIndex : base.ACHIEVEMENTS.length;
+
+export const ACHIEVEMENTS = Object.freeze([
+  ...base.ACHIEVEMENTS.slice(0, insertionIndex),
+  CHROMATIC_CAMOUFLAGE,
+  ...base.ACHIEVEMENTS.slice(insertionIndex)
+]);
+
+const ACHIEVEMENT_BY_ID = new Map(
+  ACHIEVEMENTS.map((achievement) => [achievement.id, achievement])
+);
+
+export function getAchievement(id) {
+  return ACHIEVEMENT_BY_ID.get(id) || null;
+}
+
+export * from './catalog.js?revision=r166-chromatic-base';

--- a/turn/achievements/chromatic-camouflage-r183.js
+++ b/turn/achievements/chromatic-camouflage-r183.js
@@ -89,7 +89,6 @@ export function installChromaticCamouflageAchievement() {
   if (globalThis.__turnChromaticCamouflage) return globalThis.__turnChromaticCamouflage;
 
   let achievements = globalThis.__turnAchievements || null;
-  let retryTimer = 0;
   let disposed = false;
 
   const evaluate = () => {
@@ -104,21 +103,16 @@ export function installChromaticCamouflageAchievement() {
   };
 
   const scheduleEvaluation = () => globalThis.setTimeout?.(evaluate, 0);
-  const retryUntilReady = () => {
-    if (disposed || evaluate()) return;
-    retryTimer = globalThis.setTimeout?.(retryUntilReady, 100) || 0;
-  };
 
   globalThis.addEventListener?.('turn:lap-result', scheduleEvaluation);
   globalThis.addEventListener?.('turn:home-ready', scheduleEvaluation);
-  retryUntilReady();
+  scheduleEvaluation();
 
   const api = Object.freeze({
     evaluate,
     matchesTrackColor,
     disconnect() {
       disposed = true;
-      globalThis.clearTimeout?.(retryTimer);
       globalThis.removeEventListener?.('turn:lap-result', scheduleEvaluation);
       globalThis.removeEventListener?.('turn:home-ready', scheduleEvaluation);
       globalThis.__turnChromaticCamouflage = null;

--- a/turn/achievements/chromatic-camouflage-r183.js
+++ b/turn/achievements/chromatic-camouflage-r183.js
@@ -128,4 +128,6 @@ export function installChromaticCamouflageAchievement() {
   return api;
 }
 
-installChromaticCamouflageAchievement();
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  installChromaticCamouflageAchievement();
+}

--- a/turn/achievements/chromatic-camouflage-r183.js
+++ b/turn/achievements/chromatic-camouflage-r183.js
@@ -1,0 +1,131 @@
+import { TRACK_IDS } from './catalog-chromatic-r183.js';
+import { getStoredBestLap } from '../race/rival-storage.js';
+
+export const CHROMATIC_CAMOUFLAGE_ID = 'chromatic-camouflage';
+
+const COLOR_LIMITS = Object.freeze({
+  minSaturation: 0.30,
+  minLightness: 0.28,
+  maxLightness: 0.85
+});
+
+export const TRACK_COLOR_RULES = Object.freeze({
+  countryside: Object.freeze({ hueMin: 305, hueMax: 350, name: 'pink' }),
+  airport: Object.freeze({ hueMin: 40, hueMax: 65, name: 'yellow' }),
+  harbor: Object.freeze({ hueMin: 15, hueMax: 39.999, name: 'orange' }),
+  cliffside: Object.freeze({ hueMin: 165, hueMax: 205, name: 'cyan' }),
+  'midnight-city': Object.freeze({ hueMin: 240, hueMax: 285, name: 'violet' })
+});
+
+function normalizeHex(color) {
+  if (typeof color !== 'string') return null;
+  const value = color.trim().toLowerCase();
+  if (/^#[0-9a-f]{6}$/.test(value)) return value;
+  if (/^#[0-9a-f]{3}$/.test(value)) {
+    return `#${value.slice(1).split('').map((digit) => digit + digit).join('')}`;
+  }
+  return null;
+}
+
+export function hexToHsl(color) {
+  const hex = normalizeHex(color);
+  if (!hex) return null;
+
+  const channels = [1, 3, 5].map((index) => parseInt(hex.slice(index, index + 2), 16) / 255);
+  const [red, green, blue] = channels;
+  const max = Math.max(red, green, blue);
+  const min = Math.min(red, green, blue);
+  const delta = max - min;
+  const lightness = (max + min) / 2;
+
+  let hue = 0;
+  let saturation = 0;
+  if (delta > 0) {
+    saturation = delta / (1 - Math.abs(2 * lightness - 1));
+    if (max === red) hue = 60 * (((green - blue) / delta) % 6);
+    else if (max === green) hue = 60 * (((blue - red) / delta) + 2);
+    else hue = 60 * (((red - green) / delta) + 4);
+    if (hue < 0) hue += 360;
+  }
+
+  return Object.freeze({ hue, saturation, lightness });
+}
+
+export function matchesTrackColor(trackId, color) {
+  const rule = TRACK_COLOR_RULES[trackId];
+  const hsl = hexToHsl(color);
+  if (!rule || !hsl) return false;
+  if (hsl.saturation < COLOR_LIMITS.minSaturation) return false;
+  if (hsl.lightness < COLOR_LIMITS.minLightness || hsl.lightness > COLOR_LIMITS.maxLightness) return false;
+  return hsl.hue >= rule.hueMin && hsl.hue <= rule.hueMax;
+}
+
+export function qualifyingChromaticCamouflage(getBestLap = getStoredBestLap) {
+  const matches = [];
+  for (const trackId of TRACK_IDS) {
+    const bestLap = getBestLap(trackId);
+    if (!bestLap || !matchesTrackColor(trackId, bestLap.carColor)) return null;
+    matches.push(Object.freeze({
+      trackId,
+      time: Number(bestLap.time),
+      carId: bestLap.carId || '',
+      carColor: bestLap.carColor
+    }));
+  }
+  return Object.freeze(matches);
+}
+
+function achievementContext(matches) {
+  const activeTrackId = globalThis.__turnRuntime?.state?.trackId || '';
+  const active = matches.find((entry) => entry.trackId === activeTrackId) || matches.at(-1);
+  return {
+    trackId: active?.trackId || '',
+    vehicleId: active?.carId || '',
+    time: Number.isFinite(active?.time) ? active.time : null
+  };
+}
+
+export function installChromaticCamouflageAchievement() {
+  if (globalThis.__turnChromaticCamouflage) return globalThis.__turnChromaticCamouflage;
+
+  let achievements = globalThis.__turnAchievements || null;
+  let retryTimer = 0;
+  let disposed = false;
+
+  const evaluate = () => {
+    if (disposed) return false;
+    achievements ||= globalThis.__turnAchievements || null;
+    if (!achievements?.store || !achievements?.unlock) return false;
+    if (achievements.store.isUnlocked(CHROMATIC_CAMOUFLAGE_ID)) return true;
+    const matches = qualifyingChromaticCamouflage();
+    if (!matches) return false;
+    achievements.unlock(CHROMATIC_CAMOUFLAGE_ID, achievementContext(matches));
+    return true;
+  };
+
+  const scheduleEvaluation = () => globalThis.setTimeout?.(evaluate, 0);
+  const retryUntilReady = () => {
+    if (disposed || evaluate()) return;
+    retryTimer = globalThis.setTimeout?.(retryUntilReady, 100) || 0;
+  };
+
+  globalThis.addEventListener?.('turn:lap-result', scheduleEvaluation);
+  globalThis.addEventListener?.('turn:home-ready', scheduleEvaluation);
+  retryUntilReady();
+
+  const api = Object.freeze({
+    evaluate,
+    matchesTrackColor,
+    disconnect() {
+      disposed = true;
+      globalThis.clearTimeout?.(retryTimer);
+      globalThis.removeEventListener?.('turn:lap-result', scheduleEvaluation);
+      globalThis.removeEventListener?.('turn:home-ready', scheduleEvaluation);
+      globalThis.__turnChromaticCamouflage = null;
+    }
+  });
+  globalThis.__turnChromaticCamouflage = api;
+  return api;
+}
+
+installChromaticCamouflageAchievement();

--- a/turn/index.html
+++ b/turn/index.html
@@ -110,6 +110,8 @@
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
+        "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
+        "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",
         "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260808-r162",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260808-r162",
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system-r86.js?build=20260808-r162",
@@ -186,6 +188,7 @@
   <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260808-r162-r168-shared-about-credits"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
   <script type="module" src="./app.js?build=20260808-r162-browser-consent-r176-bella-road-derived-zone"></script>
+  <script type="module" src="./achievements/chromatic-camouflage-r183.js?revision=r183-production"></script>
   <script type="module" src="./social/your-turn-share-bootstrap.js?revision=r2"></script>
   <script type="module" src="./tracks/countryside-bella-rescue-hotfix-r176.js?revision=r176-video-proven-rescue"></script>
 </body></html>

--- a/turn/progression/trophy-road-chromatic-r183.js
+++ b/turn/progression/trophy-road-chromatic-r183.js
@@ -1,0 +1,2 @@
+export const TROPHY_ROAD_MAX_THRESHOLD = 1750;
+export * from './trophy-road.js?revision=r166-chromatic-base';


### PR DESCRIPTION
## Scope
Production **TURN only**. TURN NEXT is deliberately untouched, including the AIRPORT: RUNWAY prototype.

The public release identity stays exactly **TURN 1.6.0 · build 2026.08.08-r162**. This is the only production game update in the PR.

## New hidden achievement
**CHROMATIC CAMOUFLAGE — 50 trophies**

Unlocked description:
> Set your personal best on every track in a car painted to match that track.

The achievement remains hidden until earned and uses the existing hidden-achievement treatment.

## Qualification
The five current production tracks are checked against broad hue families:
- Countryside — pink
- Airport — yellow
- Harbor — orange
- Cliffside — cyan
- Midnight City — violet

Matching is intentionally charitable: the car only needs to fall inside the approximate hue family, with a modest chroma floor and broad lightness window so near-pastels and darker body colours can count while greys, near-white and near-black do not.

This also deliberately leaves a difficult pre-PAINTJOB route possible through existing factory colours; PAINTJOB is helpful, not technically required.

The condition is based on the **currently stored personal-best lap on every track**, not merely any historical lap. It is re-evaluated when Home becomes ready and after lap results, so resetting/rebuilding records works naturally.

## Trophy Road
The total available collection becomes **1,750 trophies**. Reward thresholds are unchanged; only the road maximum expands from 1,700 to 1,750.

## Delivery / cache safety
Because the public build number remains r162, production uses small r183 achievement/Trophy Road overlays routed by the existing import map. This refreshes only the achievement graph without changing release metadata or TURN NEXT.

## QA
Adds a focused production regression covering:
- hidden/title/category/50-trophy contract
- exact 1,750 total
- all five hue families
- saturation/lightness exclusions
- a qualifying factory-colour route before PAINTJOB
- failure when one PB is the wrong colour or missing
- production 1.6.0/r162 identity
- explicit exclusion of the TURN NEXT Airport prototype from `turn/index.html`

The normal full TURN regression suite also runs because production TURN files changed.