### PR TITLE
TURN: make chorus flute articulated eighth notes

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -66,7 +66,7 @@
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
-        "/turn/audio/racing-music-v2.js?build=20260809-r163-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=r423-melodic-flute-chorus",
+        "/turn/audio/racing-music-v2.js?build=20260809-r163-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=r424-eighth-note-flute-chorus",
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",

--- a/turn-tests/racing-music-production.mjs
+++ b/turn-tests/racing-music-production.mjs
@@ -9,8 +9,8 @@ const [index, homeLayout, music] = await Promise.all([
 
 assert.match(
   index,
-  /"\/turn\/audio\/racing-music-v2\.js\?build=20260809-r163-racing-music-warm-v2": "\/turn\/audio\/racing-music-v3\.js\?revision=r423-melodic-flute-chorus"/,
-  'The existing Home music import must resolve to a fresh melodic-flute URL without disturbing the Home layout'
+  /"\/turn\/audio\/racing-music-v2\.js\?build=20260809-r163-racing-music-warm-v2": "\/turn\/audio\/racing-music-v3\.js\?revision=r424-eighth-note-flute-chorus"/,
+  'The established Home music import must resolve to the fresh eighth-note chorus URL'
 );
 assert.match(homeLayout, /audio\/racing-music-v2\.js\?build=\$\{buildKey\}-racing-music-warm-v2/,
   'The established Home lifecycle remains the single music installation point');
@@ -18,59 +18,53 @@ assert.match(homeLayout, /installRacingMusic\(\{ home \}\)/,
   'Racing music must remain attached to production Home rather than TURN NEXT');
 
 assert.match(music, /const BPM = 120/,
-  'The melodic flute chorus must preserve the user-tuned 120 BPM tempo');
-assert.match(music, /const DEFAULT_VOLUME = 50/,
-  'The melodic flute chorus must preserve the user-tuned default volume');
+  'The eighth-note chorus must preserve the current 120 BPM tempo');
+assert.match(music, /const DEFAULT_VOLUME = 25/,
+  'The eighth-note chorus must preserve the current hand-tuned 25% default volume');
 assert.match(music, /User-tuned T\/B lead transposition:[\s\S]*const hz = noteToFrequency\(note\) \/ 4/,
-  'The ordinary T/B lead must preserve the user-tuned two-octave-down transposition');
+  'The ordinary T/B lead must preserve the two-octave-down transposition');
 assert.match(music, /User-tuned bass transposition:[\s\S]*const hz = noteToFrequency\(note\) \/ 2/,
-  'The bass must preserve the user-tuned one-octave-down transposition');
+  'The bass must preserve the one-octave-down transposition');
 
 assert.match(music, /const CHORUS = Object\.freeze\(/,
   'The song must retain a distinct reusable chorus section');
-assert.match(music, /name: 'chorus',[\s\S]*sustainLead: true/,
-  'The chorus must explicitly opt into sustained lead notes');
+assert.match(music, /name: 'chorus',[\s\S]*leadVoice: 'flute'/,
+  'The chorus must keep its dedicated flute voice without using sustain as the routing flag');
+assert.doesNotMatch(music, /sustainLead|leadHoldSteps|nextSustainedLeadNote|nextNote/,
+  'The chorus must not retain the old sustain or portamento machinery');
 assert.match(
   music,
-  /'E6', null, null, null, null, null, null, null,[\s\S]*'G6', null, null, null,[\s\S]*'B6', null, null, null,[\s\S]*'G6', null, null, null,[\s\S]*'E6', null, null, null, null, null, null, null, null, null, null, null,[\s\S]*'D7', null, null, null,[\s\S]*'B6', null, null, null,[\s\S]*'A6', null, null, null,[\s\S]*'G6', null, null, null,[\s\S]*'F#6', null, null, null,[\s\S]*'A6', null, null, null,[\s\S]*'D#6', null, null, null, null, null, null, null/,
-  'The chorus melody must mix one-beat movement with selected two- and three-beat sustained hook tones'
+  /'E6', null, 'G6', null, 'B6', null, 'G6', null,[\s\S]*'G6', null, 'E6', null, 'C7', null, 'E7', null,[\s\S]*'D7', null, 'B6', null, 'G6', null, 'B6', null,[\s\S]*'F#6', null, 'A6', null, 'B6', null, 'D#7', null/,
+  'The chorus lead must articulate on alternating sixteenth-note slots, i.e. true eighth notes'
 );
 assert.match(music, /const ARRANGEMENT = Object\.freeze\(\[TUNE, TUNE, BRIDGE, TUNE, CHORUS, CHORUS\]\)/,
-  'The form must remain T T B T C C so the chorus stays a scarce two-pass payoff');
+  'The form must remain T T B T C C');
 
