### PR TITLE
TURN LAB: make viewport auto-repair event-driven

### DIFF
--- a/turn-lab/lab-bootstrap.js
+++ b/turn-lab/lab-bootstrap.js
@@ -63,7 +63,7 @@
   document.documentElement.dataset.turnLab = 'viewport-flight-recorder-r1';
 
   const repairScript = document.createElement('script');
-  repairScript.src = '/turn-lab/viewport-repair-r3.js?revision=r4-auto-repair';
+  repairScript.src = '/turn-lab/viewport-repair-r3.js?revision=r5-auto-watchdog';
   repairScript.async = true;
   document.head.appendChild(repairScript);
 

--- a/turn-lab/viewport-repair-r3.js
+++ b/turn-lab/viewport-repair-r3.js
@@ -2,12 +2,14 @@
   const BAD_GAP_MIN = 40;
   const META_PULSE_MS = 120;
   const CHECKPOINTS_MS = Object.freeze([0, 80, 250, 650]);
-  const AUTO_CHECKS_MS = Object.freeze([180, 320, 600, 1000, 1600]);
+  const AUTO_CONFIRM_MS = 90;
+  const AUTO_WATCHDOG_MS = 10000;
+  const AUTO_CHECKS_MS = Object.freeze([120, 240, 400, 650, 1000, 1600, 2500, 4000, 6000, 8000, 10000]);
   const startedAt = performance.now();
   let lastResult = null;
   let repairInFlight = false;
   let autoAttempted = false;
