### PR TITLE
Hotfix YOUR TURN iOS landscape start handoff

### DIFF
--- a/.github/workflows/turn-challenge-tests.yml
+++ b/.github/workflows/turn-challenge-tests.yml
@@ -76,8 +76,8 @@ jobs:
       - name: Run YOUR TURN r411 controls and maps regression
         run: node turn-tests/yourturn-r411-production.mjs
 
-      - name: Run YOUR TURN portrait-to-landscape viewport regression
-        run: node turn-tests/yourturn-viewport-transition-production.mjs
+      - name: Run YOUR TURN start handoff regression
+        run: node turn-tests/yourturn-start-handoff-production.mjs
 
       - name: Run YOUR TURN About modal regression
         run: node turn-tests/yourturn-about-modal-production.mjs

--- a/turn-tests/yourturn-start-handoff-production.mjs
+++ b/turn-tests/yourturn-start-handoff-production.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const handoff = fs.readFileSync('yourturn/start-handoff-r416.js', 'utf8');
+const trackMap = fs.readFileSync('yourturn/track-map-r411.js', 'utf8');
+
+assert.match(trackMap, /start-handoff-r416\.js\?revision=r416/,
+  'YOUR TURN must install the start handoff guard before a challenge can be accepted.');
+assert.doesNotMatch(trackMap, /viewport-transition-r414/,
+  'The failed viewport-only workaround must not remain on the live YOUR TURN path.');
+
+assert.match(handoff, /OPTIONAL_PLATFORM_WAIT_MS\s*=\s*900/,
+  'Optional fullscreen/orientation APIs need a bounded wait.');
+assert.match(handoff, /Promise\.race\(/,
+  'Optional platform promises must not be allowed to stall the race indefinitely.');
+assert.match(handoff, /requestFullscreen/,
+  'Fullscreen requests must be bounded on the YOUR TURN path.');
+assert.match(handoff, /screen\?\.orientation[\s\S]*'lock'/,
+  'Orientation lock must also be bounded on the YOUR TURN path.');
+
+assert.match(handoff, /hud\?\.hidden === false/,
+  'The handoff must confirm the HUD is visible before dismissing the preparing screen.');
+assert.match(handoff, /controls\?\.hidden === false/,
+  'The handoff must confirm race controls are visible before dismissing the preparing screen.');
+assert.match(handoff, /turn-lot-open/,
+  'The handoff must not finish while the hard runtime pause remains active.');
+assert.match(handoff, /yourturn-runtime-paused/,
+  'The handoff must not finish while YOUR TURN runtime pause remains active.');
+assert.match(handoff, /PREPARING YOUR RACE/,
+  'The rotate surface should become an explicit preparing state rather than exposing cyan canvas.');
+assert.match(handoff, /RACE DID NOT START/,
+  'A visible recovery state is required if the handoff still fails.');
+assert.match(handoff, /TRY AGAIN/,
+  'The recovery state must offer a direct retry.');
+assert.match(handoff, /__yourTurnStartHandoffDiagnostics/,
+  'Real-device handoff diagnostics must remain available for follow-up.');
+
+console.log('YOUR TURN start handoff production contract passed.');

--- a/yourturn/start-handoff-r416.js
+++ b/yourturn/start-handoff-r416.js
@@ -1,0 +1,207 @@
+const OPTIONAL_PLATFORM_WAIT_MS = 900;
+const HANDOFF_FAILURE_MS = 5000;
+
+const diagnostics = {
+  installed: false,
+  stage: 'boot',
+  fullscreenTimeouts: 0,
+  orientationTimeouts: 0,
+  handoffStartedAt: 0,
+  handoffReadyAt: 0,
+  recoveryShown: false
+};
+globalThis.__yourTurnStartHandoffDiagnostics = diagnostics;
+
+function boundedOptionalPromise(value, timeoutMs, onTimeout) {
+  let timer = 0;
+  return Promise.race([
+    Promise.resolve(value).then(() => true).catch(() => false),
+    new Promise((resolve) => {
+      timer = globalThis.setTimeout?.(() => {
+        onTimeout?.();
+        resolve(false);
+      }, timeoutMs);
+    })
+  ]).finally(() => globalThis.clearTimeout?.(timer));
+}
+
+export function settleOptionalFullscreen(value, timeoutMs = OPTIONAL_PLATFORM_WAIT_MS) {
+  return boundedOptionalPromise(value, timeoutMs, () => {
+    diagnostics.fullscreenTimeouts += 1;
+    diagnostics.stage = 'fullscreen-timeout';
+  });
+}
+
+export function settleOptionalOrientationLock(value, timeoutMs = OPTIONAL_PLATFORM_WAIT_MS) {
+  return boundedOptionalPromise(value, timeoutMs, () => {
+    diagnostics.orientationTimeouts += 1;
+    diagnostics.stage = 'orientation-lock-timeout';
+  });
+}
+
+function installBoundedMethod(target, property, settle) {
+  const native = target?.[property];
+  if (typeof native !== 'function' || native.__yourTurnBoundedOptional === true) return false;
+
+  const wrapped = function (...args) {
+    let result;
+    try {
+      result = native.apply(this, args);
+    } catch (_) {
+      return Promise.resolve(false);
+    }
+    return settle(result);
+  };
+  Object.defineProperty(wrapped, '__yourTurnBoundedOptional', { value: true });
+
+  try {
+    Object.defineProperty(target, property, {
+      configurable: true,
+      writable: true,
+      value: wrapped
+    });
+    return true;
+  } catch (_) {
+    try {
+      target[property] = wrapped;
+      return target[property] === wrapped;
+    } catch (_) {
+      return false;
+    }
+  }
+}
+
+function installOptionalPlatformBounds() {
+  const root = document.documentElement;
+  installBoundedMethod(root, 'requestFullscreen', settleOptionalFullscreen);
+  installBoundedMethod(root, 'webkitRequestFullscreen', settleOptionalFullscreen);
+  installBoundedMethod(globalThis.screen?.orientation, 'lock', settleOptionalOrientationLock);
+}
+
+function raceUiReady(hud, controls) {
+  return hud?.hidden === false
+    && controls?.hidden === false
+    && !document.body.classList.contains('turn-lot-open')
+    && !document.body.classList.contains('yourturn-runtime-paused');
+}
+
+function installVisibleHandoffGuard() {
+  const rotate = document.querySelector('#yourTurnRotate');
+  const hud = document.querySelector('#hud');
+  const controls = document.querySelector('#controls');
+  const title = rotate?.querySelector('#yourTurnRotateTitle, strong');
+  const copy = rotate?.querySelector('p');
+  if (!rotate || !hud || !controls || !title || !copy) return false;
+
+  const originalTitle = title.textContent;
+  const originalCopy = copy.textContent;
+  let guarding = false;
+  let failureTimer = 0;
+  let recovery = null;
+
+  function clearFailureTimer() {
+    globalThis.clearTimeout?.(failureTimer);
+    failureTimer = 0;
+  }
+
+  function removeRecovery() {
+    recovery?.remove();
+    recovery = null;
+    diagnostics.recoveryShown = false;
+  }
+
+  function showPreparing() {
+    title.textContent = 'PREPARING YOUR RACE';
+    copy.textContent = 'One moment…';
+    removeRecovery();
+  }
+
+  function showRecovery() {
+    if (!guarding || raceUiReady(hud, controls)) return;
+    diagnostics.stage = 'handoff-timeout';
+    diagnostics.recoveryShown = true;
+    title.textContent = 'RACE DID NOT START';
+    copy.textContent = 'YOUR TURN is still open. Try the challenge again rather than being left on a blank screen.';
+    if (recovery) return;
+
+    recovery = document.createElement('div');
+    recovery.className = 'yourturn-actions yourturn-handoff-recovery';
+    const retry = document.createElement('button');
+    retry.type = 'button';
+    retry.className = 'is-primary';
+    retry.textContent = 'TRY AGAIN';
+    retry.addEventListener('click', () => globalThis.location?.reload?.());
+    const openTurn = document.createElement('button');
+    openTurn.type = 'button';
+    openTurn.className = 'is-navigation';
+    openTurn.textContent = 'OPEN TURN';
+    openTurn.addEventListener('click', () => { globalThis.location.href = '/turn/'; });
+    recovery.append(retry, openTurn);
+    rotate.querySelector('.yourturn-rotate-card')?.appendChild(recovery);
+  }
+
+  function beginGuard() {
+    if (guarding) return;
+    guarding = true;
+    diagnostics.stage = 'preparing-race';
+    diagnostics.handoffStartedAt = performance.now();
+    rotate.hidden = false;
+    document.body.classList.add('yourturn-awaiting-landscape');
+    showPreparing();
+    clearFailureTimer();
+    failureTimer = globalThis.setTimeout?.(showRecovery, HANDOFF_FAILURE_MS) || 0;
+  }
+
+  function finishGuard() {
+    if (!guarding) return;
+    guarding = false;
+    clearFailureTimer();
+    removeRecovery();
+    diagnostics.stage = 'race-ready';
+    diagnostics.handoffReadyAt = performance.now();
+    title.textContent = originalTitle;
+    copy.textContent = originalCopy;
+    rotate.hidden = true;
+    document.body.classList.remove('yourturn-awaiting-landscape');
+  }
+
+  function sync() {
+    const handoffAttempted = document.body.classList.contains('yourturn-racing');
+    if (!handoffAttempted) return;
+
+    if (raceUiReady(hud, controls)) {
+      finishGuard();
+      return;
+    }
+
+    // session.js currently hides the rotate prompt before the asynchronous race
+    // start has completed. Re-show it immediately so iOS can never expose the
+    // cyan canvas as an apparent terminal state while optional platform APIs settle.
+    if (rotate.hidden || guarding) beginGuard();
+  }
+
+  const observer = typeof MutationObserver === 'function'
+    ? new MutationObserver(sync)
+    : null;
+  observer?.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+  observer?.observe(rotate, { attributes: true, attributeFilter: ['hidden'] });
+  observer?.observe(hud, { attributes: true, attributeFilter: ['hidden'] });
+  observer?.observe(controls, { attributes: true, attributeFilter: ['hidden'] });
+  window.addEventListener('turn:ui-state-change', sync);
+  sync();
+  return true;
+}
+
+function install() {
+  if (diagnostics.installed) return;
+  diagnostics.installed = true;
+  diagnostics.stage = 'installed';
+  installOptionalPlatformBounds();
+  installVisibleHandoffGuard();
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', install, { once: true });
+} else {
+  install();
+}

--- a/yourturn/track-map-r411.js
+++ b/yourturn/track-map-r411.js
@@ -1,4 +1,4 @@
-import '/yourturn/viewport-transition-r414.js?revision=r414';
+import '/yourturn/start-handoff-r416.js?revision=r416';
 import { getTrackDefinition, getTrackPreviewPoints } from '/turn/tracks/catalog.js?source=20260729-r118-m8';
 
 const MAP_VIEWS = new Set(['invitation', 'paused']);


### PR DESCRIPTION
## Real-device failure
The first #415 phone retest still produced the cyan screen after:

**open challenge in portrait → ACCEPT → rotate to landscape**

That falsifies the viewport-only diagnosis in #415.

## Revised diagnosis
YOUR TURN hides the rotate surface before its asynchronous race-start handoff has completed. At the same time the runtime is deliberately hard-paused. Optional iOS platform calls (fullscreen and orientation lock) are awaited by the shared race session; if either settles very late or not at all, YOUR TURN can expose the bare cyan canvas while the usable race state remains blocked.

## Fix
YOUR TURN only:
- remove the #415 viewport workaround from the live challenge path;
- bound optional fullscreen and screen-orientation-lock promises to 900 ms each;
- keep the rotate surface visible as **PREPARING YOUR RACE** during the async handoff;
- only dismiss it after HUD + controls are visible and the hard runtime pause has actually cleared;
- after 5 s, show a visible **RACE DID NOT START** recovery with TRY AGAIN / OPEN TURN instead of ever leaving a cyan terminal-looking state;
- expose `__yourTurnStartHandoffDiagnostics` with handoff stage and platform timeout counts for the next real-device test;
- production `/turn` remains untouched.

## Validation
- adds `turn-tests/yourturn-start-handoff-production.mjs`;
- challenge CI now gates the start-handoff contract instead of the falsified viewport-only contract;
- existing YOUR TURN, #411, sharing, About, privacy and TURN NEXT parity regressions remain in the workflow.

## Release order
This hotfix stays ahead of #410 and #414. After CI, merge and repeat the exact phone flow. Do not proceed to the iPad 9 steering A/B until the phone can enter landscape YOUR TURN reliably.