### PR TITLE
TURN r163: quarantine standalone VoiceOver carry-over at Lot entry

### DIFF
--- a/turn-lab/tests/lot-layout-production.mjs
+++ b/turn-lab/tests/lot-layout-production.mjs
@@ -42,6 +42,11 @@ assert.equal(
   `./garage/lot-accessibility-r118.js?build=${release.cacheKey}&revision=r163-voiceover-first-lot-focus`,
   'Production must bypass the cached Lot accessibility module for the first-entry VoiceOver focus fix'
 );
+assert.equal(
+  imports[`./garage/lot-enhancement-runtime.js?revision=r163-native-picker-parent-click&build=${release.cacheKey}`],
+  `./garage/lot-enhancement-runtime.js?build=${release.cacheKey}&revision=r163-voiceover-pwa-lot-carryover`,
+  'Production must bypass the cached Lot enhancer for the standalone VoiceOver carry-over guard'
+);
 
 assert.match(app, /lot-layout-r60\.css\?revision=r121-viewer-r122-fit-r128-super-sedan-notice-r129-race-button-fit/, 'The Super Sedan fit stylesheet must bypass the previous notice cache');
 assert.match(app, /lot-enhancement-runtime\.js\?revision=r121/, 'Production must load the route-independent Lot enhancer');
