### PR TITLE
Complete #411 track maps and race-control alignment

### DIFF
--- a/.github/workflows/turn-challenge-tests.yml
+++ b/.github/workflows/turn-challenge-tests.yml
@@ -9,6 +9,7 @@ on:
       - 'turn-next/**'
       - 'yourturn/**'
       - 'turn/index.html'
+      - 'turn/ui/r411-race-controls.js'
       - 'turn/social/**'
       - 'turn/telemetry/**'
       - 'turn/content/about-turn.js'
@@ -28,6 +29,7 @@ on:
       - 'turn-next/**'
       - 'yourturn/**'
       - 'turn/index.html'
+      - 'turn/ui/r411-race-controls.js'
       - 'turn/social/**'
       - 'turn/telemetry/**'
       - 'turn/content/about-turn.js'
@@ -60,6 +62,7 @@ jobs:
         run: |
           find turn-next yourturn -maxdepth 1 -type f -name '*.js' -print0 | xargs -0 -n1 node --check
           find turn/social turn/telemetry turn/stats -type f -name '*.js' -print0 | xargs -0 -n1 node --check
+          node --check turn/ui/r411-race-controls.js
 
       - name: Run Race My Ghost contract
         run: node turn-tests/challenge-mode-production.mjs
@@ -69,6 +72,9 @@ jobs:
 
       - name: Run YOUR TURN recipient contract
         run: node turn-tests/yourturn-production.mjs
+
+      - name: Run YOUR TURN r411 controls and maps regression
+        run: node turn-tests/yourturn-r411-production.mjs
 
       - name: Run YOUR TURN About modal regression
         run: node turn-tests/yourturn-about-modal-production.mjs

