### PR TITLE
TURN r163: keep Restart Lap name source-owned for VoiceOver

### DIFF
--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -33,12 +33,24 @@ const release = JSON.parse(releaseSource);
 assert.match(index, new RegExp(`TURN v${release.version.replaceAll('.', '\\.')} · Build ${release.id.replaceAll('.', '\\.')}`));
 assert.match(index, new RegExp(`in-game-menu\\.css\\?build=${release.cacheKey}`));
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
-assert.match(index, /id="resetButton"[^>]*>Restart Lap<\/button>/);
+assert.match(
+  index,
+  /id="resetButton"[^>]*aria-label="Restart the current lap from the start line"[^>]*>Restart Lap<\/button>/,
+  'Restart Lap must expose its final accessible name in source HTML before VoiceOver can focus it'
+);
+assert.match(
+  index,
+  /"\/turn\/ui\/in-game-menu\.js\?build=20260809-r163": "\/turn\/ui\/in-game-menu\.js\?build=20260809-r163&revision=r163-restart-source-label"/,
+  'The source-owned restart label patch must bypass any cached r163 menu module'
+);
 assert.match(app, /installStylesheet\('\.\/r104-polish\.css', 'data-turn-r104-polish'\)/);
 assert.match(app, /await import\(withBuild\('\.\/ui\/in-game-menu\.js'\)\)/);
 
-assert.match(menu, /backToStartButton\.textContent = 'Restart Lap'/);
-assert.match(menu, /Restart the current lap from the start line/);
+assert.doesNotMatch(menu, /backToStartButton\.textContent\s*=/,
+  'The runtime must not rewrite Restart Lap after the accessibility tree has been created');
+assert.doesNotMatch(menu, /backToStartButton\.setAttribute\('aria-label'/,
+  'The runtime must not late-mutate the Restart Lap accessible name');
+assert.match(menu, /backToStartButton\.classList\.add\('back-to-start-button'\)/);
 assert.match(menu, /backToLotButton\.textContent = 'Leave Race'/);
 assert.match(menu, /Leave the race and choose another track/);
 assert.match(menu, /inGameMenuVisibilityFor\(runtime\.state\.mode\)/);

--- a/turn/index.html
+++ b/turn/index.html
@@ -76,6 +76,7 @@
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
+        "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",
         "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260809-r163&revision=r163-native-html",
@@ -150,7 +151,7 @@
     <div class="tilt-drive" aria-hidden="true"><span><b>brake</b><b>gas</b></span><div class="tilt-track"><i class="tilt-needle" id="tiltNeedle"></i></div><small class="tilt-value" id="tiltValue">neutral</small></div>
   </div>
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
-  <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
+  <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button" aria-label="Restart the current lap from the start line">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
   <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260809-r163-r168-shared-about-credits"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
   <script type="module" src="./app.js?build=20260809-r163-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click"></script>

--- a/turn/ui/in-game-menu.js
+++ b/turn/ui/in-game-menu.js
@@ -255,8 +255,6 @@ function install(runtime) {
   simplifyResetRivalsFeedback();
   const audioButton = createAudioPanel().button;
 
-  backToStartButton.textContent = 'Restart Lap';
-  backToStartButton.setAttribute('aria-label', 'Restart the current lap from the start line');
   backToStartButton.classList.add('back-to-start-button');
 
   backToLotButton.textContent = 'Leave Race';


### PR DESCRIPTION
## Device report
On first VoiceOver focus of **Restart Lap**, iOS announced the document title/version instead of the control. Activating the same control then announced its intended label, `Restart the current lap from the start line`.

## Fix
Keep the Restart Lap accessible name in the initial HTML instead of adding/replacing it later from the in-game menu runtime. The runtime now only adds the visual/state class and visibility behavior; it no longer rewrites the button text or `aria-label` after the accessibility tree exists.

The production import map also gives the r163 in-game menu module a one-off revision so the accessibility patch is not hidden behind an already cached module URL.

## Regression
The in-game menu regression now requires:
- the source `#resetButton` to contain its final `aria-label`
- the cache-busted r163 menu module mapping
- no runtime write to Restart Lap text or `aria-label`

No race behavior, restart behavior, focus forcing, menu ordering, audio, or other VoiceOver surfaces are changed.