### PR TITLE
TURN r163: remove delegated clicks above native picker

### DIFF
--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -79,9 +79,13 @@ assert.match(audio, /case 'car-select':/);
 assert.match(audio, /case 'paint-select':/);
 assert.match(audio, /handleLotVisibilityChange/);
 assert.match(audio, /handleLotPointerDown/);
-assert.match(audio, /handleUiChange/);
-assert.match(audio, /function handleUiClick\(/);
+assert.match(audio, /function handleUiPointerDown\(/);
 assert.match(audio, /document\.addEventListener\('pointerdown', unlockFromGesture/);
+assert.match(audio, /document\.addEventListener\('pointerdown', handleUiPointerDown/);
+assert.doesNotMatch(audio, /document\.addEventListener\('click'/,
+  'Nonessential UI audio must not put a delegated click listener above native form controls');
+assert.doesNotMatch(audio, /document\.addEventListener\('change'/,
+  'Nonessential UI audio must not put delegated form handling above native controls');
 assert.match(audio, /document\.addEventListener\('keydown', unlockFromGesture/);
 assert.match(audio, /document\.addEventListener\('visibilitychange', handleVisibilityChange/);
 assert.match(audio, /window\.addEventListener\('pagehide', handlePageHide/);

--- a/turn-lab/tests/color-accessibility-production.mjs
+++ b/turn-lab/tests/color-accessibility-production.mjs
@@ -20,6 +20,8 @@ const [
   stylesSource,
   drivePadCssSource,
   manualSteeringCssSource,
+  orientationSource,
+  audioSource,
   historySource
 ] = await Promise.all([
   fs.readFile(new URL('../../turn/release.json', import.meta.url), 'utf8'),
@@ -32,6 +34,8 @@ const [
   fs.readFile(new URL('../../turn/styles.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/drive-pad.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/manual-steering.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/orientation-compat.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/audio/audio-system.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/content/about-history.js', import.meta.url), 'utf8')
 ]);
 const release = JSON.parse(releaseSource);
@@ -105,6 +109,20 @@ assert.match(drivePadCssSource, /\.drive-pad[\s\S]*touch-action:\s*none/,
 assert.match(manualSteeringCssSource, /\.manual-steer[\s\S]*touch-action:\s*none/,
   'Gesture suppression must remain local to manual steering');
 
+// Keep native form activation out of document-level click delegation. iOS VoiceOver
+// native pickers are sensitive to ancestor click listeners; TURN has no reason to put
+// unrelated orientation or UI-sound behavior in the color input's click ancestry.
+assert.doesNotMatch(orientationSource, /document\.addEventListener\(['"]click['"]/,
+  'Orientation compatibility must not delegate click handling from document');
+assert.match(orientationSource, /querySelector\('#motionButton'\)\?\.addEventListener\('click', resetSensorCalibration\)/,
+  'Motion calibration should bind directly to the control that owns it');
+assert.doesNotMatch(audioSource, /document\.addEventListener\(['"]click['"]/,
+  'Generic UI audio must not intercept every native-control click through document');
+assert.doesNotMatch(audioSource, /document\.addEventListener\(['"]change['"]/,
+  'Generic UI audio must not delegate native form changes through document');
+assert.match(audioSource, /document\.addEventListener\('pointerdown', handleUiPointerDown/,
+  'Nonessential pointer UI sounds may remain on the physical pointer path');
+
 assert.doesNotMatch(runtimeSource, /describeColorCue|lot-color-control|input\[type="color"\]|onPaintValueChange|replaceWith/,
   'The Color Cues runtime must not post-process paint controls');
 assert.match(runtimeSource, /Color cues/);
@@ -120,4 +138,4 @@ assert.match(historySource, /native HTML color input/i);
 assert.doesNotMatch(historySource, /native paint activation bridge|assistive-technology bridge/i,
   'Current release history must not claim an activation bridge that no longer exists');
 
-console.log('TURN 1.7.0 r163 HTML-first native color input and Color Cues regression passed.');
+console.log('TURN 1.7.0 r163 HTML-first native color input and VoiceOver event-boundary regression passed.');

--- a/turn/audio/audio-system.js
+++ b/turn/audio/audio-system.js
@@ -96,9 +96,8 @@ export function installTurnAudio() {
 
   document.addEventListener('pointerdown', unlockFromGesture, { capture: true, passive: true });
   document.addEventListener('pointerdown', handleLotPointerDown, { capture: true, passive: true });
+  document.addEventListener('pointerdown', handleUiPointerDown, { capture: true, passive: true });
   document.addEventListener('keydown', unlockFromGesture, { capture: true });
-  document.addEventListener('click', handleUiClick, { capture: true });
-  document.addEventListener('change', handleUiChange, { capture: true });
   document.addEventListener('visibilitychange', handleVisibilityChange, { passive: true });
   window.addEventListener('pagehide', handlePageHide, { passive: true });
   if (DRIVE_BY_EAR_ENABLED) {
@@ -221,8 +220,6 @@ export function update(frame = {}, now = performance.now()) {
   smooth(skidTone.frequency, 720 + speedRatio * 520 + strongSlip * 190, audioNow, 0.07);
   smooth(skidFilter.frequency, 980 + speedRatio * 520, audioNow, 0.09);
 
-  // DRIFT describes loss of grip without issuing a second left/right instruction.
-  // More slip widens the centred tyre image rather than moving it to one ear.
   const driftWidth = driftHeld
     ? 0.32 + strongSlip * 0.68
     : slipIntent * 0.18;
@@ -466,7 +463,6 @@ function installBoostGraph() {
   boostTone.start();
 }
 
-
 function installEmergencySirenGraph() {
   sirenGain = context.createGain();
   sirenGain.gain.value = 0;
@@ -540,8 +536,6 @@ function installDbeGraphs() {
   sliderHarmonicMix = context.createGain();
   sliderHarmonicMix.gain.value = 0.14;
 
-  // A soft tonal pair replaces the former continuous noise hiss.
-  // The fifth keeps the cue easy to localise without pushing energy into a sharp band.
   sliderTone = context.createOscillator();
   sliderTone.type = 'sine';
   sliderTone.frequency.value = 390;
@@ -560,8 +554,6 @@ function installDbeGraphs() {
   sliderTone.start();
   sliderHarmonic.start();
 
-  // Off-road surface is deliberately centred. It describes gravel and bumps,
-  // while the panned ribbon remains the only steering instruction.
   surfaceGain = context.createGain();
   surfaceGain.gain.value = 0;
   surfaceFilter = context.createBiquadFilter();
@@ -891,17 +883,13 @@ function handleLotPointerDown(event) {
   cue('car-select');
 }
 
-function handleUiChange(event) {
-  if (event.target.matches?.('.lot-color-input')) cue('paint-select');
-}
-
 function handleLotVisibilityChange() {
   const nextLotOpen = document.body?.classList.contains('turn-lot-open') || false;
   if (nextLotOpen && !lotOpen) cue('garage-open');
   lotOpen = nextLotOpen;
 }
 
-function handleUiClick(event) {
+function handleUiPointerDown(event) {
   const button = event.target.closest?.('button');
   if (!button) return;
   if (button.closest('.drive-pad') || button.classList.contains('pedal') || button.classList.contains('brake-reverse')) return;

--- a/turn/index.html
+++ b/turn/index.html
@@ -68,13 +68,14 @@
   <script src="./install-gate.js?build=20260809-r163-social-browser"></script>
   <script src="./pwa-usable-viewport-r181.js?revision=r181-usable-web-layer"></script>
   <script src="./motion-safe-zone.js?build=20260809-r163"></script>
-  <script src="./orientation-compat.js?build=20260809-r163"></script>
+  <script src="./orientation-compat.js?build=20260809-r163&revision=r163-voiceover-native-picker-events"></script>
   <script src="./live-steering-setting.js?build=20260809-r163-live-steering"></script>
   <script type="importmap">
     {
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
+        "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",
         "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260809-r163&revision=r163-native-html",

--- a/turn/orientation-compat.js
+++ b/turn/orientation-compat.js
@@ -106,13 +106,8 @@
     const viewportLandscape = viewportIsLandscape();
     const screenMatchesViewport = angleIsLandscape(normalizedScreenAngle) === viewportLandscape;
 
-    // Preserve the working iPhone path whenever the Screen Orientation API agrees with
-    // the actual viewport.
     if (normalizedScreenAngle != null && screenMatchesViewport) return normalizedScreenAngle;
 
-    // Older standalone iPads can report a portrait-like Screen Orientation angle while
-    // already rendering a landscape viewport. Prefer the legacy value only when it fixes
-    // that mismatch.
     const legacyAngle = normalizeDegrees(Number(window.orientation));
     const legacyMatchesViewport = angleIsLandscape(legacyAngle) === viewportLandscape;
     if (legacyAngle != null && legacyMatchesViewport) return legacyAngle;
@@ -253,8 +248,6 @@
   }
 
   async function requestLandscapeLock() {
-    // Prefer the broad landscape lock so both physical turning directions remain valid.
-    // Some WebKit builds behave asymmetrically when pinned to an exact landscape side.
     if (await tryOrientationLock('landscape')) return true;
 
     const exactType = preferredLandscapeLock === 'landscape'
@@ -329,8 +322,15 @@
     if (gameplayActive) void requestLandscapeLock();
   }
 
-  // Register before the game adds its own devicemotion listener. Each sensor event can
-  // therefore update the mapping before TURN reads screen.orientation.angle for that frame.
+  function bindDirectUiControls() {
+    document.querySelector('#motionButton')?.addEventListener('click', resetSensorCalibration);
+    document.querySelector('#calibrateButton')?.addEventListener('click', () => {
+      if (!gameplayActive) return;
+      steeringNeutralRoll = lastResolvedRoll;
+      clearSteeringLimitFeedback();
+    });
+  }
+
   window.addEventListener('devicemotion', observeMotion, { passive: true });
   window.addEventListener('orientationchange', () => {
     if (gameplayActive) {
@@ -351,25 +351,19 @@
     setGameplayActive(Boolean(event.detail?.running));
   });
 
-  // Safari may only accept an orientation request while processing a user interaction.
-  // Ask on actual game-start gestures, but do not re-lock on every GAS/DRIFT/BOOST touch.
   document.addEventListener('pointerdown', (event) => {
     const startsGame = event.target.closest?.('#motionButton, #manualButton, .lot-race');
     if (startsGame) void requestLandscapeLock();
   }, { passive: true, capture: true });
 
-  document.addEventListener('click', (event) => {
-    if (event.target.closest?.('#motionButton')) resetSensorCalibration();
-    if (event.target.closest?.('#calibrateButton') && gameplayActive) {
-      steeringNeutralRoll = lastResolvedRoll;
-      clearSteeringLimitFeedback();
-    }
-  });
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', bindDirectUiControls, { once: true });
+  } else {
+    bindDirectUiControls();
+  }
 
   let installed = false;
 
-  // Prefer shadowing only this ScreenOrientation instance so the compatibility correction
-  // stays local to TURN.
   try {
     Object.defineProperty(orientation, 'angle', {
       configurable: true,
@@ -381,7 +375,6 @@
     installed = true;
   } catch (_) {}
 
-  // Fallback for WebKit versions that disallow an own property on ScreenOrientation.
   if (!installed && prototypeAngleDescriptor?.get && prototypeAngleDescriptor.configurable !== false) {
     try {
       Object.defineProperty(prototype, 'angle', {


### PR DESCRIPTION
## Device result — corrected diagnosis
The latest recording needs to be read in two states:

1. **VoiceOver off:** TURN's native color input opens normally. This has worked throughout.
2. **VoiceOver on:** the same input is focused and announced, but VoiceOver's activation does not open the picker.

So PR #390 did not fix the VoiceOver failure. I also corrected my earlier PR comment that mistakenly described the first half of the recording as a successful VoiceOver test.

## A concrete remaining difference from plain HTML
After #390 the color input itself is deliberately boring HTML: one native `input[type=color]`, no TURN styling, no activation proxy, no picker fallback.

But TURN still had unrelated **document-level delegated `click` listeners above every control**:

- orientation compatibility delegated clicks from `document` just to handle Motion/Recalibrate;
- generic UI audio delegated every click from `document` to choose a beep.

This matters because WebKit bug 294649 documents the same VoiceOver/native-picker failure pattern for date/time inputs when an ancestor has a click listener. That report is not proof that it is the cause for TURN's color input, but it gives us a specific, standards-aligned thing to remove and test rather than another picker workaround.

## First-principles change
- Remove document-level `click` delegation from orientation compatibility.
- Bind Motion/Recalibrate directly to the controls that own those actions.
- Remove document-level `click` and `change` delegation from generic UI audio.
- Keep nonessential physical-pointer UI sounds on `pointerdown`; no picker behavior depends on them.
- Do not touch the color input at all.
- Add a regression that forbids delegated document clicks around the native picker path.
- Cache-bust the changed orientation script and remap the changed audio module so the physical device receives this exact experiment.

No VoiceOver detection, no `showPicker()`, no synthetic click/focus, no fallback select, no custom picker.

## Validation
CI can prove the architecture and regressions, but **only the physical iPhone + VoiceOver test can tell us whether this is the offending difference**. Do not describe the VoiceOver bug as fixed until that test passes.

Release identity remains TURN 1.7.0 · 2026.08.09-r163.