-assert.match(music, /function scheduleFluteEnvelope\(gain, time, peak, releaseTime\)/,
-  'The chorus needs a dedicated flute envelope rather than stretching the punchy lead decay');
-assert.match(music, /gain\.setValueAtTime\(peak, releaseStart\)/,
-  'The flute envelope must hold its level instead of decaying immediately');
-assert.match(music, /function nextSustainedLeadNote\(sectionIndex, step\)/,
-  'The scheduler must know the destination pitch for chorus legato');
-assert.match(music, /if \(!nextSection\?\.sustainLead\) return null/,
-  'The second chorus must not force a portamento into the returning punchy T section');
-assert.match(music, /function playFluteLead\(note, nextNote, time, holdSteps\)/,
-  'Sustained chorus notes must use a dedicated flute-like voice');
-assert.match(music, /Chorus flute sits one octave above the T\/B lead transposition\.[\s\S]*const hz = noteToFrequency\(note\) \/ 2/,
-  'The flute must sit one octave above the ordinary lead');
-assert.match(music, /const glideWindow = holdSteps >= STEPS_PER_BEAT \* 2[\s\S]*\? beatSeconds[\s\S]*: Math\.min\(STEP_SECONDS, duration \* 0\.3\)/,
-  'Long flute notes should spend their final beat leaning into the next pitch while short notes only connect briefly');
-assert.match(music, /body\.frequency\.linearRampToValueAtTime\(nextHz, endTime - 0\.025\)/,
-  'The flute must retain gentle legato movement toward the next pitch');
-assert.match(music, /body\.type = 'sine';[\s\S]*overtone\.type = 'sine';[\s\S]*vibrato\.type = 'sine'/,
-  'The chorus should retain its sine-rich flute timbre with gentle vibrato');
-assert.match(music, /vibrato\.frequency\.setValueAtTime\(5\.2, time\)/,
-  'The flute should retain subtle natural vibrato');
-assert.match(music, /scheduleFluteEnvelope\(amp\.gain, time, 0\.105, endTime\)/,
-  'The higher flute must sit substantially lower in the mix than the previous 0.18 chorus peak');
+assert.match(music, /function playFluteLead\(note, time\)/,
+  'The chorus must use a dedicated articulated flute voice');
+assert.match(music, /Chorus flute stays one octave above the T\/B lead transposition\.[\s\S]*const hz = noteToFrequency\(note\) \/ 2/,
+  'The chorus flute must stay one octave above the ordinary lead');
+assert.match(music, /const duration = STEP_SECONDS \* 2 \* 0\.88/,
+  'Each flute event must occupy one eighth note with a small articulation gap');
+assert.match(music, /scheduleGainEnvelope\(amp\.gain, time, 0\.07, endTime, 0\.035\)/,
+  'The articulated flute must preserve the current quieter 0.07 peak');
+assert.match(music, /const bodyGain = makeGain\(0\.9\)/,
+  'The flute body balance must preserve the current hand-tuned value');
 assert.match(music, /const overtoneGain = makeGain\(0\.04\)/,
-  'The octave-up flute should keep its bright overtone restrained');
+  'The flute overtone must remain restrained');
 assert.match(music, /filter\.frequency\.value = 2400/,
   'The flute chorus should remain soft rather than bright and chiptune-like');
