### PR TITLE
TURN: add a sustained chorus to the racing soundtrack

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -66,6 +66,7 @@
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
+        "/turn/audio/racing-music-v2.js?build=20260809-r163-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=r421-sustained-chorus",
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",

--- a/turn-tests/racing-music-production.mjs
+++ b/turn-tests/racing-music-production.mjs
@@ -1,83 +1,76 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [index, app, homeLayout, music] = await Promise.all([
+const [index, homeLayout, music] = await Promise.all([
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/audio/racing-music-v2.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/audio/racing-music-v3.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(index, /app\.js\?build=20260809-r163-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r420-music-warm/,
-  'The document must force a fresh app module for the music-v2 rollout');
-assert.match(app, /m8-home-fixed-layout\.js\?revision=m8\.9-track-title-alignment&trophy-road=r159&achievements=r166-bella-records&bella-rescue=r174-siren-zone&music=warm-v2/,
-  'The app must force a fresh Home layout module for the music-v2 rollout');
+assert.match(
+  index,
+  /"\/turn\/audio\/racing-music-v2\.js\?build=20260809-r163-racing-music-warm-v2": "\/turn\/audio\/racing-music-v3\.js\?revision=r421-sustained-chorus"/,
+  'The existing Home music import must resolve to a fresh chorus-v3 URL without disturbing the Home layout'
+);
 assert.match(homeLayout, /audio\/racing-music-v2\.js\?build=\$\{buildKey\}-racing-music-warm-v2/,
-  'Production Home must cache-bust and load the warmer TURN-only racing music module');
+  'The established Home lifecycle remains the single music installation point');
 assert.match(homeLayout, /installRacingMusic\(\{ home \}\)/,
-  'Racing music must join the established Home lifecycle rather than TURN NEXT');
+  'Racing music must remain attached to production Home rather than TURN NEXT');
 
-assert.match(music, /const BPM = 124/,
-  'The v2 mix should slow the original 140 BPM song without changing its composition');
-assert.match(music, /const ARRANGEMENT = Object\.freeze\(\[TUNE, TUNE, BRIDGE\]\)/,
-  'The song must reuse the main tune twice, then play the bridge, without duplicating tune data');
-assert.match(music, /'D#6'/, 'The bridge must retain its B7-to-E-minor turnaround');
-assert.doesNotMatch(music, /fetch\(|new Audio\(/,
-  'Racing music must remain generated Web Audio rather than a downloaded audio asset');
+assert.match(music, /const BPM = 120/,
+  'The chorus build must preserve the user-tuned 120 BPM tempo');
+assert.match(music, /const DEFAULT_VOLUME = 50/,
+  'The chorus build must preserve the user-tuned default volume');
+assert.match(music, /const hz = noteToFrequency\(note\) \/ 4/,
+  'The lead must preserve the user-tuned two-octave-down transposition');
+assert.match(music, /const hz = noteToFrequency\(note\) \/ 2/,
+  'The bass must preserve the user-tuned one-octave-down transposition');
+
+assert.match(music, /const CHORUS = Object\.freeze\(/,
+  'The song must gain a distinct reusable chorus section');
+assert.match(music, /name: 'chorus',[\s\S]*sustainLead: true/,
+  'The chorus must explicitly opt into sustained lead notes');
+assert.match(music, /'E6',[\s\S]*'G6',[\s\S]*'B6',[\s\S]*'D#6'/,
+  'The chorus hook must rise through E minor and end on the leading tone that pulls back to E');
+assert.match(music, /const ARRANGEMENT = Object\.freeze\(\[TUNE, TUNE, BRIDGE, TUNE, CHORUS, CHORUS\]\)/,
+  'The form must be T T B T C C so the chorus is a scarce two-pass payoff');
+assert.match(music, /function leadHoldSteps\(section, step\)/,
+  'The scheduler must derive held-note duration only for sustained sections');
+assert.match(music, /while \(step \+ hold < section\.lead\.length && section\.lead\[step \+ hold\] == null\) hold \+= 1/,
+  'Null chorus steps after a note must extend that note instead of retriggering it');
+assert.match(music, /sustained: section\.sustainLead === true/,
+  'Only chorus-style sections may use the sustained lead envelope');
+assert.match(music, /sustained \? 0\.075 : 0\.022/,
+  'Long chorus notes must use a slower attack than the punchy T/B lead');
+assert.match(music, /filter\.frequency\.value = sustained \? 2700 : 3200/,
+  'The sustained chorus lead should be slightly softer than the ordinary lead');
 
 assert.match(music, /MUSIC_VOLUME_STORAGE_KEY = 'turn-racing-music-volume-v1'/,
-  'The warmer mix must preserve existing saved music-volume preferences');
-assert.match(music, /DEFAULT_VOLUME = 10/,
-  'Fresh players should start with music at a subtle 10 percent level');
+  'The chorus rollout must preserve existing saved volume preferences');
+assert.doesNotMatch(music, /fetch\(|new Audio\(/,
+  'Racing music must remain generated Web Audio rather than a downloaded asset');
 assert.match(music, /body\.type = 'triangle'/,
-  'Lead and bass body oscillators should use a softer triangle timbre');
+  'Lead and bass body oscillators must retain the warm triangle timbre');
 assert.match(music, /overtone\.type = 'sine'/,
-  'The lead should use a gentle sine overtone instead of bright FM bite');
-assert.match(music, /oscillator\.type = 'triangle'/,
-  'The arpeggio should use a warmer triangle tone');
+  'The lead must retain its soft sine overtone');
 assert.doesNotMatch(music, /type = 'square'|type = 'sawtooth'|createWaveShaper/,
-  'The warmer mix must not reintroduce the original chiptune-like square, saw or distortion voices');
-assert.match(music, /filter\.frequency\.value = 3200/,
-  'The lead should be low-pass softened rather than left bright');
-assert.match(music, /filter\.frequency\.value = 2300/,
-  'The arpeggio should remain tucked behind the lead');
-assert.match(music, /compressor\.attack\.value = 0\.015/,
-  'The master dynamics should use a gentler attack than the original sharp mix');
+  'The chorus must not reintroduce the old chiptune-like voices');
 
 assert.match(music, /document\.addEventListener\('pointerdown', handleUserActivation/,
-  'Music must unlock from a permitted pointer gesture on browsers with autoplay restrictions');
+  'Music must unlock from a permitted pointer gesture');
 assert.match(music, /document\.addEventListener\('keydown', handleUserActivation/,
-  'Keyboard-only players must also be able to unlock the music');
-assert.match(music, /if \(shouldPlay\(\)\) void startPlayback/,
-  'The desired music state must be ON as soon as the Home interface is available');
+  'Keyboard-only players must also be able to unlock music');
+assert.match(music, /if \(musicVolume <= 0 \|\| !soundEnabled\)[\s\S]*stopPlayback/,
+  'OFF must stop the engine rather than merely mute it');
+assert.match(music, /clearScheduler\(\);[\s\S]*stopActiveSources\(\);[\s\S]*context\.suspend\(\)/,
+  'An off music engine must have no scheduler, active note sources or running AudioContext');
 
 assert.match(music, /className = 'turn-music-home-toggle'/);
-assert.match(music, /MUSIC \$\{action\.toUpperCase\(\)\}/,
-  'The Home header control must expose MUSIC OFF while playing and MUSIC ON while disabled');
-assert.match(music, /setAttribute\('aria-label', `Turn music \$\{action\}`\)/,
-  'The visible toggle action must have an explicit accessible name');
-
-assert.match(music, /label\.innerHTML = '<strong>Music volume<\/strong><small>OFF stops the music engine completely\.<\/small>'/);
-assert.match(music, /slider\.min = '0'/);
-assert.match(music, /slider\.max = '100'/);
-assert.match(music, /labels\.innerHTML = '<span>OFF<\/span><span>100%<\/span>'/,
-  'The music volume scale must say OFF rather than 0% at its minimum');
-assert.match(music, /if \(musicVolume <= 0 \|\| !soundEnabled\)[\s\S]*stopPlayback/,
-  'OFF must stop the engine rather than merely turn its gain to zero');
-assert.match(music, /clearScheduler\(\);[\s\S]*stopActiveSources\(\);[\s\S]*context\.suspend\(\)/,
-  'An off music engine must have no sequencer timer, active note sources, or running AudioContext');
-
 assert.match(music, /className = 'turn-music-blank-toggle'/);
-assert.match(music, /turn-screen-blank-control\[data-state="active"\]/,
-  'Audio-only driving must get a music toggle next to the restore-vision control');
-assert.match(music, /z-index: 2147483001/,
-  'The blank-screen music control must remain operable above the black overlay');
+assert.match(music, /label\.innerHTML = '<strong>Music volume<\/strong><small>OFF stops the music engine completely\.<\/small>'/);
+assert.match(music, /labels\.innerHTML = '<span>OFF<\/span><span>100%<\/span>'/);
+assert.match(music, /arrangement: Object\.freeze\(ARRANGEMENT\.map\(\(section\) => section\.name\)\)/,
+  'Runtime diagnostics must expose the actual T/T/B/T/C/C form');
+assert.match(music, /timbre: 'warm-v3-sustained-chorus'/);
 
-assert.match(music, /new globalThis\.GainNode\(context, \{ gain: value \}\)/,
-  'The independent music graph must avoid the central audio-preference createGain patch');
-assert.match(music, /soundEnabled = globalThis\.__turnAudioPreferences\?\.getSettings\?\.\(\)\.audioEnabled !== false/,
-  'The global Sound preference must still silence racing music');
-assert.doesNotMatch(music, /turn-lot-open|GAME_MODE|RACING|SPECTATING/,
-  'Music playback must not be gated away when moving between Home, The Lot, and races');
-
-console.log('TURN warmer generated racing music, 10 percent default and accessibility controls regression passed.');
+console.log('TURN T/T/B/T/C/C sustained chorus, user-tuned tempo/transposition, and music controls regression passed.');

--- a/turn/audio/racing-music-v3.js
+++ b/turn/audio/racing-music-v3.js
@@ -1,0 +1,792 @@
+const AudioContextClass = globalThis.AudioContext || globalThis.webkitAudioContext;
+
+const MUSIC_VOLUME_STORAGE_KEY = 'turn-racing-music-volume-v1';
+const MUSIC_LAST_VOLUME_STORAGE_KEY = 'turn-racing-music-last-volume-v1';
+const DEFAULT_VOLUME = 50;
+const BPM = 120;
+const STEPS_PER_BEAT = 4;
+const STEP_SECONDS = (60 / BPM) / STEPS_PER_BEAT;
+const LOOKAHEAD_MS = 25;
+const SCHEDULE_AHEAD_SECONDS = 0.12;
+const DESIGNED_MASTER_GAIN = 0.56;
+const HOME_STYLE_ID = 'turn-racing-music-styles';
+
+const NOTE_INDEX = Object.freeze({
+  C: 0,
+  'C#': 1,
+  Db: 1,
+  D: 2,
+  'D#': 3,
+  Eb: 3,
+  E: 4,
+  F: 5,
+  'F#': 6,
+  Gb: 6,
+  G: 7,
+  'G#': 8,
+  Ab: 8,
+  A: 9,
+  'A#': 10,
+  Bb: 10,
+  B: 11
+});
+
+// T — the established short, punchy main tune.
+const TUNE = Object.freeze({
+  name: 'tune',
+  lead: Object.freeze([
+    'E5', null, 'G5', 'B5', 'D6', null, 'B5', 'G5',
+    'E5', null, 'G5', 'A5', 'B5', 'D6', 'E6', null,
+    'D6', null, 'B5', 'A5', 'G5', null, 'E5', 'G5',
+    'A5', 'B5', 'D6', 'B5', 'A5', 'G5', 'F#5', null,
+    'E5', null, 'B5', 'D6', 'E6', 'G6', 'F#6', 'E6',
+    'D6', null, 'B5', 'G5', 'A5', 'B5', 'D6', null,
+    'B5', 'D6', 'E6', 'G6', 'F#6', 'E6', 'D6', 'B5',
+    'A5', 'B5', 'G5', 'F#5', 'E5', 'B5', 'E6', null
+  ]),
+  bass: Object.freeze([
+    'E2', null, 'E2', 'E3', null, 'B2', 'D3', null,
+    'E2', null, 'G2', 'B2', 'D3', 'B2', 'E3', null,
+    'C2', null, 'C3', 'G2', null, 'C3', 'B2', null,
+    'D2', null, 'D3', 'A2', 'D3', 'F#3', 'A2', null,
+    'E2', null, 'E3', 'B2', 'D3', 'B2', 'G2', null,
+    'E2', 'B2', 'E3', null, 'D3', 'B2', 'G2', null,
+    'C2', null, 'G2', 'C3', 'B2', null, 'D3', 'C3',
+    'D2', 'A2', 'D3', 'F#3', 'E2', 'B2', 'E3', null
+  ]),
+  arp: Object.freeze([
+    'E4', 'B4', 'G4', 'B4', 'E5', 'B4', 'G4', 'B4',
+    'E4', 'B4', 'G4', 'B4', 'E5', 'B4', 'G4', 'D5',
+    'C4', 'G4', 'E4', 'G4', 'C5', 'G4', 'E4', 'G4',
+    'D4', 'A4', 'F#4', 'A4', 'D5', 'A4', 'F#4', 'A4',
+    'E4', 'B4', 'G4', 'B4', 'E5', 'B4', 'G4', 'B4',
+    'E4', 'G4', 'B4', 'D5', 'E5', 'D5', 'B4', 'G4',
+    'C4', 'G4', 'E4', 'G4', 'C5', 'B4', 'G4', 'E4',
+    'D4', 'A4', 'F#4', 'A4', 'E4', 'B4', 'G4', 'E5'
+  ]),
+  drums: Object.freeze([
+    'KH', 'H', 'H', 'H', 'SH', 'H', 'KH', 'H',
+    'KH', 'H', 'H', 'H', 'SH', 'H', 'K', 'OH',
+    'KH', 'H', 'H', 'H', 'SH', 'H', 'K', 'H',
+    'KH', 'H', 'KH', 'H', 'SH', 'H', 'S', 'OH',
+    'KH', 'H', 'H', 'H', 'SH', 'H', 'KH', 'H',
+    'KH', 'H', 'H', 'H', 'SH', 'H', 'K', 'OH',
+    'KH', 'H', 'H', 'H', 'SH', 'H', 'KH', 'H',
+    'KH', 'H', 'SH', 'H', 'S', 'S', 'KS', 'OH'
+  ])
+});
+
+// B — contrast and harmonic tension before returning to T.
+const BRIDGE = Object.freeze({
+  name: 'bridge',
+  lead: Object.freeze([
+    'G5', null, 'B5', 'D6', 'G6', 'F#6', 'D6', 'B5',
+    'A5', 'B5', 'D6', 'E6', 'D6', 'B5', 'G5', null,
+    'F#5', null, 'A5', 'D6', 'F#6', 'E6', 'D6', 'A5',
+    'B5', 'D6', 'E6', 'F#6', 'E6', 'D6', 'A5', null,
+    'E5', 'G5', 'C6', 'E6', 'G6', 'E6', 'D6', 'C6',
+    'G5', 'C6', 'D6', 'E6', 'G6', 'E6', 'C6', null,
+    'F#5', 'A5', 'B5', 'D#6', 'F#6', 'D#6', 'B5', 'A5',
+    'F#5', 'A5', 'B5', 'D#6', 'F#6', 'D#6', 'B5', 'D#6'
+  ]),
+  bass: Object.freeze([
+    'G2', null, 'G2', 'D3', null, 'G3', 'F#3', 'D3',
+    'G2', 'B2', 'D3', null, 'G3', 'D3', 'B2', null,
+    'D2', null, 'D3', 'A2', null, 'D3', 'F#3', 'A2',
+    'D2', 'A2', 'D3', null, 'F#3', 'D3', 'A2', null,
+    'C2', null, 'C3', 'G2', null, 'C3', 'E3', 'G2',
+    'C2', 'G2', 'C3', null, 'E3', 'C3', 'G2', null,
+    'B1', null, 'B2', 'F#2', 'A2', 'B2', 'D#3', 'F#3',
+    'B1', 'F#2', 'A2', 'B2', 'D#3', 'F#3', 'B2', 'D#3'
+  ]),
+  arp: Object.freeze([
+    'G4', 'D5', 'B4', 'D5', 'G5', 'D5', 'B4', 'D5',
+    'G4', 'B4', 'D5', 'G5', 'D5', 'B4', 'D5', 'G5',
+    'D4', 'A4', 'F#4', 'A4', 'D5', 'A4', 'F#4', 'A4',
+    'D4', 'F#4', 'A4', 'D5', 'F#5', 'D5', 'A4', 'F#4',
+    'C4', 'G4', 'E4', 'G4', 'C5', 'G4', 'E4', 'G4',
+    'C4', 'E4', 'G4', 'C5', 'E5', 'C5', 'G4', 'E4',
+    'B3', 'F#4', 'A4', 'D#5', 'B4', 'F#4', 'A4', 'D#5',
+    'B3', 'A4', 'D#5', 'F#5', 'A5', 'F#5', 'D#5', 'B4'
+  ]),
+  drums: Object.freeze([
+    'KH', 'H', 'H', 'H', 'SH', 'H', 'KH', 'H',
+    'KH', 'H', 'KH', 'H', 'SH', 'H', 'K', 'OH',
+    'KH', 'H', 'KH', 'H', 'SH', 'H', 'K', 'H',
+    'KH', 'H', 'KH', 'H', 'SH', 'H', 'KS', 'OH',
+    'KH', 'H', 'H', 'H', 'SH', 'H', 'KH', 'H',
+    'KH', 'H', 'KH', 'H', 'SH', 'H', 'K', 'OH',
+    'KH', 'H', 'KH', 'H', 'SH', 'H', 'KH', 'H',
+    'KS', 'H', 'KS', 'H', 'S', 'KS', 'KS', 'KSO'
+  ])
+});
+
+// C — an eight-half-note hook over Em → C → G → B7.
+// `sustainLead` turns the nulls after each note into held time rather than silence.
+// The final D# resolves naturally into the opening E when the chorus repeats or T returns.
+const CHORUS = Object.freeze({
+  name: 'chorus',
+  sustainLead: true,
+  lead: Object.freeze([
+    'E6', null, null, null, null, null, null, null,
+    'G6', null, null, null, null, null, null, null,
+    'B6', null, null, null, null, null, null, null,
+    'G6', null, null, null, null, null, null, null,
+    'E6', null, null, null, null, null, null, null,
+    'D6', null, null, null, null, null, null, null,
+    'B5', null, null, null, null, null, null, null,
+    'D#6', null, null, null, null, null, null, null
+  ]),
+  bass: Object.freeze([
+    'E2', null, null, null, 'B2', null, null, null,
+    'E3', null, null, null, 'B2', null, null, null,
+    'C2', null, null, null, 'G2', null, null, null,
+    'C3', null, null, null, 'G2', null, null, null,
+    'G2', null, null, null, 'D3', null, null, null,
+    'G3', null, null, null, 'D3', null, null, null,
+    'B1', null, null, null, 'F#2', null, null, null,
+    'A2', null, null, null, 'D#3', null, 'F#3', null
+  ]),
+  arp: Object.freeze([
+    'E4', null, 'G4', null, 'B4', null, 'G4', null,
+    'E5', null, 'B4', null, 'G4', null, 'B4', null,
+    'C4', null, 'E4', null, 'G4', null, 'E4', null,
+    'C5', null, 'G4', null, 'E4', null, 'G4', null,
+    'G4', null, 'B4', null, 'D5', null, 'B4', null,
+    'G5', null, 'D5', null, 'B4', null, 'D5', null,
+    'B3', null, 'D#4', null, 'F#4', null, 'A4', null,
+    'B4', null, 'F#4', null, 'D#4', null, 'F#4', null
+  ]),
+  drums: Object.freeze([
+    'KH', 'H', null, 'H', 'SH', 'H', null, 'H',
+    'KH', 'H', null, 'H', 'SH', 'H', 'K', 'OH',
+    'KH', 'H', null, 'H', 'SH', 'H', null, 'H',
+    'KH', 'H', null, 'H', 'SH', 'H', 'K', 'OH',
+    'KH', 'H', null, 'H', 'SH', 'H', null, 'H',
+    'KH', 'H', null, 'H', 'SH', 'H', 'K', 'OH',
+    'KH', 'H', null, 'H', 'SH', 'H', 'KH', 'H',
+    'KS', 'H', 'K', 'H', 'SH', 'H', 'KS', 'OH'
+  ])
+});
+
+// Song form: establish T, contrast with B, return to T, then make C the scarce payoff.
+const ARRANGEMENT = Object.freeze([TUNE, TUNE, BRIDGE, TUNE, CHORUS, CHORUS]);
+
+let installed = false;
+let context = null;
+let masterGain = null;
+let noiseBuffer = null;
+let schedulerTimer = 0;
+let currentSection = 0;
+let currentStep = 0;
+let nextStepTime = 0;
+let playing = false;
+let soundEnabled = true;
+let musicVolume = readStoredNumber(MUSIC_VOLUME_STORAGE_KEY, DEFAULT_VOLUME);
+let lastNonZeroVolume = readStoredNumber(MUSIC_LAST_VOLUME_STORAGE_KEY, DEFAULT_VOLUME);
+let homeToggle = null;
+let blankToggle = null;
+let settingsSlider = null;
+let settingsOutput = null;
+const activeSources = new Set();
+
+function clamp(value, min, max, fallback = min) {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.max(min, Math.min(max, value));
+}
+
+function readStoredNumber(key, fallback) {
+  try {
+    const stored = globalThis.localStorage?.getItem(key);
+    if (stored == null || stored === '') return fallback;
+    const value = Number(stored);
+    return Number.isFinite(value) ? clamp(value, 0, 100, fallback) : fallback;
+  } catch (_) {
+    return fallback;
+  }
+}
+
+function writeStoredNumber(key, value) {
+  try {
+    globalThis.localStorage?.setItem(key, String(Math.round(value)));
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+function noteToFrequency(note) {
+  const match = /^([A-G](?:#|b)?)(-?\d+)$/.exec(note);
+  if (!match) return 440;
+  const pitch = match[1];
+  const octave = Number(match[2]);
+  const midi = NOTE_INDEX[pitch] + (octave + 1) * 12;
+  return 440 * Math.pow(2, (midi - 69) / 12);
+}
+
+function makeGain(value = 1) {
+  if (!context || typeof globalThis.GainNode !== 'function') return null;
+  return new globalThis.GainNode(context, { gain: value });
+}
+
+function makeNoiseBuffer() {
+  const buffer = context.createBuffer(1, context.sampleRate, context.sampleRate);
+  const data = buffer.getChannelData(0);
+  for (let index = 0; index < data.length; index += 1) data[index] = Math.random() * 2 - 1;
+  return buffer;
+}
+
+function ensureGraph() {
+  if (context || !AudioContextClass || typeof globalThis.GainNode !== 'function') return Boolean(context);
+  try {
+    context = new AudioContextClass({ latencyHint: 'playback' });
+  } catch (_) {
+    context = new AudioContextClass();
+  }
+
+  masterGain = makeGain(0);
+  if (!masterGain) {
+    void context.close?.();
+    context = null;
+    return false;
+  }
+
+  const compressor = context.createDynamicsCompressor();
+  compressor.threshold.value = -12;
+  compressor.knee.value = 18;
+  compressor.ratio.value = 2.5;
+  compressor.attack.value = 0.015;
+  compressor.release.value = 0.28;
+  masterGain.connect(compressor);
+  compressor.connect(context.destination);
+  noiseBuffer = makeNoiseBuffer();
+  return true;
+}
+
+function trackSource(source) {
+  activeSources.add(source);
+  source.addEventListener?.('ended', () => activeSources.delete(source), { once: true });
+  return source;
+}
+
+function stopActiveSources() {
+  for (const source of activeSources) {
+    try { source.stop(); } catch (_) {}
+  }
+  activeSources.clear();
+}
+
+function scheduleGainEnvelope(gain, time, peak, releaseTime, attack = 0.018) {
+  gain.setValueAtTime(0.0001, time);
+  gain.exponentialRampToValueAtTime(peak, time + attack);
+  gain.exponentialRampToValueAtTime(0.0001, releaseTime);
+}
+
+function leadHoldSteps(section, step) {
+  if (!section?.sustainLead || !section.lead[step]) return 1;
+  let hold = 1;
+  while (step + hold < section.lead.length && section.lead[step + hold] == null) hold += 1;
+  return hold;
+}
+
+function playLead(note, time, { holdSteps = 1, sustained = false } = {}) {
+  if (!note) return;
+  // User-tuned lead transposition: two octaves below the written melody.
+  const hz = noteToFrequency(note) / 4;
+  const body = trackSource(context.createOscillator());
+  const overtone = trackSource(context.createOscillator());
+  const bodyGain = makeGain(sustained ? 0.88 : 0.82);
+  const overtoneGain = makeGain(sustained ? 0.08 : 0.12);
+  const amp = makeGain(0.0001);
+  if (!bodyGain || !overtoneGain || !amp) return;
+  const filter = context.createBiquadFilter();
+  const duration = STEP_SECONDS * Math.max(1, holdSteps - (sustained ? 0.12 : 0));
+
+  body.type = 'triangle';
+  overtone.type = 'sine';
+  body.frequency.setValueAtTime(hz, time);
+  overtone.frequency.setValueAtTime(hz * 2, time);
+  filter.type = 'lowpass';
+  filter.frequency.value = sustained ? 2700 : 3200;
+  filter.Q.value = sustained ? 0.3 : 0.45;
+  scheduleGainEnvelope(
+    amp.gain,
+    time,
+    sustained ? 0.19 : 0.18,
+    time + duration,
+    sustained ? 0.075 : 0.022
+  );
+
+  body.connect(bodyGain);
+  overtone.connect(overtoneGain);
+  bodyGain.connect(filter);
+  overtoneGain.connect(filter);
+  filter.connect(amp);
+  amp.connect(masterGain);
+  body.start(time);
+  overtone.start(time);
+  body.stop(time + duration + 0.01);
+  overtone.stop(time + duration + 0.01);
+}
+
+function playBass(note, time) {
+  if (!note) return;
+  // User-tuned bass transposition: one octave below the written bass line.
+  const hz = noteToFrequency(note) / 2;
+  const body = trackSource(context.createOscillator());
+  const sub = trackSource(context.createOscillator());
+  const bodyGain = makeGain(0.64);
+  const subGain = makeGain(0.34);
+  const amp = makeGain(0.0001);
+  if (!bodyGain || !subGain || !amp) return;
+  const filter = context.createBiquadFilter();
+
+  body.type = 'triangle';
+  sub.type = 'sine';
+  body.frequency.setValueAtTime(hz, time);
+  sub.frequency.setValueAtTime(hz / 2, time);
+  filter.type = 'lowpass';
+  filter.Q.value = 0.7;
+  filter.frequency.setValueAtTime(1050, time);
+  filter.frequency.exponentialRampToValueAtTime(280, time + STEP_SECONDS * 0.95);
+  scheduleGainEnvelope(amp.gain, time, 0.21, time + STEP_SECONDS * 1.02, 0.016);
+
+  body.connect(bodyGain);
+  sub.connect(subGain);
+  bodyGain.connect(filter);
+  subGain.connect(filter);
+  filter.connect(amp);
+  amp.connect(masterGain);
+  body.start(time);
+  sub.start(time);
+  body.stop(time + STEP_SECONDS * 1.05);
+  sub.stop(time + STEP_SECONDS * 1.05);
+}
+
+function playArp(note, time) {
+  if (!note) return;
+  const oscillator = trackSource(context.createOscillator());
+  const amp = makeGain(0.0001);
+  if (!amp) return;
+  const filter = context.createBiquadFilter();
+  oscillator.type = 'triangle';
+  oscillator.frequency.setValueAtTime(noteToFrequency(note), time);
+  filter.type = 'lowpass';
+  filter.frequency.value = 2300;
+  filter.Q.value = 0.35;
+  scheduleGainEnvelope(amp.gain, time, 0.036, time + STEP_SECONDS * 0.92, 0.012);
+  oscillator.connect(filter);
+  filter.connect(amp);
+  amp.connect(masterGain);
+  oscillator.start(time);
+  oscillator.stop(time + STEP_SECONDS * 0.95);
+}
+
+function playKick(time) {
+  const oscillator = trackSource(context.createOscillator());
+  const amp = makeGain(0.48);
+  if (!amp) return;
+  oscillator.type = 'sine';
+  oscillator.frequency.setValueAtTime(112, time);
+  oscillator.frequency.exponentialRampToValueAtTime(45, time + 0.16);
+  amp.gain.setValueAtTime(0.48, time);
+  amp.gain.exponentialRampToValueAtTime(0.0001, time + 0.18);
+  oscillator.connect(amp);
+  amp.connect(masterGain);
+  oscillator.start(time);
+  oscillator.stop(time + 0.19);
+}
+
+function playSnare(time) {
+  const source = trackSource(context.createBufferSource());
+  const filter = context.createBiquadFilter();
+  const amp = makeGain(0.18);
+  if (!amp) return;
+  source.buffer = noiseBuffer;
+  filter.type = 'bandpass';
+  filter.frequency.value = 1350;
+  filter.Q.value = 0.55;
+  amp.gain.setValueAtTime(0.18, time);
+  amp.gain.exponentialRampToValueAtTime(0.0001, time + 0.13);
+  source.connect(filter);
+  filter.connect(amp);
+  amp.connect(masterGain);
+  source.start(time);
+  source.stop(time + 0.14);
+}
+
+function playHat(time, open = false) {
+  const source = trackSource(context.createBufferSource());
+  const filter = context.createBiquadFilter();
+  const amp = makeGain(open ? 0.045 : 0.026);
+  if (!amp) return;
+  const duration = open ? 0.18 : 0.055;
+  source.buffer = noiseBuffer;
+  filter.type = 'highpass';
+  filter.frequency.value = open ? 4300 : 5200;
+  amp.gain.setValueAtTime(open ? 0.045 : 0.026, time);
+  amp.gain.exponentialRampToValueAtTime(0.0001, time + duration);
+  source.connect(filter);
+  filter.connect(amp);
+  amp.connect(masterGain);
+  source.start(time);
+  source.stop(time + duration);
+}
+
+function playDrums(pattern, time) {
+  if (!pattern) return;
+  if (pattern.includes('K')) playKick(time);
+  if (pattern.includes('S')) playSnare(time);
+  if (pattern.includes('O')) playHat(time, true);
+  else if (pattern.includes('H')) playHat(time, false);
+}
+
+function scheduleStep(step, time) {
+  const section = ARRANGEMENT[currentSection];
+  playLead(section.lead[step], time, {
+    holdSteps: leadHoldSteps(section, step),
+    sustained: section.sustainLead === true
+  });
+  playBass(section.bass[step], time);
+  playArp(section.arp[step], time);
+  playDrums(section.drums[step], time);
+}
+
+function advanceStep() {
+  const section = ARRANGEMENT[currentSection];
+  currentStep += 1;
+  if (currentStep >= section.lead.length) {
+    currentStep = 0;
+    currentSection = (currentSection + 1) % ARRANGEMENT.length;
+  }
+  nextStepTime += STEP_SECONDS;
+}
+
+function scheduler() {
+  if (!playing || !context || context.state !== 'running') return;
+  while (playing && nextStepTime < context.currentTime + SCHEDULE_AHEAD_SECONDS) {
+    scheduleStep(currentStep, nextStepTime);
+    advanceStep();
+  }
+  schedulerTimer = globalThis.setTimeout(scheduler, LOOKAHEAD_MS);
+}
+
+function clearScheduler() {
+  globalThis.clearTimeout(schedulerTimer);
+  schedulerTimer = 0;
+}
+
+function applyMasterVolume() {
+  if (!context || !masterGain) return;
+  const now = context.currentTime;
+  const gain = soundEnabled && musicVolume > 0 ? DESIGNED_MASTER_GAIN * (musicVolume / 100) : 0;
+  try {
+    masterGain.gain.cancelScheduledValues(now);
+    masterGain.gain.setTargetAtTime(gain, now, 0.04);
+  } catch (_) {
+    masterGain.gain.value = gain;
+  }
+}
+
+async function startPlayback({ restart = false } = {}) {
+  if (!soundEnabled || musicVolume <= 0 || document.visibilityState === 'hidden') return false;
+  if (!ensureGraph()) return false;
+  if (restart) {
+    currentSection = 0;
+    currentStep = 0;
+  }
+  try {
+    if (context.state !== 'running') await context.resume();
+  } catch (_) {
+    return false;
+  }
+  if (context.state !== 'running') return false;
+  applyMasterVolume();
+  if (!playing) {
+    playing = true;
+    nextStepTime = context.currentTime + 0.05;
+    scheduler();
+  }
+  return true;
+}
+
+async function stopPlayback({ reset = false } = {}) {
+  playing = false;
+  clearScheduler();
+  stopActiveSources();
+  if (reset) {
+    currentSection = 0;
+    currentStep = 0;
+  }
+  if (!context) return;
+  applyMasterVolume();
+  try {
+    if (context.state === 'running') await context.suspend();
+  } catch (_) {}
+}
+
+function shouldPlay() {
+  return soundEnabled && musicVolume > 0 && document.visibilityState !== 'hidden';
+}
+
+function volumeLabel(value) {
+  return value <= 0 ? 'OFF' : `${Math.round(value)}%`;
+}
+
+function renderToggle(button, compact = false) {
+  if (!button) return;
+  const on = musicVolume > 0;
+  const action = on ? 'off' : 'on';
+  const icon = on ? '<span aria-hidden="true">♫×</span>' : '<span aria-hidden="true">♫</span>';
+  button.innerHTML = compact ? icon : `${icon}<span>MUSIC ${action.toUpperCase()}</span>`;
+  button.setAttribute('aria-label', `Turn music ${action}`);
+  button.title = `Turn music ${action}`;
+  button.dataset.musicEnabled = on ? 'true' : 'false';
+}
+
+function syncControls() {
+  renderToggle(homeToggle, false);
+  renderToggle(blankToggle, true);
+  if (settingsSlider) settingsSlider.value = String(Math.round(musicVolume));
+  if (settingsOutput) {
+    settingsOutput.value = volumeLabel(musicVolume);
+    settingsOutput.textContent = settingsOutput.value;
+  }
+}
+
+function setVolume(nextVolume, { restart = false } = {}) {
+  const previous = musicVolume;
+  musicVolume = clamp(Number(nextVolume), 0, 100, DEFAULT_VOLUME);
+  if (musicVolume > 0) {
+    lastNonZeroVolume = musicVolume;
+    writeStoredNumber(MUSIC_LAST_VOLUME_STORAGE_KEY, lastNonZeroVolume);
+  }
+  writeStoredNumber(MUSIC_VOLUME_STORAGE_KEY, musicVolume);
+  syncControls();
+  if (musicVolume <= 0 || !soundEnabled) {
+    void stopPlayback({ reset: musicVolume <= 0 });
+    return musicVolume;
+  }
+  if (context && context.state === 'running') applyMasterVolume();
+  if (previous <= 0 || restart || !playing) void startPlayback({ restart: previous <= 0 || restart });
+  return musicVolume;
+}
+
+function toggleMusic() {
+  if (musicVolume > 0) return setVolume(0);
+  const restored = clamp(lastNonZeroVolume || DEFAULT_VOLUME, 1, 100, DEFAULT_VOLUME);
+  return setVolume(restored, { restart: true });
+}
+
+function setSystemSoundEnabled(enabled) {
+  soundEnabled = Boolean(enabled);
+  if (!soundEnabled) void stopPlayback({ reset: false });
+  else if (musicVolume > 0) void startPlayback({ restart: false });
+}
+
+function installStyles() {
+  if (document.getElementById(HOME_STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = HOME_STYLE_ID;
+  style.textContent = `
+    .m8-home.m8-home-fixed-layout .m8-home-head {
+      grid-template-columns: clamp(84px, 10vw, 126px) minmax(180px, 1fr) auto auto !important;
+    }
+    .m8-home.m8-home-fixed-layout .turn-music-home-toggle {
+      grid-column: 3; grid-row: 1; align-self: center; justify-self: center;
+      display: inline-flex; align-items: center; justify-content: center; gap: .38em;
+      min-width: 112px; min-height: 44px; margin: 0; padding: 6px 10px;
+      border: 0; border-radius: 8px; background: transparent; color: var(--m8-ink, #08090a);
+      box-shadow: none; font: inherit; font-size: clamp(.72rem, 1.15vw, .98rem);
+      font-weight: 950; line-height: 1; letter-spacing: .035em; cursor: pointer;
+    }
+    .m8-home.m8-home-fixed-layout .turn-music-home-toggle > span:first-child {
+      font-size: 1.35em; letter-spacing: -.2em; margin-right: .14em;
+    }
+    .m8-home.m8-home-fixed-layout .turn-music-home-toggle:hover {
+      text-decoration: underline; text-decoration-thickness: 2px; text-underline-offset: .2em;
+    }
+    .m8-home.m8-home-fixed-layout .turn-music-home-toggle:focus-visible {
+      outline: 4px solid var(--m8-blue, #66c7e8); outline-offset: 2px;
+    }
+    .m8-home.m8-home-fixed-layout .m8-home-build,
+    .m8-home.m8-home-fixed-layout .m8-home-meta { grid-column: 4 !important; }
+    .m8-music-volume-row { display: grid; gap: 3px; margin-top: 16px; }
+    .m8-music-volume-row small { font-weight: 650; }
+    #m8MusicVolume { width: 100%; margin-top: 8px; }
+    .m8-music-volume-labels {
+      display: flex; justify-content: space-between; gap: 12px; margin-top: 2px;
+      font-size: .75rem; font-weight: 850;
+    }
+    #m8MusicVolumeValue { display: block; margin-top: 4px; font-weight: 950; }
+    .turn-music-blank-toggle {
+      position: fixed; z-index: 2147483001; display: grid; place-items: center;
+      width: 50px; height: 50px; min-width: 50px; min-height: 50px; margin: 0; padding: 4px;
+      border: 3px solid #08090a; border-radius: 12px; background: #ff7b54; color: #08090a;
+      box-shadow: 5px 5px 0 #08090a; font: 950 1.25rem/1 system-ui, sans-serif; touch-action: manipulation;
+    }
+    .turn-music-blank-toggle[hidden] { display: none; }
+    .turn-music-blank-toggle:focus-visible { outline: 4px solid #ffd43b; outline-offset: 4px; }
+    @media (max-height: 560px) and (orientation: landscape) {
+      .m8-home.m8-home-fixed-layout .m8-home-head {
+        grid-template-columns: clamp(68px, 10vw, 84px) minmax(150px, 1fr) auto auto !important;
+      }
+      .m8-home.m8-home-fixed-layout .turn-music-home-toggle {
+        min-width: 96px; min-height: 40px; padding: 4px 7px; font-size: .72rem;
+      }
+    }
+    @media (max-height: 430px) {
+      .turn-music-blank-toggle { width: 40px; height: 40px; min-width: 40px; min-height: 40px; padding: 3px; }
+    }
+    @media (max-width: 760px) and (orientation: portrait) {
+      .m8-home.m8-home-fixed-layout .m8-home-head { grid-template-columns: 82px minmax(0, 1fr) auto !important; }
+      .m8-home.m8-home-fixed-layout .turn-music-home-toggle {
+        grid-column: 3; min-width: 48px; max-width: 92px; min-height: 44px; padding-inline: 5px; font-size: .64rem;
+      }
+      .m8-home.m8-home-fixed-layout .m8-home-build,
+      .m8-home.m8-home-fixed-layout .m8-home-meta { display: none !important; }
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+function installHomeToggle(home) {
+  const header = home?.querySelector('.m8-home-head');
+  const pitch = header?.querySelector('.m8-home-pitch');
+  if (!header || !pitch) return null;
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'turn-music-home-toggle';
+  button.addEventListener('click', toggleMusic);
+  pitch.after(button);
+  homeToggle = button;
+  renderToggle(homeToggle, false);
+  return button;
+}
+
+function installSettingsControl() {
+  const dialog = document.querySelector('.m8-settings-dialog');
+  const audioTitle = dialog?.querySelector('#m8AudioTitle');
+  const audioCard = audioTitle?.closest('.m8-setting-card');
+  if (!dialog || !audioCard || dialog.querySelector('#m8MusicVolume')) return null;
+
+  const label = document.createElement('label');
+  label.className = 'm8-music-volume-row';
+  label.htmlFor = 'm8MusicVolume';
+  label.innerHTML = '<strong>Music volume</strong><small>OFF stops the music engine completely.</small>';
+  const slider = document.createElement('input');
+  slider.id = 'm8MusicVolume';
+  slider.type = 'range';
+  slider.min = '0';
+  slider.max = '100';
+  slider.step = '1';
+  slider.value = String(Math.round(musicVolume));
+  slider.setAttribute('aria-describedby', 'm8MusicVolumeValue');
+  const labels = document.createElement('div');
+  labels.className = 'm8-music-volume-labels';
+  labels.setAttribute('aria-hidden', 'true');
+  labels.innerHTML = '<span>OFF</span><span>100%</span>';
+  const output = document.createElement('output');
+  output.id = 'm8MusicVolumeValue';
+  output.htmlFor = 'm8MusicVolume';
+  output.value = volumeLabel(musicVolume);
+  output.textContent = output.value;
+  audioCard.append(label, slider, labels, output);
+  settingsSlider = slider;
+  settingsOutput = output;
+  slider.addEventListener('input', () => setVolume(Number(slider.value)));
+  slider.addEventListener('change', () => {
+    const status = dialog.querySelector('.m8-settings-status');
+    if (status) status.textContent = `Music ${musicVolume <= 0 ? 'off' : `volume ${Math.round(musicVolume)}%`}.`;
+  });
+  const soundToggle = dialog.querySelector('#m8AudioEnabled');
+  soundToggle?.addEventListener('change', () => {
+    const enabled = globalThis.__turnAudioPreferences?.getSettings?.().audioEnabled !== false;
+    setSystemSoundEnabled(enabled);
+  });
+  dialog.addEventListener('toggle', syncControls);
+  return slider;
+}
+
+function positionBlankToggle() {
+  if (!blankToggle) return;
+  const blankControl = document.querySelector('.turn-screen-blank-control[data-state="active"]');
+  const blanked = document.documentElement.classList.contains('turn-screen-blanked');
+  if (!blanked || !blankControl || blankControl.hidden) {
+    blankToggle.hidden = true;
+    return;
+  }
+  const rect = blankControl.getBoundingClientRect();
+  const gap = 10;
+  const size = rect.width || 50;
+  let left = rect.right + gap;
+  if (left + size > globalThis.innerWidth - 8) left = Math.max(8, rect.left - gap - size);
+  blankToggle.style.left = `${left}px`;
+  blankToggle.style.top = `${rect.top}px`;
+  blankToggle.style.width = `${size}px`;
+  blankToggle.style.height = `${rect.height || size}px`;
+  blankToggle.hidden = false;
+}
+
+function installBlankScreenToggle() {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'turn-music-blank-toggle';
+  button.hidden = true;
+  button.addEventListener('click', toggleMusic);
+  document.body.appendChild(button);
+  blankToggle = button;
+  renderToggle(blankToggle, true);
+  const observer = new MutationObserver(positionBlankToggle);
+  observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+  const blankControl = document.querySelector('.turn-screen-blank-control');
+  if (blankControl) observer.observe(blankControl, { attributes: true, attributeFilter: ['data-state', 'hidden', 'style'] });
+  globalThis.addEventListener('resize', positionBlankToggle, { passive: true });
+  return button;
+}
+
+function handleVisibilityChange() {
+  if (document.visibilityState === 'hidden') {
+    void stopPlayback({ reset: false });
+    return;
+  }
+  if (shouldPlay()) void startPlayback({ restart: false });
+}
+
+function handleUserActivation() {
+  if (!shouldPlay() || playing) return;
+  void startPlayback({ restart: false });
+}
+
+export function installRacingMusic({ home = document.querySelector('.m8-home') } = {}) {
+  if (installed) return globalThis.__turnRacingMusic;
+  installed = true;
+  soundEnabled = globalThis.__turnAudioPreferences?.getSettings?.().audioEnabled !== false;
+  installStyles();
+  installHomeToggle(home);
+  installSettingsControl();
+  installBlankScreenToggle();
+  syncControls();
+  document.addEventListener('pointerdown', handleUserActivation, { capture: true, passive: true });
+  document.addEventListener('keydown', handleUserActivation, { capture: true });
+  document.addEventListener('visibilitychange', handleVisibilityChange, { passive: true });
+  globalThis.addEventListener('pagehide', () => void stopPlayback({ reset: false }), { passive: true });
+  if (shouldPlay()) void startPlayback({ restart: false });
+
+  const api = Object.freeze({
+    bpm: BPM,
+    arrangement: Object.freeze(ARRANGEMENT.map((section) => section.name)),
+    timbre: 'warm-v3-sustained-chorus',
+    get volume() { return musicVolume; },
+    get enabled() { return musicVolume > 0; },
+    get playing() { return playing; },
+    get state() { return context?.state || 'not-created'; },
+    setVolume,
+    toggle: toggleMusic,
+    start: () => startPlayback({ restart: false }),
+    stop: () => setVolume(0),
+    syncControls
+  });
+  globalThis.__turnRacingMusic = api;
+  return api;
+}

--- a/turn/index.html
+++ b/turn/index.html
@@ -76,6 +76,7 @@
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
+        "/turn/audio/racing-music-v2.js?build=20260809-r163-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=r421-sustained-chorus",
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",


### PR DESCRIPTION
Adds a true chorus section to the generated TURN soundtrack while preserving the hand-tuned values already on `main`.

## Song form
Uses **T → T → B → T → C → C**, then loops.

The intent is to make the chorus scarce enough to anticipate: T is established twice, B provides contrast, T returns once, then C gets two passes as the payoff.

## Chorus
- new reusable `CHORUS` section;
- long sustained lead notes rather than T/B's short punchy lead articulation;
- chorus hook follows E minor with an Em → C → G → B7 foundation;
- melody rises E → G → B, falls back through E/D/B, and ends on D# so the repeat/return resolves into E;
- chorus arpeggio is deliberately sparser so the held melody has room;
- C is repeated twice in the arrangement.

## Preserve Erik's current tuning
This branch is based on the current `main` file and deliberately keeps:
- **120 BPM**;
- **50% default music volume**;
- lead at `noteToFrequency(note) / 4` (two octaves down);
- bass at `noteToFrequency(note) / 2` (one octave down);
- the existing warmer triangle/sine timbre and music controls.

## Implementation
Only sections with `sustainLead: true` convert the following null steps into hold duration. T and B continue using the existing punchy envelope unchanged.

The existing Home import is redirected through the production import map to a fresh `racing-music-v3.js?revision=r421-sustained-chorus` URL, avoiding stale iOS module caching without changing the Home layout lifecycle.

## Tests
Updates the production racing-music regression to lock the T/T/B/T/C/C form, sustained-note scheduler behavior, current user-tuned tempo/transpositions/default volume, warm timbre, cache routing, and MUSIC OFF shutdown contract.