### PR TITLE
Fix YOUR TURN portrait-to-landscape viewport on iOS Safari

### DIFF
--- a/.github/workflows/turn-challenge-tests.yml
+++ b/.github/workflows/turn-challenge-tests.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Run YOUR TURN r411 controls and maps regression
         run: node turn-tests/yourturn-r411-production.mjs
 
+      - name: Run YOUR TURN portrait-to-landscape viewport regression
+        run: node turn-tests/yourturn-viewport-transition-production.mjs
+
       - name: Run YOUR TURN About modal regression
         run: node turn-tests/yourturn-about-modal-production.mjs
 

--- a/turn-tests/yourturn-viewport-transition-production.mjs
+++ b/turn-tests/yourturn-viewport-transition-production.mjs
@@ -1,0 +1,48 @@
+import fs from 'node:fs';
+import assert from 'node:assert/strict';
+
+const viewport = fs.readFileSync('yourturn/viewport-transition-r414.js', 'utf8');
+const mapRuntime = fs.readFileSync('yourturn/track-map-r411.js', 'utf8');
+
+assert.match(
+  mapRuntime,
+  /import '\/yourturn\/viewport-transition-r414\.js\?revision=r414';/,
+  'YOUR TURN must install the viewport boundary from an already-loaded challenge module'
+);
+
+assert.match(
+  viewport,
+  /const visual = windowRef\?\.visualViewport;[\s\S]*if \(visualWidth && visualHeight\)/,
+  'the reachable viewport must prefer VisualViewport when both axes are available'
+);
+assert.match(viewport, /source: 'visualViewport'/);
+assert.match(viewport, /source: 'innerViewport'/);
+assert.match(viewport, /source: 'clientViewport'/);
+
+assert.match(
+  viewport,
+  /renderer\.setSize = \(requestedWidth, requestedHeight, updateStyle\) => \{[\s\S]*nativeSetSize\(size\.width, size\.height, updateStyle\)/,
+  'canonical renderer resizes must be clamped to the reachable YOUR TURN viewport'
+);
+assert.match(
+  viewport,
+  /runtime\.camera\.aspect = size\.width \/ size\.height;[\s\S]*runtime\.camera\.updateProjectionMatrix/,
+  'camera aspect must be repaired together with renderer size'
+);
+assert.match(viewport, /--app-width/);
+assert.match(viewport, /--app-height/);
+
+for (const delay of ['0', '120', '350', '900', '1500']) {
+  assert.match(viewport, new RegExp(`\\b${delay}\\b`), `post-rotation viewport resampling must retain the ${delay}ms checkpoint`);
+}
+assert.match(viewport, /orientationchange/);
+assert.match(viewport, /visual-resize/);
+assert.match(viewport, /pageshow/);
+
+assert.doesNotMatch(
+  viewport,
+  /screen\.(?:width|height|availWidth|availHeight)/,
+  'YOUR TURN must not size from the physical screen instead of the reachable browser viewport'
+);
+
+console.log('YOUR TURN portrait-to-landscape viewport regression passed.');

--- a/yourturn/track-map-r411.js
+++ b/yourturn/track-map-r411.js
@@ -1,3 +1,4 @@
+import '/yourturn/viewport-transition-r414.js?revision=r414';
 import { getTrackDefinition, getTrackPreviewPoints } from '/turn/tracks/catalog.js?source=20260729-r118-m8';
 
 const MAP_VIEWS = new Set(['invitation', 'paused']);

--- a/yourturn/viewport-transition-r414.js
+++ b/yourturn/viewport-transition-r414.js
@@ -1,0 +1,123 @@
+const SETTLE_DELAYS_MS = Object.freeze([0, 120, 350, 900, 1500]);
+
+function finitePositive(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : 0;
+}
+
+export function readReachableViewport(windowRef = globalThis.window, documentRef = globalThis.document) {
+  const visual = windowRef?.visualViewport;
+  const visualWidth = finitePositive(visual?.width);
+  const visualHeight = finitePositive(visual?.height);
+
+  // YOUR TURN deliberately crosses portrait -> landscape after ACCEPT. On older
+  // iPad Safari the layout viewport/client dimensions can lag behind that rotation.
+  // visualViewport is the browser's actually reachable rectangle, including its
+  // current toolbar allocation, so prefer it whenever both axes are available.
+  if (visualWidth && visualHeight) {
+    return Object.freeze({
+      width: Math.max(1, Math.round(visualWidth)),
+      height: Math.max(1, Math.round(visualHeight)),
+      source: 'visualViewport'
+    });
+  }
+
+  const innerWidth = finitePositive(windowRef?.innerWidth);
+  const innerHeight = finitePositive(windowRef?.innerHeight);
+  if (innerWidth && innerHeight) {
+    return Object.freeze({
+      width: Math.max(1, Math.round(innerWidth)),
+      height: Math.max(1, Math.round(innerHeight)),
+      source: 'innerViewport'
+    });
+  }
+
+  const root = documentRef?.documentElement;
+  return Object.freeze({
+    width: Math.max(1, Math.round(finitePositive(root?.clientWidth) || 1)),
+    height: Math.max(1, Math.round(finitePositive(root?.clientHeight) || 1)),
+    source: 'clientViewport'
+  });
+}
+
+function publishDiagnostics(size, reason, requested = null) {
+  globalThis.__yourTurnViewportDiagnostics = Object.freeze({
+    reason,
+    source: size.source,
+    width: size.width,
+    height: size.height,
+    requestedWidth: finitePositive(requested?.width) || null,
+    requestedHeight: finitePositive(requested?.height) || null,
+    visualWidth: finitePositive(globalThis.visualViewport?.width) || null,
+    visualHeight: finitePositive(globalThis.visualViewport?.height) || null,
+    innerWidth: finitePositive(globalThis.innerWidth) || null,
+    innerHeight: finitePositive(globalThis.innerHeight) || null,
+    clientWidth: finitePositive(globalThis.document?.documentElement?.clientWidth) || null,
+    clientHeight: finitePositive(globalThis.document?.documentElement?.clientHeight) || null
+  });
+}
+
+function applyReachableViewport(runtime, reason = 'apply') {
+  if (!runtime?.renderer || !runtime?.camera) return false;
+  const size = readReachableViewport();
+  const root = globalThis.document?.documentElement;
+  root?.style?.setProperty('--app-width', `${size.width}px`);
+  root?.style?.setProperty('--app-height', `${size.height}px`);
+  runtime.camera.aspect = size.width / size.height;
+  runtime.camera.updateProjectionMatrix?.();
+  runtime.renderer.setSize(size.width, size.height);
+  publishDiagnostics(size, reason);
+  return true;
+}
+
+function scheduleSettledApplies(runtime, reason) {
+  for (const delay of SETTLE_DELAYS_MS) {
+    globalThis.setTimeout?.(() => applyReachableViewport(runtime, `${reason}+${delay}`), delay);
+  }
+}
+
+export function installYourTurnViewportBoundary(runtime = globalThis.__turnRuntime) {
+  if (!runtime?.renderer || !runtime?.camera) return false;
+  if (runtime.__yourTurnViewportBoundaryInstalled) return true;
+  runtime.__yourTurnViewportBoundaryInstalled = true;
+
+  const renderer = runtime.renderer;
+  const nativeSetSize = renderer.setSize.bind(renderer);
+
+  // The canonical TURN resize path can ask for stale portrait client dimensions
+  // during the iPad Safari rotation. Clamp every renderer resize to the current
+  // reachable viewport and repair the CSS app boundary/camera aspect at the same
+  // seam. Production TURN never loads this module.
+  renderer.setSize = (requestedWidth, requestedHeight, updateStyle) => {
+    const size = readReachableViewport();
+    const root = globalThis.document?.documentElement;
+    root?.style?.setProperty('--app-width', `${size.width}px`);
+    root?.style?.setProperty('--app-height', `${size.height}px`);
+    runtime.camera.aspect = size.width / size.height;
+    runtime.camera.updateProjectionMatrix?.();
+    publishDiagnostics(size, 'renderer-setSize', {
+      width: requestedWidth,
+      height: requestedHeight
+    });
+    return nativeSetSize(size.width, size.height, updateStyle);
+  };
+
+  const resample = (reason) => scheduleSettledApplies(runtime, reason);
+  globalThis.addEventListener?.('resize', () => resample('window-resize'), { passive: true });
+  globalThis.addEventListener?.('orientationchange', () => resample('orientationchange'), { passive: true });
+  globalThis.addEventListener?.('pageshow', () => resample('pageshow'), { passive: true });
+  globalThis.visualViewport?.addEventListener?.('resize', () => resample('visual-resize'), { passive: true });
+  globalThis.visualViewport?.addEventListener?.('scroll', () => resample('visual-scroll'), { passive: true });
+
+  scheduleSettledApplies(runtime, 'install');
+  return true;
+}
+
+function bootstrap() {
+  if (installYourTurnViewportBoundary()) return;
+  globalThis.addEventListener?.('turn:runtime-ready', (event) => {
+    installYourTurnViewportBoundary(event.detail || globalThis.__turnRuntime);
+  }, { once: true });
+}
+
+bootstrap();


### PR DESCRIPTION
## Device report
On iOS Safari, YOUR TURN opens correctly in portrait. After **ACCEPT CHALLENGE → rotate to landscape**, the visible result can become an almost entirely cyan page with the race/challenge UI missing. This report was reproduced on the user's phone, not the iPad 9. Normal TURN is not showing the same landscape failure on the same device/browser path.

## Diagnosis
YOUR TURN uniquely and deliberately crosses portrait → landscape after the challenge has already loaded. TURN's canonical renderer resize path chooses the largest value across `visualViewport`, `inner*` and `documentElement.client*`. During iOS Safari rotation, layout/client dimensions can temporarily lag behind the visible viewport, allowing a stale portrait dimension to win during the landscape handoff.

That stale request can corrupt the renderer size/camera aspect during exactly the transition YOUR TURN depends on.

## Fix
YOUR TURN only:
- add a small reachable-viewport boundary that prefers `visualViewport` when both axes are available;
- clamp later renderer `setSize()` requests to that reachable rectangle;
- repair the camera aspect and `--app-width` / `--app-height` at the same seam;
- resample immediately and at 120/350/900/1500 ms after resize, orientation, VisualViewport changes and pageshow so Safari can settle asynchronously;
- expose `__yourTurnViewportDiagnostics` with requested/reachable/visual/inner/client dimensions for real-device follow-up;
- never size from physical `screen.width` / `screen.height`;
- production `/turn` is untouched.

The boundary is imported by the already-loaded YOUR TURN challenge-map runtime, so no new production TURN bootstrap dependency is introduced.

## Validation
- adds a focused `yourturn-viewport-transition-production.mjs` regression;
- challenge CI syntax-checks the new module and runs the new contract;
- existing YOUR TURN and #411 regressions remain in the same workflow.

## Device gate
First re-test the exact phone flow that produced the screenshot: open challenge in portrait → ACCEPT → rotate to landscape. If that handoff is healthy, the separate planned iPad 9 TURN-vs-YOUR-TURN steering comparison can proceed for #410.