@@ -59,6 +64,17 @@ assert.doesNotMatch(wrapper, /installLotLayout|installLotStatLegend|installLotAc
 
 assert.match(enhancementRuntime, /ENHANCEMENT_ID = 'enhanced-lot-r121'/, 'The restored Lot contract must have an explicit identity');
 assert.match(enhancementRuntime, /activeEnhancements = new WeakMap\(\)/, 'Enhancements must be idempotent per Lot screen');
+assert.match(enhancementRuntime, /LOT_ENTRY_CLICK_GUARD_MS = 600/, 'The Lot must keep a short bounded entry quarantine for carry-over activations');
+assert.match(enhancementRuntime, /const card = screen\.querySelector\('\.lot-card'\)/, 'The entry guard must live on the information card, not on the whole Lot');
+assert.match(enhancementRuntime, /event\.target\?\.closest\?\.\('\.lot-race'\)/, 'The entry guard must target only Race This Car');
+assert.match(enhancementRuntime, /event\.preventDefault\(\);[\s\S]*event\.stopImmediatePropagation\(\);/, 'A carry-over activation must stop before the motion gate can run');
+assert.match(enhancementRuntime, /card\.addEventListener\('click', blockCarryOverRaceClick, true\)/, 'The card capture guard must run before the Race This Car target listener');
+assert.match(enhancementRuntime, /card\.removeEventListener\('click', blockCarryOverRaceClick, true\)/, 'The temporary entry guard must clean itself up');
+assert.doesNotMatch(enhancementRuntime, /document\.addEventListener\('click'/, 'The carry-over fix must not restore a document-level click listener around native controls');
+assert.ok(
+  enhancementRuntime.indexOf('installLotEntryClickGuard(screen)') < enhancementRuntime.indexOf('gateLotNow(scope)'),
+  'The carry-over guard must attach before the ordinary Lot gates'
+);
 assert.match(enhancementRuntime, /installLotStatLegend\(scope\)/, 'Every Lot route must receive the stat legend');
 assert.match(enhancementRuntime, /installLotLayout\(scope\)/, 'Every Lot route must receive the shared visual layout enhancement');
 assert.match(enhancementRuntime, /installLotAccessibility\(scope\)/, 'Every Lot route must receive the r118 accessibility model');

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -9,11 +9,47 @@ import { gateLotPaintNow } from '../progression/lot-paint-reward.js?revision=r16
 // TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r154-trophy-road-feedback'
 const ENHANCEMENT_ID = 'enhanced-lot-r163-native-picker-parent-click';
 const TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r157-paint-monster';
+const LOT_ENTRY_CLICK_GUARD_MS = 600;
 const activeEnhancements = new WeakMap();
 
 function findLotScreen(root) {
   if (root?.matches?.('.lot-screen')) return root;
   return root?.querySelector?.('.lot-screen') || null;
+}
+
+function installLotEntryClickGuard(screen) {
+  const card = screen.querySelector('.lot-card');
+  if (!card) return () => {};
+
+  const startedAt = globalThis.performance?.now?.() ?? Date.now();
+  const now = () => globalThis.performance?.now?.() ?? Date.now();
+  let active = true;
+
+  const blockCarryOverRaceClick = (event) => {
+    if (!active || now() - startedAt >= LOT_ENTRY_CLICK_GUARD_MS) return;
+    const raceButton = event.target?.closest?.('.lot-race');
+    if (!raceButton || !card.contains(raceButton)) return;
+
+    // A VoiceOver double-tap that opens a full-screen route can leave a second
+    // hit-test activation behind in standalone iOS landscape. Race This Car is
+    // mounted in almost the same screen region as Home RACE, so keep only this
+    // newly mounted action out of that finishing gesture. The paint picker is a
+    // sibling of .lot-card and therefore has no click-listener ancestor added.
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  };
+
+  card.addEventListener('click', blockCarryOverRaceClick, true);
+  const timer = globalThis.setTimeout?.(() => {
+    active = false;
+    card.removeEventListener('click', blockCarryOverRaceClick, true);
+  }, LOT_ENTRY_CLICK_GUARD_MS);
+
+  return () => {
+    active = false;
+    if (timer != null) globalThis.clearTimeout?.(timer);
+    card.removeEventListener('click', blockCarryOverRaceClick, true);
+  };
 }
 
 export function enhanceLotNow(root = document.body) {
@@ -24,6 +60,7 @@ export function enhanceLotNow(root = document.body) {
   if (active) return active.release;
 
   const scope = screen.parentElement || document.body;
+  const removeEntryClickGuard = installLotEntryClickGuard(screen);
   const removeTrophyGate = gateLotNow(scope);
   const removePaintGate = gateLotPaintNow(scope);
   const removeStatLegend = installLotStatLegend(scope);
@@ -39,6 +76,7 @@ export function enhanceLotNow(root = document.body) {
     removeStatLegend();
     removePaintGate();
     removeTrophyGate();
+    removeEntryClickGuard();
     activeEnhancements.delete(screen);
     delete screen.dataset.lotEnhancements;
   };

--- a/turn/index.html
+++ b/turn/index.html
@@ -80,6 +80,7 @@
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",
         "./garage/lot-accessibility-r118.js?build=20260729-r118": "./garage/lot-accessibility-r118.js?build=20260809-r163&revision=r163-voiceover-first-lot-focus",
+        "./garage/lot-enhancement-runtime.js?revision=r163-native-picker-parent-click&build=20260809-r163": "./garage/lot-enhancement-runtime.js?build=20260809-r163&revision=r163-voiceover-pwa-lot-carryover",
         "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260809-r163&revision=r163-native-html",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260809-r163",
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system-r86.js?build=20260809-r163",


### PR DESCRIPTION
## Device evidence
The first-entry VoiceOver bug still reproduces in the installed Home Screen app after #397, but does **not** reproduce in the browser. The supplied recording also shows Home RACE still focused immediately before The Lot appears, with the native motion permission sheet already present about 150 ms later.

That makes the previous focus-handoff diagnosis insufficient. The remaining failure is consistent with a route-transition activation/hit-test carry-over in standalone iOS landscape: the newly mounted **Race This Car** action occupies roughly the same screen region as Home **RACE**, and it is the only Lot action that can request motion permission.

## Fix
Keep the workaround narrow and temporary:
- when a Lot screen is mounted, attach a capture guard only to `.lot-card` (the Race/attributes card, **not** the whole Lot and not the paint-picker ancestry)
- for the first 600 ms only, swallow a click specifically targeting `.lot-race` before the normal motion-access gate can run
- remove the listener automatically after that bounded entry window or when The Lot closes
- no VoiceOver detection, no standalone detection, no document-level click listener, no changes to the native color input, car chooser, motion API, or normal Race This Car flow

The 600 ms window is intentionally longer than the ~150 ms carry-over visible in the device recording but far shorter than a human can enter The Lot, inspect/navigate it, and intentionally reach Race This Car.

## Why this is different from #397
#397 moved DOM focus but did not stop a separate hit-tested activation from reaching the newly mounted action. This guard sits in the event path *above* Race This Car during the route-entry window, so it can stop that activation before `prepareMotionAccess()` is called.

## Color-picker safety
The guard is on `.lot-card`. The native paint input remains in the sibling 3D/paint panel, so this does not reintroduce the click-listener ancestry that broke VoiceOver color-picker activation earlier.

## Regression
The Lot regression requires:
- the bounded 600 ms guard
- `.lot-card` scope
- `.lot-race`-only targeting
- capture before ordinary Lot gates
- cleanup
- no `document` click listener
- a fresh import-map URL for the updated enhancer

This remains TURN 1.7.0 / r163.