### PR TITLE
TURN r163: add a native named-color fallback

### DIFF
--- a/turn-lab/tests/color-accessibility-production.mjs
+++ b/turn-lab/tests/color-accessibility-production.mjs
@@ -43,23 +43,35 @@ assert.equal(saveColorCuesEnabled(false, storage), true);
 
 assert.equal(release.version, '1.7.0');
 assert.equal(release.id, '2026.08.09-r163');
-assert.match(indexSource, /garage\/lot-r10\.css\?build=20260809-r163-paint-basics/);
+assert.match(indexSource, /garage\/lot-r10\.css\?build=20260809-r163-named-color-fallback/);
+assert.match(indexSource, /lot-track-select\.js\?build=20260809-r163&revision=r163-named-color-fallback/);
 assert.match(indexSource, /color-accessibility-r163\.js\?build=20260809-r163-paint-basics/);
 assert.doesNotMatch(indexSource, /native-color-input-r163\.css/,
   'There must not be a second stylesheet whose job is to undo the paint-control stylesheet');
 assert.doesNotMatch(indexSource, /syncFixedLiveryRail|emergencyVehicleNames/,
   'Production index must not patch The Lot after render');
 
-assert.match(lotSource, /const control = document\.createElement\('label'\)/,
-  'The paint field must use an ordinary label around the native input');
 assert.match(lotSource, /input\.type = 'color'/,
-  'The visible paint swatch and interactive control must be the native input[type=color]');
+  'The visible paint swatch and interactive control must remain the native input[type=color]');
 assert.match(lotSource, /input\.className = 'lot-color-input'/);
