### PR TITLE
Hotfix racing music cache revision

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -67,7 +67,7 @@
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
-        "/turn/audio/racing-music-v2.js?build=20260809-r163-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=r424-eighth-note-flute-chorus",
+        "/turn/audio/racing-music-v2.js?build=20260809-r163-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=blob-6334b9d55695",
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",

--- a/turn-tests/racing-music-production.mjs
+++ b/turn-tests/racing-music-production.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { Buffer } from 'node:buffer';
 import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
 

--- a/turn-tests/racing-music-production.mjs
+++ b/turn-tests/racing-music-production.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
 
 const [index, labIndex, homeLayout, music, headerFix] = await Promise.all([
@@ -9,10 +10,30 @@ const [index, labIndex, homeLayout, music, headerFix] = await Promise.all([
   fs.readFile(new URL('../turn/home-header-r425.css', import.meta.url), 'utf8')
 ]);
 
-assert.match(
-  index,
-  /"\/turn\/audio\/racing-music-v2\.js\?build=20260809-r163-racing-music-warm-v2": "\/turn\/audio\/racing-music-v3\.js\?revision=r424-eighth-note-flute-chorus"/,
-  'The established compatibility import must still resolve Home music to the approved v3 source'
+function gitBlobSha(source) {
+  const header = `blob ${Buffer.byteLength(source, 'utf8')}\0`;
+  return crypto.createHash('sha1').update(header).update(source).digest('hex');
+}
+
+function importMapImports(source) {
+  const jsonText = source.match(/<script type="importmap">\s*([\s\S]*?)\s*<\/script>/)?.[1];
+  assert.ok(jsonText, 'TURN must expose an import map');
+  return JSON.parse(jsonText).imports;
+}
+
+const musicSpecifier = '/turn/audio/racing-music-v2.js?build=20260809-r163-racing-music-warm-v2';
+const musicRevision = `blob-${gitBlobSha(music).slice(0, 12)}`;
+const expectedMusicTarget = `/turn/audio/racing-music-v3.js?revision=${musicRevision}`;
+
+assert.equal(
+  importMapImports(index)[musicSpecifier],
+  expectedMusicTarget,
+  'Production must fingerprint the approved v3 music URL from the actual racing-music-v3.js blob so direct song edits cannot reuse stale cached bytes'
+);
+assert.equal(
+  importMapImports(labIndex)[musicSpecifier],
+  expectedMusicTarget,
+  'TURN LAB must use the same content-fingerprinted racing music URL as production'
 );
 assert.match(homeLayout, /audio\/racing-music-v2\.js\?build=\$\{buildKey\}-racing-music-warm-v2/,
   'The established Home lifecycle remains the single music installation point');
@@ -110,4 +131,4 @@ assert.match(music, /arrangement: Object\.freeze\(ARRANGEMENT\.map\(\(section\) 
 assert.match(music, /timbre: 'warm-v3-eighth-note-flute-chorus'/,
   'The existing runtime timbre identifier must remain stable for compatibility');
 
-console.log('TURN approved 120 BPM / 50% generated racing music, Home header and controls regression passed.');
+console.log(`TURN approved 120 BPM / 50% generated racing music and content-fingerprinted cache revision ${musicRevision} passed.`);

--- a/turn/index.html
+++ b/turn/index.html
@@ -77,7 +77,7 @@
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
-        "/turn/audio/racing-music-v2.js?build=20260809-r163-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=r424-eighth-note-flute-chorus",
+        "/turn/audio/racing-music-v2.js?build=20260809-r163-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=blob-6334b9d55695",
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",


### PR DESCRIPTION
## TURN r164 cache hotfix

The approved `turn/audio/racing-music-v3.js` source remains completely unchanged.

### Root cause
Production and TURN LAB still loaded the song through the historical URL `racing-music-v3.js?revision=r424-eighth-note-flute-chorus`. That URL originally referred to older song bytes, so Safari/PWA module caching could legitimately reuse the older version even though the repository file is now the approved song.

### Fix
- Change the music target to `racing-music-v3.js?revision=blob-6334b9d55695`, derived from the current music file's actual Git blob SHA.
- Keep TURN LAB on the identical import-map target.
- Upgrade the racing-music regression to compute the music file's Git blob SHA itself and require both production and LAB URLs to match it. Future direct song edits therefore fail CI until their cache revision is updated.

No music source, Web Audio code, volume, BPM, arrangement, vehicle physics, progression, or release identity changes are included.

### Validation
- Full TURN regression suite: **green**
- TURN challenge regression: **green**
- TURN color accessibility regression: **green**
- TURN admin unlock regression: **green**
- TURN Chromatic Camouflage regression: **green**