### PR TITLE
TURN r163 hotfix: open native color picker with VoiceOver on iOS

### DIFF
--- a/turn-lab/tests/color-accessibility-production.mjs
+++ b/turn-lab/tests/color-accessibility-production.mjs
@@ -9,11 +9,23 @@ import {
   trackColorCue
 } from '../../turn/accessibility/color-cues.js';
 
-const [releaseSource, indexSource, runtimeSource, cssSource, historySource] = await Promise.all([
+const [
+  releaseSource,
+  indexSource,
+  runtimeSource,
+  cueCssSource,
+  lotSource,
+  lotCssSource,
+  lotTrackSelectSource,
+  historySource
+] = await Promise.all([
   fs.readFile(new URL('../../turn/release.json', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/accessibility/color-accessibility-r163.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/accessibility/color-cues-r163.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-r10.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-r10.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-track-select.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/content/about-history.js', import.meta.url), 'utf8')
 ]);
 const release = JSON.parse(releaseSource);
@@ -57,44 +69,57 @@ assert.equal(release.version, '1.7.0');
 assert.equal(release.id, '2026.08.09-r163');
 assert.equal(release.cacheKey, '20260809-r163');
 assert.match(indexSource, /TURN v1\.7\.0 · Build 2026\.08\.09-r163/);
-assert.match(indexSource, /accessibility\/color-cues-r163\.css/);
-assert.match(indexSource, /accessibility\/color-accessibility-r163\.js/);
+assert.match(indexSource, /garage\/lot-r10\.css\?build=20260809-r163-accessible-paint/);
+assert.match(indexSource, /accessibility\/color-cues-r163\.css\?build=20260809-r163-accessible-paint/);
+assert.match(indexSource, /accessibility\/color-accessibility-r163\.js\?build=20260809-r163-accessible-paint/);
+assert.match(indexSource, /lot-track-select\.js\?build=20260809-r163-accessible-paint/);
+assert.match(lotTrackSelectSource, /lot-r10\.js\?build=20260809-r163-accessible-paint/);
 
-assert.match(runtimeSource, /input\[type="color"\]/,
-  'TURN must keep the real native color input rather than substitute a custom picker');
-assert.match(runtimeSource, /lot-color-trigger/,
-  'An ordinary button must provide an assistive-technology activation path');
-assert.match(runtimeSource, /WebKit bug 312177 \/ rdar 172218114/,
-  'The workaround must document the upstream WebKit AXPress defect it is targeting');
-assert.match(runtimeSource, /function isIOSFamily\(\)/,
+// The Lot owns the paint control. The accessibility runtime must not replace
+// or rebuild it after render.
+assert.match(lotSource, /input\.type = 'color'/,
+  'The Lot must keep the real native color input rather than substitute a custom picker');
+assert.match(lotSource, /trigger\.className = 'lot-color-trigger'/,
+  'The Lot itself must create the accessible paint trigger');
+assert.match(lotSource, /input\.setAttribute\('aria-hidden', 'true'\)/,
+  'The broken native AXPress target must stay out of the VoiceOver swipe order');
+assert.match(lotSource, /trigger\.setAttribute\('aria-label', `\$\{label\} colour\. \$\{colourName\}\. Opens system color picker\.`\)/,
+  'The accessible trigger must expose the selected semantic color name');
+assert.match(lotSource, /function isIOSFamily\(\)/,
   'The iOS workaround must be scoped to iPhone and iPad rather than change desktop picker behavior');
-assert.match(runtimeSource, /input\.focus\(\{ preventScroll: true \}\)/,
+assert.match(lotSource, /input\.focus\(\{ preventScroll: true \}\)/,
   'On iOS, the accessible button must open the native form picker through DOM focus');
-assert.match(runtimeSource, /if \(isIOSFamily\(\)\)[\s\S]*focusNativeColorInput\(input\)[\s\S]*input\.click\(\)/,
+assert.match(lotSource, /if \(isIOSFamily\(\)\)[\s\S]*focusNativeColorInput\(input\)[\s\S]*input\.click\(\)/,
   'iOS must use focus while other platforms retain normal click activation');
-assert.doesNotMatch(runtimeSource, /label\.click\(/,
+assert.doesNotMatch(lotSource, /label\.click\(/,
   'Do not route through a synthetic label click; device testing showed that only moved VoiceOver to a hidden target');
-assert.doesNotMatch(runtimeSource, /showPicker\(/,
-  'The iOS accessibility fix must not rely on showPicker(), which is not dependable on affected iOS versions');
-assert.match(runtimeSource, /platform's own semantic color names/,
-  'The implementation must deliberately retain the system picker semantic color naming');
+assert.doesNotMatch(lotSource, /showPicker\(/,
+  'The iOS accessibility fix must not rely on showPicker(), which is not implemented for these iOS controls');
+assert.match(lotSource, /describeColorCue\(color\)/,
+  'Paint cues and accessible names must share the same semantic color classifier');
+assert.match(lotSource, /cue\.textContent = `COLOR · \$\{colourName\.toUpperCase\(\)\}`/);
+
+assert.doesNotMatch(runtimeSource, /lot-color-control|lot-color-trigger|input\[type="color"\]|replaceWith|enhancePaintControl/,
+  'Color Cues runtime must not post-process or replace The Lot paint controls');
 assert.match(runtimeSource, /Color cues/);
 assert.match(runtimeSource, /turn:color-cues-changed/);
 assert.match(runtimeSource, /TRACK COLOR ·/);
-assert.match(runtimeSource, /COLOR ·/);
 assert.doesNotMatch(runtimeSource, /setInterval|setAnimationLoop/,
   'Color accessibility must remain event/DOM driven rather than add a polling loop');
 
-assert.match(cssSource, /data-turn-color-cues='on'/);
-assert.match(cssSource, /lot-color-native/);
-assert.match(cssSource, /top: 50% !important/,
+assert.match(lotCssSource, /\.lot-color-input/);
+assert.match(lotCssSource, /\.lot-color-trigger/);
+assert.match(lotCssSource, /top: 50%/,
   'The native input must remain aligned with the visible paint swatch rather than at the viewport origin');
-assert.match(cssSource, /right: 5px !important/,
+assert.match(lotCssSource, /right: 5px/,
   'The native input focus geometry must match the visible trigger');
-assert.match(cssSource, /lot-color-trigger/);
-assert.match(cssSource, /track-card-color-cue/);
-assert.match(cssSource, /repeating-linear-gradient/,
+assert.match(cueCssSource, /data-turn-color-cues='on'/);
+assert.match(cueCssSource, /track-card-color-cue/);
+assert.match(cueCssSource, /lot-color-cue/);
+assert.match(cueCssSource, /repeating-linear-gradient/,
   'Color Cues must include a non-color pattern channel as well as text');
+assert.doesNotMatch(cueCssSource, /lot-color-native|lot-color-trigger/,
+  'Core paint-control styling must live with The Lot rather than in the optional Color Cues layer');
 
 assert.match(historySource, /1\.7\.0 r163/);
 assert.match(historySource, /accessibility patch/i);

--- a/turn-lab/tests/color-accessibility-production.mjs
+++ b/turn-lab/tests/color-accessibility-production.mjs
@@ -72,7 +72,7 @@ assert.match(indexSource, /TURN v1\.7\.0 · Build 2026\.08\.09-r163/);
 assert.match(indexSource, /garage\/lot-r10\.css\?build=20260809-r163-accessible-paint/);
 assert.match(indexSource, /accessibility\/color-cues-r163\.css\?build=20260809-r163-accessible-paint/);
 assert.match(indexSource, /accessibility\/color-accessibility-r163\.js\?build=20260809-r163-accessible-paint/);
-assert.match(indexSource, /lot-track-select\.js\?build=20260809-r163-accessible-paint/);
+assert.match(indexSource, /lot-track-select\.js\?build=20260809-r163&revision=r163-accessible-paint/);
 assert.match(lotTrackSelectSource, /lot-r10\.js\?build=20260809-r163-accessible-paint/);
 
 // The Lot owns the paint control. The accessibility runtime must not replace

--- a/turn-lab/tests/color-accessibility-production.mjs
+++ b/turn-lab/tests/color-accessibility-production.mjs
@@ -64,8 +64,16 @@ assert.match(runtimeSource, /input\[type="color"\]/,
   'TURN must keep the real native color input rather than substitute a custom picker');
 assert.match(runtimeSource, /lot-color-trigger/,
   'An ordinary button must provide an assistive-technology activation path');
-assert.match(runtimeSource, /trigger\.addEventListener\('click', \(\) => label\.click\(\)\)/,
-  'The accessible trigger must activate the associated label so iOS opens the native picker');
+assert.match(runtimeSource, /WebKit bug 312177 \/ rdar 172218114/,
+  'The workaround must document the upstream WebKit AXPress defect it is targeting');
+assert.match(runtimeSource, /function isIOSFamily\(\)/,
+  'The iOS workaround must be scoped to iPhone and iPad rather than change desktop picker behavior');
+assert.match(runtimeSource, /input\.focus\(\{ preventScroll: true \}\)/,
+  'On iOS, the accessible button must open the native form picker through DOM focus');
+assert.match(runtimeSource, /if \(isIOSFamily\(\)\)[\s\S]*focusNativeColorInput\(input\)[\s\S]*input\.click\(\)/,
+  'iOS must use focus while other platforms retain normal click activation');
+assert.doesNotMatch(runtimeSource, /label\.click\(/,
+  'Do not route through a synthetic label click; device testing showed that only moved VoiceOver to a hidden target');
 assert.doesNotMatch(runtimeSource, /showPicker\(/,
   'The iOS accessibility fix must not rely on showPicker(), which is not dependable on affected iOS versions');
 assert.match(runtimeSource, /platform's own semantic color names/,
@@ -79,6 +87,10 @@ assert.doesNotMatch(runtimeSource, /setInterval|setAnimationLoop/,
 
 assert.match(cssSource, /data-turn-color-cues='on'/);
 assert.match(cssSource, /lot-color-native/);
+assert.match(cssSource, /top: 50% !important/,
+  'The native input must remain aligned with the visible paint swatch rather than at the viewport origin');
+assert.match(cssSource, /right: 5px !important/,
+  'The native input focus geometry must match the visible trigger');
 assert.match(cssSource, /lot-color-trigger/);
 assert.match(cssSource, /track-card-color-cue/);
 assert.match(cssSource, /repeating-linear-gradient/,

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -147,7 +147,10 @@ assert.match(index, new RegExp(`TURN v${release.version.replaceAll('.', '\\.')} 
 assert.match(index, new RegExp(`\\.\\/garage\\/lot-r10\\.css\\?build=${release.cacheKey}`));
 assert.match(index, new RegExp(`\\.\\/track-intro\\.css\\?build=${release.cacheKey}`));
 assert.match(index, new RegExp(`src="\\.\\/app\\.js\\?build=${release.cacheKey}-browser-consent(?:-[^"]+)?"`));
-assert.equal(imports['./garage/lot-r10.js?build=20260720-r19'], releaseTarget('./garage/lot-track-select.js'));
+assert.equal(
+  imports['./garage/lot-r10.js?build=20260720-r19'],
+  `${releaseTarget('./garage/lot-track-select.js')}&revision=r163-accessible-paint`
+);
 assert.equal(imports['./ui/track-intro.js?build=20260725-r75'], releaseTarget('./ui/track-intro.js'));
 assert.equal(imports['./race/lap-system.js?build=20260720-r19'], releaseTarget('./race/lap-system-r86.js'));
 

--- a/turn-lab/tests/lot-layout-production.mjs
+++ b/turn-lab/tests/lot-layout-production.mjs
@@ -32,7 +32,11 @@ const imports = JSON.parse(importMapText).imports;
 
 assert.match(index, new RegExp(`lot-layout-r60\\.css\\?build=${release.cacheKey}`), 'Production must retain the baseline Lot layout stylesheet');
 assert.match(index, new RegExp(`app\\.js\\?build=${release.cacheKey}-browser-consent`), 'Production must cache-bust the browser-gated canonical runtime');
-assert.equal(imports['./garage/lot-r10.js?build=20260720-r19'], `./garage/lot-track-select.js?build=${release.cacheKey}`, 'Production must retain the track-first compatibility wrapper');
+assert.equal(
+  imports['./garage/lot-r10.js?build=20260720-r19'],
+  `./garage/lot-track-select.js?build=${release.cacheKey}&revision=r163-accessible-paint`,
+  'Production must retain the track-first compatibility wrapper with the accessible-paint revision'
+);
 
 assert.match(app, /lot-layout-r60\.css\?revision=r121-viewer-r122-fit-r128-super-sedan-notice-r129-race-button-fit/, 'The Super Sedan fit stylesheet must bypass the previous notice cache');
 assert.match(app, /lot-enhancement-runtime\.js\?revision=r121/, 'Production must load the route-independent Lot enhancer');

--- a/turn-lab/tests/stat-legend-production.mjs
+++ b/turn-lab/tests/stat-legend-production.mjs
@@ -31,7 +31,11 @@ assert.ok(importMapText, 'Production must expose its import map');
 const imports = JSON.parse(importMapText).imports;
 
 assert.match(index, new RegExp(`lot-stat-legend\\.css\\?build=${release.cacheKey}`), 'Production must load the stat-legend styling through the current release');
-assert.equal(imports['./garage/lot-r10.js?build=20260720-r19'], `./garage/lot-track-select.js?build=${release.cacheKey}`, 'Production must publish the compact Lot wrapper through the current release');
+assert.equal(
+  imports['./garage/lot-r10.js?build=20260720-r19'],
+  `./garage/lot-track-select.js?build=${release.cacheKey}&revision=r163-accessible-paint`,
+  'Production must publish the compact accessible Lot wrapper through the current release'
+);
 assert.equal(imports['./vehicle/physics.js?build=20260720-r19'], `./vehicle/physics.js?build=${release.cacheKey}`, 'Production must publish the mandatory DRIFT penalty through the current release');
 assert.equal(imports['./vehicle/catalog.js?build=20260720-r19'], `./vehicle/catalog.js?build=${release.cacheKey}`, 'Production must publish the shared stat definitions through the current release');
 assert.match(wrapper, /const lotResult = showOriginalLot\(options\)/, 'The verified Lot must mount synchronously before enhancement');

--- a/turn/accessibility/color-accessibility-r163.js
+++ b/turn/accessibility/color-accessibility-r163.js
@@ -6,12 +6,30 @@ import {
   trackColorCue
 } from './color-cues.js?revision=r163';
 
-const RUNTIME_ID = 'color-accessibility-r163';
+const RUNTIME_ID = 'color-accessibility-r163-focus-bridge';
 let paintControlSerial = 0;
 let scheduled = false;
 
 function settingsStatus(dialog) {
   return dialog.querySelector('.m8-settings-status');
+}
+
+function isIOSFamily() {
+  const navigatorObject = globalThis.navigator;
+  if (!navigatorObject) return false;
+  const platform = String(navigatorObject.platform || '');
+  const userAgent = String(navigatorObject.userAgent || '');
+  return /iPhone|iPad|iPod/i.test(platform)
+    || /iPhone|iPad|iPod/i.test(userAgent)
+    || (platform === 'MacIntel' && Number(navigatorObject.maxTouchPoints || 0) > 1);
+}
+
+function focusNativeColorInput(input) {
+  try {
+    input.focus({ preventScroll: true });
+  } catch (_) {
+    input.focus();
+  }
 }
 
 function installColorCueSetting() {
@@ -97,10 +115,11 @@ function enhancePaintControl(control) {
   const copy = document.createElement('span');
   copy.className = 'lot-color-copy';
 
-  const label = document.createElement('label');
+  // Use ordinary text to name the accessible trigger. A <label> here would
+  // activate the broken native AXPress path again on affected iOS versions.
+  const label = document.createElement('span');
   label.className = 'lot-color-label';
   label.id = labelId;
-  label.htmlFor = inputId;
   label.textContent = labelText.toUpperCase();
 
   const cue = document.createElement('span');
@@ -119,12 +138,19 @@ function enhancePaintControl(control) {
     cue.textContent = `COLOR · ${describeColorCue(color).toUpperCase()}`;
   };
 
-  // WebKit before Safari 27 exposes the native color well to VoiceOver but its
-  // accessibility Press action can fail to open the picker. A real button can
-  // still receive the assistive-technology activation. Forward that activation
-  // through the associated label: iOS then opens the same native color picker,
-  // including the platform's own semantic color names, without TURN replacing it.
-  trigger.addEventListener('click', () => label.click());
+  // WebKit bug 312177 / rdar 172218114 prevents VoiceOver AXPress from
+  // activating input[type="color"] before Safari 27. iOS still opens native
+  // form pickers when their input receives DOM focus, so the real button uses
+  // focus() on iPhone/iPad. Other platforms keep the normal click() route.
+  // The native input remains the source of truth and the picker keeps the
+  // platform's own semantic color names, including custom colors.
+  trigger.addEventListener('click', () => {
+    if (isIOSFamily()) {
+      focusNativeColorInput(input);
+      return;
+    }
+    input.click();
+  });
   input.addEventListener('input', () => requestAnimationFrame(sync));
   input.addEventListener('change', sync);
 

--- a/turn/accessibility/color-accessibility-r163.js
+++ b/turn/accessibility/color-accessibility-r163.js
@@ -1,35 +1,15 @@
 import {
   applyColorCuesState,
-  describeColorCue,
   loadColorCuesEnabled,
   saveColorCuesEnabled,
   trackColorCue
 } from './color-cues.js?revision=r163';
 
-const RUNTIME_ID = 'color-accessibility-r163-focus-bridge';
-let paintControlSerial = 0;
+const RUNTIME_ID = 'color-cues-r163';
 let scheduled = false;
 
 function settingsStatus(dialog) {
   return dialog.querySelector('.m8-settings-status');
-}
-
-function isIOSFamily() {
-  const navigatorObject = globalThis.navigator;
-  if (!navigatorObject) return false;
-  const platform = String(navigatorObject.platform || '');
-  const userAgent = String(navigatorObject.userAgent || '');
-  return /iPhone|iPad|iPod/i.test(platform)
-    || /iPhone|iPad|iPod/i.test(userAgent)
-    || (platform === 'MacIntel' && Number(navigatorObject.maxTouchPoints || 0) > 1);
-}
-
-function focusNativeColorInput(input) {
-  try {
-    input.focus({ preventScroll: true });
-  } catch (_) {
-    input.focus();
-  }
 }
 
 function installColorCueSetting() {
@@ -89,88 +69,10 @@ function installTrackColorCues() {
   }
 }
 
-function paintLabel(control) {
-  return control.dataset.paintLabel || control.querySelector('span')?.textContent?.trim() || 'Paint';
-}
-
-function enhancePaintControl(control) {
-  if (control.dataset.turnColorAccessibility === RUNTIME_ID) return;
-  const input = control.querySelector('input[type="color"]');
-  if (!input) return;
-
-  const labelText = paintLabel(control);
-  const replacement = document.createElement('div');
-  replacement.className = control.className;
-  replacement.dataset.paintLabel = labelText;
-  replacement.dataset.turnColorAccessibility = RUNTIME_ID;
-
-  const serial = ++paintControlSerial;
-  const inputId = input.id || `turnPaintColor${serial}`;
-  const labelId = `turnPaintColorLabel${serial}`;
-  input.id = inputId;
-  input.classList.add('lot-color-native');
-  input.tabIndex = -1;
-  input.setAttribute('aria-hidden', 'true');
-
-  const copy = document.createElement('span');
-  copy.className = 'lot-color-copy';
-
-  // Use ordinary text to name the accessible trigger. A <label> here would
-  // activate the broken native AXPress path again on affected iOS versions.
-  const label = document.createElement('span');
-  label.className = 'lot-color-label';
-  label.id = labelId;
-  label.textContent = labelText.toUpperCase();
-
-  const cue = document.createElement('span');
-  cue.className = 'turn-color-cue lot-color-cue';
-  cue.setAttribute('aria-hidden', 'true');
-
-  const trigger = document.createElement('button');
-  trigger.type = 'button';
-  trigger.className = 'lot-color-trigger';
-  trigger.setAttribute('aria-labelledby', labelId);
-  trigger.setAttribute('aria-description', 'Opens the system color picker.');
-
-  const sync = () => {
-    const color = input.value || '#ffcc00';
-    trigger.style.setProperty('--lot-color-value', color);
-    cue.textContent = `COLOR · ${describeColorCue(color).toUpperCase()}`;
-  };
-
-  // WebKit bug 312177 / rdar 172218114 prevents VoiceOver AXPress from
-  // activating input[type="color"] before Safari 27. iOS still opens native
-  // form pickers when their input receives DOM focus, so the real button uses
-  // focus() on iPhone/iPad. Other platforms keep the normal click() route.
-  // The native input remains the source of truth and the picker keeps the
-  // platform's own semantic color names, including custom colors.
-  trigger.addEventListener('click', () => {
-    if (isIOSFamily()) {
-      focusNativeColorInput(input);
-      return;
-    }
-    input.click();
-  });
-  input.addEventListener('input', () => requestAnimationFrame(sync));
-  input.addEventListener('change', sync);
-
-  copy.append(label, cue);
-  replacement.append(copy, input, trigger);
-  control.replaceWith(replacement);
-  sync();
-}
-
-function installAccessiblePaintControls() {
-  for (const control of document.querySelectorAll('.lot-color-control:not(.lot-fixed-livery)')) {
-    enhancePaintControl(control);
-  }
-}
-
 function sync() {
   scheduled = false;
   installColorCueSetting();
   installTrackColorCues();
-  installAccessiblePaintControls();
 }
 
 function scheduleSync() {

--- a/turn/accessibility/color-cues-r163.css
+++ b/turn/accessibility/color-cues-r163.css
@@ -52,7 +52,6 @@ html[data-turn-color-cues='on'] .turn-color-cue {
   letter-spacing: 0.055em;
   text-overflow: ellipsis;
   white-space: nowrap;
-  cursor: pointer;
 }
 
 .lot-color-cue {
@@ -78,22 +77,27 @@ html[data-turn-color-cues='on'] .turn-color-cue {
   content: '';
 }
 
-/* Keep the real input rendered so iOS can present its native colour picker,
-   but do not expose its currently broken VoiceOver press action. The adjacent
-   real button activates the associated label, which lets WebKit open the same
-   native picker and retain the platform's own colour semantics. */
+/* Keep the real input rendered because iOS opens its native picker from DOM
+   focus. It sits directly beneath the visible trigger rather than at 0,0, so
+   even a failed platform hand-off cannot create a stray focus target on the
+   left side of The Lot. The adjacent real button is the accessible control. */
 .lot-color-native {
   position: absolute !important;
-  width: 1px !important;
-  height: 1px !important;
+  top: 50% !important;
+  right: 5px !important;
+  width: 38px !important;
+  height: 28px !important;
   margin: 0 !important;
   padding: 0 !important;
   border: 0 !important;
   opacity: 0.001 !important;
   pointer-events: none !important;
+  transform: translateY(-50%);
 }
 
 .lot-color-trigger {
+  position: relative;
+  z-index: 1;
   width: 38px;
   height: 28px;
   min-height: 0;
@@ -119,9 +123,10 @@ html[data-turn-color-cues='on'] .turn-color-cue {
 }
 
 @media (max-height: 520px) {
+  .lot-color-native,
   .lot-color-trigger {
-    width: 34px;
-    height: 26px;
+    width: 34px !important;
+    height: 26px !important;
   }
 
   .lot-color-label { font-size: 0.42rem; }
@@ -129,9 +134,10 @@ html[data-turn-color-cues='on'] .turn-color-cue {
 }
 
 @media (max-height: 430px) {
+  .lot-color-native,
   .lot-color-trigger {
-    width: 32px;
-    height: 25px;
+    width: 32px !important;
+    height: 25px !important;
   }
 
   .lot-color-copy { gap: 1px; }

--- a/turn/accessibility/color-cues-r163.css
+++ b/turn/accessibility/color-cues-r163.css
@@ -35,25 +35,6 @@ html[data-turn-color-cues='on'] .turn-color-cue {
   content: '';
 }
 
-.lot-color-control {
-  position: relative;
-}
-
-.lot-color-copy {
-  min-width: 0;
-  display: grid;
-  gap: 2px;
-}
-
-.lot-color-label {
-  overflow: hidden;
-  font-size: 0.45rem;
-  font-weight: 900;
-  letter-spacing: 0.055em;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .lot-color-cue {
   align-items: center;
   gap: 4px;
@@ -77,69 +58,10 @@ html[data-turn-color-cues='on'] .turn-color-cue {
   content: '';
 }
 
-/* Keep the real input rendered because iOS opens its native picker from DOM
-   focus. It sits directly beneath the visible trigger rather than at 0,0, so
-   even a failed platform hand-off cannot create a stray focus target on the
-   left side of The Lot. The adjacent real button is the accessible control. */
-.lot-color-native {
-  position: absolute !important;
-  top: 50% !important;
-  right: 5px !important;
-  width: 38px !important;
-  height: 28px !important;
-  margin: 0 !important;
-  padding: 0 !important;
-  border: 0 !important;
-  opacity: 0.001 !important;
-  pointer-events: none !important;
-  transform: translateY(-50%);
-}
-
-.lot-color-trigger {
-  position: relative;
-  z-index: 1;
-  width: 38px;
-  height: 28px;
-  min-height: 0;
-  padding: 2px;
-  border: 2px solid var(--ink, #08090a);
-  border-radius: 7px;
-  background: var(--lot-color-value, #ffcc00);
-  box-shadow: none;
-  cursor: pointer;
-}
-
-.lot-color-trigger:hover {
-  transform: none;
-}
-
-.lot-color-trigger:active {
-  transform: translate(1px, 1px);
-}
-
-.lot-color-trigger:focus-visible {
-  outline: 3px solid var(--cyan, #38d9ff);
-  outline-offset: 2px;
-}
-
 @media (max-height: 520px) {
-  .lot-color-native,
-  .lot-color-trigger {
-    width: 34px !important;
-    height: 26px !important;
-  }
-
-  .lot-color-label { font-size: 0.42rem; }
   .lot-color-cue { font-size: 0.36rem; }
 }
 
 @media (max-height: 430px) {
-  .lot-color-native,
-  .lot-color-trigger {
-    width: 32px !important;
-    height: 25px !important;
-  }
-
-  .lot-color-copy { gap: 1px; }
   .lot-color-cue { font-size: 0.33rem; }
 }

--- a/turn/content/about-history.js
+++ b/turn/content/about-history.js
@@ -153,12 +153,12 @@ export const DEVELOPMENT_HISTORY = Object.freeze([
     paragraphs: [
       'CHROMATIC CAMOUFLAGE added a hidden 50-trophy challenge built around the five production track colours. It checks the current personal best on every track and deliberately accepts broad hue families rather than exact paint values, bringing the collection to 29 achievements and 1,750 available trophies. Device testing widened Countryside’s accepted pink family so canonical #FF00FF Magenta is not rejected on a five-degree technicality.',
       'The new color-based achievement exposed an accessibility gap: common colour-vision simulations collapse several track colours toward similar greys, olives and violets. TURN 1.7.0 is therefore an accessibility patch, adding optional Color Cues, off by default, with compact text and pattern labels for track colours and selected vehicle paint without recolouring the game or creating a separate visual mode.',
-      'Real-device VoiceOver testing also exposed a WebKit defect: the native color input could be read, and the system picker itself supplied useful semantic colour names, but VoiceOver could no longer activate the colour well. TURN keeps the native system picker and its semantics, while routing assistive-technology activation through an ordinary button and the input’s associated label.'
+      'Real-device VoiceOver testing also exposed a WebKit defect: the native color input could be read, and the system picker itself supplied useful semantic colour names, but VoiceOver could no longer activate the colour well. An initial label-forwarding workaround failed on device and only exposed a hidden focus target. The corrected design makes The Lot own one accessible paint control from creation time: an ordinary button bridges affected iOS VoiceOver activation directly to the real native input while the system picker, its native semantics and the input value remain canonical.'
     ],
     milestones: [
       'CHROMATIC CAMOUFLAGE · 50 trophies with generous pink-family matching',
       'Optional Color Cues with text and pattern redundancy',
-      'TURN 1.7.0 · 2026.08.09-r163 accessibility patch with accessible native paint activation'
+      'TURN 1.7.0 · 2026.08.09-r163 accessibility patch with native paint activation bridge'
     ]
   }
 ]);
@@ -330,9 +330,9 @@ export const CHANGELOG = Object.freeze([
   {
     date: '9 August',
     entries: [
-      ['1.7.0 r163', 'Accessibility patch prompted by the new color-based CHROMATIC CAMOUFLAGE achievement: adds Color Cues and repairs assistive-technology activation of the native paint picker.'],
+      ['1.7.0 r163', 'Accessibility patch prompted by the new color-based CHROMATIC CAMOUFLAGE achievement: adds Color Cues and an assistive-technology bridge to the native paint picker.'],
       ['CHROMATIC CAMOUFLAGE', 'Hidden 50-trophy achievement for setting a matching-colour personal best on all five production tracks; broad hue ranges now include canonical #FF00FF Magenta for Countryside’s pink family.'],
-      ['Color accessibility', 'Color Cues are off by default and add text plus pattern redundancy; VoiceOver can activate vehicle paint again while TURN keeps the system color picker and its native semantic colour names.']
+      ['Color accessibility', 'Color Cues are off by default and add text plus pattern redundancy. After the first VoiceOver activation workaround failed device testing, The Lot was refactored to own the accessible paint control directly while preserving the native system picker and its semantic colour names.']
     ]
   }
 ]);
@@ -340,5 +340,5 @@ export const CHANGELOG = Object.freeze([
 export const CURRENT_RELEASE = Object.freeze({
   version: '1.7.0',
   build: '2026.08.09-r163',
-  note: 'Accessibility patch prompted by the new color-based Chromatic Camouflage achievement, adding optional Color Cues and repaired assistive-technology access to the native vehicle paint picker.'
+  note: 'Accessibility patch prompted by the new color-based Chromatic Camouflage achievement, adding optional Color Cues and an assistive-technology bridge to the native vehicle paint picker.'
 });

--- a/turn/garage/lot-r10.css
+++ b/turn/garage/lot-r10.css
@@ -273,6 +273,7 @@
 }
 
 .lot-color-control {
+  position: relative;
   display: grid;
   grid-template-columns: minmax(0, 1fr) 38px;
   align-items: center;
@@ -283,12 +284,18 @@
   border-radius: 10px;
   background: var(--paper);
   box-shadow: 2px 2px 0 var(--ink);
-  cursor: pointer;
 }
 
-.lot-color-control > span {
+.lot-color-copy {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.lot-color-label {
   overflow: hidden;
   font-size: 0.45rem;
+  font-weight: 900;
   letter-spacing: 0.055em;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -309,27 +316,48 @@
   white-space: nowrap;
 }
 
+/* The real native input stays rendered so iOS can present its system picker
+   when TURN moves DOM focus to it. It shares the visible swatch geometry but
+   is removed from the accessibility order; the adjacent button is the single
+   assistive-technology target. */
 .lot-color-input {
+  position: absolute;
+  top: 50%;
+  right: 5px;
   width: 38px;
   height: 28px;
   min-height: 0;
+  margin: 0;
   padding: 0;
+  border: 0;
+  opacity: 0.001;
+  pointer-events: none;
+  transform: translateY(-50%);
+}
+
+.lot-color-trigger {
+  position: relative;
+  z-index: 1;
+  width: 38px;
+  height: 28px;
+  min-height: 0;
+  padding: 2px;
   border: 2px solid var(--ink);
   border-radius: 7px;
-  background: transparent;
+  background: var(--lot-color-value, #ffcc00);
+  box-shadow: none;
   cursor: pointer;
 }
 
-.lot-color-input::-webkit-color-swatch-wrapper {
-  padding: 2px;
+.lot-color-trigger:hover {
+  transform: none;
 }
 
-.lot-color-input::-webkit-color-swatch {
-  border: 0;
-  border-radius: 3px;
+.lot-color-trigger:active {
+  transform: translate(1px, 1px);
 }
 
-.lot-color-input:focus-visible {
+.lot-color-trigger:focus-visible {
   outline: 3px solid var(--cyan);
   outline-offset: 2px;
 }
@@ -405,6 +433,10 @@
   .lot-stat > span { font-size: 0.43rem; }
   .lot-stat i { height: 6px; }
   .lot-colors { gap: 4px; margin: 6px 0 8px; }
+  .lot-color-input,
+  .lot-color-trigger { width: 32px; height: 25px; }
+  .lot-color-label { font-size: 0.42rem; }
+  .lot-color-copy { gap: 1px; }
   .lot-view-open,
   .lot-race { min-height: 34px; }
 }

--- a/turn/garage/lot-r10.js
+++ b/turn/garage/lot-r10.js
@@ -10,9 +10,11 @@ import {
 } from '../vehicle/catalog.js?build=20260720-r20';
 import { createCarVisual, recolorCarVisual } from '../vehicle/car-models.js?build=20260720-r22';
 import { recordPerformanceFrame } from '../performance-monitor.js?build=20260720-r20';
+import { describeColorCue } from '../accessibility/color-cues.js?revision=r163';
 
 const UNSELECTED_COLOR = new THREE.Color(0x313131);
 const VIEWER_INITIAL_YAW = Math.PI - 0.55;
+let paintControlSerial = 0;
 const CAR_DESCRIPTIONS = Object.freeze({
   convertible: 'A low, open-top sports car with a long bonnet and compact cabin.',
   classic: 'A small, upright classic car with rounded bodywork and a friendly shape.',
@@ -30,6 +32,36 @@ const CAR_DESCRIPTIONS = Object.freeze({
   truck: 'A sturdy pickup truck with a separate cab and cargo bed.',
   van: 'A tall enclosed van with a boxy body and short bonnet.'
 });
+
+function isIOSFamily() {
+  const navigatorObject = globalThis.navigator;
+  if (!navigatorObject) return false;
+  const platform = String(navigatorObject.platform || '');
+  const userAgent = String(navigatorObject.userAgent || '');
+  return /iPhone|iPad|iPod/i.test(platform)
+    || /iPhone|iPad|iPod/i.test(userAgent)
+    || (platform === 'MacIntel' && Number(navigatorObject.maxTouchPoints || 0) > 1);
+}
+
+function focusNativeColorInput(input) {
+  try {
+    input.focus({ preventScroll: true });
+  } catch (_) {
+    input.focus();
+  }
+}
+
+function openNativeColorPicker(input) {
+  // WebKit on iOS before the AXPress fix does not activate input[type="color"]
+  // reliably from VoiceOver. Native iOS form pickers are tied to DOM focus, so
+  // the accessible button focuses the real input there. Other platforms use
+  // the input's normal activation behavior. The system picker remains native.
+  if (isIOSFamily()) {
+    focusNativeColorInput(input);
+    return;
+  }
+  input.click();
+}
 
 export function showTheLot({ initialSelection } = {}) {
   return new Promise((resolve) => {
@@ -219,7 +251,6 @@ export function showTheLot({ initialSelection } = {}) {
           onInput(value) {
             selectedColor = normalizeVehicleColor(value);
             applySelectedPaint();
-            updatePaintAccessibleNames();
           }
         })];
         if (car.secondaryPaint) {
@@ -230,13 +261,11 @@ export function showTheLot({ initialSelection } = {}) {
             onInput(value) {
               selectedSecondaryColor = normalizeVehicleSecondaryColor(value);
               applySelectedPaint();
-              updatePaintAccessibleNames();
             }
           }));
         }
         colors.replaceChildren(...paintControls);
         colors.setAttribute('aria-label', 'Choose car paint colours');
-        updatePaintAccessibleNames();
       }
 
       for (const [carId, platform] of platforms) {
@@ -278,32 +307,54 @@ export function showTheLot({ initialSelection } = {}) {
     });
 
     function makeColorInput({ label, value, secondary = false, onInput }) {
-      const control = document.createElement('label');
+      const control = document.createElement('div');
       control.className = 'lot-color-control';
       control.dataset.paintLabel = label;
 
+      const copy = document.createElement('span');
+      copy.className = 'lot-color-copy';
+
       const name = document.createElement('span');
+      name.className = 'lot-color-label';
       name.textContent = label.toUpperCase();
+
+      const cue = document.createElement('span');
+      cue.className = 'turn-color-cue lot-color-cue';
+      cue.setAttribute('aria-hidden', 'true');
 
       const input = document.createElement('input');
       input.type = 'color';
-      input.className = 'lot-color-input';
+      input.className = 'lot-color-input lot-color-native';
+      input.id = `turnPaintColor${++paintControlSerial}`;
+      input.tabIndex = -1;
+      input.setAttribute('aria-hidden', 'true');
       input.value = secondary
         ? normalizeVehicleSecondaryColor(value)
         : normalizeVehicleColor(value);
-      input.addEventListener('input', () => onInput(input.value));
 
-      control.append(name, input);
-      return control;
-    }
+      const trigger = document.createElement('button');
+      trigger.type = 'button';
+      trigger.className = 'lot-color-trigger';
 
-    function updatePaintAccessibleNames() {
-      colors.querySelectorAll('.lot-color-control').forEach((control) => {
-        const input = control.querySelector('input');
-        const label = control.dataset.paintLabel || 'Paint';
-        const colourName = describeHexColor(input.value);
-        input.setAttribute('aria-label', `${label} colour. ${colourName}`);
+      const syncColorSemantics = () => {
+        const color = input.value || '#ffcc00';
+        const colourName = describeColorCue(color);
+        trigger.style.setProperty('--lot-color-value', color);
+        trigger.setAttribute('aria-label', `${label} colour. ${colourName}. Opens system color picker.`);
+        cue.textContent = `COLOR · ${colourName.toUpperCase()}`;
+      };
+
+      trigger.addEventListener('click', () => openNativeColorPicker(input));
+      input.addEventListener('input', () => {
+        syncColorSemantics();
+        onInput(input.value);
       });
+      input.addEventListener('change', syncColorSemantics);
+
+      copy.append(name, cue);
+      control.append(copy, input, trigger);
+      syncColorSemantics();
+      return control;
     }
 
     function applySelectedPaint() {
@@ -613,42 +664,4 @@ function makeStats(vehicleStats) {
     row.innerHTML = `<span aria-hidden="true">${label}</span><i aria-hidden="true">${Array.from({ length: 5 }, (_, index) => `<b class="${index < value ? 'is-full' : ''}"></b>`).join('')}</i>`;
     return row;
   });
-}
-
-function describeHexColor(hex) {
-  const clean = String(hex || '').replace('#', '').trim();
-  if (!/^[0-9a-f]{6}$/i.test(clean)) return 'custom colour';
-  const r = parseInt(clean.slice(0, 2), 16) / 255;
-  const g = parseInt(clean.slice(2, 4), 16) / 255;
-  const b = parseInt(clean.slice(4, 6), 16) / 255;
-  const max = Math.max(r, g, b);
-  const min = Math.min(r, g, b);
-  const lightness = (max + min) / 2;
-  const delta = max - min;
-  const saturation = delta === 0 ? 0 : delta / (1 - Math.abs(2 * lightness - 1));
-  let hue = 0;
-  if (delta !== 0) {
-    if (max === r) hue = 60 * (((g - b) / delta) % 6);
-    else if (max === g) hue = 60 * (((b - r) / delta) + 2);
-    else hue = 60 * (((r - g) / delta) + 4);
-  }
-  if (hue < 0) hue += 360;
-
-  if (lightness < 0.09) return 'black';
-  if (lightness > 0.94 && saturation < 0.16) return 'white';
-  if (saturation < 0.12) {
-    if (lightness < 0.32) return 'dark grey';
-    if (lightness > 0.72) return 'light grey';
-    return 'grey';
-  }
-
-  const names = [
-    [15, 'red'], [42, 'orange'], [68, 'yellow'], [105, 'yellow green'],
-    [165, 'green'], [195, 'turquoise'], [225, 'blue'], [255, 'indigo'],
-    [285, 'violet'], [330, 'magenta'], [360, 'red']
-  ];
-  const base = names.find(([limit]) => hue < limit)?.[1] || 'red';
-  if (lightness < 0.28) return `dark ${base}`;
-  if (lightness > 0.74) return `light ${base}`;
-  return base;
 }

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -1,4 +1,4 @@
-import { showTheLot as showOriginalLot } from './lot-r10.js?build=20260804-r157-factory-colors';
+import { showTheLot as showOriginalLot } from './lot-r10.js?build=20260809-r163-accessible-paint';
 // Historical regression marker for the established compatibility wrapper:
 // lot-enhancement-runtime.js?revision=r121&build=20260731-r120
 import { enhanceLotNow } from './lot-enhancement-runtime.js?revision=r157&build=20260804-r157';

--- a/turn/index.html
+++ b/turn/index.html
@@ -63,7 +63,7 @@
   <link rel="stylesheet" href="./garage/lot-r10.css?build=20260809-r163">
   <link rel="stylesheet" href="./garage/lot-stat-legend.css?build=20260809-r163">
   <link rel="stylesheet" href="./garage/lot-layout-r60.css?build=20260809-r163">
-  <link rel="stylesheet" href="./accessibility/color-cues-r163.css?build=20260809-r163">
+  <link rel="stylesheet" href="./accessibility/color-cues-r163.css?build=20260809-r163-focus-bridge">
   <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260809-r163-menu-font-v3">
   <script src="./install-gate.js?build=20260809-r163-social-browser"></script>
   <script src="./pwa-usable-viewport-r181.js?revision=r181-usable-web-layer"></script>
@@ -189,7 +189,7 @@
   <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260809-r163-r168-shared-about-credits"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
   <script type="module" src="./app.js?build=20260809-r163-browser-consent-r176-bella-road-derived-zone"></script>
-  <script type="module" src="./accessibility/color-accessibility-r163.js?build=20260809-r163"></script>
+  <script type="module" src="./accessibility/color-accessibility-r163.js?build=20260809-r163-focus-bridge"></script>
   <script type="module" src="./achievements/chromatic-camouflage-r183.js?revision=r183-production"></script>
   <script type="module" src="./social/your-turn-share-bootstrap.js?revision=r2"></script>
   <script type="module" src="./tracks/countryside-bella-rescue-hotfix-r176.js?revision=r176-video-proven-rescue"></script>

--- a/turn/index.html
+++ b/turn/index.html
@@ -60,10 +60,10 @@
   <link rel="stylesheet" href="./track-select-r78.css?build=20260809-r163">
   <link rel="stylesheet" href="./track-select-r79.css?build=20260809-r163">
   <link rel="stylesheet" href="./track-intro.css?build=20260809-r163">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260809-r163">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260809-r163-accessible-paint">
   <link rel="stylesheet" href="./garage/lot-stat-legend.css?build=20260809-r163">
   <link rel="stylesheet" href="./garage/lot-layout-r60.css?build=20260809-r163">
-  <link rel="stylesheet" href="./accessibility/color-cues-r163.css?build=20260809-r163-focus-bridge">
+  <link rel="stylesheet" href="./accessibility/color-cues-r163.css?build=20260809-r163-accessible-paint">
   <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260809-r163-menu-font-v3">
   <script src="./install-gate.js?build=20260809-r163-social-browser"></script>
   <script src="./pwa-usable-viewport-r181.js?revision=r181-usable-web-layer"></script>
@@ -113,7 +113,7 @@
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",
-        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260809-r163",
+        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260809-r163-accessible-paint",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260809-r163",
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system-r86.js?build=20260809-r163",
         "./race/game-state.js": "./race/game-state.js?build=20260809-r163",
@@ -189,7 +189,7 @@
   <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260809-r163-r168-shared-about-credits"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
   <script type="module" src="./app.js?build=20260809-r163-browser-consent-r176-bella-road-derived-zone"></script>
-  <script type="module" src="./accessibility/color-accessibility-r163.js?build=20260809-r163-focus-bridge"></script>
+  <script type="module" src="./accessibility/color-accessibility-r163.js?build=20260809-r163-accessible-paint"></script>
   <script type="module" src="./achievements/chromatic-camouflage-r183.js?revision=r183-production"></script>
   <script type="module" src="./social/your-turn-share-bootstrap.js?revision=r2"></script>
   <script type="module" src="./tracks/countryside-bella-rescue-hotfix-r176.js?revision=r176-video-proven-rescue"></script>

--- a/turn/index.html
+++ b/turn/index.html
@@ -113,7 +113,7 @@
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",
-        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260809-r163-accessible-paint",
+        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260809-r163&revision=r163-accessible-paint",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260809-r163",
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system-r86.js?build=20260809-r163",
         "./race/game-state.js": "./race/game-state.js?build=20260809-r163",


### PR DESCRIPTION
## What device testing showed
The first r163 workaround used an accessible button that forwarded activation through a synthetic `<label>.click()`. On iOS with VoiceOver that did **not** open the picker; it only moved focus to the hidden native color input, which appeared as a stray focus target on the left.

## Root cause
This is an upstream WebKit accessibility defect: affected iOS WebKit versions expose the native `input[type="color"]` but do not reliably perform its picker-opening action from VoiceOver Press. WebKit also documents that native iOS form pickers are tied to element focus, while `showPicker()` is not implemented for these controls on iOS.

## Clean fix — no post-render paint patching
The first attempt also had an architectural smell: The Lot created one paint control, then the accessibility runtime found it with a MutationObserver and replaced it with another DOM structure. This PR removes that path entirely.

**The Lot now owns the complete paint control from creation time:**
- the real `input[type="color"]` remains the value source and opens the native system picker;
- one ordinary button is the assistive-technology target and visible color well;
- on iPhone/iPad, that button moves DOM focus to the real native input so WebKit presents the system picker;
- other platforms keep the input's normal `click()` activation;
- the native input is aligned with the visible swatch and removed from the VoiceOver swipe order, avoiding the stray left-side focus target;
- the trigger exposes TURN's broad semantic color name, while the native picker retains the platform's richer semantic naming once open.

The optional Color Cues span is created as part of the same paint control and uses the same `describeColorCue()` classifier. The accessibility runtime is now limited to what it actually owns: the **Color Cues setting and track cues**. It no longer queries, replaces, or rebuilds paint controls.

Core paint-control CSS also moved back into The Lot stylesheet. `color-cues-r163.css` now contains only optional cue presentation.

## QA
Regression coverage now protects the architecture as well as the behavior:
- The Lot itself must create the native input and accessible trigger;
- iOS focus bridge is present and scoped to iPhone/iPad;
- no `label.click()` or `showPicker()` fallback;
- Color Cues runtime must not contain paint-control replacement logic;
- core paint styling must live with The Lot, not in the Color Cues layer;
- cache-busting remains compatible with the release-source-of-truth generator.

No version/build bump: this remains the same-release hotfix for **TURN 1.7.0 · 2026.08.09-r163**.