### PR TITLE
Hotfix r164 Lot interaction freeze

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -72,7 +72,7 @@
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",
         "./garage/lot-accessibility-r118.js?build=20260729-r118": "./garage/lot-accessibility-r118.js?build=20260811-r164&revision=r163-voiceover-first-lot-focus",
-        "./garage/lot-enhancement-runtime.js?revision=r163-native-picker-parent-click&build=20260809-r163": "./garage/lot-enhancement-runtime.js?build=20260811-r164&revision=r163-voiceover-pwa-lot-carryover",
+        "./garage/lot-enhancement-runtime.js?revision=r163-native-picker-parent-click&build=20260809-r163": "./garage/lot-enhancement-runtime.js?build=20260811-r164&revision=r164-perk-observer-hotfix",
         "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260811-r164&revision=r163-native-html",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260811-r164",
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system-r86.js?build=20260811-r164",

--- a/turn-lab/tests/lot-layout-production.mjs
+++ b/turn-lab/tests/lot-layout-production.mjs
@@ -46,6 +46,11 @@ assert.equal(
   imports['./garage/lot-accessibility-r118.js?build=20260729-r118'],
   `./garage/lot-accessibility-r118.js?build=${release.cacheKey}&revision=r163-voiceover-first-lot-focus`
 );
