### PR TITLE
TURN r163: remove paint parent click listener from native picker path

### DIFF
--- a/turn-lab/tests/color-accessibility-production.mjs
+++ b/turn-lab/tests/color-accessibility-production.mjs
@@ -17,6 +17,7 @@ const [
   lotSource,
   lotCssSource,
   layoutSource,
+  paintGateSource,
   stylesSource,
   drivePadCssSource,
   manualSteeringCssSource,
@@ -31,6 +32,7 @@ const [
   fs.readFile(new URL('../../turn/garage/lot-r10.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-r10.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-layout-r60.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/progression/lot-paint-reward.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/styles.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/drive-pad.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/manual-steering.css', import.meta.url), 'utf8'),
@@ -67,6 +69,8 @@ assert.match(indexSource, /styles\.css\?build=20260809-r163-native-html/);
 assert.match(indexSource, /garage\/lot-r10\.css\?build=20260809-r163-native-html/);
 assert.match(indexSource, /garage\/lot-layout-r60\.css\?build=20260809-r163-native-html/);
 assert.match(indexSource, /lot-track-select\.js\?build=20260809-r163&revision=r163-native-html/);
+assert.match(indexSource, /app\.js\?build=20260809-r163-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click/,
+  'The device must receive the native-picker ancestry experiment under a fresh module URL');
 assert.doesNotMatch(indexSource, /named-color-fallback|native-color-input-r163\.css/,
   'Production must not load fallback or corrective paint layers');
 
@@ -109,9 +113,9 @@ assert.match(drivePadCssSource, /\.drive-pad[\s\S]*touch-action:\s*none/,
 assert.match(manualSteeringCssSource, /\.manual-steer[\s\S]*touch-action:\s*none/,
   'Gesture suppression must remain local to manual steering');
 
-// Keep native form activation out of document-level click delegation. iOS VoiceOver
-// native pickers are sensitive to ancestor click listeners; TURN has no reason to put
-// unrelated orientation or UI-sound behavior in the color input's click ancestry.
+// Keep native form activation out of click delegation. WebKit native pickers can
+// be sensitive to click listeners on ancestors; TURN has no reason to put unrelated
+// behavior anywhere in the color input's click ancestry.
 assert.doesNotMatch(orientationSource, /document\.addEventListener\(['"]click['"]/,
   'Orientation compatibility must not delegate click handling from document');
 assert.match(orientationSource, /querySelector\('#motionButton'\)\?\.addEventListener\('click', resetSensorCalibration\)/,
@@ -122,6 +126,14 @@ assert.doesNotMatch(audioSource, /document\.addEventListener\(['"]change['"]/,
   'Generic UI audio must not delegate native form changes through document');
 assert.match(audioSource, /document\.addEventListener\('pointerdown', handleUiPointerDown/,
   'Nonessential pointer UI sounds may remain on the physical pointer path');
+assert.doesNotMatch(paintGateSource, /colors\.addEventListener\(['"]click['"]/,
+  'The paint group itself must not be a click-listener ancestor of its native color inputs');
+assert.doesNotMatch(paintGateSource, /colors\.setAttribute\('role', 'button'\)|colors\.tabIndex\s*=/,
+  'Unlocked native paint must not inherit faux-button semantics from the Trophy Road lock');
+assert.match(paintGateSource, /button\.className = 'lot-paint-lock-button'/,
+  'When paint is locked, its explanation belongs on a separate real button');
+assert.match(paintGateSource, /button\.addEventListener\('click', showLockedPaintInfo\)/,
+  'The lock button may own its own click listener without becoming an ancestor of the color input');
 
 assert.doesNotMatch(runtimeSource, /describeColorCue|lot-color-control|input\[type="color"\]|onPaintValueChange|replaceWith/,
   'The Color Cues runtime must not post-process paint controls');
@@ -138,4 +150,4 @@ assert.match(historySource, /native HTML color input/i);
 assert.doesNotMatch(historySource, /native paint activation bridge|assistive-technology bridge/i,
   'Current release history must not claim an activation bridge that no longer exists');
 
-console.log('TURN 1.7.0 r163 HTML-first native color input and VoiceOver event-boundary regression passed.');
+console.log('TURN 1.7.0 r163 HTML-first native color input and click-ancestry regression passed.');

--- a/turn-lab/tests/paint-lock-observer-production.mjs
+++ b/turn-lab/tests/paint-lock-observer-production.mjs
@@ -18,18 +18,25 @@ assert.match(paintGate, /observer\.observe\(picker,/,
   'Paint synchronization must observe the car picker rather than the whole Lot screen');
 assert.doesNotMatch(paintGate, /observer\.observe\(screen,/,
   'The lock presentation must not be inside the paint observer target');
-assert.match(syncBody, /setLockedInteraction\(locked, carId\)/,
-  'Paint synchronization must retain the compact rail and recolour its lock for the current car');
+assert.match(syncBody, /if \(locked\) ensureLockButton\(carId\);[\s\S]*else removeLockPresentation\(\)/,
+  'Paint synchronization must keep the compact lock control only while paint is actually locked');
 assert.doesNotMatch(syncBody, /lot-paint-lock[\s\S]*remove\(\);[\s\S]*if \(locked\)/,
-  'A synchronization pass must never remove and immediately recreate its own lock icon');
+  'A synchronization pass must never remove and immediately recreate its own lock control');
 assert.match(paintGate, /try \{[\s\S]*\} finally \{[\s\S]*syncing = false/,
   'The synchronization guard must always be released');
-assert.match(paintGate, /colors\.addEventListener\('click', handleLockedAreaClick\)/,
-  'Any tap in the locked paint rail must explain the Trophy Road requirement');
-assert.match(paintGate, /colors\.addEventListener\('keydown', handleLockedAreaKeydown\)/,
-  'The locked paint rail must expose the same explanation from the keyboard');
-assert.match(paintGate, /colors\.setAttribute\('role', 'button'\)/);
-assert.match(paintGate, /colors\.tabIndex = 0/);
+
+assert.doesNotMatch(paintGate, /colors\.addEventListener\(['"]click['"]/,
+  'The paint container must never be a click-listener ancestor of the native color input');
+assert.doesNotMatch(paintGate, /colors\.addEventListener\(['"]keydown['"]/,
+  'The paint container must not emulate button keyboard behavior');
+assert.doesNotMatch(paintGate, /colors\.setAttribute\('role', 'button'\)|colors\.tabIndex\s*=/,
+  'The paint group must keep its real group semantics instead of becoming a faux button');
+assert.match(paintGate, /button = document\.createElement\('button'\)/,
+  'Locked Paintjob feedback should use a real button');
+assert.match(paintGate, /button\.type = 'button'/);
+assert.match(paintGate, /button\.className = 'lot-paint-lock-button'/);
+assert.match(paintGate, /button\.addEventListener\('click', showLockedPaintInfo\)/,
+  'The lock explanation belongs directly to the lock button, not an ancestor of paint inputs');
 assert.match(paintGate, /lot-paint-lock-copy/);
 assert.match(paintGate, /<strong>PAINTJOB<\/strong>/);
 assert.doesNotMatch(paintGate, /<i>•<\/i>|<b>LOCKED<\/b>/,
@@ -41,12 +48,11 @@ assert.match(paintGate, /--lot-paint-lock-background/);
 assert.match(paintGate, /--lot-paint-lock-foreground/);
 assert.match(paintGate, /getVehicleDefaultColor\(carId\)/,
   'The locked swatch must represent the selected car factory colour');
-assert.doesNotMatch(paintGate, /document\.createElement\('button'\)[\s\S]*lot-paint-lock/,
-  'The compact lock must not create a nested oversized button');
+
 assert.match(paintCss, /\.lot-colors\.is-paint-locked[\s\S]*min-height: 54px/);
 assert.match(
   paintCss,
-  /\.lot-viewbox-with-paint \.lot-colors\.is-paint-locked \{[\s\S]*position: absolute;[\s\S]*bottom: 0;[\s\S]*grid-template-columns: minmax\(0, 1fr\) auto;/,
+  /\.lot-viewbox-with-paint \.lot-colors\.is-paint-locked \{[\s\S]*position: absolute;[\s\S]*bottom: 0;/,
   'The locked Paintjob treatment must occupy the reserved bottom rail rather than cover the 3D viewer'
 );
 assert.doesNotMatch(
@@ -54,6 +60,10 @@ assert.doesNotMatch(
   /position: relative/,
   'The generic locked state must not override the absolute bottom-rail placement'
 );
+const paintLockButtonRule = paintCss.match(/\.lot-paint-lock-button\s*\{([\s\S]*?)\}/)?.[1] || '';
+assert.ok(paintLockButtonRule, 'The real locked Paintjob button must have its own layout rule');
+assert.match(paintLockButtonRule, /grid-template-columns: minmax\(0, 1fr\) auto/);
+assert.match(paintLockButtonRule, /width: 100%/);
 const paintLockRule = paintCss.match(/\.lot-paint-lock\s*\{([\s\S]*?)\}/)?.[1] || '';
 assert.ok(paintLockRule, 'The compact paint lock must have its own CSS rule');
 assert.match(paintLockRule, /width: 36px/);
@@ -73,12 +83,12 @@ assert.match(lotGate, /if \(lastAnnouncedCarId\) dismissVisibleUnlockNotice\(\);
   'Leaving The Lot must not leave a vehicle lock notice behind');
 
 assert.match(lotRuntime, /lot-trophy-gate\.js\?revision=r162-dismiss-unlocked-car-toast/);
-assert.match(lotRuntime, /lot-paint-reward\.js\?revision=r161-car-colour-lock/);
-assert.match(app, /trophy-road-r157\.css\?revision=r161-car-colour-lock/);
-assert.match(app, /lot-enhancement-runtime\.js\?revision=r121&trophy-road=r159&paint=r161-car-colour-lock&toast=r162-dismiss-unlocked-car/);
+assert.match(lotRuntime, /lot-paint-reward\.js\?revision=r163-native-picker-parent-click/);
+assert.match(app, /trophy-road-r157\.css\?revision=r163-native-picker-parent-click/);
+assert.match(app, /lot-enhancement-runtime\.js\?revision=r163-native-picker-parent-click/);
 assert.match(
   index,
-  new RegExp(`app\\.js\\?build=${release.cacheKey}-browser-consent-r176-bella-road-derived-zone`)
+  new RegExp(`app\\.js\\?build=${release.cacheKey}-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click`)
 );
 
-console.log('TURN Lot lock feedback and Paintjob rail regressions passed.');
+console.log('TURN Lot lock feedback and native paint ancestry regressions passed.');

--- a/turn/app.js
+++ b/turn/app.js
@@ -174,7 +174,7 @@ installStylesheet(
 // Historical stylesheet bundle marker retained for the Trophy Road regression contract:
 // trophy-road-r157.css?revision=r157-paint-monster
 installStylesheet(
-  './progression/trophy-road-r157.css?revision=r161-car-colour-lock',
+  './progression/trophy-road-r157.css?revision=r163-native-picker-parent-click',
   'data-turn-trophy-road'
 );
 const { prepareTrophyRoadProfile } = await import(
@@ -268,7 +268,7 @@ installHarborHiddenFaceOrientation();
 // lot-enhancement-runtime.js?revision=r121&trophy-road=r154
 // lot-enhancement-runtime.js?revision=r121&trophy-road=r157
 const { installLotEnhancementRuntime } = await import(
-  withBuild('./garage/lot-enhancement-runtime.js?revision=r121&trophy-road=r159&paint=r161-car-colour-lock&toast=r162-dismiss-unlocked-car')
+  withBuild('./garage/lot-enhancement-runtime.js?revision=r163-native-picker-parent-click')
 );
 installLotEnhancementRuntime();
 

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -2,12 +2,12 @@ import { installLotStatLegend } from './lot-stat-legend.js?build=20260724-r59';
 import { installLotLayout } from './lot-layout-r60.js?build=20260729-r116';
 import { installLotAccessibility } from './lot-accessibility-r118.js?build=20260729-r118';
 import { gateLotNow } from '../progression/lot-trophy-gate.js?revision=r162-dismiss-unlocked-car-toast';
-import { gateLotPaintNow } from '../progression/lot-paint-reward.js?revision=r161-car-colour-lock';
+import { gateLotPaintNow } from '../progression/lot-paint-reward.js?revision=r163-native-picker-parent-click';
 
 // Historical regression markers for the established enhancement layers:
 // ENHANCEMENT_ID = 'enhanced-lot-r121'
 // TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r154-trophy-road-feedback'
-const ENHANCEMENT_ID = 'enhanced-lot-r162-dismiss-unlocked-car-toast';
+const ENHANCEMENT_ID = 'enhanced-lot-r163-native-picker-parent-click';
 const TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r157-paint-monster';
 const activeEnhancements = new WeakMap();
 

--- a/turn/index.html
+++ b/turn/index.html
@@ -153,7 +153,7 @@
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
   <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260809-r163-r168-shared-about-credits"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
-  <script type="module" src="./app.js?build=20260809-r163-browser-consent-r176-bella-road-derived-zone"></script>
+  <script type="module" src="./app.js?build=20260809-r163-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click"></script>
   <script type="module" src="./accessibility/color-accessibility-r163.js?build=20260809-r163-paint-basics"></script>
   <script type="module" src="./achievements/chromatic-camouflage-r183.js?revision=r183-production"></script>
   <script type="module" src="./social/your-turn-share-bootstrap.js?revision=r2"></script>

--- a/turn/progression/lot-paint-reward.js
+++ b/turn/progression/lot-paint-reward.js
@@ -54,8 +54,6 @@ export function gateLotPaintNow(root = document.body) {
   const picker = screen.querySelector('.lot-car-picker');
   if (!colors || !raceButton || !picker) return () => {};
 
-  const originalRole = colors.getAttribute('role');
-  const originalTabIndex = colors.getAttribute('tabindex');
   let syncing = false;
   let lastCarId = selectedCarId(screen);
   let paintWasUnlocked = isPaintUnlocked();
@@ -83,60 +81,44 @@ export function gateLotPaintNow(root = document.body) {
     });
   }
 
-  function ensureLockLabel() {
-    let label = colors.querySelector('.lot-paint-lock-copy');
-    if (label) return label;
-    label = document.createElement('span');
-    label.className = 'lot-paint-lock-copy';
-    label.setAttribute('aria-hidden', 'true');
-    label.innerHTML = '<strong>PAINTJOB</strong>';
-    colors.prepend(label);
-    return label;
-  }
-
   function applyLockColour(icon, carId) {
     const bodyColour = getVehicleDefaultColor(carId);
     icon.style.setProperty('--lot-paint-lock-background', bodyColour);
     icon.style.setProperty('--lot-paint-lock-foreground', contrastingInk(bodyColour));
   }
 
-  function ensureLockIcon(carId) {
-    let icon = colors.querySelector('.lot-paint-lock');
-    if (!icon) {
-      icon = document.createElement('span');
+  function ensureLockButton(carId) {
+    let button = colors.querySelector('.lot-paint-lock-button');
+    if (!button) {
+      button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'lot-paint-lock-button';
+
+      const copy = document.createElement('span');
+      copy.className = 'lot-paint-lock-copy';
+      copy.innerHTML = '<strong>PAINTJOB</strong>';
+
+      const icon = document.createElement('span');
       icon.className = 'lot-paint-lock';
       icon.setAttribute('aria-hidden', 'true');
       icon.innerHTML = LOCK_ICON;
-      colors.append(icon);
+
+      button.append(copy, icon);
+      button.addEventListener('click', showLockedPaintInfo);
+      colors.prepend(button);
     }
-    applyLockColour(icon, carId);
-    return icon;
+
+    const threshold = reward()?.threshold || 500;
+    button.setAttribute(
+      'aria-label',
+      `Paintjob locked. Vehicle paint controls unlock at ${threshold} trophies on Trophy Road.`
+    );
+    applyLockColour(button.querySelector('.lot-paint-lock'), carId);
+    return button;
   }
 
   function removeLockPresentation() {
-    colors.querySelector('.lot-paint-lock-copy')?.remove();
-    colors.querySelector('.lot-paint-lock')?.remove();
-  }
-
-  function setLockedInteraction(locked, carId) {
-    if (locked) {
-      const threshold = reward()?.threshold || 500;
-      colors.setAttribute('role', 'button');
-      colors.tabIndex = 0;
-      colors.setAttribute(
-        'aria-label',
-        `Paintjob locked. Vehicle paint controls unlock at ${threshold} trophies on Trophy Road.`
-      );
-      ensureLockLabel();
-      ensureLockIcon(carId);
-      return;
-    }
-
-    removeLockPresentation();
-    if (originalRole == null) colors.removeAttribute('role');
-    else colors.setAttribute('role', originalRole);
-    if (originalTabIndex == null) colors.removeAttribute('tabindex');
-    else colors.setAttribute('tabindex', originalTabIndex);
+    colors.querySelector('.lot-paint-lock-button')?.remove();
   }
 
   function sync() {
@@ -161,10 +143,8 @@ export function gateLotPaintNow(root = document.body) {
         if (input) input.disabled = locked;
       }
 
-      setLockedInteraction(locked, carId);
-      if (!locked && car && !car.fixedLivery) {
-        colors.setAttribute('aria-label', 'Choose car paint colours');
-      }
+      if (locked) ensureLockButton(carId);
+      else removeLockPresentation();
 
       if (!paintWasUnlocked && paintUnlocked) {
         window.dispatchEvent(new CustomEvent('turn:paint-controls-unlocked'));
@@ -187,17 +167,6 @@ export function gateLotPaintNow(root = document.body) {
     attributeFilter: ['aria-checked']
   });
 
-  const handleLockedAreaClick = (event) => {
-    if (!colors.classList.contains('is-paint-locked')) return;
-    event.preventDefault();
-    showLockedPaintInfo();
-  };
-  const handleLockedAreaKeydown = (event) => {
-    if (!colors.classList.contains('is-paint-locked')) return;
-    if (event.key !== 'Enter' && event.key !== ' ') return;
-    event.preventDefault();
-    showLockedPaintInfo();
-  };
   const handleReward = sync;
   const handleStorage = (event) => {
     if (event.key === 'turn-achievements-v1') sync();
@@ -205,8 +174,6 @@ export function gateLotPaintNow(root = document.body) {
   window.addEventListener('turn:trophy-road-updated', handleReward);
   window.addEventListener('storage', handleStorage);
   raceButton.addEventListener('click', sync, { capture: true });
-  colors.addEventListener('click', handleLockedAreaClick);
-  colors.addEventListener('keydown', handleLockedAreaKeydown);
   sync();
 
   const release = () => {
@@ -214,8 +181,6 @@ export function gateLotPaintNow(root = document.body) {
     window.removeEventListener('turn:trophy-road-updated', handleReward);
     window.removeEventListener('storage', handleStorage);
     raceButton.removeEventListener('click', sync, { capture: true });
-    colors.removeEventListener('click', handleLockedAreaClick);
-    colors.removeEventListener('keydown', handleLockedAreaKeydown);
     removeLockPresentation();
     for (const control of colors.querySelectorAll('.lot-color-control')) {
       control.hidden = false;
@@ -223,10 +188,6 @@ export function gateLotPaintNow(root = document.body) {
       if (input) input.disabled = false;
     }
     colors.classList.remove('is-paint-locked');
-    if (originalRole == null) colors.removeAttribute('role');
-    else colors.setAttribute('role', originalRole);
-    if (originalTabIndex == null) colors.removeAttribute('tabindex');
-    else colors.setAttribute('tabindex', originalTabIndex);
     delete screen.dataset.turnPaintUnlocked;
     activeGates.delete(screen);
   };

--- a/turn/progression/trophy-road-r157.css
+++ b/turn/progression/trophy-road-r157.css
@@ -52,7 +52,6 @@
   display: grid;
   place-items: center;
   color: var(--turn-ink, #08090a);
-  cursor: help;
 }
 
 /* The locked state remains the paint rail below the 3D preview. A more general
@@ -67,9 +66,6 @@
   min-height: var(--lot-paint-rail-height, 54px);
   margin: 0;
   padding: 7px 10px 7px 14px;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 10px;
-  place-items: center stretch;
   border: 0;
   border-top: 3px solid var(--turn-ink, #08090a);
   border-radius: 0;
@@ -77,9 +73,27 @@
   box-shadow: none;
 }
 
-.lot-colors.is-paint-locked:focus-visible {
+.lot-paint-lock-button {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  width: 100%;
+  min-height: 36px;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.lot-paint-lock-button:focus-visible {
   outline: 4px solid var(--turn-action-information, #38d9ff);
-  outline-offset: -6px;
+  outline-offset: 2px;
 }
 
 .lot-paint-lock-copy {
@@ -130,6 +144,10 @@
   .lot-viewbox-with-paint .lot-colors.is-paint-locked {
     min-height: var(--lot-paint-rail-height, 47px);
     padding: 5px 7px 5px 10px;
+  }
+
+  .lot-paint-lock-button {
+    min-height: 30px;
   }
 
   .lot-paint-lock-copy {


### PR DESCRIPTION
## Device result
VoiceOver still does not open the native color picker after #391. So the document-level delegated listeners were not the whole cause.

## The listener we missed
There was still a much closer click-listener ancestor around the color input itself: `lot-paint-reward.js` always attached a `click` handler to `.lot-colors`, even when Paintjob was unlocked and the handler immediately returned.

That means the DOM was effectively:

```html
<div class="lot-colors"> <!-- click listener -->
  <div>
    <input type="color">
  </div>
</div>
```

This is exactly the ancestry pattern we were trying to remove after the WebKit native-picker/VoiceOver finding, and it explains why removing only the document listeners was insufficient.

## First-principles fix
- `.lot-colors` no longer owns any click or keyboard listener.
- It no longer becomes a faux `role="button"` or gets a scripted `tabindex` when paint is locked.
- Locked Paintjob feedback is now its own real `<button type="button">` sibling to the hidden/disabled paint controls.
- That button owns its own click handler and is removed entirely once paint is unlocked.
- The native color input remains untouched: no activation proxy, no custom picker, no VoiceOver detection, no synthetic focus/click.
- This also stops the Trophy Road paint gate from overwriting the paint group's accessibility semantics after the Lot accessibility layer has installed them.

## Cache and regression coverage
The paint gate, its CSS, the Lot enhancement module and `app.js` are cache-busted so the physical device receives this exact experiment. Regressions now explicitly forbid a click listener or faux-button semantics on the `.lot-colors` ancestor.

Release identity remains TURN 1.7.0 · 2026.08.09-r163.

As before, CI can validate the architecture, but only the real iPhone + VoiceOver test can tell us whether this is the remaining activation blocker.