### PR TITLE
TURN r163: rebalance requested vehicle visual sizes

### DIFF
--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -41,8 +41,11 @@ const expectedVisualScales = new Map([
 ]);
 
 const expectedGlobalSizeMultipliers = new Map([
-  ['convertible', 0.6],
-  ['classic', 0.6]
+  ['convertible', 0.72],
+  ['classic', 0.72],
+  ['vintage-racer', 0.75],
+  ['toy-racer', 0.7],
+  ['police', 1.15]
 ]);
 
 const expectedFeaturedSizeMultipliers = new Map([
@@ -107,9 +110,15 @@ for (const car of catalog.CAR_CATALOG) {
 
 const convertible = catalog.getCarDefinition('convertible');
 const trainingCar = catalog.getCarDefinition('classic');
+const vintageRacer = catalog.getCarDefinition('vintage-racer');
+const toyRacer = catalog.getCarDefinition('toy-racer');
+const policeCar = catalog.getCarDefinition('police');
 const monsterTruck = catalog.getCarDefinition('monster-truck');
-assertClose(convertible.visualScale * convertible.visualSizeMultiplier, 0.588, 'Convertible effective visual scale');
-assertClose(trainingCar.visualScale * trainingCar.visualSizeMultiplier, 0.6, 'Training Car effective visual scale');
+assertClose(convertible.visualScale * convertible.visualSizeMultiplier, 0.7056, 'Convertible effective visual scale');
+assertClose(trainingCar.visualScale * trainingCar.visualSizeMultiplier, 0.72, 'Training Car effective visual scale');
+assertClose(vintageRacer.visualScale * vintageRacer.visualSizeMultiplier, 0.72, 'Vintage Racer effective visual scale');
+assertClose(toyRacer.visualScale * toyRacer.visualSizeMultiplier, 0.658, 'Toy Racer effective visual scale');
+assertClose(policeCar.visualScale * policeCar.visualSizeMultiplier, 1.127, 'Police Car effective visual scale');
 assertClose(monsterTruck.visualScale * monsterTruck.visualSizeMultiplier, 0.83, 'Monster Truck compact visual scale');
 assertClose(
   monsterTruck.visualScale * monsterTruck.visualSizeMultiplier * monsterTruck.featuredVisualSizeMultiplier,

--- a/turn/vehicle/catalog.js
+++ b/turn/vehicle/catalog.js
@@ -59,7 +59,13 @@ const DEFAULT_SECONDARY_COLOR_BY_ID = Object.freeze({
   ambulance: Object.freeze({ fallback: '#d92d20', p3: Object.freeze([0.82, 0.08, 0.04]) })
 });
 
-const VISUAL_SIZE_MULTIPLIER_BY_ID = Object.freeze({ convertible: 0.6, classic: 0.6 });
+const VISUAL_SIZE_MULTIPLIER_BY_ID = Object.freeze({
+  convertible: 0.72,
+  classic: 0.72,
+  'vintage-racer': 0.75,
+  'toy-racer': 0.7,
+  police: 1.15
+});
 const FEATURED_VISUAL_SIZE_MULTIPLIER_BY_ID = Object.freeze({ 'monster-truck': 1.2 });
 const EMERGENCY_SERVICE_BY_ID = Object.freeze({ firetruck: 'firetruck', police: 'police', ambulance: 'ambulance' });
 const FIXED_LIVERY_IDS = new Set(Object.keys(EMERGENCY_SERVICE_BY_ID));


### PR DESCRIPTION
## Requested visual-size changes

Applies the requested size changes through TURN's existing global `visualSizeMultiplier` path, so the change is consistent across the Lot, expanded 3D view, race cars/rivals, and record-car previews unless a surface already has its own explicit featured-size rule.

- Vintage Racer: -25% → `0.75`
- Toy Racer: -30% → `0.70`
- Police Car: +15% → `1.15`
- Training Car: +20% from its current reduced size → `0.72`
- Convertible: +20% from its current reduced size → `0.72`

Monster Truck keeps its existing separate Lot/race featured multiplier.

## Scope

No vehicle stats, tuning, collision, paint, unlocks, emergency-service behavior, or model orientation change.

## Regression

Updates the existing all-car orientation/surface-size regression to lock the new global multipliers and resulting effective scales.