### PR TITLE
TURN: add a high-contrast edge to the boost level

### DIFF
--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -119,6 +119,7 @@ assert.match(css, /place-items: center/, 'Drive-zone labels must be vertically a
 assert.match(css, /content: "LEAVE"/, 'Boost lock hint must explain that leaving the Boost zone re-arms it');
 assert.match(css, /\.drive-pad \.drive-brake-zone \{/, 'Brake and Reverse must be styled as an internal drive-pad zone');
 assert.match(css, /\.drive-brake-zone\.is-active/, 'Brake must have visible active feedback');
+assert.match(gameplayCss, /\.boost-hud i \{[\s\S]*box-shadow: 3px 0 0 var\(--ink\);/, 'Boost charge must have a high-contrast ink edge at the live fill level');
 assert.match(gameplayCss, /\.boost-hud\.is-boost-full-flash/, 'Boost HUD must visibly react when recharge reaches full capacity');
 assert.match(gameplayCss, /\.boost-hud\.is-boost-empty-flash/, 'Boost HUD must react distinctly when the tank becomes empty');
 assert.match(gameplayCss, /@keyframes turn-boost-full-flash/, 'Full boost feedback must have its own animation');

--- a/turn/gameplay-v2.css
+++ b/turn/gameplay-v2.css
@@ -71,6 +71,7 @@
   inset: 0 auto 0 0;
   width: var(--boost-charge);
   background: linear-gradient(90deg, #ff922b, #ff5a5f);
+  box-shadow: 3px 0 0 var(--ink);
   transition: width 70ms linear;
 }
 


### PR DESCRIPTION
Accessibility priority: the current BOOST meter relies too much on the color transition between the charged portion and the pale remainder. On some track/background combinations that live fill endpoint is not visually distinct enough.

This adds one 3px ink separator at the moving boost-charge edge, matching the reference treatment in the supplied screenshot. Because it is attached to the existing fill element, it tracks the live `--boost-charge` width automatically for both the ordinary orange/red state and the cyan/green drift-recharge state. At full charge the extra shadow is clipped by the existing meter boundary, so the established outer border remains the visible edge.

No boost mechanics, timing, audio, input, achievements, race logic, or accessibility semantics change.

A production regression assertion now protects the non-color boost-level edge so this contrast affordance cannot disappear accidentally.

Release identity remains TURN 1.7.0 · 2026.08.09-r163.