+assert.doesNotMatch(music, /const vibrato =|linearRampToValueAtTime\(nextHz|scheduleFluteEnvelope/,
+  'Eighth-note chorus events must not use sustained vibrato, glide, or hold envelopes');
 
-assert.match(music, /if \(sustained\) \{[\s\S]*playFluteLead\(note, nextNote, time, holdSteps\);[\s\S]*return;/,
-  'Only sustained chorus notes should use the flute path');
+assert.match(music, /function playLead\(note, time, \{ voice = 'lead' \} = \{\}\)/,
+  'Lead voice selection must be independent of note sustain');
+assert.match(music, /if \(voice === 'flute'\) \{[\s\S]*playFluteLead\(note, time\);[\s\S]*return;/,
+  'The dedicated chorus voice must route to the flute synth');
+assert.match(music, /voice: section\.leadVoice \|\| 'lead'/,
+  'The scheduler must select the chorus flute by voice rather than by sustain');
 assert.match(music, /body\.type = 'triangle'/,
   'The ordinary T/B lead and bass must keep the established warm triangle character');
-assert.match(music, /nextNote: section\.sustainLead \? nextSustainedLeadNote\(currentSection, step\) : null/,
-  'The scheduler must provide portamento destinations only to sustained sections');
 
 assert.match(music, /MUSIC_VOLUME_STORAGE_KEY = 'turn-racing-music-volume-v1'/,
   'The chorus rollout must preserve existing saved volume preferences');
@@ -94,6 +88,6 @@ assert.match(music, /label\.innerHTML = '<strong>Music volume<\/strong><small>OF
 assert.match(music, /labels\.innerHTML = '<span>OFF<\/span><span>100%<\/span>'/);
 assert.match(music, /arrangement: Object\.freeze\(ARRANGEMENT\.map\(\(section\) => section\.name\)\)/,
   'Runtime diagnostics must expose the actual T/T/B/T/C/C form');
-assert.match(music, /timbre: 'warm-v3-melodic-flute-chorus'/);
+assert.match(music, /timbre: 'warm-v3-eighth-note-flute-chorus'/);
 
-console.log('TURN T/T/B/T/C/C melodic flute chorus, preserved tuning, and music controls regression passed.');
+console.log('TURN T/T/B/T/C/C eighth-note flute chorus, preserved hand tuning, and music controls regression passed.');

--- a/turn/audio/racing-music-v3.js
+++ b/turn/audio/racing-music-v3.js
@@ -121,28 +121,24 @@ const BRIDGE = Object.freeze({
   ])
 });
 
-// C — a melodic flute hook over Em → C → G → B7.
-// Most notes move every beat; selected hook tones breathe for two or three beats.
+// C — a short, articulated flute hook over Em → C → G → B7.
+// The sequencer grid is sixteenth notes, so alternating note/null slots make true eighth notes.
 const CHORUS = Object.freeze({
   name: 'chorus',
-  sustainLead: false,
+  leadVoice: 'flute',
   lead: Object.freeze([
-    // Em: E (2 beats) → G → B
-    'E6', null, null, null, null, null, null, null,
-    'G6', null, null, null,
-    'B6', null, null, null,
-    // C: G → E (3 beats)
-    'G6', null, null, null,
-    'E6', null, null, null, null, null, null, null, null, null, null, null,
-    // G: D → B → A → G
-    'D7', null, null, null,
-    'B6', null, null, null,
-    'A6', null, null, null,
-    'G6', null, null, null,
-    // B7: F# → A → D# (2 beats), resolving to E when C repeats
-    'F#6', null, null, null,
-    'A6', null, null, null,
-    'D#6', null, null, null, null, null, null, null
+    // Em — eight eighth notes
+    'E6', null, 'G6', null, 'B6', null, 'G6', null,
+    'E7', null, 'B6', null, 'G6', null, 'B6', null,
+    // C — eight eighth notes
+    'G6', null, 'E6', null, 'C7', null, 'E7', null,
+    'G7', null, 'E7', null, 'D7', null, 'C7', null,
+    // G — eight eighth notes
+    'D7', null, 'B6', null, 'G6', null, 'B6', null,
+    'D7', null, 'B6', null, 'A6', null, 'G6', null,
+    // B7 — eight eighth notes, ending on D# to pull back into E
+    'F#6', null, 'A6', null, 'B6', null, 'D#7', null,
+    'B6', null, 'A6', null, 'F#6', null, 'D#6', null
   ]),
   bass: Object.freeze([
     'E2', null, null, null, 'B2', null, null, null,
@@ -289,81 +285,31 @@ function scheduleGainEnvelope(gain, time, peak, releaseTime, attack = 0.018) {
   gain.exponentialRampToValueAtTime(0.0001, releaseTime);
 }
 
-function scheduleFluteEnvelope(gain, time, peak, releaseTime) {
-  const attackEnd = Math.min(releaseTime - 0.08, time + 0.1);
-  const releaseStart = Math.max(attackEnd, releaseTime - 0.06);
-  gain.setValueAtTime(0.0001, time);
-  gain.linearRampToValueAtTime(peak, attackEnd);
-  gain.setValueAtTime(peak, releaseStart);
-  gain.exponentialRampToValueAtTime(0.0001, releaseTime);
-}
-
-function leadHoldSteps(section, step) {
-  if (!section?.sustainLead || !section.lead[step]) return 1;
-  let hold = 1;
-  while (step + hold < section.lead.length && section.lead[step + hold] == null) hold += 1;
-  return hold;
-}
-
-function nextSustainedLeadNote(sectionIndex, step) {
-  const section = ARRANGEMENT[sectionIndex];
-  if (!section?.sustainLead) return null;
-  for (let index = step + 1; index < section.lead.length; index += 1) {
-    if (section.lead[index]) return section.lead[index];
-  }
-  const nextSection = ARRANGEMENT[(sectionIndex + 1) % ARRANGEMENT.length];
-  if (!nextSection?.sustainLead) return null;
-  return nextSection.lead.find(Boolean) || null;
-}
-
-function playFluteLead(note, nextNote, time, holdSteps) {
+function playFluteLead(note, time) {
   if (!note) return;
-  // Chorus flute sits one octave above the T/B lead transposition.
+  // Chorus flute stays one octave above the T/B lead transposition.
   const hz = noteToFrequency(note) / 2;
-  const nextHz = nextNote ? noteToFrequency(nextNote) / 2 : null;
-  const duration = STEP_SECONDS * Math.max(1, holdSteps);
+  // One eighth note = two sixteenth-note sequencer steps. Leave a tiny articulation gap.
+  const duration = STEP_SECONDS * 2 * 0.88;
   const endTime = time + duration;
-  const beatSeconds = STEP_SECONDS * STEPS_PER_BEAT;
-  // Long notes lean toward the next pitch across their final beat; short notes only connect briefly.
-  const glideWindow = holdSteps >= STEPS_PER_BEAT * 2
-    ? beatSeconds
-    : Math.min(STEP_SECONDS, duration * 0.3);
-  const glideStart = Math.max(time + 0.08, endTime - glideWindow);
 
   const body = trackSource(context.createOscillator());
   const overtone = trackSource(context.createOscillator());
-  const vibrato = trackSource(context.createOscillator());
   const bodyGain = makeGain(0.9);
   const overtoneGain = makeGain(0.04);
-  const vibratoGain = makeGain(0);
   const amp = makeGain(0.0001);
-  if (!bodyGain || !overtoneGain || !vibratoGain || !amp) return;
+  if (!bodyGain || !overtoneGain || !amp) return;
   const filter = context.createBiquadFilter();
 
   body.type = 'sine';
   overtone.type = 'sine';
-  vibrato.type = 'sine';
   body.frequency.setValueAtTime(hz, time);
   overtone.frequency.setValueAtTime(hz * 2, time);
-  vibrato.frequency.setValueAtTime(5.2, time);
-  vibratoGain.gain.setValueAtTime(0, time);
-  vibratoGain.gain.linearRampToValueAtTime(4.2, Math.min(endTime - 0.08, time + beatSeconds));
-
-  if (nextHz && glideStart < endTime - 0.04) {
-    body.frequency.setValueAtTime(hz, glideStart);
-    body.frequency.linearRampToValueAtTime(nextHz, endTime - 0.025);
-    overtone.frequency.setValueAtTime(hz * 2, glideStart);
-    overtone.frequency.linearRampToValueAtTime(nextHz * 2, endTime - 0.025);
-  }
-
   filter.type = 'lowpass';
   filter.frequency.value = 2400;
   filter.Q.value = 0.18;
-  scheduleFluteEnvelope(amp.gain, time, 0.07, endTime);
+  scheduleGainEnvelope(amp.gain, time, 0.07, endTime, 0.035);
 
-  vibrato.connect(vibratoGain);
-  vibratoGain.connect(body.detune);
-  vibratoGain.connect(overtone.detune);
   body.connect(bodyGain);
   overtone.connect(overtoneGain);
   bodyGain.connect(filter);
@@ -373,16 +319,14 @@ function playFluteLead(note, nextNote, time, holdSteps) {
 
   body.start(time);
   overtone.start(time);
-  vibrato.start(time);
   body.stop(endTime + 0.01);
   overtone.stop(endTime + 0.01);
-  vibrato.stop(endTime + 0.01);
 }
 
-function playLead(note, time, { holdSteps = 1, sustained = false, nextNote = null } = {}) {
+function playLead(note, time, { voice = 'lead' } = {}) {
   if (!note) return;
-  if (sustained) {
-    playFluteLead(note, nextNote, time, holdSteps);
+  if (voice === 'flute') {
+    playFluteLead(note, time);
     return;
   }
 
@@ -533,9 +477,7 @@ function playDrums(pattern, time) {
 function scheduleStep(step, time) {
   const section = ARRANGEMENT[currentSection];
   playLead(section.lead[step], time, {
-    holdSteps: leadHoldSteps(section, step),
-    sustained: section.sustainLead === true,
-    nextNote: section.sustainLead ? nextSustainedLeadNote(currentSection, step) : null
+    voice: section.leadVoice || 'lead'
   });
   playBass(section.bass[step], time);
   playArp(section.arp[step], time);
@@ -866,7 +808,7 @@ export function installRacingMusic({ home = document.querySelector('.m8-home') }
   const api = Object.freeze({
     bpm: BPM,
     arrangement: Object.freeze(ARRANGEMENT.map((section) => section.name)),
-    timbre: 'warm-v3-melodic-flute-chorus',
+    timbre: 'warm-v3-eighth-note-flute-chorus',
     get volume() { return musicVolume; },
     get enabled() { return musicVolume > 0; },
     get playing() { return playing; },

--- a/turn/index.html
+++ b/turn/index.html
@@ -76,7 +76,7 @@
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
-        "/turn/audio/racing-music-v2.js?build=20260809-r163-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=r423-melodic-flute-chorus",
+        "/turn/audio/racing-music-v2.js?build=20260809-r163-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=r424-eighth-note-flute-chorus",
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",


### PR DESCRIPTION
Follow-up listening pass on the TURN chorus using the current hand-edited `main` as source of truth.

## What changed
- keeps **T → T → B → T → C → C**;
- C now contains **32 articulated eighth-note flute events** across its four bars (note/null on the 16th-note scheduler grid);
- removes chorus sustain, hold-duration, vibrato and pitch-glide/portamento machinery;
- keeps the dedicated flute timbre via a new `leadVoice: 'flute'` routing flag, so flute character is no longer coupled to sustain;
- each flute event lasts just under one eighth note (`2 × STEP_SECONDS × 0.88`) to leave a small articulation gap.

## Preserved from current main
- **120 BPM**;
- **25% default music volume**;
- chorus flute peak **0.07**;
- flute body/overtone balance **0.9 / 0.04**;
- flute one octave above the T/B lead transposition;
- T/B melody, articulation, bass, arp, drums and all music controls;
- MUSIC OFF shutdown behavior.

## Cache + tests
- production and TURN LAB import maps move to `r424-eighth-note-flute-chorus`;
- generated-music regression now explicitly protects the current hand-tuned 25% / 0.07 values and verifies that flute voice selection is independent from sustain.