-  let consecutiveBadChecks = 0;
+  let autoConfirmationTimer = 0;
 
   function round(value, digits = 1) {
     const factor = 10 ** digits;
@@ -169,7 +171,7 @@
         after.gap < 20;
 
       lastResult = {
-        lab: 'TURN viewport repair bench r4 auto',
+        lab: 'TURN viewport repair bench r5 watchdog',
         productionBuild: globalThis.__TURN_BUILD__ || null,
         standalone: isStandalone(),
         trigger,
@@ -216,7 +218,7 @@
     bench.dataset.labRepairBench = '';
     bench.style.cssText = 'width:100%;margin:10px 0 0;padding-top:10px;border-top:3px solid #08090a;';
     bench.innerHTML = `
-      <strong>REPAIR BENCH r4 · AUTO ARMED</strong>
+      <strong>REPAIR BENCH r5 · WATCHDOG ARMED</strong>
       <div data-lab-repair-signature style="margin:6px 0"></div>
       <button type="button" data-lab-meta-reflow>TRY VIEWPORT REFLOW</button>
       <button type="button" data-lab-copy-repair disabled>COPY REPAIR RESULT</button>`;
@@ -257,23 +259,39 @@
     observer.observe(document.documentElement, { childList: true, subtree: true });
   }
 
-  function autoCheck(label) {
-    if (autoAttempted || repairInFlight || !document.body) return;
-    const sample = snapshot(`auto-check:${label}`);
-    if (!hasBadSignature(sample)) {
-      consecutiveBadChecks = 0;
-      return;
-    }
+  function confirmAutoRepair(reason) {
+    if (autoAttempted || repairInFlight || autoConfirmationTimer || !document.body) return;
+    if (performance.now() - startedAt > AUTO_WATCHDOG_MS + 250) return;
 
-    consecutiveBadChecks += 1;
-    if (consecutiveBadChecks < 2) return;
-    autoAttempted = true;
-    runMetaReflow({ trigger: 'auto' });
+    const first = snapshot(`auto-watch:${reason}`);
+    if (!hasBadSignature(first)) return;
+
+    autoConfirmationTimer = window.setTimeout(() => {
+      autoConfirmationTimer = 0;
+      if (autoAttempted || repairInFlight || !document.body) return;
+      const confirmed = snapshot(`auto-confirm:${reason}`);
+      if (!hasBadSignature(confirmed)) return;
+      autoAttempted = true;
+      runMetaReflow({ trigger: 'auto' });
+    }, AUTO_CONFIRM_MS);
+  }
+
+  function onWatchdogEvent(event) {
+    if (autoAttempted || repairInFlight) return;
+    window.setTimeout(() => confirmAutoRepair(event?.type || 'event'), 0);
   }
 
   for (const delayMs of AUTO_CHECKS_MS) {
-    setTimeout(() => autoCheck(`startup+${delayMs}`), delayMs);
+    setTimeout(() => confirmAutoRepair(`startup+${delayMs}`), delayMs);
   }
+
+  window.addEventListener('resize', onWatchdogEvent, { passive: true });
+  window.addEventListener('orientationchange', onWatchdogEvent, { passive: true });
+  window.addEventListener('pageshow', onWatchdogEvent, { passive: true });
+  window.addEventListener('focus', onWatchdogEvent, { passive: true });
+  window.visualViewport?.addEventListener('resize', onWatchdogEvent, { passive: true });
+  window.addEventListener('turn:runtime-ready', onWatchdogEvent);
+  window.addEventListener('turn:home-ready', onWatchdogEvent);
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', waitForBench, { once: true });

--- a/turn-tests/viewport-coverage-production.mjs
+++ b/turn-tests/viewport-coverage-production.mjs
@@ -143,8 +143,8 @@ assert.doesNotMatch(labBootstrap, /seed|COPY_ONCE|turn-personal-rivals/,
   'The fresh viewport lab must not seed or modify production TURN save data');
 assert.match(labBootstrap, /__turnLaunchReady/,
   'LAB must preserve the production startup gate contract');
-assert.match(labBootstrap, /viewport-repair-r3\.js\?revision=r4-auto-repair/,
-  'LAB must load the cache-busted automatic repair experiment without modifying production TURN');
+assert.match(labBootstrap, /viewport-repair-r3\.js\?revision=r5-auto-watchdog/,
+  'LAB must load the cache-busted event-driven repair watchdog without modifying production TURN');
 
 for (const requiredDiagnostic of [
   'screen.width',
@@ -169,7 +169,7 @@ assert.match(labDiagnostics, /MAX_SESSIONS = 8/,
 assert.match(labDiagnostics, /localStorage\.setItem\(STORAGE_KEY/,
   'Viewport evidence must survive reloads and orientation cycles');
 
-// The repair bench remains LAB-only. Automatic mode requires two consecutive known-BAD measurements.
+// The repair bench remains LAB-only. Automatic mode watches startup events and confirms a persistent BAD signature before pulsing viewport meta.
 assert.doesNotThrow(() => new Function(labRepair), 'The LAB repair probe must remain valid JavaScript');
 for (const requiredRepair of [
   "measureHeight('100dvh')",
@@ -180,8 +180,13 @@ for (const requiredRepair of [
   'TRY VIEWPORT REFLOW',
   'META_PULSE_MS = 120',
   'CHECKPOINTS_MS = Object.freeze([0, 80, 250, 650])',
-  'AUTO_CHECKS_MS = Object.freeze([180, 320, 600, 1000, 1600])',
-  'consecutiveBadChecks < 2',
+  'AUTO_CONFIRM_MS = 90',
+  'AUTO_WATCHDOG_MS = 10000',
+  'AUTO_CHECKS_MS = Object.freeze([120, 240, 400, 650, 1000, 1600, 2500, 4000, 6000, 8000, 10000])',
+  "snapshot(`auto-confirm:${reason}`)",
+  "window.addEventListener('turn:runtime-ready', onWatchdogEvent)",
+  "window.addEventListener('turn:home-ready', onWatchdogEvent)",
+  "window.visualViewport?.addEventListener('resize', onWatchdogEvent",
   "runMetaReflow({ trigger: 'auto' })",
   "meta.setAttribute('content', pulse)",
   "meta.setAttribute('content', original)",


### PR DESCRIPTION
The first automatic-repair experiment missed a real BAD launch. The reason is visible in the LAB code: r4 only sampled at fixed startup times through 1.6s and required two scheduled BAD samples, so a persistent bad state that settled outside that window could remain untouched.

This LAB-only follow-up keeps production TURN and TURN NEXT unchanged and replaces that narrow startup sampler with a surgical watchdog:

- watches for 10s instead of stopping at 1.6s
- checks on resize, VisualViewport resize, orientationchange, pageshow, focus, runtime-ready and home-ready
- keeps sparse fallback checks through 10s
- when the exact known BAD signature appears, waits 90ms and confirms it is still BAD before doing anything
- only then runs the same real-device-proven 120ms viewport-meta pulse
- still never sizes from physical screen dimensions
- cache-busts the LAB repair script and updates the regression contract

This directly addresses the observed missed autocorrection without broadening the repair to healthy/transitional viewport states.

Issue: #394