### PR TITLE
TURN: keep RACE reachable in the short iOS standalone viewport

### DIFF
--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -1,4 +1,5 @@
 const STYLE_ATTRIBUTE = 'data-turn-m8-fixed-home-styles';
+const SHORT_VIEWPORT_STYLE_ID = 'turn-m8-short-viewport-race-dock';
 const LAYOUT_ID = 'fixed-grid-v7';
 
 function installStylesheet() {
@@ -9,6 +10,32 @@ function installStylesheet() {
   stylesheet.href = `/turn/m8-home-fixed-layout.css?build=${buildKey}-m8.7-home-polish`;
   stylesheet.setAttribute(STYLE_ATTRIBUTE, '');
   document.head.appendChild(stylesheet);
+}
+
+function installShortViewportRaceDock() {
+  if (document.getElementById(SHORT_VIEWPORT_STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = SHORT_VIEWPORT_STYLE_ID;
+  style.textContent = `
+    @media (max-height: 430px) and (orientation: landscape) {
+      html.turn-standalone .m8-home-fixed-layout .m8-home-menu {
+        overflow-y: auto;
+        overscroll-behavior-y: contain;
+        padding-bottom: 76px;
+        scroll-padding-bottom: 76px;
+      }
+
+      html.turn-standalone .m8-home-fixed-layout .m8-track-continue {
+        position: fixed;
+        z-index: 70;
+        right: max(14px, env(safe-area-inset-right));
+        bottom: max(12px, env(safe-area-inset-bottom));
+        width: clamp(150px, 20vw, 205px);
+        max-width: calc(100vw - 28px - env(safe-area-inset-left) - env(safe-area-inset-right));
+      }
+    }
+  `;
+  document.head.appendChild(style);
 }
 
 function waitForHome() {
@@ -53,6 +80,7 @@ function installDriveByEarSpokenLabels(training) {
 
 export async function installM8HomeFixedLayout() {
   installStylesheet();
+  installShortViewportRaceDock();
   const home = await waitForHome();
   if (home.dataset.m8HomeLayout === LAYOUT_ID) return globalThis.__turnHomeLayout;
 


### PR DESCRIPTION
Mitigates the user-visible consequence of issue #394 in production TURN without trying to size the game into WebKit's unreachable cyan strip.

On the known bad iOS standalone launch, the reachable landscape viewport collapses from about 462px to 393px high. Home correctly follows that reachable viewport, but the expanded MENU column can then push the primary RACE action below the clipped Home surface.

This change keeps the **existing** RACE button accessible when the installed landscape viewport is unusually short:
- only applies in standalone landscape at `max-height: 430px`, so the normal 462px Home layout is unchanged;
- fixes the existing RACE control to the bottom-right of the *reachable* viewport, above `env(safe-area-inset-bottom)`;
- makes the menu itself vertically scrollable with reserved bottom space so secondary actions are not lost behind the floating primary action;
- does not duplicate RACE, change DOM order/accessibility semantics, inspect physical `screen.height`, or touch viewport-meta repair logic;
- production `/turn` only; TURN NEXT and TURN LAB are untouched.

This does not pretend to fix the underlying WebKit viewport allocation bug. It is a product-level containment: even when iOS gives TURN only the 393px web layer, the action needed to continue playing remains reachable.