### PR TITLE
TURN LAB: test unrestricted startup orientation

### DIFF
--- a/turn-lab/site.webmanifest
+++ b/turn-lab/site.webmanifest
@@ -7,7 +7,7 @@
   "scope": "/turn-lab/",
   "display": "standalone",
   "display_override": ["standalone"],
-  "orientation": "landscape",
+  "orientation": "any",
   "background_color": "#08090a",
   "theme_color": "#08090a",
   "icons": [

--- a/turn-tests/viewport-coverage-production.mjs
+++ b/turn-tests/viewport-coverage-production.mjs
@@ -130,7 +130,8 @@ assert.equal(labManifest.start_url, '/turn-lab/');
 assert.equal(labManifest.scope, '/turn-lab/');
 assert.equal(labManifest.display, 'standalone');
 assert.deepEqual(labManifest.display_override, ['standalone']);
-assert.equal(labManifest.orientation, 'landscape');
+assert.equal(labManifest.orientation, 'any',
+  'TURN LAB deliberately removes the landscape manifest lock for the real-device startup-orientation experiment');
 
 assert.match(labBootstrap, /LOCAL_PREFIX = 'turn-lab:'/,
   'LAB local storage must stay in its own namespace');


### PR DESCRIPTION
Real-device GOOD/BAD viewport evidence on iOS 26.5.2 shows the failure is created during the installed-app portrait→landscape startup transition, before TURN Home/runtime layout. In the BAD state WebKit settles at 1002×393 with 100dvh/100svh ≈393 while 100vh/100lvh remain ≈462; GOOD settles at 1002×462 across all units. The missing 69 CSS px × 0.85 scale ≈59 physical px matches the system strip.

This LAB-only experiment changes the installed TURN LAB manifest orientation from `landscape` to `any` so we can test whether removing the immediate manifest-driven landscape lock avoids the bad startup path. Production TURN and TURN NEXT remain locked to landscape and are untouched.

Because manifest orientation is install metadata, the real-device test should delete and reinstall TURN LAB before judging the result.