### PR TITLE
Hotfix: roll back TURN audio to reviewed #424 baseline

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -67,7 +67,7 @@
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
-        "/turn/audio/racing-music-v2.js?build=20260809-r163-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=r424-eighth-note-flute-chorus",
+        "/turn/audio/racing-music-v2.js?build=20260809-r163-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=r429-reviewed-audio-rollback",
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",

--- a/turn-tests/racing-music-production.mjs
+++ b/turn-tests/racing-music-production.mjs
@@ -11,8 +11,8 @@ const [index, labIndex, homeLayout, music, headerFix] = await Promise.all([
 
 assert.match(
   index,
-  /"\/turn\/audio\/racing-music-v2\.js\?build=20260809-r163-racing-music-warm-v2": "\/turn\/audio\/racing-music-v3\.js\?revision=r424-eighth-note-flute-chorus"/,
-  'The established Home music import must resolve to the current chorus engine URL'
+  /"\/turn\/audio\/racing-music-v2\.js\?build=20260809-r163-racing-music-warm-v2": "\/turn\/audio\/racing-music-v3\.js\?revision=r429-reviewed-audio-rollback"/,
+  'The established Home music import must resolve to the fresh reviewed rollback URL'
 );
 assert.match(homeLayout, /audio\/racing-music-v2\.js\?build=\$\{buildKey\}-racing-music-warm-v2/,
   'The established Home lifecycle remains the single music installation point');
@@ -33,9 +33,9 @@ assert.match(headerFix, /@media \(max-width: 760px\) and \(orientation: portrait
   'Portrait Home must not inherit the landscape metadata alignment offset');
 
 assert.match(music, /const BPM = 120/,
-  'The current chorus must preserve the hand-tuned 120 BPM tempo');
+  'The reviewed chorus must preserve the hand-tuned 120 BPM tempo');
 assert.match(music, /const DEFAULT_VOLUME = 25/,
-  'The current chorus must preserve the hand-tuned 25% default volume');
+  'The rollback restores the reviewed 25% default while the audio fault is isolated');
 assert.match(music, /User-tuned T\/B lead transposition:[\s\S]*const hz = noteToFrequency\(note\) \/ 4/,
   'The ordinary T/B lead must preserve the two-octave-down transposition');
 assert.match(music, /User-tuned bass transposition:[\s\S]*const hz = noteToFrequency\(note\) \/ 2/,
@@ -49,28 +49,28 @@ assert.doesNotMatch(music, /sustainLead|leadHoldSteps|nextSustainedLeadNote|next
   'The chorus must not retain the old sustain or portamento machinery');
 assert.match(
   music,
-  /'E6', 'E6', 'G6', 'G6', 'B6', 'B6', 'G6', 'G6',[\s\S]*'G6', 'G6', 'E6', 'E6', 'C7', 'C7', 'E7', 'E7',[\s\S]*'D7', 'D7', 'B6', 'B6', 'G6', 'G6', 'B6', 'B6',[\s\S]*'F#6', 'F#6', 'A6', 'A6', 'B6', 'B6', 'D#7', 'D#7'/,
-  'The chorus lead must preserve the current paired sixteenth-note melody'
+  /'E6', null, 'G6', null, 'B6', null, 'G6', null,[\s\S]*'G6', null, 'E6', null, 'C7', null, 'E7', null,[\s\S]*'D7', null, 'B6', null, 'G6', null, 'B6', null,[\s\S]*'F#6', null, 'A6', null, 'B6', null, 'D#7', null/,
+  'The chorus lead must restore the reviewed alternating eighth-note melody'
 );
 assert.match(music, /const ARRANGEMENT = Object\.freeze\(\[TUNE, TUNE, BRIDGE, TUNE, CHORUS, CHORUS\]\)/,
-  'The current form must remain T T B T C C');
+  'The reviewed form must remain T T B T C C');
 
 assert.match(music, /function playFluteLead\(note, time\)/,
   'The chorus must use a dedicated articulated flute voice');
 assert.match(music, /Chorus flute stays one octave above the T\/B lead transposition\.[\s\S]*const hz = noteToFrequency\(note\) \/ 2/,
   'The chorus flute must stay one octave above the ordinary lead');
-assert.match(music, /const duration = STEP_SECONDS \* 0\.88/,
-  'Each flute event must occupy one articulated sixteenth note with a small gap');
-assert.match(music, /scheduleGainEnvelope\(amp\.gain, time, 0\.05, endTime, 0\.035\)/,
-  'The articulated flute must preserve the current quieter 0.05 peak');
+assert.match(music, /const duration = STEP_SECONDS \* 2 \* 0\.88/,
+  'Each flute event must occupy one eighth note with a small articulation gap');
+assert.match(music, /scheduleGainEnvelope\(amp\.gain, time, 0\.07, endTime, 0\.035\)/,
+  'The articulated flute must restore the reviewed 0.07 peak');
 assert.match(music, /const bodyGain = makeGain\(0\.9\)/,
-  'The flute body balance must preserve the current hand-tuned value');
+  'The flute body balance must preserve the reviewed value');
 assert.match(music, /const overtoneGain = makeGain\(0\.04\)/,
   'The flute overtone must remain restrained');
 assert.match(music, /filter\.frequency\.value = 2400/,
   'The flute chorus should remain soft rather than bright and chiptune-like');
 assert.doesNotMatch(music, /const vibrato =|linearRampToValueAtTime\(nextHz|scheduleFluteEnvelope/,
-  'Sixteenth-note chorus events must not use sustained vibrato, glide, or hold envelopes');
+  'Eighth-note chorus events must not use sustained vibrato, glide, or hold envelopes');
 
 assert.match(music, /function playLead\(note, time, \{ voice = 'lead' \} = \{\}\)/,
   'Lead voice selection must be independent of note sustain');
