### PR TITLE
Reapply Monster Truck off-road perk

### DIFF
--- a/turn-lab/tests/vehicle-drift-production.mjs
+++ b/turn-lab/tests/vehicle-drift-production.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 
 import { CAR_CATALOG, deriveVehicleTuning } from '../../turn/vehicle/catalog.js';
-import { getVehicleSpeedLimit } from '../../turn/vehicle/physics.js';
+import { getVehicleSpeedLimit, vehicleIgnoresOffRoadPenalty } from '../../turn/vehicle/physics.js';
 
 const driftTunings = [1, 2, 3, 4, 5].map((drift) => deriveVehicleTuning({
   speed: 3,
@@ -21,6 +21,44 @@ assert.deepEqual(
   driftTunings.map((tuning) => tuning.driftStabilityMultiplier),
   [0.82, 0.91, 1, 1.09, 1.18],
   'Higher DRIFT ratings must settle lateral motion more cleanly'
+);
+
+const monsterTruck = CAR_CATALOG.find((car) => car.id === 'monster-truck');
+assert.ok(monsterTruck, 'Monster Truck must remain in the vehicle catalog');
+assert.equal(
+  vehicleIgnoresOffRoadPenalty(monsterTruck.id),
+  true,
+  'Monster Truck must treat off-road terrain as track for vehicle physics'
+);
+for (const car of CAR_CATALOG.filter((candidate) => candidate.id !== 'monster-truck')) {
+  assert.equal(
+    vehicleIgnoresOffRoadPenalty(car.id),
+    false,
+    `${car.name} must keep the normal off-road physics penalty`
+  );
+}
+
+const monsterMaxSpeed = 88 * monsterTruck.tuning.topSpeedMultiplier;
+const monsterRoadLimit = getVehicleSpeedLimit({
+  offRoad: false,
+  boostActive: false,
+  maxSpeed: monsterMaxSpeed,
+  boostSpeedMultiplier: monsterTruck.tuning.boostSpeedMultiplier,
+  driftHeld: false,
+  driftSpeedMultiplier: monsterTruck.tuning.driftSpeedMultiplier
+});
+const monsterEffectiveOffRoadLimit = getVehicleSpeedLimit({
+  offRoad: !vehicleIgnoresOffRoadPenalty(monsterTruck.id),
+  boostActive: false,
+  maxSpeed: monsterMaxSpeed,
+  boostSpeedMultiplier: monsterTruck.tuning.boostSpeedMultiplier,
+  driftHeld: false,
+  driftSpeedMultiplier: monsterTruck.tuning.driftSpeedMultiplier
+});
+assert.equal(
+  monsterEffectiveOffRoadLimit,
+  monsterRoadLimit,
+  'Monster Truck must retain its road speed limit while physically off-road'
 );
 
 const drivingModes = [
@@ -64,4 +102,4 @@ for (const car of CAR_CATALOG) {
   }
 }
 
-console.log('TURN DRIFT speed, engine, drag and stability contract passed for all 15 cars.');
+console.log('TURN DRIFT and Monster Truck off-road physics contract passed for all 15 cars.');

--- a/turn/progression/trophy-road.js
+++ b/turn/progression/trophy-road.js
@@ -63,7 +63,7 @@ export const TROPHY_ROAD_REWARDS = Object.freeze([
     type: 'vehicle',
     vehicleIds: Object.freeze(['monster-truck']),
     icon: 'monster',
-    description: 'Unlock the Monster Truck: a dark military-green heavyweight with enormous tyres, strong drift stability and a long Boost tank.'
+    description: 'Unlock the Monster Truck: a dark military-green heavyweight with enormous tyres, strong drift-stability and a long-lasting Boost tank. Going off-road doesn’t slow it down.'
   })
 ]);
 

--- a/turn/vehicle/physics.js
+++ b/turn/vehicle/physics.js
@@ -1,6 +1,12 @@
 import { resolveWorldCollisionState } from '../race/world-collision.js?build=20260723-r53';
 import { trackPitch, trackSurfaceY } from '../tracks/elevation.js?build=20260725-r67';
 
+const OFFROAD_CAPABLE_VEHICLE_IDS = new Set(['monster-truck']);
+
+export function vehicleIgnoresOffRoadPenalty(vehicleId) {
+  return OFFROAD_CAPABLE_VEHICLE_IDS.has(String(vehicleId || ''));
+}
+
 export function getVehicleSpeedLimit({
   offRoad = false,
   boostActive = false,
@@ -62,6 +68,7 @@ export function updateVehiclePhysicsState({
   state.nearestTrackIndex = nearestBefore.index;
   state.trackDistance = nearestBefore.distance;
   state.offRoad = nearestBefore.distance > trackWidth * 0.58 && !isForgivingSurface(state.position);
+  const physicsOffRoad = state.offRoad && !vehicleIgnoresOffRoadPenalty(state.vehicleId);
 
   const forward = getForward();
   const right = getRight();
@@ -74,11 +81,11 @@ export function updateVehiclePhysicsState({
   const effectiveBoostActive = boostActive && !brakingOrReversing;
 
   const enginePower =
-    (state.offRoad ? 36 : 43) *
+    (physicsOffRoad ? 36 : 43) *
     accelerationMultiplier *
     (driftHeld ? driftEngineMultiplier : 1);
   const boostPower = effectiveBoostActive
-    ? (state.offRoad ? 16 : 36) * tuningBoostPowerMultiplier
+    ? (physicsOffRoad ? 16 : 36) * tuningBoostPowerMultiplier
     : 0;
   state.velocity.addScaledVector(
     forward,
@@ -97,7 +104,7 @@ export function updateVehiclePhysicsState({
       );
     } else {
       // Once forward motion is essentially gone, the same held control becomes reverse.
-      const reversePower = (state.offRoad ? 20 : 27) * accelerationMultiplier;
+      const reversePower = (physicsOffRoad ? 20 : 27) * accelerationMultiplier;
       state.velocity.addScaledVector(forward, -reversePower * state.brake * dt);
 
       const reverseSpeed = state.velocity.dot(forward);
@@ -155,7 +162,7 @@ export function updateVehiclePhysicsState({
     ? 0.42 * driftStabilityMultiplier
     : 1;
   const grip = (
-    state.offRoad
+    physicsOffRoad
       ? lerp(3.4, 1.35, state.driftAmount)
       : lerp(11.5, 1.45, state.driftAmount)
   ) * controlGripMultiplier * driftGripMultiplier;
@@ -171,13 +178,13 @@ export function updateVehiclePhysicsState({
     );
   }
 
-  const drag = state.offRoad
+  const drag = physicsOffRoad
     ? 0.34
     : 0.11 + speed * 0.0009 + (driftHeld ? driftDragAdd : 0);
   state.velocity.multiplyScalar(Math.exp(-drag * dt));
 
   const speedLimit = getVehicleSpeedLimit({
-    offRoad: state.offRoad,
+    offRoad: physicsOffRoad,
     boostActive: effectiveBoostActive,
     maxSpeed: effectiveMaxSpeed,
     boostSpeedMultiplier: tuningBoostSpeedMultiplier,


### PR DESCRIPTION
## What changed
Reapplies the previously verified Monster Truck perk, and only that perk:
- Monster Truck keeps road-equivalent acceleration, Boost power, reverse power, grip, drag and speed limits while physically off-road.
- `state.offRoad` remains truthful for DBE/off-road audio and other systems.
- collision/rail/barrier handling remains unchanged.
- Trophy Road copy restored to: “Unlock the Monster Truck: a dark military-green heavyweight with enormous tyres, strong drift-stability and a long-lasting Boost tank. Going off-road doesn’t slow it down.”
- regression coverage restored for Monster-only off-road immunity.

## Audio isolation
This PR does **not** touch:
- `turn/audio/**`
- music files
- AudioContext code
- import maps
- app/bootstrap files
- release/cache metadata

The resulting working tree is byte-for-byte identical to the original #427 result; GitHub comparison against merge commit `46549cd...` reports zero changed files. The difference this time is that the later #429/#430 audio experiments are not present.

## Known CI state
The pre-existing racing-music test still expects 25% while the user-authored music baseline intentionally uses 50%. Do not modify that as part of this PR.