### PR TITLE
TURN r163: use the native color input as the paint swatch

### DIFF
--- a/turn-lab/tests/color-accessibility-production.mjs
+++ b/turn-lab/tests/color-accessibility-production.mjs
@@ -14,18 +14,16 @@ const [
   indexSource,
   runtimeSource,
   cueCssSource,
+  nativeInputCssSource,
   lotSource,
-  lotCssSource,
-  lotTrackSelectSource,
   historySource
 ] = await Promise.all([
   fs.readFile(new URL('../../turn/release.json', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/accessibility/color-accessibility-r163.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/accessibility/color-cues-r163.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/accessibility/native-color-input-r163.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-r10.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/garage/lot-r10.css', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/garage/lot-track-select.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/content/about-history.js', import.meta.url), 'utf8')
 ]);
 const release = JSON.parse(releaseSource);
@@ -69,57 +67,56 @@ assert.equal(release.version, '1.7.0');
 assert.equal(release.id, '2026.08.09-r163');
 assert.equal(release.cacheKey, '20260809-r163');
 assert.match(indexSource, /TURN v1\.7\.0 · Build 2026\.08\.09-r163/);
-assert.match(indexSource, /garage\/lot-r10\.css\?build=20260809-r163-accessible-paint/);
-assert.match(indexSource, /accessibility\/color-cues-r163\.css\?build=20260809-r163-accessible-paint/);
-assert.match(indexSource, /accessibility\/color-accessibility-r163\.js\?build=20260809-r163-accessible-paint/);
-assert.match(indexSource, /lot-track-select\.js\?build=20260809-r163&revision=r163-accessible-paint/);
-assert.match(lotTrackSelectSource, /lot-r10\.js\?build=20260809-r163-accessible-paint/);
+assert.match(indexSource, /accessibility\/native-color-input-r163\.css\?revision=r163-native-input/,
+  'The native-input correction must have its own uncached stylesheet');
+assert.match(indexSource, /accessibility\/color-accessibility-r163\.js\?build=20260809-r163-native-input/,
+  'The device-tested native-input correction must bypass the failed bridge cache');
 
