### PR TITLE
TURN LAB: keep viewport auto-repair armed after app resume

### DIFF
--- a/turn-lab/lab-bootstrap.js
+++ b/turn-lab/lab-bootstrap.js
@@ -63,7 +63,7 @@
   document.documentElement.dataset.turnLab = 'viewport-flight-recorder-r1';
 
   const repairScript = document.createElement('script');
-  repairScript.src = '/turn-lab/viewport-repair-r3.js?revision=r5-auto-watchdog';
+  repairScript.src = '/turn-lab/viewport-repair-r6.js?revision=r6-resume-watchdog';
   repairScript.async = true;
   document.head.appendChild(repairScript);
 

--- a/turn-lab/viewport-repair-r6.js
+++ b/turn-lab/viewport-repair-r6.js
@@ -1,0 +1,331 @@
+(() => {
+  const BAD_GAP_MIN = 40;
+  const META_PULSE_MS = 120;
+  const CHECKPOINTS_MS = Object.freeze([0, 80, 250, 650]);
+  const AUTO_CONFIRM_MS = 90;
+  const AUTO_COOLDOWN_MS = 1200;
+  const STARTUP_CHECKS_MS = Object.freeze([120, 240, 400, 650, 1000, 1600, 2500, 4000, 6000, 8000, 10000]);
+  const LIFECYCLE_SETTLE_MS = Object.freeze([0, 120, 350]);
+  const startedAt = performance.now();
+  let lastResult = null;
+  let repairInFlight = false;
+  let autoConfirmationTimer = 0;
+  let incidentArmed = true;
+  let lastAutoAttemptAt = -Infinity;
+
+  function round(value, digits = 1) {
+    const factor = 10 ** digits;
+    return Math.round((Number(value) || 0) * factor) / factor;
+  }
+
+  function measureHeight(value) {
+    if (!document.body) return 0;
+    const probe = document.createElement('i');
+    probe.setAttribute('aria-hidden', 'true');
+    probe.style.cssText = `position:fixed;left:-10000px;top:-10000px;display:block;width:1px;height:${value};visibility:hidden;pointer-events:none;`;
+    document.body.appendChild(probe);
+    const height = round(probe.getBoundingClientRect().height);
+    probe.remove();
+    return height;
+  }
+
+  function snapshot(reason) {
+    const viewport = window.visualViewport;
+    const game = document.querySelector('#game')?.getBoundingClientRect();
+    const dvh = measureHeight('100dvh');
+    const lvh = measureHeight('100lvh');
+    return {
+      t: round(performance.now() - startedAt),
+      reason,
+      landscape: Boolean(window.matchMedia?.('(orientation: landscape)').matches),
+      innerH: Number(window.innerHeight) || 0,
+      clientH: Number(document.documentElement.clientHeight) || 0,
+      visualH: round(viewport?.height || 0),
+      visualScale: round(viewport?.scale || 0, 3),
+      dvh,
+      lvh,
+      gap: round(lvh - dvh),
+      gameH: round(game?.height || 0)
+    };
+  }
+
+  function isStandalone() {
+    return document.documentElement.classList.contains('turn-standalone') ||
+      Boolean(window.matchMedia?.('(display-mode: standalone)').matches) ||
+      navigator.standalone === true;
+  }
+
+  function hasBadSignature(sample) {
+    return Boolean(
+      isStandalone() &&
+      sample?.landscape &&
+      sample.gap >= BAD_GAP_MIN &&
+      Math.abs(sample.clientH - sample.dvh) <= 2 &&
+      Math.abs(sample.visualH - sample.dvh) <= 2
+    );
+  }
+
+  function classification(sample = snapshot('classify')) {
+    return hasBadSignature(sample)
+      ? `BAD signature · ${round(sample.gap)}px missing`
+      : `GOOD/other signature · ${round(sample.gap)}px lvh-dvh gap`;
+  }
+
+  function delay(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  async function copyText(text) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch (_) {}
+
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.left = '-9999px';
+    document.body.appendChild(textarea);
+    textarea.select();
+    let copied = false;
+    try { copied = document.execCommand('copy'); } catch (_) {}
+    textarea.remove();
+    return copied;
+  }
+
+  function benchUi() {
+    const panel = document.querySelector('#turnLabDiagnosticsPanel');
+    const bench = panel?.querySelector('[data-lab-repair-bench]');
+    return {
+      status: panel?.querySelector('.turn-lab-status') || null,
+      signatureText: bench?.querySelector('[data-lab-repair-signature]') || null,
+      reflowButton: bench?.querySelector('[data-lab-meta-reflow]') || null,
+      copyButton: bench?.querySelector('[data-lab-copy-repair]') || null
+    };
+  }
+
+  function syncBenchUi(sample = null) {
+    const ui = benchUi();
+    if (ui.signatureText) ui.signatureText.textContent = classification(sample || undefined);
+    if (ui.reflowButton) ui.reflowButton.disabled = repairInFlight;
+    if (ui.copyButton) ui.copyButton.disabled = repairInFlight || !lastResult;
+    return ui;
+  }
+
+  async function runMetaReflow({ trigger = 'manual' } = {}) {
+    if (repairInFlight) return null;
+
+    const meta = document.querySelector('meta[name="viewport"]');
+    const ui = syncBenchUi();
+    if (!meta) {
+      if (ui.status) ui.status.textContent = 'Viewport meta tag not found.';
+      return null;
+    }
+
+    const before = snapshot('before');
+    if (ui.signatureText) ui.signatureText.textContent = classification(before);
+    if (!hasBadSignature(before)) {
+      incidentArmed = true;
+      if (ui.status && trigger === 'manual') {
+        ui.status.textContent = 'Not in the known BAD 393/462 signature. No repair was run.';
+      }
+      return null;
+    }
+
+    repairInFlight = true;
+    syncBenchUi(before);
+    if (ui.status) {
+      ui.status.textContent = trigger === 'auto'
+        ? 'Known BAD viewport detected. Verifying automatic repair…'
+        : 'Repairing viewport and verifying the result…';
+    }
+
+    const original = meta.getAttribute('content') || '';
+    const events = [];
+    const noteEvent = (name) => {
+      if (events.length < 12) events.push(`${name}@${round(performance.now() - startedAt)}ms`);
+    };
+    const onResize = () => noteEvent('resize');
+    const onVisualResize = () => noteEvent('visualViewport.resize');
+    window.addEventListener('resize', onResize, { passive: true });
+    window.visualViewport?.addEventListener('resize', onVisualResize, { passive: true });
+
+    const pulse = 'width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no';
+    try {
+      meta.setAttribute('content', pulse);
+      void document.documentElement.clientHeight;
+      await delay(META_PULSE_MS);
+      meta.setAttribute('content', original);
+      void document.documentElement.clientHeight;
+
+      const checkpoints = [];
+      let elapsed = 0;
+      for (const target of CHECKPOINTS_MS) {
+        const wait = Math.max(0, target - elapsed);
+        if (wait) await delay(wait);
+        elapsed = target;
+        checkpoints.push(snapshot(`after+${target}`));
+      }
+
+      const after = checkpoints.at(-1) || snapshot('after');
+      const recovered = !hasBadSignature(after) &&
+        after.clientH >= before.clientH + BAD_GAP_MIN &&
+        after.gap < 20;
+
+      incidentArmed = recovered;
+      lastResult = {
+        lab: 'TURN viewport repair bench r6 lifecycle watchdog',
+        productionBuild: globalThis.__TURN_BUILD__ || null,
+        standalone: isStandalone(),
+        trigger,
+        originalMeta: original,
+        pulseMeta: pulse,
+        pulseMs: META_PULSE_MS,
+        before,
+        checkpoints,
+        events,
+        outcome: recovered ? 'RECOVERED' : 'STILL_BAD'
+      };
+      globalThis.__turnLabViewportRepairResult = lastResult;
+      globalThis.__turnLabViewportAutoRepairResult = trigger === 'auto' ? lastResult : null;
+
+      const currentUi = benchUi();
+      if (currentUi.signatureText) currentUi.signatureText.textContent = classification(after);
+      if (currentUi.status) {
+        currentUi.status.textContent = recovered
+          ? `${trigger === 'auto' ? 'AUTO-RECOVERED' : 'RECOVERED'}: WebKit restored the full reachable viewport.`
+          : `${trigger === 'auto' ? 'AUTO REPAIR FAILED' : 'STILL BAD'}: viewport-meta reflow did not recover the missing height.`;
+      }
+      window.dispatchEvent(new CustomEvent('turn-lab:viewport-repair-result', {
+        detail: { trigger, outcome: lastResult.outcome }
+      }));
+      return lastResult;
+    } finally {
+      meta.setAttribute('content', original);
+      window.removeEventListener('resize', onResize);
+      window.visualViewport?.removeEventListener('resize', onVisualResize);
+      repairInFlight = false;
+      syncBenchUi();
+    }
+  }
+
+  function installRepairBench() {
+    const panel = document.querySelector('#turnLabDiagnosticsPanel');
+    if (!panel || panel.querySelector('[data-lab-repair-bench]')) return false;
+
+    const status = panel.querySelector('.turn-lab-status');
+    const actions = panel.querySelector('.turn-lab-actions');
+    if (!status || !actions) return false;
+
+    const bench = document.createElement('div');
+    bench.dataset.labRepairBench = '';
+    bench.style.cssText = 'width:100%;margin:10px 0 0;padding-top:10px;border-top:3px solid #08090a;';
+    bench.innerHTML = `
+      <strong>REPAIR BENCH r6 · LIFECYCLE WATCHDOG ARMED</strong>
+      <div data-lab-repair-signature style="margin:6px 0"></div>
+      <button type="button" data-lab-meta-reflow>TRY VIEWPORT REFLOW</button>
+      <button type="button" data-lab-copy-repair disabled>COPY REPAIR RESULT</button>`;
+    actions.after(bench);
+
+    const signatureText = bench.querySelector('[data-lab-repair-signature]');
+    const reflowButton = bench.querySelector('[data-lab-meta-reflow]');
+    const copyButton = bench.querySelector('[data-lab-copy-repair]');
+    signatureText.textContent = classification();
+
+    reflowButton.addEventListener('click', () => runMetaReflow({ trigger: 'manual' }));
+    copyButton.addEventListener('click', async () => {
+      if (repairInFlight) {
+        status.textContent = 'Repair is still verifying. COPY REPAIR RESULT will enable when it is finished.';
+        return;
+      }
+      const result = lastResult || globalThis.__turnLabViewportRepairResult || null;
+      if (!result) {
+        status.textContent = 'No repair result yet.';
+        return;
+      }
+      const copied = await copyText(JSON.stringify(result, null, 2));
+      status.textContent = copied ? 'Copied compact repair result.' : 'Copy failed.';
+    });
+
+    const labButton = document.querySelector('#turnLabDiagnosticsButton');
+    labButton?.addEventListener('click', () => syncBenchUi());
+    syncBenchUi();
+    return true;
+  }
+
+  function waitForBench() {
+    if (installRepairBench()) return;
+    const observer = new MutationObserver(() => {
+      if (!installRepairBench()) return;
+      observer.disconnect();
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+  }
+
+  function confirmAutoRepair(reason) {
+    if (repairInFlight || autoConfirmationTimer || !document.body) return;
+
+    const first = snapshot(`auto-watch:${reason}`);
+    if (!hasBadSignature(first)) {
+      incidentArmed = true;
+      return;
+    }
+    if (!incidentArmed) return;
+    if (performance.now() - lastAutoAttemptAt < AUTO_COOLDOWN_MS) return;
+
+    autoConfirmationTimer = window.setTimeout(() => {
+      autoConfirmationTimer = 0;
+      if (repairInFlight || !document.body) return;
+      const confirmed = snapshot(`auto-confirm:${reason}`);
+      if (!hasBadSignature(confirmed)) {
+        incidentArmed = true;
+        return;
+      }
+      if (!incidentArmed) return;
+      incidentArmed = false;
+      lastAutoAttemptAt = performance.now();
+      runMetaReflow({ trigger: 'auto' });
+    }, AUTO_CONFIRM_MS);
+  }
+
+  function scheduleLifecycleChecks(reason) {
+    for (const delayMs of LIFECYCLE_SETTLE_MS) {
+      window.setTimeout(() => confirmAutoRepair(`${reason}+${delayMs}`), delayMs);
+    }
+  }
+
+  function onWatchdogEvent(event) {
+    if (repairInFlight) return;
+    scheduleLifecycleChecks(event?.type || 'event');
+  }
+
+  for (const delayMs of STARTUP_CHECKS_MS) {
+    setTimeout(() => confirmAutoRepair(`startup+${delayMs}`), delayMs);
+  }
+
+  window.addEventListener('resize', onWatchdogEvent, { passive: true });
+  window.addEventListener('orientationchange', onWatchdogEvent, { passive: true });
+  window.addEventListener('pageshow', onWatchdogEvent, { passive: true });
+  window.addEventListener('focus', onWatchdogEvent, { passive: true });
+  window.visualViewport?.addEventListener('resize', onWatchdogEvent, { passive: true });
+  window.addEventListener('turn:runtime-ready', onWatchdogEvent);
+  window.addEventListener('turn:home-ready', onWatchdogEvent);
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') {
+      if (autoConfirmationTimer) {
+        clearTimeout(autoConfirmationTimer);
+        autoConfirmationTimer = 0;
+      }
+      incidentArmed = true;
+      return;
+    }
+    scheduleLifecycleChecks('visibility:visible');
+  }, { passive: true });
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', waitForBench, { once: true });
+  } else {
+    waitForBench();
+  }
+})();

