### PR TITLE
TURN: add Q = Drift and E = Boost keyboard controls

### DIFF
--- a/turn-tests/covered-rendering-production.mjs
+++ b/turn-tests/covered-rendering-production.mjs
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
+// This test is already part of the production regression workflow; keep the small
+// keyboard input contract in that same run without adding another CI workflow edge.
+await import('./qe-drive-controls-production.mjs');
+
 const [releaseSource, index, app, guard, selector, main] = await Promise.all([
   fs.readFile(new URL('../turn/release.json', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),

--- a/turn-tests/qe-drive-controls-production.mjs
+++ b/turn-tests/qe-drive-controls-production.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import {
+  QE_DRIVE_BINDINGS,
+  createQeHoldController,
+  qeDriveZoneForEvent
+} from '../turn/input/qe-drive-controls.js';
+
+assert.deepEqual(QE_DRIVE_BINDINGS, { KeyQ: 'drift', KeyE: 'boost' });
+assert.equal(qeDriveZoneForEvent({ code: 'KeyQ', key: 'q' }), 'drift');
+assert.equal(qeDriveZoneForEvent({ code: 'KeyE', key: 'e' }), 'boost');
+assert.equal(qeDriveZoneForEvent({ key: 'Q' }), 'drift');
+assert.equal(qeDriveZoneForEvent({ key: 'E' }), 'boost');
+assert.equal(qeDriveZoneForEvent({ code: 'ShiftLeft', key: 'Shift' }), null,
+  'Q/E are the only new shortcuts; old Shift/Control aliases must not return');
+
+const transitions = [];
+const held = createQeHoldController((zone) => transitions.push(zone));
+assert.equal(held.press('KeyQ', 'drift'), true);
+assert.equal(held.getActiveZone(), 'drift');
+assert.equal(held.press('KeyQ', 'drift'), false, 'Repeated keydown must not toggle Drift');
+assert.deepEqual(transitions, ['drift']);
+
+assert.equal(held.press('KeyE', 'boost'), true);
+assert.equal(held.getActiveZone(), 'boost', 'Most recently pressed Q/E action should own the shared drive zone');
+assert.equal(held.release('KeyE'), true);
+assert.equal(held.getActiveZone(), 'drift', 'Releasing E while Q remains held must return to Drift');
+assert.equal(held.release('KeyQ'), true);
+assert.equal(held.getActiveZone(), null, 'Releasing the final shortcut must release the drive pad');
+assert.deepEqual(transitions, ['drift', 'boost', 'drift', null]);
+
+const [source, bootstrap, index] = await Promise.all([
+  fs.readFile(new URL('../turn/input/qe-drive-controls.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/input/qe-drive-controls-bootstrap.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8')
+]);
+
+assert.match(source, /\.drive-drift-zone/);
+assert.match(source, /\.drive-boost-zone/);
+assert.match(source, /dispatchKeyboardPointer\('pointerdown', nextZone\)/,
+  'Keyboard press must enter the same unified drive-pad pointer path as touch');
+assert.match(source, /dispatchKeyboardPointer\('pointermove', nextZone\)/,
+  'Switching Q/E while held must move within the same unified drive surface');
+assert.match(source, /dispatchKeyboardPointer\('pointerup', activePointerZone\)/,
+  'Keyboard release must leave the canonical drive surface');
+assert.match(source, /reason === 'race-reset'/);
+assert.match(source, /visibilitychange/);
+assert.match(source, /windowRef\.addEventListener\('blur', releaseAll\)/);
+assert.match(source, /interactiveTarget\(event\.target\)/,
+  'Driving shortcuts must not steal ordinary control input');
+assert.match(bootstrap, /attempt < 300/,
+  'The Q/E loader must wait for gameplay-controls to construct the unified drive pad');
+assert.match(index, /qe-drive-controls-bootstrap\.js\?revision=r418-qe/,
+  'Production TURN must load a cache-busted Q/E keyboard entry point');
+
+console.log('TURN Q = Drift / E = Boost unified keyboard control regression passed.');

--- a/turn/index.html
+++ b/turn/index.html
@@ -157,6 +157,7 @@
   <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260809-r163-r168-shared-about-credits"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
   <script type="module" src="./app.js?build=20260809-r163-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click"></script>
+  <script type="module" src="./input/qe-drive-controls-bootstrap.js?revision=r418-qe"></script>
   <script type="module" src="./ui/r411-race-controls.js?revision=r411"></script>
   <script type="module" src="./accessibility/color-accessibility-r163.js?build=20260809-r163-paint-basics"></script>
   <script type="module" src="./achievements/chromatic-camouflage-r183.js?revision=r183-production"></script>

--- a/turn/input/qe-drive-controls-bootstrap.js
+++ b/turn/input/qe-drive-controls-bootstrap.js
@@ -1,0 +1,13 @@
+import { installQeDriveControls } from './qe-drive-controls.js?revision=r418-qe';
+
+function bootstrap(attempt = 0) {
+  const result = installQeDriveControls();
+  if (result.installed) return;
+  if (attempt < 300) requestAnimationFrame(() => bootstrap(attempt + 1));
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => bootstrap(), { once: true });
+} else {
+  bootstrap();
+}

--- a/turn/input/qe-drive-controls.js
+++ b/turn/input/qe-drive-controls.js
@@ -1,0 +1,244 @@
+const KEYBOARD_POINTER_ID = 2147483002;
+
+export const QE_DRIVE_BINDINGS = Object.freeze({
+  KeyQ: 'drift',
+  KeyE: 'boost'
+});
+
+export function qeDriveZoneForEvent(event = {}) {
+  const byCode = QE_DRIVE_BINDINGS[String(event.code || '')];
+  if (byCode) return byCode;
+  const key = String(event.key || '').toLowerCase();
+  if (key === 'q') return 'drift';
+  if (key === 'e') return 'boost';
+  return null;
+}
+
+export function createQeHoldController(onZoneChange) {
+  if (typeof onZoneChange !== 'function') throw new TypeError('Q/E drive controller requires onZoneChange().');
+  const held = new Map();
+  let activeZone = null;
+
+  function sync() {
+    const values = [...held.values()];
+    const nextZone = values.length ? values.at(-1) : null;
+    if (nextZone === activeZone) return;
+    activeZone = nextZone;
+    onZoneChange(nextZone);
+  }
+
+  return Object.freeze({
+    press(identifier, zone) {
+      if (!identifier || !zone || held.has(identifier)) return false;
+      held.set(identifier, zone);
+      sync();
+      return true;
+    },
+    release(identifier) {
+      if (!held.has(identifier)) return false;
+      held.delete(identifier);
+      sync();
+      return true;
+    },
+    clear() {
+      if (!held.size && activeZone === null) return;
+      held.clear();
+      sync();
+    },
+    getActiveZone: () => activeZone,
+    getHeldCount: () => held.size
+  });
+}
+
+export function installQeDriveControls({ environment = globalThis } = {}) {
+  if (environment.__turnQeDriveControls?.installed) return environment.__turnQeDriveControls;
+
+  const windowRef = environment.window || environment;
+  const documentRef = environment.document || windowRef?.document;
+  const controls = documentRef?.querySelector?.('#controls');
+  const drivePad = documentRef?.querySelector?.('.drive-pad');
+  const zones = Object.freeze({
+    drift: documentRef?.querySelector?.('.drive-drift-zone'),
+    boost: documentRef?.querySelector?.('.drive-boost-zone')
+  });
+
+  if (!documentRef?.body || !controls || !drivePad || !zones.drift || !zones.boost || typeof windowRef?.addEventListener !== 'function') {
+    const unavailable = Object.freeze({ installed: false, release() {} });
+    environment.__turnQeDriveControls = unavailable;
+    return unavailable;
+  }
+
+  let keyboardPointerActive = false;
+  let activePointerZone = null;
+  let released = false;
+
+  function runtimeState() {
+    return environment.__turnRuntime?.state || null;
+  }
+
+  function hasBlockingOverlay() {
+    if (documentRef.body.classList.contains('turn-home-open')) return true;
+    if (documentRef.body.classList.contains('turn-lot-open')) return true;
+    if (documentRef.body.classList.contains('turn-spectating')) return true;
+    if (documentRef.querySelector?.('dialog[open]')) return true;
+    return Boolean(documentRef.querySelector?.('[role="dialog"]:not([hidden])'));
+  }
+
+  function interactiveTarget(target) {
+    const ElementConstructor = environment.Element;
+    if (typeof ElementConstructor !== 'function' || !(target instanceof ElementConstructor)) return false;
+    if (target.closest?.('.drive-pad')) return false;
+    return Boolean(target.closest?.(
+      'a, button, input, select, textarea, summary, [contenteditable="true"], [role="button"], [role="radio"], [role="slider"]'
+    ));
+  }
+
+  function acceptsDrivingInput(event = {}) {
+    const state = runtimeState();
+    if (!state?.running || documentRef.hidden || controls.hidden || hasBlockingOverlay()) return false;
+    return !interactiveTarget(event.target);
+  }
+
+  function createKeyboardPointerEvent(type, target) {
+    const rect = target.getBoundingClientRect();
+    const init = {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      pointerId: KEYBOARD_POINTER_ID,
+      pointerType: 'keyboard',
+      isPrimary: true,
+      button: 0,
+      buttons: type === 'pointerup' || type === 'pointercancel' ? 0 : 1,
+      clientX: rect.left + rect.width / 2,
+      clientY: rect.top + rect.height / 2
+    };
+
+    if (typeof environment.PointerEvent === 'function') return new environment.PointerEvent(type, init);
+
+    const event = new environment.Event(type, init);
+    for (const [property, value] of Object.entries(init)) {
+      try {
+        Object.defineProperty(event, property, { configurable: true, value });
+      } catch (_) {}
+    }
+    return event;
+  }
+
+  function dispatchKeyboardPointer(type, zoneName) {
+    const target = zones[zoneName] || drivePad;
+    const hadOwnSet = Object.prototype.hasOwnProperty.call(drivePad, 'setPointerCapture');
+    const hadOwnRelease = Object.prototype.hasOwnProperty.call(drivePad, 'releasePointerCapture');
+    const originalSet = drivePad.setPointerCapture;
+    const originalRelease = drivePad.releasePointerCapture;
+
+    try {
+      drivePad.setPointerCapture = function setPointerCapture(pointerId) {
+        if (pointerId === KEYBOARD_POINTER_ID) return;
+        return originalSet?.call(this, pointerId);
+      };
+      drivePad.releasePointerCapture = function releasePointerCapture(pointerId) {
+        if (pointerId === KEYBOARD_POINTER_ID) return;
+        return originalRelease?.call(this, pointerId);
+      };
+      target.dispatchEvent(createKeyboardPointerEvent(type, target));
+      return true;
+    } catch (error) {
+      console.warn('TURN: Q/E keyboard input could not enter the unified drive pad.', error);
+      return false;
+    } finally {
+      if (hadOwnSet) drivePad.setPointerCapture = originalSet;
+      else delete drivePad.setPointerCapture;
+      if (hadOwnRelease) drivePad.releasePointerCapture = originalRelease;
+      else delete drivePad.releasePointerCapture;
+    }
+  }
+
+  function syncPointerZone(nextZone) {
+    if (nextZone === activePointerZone) return;
+
+    if (!keyboardPointerActive && nextZone) {
+      if (!dispatchKeyboardPointer('pointerdown', nextZone)) return;
+      keyboardPointerActive = true;
+    } else if (keyboardPointerActive && nextZone) {
+      if (!dispatchKeyboardPointer('pointermove', nextZone)) return;
+    } else if (keyboardPointerActive) {
+      dispatchKeyboardPointer('pointerup', activePointerZone);
+      keyboardPointerActive = false;
+    }
+
+    activePointerZone = nextZone;
+  }
+
+  const held = createQeHoldController(syncPointerZone);
+
+  function identifier(event) {
+    return String(event.code || event.key || '');
+  }
+
+  function consume(event) {
+    event.preventDefault?.();
+    event.stopPropagation?.();
+  }
+
+  function onKeyDown(event) {
+    const zone = qeDriveZoneForEvent(event);
+    if (!zone || !acceptsDrivingInput(event)) return;
+    consume(event);
+    held.press(identifier(event), zone);
+  }
+
+  function onKeyUp(event) {
+    const zone = qeDriveZoneForEvent(event);
+    if (!zone) return;
+    const key = identifier(event);
+    if (held.release(key)) consume(event);
+  }
+
+  function releaseAll() {
+    held.clear();
+  }
+
+  function onUiStateChange(event) {
+    const reason = event.detail?.reason;
+    if (!event.detail?.running || reason === 'race-reset' || reason === 'home-open' || reason === 'lot-open' || reason === 'spectate-started') {
+      releaseAll();
+    }
+  }
+
+  function onVisibilityChange() {
+    if (documentRef.hidden) releaseAll();
+  }
+
+  function onFocusIn(event) {
+    if (interactiveTarget(event.target)) releaseAll();
+  }
+
+  windowRef.addEventListener('keydown', onKeyDown, { capture: true });
+  windowRef.addEventListener('keyup', onKeyUp, { capture: true });
+  windowRef.addEventListener('blur', releaseAll);
+  windowRef.addEventListener('turn:ui-state-change', onUiStateChange);
+  documentRef.addEventListener('visibilitychange', onVisibilityChange);
+  documentRef.addEventListener('focusin', onFocusIn);
+
+  const api = Object.freeze({
+    installed: true,
+    bindings: QE_DRIVE_BINDINGS,
+    release() {
+      if (released) return;
+      released = true;
+      releaseAll();
+      windowRef.removeEventListener('keydown', onKeyDown, { capture: true });
+      windowRef.removeEventListener('keyup', onKeyUp, { capture: true });
+      windowRef.removeEventListener('blur', releaseAll);
+      windowRef.removeEventListener('turn:ui-state-change', onUiStateChange);
+      documentRef.removeEventListener('visibilitychange', onVisibilityChange);
+      documentRef.removeEventListener('focusin', onFocusIn);
+      if (environment.__turnQeDriveControls === api) delete environment.__turnQeDriveControls;
+    }
+  });
+
+  environment.__turnQeDriveControls = api;
+  documentRef.documentElement.dataset.turnQeDriveControls = 'q-drift-e-boost';
+  return api;
+}


### PR DESCRIPTION
Closes #409.

## Scope
Adds only the two requested desktop keyboard actions:
- **Q = DRIFT**
- **E = BOOST**

No desktop support gate, no TURN NEXT changes, no Shift/Control aliases, and no changes to the established Arrow/WASD/Space/R handling.

## Input behavior
- Q/E are press-and-hold controls, not toggles.
- Keyboard input is translated into the existing unified drive-pad Drift/Boost zones rather than setting physics globals independently. This keeps boost charge/depletion, drift recharge, audio, achievements and physics on the canonical touch path.
- If Q and E overlap, the most recently pressed action owns the drive zone; releasing it returns to the still-held other key.
- Held Q/E state is cleared on blur, visibility loss and race/session transitions.
- Shortcuts do not steal input from ordinary buttons, links, forms, dialogs or sliders.

## Cache safety
Production `turn/index.html` loads a fresh `r418-qe` entry point rather than relying on an already-cached module URL.

## Regression coverage
Adds `turn-tests/qe-drive-controls-production.mjs`, covering bindings, repeat keydown behavior, overlapping holds/releases, canonical drive-pad pointer routing, cleanup boundaries and the production cache-busted loader. It is executed through the existing production regression run.

## Release order
This is intentionally ahead of #414 music. #410 remains open and blocked on physical iPad 9 A/B verification; this keyboard-only change does not alter motion/orientation behavior.