-assert.match(lotSource, /control\.append\(copy, input\)/);
+assert.match(lotSource, /inputLabel\.htmlFor = input\.id/,
+  'The native color input must use a direct explicit label');
+assert.match(lotSource, /NAMED_COLOR_PRESETS/,
+  'The Lot must provide a small native named-color fallback while shipping WebKit cannot press the color input');
+assert.match(lotSource, /named\.className = 'lot-color-preset'/);
+assert.match(lotSource, /named\.setAttribute\('aria-label', `Choose \$\{label\} colour by name`\)/);
+for (const value of ['#ff70b4', '#ff00ff', '#f28b39', '#ffcc00', '#00aabb', '#5e3c87']) {
+  assert.match(lotSource, new RegExp(value.replace('#', '\\#')),
+    `Named-color fallback must include ${value}`);
+}
+assert.match(lotSource, /input\.value = named\.value[\s\S]*input\.dispatchEvent\(new Event\('input', \{ bubbles: true \}\)\)/,
+  'Named-color selection must feed the same native input event path as the system picker');
+assert.match(lotSource, /named\.value = ''/,
+  'The named-color select is an action fallback, not a second stored paint state');
 assert.match(lotSource, /cue\.textContent = `COLOR · \$\{describeColorCue\(input\.value\)\.toUpperCase\(\)\}`/,
   'Color Cues must use the shared broad semantic classifier');
 assert.doesNotMatch(lotSource, /lot-color-trigger|lot-color-native|openNativeColorPicker|focusNativeColorInput|isIOSFamily|showPicker\(|label\.click\(/,
-  'The Lot must not contain a second swatch or synthetic picker activation path');
+  'The Lot must not contain a duplicate swatch or synthetic picker activation path');
 assert.doesNotMatch(lotSource, /input\.setAttribute\('aria-label'/,
   'Color Cues should not replace the native input semantics with a scripted accessible name');
 assert.doesNotMatch(lotSource, /input\.setAttribute\('aria-hidden'|input\.tabIndex = -1/,
@@ -67,6 +79,8 @@ assert.doesNotMatch(lotSource, /input\.setAttribute\('aria-hidden'|input\.tabInd
 
 assert.match(lotCssSource, /\.lot-color-input \{[\s\S]*width: 38px[\s\S]*height: 28px[\s\S]*border: 2px solid var\(--ink\)/,
   'The native input must be styled directly as the visible swatch');
+assert.match(lotCssSource, /\.lot-color-preset \{/,
+  'The fallback must remain a plain native select rather than a custom menu');
 assert.doesNotMatch(lotCssSource, /\.lot-color-trigger|opacity: 0\.001/,
   'Core Lot CSS must not contain the retired hidden-input or duplicate-trigger treatment');
 const paintInputCss = lotCssSource.match(/\.lot-color-input \{[\s\S]*?\}/)?.[0] || '';
@@ -89,4 +103,4 @@ assert.match(historySource, /accessibility patch/i);
 assert.match(historySource, /CHROMATIC CAMOUFLAGE/);
 assert.match(historySource, /Color Cues/);
 
-console.log('TURN 1.7.0 r163 first-principles native color input and Color Cues regression passed.');
+console.log('TURN 1.7.0 r163 native color input, named fallback and Color Cues regression passed.');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -149,7 +149,7 @@ assert.match(index, new RegExp(`\\.\\/track-intro\\.css\\?build=${release.cacheK
 assert.match(index, new RegExp(`src="\\.\\/app\\.js\\?build=${release.cacheKey}-browser-consent(?:-[^"]+)?"`));
 assert.equal(
   imports['./garage/lot-r10.js?build=20260720-r19'],
-  `${releaseTarget('./garage/lot-track-select.js')}&revision=r163-paint-basics`
+  `${releaseTarget('./garage/lot-track-select.js')}&revision=r163-named-color-fallback`
 );
 assert.equal(imports['./ui/track-intro.js?build=20260725-r75'], releaseTarget('./ui/track-intro.js'));
 assert.equal(imports['./race/lap-system.js?build=20260720-r19'], releaseTarget('./race/lap-system-r86.js'));

--- a/turn-lab/tests/lot-layout-production.mjs
+++ b/turn-lab/tests/lot-layout-production.mjs
@@ -34,8 +34,8 @@ assert.match(index, new RegExp(`lot-layout-r60\\.css\\?build=${release.cacheKey}
 assert.match(index, new RegExp(`app\\.js\\?build=${release.cacheKey}-browser-consent`), 'Production must cache-bust the browser-gated canonical runtime');
 assert.equal(
   imports['./garage/lot-r10.js?build=20260720-r19'],
-  `./garage/lot-track-select.js?build=${release.cacheKey}&revision=r163-paint-basics`,
-  'Production must retain the track-first compatibility wrapper with the paint-basics revision'
+  `./garage/lot-track-select.js?build=${release.cacheKey}&revision=r163-named-color-fallback`,
+  'Production must retain the track-first compatibility wrapper with the named-color fallback revision'
 );
 
 assert.match(app, /lot-layout-r60\.css\?revision=r121-viewer-r122-fit-r128-super-sedan-notice-r129-race-button-fit/, 'The Super Sedan fit stylesheet must bypass the previous notice cache');

--- a/turn-lab/tests/stat-legend-production.mjs
+++ b/turn-lab/tests/stat-legend-production.mjs
@@ -33,7 +33,7 @@ const imports = JSON.parse(importMapText).imports;
 assert.match(index, new RegExp(`lot-stat-legend\\.css\\?build=${release.cacheKey}`), 'Production must load the stat-legend styling through the current release');
 assert.equal(
   imports['./garage/lot-r10.js?build=20260720-r19'],
-  `./garage/lot-track-select.js?build=${release.cacheKey}&revision=r163-paint-basics`,
+  `./garage/lot-track-select.js?build=${release.cacheKey}&revision=r163-named-color-fallback`,
   'Production must publish the compact Lot wrapper through the current release'
 );
 assert.equal(imports['./vehicle/physics.js?build=20260720-r19'], `./vehicle/physics.js?build=${release.cacheKey}`, 'Production must publish the mandatory DRIFT penalty through the current release');

--- a/turn/garage/lot-r10.css
+++ b/turn/garage/lot-r10.css
@@ -278,18 +278,22 @@
   align-items: center;
   gap: 6px;
   min-height: 38px;
-  padding: 4px 5px 4px 7px;
+  padding: 2px 5px 2px 7px;
   border: 2px solid var(--ink);
   border-radius: 10px;
   background: var(--paper);
   box-shadow: 2px 2px 0 var(--ink);
-  cursor: pointer;
 }
 
-.lot-color-copy {
+.lot-color-copy,
+.lot-color-name {
   min-width: 0;
   display: grid;
   gap: 2px;
+}
+
+.lot-color-name {
+  cursor: pointer;
 }
 
 .lot-color-label {
@@ -299,6 +303,23 @@
   letter-spacing: 0.055em;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.lot-color-preset {
+  width: 100%;
+  min-width: 0;
+  height: 18px;
+  min-height: 0;
+  margin: 0;
+  padding: 0 3px;
+  border: 1.5px solid var(--ink);
+  border-radius: 5px;
+  background: var(--paper);
+  color: var(--ink);
+  font: inherit;
+  font-size: 0.38rem;
+  font-weight: 900;
+  letter-spacing: 0.035em;
 }
 
 .lot-color-input {
@@ -313,7 +334,8 @@
   cursor: pointer;
 }
 
-.lot-color-input:focus-visible {
+.lot-color-input:focus-visible,
+.lot-color-preset:focus-visible {
   outline: 3px solid var(--cyan);
   outline-offset: 2px;
 }
@@ -391,7 +413,9 @@
   .lot-colors { gap: 4px; margin: 6px 0 8px; }
   .lot-color-input { width: 32px; height: 25px; }
   .lot-color-label { font-size: 0.42rem; }
-  .lot-color-copy { gap: 1px; }
+  .lot-color-preset { height: 17px; font-size: 0.34rem; }
+  .lot-color-copy,
+  .lot-color-name { gap: 1px; }
   .lot-view-open,
   .lot-race { min-height: 34px; }
 }

--- a/turn/garage/lot-r10.js
+++ b/turn/garage/lot-r10.js
@@ -14,6 +14,23 @@ import { describeColorCue } from '../accessibility/color-cues.js?revision=r163';
 
 const UNSELECTED_COLOR = new THREE.Color(0x313131);
 const VIEWER_INITIAL_YAW = Math.PI - 0.55;
+let paintControlSerial = 0;
+const NAMED_COLOR_PRESETS = Object.freeze([
+  ['Pink', '#ff70b4'],
+  ['Magenta', '#ff00ff'],
+  ['Red', '#d92d20'],
+  ['Orange', '#f28b39'],
+  ['Yellow', '#ffcc00'],
+  ['Yellow green', '#9acd32'],
+  ['Green', '#26cb00'],
+  ['Cyan', '#00aabb'],
+  ['Blue', '#2ab7ff'],
+  ['Violet', '#5e3c87'],
+  ['Brown', '#8b5a2b'],
+  ['Grey', '#777777'],
+  ['Black', '#08090a'],
+  ['White', '#f8f9fa']
+]);
 const CAR_DESCRIPTIONS = Object.freeze({
   convertible: 'A low, open-top sports car with a long bonnet and compact cabin.',
   classic: 'A small, upright classic car with rounded bodywork and a friendly shape.',
@@ -276,12 +293,24 @@ export function showTheLot({ initialSelection } = {}) {
     });
 
     function makeColorInput({ label, value, secondary = false, onInput }) {
-      const control = document.createElement('label');
+      const control = document.createElement('div');
       control.className = 'lot-color-control';
       control.dataset.paintLabel = label;
 
       const copy = document.createElement('span');
       copy.className = 'lot-color-copy';
+
+      const input = document.createElement('input');
+      input.type = 'color';
+      input.className = 'lot-color-input';
+      input.id = `turnPaintColor${++paintControlSerial}`;
+      input.value = secondary
+        ? normalizeVehicleSecondaryColor(value)
+        : normalizeVehicleColor(value);
+
+      const inputLabel = document.createElement('label');
+      inputLabel.className = 'lot-color-name';
+      inputLabel.htmlFor = input.id;
 
       const name = document.createElement('span');
       name.className = 'lot-color-label';
@@ -290,12 +319,13 @@ export function showTheLot({ initialSelection } = {}) {
       const cue = document.createElement('span');
       cue.className = 'turn-color-cue lot-color-cue';
 
-      const input = document.createElement('input');
-      input.type = 'color';
-      input.className = 'lot-color-input';
-      input.value = secondary
-        ? normalizeVehicleSecondaryColor(value)
-        : normalizeVehicleColor(value);
+      const named = document.createElement('select');
+      named.className = 'lot-color-preset';
+      named.setAttribute('aria-label', `Choose ${label} colour by name`);
+      named.append(new Option('BY NAME…', ''));
+      for (const [colorName, colorValue] of NAMED_COLOR_PRESETS) {
+        named.append(new Option(colorName.toUpperCase(), colorValue));
+      }
 
       const syncCue = () => {
         cue.textContent = `COLOR · ${describeColorCue(input.value).toUpperCase()}`;
@@ -306,7 +336,18 @@ export function showTheLot({ initialSelection } = {}) {
         onInput(input.value);
       });
 
-      copy.append(name, cue);
+      // Shipping iOS/WebKit can expose the native color value to VoiceOver but
+      // fail its Press action. A plain select provides a second native path; it
+      // does not replace, proxy or script activation of the color input.
+      named.addEventListener('change', () => {
+        if (!named.value) return;
+        input.value = named.value;
+        named.value = '';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+      });
+
+      inputLabel.append(name, cue);
+      copy.append(inputLabel, named);
       control.append(copy, input);
       syncCue();
       return control;

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -1,4 +1,4 @@
-import { showTheLot as showOriginalLot } from './lot-r10.js?build=20260809-r163-paint-basics';
+import { showTheLot as showOriginalLot } from './lot-r10.js?build=20260809-r163-named-color-fallback';
 // Historical regression marker for the established compatibility wrapper:
 // lot-enhancement-runtime.js?revision=r121&build=20260731-r120
 import { enhanceLotNow } from './lot-enhancement-runtime.js?revision=r157&build=20260804-r157';

--- a/turn/index.html
+++ b/turn/index.html
@@ -60,7 +60,7 @@
   <link rel="stylesheet" href="./track-select-r78.css?build=20260809-r163">
   <link rel="stylesheet" href="./track-select-r79.css?build=20260809-r163">
   <link rel="stylesheet" href="./track-intro.css?build=20260809-r163">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260809-r163-paint-basics">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260809-r163-named-color-fallback">
   <link rel="stylesheet" href="./garage/lot-stat-legend.css?build=20260809-r163">
   <link rel="stylesheet" href="./garage/lot-layout-r60.css?build=20260809-r163">
   <link rel="stylesheet" href="./accessibility/color-cues-r163.css?build=20260809-r163-accessible-paint">
@@ -77,7 +77,7 @@
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",
-        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260809-r163&revision=r163-paint-basics",
+        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260809-r163&revision=r163-named-color-fallback",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260809-r163",
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system-r86.js?build=20260809-r163",
         "./race/game-state.js": "./race/game-state.js?build=20260809-r163",


### PR DESCRIPTION
## What the latest device test tells us
The new VoiceOver recording is actually decisive: VoiceOver announces the native color value (apparently Swedish **“mättad gul” / “saturated yellow”**) while focused on the real `input[type=color]`, but its Press action still fails and focus moves on instead of opening the picker.

That matches the upstream WebKit accessibility defect that has since been fixed in newer WebKit builds: color-picker inputs could not be activated with VoiceOver’s Press action. Shipping iOS on the test device clearly does not have that fix yet.

## First-principles response
Do **not** try another activation bridge.

- Keep the real native color input as the visible swatch and full custom-color picker.
- Keep Apple’s own semantic color announcement untouched.
- Add one plain native `<select>` labelled **“Choose Body colour by name”** (and equivalent for secondary paint) as a second, independent route.
- The select is an action menu (`BY NAME…`), not another paint state or another swatch.
- Choosing a named color writes that value into the same native color input and emits its normal `input` event, so car recoloring, achievements and the Super Sedan easter egg all stay on the existing path.
- No screen-reader detection, no custom picker, no `showPicker()`, no synthetic click/focus forwarding.

The named list includes the five Chromatic track families (pink/magenta, yellow, orange, cyan, violet) plus common red/green/blue/brown/grey/black/white choices.

Color Cues remains separate: when enabled, `COLOR · …` is still part of the explicit label for the native input. When disabled, TURN does not replace Apple’s native semantic value.

Release identity remains TURN 1.7.0 · 2026.08.09-r163.