### PR TITLE
TURN r163: restore native HTML paint control

### DIFF
--- a/turn-lab/tests/color-accessibility-production.mjs
+++ b/turn-lab/tests/color-accessibility-production.mjs
@@ -9,13 +9,29 @@ import {
   trackColorCue
 } from '../../turn/accessibility/color-cues.js';
 
-const [releaseSource, indexSource, runtimeSource, cueCssSource, lotSource, lotCssSource, historySource] = await Promise.all([
+const [
+  releaseSource,
+  indexSource,
+  runtimeSource,
+  cueCssSource,
+  lotSource,
+  lotCssSource,
+  layoutSource,
+  stylesSource,
+  drivePadCssSource,
+  manualSteeringCssSource,
+  historySource
+] = await Promise.all([
   fs.readFile(new URL('../../turn/release.json', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/accessibility/color-accessibility-r163.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/accessibility/color-cues-r163.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-r10.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-r10.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-layout-r60.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/styles.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/drive-pad.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/manual-steering.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/content/about-history.js', import.meta.url), 'utf8')
 ]);
 const release = JSON.parse(releaseSource);
@@ -43,52 +59,54 @@ assert.equal(saveColorCuesEnabled(false, storage), true);
 
 assert.equal(release.version, '1.7.0');
 assert.equal(release.id, '2026.08.09-r163');
-assert.match(indexSource, /garage\/lot-r10\.css\?build=20260809-r163-named-color-fallback/);
-assert.match(indexSource, /lot-track-select\.js\?build=20260809-r163&revision=r163-named-color-fallback/);
-assert.match(indexSource, /color-accessibility-r163\.js\?build=20260809-r163-paint-basics/);
-assert.doesNotMatch(indexSource, /native-color-input-r163\.css/,
-  'There must not be a second stylesheet whose job is to undo the paint-control stylesheet');
-assert.doesNotMatch(indexSource, /syncFixedLiveryRail|emergencyVehicleNames/,
-  'Production index must not patch The Lot after render');
+assert.match(indexSource, /styles\.css\?build=20260809-r163-native-html/);
+assert.match(indexSource, /garage\/lot-r10\.css\?build=20260809-r163-native-html/);
+assert.match(indexSource, /garage\/lot-layout-r60\.css\?build=20260809-r163-native-html/);
+assert.match(indexSource, /lot-track-select\.js\?build=20260809-r163&revision=r163-native-html/);
+assert.doesNotMatch(indexSource, /named-color-fallback|native-color-input-r163\.css/,
+  'Production must not load fallback or corrective paint layers');
 
 assert.match(lotSource, /input\.type = 'color'/,
-  'The visible paint swatch and interactive control must remain the native input[type=color]');
-assert.match(lotSource, /input\.className = 'lot-color-input'/);
+  'Vehicle paint must start with a real HTML color input');
 assert.match(lotSource, /inputLabel\.htmlFor = input\.id/,
-  'The native color input must use a direct explicit label');
-assert.match(lotSource, /NAMED_COLOR_PRESETS/,
-  'The Lot must provide a small native named-color fallback while shipping WebKit cannot press the color input');
-assert.match(lotSource, /named\.className = 'lot-color-preset'/);
-assert.match(lotSource, /named\.setAttribute\('aria-label', `Choose \$\{label\} colour by name`\)/);
-for (const value of ['#ff70b4', '#ff00ff', '#f28b39', '#ffcc00', '#00aabb', '#5e3c87']) {
-  assert.match(lotSource, new RegExp(value.replace('#', '\\#')),
-    `Named-color fallback must include ${value}`);
-}
-assert.match(lotSource, /input\.value = named\.value[\s\S]*input\.dispatchEvent\(new Event\('input', \{ bubbles: true \}\)\)/,
-  'Named-color selection must feed the same native input event path as the system picker');
-assert.match(lotSource, /named\.value = ''/,
-  'The named-color select is an action fallback, not a second stored paint state');
+  'The native color input must have a real explicit label');
+assert.match(lotSource, /input\.addEventListener\('input'/,
+  'Progressive enhancement must listen to the native input rather than replace activation');
 assert.match(lotSource, /cue\.textContent = `COLOR · \$\{describeColorCue\(input\.value\)\.toUpperCase\(\)\}`/,
-  'Color Cues must use the shared broad semantic classifier');
-assert.doesNotMatch(lotSource, /lot-color-trigger|lot-color-native|openNativeColorPicker|focusNativeColorInput|isIOSFamily|showPicker\(|label\.click\(/,
-  'The Lot must not contain a duplicate swatch or synthetic picker activation path');
-assert.doesNotMatch(lotSource, /input\.setAttribute\('aria-label'/,
-  'Color Cues should not replace the native input semantics with a scripted accessible name');
-assert.doesNotMatch(lotSource, /input\.setAttribute\('aria-hidden'|input\.tabIndex = -1/,
-  'The native input must remain in the normal accessibility and keyboard order');
+  'Color Cues may progressively add TURN’s broad semantic name');
+assert.doesNotMatch(lotSource, /NAMED_COLOR_PRESETS|lot-color-preset|BY NAME|document\.createElement\('select'\)/,
+  'The rejected named-color fallback must be gone');
+assert.doesNotMatch(lotSource, /lot-color-trigger|lot-color-native|showPicker\(|\.click\(\)|focusNativeColorInput|isIOSFamily|label\.click\(/,
+  'TURN must not proxy or synthesize native picker activation');
+assert.doesNotMatch(lotSource, /input\.className|input\.classList|input\.setAttribute\('aria-|input\.tabIndex/,
+  'The color input itself must not be restyled or have its accessibility semantics rewritten');
 
-assert.match(lotCssSource, /\.lot-color-input \{[\s\S]*width: 38px[\s\S]*height: 28px[\s\S]*border: 2px solid var\(--ink\)/,
-  'The native input must be styled directly as the visible swatch');
-assert.match(lotCssSource, /\.lot-color-preset \{/,
-  'The fallback must remain a plain native select rather than a custom menu');
-assert.doesNotMatch(lotCssSource, /\.lot-color-trigger|opacity: 0\.001/,
-  'Core Lot CSS must not contain the retired hidden-input or duplicate-trigger treatment');
-const paintInputCss = lotCssSource.match(/\.lot-color-input \{[\s\S]*?\}/)?.[0] || '';
-assert.doesNotMatch(paintInputCss, /pointer-events:\s*none|opacity:\s*0(?:\.0+)?/,
-  'The native paint input itself must remain visible and interactive');
+assert.match(lotSource, /<section class="lot-viewbox lot-viewbox-with-paint">[\s\S]*<div class="lot-colors" aria-label="Choose car paint colours"><\/div>[\s\S]*<\/section>/,
+  'Paint controls must be created in their final semantic DOM location');
+assert.match(lotSource, /lot-viewbox-head" aria-hidden="true"/);
+assert.match(lotSource, /lot-view-host" aria-hidden="true"/);
+assert.doesNotMatch(layoutSource, /appendChild\(colors\)|removeAttribute\('aria-hidden'\)|lot-view-close|lot-view-open/,
+  'The layout enhancer must not relocate paint or repair parent accessibility after render');
 
-assert.doesNotMatch(runtimeSource, /describeColorCue|lot-color-control|input\[type="color"\]|onPaintValueChange|replaceWith|removeAttribute\('aria-hidden'/,
-  'Color Cues runtime must not post-process paint controls');
+assert.doesNotMatch(lotCssSource, /\.lot-color-input|\.lot-color-preset|input\[type=['"]?color/,
+  'TURN CSS must leave the native color input appearance untouched');
+
+const universalBlock = stylesSource.match(/\*\s*\{[\s\S]*?\}/)?.[0] || '';
+const htmlBodyBlock = stylesSource.match(/html,\s*\nbody\s*\{[\s\S]*?\}/)?.[0] || '';
+const buttonBlock = stylesSource.match(/button\s*\{[\s\S]*?\}/)?.[0] || '';
+assert.doesNotMatch(universalBlock, /user-select|touch-action|-webkit-touch-callout|-webkit-tap-highlight-color/,
+  'Universal CSS must not suppress native interaction');
+assert.doesNotMatch(htmlBodyBlock, /touch-action:\s*none|user-select:\s*none/,
+  'The document root must not disable native touch or selection semantics');
+assert.doesNotMatch(buttonBlock, /touch-action:\s*none|user-select:\s*none|-webkit-touch-callout/,
+  'Generic controls must not inherit game-gesture suppression');
+assert.match(drivePadCssSource, /\.drive-pad[\s\S]*touch-action:\s*none/,
+  'Gesture suppression must remain local to the driving surface');
+assert.match(manualSteeringCssSource, /\.manual-steer[\s\S]*touch-action:\s*none/,
+  'Gesture suppression must remain local to manual steering');
+
+assert.doesNotMatch(runtimeSource, /describeColorCue|lot-color-control|input\[type="color"\]|onPaintValueChange|replaceWith/,
+  'The Color Cues runtime must not post-process paint controls');
 assert.match(runtimeSource, /Color cues/);
 assert.match(runtimeSource, /TRACK COLOR ·/);
 assert.doesNotMatch(runtimeSource, /setInterval|setAnimationLoop/);
@@ -98,9 +116,8 @@ assert.match(cueCssSource, /track-card-color-cue/);
 assert.match(cueCssSource, /lot-color-cue/);
 assert.match(cueCssSource, /repeating-linear-gradient/);
 
-assert.match(historySource, /1\.7\.0 r163/);
-assert.match(historySource, /accessibility patch/i);
-assert.match(historySource, /CHROMATIC CAMOUFLAGE/);
-assert.match(historySource, /Color Cues/);
+assert.match(historySource, /native HTML color input/i);
+assert.doesNotMatch(historySource, /native paint activation bridge|named-color fallback/i,
+  'Current release history must not claim a workaround that no longer exists');
 
-console.log('TURN 1.7.0 r163 native color input, named fallback and Color Cues regression passed.');
+console.log('TURN 1.7.0 r163 HTML-first native color input and Color Cues regression passed.');

--- a/turn-lab/tests/color-accessibility-production.mjs
+++ b/turn-lab/tests/color-accessibility-production.mjs
@@ -117,7 +117,7 @@ assert.match(cueCssSource, /lot-color-cue/);
 assert.match(cueCssSource, /repeating-linear-gradient/);
 
 assert.match(historySource, /native HTML color input/i);
-assert.doesNotMatch(historySource, /native paint activation bridge|named-color fallback/i,
-  'Current release history must not claim a workaround that no longer exists');
+assert.doesNotMatch(historySource, /native paint activation bridge|assistive-technology bridge/i,
+  'Current release history must not claim an activation bridge that no longer exists');
 
 console.log('TURN 1.7.0 r163 HTML-first native color input and Color Cues regression passed.');

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -144,12 +144,12 @@ const imports = JSON.parse(importMapText).imports;
 const releaseTarget = (filePath) => `${filePath}?build=${release.cacheKey}`;
 
 assert.match(index, new RegExp(`TURN v${release.version.replaceAll('.', '\\.')} · Build ${release.id.replaceAll('.', '\\.')}`));
-assert.match(index, new RegExp(`\\.\\/garage\\/lot-r10\\.css\\?build=${release.cacheKey}`));
+assert.match(index, /\.\/garage\/lot-r10\.css\?build=20260809-r163-native-html/);
 assert.match(index, new RegExp(`\\.\\/track-intro\\.css\\?build=${release.cacheKey}`));
 assert.match(index, new RegExp(`src="\\.\\/app\\.js\\?build=${release.cacheKey}-browser-consent(?:-[^"]+)?"`));
 assert.equal(
   imports['./garage/lot-r10.js?build=20260720-r19'],
-  `${releaseTarget('./garage/lot-track-select.js')}&revision=r163-named-color-fallback`
+  `${releaseTarget('./garage/lot-track-select.js')}&revision=r163-native-html`
 );
 assert.equal(imports['./ui/track-intro.js?build=20260725-r75'], releaseTarget('./ui/track-intro.js'));
 assert.equal(imports['./race/lap-system.js?build=20260720-r19'], releaseTarget('./race/lap-system-r86.js'));
@@ -161,12 +161,15 @@ assert.match(app, /lot-enhancement-runtime\.js\?revision=r121&trophy-road=r154/)
 assert.ok(app.indexOf('installLotEnhancementRuntime()') < app.indexOf("withBuild('./main.js')"));
 
 assert.match(lotWrapper, /showOriginalLot/);
+assert.match(lotWrapper, /lot-r10\.js\?build=20260809-r163-native-html/);
 assert.match(lotWrapper, /export async function showEnhancedLot/);
 assert.match(lotWrapper, /enhanceLotNow\(\)/);
 assert.match(lotWrapper, /await chooseTrackBeforeLot\(\)/);
 assert.match(lotWrapper, /track-manager\.js\?build=20260722-r52/);
 assert.doesNotMatch(lotWrapper, /installLotLayout|installLotStatLegend|installLotAccessibility/);
 assert.match(originalLot, /export function showTheLot/);
+assert.match(originalLot, /input\.type = 'color'/);
+assert.doesNotMatch(originalLot, /NAMED_COLOR_PRESETS|lot-color-preset|showPicker\(|label\.click\(/);
 
 assert.match(lotEnhancementRuntime, /ENHANCEMENT_ID = 'enhanced-lot-r121'/);
 assert.match(lotEnhancementRuntime, /TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r154-trophy-road-feedback'/);
@@ -187,14 +190,14 @@ assert.match(lotTrophyGate, /lot-selected-car-lock/);
 assert.match(lotTrophyGate, /showTrophyUnlockNotice/);
 assert.doesNotMatch(lotTrophyGate, /colors\.hidden|carPicker\.hidden/);
 
-assert.match(lotLayout, /viewbox\.appendChild\(colors\)/);
+assert.match(originalLot, /<section class="lot-viewbox lot-viewbox-with-paint">[\s\S]*<div class="lot-colors" aria-label="Choose car paint colours"><\/div>[\s\S]*<\/section>/);
+assert.doesNotMatch(lotLayout, /appendChild\(colors\)|removeAttribute\('aria-hidden'\)|lot-view-close|lot-view-open/);
 assert.match(lotLayout, /attributesHeading\.replaceChildren\(document\.createTextNode\('ATTRIBUTES'\)\)/);
-assert.match(lotLayout, /lot-viewbox-with-paint/);
 assert.match(lotLayoutCss, /\.lot-viewbox-with-paint[\s\S]*flex: 1 1 auto/);
 assert.match(lotLayoutCss, /min-height: clamp\(150px, 28vh, 230px\)/);
 assert.match(lotLayoutCss, /--lot-paint-rail-height: 54px/);
 assert.match(lotLayoutCss, /\.lot-viewbox-with-paint \.lot-view-host[\s\S]*inset: 0 0 var\(--lot-paint-rail-height\)/);
-assert.match(lotLayoutCss, /\.lot-view-close,[\s\S]*\.lot-view-open[\s\S]*display: none !important/);
+assert.doesNotMatch(lotLayoutCss, /\.lot-color-input|\.lot-color-preset/);
 assert.match(lotLayoutCss, /\.lot-secret-notice \{[\s\S]*background: #d9f5c2[\s\S]*border: 3px solid var\(--ink\)/);
 assert.match(lotLayoutCss, /\.lot-secret-notice\[hidden\][\s\S]*display: none/);
 assert.match(lotLayoutCss, /\.lot-secret-notice-chip[\s\S]*background: var\(--yellow\)/);
@@ -260,4 +263,4 @@ assert.match(easterEggUi, /notice\.setAttribute\('role', 'status'\)/);
 assert.match(easterEggUi, /notice\.setAttribute\('aria-live', 'polite'\)/);
 assert.match(easterEggUi, /card\.insertBefore\(notice, actions \|\| null\)/, 'The explanation must sit immediately before RACE THIS CAR');
 
-console.log(`TURN ${release.id} enhanced Lot route, Trophy Road gating, accessibility and garage setup passed.`);
+console.log(`TURN ${release.id} enhanced Lot route, Trophy Road gating, native paint and garage setup passed.`);

--- a/turn-lab/tests/lot-layout-production.mjs
+++ b/turn-lab/tests/lot-layout-production.mjs
@@ -30,12 +30,12 @@ const importMapText = index.match(/<script type="importmap">\s*([\s\S]*?)\s*<\/s
 assert.ok(importMapText, 'Production must expose its import map');
 const imports = JSON.parse(importMapText).imports;
 
-assert.match(index, new RegExp(`lot-layout-r60\\.css\\?build=${release.cacheKey}`), 'Production must retain the baseline Lot layout stylesheet');
+assert.match(index, /lot-layout-r60\.css\?build=20260809-r163-native-html/, 'Production must cache-bust the HTML-first Lot layout stylesheet');
 assert.match(index, new RegExp(`app\\.js\\?build=${release.cacheKey}-browser-consent`), 'Production must cache-bust the browser-gated canonical runtime');
 assert.equal(
   imports['./garage/lot-r10.js?build=20260720-r19'],
-  `./garage/lot-track-select.js?build=${release.cacheKey}&revision=r163-named-color-fallback`,
-  'Production must retain the track-first compatibility wrapper with the named-color fallback revision'
+  `./garage/lot-track-select.js?build=${release.cacheKey}&revision=r163-native-html`,
+  'Production must retain the track-first compatibility wrapper with the native HTML revision'
 );
 
 assert.match(app, /lot-layout-r60\.css\?revision=r121-viewer-r122-fit-r128-super-sedan-notice-r129-race-button-fit/, 'The Super Sedan fit stylesheet must bypass the previous notice cache');
@@ -55,7 +55,7 @@ assert.doesNotMatch(wrapper, /installLotLayout|installLotStatLegend|installLotAc
 assert.match(enhancementRuntime, /ENHANCEMENT_ID = 'enhanced-lot-r121'/, 'The restored Lot contract must have an explicit identity');
 assert.match(enhancementRuntime, /activeEnhancements = new WeakMap\(\)/, 'Enhancements must be idempotent per Lot screen');
 assert.match(enhancementRuntime, /installLotStatLegend\(scope\)/, 'Every Lot route must receive the stat legend');
-assert.match(enhancementRuntime, /installLotLayout\(scope\)/, 'Every Lot route must receive the shared 3D and paint layout');
+assert.match(enhancementRuntime, /installLotLayout\(scope\)/, 'Every Lot route must receive the shared visual layout enhancement');
 assert.match(enhancementRuntime, /installLotAccessibility\(scope\)/, 'Every Lot route must receive the r118 accessibility model');
 assert.ok(
   enhancementRuntime.indexOf('installLotStatLegend(scope)') < enhancementRuntime.indexOf('installLotLayout(scope)'),
@@ -63,19 +63,20 @@ assert.ok(
 );
 assert.ok(
   enhancementRuntime.indexOf('installLotLayout(scope)') < enhancementRuntime.indexOf('installLotAccessibility(scope)'),
-  'Accessibility landmarks must attach after paint reaches its final DOM position'
+  'Accessibility landmarks must attach after visual layout enhancement'
 );
 assert.match(enhancementRuntime, /new MutationObserver\(sync\)/, 'The runtime must catch M8 and any future Lot route');
 assert.match(enhancementRuntime, /if \(active\) return active\.release/, 'Repeated route helpers must not install duplicate observers or headings');
 assert.match(enhancementRuntime, /released = true/, 'Cleanup must be safe when both the route and observer release the same screen');
 
-assert.match(layout, /viewbox\.removeAttribute\('aria-hidden'\)/, 'The shared 3D and paint panel must remain in the accessibility tree');
-assert.match(layout, /lot-viewbox-head'\)\?\.setAttribute\('aria-hidden', 'true'\)/, 'Decorative 3D chrome must remain hidden from assistive technology');
-assert.match(layout, /lot-view-host'\)\?\.setAttribute\('aria-hidden', 'true'\)/, 'The decorative WebGL host must remain hidden from assistive technology');
-assert.match(layout, /viewbox\.appendChild\(colors\)/, 'The live paint controls and 3D preview must share one actual panel');
-assert.doesNotMatch(layout, /lot-paint-a11y-host/, 'The retired overlapping paint-host workaround must not return');
-assert.match(layout, /lot-view-close'\)\?\.remove\(\)/, 'The redundant 3D close control must be removed');
-assert.match(layout, /lot-view-open'\)\?\.remove\(\)/, 'The retired 3D reopen control must be removed with it');
+assert.match(lot, /<section class="lot-viewbox lot-viewbox-with-paint">[\s\S]*<div class="lot-colors" aria-label="Choose car paint colours"><\/div>[\s\S]*<\/section>/,
+  'The native paint controls and 3D preview must share their final panel from initial render');
+assert.match(lot, /lot-viewbox-head" aria-hidden="true"/, 'Decorative 3D chrome must be hidden at source');
+assert.match(lot, /lot-view-host" aria-hidden="true"/, 'The decorative WebGL host must be hidden at source');
+assert.match(lot, /<small aria-hidden="true">DRAG TO ROTATE<\/small>/, 'Decorative viewer guidance must be hidden at source');
+assert.doesNotMatch(lot, /lot-view-close|lot-view-open/, 'Dormant 3D controls must not be rendered just to be removed later');
+assert.doesNotMatch(layout, /viewbox|colors|appendChild\(colors\)|aria-hidden|lot-view-close|lot-view-open/,
+  'The layout enhancer must not rearrange or repair the paint control DOM');
 assert.match(layout, /document\.createTextNode\('ATTRIBUTES'\)/, 'The lower card must be headed Attributes visually');
 assert.match(layout, /infoButton\.textContent = 'i'/, 'The verbose help button must become a conventional info icon');
 assert.match(layout, /aria-label', 'What do the attributes mean\?'/, 'The compact icon must keep an explicit accessible name');
@@ -103,7 +104,7 @@ assert.match(accessibility, /Drift/, 'Car descriptions must include drift');
 assert.match(accessibility, /Boost power/, 'Car descriptions must include boost power');
 assert.match(accessibility, /Boost tank/, 'Car descriptions must include boost tank');
 assert.match(accessibility, /out of 5\./, 'Every described attribute must use the agreed out-of-five scale');
-assert.match(accessibility, /colors\.setAttribute\('aria-labelledby', paintHeading\.id\)/, 'The colour controls must have a useful accessible name');
+assert.match(accessibility, /colors\.setAttribute\('aria-labelledby', paintHeading\.id\)/, 'The colour controls must have a useful accessible group name');
 assert.match(accessibility, /card\.setAttribute\('role', 'region'\)/, 'Selected-car information must remain a named navigable region');
 assert.doesNotMatch(accessibility, /setInterval|requestAnimationFrame|setAnimationLoop/, 'The accessibility enhancer must not add polling or animation work');
 
@@ -111,21 +112,20 @@ assert.match(layoutCss, /\.lot-a11y-only \{[\s\S]*clip-path: inset\(50%\)/, 'Nav
 assert.match(layoutCss, /--lot-paint-rail-height: 54px/, 'Paint controls must use a compact dock to protect the 3D preview');
 assert.match(layoutCss, /min-height: clamp\(150px, 28vh, 230px\)/, 'The 3D viewer must receive a meaningful responsive minimum height');
 assert.match(layoutCss, /flex: 1 1 auto/, 'The 3D panel must receive the remaining rail height instead of being squashed');
-assert.match(layoutCss, /\.lot-viewbox-with-paint \.lot-colors \{[\s\S]*border-top: 3px solid var\(--ink\)/, 'Accessible paint controls must preserve their visual dock inside the 3D card');
+assert.match(layoutCss, /\.lot-viewbox-with-paint \.lot-colors \{[\s\S]*border-top: 3px solid var\(--ink\)/, 'Paint controls must preserve their visual dock inside the 3D card');
+assert.doesNotMatch(layoutCss, /\.lot-color-input|\.lot-color-preset/, 'Layout CSS must not style or replace native paint controls');
 assert.match(layoutCss, /\.lot-card-actions \{[\s\S]*grid-template-columns: 1fr[\s\S]*margin-top: 4px/, 'Race This Car must follow the secret notice with only the explicit minimum gap');
 assert.match(layoutCss, /\.lot-secret-notice \{[\s\S]*margin: 8px 0 0/, 'The secret notice must not reserve an additional bottom margin above Race This Car');
 assert.match(layoutCss, /\.lot-screen\.is-super-sedan-unlocked \.lot-card \{[\s\S]*display: flex[\s\S]*flex-direction: column/, 'The unlocked card must keep the notice and action in one deterministic vertical flow');
 assert.match(layoutCss, /\.lot-screen\.is-super-sedan-unlocked \.lot-viewbox-with-paint \{[\s\S]*min-height: clamp\(132px, 22vh, 176px\)/, 'The temporary secret message must borrow enough rail height to keep Race This Car above the fold');
 assert.match(layoutCss, /\.lot-stats-help \{[\s\S]*border-radius: 50%/, 'The Attributes help control must read as a conventional circular info icon');
 assert.match(layoutCss, /\.lot-race \{[\s\S]*background: var\(--pink\)/, 'Race This Car must use the pink action treatment shown in the fitted design');
-assert.match(layoutCss, /\.lot-view-close,[\s\S]*\.lot-view-open \{[\s\S]*display: none !important/, 'No dormant 3D close or reopen affordance may flash during setup');
 assert.match(layoutCss, /@media \(max-height: 520px\)[\s\S]*\.lot-side \{[\s\S]*top: max\(62px,[\s\S]*\.lot-card \{[\s\S]*padding: 9px/, 'Tablet-sized short landscapes must compact the rail before Race can leave the viewport');
 assert.match(layoutCss, /@media \(max-height: 520px\)[\s\S]*\.lot-screen\.is-super-sedan-unlocked \.lot-viewbox-with-paint \{[\s\S]*min-height: 112px/, 'Short tablet landscapes must give the unlocked action enough room');
 assert.match(layoutCss, /@media \(max-height: 520px\)[\s\S]*min-height: 140px/, 'The fitted layout must preserve a useful 3D preview on short tablet landscapes');
 assert.match(layoutCss, /@media \(max-height: 430px\)[\s\S]*\.lot-screen\.is-super-sedan-unlocked \.lot-viewbox-with-paint \{[\s\S]*min-height: 96px/, 'Short iPhone landscapes must prioritise the unlocked race action without removing the viewer');
 assert.match(layoutCss, /@media \(max-height: 430px\)[\s\S]*min-height: 120px/, 'Short iPhone landscapes must keep the viewer without pushing Race off-screen');
 
-assert.match(lot, /<div class="lot-colors" aria-label="Choose car paint colours"><\/div>/, 'The verified Lot must still own the live native paint controls before enhancement');
 assert.match(legend, /aria-haspopup', 'dialog'/, 'The relocated info icon must still open the full stat legend');
 
-console.log(`TURN ${release.id} route-independent enhanced Lot, fitted Super Sedan action rail and selected-car accessibility passed.`);
+console.log(`TURN ${release.id} source-owned native paint layout and selected-car accessibility passed.`);

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -37,10 +37,12 @@ const [index, releaseSource, lot, css, carModels, main, lapSystem, rivalStorage]
 
 const release = JSON.parse(releaseSource);
 assert.match(index, new RegExp(`TURN v${release.version.replaceAll('.', '\\.')} · Build ${release.id.replaceAll('.', '\\.')}`));
-assert.match(lot, /input\.type = 'color'/, 'The Lot must invoke the browser or OS colour picker');
+assert.match(lot, /input\.type = 'color'/, 'The Lot must use the browser or OS colour picker');
+assert.match(lot, /inputLabel\.htmlFor = input\.id/, 'The native input must have an explicit HTML label');
 assert.match(lot, /input\.addEventListener\('input'/, 'Native picker changes must preview immediately');
-assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton/, 'The production Lot must not render the custom palette');
-assert.match(css, /\.lot-color-input/);
+assert.doesNotMatch(lot, /CAR_PALETTE|makeColorButton|NAMED_COLOR_PRESETS|lot-color-preset/, 'Production must not add a custom or fallback palette');
+assert.doesNotMatch(lot, /input\.className|input\.classList|input\.setAttribute\('aria-/, 'The native color input must remain semantically and visually native');
+assert.doesNotMatch(css, /\.lot-color-input|input\[type=['"]?color/, 'TURN must not style the native color input itself');
 assert.doesNotMatch(css, /\.lot-color\[aria-pressed=/, 'The retired custom swatch state must be removed');
 assert.match(carModels, /turnSecondaryPaintMaterials/);
 assert.match(carModels, /isSecondaryPaint\(node, car\)/);
@@ -50,7 +52,7 @@ assert.match(lapSystem, /carSecondaryColor: state\.vehicleSecondaryColor \|\| '#
 assert.match(rivalStorage, /version: 6/, 'Track-scoped rivals must preserve geometry revision and secondary paint metadata');
 assert.match(rivalStorage, /normalizeVehicleSecondaryColor\(lap\.carSecondaryColor\)/);
 
-console.log(`TURN ${release.id} native and secondary paint passed.`);
+console.log(`TURN ${release.id} bare native and secondary paint passed.`);
 
 function readGlbJson(buffer) {
   assert.equal(buffer.toString('utf8', 0, 4), 'glTF');

--- a/turn-lab/tests/stat-legend-production.mjs
+++ b/turn-lab/tests/stat-legend-production.mjs
@@ -33,8 +33,8 @@ const imports = JSON.parse(importMapText).imports;
 assert.match(index, new RegExp(`lot-stat-legend\\.css\\?build=${release.cacheKey}`), 'Production must load the stat-legend styling through the current release');
 assert.equal(
   imports['./garage/lot-r10.js?build=20260720-r19'],
-  `./garage/lot-track-select.js?build=${release.cacheKey}&revision=r163-named-color-fallback`,
-  'Production must publish the compact Lot wrapper through the current release'
+  `./garage/lot-track-select.js?build=${release.cacheKey}&revision=r163-native-html`,
+  'Production must publish the native HTML Lot wrapper through the current release'
 );
 assert.equal(imports['./vehicle/physics.js?build=20260720-r19'], `./vehicle/physics.js?build=${release.cacheKey}`, 'Production must publish the mandatory DRIFT penalty through the current release');
 assert.equal(imports['./vehicle/catalog.js?build=20260720-r19'], `./vehicle/catalog.js?build=${release.cacheKey}`, 'Production must publish the shared stat definitions through the current release');

--- a/turn/content/about-history.js
+++ b/turn/content/about-history.js
@@ -153,12 +153,12 @@ export const DEVELOPMENT_HISTORY = Object.freeze([
     paragraphs: [
       'CHROMATIC CAMOUFLAGE added a hidden 50-trophy challenge built around the five production track colours. It checks the current personal best on every track and deliberately accepts broad hue families rather than exact paint values, bringing the collection to 29 achievements and 1,750 available trophies. Device testing widened Countryside’s accepted pink family so canonical #FF00FF Magenta is not rejected on a five-degree technicality.',
       'The new color-based achievement exposed an accessibility gap: common colour-vision simulations collapse several track colours toward similar greys, olives and violets. TURN 1.7.0 is therefore an accessibility patch, adding optional Color Cues, off by default, with compact text and pattern labels for track colours and selected vehicle paint without recolouring the game or creating a separate visual mode.',
-      'Real-device VoiceOver testing also exposed a WebKit defect: the native color input could be read, and the system picker itself supplied useful semantic colour names, but VoiceOver could no longer activate the colour well. An initial label-forwarding workaround failed on device and only exposed a hidden focus target. The corrected design makes The Lot own one accessible paint control from creation time: an ordinary button bridges affected iOS VoiceOver activation directly to the real native input while the system picker, its native semantics and the input value remain canonical.'
+      'VoiceOver testing then showed TURN’s paint control behaving differently from a plain HTML color input in the same browser session. The response was to remove the workaround stack rather than add another bridge: the Lot now creates the real input in its final semantic location, leaves the native control appearance and accessible value untouched, stops globally disabling selection and touch behaviour, and progressively adds only TURN’s label and optional Color Cue.'
     ],
     milestones: [
       'CHROMATIC CAMOUFLAGE · 50 trophies with generous pink-family matching',
       'Optional Color Cues with text and pattern redundancy',
-      'TURN 1.7.0 · 2026.08.09-r163 accessibility patch with native paint activation bridge'
+      'TURN 1.7.0 · 2026.08.09-r163 accessibility patch returning paint to native HTML first'
     ]
   }
 ]);
@@ -330,9 +330,9 @@ export const CHANGELOG = Object.freeze([
   {
     date: '9 August',
     entries: [
-      ['1.7.0 r163', 'Accessibility patch prompted by the new color-based CHROMATIC CAMOUFLAGE achievement: adds Color Cues and an assistive-technology bridge to the native paint picker.'],
+      ['1.7.0 r163', 'Accessibility patch prompted by the new color-based CHROMATIC CAMOUFLAGE achievement: adds optional Color Cues while keeping vehicle paint on the native HTML color input.'],
       ['CHROMATIC CAMOUFLAGE', 'Hidden 50-trophy achievement for setting a matching-colour personal best on all five production tracks; broad hue ranges now include canonical #FF00FF Magenta for Countryside’s pink family.'],
-      ['Color accessibility', 'Color Cues are off by default and add text plus pattern redundancy. After the first VoiceOver activation workaround failed device testing, The Lot was refactored to own the accessible paint control directly while preserving the native system picker and its semantic colour names.']
+      ['Color accessibility', 'Device comparison against a plain HTML color input led to removing activation bridges, named-color fallbacks, post-render paint relocation and broad interaction-suppressing CSS. TURN now starts with the native input and progressively adds only layout and optional Color Cues.']
     ]
   }
 ]);
@@ -340,5 +340,5 @@ export const CHANGELOG = Object.freeze([
 export const CURRENT_RELEASE = Object.freeze({
   version: '1.7.0',
   build: '2026.08.09-r163',
-  note: 'Accessibility patch prompted by the new color-based Chromatic Camouflage achievement, adding optional Color Cues and an assistive-technology bridge to the native vehicle paint picker.'
+  note: 'Accessibility patch prompted by the new color-based Chromatic Camouflage achievement, adding optional Color Cues while keeping vehicle paint on the native HTML color input.'
 });

--- a/turn/garage/lot-layout-r60.css
+++ b/turn/garage/lot-layout-r60.css
@@ -138,11 +138,6 @@
   background: var(--pink);
 }
 
-.lot-view-close,
-.lot-view-open {
-  display: none !important;
-}
-
 @media (max-height: 520px) {
   .lot-side {
     top: max(62px, calc(env(safe-area-inset-top) + 54px));
@@ -170,13 +165,7 @@
 
   .lot-viewbox-with-paint .lot-color-control {
     min-height: 35px;
-    grid-template-columns: minmax(0, 1fr) 34px;
-    padding: 3px 4px 3px 6px;
-  }
-
-  .lot-viewbox-with-paint .lot-color-input {
-    width: 34px;
-    height: 26px;
+    padding: 3px 6px;
   }
 
   .lot-viewbox-with-paint > small {
@@ -257,13 +246,7 @@
 
   .lot-viewbox-with-paint .lot-color-control {
     min-height: 33px;
-    grid-template-columns: minmax(0, 1fr) 32px;
-    padding: 3px 4px 3px 6px;
-  }
-
-  .lot-viewbox-with-paint .lot-color-input {
-    width: 32px;
-    height: 25px;
+    padding: 3px 6px;
   }
 
   .lot-viewbox-with-paint > small {

--- a/turn/garage/lot-layout-r60.js
+++ b/turn/garage/lot-layout-r60.js
@@ -1,28 +1,11 @@
 export function installLotLayout(root = document.body) {
   const screen = root.querySelector('.lot-screen');
-  const viewbox = screen?.querySelector('.lot-viewbox');
-  const colors = screen?.querySelector('.lot-colors');
   const attributesHeading = screen?.querySelector('.lot-car-title > span');
   const infoButton = screen?.querySelector('.lot-stats-help');
 
-  if (!screen || !viewbox || !colors || !attributesHeading) return () => {};
-
-  viewbox.hidden = false;
-  viewbox.classList.add('lot-viewbox-with-paint');
-
-  // The panel contains both the visual 3D preview and the interactive paint
-  // controls. Keep the panel itself in the accessibility tree, then hide only
-  // the decorative WebGL preview and its visual chrome.
-  viewbox.removeAttribute('aria-hidden');
-  viewbox.removeAttribute('aria-label');
-  viewbox.querySelector('.lot-viewbox-head')?.setAttribute('aria-hidden', 'true');
-  viewbox.querySelector('.lot-view-host')?.setAttribute('aria-hidden', 'true');
-  viewbox.querySelector(':scope > small')?.setAttribute('aria-hidden', 'true');
-  viewbox.appendChild(colors);
+  if (!screen || !attributesHeading) return () => {};
 
   screen.classList.remove('is-view-closed');
-  screen.querySelector('.lot-view-close')?.remove();
-  screen.querySelector('.lot-view-open')?.remove();
 
   attributesHeading.replaceChildren(document.createTextNode('ATTRIBUTES'));
   if (infoButton) {

--- a/turn/garage/lot-r10.css
+++ b/turn/garage/lot-r10.css
@@ -146,19 +146,6 @@
   letter-spacing: 0.08em;
 }
 
-.lot-view-close {
-  width: 30px;
-  height: 30px;
-  min-height: 0;
-  padding: 0;
-  border-width: 2px;
-  border-radius: 50%;
-  background: var(--pink);
-  font-size: 1rem;
-  line-height: 1;
-  pointer-events: auto;
-}
-
 .lot-view-host,
 .lot-view-host canvas {
   position: absolute;
@@ -273,26 +260,21 @@
 }
 
 .lot-color-control {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 38px;
+  display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 7px;
   min-height: 38px;
-  padding: 2px 5px 2px 7px;
+  padding: 4px 7px;
   border: 2px solid var(--ink);
   border-radius: 10px;
   background: var(--paper);
   box-shadow: 2px 2px 0 var(--ink);
 }
 
-.lot-color-copy,
 .lot-color-name {
   min-width: 0;
   display: grid;
   gap: 2px;
-}
-
-.lot-color-name {
   cursor: pointer;
 }
 
@@ -305,71 +287,20 @@
   white-space: nowrap;
 }
 
-.lot-color-preset {
-  width: 100%;
-  min-width: 0;
-  height: 18px;
-  min-height: 0;
-  margin: 0;
-  padding: 0 3px;
-  border: 1.5px solid var(--ink);
-  border-radius: 5px;
-  background: var(--paper);
-  color: var(--ink);
-  font: inherit;
-  font-size: 0.38rem;
-  font-weight: 900;
-  letter-spacing: 0.035em;
-}
-
-.lot-color-input {
-  width: 38px;
-  height: 28px;
-  min-height: 0;
-  margin: 0;
-  padding: 0;
-  border: 2px solid var(--ink);
-  border-radius: 7px;
-  background: transparent;
-  cursor: pointer;
-}
-
-.lot-color-input:focus-visible,
-.lot-color-preset:focus-visible {
-  outline: 3px solid var(--cyan);
-  outline-offset: 2px;
-}
-
 .lot-card-actions {
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: 1fr;
   gap: 7px;
 }
 
-.lot-view-open,
 .lot-race {
   min-height: 42px;
+  width: 100%;
   padding: 7px 10px;
   border-radius: 12px;
+  background: var(--lime);
   font-size: clamp(0.58rem, 1.4vw, 0.8rem);
   letter-spacing: 0.04em;
-}
-
-.lot-view-open {
-  background: var(--cyan);
-}
-
-.lot-view-open[hidden] {
-  display: none;
-}
-
-.lot-race {
-  width: 100%;
-  background: var(--lime);
-}
-
-.lot-card-actions:has(.lot-view-open[hidden]) {
-  grid-template-columns: 1fr;
 }
 
 .lot-loading {
@@ -411,12 +342,8 @@
   .lot-stat > span { font-size: 0.43rem; }
   .lot-stat i { height: 6px; }
   .lot-colors { gap: 4px; margin: 6px 0 8px; }
-  .lot-color-input { width: 32px; height: 25px; }
   .lot-color-label { font-size: 0.42rem; }
-  .lot-color-preset { height: 17px; font-size: 0.34rem; }
-  .lot-color-copy,
   .lot-color-name { gap: 1px; }
-  .lot-view-open,
   .lot-race { min-height: 34px; }
 }
 

--- a/turn/garage/lot-r10.js
+++ b/turn/garage/lot-r10.js
@@ -15,22 +15,6 @@ import { describeColorCue } from '../accessibility/color-cues.js?revision=r163';
 const UNSELECTED_COLOR = new THREE.Color(0x313131);
 const VIEWER_INITIAL_YAW = Math.PI - 0.55;
 let paintControlSerial = 0;
-const NAMED_COLOR_PRESETS = Object.freeze([
-  ['Pink', '#ff70b4'],
-  ['Magenta', '#ff00ff'],
-  ['Red', '#d92d20'],
-  ['Orange', '#f28b39'],
-  ['Yellow', '#ffcc00'],
-  ['Yellow green', '#9acd32'],
-  ['Green', '#26cb00'],
-  ['Cyan', '#00aabb'],
-  ['Blue', '#2ab7ff'],
-  ['Violet', '#5e3c87'],
-  ['Brown', '#8b5a2b'],
-  ['Grey', '#777777'],
-  ['Black', '#08090a'],
-  ['White', '#f8f9fa']
-]);
 const CAR_DESCRIPTIONS = Object.freeze({
   convertible: 'A low, open-top sports car with a long bonnet and compact cabin.',
   classic: 'A small, upright classic car with rounded bodywork and a friendly shape.',
@@ -66,13 +50,13 @@ export function showTheLot({ initialSelection } = {}) {
       <div class="lot-car-picker" role="radiogroup" aria-label="Choose a car"></div>
 
       <div class="lot-side">
-        <section class="lot-viewbox" aria-hidden="true">
-          <div class="lot-viewbox-head">
+        <section class="lot-viewbox lot-viewbox-with-paint">
+          <div class="lot-viewbox-head" aria-hidden="true">
             <span>3D VIEW</span>
-            <button class="lot-view-close" type="button" tabindex="-1">×</button>
           </div>
-          <div class="lot-view-host"></div>
-          <small>DRAG TO ROTATE</small>
+          <div class="lot-view-host" aria-hidden="true"></div>
+          <small aria-hidden="true">DRAG TO ROTATE</small>
+          <div class="lot-colors" aria-label="Choose car paint colours"></div>
         </section>
 
         <aside class="lot-card">
@@ -82,9 +66,7 @@ export function showTheLot({ initialSelection } = {}) {
           </div>
           <p class="lot-car-description"></p>
           <div class="lot-stats"></div>
-          <div class="lot-colors" aria-label="Choose car paint colours"></div>
           <div class="lot-card-actions">
-            <button class="lot-view-open" type="button" hidden aria-hidden="true" tabindex="-1">VIEW 3D</button>
             <button class="lot-race" type="button">RACE THIS CAR</button>
           </div>
         </aside>
@@ -297,12 +279,8 @@ export function showTheLot({ initialSelection } = {}) {
       control.className = 'lot-color-control';
       control.dataset.paintLabel = label;
 
-      const copy = document.createElement('span');
-      copy.className = 'lot-color-copy';
-
       const input = document.createElement('input');
       input.type = 'color';
-      input.className = 'lot-color-input';
       input.id = `turnPaintColor${++paintControlSerial}`;
       input.value = secondary
         ? normalizeVehicleSecondaryColor(value)
@@ -319,14 +297,6 @@ export function showTheLot({ initialSelection } = {}) {
       const cue = document.createElement('span');
       cue.className = 'turn-color-cue lot-color-cue';
 
-      const named = document.createElement('select');
-      named.className = 'lot-color-preset';
-      named.setAttribute('aria-label', `Choose ${label} colour by name`);
-      named.append(new Option('BY NAME…', ''));
-      for (const [colorName, colorValue] of NAMED_COLOR_PRESETS) {
-        named.append(new Option(colorName.toUpperCase(), colorValue));
-      }
-
       const syncCue = () => {
         cue.textContent = `COLOR · ${describeColorCue(input.value).toUpperCase()}`;
       };
@@ -336,19 +306,8 @@ export function showTheLot({ initialSelection } = {}) {
         onInput(input.value);
       });
 
-      // Shipping iOS/WebKit can expose the native color value to VoiceOver but
-      // fail its Press action. A plain select provides a second native path; it
-      // does not replace, proxy or script activation of the color input.
-      named.addEventListener('change', () => {
-        if (!named.value) return;
-        input.value = named.value;
-        named.value = '';
-        input.dispatchEvent(new Event('input', { bubbles: true }));
-      });
-
       inputLabel.append(name, cue);
-      copy.append(inputLabel, named);
-      control.append(copy, input);
+      control.append(input, inputLabel);
       syncCue();
       return control;
     }

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -1,4 +1,4 @@
-import { showTheLot as showOriginalLot } from './lot-r10.js?build=20260809-r163-named-color-fallback';
+import { showTheLot as showOriginalLot } from './lot-r10.js?build=20260809-r163-native-html';
 // Historical regression marker for the established compatibility wrapper:
 // lot-enhancement-runtime.js?revision=r121&build=20260731-r120
 import { enhanceLotNow } from './lot-enhancement-runtime.js?revision=r157&build=20260804-r157';

--- a/turn/index.html
+++ b/turn/index.html
@@ -38,7 +38,7 @@
   <link rel="icon" href="./TURNicon.PNG?icon=20260803-profile-512" type="image/png" sizes="512x512">
   <link rel="apple-touch-icon" href="./TURNicon.PNG?icon=20260803-profile-512" sizes="512x512">
   <link rel="manifest" href="./site.webmanifest?build=20260809-r163-icon-20260803-profile-512">
-  <link rel="stylesheet" href="./styles.css?build=20260809-r163">
+  <link rel="stylesheet" href="./styles.css?build=20260809-r163-native-html">
   <link rel="stylesheet" href="./vertical-drive.css?build=20260809-r163">
   <link rel="stylesheet" href="./hud-tuning.css?build=20260809-r163">
   <link rel="stylesheet" href="./install-gate.css?build=20260809-r163-social-browser">
@@ -60,9 +60,9 @@
   <link rel="stylesheet" href="./track-select-r78.css?build=20260809-r163">
   <link rel="stylesheet" href="./track-select-r79.css?build=20260809-r163">
   <link rel="stylesheet" href="./track-intro.css?build=20260809-r163">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260809-r163-named-color-fallback">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260809-r163-native-html">
   <link rel="stylesheet" href="./garage/lot-stat-legend.css?build=20260809-r163">
-  <link rel="stylesheet" href="./garage/lot-layout-r60.css?build=20260809-r163">
+  <link rel="stylesheet" href="./garage/lot-layout-r60.css?build=20260809-r163-native-html">
   <link rel="stylesheet" href="./accessibility/color-cues-r163.css?build=20260809-r163-accessible-paint">
   <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260809-r163-menu-font-v3">
   <script src="./install-gate.js?build=20260809-r163-social-browser"></script>
@@ -77,7 +77,7 @@
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",
-        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260809-r163&revision=r163-named-color-fallback",
+        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260809-r163&revision=r163-native-html",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260809-r163",
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system-r86.js?build=20260809-r163",
         "./race/game-state.js": "./race/game-state.js?build=20260809-r163",

--- a/turn/styles.css
+++ b/turn/styles.css
@@ -20,10 +20,6 @@
 
 * {
   box-sizing: border-box;
-  -webkit-tap-highlight-color: transparent;
-  -webkit-user-select: none;
-  user-select: none;
-  -webkit-touch-callout: none;
 }
 
 html,
@@ -33,7 +29,6 @@ body {
   margin: 0;
   overflow: hidden;
   overscroll-behavior: none;
-  touch-action: none;
   background: var(--cyan);
 }
 
@@ -76,10 +71,6 @@ button {
   font: inherit;
   color: var(--ink);
   box-shadow: 5px 5px 0 var(--ink);
-  -webkit-user-select: none;
-  user-select: none;
-  -webkit-touch-callout: none;
-  touch-action: none;
 }
 
 button:active,
@@ -403,6 +394,9 @@ h1 {
   border-radius: 50%;
   font-size: clamp(0.68rem, 1.8vw, 0.95rem);
   text-transform: uppercase;
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .brake { background: var(--pink); }


### PR DESCRIPTION
## What the device comparison changed
The latest recording compares TURN with a plain HTML `input[type="color"]` in the same Safari/VoiceOver session. The plain HTML control opens; TURN's does not. That disproves the earlier framing that this is simply an iOS/WebKit limitation. We should treat TURN as the source of the regression until proven otherwise.

## HTML first
This PR removes the fallback and peels back TURN-specific behavior around the color input:

- removes the `BY NAME…` / named-color fallback entirely;
- keeps one real `input[type="color"]` as the only paint control and value source;
- leaves that input unclassed and unstyled by TURN so the browser owns its native appearance and interaction;
- creates the paint rail in its final semantic DOM location instead of rendering it elsewhere and moving it after the fact;
- removes the viewbox `aria-hidden` repair/reparenting pass and dormant controls that existed only to be removed later;
- removes broad global `user-select: none`, `touch-action: none`, touch-callout and tap-highlight suppression from the document/generic controls;
- keeps gesture suppression scoped to the actual driving surfaces that need it;
- keeps Color Cues as progressive enhancement only: ordinary label text/pattern derived from the native input value, off by default.

No picker activation bridge, synthetic click/focus, platform detection, custom palette or fallback select remains.

## Testing philosophy
The regression tests now protect the absence of these layers: no native-input styling, no post-render paint relocation, no broad interaction suppression, and no activation proxies. They also verify that deliberate touch suppression remains local to driving controls.

Release identity remains TURN 1.7.0 · 2026.08.09-r163. Real-device VoiceOver testing remains the decisive validation for picker activation.