+assert.equal(
+  imports['./garage/lot-enhancement-runtime.js?revision=r163-native-picker-parent-click&build=20260809-r163'],
+  `./garage/lot-enhancement-runtime.js?build=${release.cacheKey}&revision=r164-perk-observer-hotfix`,
+  'The interaction-freeze hotfix must use a fresh enhancement-runtime URL so installed PWAs cannot reuse the broken r164 observer graph'
+);
 
 assert.match(app, /installLotEnhancementRuntime\(\)/);
 assert.ok(
@@ -58,7 +63,8 @@ assert.match(wrapper, /const removeEnhancements = enhanceLotNow\(\)/);
 assert.match(wrapper, /await chooseTrackBeforeLot\(\)/);
 assert.doesNotMatch(wrapper, /installLotLayout|installLotStatLegend|installLotAccessibility/);
 
-assert.match(enhancementRuntime, /ENHANCEMENT_ID = 'enhanced-lot-r164-perks'/);
+assert.match(enhancementRuntime, /ENHANCEMENT_ID = 'enhanced-lot-r164-perks-observer-hotfix'/);
+assert.match(enhancementRuntime, /lot-perk-disclosure\.js\?revision=r164-perks-observer-hotfix/);
 assert.match(enhancementRuntime, /activeEnhancements = new WeakMap\(\)/);
 assert.match(enhancementRuntime, /LOT_ENTRY_CLICK_GUARD_MS = 600/);
 assert.match(enhancementRuntime, /installLotPerkDisclosure\(scope\)/);
@@ -78,6 +84,16 @@ assert.match(perkDisclosure, /aria-expanded/);
 assert.match(perkDisclosure, /<strong>PERK:<\/strong>/);
 assert.match(perkDisclosure, /-webkit-line-clamp: 2/);
 assert.match(perkDisclosure, /reward\?\.perkDescription/);
+assert.match(perkDisclosure, /const picker = screen\?\.querySelector\?\.\('\.lot-car-picker'\)/);
+assert.match(
+  perkDisclosure,
+  /observer\.observe\(picker, \{[\s\S]*subtree: true,[\s\S]*attributes: true,[\s\S]*attributeFilter: \['aria-checked'\][\s\S]*\}\);/,
+  'Perk synchronization must observe only car radio selection state'
+);
+assert.doesNotMatch(perkDisclosure, /observer\.observe\(screen,/,
+  'The perk disclosure must never observe the subtree that contains its own generated copy');
+assert.doesNotMatch(perkDisclosure, /childList:\s*true|characterData:\s*true/,
+  'The perk disclosure must not react to DOM/text mutations that its own sync function can create');
 
 assert.match(
   lot,
@@ -122,4 +138,4 @@ assert.match(legend, /role', 'dialog'/);
 assert.match(legend, /name\.textContent = entry\.label/);
 assert.match(legend, /description\.textContent = entry\.description/);
 
-console.log(`TURN ${release.id} compact Lot layout, perk disclosure and accessibility contract passed.`);
+console.log(`TURN ${release.id} compact Lot layout, non-self-triggering perk disclosure and accessibility contract passed.`);

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -1,14 +1,14 @@
 import { installLotStatLegend } from './lot-stat-legend.js?build=20260724-r59';
 import { installLotLayout } from './lot-layout-r60.js?build=20260729-r116';
 import { installLotAccessibility } from './lot-accessibility-r118.js?build=20260729-r118';
-import { installLotPerkDisclosure } from './lot-perk-disclosure.js?revision=r164-perks';
+import { installLotPerkDisclosure } from './lot-perk-disclosure.js?revision=r164-perks-observer-hotfix';
 import { gateLotNow } from '../progression/lot-trophy-gate.js?revision=r164-perks';
 import { gateLotPaintNow } from '../progression/lot-paint-reward.js?revision=r164-perks';
 
 // Historical regression markers for the established enhancement layers:
 // ENHANCEMENT_ID = 'enhanced-lot-r121'
 // TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r154-trophy-road-feedback'
-const ENHANCEMENT_ID = 'enhanced-lot-r164-perks';
+const ENHANCEMENT_ID = 'enhanced-lot-r164-perks-observer-hotfix';
 const TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r164-perks';
 const LOT_ENTRY_CLICK_GUARD_MS = 600;
 const activeEnhancements = new WeakMap();

--- a/turn/garage/lot-perk-disclosure.js
+++ b/turn/garage/lot-perk-disclosure.js
@@ -59,7 +59,8 @@ export function installLotPerkDisclosure(root = document.body) {
   const screen = root?.matches?.('.lot-screen') ? root : root?.querySelector?.('.lot-screen');
   const card = screen?.querySelector?.('.lot-card');
   const description = card?.querySelector?.('.lot-car-description');
-  if (!screen || !card || !description) return () => {};
+  const picker = screen?.querySelector?.('.lot-car-picker');
+  if (!screen || !card || !description || !picker) return () => {};
 
   installStyles();
 
@@ -83,6 +84,7 @@ export function installLotPerkDisclosure(root = document.body) {
   description.after(disclosure);
 
   let currentVehicleId = '';
+  let currentPerkDescription = '';
 
   function collapse() {
     button.setAttribute('aria-expanded', 'false');
@@ -101,12 +103,16 @@ export function installLotPerkDisclosure(root = document.body) {
 
     disclosure.hidden = !perkDescription;
     if (!perkDescription) {
-      copy.replaceChildren();
+      if (currentPerkDescription) copy.replaceChildren();
+      currentPerkDescription = '';
       button.setAttribute('aria-label', 'Perk information');
       return;
     }
 
-    copy.innerHTML = `<strong>PERK:</strong> ${perkDescription}`;
+    if (perkDescription !== currentPerkDescription) {
+      copy.innerHTML = `<strong>PERK:</strong> ${perkDescription}`;
+      currentPerkDescription = perkDescription;
+    }
     const vehicleName = screen.querySelector('.lot-car-title strong')?.textContent?.trim() || 'Selected car';
     button.setAttribute('aria-label', `Show ${vehicleName} perk`);
   }
@@ -119,13 +125,15 @@ export function installLotPerkDisclosure(root = document.body) {
     button.setAttribute('aria-label', `${expanded ? 'Show' : 'Hide'} ${vehicleName} perk`);
   });
 
+  // Observe only the radio-selection state. The original r164 implementation
+  // observed the whole Lot subtree for child/text changes, then rewrote its own
+  // perk copy inside that subtree. That created a self-triggering microtask loop
+  // after ordinary Lot interactions and could freeze the main thread.
   const observer = new MutationObserver(sync);
-  observer.observe(screen, {
+  observer.observe(picker, {
     subtree: true,
     attributes: true,
-    attributeFilter: ['aria-checked'],
-    childList: true,
-    characterData: true
+    attributeFilter: ['aria-checked']
   });
   sync();
 

--- a/turn/index.html
+++ b/turn/index.html
@@ -82,7 +82,7 @@
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",
         "./garage/lot-accessibility-r118.js?build=20260729-r118": "./garage/lot-accessibility-r118.js?build=20260811-r164&revision=r163-voiceover-first-lot-focus",
-        "./garage/lot-enhancement-runtime.js?revision=r163-native-picker-parent-click&build=20260809-r163": "./garage/lot-enhancement-runtime.js?build=20260811-r164&revision=r163-voiceover-pwa-lot-carryover",
+        "./garage/lot-enhancement-runtime.js?revision=r163-native-picker-parent-click&build=20260809-r163": "./garage/lot-enhancement-runtime.js?build=20260811-r164&revision=r164-perk-observer-hotfix",
         "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260811-r164&revision=r163-native-html",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260811-r164",
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system-r86.js?build=20260811-r164",


### PR DESCRIPTION
## Critical r164 hotfix

Fixes a main-thread freeze introduced by the new Lot perk disclosure in TURN 1.8.0.

### Root cause
`lot-perk-disclosure.js` observed the entire `.lot-screen` subtree for `childList` and text mutations. Its observer callback then rewrote the perk copy inside that same observed subtree. Ordinary interactions such as entering The Lot or selecting a car could therefore create a self-triggering MutationObserver microtask loop and freeze the UI.

### Fix
- Observe only `aria-checked` changes inside the static car radiogroup.
- Never observe the disclosure's own generated DOM/text.
- Avoid rewriting unchanged perk copy.
- Cache-bust both the enhancement runtime and perk module so installed PWAs cannot reuse the broken r164 module graph.
- Keep TURN LAB on the exact same production import-map graph.
- Add a regression that explicitly forbids whole-Lot, `childList`, or `characterData` observation in the perk disclosure.

No audio, vehicle physics, Trophy Road thresholds, music, or OVERDRIVE behavior is changed.