### PR TITLE
Name vehicle perks and show them inline

### DIFF
--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -173,7 +173,7 @@ assert.match(originalLot, /export function showTheLot/);
 assert.match(originalLot, /input\.type = 'color'/);
 assert.doesNotMatch(originalLot, /NAMED_COLOR_PRESETS|lot-color-preset|showPicker\(|label\.click\(/);
 
-assert.match(lotEnhancementRuntime, /ENHANCEMENT_ID = 'enhanced-lot-r164-perks'/);
+assert.match(lotEnhancementRuntime, /ENHANCEMENT_ID = 'enhanced-lot-r164-perk-titles-inline'/);
 assert.match(lotEnhancementRuntime, /TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r164-perks'/);
 assert.match(lotEnhancementRuntime, /activeEnhancements = new WeakMap\(\)/);
 assert.match(lotEnhancementRuntime, /gateLotNow\(scope\)/);
@@ -187,9 +187,11 @@ assert.ok(
 );
 assert.match(lotEnhancementRuntime, /new MutationObserver\(sync\)/);
 assert.match(lotEnhancementRuntime, /screen\.dataset\.lotEnhancements = ENHANCEMENT_ID/);
-assert.match(lotPerkDisclosure, /aria-expanded/);
-assert.match(lotPerkDisclosure, /<strong>PERK:<\/strong>/);
-assert.match(lotPerkDisclosure, /-webkit-line-clamp: 2/);
+assert.match(lotPerkDisclosure, /reward\?\.perkTitle/);
+assert.match(lotPerkDisclosure, /reward\?\.perkDescription/);
+assert.match(lotPerkDisclosure, /<strong>\$\{perkTitle\}:<\/strong>/);
+assert.match(lotPerkDisclosure, /color: #2f6f38/);
+assert.doesNotMatch(lotPerkDisclosure, /lot-perk-button|aria-expanded|<strong>PERK:<\/strong>/);
 assert.match(lotTrophyGate, /FALLBACK_VEHICLE_ID = 'classic'/);
 assert.match(lotTrophyGate, /raceButton\.disabled = locked/);
 assert.match(lotTrophyGate, /lot-selected-car-lock/);
@@ -269,4 +271,4 @@ assert.match(easterEggUi, /notice\.setAttribute\('role', 'status'\)/);
 assert.match(easterEggUi, /notice\.setAttribute\('aria-live', 'polite'\)/);
 assert.match(easterEggUi, /card\.insertBefore\(notice, actions \|\| null\)/, 'The explanation must sit immediately before RACE THIS CAR');
 
-console.log(`TURN ${release.id} enhanced Lot route, Trophy Road gating, perks, native paint and garage setup passed.`);
+console.log(`TURN ${release.id} enhanced Lot route, Trophy Road gating, named inline perks, native paint and garage setup passed.`);

--- a/turn-lab/tests/lot-layout-production.mjs
+++ b/turn-lab/tests/lot-layout-production.mjs
@@ -49,7 +49,7 @@ assert.equal(
 assert.equal(
   imports['./garage/lot-enhancement-runtime.js?revision=r163-native-picker-parent-click&build=20260809-r163'],
   `./garage/lot-enhancement-runtime.js?build=${release.cacheKey}&revision=r164-perk-observer-hotfix`,
-  'The interaction-freeze hotfix must use a fresh enhancement-runtime URL so installed PWAs cannot reuse the broken r164 observer graph'
+  'The interaction-freeze hotfix must retain its cache-safe enhancement-runtime route'
 );
 
 assert.match(app, /installLotEnhancementRuntime\(\)/);
@@ -63,8 +63,8 @@ assert.match(wrapper, /const removeEnhancements = enhanceLotNow\(\)/);
 assert.match(wrapper, /await chooseTrackBeforeLot\(\)/);
 assert.doesNotMatch(wrapper, /installLotLayout|installLotStatLegend|installLotAccessibility/);
 
-assert.match(enhancementRuntime, /ENHANCEMENT_ID = 'enhanced-lot-r164-perks-observer-hotfix'/);
-assert.match(enhancementRuntime, /lot-perk-disclosure\.js\?revision=r164-perks-observer-hotfix/);
+assert.match(enhancementRuntime, /ENHANCEMENT_ID = 'enhanced-lot-r164-perk-titles-inline'/);
+assert.match(enhancementRuntime, /lot-perk-disclosure\.js\?revision=r164-perk-titles-inline/);
 assert.match(enhancementRuntime, /activeEnhancements = new WeakMap\(\)/);
 assert.match(enhancementRuntime, /LOT_ENTRY_CLICK_GUARD_MS = 600/);
 assert.match(enhancementRuntime, /installLotPerkDisclosure\(scope\)/);
@@ -79,11 +79,13 @@ assert.match(enhancementRuntime, /new MutationObserver\(sync\)/);
 assert.match(enhancementRuntime, /if \(active\) return active\.release/);
 assert.match(enhancementRuntime, /released = true/);
 
-assert.match(perkDisclosure, /className = 'lot-perk-button'/);
-assert.match(perkDisclosure, /aria-expanded/);
-assert.match(perkDisclosure, /<strong>PERK:<\/strong>/);
-assert.match(perkDisclosure, /-webkit-line-clamp: 2/);
+assert.match(perkDisclosure, /className = 'lot-perk-copy'/);
+assert.match(perkDisclosure, /reward\?\.perkTitle/);
 assert.match(perkDisclosure, /reward\?\.perkDescription/);
+assert.match(perkDisclosure, /<strong>\$\{perkTitle\}:<\/strong>/);
+assert.match(perkDisclosure, /color: #2f6f38/);
+assert.doesNotMatch(perkDisclosure, /lot-perk-button|aria-expanded/,
+  'Perk content must be inline instead of hidden behind a disclosure button');
 assert.match(perkDisclosure, /const picker = screen\?\.querySelector\?\.\('\.lot-car-picker'\)/);
 assert.match(
   perkDisclosure,
@@ -91,9 +93,9 @@ assert.match(
   'Perk synchronization must observe only car radio selection state'
 );
 assert.doesNotMatch(perkDisclosure, /observer\.observe\(screen,/,
-  'The perk disclosure must never observe the subtree that contains its own generated copy');
+  'The perk presentation must never observe the subtree that contains its own generated copy');
 assert.doesNotMatch(perkDisclosure, /childList:\s*true|characterData:\s*true/,
-  'The perk disclosure must not react to DOM/text mutations that its own sync function can create');
+  'The perk presentation must not react to DOM/text mutations that its own sync function can create');
 
 assert.match(
   lot,
@@ -138,4 +140,4 @@ assert.match(legend, /role', 'dialog'/);
 assert.match(legend, /name\.textContent = entry\.label/);
 assert.match(legend, /description\.textContent = entry\.description/);
 
-console.log(`TURN ${release.id} compact Lot layout, non-self-triggering perk disclosure and accessibility contract passed.`);
+console.log(`TURN ${release.id} compact Lot layout, inline named perks and accessibility contract passed.`);

--- a/turn-lab/tests/paint-lock-observer-production.mjs
+++ b/turn-lab/tests/paint-lock-observer-production.mjs
@@ -1,11 +1,12 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [lotGate, paintGate, paintCss, lotRuntime, app, index, releaseSource] = await Promise.all([
+const [lotGate, paintGate, paintCss, lotRuntime, perkPresentation, app, index, releaseSource] = await Promise.all([
   fs.readFile(new URL('../../turn/progression/lot-trophy-gate.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/progression/lot-paint-reward.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/progression/trophy-road-r157.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-enhancement-runtime.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-perk-disclosure.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/release.json', import.meta.url), 'utf8')
@@ -84,7 +85,18 @@ assert.match(lotGate, /if \(lastAnnouncedCarId\) dismissVisibleUnlockNotice\(\);
 
 assert.match(lotRuntime, /lot-trophy-gate\.js\?revision=r164-perks/);
 assert.match(lotRuntime, /lot-paint-reward\.js\?revision=r164-perks/);
-assert.match(lotRuntime, /lot-perk-disclosure\.js\?revision=r164-perks/);
+assert.match(lotRuntime, /lot-perk-disclosure\.js\?revision=r164-perk-titles-inline/);
+
+assert.match(
+  perkPresentation,
+  /observer\.observe\(picker, \{[\s\S]*subtree: true,[\s\S]*attributes: true,[\s\S]*attributeFilter: \['aria-checked'\][\s\S]*\}\);/,
+  'Inline perk synchronization must remain scoped to selected-car radio state'
+);
+assert.doesNotMatch(perkPresentation, /observer\.observe\(screen,/,
+  'Inline perk presentation must never observe the DOM subtree that contains its own copy');
+assert.doesNotMatch(perkPresentation, /childList:\s*true|characterData:\s*true/,
+  'Inline perk presentation must not reintroduce the self-triggering DOM/text observer that froze The Lot');
+
 assert.match(app, /trophy-road-r157\.css\?revision=r163-native-picker-parent-click/);
 assert.match(app, /lot-enhancement-runtime\.js\?revision=r163-native-picker-parent-click/);
 assert.match(
@@ -92,4 +104,4 @@ assert.match(
   new RegExp(`app\\.js\\?build=${release.cacheKey}-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click`)
 );
 
-console.log('TURN Lot lock feedback, perk revisions and native paint ancestry regressions passed.');
+console.log('TURN Lot lock feedback, named perk observer safety and native paint ancestry regressions passed.');

--- a/turn-lab/tests/trophy-road-production.mjs
+++ b/turn-lab/tests/trophy-road-production.mjs
@@ -73,10 +73,30 @@ assert.equal(rewardForVehicle('race-future')?.id, 'future-racer');
 assert.equal(rewardForVehicle('monster-truck')?.id, 'monster');
 assert.equal(rewardForFeature('vehicle-paint')?.id, 'paintjob');
 assert.equal(getTrophyRoadReward('invented'), null);
-assert.match(getTrophyRoadReward('future-racer')?.perkDescription || '', /OVERDRIVE/);
-assert.match(getTrophyRoadReward('future-racer')?.description || '', /<strong>PERK:<\/strong>/);
-assert.match(getTrophyRoadReward('monster')?.perkDescription || '', /off-road/i);
-assert.match(getTrophyRoadReward('monster')?.description || '', /<strong>PERK:<\/strong>/);
+
+const futurePerk = getTrophyRoadReward('future-racer');
+assert.equal(futurePerk?.perkTitle, 'OVERDRIVE');
+assert.match(futurePerk?.perkDescription || '', /5 clean seconds/);
+assert.match(futurePerk?.description || '', /<strong>OVERDRIVE:<\/strong>/);
+
+const emergencyPerk = getTrophyRoadReward('emergency-pack');
+assert.equal(emergencyPerk?.perkTitle, 'SIRENS');
+assert.match(emergencyPerk?.perkDescription || '', /emergency lights and sirens/i);
+assert.match(emergencyPerk?.description || '', /<strong>SIRENS:<\/strong>/);
+for (const vehicleId of ['firetruck', 'ambulance', 'police']) {
+  assert.equal(rewardForVehicle(vehicleId)?.perkTitle, 'SIRENS');
+}
+
+const monsterPerk = getTrophyRoadReward('monster');
+assert.equal(monsterPerk?.perkTitle, 'OVERSIZED');
+assert.match(monsterPerk?.perkDescription || '', /off-road/i);
+assert.match(monsterPerk?.description || '', /<strong>OVERSIZED:<\/strong>/);
+
+for (const reward of [futurePerk, emergencyPerk, monsterPerk]) {
+  assert.doesNotMatch(reward?.description || '', /<strong>PERK:<\/strong>/,
+    'Unlock details must lead with the actual perk title rather than the generic word PERK');
+}
+
 assert.deepEqual(grandfatheredRewardIdsForVersion(3), ['paintjob', 'monster']);
 assert.deepEqual(
   grandfatheredRewardIdsForVersion(2),
@@ -147,10 +167,12 @@ for (const threshold of [300, 400, 500, 600, 700]) {
 }
 assert.match(roadSource, /id: 'paintjob'/);
 assert.match(roadSource, /id: 'future-racer'/);
-assert.match(roadSource, /OVERDRIVE/);
-assert.match(roadSource, /<strong>PERK:<\/strong>/);
+assert.match(roadSource, /perkTitle: 'OVERDRIVE'/);
 assert.match(roadSource, /id: 'emergency-pack'/);
+assert.match(roadSource, /perkTitle: 'SIRENS'/);
 assert.match(roadSource, /id: 'monster'/);
+assert.match(roadSource, /perkTitle: 'OVERSIZED'/);
+assert.doesNotMatch(roadSource, /<strong>PERK:<\/strong>/);
 assert.match(roadSource, /grandfatheredRewardIdsForVersion/);
 assert.doesNotMatch(roadSource, /clearRivals|resetRivals|rival-storage/);
 
@@ -163,12 +185,17 @@ assert.match(workflow, /Run Trophy Road progression regression/);
 assert.match(workflow, /node turn-lab\/tests\/trophy-road-production\.mjs/);
 assert.match(perkWrapper, /TROPHY_ROAD_MAX_THRESHOLD = 1750/,
   'The production Chromatic-era Trophy Road must keep the full 1,750 trophy scale');
-assert.match(perkWrapper, /trophy-road\.js\?revision=r164-perks/);
-assert.match(perkDisclosure, /aria-expanded/);
-assert.match(perkDisclosure, /<strong>PERK:<\/strong>/);
-assert.match(perkDisclosure, /-webkit-line-clamp: 2/,
-  'Expanded Lot perk copy must remain visually capped at two rows');
-assert.match(enhancementRuntime, /installLotPerkDisclosure/);
-assert.match(enhancementRuntime, /revision=r164-perks/);
+assert.match(perkWrapper, /trophy-road\.js\?revision=r164-perk-titles/);
 
-console.log('TURN expanded Trophy Road, reward swap and perk presentation regression passed.');
+assert.match(perkDisclosure, /reward\?\.perkTitle/);
+assert.match(perkDisclosure, /reward\?\.perkDescription/);
+assert.match(perkDisclosure, /className = 'lot-perk-copy'/);
+assert.match(perkDisclosure, /color: #2f6f38/,
+  'Named vehicle perk copy must use the dark achievement-green treatment');
+assert.doesNotMatch(perkDisclosure, /lot-perk-button|aria-expanded/,
+  'Named perk information must be inline and must not spend vertical space on a disclosure button');
+assert.match(perkDisclosure, /<strong>\$\{perkTitle\}:<\/strong>/);
+assert.match(enhancementRuntime, /installLotPerkDisclosure/);
+assert.match(enhancementRuntime, /lot-perk-disclosure\.js\?revision=r164-perk-titles-inline/);
+
+console.log('TURN expanded Trophy Road, named vehicle perks and inline Lot perk presentation regression passed.');

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -1,14 +1,14 @@
 import { installLotStatLegend } from './lot-stat-legend.js?build=20260724-r59';
 import { installLotLayout } from './lot-layout-r60.js?build=20260729-r116';
 import { installLotAccessibility } from './lot-accessibility-r118.js?build=20260729-r118';
-import { installLotPerkDisclosure } from './lot-perk-disclosure.js?revision=r164-perks-observer-hotfix';
+import { installLotPerkDisclosure } from './lot-perk-disclosure.js?revision=r164-perk-titles-inline';
 import { gateLotNow } from '../progression/lot-trophy-gate.js?revision=r164-perks';
 import { gateLotPaintNow } from '../progression/lot-paint-reward.js?revision=r164-perks';
 
 // Historical regression markers for the established enhancement layers:
 // ENHANCEMENT_ID = 'enhanced-lot-r121'
 // TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r154-trophy-road-feedback'
-const ENHANCEMENT_ID = 'enhanced-lot-r164-perks-observer-hotfix';
+const ENHANCEMENT_ID = 'enhanced-lot-r164-perk-titles-inline';
 const TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r164-perks';
 const LOT_ENTRY_CLICK_GUARD_MS = 600;
 const activeEnhancements = new WeakMap();

--- a/turn/garage/lot-perk-disclosure.js
+++ b/turn/garage/lot-perk-disclosure.js
@@ -1,7 +1,6 @@
-import { rewardForVehicle } from '../progression/trophy-road.js?revision=r164-perks';
+import { rewardForVehicle } from '../progression/trophy-road.js?revision=r164-perk-titles';
 
-const STYLE_ID = 'turn-lot-perk-disclosure-styles';
-const COPY_ID = 'turnLotPerkDescription';
+const STYLE_ID = 'turn-lot-perk-inline-styles';
 
 function installStyles() {
   if (document.getElementById(STYLE_ID)) return;
@@ -9,42 +8,25 @@ function installStyles() {
   style.id = STYLE_ID;
   style.textContent = `
     .lot-perk-disclosure {
-      display: grid;
-      justify-items: start;
-      gap: 4px;
       margin: 6px 0 0;
     }
-    .lot-perk-disclosure[hidden],
-    .lot-perk-copy[hidden] {
+    .lot-perk-disclosure[hidden] {
       display: none !important;
     }
-    .lot-perk-button {
-      min-height: 25px;
-      padding: 3px 7px;
-      border: 2px solid var(--ink);
-      border-radius: 999px;
-      background: var(--yellow);
-      box-shadow: 2px 2px 0 var(--ink);
-      font-size: 0.46rem;
-      letter-spacing: 0.055em;
-      line-height: 1;
-    }
-    .lot-perk-button .lot-perk-symbol {
-      margin-right: 3px;
-    }
     .lot-perk-copy {
-      display: -webkit-box;
       max-width: 100%;
       margin: 0;
-      overflow: hidden;
-      -webkit-box-orient: vertical;
-      -webkit-line-clamp: 2;
+      color: #2f6f38;
       font-size: 0.52rem;
+      font-weight: 800;
       line-height: 1.25;
+    }
+    .lot-perk-copy strong {
+      color: inherit;
+      font-weight: 950;
     }
     @media (max-height: 430px) {
       .lot-perk-disclosure { margin-top: 4px; }
-      .lot-perk-button { min-height: 22px; padding: 2px 6px; }
       .lot-perk-copy { font-size: 0.48rem; }
     }
   `;
@@ -64,71 +46,43 @@ export function installLotPerkDisclosure(root = document.body) {
 
   installStyles();
 
-  const disclosure = document.createElement('div');
-  disclosure.className = 'lot-perk-disclosure';
-  disclosure.hidden = true;
-
-  const button = document.createElement('button');
-  button.type = 'button';
-  button.className = 'lot-perk-button';
-  button.setAttribute('aria-expanded', 'false');
-  button.setAttribute('aria-controls', COPY_ID);
-  button.innerHTML = '<span class="lot-perk-symbol" aria-hidden="true">✦</span>PERK';
+  const perk = document.createElement('div');
+  perk.className = 'lot-perk-disclosure';
+  perk.hidden = true;
 
   const copy = document.createElement('p');
-  copy.id = COPY_ID;
   copy.className = 'lot-perk-copy';
-  copy.hidden = true;
-
-  disclosure.append(button, copy);
-  description.after(disclosure);
+  perk.appendChild(copy);
+  description.after(perk);
 
   let currentVehicleId = '';
-  let currentPerkDescription = '';
-
-  function collapse() {
-    button.setAttribute('aria-expanded', 'false');
-    copy.hidden = true;
-  }
+  let currentPerkText = '';
 
   function sync() {
     const vehicleId = selectedVehicleId(screen);
     const reward = rewardForVehicle(vehicleId);
+    const perkTitle = reward?.perkTitle || '';
     const perkDescription = reward?.perkDescription || '';
+    const perkText = perkTitle && perkDescription
+      ? `${perkTitle}: ${perkDescription}`
+      : '';
 
-    if (vehicleId !== currentVehicleId) {
-      currentVehicleId = vehicleId;
-      collapse();
-    }
-
-    disclosure.hidden = !perkDescription;
-    if (!perkDescription) {
-      if (currentPerkDescription) copy.replaceChildren();
-      currentPerkDescription = '';
-      button.setAttribute('aria-label', 'Perk information');
+    currentVehicleId = vehicleId;
+    perk.hidden = !perkText;
+    if (!perkText) {
+      if (currentPerkText) copy.replaceChildren();
+      currentPerkText = '';
       return;
     }
 
-    if (perkDescription !== currentPerkDescription) {
-      copy.innerHTML = `<strong>PERK:</strong> ${perkDescription}`;
-      currentPerkDescription = perkDescription;
+    if (perkText !== currentPerkText) {
+      copy.innerHTML = `<strong>${perkTitle}:</strong> ${perkDescription}`;
+      currentPerkText = perkText;
     }
-    const vehicleName = screen.querySelector('.lot-car-title strong')?.textContent?.trim() || 'Selected car';
-    button.setAttribute('aria-label', `Show ${vehicleName} perk`);
   }
 
-  button.addEventListener('click', () => {
-    const expanded = button.getAttribute('aria-expanded') === 'true';
-    button.setAttribute('aria-expanded', String(!expanded));
-    copy.hidden = expanded;
-    const vehicleName = screen.querySelector('.lot-car-title strong')?.textContent?.trim() || 'selected car';
-    button.setAttribute('aria-label', `${expanded ? 'Show' : 'Hide'} ${vehicleName} perk`);
-  });
-
-  // Observe only the radio-selection state. The original r164 implementation
-  // observed the whole Lot subtree for child/text changes, then rewrote its own
-  // perk copy inside that subtree. That created a self-triggering microtask loop
-  // after ordinary Lot interactions and could freeze the main thread.
+  // Observe only the radio-selection state. Perk copy lives outside the picker,
+  // so updating it cannot trigger this observer or recreate the r164 freeze loop.
   const observer = new MutationObserver(sync);
   observer.observe(picker, {
     subtree: true,
@@ -139,6 +93,6 @@ export function installLotPerkDisclosure(root = document.body) {
 
   return () => {
     observer.disconnect();
-    disclosure.remove();
+    perk.remove();
   };
 }

--- a/turn/garage/lot-perk-disclosure.js
+++ b/turn/garage/lot-perk-disclosure.js
@@ -55,7 +55,6 @@ export function installLotPerkDisclosure(root = document.body) {
   perk.appendChild(copy);
   description.after(perk);
 
-  let currentVehicleId = '';
   let currentPerkText = '';
 
   function sync() {
@@ -67,7 +66,6 @@ export function installLotPerkDisclosure(root = document.body) {
       ? `${perkTitle}: ${perkDescription}`
       : '';
 
-    currentVehicleId = vehicleId;
     perk.hidden = !perkText;
     if (!perkText) {
       if (currentPerkText) copy.replaceChildren();

--- a/turn/progression/trophy-road-chromatic-r183.js
+++ b/turn/progression/trophy-road-chromatic-r183.js
@@ -1,2 +1,2 @@
 export const TROPHY_ROAD_MAX_THRESHOLD = 1750;
-export * from './trophy-road.js?revision=r164-perks';
+export * from './trophy-road.js?revision=r164-perk-titles';

--- a/turn/progression/trophy-road-perks-r164.js
+++ b/turn/progression/trophy-road-perks-r164.js
@@ -1,2 +1,2 @@
 export const TROPHY_ROAD_MAX_THRESHOLD = 1750;
-export * from './trophy-road.js?revision=r164-perks';
+export * from './trophy-road.js?revision=r164-perk-titles';

--- a/turn/progression/trophy-road.js
+++ b/turn/progression/trophy-road.js
@@ -43,8 +43,9 @@ export const TROPHY_ROAD_REWARDS = Object.freeze([
     type: 'vehicle',
     vehicleIds: Object.freeze(['race-future']),
     icon: 'future',
-    perkDescription: 'OVERDRIVE — 5 clean seconds builds +6% top speed. Off-road or collisions reset it.',
-    description: 'Unlock the Future Racer: built for advanced time trials.<br><strong>PERK:</strong> OVERDRIVE — 5 clean seconds builds +6%; off-road or hits reset.'
+    perkTitle: 'OVERDRIVE',
+    perkDescription: '5 clean seconds builds +6% top speed. Off-road or collisions reset it.',
+    description: 'Unlock the Future Racer: built for advanced time trials.<br><strong>OVERDRIVE:</strong> 5 clean seconds builds +6% top speed; off-road or hits reset.'
   }),
   Object.freeze({
     id: 'emergency-pack',
@@ -54,7 +55,9 @@ export const TROPHY_ROAD_REWARDS = Object.freeze([
     type: 'vehicle-pack',
     vehicleIds: Object.freeze(['firetruck', 'ambulance', 'police']),
     icon: 'emergency',
-    description: 'Unlock the Fire Truck, Ambulance and Police Car. During Boost, their emergency lights flash and their sirens sound. All three have maximum Boost tanks.'
+    perkTitle: 'SIRENS',
+    perkDescription: 'Boost activates flashing emergency lights and sirens.',
+    description: 'Unlock the Fire Truck, Ambulance and Police Car. All three have maximum Boost tanks.<br><strong>SIRENS:</strong> Boost activates flashing emergency lights and sirens.'
   }),
   Object.freeze({
     id: 'monster',
@@ -64,8 +67,9 @@ export const TROPHY_ROAD_REWARDS = Object.freeze([
     type: 'vehicle',
     vehicleIds: Object.freeze(['monster-truck']),
     icon: 'monster',
+    perkTitle: 'OVERSIZED',
     perkDescription: 'Going off-road doesn’t slow it down.',
-    description: 'Unlock the Monster Truck: a military-green heavyweight.<br><strong>PERK:</strong> Going off-road doesn’t slow it down.'
+    description: 'Unlock the Monster Truck: a military-green heavyweight.<br><strong>OVERSIZED:</strong> Going off-road doesn’t slow it down.'
   })
 ]);
 


### PR DESCRIPTION
## TURN vehicle perk presentation

Updates Trophy Road and THE LOT so named perks are treated as actual feature names rather than generic disclosures.

### Perk names
- Future Racer: **OVERDRIVE**
- Emergency Pack + Police / Ambulance / Fire Truck: **SIRENS**
- Monster Truck: **OVERSIZED**

### Trophy Road
- Replaces `PERK:` in reward detail copy with the actual perk title.
- Adds **SIRENS:** to the Emergency Pack unlock information.

### The Lot
- Removes the separate PERK disclosure button entirely.
- Shows `{PERK TITLE:} description` inline directly beneath the car description.
- Uses dark achievement-green (`#2f6f38`) for the full perk line for contrast and achievement association.
- Keeps the freeze-safe observer scoped only to car `aria-checked` selection state.

No vehicle physics, perk behavior, progression thresholds, audio, or car stats are changed.

Regression coverage now locks the three perk names, Emergency Pack propagation to all three vehicles, inline presentation, dark-green treatment, absence of a disclosure button, and the non-self-triggering observer contract.