### PR TITLE
Lock Vintage and Rally racers with built-in perks

### DIFF
--- a/turn-lab/tests/achievements-production.mjs
+++ b/turn-lab/tests/achievements-production.mjs
@@ -161,7 +161,8 @@ assert.deepEqual(normalizeChallengeProgress({
 });
 
 const empty = normalizeAchievementState(null);
-assert.equal(empty.version, 4);
+assert.equal(empty.version, 5,
+  'Trophy Road v5 distinguishes existing owners of Vintage/Rally from new profiles after those cars become locked rewards');
 assert.deepEqual(empty.progress.tracks, []);
 assert.deepEqual(empty.progress.blankTracks, []);
 assert.deepEqual(empty.rewards.unlocked, []);

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -22,9 +22,22 @@ const sedan = catalog.getCarDefinition('sedan');
 const race = catalog.getCarDefinition('race');
 const truck = catalog.getCarDefinition('truck');
 const monsterTruck = catalog.getCarDefinition('monster-truck');
+const vintageRacer = catalog.getCarDefinition('vintage-racer');
+const rallyRacer = catalog.getCarDefinition('toy-racer');
+const futureRacer = catalog.getCarDefinition('race-future');
 const trainingCar = catalog.getCarDefinition('classic');
 assert.equal(catalog.DEFAULT_VEHICLE_ID, 'classic');
 assert.equal(trainingCar.name, 'Training Car');
+assert.equal(vintageRacer.name, 'Vintage Racer');
+assert.equal(vintageRacer.perk?.title, 'DRIFTAGE');
+assert.equal(rallyRacer.id, 'toy-racer', 'Rally Racer must preserve the Toy Racer stable storage/ghost id');
+assert.equal(rallyRacer.name, 'Rally Racer');
+assert.equal(rallyRacer.perk?.title, 'TWITCHY TURNY');
+assert.equal(monsterTruck.perk?.title, 'OVERSIZED');
+assert.equal(futureRacer.perk?.title, 'OVERDRIVE');
+for (const id of ['firetruck', 'police', 'ambulance']) {
+  assert.equal(catalog.getCarDefinition(id).perk?.title, 'SIRENS');
+}
 assert.deepEqual(
   trainingCar.stats,
   { speed: 1, acceleration: 1, control: 5, drift: 5, boostPower: 1, boostDuration: 5 }
@@ -82,6 +95,9 @@ globalThis.localStorage = {
 };
 try {
   assert.equal(catalog.loadVehicleSelection().carId, 'classic');
+  const savedRally = catalog.saveVehicleSelection({ carId: 'toy-racer' });
+  assert.equal(savedRally.carId, 'toy-racer');
+  assert.equal(catalog.getCarDefinition(savedRally.carId).name, 'Rally Racer');
   const savedEgg = catalog.saveVehicleSelection(easterEggSelection);
   assert.equal(savedEgg.secondaryColor, '#666666');
   assert.deepEqual(catalog.getCarDefinition('sedan-sports').stats, catalog.MAXED_VEHICLE_STATS);
@@ -173,8 +189,10 @@ assert.match(originalLot, /export function showTheLot/);
 assert.match(originalLot, /input\.type = 'color'/);
 assert.doesNotMatch(originalLot, /NAMED_COLOR_PRESETS|lot-color-preset|showPicker\(|label\.click\(/);
 
-assert.match(lotEnhancementRuntime, /ENHANCEMENT_ID = 'enhanced-lot-r164-perk-titles-inline'/);
-assert.match(lotEnhancementRuntime, /TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r164-perks'/);
+assert.match(lotEnhancementRuntime, /ENHANCEMENT_ID = 'enhanced-lot-r164-vintage-rally-perks'/);
+assert.match(lotEnhancementRuntime, /TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r164-vintage-rally-perks'/);
+assert.match(lotEnhancementRuntime, /lot-perk-disclosure\.js\?revision=r164-vintage-rally-perks/);
+assert.match(lotEnhancementRuntime, /lot-trophy-gate\.js\?revision=r164-vintage-rally-perks/);
 assert.match(lotEnhancementRuntime, /activeEnhancements = new WeakMap\(\)/);
 assert.match(lotEnhancementRuntime, /gateLotNow\(scope\)/);
 assert.match(lotEnhancementRuntime, /installLotPerkDisclosure\(scope\)/);
@@ -187,11 +205,13 @@ assert.ok(
 );
 assert.match(lotEnhancementRuntime, /new MutationObserver\(sync\)/);
 assert.match(lotEnhancementRuntime, /screen\.dataset\.lotEnhancements = ENHANCEMENT_ID/);
-assert.match(lotPerkDisclosure, /reward\?\.perkTitle/);
-assert.match(lotPerkDisclosure, /reward\?\.perkDescription/);
+assert.match(lotPerkDisclosure, /getCarDefinition\(vehicleId\)\?\.perk/);
+assert.doesNotMatch(lotPerkDisclosure, /rewardForVehicle|trophy-road/,
+  'Perk identity and display must come directly from the car definition');
 assert.match(lotPerkDisclosure, /<strong>\$\{perkTitle\}:<\/strong>/);
 assert.match(lotPerkDisclosure, /color: #2f6f38/);
 assert.doesNotMatch(lotPerkDisclosure, /lot-perk-button|aria-expanded|<strong>PERK:<\/strong>/);
+assert.match(lotTrophyGate, /trophy-road\.js\?revision=r164-vintage-rally-perks/);
 assert.match(lotTrophyGate, /FALLBACK_VEHICLE_ID = 'classic'/);
 assert.match(lotTrophyGate, /raceButton\.disabled = locked/);
 assert.match(lotTrophyGate, /lot-selected-car-lock/);
@@ -253,9 +273,13 @@ assert.match(rivalStorage, /normalizeVehicleId\(lap\.carId\)/);
 assert.match(rivalStorage, /normalizeVehicleColor\(lap\.carColor\)/);
 assert.match(rivalStorage, /normalizeVehicleSecondaryColor\(lap\.carSecondaryColor\)/);
 assert.match(controls, /boostDurationSeconds/);
+assert.match(controls, /driftBoostRechargeMultiplier/);
 assert.match(catalogSource, /asset: `\.\/assets\/cars\/\$\{id\}\.glb`/);
 assert.match(catalogSource, /SPORTS_SEDAN_EASTER_EGG_COLOR = '#666666'/);
 assert.match(catalogSource, /MAXED_VEHICLE_STATS/);
+assert.match(catalogSource, /'toy-racer', 'Rally Racer'/);
+assert.match(catalogSource, /title: 'DRIFTAGE'/);
+assert.match(catalogSource, /title: 'TWITCHY TURNY'/);
 assert.match(carModels, /loadCarSource\(car\.id\)/);
 assert.match(easterEggUi, /getEffectiveVehicleStats/);
 assert.match(easterEggUi, /isSportsSedanEasterEgg/);
@@ -271,4 +295,4 @@ assert.match(easterEggUi, /notice\.setAttribute\('role', 'status'\)/);
 assert.match(easterEggUi, /notice\.setAttribute\('aria-live', 'polite'\)/);
 assert.match(easterEggUi, /card\.insertBefore\(notice, actions \|\| null\)/, 'The explanation must sit immediately before RACE THIS CAR');
 
-console.log(`TURN ${release.id} enhanced Lot route, Trophy Road gating, named inline perks, native paint and garage setup passed.`);
+console.log(`TURN ${release.id} enhanced Lot route, Vintage/Rally Trophy Road gating, car-owned perks, native paint and garage setup passed.`);

--- a/turn-lab/tests/lot-layout-production.mjs
+++ b/turn-lab/tests/lot-layout-production.mjs
@@ -63,8 +63,10 @@ assert.match(wrapper, /const removeEnhancements = enhanceLotNow\(\)/);
 assert.match(wrapper, /await chooseTrackBeforeLot\(\)/);
 assert.doesNotMatch(wrapper, /installLotLayout|installLotStatLegend|installLotAccessibility/);
 
-assert.match(enhancementRuntime, /ENHANCEMENT_ID = 'enhanced-lot-r164-perk-titles-inline'/);
-assert.match(enhancementRuntime, /lot-perk-disclosure\.js\?revision=r164-perk-titles-inline/);
+assert.match(enhancementRuntime, /ENHANCEMENT_ID = 'enhanced-lot-r164-vintage-rally-perks'/);
+assert.match(enhancementRuntime, /TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r164-vintage-rally-perks'/);
+assert.match(enhancementRuntime, /lot-perk-disclosure\.js\?revision=r164-vintage-rally-perks/);
+assert.match(enhancementRuntime, /lot-trophy-gate\.js\?revision=r164-vintage-rally-perks/);
 assert.match(enhancementRuntime, /activeEnhancements = new WeakMap\(\)/);
 assert.match(enhancementRuntime, /LOT_ENTRY_CLICK_GUARD_MS = 600/);
 assert.match(enhancementRuntime, /installLotPerkDisclosure\(scope\)/);
@@ -80,8 +82,9 @@ assert.match(enhancementRuntime, /if \(active\) return active\.release/);
 assert.match(enhancementRuntime, /released = true/);
 
 assert.match(perkDisclosure, /className = 'lot-perk-copy'/);
-assert.match(perkDisclosure, /reward\?\.perkTitle/);
-assert.match(perkDisclosure, /reward\?\.perkDescription/);
+assert.match(perkDisclosure, /getCarDefinition\(vehicleId\)\?\.perk/);
+assert.doesNotMatch(perkDisclosure, /rewardForVehicle|trophy-road/,
+  'Perk display must be driven by the selected car definition rather than Trophy Road ownership');
 assert.match(perkDisclosure, /<strong>\$\{perkTitle\}:<\/strong>/);
 assert.match(perkDisclosure, /color: #2f6f38/);
 assert.doesNotMatch(perkDisclosure, /lot-perk-button|aria-expanded/,
@@ -140,4 +143,4 @@ assert.match(legend, /role', 'dialog'/);
 assert.match(legend, /name\.textContent = entry\.label/);
 assert.match(legend, /description\.textContent = entry\.description/);
 
-console.log(`TURN ${release.id} compact Lot layout, inline named perks and accessibility contract passed.`);
+console.log(`TURN ${release.id} compact Lot layout, car-owned named perks and accessibility contract passed.`);

--- a/turn-lab/tests/paint-lock-observer-production.mjs
+++ b/turn-lab/tests/paint-lock-observer-production.mjs
@@ -78,15 +78,20 @@ assert.doesNotMatch(paintLockRule, /width: 100%/);
 assert.match(lotGate, /function dismissVisibleUnlockNotice\(\)/);
 assert.match(lotGate, /\.turn-unlock-notice\.is-visible/);
 assert.match(lotGate, /notice\.classList\.remove\('is-visible'\)/);
+assert.match(lotGate, /trophy-road\.js\?revision=r164-vintage-rally-perks/);
 assert.match(lotGate, /if \(lastAnnouncedCarId\) dismissVisibleUnlockNotice\(\)/,
   'Selecting an available vehicle after a locked one must remove the stale lock notice');
 assert.match(lotGate, /if \(lastAnnouncedCarId\) dismissVisibleUnlockNotice\(\);[\s\S]*raceButton\.classList\.remove/,
   'Leaving The Lot must not leave a vehicle lock notice behind');
 
-assert.match(lotRuntime, /lot-trophy-gate\.js\?revision=r164-perks/);
+assert.match(lotRuntime, /lot-trophy-gate\.js\?revision=r164-vintage-rally-perks/);
 assert.match(lotRuntime, /lot-paint-reward\.js\?revision=r164-perks/);
-assert.match(lotRuntime, /lot-perk-disclosure\.js\?revision=r164-perk-titles-inline/);
+assert.match(lotRuntime, /lot-perk-disclosure\.js\?revision=r164-vintage-rally-perks/);
 
+assert.match(perkPresentation, /getCarDefinition\(vehicleId\)\?\.perk/,
+  'Inline perk identity must be read from the selected car itself');
+assert.doesNotMatch(perkPresentation, /rewardForVehicle|trophy-road/,
+  'Inline perk presentation must not become a progression entitlement');
 assert.match(
   perkPresentation,
   /observer\.observe\(picker, \{[\s\S]*subtree: true,[\s\S]*attributes: true,[\s\S]*attributeFilter: \['aria-checked'\][\s\S]*\}\);/,
@@ -104,4 +109,4 @@ assert.match(
   new RegExp(`app\\.js\\?build=${release.cacheKey}-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click`)
 );
 
-console.log('TURN Lot lock feedback, named perk observer safety and native paint ancestry regressions passed.');
+console.log('TURN Lot lock feedback, car-owned perk observer safety and native paint ancestry regressions passed.');

--- a/turn-lab/tests/trophy-road-production.mjs
+++ b/turn-lab/tests/trophy-road-production.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import { createAchievementStore, normalizeAchievementState } from '../../turn/achievements/store.js';
+import { getCarDefinition } from '../../turn/vehicle/catalog.js';
 import {
   TROPHY_ROAD_MAX_THRESHOLD,
   TROPHY_ROAD_REWARDS,
@@ -43,9 +44,14 @@ function createMemoryStorage(initial = {}) {
   };
 }
 
+const rewardIds = TROPHY_ROAD_REWARDS.map((reward) => reward.id);
+const through700 = ['midnight-city', 'paintjob', 'future-racer', 'emergency-pack', 'monster'];
+const through800 = [...through700, 'vintage-racer'];
+const through900 = [...through800, 'rally-racer'];
+
 assert.equal(TROPHY_ROAD_STORAGE_KEY, 'turn-achievements-v1');
-assert.equal(TROPHY_ROAD_STORAGE_VERSION, 4,
-  'The extra all-track progress uses its own storage and must not force a Trophy Road migration');
+assert.equal(TROPHY_ROAD_STORAGE_VERSION, 5,
+  'Adding locks to previously unrestricted cars requires a one-time ownership grandfather migration');
 assert.equal(TROPHY_ROAD_MAX_THRESHOLD, 1700,
   'The base road must retain room for the complete expanded trophy collection');
 assert.equal(TROPHY_ROAD_VIEWPORT_THRESHOLD, 600);
@@ -56,7 +62,9 @@ assert.deepEqual(
     ['paintjob', 400],
     ['future-racer', 500],
     ['emergency-pack', 600],
-    ['monster', 700]
+    ['monster', 700],
+    ['vintage-racer', 800],
+    ['rally-racer', 900]
   ]
 );
 
@@ -65,12 +73,16 @@ assert.deepEqual(rewardIdsForTrophies(300), ['midnight-city']);
 assert.deepEqual(rewardIdsForTrophies(400), ['midnight-city', 'paintjob']);
 assert.deepEqual(rewardIdsForTrophies(500), ['midnight-city', 'paintjob', 'future-racer']);
 assert.deepEqual(rewardIdsForTrophies(600), ['midnight-city', 'paintjob', 'future-racer', 'emergency-pack']);
-assert.deepEqual(rewardIdsForTrophies(700), ['midnight-city', 'paintjob', 'future-racer', 'emergency-pack', 'monster']);
-assert.deepEqual(rewardIdsForTrophies(1700), TROPHY_ROAD_REWARDS.map((reward) => reward.id));
+assert.deepEqual(rewardIdsForTrophies(700), through700);
+assert.deepEqual(rewardIdsForTrophies(800), through800);
+assert.deepEqual(rewardIdsForTrophies(900), through900);
+assert.deepEqual(rewardIdsForTrophies(1700), rewardIds);
 assert.equal(rewardForTrack('midnight-city')?.id, 'midnight-city');
 assert.equal(rewardForVehicle('firetruck')?.id, 'emergency-pack');
 assert.equal(rewardForVehicle('race-future')?.id, 'future-racer');
 assert.equal(rewardForVehicle('monster-truck')?.id, 'monster');
+assert.equal(rewardForVehicle('vintage-racer')?.id, 'vintage-racer');
+assert.equal(rewardForVehicle('toy-racer')?.id, 'rally-racer');
 assert.equal(rewardForFeature('vehicle-paint')?.id, 'paintjob');
 assert.equal(getTrophyRoadReward('invented'), null);
 
@@ -85,24 +97,41 @@ assert.match(emergencyPerk?.perkDescription || '', /emergency lights and sirens/
 assert.match(emergencyPerk?.description || '', /<strong>SIRENS:<\/strong>/);
 for (const vehicleId of ['firetruck', 'ambulance', 'police']) {
   assert.equal(rewardForVehicle(vehicleId)?.perkTitle, 'SIRENS');
+  assert.equal(getCarDefinition(vehicleId).perk?.title, 'SIRENS');
 }
 
 const monsterPerk = getTrophyRoadReward('monster');
 assert.equal(monsterPerk?.perkTitle, 'OVERSIZED');
 assert.match(monsterPerk?.perkDescription || '', /off-road/i);
 assert.match(monsterPerk?.description || '', /<strong>OVERSIZED:<\/strong>/);
+assert.equal(getCarDefinition('monster-truck').perk?.title, 'OVERSIZED');
 
-for (const reward of [futurePerk, emergencyPerk, monsterPerk]) {
+const vintagePerk = getTrophyRoadReward('vintage-racer');
+assert.equal(vintagePerk?.perkTitle, 'DRIFTAGE');
+assert.match(vintagePerk?.perkDescription || '', /larger slip angles/i);
+assert.match(vintagePerk?.description || '', /<strong>DRIFTAGE:<\/strong>/);
+assert.equal(getCarDefinition('vintage-racer').perk?.title, 'DRIFTAGE');
+
+const rallyPerk = getTrophyRoadReward('rally-racer');
+assert.equal(rallyPerk?.perkTitle, 'TWITCHY TURNY');
+assert.match(rallyPerk?.perkDescription || '', /fills BOOST even faster/i);
+assert.match(rallyPerk?.description || '', /<strong>TWITCHY TURNY:<\/strong>/);
+assert.equal(getCarDefinition('toy-racer').name, 'Rally Racer');
+assert.equal(getCarDefinition('toy-racer').perk?.title, 'TWITCHY TURNY');
+
+assert.equal(getCarDefinition('race-future').perk?.title, 'OVERDRIVE');
+for (const reward of [futurePerk, emergencyPerk, monsterPerk, vintagePerk, rallyPerk]) {
   assert.doesNotMatch(reward?.description || '', /<strong>PERK:<\/strong>/,
     'Unlock details must lead with the actual perk title rather than the generic word PERK');
 }
 
-assert.deepEqual(grandfatheredRewardIdsForVersion(3), ['paintjob', 'monster']);
 assert.deepEqual(
-  grandfatheredRewardIdsForVersion(2),
-  ['midnight-city', 'paintjob', 'future-racer', 'emergency-pack', 'monster']
+  grandfatheredRewardIdsForVersion(3),
+  ['paintjob', 'monster', 'vintage-racer', 'rally-racer']
 );
-assert.deepEqual(grandfatheredRewardIdsForVersion(4), []);
+assert.deepEqual(grandfatheredRewardIdsForVersion(4), ['vintage-racer', 'rally-racer']);
+assert.deepEqual(grandfatheredRewardIdsForVersion(2), rewardIds);
+assert.deepEqual(grandfatheredRewardIdsForVersion(5), []);
 
 const freshStorage = createMemoryStorage();
 assert.equal(prepareTrophyRoadProfile(freshStorage), null);
@@ -112,19 +141,58 @@ assert.equal(isTrackUnlocked('midnight-city', freshStorage), false);
 assert.equal(isVehicleUnlocked('classic', freshStorage), true);
 assert.equal(isVehicleUnlocked('firetruck', freshStorage), false);
 assert.equal(isVehicleUnlocked('monster-truck', freshStorage), false);
+assert.equal(isVehicleUnlocked('vintage-racer', freshStorage), false);
+assert.equal(isVehicleUnlocked('toy-racer', freshStorage), false);
 assert.equal(isPaintUnlocked(freshStorage), false);
+
+const priorProductionProfile = createMemoryStorage({
+  'turn-achievements-v1': JSON.stringify({
+    version: 4,
+    unlocked: {},
+    seen: [],
+    progress: { tracks: [], blankTracks: [] },
+    rewards: { unlocked: [], seen: [] }
+  })
+});
+assert.deepEqual(
+  readTrophyRoadSnapshot(priorProductionProfile).unlockedRewardIds,
+  ['vintage-racer', 'rally-racer'],
+  'Every pre-lock v4 profile already owned both formerly unrestricted cars'
+);
+assert.equal(isVehicleUnlocked('vintage-racer', priorProductionProfile), true);
+assert.equal(isVehicleUnlocked('toy-racer', priorProductionProfile), true);
+
+const normalizedPriorProduction = normalizeAchievementState({
+  version: 4,
+  unlocked: {},
+  seen: [],
+  progress: { tracks: [], blankTracks: [] },
+  rewards: { unlocked: [], seen: [] }
+});
+assert.equal(normalizedPriorProduction.version, 5);
+assert.deepEqual(normalizedPriorProduction.rewards.unlocked, ['vintage-racer', 'rally-racer']);
+assert.deepEqual(normalizedPriorProduction.rewards.seen, ['vintage-racer', 'rally-racer']);
+
+const newVersionFiveProfile = normalizeAchievementState({
+  version: 5,
+  unlocked: {},
+  seen: [],
+  progress: { tracks: [], blankTracks: [] },
+  rewards: { unlocked: [], seen: [] }
+});
+assert.deepEqual(newVersionFiveProfile.rewards.unlocked, [],
+  'New v5 players must earn Vintage and Rally rather than inherit them');
 
 const legacyWithoutAchievements = createMemoryStorage({
   'turn-vehicle-selection-v1': JSON.stringify({ carId: 'police' })
 });
 const preparedLegacy = prepareTrophyRoadProfile(legacyWithoutAchievements);
 assert.equal(preparedLegacy?.version, 2);
-assert.deepEqual(
-  readTrophyRoadSnapshot(legacyWithoutAchievements).unlockedRewardIds,
-  ['midnight-city', 'paintjob', 'future-racer', 'emergency-pack', 'monster']
-);
+assert.deepEqual(readTrophyRoadSnapshot(legacyWithoutAchievements).unlockedRewardIds, rewardIds);
 assert.equal(isPaintUnlocked(legacyWithoutAchievements), true);
 assert.equal(isVehicleUnlocked('monster-truck', legacyWithoutAchievements), true);
+assert.equal(isVehicleUnlocked('vintage-racer', legacyWithoutAchievements), true);
+assert.equal(isVehicleUnlocked('toy-racer', legacyWithoutAchievements), true);
 
 const migratedLegacy = normalizeAchievementState({
   version: 2,
@@ -134,11 +202,8 @@ const migratedLegacy = normalizeAchievementState({
   seen: ['first-turn'],
   progress: { tracks: ['countryside'], blankTracks: [] }
 });
-assert.equal(migratedLegacy.version, 4);
-assert.deepEqual(
-  migratedLegacy.rewards.unlocked,
-  ['midnight-city', 'paintjob', 'future-racer', 'emergency-pack', 'monster']
-);
+assert.equal(migratedLegacy.version, 5);
+assert.deepEqual(migratedLegacy.rewards.unlocked, rewardIds);
 assert.deepEqual(migratedLegacy.rewards.seen, migratedLegacy.rewards.unlocked);
 
 const progressionStorage = createMemoryStorage();
@@ -154,15 +219,21 @@ assert.equal(store.unlock('around-the-turn', { trackId: 'harbor' })?.trophies, 1
 assert.deepEqual(store.syncRewards().map((reward) => reward.id), ['emergency-pack']);
 assert.equal(store.unlock('faster-than-the-dev', { trackId: 'midnight-city' })?.trophies, 100);
 assert.deepEqual(store.syncRewards().map((reward) => reward.id), ['monster']);
+assert.equal(store.unlock('night-shift-sheriff', { trackId: 'midnight-city', vehicleId: 'police' })?.trophies, 100);
+assert.deepEqual(store.syncRewards().map((reward) => reward.id), ['vintage-racer']);
+assert.equal(store.unlock('on-course-of-course', { trackId: 'harbor' })?.trophies, 100);
+assert.deepEqual(store.syncRewards().map((reward) => reward.id), ['rally-racer']);
 assert.equal(isTrackUnlocked('midnight-city', progressionStorage), true);
 assert.equal(isVehicleUnlocked('firetruck', progressionStorage), true);
 assert.equal(isVehicleUnlocked('monster-truck', progressionStorage), true);
+assert.equal(isVehicleUnlocked('vintage-racer', progressionStorage), true);
+assert.equal(isVehicleUnlocked('toy-racer', progressionStorage), true);
 assert.equal(isPaintUnlocked(progressionStorage), true);
 
-assert.match(roadSource, /TROPHY_ROAD_STORAGE_VERSION = 4/);
+assert.match(roadSource, /TROPHY_ROAD_STORAGE_VERSION = 5/);
 assert.match(roadSource, /TROPHY_ROAD_MAX_THRESHOLD = 1700/);
 assert.match(roadSource, /TROPHY_ROAD_VIEWPORT_THRESHOLD = 600/);
-for (const threshold of [300, 400, 500, 600, 700]) {
+for (const threshold of [300, 400, 500, 600, 700, 800, 900]) {
   assert.match(roadSource, new RegExp(`threshold: ${threshold}`));
 }
 assert.match(roadSource, /id: 'paintjob'/);
@@ -172,7 +243,12 @@ assert.match(roadSource, /id: 'emergency-pack'/);
 assert.match(roadSource, /perkTitle: 'SIRENS'/);
 assert.match(roadSource, /id: 'monster'/);
 assert.match(roadSource, /perkTitle: 'OVERSIZED'/);
+assert.match(roadSource, /id: 'vintage-racer'/);
+assert.match(roadSource, /perkTitle: 'DRIFTAGE'/);
+assert.match(roadSource, /id: 'rally-racer'/);
+assert.match(roadSource, /perkTitle: 'TWITCHY TURNY'/);
 assert.doesNotMatch(roadSource, /<strong>PERK:<\/strong>/);
+assert.match(roadSource, /VERSION_FOUR_GRANDFATHERED_REWARDS/);
 assert.match(roadSource, /grandfatheredRewardIdsForVersion/);
 assert.doesNotMatch(roadSource, /clearRivals|resetRivals|rival-storage/);
 
@@ -185,10 +261,12 @@ assert.match(workflow, /Run Trophy Road progression regression/);
 assert.match(workflow, /node turn-lab\/tests\/trophy-road-production\.mjs/);
 assert.match(perkWrapper, /TROPHY_ROAD_MAX_THRESHOLD = 1750/,
   'The production Chromatic-era Trophy Road must keep the full 1,750 trophy scale');
-assert.match(perkWrapper, /trophy-road\.js\?revision=r164-perk-titles/);
+assert.match(perkWrapper, /trophy-road\.js\?revision=r164-vintage-rally-perks/);
 
-assert.match(perkDisclosure, /reward\?\.perkTitle/);
-assert.match(perkDisclosure, /reward\?\.perkDescription/);
+assert.match(perkDisclosure, /getCarDefinition\(vehicleId\)\?\.perk/,
+  'The Lot must read perk identity directly from the selected car, not from progression ownership');
+assert.doesNotMatch(perkDisclosure, /rewardForVehicle|trophy-road/,
+  'Vehicle perks must not be free-floating Trophy Road entitlements');
 assert.match(perkDisclosure, /className = 'lot-perk-copy'/);
 assert.match(perkDisclosure, /color: #2f6f38/,
   'Named vehicle perk copy must use the dark achievement-green treatment');
@@ -196,6 +274,7 @@ assert.doesNotMatch(perkDisclosure, /lot-perk-button|aria-expanded/,
   'Named perk information must be inline and must not spend vertical space on a disclosure button');
 assert.match(perkDisclosure, /<strong>\$\{perkTitle\}:<\/strong>/);
 assert.match(enhancementRuntime, /installLotPerkDisclosure/);
-assert.match(enhancementRuntime, /lot-perk-disclosure\.js\?revision=r164-perk-titles-inline/);
+assert.match(enhancementRuntime, /lot-perk-disclosure\.js\?revision=r164-vintage-rally-perks/);
+assert.match(enhancementRuntime, /lot-trophy-gate\.js\?revision=r164-vintage-rally-perks/);
 
-console.log('TURN expanded Trophy Road, named vehicle perks and inline Lot perk presentation regression passed.');
+console.log('TURN Trophy Road Vintage/Rally locks, grandfathering and car-owned perk presentation regression passed.');

--- a/turn-lab/tests/vehicle-drift-production.mjs
+++ b/turn-lab/tests/vehicle-drift-production.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
 
 import { CAR_CATALOG, deriveVehicleTuning } from '../../turn/vehicle/catalog.js';
 import {
@@ -10,6 +11,11 @@ import {
   vehicleHasOverdrive,
   vehicleIgnoresOffRoadPenalty
 } from '../../turn/vehicle/physics.js';
+
+const [physicsSource, controlsSource] = await Promise.all([
+  fs.readFile(new URL('../../turn/vehicle/physics.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/ui/gameplay-controls.js', import.meta.url), 'utf8')
+]);
 
 const driftTunings = [1, 2, 3, 4, 5].map((drift) => deriveVehicleTuning({
   speed: 3,
@@ -23,16 +29,65 @@ const driftTunings = [1, 2, 3, 4, 5].map((drift) => deriveVehicleTuning({
 assert.deepEqual(
   driftTunings.map((tuning) => tuning.driftSpeedMultiplier),
   [0.76, 0.8, 0.84, 0.88, 0.92],
-  'DRIFT ratings must retain the agreed 24% to 8% speed-penalty curve'
+  'Ordinary DRIFT ratings must retain the agreed 24% to 8% speed-penalty curve'
 );
 assert.deepEqual(
   driftTunings.map((tuning) => tuning.driftStabilityMultiplier),
   [0.82, 0.91, 1, 1.09, 1.18],
-  'Higher DRIFT ratings must settle lateral motion more cleanly'
+  'Higher ordinary DRIFT ratings must settle lateral motion more cleanly'
+);
+
+const vintageRacer = CAR_CATALOG.find((car) => car.id === 'vintage-racer');
+assert.ok(vintageRacer, 'Vintage Racer must remain in the vehicle catalog');
+assert.equal(vintageRacer.perk?.title, 'DRIFTAGE');
+assert.match(vintageRacer.perk?.description || '', /larger slip angles/i);
+assert.equal(vintageRacer.tuning.driftSpeedMultiplier, 0.9,
+  'DRIFTAGE must retain substantially more speed than the Vintage Racer ordinary DRIFT-2 baseline');
+assert.equal(vintageRacer.tuning.driftDragAdd, 0.07,
+  'DRIFTAGE must add less drag while DRIFT is held');
+assert.equal(vintageRacer.tuning.driftYawMultiplier, 1.28,
+  'DRIFTAGE steering must become more aggressive while drifting');
+assert.equal(vintageRacer.tuning.driftGripMultiplier, 0.72,
+  'DRIFTAGE must reduce lateral correction so larger slip angles can be held');
+assert.equal(vintageRacer.tuning.driftSlideMultiplier, 1.18,
+  'DRIFTAGE must support a larger sustained slide');
+const ordinaryDriftTwo = deriveVehicleTuning({
+  speed: 4,
+  acceleration: 4,
+  control: 3,
+  drift: 2,
+  boostPower: 3,
+  boostDuration: 2
+});
+assert.ok(vintageRacer.tuning.driftSpeedMultiplier > ordinaryDriftTwo.driftSpeedMultiplier);
+assert.ok(vintageRacer.tuning.driftDragAdd < ordinaryDriftTwo.driftDragAdd);
+assert.match(physicsSource, /steeringStatMultiplier \*[\s\S]*driftYawMultiplier/,
+  'Vehicle physics must apply the car-owned DRIFT yaw multiplier');
+assert.match(physicsSource, /0\.42 \* driftStabilityMultiplier \* driftGripTuningMultiplier/,
+  'Vehicle physics must apply the car-owned slip/grip multiplier');
+assert.match(physicsSource, /slideStrength = \(driftHeld \? 0\.235 : 0\.12\) \* driftSlideMultiplier/,
+  'Vehicle physics must apply the car-owned sustained-slide multiplier');
+
+const rallyRacer = CAR_CATALOG.find((car) => car.id === 'toy-racer');
+assert.ok(rallyRacer, 'The former Toy Racer asset/id must remain available for saved selections and ghosts');
+assert.equal(rallyRacer.name, 'Rally Racer', 'Toy Racer must be presented as Rally Racer without changing its stable id');
+assert.equal(rallyRacer.perk?.title, 'TWITCHY TURNY');
+assert.match(rallyRacer.perk?.description || '', /fills BOOST even faster/i);
+assert.equal(rallyRacer.tuning.boostDurationSeconds, 1.2,
+  'Rally Racer must retain the smallest Boost tank');
+assert.equal(rallyRacer.tuning.driftBoostRechargeMultiplier, 3.6,
+  'TWITCHY TURNY must recharge Boost 50% faster than the ordinary 2.4x DRIFT recharge');
+assert.match(controlsSource, /function getDriftRechargeMultiplier\(\)/);
+assert.match(controlsSource, /driftBoostRechargeMultiplier/);
+assert.match(
+  controlsSource,
+  /globalThis\.__turnDriftHeld \? getDriftRechargeMultiplier\(\) : 1/,
+  'Boost recharge must read the selected car tuning only while DRIFT is held'
 );
 
 const monsterTruck = CAR_CATALOG.find((car) => car.id === 'monster-truck');
 assert.ok(monsterTruck, 'Monster Truck must remain in the vehicle catalog');
+assert.equal(monsterTruck.perk?.title, 'OVERSIZED');
 assert.equal(
   vehicleIgnoresOffRoadPenalty(monsterTruck.id),
   true,
@@ -71,6 +126,7 @@ assert.equal(
 
 const futureRacer = CAR_CATALOG.find((car) => car.id === 'race-future');
 assert.ok(futureRacer, 'Future Racer must remain in the vehicle catalog');
+assert.equal(futureRacer.perk?.title, 'OVERDRIVE');
 assert.equal(OVERDRIVE_BUILD_SECONDS, 5, 'OVERDRIVE must take five clean seconds to fully build');
 assert.equal(OVERDRIVE_MAX_SPEED_MULTIPLIER, 1.06, 'OVERDRIVE must top out at a small 6% speed-ceiling bonus');
 assert.equal(vehicleHasOverdrive(futureRacer.id), true, 'Future Racer must own OVERDRIVE');
@@ -137,9 +193,9 @@ for (const car of CAR_CATALOG) {
     );
     assert.ok(
       Math.abs(driftLimit / gasLimit - car.tuning.driftSpeedMultiplier) < 1e-12,
-      `${car.name} must apply its DRIFT rating consistently on ${mode.name}`
+      `${car.name} must apply its DRIFT ceiling consistently on ${mode.name}`
     );
   }
 }
 
-console.log('TURN DRIFT, Monster Truck all-terrain and Future Racer OVERDRIVE contracts passed for all 15 cars.');
+console.log('TURN DRIFT, DRIFTAGE, TWITCHY TURNY, OVERSIZED and OVERDRIVE contracts passed for all 15 cars.');

--- a/turn/achievements/catalog-chromatic-r183.js
+++ b/turn/achievements/catalog-chromatic-r183.js
@@ -21,6 +21,11 @@ export const ACHIEVEMENTS = Object.freeze([
   ...base.ACHIEVEMENTS.slice(insertionIndex)
 ]);
 
+export const VEHICLE_NAMES = Object.freeze({
+  ...base.VEHICLE_NAMES,
+  'toy-racer': 'Rally Racer'
+});
+
 const ACHIEVEMENT_BY_ID = new Map(
   ACHIEVEMENTS.map((achievement) => [achievement.id, achievement])
 );

--- a/turn/achievements/store.js
+++ b/turn/achievements/store.js
@@ -10,7 +10,7 @@ import {
   getTrophyRoadReward,
   grandfatheredRewardIdsForVersion,
   rewardIdsForTrophies
-} from '../progression/trophy-road-perks-r164.js?revision=r164-perks';
+} from '../progression/trophy-road-perks-r164.js?revision=r164-vintage-rally-perks';
 
 export const ACHIEVEMENT_STORAGE_KEY = TROPHY_ROAD_STORAGE_KEY;
 const STORAGE_VERSION = TROPHY_ROAD_STORAGE_VERSION;

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -1,15 +1,15 @@
 import { installLotStatLegend } from './lot-stat-legend.js?build=20260724-r59';
 import { installLotLayout } from './lot-layout-r60.js?build=20260729-r116';
 import { installLotAccessibility } from './lot-accessibility-r118.js?build=20260729-r118';
-import { installLotPerkDisclosure } from './lot-perk-disclosure.js?revision=r164-perk-titles-inline';
-import { gateLotNow } from '../progression/lot-trophy-gate.js?revision=r164-perks';
+import { installLotPerkDisclosure } from './lot-perk-disclosure.js?revision=r164-vintage-rally-perks';
+import { gateLotNow } from '../progression/lot-trophy-gate.js?revision=r164-vintage-rally-perks';
 import { gateLotPaintNow } from '../progression/lot-paint-reward.js?revision=r164-perks';
 
 // Historical regression markers for the established enhancement layers:
 // ENHANCEMENT_ID = 'enhanced-lot-r121'
 // TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r154-trophy-road-feedback'
-const ENHANCEMENT_ID = 'enhanced-lot-r164-perk-titles-inline';
-const TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r164-perks';
+const ENHANCEMENT_ID = 'enhanced-lot-r164-vintage-rally-perks';
+const TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r164-vintage-rally-perks';
 const LOT_ENTRY_CLICK_GUARD_MS = 600;
 const activeEnhancements = new WeakMap();
 

--- a/turn/garage/lot-perk-disclosure.js
+++ b/turn/garage/lot-perk-disclosure.js
@@ -1,4 +1,4 @@
-import { rewardForVehicle } from '../progression/trophy-road.js?revision=r164-perk-titles';
+import { getCarDefinition } from '../vehicle/catalog.js?revision=r164-vintage-rally-perks';
 
 const STYLE_ID = 'turn-lot-perk-inline-styles';
 
@@ -59,9 +59,9 @@ export function installLotPerkDisclosure(root = document.body) {
 
   function sync() {
     const vehicleId = selectedVehicleId(screen);
-    const reward = rewardForVehicle(vehicleId);
-    const perkTitle = reward?.perkTitle || '';
-    const perkDescription = reward?.perkDescription || '';
+    const vehiclePerk = getCarDefinition(vehicleId)?.perk;
+    const perkTitle = vehiclePerk?.title || '';
+    const perkDescription = vehiclePerk?.description || '';
     const perkText = perkTitle && perkDescription
       ? `${perkTitle}: ${perkDescription}`
       : '';

--- a/turn/progression/lot-trophy-gate.js
+++ b/turn/progression/lot-trophy-gate.js
@@ -3,7 +3,7 @@ import {
   isVehicleUnlocked,
   rewardForVehicle,
   showTrophyUnlockNotice
-} from './trophy-road.js?revision=r164-perks';
+} from './trophy-road.js?revision=r164-vintage-rally-perks';
 
 const FALLBACK_VEHICLE_ID = 'classic';
 const activeGates = new WeakMap();

--- a/turn/progression/trophy-road-chromatic-r183.js
+++ b/turn/progression/trophy-road-chromatic-r183.js
@@ -1,2 +1,2 @@
 export const TROPHY_ROAD_MAX_THRESHOLD = 1750;
-export * from './trophy-road.js?revision=r164-perk-titles';
+export * from './trophy-road.js?revision=r164-vintage-rally-perks';

--- a/turn/progression/trophy-road-perks-r164.js
+++ b/turn/progression/trophy-road-perks-r164.js
@@ -1,2 +1,2 @@
 export const TROPHY_ROAD_MAX_THRESHOLD = 1750;
-export * from './trophy-road.js?revision=r164-perk-titles';
+export * from './trophy-road.js?revision=r164-vintage-rally-perks';

--- a/turn/progression/trophy-road.js
+++ b/turn/progression/trophy-road.js
@@ -1,5 +1,5 @@
 export const TROPHY_ROAD_STORAGE_KEY = 'turn-achievements-v1';
-export const TROPHY_ROAD_STORAGE_VERSION = 4;
+export const TROPHY_ROAD_STORAGE_VERSION = 5;
 export const TROPHY_ROAD_MAX_THRESHOLD = 1700;
 export const TROPHY_ROAD_VIEWPORT_THRESHOLD = 600;
 
@@ -11,7 +11,9 @@ export const TROPHY_ROAD_REWARD_ICONS = Object.freeze({
   future: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M5 32h8l7-7h9l5-8h8l5 8h9l4 7v7H5Z"></path><path d="M21 25h26M36 17l5 8M47 13h12v6H45"></path><circle cx="17" cy="39" r="5"></circle><circle cx="50" cy="39" r="5"></circle><path d="M2 22h12M1 16h17M7 28h9"></path></svg>',
   paint: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M10 7h29v13H10Z"></path><path d="M39 11h8c5 0 7 3 7 7v4H31v8"></path><path d="M27 28h8v16h-8Z"></path><path d="M15 12h18M15 16h12"></path></svg>',
   emergency: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M18 35V21a14 14 0 0 1 28 0v14"></path><path d="M12 35h40v9H12Z"></path><path d="M32 2v7M9 9l6 6M55 9l-6 6M3 25h8M53 25h8"></path><path d="M24 34V22a8 8 0 0 1 16 0v12"></path></svg>',
-  monster: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M10 28h8l5-10h20l7 10h5v9H9Z"></path><path d="M28 18v10M23 28h27M45 22h8l4 6"></path><circle cx="18" cy="38" r="8"></circle><circle cx="48" cy="38" r="8"></circle><circle cx="18" cy="38" r="3"></circle><circle cx="48" cy="38" r="3"></circle></svg>'
+  monster: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M10 28h8l5-10h20l7 10h5v9H9Z"></path><path d="M28 18v10M23 28h27M45 22h8l4 6"></path><circle cx="18" cy="38" r="8"></circle><circle cx="48" cy="38" r="8"></circle><circle cx="18" cy="38" r="3"></circle><circle cx="48" cy="38" r="3"></circle></svg>',
+  vintage: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M5 31h9l7-8h20l8 4h9v10H5Z"></path><path d="M21 23l5-8h12l6 8M27 15v8M12 31h39"></path><circle cx="17" cy="38" r="6"></circle><circle cx="49" cy="38" r="6"></circle></svg>',
+  rally: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M7 31h7l6-12h24l8 12h6v7H7Z"></path><path d="M24 19v12M20 24h27M11 27h7M47 15h8l3 7"></path><circle cx="18" cy="39" r="5"></circle><circle cx="49" cy="39" r="5"></circle></svg>'
 });
 
 export const TROPHY_ROAD_REWARDS = Object.freeze([
@@ -70,6 +72,30 @@ export const TROPHY_ROAD_REWARDS = Object.freeze([
     perkTitle: 'OVERSIZED',
     perkDescription: 'Going off-road doesn’t slow it down.',
     description: 'Unlock the Monster Truck: a military-green heavyweight.<br><strong>OVERSIZED:</strong> Going off-road doesn’t slow it down.'
+  }),
+  Object.freeze({
+    id: 'vintage-racer',
+    threshold: 800,
+    title: 'VINTAGE RACER',
+    shortTitle: 'Vintage Racer',
+    type: 'vehicle',
+    vehicleIds: Object.freeze(['vintage-racer']),
+    icon: 'vintage',
+    perkTitle: 'DRIFTAGE',
+    perkDescription: 'DRIFT drains less speed, steering becomes more aggressive and the car can hold larger slip angles.',
+    description: 'Unlock the Vintage Racer: the car for linking corners beautifully.<br><strong>DRIFTAGE:</strong> DRIFT drains less speed, steering becomes more aggressive and it can hold larger slip angles.'
+  }),
+  Object.freeze({
+    id: 'rally-racer',
+    threshold: 900,
+    title: 'RALLY RACER',
+    shortTitle: 'Rally Racer',
+    type: 'vehicle',
+    vehicleIds: Object.freeze(['toy-racer']),
+    icon: 'rally',
+    perkTitle: 'TWITCHY TURNY',
+    perkDescription: 'DRIFT fills BOOST even faster than normal, but the tank is tiny.',
+    description: 'Unlock the Rally Racer: tiny, twitchy and perfect for curvy tracks.<br><strong>TWITCHY TURNY:</strong> DRIFT fills BOOST even faster than normal, but the tank is tiny.'
   })
 ]);
 
@@ -84,7 +110,13 @@ const REWARD_BY_FEATURE = new Map(
   TROPHY_ROAD_REWARDS.filter((reward) => reward.featureId).map((reward) => [reward.featureId, reward])
 );
 const PREPARED_STORAGE = new WeakSet();
-const VERSION_THREE_GRANDFATHERED_REWARDS = Object.freeze(['paintjob', 'monster']);
+const VERSION_THREE_GRANDFATHERED_REWARDS = Object.freeze([
+  'paintjob',
+  'monster',
+  'vintage-racer',
+  'rally-racer'
+]);
+const VERSION_FOUR_GRANDFATHERED_REWARDS = Object.freeze(['vintage-racer', 'rally-racer']);
 
 let unlockNotice = null;
 let unlockNoticeTimer = 0;
@@ -109,6 +141,7 @@ export function grandfatheredRewardIdsForVersion(version) {
   const numericVersion = Number(version) || 0;
   if (numericVersion < 3) return TROPHY_ROAD_REWARDS.map((reward) => reward.id);
   if (numericVersion === 3) return [...VERSION_THREE_GRANDFATHERED_REWARDS];
+  if (numericVersion === 4) return [...VERSION_FOUR_GRANDFATHERED_REWARDS];
   return [];
 }
 

--- a/turn/stats/stats.js
+++ b/turn/stats/stats.js
@@ -12,7 +12,7 @@ const CARS = Object.freeze([
   ['convertible', 'Convertible'],
   ['classic', 'Training Car'],
   ['vintage-racer', 'Vintage Racer'],
-  ['toy-racer', 'Toy Racer'],
+  ['toy-racer', 'Rally Racer'],
   ['monster-truck', 'Monster Truck'],
   ['race-future', 'Future Racer'],
   ['race', 'Race Car'],

--- a/turn/ui/gameplay-controls.js
+++ b/turn/ui/gameplay-controls.js
@@ -174,6 +174,12 @@ function installGameplayUi() {
     return Math.max(0.8, Math.min(5, duration));
   }
 
+  function getDriftRechargeMultiplier() {
+    const multiplier = Number(globalThis.__turnVehicleTuning?.driftBoostRechargeMultiplier);
+    if (!Number.isFinite(multiplier)) return DRIFT_RECHARGE_MULTIPLIER;
+    return Math.max(1, Math.min(6, multiplier));
+  }
+
   function refillBoost() {
     window.clearTimeout(boostFlashTimer);
     boostFlashTimer = 0;
@@ -402,7 +408,7 @@ function installGameplayUi() {
         safeVibrate([28, 36, 62]);
       }
     } else {
-      const rechargeMultiplier = globalThis.__turnDriftHeld ? DRIFT_RECHARGE_MULTIPLIER : 1;
+      const rechargeMultiplier = globalThis.__turnDriftHeld ? getDriftRechargeMultiplier() : 1;
       boostCharge = Math.min(1, boostCharge + dt * rechargeMultiplier / BOOST_RECHARGE_SECONDS);
     }
 

--- a/turn/vehicle/catalog.js
+++ b/turn/vehicle/catalog.js
@@ -75,11 +75,51 @@ const RETIRED_VEHICLE_REPLACEMENTS = Object.freeze({
   'truck-flat': 'ambulance'
 });
 
+const SIRENS_PERK = Object.freeze({
+  title: 'SIRENS',
+  description: 'Boost activates flashing emergency lights and sirens.'
+});
+
+const VEHICLE_PERK_BY_ID = Object.freeze({
+  'vintage-racer': Object.freeze({
+    title: 'DRIFTAGE',
+    description: 'DRIFT drains less speed, steering becomes more aggressive and the car can hold larger slip angles.'
+  }),
+  'toy-racer': Object.freeze({
+    title: 'TWITCHY TURNY',
+    description: 'DRIFT fills BOOST even faster than normal, but the tank is tiny.'
+  }),
+  'monster-truck': Object.freeze({
+    title: 'OVERSIZED',
+    description: 'Going off-road doesn’t slow it down.'
+  }),
+  'race-future': Object.freeze({
+    title: 'OVERDRIVE',
+    description: '5 clean seconds builds +6% top speed. Off-road or collisions reset it.'
+  }),
+  firetruck: SIRENS_PERK,
+  police: SIRENS_PERK,
+  ambulance: SIRENS_PERK
+});
+
+const TUNING_OVERRIDE_BY_ID = Object.freeze({
+  'vintage-racer': Object.freeze({
+    driftDragAdd: 0.07,
+    driftSpeedMultiplier: 0.9,
+    driftYawMultiplier: 1.28,
+    driftGripMultiplier: 0.72,
+    driftSlideMultiplier: 1.18
+  }),
+  'toy-racer': Object.freeze({
+    driftBoostRechargeMultiplier: 3.6
+  })
+});
+
 const RAW_CARS = [
   ['convertible', 'Convertible', 'prototype', { speed: 4, acceleration: 4, control: 4, drift: 2, boostPower: 3, boostDuration: 1 }, 0.98, 1, 1.08],
   ['classic', 'Training Car', 'prototype', { speed: 1, acceleration: 1, control: 5, drift: 5, boostPower: 1, boostDuration: 5 }, 1.00, 1, 0.88],
   ['vintage-racer', 'Vintage Racer', 'toy', { speed: 4, acceleration: 4, control: 3, drift: 2, boostPower: 3, boostDuration: 2 }, 0.96, 0, 1.28],
-  ['toy-racer', 'Toy Racer', 'toy', { speed: 4, acceleration: 5, control: 5, drift: 1, boostPower: 2, boostDuration: 1 }, 0.94, 2, 1.18],
+  ['toy-racer', 'Rally Racer', 'toy', { speed: 4, acceleration: 5, control: 5, drift: 1, boostPower: 2, boostDuration: 1 }, 0.94, 2, 1.18],
   ['monster-truck', 'Monster Truck', 'toy', { speed: 2, acceleration: 3, control: 2, drift: 5, boostPower: 2, boostDuration: 4 }, 0.83, 2, 0.62],
   ['race-future', 'Future Racer', 'car', { speed: 5, acceleration: 5, control: 3, drift: 1, boostPower: 3, boostDuration: 1 }, 0.96, 0, 1.42],
   ['race', 'Race Car', 'car', { speed: 5, acceleration: 4, control: 4, drift: 2, boostPower: 2, boostDuration: 1 }, 0.94, 0, 1.55],
@@ -116,7 +156,12 @@ export const CAR_CATALOG = Object.freeze(RAW_CARS.map(([
   secondaryPaint: SECONDARY_PAINT_BY_ID[id] || null,
   emergencyService: EMERGENCY_SERVICE_BY_ID[id] || null,
   fixedLivery: FIXED_LIVERY_IDS.has(id),
-  tuning: Object.freeze({ ...deriveVehicleTuning(stats), enginePitch })
+  perk: VEHICLE_PERK_BY_ID[id] || null,
+  tuning: Object.freeze({
+    ...deriveVehicleTuning(stats),
+    ...(TUNING_OVERRIDE_BY_ID[id] || {}),
+    enginePitch
+  })
 })));
 
 const CAR_BY_ID = new Map(CAR_CATALOG.map((car) => [car.id, car]));

--- a/turn/vehicle/physics.js
+++ b/turn/vehicle/physics.js
@@ -97,6 +97,15 @@ export function updateVehiclePhysicsState({
   const driftDragAdd = nonNegativeNumber(tuning?.driftDragAdd, 0.1);
   const driftSpeedMultiplier = clamp(positiveNumber(tuning?.driftSpeedMultiplier, 0.84), 0.5, 0.99);
   const driftStabilityMultiplier = clamp(positiveNumber(tuning?.driftStabilityMultiplier, 1), 0.75, 1.25);
+  const driftYawMultiplier = driftHeld
+    ? clamp(positiveNumber(tuning?.driftYawMultiplier, 1), 0.75, 1.5)
+    : 1;
+  const driftGripTuningMultiplier = driftHeld
+    ? clamp(positiveNumber(tuning?.driftGripMultiplier, 1), 0.55, 1.25)
+    : 1;
+  const driftSlideMultiplier = driftHeld
+    ? clamp(positiveNumber(tuning?.driftSlideMultiplier, 1), 0.75, 1.5)
+    : 1;
   const tuningBoostPowerMultiplier = positiveNumber(tuning?.boostPowerMultiplier, 1);
   const tuningBoostSpeedMultiplier = positiveNumber(tuning?.boostSpeedMultiplier, 1.32);
   const effectiveMaxSpeed = maxSpeed;
@@ -190,6 +199,7 @@ export function updateVehiclePhysicsState({
     (0.18 + Math.abs(forwardSpeed) * 0.012) *
     steeringAuthority *
     steeringStatMultiplier *
+    driftYawMultiplier *
     (1 + state.driftAmount * 0.65 + (driftHeld ? 0.58 : 0));
 
   state.heading = normalizeAngle(state.heading + yawRate * dt);
@@ -201,7 +211,7 @@ export function updateVehiclePhysicsState({
     ? 1
     : 0.92 + controlMultiplier * 0.08;
   const driftGripMultiplier = driftHeld
-    ? 0.42 * driftStabilityMultiplier
+    ? 0.42 * driftStabilityMultiplier * driftGripTuningMultiplier
     : 1;
   const grip = (
     physicsOffRoad
@@ -213,7 +223,7 @@ export function updateVehiclePhysicsState({
   state.velocity.addScaledVector(newRight, -lateralSpeed * lateralCorrection);
 
   if ((state.driftAmount > 0.18 || driftHeld) && speed > 14) {
-    const slideStrength = driftHeld ? 0.235 : 0.12;
+    const slideStrength = (driftHeld ? 0.235 : 0.12) * driftSlideMultiplier;
     state.velocity.addScaledVector(
       newRight,
       state.steering * speed * Math.max(state.driftAmount, 0.48) * slideStrength * dt


### PR DESCRIPTION
## TURN Vintage + Rally progression

Adds two more Trophy Road vehicle rewards while keeping their perks intrinsic to the cars themselves.

### 800 trophies — Vintage Racer
- New built-in perk: **DRIFTAGE**
- DRIFT retains substantially more speed than the Vintage Racer's ordinary tuning would.
- Steering becomes more aggressive while DRIFT is held.
- Lower lateral correction + stronger slide support allow larger sustained slip angles.

### 900 trophies — Rally Racer
- Renames the existing Toy Racer presentation to **Rally Racer** while preserving the stable `toy-racer` ID, asset, saved selections, rivals, ghosts and stats identity.
- New built-in perk: **TWITCHY TURNY**
- DRIFT recharges BOOST at 3.6× normal recharge rate versus the ordinary 2.4× DRIFT rate.
- Keeps its existing smallest Boost tank (1.2 seconds full-to-empty).

### Existing-player ownership
Trophy Road storage moves from v4 to v5. Every existing v4 TURN profile is grandfathered both `vintage-racer` and `rally-racer`, because both cars were unrestricted before these locks existed. New v5 profiles must earn 800/900 trophies normally.

Perks are not separate progression entitlements: car definitions now own the perk metadata and tuning, and The Lot reads perk information directly from the selected car. Trophy Road only gates access and describes the built-in perk.

### Compatibility / scope
- Existing Monster Truck OVERSIZED and Future Racer OVERDRIVE behavior remains unchanged.
- Emergency SIRENS remains car-owned presentation.
- No audio/music changes.
- Stable vehicle IDs preserved.

Regression coverage adds the new thresholds, v4→v5 grandfathering, fresh-profile locks, Rally naming/ID compatibility, DRIFTAGE tuning behavior and TWITCHY TURNY recharge behavior.