### PR TITLE
TURN LAB: add surgical viewport repair bench

### DIFF
--- a/turn-lab/lab-bootstrap.js
+++ b/turn-lab/lab-bootstrap.js
@@ -62,6 +62,11 @@
   document.documentElement.classList.toggle('turn-browser', !isStandalone);
   document.documentElement.dataset.turnLab = 'viewport-flight-recorder-r1';
 
+  const repairScript = document.createElement('script');
+  repairScript.src = '/turn-lab/viewport-repair-r3.js?revision=r3-meta-reflow';
+  repairScript.async = true;
+  document.head.appendChild(repairScript);
+
   let releaseBrowserLaunch = null;
   let browserReleased = false;
   globalThis.__turnLaunchReady = isStandalone

--- a/turn-lab/viewport-repair-r3.js
+++ b/turn-lab/viewport-repair-r3.js
@@ -1,0 +1,216 @@
+(() => {
+  const BAD_GAP_MIN = 40;
+  const META_PULSE_MS = 120;
+  const CHECKPOINTS_MS = Object.freeze([0, 80, 250, 650]);
+  const startedAt = performance.now();
+  let lastResult = null;
+
+  function round(value, digits = 1) {
+    const factor = 10 ** digits;
+    return Math.round((Number(value) || 0) * factor) / factor;
+  }
+
+  function measureHeight(value) {
+    if (!document.body) return 0;
+    const probe = document.createElement('i');
+    probe.setAttribute('aria-hidden', 'true');
+    probe.style.cssText = `position:fixed;left:-10000px;top:-10000px;display:block;width:1px;height:${value};visibility:hidden;pointer-events:none;`;
+    document.body.appendChild(probe);
+    const height = round(probe.getBoundingClientRect().height);
+    probe.remove();
+    return height;
+  }
+
+  function snapshot(reason) {
+    const viewport = window.visualViewport;
+    const game = document.querySelector('#game')?.getBoundingClientRect();
+    const dvh = measureHeight('100dvh');
+    const lvh = measureHeight('100lvh');
+    return {
+      t: round(performance.now() - startedAt),
+      reason,
+      landscape: Boolean(window.matchMedia?.('(orientation: landscape)').matches),
+      innerH: Number(window.innerHeight) || 0,
+      clientH: Number(document.documentElement.clientHeight) || 0,
+      visualH: round(viewport?.height || 0),
+      visualScale: round(viewport?.scale || 0, 3),
+      dvh,
+      lvh,
+      gap: round(lvh - dvh),
+      gameH: round(game?.height || 0)
+    };
+  }
+
+  function isStandalone() {
+    return document.documentElement.classList.contains('turn-standalone') ||
+      Boolean(window.matchMedia?.('(display-mode: standalone)').matches) ||
+      navigator.standalone === true;
+  }
+
+  function hasBadSignature(sample) {
+    return Boolean(
+      isStandalone() &&
+      sample?.landscape &&
+      sample.gap >= BAD_GAP_MIN &&
+      Math.abs(sample.clientH - sample.dvh) <= 2
+    );
+  }
+
+  function classification(sample = snapshot('classify')) {
+    return hasBadSignature(sample)
+      ? `BAD signature · ${round(sample.gap)}px missing`
+      : `GOOD/other signature · ${round(sample.gap)}px lvh-dvh gap`;
+  }
+
+  function delay(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  async function copyText(text) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch (_) {}
+
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.left = '-9999px';
+    document.body.appendChild(textarea);
+    textarea.select();
+    let copied = false;
+    try { copied = document.execCommand('copy'); } catch (_) {}
+    textarea.remove();
+    return copied;
+  }
+
+  async function runMetaReflow(status, signatureText, button) {
+    if (button.disabled) return;
+    button.disabled = true;
+
+    const meta = document.querySelector('meta[name="viewport"]');
+    if (!meta) {
+      status.textContent = 'Viewport meta tag not found.';
+      button.disabled = false;
+      return;
+    }
+
+    const before = snapshot('before');
+    signatureText.textContent = classification(before);
+    if (!hasBadSignature(before)) {
+      status.textContent = 'Not in the known BAD 393/462 signature. No repair was run.';
+      button.disabled = false;
+      return;
+    }
+
+    const original = meta.getAttribute('content') || '';
+    const events = [];
+    const noteEvent = (name) => {
+      if (events.length < 12) events.push(`${name}@${round(performance.now() - startedAt)}ms`);
+    };
+    const onResize = () => noteEvent('resize');
+    const onVisualResize = () => noteEvent('visualViewport.resize');
+    window.addEventListener('resize', onResize, { passive: true });
+    window.visualViewport?.addEventListener('resize', onVisualResize, { passive: true });
+
+    const pulse = 'width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no';
+    meta.setAttribute('content', pulse);
+    void document.documentElement.clientHeight;
+    await delay(META_PULSE_MS);
+    meta.setAttribute('content', original);
+    void document.documentElement.clientHeight;
+
+    const checkpoints = [];
+    let elapsed = 0;
+    for (const target of CHECKPOINTS_MS) {
+      const wait = Math.max(0, target - elapsed);
+      if (wait) await delay(wait);
+      elapsed = target;
+      checkpoints.push(snapshot(`after+${target}`));
+    }
+
+    window.removeEventListener('resize', onResize);
+    window.visualViewport?.removeEventListener('resize', onVisualResize);
+
+    const after = checkpoints.at(-1) || snapshot('after');
+    const recovered = !hasBadSignature(after) &&
+      after.clientH >= before.clientH + BAD_GAP_MIN &&
+      after.gap < 20;
+
+    lastResult = {
+      lab: 'TURN viewport repair bench r3',
+      productionBuild: globalThis.__TURN_BUILD__ || null,
+      standalone: isStandalone(),
+      originalMeta: original,
+      pulseMeta: pulse,
+      pulseMs: META_PULSE_MS,
+      before,
+      checkpoints,
+      events,
+      outcome: recovered ? 'RECOVERED' : 'STILL_BAD'
+    };
+    globalThis.__turnLabViewportRepairResult = lastResult;
+
+    signatureText.textContent = classification(after);
+    status.textContent = recovered
+      ? 'RECOVERED: WebKit expanded the reachable viewport without rotating. Copy the repair result.'
+      : 'STILL BAD: viewport-meta reflow did not recover the missing height. Copy the repair result.';
+    button.disabled = false;
+  }
+
+  function installRepairBench() {
+    const panel = document.querySelector('#turnLabDiagnosticsPanel');
+    if (!panel || panel.querySelector('[data-lab-repair-bench]')) return false;
+
+    const status = panel.querySelector('.turn-lab-status');
+    const actions = panel.querySelector('.turn-lab-actions');
+    if (!status || !actions) return false;
+
+    const bench = document.createElement('div');
+    bench.dataset.labRepairBench = '';
+    bench.style.cssText = 'width:100%;margin:10px 0 0;padding-top:10px;border-top:3px solid #08090a;';
+    bench.innerHTML = `
+      <strong>REPAIR BENCH r3</strong>
+      <div data-lab-repair-signature style="margin:6px 0"></div>
+      <button type="button" data-lab-meta-reflow>TRY VIEWPORT REFLOW</button>
+      <button type="button" data-lab-copy-repair>COPY REPAIR RESULT</button>`;
+    actions.after(bench);
+
+    const signatureText = bench.querySelector('[data-lab-repair-signature]');
+    const reflowButton = bench.querySelector('[data-lab-meta-reflow]');
+    const copyButton = bench.querySelector('[data-lab-copy-repair]');
+    signatureText.textContent = classification();
+
+    reflowButton.addEventListener('click', () => runMetaReflow(status, signatureText, reflowButton));
+    copyButton.addEventListener('click', async () => {
+      if (!lastResult) {
+        status.textContent = 'Run TRY VIEWPORT REFLOW first.';
+        return;
+      }
+      const copied = await copyText(JSON.stringify(lastResult, null, 2));
+      status.textContent = copied ? 'Copied compact repair result.' : 'Copy failed.';
+    });
+
+    const labButton = document.querySelector('#turnLabDiagnosticsButton');
+    labButton?.addEventListener('click', () => {
+      signatureText.textContent = classification();
+    });
+    return true;
+  }
+
+  function waitForBench() {
+    if (installRepairBench()) return;
+    const observer = new MutationObserver(() => {
+      if (!installRepairBench()) return;
+      observer.disconnect();
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', waitForBench, { once: true });
+  } else {
+    waitForBench();
+  }
+})();

--- a/turn-tests/viewport-coverage-production.mjs
+++ b/turn-tests/viewport-coverage-production.mjs
@@ -13,7 +13,8 @@ const [
   nextManifestSource,
   labManifestSource,
   labBootstrap,
-  labDiagnostics
+  labDiagnostics,
+  labRepair
 ] = await Promise.all([
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-next/index.html', import.meta.url), 'utf8'),
@@ -26,7 +27,8 @@ const [
   fs.readFile(new URL('../turn-next/site.webmanifest', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-lab/site.webmanifest', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-lab/lab-bootstrap.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn-lab/viewport-diagnostics.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn-lab/viewport-diagnostics.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn-lab/viewport-repair-r3.js', import.meta.url), 'utf8')
 ]);
 
 const release = JSON.parse(releaseSource);
@@ -141,6 +143,8 @@ assert.doesNotMatch(labBootstrap, /seed|COPY_ONCE|turn-personal-rivals/,
   'The fresh viewport lab must not seed or modify production TURN save data');
 assert.match(labBootstrap, /__turnLaunchReady/,
   'LAB must preserve the production startup gate contract');
+assert.match(labBootstrap, /viewport-repair-r3\.js\?revision=r3-meta-reflow/,
+  'LAB must load the isolated repair bench without modifying production TURN');
 
 for (const requiredDiagnostic of [
   'screen.width',
@@ -165,4 +169,27 @@ assert.match(labDiagnostics, /MAX_SESSIONS = 8/,
 assert.match(labDiagnostics, /localStorage\.setItem\(STORAGE_KEY/,
   'Viewport evidence must survive reloads and orientation cycles');
 
-console.log(`TURN ${release.id} usable iOS standalone viewport boundary and TURN LAB recorder passed.`);
+// The r3 repair bench is LAB-only and only experiments on the measured BAD signature.
+assert.doesNotThrow(() => new Function(labRepair), 'The LAB repair probe must remain valid JavaScript');
+for (const requiredRepair of [
+  "measureHeight('100dvh')",
+  "measureHeight('100lvh')",
+  'BAD_GAP_MIN = 40',
+  'Math.abs(sample.clientH - sample.dvh) <= 2',
+  'TRY VIEWPORT REFLOW',
+  'META_PULSE_MS = 120',
+  'CHECKPOINTS_MS = Object.freeze([0, 80, 250, 650])',
+  "meta.setAttribute('content', pulse)",
+  "meta.setAttribute('content', original)",
+  '__turnLabViewportRepairResult',
+  "outcome: recovered ? 'RECOVERED' : 'STILL_BAD'",
+  'COPY REPAIR RESULT'
+]) {
+  assert.ok(labRepair.includes(requiredRepair), `TURN LAB repair bench must include ${requiredRepair}`);
+}
+assert.doesNotMatch(labRepair, /screen\.(?:width|height)/,
+  'The repair experiment must never size content from physical screen dimensions');
+assert.match(labRepair, /if \(!hasBadSignature\(before\)\)/,
+  'The viewport meta pulse must not run on healthy launches');
+
+console.log(`TURN ${release.id} usable iOS standalone viewport boundary and TURN LAB recorder/repair bench passed.`);


### PR DESCRIPTION
The latest real-device BAD capture reproduces even with TURN LAB manifest `orientation:any`, so that experiment does not eliminate issue #394. The measured BAD signature remains stable: landscape standalone settles at 1002×393 for inner/client/VisualViewport/100dvh/100svh while 100lvh remains ≈462 (≈69 CSS px gap).

This LAB-only PR moves from observation to one controlled repair experiment without changing production TURN:

- adds an r3 repair bench inside the existing LAB diagnostics panel
- classifies the known BAD state from `100lvh - 100dvh >= 40px` plus clientHeight≈dvh
- only enables the experiment when that BAD signature is actually present
- `TRY VIEWPORT REFLOW` temporarily pulses the viewport meta state for 120ms, restores the exact original meta content, and records four small checkpoints over 650ms
- records only compact before/checkpoint/event/outcome data and exposes `COPY REPAIR RESULT`
- never sizes TURN from `screen.width` / `screen.height`
- keeps production `/turn/` and TURN NEXT untouched

The experiment is motivated by a related open WebKit standalone-PWA viewport corruption report where toggling the viewport meta state is reported to force WebKit to recalculate a broken viewport. This is deliberately diagnostic: real-device success/failure is required before considering any production mitigation.

Issue: #394