--- a/turn-tests/viewport-coverage-production.mjs
+++ b/turn-tests/viewport-coverage-production.mjs
@@ -28,7 +28,7 @@ const [
   fs.readFile(new URL('../turn-lab/site.webmanifest', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-lab/lab-bootstrap.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-lab/viewport-diagnostics.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn-lab/viewport-repair-r3.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn-lab/viewport-repair-r6.js', import.meta.url), 'utf8')
 ]);
 
 const release = JSON.parse(releaseSource);
@@ -143,8 +143,8 @@ assert.doesNotMatch(labBootstrap, /seed|COPY_ONCE|turn-personal-rivals/,
   'The fresh viewport lab must not seed or modify production TURN save data');
 assert.match(labBootstrap, /__turnLaunchReady/,
   'LAB must preserve the production startup gate contract');
-assert.match(labBootstrap, /viewport-repair-r3\.js\?revision=r5-auto-watchdog/,
-  'LAB must load the cache-busted event-driven repair watchdog without modifying production TURN');
+assert.match(labBootstrap, /viewport-repair-r6\.js\?revision=r6-resume-watchdog/,
+  'LAB must load the cache-busted lifecycle repair watchdog without modifying production TURN');
 
 for (const requiredDiagnostic of [
   'screen.width',
@@ -169,7 +169,7 @@ assert.match(labDiagnostics, /MAX_SESSIONS = 8/,
 assert.match(labDiagnostics, /localStorage\.setItem\(STORAGE_KEY/,
   'Viewport evidence must survive reloads and orientation cycles');
 
-// The repair bench remains LAB-only. Automatic mode watches startup events and confirms a persistent BAD signature before pulsing viewport meta.
+// The repair bench remains LAB-only. Automatic mode watches both startup and later app lifecycle events.
 assert.doesNotThrow(() => new Function(labRepair), 'The LAB repair probe must remain valid JavaScript');
 for (const requiredRepair of [
   "measureHeight('100dvh')",
@@ -181,23 +181,30 @@ for (const requiredRepair of [
   'META_PULSE_MS = 120',
   'CHECKPOINTS_MS = Object.freeze([0, 80, 250, 650])',
   'AUTO_CONFIRM_MS = 90',
-  'AUTO_WATCHDOG_MS = 10000',
-  'AUTO_CHECKS_MS = Object.freeze([120, 240, 400, 650, 1000, 1600, 2500, 4000, 6000, 8000, 10000])',
+  'AUTO_COOLDOWN_MS = 1200',
+  'STARTUP_CHECKS_MS = Object.freeze([120, 240, 400, 650, 1000, 1600, 2500, 4000, 6000, 8000, 10000])',
+  'LIFECYCLE_SETTLE_MS = Object.freeze([0, 120, 350])',
   "snapshot(`auto-confirm:${reason}`)",
   "window.addEventListener('turn:runtime-ready', onWatchdogEvent)",
   "window.addEventListener('turn:home-ready', onWatchdogEvent)",
   "window.visualViewport?.addEventListener('resize', onWatchdogEvent",
+  "document.addEventListener('visibilitychange'",
+  "scheduleLifecycleChecks('visibility:visible')",
   "runMetaReflow({ trigger: 'auto' })",
   "meta.setAttribute('content', pulse)",
   "meta.setAttribute('content', original)",
   '__turnLabViewportRepairResult',
   '__turnLabViewportAutoRepairResult',
   "outcome: recovered ? 'RECOVERED' : 'STILL_BAD'",
+  'incidentArmed = true',
+  'performance.now() - lastAutoAttemptAt < AUTO_COOLDOWN_MS',
   'repairInFlight',
   'COPY REPAIR RESULT'
 ]) {
   assert.ok(labRepair.includes(requiredRepair), `TURN LAB repair bench must include ${requiredRepair}`);
 }
+assert.doesNotMatch(labRepair, /AUTO_WATCHDOG_MS|performance\.now\(\) - startedAt >/,
+  'Resume-time recovery must not expire just because the app has been alive longer than the cold-start window');
 assert.doesNotMatch(labRepair, /screen\.(?:width|height)/,
   'The repair experiment must never size content from physical screen dimensions');
 assert.match(labRepair, /if \(!hasBadSignature\(before\)\)/,


### PR DESCRIPTION
Closes the hole exposed by the latest real-device BAD run for #394.

The pasted manual recovery result starts with `before.t = 22776ms`, while LAB r5 explicitly stopped automatic diagnosis after ~10.25s. That exactly explains the observed behavior after swiping TURN LAB away, using other apps, then returning: the BAD 393/462 signature was present, the manual viewport-meta pulse recovered it, but the auto path had already expired and therefore produced no visible auto-repair status.

This LAB-only r6 experiment:
- removes the global 10s lifetime cutoff from auto recovery;
- keeps the sparse 10s startup checks for cold-launch coverage;
- adds lifecycle checks after focus/pageshow/visibility-visible/resize/orientation changes;
- samples each lifecycle event at 0/120/350ms to allow iOS viewport state to settle;
- confirms the exact known BAD signature for 90ms before pulsing viewport meta;
- rearms after a healthy state or after the app is backgrounded, but only attempts once per persistent BAD incident with a 1200ms cooldown;
- leaves production TURN and TURN NEXT untouched.

Regression coverage now explicitly forbids reintroducing a `performance.now() - startedAt` expiry for resume-time recovery.