### PR TITLE
TURN r163: keep release metadata out of VoiceOver page context

### DIFF
--- a/turn-lab/tests/in-game-menu-production.mjs
+++ b/turn-lab/tests/in-game-menu-production.mjs
@@ -31,6 +31,10 @@ const [index, releaseSource, app, menu, controls, backToLot, main, menuCss, poli
 
 const release = JSON.parse(releaseSource);
 assert.match(index, new RegExp(`TURN v${release.version.replaceAll('.', '\\.')} · Build ${release.id.replaceAll('.', '\\.')}`));
+assert.match(index, /<title>TURN<\/title>/,
+  'The document title must stay product-only so VoiceOver never announces release metadata as page context');
+assert.doesNotMatch(index, /<title>[^<]*(?:\bv\d|\bbuild\b)[^<]*<\/title>/i,
+  'Version and build metadata must not live in the document title');
 assert.match(index, new RegExp(`in-game-menu\\.css\\?build=${release.cacheKey}`));
 assert.match(index, /id="calibrateButton"[^>]*>Recalibrate<\/button>/);
 assert.match(

--- a/turn-tests/release-production.mjs
+++ b/turn-tests/release-production.mjs
@@ -36,11 +36,12 @@ const [
 await checkReleaseFiles();
 
 const visibleBuild = `TURN v${release.version} · Build ${release.id}`;
-assert.match(index, new RegExp(escapeRegExp(`<title>${visibleBuild}</title>`)));
+assert.match(index, /<title>TURN<\/title>/,
+  'The document title must identify the product without exposing release metadata to screen-reader page context');
 assert.equal(
   index.split(visibleBuild).length - 1,
-  2,
-  'Title and install onboarding must share the static release identity; Home receives it from the runtime source of truth'
+  1,
+  'Install onboarding keeps the static release identity; Home receives it from the runtime source of truth'
 );
 assert.match(index, new RegExp(`version: '${escapeRegExp(release.version)}'`));
 assert.match(index, new RegExp(`id: '${escapeRegExp(release.id)}'`));

--- a/turn/index.html
+++ b/turn/index.html
@@ -27,7 +27,7 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN v1.7.0 · Build 2026.08.09-r163</title>
+  <title>TURN</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
       version: '1.7.0',


### PR DESCRIPTION
## Device result after #395
The source-owned Restart Lap label was not the cause. On first VoiceOver focus during the race, iOS still announces `TURN v1.7.0 · Build 2026.08.09-r163`; activating Restart Lap then correctly announces the button label.

## New diagnosis
That exact string is TURN's document `<title>`. In the installed PWA it is not visible during the race, but VoiceOver can use the document title as web/page context when accessibility focus enters the race UI. We were fixing the button even though the spoken text was coming from page metadata.

## Fix
Change only the production document title from release metadata to the product name:

`<title>TURN</title>`

Release/version/build remain available in the existing release source of truth and visible About/Home metadata. Restart Lap keeps the source-owned accessible label added in #395.

## Regression
The in-game menu regression now requires a product-only `<title>TURN</title>` and rejects version/build metadata inside the document title.

No focus scripting, VoiceOver detection, button behavior, race behavior, audio, or other accessibility surfaces are changed.