-// The Lot owns the paint control. The accessibility runtime must not replace
-// or rebuild it after render.
+// The verified Lot still creates the old r163 bridge, but the accessibility
+// runtime must synchronously reduce it back to one real native input before it
+// becomes the interactive UI. This protects the hotfix while the older Lot
+// renderer remains release-frozen.
 assert.match(lotSource, /input\.type = 'color'/,
-  'The Lot must keep the real native color input rather than substitute a custom picker');
-assert.match(lotSource, /trigger\.className = 'lot-color-trigger'/,
-  'The Lot itself must create the accessible paint trigger');
-assert.match(lotSource, /input\.setAttribute\('aria-hidden', 'true'\)/,
-  'The broken native AXPress target must stay out of the VoiceOver swipe order');
-assert.match(lotSource, /trigger\.setAttribute\('aria-label', `\$\{label\} colour\. \$\{colourName\}\. Opens system color picker\.`\)/,
-  'The accessible trigger must expose the selected semantic color name');
-assert.match(lotSource, /function isIOSFamily\(\)/,
-  'The iOS workaround must be scoped to iPhone and iPad rather than change desktop picker behavior');
-assert.match(lotSource, /input\.focus\(\{ preventScroll: true \}\)/,
-  'On iOS, the accessible button must open the native form picker through DOM focus');
-assert.match(lotSource, /if \(isIOSFamily\(\)\)[\s\S]*focusNativeColorInput\(input\)[\s\S]*input\.click\(\)/,
-  'iOS must use focus while other platforms retain normal click activation');
-assert.doesNotMatch(lotSource, /label\.click\(/,
-  'Do not route through a synthetic label click; device testing showed that only moved VoiceOver to a hidden target');
-assert.doesNotMatch(lotSource, /showPicker\(/,
-  'The iOS accessibility fix must not rely on showPicker(), which is not implemented for these iOS controls');
-assert.match(lotSource, /describeColorCue\(color\)/,
-  'Paint cues and accessible names must share the same semantic color classifier');
-assert.match(lotSource, /cue\.textContent = `COLOR · \$\{colourName\.toUpperCase\(\)\}`/);
-
-assert.doesNotMatch(runtimeSource, /lot-color-control|lot-color-trigger|input\[type="color"\]|replaceWith|enhancePaintControl/,
-  'Color Cues runtime must not post-process or replace The Lot paint controls');
+  'TURN must retain a real input[type=color] as the paint value source');
+assert.match(runtimeSource, /control\.querySelector\('\.lot-color-trigger'\)\?\.remove\(\)/,
+  'The failed duplicate swatch/button must be removed from the live Lot');
+assert.match(runtimeSource, /input\.removeAttribute\('aria-hidden'\)/,
+  'The real native input must return to the accessibility tree');
+assert.match(runtimeSource, /input\.removeAttribute\('tabindex'\)/,
+  'The real native input must return to normal keyboard and swipe order');
+assert.match(runtimeSource, /input\.classList\.remove\('lot-color-native'\)/,
+  'The native input must no longer carry the hidden-bridge marker');
+assert.match(runtimeSource, /describeColorCue\(input\.value\)/,
+  'The same semantic classifier must name the selected paint for Color Cues');
+assert.match(runtimeSource, /cuesEnabled[\s\S]*`\$\{label\} colour\. \$\{colorName\}\.`[\s\S]*`\$\{label\} colour\.`/,
+  'TURN must expose its semantic color name only when Color Cues is enabled');
+assert.match(runtimeSource, /document\.addEventListener\('input', onPaintValueChange, true\)/,
+  'The Color Cue name must follow live native picker changes');
+assert.match(runtimeSource, /document\.addEventListener\('change', onPaintValueChange, true\)/,
+  'The Color Cue name must also follow committed native picker changes');
+assert.doesNotMatch(runtimeSource, /showPicker\(|\.click\(\)|focusNativeColorInput|isIOSFamily|label\.click\(/,
+  'TURN must stop trying to synthesize or forward activation of the native picker');
 assert.match(runtimeSource, /Color cues/);
 assert.match(runtimeSource, /turn:color-cues-changed/);
 assert.match(runtimeSource, /TRACK COLOR ·/);
 assert.doesNotMatch(runtimeSource, /setInterval|setAnimationLoop/,
-  'Color accessibility must remain event/DOM driven rather than add a polling loop');
+  'Color accessibility must remain event/DOM driven rather than add polling');
 
-assert.match(lotCssSource, /\.lot-color-input/);
-assert.match(lotCssSource, /\.lot-color-trigger/);
-assert.match(lotCssSource, /top: 50%/,
-  'The native input must remain aligned with the visible paint swatch rather than at the viewport origin');
-assert.match(lotCssSource, /right: 5px/,
-  'The native input focus geometry must match the visible trigger');
+assert.match(nativeInputCssSource, /\.lot-color-control \.lot-color-input/);
+assert.match(nativeInputCssSource, /opacity: 1 !important/,
+  'The native input itself must be visible as the color swatch');
+assert.match(nativeInputCssSource, /pointer-events: auto !important/,
+  'The native input itself must receive pointer interaction');
+assert.match(nativeInputCssSource, /\.lot-color-control \.lot-color-trigger[\s\S]*display: none !important/,
+  'The duplicate swatch must never flash before the runtime removes it');
+assert.match(nativeInputCssSource, /\.lot-color-input:focus-visible/,
+  'The real native input must retain a visible keyboard focus treatment');
+
 assert.match(cueCssSource, /data-turn-color-cues='on'/);
 assert.match(cueCssSource, /track-card-color-cue/);
 assert.match(cueCssSource, /lot-color-cue/);
 assert.match(cueCssSource, /repeating-linear-gradient/,
   'Color Cues must include a non-color pattern channel as well as text');
-assert.doesNotMatch(cueCssSource, /lot-color-native|lot-color-trigger/,
-  'Core paint-control styling must live with The Lot rather than in the optional Color Cues layer');
 
 assert.match(historySource, /1\.7\.0 r163/);
 assert.match(historySource, /accessibility patch/i);
@@ -127,4 +124,4 @@ assert.match(historySource, /CHROMATIC CAMOUFLAGE/);
 assert.match(historySource, /Color Cues/);
 assert.match(historySource, /VoiceOver/);
 
-console.log('TURN 1.7.0 r163 color accessibility regression passed.');
+console.log('TURN 1.7.0 r163 native color input and Color Cues regression passed.');

--- a/turn/accessibility/color-accessibility-r163.js
+++ b/turn/accessibility/color-accessibility-r163.js
@@ -1,11 +1,12 @@
 import {
   applyColorCuesState,
+  describeColorCue,
   loadColorCuesEnabled,
   saveColorCuesEnabled,
   trackColorCue
 } from './color-cues.js?revision=r163';
 
-const RUNTIME_ID = 'color-cues-r163';
+const RUNTIME_ID = 'color-cues-r163-native-input';
 let scheduled = false;
 
 function settingsStatus(dialog) {
@@ -63,9 +64,36 @@ function installTrackColorCues() {
 
     const cue = document.createElement('span');
     cue.className = 'turn-color-cue track-card-color-cue';
-    cue.setAttribute('aria-hidden', 'true');
     cue.textContent = `TRACK COLOR · ${colorName.toUpperCase()}`;
     summary.append(cue);
+  }
+}
+
+function syncNativePaintControl(control) {
+  const input = control?.querySelector('input[type="color"]');
+  if (!input) return;
+
+  // The visible swatch and the interactive control are the same native input.
+  // Earlier r163 device-tested bridges added a second button to work around an
+  // iOS VoiceOver/WebKit activation defect, but neither synthetic label clicks
+  // nor focus forwarding opened the picker reliably. Do not replace the native
+  // control with another swatch: expose it directly and let the platform own it.
+  control.querySelector('.lot-color-trigger')?.remove();
+  input.removeAttribute('aria-hidden');
+  input.removeAttribute('tabindex');
+  input.classList.remove('lot-color-native');
+
+  const label = control.dataset.paintLabel || control.querySelector('.lot-color-label')?.textContent?.trim() || 'Paint';
+  const colorName = describeColorCue(input.value);
+  const cuesEnabled = document.documentElement.dataset.turnColorCues === 'on';
+  input.setAttribute('aria-label', cuesEnabled
+    ? `${label} colour. ${colorName}.`
+    : `${label} colour.`);
+}
+
+function installNativePaintInputs() {
+  for (const control of document.querySelectorAll('.lot-color-control:not(.lot-fixed-livery)')) {
+    syncNativePaintControl(control);
   }
 }
 
@@ -73,12 +101,20 @@ function sync() {
   scheduled = false;
   installColorCueSetting();
   installTrackColorCues();
+  installNativePaintInputs();
 }
 
 function scheduleSync() {
   if (scheduled) return;
   scheduled = true;
   queueMicrotask(sync);
+}
+
+function onPaintValueChange(event) {
+  const input = event.target;
+  if (!(input instanceof HTMLInputElement) || input.type !== 'color') return;
+  const control = input.closest('.lot-color-control');
+  if (control) syncNativePaintControl(control);
 }
 
 export function installColorAccessibility() {
@@ -89,6 +125,8 @@ export function installColorAccessibility() {
   observer.observe(document.body, { childList: true, subtree: true });
   globalThis.addEventListener('turn:home-ready', scheduleSync);
   globalThis.addEventListener('turn:color-cues-changed', scheduleSync);
+  document.addEventListener('input', onPaintValueChange, true);
+  document.addEventListener('change', onPaintValueChange, true);
   sync();
 
   const api = Object.freeze({
@@ -98,6 +136,8 @@ export function installColorAccessibility() {
       observer.disconnect();
       globalThis.removeEventListener('turn:home-ready', scheduleSync);
       globalThis.removeEventListener('turn:color-cues-changed', scheduleSync);
+      document.removeEventListener('input', onPaintValueChange, true);
+      document.removeEventListener('change', onPaintValueChange, true);
       globalThis.__turnColorAccessibility = null;
     }
   });

--- a/turn/accessibility/native-color-input-r163.css
+++ b/turn/accessibility/native-color-input-r163.css
@@ -1,0 +1,44 @@
+/* TURN 1.7.0 r163 hotfix: the native color input is the swatch and control. */
+
+.lot-color-control .lot-color-input {
+  position: static !important;
+  z-index: auto;
+  width: 38px;
+  height: 28px;
+  min-height: 0;
+  margin: 0;
+  padding: 0;
+  border: 2px solid var(--ink, #08090a);
+  border-radius: 7px;
+  background: transparent;
+  opacity: 1 !important;
+  pointer-events: auto !important;
+  transform: none !important;
+  cursor: pointer;
+}
+
+/* The duplicate swatch/button was a failed VoiceOver workaround. Keep it out
+   of the rendered UI even during the brief interval before the r163 runtime
+   removes it from the DOM. */
+.lot-color-control .lot-color-trigger {
+  display: none !important;
+}
+
+.lot-color-input:focus-visible {
+  outline: 3px solid var(--cyan, #38d9ff);
+  outline-offset: 2px;
+}
+
+@media (max-height: 520px) {
+  .lot-color-control .lot-color-input {
+    width: 34px;
+    height: 26px;
+  }
+}
+
+@media (max-height: 430px) {
+  .lot-color-control .lot-color-input {
+    width: 32px;
+    height: 25px;
+  }
+}

--- a/turn/index.html
+++ b/turn/index.html
@@ -64,6 +64,7 @@
   <link rel="stylesheet" href="./garage/lot-stat-legend.css?build=20260809-r163">
   <link rel="stylesheet" href="./garage/lot-layout-r60.css?build=20260809-r163">
   <link rel="stylesheet" href="./accessibility/color-cues-r163.css?build=20260809-r163-accessible-paint">
+  <link rel="stylesheet" href="./accessibility/native-color-input-r163.css?revision=r163-native-input">
   <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260809-r163-menu-font-v3">
   <script src="./install-gate.js?build=20260809-r163-social-browser"></script>
   <script src="./pwa-usable-viewport-r181.js?revision=r181-usable-web-layer"></script>
@@ -189,7 +190,7 @@
   <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260809-r163-r168-shared-about-credits"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
   <script type="module" src="./app.js?build=20260809-r163-browser-consent-r176-bella-road-derived-zone"></script>
-  <script type="module" src="./accessibility/color-accessibility-r163.js?build=20260809-r163-accessible-paint"></script>
+  <script type="module" src="./accessibility/color-accessibility-r163.js?build=20260809-r163-native-input"></script>
   <script type="module" src="./achievements/chromatic-camouflage-r183.js?revision=r183-production"></script>
   <script type="module" src="./social/your-turn-share-bootstrap.js?revision=r2"></script>
   <script type="module" src="./tracks/countryside-bella-rescue-hotfix-r176.js?revision=r176-video-proven-rescue"></script>


### PR DESCRIPTION
## Why
Real-device testing showed that the second paint swatch/button added as a VoiceOver workaround is both confusing and ineffective: it duplicates the native color well, and the attempted activation bridges still do not reliably open the iOS picker.

## Change
- The visible paint swatch is again the real `input[type="color"]`.
- The duplicate `.lot-color-trigger` is hidden immediately and removed from the live Lot DOM.
- The native input returns to normal keyboard / assistive-technology order instead of being `aria-hidden` and `tabindex=-1`.
- TURN no longer synthesizes picker activation with click, label forwarding, or focus forwarding. The platform owns activation of its native control.
- With **Color Cues off**, the input is simply named `Body colour` / the relevant paint field and the native picker owns its color semantics.
- With **Color Cues on**, TURN adds its broad semantic name (for example `pink`) to the input name and keeps the visible `COLOR · PINK` cue.
- Track color cue text is no longer hidden from assistive technology when the setting is enabled.

The existing 1.7.0 / r163 release identity is unchanged. A cache-specific runtime URL and a small native-input stylesheet ensure this correction is actually picked up without pretending it is a new release.

## Device-test context
The previous two approaches were intentionally removed from the active interaction path:
1. synthetic associated-label activation;
2. iOS focus forwarding to the hidden input.

Both looked plausible in code; neither solved the real iPhone + VoiceOver interaction. This PR returns to the simplest truthful control instead of layering another workaround on top.