### PR TITLE
TURN: auto-repair the known short iOS viewport after START settles

### DIFF
--- a/turn-tests/short-viewport-repair-production.mjs
+++ b/turn-tests/short-viewport-repair-production.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const [homeLayout, repair] = await Promise.all([
+  fs.readFile(new URL('../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/pwa-short-viewport-repair-r184.js', import.meta.url), 'utf8')
+]);
+
+for (const verticalOnlyMenuRule of [
+  'overflow-y: auto',
+  'overflow-x: hidden',
+  'overscroll-behavior-x: none',
+  'touch-action: pan-y',
+  'padding-right: 8px'
+]) {
+  assert.ok(
+    homeLayout.includes(verticalOnlyMenuRule),
+    `Short-viewport Home menu must keep scrolling vertical-only: ${verticalOnlyMenuRule}`
+  );
+}
+
+assert.match(
+  homeLayout,
+  /pwa-short-viewport-repair-r184\.js\?build=\$\{buildKey\}&revision=r184-start-settle-first-activation/,
+  'Production Home must load the cache-distinct minimal viewport repair module'
+);
+
+const parseableRepair = repair.replace('export function installShortViewportAutoRepair', 'function installShortViewportAutoRepair');
+assert.doesNotThrow(() => new Function(parseableRepair), 'Production short-viewport repair must remain valid JavaScript');
+
+for (const requiredRepair of [
+  "measureHeight('100dvh')",
+  "measureHeight('100lvh')",
+  'BAD_GAP_MIN = 40',
+  'Math.abs(sample.clientH - sample.dvh) <= 2',
+  'Math.abs(sample.visualH - sample.dvh) <= 2',
+  'AUTO_SETTLE_MS = 160',
+  'AUTO_CONFIRM_MS = 90',
+  'META_PULSE_MS = 120',
+  "document.addEventListener('turn:home-ready'",
+  "home.addEventListener('click', onFirstHomeActivation",
+  "'first-home-activation'",
+  "meta.setAttribute('content', pulse)",
+  "meta.setAttribute('content', original)",
+  'autoAttempted',
+  'interactionAttempted'
+]) {
+  assert.ok(repair.includes(requiredRepair), `Production repair must include ${requiredRepair}`);
+}
+
+assert.doesNotMatch(repair, /screen\.(?:width|height)/,
+  'Physical screen dimensions must never participate in viewport repair');
+assert.doesNotMatch(repair, /TURN viewport repair bench|COPY REPAIR RESULT|COLOR LAYERS|AUTO_RETRY_DELAYS|STARTUP_CHECKS_MS/,
+  'Production must not clone TURN LAB diagnostics, UI, or long-running watchdog machinery');
+assert.doesNotMatch(repair, /document\.addEventListener\('click'|window\.addEventListener\('click'/,
+  'The first-interaction fallback must stay scoped to Home rather than becoming a global click delegate');
+
+console.log('TURN short iOS viewport production repair and vertical-only Home menu passed.');

--- a/turn-tests/viewport-coverage-production.mjs
+++ b/turn-tests/viewport-coverage-production.mjs
@@ -214,4 +214,6 @@ assert.match(labRepair, /if \(!hasBadSignature\(before\)\)/,
 assert.match(labRepair, /if \(repairInFlight \|\| autoConfirmationTimer \|\| !document\.body \|\| !autoAllowed\(\)\) return;/,
   'Automatic repair must stay out of cold-start loading until Home has actually initialized');
 
+await import('./short-viewport-repair-production.mjs');
+
 console.log(`TURN ${release.id} usable iOS standalone viewport boundary and TURN LAB recorder/repair bench passed.`);

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -20,7 +20,12 @@ function installShortViewportRaceDock() {
     @media (max-height: 430px) and (orientation: landscape) {
       html.turn-standalone .m8-home-fixed-layout .m8-home-menu {
         overflow-y: auto;
+        overflow-x: hidden;
         overscroll-behavior-y: contain;
+        overscroll-behavior-x: none;
+        touch-action: pan-y;
+        box-sizing: border-box;
+        padding-right: 8px;
         padding-bottom: 76px;
         scroll-padding-bottom: 76px;
       }
@@ -142,6 +147,11 @@ export async function installM8HomeFixedLayout() {
   document.documentElement.dataset.turnHomeLayout = LAYOUT_ID;
 
   const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
+  const { installShortViewportAutoRepair } = await import(
+    `/turn/pwa-short-viewport-repair-r184.js?build=${buildKey}&revision=r184-start-settle-first-activation`
+  );
+  const shortViewportAutoRepair = installShortViewportAutoRepair({ home });
+
   const { installM8HomeCardScrollFixes } = await import(
     `/turn/m8-home-card-scroll-fixes.js?build=${buildKey}-m8.9-track-title-alignment`
   );
@@ -188,6 +198,7 @@ export async function installM8HomeFixedLayout() {
     trackBrowser,
     menu,
     raceButton,
+    shortViewportAutoRepair,
     cardScrollFixes,
     trophyGate,
     achievements,

--- a/turn/pwa-short-viewport-repair-r184.js
+++ b/turn/pwa-short-viewport-repair-r184.js
@@ -1,0 +1,189 @@
+const BAD_GAP_MIN = 40;
+const RECOVERED_GAP_MAX = 20;
+const AUTO_SETTLE_MS = 160;
+const AUTO_CONFIRM_MS = 90;
+const INTERACTION_CONFIRM_MS = 40;
+const META_PULSE_MS = 120;
+const VERIFY_MS = 80;
+const INSTALL_KEY = '__turnShortViewportRepairR184';
+
+function delay(ms) {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
+function isStandalone() {
+  return document.documentElement.classList.contains('turn-standalone') ||
+    Boolean(window.matchMedia?.('(display-mode: standalone)').matches) ||
+    Boolean(window.matchMedia?.('(display-mode: fullscreen)').matches) ||
+    navigator.standalone === true;
+}
+
+function measureHeight(value) {
+  if (!document.body) return 0;
+  const probe = document.createElement('i');
+  probe.setAttribute('aria-hidden', 'true');
+  probe.style.cssText = `position:fixed;left:-10000px;top:-10000px;display:block;width:1px;height:${value};visibility:hidden;pointer-events:none;`;
+  document.body.appendChild(probe);
+  const height = probe.getBoundingClientRect().height;
+  probe.remove();
+  return height;
+}
+
+function sampleViewport() {
+  const viewport = window.visualViewport;
+  const dvh = measureHeight('100dvh');
+  const lvh = measureHeight('100lvh');
+  return Object.freeze({
+    landscape: Boolean(window.matchMedia?.('(orientation: landscape)').matches),
+    innerH: Number(window.innerHeight) || 0,
+    clientH: Number(document.documentElement.clientHeight) || 0,
+    visualH: Number(viewport?.height) || 0,
+    dvh,
+    lvh,
+    gap: lvh - dvh
+  });
+}
+
+function hasBadSignature(sample) {
+  return Boolean(
+    isStandalone() &&
+    sample?.landscape &&
+    sample.gap >= BAD_GAP_MIN &&
+    Math.abs(sample.clientH - sample.dvh) <= 2 &&
+    Math.abs(sample.visualH - sample.dvh) <= 2
+  );
+}
+
+function homeIsUsable(home) {
+  if (!home?.isConnected || document.visibilityState !== 'visible') return false;
+  const style = getComputedStyle(home);
+  const rect = home.getBoundingClientRect();
+  return !home.hidden && style.display !== 'none' && style.visibility !== 'hidden' && rect.width > 0 && rect.height > 0;
+}
+
+export function installShortViewportAutoRepair({ home } = {}) {
+  if (!home || !isStandalone()) return null;
+  if (globalThis[INSTALL_KEY]) return globalThis[INSTALL_KEY];
+
+  const root = document.documentElement;
+  let repairInFlight = false;
+  let autoTimer = 0;
+  let incidentActive = false;
+  let autoAttempted = false;
+  let interactionAttempted = false;
+
+  function resetIncident() {
+    incidentActive = false;
+    autoAttempted = false;
+    interactionAttempted = false;
+  }
+
+  function observe(sample = sampleViewport()) {
+    if (hasBadSignature(sample)) {
+      incidentActive = true;
+      return sample;
+    }
+    if (incidentActive && sample.gap < RECOVERED_GAP_MAX) resetIncident();
+    return sample;
+  }
+
+  async function pulseViewportMeta(trigger) {
+    if (repairInFlight || !homeIsUsable(home)) return false;
+    const meta = document.querySelector('meta[name="viewport"]');
+    if (!meta) return false;
+
+    const before = observe();
+    if (!hasBadSignature(before)) return false;
+
+    repairInFlight = true;
+    const original = meta.getAttribute('content') || '';
+    const pulse = 'width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no';
+    root.dataset.turnViewportRepair = `trying-${trigger}`;
+
+    try {
+      meta.setAttribute('content', pulse);
+      void root.clientHeight;
+      await delay(META_PULSE_MS);
+      meta.setAttribute('content', original);
+      void root.clientHeight;
+      await delay(VERIFY_MS);
+
+      const after = observe();
+      const recovered = !hasBadSignature(after) &&
+        after.clientH >= before.clientH + BAD_GAP_MIN &&
+        after.gap < RECOVERED_GAP_MAX;
+      root.dataset.turnViewportRepair = recovered ? 'recovered' : 'still-bad';
+      globalThis.__turnShortViewportRepairResult = Object.freeze({
+        trigger,
+        recovered,
+        before: Object.freeze({ clientH: before.clientH, dvh: before.dvh, lvh: before.lvh, gap: before.gap }),
+        after: Object.freeze({ clientH: after.clientH, dvh: after.dvh, lvh: after.lvh, gap: after.gap })
+      });
+      if (recovered) resetIncident();
+      return recovered;
+    } finally {
+      meta.setAttribute('content', original);
+      repairInFlight = false;
+    }
+  }
+
+  async function confirmAndRepair(trigger, confirmMs) {
+    if (repairInFlight || !homeIsUsable(home)) return false;
+    const first = observe();
+    if (!hasBadSignature(first)) return false;
+    await delay(confirmMs);
+    if (repairInFlight || !homeIsUsable(home)) return false;
+    const confirmed = observe();
+    if (!hasBadSignature(confirmed)) return false;
+    return pulseViewportMeta(trigger);
+  }
+
+  function scheduleSettledAutoRepair(reason) {
+    if (autoTimer) window.clearTimeout(autoTimer);
+    autoTimer = window.setTimeout(async () => {
+      autoTimer = 0;
+      if (!homeIsUsable(home)) return;
+      const sample = observe();
+      if (!hasBadSignature(sample) || autoAttempted) return;
+      autoAttempted = true;
+      await confirmAndRepair(reason, AUTO_CONFIRM_MS);
+    }, AUTO_SETTLE_MS);
+  }
+
+  function onFirstHomeActivation() {
+    window.setTimeout(async () => {
+      if (repairInFlight || !homeIsUsable(home)) return;
+      const sample = observe();
+      if (!hasBadSignature(sample) || interactionAttempted) return;
+      interactionAttempted = true;
+      await confirmAndRepair('first-home-activation', INTERACTION_CONFIRM_MS);
+    }, 0);
+  }
+
+  home.addEventListener('click', onFirstHomeActivation, { passive: true });
+
+  document.addEventListener('turn:home-ready', () => {
+    scheduleSettledAutoRepair('home-ready');
+  });
+  window.addEventListener('pageshow', () => {
+    scheduleSettledAutoRepair('pageshow');
+  }, { passive: true });
+  window.addEventListener('focus', () => {
+    scheduleSettledAutoRepair('focus');
+  }, { passive: true });
+  document.addEventListener('visibilitychange', () => {
+    if (!document.hidden) scheduleSettledAutoRepair('visibility-visible');
+  }, { passive: true });
+
+  if (root.classList.contains('turn-home-ready')) {
+    scheduleSettledAutoRepair('already-home-ready');
+  }
+
+  const api = Object.freeze({
+    sample: sampleViewport,
+    hasBadSignature,
+    repairNow: () => confirmAndRepair('manual-api', 0)
+  });
+  globalThis[INSTALL_KEY] = api;
+  return api;
+}

--- a/turn/pwa-short-viewport-repair-r184.js
+++ b/turn/pwa-short-viewport-repair-r184.js
@@ -55,6 +55,8 @@ function hasBadSignature(sample) {
 }
 
 function homeIsUsable(home) {
+  const root = document.documentElement;
+  if (!root.classList.contains('turn-home-ready')) return false;
   if (!home?.isConnected || document.visibilityState !== 'visible') return false;
   const style = getComputedStyle(home);
   const rect = home.getBoundingClientRect();


### PR DESCRIPTION
Production-only follow-up to #394/#407. This deliberately ports only the proven repair core from TURN LAB; it does not clone the LAB recorder/watchdog/UI into `/turn`.

What changes:
- keep the existing short-viewport RACE dock from #407, but make the MENU scroll strictly vertical (`overflow-x: hidden`, horizontal overscroll disabled, `touch-action: pan-y`) and reserve 8px on the right so button shadows do not create sideways overflow;
- add a small production repair module for the exact established BAD signature: standalone landscape, `100lvh - 100dvh >= 40px`, client≈dvh and visual≈dvh;
- wait until the START/Home screen has actually finished (`turn:home-ready` is listened for on **document**, matching where `app.js` dispatches it), then let it settle for 160ms and confirm the BAD signature for another 90ms before running the proven 120ms viewport-meta pulse;
- keep the repair invisible and restore the exact original viewport meta immediately after the pulse;
- if a BAD incident persists, the first Home activation provides one additional fallback attempt after the user's click has completed. The listener is scoped to `.m8-home`, not document/window, and never prevents/defaults or intercepts activation;
- re-arm only after the viewport becomes healthy, so a later bad resume can be handled as a new incident; lifecycle checks are limited to Home-ready/pageshow/focus/visibility-visible rather than the LAB's long watchdog/retry machinery;
- physical `screen.width`/`screen.height` never participate in detection or sizing;
- TURN NEXT and TURN LAB are not copied into production.

Regression coverage explicitly protects the vertical-only menu, exact BAD signature, Home-scoped first-interaction fallback, exact meta restoration, and absence of LAB diagnostics/retry machinery.

Release identity remains TURN 1.7.0 · 2026.08.09-r163.