### PR TITLE
TURN: fix Home header yellow bleed and align music control

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -54,6 +54,7 @@
   <link rel="stylesheet" href="./garage/lot-layout-r60.css?build=20260809-r163-native-html">
   <link rel="stylesheet" href="./accessibility/color-cues-r163.css?build=20260809-r163-accessible-paint">
   <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260809-r163-menu-font-v3">
+  <link rel="stylesheet" href="./home-header-r425.css?revision=r425-header-boundary">
   <script src="/turn-lab/lab-bootstrap.js?revision=viewport-flight-recorder-r1"></script>
   <script src="/turn-lab/viewport-diagnostics.js?revision=viewport-flight-recorder-r1"></script>
   <script src="./pwa-usable-viewport-r181.js?revision=r181-usable-web-layer"></script>

--- a/turn-tests/racing-music-production.mjs
+++ b/turn-tests/racing-music-production.mjs
@@ -1,10 +1,12 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [index, homeLayout, music] = await Promise.all([
+const [index, labIndex, homeLayout, music, headerFix] = await Promise.all([
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn-lab/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/audio/racing-music-v3.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/audio/racing-music-v3.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/home-header-r425.css', import.meta.url), 'utf8')
 ]);
 
 assert.match(
@@ -16,6 +18,19 @@ assert.match(homeLayout, /audio\/racing-music-v2\.js\?build=\$\{buildKey\}-racin
   'The established Home lifecycle remains the single music installation point');
 assert.match(homeLayout, /installRacingMusic\(\{ home \}\)/,
   'Racing music must remain attached to production Home rather than TURN NEXT');
+
+assert.match(index, /home-header-r425\.css\?revision=r425-header-boundary/,
+  'Production TURN must load the cache-busted Home header correction');
+assert.match(labIndex, /home-header-r425\.css\?revision=r425-header-boundary/,
+  'TURN LAB must load the same Home header correction as production');
+assert.match(headerFix, /html \.m8-home\.m8-home-fixed-layout \{\s*background: var\(--m8-blue\);/,
+  'The fixed Home canvas must own the blue background instead of a percentage-based yellow split');
+assert.match(headerFix, /html \.m8-home\.m8-home-fixed-layout \.m8-home-head \{\s*background: var\(--m8-yellow\);/,
+  'The actual Home header must own the yellow background so it stops at its real border');
+assert.match(headerFix, /turn-music-home-toggle \{\s*transform: translateY\(clamp\(-14px, -1\.8vh, -8px\)\);/,
+  'The Home music control must align upward with the version/build row while retaining its hit target');
+assert.match(headerFix, /@media \(max-width: 760px\) and \(orientation: portrait\)[\s\S]*turn-music-home-toggle \{\s*transform: none;/,
+  'Portrait Home must not inherit the landscape metadata alignment offset');
 
 assert.match(music, /const BPM = 120/,
   'The eighth-note chorus must preserve the current 120 BPM tempo');
@@ -37,8 +52,8 @@ assert.match(
   /'E6', null, 'G6', null, 'B6', null, 'G6', null,[\s\S]*'G6', null, 'E6', null, 'C7', null, 'E7', null,[\s\S]*'D7', null, 'B6', null, 'G6', null, 'B6', null,[\s\S]*'F#6', null, 'A6', null, 'B6', null, 'D#7', null/,
   'The chorus lead must articulate on alternating sixteenth-note slots, i.e. true eighth notes'
 );
-assert.match(music, /const ARRANGEMENT = Object\.freeze\(\[TUNE, TUNE, BRIDGE, TUNE, CHORUS, CHORUS\]\)/,
-  'The form must remain T T B T C C');
+assert.match(music, /const ARRANGEMENT = Object\.freeze\(\[TUNE, TUNE, BRIDGE, TUNE, CHORUS, CHORUS, BRIDGE, BRIDGE\]\)/,
+  'The approved form must remain T T B T C C B B');
 
 assert.match(music, /function playFluteLead\(note, time\)/,
   'The chorus must use a dedicated articulated flute voice');
@@ -87,7 +102,7 @@ assert.match(music, /className = 'turn-music-blank-toggle'/);
 assert.match(music, /label\.innerHTML = '<strong>Music volume<\/strong><small>OFF stops the music engine completely\.<\/small>'/);
 assert.match(music, /labels\.innerHTML = '<span>OFF<\/span><span>100%<\/span>'/);
 assert.match(music, /arrangement: Object\.freeze\(ARRANGEMENT\.map\(\(section\) => section\.name\)\)/,
-  'Runtime diagnostics must expose the actual T/T/B/T/C/C form');
+  'Runtime diagnostics must expose the actual T/T/B/T/C/C/B/B form');
 assert.match(music, /timbre: 'warm-v3-eighth-note-flute-chorus'/);
 
-console.log('TURN T/T/B/T/C/C eighth-note flute chorus, preserved hand tuning, and music controls regression passed.');
+console.log('TURN T/T/B/T/C/C/B/B eighth-note flute chorus, Home header boundary, music alignment, and controls regression passed.');

--- a/turn/home-header-r425.css
+++ b/turn/home-header-r425.css
@@ -1,0 +1,28 @@
+/* TURN Home header boundary + metadata alignment.
+   The fixed Home canvas is blue; the header itself owns the yellow fill so
+   yellow can never extend below the header's real grid-row height. */
+html .m8-home.m8-home-fixed-layout {
+  background: var(--m8-blue);
+}
+
+html .m8-home.m8-home-fixed-layout .m8-home-head {
+  background: var(--m8-yellow);
+}
+
+/* Keep the music control's full touch target, but align its visible label
+   with the first (version/build) row of the metadata block. */
+html .m8-home.m8-home-fixed-layout .turn-music-home-toggle {
+  transform: translateY(calc(-1 * clamp(8px, 1.8vh, 14px)));
+}
+
+@media (max-height: 560px) and (orientation: landscape) {
+  html .m8-home.m8-home-fixed-layout .turn-music-home-toggle {
+    transform: translateY(-8px);
+  }
+}
+
+@media (max-width: 760px) and (orientation: portrait) {
+  html .m8-home.m8-home-fixed-layout .turn-music-home-toggle {
+    transform: none;
+  }
+}

--- a/turn/home-header-r425.css
+++ b/turn/home-header-r425.css
@@ -12,7 +12,7 @@ html .m8-home.m8-home-fixed-layout .m8-home-head {
 /* Keep the music control's full touch target, but align its visible label
    with the first (version/build) row of the metadata block. */
 html .m8-home.m8-home-fixed-layout .turn-music-home-toggle {
-  transform: translateY(calc(-1 * clamp(8px, 1.8vh, 14px)));
+  transform: translateY(clamp(-14px, -1.8vh, -8px));
 }
 
 @media (max-height: 560px) and (orientation: landscape) {

--- a/turn/index.html
+++ b/turn/index.html
@@ -65,6 +65,7 @@
   <link rel="stylesheet" href="./garage/lot-layout-r60.css?build=20260809-r163-native-html">
   <link rel="stylesheet" href="./accessibility/color-cues-r163.css?build=20260809-r163-accessible-paint">
   <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260809-r163-menu-font-v3">
+  <link rel="stylesheet" href="./home-header-r425.css?revision=r425-header-boundary">
   <script src="./install-gate.js?build=20260809-r163-social-browser"></script>
   <script src="./pwa-usable-viewport-r181.js?revision=r181-usable-web-layer"></script>
   <script src="./motion-safe-zone.js?build=20260809-r163"></script>


### PR DESCRIPTION
Fixes the Home header regression shown in the Aug 10 screenshot.

## Header boundary
The fixed Home layout currently paints yellow as the first 18% of the whole Home background while the real header row is `clamp(..., 15vh, ...)`. On viewports where those values differ, yellow continues below the header's 5px black border.

This change makes the ownership explicit:
- the fixed Home canvas is blue;
- the actual `.m8-home-head` owns the yellow background;
- therefore yellow ends at the real header border regardless of viewport height.

## Music control alignment
The existing 44px MUSIC ON/OFF hit target stays intact, but its visual position moves upward responsively so the label aligns with the TURN version/build row rather than sitting between the build and ABOUT TURN rows.

- normal landscape: `clamp(-14px, -1.8vh, -8px)`
- short landscape: `-8px`
- portrait: no offset (build metadata is hidden there)

## Delivery/cache safety
Uses a new top-level `home-header-r425.css?revision=r425-header-boundary` stylesheet URL in both production TURN and TURN LAB, so the fix does not depend on an already-cached Home-layout module or stylesheet being refreshed.

No game, music, track, control, or layout sizing logic is changed.