### PR TITLE
TURN: make the chorus flute higher, quieter and more melodic

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -66,7 +66,7 @@
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
-        "/turn/audio/racing-music-v2.js?build=20260809-r163-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=r422-flute-legato-chorus",
+        "/turn/audio/racing-music-v2.js?build=20260809-r163-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=r423-melodic-flute-chorus",
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",

--- a/turn-tests/racing-music-production.mjs
+++ b/turn-tests/racing-music-production.mjs
@@ -9,8 +9,8 @@ const [index, homeLayout, music] = await Promise.all([
 
 assert.match(
   index,
-  /"\/turn\/audio\/racing-music-v2\.js\?build=20260809-r163-racing-music-warm-v2": "\/turn\/audio\/racing-music-v3\.js\?revision=r422-flute-legato-chorus"/,
-  'The existing Home music import must resolve to a fresh flute-chorus URL without disturbing the Home layout'
+  /"\/turn\/audio\/racing-music-v2\.js\?build=20260809-r163-racing-music-warm-v2": "\/turn\/audio\/racing-music-v3\.js\?revision=r423-melodic-flute-chorus"/,
+  'The existing Home music import must resolve to a fresh melodic-flute URL without disturbing the Home layout'
 );
 assert.match(homeLayout, /audio\/racing-music-v2\.js\?build=\$\{buildKey\}-racing-music-warm-v2/,
   'The established Home lifecycle remains the single music installation point');
@@ -18,12 +18,12 @@ assert.match(homeLayout, /installRacingMusic\(\{ home \}\)/,
   'Racing music must remain attached to production Home rather than TURN NEXT');
 
 assert.match(music, /const BPM = 120/,
-  'The flute chorus must preserve the user-tuned 120 BPM tempo');
+  'The melodic flute chorus must preserve the user-tuned 120 BPM tempo');
 assert.match(music, /const DEFAULT_VOLUME = 50/,
-  'The flute chorus must preserve the user-tuned default volume');
-assert.match(music, /const hz = noteToFrequency\(note\) \/ 4/,
-  'The lead must preserve the user-tuned two-octave-down transposition');
-assert.match(music, /const hz = noteToFrequency\(note\) \/ 2/,
+  'The melodic flute chorus must preserve the user-tuned default volume');
+assert.match(music, /User-tuned T\/B lead transposition:[\s\S]*const hz = noteToFrequency\(note\) \/ 4/,
+  'The ordinary T/B lead must preserve the user-tuned two-octave-down transposition');
+assert.match(music, /User-tuned bass transposition:[\s\S]*const hz = noteToFrequency\(note\) \/ 2/,
   'The bass must preserve the user-tuned one-octave-down transposition');
 
 assert.match(music, /const CHORUS = Object\.freeze\(/,
@@ -32,8 +32,8 @@ assert.match(music, /name: 'chorus',[\s\S]*sustainLead: true/,
   'The chorus must explicitly opt into sustained lead notes');
 assert.match(
   music,
-  /'E6', null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,[\s\S]*'G6', null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,[\s\S]*'B6', null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,[\s\S]*'D#6', null, null, null, null, null, null, null, null, null, null, null, null, null, null, null/,
-  'Each chorus pitch must occupy a full sixteen-step 4/4 bar before the next written note'
+  /'E6', null, null, null, null, null, null, null,[\s\S]*'G6', null, null, null,[\s\S]*'B6', null, null, null,[\s\S]*'G6', null, null, null,[\s\S]*'E6', null, null, null, null, null, null, null, null, null, null, null,[\s\S]*'D7', null, null, null,[\s\S]*'B6', null, null, null,[\s\S]*'A6', null, null, null,[\s\S]*'G6', null, null, null,[\s\S]*'F#6', null, null, null,[\s\S]*'A6', null, null, null,[\s\S]*'D#6', null, null, null, null, null, null, null/,
+  'The chorus melody must mix one-beat movement with selected two- and three-beat sustained hook tones'
 );
 assert.match(music, /const ARRANGEMENT = Object\.freeze\(\[TUNE, TUNE, BRIDGE, TUNE, CHORUS, CHORUS\]\)/,
   'The form must remain T T B T C C so the chorus stays a scarce two-pass payoff');
@@ -41,23 +41,27 @@ assert.match(music, /const ARRANGEMENT = Object\.freeze\(\[TUNE, TUNE, BRIDGE, T
 assert.match(music, /function scheduleFluteEnvelope\(gain, time, peak, releaseTime\)/,
   'The chorus needs a dedicated flute envelope rather than stretching the punchy lead decay');
 assert.match(music, /gain\.setValueAtTime\(peak, releaseStart\)/,
-  'The flute envelope must hold its level until the very end instead of fading through beats two and three');
+  'The flute envelope must hold its level instead of decaying immediately');
 assert.match(music, /function nextSustainedLeadNote\(sectionIndex, step\)/,
   'The scheduler must know the destination pitch for chorus legato');
 assert.match(music, /if \(!nextSection\?\.sustainLead\) return null/,
   'The second chorus must not force a portamento into the returning punchy T section');
 assert.match(music, /function playFluteLead\(note, nextNote, time, holdSteps\)/,
   'Sustained chorus notes must use a dedicated flute-like voice');
-assert.match(music, /const beatSeconds = STEP_SECONDS \* STEPS_PER_BEAT/,
-  'The legato transition must be phrased in musical beats');
-assert.match(music, /const glideStart = Math\.max\(time \+ 0\.2, endTime - beatSeconds\)/,
-  'Pitch movement must begin on beat four after holding through beats one to three');
+assert.match(music, /Chorus flute sits one octave above the T\/B lead transposition\.[\s\S]*const hz = noteToFrequency\(note\) \/ 2/,
+  'The flute must sit one octave above the ordinary lead');
+assert.match(music, /const glideWindow = holdSteps >= STEPS_PER_BEAT \* 2[\s\S]*\? beatSeconds[\s\S]*: Math\.min\(STEP_SECONDS, duration \* 0\.3\)/,
+  'Long flute notes should spend their final beat leaning into the next pitch while short notes only connect briefly');
 assert.match(music, /body\.frequency\.linearRampToValueAtTime\(nextHz, endTime - 0\.025\)/,
-  'The flute must glide toward the next pitch during beat four');
+  'The flute must retain gentle legato movement toward the next pitch');
 assert.match(music, /body\.type = 'sine';[\s\S]*overtone\.type = 'sine';[\s\S]*vibrato\.type = 'sine'/,
-  'The sustained chorus should use a sine-rich flute timbre with gentle vibrato');
+  'The chorus should retain its sine-rich flute timbre with gentle vibrato');
 assert.match(music, /vibrato\.frequency\.setValueAtTime\(5\.2, time\)/,
-  'The held flute note should carry subtle natural vibrato');
+  'The flute should retain subtle natural vibrato');
+assert.match(music, /scheduleFluteEnvelope\(amp\.gain, time, 0\.105, endTime\)/,
+  'The higher flute must sit substantially lower in the mix than the previous 0.18 chorus peak');
+assert.match(music, /const overtoneGain = makeGain\(0\.04\)/,
+  'The octave-up flute should keep its bright overtone restrained');
 assert.match(music, /filter\.frequency\.value = 2400/,
   'The flute chorus should remain soft rather than bright and chiptune-like');
 
@@ -90,6 +94,6 @@ assert.match(music, /label\.innerHTML = '<strong>Music volume<\/strong><small>OF
 assert.match(music, /labels\.innerHTML = '<span>OFF<\/span><span>100%<\/span>'/);
 assert.match(music, /arrangement: Object\.freeze\(ARRANGEMENT\.map\(\(section\) => section\.name\)\)/,
   'Runtime diagnostics must expose the actual T/T/B/T/C/C form');
-assert.match(music, /timbre: 'warm-v3-flute-legato-chorus'/);
+assert.match(music, /timbre: 'warm-v3-melodic-flute-chorus'/);
 
-console.log('TURN T/T/B/T/C/C flute-legato chorus, user-tuned tempo/transposition, and music controls regression passed.');
+console.log('TURN T/T/B/T/C/C melodic flute chorus, preserved tuning, and music controls regression passed.');

--- a/turn/audio/racing-music-v3.js
+++ b/turn/audio/racing-music-v3.js
@@ -121,17 +121,28 @@ const BRIDGE = Object.freeze({
   ])
 });
 
-// C — a four-bar flute-like hook over Em → C → G → B7.
-// Each written note owns a whole 4/4 bar: it stays level through beats 1–3,
-// then glides toward the next chorus pitch across beat 4.
+// C — a melodic flute hook over Em → C → G → B7.
+// Most notes move every beat; selected hook tones breathe for two or three beats.
 const CHORUS = Object.freeze({
   name: 'chorus',
   sustainLead: true,
   lead: Object.freeze([
-    'E6', null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
-    'G6', null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
-    'B6', null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
-    'D#6', null, null, null, null, null, null, null, null, null, null, null, null, null, null, null
+    // Em: E (2 beats) → G → B
+    'E6', null, null, null, null, null, null, null,
+    'G6', null, null, null,
+    'B6', null, null, null,
+    // C: G → E (3 beats)
+    'G6', null, null, null,
+    'E6', null, null, null, null, null, null, null, null, null, null, null,
+    // G: D → B → A → G
+    'D7', null, null, null,
+    'B6', null, null, null,
+    'A6', null, null, null,
+    'G6', null, null, null,
+    // B7: F# → A → D# (2 beats), resolving to E when C repeats
+    'F#6', null, null, null,
+    'A6', null, null, null,
+    'D#6', null, null, null, null, null, null, null
   ]),
   bass: Object.freeze([
     'E2', null, null, null, 'B2', null, null, null,
@@ -279,8 +290,8 @@ function scheduleGainEnvelope(gain, time, peak, releaseTime, attack = 0.018) {
 }
 
 function scheduleFluteEnvelope(gain, time, peak, releaseTime) {
-  const attackEnd = Math.min(releaseTime - 0.08, time + 0.12);
-  const releaseStart = Math.max(attackEnd, releaseTime - 0.07);
+  const attackEnd = Math.min(releaseTime - 0.08, time + 0.1);
+  const releaseStart = Math.max(attackEnd, releaseTime - 0.06);
   gain.setValueAtTime(0.0001, time);
   gain.linearRampToValueAtTime(peak, attackEnd);
   gain.setValueAtTime(peak, releaseStart);
@@ -307,19 +318,23 @@ function nextSustainedLeadNote(sectionIndex, step) {
 
 function playFluteLead(note, nextNote, time, holdSteps) {
   if (!note) return;
-  // User-tuned lead transposition remains two octaves below the written melody.
-  const hz = noteToFrequency(note) / 4;
-  const nextHz = nextNote ? noteToFrequency(nextNote) / 4 : null;
+  // Chorus flute sits one octave above the T/B lead transposition.
+  const hz = noteToFrequency(note) / 2;
+  const nextHz = nextNote ? noteToFrequency(nextNote) / 2 : null;
   const duration = STEP_SECONDS * Math.max(1, holdSteps);
   const endTime = time + duration;
   const beatSeconds = STEP_SECONDS * STEPS_PER_BEAT;
-  const glideStart = Math.max(time + 0.2, endTime - beatSeconds);
+  // Long notes lean toward the next pitch across their final beat; short notes only connect briefly.
+  const glideWindow = holdSteps >= STEPS_PER_BEAT * 2
+    ? beatSeconds
+    : Math.min(STEP_SECONDS, duration * 0.3);
+  const glideStart = Math.max(time + 0.08, endTime - glideWindow);
 
   const body = trackSource(context.createOscillator());
   const overtone = trackSource(context.createOscillator());
   const vibrato = trackSource(context.createOscillator());
-  const bodyGain = makeGain(0.92);
-  const overtoneGain = makeGain(0.07);
+  const bodyGain = makeGain(0.9);
+  const overtoneGain = makeGain(0.04);
   const vibratoGain = makeGain(0);
   const amp = makeGain(0.0001);
   if (!bodyGain || !overtoneGain || !vibratoGain || !amp) return;
@@ -332,7 +347,7 @@ function playFluteLead(note, nextNote, time, holdSteps) {
   overtone.frequency.setValueAtTime(hz * 2, time);
   vibrato.frequency.setValueAtTime(5.2, time);
   vibratoGain.gain.setValueAtTime(0, time);
-  vibratoGain.gain.linearRampToValueAtTime(5.5, Math.min(endTime - 0.1, time + beatSeconds * 1.25));
+  vibratoGain.gain.linearRampToValueAtTime(4.2, Math.min(endTime - 0.08, time + beatSeconds));
 
   if (nextHz && glideStart < endTime - 0.04) {
     body.frequency.setValueAtTime(hz, glideStart);
@@ -343,8 +358,8 @@ function playFluteLead(note, nextNote, time, holdSteps) {
 
   filter.type = 'lowpass';
   filter.frequency.value = 2400;
-  filter.Q.value = 0.2;
-  scheduleFluteEnvelope(amp.gain, time, 0.18, endTime);
+  filter.Q.value = 0.18;
+  scheduleFluteEnvelope(amp.gain, time, 0.105, endTime);
 
   vibrato.connect(vibratoGain);
   vibratoGain.connect(body.detune);
@@ -851,7 +866,7 @@ export function installRacingMusic({ home = document.querySelector('.m8-home') }
   const api = Object.freeze({
     bpm: BPM,
     arrangement: Object.freeze(ARRANGEMENT.map((section) => section.name)),
-    timbre: 'warm-v3-flute-legato-chorus',
+    timbre: 'warm-v3-melodic-flute-chorus',
     get volume() { return musicVolume; },
     get enabled() { return musicVolume > 0; },
     get playing() { return playing; },

--- a/turn/index.html
+++ b/turn/index.html
@@ -76,7 +76,7 @@
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
-        "/turn/audio/racing-music-v2.js?build=20260809-r163-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=r422-flute-legato-chorus",
+        "/turn/audio/racing-music-v2.js?build=20260809-r163-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=r423-melodic-flute-chorus",
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",


### PR DESCRIPTION
Follow-up listening pass on the TURN chorus after #422.

## Chorus melody
Keeps **T → T → B → T → C → C** and the Em → C → G → B7 foundation, but replaces the four whole-bar tones with a more melodic phrase:

- Em: **E (2 beats) → G → B**
- C: **G → E (3 beats)**
- G: **D → B → A → G**
- B7: **F# → A → D# (2 beats)**

The final D# still resolves naturally into E when C repeats.

## Flute placement
- chorus flute moves **one octave up** relative to the ordinary T/B lead transposition (`/2` instead of `/4`);
- flute peak is reduced from **0.18 to 0.105** so the higher voice sits behind the track rather than dominating it;
- overtone is reduced from 0.07 to 0.04;
- sine-rich flute character, soft filtering and 5.2 Hz vibrato remain;
- one-beat notes use only a brief final connection, while sustained notes retain the longer legato glide.

## Preserved
- T/B melody and articulation;
- bass, arp and drums;
- 120 BPM;
- current global/default music-volume behavior and saved preferences;
- MUSIC OFF shutdown contract;
- production/LAB import-map parity.

## Cache + tests
Uses a fresh `r423-melodic-flute-chorus` module revision in production and TURN LAB. The generated-music regression now locks the more varied 64-step phrase, octave-up flute path, lower chorus gain, restrained overtone and existing control/shutdown behavior.