### PR TITLE
TURN r163: keep first VoiceOver race entry in The Lot

### DIFF
--- a/turn-lab/tests/lot-layout-production.mjs
+++ b/turn-lab/tests/lot-layout-production.mjs
@@ -37,6 +37,11 @@ assert.equal(
   `./garage/lot-track-select.js?build=${release.cacheKey}&revision=r163-native-html`,
   'Production must retain the track-first compatibility wrapper with the native HTML revision'
 );
+assert.equal(
+  imports['./garage/lot-accessibility-r118.js?build=20260729-r118'],
+  `./garage/lot-accessibility-r118.js?build=${release.cacheKey}&revision=r163-voiceover-first-lot-focus`,
+  'Production must bypass the cached Lot accessibility module for the first-entry VoiceOver focus fix'
+);
 
 assert.match(app, /lot-layout-r60\.css\?revision=r121-viewer-r122-fit-r128-super-sedan-notice-r129-race-button-fit/, 'The Super Sedan fit stylesheet must bypass the previous notice cache');
 assert.match(app, /lot-enhancement-runtime\.js\?revision=r121/, 'Production must load the route-independent Lot enhancer');
@@ -97,6 +102,10 @@ assert.match(accessibility, /aria-posinset/, 'Reordered radios must retain their
 assert.match(accessibility, /aria-setsize/, 'Reordered radios must retain the catalogue size');
 assert.match(accessibility, /attributeFilter: \['aria-checked'\]/, 'Selected-car semantics must follow live radio changes without polling');
 assert.doesNotMatch(accessibility, /setAttribute\('aria-activedescendant'/, 'A non-focusable radiogroup must not pretend to own active-descendant focus');
+assert.match(accessibility, /const lotTitle = screen\?\.querySelector\('#lot-title'\)/, 'The full-screen Lot route must expose its own focus handoff target');
+assert.match(accessibility, /if \(lotTitle && !screen\.contains\(document\.activeElement\)\)/, 'Lot entry focus must move only when focus is still outside the new route');
+assert.match(accessibility, /lotTitle\.tabIndex = -1/, 'The Lot heading must be programmatically focusable without joining normal tab order');
+assert.match(accessibility, /lotTitle\.focus\(\{ preventScroll: true \}\)/, 'The Lot focus handoff must not scroll or activate Race This Car');
 assert.match(accessibility, /Top speed/, 'Car descriptions must include top speed');
 assert.match(accessibility, /Acceleration/, 'Car descriptions must include acceleration');
 assert.match(accessibility, /Control/, 'Car descriptions must include control');
@@ -106,7 +115,7 @@ assert.match(accessibility, /Boost tank/, 'Car descriptions must include boost t
 assert.match(accessibility, /out of 5\./, 'Every described attribute must use the agreed out-of-five scale');
 assert.match(accessibility, /colors\.setAttribute\('aria-labelledby', paintHeading\.id\)/, 'The colour controls must have a useful accessible group name');
 assert.match(accessibility, /card\.setAttribute\('role', 'region'\)/, 'Selected-car information must remain a named navigable region');
-assert.doesNotMatch(accessibility, /setInterval|requestAnimationFrame|setAnimationLoop/, 'The accessibility enhancer must not add polling or animation work');
+assert.doesNotMatch(accessibility, /setInterval|setTimeout|requestAnimationFrame|setAnimationLoop/, 'The accessibility enhancer must not add timing workarounds, polling or animation work');
 
 assert.match(layoutCss, /\.lot-a11y-only \{[\s\S]*clip-path: inset\(50%\)/, 'Navigation headings and summaries must be visually hidden without leaving the accessibility tree');
 assert.match(layoutCss, /--lot-paint-rail-height: 54px/, 'Paint controls must use a compact dock to protect the 3D preview');

--- a/turn/garage/lot-accessibility-r118.js
+++ b/turn/garage/lot-accessibility-r118.js
@@ -11,6 +11,7 @@ const STAT_FIELDS = Object.freeze([
 
 export function installLotAccessibility(root = document.body) {
   const screen = root.querySelector('.lot-screen');
+  const lotTitle = screen?.querySelector('#lot-title');
   const carPicker = screen?.querySelector('.lot-car-picker');
   const colors = screen?.querySelector('.lot-colors');
   const card = screen?.querySelector('.lot-card');
@@ -116,6 +117,18 @@ export function installLotAccessibility(root = document.body) {
   };
 
   syncSelectedCarSemantics();
+
+  // The Lot is a full-screen route. If focus is still on the Home control that
+  // opened it, explicitly hand focus to the new view before VoiceOver can retain
+  // the old screen position and accidentally activate Race This Car underneath.
+  if (lotTitle && !screen.contains(document.activeElement)) {
+    lotTitle.tabIndex = -1;
+    try {
+      lotTitle.focus({ preventScroll: true });
+    } catch (_) {
+      lotTitle.focus();
+    }
+  }
 
   const selectionObserver = new MutationObserver(syncSelectedCarSemantics);
   selectionObserver.observe(carPicker, {

--- a/turn/index.html
+++ b/turn/index.html
@@ -79,6 +79,7 @@
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",
+        "./garage/lot-accessibility-r118.js?build=20260729-r118": "./garage/lot-accessibility-r118.js?build=20260809-r163&revision=r163-voiceover-first-lot-focus",
         "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260809-r163&revision=r163-native-html",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260809-r163",
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system-r86.js?build=20260809-r163",


### PR DESCRIPTION
## Device report
On a fresh VoiceOver session, activating Home **RACE** for the first race opens The Lot but immediately opens the iOS motion-access prompt, so the player never gets a chance to choose a car. Later races in the same session behave correctly.

The supplied recording shows VoiceOver focus on Home RACE, then The Lot appearing with the native motion permission dialog already open roughly one frame later.

## Diagnosis
The Lot is a full-screen route but did not explicitly take focus when it replaced Home. VoiceOver could therefore retain the old screen-position context as Home disappeared. Because **Race This Car** occupies the same lower-right region and is the control that owns motion permission, the first route transition could fall through to that action before the player navigated the new view.

## Fix
Keep this inside the existing Lot accessibility layer:
- when The Lot opens and DOM focus is still outside it, make the real `THE LOT` heading programmatically focusable with `tabindex=-1`
- move focus to that heading with `preventScroll`
- do not use VoiceOver detection, timers, synthetic activation, or special-case the Race button
- leave the existing car radiogroup, paint controls and Race This Car flow unchanged

An import-map mapping gives the accessibility module a fresh r163 URL so the device test cannot accidentally use the cached pre-fix module.

## Regression
The Lot regression now requires the focus handoff, its no-timer/no-polling design, and the cache-busted accessibility module mapping.

This is intentionally a route-focus fix, not a motion-permission workaround.