@@ -82,7 +82,7 @@ assert.match(music, /body\.type = 'triangle'/,
   'The ordinary T/B lead and bass must keep the established warm triangle character');
 
 assert.match(music, /MUSIC_VOLUME_STORAGE_KEY = 'turn-racing-music-volume-v1'/,
-  'The chorus rollout must preserve existing saved volume preferences');
+  'The rollback must preserve existing saved volume preferences');
 assert.doesNotMatch(music, /fetch\(|new Audio\(/,
   'Racing music must remain generated Web Audio rather than a downloaded asset');
 assert.doesNotMatch(music, /type = 'square'|type = 'sawtooth'|createWaveShaper/,
@@ -106,4 +106,4 @@ assert.match(music, /arrangement: Object\.freeze\(ARRANGEMENT\.map\(\(section\) 
 assert.match(music, /timbre: 'warm-v3-eighth-note-flute-chorus'/,
   'The existing runtime timbre identifier remains stable for compatibility');
 
-console.log('TURN T/T/B/T/C/C sixteenth-note flute chorus, Home header boundary, music alignment, and controls regression passed.');
+console.log('TURN reviewed T/T/B/T/C/C eighth-note flute chorus, Home header boundary, music alignment, and controls regression passed.');

--- a/turn/audio/racing-music-v3.js
+++ b/turn/audio/racing-music-v3.js
@@ -2,7 +2,7 @@ const AudioContextClass = globalThis.AudioContext || globalThis.webkitAudioConte
 
 const MUSIC_VOLUME_STORAGE_KEY = 'turn-racing-music-volume-v1';
 const MUSIC_LAST_VOLUME_STORAGE_KEY = 'turn-racing-music-last-volume-v1';
-const DEFAULT_VOLUME = 50;
+const DEFAULT_VOLUME = 25;
 const BPM = 120;
 const STEPS_PER_BEAT = 4;
 const STEP_SECONDS = (60 / BPM) / STEPS_PER_BEAT;
@@ -126,27 +126,30 @@ const BRIDGE = Object.freeze({
 const CHORUS = Object.freeze({
   name: 'chorus',
   leadVoice: 'flute',
-lead: Object.freeze([
-  'E4', 'E4', 'G4', 'G4', 'B4', 'B4', 'G4', 'G4',
-  'E5', 'E5', 'B4', 'B4', 'G4', 'G4', 'B4', 'B4',
-  'G4', 'G4', 'E4', 'E4', 'C5', 'C5', 'E5', 'E5',
-  'G5', 'G5', 'E5', 'E5', 'D5', 'D5', 'C5', 'C5',
-  'D5', 'D5', 'B4', 'B4', 'G4', 'G4', 'B4', 'B4',
-  'D5', 'D5', 'B4', 'B4', 'A4', 'A4', 'G4', 'G4',
-  'F#4', 'F#4', 'A4', 'A4', 'B4', 'B4', 'D#5', 'D#5',
-  'B4', 'B4', 'A4', 'A4', 'F#4', 'F#4', 'D#4', 'D#4'
-]),
+  lead: Object.freeze([
+    // Em — eight eighth notes
+    'E6', null, 'G6', null, 'B6', null, 'G6', null,
+    'E7', null, 'B6', null, 'G6', null, 'B6', null,
+    // C — eight eighth notes
+    'G6', null, 'E6', null, 'C7', null, 'E7', null,
+    'G7', null, 'E7', null, 'D7', null, 'C7', null,
+    // G — eight eighth notes
+    'D7', null, 'B6', null, 'G6', null, 'B6', null,
+    'D7', null, 'B6', null, 'A6', null, 'G6', null,
+    // B7 — eight eighth notes, ending on D# to pull back into E
+    'F#6', null, 'A6', null, 'B6', null, 'D#7', null,
+    'B6', null, 'A6', null, 'F#6', null, 'D#6', null
+  ]),
   bass: Object.freeze([
-  'E2', 'E2', 'E2', 'E2', 'B2', 'B2', 'B2', 'B2',
-  'E3', 'E3', 'E3', 'E3', 'B2', 'B2', 'B2', 'B2',
-  'C2', 'C2', 'C2', 'C2', 'G2', 'G2', 'G2', 'G2',
-  'C3', 'C3', 'C3', 'C3', 'G2', 'G2', 'G2', 'G2',
-  'G2', 'G2', 'G2', 'G2', 'D3', 'D3', 'D3', 'D3',
-  'G3', 'G3', 'G3', 'G3', 'D3', 'D3', 'D3', 'D3',
-  'B1', 'B1', 'B1', 'B1', 'F#2', 'F#2', 'F#2', 'F#2',
-  'A2', 'A2', 'A2', 'A2', 'D#3', 'D#3', 'F#3', 'F#3'
-]),
-
+    'E2', null, null, null, 'B2', null, null, null,
+    'E3', null, null, null, 'B2', null, null, null,
+    'C2', null, null, null, 'G2', null, null, null,
+    'C3', null, null, null, 'G2', null, null, null,
+    'G2', null, null, null, 'D3', null, null, null,
+    'G3', null, null, null, 'D3', null, null, null,
+    'B1', null, null, null, 'F#2', null, null, null,
+    'A2', null, null, null, 'D#3', null, 'F#3', null
+  ]),
   arp: Object.freeze([
     'E4', null, 'G4', null, 'B4', null, 'G4', null,
     'E5', null, 'B4', null, 'G4', null, 'B4', null,
@@ -158,19 +161,19 @@ lead: Object.freeze([
     'B4', null, 'F#4', null, 'D#4', null, 'F#4', null
   ]),
   drums: Object.freeze([
-    'KH', 'H', 'H', 'H', 'SH', 'H', null, 'H',
-    'KH', 'H', 'H', 'H', 'SH', 'H', 'K', 'OH',
-    'KH', 'H', 'H', 'H', 'SH', 'H', null, 'H',
-    'KH', 'H', 'H', 'OH', 'SH', 'H', 'K', 'OH',
-    'KH', 'H', 'H', 'H', 'SH', 'H', null, 'H',
-    'KH', 'H', 'H', 'H', 'SH', 'H', 'K', 'OH',
-    'KH', 'H', 'H', 'H', 'SH', 'H', 'KH', 'H',
-    'KS', 'H', 'K', 'OH', 'SH', 'H', 'KS', 'OH'
+    'KH', 'H', null, 'H', 'SH', 'H', null, 'H',
+    'KH', 'H', null, 'H', 'SH', 'H', 'K', 'OH',
+    'KH', 'H', null, 'H', 'SH', 'H', null, 'H',
+    'KH', 'H', null, 'H', 'SH', 'H', 'K', 'OH',
+    'KH', 'H', null, 'H', 'SH', 'H', null, 'H',
+    'KH', 'H', null, 'H', 'SH', 'H', 'K', 'OH',
+    'KH', 'H', null, 'H', 'SH', 'H', 'KH', 'H',
+    'KS', 'H', 'K', 'H', 'SH', 'H', 'KS', 'OH'
   ])
 });
 
 // Song form: establish T, contrast with B, return to T, then make C the scarce payoff.
-const ARRANGEMENT = Object.freeze([CHORUS, CHORUS, TUNE, TUNE, BRIDGE, TUNE]);
+const ARRANGEMENT = Object.freeze([TUNE, TUNE, BRIDGE, TUNE, CHORUS, CHORUS]);
 
 let installed = false;
 let context = null;
@@ -282,13 +285,12 @@ function scheduleGainEnvelope(gain, time, peak, releaseTime, attack = 0.018) {
   gain.exponentialRampToValueAtTime(0.0001, releaseTime);
 }
 
-/*
 function playFluteLead(note, time) {
   if (!note) return;
   // Chorus flute stays one octave above the T/B lead transposition.
   const hz = noteToFrequency(note) / 2;
   // One eighth note = two sixteenth-note sequencer steps. Leave a tiny articulation gap.
-const duration = STEP_SECONDS * 0.88;
+  const duration = STEP_SECONDS * 2 * 0.88;
   const endTime = time + duration;
 
   const body = trackSource(context.createOscillator());
@@ -306,7 +308,7 @@ const duration = STEP_SECONDS * 0.88;
   filter.type = 'lowpass';
   filter.frequency.value = 2400;
   filter.Q.value = 0.18;
-  scheduleGainEnvelope(amp.gain, time, 0.05, endTime, 0.035);
+  scheduleGainEnvelope(amp.gain, time, 0.07, endTime, 0.035);
 
   body.connect(bodyGain);
   overtone.connect(overtoneGain);
@@ -319,98 +321,6 @@ const duration = STEP_SECONDS * 0.88;
   overtone.start(time);
   body.stop(endTime + 0.01);
   overtone.stop(endTime + 0.01);
-}
-*/
-
-function playFluteLead(note, time) {
-  if (!note) return;
-
-  // Keep the chorus in its current octave.
-  const hz = noteToFrequency(note) / 2;
-
-  // One sixteenth-note event with a small gap.
-  const duration = STEP_SECONDS * 0.88;
-  const endTime = time + duration;
-
-  // Main guitar body + brighter harmonic.
-  const body = trackSource(context.createOscillator());
-  const harmonic = trackSource(context.createOscillator());
-
-  const bodyGain = makeGain(0.75);
-  const harmonicGain = makeGain(0.16);
-  const amp = makeGain(0.0001);
-
-  if (!bodyGain || !harmonicGain || !amp) return;
-
-  const filter = context.createBiquadFilter();
-
-  // Triangle keeps it warm, while the second oscillator
-  // gives that slightly synthetic 90s-game guitar edge.
-  body.type = 'triangle';
-  harmonic.type = 'triangle';
-
-  body.frequency.setValueAtTime(hz, time);
-  harmonic.frequency.setValueAtTime(hz * 2, time);
-
-  // Tiny downward pitch "pluck" at the start.
-  // Gives the note a picked-string character.
-  body.frequency.setValueAtTime(hz * 1.018, time);
-  body.frequency.exponentialRampToValueAtTime(
-    hz,
-    time + 0.025
-  );
-
-  harmonic.frequency.setValueAtTime(hz * 2.025, time);
-  harmonic.frequency.exponentialRampToValueAtTime(
-    hz * 2,
-    time + 0.022
-  );
-
-  // Start bright, then quickly darken like a plucked string.
-  filter.type = 'lowpass';
-  filter.Q.value = 1.2;
-
-  filter.frequency.setValueAtTime(2000, time);
-  filter.frequency.exponentialRampToValueAtTime(
-    1000,
-    endTime
-  );
-
-  // Guitar-style envelope:
-  // very quick pick attack,
-  // strong initial hit,
-  // then decay rather than a flute sustain.
-  amp.gain.setValueAtTime(0.0001, time);
-
-  amp.gain.exponentialRampToValueAtTime(
-    0.075,
-    time + 0.008
-  );
-
-  amp.gain.exponentialRampToValueAtTime(
-    0.025,
-    time + duration * 0.38
-  );
-
-  amp.gain.exponentialRampToValueAtTime(
-    0.0001,
-    endTime
-  );
-
-  body.connect(bodyGain);
-  harmonic.connect(harmonicGain);
-
-  bodyGain.connect(filter);
-  harmonicGain.connect(filter);
-
-  filter.connect(amp);
-  amp.connect(masterGain);
-
-  body.start(time);
-  harmonic.start(time);
-
-  body.stop(endTime + 0.01);
-  harmonic.stop(endTime + 0.01);
 }
 
 function playLead(note, time, { voice = 'lead' } = {}) {

--- a/turn/index.html
+++ b/turn/index.html
@@ -77,7 +77,7 @@
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
-        "/turn/audio/racing-music-v2.js?build=20260809-r163-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=r424-eighth-note-flute-chorus",
+        "/turn/audio/racing-music-v2.js?build=20260809-r163-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=r429-reviewed-audio-rollback",
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",


### PR DESCRIPTION
## Why
Real-device report: the soundtrack suddenly plays far too fast despite `BPM = 120`, and audio is perceived as pitched up. The current `main` music file had accumulated many direct post-#424 edits outside the reviewed PR, including a change from alternating eighth-note chorus events to paired sixteenth-note events and additional timbre/arrangement edits.

The central TURN game-audio engine (`audio-system.js`) has not changed since August 9, so this hotfix removes the unreviewed music delta first rather than tuning around the symptom.

## What this rolls back
- restores `turn/audio/racing-music-v3.js` byte-for-byte to merged PR #424;
- restores the reviewed **120 BPM**, **T → T → B → T → C → C** form and true alternating eighth-note chorus events;
- restores the reviewed flute articulation/timbre and scheduler behavior;
- restores #424's 25% default for new players temporarily; existing saved music-volume preferences are unchanged;
- cache-busts the production import to `r429-reviewed-audio-rollback` so iOS cannot keep executing the suspect cached module;
- restores the music regression to the reviewed eighth-note contract.

## Scope deliberately untouched
- Monster Truck off-road perk from #427 remains on `main`;
- `turn/audio/audio-system.js` is untouched;
- game physics, YOUR TURN, controls and accessibility code are untouched.

## Follow-up
If the device audio is normal again, restore the intended 50% default as a separate one-line change with the regression updated at the same time. If *all* game audio remains pitched up after this fresh-module rollback, that points away from the composition and toward an iOS/Web Audio output-context issue, which should be investigated separately.