--- a/turn-tests/yourturn-r411-production.mjs
+++ b/turn-tests/yourturn-r411-production.mjs
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import { TRACK_DEFINITIONS } from '../turn/tracks/definitions.js';
+
+const [
+  yourTurnIndex,
+  yourTurnControls,
+  yourTurnMap,
+  yourTurnCss,
+  turnIndex,
+  turnControls
+] = await Promise.all([
+  fs.readFile(new URL('../yourturn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/race-controls-r411.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/track-map-r411.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/r411.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/ui/r411-race-controls.js', import.meta.url), 'utf8')
+]);
+
+assert.match(yourTurnIndex, /race-controls-r411\.js\?revision=r411/);
+assert.match(yourTurnIndex, /track-map-r411\.js\?revision=r411/);
+assert.match(yourTurnIndex, /r411\.css\?revision=r411/);
+assert.match(turnIndex, /ui\/r411-race-controls\.js\?revision=r411/);
+
+assert.match(yourTurnMap, /getTrackPreviewPoints/,
+  'YOUR TURN maps must derive from TURN canonical track geometry');
+assert.match(yourTurnMap, /getTrackDefinition/,
+  'YOUR TURN map accents and identity must come from TURN track definitions');
+assert.match(yourTurnMap, /MAP_VIEWS = new Set\(\['invitation', 'paused'\]\)/,
+  'Track maps must appear on the invitation and central challenge view before racing');
+for (const track of TRACK_DEFINITIONS) {
+  assert.ok(track.id, 'Every production track must have a stable id');
+  assert.doesNotMatch(yourTurnMap, new RegExp(`case ['\"]${track.id}['\"]`),
+    `Track ${track.id} must not require a YOUR TURN-specific geometry branch`);
+}
+
+assert.match(yourTurnControls, /className = 'utility yourturn-settings-button'/);
+assert.match(yourTurnControls, /className = 'utility yourturn-spectate-button'/);
+assert.doesNotMatch(yourTurnControls, /RESET RIVALS|Personal rivals/,
+  'YOUR TURN Settings must not expose Reset Rivals');
+assert.match(yourTurnControls, /restartButton\.hidden = true/,
+  'YOUR TURN must keep the direct Restart Lap control hidden');
+assert.match(yourTurnControls,
+  /const ordered = \[challengeButton\];[\s\S]*ordered\.push\(blankButton\);[\s\S]*ordered\.push\(recalibrateButton, settingsButton, spectateButton\)/,
+  'YOUR TURN staged controls must follow THE CHALLENGE, Blank Screen, Recalibrate, Settings, Spectate');
+assert.match(yourTurnControls, /state\.scene\?\.setPhase\('preview'\)/,
+  'YOUR TURN Spectate must use the existing challenge replay scene to teach the track');
+assert.match(yourTurnControls, /classList\.toggle\('is-lap-invalid', invalid\)/,
+  'YOUR TURN must reflect LAP VOID on THE CHALLENGE button');
+assert.match(yourTurnCss, /\.yourturn-challenge-button\.is-lap-invalid[\s\S]*#ff6b6b/);
+assert.doesNotMatch(yourTurnCss, /\.utility-group\s*\{/,
+  'The mockup must not cause global utility-row spacing or alignment changes');
+
+assert.match(turnControls, /menuState === 'racing'[\s\S]*restartButton\.hidden = false[\s\S]*recalibrateButton\.hidden = false/,
+  'TURN must expose Restart Lap and Recalibrate during an active race');
+assert.match(turnControls, /utilityGroup\.prepend\(recalibrateButton\);[\s\S]*utilityGroup\.prepend\(restartButton\)/,
+  'TURN active-race DOM order must be Restart Lap then Recalibrate');
+assert.match(turnControls, /blankScreenButton\.after\(recalibrateButton\)/,
+  'TURN must restore Recalibrate to its established staged position after Blank Screen');
+assert.match(turnControls, /back-to-start-button[\s\S]*#ff7b54/,
+  'TURN Restart Lap must be orange during a valid active lap');
+assert.match(turnControls, /back-to-start-button\.is-lap-invalid[\s\S]*#ff6b6b/,
+  'TURN Restart Lap must turn red for LAP VOID');
+assert.doesNotMatch(turnControls, /gap:|align-items:|top:|bottom:|translate|margin:/,
+  'The TURN r411 control patch must not copy incidental mockup layout changes');
+
+console.log('TURN/YOUR TURN r411 maps and race-control alignment regression passed.');

--- a/turn/index.html
+++ b/turn/index.html
@@ -157,6 +157,7 @@
   <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260809-r163-r168-shared-about-credits"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
   <script type="module" src="./app.js?build=20260809-r163-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click"></script>
+  <script type="module" src="./ui/r411-race-controls.js?revision=r411"></script>
   <script type="module" src="./accessibility/color-accessibility-r163.js?build=20260809-r163-paint-basics"></script>
   <script type="module" src="./achievements/chromatic-camouflage-r183.js?revision=r183-production"></script>
   <script type="module" src="./social/your-turn-share-bootstrap.js?revision=r2"></script>

--- a/turn/ui/r411-race-controls.js
+++ b/turn/ui/r411-race-controls.js
@@ -1,0 +1,70 @@
+function installStyles() {
+  if (document.querySelector('#turn-r411-race-control-styles')) return;
+  const style = document.createElement('style');
+  style.id = 'turn-r411-race-control-styles';
+  style.textContent = `
+    .utility-group[data-menu-state="racing"] .back-to-start-button {
+      background: #ff7b54;
+    }
+
+    .utility-group[data-menu-state="racing"] .back-to-start-button.is-lap-invalid {
+      background: #ff6b6b;
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+function install() {
+  const utilityGroup = document.querySelector('.utility-group');
+  const restartButton = document.querySelector('#resetButton');
+  const recalibrateButton = document.querySelector('#calibrateButton');
+  if (!utilityGroup || !restartButton || !recalibrateButton) return false;
+  if (utilityGroup.dataset.r411RaceControls === 'true') return true;
+
+  utilityGroup.dataset.r411RaceControls = 'true';
+  installStyles();
+
+  function sync() {
+    const menuState = utilityGroup.dataset.menuState;
+    if (menuState === 'racing') {
+      restartButton.hidden = false;
+      recalibrateButton.hidden = false;
+      // The active-race order is intentionally RESTART LAP → RECALIBRATE.
+      // Moving the existing nodes keeps visual and keyboard focus order aligned.
+      utilityGroup.prepend(recalibrateButton);
+      utilityGroup.prepend(restartButton);
+      return;
+    }
+
+    if (menuState !== 'staged') return;
+
+    // Restore TURN's established start-line order without touching gaps, alignment,
+    // or the position of Settings/Achievements/Spectate added by their own modules.
+    const blankScreenButton = utilityGroup.querySelector('.turn-screen-blank-control');
+    const leaveRaceButton = utilityGroup.querySelector('.back-to-lot-button');
+    if (blankScreenButton?.parentElement === utilityGroup) {
+      blankScreenButton.after(recalibrateButton);
+    } else if (leaveRaceButton?.parentElement === utilityGroup) {
+      leaveRaceButton.after(recalibrateButton);
+    }
+  }
+
+  const observer = typeof MutationObserver === 'function'
+    ? new MutationObserver(sync)
+    : null;
+  observer?.observe(utilityGroup, { attributes: true, attributeFilter: ['data-menu-state'] });
+  window.addEventListener('turn:ui-state-change', sync);
+  sync();
+  return true;
+}
+
+function bootstrap(attempt = 0) {
+  if (install()) return;
+  if (attempt < 240) requestAnimationFrame(() => bootstrap(attempt + 1));
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => bootstrap(), { once: true });
+} else {
+  bootstrap();
+}

--- a/yourturn/index.html
+++ b/yourturn/index.html
@@ -44,6 +44,7 @@
   <link rel="stylesheet" href="/yourturn/nonvisual.css?revision=r1">
   <link rel="stylesheet" href="/yourturn/growing-challenge.css?revision=r2">
   <link rel="stylesheet" href="/yourturn/about-links.css?revision=r2">
+  <link rel="stylesheet" href="/yourturn/r411.css?revision=r411">
 
   <script src="/yourturn/storage-bootstrap.js?revision=r2"></script>
   <script type="importmap">
@@ -149,6 +150,8 @@
 
   <script type="module" src="/yourturn/app.js?revision=r6"></script>
   <script type="module" src="/yourturn/nonvisual.js?revision=r1"></script>
+  <script type="module" src="/yourturn/race-controls-r411.js?revision=r411"></script>
+  <script type="module" src="/yourturn/track-map-r411.js?revision=r411"></script>
   <script type="module" src="/yourturn/racer-labels-bootstrap.js?revision=r3"></script>
   <script type="module" src="/yourturn/racer-colors.js?revision=r2"></script>
   <script type="module" src="/yourturn/start-gate.js?revision=r1"></script>

--- a/yourturn/r411.css
+++ b/yourturn/r411.css
@@ -1,0 +1,212 @@
+.yourturn-track-map {
+  width: min(320px, 58vw);
+  margin: 0 0 12px;
+}
+
+.yourturn-track-map svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.yourturn-track-map-shadow,
+.yourturn-track-map-road,
+.yourturn-track-map-line {
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.yourturn-track-map-shadow {
+  stroke: #08090a;
+  stroke-width: 18;
+}
+
+.yourturn-track-map-road {
+  stroke: #fff8e8;
+  stroke-width: 11;
+}
+
+.yourturn-track-map-line {
+  stroke-width: 6;
+}
+
+.yourturn-track-map-start {
+  fill: #ffff09;
+  stroke: #08090a;
+  stroke-width: 4;
+}
+
+.yourturn-challenge-button.is-lap-invalid {
+  background: #ff6b6b !important;
+}
+
+.yourturn-settings-dialog {
+  width: min(920px, calc(100vw - 24px));
+  max-height: calc(100dvh - 24px);
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: #08090a;
+  overflow: visible;
+}
+
+.yourturn-settings-dialog::backdrop {
+  background: rgb(8 9 10 / 0.62);
+  backdrop-filter: blur(5px);
+}
+
+.yourturn-settings-card {
+  box-sizing: border-box;
+  max-height: calc(100dvh - 24px);
+  overflow: auto;
+  padding: clamp(18px, 3vw, 30px);
+  border: 5px solid #08090a;
+  border-radius: 26px;
+  background: #fff8e8;
+  box-shadow: 10px 10px 0 #08090a;
+}
+
+.yourturn-settings-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 18px;
+}
+
+.yourturn-settings-head span {
+  display: block;
+  margin-bottom: 3px;
+  color: #6b3fa0;
+  font-size: 0.78rem;
+  font-weight: 1000;
+  letter-spacing: 0.14em;
+}
+
+.yourturn-settings-head h2 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 4rem);
+  line-height: 0.9;
+  letter-spacing: -0.05em;
+}
+
+.yourturn-settings-close {
+  flex: 0 0 auto;
+  width: 48px;
+  height: 48px;
+  padding: 0;
+  border: 4px solid #08090a;
+  border-radius: 50%;
+  background: #ff9b66;
+  color: #08090a;
+  box-shadow: 4px 4px 0 #08090a;
+  font: inherit;
+  font-size: 1.8rem;
+  font-weight: 1000;
+  line-height: 1;
+}
+
+.yourturn-settings-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.yourturn-setting-card {
+  min-width: 0;
+  padding: 16px;
+  border: 4px solid #08090a;
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: 4px 4px 0 #08090a;
+}
+
+.yourturn-setting-card legend,
+.yourturn-setting-card > h3 {
+  margin: 0 0 8px;
+  padding: 0;
+  font-size: 1.15rem;
+  font-weight: 1000;
+}
+
+.yourturn-steering-setting label,
+.yourturn-toggle-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  margin-top: 10px;
+  cursor: pointer;
+}
+
+.yourturn-steering-setting input,
+.yourturn-toggle-row input {
+  width: 28px;
+  height: 28px;
+  margin: 0;
+}
+
+.yourturn-steering-setting strong,
+.yourturn-toggle-row strong,
+.yourturn-balance-row strong {
+  display: block;
+}
+
+.yourturn-steering-setting small,
+.yourturn-toggle-row small,
+.yourturn-balance-row small {
+  display: block;
+  margin-top: 2px;
+  line-height: 1.25;
+}
+
+.yourturn-motion-note,
+.yourturn-settings-status {
+  margin: 10px 0 0;
+  font-weight: 800;
+}
+
+.yourturn-balance-row {
+  display: block;
+  margin-top: 12px;
+}
+
+#yourTurnAudioBalance {
+  width: 100%;
+  margin-top: 10px;
+}
+
+.yourturn-balance-labels {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 0.72rem;
+  font-weight: 850;
+}
+
+#yourTurnAudioBalanceValue {
+  display: block;
+  margin-top: 4px;
+  font-weight: 900;
+}
+
+.yourturn-settings-status {
+  min-height: 1.2em;
+}
+
+.yourturn-settings-close:focus-visible,
+.yourturn-setting-card :focus-visible {
+  outline: 4px solid #38d9ff;
+  outline-offset: 4px;
+}
+
+@media (max-width: 680px), (max-height: 430px) {
+  .yourturn-settings-list {
+    grid-template-columns: 1fr;
+  }
+
+  .yourturn-settings-card {
+    padding: 15px;
+  }
+}

--- a/yourturn/race-controls-r411.js
+++ b/yourturn/race-controls-r411.js
@@ -1,0 +1,378 @@
+import { saveDriveByEarEnabled } from '/turn/ui/drive-by-ear-setting.js';
+import {
+  loadColorCuesEnabled,
+  saveColorCuesEnabled
+} from '/turn/accessibility/color-cues.js?revision=r163';
+
+const STEERING_MODE_KEY = 'turn-steering-mode-v1';
+const STEERING_MODE = Object.freeze({ MOTION: 'motion', MANUAL: 'manual' });
+
+function saveSteeringMode(mode) {
+  const value = mode === STEERING_MODE.MOTION ? STEERING_MODE.MOTION : STEERING_MODE.MANUAL;
+  try {
+    localStorage.setItem(STEERING_MODE_KEY, value);
+  } catch (_) {}
+  return value;
+}
+
+function balanceLabel(value) {
+  if (value < 45) return `${100 - value}% other sounds`;
+  if (value > 55) return `${value}% Drive By Ear`;
+  return 'Balanced';
+}
+
+function createSettingsDialog({ runtime, raceSession, trigger }) {
+  const dialog = document.createElement('dialog');
+  dialog.className = 'yourturn-settings-dialog';
+  dialog.setAttribute('aria-labelledby', 'yourTurnSettingsTitle');
+  dialog.innerHTML = `
+    <article class="yourturn-settings-card">
+      <header class="yourturn-settings-head">
+        <div><span>YOUR TURN</span><h2 id="yourTurnSettingsTitle">SETTINGS</h2></div>
+        <button class="yourturn-settings-close" type="button" aria-label="Close settings">×</button>
+      </header>
+
+      <div class="yourturn-settings-list">
+        <fieldset class="yourturn-setting-card yourturn-steering-setting">
+          <legend>Steering</legend>
+          <label><input type="radio" name="yourTurnSteering" value="motion"><span><strong>Device rotation</strong><small>Turn the whole device like a steering wheel.</small></span></label>
+          <label><input type="radio" name="yourTurnSteering" value="manual"><span><strong>On-screen steering</strong><small>Use the steering control on the left.</small></span></label>
+          <p class="yourturn-motion-note" hidden>Device rotation is not available in this browser.</p>
+        </fieldset>
+
+        <section class="yourturn-setting-card" aria-labelledby="yourTurnAudioTitle">
+          <h3 id="yourTurnAudioTitle">Audio</h3>
+          <label class="yourturn-toggle-row"><input id="yourTurnAudioEnabled" type="checkbox"><span><strong>Sound</strong><small>Turn every TURN sound on or off.</small></span></label>
+          <label class="yourturn-toggle-row"><input id="yourTurnDbeEnabled" type="checkbox"><span><strong>Drive By Ear™</strong><small>Spatial steering guidance, pace notes, recovery cues and rival warnings.</small></span></label>
+          <label class="yourturn-balance-row" for="yourTurnAudioBalance"><strong>Sound balance</strong><small>Choose between car and world sounds or Drive By Ear guidance.</small></label>
+          <input id="yourTurnAudioBalance" type="range" min="0" max="100" step="1" value="50" aria-describedby="yourTurnAudioBalanceValue">
+          <div class="yourturn-balance-labels" aria-hidden="true"><span>Other sounds</span><span>Drive By Ear</span></div>
+          <output id="yourTurnAudioBalanceValue" for="yourTurnAudioBalance">Balanced</output>
+        </section>
+
+        <section class="yourturn-setting-card" aria-labelledby="yourTurnAccessibilityTitle">
+          <h3 id="yourTurnAccessibilityTitle">Accessibility</h3>
+          <label class="yourturn-toggle-row"><input id="yourTurnColorCuesEnabled" type="checkbox"><span><strong>Color cues</strong><small>Add text and pattern cues wherever TURN uses color to communicate.</small></span></label>
+        </section>
+      </div>
+      <p class="yourturn-settings-status" role="status" aria-live="polite"></p>
+    </article>`;
+  document.body.appendChild(dialog);
+
+  const closeButton = dialog.querySelector('.yourturn-settings-close');
+  const motionRadio = dialog.querySelector('input[value="motion"]');
+  const manualRadio = dialog.querySelector('input[value="manual"]');
+  const motionNote = dialog.querySelector('.yourturn-motion-note');
+  const soundToggle = dialog.querySelector('#yourTurnAudioEnabled');
+  const dbeToggle = dialog.querySelector('#yourTurnDbeEnabled');
+  const balanceSlider = dialog.querySelector('#yourTurnAudioBalance');
+  const balanceOutput = dialog.querySelector('#yourTurnAudioBalanceValue');
+  const colorCuesToggle = dialog.querySelector('#yourTurnColorCuesEnabled');
+  const status = dialog.querySelector('.yourturn-settings-status');
+
+  function audioPreferences() {
+    return globalThis.__turnAudioPreferences;
+  }
+
+  function sync() {
+    const motionAvailable = typeof globalThis.DeviceMotionEvent !== 'undefined';
+    motionRadio.disabled = !motionAvailable;
+    motionRadio.checked = runtime.state.sensorMode === true;
+    manualRadio.checked = runtime.state.sensorMode !== true;
+    motionNote.hidden = motionAvailable;
+
+    const audio = audioPreferences()?.getSettings?.() || {
+      audioEnabled: true,
+      dbeEnabled: globalThis.__turnDriveByEarEnabled !== false,
+      balance: 0.5
+    };
+    soundToggle.checked = audio.audioEnabled !== false;
+    dbeToggle.checked = audio.dbeEnabled !== false;
+    const storedBalance = Number(audio.balance);
+    const percent = Math.round((Number.isFinite(storedBalance) ? storedBalance : 0.5) * 100);
+    balanceSlider.value = String(percent);
+    balanceOutput.value = balanceLabel(percent);
+    balanceOutput.textContent = balanceOutput.value;
+    colorCuesToggle.checked = loadColorCuesEnabled();
+    status.textContent = '';
+  }
+
+  async function setSteering(mode) {
+    if (mode === STEERING_MODE.MANUAL) {
+      saveSteeringMode(mode);
+      runtime.state.sensorMode = false;
+      runtime.state.roll = 0;
+      runtime.state.targetRoll = 0;
+      runtime.state.neutralRoll = 0;
+      runtime.state.horizonRollReference = 0;
+      runtime.state.pitch = 0;
+      runtime.state.targetPitch = 0;
+      runtime.state.neutralPitch = 0;
+      document.querySelector('#manualSteer')?.removeAttribute('hidden');
+      status.textContent = 'Steering set to the on-screen control.';
+      sync();
+      return;
+    }
+
+    if (runtime.state.sensorMode === true) {
+      saveSteeringMode(mode);
+      document.querySelector('#manualSteer')?.setAttribute('hidden', '');
+      status.textContent = 'Steering set to device rotation.';
+      sync();
+      return;
+    }
+
+    motionRadio.disabled = true;
+    try {
+      await raceSession.prepareMotionAccess();
+      saveSteeringMode(mode);
+      document.querySelector('#manualSteer')?.setAttribute('hidden', '');
+      document.querySelector('#calibrateButton')?.click();
+      status.textContent = 'Steering set to device rotation.';
+    } catch (error) {
+      runtime.state.sensorMode = false;
+      saveSteeringMode(STEERING_MODE.MANUAL);
+      status.textContent = error instanceof Error ? error.message : 'Motion steering could not be enabled.';
+    } finally {
+      motionRadio.disabled = false;
+      sync();
+    }
+  }
+
+  motionRadio.addEventListener('change', () => {
+    if (motionRadio.checked) void setSteering(STEERING_MODE.MOTION);
+  });
+  manualRadio.addEventListener('change', () => {
+    if (manualRadio.checked) void setSteering(STEERING_MODE.MANUAL);
+  });
+  soundToggle.addEventListener('change', () => {
+    const enabled = audioPreferences()?.setAudioEnabled?.(soundToggle.checked) ?? soundToggle.checked;
+    soundToggle.checked = enabled;
+    status.textContent = `Sound ${enabled ? 'on' : 'off'}.`;
+  });
+  dbeToggle.addEventListener('change', () => {
+    const enabled = dbeToggle.checked;
+    if (!saveDriveByEarEnabled(enabled)) {
+      dbeToggle.checked = !enabled;
+      status.textContent = 'Drive By Ear could not be changed because local storage is unavailable.';
+      return;
+    }
+    audioPreferences()?.setDriveByEarEnabled?.(enabled);
+    status.textContent = enabled ? 'Drive By Ear on.' : 'Drive By Ear off.';
+  });
+  balanceSlider.addEventListener('input', () => {
+    const value = Number(balanceSlider.value);
+    audioPreferences()?.setBalance?.(value / 100);
+    balanceOutput.value = balanceLabel(value);
+    balanceOutput.textContent = balanceOutput.value;
+  });
+  balanceSlider.addEventListener('change', () => {
+    status.textContent = `Sound balance: ${balanceLabel(Number(balanceSlider.value))}.`;
+  });
+  colorCuesToggle.addEventListener('change', () => {
+    const enabled = colorCuesToggle.checked;
+    if (!saveColorCuesEnabled(enabled)) {
+      colorCuesToggle.checked = !enabled;
+      status.textContent = 'Color cues could not be changed because local storage is unavailable.';
+      return;
+    }
+    status.textContent = `Color cues ${enabled ? 'on' : 'off'}.`;
+  });
+
+  function close() {
+    if (typeof dialog.close === 'function' && dialog.open) dialog.close();
+    else dialog.removeAttribute('open');
+    trigger.focus({ preventScroll: true });
+  }
+
+  closeButton.addEventListener('click', close);
+  dialog.addEventListener('cancel', (event) => {
+    event.preventDefault();
+    close();
+  });
+  dialog.addEventListener('click', (event) => {
+    if (event.target === dialog) close();
+  });
+
+  return Object.freeze({
+    open() {
+      sync();
+      if (typeof dialog.showModal === 'function' && !dialog.open) dialog.showModal();
+      else dialog.setAttribute('open', '');
+      closeButton.focus();
+    },
+    sync
+  });
+}
+
+function install() {
+  const runtime = globalThis.__turnRuntime;
+  const raceSession = globalThis.__turnRaceSession;
+  const session = globalThis.__yourTurnSession;
+  const utilityGroup = document.querySelector('#controls .utility-group');
+  const challengeButton = document.querySelector('#yourTurnChallengeButton');
+  const blankButton = document.querySelector('.turn-screen-blank-control');
+  const recalibrateButton = document.querySelector('#calibrateButton');
+  const restartButton = document.querySelector('#resetButton');
+  if (!runtime || !raceSession || !session || !utilityGroup || !challengeButton || !blankButton || !recalibrateButton || !restartButton) {
+    return false;
+  }
+  if (utilityGroup.dataset.r411YourTurnControls === 'true') return true;
+  utilityGroup.dataset.r411YourTurnControls = 'true';
+
+  restartButton.hidden = true;
+
+  const settingsButton = document.createElement('button');
+  settingsButton.type = 'button';
+  settingsButton.className = 'utility yourturn-settings-button';
+  settingsButton.textContent = 'Settings';
+  settingsButton.setAttribute('aria-label', 'Open YOUR TURN settings');
+
+  const spectateButton = document.createElement('button');
+  spectateButton.type = 'button';
+  spectateButton.className = 'utility yourturn-spectate-button';
+  spectateButton.textContent = 'Spectate';
+  spectateButton.setAttribute('aria-label', 'Spectate a run to learn the track');
+
+  utilityGroup.append(settingsButton, spectateButton);
+  const settings = createSettingsDialog({ runtime, raceSession, trigger: settingsButton });
+  let spectating = false;
+  let syncing = false;
+  let syncQueued = false;
+
+  function setChallengeInvalidState() {
+    const invalid = runtime.state.lapActive === true && runtime.state.lapInvalid === true;
+    challengeButton.classList.toggle('is-lap-invalid', invalid);
+  }
+
+  function reorder(nodes) {
+    for (const node of nodes) {
+      if (!node || node.parentElement !== utilityGroup) continue;
+      utilityGroup.appendChild(node);
+    }
+  }
+
+  function sync() {
+    if (syncing) return;
+    syncing = true;
+    try {
+      restartButton.hidden = true;
+      setChallengeInvalidState();
+
+      const state = session.getState();
+      const activeLap = runtime.state.lapActive === true || state.phase === 'racing';
+      const accepted = state.accepted === true;
+
+      if (!accepted) {
+        settingsButton.hidden = true;
+        spectateButton.hidden = true;
+        return;
+      }
+
+      if (spectating) {
+        challengeButton.hidden = true;
+        recalibrateButton.hidden = true;
+        settingsButton.hidden = true;
+        if (blankButton.dataset.state !== 'active') blankButton.hidden = true;
+        spectateButton.hidden = false;
+        spectateButton.textContent = 'Stop Spectating';
+        spectateButton.setAttribute('aria-label', 'Stop spectating and return to the starting line');
+        reorder([spectateButton]);
+        return;
+      }
+
+      spectateButton.textContent = 'Spectate';
+      spectateButton.setAttribute('aria-label', 'Spectate a run to learn the track');
+      challengeButton.hidden = false;
+      recalibrateButton.hidden = false;
+
+      if (activeLap) {
+        settingsButton.hidden = true;
+        spectateButton.hidden = true;
+        if (blankButton.dataset.state !== 'active') blankButton.hidden = true;
+        reorder([challengeButton, recalibrateButton]);
+        return;
+      }
+
+      if (state.phase === 'staged') {
+        settingsButton.hidden = false;
+        spectateButton.hidden = false;
+        if (blankButton.dataset.state !== 'active') blankButton.hidden = false;
+        const ordered = [challengeButton];
+        if (blankButton.dataset.state !== 'active') ordered.push(blankButton);
+        ordered.push(recalibrateButton, settingsButton, spectateButton);
+        reorder(ordered);
+      }
+    } finally {
+      syncing = false;
+    }
+  }
+
+  function queueSync() {
+    if (syncQueued) return;
+    syncQueued = true;
+    queueMicrotask(() => {
+      syncQueued = false;
+      sync();
+    });
+  }
+
+  function startSpectating() {
+    const state = session.getState();
+    if (spectating || state.phase !== 'staged' || runtime.state.lapActive) return;
+    spectating = true;
+    runtime.state.velocity.set(0, 0, 0);
+    runtime.state.speed = 0;
+    state.phase = 'preview';
+    state.scene?.setPhase('preview');
+    runtime.setGameMode(runtime.GAME_MODE.SPECTATING);
+    queueSync();
+  }
+
+  function stopSpectating() {
+    if (!spectating) return;
+    const state = session.getState();
+    spectating = false;
+    state.phase = 'staged';
+    state.scene?.setPhase('staged');
+    runtime.setGameMode(runtime.GAME_MODE.STAGED);
+    runtime.state.lastFrame = performance.now();
+    queueSync();
+  }
+
+  settingsButton.addEventListener('click', () => settings.open());
+  spectateButton.addEventListener('click', () => {
+    if (spectating) stopSpectating();
+    else startSpectating();
+  });
+
+  window.addEventListener('turn:ui-state-change', () => {
+    if (runtime.state.lapActive && spectating) spectating = false;
+    queueSync();
+  });
+
+  const lapTimeChip = document.querySelector('#lapTime')?.closest('.chip');
+  const lapObserver = lapTimeChip && typeof MutationObserver === 'function'
+    ? new MutationObserver(queueSync)
+    : null;
+  lapObserver?.observe(lapTimeChip, { attributes: true, attributeFilter: ['class'] });
+
+  const controlsObserver = typeof MutationObserver === 'function'
+    ? new MutationObserver(queueSync)
+    : null;
+  controlsObserver?.observe(utilityGroup, { childList: true });
+
+  queueSync();
+  return true;
+}
+
+function bootstrap(attempt = 0) {
+  if (install()) return;
+  if (attempt < 300) requestAnimationFrame(() => bootstrap(attempt + 1));
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => bootstrap(), { once: true });
+} else {
+  bootstrap();
+}

--- a/yourturn/track-map-r411.js
+++ b/yourturn/track-map-r411.js
@@ -1,0 +1,92 @@
+import { getTrackDefinition, getTrackPreviewPoints } from '/turn/tracks/catalog.js?source=20260729-r118-m8';
+
+const MAP_VIEWS = new Set(['invitation', 'paused']);
+const VIEWBOX_WIDTH = 320;
+const VIEWBOX_HEIGHT = 185;
+const MAP_WIDTH = 270;
+const MAP_HEIGHT = 135;
+
+export function makeChallengeTrackMapSvg(trackId) {
+  const track = getTrackDefinition(trackId);
+  const points = getTrackPreviewPoints(track.id, 110);
+  const xs = points.map((point) => point.x);
+  const zs = points.map((point) => point.z);
+  const minX = Math.min(...xs);
+  const maxX = Math.max(...xs);
+  const minZ = Math.min(...zs);
+  const maxZ = Math.max(...zs);
+  const width = Math.max(1, maxX - minX);
+  const height = Math.max(1, maxZ - minZ);
+  const scale = Math.min(MAP_WIDTH / width, MAP_HEIGHT / height);
+  const offsetX = (VIEWBOX_WIDTH - width * scale) / 2;
+  const offsetY = (VIEWBOX_HEIGHT - height * scale) / 2;
+  const path = points.map((point, index) => {
+    const x = offsetX + (point.x - minX) * scale;
+    const y = offsetY + (point.z - minZ) * scale;
+    return `${index ? 'L' : 'M'}${x.toFixed(1)} ${y.toFixed(1)}`;
+  }).join(' ');
+  const startX = offsetX + (points[0].x - minX) * scale;
+  const startY = offsetY + (points[0].z - minZ) * scale;
+
+  return `
+    <svg viewBox="0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}" focusable="false" aria-hidden="true">
+      <path class="yourturn-track-map-shadow" d="${path} Z"></path>
+      <path class="yourturn-track-map-road" d="${path} Z"></path>
+      <path class="yourturn-track-map-line" d="${path} Z" style="stroke:${track.accent}"></path>
+      <circle class="yourturn-track-map-start" cx="${startX.toFixed(1)}" cy="${startY.toFixed(1)}" r="7"></circle>
+    </svg>`;
+}
+
+function mapMarkup(challenge) {
+  if (!challenge?.trackId) return '';
+  return `<div class="yourturn-track-map" data-yourturn-track-map="${challenge.trackId}" aria-hidden="true">${makeChallengeTrackMapSvg(challenge.trackId)}</div>`;
+}
+
+function install() {
+  const session = globalThis.__yourTurnSession;
+  const dialog = document.querySelector('#yourTurnDialog');
+  const card = dialog?.querySelector('.yourturn-card');
+  const extra = dialog?.querySelector('.yourturn-extra');
+  if (!session || !dialog || !card || !extra) return false;
+  if (dialog.dataset.r411TrackMap === 'true') return true;
+  dialog.dataset.r411TrackMap = 'true';
+
+  function sync() {
+    const challenge = session.getState?.().challenge;
+    const view = card.dataset.view || '';
+    const existing = extra.querySelector('[data-yourturn-track-map]');
+    if (!dialog.open || !challenge || !MAP_VIEWS.has(view)) {
+      existing?.remove();
+      return;
+    }
+
+    if (existing?.dataset.yourturnTrackMap === challenge.trackId) return;
+    existing?.remove();
+    extra.insertAdjacentHTML('afterbegin', mapMarkup(challenge));
+  }
+
+  const observer = typeof MutationObserver === 'function'
+    ? new MutationObserver(sync)
+    : null;
+  observer?.observe(dialog, {
+    attributes: true,
+    attributeFilter: ['open'],
+    childList: true,
+    subtree: true
+  });
+  observer?.observe(card, { attributes: true, attributeFilter: ['data-view'] });
+  dialog.addEventListener('close', sync);
+  sync();
+  return true;
+}
+
+function bootstrap(attempt = 0) {
+  if (install()) return;
+  if (attempt < 240) requestAnimationFrame(() => bootstrap(attempt + 1));
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => bootstrap(), { once: true });
+} else {
+  bootstrap();
+}


### PR DESCRIPTION
Closes #411.

## What changed

### YOUR TURN track maps
- adds a canonical-geometry track map to the invitation and THE CHALLENGE view
- derives every map from TURN's `getTrackPreviewPoints()` / track catalog rather than maintaining YOUR TURN-specific geometry
- uses the challenged track's own accent and start marker
- keeps the visual map decorative to screen readers because the track identity is already present as text and the live race has its existing non-visual guidance

### YOUR TURN controls
At the starting line, the live control DOM/visual order is now:

1. THE CHALLENGE
2. Blank Screen
3. RECALIBRATE
4. SETTINGS
5. SPECTATE

- SETTINGS contains steering, audio, Drive By Ear, sound balance and Color Cues, but deliberately has no Reset Rivals
- SPECTATE uses the existing challenge replay scene so a first-time recipient can watch the lead run and learn the track before starting
- direct RESTART LAP stays hidden in YOUR TURN; restart remains in THE CHALLENGE modal
- during an active lap, YOUR TURN keeps THE CHALLENGE + RECALIBRATE only
- THE CHALLENGE remains orange for a valid lap and turns red when LAP VOID is true; the existing visible/spoken LAP VOID state remains primary

### TURN controls
- no start-line control inventory/layout change
- during an active race, TURN now exposes RESTART LAP followed by RECALIBRATE
- RESTART LAP is orange normally and red for LAP VOID
- returning to the start line restores RECALIBRATE after Blank Screen without rearranging Settings/Achievements/Spectate

## Mockup boundary
The supplied mockups were treated only as button availability/order references. This PR intentionally does not copy incidental vertical alignment, gaps, HUD movement, or other geometry.

## Validation
- adds `turn-tests/yourturn-r411-production.mjs`
- extends TURN challenge CI to syntax-check the new modules and run the r411 contract
- existing YOUR TURN/challenge regressions remain in the workflow

## Device follow-up
After CI, this needs the planned physical test on iPad 9 and current iPhone. The iPad steering/motion defect remains separately tracked in #410 and is not modified here.