### PR TITLE
Hotfix TURN Web Audio to one shared context

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -67,7 +67,7 @@
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
-        "/turn/audio/racing-music-v2.js?build=20260809-r163-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=r429-reviewed-audio-rollback",
+        "/turn/audio/racing-music-v2.js?build=20260809-r163-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=r430-single-context",
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",

--- a/turn-tests/racing-music-production.mjs
+++ b/turn-tests/racing-music-production.mjs
@@ -1,18 +1,25 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [index, labIndex, homeLayout, music, headerFix] = await Promise.all([
+const [index, labIndex, homeLayout, music, sharedContext, audioPreferences, headerFix] = await Promise.all([
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-lab/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/audio/racing-music-v3.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/audio/shared-audio-context-r430.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/audio/audio-preferences.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/home-header-r425.css', import.meta.url), 'utf8')
 ]);
 
 assert.match(
   index,
-  /"\/turn\/audio\/racing-music-v2\.js\?build=20260809-r163-racing-music-warm-v2": "\/turn\/audio\/racing-music-v3\.js\?revision=r429-reviewed-audio-rollback"/,
-  'The established Home music import must resolve to the fresh reviewed rollback URL'
+  /"\/turn\/audio\/racing-music-v2\.js\?build=20260809-r163-racing-music-warm-v2": "\/turn\/audio\/racing-music-v3\.js\?revision=r430-single-context"/,
+  'Production must cache-bust the single-context music engine'
+);
+assert.match(
+  labIndex,
+  /"\/turn\/audio\/racing-music-v2\.js\?build=20260809-r163-racing-music-warm-v2": "\/turn\/audio\/racing-music-v3\.js\?revision=r430-single-context"/,
+  'TURN LAB must exercise the same single-context music engine as production'
 );
 assert.match(homeLayout, /audio\/racing-music-v2\.js\?build=\$\{buildKey\}-racing-music-warm-v2/,
   'The established Home lifecycle remains the single music installation point');
@@ -32,10 +39,35 @@ assert.match(headerFix, /turn-music-home-toggle \{\s*transform: translateY\(clam
 assert.match(headerFix, /@media \(max-width: 760px\) and \(orientation: portrait\)[\s\S]*turn-music-home-toggle \{\s*transform: none;/,
   'Portrait Home must not inherit the landscape metadata alignment offset');
 
+assert.match(sharedContext, /const NativeAudioContextClass = globalThis\.AudioContext \|\| globalThis\.webkitAudioContext/,
+  'The broker must retain the native browser constructor before replacing the public constructor');
+assert.match(sharedContext, /let sharedContext = null/,
+  'TURN must own exactly one shared Web Audio context reference');
+assert.match(sharedContext, /return new NativeAudioContextClass\(\{ latencyHint: 'interactive' \}\)/,
+  'The single shared context should favor interactive game audio latency');
+assert.match(sharedContext, /function TurnSharedAudioContext\(\) \{\s*return getSharedAudioContext\(\);\s*\}/,
+  'Legacy TURN modules that construct AudioContext must receive the shared native context');
+assert.match(sharedContext, /globalThis\.AudioContext = TurnSharedAudioContext/);
+assert.match(sharedContext, /globalThis\.webkitAudioContext = TurnSharedAudioContext/);
+assert.match(audioPreferences, /^import \{ installSharedAudioContextConstructor \} from '\.\/shared-audio-context-r430\.js\?revision=r430-single-context';/,
+  'The shared constructor must be installed before audio-system.js is evaluated');
+assert.match(audioPreferences, /installSharedAudioContextConstructor\(\);/);
+
+assert.match(music, /^import \{ getSharedAudioContext, resumeSharedAudioContext \} from '\.\/shared-audio-context-r430\.js\?revision=r430-single-context';/,
+  'Racing music must explicitly join TURN’s shared audio clock');
+assert.doesNotMatch(music, /const AudioContextClass|new AudioContextClass/,
+  'Racing music must not create a second AudioContext');
+assert.match(music, /context = getSharedAudioContext\(\)/,
+  'The music graph must be built on the shared context');
+assert.match(music, /const ready = await resumeSharedAudioContext\(\)/,
+  'Music activation must resume the shared TURN context rather than a private one');
+assert.doesNotMatch(music, /context\.suspend\(|context\.close\(/,
+  'Music OFF and graph setup must never suspend or close the shared game-audio context');
+
 assert.match(music, /const BPM = 120/,
   'The reviewed chorus must preserve the hand-tuned 120 BPM tempo');
 assert.match(music, /const DEFAULT_VOLUME = 25/,
-  'The rollback restores the reviewed 25% default while the audio fault is isolated');
+  'The hotfix keeps the reviewed 25% default while the device audio fault is isolated');
 assert.match(music, /User-tuned T\/B lead transposition:[\s\S]*const hz = noteToFrequency\(note\) \/ 4/,
   'The ordinary T/B lead must preserve the two-octave-down transposition');
 assert.match(music, /User-tuned bass transposition:[\s\S]*const hz = noteToFrequency\(note\) \/ 2/,
@@ -50,7 +82,7 @@ assert.doesNotMatch(music, /sustainLead|leadHoldSteps|nextSustainedLeadNote|next
 assert.match(
   music,
   /'E6', null, 'G6', null, 'B6', null, 'G6', null,[\s\S]*'G6', null, 'E6', null, 'C7', null, 'E7', null,[\s\S]*'D7', null, 'B6', null, 'G6', null, 'B6', null,[\s\S]*'F#6', null, 'A6', null, 'B6', null, 'D#7', null/,
-  'The chorus lead must restore the reviewed alternating eighth-note melody'
+  'The chorus lead must retain the reviewed alternating eighth-note melody'
 );
 assert.match(music, /const ARRANGEMENT = Object\.freeze\(\[TUNE, TUNE, BRIDGE, TUNE, CHORUS, CHORUS\]\)/,
   'The reviewed form must remain T T B T C C');
@@ -62,27 +94,16 @@ assert.match(music, /Chorus flute stays one octave above the T\/B lead transposi
 assert.match(music, /const duration = STEP_SECONDS \* 2 \* 0\.88/,
   'Each flute event must occupy one eighth note with a small articulation gap');
 assert.match(music, /scheduleGainEnvelope\(amp\.gain, time, 0\.07, endTime, 0\.035\)/,
-  'The articulated flute must restore the reviewed 0.07 peak');
+  'The articulated flute must preserve the reviewed 0.07 peak');
 assert.match(music, /const bodyGain = makeGain\(0\.9\)/,
   'The flute body balance must preserve the reviewed value');
 assert.match(music, /const overtoneGain = makeGain\(0\.04\)/,
   'The flute overtone must remain restrained');
 assert.match(music, /filter\.frequency\.value = 2400/,
   'The flute chorus should remain soft rather than bright and chiptune-like');
-assert.doesNotMatch(music, /const vibrato =|linearRampToValueAtTime\(nextHz|scheduleFluteEnvelope/,
-  'Eighth-note chorus events must not use sustained vibrato, glide, or hold envelopes');
-
-assert.match(music, /function playLead\(note, time, \{ voice = 'lead' \} = \{\}\)/,
-  'Lead voice selection must be independent of note sustain');
-assert.match(music, /if \(voice === 'flute'\) \{[\s\S]*playFluteLead\(note, time\);[\s\S]*return;/,
-  'The dedicated chorus voice must route to the flute synth');
-assert.match(music, /voice: section\.leadVoice \|\| 'lead'/,
-  'The scheduler must select the chorus flute by voice rather than by sustain');
-assert.match(music, /body\.type = 'triangle'/,
-  'The ordinary T/B lead and bass must keep the established warm triangle character');
 
 assert.match(music, /MUSIC_VOLUME_STORAGE_KEY = 'turn-racing-music-volume-v1'/,
-  'The rollback must preserve existing saved volume preferences');
+  'The hotfix must preserve existing saved volume preferences');
 assert.doesNotMatch(music, /fetch\(|new Audio\(/,
   'Racing music must remain generated Web Audio rather than a downloaded asset');
 assert.doesNotMatch(music, /type = 'square'|type = 'sawtooth'|createWaveShaper/,
@@ -93,17 +114,19 @@ assert.match(music, /document\.addEventListener\('pointerdown', handleUserActiva
 assert.match(music, /document\.addEventListener\('keydown', handleUserActivation/,
   'Keyboard-only players must also be able to unlock music');
 assert.match(music, /if \(musicVolume <= 0 \|\| !soundEnabled\)[\s\S]*stopPlayback/,
-  'OFF must stop the engine rather than merely mute it');
-assert.match(music, /clearScheduler\(\);[\s\S]*stopActiveSources\(\);[\s\S]*context\.suspend\(\)/,
-  'An off music engine must have no scheduler, active note sources or running AudioContext');
+  'OFF must stop the music engine rather than merely mute it');
+assert.match(music, /clearScheduler\(\);[\s\S]*stopActiveSources\(\);/,
+  'An off music engine must have no scheduler or active note sources');
 
 assert.match(music, /className = 'turn-music-home-toggle'/);
 assert.match(music, /className = 'turn-music-blank-toggle'/);
 assert.match(music, /label\.innerHTML = '<strong>Music volume<\/strong><small>OFF stops the music engine completely\.<\/small>'/);
 assert.match(music, /labels\.innerHTML = '<span>OFF<\/span><span>100%<\/span>'/);
+assert.match(music, /get sampleRate\(\) \{ return context\?\.sampleRate \|\| 0; \}/,
+  'Runtime diagnostics must expose the active shared sample rate for device debugging');
 assert.match(music, /arrangement: Object\.freeze\(ARRANGEMENT\.map\(\(section\) => section\.name\)\)/,
   'Runtime diagnostics must expose the actual T/T/B/T/C/C form');
 assert.match(music, /timbre: 'warm-v3-eighth-note-flute-chorus'/,
   'The existing runtime timbre identifier remains stable for compatibility');
 
-console.log('TURN reviewed T/T/B/T/C/C eighth-note flute chorus, Home header boundary, music alignment, and controls regression passed.');
+console.log('TURN single-context Web Audio, reviewed T/T/B/T/C/C chorus, Home music controls and cache parity passed.');

--- a/turn/audio/audio-preferences.js
+++ b/turn/audio/audio-preferences.js
@@ -1,3 +1,7 @@
+import { installSharedAudioContextConstructor } from './shared-audio-context-r430.js?revision=r430-single-context';
+
+installSharedAudioContextConstructor();
+
 const AUDIO_ENABLED_STORAGE_KEY = 'turn-audio-enabled-v1';
 const AUDIO_BALANCE_STORAGE_KEY = 'turn-audio-balance-v1';
 const DEFAULT_BALANCE = 0.5;

--- a/turn/audio/racing-music-v3.js
+++ b/turn/audio/racing-music-v3.js
@@ -1,4 +1,4 @@
-const AudioContextClass = globalThis.AudioContext || globalThis.webkitAudioContext;
+import { getSharedAudioContext, resumeSharedAudioContext } from './shared-audio-context-r430.js?revision=r430-single-context';
 
 const MUSIC_VOLUME_STORAGE_KEY = 'turn-racing-music-volume-v1';
 const MUSIC_LAST_VOLUME_STORAGE_KEY = 'turn-racing-music-last-volume-v1';
@@ -240,16 +240,12 @@ function makeNoiseBuffer() {
 }
 
 function ensureGraph() {
-  if (context || !AudioContextClass || typeof globalThis.GainNode !== 'function') return Boolean(context);
-  try {
-    context = new AudioContextClass({ latencyHint: 'playback' });
-  } catch (_) {
-    context = new AudioContextClass();
-  }
+  if (context) return true;
+  context = getSharedAudioContext();
+  if (!context || typeof globalThis.GainNode !== 'function') return false;
 
   masterGain = makeGain(0);
   if (!masterGain) {
-    void context.close?.();
     context = null;
     return false;
   }
@@ -523,16 +519,12 @@ function applyMasterVolume() {
 async function startPlayback({ restart = false } = {}) {
   if (!soundEnabled || musicVolume <= 0 || document.visibilityState === 'hidden') return false;
   if (!ensureGraph()) return false;
+  const ready = await resumeSharedAudioContext();
+  if (!ready || context.state !== 'running') return false;
   if (restart) {
     currentSection = 0;
     currentStep = 0;
   }
-  try {
-    if (context.state !== 'running') await context.resume();
-  } catch (_) {
-    return false;
-  }
-  if (context.state !== 'running') return false;
   applyMasterVolume();
   if (!playing) {
     playing = true;
@@ -552,9 +544,6 @@ async function stopPlayback({ reset = false } = {}) {
   }
   if (!context) return;
   applyMasterVolume();
-  try {
-    if (context.state === 'running') await context.suspend();
-  } catch (_) {}
 }
 
 function shouldPlay() {
@@ -813,6 +802,7 @@ export function installRacingMusic({ home = document.querySelector('.m8-home') }
     get enabled() { return musicVolume > 0; },
     get playing() { return playing; },
     get state() { return context?.state || 'not-created'; },
+    get sampleRate() { return context?.sampleRate || 0; },
     setVolume,
     toggle: toggleMusic,
     start: () => startPlayback({ restart: false }),

--- a/turn/audio/shared-audio-context-r430.js
+++ b/turn/audio/shared-audio-context-r430.js
@@ -1,0 +1,73 @@
+const NativeAudioContextClass = globalThis.AudioContext || globalThis.webkitAudioContext;
+
+let sharedContext = null;
+let installed = false;
+
+function createNativeContext() {
+  if (!NativeAudioContextClass) return null;
+  try {
+    return new NativeAudioContextClass({ latencyHint: 'interactive' });
+  } catch (_) {
+    try {
+      return new NativeAudioContextClass();
+    } catch (_) {
+      return null;
+    }
+  }
+}
+
+export function getSharedAudioContext() {
+  if (sharedContext?.state === 'closed') sharedContext = null;
+  if (!sharedContext) sharedContext = createNativeContext();
+  return sharedContext;
+}
+
+export async function resumeSharedAudioContext() {
+  const context = getSharedAudioContext();
+  if (!context) return false;
+  if (context.state === 'running') return true;
+  try {
+    await context.resume();
+  } catch (_) {
+    return false;
+  }
+  return context.state === 'running';
+}
+
+export function installSharedAudioContextConstructor() {
+  if (installed) return Boolean(NativeAudioContextClass);
+  installed = true;
+  if (!NativeAudioContextClass) return false;
+
+  function TurnSharedAudioContext() {
+    return getSharedAudioContext();
+  }
+
+  try {
+    Object.setPrototypeOf(TurnSharedAudioContext, NativeAudioContextClass);
+  } catch (_) {}
+  TurnSharedAudioContext.prototype = NativeAudioContextClass.prototype;
+
+  try {
+    globalThis.AudioContext = TurnSharedAudioContext;
+  } catch (_) {}
+  try {
+    globalThis.webkitAudioContext = TurnSharedAudioContext;
+  } catch (_) {}
+
+  globalThis.__turnSharedAudioContext = Object.freeze({
+    get context() {
+      return sharedContext;
+    },
+    get state() {
+      return sharedContext?.state || 'not-created';
+    },
+    get sampleRate() {
+      return sharedContext?.sampleRate || 0;
+    },
+    get currentTime() {
+      return sharedContext?.currentTime || 0;
+    }
+  });
+  return true;
+}

--- a/turn/index.html
+++ b/turn/index.html
@@ -77,7 +77,7 @@
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
-        "/turn/audio/racing-music-v2.js?build=20260809-r163-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=r429-reviewed-audio-rollback",
+        "/turn/audio/racing-music-v2.js?build=20260809-r163-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=r430-single-context",
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",


### PR DESCRIPTION
## Why
Real-device iOS report: TURN music runs much too fast and *all* generated game audio is pitched up, even after restoring the reviewed #424 song byte-for-byte. That rules out BPM, melody density and the composition as the root cause.

TURN was running two independent Web Audio contexts:
- gameplay / DBE / sirens via `audio-system.js` (`latencyHint: interactive`)
- racing music via `racing-music-v3.js` (`latencyHint: playback`)

This hotfix makes TURN use one native AudioContext and therefore one audio clock/sample-rate path.

## What changed
- adds `shared-audio-context-r430.js`, which owns the single native AudioContext and exposes a compatibility constructor for existing TURN modules;
- installs that constructor from `audio-preferences.js` before `audio-system.js` is evaluated;
- moves racing music onto the shared context instead of constructing its own;
- MUSIC OFF still clears the sequencer and stops all active music sources, but no longer suspends/closes the shared context used by engine/DBE/game sounds;
- keeps the reviewed 120 BPM, T → T → B → T → C → C song, pitches, eighth-note chorus and 25% temporary rollback default unchanged;
- exposes the active shared sample rate in music runtime diagnostics;
- cache-busts production and TURN LAB to `r430-single-context`;
- extends the racing-music regression to lock the single-context architecture and ensure music can never suspend/close game audio.

## Deliberately unchanged
- no song notes, timing grid, BPM or pitch multipliers changed;
- no gameplay/physics changes;
- Monster Truck perk remains untouched;
- r164 release PR remains separate/paused.

## Device validation
After merge, fully close and reopen the installed TURN PWA before listening so the old AudioContext/document is gone. If audio is still globally pitch-shifted after this single-context fresh load, the next step is to log the reported shared sample rate/currentTime against wall-clock time on the affected device.