### PR TITLE
TURN long-session robustness and thermal optimisation

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -199,6 +199,9 @@ jobs:
       - name: Run production performance and diagnostics regression
         run: node turn-lab/tests/performance-production.mjs
 
+      - name: Run long-session lifecycle regression
+        run: node turn-tests/long-session-lifecycle-production.mjs
+
       - name: Run covered rendering regression
         run: node turn-tests/covered-rendering-production.mjs
 

--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -72,6 +72,7 @@
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/achievements/trophy-road-showcase.js?revision=r160-reward-detail-sync": "/turn/achievements/trophy-road-showcase.js?revision=r164-long-session-robustness",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",
+        "/turn/render/covered-rendering.js?build=20260811-r164": "/turn/render/covered-rendering.js?build=20260811-r164&revision=r164-long-session-robustness",
         "./garage/lot-accessibility-r118.js?build=20260729-r118": "./garage/lot-accessibility-r118.js?build=20260811-r164&revision=r163-voiceover-first-lot-focus",
         "./garage/lot-enhancement-runtime.js?revision=r163-native-picker-parent-click&build=20260809-r163": "./garage/lot-enhancement-runtime.js?build=20260811-r164&revision=r164-perk-observer-hotfix",
         "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260811-r164&revision=r164-long-session-robustness",

--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -84,7 +84,7 @@
         "./race/rival-storage.js?build=20260722-r50": "./race/rival-storage.js?build=20260811-r164",
         "./race/track-spatial-index.js?build=20260720-r19": "./race/track-spatial-index.js?build=20260811-r164",
         "./performance-monitor.js?build=20260720-r19": "./performance-monitor.js?build=20260811-r164",
-        "./world-assets.js": "./world-assets.js?build=20260811-r164",
+        "./world-assets.js": "./world-assets.js?build=20260811-r164&revision=r164-long-session-robustness",
         "./vehicle/physics.js?build=20260720-r19": "./vehicle/physics.js?build=20260811-r164",
         "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260811-r164",
         "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260811-r164",

--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -67,7 +67,7 @@
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
-        "/turn/audio/racing-music-v2.js?build=20260811-r164-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=blob-6334b9d55695",
+        "/turn/audio/racing-music-v2.js?build=20260811-r164-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=blob-8319c3923e0a",
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/achievements/trophy-road-showcase.js?revision=r160-reward-detail-sync": "/turn/achievements/trophy-road-showcase.js?revision=r164-long-session-robustness",
@@ -139,4 +139,19 @@
     <button id="manualButton" type="button" hidden></button>
     <p id="status" role="status" hidden>Steering uses device rotation</p>
   </section>
-  <section class="rotate-panel" aria-label="Rotate your device to landscape"><div class="rotate-card"... (truncated)
+  <section class="rotate-panel" aria-label="Rotate your device to landscape"><div class="rotate-card"><div class="rotate-phone" aria-hidden="true"></div><strong>ROTATE YOUR DEVICE TO LANDSCAPE</strong></div></section>
+  <div class="hud" id="hud" hidden>
+    <div class="topbar"><div class="stats"><div class="chip">speed<strong><span id="speed">0</span> km/h</strong></div><div class="chip">lap<strong id="lap">1</strong></div><div class="chip">time<strong id="lapTime">0:00.000</strong></div><div class="chip">best<strong id="bestTime">--:--.---</strong></div></div><div class="map-wrap"><canvas id="map" width="300" height="210" aria-label="Track map"></canvas></div></div>
+    <div class="message" id="message" role="status"></div>
+    <div class="tilt-drive" aria-hidden="true"><span><b>brake</b><b>gas</b></span><div class="tilt-track"><i class="tilt-needle" id="tiltNeedle"></i></div><small class="tilt-value" id="tiltValue">neutral</small></div>
+  </div>
+  <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
+  <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button" aria-label="Restart the current lap from the start line">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
+  <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260811-r164-r168-shared-about-credits"></script>
+  <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
+  <script type="module" src="./app.js?build=20260811-r164-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r164-long-session-robustness"></script>
+  <script type="module" src="./accessibility/color-accessibility-r163.js?build=20260811-r164-paint-basics"></script>
+  <script type="module" src="./achievements/chromatic-camouflage-r183.js?revision=r183-production"></script>
+  <script type="module" src="./social/your-turn-share-bootstrap.js?revision=r2"></script>
+  <script type="module" src="./tracks/countryside-bella-rescue-hotfix-r176.js?revision=r164-long-session-robustness"></script>
+</body></html>

--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -70,10 +70,11 @@
         "/turn/audio/racing-music-v2.js?build=20260811-r164-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=blob-6334b9d55695",
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
+        "/turn/achievements/trophy-road-showcase.js?revision=r160-reward-detail-sync": "/turn/achievements/trophy-road-showcase.js?revision=r164-long-session-robustness",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",
         "./garage/lot-accessibility-r118.js?build=20260729-r118": "./garage/lot-accessibility-r118.js?build=20260811-r164&revision=r163-voiceover-first-lot-focus",
         "./garage/lot-enhancement-runtime.js?revision=r163-native-picker-parent-click&build=20260809-r163": "./garage/lot-enhancement-runtime.js?build=20260811-r164&revision=r164-perk-observer-hotfix",
-        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260811-r164&revision=r163-native-html",
+        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260811-r164&revision=r164-long-session-robustness",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260811-r164",
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system-r86.js?build=20260811-r164",
         "./race/game-state.js": "./race/game-state.js?build=20260811-r164",
@@ -147,7 +148,7 @@
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button" aria-label="Restart the current lap from the start line">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
   <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260811-r164-r168-shared-about-credits"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
-  <script type="module" src="./app.js?build=20260811-r164-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click"></script>
+  <script type="module" src="./app.js?build=20260811-r164-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r164-long-session-robustness"></script>
   <script type="module" src="./accessibility/color-accessibility-r163.js?build=20260811-r164-paint-basics"></script>
   <script type="module" src="./achievements/chromatic-camouflage-r183.js?revision=r183-production"></script>
   <script type="module" src="./social/your-turn-share-bootstrap.js?revision=r2"></script>

--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -99,7 +99,7 @@
         "./tracks/cliffside-world.js": "./tracks/cliffside-world-r76.js?build=20260811-r164",
         "./tracks/harbor-collision.js": "./tracks/harbor-collision.js?build=20260811-r164",
         "./tracks/harbor-layout.js": "./tracks/harbor-layout.js?build=20260811-r164",
-        "./tracks/harbor-world.js": "./tracks/harbor-world-r81.js?build=20260811-r164",
+        "./tracks/harbor-world.js": "./tracks/harbor-world-r82.js?build=20260811-r164&revision=r164-long-session-robustness",
         "./tracks/definitions.js": "./tracks/definitions.js?build=20260811-r164",
         "./tracks/elevation.js": "./tracks/elevation.js?build=20260811-r164",
         "./tracks/pace-notes.js": "./tracks/pace-notes.js?build=20260811-r164",
@@ -139,19 +139,4 @@
     <button id="manualButton" type="button" hidden></button>
     <p id="status" role="status" hidden>Steering uses device rotation</p>
   </section>
-  <section class="rotate-panel" aria-label="Rotate your device to landscape"><div class="rotate-card"><div class="rotate-phone" aria-hidden="true"></div><strong>ROTATE YOUR DEVICE TO LANDSCAPE</strong></div></section>
-  <div class="hud" id="hud" hidden>
-    <div class="topbar"><div class="stats"><div class="chip">speed<strong><span id="speed">0</span> km/h</strong></div><div class="chip">lap<strong id="lap">1</strong></div><div class="chip">time<strong id="lapTime">0:00.000</strong></div><div class="chip">best<strong id="bestTime">--:--.---</strong></div></div><div class="map-wrap"><canvas id="map" width="300" height="210" aria-label="Track map"></canvas></div></div>
-    <div class="message" id="message" role="status"></div>
-    <div class="tilt-drive" aria-hidden="true"><span><b>brake</b><b>gas</b></span><div class="tilt-track"><i class="tilt-needle" id="tiltNeedle"></i></div><small class="tilt-value" id="tiltValue">neutral</small></div>
-  </div>
-  <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
-  <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button" aria-label="Restart the current lap from the start line">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
-  <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260811-r164-r168-shared-about-credits"></script>
-  <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
-  <script type="module" src="./app.js?build=20260811-r164-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r164-long-session-robustness"></script>
-  <script type="module" src="./accessibility/color-accessibility-r163.js?build=20260811-r164-paint-basics"></script>
-  <script type="module" src="./achievements/chromatic-camouflage-r183.js?revision=r183-production"></script>
-  <script type="module" src="./social/your-turn-share-bootstrap.js?revision=r2"></script>
-  <script type="module" src="./tracks/countryside-bella-rescue-hotfix-r176.js?revision=r176-video-proven-rescue"></script>
-</body></html>
+  <section class="rotate-panel" aria-label="Rotate your device to landscape"><div class="rotate-card"... (truncated)

--- a/turn-lab/tests/audio-foundation-production.mjs
+++ b/turn-lab/tests/audio-foundation-production.mjs
@@ -1,13 +1,30 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [index, releaseSource, app, audio, controls, catalogSource] = await Promise.all([
+const [
+  index,
+  releaseSource,
+  app,
+  audio,
+  controls,
+  catalogSource,
+  organicRibbon,
+  recoveryGuidance,
+  driveByEarRuntime,
+  musicHealth,
+  homeLayout
+] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/release.json', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/audio/audio-system.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/ui/gameplay-controls.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/vehicle/catalog.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../../turn/vehicle/catalog.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/audio/organic-ribbon.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/audio/recovery-guidance.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/audio/drive-by-ear-runtime.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/audio/racing-music-health.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8')
 ]);
 const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
 const release = JSON.parse(releaseSource);
@@ -16,7 +33,8 @@ assert.ok(importMapText, 'Production must expose its import map');
 const imports = JSON.parse(importMapText).imports;
 
 assert.match(index, new RegExp(`TURN v${release.version.replaceAll('.', '\\.')} · Build ${release.id.replaceAll('.', '\\.')}`));
-assert.match(index, new RegExp(`\\.\\/app\\.js\\?build=${release.cacheKey}`));
+assert.match(index, new RegExp(`\\.\\/app\\.js\\?build=${release.cacheKey}[^\"]*r164-long-session-robustness`),
+  'The installed-app root must request a fresh robustness app module');
 assert.equal(
   imports['./vehicle/catalog.js?build=20260720-r19'],
   `./vehicle/catalog.js?build=${release.cacheKey}`,
@@ -28,7 +46,12 @@ assert.equal(
   'The Lot must use the same current vehicle handling catalog'
 );
 
-assert.match(app, /import\(withBuild\('\.\/audio\/audio-system\.js'\)\)/, 'Production must load the central audio module');
+assert.match(app, /audio\/audio-system\.js\?revision=r164-long-session-robustness/,
+  'Production must load the cache-safe long-session central audio module');
+assert.match(app, /audio\/drive-by-ear-runtime\.js\?revision=r164-long-session-robustness/,
+  'Production must load the cache-safe Drive By Ear robustness graph');
+assert.match(app, /performance-profile\.js\?revision=r164-long-session-robustness/,
+  'Production must load the cache-safe mobile performance profile');
 assert.match(app, /installTurnAudio\(\)/, 'The audio foundation must install before gameplay starts');
 assert.ok(
   app.indexOf('./audio/audio-system.js') < app.indexOf('./ui/gameplay-controls.js'),
@@ -37,8 +60,10 @@ assert.ok(
 
 assert.match(audio, /globalThis\.AudioContext \|\| globalThis\.webkitAudioContext/, 'Audio must support iOS WebKit AudioContext');
 assert.match(audio, /AUDIO_UPDATE_INTERVAL_MS = 1000 \/ 30/, 'Continuous audio updates must stay capped at 30 Hz');
+assert.match(audio, /AUDIO_RECOVERY_RETRY_MS = 1000/, 'Interrupted game audio recovery must be throttled');
 assert.match(audio, /globalThis\.__turnAudio = api/, 'The foundation must expose one shared audio API');
 assert.match(audio, /unlock,\s*update,\s*cue,\s*silence/, 'The shared audio API must expose lifecycle, continuous state, and one-shot cues');
+assert.match(audio, /get diagnostics\(\)/, 'Long-session audio health must expose bounded diagnostics');
 
 assert.match(audio, /function installEngineGraph\(/, 'The foundation must provide a continuous engine layer');
 assert.match(audio, /function installDriftGraph\(/, 'The foundation must provide a continuous drift layer');
@@ -88,8 +113,52 @@ assert.doesNotMatch(audio, /document\.addEventListener\('change'/,
   'Nonessential UI audio must not put delegated form handling above native controls');
 assert.match(audio, /document\.addEventListener\('keydown', unlockFromGesture/);
 assert.match(audio, /document\.addEventListener\('visibilitychange', handleVisibilityChange/);
+assert.match(audio, /window\.addEventListener\('pageshow', handlePageShow/);
 assert.match(audio, /window\.addEventListener\('pagehide', handlePageHide/);
+assert.match(audio, /context\.addEventListener\?\.\('statechange', handleContextStateChange\)/,
+  'The shared game AudioContext must detect WebKit interruptions');
+assert.match(audio, /function requestContextRecovery\(/,
+  'A non-running visible game AudioContext must have a self-recovery path');
+assert.match(audio, /if \(context\.state !== 'running'\) \{[\s\S]*requestContextRecovery\(now\)/,
+  'Continuous game audio must try to recover rather than silently remaining dead');
 assert.match(audio, /function hardMute\(/);
+
+// Persistent AudioParams used to accumulated a new automation event on every
+// 30 Hz update for the lifetime of the session. Every retarget must replace the
+// pending tail before scheduling a new value.
+assert.match(audio, /function smooth\([\s\S]*cancelAndHoldAtTime\(time\)[\s\S]*cancelScheduledValues\(time\)[\s\S]*setTargetAtTime\(value, time, timeConstant\)/,
+  'Persistent game-audio automation must remain bounded over long sessions');
+assert.match(organicRibbon, /ORGANIC_UPDATE_INTERVAL_MS = 1000 \/ 30/);
+assert.match(organicRibbon, /function retarget\([\s\S]*cancelAndHoldAtTime\(now\)[\s\S]*cancelScheduledValues\(now\)[\s\S]*setTargetAtTime\(value, now, timeConstant\)/,
+  'Organic ribbon automation must remain bounded');
+assert.match(recoveryGuidance, /RECOVERY_UPDATE_INTERVAL_MS = 1000 \/ 30/);
+assert.match(recoveryGuidance, /lastWrongWayUpdateAt/,
+  'Wrong-way tone retargeting must not run at display refresh rate');
+assert.match(recoveryGuidance, /function setTarget\([\s\S]*cancelAndHoldAtTime\(now\)[\s\S]*cancelScheduledValues\(now\)[\s\S]*setTargetAtTime\(value, now, timeConstant\)/,
+  'Recovery guidance automation must remain bounded');
+assert.match(driveByEarRuntime, /organic-ribbon\.js\?revision=r164-long-session-robustness/);
+assert.match(driveByEarRuntime, /recovery-guidance\.js\?revision=r164-long-session-robustness/);
+
+// One-shot cue graphs must become collectible instead of accumulating connected
+// oscillator/filter/panner graphs for the duration of the app process.
+assert.match(audio, /activeTransientSources = new Set\(\)/);
+assert.match(audio, /transientNoiseBuffers = new Map\(\)/,
+  'Repeated cue noise must reuse a small buffer cache instead of allocating a new AudioBuffer each cue');
+assert.match(audio, /function trackTransientSource\(/);
+assert.match(audio, /disconnectNodes\(\.\.\.nodes\)/);
+assert.match(audio, /source\.buffer = transientNoiseBuffer\(smoothing\)/);
+
+// Keep the exact user-tuned v3 song source untouched. Robustness lives beside it
+// and repairs a scheduler/context interruption by forcing a clean stop/restart.
+assert.match(homeLayout, /racing-music-v2\.js\?build=\$\{buildKey\}-racing-music-warm-v2/);
+assert.match(homeLayout, /racing-music-health\.js\?build=\$\{buildKey\}&revision=r164-long-session-robustness/);
+assert.match(musicHealth, /HEALTH_CHECK_INTERVAL_MS = 1000/);
+assert.match(musicHealth, /music\.stop\(\)/);
+assert.match(musicHealth, /music\.setVolume\(restoreVolume, \{ restart: true \}\)/);
+assert.match(musicHealth, /document\.visibilityState !== 'hidden'/);
+assert.doesNotMatch(musicHealth, /AudioContext|createOscillator|createBufferSource/,
+  'The music health layer must not fork or rewrite the tuned music synthesis graph');
+
 assert.doesNotMatch(audio, /requestAnimationFrame|setAnimationLoop|setInterval/);
 assert.doesNotMatch(audio, /fetch\(|new Audio\(/);
 assert.match(controls, /function updateAudio\(now, boosting\)/);
@@ -104,4 +173,4 @@ assert.match(controls, /globalThis\.__turnAudio\?\.cue\('boost-full'\)/);
 assert.match(controls, /if \(position < lastPosition\)/);
 assert.match(controls, /globalThis\.__turnAudio\?\.cue\('overtake'/);
 
-console.log(`TURN ${release.id} drift, boost and rival sound production passed.`);
+console.log(`TURN ${release.id} long-session audio, drift, boost and rival sound production passed.`);

--- a/turn-lab/tests/bella-rescue-production.mjs
+++ b/turn-lab/tests/bella-rescue-production.mjs
@@ -122,17 +122,23 @@ assert.match(app, /render\/world\.js\?revision=r164-long-session-robustness/,
   'The app must request the optimized world graph rather than an older Bella world cache identity');
 assert.match(homeLayout, /secret-achievements\.js\?build=\$\{buildKey\}-r174-bella-siren-zone/);
 
+assert.match(bootstrap, /countryside-bella-rescue-r173\.js\?revision=r164-long-session-robustness/,
+  'The independent Bella bootstrap must reinstall the same robustness behavior as the world graph');
 assert.match(bootstrap, /turnBellaDisposeRescueBehavior\?\.\(\)/);
 assert.match(bootstrap, /turnBellaRescueBehaviorInstalled = false/);
 assert.match(bootstrap, /installBellaRescueBehavior\(\{ root, runtime \}\)/);
-assert.match(bootstrap, /turnBellaRescueBootstrap = 'r176-road-derived-zone'/,
-  'The production bootstrap must dispose and replace any rescue timer installed by a cached world module');
+assert.match(bootstrap, /turnBellaRescueBootstrap = 'r164-long-session-robustness'/,
+  'The production bootstrap must identify the long-session behavior it reinstalls');
+assert.match(bootstrap, /RETRY_DELAYS_MS = Object\.freeze\(\[250, 350, 500, 700, 900, 1200, 1600, 2200, 3000, 4000\]\)/,
+  'Async Bella discovery should use a bounded back-off rather than an 8 Hz startup poll');
+assert.doesNotMatch(bootstrap, /setInterval/,
+  'The independent Bella bootstrap must not maintain its old fixed 120 ms polling interval');
 assert.match(index, new RegExp(`app\\.js\\?build=${escapeRegex(release.cacheKey)}-browser-consent-r176-bella-road-derived-zone`),
   'The top-level app URL must use the canonical release cache key so Safari cannot retain an old dependency graph');
 assert.match(index, /countryside-bella-rescue-hotfix-r176\.js\?revision=r176-video-proven-rescue/,
-  'The current rescue replacement must be loaded independently from the cached world graph');
+  'The current rescue replacement remains independently loaded until its outer script URL receives the final robustness cache revision');
 
-console.log('TURN Bella video-proven rescue, on-demand directional audio and cache replacement regression passed.');
+console.log('TURN Bella video-proven rescue, on-demand directional audio and bounded bootstrap regression passed.');
 
 function escapeRegex(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/turn-lab/tests/bella-rescue-production.mjs
+++ b/turn-lab/tests/bella-rescue-production.mjs
@@ -90,10 +90,36 @@ assert.match(behavior, /__turnAudioPreferences\?\.getSettings/);
 assert.match(behavior, /createStereoPanner/);
 assert.match(behavior, /voice\.frequency\.exponentialRampToValueAtTime/);
 
-assert.match(world, /countryside-bella-rescue-r173\.js\?revision=r176-road-derived-rescue-zone/);
+// Bella keeps its tiny directional world-sound context separate from the central
+// game/DBE graph, but ordinary sessions must not keep that third context running.
+assert.match(behavior, /function meowContextWanted\(/);
+assert.match(
+  behavior,
+  /activeTrackId\(runtime\) === 'countryside'[\s\S]*vehicleId \|\| ''\)\.toLowerCase\(\) === REQUIRED_VEHICLE_ID[\s\S]*otherSoundPreference\(\) > 0\.001[\s\S]*document\.visibilityState !== 'hidden'/,
+  'Bella audio must only arm for a visible Countryside Fire Truck run with other sounds enabled'
+);
+assert.match(
+  behavior,
+  /function unlockMeowContext\(\)[\s\S]*if \(meowContextWanted\(\)\) ensureMeowContext\(\)/,
+  'Ordinary gestures must not eagerly create the Bella AudioContext'
+);
+assert.match(behavior, /function suspendMeowContext\(\)/);
+assert.match(
+  behavior,
+  /if \(!eligible \|\| document\.hidden\) \{[\s\S]*suspendMeowContext\(\)/,
+  'Leaving an eligible rescue run must suspend Bella audio'
+);
+assert.match(
+  behavior,
+  /meowContext\.close\?\.\(\)[\s\S]*meowContext = null/,
+  'Disposal must close and release Bella audio completely'
+);
+
+assert.match(world, /countryside-bella-rescue-r173\.js\?revision=r164-long-session-robustness/,
+  'The Countryside world bootstrap must request the on-demand Bella audio lifecycle under a fresh URL');
 assert.match(world, /applyBellaFinalVisuals\(bellaRoot\);\s*installBellaRescueBehavior\(\{ root: bellaRoot, runtime \}\);/);
-assert.match(app, /render\/world\.js\?revision=r175-bella-broad-rear-zone/,
-  'The established app world entry remains valid while the independent rescue bootstrap replaces cached behavior');
+assert.match(app, /render\/world\.js\?revision=r164-long-session-robustness/,
+  'The app must request the optimized world graph rather than an older Bella world cache identity');
 assert.match(homeLayout, /secret-achievements\.js\?build=\$\{buildKey\}-r174-bella-siren-zone/);
 
 assert.match(bootstrap, /turnBellaDisposeRescueBehavior\?\.\(\)/);
@@ -106,7 +132,7 @@ assert.match(index, new RegExp(`app\\.js\\?build=${escapeRegex(release.cacheKey)
 assert.match(index, /countryside-bella-rescue-hotfix-r176\.js\?revision=r176-video-proven-rescue/,
   'The current rescue replacement must be loaded independently from the cached world graph');
 
-console.log('TURN Bella video-proven road-derived rescue, siren input, ground transition and cache replacement regression passed.');
+console.log('TURN Bella video-proven rescue, on-demand directional audio and cache replacement regression passed.');
 
 function escapeRegex(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/turn-lab/tests/bella-rescue-production.mjs
+++ b/turn-lab/tests/bella-rescue-production.mjs
@@ -135,8 +135,8 @@ assert.doesNotMatch(bootstrap, /setInterval/,
   'The independent Bella bootstrap must not maintain its old fixed 120 ms polling interval');
 assert.match(index, new RegExp(`app\\.js\\?build=${escapeRegex(release.cacheKey)}-browser-consent-r176-bella-road-derived-zone`),
   'The top-level app URL must use the canonical release cache key so Safari cannot retain an old dependency graph');
-assert.match(index, /countryside-bella-rescue-hotfix-r176\.js\?revision=r176-video-proven-rescue/,
-  'The current rescue replacement remains independently loaded until its outer script URL receives the final robustness cache revision');
+assert.match(index, /countryside-bella-rescue-hotfix-r176\.js\?revision=r164-long-session-robustness/,
+  'The independent rescue replacement must have a fresh outer module URL so Safari cannot reuse the old r176 bootstrap bytes');
 
 console.log('TURN Bella video-proven rescue, on-demand directional audio and bounded bootstrap regression passed.');
 

--- a/turn-lab/tests/color-accessibility-production.mjs
+++ b/turn-lab/tests/color-accessibility-production.mjs
@@ -70,7 +70,7 @@ assert.ok(
 assert.ok(indexSource.includes(`styles.css?build=${release.cacheKey}-native-html`));
 assert.ok(indexSource.includes(`garage/lot-r10.css?build=${release.cacheKey}-native-html`));
 assert.ok(indexSource.includes(`garage/lot-layout-r60.css?build=${release.cacheKey}-native-html`));
-assert.ok(indexSource.includes(`lot-track-select.js?build=${release.cacheKey}&revision=r163-native-html`));
+assert.ok(indexSource.includes(`lot-track-select.js?build=${release.cacheKey}&revision=r164-long-session-robustness`));
 assert.ok(
   indexSource.includes(`app.js?build=${release.cacheKey}-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click`),
   'The device must receive the native-picker ancestry experiment under a fresh release module URL'

--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -167,7 +167,7 @@ assert.match(index, new RegExp(`\\.\\/track-intro\\.css\\?build=${release.cacheK
 assert.match(index, new RegExp(`src="\\.\\/app\\.js\\?build=${release.cacheKey}-browser-consent(?:-[^"]+)?"`));
 assert.equal(
   imports['./garage/lot-r10.js?build=20260720-r19'],
-  `${releaseTarget('./garage/lot-track-select.js')}&revision=r163-native-html`
+  `${releaseTarget('./garage/lot-track-select.js')}&revision=r164-long-session-robustness`
 );
 assert.equal(imports['./ui/track-intro.js?build=20260725-r75'], releaseTarget('./ui/track-intro.js'));
 assert.equal(imports['./race/lap-system.js?build=20260720-r19'], releaseTarget('./race/lap-system-r86.js'));

--- a/turn-lab/tests/lot-layout-production.mjs
+++ b/turn-lab/tests/lot-layout-production.mjs
@@ -40,7 +40,8 @@ assert.match(
 assert.match(index, new RegExp(`app\\.js\\?build=${release.cacheKey}-browser-consent`));
 assert.equal(
   imports['./garage/lot-r10.js?build=20260720-r19'],
-  `./garage/lot-track-select.js?build=${release.cacheKey}&revision=r163-native-html`
+  `./garage/lot-track-select.js?build=${release.cacheKey}&revision=r164-long-session-robustness`,
+  'Production must request the optimized Lot wrapper under a fresh cache identity'
 );
 assert.equal(
   imports['./garage/lot-accessibility-r118.js?build=20260729-r118'],
@@ -59,6 +60,8 @@ assert.ok(
 );
 
 assert.match(wrapper, /export async function showEnhancedLot/);
+assert.match(wrapper, /lot-r10\.js\?build=20260809-r163-native-html&revision=r164-long-session-robustness/,
+  'The wrapper must load the optimized Lot implementation under a fresh URL');
 assert.match(wrapper, /const removeEnhancements = enhanceLotNow\(\)/);
 assert.match(wrapper, /await chooseTrackBeforeLot\(\)/);
 assert.doesNotMatch(wrapper, /installLotLayout|installLotStatLegend|installLotAccessibility/);
@@ -108,6 +111,10 @@ assert.match(
 assert.match(lot, /lot-viewbox-head" aria-hidden="true"/);
 assert.match(lot, /lot-view-host" aria-hidden="true"/);
 assert.doesNotMatch(lot, /lot-view-close|lot-view-open/);
+assert.match(lot, /LOT_FRAME_INTERVAL_MS = 1000 \/ 30/,
+  'The Lot must stay at a cooler 30fps without changing race rendering');
+assert.match(lot, /renderer\.forceContextLoss\?\.\(\)/,
+  'Closing The Lot must release its WebGL context');
 
 assert.doesNotMatch(layout, /appendChild\(colors\)|lot-view-close|lot-view-open/);
 assert.match(layout, /document\.createTextNode\('ATTRIBUTES'\)/);
@@ -143,4 +150,4 @@ assert.match(legend, /role', 'dialog'/);
 assert.match(legend, /name\.textContent = entry\.label/);
 assert.match(legend, /description\.textContent = entry\.description/);
 
-console.log(`TURN ${release.id} compact Lot layout, car-owned named perks and accessibility contract passed.`);
+console.log(`TURN ${release.id} compact optimized Lot layout, car-owned named perks and accessibility contract passed.`);

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -176,7 +176,11 @@ assert.match(index, new RegExp(`TURN v${release.version.replaceAll('.', '\\.')} 
 assert.equal(imports['./race/replay-system.js'], releaseTarget('./race/replay-system.js'), 'The current release must publish the shared replay sampler cache');
 assert.equal(imports['./race/track-spatial-index.js?build=20260720-r19'], releaseTarget('./race/track-spatial-index.js'), 'The current release must publish the rebuildable bounded track search');
 assert.equal(imports['./performance-monitor.js?build=20260720-r19'], releaseTarget('./performance-monitor.js'), 'The current release must publish the diagnostics module');
-assert.equal(imports['./world-assets.js'], releaseTarget('./world-assets.js'), 'The current release must publish both countryside tree-grounding passes');
+assert.equal(
+  imports['./world-assets.js'],
+  `${releaseTarget('./world-assets.js')}&revision=r164-long-session-robustness`,
+  'The current release must publish the fresh tree-grounding and contour-suppression pass'
+);
 assert.equal(
   imports['/turn/achievements/trophy-road-showcase.js?revision=r160-reward-detail-sync'],
   '/turn/achievements/trophy-road-showcase.js?revision=r164-long-session-robustness',
@@ -184,11 +188,11 @@ assert.equal(
 );
 assert.match(app, /performance-profile\.js\?revision=r164-long-session-robustness/,
   'The installed runtime must request the mobile thermal profile under a fresh URL');
-assert.match(app, /installPerformanceProfile\(\)/, 'Renderer profile installation must run before the game runtime');
+assert.match(app, /installPerformanceProfile\(\)/, 'Renderer profile installation must run before gameplay starts');
 assert.ok(app.indexOf('./performance-profile.js') < app.indexOf('./main.js'), 'The DPR cap must be ready before main.js creates the runtime');
 assert.match(profile, /DEFAULT_DPR_CAP = 1\.5/, 'Desktop production DPR ceiling must stay at 1.5');
 assert.match(profile, /TOUCH_DPR_CAP = 1\.25/, 'Touch production must reserve thermal headroom with DPR 1.25');
-assert.match(profile, /TOUCH_SHADOW_MAP_SIZE = 512/, 'Touch production must use the cheaper 512px shadow map');
+assert.match(profile, /TOUCH_SHADOW_MAP_SIZE = 512/, 'Touch devices must use the cheaper 512px shadow map');
 assert.match(profile, /maxTouchPoints/);
 assert.match(profile, /pointer: coarse/);
 assert.match(profile, /MAX_DPR_CAP = 1\.5/, 'Diagnostics must never restore the retired DPR 2 tier');

--- a/turn-lab/tests/performance-production.mjs
+++ b/turn-lab/tests/performance-production.mjs
@@ -45,36 +45,52 @@ assert.equal(performanceModeRequested('?perf=1'), true);
 assert.equal(performanceModeRequested('?perf=0'), false);
 assert.equal(performanceModeRequested(''), false);
 
-const baselineProfile = performanceProfileFromSearch('?perf=1', 2);
-assert.equal(baselineProfile.active, false, 'Perf diagnostics alone must not add a separate quality tier');
-assert.equal(baselineProfile.dprCap, 1.5, 'TURN must use one universal DPR 1.5 ceiling');
+// Desktop/precise-pointer rendering keeps the established quality baseline.
+const baselineProfile = performanceProfileFromSearch('?perf=1', 2, { touchOptimized: false });
+assert.equal(baselineProfile.active, false, 'Perf diagnostics alone must not add a separate desktop quality tier');
+assert.equal(baselineProfile.dprCap, 1.5, 'Desktop TURN must retain its DPR 1.5 ceiling');
 assert.equal(baselineProfile.pixelRatio, 1.5);
 assert.equal(baselineProfile.shadowsEnabled, true);
 assert.equal(baselineProfile.shadowMapSize, 1024);
+assert.equal(baselineProfile.touchOptimized, false);
 
-const dprProfile = performanceProfileFromSearch('?perf=1&dpr=1.25', 2);
+// Touch hardware does the same gameplay work at a saner fill-rate/shadow cost.
+const touchProfile = performanceProfileFromSearch('', 3, { touchOptimized: true });
+assert.equal(touchProfile.active, false, 'Mobile thermal defaults are production behavior, not a diagnostic quality mode');
+assert.equal(touchProfile.touchOptimized, true);
+assert.equal(touchProfile.dprCap, 1.25, 'Touch devices must cap pixel density at 1.25 for long-session thermal headroom');
+assert.equal(touchProfile.pixelRatio, 1.25);
+assert.equal(touchProfile.shadowsEnabled, true);
+assert.equal(touchProfile.shadowMapSize, 512, 'Touch devices must use the cheaper production shadow map');
+
+const dprProfile = performanceProfileFromSearch('?perf=1&dpr=1.25', 2, { touchOptimized: false });
 assert.equal(dprProfile.active, true);
 assert.equal(dprProfile.dprCap, 1.25);
 assert.equal(dprProfile.pixelRatio, 1.25);
 assert.match(dprProfile.label, /DPR≤1\.25/);
 
-const lowDprProfile = performanceProfileFromSearch('?perf=1&dpr=0.2', 2);
+const lowDprProfile = performanceProfileFromSearch('?perf=1&dpr=0.2', 2, { touchOptimized: false });
 assert.equal(lowDprProfile.dprCap, 0.75, 'Diagnostic DPR overrides must stay within the safe lower bound');
-const highDprProfile = performanceProfileFromSearch('?perf=1&dpr=9', 3);
-assert.equal(highDprProfile.dprCap, 1.5, 'No diagnostic profile may exceed the universal production cap');
+const highDprProfile = performanceProfileFromSearch('?perf=1&dpr=9', 3, { touchOptimized: false });
+assert.equal(highDprProfile.dprCap, 1.5, 'No diagnostic profile may exceed the desktop production cap');
 
-const shadowProfile = performanceProfileFromSearch('?perf=1&shadow=512', 2);
+const shadowProfile = performanceProfileFromSearch('?perf=1&shadow=512', 2, { touchOptimized: false });
 assert.equal(shadowProfile.active, true);
 assert.equal(shadowProfile.shadowsEnabled, true);
 assert.equal(shadowProfile.shadowMapSize, 512);
-const noShadowProfile = performanceProfileFromSearch('?perf=1&shadow=off', 2);
+const noShadowProfile = performanceProfileFromSearch('?perf=1&shadow=off', 2, { touchOptimized: false });
 assert.equal(noShadowProfile.shadowsEnabled, false);
 assert.match(noShadowProfile.label, /shadows off/);
-const ignoredProfile = performanceProfileFromSearch('?dpr=1&shadow=off', 2);
+const ignoredProfile = performanceProfileFromSearch('?dpr=1&shadow=off', 2, { touchOptimized: false });
 assert.equal(ignoredProfile.active, false, 'Renderer overrides must be ignored outside explicit perf mode');
 assert.equal(ignoredProfile.dprCap, 1.5);
-assert.equal(ignoredProfile.pixelRatio, 1.5, 'Normal play must still receive the universal DPR cap');
+assert.equal(ignoredProfile.pixelRatio, 1.5, 'Normal desktop play must retain the desktop DPR cap');
 assert.equal(ignoredProfile.shadowsEnabled, true);
+
+const touchDiagnosticOverride = performanceProfileFromSearch('?perf=1&dpr=1.5&shadow=1024', 3, { touchOptimized: true });
+assert.equal(touchDiagnosticOverride.active, true, 'Perf mode may deliberately restore heavier settings for A/B diagnosis');
+assert.equal(touchDiagnosticOverride.dprCap, 1.5);
+assert.equal(touchDiagnosticOverride.shadowMapSize, 1024);
 
 const replayLap = {
   time: 2,
@@ -100,7 +116,31 @@ assert.equal(summary.p95Ms, 50);
 assert.equal(summary.slowPercent, 40);
 assert.ok(Math.abs(summary.fps - 1000 / 30) < 1e-9);
 
-const [index, releaseSource, app, main, worldAssets, worldRender, controls, menu, spectate, hud, physics, camera, cars, lot, monitor, profile, replay, audio, orientationCompat, airportWorld, airportPolish, worldCollision] = await Promise.all([
+const [
+  index,
+  releaseSource,
+  app,
+  main,
+  worldAssets,
+  worldRender,
+  controls,
+  menu,
+  spectate,
+  hud,
+  physics,
+  camera,
+  cars,
+  lot,
+  trophyShowcase,
+  monitor,
+  profile,
+  replay,
+  audio,
+  orientationCompat,
+  airportWorld,
+  airportPolish,
+  worldCollision
+] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/release.json', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/app.js', import.meta.url), 'utf8'),
@@ -115,6 +155,7 @@ const [index, releaseSource, app, main, worldAssets, worldRender, controls, menu
   fs.readFile(new URL('../../turn/render/camera.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/vehicle/car-models.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-r10.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/achievements/trophy-road-showcase.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/performance-monitor.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/performance-profile.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/race/replay-system.js', import.meta.url), 'utf8'),
@@ -136,12 +177,23 @@ assert.equal(imports['./race/replay-system.js'], releaseTarget('./race/replay-sy
 assert.equal(imports['./race/track-spatial-index.js?build=20260720-r19'], releaseTarget('./race/track-spatial-index.js'), 'The current release must publish the rebuildable bounded track search');
 assert.equal(imports['./performance-monitor.js?build=20260720-r19'], releaseTarget('./performance-monitor.js'), 'The current release must publish the diagnostics module');
 assert.equal(imports['./world-assets.js'], releaseTarget('./world-assets.js'), 'The current release must publish both countryside tree-grounding passes');
+assert.equal(
+  imports['/turn/achievements/trophy-road-showcase.js?revision=r160-reward-detail-sync'],
+  '/turn/achievements/trophy-road-showcase.js?revision=r164-long-session-robustness',
+  'Trophy Road must receive the fresh throttled preview renderer instead of a cached full-refresh module'
+);
+assert.match(app, /performance-profile\.js\?revision=r164-long-session-robustness/,
+  'The installed runtime must request the mobile thermal profile under a fresh URL');
 assert.match(app, /installPerformanceProfile\(\)/, 'Renderer profile installation must run before the game runtime');
-assert.ok(app.indexOf('./performance-profile.js') < app.indexOf('./main.js'), 'The universal DPR cap must be ready before main.js creates the runtime');
-assert.match(profile, /DEFAULT_DPR_CAP = 1\.5/, 'The universal production DPR ceiling must stay at 1.5');
+assert.ok(app.indexOf('./performance-profile.js') < app.indexOf('./main.js'), 'The DPR cap must be ready before main.js creates the runtime');
+assert.match(profile, /DEFAULT_DPR_CAP = 1\.5/, 'Desktop production DPR ceiling must stay at 1.5');
+assert.match(profile, /TOUCH_DPR_CAP = 1\.25/, 'Touch production must reserve thermal headroom with DPR 1.25');
+assert.match(profile, /TOUCH_SHADOW_MAP_SIZE = 512/, 'Touch production must use the cheaper 512px shadow map');
+assert.match(profile, /maxTouchPoints/);
+assert.match(profile, /pointer: coarse/);
 assert.match(profile, /MAX_DPR_CAP = 1\.5/, 'Diagnostics must never restore the retired DPR 2 tier');
-assert.match(profile, /if \(!runtime\?\.renderer\) return;/, 'The universal renderer profile must apply even without a diagnostic override');
-assert.doesNotMatch(profile, /if \(!profile\.active \|\| !runtime\?\.renderer\) return;/, 'Normal play must not bypass the universal DPR cap');
+assert.match(profile, /if \(!runtime\?\.renderer\) return;/, 'The renderer profile must apply even without a diagnostic override');
+assert.doesNotMatch(profile, /if \(!profile\.active \|\| !runtime\?\.renderer\) return;/, 'Normal play must not bypass its device-appropriate DPR cap');
 assert.match(profile, /renderer\.setPixelRatio = \(value\) =>/, 'The DPR cap must survive TURN resize calls');
 assert.match(profile, /renderer\.shadowMap\.enabled = profile\.shadowsEnabled/, 'Shadow A/B testing must remain available without a second loop');
 assert.doesNotMatch(profile, /requestAnimationFrame|setAnimationLoop|setInterval/, 'Performance profiles must add no animation loop');
@@ -176,7 +228,24 @@ assert.doesNotMatch(camera, /state\.position\.clone\(\)/);
 assert.match(cars, /record\.node\.castShadow = !ghost/);
 assert.doesNotMatch(lot, /root\.scale\.lerp\(new THREE\.Vector3/);
 assert.match(lot, /recordPerformanceFrame/);
+assert.match(lot, /LOT_FRAME_INTERVAL_MS = 1000 \/ 30/,
+  'The two-renderer Lot surface must not render at 60/120 Hz');
+assert.match(lot, /now - lastRenderAt < LOT_FRAME_INTERVAL_MS/);
+assert.match(lot, /rendererPixelRatio\(1\.5\)/,
+  'Both Lot renderers must inherit the production touch DPR cap');
+assert.match(lot, /renderer\.forceContextLoss\?\.\(\)/,
+  'Closing The Lot must release its WebGL context instead of accumulating contexts across visits');
+assert.match(lot, /function disposeVisualMaterials\(/,
+  'Repeated 3D viewer swaps must release cloned materials');
+assert.doesNotMatch(lot, /geometry\.dispose/,
+  'The Lot must not dispose shared cached vehicle geometries while releasing per-view materials');
 assert.doesNotMatch(lot, /GLTFLoader|InstancedMesh|installBrickScenery/, 'The clean Lot must not spend asset or draw-call budget on decorative wall scenery');
+assert.match(trophyShowcase, /SHOWCASE_FRAME_INTERVAL_MS = 1000 \/ 30/,
+  'Trophy Road decorative 3D models must stay at 30 fps');
+assert.match(trophyShowcase, /now - lastRenderAt < SHOWCASE_FRAME_INTERVAL_MS/);
+assert.match(trophyShowcase, /__turnPerformanceProfile\?\.dprCap/);
+assert.match(trophyShowcase, /renderer\?\.forceContextLoss\?\.\(\)/,
+  'Closing the Achievements renderer must release its WebGL context');
 assert.match(audio, /AUDIO_UPDATE_INTERVAL_MS = 1000 \/ 30/, 'Audio state must stay capped at 30 Hz');
 assert.doesNotMatch(audio, /requestAnimationFrame|setAnimationLoop|setInterval/, 'New sound cues must not add a second loop');
 assert.doesNotMatch(orientationCompat, /requestAnimationFrame|setAnimationLoop|setInterval/, 'The orientation guard must remain event-driven and add no render loop');
@@ -187,4 +256,4 @@ assert.doesNotMatch(worldCollision, /requestAnimationFrame|setAnimationLoop|setI
 assert.match(monitor, /turn:perf-snapshot/);
 assert.match(monitor, /trackChecksPerQuery/);
 
-console.log(`TURN ${release.id} universal DPR, world containment, complete tree grounding, rebuildable bounded spatial search and diagnostics passed (${(trackChecks / trackQueries).toFixed(1)} average on-track checks vs 720).`);
+console.log(`TURN ${release.id} mobile thermal profile, 30fps menu 3D, world containment, bounded spatial search and diagnostics passed (${(trackChecks / trackQueries).toFixed(1)} average on-track checks vs 720).`);

--- a/turn-lab/tests/stat-legend-production.mjs
+++ b/turn-lab/tests/stat-legend-production.mjs
@@ -34,8 +34,8 @@ const imports = JSON.parse(importMapText).imports;
 assert.match(index, new RegExp(`lot-stat-legend\\.css\\?build=${release.cacheKey}`), 'Production must load the stat-legend styling through the current release');
 assert.equal(
   imports['./garage/lot-r10.js?build=20260720-r19'],
-  `./garage/lot-track-select.js?build=${release.cacheKey}&revision=r163-native-html`,
-  'Production must publish the native HTML Lot wrapper through the current release'
+  `./garage/lot-track-select.js?build=${release.cacheKey}&revision=r164-long-session-robustness`,
+  'Production must publish the optimized native HTML Lot wrapper through the current release'
 );
 assert.equal(imports['./vehicle/physics.js?build=20260720-r19'], `./vehicle/physics.js?build=${release.cacheKey}`, 'Production must publish the mandatory DRIFT penalty through the current release');
 assert.equal(imports['./vehicle/catalog.js?build=20260720-r19'], `./vehicle/catalog.js?build=${release.cacheKey}`, 'Production must publish the shared stat definitions through the current release');

--- a/turn-tests/covered-rendering-production.mjs
+++ b/turn-tests/covered-rendering-production.mjs
@@ -15,8 +15,16 @@ const [releaseSource, index, app, guard, selector, main] = await Promise.all([
 ]);
 
 const release = JSON.parse(releaseSource);
+const importMapText = index.match(/<script type="importmap">\s*([\s\S]*?)\s*<\/script>/)?.[1];
+assert.ok(importMapText, 'Production must expose its import map');
+const imports = JSON.parse(importMapText).imports;
 assert.match(index, new RegExp(`TURN v${release.version.replaceAll('.', '\\.')} · Build ${release.id.replaceAll('.', '\\.')}`));
 assert.match(index, new RegExp(`\\.\\/app\\.js\\?build=${release.cacheKey}`));
+assert.equal(
+  imports[`/turn/render/covered-rendering.js?build=${release.cacheKey}`],
+  `/turn/render/covered-rendering.js?build=${release.cacheKey}&revision=r164-long-session-robustness`,
+  'The installed app must receive the high-refresh guard under a fresh URL'
+);
 
 assert.match(app, /import\(withBuild\('\.\/render\/covered-rendering\.js'\)\)/, 'The covered-rendering policy must load through the release-aware app loader');
 assert.match(app, /installCoveredRenderingGuard\(\)/, 'The renderer guard must install before the game core');
@@ -31,7 +39,13 @@ assert.match(guard, /PAUSE_CLASSES[\s\S]*turn-track-select-open[\s\S]*turn-runti
 assert.match(guard, /PAUSE_CLASSES\.some\(\(className\) => document\.body\?\.classList\.contains\(className\)\)/,
   'Covered frames must be detected from the declared pause lifecycle classes');
 assert.match(guard, /stats\.skippedFrames \+= 1/, 'Skipped covered frames must remain measurable through diagnostics');
-assert.match(guard, /callback\.call\(renderer, time, frame\)/, 'Visible frames must preserve the original renderer callback context and arguments');
+assert.match(guard, /MAX_RENDER_FPS = 60/, 'No WebGL surface should render above the game’s 60 Hz simulation ceiling');
+assert.match(guard, /RENDER_INTERVAL_MS = 1000 \/ MAX_RENDER_FPS/);
+assert.match(guard, /stats\.skippedHighRefreshFrames \+= 1/,
+  'High-refresh frames skipped for thermal headroom must remain measurable');
+assert.match(guard, /lastDeliveredAt \+= slots \* RENDER_INTERVAL_MS/,
+  '90 Hz displays must use accumulated 60 Hz slots instead of falling to a simple 45 Hz every-other-frame cadence');
+assert.match(guard, /callback\.call\(renderer, time, frame\)/, 'Visible delivered frames must preserve the original renderer callback context and arguments');
 assert.match(guard, /typeof callback !== 'function'/, 'Removing an animation loop must still delegate directly to Three.js');
 assert.match(guard, /Symbol\.for\('turn\.covered-rendering-installed'\)/, 'Installation must be idempotent across app reload paths');
 assert.match(guard, /globalThis\.__turnCoveredRendering = diagnostics/, 'Diagnostics must be inspectable without changing gameplay state');
@@ -42,4 +56,4 @@ assert.match(selector, /document\.body\.classList\.remove\('turn-track-select-op
 assert.match(main, /if \(document\.body\.classList\.contains\('turn-lot-open'\)\) return 'lot'/, 'The existing Lot pause must remain intact');
 assert.match(main, /if \(installGate && !installGate\.hidden\) return 'install gate'/, 'The existing install-gate pause must remain intact');
 
-console.log(`TURN ${release.id} covered rendering and modal pause guard passed.`);
+console.log(`TURN ${release.id} 60fps high-refresh cap, covered rendering and modal pause guard passed.`);

--- a/turn-tests/covered-rendering-production.mjs
+++ b/turn-tests/covered-rendering-production.mjs
@@ -5,13 +5,14 @@ import fs from 'node:fs/promises';
 // keyboard input contract in that same run without adding another CI workflow edge.
 await import('./qe-drive-controls-production.mjs');
 
-const [releaseSource, index, app, guard, selector, main] = await Promise.all([
+const [releaseSource, index, app, guard, selector, main, home] = await Promise.all([
   fs.readFile(new URL('../turn/release.json', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/render/covered-rendering.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/ui/track-select.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/main.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/main.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/m8-home.js', import.meta.url), 'utf8')
 ]);
 
 const release = JSON.parse(releaseSource);
@@ -38,6 +39,14 @@ assert.match(guard, /PAUSE_CLASSES[\s\S]*turn-track-select-open[\s\S]*turn-runti
   'The renderer guard must support both track selection and deliberate modal pauses');
 assert.match(guard, /PAUSE_CLASSES\.some\(\(className\) => document\.body\?\.classList\.contains\(className\)\)/,
   'Covered frames must be detected from the declared pause lifecycle classes');
+assert.match(guard, /MAIN_RENDERER_PAUSE_CLASSES[\s\S]*turn-home-open/,
+  'The opaque Home screen must declare the main race renderer covered');
+assert.match(guard, /renderer === globalThis\.__turnRuntime\?\.renderer/,
+  'Home coverage must pause only the main race renderer, not Trophy Road or other foreground 3D surfaces');
+assert.match(guard, /stats\.skippedCoveredMainFrames \+= 1/,
+  'Main-world frames saved while Home is open must remain measurable');
+assert.match(guard, /lastDeliveredAt = -Infinity/,
+  'Returning from a long covered Home stay must reset the high-refresh delivery cadence');
 assert.match(guard, /stats\.skippedFrames \+= 1/, 'Skipped covered frames must remain measurable through diagnostics');
 assert.match(guard, /MAX_RENDER_FPS = 60/, 'No WebGL surface should render above the game’s 60 Hz simulation ceiling');
 assert.match(guard, /RENDER_INTERVAL_MS = 1000 \/ MAX_RENDER_FPS/);
@@ -53,7 +62,11 @@ assert.doesNotMatch(guard, /requestAnimationFrame|setInterval|setTimeout/, 'The 
 
 assert.match(selector, /document\.body\.classList\.add\('turn-track-select-open'\)/, 'Track selection must announce when it fully covers the race scene');
 assert.match(selector, /document\.body\.classList\.remove\('turn-track-select-open'\)/, 'Closing track selection must resume normal rendering');
+assert.match(home, /document\.body\.classList\.add\('turn-m8-active', 'turn-home-open'\)/,
+  'Home must expose the lifecycle class used to stop the covered race world');
+assert.match(home, /document\.body\.classList\.remove\('turn-home-open'\)/,
+  'Leaving Home must resume the main renderer before the race setup flow');
 assert.match(main, /if \(document\.body\.classList\.contains\('turn-lot-open'\)\) return 'lot'/, 'The existing Lot pause must remain intact');
 assert.match(main, /if \(installGate && !installGate\.hidden\) return 'install gate'/, 'The existing install-gate pause must remain intact');
 
-console.log(`TURN ${release.id} 60fps high-refresh cap, covered rendering and modal pause guard passed.`);
+console.log(`TURN ${release.id} Home-covered renderer pause, 60fps high-refresh cap and modal pause guard passed.`);

--- a/turn-tests/long-session-lifecycle-production.mjs
+++ b/turn-tests/long-session-lifecycle-production.mjs
@@ -11,7 +11,8 @@ const [
   achievementRuntime,
   worldAssets,
   worldRender,
-  bellaRescue
+  bellaRescue,
+  harborOptimized
 ] = await Promise.all([
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-lab/index.html', import.meta.url), 'utf8'),
@@ -22,7 +23,8 @@ const [
   fs.readFile(new URL('../turn/achievements/runtime.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/world-assets.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/render/world.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/tracks/countryside-bella-rescue-r173.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/tracks/countryside-bella-rescue-r173.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/tracks/harbor-world-r82.js', import.meta.url), 'utf8')
 ]);
 
 const release = JSON.parse(releaseSource);
@@ -36,6 +38,7 @@ function importMap(source) {
 const productionImports = importMap(index);
 const labImports = importMap(labIndex);
 const optimizedWorldAssetTarget = `./world-assets.js?build=${release.cacheKey}&revision=r164-long-session-robustness`;
+const optimizedHarborTarget = `./tracks/harbor-world-r82.js?build=${release.cacheKey}&revision=r164-long-session-robustness`;
 
 assert.equal(
   productionImports['./world-assets.js'],
@@ -46,6 +49,16 @@ assert.equal(
   labImports['./world-assets.js'],
   optimizedWorldAssetTarget,
   'TURN LAB must exercise the same tree-optimized world asset module as production'
+);
+assert.equal(
+  productionImports['./tracks/harbor-world.js'],
+  optimizedHarborTarget,
+  'Production Harbor must use the draw-call-batched container-yard layer'
+);
+assert.equal(
+  labImports['./tracks/harbor-world.js'],
+  optimizedHarborTarget,
+  'TURN LAB must use the same optimized Harbor world as production'
 );
 assert.match(
   app,
@@ -134,6 +147,23 @@ assert.match(
   'Late forest clusters must be de-contoured as part of their one-time grounding pass'
 );
 
+// Harbor used to keep one MeshStandardMaterial shell plus a separate wireframe mesh for
+// every container. Grouping identical geometry by paint colour retains the yard while
+// collapsing those permanent draw calls to a handful of InstancedMesh batches.
+assert.match(harborOptimized, /installHarborWorldR81/);
+assert.match(harborOptimized, /function batchContainerYards\(world\)/);
+assert.match(harborOptimized, /const shellsByColor = new Map\(\)/);
+assert.match(harborOptimized, /new THREE\.InstancedMesh\(containerGeometry, material, entries\.length\)/);
+assert.match(harborOptimized, /new THREE\.InstancedMesh\(ribGeometry, ribMaterial, ribs\.length\)/);
+assert.match(harborOptimized, /batch\.castShadow = true/,
+  'Batching must preserve the established container shadows');
+assert.match(harborOptimized, /batch\.receiveShadow = true/,
+  'Batching must preserve the established container shadow reception');
+assert.match(harborOptimized, /gameplayGeometryUnchanged: true/,
+  'Harbor batching must remain a rendering-only optimization');
+assert.doesNotMatch(harborOptimized, /setAnimationLoop|requestAnimationFrame|setInterval/,
+  'The Harbor optimization must add no independent runtime loop');
+
 // Bella may use a tiny separate Web Audio context, but ordinary TURN sessions should
 // never keep a third live context merely because the rescue behavior is installed.
 assert.match(bellaRescue, /function meowContextWanted\(/);
@@ -164,4 +194,4 @@ assert.match(
   'Disposing the rescue behavior must close and release Bella’s context'
 );
 
-console.log(`TURN ${release.id} long-session timer, scenery contour, cache and Bella audio lifecycle passed.`);
+console.log(`TURN ${release.id} long-session timers, scenery batching/contours, cache and Bella audio lifecycle passed.`);

--- a/turn-tests/long-session-lifecycle-production.mjs
+++ b/turn-tests/long-session-lifecycle-production.mjs
@@ -1,0 +1,167 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const [
+  index,
+  labIndex,
+  releaseSource,
+  app,
+  fixedLayout,
+  achievementsFacade,
+  achievementRuntime,
+  worldAssets,
+  worldRender,
+  bellaRescue
+] = await Promise.all([
+  fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn-lab/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/release.json', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/achievements.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/achievements/runtime.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/world-assets.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/render/world.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/tracks/countryside-bella-rescue-r173.js', import.meta.url), 'utf8')
+]);
+
+const release = JSON.parse(releaseSource);
+
+function importMap(source) {
+  const json = source.match(/<script type="importmap">\s*([\s\S]*?)\s*<\/script>/)?.[1];
+  assert.ok(json, 'TURN entry must expose an import map');
+  return JSON.parse(json).imports;
+}
+
+const productionImports = importMap(index);
+const labImports = importMap(labIndex);
+const optimizedWorldAssetTarget = `./world-assets.js?build=${release.cacheKey}&revision=r164-long-session-robustness`;
+
+assert.equal(
+  productionImports['./world-assets.js'],
+  optimizedWorldAssetTarget,
+  'Production must request the tree-optimized shared world assets under a fresh module identity'
+);
+assert.equal(
+  labImports['./world-assets.js'],
+  optimizedWorldAssetTarget,
+  'TURN LAB must exercise the same tree-optimized world asset module as production'
+);
+assert.match(
+  app,
+  /render\/world\.js\?revision=r164-long-session-robustness/,
+  'The runtime must receive the optimized Countryside world bootstrap through a fresh URL'
+);
+assert.match(
+  worldRender,
+  /countryside-bella-rescue-r173\.js\?revision=r164-long-session-robustness/,
+  'The world bootstrap must request Bella’s on-demand audio lifecycle through a fresh URL'
+);
+
+// Achievements need 100 ms samples while driving, but should contribute zero timer
+// wake-ups while the player is on Home, in The Lot, backgrounded, or otherwise idle.
+assert.match(achievementRuntime, /const SAMPLE_INTERVAL_MS = 100/);
+assert.match(achievementRuntime, /samplingTimer: 0/);
+assert.match(achievementRuntime, /function startDrivingSampler\(\)/);
+assert.match(achievementRuntime, /function stopDrivingSampler\(\)/);
+assert.match(achievementRuntime, /function syncDrivingSampler\(\)/);
+assert.match(
+  achievementRuntime,
+  /const active = state\?\.running === true \|\| state\?\.lapActive === true/,
+  'Achievement sampling must be scoped to active driving state'
+);
+assert.match(
+  achievementRuntime,
+  /session\.samplingTimer = window\.setInterval\(sampleDrivingState, SAMPLE_INTERVAL_MS\)/,
+  'The 100 ms sampler should only be created by its lifecycle helper'
+);
+assert.equal(
+  (achievementRuntime.match(/window\.setInterval\(sampleDrivingState, SAMPLE_INTERVAL_MS\)/g) || []).length,
+  1,
+  'There must be one controlled achievement sampling interval, not duplicate or unconditional samplers'
+);
+assert.match(
+  achievementRuntime,
+  /document\.addEventListener\('visibilitychange', syncDrivingSampler, \{ passive: true \}\)/,
+  'Backgrounding must stop the achievement sampler'
+);
+assert.doesNotMatch(
+  achievementRuntime,
+  /importStoredTimeTrials\(\);\s*window\.setInterval\(sampleDrivingState/,
+  'Achievement installation must never start an unconditional all-session 10 Hz timer'
+);
+assert.match(
+  fixedLayout,
+  /achievements\.js\?build=\$\{buildKey\}-r166-bella-records&robustness=r164-long-session/,
+  'Home must request the facade containing the lifecycle-optimized achievement runtime under a fresh URL'
+);
+assert.match(
+  achievementsFacade,
+  /achievements\/runtime\.js\?revision=r164-long-session-robustness/,
+  'The achievement facade must cache-bust the race-scoped sampler implementation'
+);
+
+// Repeated vegetation is a poor place to spend a second draw call per source mesh.
+// Buildings/start landmarks may keep intentional contours; tree belts opt out before
+// the broad compatibility art pass can add enlarged back-face shells.
+assert.match(worldAssets, /suppressAutoOutline = false/);
+assert.match(
+  worldAssets,
+  /if \(suppressAutoOutline\) node\.userData\.turnOutlined = true/,
+  'Shared model preparation must expose a marker understood by the world contour pass'
+);
+assert.match(
+  worldAssets,
+  /function placeTreeBelt[\s\S]*suppressAutoOutline: true/,
+  'The repeated Countryside tree belt must not receive duplicate contour meshes'
+);
+assert.match(
+  worldAssets,
+  /function placeStartArea[\s\S]*outline: true/,
+  'Intentional start-area silhouettes should remain available rather than globally removing TURN outlines'
+);
+assert.match(worldRender, /function suppressTreeClusterContours\(/);
+assert.match(worldRender, /if \(isContourShell\(node\)\)/);
+assert.match(worldRender, /for \(const shell of contourShells\) shell\.parent\?\.remove\(shell\)/);
+assert.match(
+  worldRender,
+  /node\.userData\.turnOutlined = true/,
+  'Late tree clusters must remain opted out after any already-created contour shell is stripped'
+);
+assert.match(
+  worldRender,
+  /suppressTreeClusterContours\(child\)/,
+  'Late forest clusters must be de-contoured as part of their one-time grounding pass'
+);
+
+// Bella may use a tiny separate Web Audio context, but ordinary TURN sessions should
+// never keep a third live context merely because the rescue behavior is installed.
+assert.match(bellaRescue, /function meowContextWanted\(/);
+assert.match(
+  bellaRescue,
+  /activeTrackId\(runtime\) === 'countryside'[\s\S]*vehicleId \|\| ''\)\.toLowerCase\(\) === REQUIRED_VEHICLE_ID[\s\S]*otherSoundPreference\(\) > 0\.001[\s\S]*document\.visibilityState !== 'hidden'/,
+  'Bella audio should be eligible only for a visible Countryside Fire Truck run with other sounds enabled'
+);
+assert.match(
+  bellaRescue,
+  /function unlockMeowContext\(\)[\s\S]*if \(meowContextWanted\(\)\) ensureMeowContext\(\)/,
+  'Ordinary pointer/key gestures must not eagerly create Bella’s AudioContext'
+);
+assert.doesNotMatch(
+  bellaRescue,
+  /function unlockMeowContext\(\) \{\s*ensureMeowContext\(\)/,
+  'Bella’s old eager gesture-unlock behavior must not return'
+);
+assert.match(bellaRescue, /function suspendMeowContext\(\)/);
+assert.match(
+  bellaRescue,
+  /if \(!eligible \|\| document\.hidden\) \{[\s\S]*suspendMeowContext\(\)/,
+  'Leaving the eligible rescue state must suspend Bella audio rather than leaving another running context'
+);
+assert.match(
+  bellaRescue,
+  /meowContext\.close\?\.\(\)[\s\S]*meowContext = null/,
+  'Disposing the rescue behavior must close and release Bella’s context'
+);
+
+console.log(`TURN ${release.id} long-session timer, scenery contour, cache and Bella audio lifecycle passed.`);

--- a/turn-tests/long-session-lifecycle-production.mjs
+++ b/turn-tests/long-session-lifecycle-production.mjs
@@ -9,9 +9,11 @@ const [
   fixedLayout,
   achievementsFacade,
   achievementRuntime,
+  performanceProfile,
   worldAssets,
   worldRender,
   bellaRescue,
+  bellaBootstrap,
   harborOptimized
 ] = await Promise.all([
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
@@ -21,9 +23,11 @@ const [
   fs.readFile(new URL('../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/achievements.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/achievements/runtime.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/performance-profile.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/world-assets.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/render/world.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/tracks/countryside-bella-rescue-r173.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/tracks/countryside-bella-rescue-hotfix-r176.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/tracks/harbor-world-r82.js', import.meta.url), 'utf8')
 ]);
 
@@ -70,6 +74,27 @@ assert.match(
   /countryside-bella-rescue-r173\.js\?revision=r164-long-session-robustness/,
   'The world bootstrap must request Bella’s on-demand audio lifecycle through a fresh URL'
 );
+assert.match(
+  index,
+  /countryside-bella-rescue-hotfix-r176\.js\?revision=r164-long-session-robustness/,
+  'Production must cache-bust the independent Bella bootstrap itself, not just the behavior it imports'
+);
+
+// Touch hardware keeps 60 Hz gameplay but should not redraw the complete dynamic
+// shadow map at 60 Hz too. The profile piggybacks the existing renderer call rather
+// than adding another timer or animation loop.
+assert.match(performanceProfile, /TOUCH_SHADOW_REFRESH_INTERVAL_MS = 1000 \/ 30/);
+assert.match(performanceProfile, /function installTouchShadowRefreshCap\(renderer, profile\)/);
+assert.match(performanceProfile, /renderer\.shadowMap\.autoUpdate = false/,
+  'Touch rendering should explicitly own shadow refresh cadence');
+assert.match(performanceProfile, /renderer\.userData\.turnOriginalRender = originalRender/,
+  'The runtime renderer must only be wrapped once');
+assert.match(performanceProfile, /now - lastShadowRefreshAt >= TOUCH_SHADOW_REFRESH_INTERVAL_MS/);
+assert.match(performanceProfile, /renderer\.shadowMap\.needsUpdate = true/);
+assert.match(performanceProfile, /renderer\.shadowMap\.autoUpdate = true/,
+  'Desktop and non-touch rendering must retain full-refresh shadow behavior');
+assert.doesNotMatch(performanceProfile, /setInterval|requestAnimationFrame|setAnimationLoop/,
+  'Shadow throttling must add no independent scheduling loop');
 
 // Achievements need 100 ms samples while driving, but should contribute zero timer
 // wake-ups while the player is on Home, in The Lot, backgrounded, or otherwise idle.
@@ -193,5 +218,9 @@ assert.match(
   /meowContext\.close\?\.\(\)[\s\S]*meowContext = null/,
   'Disposing the rescue behavior must close and release Bella’s context'
 );
+assert.match(bellaBootstrap, /countryside-bella-rescue-r173\.js\?revision=r164-long-session-robustness/);
+assert.match(bellaBootstrap, /RETRY_DELAYS_MS = Object\.freeze/);
+assert.doesNotMatch(bellaBootstrap, /setInterval/,
+  'The independent Bella bootstrap must use bounded startup retries rather than a fixed polling interval');
 
-console.log(`TURN ${release.id} long-session timers, scenery batching/contours, cache and Bella audio lifecycle passed.`);
+console.log(`TURN ${release.id} long-session timers, touch shadows, scenery batching/contours, cache and Bella audio lifecycle passed.`);

--- a/turn-tests/racing-music-production.mjs
+++ b/turn-tests/racing-music-production.mjs
@@ -118,6 +118,36 @@ assert.match(music, /voice: section\.leadVoice \|\| 'lead'/,
 assert.match(music, /body\.type = 'triangle'/,
   'The generated song must keep its established warm triangle character');
 
+// Long sessions create thousands of short note/drum graphs. WebKit must not be
+// asked to discover connected-but-silent Gain/Filter branches by GC alone.
+assert.match(music, /const activeGraphs = new Map\(\)/,
+  'Racing music must track the downstream graph belonging to each short-lived source');
+assert.match(music, /function cleanupGraph\(source\)/);
+assert.match(music, /activeGraphs\.delete\(source\)/);
+assert.match(music, /node\?\.disconnect\?\.\(\)/,
+  'Completed music voices must explicitly disconnect their local Web Audio nodes');
+assert.match(music, /function trackGraph\(source, nodes\)/);
+assert.match(
+  music,
+  /source\.addEventListener\?\.\('ended',[\s\S]*activeSources\.delete\(source\);[\s\S]*cleanupGraph\(source\)/,
+  'Natural source completion must tear down the associated graph immediately'
+);
+assert.match(
+  music,
+  /function stopActiveSources\(\)[\s\S]*for \(const source of \[\.\.\.activeGraphs\.keys\(\)\]\) cleanupGraph\(source\)/,
+  'Music OFF/background stop must explicitly release graph branches even before ended events arrive'
+);
+for (const graphContract of [
+  /trackGraph\(body, \[body, harmonic, bodyGain, harmonicGain, filter, amp\]\)/,
+  /trackGraph\(body, \[body, overtone, bodyGain, overtoneGain, filter, amp\]\)/,
+  /trackGraph\(body, \[body, sub, bodyGain, subGain, filter, amp\]\)/,
+  /trackGraph\(oscillator, \[oscillator, filter, amp\]\)/,
+  /trackGraph\(oscillator, \[oscillator, amp\]\)/,
+  /trackGraph\(source, \[source, filter, amp\]\)/
+]) {
+  assert.match(music, graphContract, 'Every generated music voice family must participate in explicit graph teardown');
+}
+
 assert.match(music, /MUSIC_VOLUME_STORAGE_KEY = 'turn-racing-music-volume-v1'/,
   'The release must preserve existing saved volume preferences');
 assert.doesNotMatch(music, /fetch\(|new Audio\(/,
@@ -143,4 +173,4 @@ assert.match(music, /arrangement: Object\.freeze\(ARRANGEMENT\.map\(\(section\) 
 assert.match(music, /timbre: 'warm-v3-eighth-note-flute-chorus'/,
   'The existing runtime timbre identifier must remain stable for compatibility');
 
-console.log(`TURN approved music runtime routing resolves ${musicSpecifier} to ${musicRevision}.`);
+console.log(`TURN approved music runtime routing resolves ${musicSpecifier} to ${musicRevision} with explicit voice-graph teardown.`);

--- a/turn-tests/startup-and-unread-production.mjs
+++ b/turn-tests/startup-and-unread-production.mjs
@@ -21,8 +21,8 @@ assert.ok(
   index.includes(`app.js?build=${release.cacheKey}-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r420-music-warm-r426-loading-copy`),
   'The production document must cache-bust the revised loading-screen copy under the current release key'
 );
-assert.match(index, /countryside-bella-rescue-hotfix-r176\.js\?revision=r176-video-proven-rescue/,
-  'The canonical startup document must replace cached Bella rescue behavior independently');
+assert.match(index, /countryside-bella-rescue-hotfix-r176\.js\?revision=r164-long-session-robustness/,
+  'The canonical startup document must cache-bust the independent Bella rescue bootstrap with the long-session behavior');
 assert.match(nextIndex, new RegExp(`TURN NEXT · Source TURN v${escapedVersion} · Build ${escapedId}`));
 assert.match(nextIndex, new RegExp(`turn-next\\/app\\.js\\?source=${escapedCacheKey}-browser-consent-r166-bella-records`));
 

--- a/turn/achievements.js
+++ b/turn/achievements.js
@@ -31,4 +31,4 @@ export {
   isPaintUnlocked,
   prepareTrophyRoadProfile
 } from './progression/trophy-road-perks-r164.js?revision=r164-perks';
-export { installAchievements } from './achievements/runtime.js?revision=r164-perks';
+export { installAchievements } from './achievements/runtime.js?revision=r164-long-session-robustness';

--- a/turn/achievements/runtime.js
+++ b/turn/achievements/runtime.js
@@ -96,6 +96,7 @@ export function installAchievements(runtime = globalThis.__turnRuntime) {
     pendingToastRewards: [],
     toastTimer: 0,
     rewardToastTimer: 0,
+    samplingTimer: 0,
     listenCloselyMs: 0,
     lastSampleAt: performance.now(),
     secondWind: {
@@ -309,9 +310,29 @@ export function installAchievements(runtime = globalThis.__turnRuntime) {
     secondWind.previousBoostActive = boostActive;
   }
 
+  function startDrivingSampler() {
+    if (session.samplingTimer || document.visibilityState === 'hidden') return;
+    session.lastSampleAt = performance.now();
+    session.samplingTimer = window.setInterval(sampleDrivingState, SAMPLE_INTERVAL_MS);
+  }
+
+  function stopDrivingSampler() {
+    if (session.samplingTimer) window.clearInterval(session.samplingTimer);
+    session.samplingTimer = 0;
+    session.lastSampleAt = performance.now();
+  }
+
+  function syncDrivingSampler() {
+    const state = runtime?.state;
+    const active = state?.running === true || state?.lapActive === true;
+    if (active && document.visibilityState !== 'hidden') startDrivingSampler();
+    else stopDrivingSampler();
+  }
+
   function beginLap() {
     session.currentLapVoid = false;
     session.currentLap = makeLapAttempt(runtime, drivePad, session.recalibratedPending);
+    startDrivingSampler();
     sampleDrivingState();
     view.render();
   }
@@ -432,9 +453,12 @@ export function installAchievements(runtime = globalThis.__turnRuntime) {
       session.spectateStartedAt = 0;
       session.listenCloselyMs = 0;
     }
+    syncDrivingSampler();
     syncRaceTriggerVisibility();
     view.render();
   });
+
+  document.addEventListener('visibilitychange', syncDrivingSampler, { passive: true });
 
   const menuObserver = typeof MutationObserver === 'function'
     ? new MutationObserver(syncRaceTriggerVisibility)
@@ -442,7 +466,7 @@ export function installAchievements(runtime = globalThis.__turnRuntime) {
   menuObserver?.observe(utilityGroup, { attributes: true, attributeFilter: ['data-menu-state'] });
 
   importStoredTimeTrials();
-  window.setInterval(sampleDrivingState, SAMPLE_INTERVAL_MS);
+  syncDrivingSampler();
   syncRaceTriggerVisibility();
 
   const api = Object.freeze({

--- a/turn/achievements/trophy-road-showcase.js
+++ b/turn/achievements/trophy-road-showcase.js
@@ -6,6 +6,7 @@ import {
 import { createCarVisual } from '../vehicle/emergency-livery-models.js?build=20260804-r157-display-p3';
 import { configureRendererWideGamut } from '../vehicle/wide-gamut.js?revision=r157-display-p3';
 
+const SHOWCASE_FRAME_INTERVAL_MS = 1000 / 30;
 const REWARD_CARS = Object.freeze({
   'future-racer': Object.freeze([
     Object.freeze({ carId: 'race-future', x: 0, targetLength: 6.4, yaw: Math.PI - 0.55 })
@@ -42,6 +43,7 @@ export function createTrophyRoadShowcase() {
   let running = false;
   let disposed = false;
   let resizeObserver = null;
+  let lastRenderAt = -Infinity;
   const groups = new Map();
   const groupPromises = new Map();
   const clock = new THREE.Clock();
@@ -67,7 +69,9 @@ export function createTrophyRoadShowcase() {
       powerPreference: 'high-performance'
     });
     configureRendererWideGamut(renderer);
-    renderer.setPixelRatio(Math.min(globalThis.devicePixelRatio || 1, 1.35));
+    const profileCap = Number(globalThis.__turnPerformanceProfile?.dprCap);
+    const dprCap = Number.isFinite(profileCap) ? Math.min(1.35, profileCap) : 1.35;
+    renderer.setPixelRatio(Math.min(globalThis.devicePixelRatio || 1, dprCap));
     renderer.setClearColor(0x000000, 0);
     resizeObserver = new ResizeObserver(resize);
   }
@@ -175,8 +179,10 @@ export function createTrophyRoadShowcase() {
     renderer.setSize(Math.round(rect.width), Math.round(rect.height), false);
   }
 
-  function render() {
+  function render(now) {
     if (!running || disposed || !renderer || !scene || !camera) return;
+    if (now - lastRenderAt < SHOWCASE_FRAME_INTERVAL_MS) return;
+    lastRenderAt = now;
     const elapsed = clock.getElapsedTime();
     const visuals = activeGroup?.userData?.turnRewardVisuals || [];
     for (const visual of visuals) {
@@ -190,6 +196,7 @@ export function createTrophyRoadShowcase() {
 
   function resume() {
     if (running || disposed || !renderer || !activeGroup) return;
+    lastRenderAt = -Infinity;
     running = true;
     renderer.setAnimationLoop(render);
   }
@@ -220,6 +227,8 @@ export function createTrophyRoadShowcase() {
     clear();
     resizeObserver?.disconnect();
     renderer?.dispose();
+    renderer?.forceContextLoss?.();
+    renderer?.domElement?.remove();
     renderer = null;
     activeHost = null;
     groups.clear();

--- a/turn/achievements/trophy-road-showcase.js
+++ b/turn/achievements/trophy-road-showcase.js
@@ -114,7 +114,10 @@ export function createTrophyRoadShowcase() {
           color: getVehicleDefaultColor(definition.carId),
           secondaryColor: getVehicleDefaultSecondaryColor(definition.carId),
           targetLength: definition.targetLength,
-          outline: true
+          // Trophy Road cards are small, continuously rotating previews. The
+          // contour shell would render every car mesh twice for little visual
+          // benefit here, so keep the actual model only.
+          outline: false
         });
         visual.position.set(definition.x, 0, 0);
         visual.rotation.y = definition.yaw;

--- a/turn/app.js
+++ b/turn/app.js
@@ -182,7 +182,9 @@ const { prepareTrophyRoadProfile } = await import(
 );
 prepareTrophyRoadProfile();
 
-const { installPerformanceProfile } = await import(withBuild('./performance-profile.js'));
+const { installPerformanceProfile } = await import(
+  withBuild('./performance-profile.js?revision=r164-long-session-robustness')
+);
 installPerformanceProfile();
 
 const { installCoveredRenderingGuard } = await import(withBuild('./render/covered-rendering.js'));
@@ -197,7 +199,7 @@ const {
   prepareDriveByEarRuntime,
   ensureDriveByEarRuntime
 } = await import(
-  withBuild('./audio/drive-by-ear-runtime.js?revision=r143-temporary-audio-only')
+  withBuild('./audio/drive-by-ear-runtime.js?revision=r164-long-session-robustness')
 );
 await prepareDriveByEarRuntime();
 
@@ -214,7 +216,9 @@ globalThis.__turnDriveByEarEnabled = true;
 const { installAudioPreferences } = await import(withBuild('./audio/audio-preferences.js'));
 const audioPreferences = installAudioPreferences({ driveByEarGraphAvailable: driveByEarEnabled });
 
-const { installTurnAudio } = await import(withBuild('./audio/audio-system.js'));
+const { installTurnAudio } = await import(
+  withBuild('./audio/audio-system.js?revision=r164-long-session-robustness')
+);
 installTurnAudio();
 audioPreferences.setDriveByEarEnabled(driveByEarEnabled);
 
@@ -342,7 +346,7 @@ if (buildLabel) {
 // Historical regression marker for the paint and Monster Home bundle:
 // m8-home-fixed-layout.js?revision=m8.9-track-title-alignment&trophy-road=r157
 const { installM8HomeFixedLayout } = await import(
-  withBuild('./m8-home-fixed-layout.js?revision=m8.9-track-title-alignment&trophy-road=r159&achievements=r166-bella-records&bella-rescue=r174-siren-zone&music=warm-v2')
+  withBuild('./m8-home-fixed-layout.js?revision=m8.9-track-title-alignment&trophy-road=r159&achievements=r166-bella-records&bella-rescue=r174-siren-zone&music=warm-v2&robustness=r164-long-session')
 );
 await installM8HomeFixedLayout();
 installStylesheet(

--- a/turn/app.js
+++ b/turn/app.js
@@ -300,7 +300,7 @@ installTrackIntroCamera();
 // render/world.js?revision=r166-bella-records
 // render/world.js?revision=r174-bella-siren-zone
 await Promise.all([
-  import(withBuild('./render/world.js?revision=r175-bella-broad-rear-zone')),
+  import(withBuild('./render/world.js?revision=r164-long-session-robustness')),
   import(withBuild('./ui/spectate.js')),
   import(withBuild('./ui/back-to-lot.js'))
 ]);

--- a/turn/audio/audio-system.js
+++ b/turn/audio/audio-system.js
@@ -1,6 +1,7 @@
 const AudioContextClass = globalThis.AudioContext || globalThis.webkitAudioContext;
 
 const AUDIO_UPDATE_INTERVAL_MS = 1000 / 30;
+const AUDIO_RECOVERY_RETRY_MS = 1000;
 const MASTER_GAIN = 0.72;
 const RIVAL_NEAR_ENTER_METERS = 10;
 const RIVAL_NEAR_EXIT_METERS = 15;
@@ -8,6 +9,7 @@ const PACE_NOTE_LEVEL = 0.052;
 const PACE_NOTE_DURATION_SECONDS = 0.055;
 const PACE_NOTE_STEP_SECONDS = 0.105;
 const PACE_NOTE_GROUP_GAP_SECONDS = 0.22;
+const TRANSIENT_NOISE_SECONDS = 0.5;
 const DRIVE_BY_EAR_ENABLED = globalThis.__turnDriveByEarEnabled !== false;
 const EMERGENCY_SERVICE_BY_VEHICLE_ID = Object.freeze({
   firetruck: 'firetruck',
@@ -72,8 +74,15 @@ let safetyMode = 'none';
 let offRoadLatched = false;
 let lotOpen = false;
 let installed = false;
+let recoveryInFlight = false;
+let lastRecoveryAttemptAt = -Infinity;
+let recoveryAttempts = 0;
+let recoverySuccesses = 0;
+let maxTransientSources = 0;
 const cueTimes = new Map();
 const activePaceNoteSources = new Set();
+const activeTransientSources = new Set();
+const transientNoiseBuffers = new Map();
 
 export function installTurnAudio() {
   if (installed) return globalThis.__turnAudio;
@@ -89,6 +98,16 @@ export function installTurnAudio() {
     },
     get state() {
       return context?.state || 'unavailable';
+    },
+    get diagnostics() {
+      return Object.freeze({
+        state: context?.state || 'unavailable',
+        activeTransientSources: activeTransientSources.size,
+        activePaceNoteSources: activePaceNoteSources.size,
+        maxTransientSources,
+        recoveryAttempts,
+        recoverySuccesses
+      });
     }
   });
 
@@ -99,6 +118,7 @@ export function installTurnAudio() {
   document.addEventListener('pointerdown', handleUiPointerDown, { capture: true, passive: true });
   document.addEventListener('keydown', unlockFromGesture, { capture: true });
   document.addEventListener('visibilitychange', handleVisibilityChange, { passive: true });
+  window.addEventListener('pageshow', handlePageShow, { passive: true });
   window.addEventListener('pagehide', handlePageHide, { passive: true });
   if (DRIVE_BY_EAR_ENABLED) {
     window.addEventListener('turn:pace-note', handlePaceNoteAudio);
@@ -120,16 +140,23 @@ export async function unlock() {
   if (!context) return false;
   if (context.state === 'running') return true;
 
+  recoveryAttempts += 1;
   try {
     await context.resume();
   } catch (_) {
     return false;
   }
-  return context.state === 'running';
+  const ready = context.state === 'running';
+  if (ready) recoverySuccesses += 1;
+  return ready;
 }
 
 export function update(frame = {}, now = performance.now()) {
-  if (!context || context.state !== 'running') return;
+  if (!context) return;
+  if (context.state !== 'running') {
+    requestContextRecovery(now);
+    return;
+  }
   if (now - lastUpdateAt < AUDIO_UPDATE_INTERVAL_MS) return;
   lastUpdateAt = now;
 
@@ -298,6 +325,7 @@ function ensureGraph() {
   } catch (_) {
     context = new AudioContextClass();
   }
+  context.addEventListener?.('statechange', handleContextStateChange);
 
   const compressor = context.createDynamicsCompressor();
   compressor.threshold.value = -18;
@@ -687,24 +715,24 @@ function schedulePaceNoteBeep(startAt, pan, severity) {
 
   const record = { oscillator, gain, panner };
   activePaceNoteSources.add(record);
-  oscillator.addEventListener('ended', () => {
-    activePaceNoteSources.delete(record);
-    oscillator.disconnect();
-    gain.disconnect();
-    panner.disconnect();
-  }, { once: true });
+  oscillator.addEventListener('ended', () => cleanupPaceNoteSource(record), { once: true });
 
   oscillator.start(startAt);
   oscillator.stop(endAt + 0.01);
 }
 
+function cleanupPaceNoteSource(record) {
+  activePaceNoteSources.delete(record);
+  disconnectNodes(record.oscillator, record.gain, record.panner);
+}
+
 function stopPaceNoteSources() {
-  for (const record of activePaceNoteSources) {
+  for (const record of [...activePaceNoteSources]) {
     try {
       record.oscillator.stop();
     } catch (_) {}
+    cleanupPaceNoteSource(record);
   }
-  activePaceNoteSources.clear();
   routeDuckUntil = -Infinity;
 }
 
@@ -799,7 +827,8 @@ function playTone(startHz, endHz, duration, level, type, startAt, pan = 0, outpu
   gain.gain.exponentialRampToValueAtTime(0.0001, endAt);
 
   oscillator.connect(gain);
-  connectPanned(gain, pan, output);
+  const panner = connectPanned(gain, pan, output);
+  trackTransientSource(oscillator, [oscillator, gain, panner]);
   oscillator.start(startAt);
   oscillator.stop(endAt + 0.02);
 }
@@ -819,7 +848,7 @@ function playNoiseBurst(
   const gain = context.createGain();
   const endAt = startAt + duration;
 
-  source.buffer = makeNoiseBuffer(context, Math.max(0.2, duration), smoothing);
+  source.buffer = transientNoiseBuffer(smoothing);
   filter.type = 'bandpass';
   filter.Q.value = 0.7;
   filter.frequency.setValueAtTime(Math.max(1, lowHz), startAt);
@@ -831,9 +860,39 @@ function playNoiseBurst(
 
   source.connect(filter);
   filter.connect(gain);
-  connectPanned(gain, pan, output);
-  source.start(startAt);
+  const panner = connectPanned(gain, pan, output);
+  trackTransientSource(source, [source, filter, gain, panner]);
+  const maxOffset = Math.max(0, TRANSIENT_NOISE_SECONDS - duration - 0.02);
+  source.start(startAt, Math.random() * maxOffset);
   source.stop(endAt + 0.02);
+}
+
+function trackTransientSource(source, nodes) {
+  const record = { source, nodes };
+  activeTransientSources.add(record);
+  maxTransientSources = Math.max(maxTransientSources, activeTransientSources.size);
+  source.addEventListener?.('ended', () => {
+    activeTransientSources.delete(record);
+    disconnectNodes(...nodes);
+  }, { once: true });
+}
+
+function transientNoiseBuffer(smoothing) {
+  const key = clamp(Number(smoothing) || 0.78, 0, 0.98).toFixed(3);
+  let buffer = transientNoiseBuffers.get(key);
+  if (!buffer) {
+    buffer = makeNoiseBuffer(context, TRANSIENT_NOISE_SECONDS, Number(key));
+    transientNoiseBuffers.set(key, buffer);
+  }
+  return buffer;
+}
+
+function disconnectNodes(...nodes) {
+  for (const node of nodes) {
+    try {
+      node?.disconnect?.();
+    } catch (_) {}
+  }
 }
 
 function connectPanned(node, pan, output = masterGain) {
@@ -841,6 +900,7 @@ function connectPanned(node, pan, output = masterGain) {
   if (panner.pan) panner.pan.value = clamp(Number(pan) || 0, -1, 1);
   node.connect(panner);
   panner.connect(output || masterGain);
+  return panner;
 }
 
 function createPannerNode() {
@@ -870,12 +930,33 @@ function makeNoiseBuffer(audioContext, seconds, smoothing = 0.72) {
 }
 
 function smooth(param, value, time, timeConstant) {
-  param.setTargetAtTime(value, time, timeConstant);
+  if (!param) return;
+  try {
+    if (typeof param.cancelAndHoldAtTime === 'function') {
+      param.cancelAndHoldAtTime(time);
+    } else {
+      const currentValue = Number(param.value);
+      param.cancelScheduledValues(time);
+      if (Number.isFinite(currentValue)) param.setValueAtTime(currentValue, time);
+    }
+    param.setTargetAtTime(value, time, timeConstant);
+  } catch (_) {
+    try {
+      param.value = value;
+    } catch (_) {}
+  }
 }
 
 function hardMute(param, time) {
-  param.cancelScheduledValues(time);
-  param.setValueAtTime(0, time);
+  if (!param) return;
+  try {
+    param.cancelScheduledValues(time);
+    param.setValueAtTime(0, time);
+  } catch (_) {
+    try {
+      param.value = 0;
+    } catch (_) {}
+  }
 }
 
 function handleLotPointerDown(event) {
@@ -909,11 +990,47 @@ function unlockFromGesture() {
   void unlock();
 }
 
+function audioShouldRun() {
+  return !document.hidden
+    && globalThis.__turnAudioPreferences?.getSettings?.().audioEnabled !== false;
+}
+
+function requestContextRecovery(now = performance.now(), force = false) {
+  if (!context || context.state === 'running' || context.state === 'closed') return;
+  if (!audioShouldRun() || recoveryInFlight) return;
+  if (!force && now - lastRecoveryAttemptAt < AUDIO_RECOVERY_RETRY_MS) return;
+
+  lastRecoveryAttemptAt = now;
+  recoveryInFlight = true;
+  recoveryAttempts += 1;
+  void Promise.resolve(context.resume())
+    .then(() => {
+      recoveryInFlight = false;
+      if (context?.state === 'running') {
+        recoverySuccesses += 1;
+        lastUpdateAt = -Infinity;
+      }
+    })
+    .catch(() => {
+      recoveryInFlight = false;
+    });
+}
+
+function handleContextStateChange() {
+  if (context?.state !== 'running') requestContextRecovery(performance.now(), false);
+}
+
 function handleVisibilityChange() {
   if (document.hidden) {
     silence();
     suspendContext();
+    return;
   }
+  requestContextRecovery(performance.now(), true);
+}
+
+function handlePageShow() {
+  requestContextRecovery(performance.now(), true);
 }
 
 function handlePageHide() {

--- a/turn/audio/drive-by-ear-runtime.js
+++ b/turn/audio/drive-by-ear-runtime.js
@@ -13,8 +13,8 @@ export function prepareDriveByEarRuntime() {
   if (preparationPromise) return preparationPromise;
 
   preparationPromise = Promise.all([
-    import(withBuild('./organic-ribbon.js')),
-    import(withBuild('./recovery-guidance.js')),
+    import(withBuild('./organic-ribbon.js?revision=r164-long-session-robustness')),
+    import(withBuild('./recovery-guidance.js?revision=r164-long-session-robustness')),
     import(withBuild('./pace-note-priority.js?revision=r123-final-hold'))
   ]).then(([organicRibbon, recoveryGuidance, paceNotePriority]) => {
     organicRibbon.prepareOrganicRibbonCapture();

--- a/turn/audio/organic-ribbon.js
+++ b/turn/audio/organic-ribbon.js
@@ -1,3 +1,5 @@
+const ORGANIC_UPDATE_INTERVAL_MS = 1000 / 30;
+
 const CAPTURED = Object.seal({
   contexts: [],
   oscillators: [],
@@ -18,6 +20,7 @@ let restoreFactories = null;
 let organicRoot = null;
 let organicSub = null;
 let organicContext = null;
+let lastOrganicUpdateAt = -Infinity;
 
 export function prepareOrganicRibbonCapture() {
   if (prepared) return;
@@ -41,7 +44,10 @@ export function installOrganicRibbon() {
     },
     update(frame = {}, now = performance.now()) {
       decorateCapturedRibbon();
-      updateOrganicVoices(frame);
+      if (now - lastOrganicUpdateAt >= ORGANIC_UPDATE_INTERVAL_MS) {
+        updateOrganicVoices(frame);
+        lastOrganicUpdateAt = now;
+      }
       baseAudio.update(frame, now);
     },
     cue: (...args) => baseAudio.cue(...args),
@@ -229,8 +235,26 @@ function updateOrganicVoices(frame) {
     : 388 + risk * 72;
   const now = organicContext.currentTime;
 
-  organicRoot.frequency.setTargetAtTime(fundamental, now, 0.18);
-  organicSub.frequency.setTargetAtTime(fundamental * 0.5, now, 0.22);
+  retarget(organicRoot.frequency, fundamental, now, 0.18);
+  retarget(organicSub.frequency, fundamental * 0.5, now, 0.22);
+}
+
+function retarget(parameter, value, now, timeConstant) {
+  if (!parameter) return;
+  try {
+    if (typeof parameter.cancelAndHoldAtTime === 'function') {
+      parameter.cancelAndHoldAtTime(now);
+    } else {
+      const currentValue = Number(parameter.value);
+      parameter.cancelScheduledValues(now);
+      if (Number.isFinite(currentValue)) parameter.setValueAtTime(currentValue, now);
+    }
+    parameter.setTargetAtTime(value, now, timeConstant);
+  } catch (_) {
+    try {
+      parameter.value = value;
+    } catch (_) {}
+  }
 }
 
 function findOscillatorNear(frequency, tolerance) {

--- a/turn/audio/racing-music-health.js
+++ b/turn/audio/racing-music-health.js
@@ -1,0 +1,122 @@
+const HEALTH_CHECK_INTERVAL_MS = 1000;
+const RECOVERY_GRACE_MS = 900;
+const INSTALL_RETRY_MS = 250;
+const INSTALL_RETRY_LIMIT = 40;
+
+let installed = null;
+
+export function installRacingMusicHealth(music = globalThis.__turnRacingMusic) {
+  if (installed) return installed;
+  if (!music) return null;
+
+  let checkTimer = 0;
+  let unhealthySince = 0;
+  let recovering = false;
+  let hasPlayed = music.state === 'running' && music.playing;
+  let recoveryCount = 0;
+
+  function shouldRun() {
+    return music.enabled
+      && document.visibilityState !== 'hidden'
+      && globalThis.__turnAudioPreferences?.getSettings?.().audioEnabled !== false;
+  }
+
+  function schedule(delay = HEALTH_CHECK_INTERVAL_MS) {
+    globalThis.clearTimeout(checkTimer);
+    checkTimer = globalThis.setTimeout(check, delay);
+  }
+
+  function check() {
+    checkTimer = 0;
+    const healthy = music.state === 'running' && music.playing;
+    if (healthy) {
+      hasPlayed = true;
+      unhealthySince = 0;
+      schedule();
+      return;
+    }
+
+    if (!hasPlayed || !shouldRun()) {
+      unhealthySince = 0;
+      schedule();
+      return;
+    }
+
+    const now = performance.now();
+    if (!unhealthySince) unhealthySince = now;
+    if (!recovering && now - unhealthySince >= RECOVERY_GRACE_MS) {
+      void recover();
+      return;
+    }
+    schedule(Math.min(HEALTH_CHECK_INTERVAL_MS, RECOVERY_GRACE_MS));
+  }
+
+  async function recover() {
+    if (recovering || !shouldRun()) {
+      schedule();
+      return false;
+    }
+
+    recovering = true;
+    const restoreVolume = music.volume;
+    try {
+      // v3 deliberately stops every scheduled source synchronously when volume
+      // reaches zero. This also clears its `playing` flag, so a restore creates
+      // a fresh scheduler even if WebKit interrupted the context mid-song.
+      music.stop();
+      await Promise.resolve();
+      if (restoreVolume > 0 && document.visibilityState !== 'hidden'
+        && globalThis.__turnAudioPreferences?.getSettings?.().audioEnabled !== false) {
+        music.setVolume(restoreVolume, { restart: true });
+        recoveryCount += 1;
+      }
+    } finally {
+      recovering = false;
+      unhealthySince = 0;
+      schedule(HEALTH_CHECK_INTERVAL_MS);
+    }
+    return true;
+  }
+
+  function checkSoon() {
+    if (!hasPlayed && music.state === 'running' && music.playing) hasPlayed = true;
+    schedule(120);
+  }
+
+  document.addEventListener('visibilitychange', checkSoon, { passive: true });
+  document.addEventListener('pointerdown', checkSoon, { capture: true, passive: true });
+  document.addEventListener('keydown', checkSoon, { capture: true });
+  globalThis.addEventListener('pageshow', checkSoon, { passive: true });
+  globalThis.addEventListener('pagehide', () => {
+    unhealthySince = 0;
+    globalThis.clearTimeout(checkTimer);
+    checkTimer = 0;
+  }, { passive: true });
+
+  schedule();
+  installed = Object.freeze({
+    id: 'r164-long-session-music-health',
+    check: checkSoon,
+    get recoveryCount() {
+      return recoveryCount;
+    }
+  });
+  globalThis.__turnRacingMusicHealth = installed;
+  return installed;
+}
+
+function installWhenHomeReady() {
+  let attempts = 0;
+  const tryInstall = () => {
+    if (installRacingMusicHealth()) return;
+    attempts += 1;
+    if (attempts < INSTALL_RETRY_LIMIT) globalThis.setTimeout(tryInstall, INSTALL_RETRY_MS);
+  };
+  tryInstall();
+}
+
+if (globalThis.__turnRacingMusic) {
+  installWhenHomeReady();
+} else {
+  document.addEventListener('turn:home-ready', installWhenHomeReady, { once: true });
+}

--- a/turn/audio/racing-music-health.js
+++ b/turn/audio/racing-music-health.js
@@ -63,9 +63,9 @@ export function installRacingMusicHealth(music = globalThis.__turnRacingMusic) {
     const restoreVolume = music.volume;
     try {
       // v3 deliberately stops every scheduled source synchronously when volume
-      // reaches zero. Its public stop also begins an async AudioContext suspend,
-      // so wait for that lifecycle to settle before restoring volume; otherwise
-      // an old suspend can land after the new scheduler has already started.
+      // reaches zero. Its public stop also begins an async context suspend, so
+      // wait for that lifecycle to settle before restoring volume; otherwise an
+      // old suspend can land after the new scheduler has already started.
       music.stop();
       await waitForStoppedPlayback(music);
       if (restoreVolume > 0 && document.visibilityState !== 'hidden'

--- a/turn/audio/racing-music-health.js
+++ b/turn/audio/racing-music-health.js
@@ -1,5 +1,7 @@
 const HEALTH_CHECK_INTERVAL_MS = 1000;
 const RECOVERY_GRACE_MS = 900;
+const STOP_SETTLE_TIMEOUT_MS = 600;
+const STOP_SETTLE_POLL_MS = 20;
 const INSTALL_RETRY_MS = 250;
 const INSTALL_RETRY_LIMIT = 40;
 
@@ -61,10 +63,11 @@ export function installRacingMusicHealth(music = globalThis.__turnRacingMusic) {
     const restoreVolume = music.volume;
     try {
       // v3 deliberately stops every scheduled source synchronously when volume
-      // reaches zero. This also clears its `playing` flag, so a restore creates
-      // a fresh scheduler even if WebKit interrupted the context mid-song.
+      // reaches zero. Its public stop also begins an async AudioContext suspend,
+      // so wait for that lifecycle to settle before restoring volume; otherwise
+      // an old suspend can land after the new scheduler has already started.
       music.stop();
-      await Promise.resolve();
+      await waitForStoppedPlayback(music);
       if (restoreVolume > 0 && document.visibilityState !== 'hidden'
         && globalThis.__turnAudioPreferences?.getSettings?.().audioEnabled !== false) {
         music.setVolume(restoreVolume, { restart: true });
@@ -103,6 +106,19 @@ export function installRacingMusicHealth(music = globalThis.__turnRacingMusic) {
   });
   globalThis.__turnRacingMusicHealth = installed;
   return installed;
+}
+
+async function waitForStoppedPlayback(music) {
+  const deadline = performance.now() + STOP_SETTLE_TIMEOUT_MS;
+  while (performance.now() < deadline) {
+    if (!music.playing && music.state !== 'running') return true;
+    await delay(STOP_SETTLE_POLL_MS);
+  }
+  return !music.playing;
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => globalThis.setTimeout(resolve, milliseconds));
 }
 
 function installWhenHomeReady() {

--- a/turn/audio/racing-music-v3.js
+++ b/turn/audio/racing-music-v3.js
@@ -189,6 +189,7 @@ let blankToggle = null;
 let settingsSlider = null;
 let settingsOutput = null;
 const activeSources = new Set();
+const activeGraphs = new Map();
 
 function clamp(value, min, max, fallback = min) {
   if (!Number.isFinite(value)) return fallback;
@@ -263,9 +264,25 @@ function ensureGraph() {
   return true;
 }
 
+function cleanupGraph(source) {
+  const nodes = activeGraphs.get(source);
+  if (!nodes) return;
+  activeGraphs.delete(source);
+  for (const node of nodes) {
+    try { node?.disconnect?.(); } catch (_) {}
+  }
+}
+
+function trackGraph(source, nodes) {
+  activeGraphs.set(source, nodes.filter(Boolean));
+}
+
 function trackSource(source) {
   activeSources.add(source);
-  source.addEventListener?.('ended', () => activeSources.delete(source), { once: true });
+  source.addEventListener?.('ended', () => {
+    activeSources.delete(source);
+    cleanupGraph(source);
+  }, { once: true });
   return source;
 }
 
@@ -273,6 +290,7 @@ function stopActiveSources() {
   for (const source of activeSources) {
     try { source.stop(); } catch (_) {}
   }
+  for (const source of [...activeGraphs.keys()]) cleanupGraph(source);
   activeSources.clear();
 }
 
@@ -405,6 +423,7 @@ function playFluteLead(note, time) {
 
   filter.connect(amp);
   amp.connect(masterGain);
+  trackGraph(body, [body, harmonic, bodyGain, harmonicGain, filter, amp]);
 
   body.start(time);
   harmonic.start(time);
@@ -446,6 +465,7 @@ function playLead(note, time, { voice = 'lead' } = {}) {
   overtoneGain.connect(filter);
   filter.connect(amp);
   amp.connect(masterGain);
+  trackGraph(body, [body, overtone, bodyGain, overtoneGain, filter, amp]);
   body.start(time);
   overtone.start(time);
   body.stop(time + duration * 1.08);
@@ -480,6 +500,7 @@ function playBass(note, time) {
   subGain.connect(filter);
   filter.connect(amp);
   amp.connect(masterGain);
+  trackGraph(body, [body, sub, bodyGain, subGain, filter, amp]);
   body.start(time);
   sub.start(time);
   body.stop(time + STEP_SECONDS * 1.05);
@@ -501,6 +522,7 @@ function playArp(note, time) {
   oscillator.connect(filter);
   filter.connect(amp);
   amp.connect(masterGain);
+  trackGraph(oscillator, [oscillator, filter, amp]);
   oscillator.start(time);
   oscillator.stop(time + STEP_SECONDS * 0.95);
 }
@@ -516,6 +538,7 @@ function playKick(time) {
   amp.gain.exponentialRampToValueAtTime(0.0001, time + 0.18);
   oscillator.connect(amp);
   amp.connect(masterGain);
+  trackGraph(oscillator, [oscillator, amp]);
   oscillator.start(time);
   oscillator.stop(time + 0.19);
 }
@@ -534,6 +557,7 @@ function playSnare(time) {
   source.connect(filter);
   filter.connect(amp);
   amp.connect(masterGain);
+  trackGraph(source, [source, filter, amp]);
   source.start(time);
   source.stop(time + 0.14);
 }
@@ -552,6 +576,7 @@ function playHat(time, open = false) {
   source.connect(filter);
   filter.connect(amp);
   amp.connect(masterGain);
+  trackGraph(source, [source, filter, amp]);
   source.start(time);
   source.stop(time + duration);
 }

--- a/turn/audio/recovery-guidance.js
+++ b/turn/audio/recovery-guidance.js
@@ -10,6 +10,7 @@ let prepared = false;
 let installed = false;
 let wrappedAudio = null;
 let lastComputedAt = -Infinity;
+let lastWrongWayUpdateAt = -Infinity;
 let cachedOverrides = Object.freeze({});
 let wrongWayGain = null;
 let wrongWayPanner = null;
@@ -62,7 +63,7 @@ export function installRecoveryGuidance() {
 
       if (!dbeEnabled) {
         cachedOverrides = Object.freeze({});
-        updateWrongWayTone({ active: false }, settings);
+        updateWrongWayTone({ active: false }, settings, now);
         baseAudio.update(frame, now);
         return;
       }
@@ -75,12 +76,17 @@ export function installRecoveryGuidance() {
       }
 
       const nextFrame = { ...frame, ...cachedOverrides };
-      updateWrongWayTone(nextFrame, settings);
+      updateWrongWayTone(nextFrame, settings, now);
       baseAudio.update(nextFrame, now);
     },
     cue: (...args) => baseAudio.cue(...args),
     silence(...args) {
-      updateWrongWayTone({ active: false }, globalThis.__turnAudioPreferences?.getSettings?.());
+      updateWrongWayTone(
+        { active: false },
+        globalThis.__turnAudioPreferences?.getSettings?.(),
+        performance.now(),
+        true
+      );
       return baseAudio.silence(...args);
     },
     get available() {
@@ -238,7 +244,10 @@ function createWrongWayRecoveryFrame({ forward, right, currentSample, frame }) {
   };
 }
 
-function updateWrongWayTone(frame, settings = {}) {
+function updateWrongWayTone(frame, settings = {}, nowMilliseconds = performance.now(), force = false) {
+  if (!force && nowMilliseconds - lastWrongWayUpdateAt < RECOVERY_UPDATE_INTERVAL_MS) return;
+  lastWrongWayUpdateAt = nowMilliseconds;
+
   const ready = ensureWrongWayGraph();
   if (!ready) return;
 
@@ -346,6 +355,13 @@ function setPannerTarget(panner, value, now, timeConstant) {
 function setTarget(parameter, value, now, timeConstant) {
   if (!parameter) return;
   try {
+    if (typeof parameter.cancelAndHoldAtTime === 'function') {
+      parameter.cancelAndHoldAtTime(now);
+    } else {
+      const currentValue = Number(parameter.value);
+      parameter.cancelScheduledValues(now);
+      if (Number.isFinite(currentValue)) parameter.setValueAtTime(currentValue, now);
+    }
     parameter.setTargetAtTime(value, now, timeConstant);
   } catch (_) {
     try {

--- a/turn/garage/lot-r10.js
+++ b/turn/garage/lot-r10.js
@@ -14,6 +14,7 @@ import { describeColorCue } from '../accessibility/color-cues.js?revision=r163';
 
 const UNSELECTED_COLOR = new THREE.Color(0x313131);
 const VIEWER_INITIAL_YAW = Math.PI - 0.55;
+const LOT_FRAME_INTERVAL_MS = 1000 / 30;
 let paintControlSerial = 0;
 const CAR_DESCRIPTIONS = Object.freeze({
   convertible: 'A low, open-top sports car with a long bonnet and compact cabin.',
@@ -95,7 +96,7 @@ export function showTheLot({ initialSelection } = {}) {
 
     const renderer = new THREE.WebGLRenderer({ antialias: true, powerPreference: 'high-performance' });
     renderer.outputColorSpace = THREE.SRGBColorSpace;
-    renderer.setPixelRatio(Math.min(devicePixelRatio, 1.55));
+    renderer.setPixelRatio(rendererPixelRatio(1.5));
     renderer.shadowMap.enabled = false;
     host.appendChild(renderer.domElement);
 
@@ -166,7 +167,10 @@ export function showTheLot({ initialSelection } = {}) {
         targetLength: 5.15,
         outline: true
       }).then((visual) => {
-        if (disposed) return;
+        if (disposed) {
+          disposeVisualMaterials(visual);
+          return;
+        }
         visual.position.set(x, 0.08, z);
         visual.rotation.y = Math.PI;
         visual.userData.turnLotCarId = car.id;
@@ -346,8 +350,11 @@ export function showTheLot({ initialSelection } = {}) {
       disposed = true;
       resizeObserver.disconnect();
       renderer.setAnimationLoop(null);
-      renderer.dispose();
+      for (const root of carRoots.values()) disposeVisualMaterials(root);
       viewer.dispose();
+      renderer.dispose();
+      renderer.forceContextLoss?.();
+      renderer.domElement.remove();
       overlay.remove();
       document.body.classList.remove('turn-lot-open');
       resolve(result ? normalizeVehicleSelection(result) : null);
@@ -372,8 +379,10 @@ export function showTheLot({ initialSelection } = {}) {
     resize();
 
     const clock = new THREE.Clock();
-    renderer.setAnimationLoop(() => {
-      if (disposed) return;
+    let lastRenderAt = -Infinity;
+    renderer.setAnimationLoop((now) => {
+      if (disposed || now - lastRenderAt < LOT_FRAME_INTERVAL_MS) return;
+      lastRenderAt = now;
       const elapsed = clock.getElapsedTime();
       for (const root of carRoots.values()) {
         const selected = Boolean(root.userData.turnLotSelected);
@@ -388,7 +397,7 @@ export function showTheLot({ initialSelection } = {}) {
       recordPerformanceFrame(
         'lot',
         viewerRendered ? [renderer, viewer.renderer] : renderer,
-        performance.now()
+        now
       );
     });
   });
@@ -398,7 +407,7 @@ function createViewer(host) {
   const scene = new THREE.Scene();
   const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
   renderer.outputColorSpace = THREE.SRGBColorSpace;
-  renderer.setPixelRatio(Math.min(devicePixelRatio, 1.5));
+  renderer.setPixelRatio(rendererPixelRatio(1.5));
   host.appendChild(renderer.domElement);
 
   const camera = new THREE.PerspectiveCamera(34, 1, 0.1, 60);
@@ -466,8 +475,14 @@ function createViewer(host) {
           targetLength: 6.4,
           outline: true
         });
-        if (request !== generation) return;
-        if (visual) stage.remove(visual);
+        if (request !== generation) {
+          disposeVisualMaterials(next);
+          return;
+        }
+        if (visual) {
+          stage.remove(visual);
+          disposeVisualMaterials(visual);
+        }
         visual = next;
         stage.add(visual);
         recolorCarVisual(visual, currentColor, currentSecondaryColor);
@@ -499,9 +514,33 @@ function createViewer(host) {
     },
     dispose() {
       generation += 1;
+      if (visual) {
+        stage.remove(visual);
+        disposeVisualMaterials(visual);
+        visual = null;
+      }
       renderer.dispose();
+      renderer.forceContextLoss?.();
+      renderer.domElement.remove();
     }
   };
+}
+
+function rendererPixelRatio(fallbackCap) {
+  const deviceRatio = Math.max(1, Number(globalThis.devicePixelRatio) || 1);
+  const profileCap = Number(globalThis.__turnPerformanceProfile?.dprCap);
+  const cap = Number.isFinite(profileCap) ? profileCap : fallbackCap;
+  return Math.min(deviceRatio, cap);
+}
+
+function disposeVisualMaterials(root) {
+  const materials = new Set();
+  root?.traverse?.((node) => {
+    if (!node?.isMesh || !node.material) return;
+    const nodeMaterials = Array.isArray(node.material) ? node.material : [node.material];
+    for (const material of nodeMaterials) materials.add(material);
+  });
+  for (const material of materials) material.dispose?.();
 }
 
 function rememberMaterialState(root) {

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -1,4 +1,4 @@
-import { showTheLot as showOriginalLot } from './lot-r10.js?build=20260809-r163-native-html';
+import { showTheLot as showOriginalLot } from './lot-r10.js?build=20260809-r163-native-html&revision=r164-long-session-robustness';
 // Historical regression marker for the established compatibility wrapper:
 // lot-enhancement-runtime.js?revision=r121&build=20260731-r120
 import { enhanceLotNow } from './lot-enhancement-runtime.js?revision=r157&build=20260804-r157';

--- a/turn/index.html
+++ b/turn/index.html
@@ -77,7 +77,7 @@
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
-        "/turn/audio/racing-music-v2.js?build=20260811-r164-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=blob-6334b9d55695",
+        "/turn/audio/racing-music-v2.js?build=20260811-r164-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=blob-8319c3923e0a",
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/achievements/trophy-road-showcase.js?revision=r160-reward-detail-sync": "/turn/achievements/trophy-road-showcase.js?revision=r164-long-session-robustness",

--- a/turn/index.html
+++ b/turn/index.html
@@ -82,6 +82,7 @@
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/achievements/trophy-road-showcase.js?revision=r160-reward-detail-sync": "/turn/achievements/trophy-road-showcase.js?revision=r164-long-session-robustness",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",
+        "/turn/render/covered-rendering.js?build=20260811-r164": "/turn/render/covered-rendering.js?build=20260811-r164&revision=r164-long-session-robustness",
         "./garage/lot-accessibility-r118.js?build=20260729-r118": "./garage/lot-accessibility-r118.js?build=20260811-r164&revision=r163-voiceover-first-lot-focus",
         "./garage/lot-enhancement-runtime.js?revision=r163-native-picker-parent-click&build=20260809-r163": "./garage/lot-enhancement-runtime.js?build=20260811-r164&revision=r164-perk-observer-hotfix",
         "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260811-r164&revision=r164-long-session-robustness",

--- a/turn/index.html
+++ b/turn/index.html
@@ -109,7 +109,7 @@
         "./tracks/cliffside-world.js": "./tracks/cliffside-world-r76.js?build=20260811-r164",
         "./tracks/harbor-collision.js": "./tracks/harbor-collision.js?build=20260811-r164",
         "./tracks/harbor-layout.js": "./tracks/harbor-layout.js?build=20260811-r164",
-        "./tracks/harbor-world.js": "./tracks/harbor-world-r81.js?build=20260811-r164",
+        "./tracks/harbor-world.js": "./tracks/harbor-world-r82.js?build=20260811-r164&revision=r164-long-session-robustness",
         "./tracks/definitions.js": "./tracks/definitions.js?build=20260811-r164",
         "./tracks/elevation.js": "./tracks/elevation.js?build=20260811-r164",
         "./tracks/pace-notes.js": "./tracks/pace-notes.js?build=20260811-r164",

--- a/turn/index.html
+++ b/turn/index.html
@@ -165,5 +165,5 @@
   <script type="module" src="./accessibility/color-accessibility-r163.js?build=20260811-r164-paint-basics"></script>
   <script type="module" src="./achievements/chromatic-camouflage-r183.js?revision=r183-production"></script>
   <script type="module" src="./social/your-turn-share-bootstrap.js?revision=r2"></script>
-  <script type="module" src="./tracks/countryside-bella-rescue-hotfix-r176.js?revision=r176-video-proven-rescue"></script>
+  <script type="module" src="./tracks/countryside-bella-rescue-hotfix-r176.js?revision=r164-long-session-robustness"></script>
 </body></html>

--- a/turn/index.html
+++ b/turn/index.html
@@ -94,7 +94,7 @@
         "./race/rival-storage.js?build=20260722-r50": "./race/rival-storage.js?build=20260811-r164",
         "./race/track-spatial-index.js?build=20260720-r19": "./race/track-spatial-index.js?build=20260811-r164",
         "./performance-monitor.js?build=20260720-r19": "./performance-monitor.js?build=20260811-r164",
-        "./world-assets.js": "./world-assets.js?build=20260811-r164",
+        "./world-assets.js": "./world-assets.js?build=20260811-r164&revision=r164-long-session-robustness",
         "./vehicle/physics.js?build=20260720-r19": "./vehicle/physics.js?build=20260811-r164",
         "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260811-r164",
         "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260811-r164",

--- a/turn/index.html
+++ b/turn/index.html
@@ -80,10 +80,11 @@
         "/turn/audio/racing-music-v2.js?build=20260811-r164-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=blob-6334b9d55695",
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
+        "/turn/achievements/trophy-road-showcase.js?revision=r160-reward-detail-sync": "/turn/achievements/trophy-road-showcase.js?revision=r164-long-session-robustness",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",
         "./garage/lot-accessibility-r118.js?build=20260729-r118": "./garage/lot-accessibility-r118.js?build=20260811-r164&revision=r163-voiceover-first-lot-focus",
         "./garage/lot-enhancement-runtime.js?revision=r163-native-picker-parent-click&build=20260809-r163": "./garage/lot-enhancement-runtime.js?build=20260811-r164&revision=r164-perk-observer-hotfix",
-        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260811-r164&revision=r163-native-html",
+        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260811-r164&revision=r164-long-session-robustness",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260811-r164",
         "./race/lap-system.js?build=20260720-r19": "./race/lap-system-r86.js?build=20260811-r164",
         "./race/game-state.js": "./race/game-state.js?build=20260811-r164",
@@ -157,7 +158,7 @@
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button" aria-label="Restart the current lap from the start line">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
   <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260811-r164-r168-shared-about-credits"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
-  <script type="module" src="./app.js?build=20260811-r164-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r420-music-warm-r426-loading-copy"></script>
+  <script type="module" src="./app.js?build=20260811-r164-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r420-music-warm-r426-loading-copy-r164-long-session-robustness"></script>
   <script type="module" src="./input/qe-drive-controls-bootstrap.js?revision=r418-qe"></script>
   <script type="module" src="./ui/r411-race-controls.js?revision=r411"></script>
   <script type="module" src="./accessibility/color-accessibility-r163.js?build=20260811-r164-paint-basics"></script>

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -182,7 +182,7 @@ export async function installM8HomeFixedLayout() {
     achievements
   });
   const { installTrophyRoadFeedback } = await import(
-    `/turn/achievements/trophy-road-feedback.js?build=${buildKey}-r166-bella-records`
+    `/turn/achievements/trophy-road-feedback.js?build=${buildKey}-r166-bella-records&robustness=r164-long-session`
   );
   const trophyRoadFeedback = installTrophyRoadFeedback(achievements);
 
@@ -196,6 +196,10 @@ export async function installM8HomeFixedLayout() {
     `/turn/audio/racing-music-v2.js?build=${buildKey}-racing-music-warm-v2`
   );
   const racingMusic = installRacingMusic({ home });
+  const { installRacingMusicHealth } = await import(
+    `/turn/audio/racing-music-health.js?build=${buildKey}&revision=r164-long-session-robustness`
+  );
+  const racingMusicHealth = installRacingMusicHealth(racingMusic);
 
   globalThis.__turnHomeLayout = Object.freeze({
     id: LAYOUT_ID,
@@ -212,7 +216,8 @@ export async function installM8HomeFixedLayout() {
     achievementChallengeExpansion,
     trophyRoadFeedback,
     driveByEarTraining,
-    racingMusic
+    racingMusic,
+    racingMusicHealth
   });
   return globalThis.__turnHomeLayout;
 }

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -163,7 +163,7 @@ export async function installM8HomeFixedLayout() {
   const trophyGate = installM8TrophyGate(globalThis.__turnNextHome);
 
   const { installAchievements } = await import(
-    `/turn/achievements.js?build=${buildKey}-r166-bella-records`
+    `/turn/achievements.js?build=${buildKey}-r166-bella-records&robustness=r164-long-session`
   );
   const achievements = installAchievements(globalThis.__turnRuntime);
   const { installAchievementUnreadMarkers } = await import(

--- a/turn/performance-profile.js
+++ b/turn/performance-profile.js
@@ -1,115 +1,129 @@
 const DEFAULT_DPR_CAP = 1.5;
 const DEFAULT_SHADOW_MAP_SIZE = 1024;
+const TOUCH_DPR_CAP = 1.25;
+const TOUCH_SHADOW_MAP_SIZE = 512;
 const MIN_DPR_CAP = 0.75;
 const MAX_DPR_CAP = 1.5;
 const SHADOW_MAP_SIZES = new Set([256, 512, 1024]);
-const rendererPixelRatioSetters = new WeakMap();
 
-let installed = false;
+let installed = null;
 
 export function performanceProfileFromSearch(
   search = globalThis.location?.search || '',
-  devicePixelRatio = Number(globalThis.devicePixelRatio) || 1
+  devicePixelRatio = globalThis.devicePixelRatio || 1,
+  environment = currentPerformanceEnvironment()
 ) {
-  let params;
-  try {
-    params = new URLSearchParams(search);
-  } catch (_) {
-    params = new URLSearchParams();
+  const parameters = safeSearchParameters(search);
+  const diagnostics = parameters.get('perf') === '1';
+  const touchOptimized = Boolean(environment?.touchOptimized);
+  const productionDprCap = touchOptimized ? TOUCH_DPR_CAP : DEFAULT_DPR_CAP;
+  const productionShadowMapSize = touchOptimized ? TOUCH_SHADOW_MAP_SIZE : DEFAULT_SHADOW_MAP_SIZE;
+  let dprCap = productionDprCap;
+  let shadowsEnabled = true;
+  let shadowMapSize = productionShadowMapSize;
+
+  if (diagnostics) {
+    const requestedDpr = Number(parameters.get('dpr'));
+    if (Number.isFinite(requestedDpr) && requestedDpr > 0) {
+      dprCap = clamp(requestedDpr, MIN_DPR_CAP, MAX_DPR_CAP);
+    }
+
+    const shadowSetting = parameters.get('shadow');
+    if (shadowSetting === 'off' || shadowSetting === '0') {
+      shadowsEnabled = false;
+    } else {
+      const requestedShadowMapSize = Number(shadowSetting);
+      if (SHADOW_MAP_SIZES.has(requestedShadowMapSize)) shadowMapSize = requestedShadowMapSize;
+    }
   }
 
-  const perfEnabled = params.get('perf') === '1';
-  const dprRequest = perfEnabled ? params.get('dpr') : null;
-  const requestedDpr = dprRequest == null || String(dprRequest).trim() === ''
-    ? Number.NaN
-    : Number(dprRequest);
-  const hasDprOverride = perfEnabled && Number.isFinite(requestedDpr);
-  const dprCap = hasDprOverride
-    ? clamp(requestedDpr, MIN_DPR_CAP, MAX_DPR_CAP)
-    : DEFAULT_DPR_CAP;
-
-  const shadowRequest = perfEnabled ? String(params.get('shadow') || '') : '';
-  const shadowsEnabled = shadowRequest !== 'off';
-  const requestedShadowSize = Number(shadowRequest);
-  const shadowMapSize = shadowsEnabled && SHADOW_MAP_SIZES.has(requestedShadowSize)
-    ? requestedShadowSize
-    : DEFAULT_SHADOW_MAP_SIZE;
-  const hasShadowOverride = perfEnabled && params.has('shadow');
-
-  const active = hasDprOverride || hasShadowOverride;
+  const pixelRatio = Math.min(Math.max(0.5, Number(devicePixelRatio) || 1), dprCap);
+  const label = `DPR≤${dprCap.toFixed(2)} · shadows ${shadowsEnabled ? shadowMapSize : 'off'}`;
 
   return Object.freeze({
-    active,
-    perfEnabled,
+    active: diagnostics && (
+      Math.abs(dprCap - productionDprCap) > 0.001
+      || shadowsEnabled === false
+      || shadowMapSize !== productionShadowMapSize
+    ),
+    diagnostics,
+    touchOptimized,
     dprCap,
-    pixelRatio: Math.min(Math.max(0.1, Number(devicePixelRatio) || 1), dprCap),
+    pixelRatio,
     shadowsEnabled,
     shadowMapSize,
-    label: profileLabel({ dprCap, shadowsEnabled, shadowMapSize })
+    label
   });
 }
 
 export function installPerformanceProfile() {
-  if (installed) return globalThis.__turnPerformanceProfile || null;
-  installed = true;
-
+  if (installed) return installed;
   const profile = performanceProfileFromSearch();
-  globalThis.__turnPerformanceProfile = profile;
+  let runtimeApplied = false;
 
-  const apply = (runtime) => {
+  function apply(runtime = globalThis.__turnRuntime) {
     if (!runtime?.renderer) return;
-    applyRendererProfile(runtime, profile);
-  };
-
-  if (globalThis.__turnRuntime) apply(globalThis.__turnRuntime);
-  else {
-    window.addEventListener('turn:runtime-ready', (event) => {
-      apply(event.detail || globalThis.__turnRuntime);
-    }, { once: true });
-  }
-
-  return profile;
-}
-
-function applyRendererProfile(runtime, profile) {
-  const { renderer, sun } = runtime;
-
-  if (!rendererPixelRatioSetters.has(renderer)) {
-    rendererPixelRatioSetters.set(renderer, renderer.setPixelRatio.bind(renderer));
-  }
-  const setBasePixelRatio = rendererPixelRatioSetters.get(renderer);
-  renderer.setPixelRatio = (value) => {
-    const requested = Number(value);
-    const safeRequested = Number.isFinite(requested) ? requested : 1;
-    return setBasePixelRatio(Math.min(safeRequested, profile.dprCap));
-  };
-  renderer.setPixelRatio(Math.min(Number(globalThis.devicePixelRatio) || 1, profile.dprCap));
-
-  const viewport = globalThis.visualViewport;
-  const width = Math.max(1, Math.round(viewport?.width || globalThis.innerWidth || renderer.domElement.clientWidth || 1));
-  const height = Math.max(1, Math.round(viewport?.height || globalThis.innerHeight || renderer.domElement.clientHeight || 1));
-  renderer.setSize(width, height);
-
-  renderer.shadowMap.enabled = profile.shadowsEnabled;
-  if (sun) {
-    sun.castShadow = profile.shadowsEnabled;
-    if (profile.shadowsEnabled && sun.shadow?.mapSize) {
-      const sizeChanged = sun.shadow.mapSize.x !== profile.shadowMapSize || sun.shadow.mapSize.y !== profile.shadowMapSize;
-      sun.shadow.mapSize.set(profile.shadowMapSize, profile.shadowMapSize);
-      if (sizeChanged && sun.shadow.map) {
-        sun.shadow.map.dispose?.();
-        sun.shadow.map = null;
-      }
+    const renderer = runtime.renderer;
+    if (!renderer.userData) renderer.userData = {};
+    if (!renderer.userData.turnOriginalSetPixelRatio) {
+      const originalSetPixelRatio = renderer.setPixelRatio.bind(renderer);
+      renderer.userData.turnOriginalSetPixelRatio = originalSetPixelRatio;
+      renderer.setPixelRatio = (value) => originalSetPixelRatio(Math.min(Number(value) || 1, profile.dprCap));
     }
+    renderer.setPixelRatio(profile.pixelRatio);
+    renderer.shadowMap.enabled = profile.shadowsEnabled;
+    const shadowMapSize = profile.shadowMapSize;
+    runtime.scene?.traverse?.((node) => {
+      if (!node?.isLight || !node.shadow?.mapSize) return;
+      node.shadow.mapSize.set(shadowMapSize, shadowMapSize);
+      if (node.shadow.map) {
+        node.shadow.map.dispose?.();
+        node.shadow.map = null;
+      }
+      node.shadow.needsUpdate = true;
+    });
+    renderer.userData.turnPerformanceProfile = profile;
+    runtimeApplied = true;
   }
-  renderer.shadowMap.needsUpdate = true;
 
-  globalThis.__turnPerformanceProfile = Object.freeze({ ...profile, applied: true });
+  function onRuntimeReady(event) {
+    apply(event.detail || globalThis.__turnRuntime);
+  }
+
+  window.addEventListener('turn:runtime-ready', onRuntimeReady);
+  if (globalThis.__turnRuntime) apply(globalThis.__turnRuntime);
+
+  installed = Object.freeze({
+    profile,
+    apply,
+    get runtimeApplied() {
+      return runtimeApplied;
+    }
+  });
+  globalThis.__turnPerformanceProfile = profile;
+  globalThis.__turnPerformanceProfileRuntime = installed;
+  return installed;
 }
 
-function profileLabel({ dprCap, shadowsEnabled, shadowMapSize }) {
-  const shadows = shadowsEnabled ? `shadows ${shadowMapSize}` : 'shadows off';
-  return `DPR≤${Number(dprCap).toFixed(2)} · ${shadows}`;
+function currentPerformanceEnvironment() {
+  let coarsePointer = false;
+  try {
+    coarsePointer = Boolean(globalThis.matchMedia?.('(pointer: coarse)')?.matches);
+  } catch (_) {}
+  const maxTouchPoints = Math.max(0, Number(globalThis.navigator?.maxTouchPoints) || 0);
+  return Object.freeze({
+    coarsePointer,
+    maxTouchPoints,
+    touchOptimized: coarsePointer || maxTouchPoints > 0
+  });
+}
+
+function safeSearchParameters(search) {
+  try {
+    return new URLSearchParams(search);
+  } catch (_) {
+    return new URLSearchParams();
+  }
 }
 
 function clamp(value, min, max) {

--- a/turn/performance-profile.js
+++ b/turn/performance-profile.js
@@ -2,6 +2,7 @@ const DEFAULT_DPR_CAP = 1.5;
 const DEFAULT_SHADOW_MAP_SIZE = 1024;
 const TOUCH_DPR_CAP = 1.25;
 const TOUCH_SHADOW_MAP_SIZE = 512;
+const TOUCH_SHADOW_REFRESH_INTERVAL_MS = 1000 / 30;
 const MIN_DPR_CAP = 0.75;
 const MAX_DPR_CAP = 1.5;
 const SHADOW_MAP_SIZES = new Set([256, 512, 1024]);
@@ -72,6 +73,7 @@ export function installPerformanceProfile() {
     }
     renderer.setPixelRatio(profile.pixelRatio);
     renderer.shadowMap.enabled = profile.shadowsEnabled;
+    installTouchShadowRefreshCap(renderer, profile);
     const shadowMapSize = profile.shadowMapSize;
     runtime.scene?.traverse?.((node) => {
       if (!node?.isLight || !node.shadow?.mapSize) return;
@@ -103,6 +105,30 @@ export function installPerformanceProfile() {
   globalThis.__turnPerformanceProfile = profile;
   globalThis.__turnPerformanceProfileRuntime = installed;
   return installed;
+}
+
+function installTouchShadowRefreshCap(renderer, profile) {
+  if (!renderer?.shadowMap) return;
+  if (!profile.touchOptimized || !profile.shadowsEnabled) {
+    renderer.shadowMap.autoUpdate = true;
+    return;
+  }
+
+  renderer.shadowMap.autoUpdate = false;
+  if (renderer.userData.turnOriginalRender) return;
+
+  const originalRender = renderer.render.bind(renderer);
+  renderer.userData.turnOriginalRender = originalRender;
+  let lastShadowRefreshAt = -Infinity;
+
+  renderer.render = (scene, camera) => {
+    const now = performance.now();
+    if (now - lastShadowRefreshAt >= TOUCH_SHADOW_REFRESH_INTERVAL_MS) {
+      renderer.shadowMap.needsUpdate = true;
+      lastShadowRefreshAt = now;
+    }
+    return originalRender(scene, camera);
+  };
 }
 
 function currentPerformanceEnvironment() {

--- a/turn/render/covered-rendering.js
+++ b/turn/render/covered-rendering.js
@@ -1,6 +1,9 @@
 import * as THREE from 'three';
 
 const INSTALL_FLAG = Symbol.for('turn.covered-rendering-installed');
+const MAX_RENDER_FPS = 60;
+const RENDER_INTERVAL_MS = 1000 / MAX_RENDER_FPS;
+const FRAME_TOLERANCE_MS = 0.6;
 const PAUSE_CLASSES = Object.freeze([
   'turn-track-select-open',
   'turn-runtime-paused'
@@ -13,7 +16,8 @@ export function installCoveredRenderingGuard() {
   const originalSetAnimationLoop = prototype.setAnimationLoop;
   const stats = {
     guardedLoops: 0,
-    skippedFrames: 0
+    skippedFrames: 0,
+    skippedHighRefreshFrames: 0
   };
 
   prototype.setAnimationLoop = function setCoveredAwareAnimationLoop(callback) {
@@ -22,11 +26,30 @@ export function installCoveredRenderingGuard() {
     }
 
     const renderer = this;
+    let lastDeliveredAt = -Infinity;
     const guardedCallback = (time, frame) => {
       if (PAUSE_CLASSES.some((className) => document.body?.classList.contains(className))) {
         stats.skippedFrames += 1;
         return;
       }
+
+      if (Number.isFinite(lastDeliveredAt)) {
+        const elapsed = time - lastDeliveredAt;
+        if (elapsed < RENDER_INTERVAL_MS - FRAME_TOLERANCE_MS) {
+          stats.skippedHighRefreshFrames += 1;
+          return;
+        }
+
+        // Advance by fixed 60 Hz slots instead of assigning `time`. On 90 Hz
+        // displays this produces a 60-ish Hz 2/3 cadence rather than collapsing
+        // to 45 Hz, while a long pause snaps back to the current timestamp.
+        const slots = Math.max(1, Math.floor((elapsed + FRAME_TOLERANCE_MS) / RENDER_INTERVAL_MS));
+        lastDeliveredAt += slots * RENDER_INTERVAL_MS;
+        if (time - lastDeliveredAt > RENDER_INTERVAL_MS * 2) lastDeliveredAt = time;
+      } else {
+        lastDeliveredAt = time;
+      }
+
       callback.call(renderer, time, frame);
     };
 

--- a/turn/render/covered-rendering.js
+++ b/turn/render/covered-rendering.js
@@ -8,6 +8,9 @@ const PAUSE_CLASSES = Object.freeze([
   'turn-track-select-open',
   'turn-runtime-paused'
 ]);
+const MAIN_RENDERER_PAUSE_CLASSES = Object.freeze([
+  'turn-home-open'
+]);
 
 export function installCoveredRenderingGuard() {
   const prototype = THREE.WebGLRenderer.prototype;
@@ -17,6 +20,7 @@ export function installCoveredRenderingGuard() {
   const stats = {
     guardedLoops: 0,
     skippedFrames: 0,
+    skippedCoveredMainFrames: 0,
     skippedHighRefreshFrames: 0
   };
 
@@ -30,6 +34,16 @@ export function installCoveredRenderingGuard() {
     const guardedCallback = (time, frame) => {
       if (PAUSE_CLASSES.some((className) => document.body?.classList.contains(className))) {
         stats.skippedFrames += 1;
+        return;
+      }
+
+      const mainRendererCovered = renderer === globalThis.__turnRuntime?.renderer
+        && MAIN_RENDERER_PAUSE_CLASSES.some((className) => document.body?.classList.contains(className));
+      if (mainRendererCovered) {
+        stats.skippedCoveredMainFrames += 1;
+        // Reset the delivery clock so returning from Home does not inherit a
+        // stale accumulated cadence from minutes of intentionally skipped work.
+        lastDeliveredAt = -Infinity;
         return;
       }
 

--- a/turn/render/world.js
+++ b/turn/render/world.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 
 const buildId = new URL(import.meta.url).searchParams.get('build');
 const TREE_CLUSTER_SINK_RATIO = 0.07;
+const TURN_INK = 0x08090a;
 
 function moduleUrl(relativePath) {
   const url = new URL(relativePath, import.meta.url);
@@ -42,6 +43,33 @@ function waitForRuntime() {
   }, { once: true });
 }
 
+function isContourShell(node) {
+  if (!node?.isMesh || !node.material) return false;
+  if (node.userData?.turnOutline) return true;
+  const materials = Array.isArray(node.material) ? node.material : [node.material];
+  return materials.some((material) => (
+    material?.side === THREE.BackSide
+    && material?.color?.getHex?.() === TURN_INK
+  ));
+}
+
+function suppressTreeClusterContours(root) {
+  const contourShells = [];
+  root.traverse((node) => {
+    if (!node?.isMesh) return;
+    if (isContourShell(node)) {
+      contourShells.push(node);
+      return;
+    }
+    // world-art-pass.js checks this marker before creating an enlarged
+    // back-face contour shell. Leave it set even after stripping an already
+    // created shell so the later compatibility sweeps cannot recreate it.
+    node.userData.turnOutlined = true;
+  });
+
+  for (const shell of contourShells) shell.parent?.remove(shell);
+}
+
 function groundLateTreeClusters(world, baselineChildren) {
   const bounds = new THREE.Box3();
   const size = new THREE.Vector3();
@@ -64,11 +92,12 @@ function groundLateTreeClusters(world, baselineChildren) {
       && size.z >= 5;
 
     if (!treeCluster) continue;
+    suppressTreeClusterContours(child);
     child.position.y -= size.y * TREE_CLUSTER_SINK_RATIO;
     groundedCount += 1;
   }
 
-  if (groundedCount) console.info(`TURN: grounded ${groundedCount} late tree clusters.`);
+  if (groundedCount) console.info(`TURN: grounded ${groundedCount} late tree clusters without contour shells.`);
 }
 
 async function install(runtime) {

--- a/turn/render/world.js
+++ b/turn/render/world.js
@@ -18,7 +18,7 @@ async function loadWorldModules() {
     import(moduleUrl('../section-intensity.js')),
     import(moduleUrl('../tracks/countryside-bella-r166.js?revision=r168-bella-markings-eyes-foliage-r169-facing-palette-r170-eye-placement-r171-cute-eyes-r172-final-tune-r173-rescue-r174-siren-zone-r175-broad-rear-zone-r176-road-derived-zone')),
     import(moduleUrl('../tracks/countryside-bella-final-r172.js?revision=r172-final-tune-r173-rescue-r174-siren-zone-r175-broad-rear-zone-r176-road-derived-zone')),
-    import(moduleUrl('../tracks/countryside-bella-rescue-r173.js?revision=r176-road-derived-rescue-zone'))
+    import(moduleUrl('../tracks/countryside-bella-rescue-r173.js?revision=r164-long-session-robustness'))
   ]);
 
   return {

--- a/turn/tracks/countryside-bella-rescue-hotfix-r176.js
+++ b/turn/tracks/countryside-bella-rescue-hotfix-r176.js
@@ -1,7 +1,6 @@
-import { installBellaRescueBehavior } from './countryside-bella-rescue-r173.js?revision=r176-road-derived-rescue-zone';
+import { installBellaRescueBehavior } from './countryside-bella-rescue-r173.js?revision=r164-long-session-robustness';
 
-const RETRY_INTERVAL_MS = 120;
-const RETRY_LIMIT = 100;
+const RETRY_DELAYS_MS = Object.freeze([250, 350, 500, 700, 900, 1200, 1600, 2200, 3000, 4000]);
 
 function bellaRoot(runtime) {
   return runtime?.world?.children?.find?.(
@@ -16,19 +15,23 @@ function reinstall(runtime) {
   root.userData.turnBellaDisposeRescueBehavior?.();
   root.userData.turnBellaRescueBehaviorInstalled = false;
   installBellaRescueBehavior({ root, runtime });
-  root.userData.turnBellaRescueBootstrap = 'r176-road-derived-zone';
+  root.userData.turnBellaRescueBootstrap = 'r164-long-session-robustness';
   return true;
 }
 
 function start(runtime = globalThis.__turnRuntime) {
   if (reinstall(runtime)) return;
-  let attempts = 0;
-  const timer = window.setInterval(() => {
-    attempts += 1;
-    if (reinstall(globalThis.__turnRuntime) || attempts >= RETRY_LIMIT) {
-      window.clearInterval(timer);
-    }
-  }, RETRY_INTERVAL_MS);
+
+  let attempt = 0;
+  const retry = () => {
+    if (reinstall(globalThis.__turnRuntime)) return;
+    if (attempt >= RETRY_DELAYS_MS.length) return;
+    const delay = RETRY_DELAYS_MS[attempt];
+    attempt += 1;
+    window.setTimeout(retry, delay);
+  };
+
+  retry();
 }
 
 if (globalThis.__turnRuntime) start(globalThis.__turnRuntime);

--- a/turn/tracks/countryside-bella-rescue-r173.js
+++ b/turn/tracks/countryside-bella-rescue-r173.js
@@ -76,6 +76,15 @@ function otherSoundPreference() {
   return balance > 0.5 ? clamp((1 - balance) / 0.5, 0, 1) : 1;
 }
 
+function meowContextWanted(runtime = globalThis.__turnRuntime) {
+  const state = runtime?.state;
+  return (state?.running === true || state?.lapActive === true)
+    && activeTrackId(runtime) === 'countryside'
+    && String(state?.vehicleId || '').toLowerCase() === REQUIRED_VEHICLE_ID
+    && otherSoundPreference() > 0.001
+    && document.visibilityState !== 'hidden';
+}
+
 function ensureMeowContext() {
   if (!AudioContextClass) return null;
   if (!meowContext) {
@@ -89,8 +98,16 @@ function ensureMeowContext() {
   return meowContext;
 }
 
+function suspendMeowContext() {
+  if (meowContext?.state !== 'running') return;
+  void meowContext.suspend().catch(() => {});
+}
+
 function unlockMeowContext() {
-  ensureMeowContext();
+  // Bella is the only intentionally separate world-sound context. Do not keep a
+  // third live AudioContext in ordinary TURN sessions: arm it only while the
+  // Fire Truck is actually racing on Countryside and other sounds are enabled.
+  if (meowContextWanted()) ensureMeowContext();
 }
 
 function scheduleMeow({ pan = 0, intensity = 0.5, rescued = false } = {}) {
@@ -143,6 +160,7 @@ function scheduleMeow({ pan = 0, intensity = 0.5, rescued = false } = {}) {
     formantGain.disconnect();
     gain.disconnect();
     panner.disconnect();
+    if (rescued) suspendMeowContext();
   }, { once: true });
   return true;
 }
@@ -290,6 +308,7 @@ export function installBellaRescueBehavior({ root, runtime = globalThis.__turnRu
       && player;
     if (!eligible || document.hidden) {
       wasInRange = false;
+      suspendMeowContext();
       return;
     }
 
@@ -349,7 +368,8 @@ export function installBellaRescueBehavior({ root, runtime = globalThis.__turnRu
     rangeMeters: MEOW_RANGE_METERS,
     directional: true,
     cadence: 'Meows repeat more often as the Fire Truck approaches.',
-    availability: 'Other-sounds preference and global audio setting are respected.'
+    availability: 'Other-sounds preference and global audio setting are respected.',
+    contextPolicy: 'The meow AudioContext is created only during an eligible Countryside Fire Truck race and suspends when that condition stops.'
   });
   root.userData.turnBellaDisposeRescueBehavior = () => {
     if (disposed) return;
@@ -359,6 +379,10 @@ export function installBellaRescueBehavior({ root, runtime = globalThis.__turnRu
     globalThis.removeEventListener('turn:achievements-updated', handleAchievementUpdate);
     document.removeEventListener('pointerdown', unlockMeowContext, { capture: true });
     document.removeEventListener('keydown', unlockMeowContext, { capture: true });
+    if (meowContext) {
+      void meowContext.close?.().catch?.(() => {});
+      meowContext = null;
+    }
   };
 
   sample();

--- a/turn/tracks/harbor-world-r82.js
+++ b/turn/tracks/harbor-world-r82.js
@@ -1,0 +1,138 @@
+import * as THREE from 'three';
+import { installHarborWorld as installHarborWorldR81 } from './harbor-world-r81.js?revision=r164-container-batching';
+
+const CONTAINER_SIZE = Object.freeze({ width: 19, height: 7.3, depth: 7.4 });
+const RIB_SIZE = Object.freeze({ width: 17.8, height: 6.45, depth: 7.48 });
+const SIZE_EPSILON = 0.02;
+
+function boxDimensions(mesh) {
+  const parameters = mesh?.geometry?.parameters;
+  if (mesh?.geometry?.type !== 'BoxGeometry' || !parameters) return null;
+  return {
+    width: Number(parameters.width),
+    height: Number(parameters.height),
+    depth: Number(parameters.depth)
+  };
+}
+
+function matchesSize(dimensions, target) {
+  return dimensions
+    && Math.abs(dimensions.width - target.width) <= SIZE_EPSILON
+    && Math.abs(dimensions.height - target.height) <= SIZE_EPSILON
+    && Math.abs(dimensions.depth - target.depth) <= SIZE_EPSILON;
+}
+
+function isContainerShell(mesh) {
+  if (!mesh?.isMesh || mesh.isInstancedMesh || !mesh.material) return false;
+  const material = Array.isArray(mesh.material) ? null : mesh.material;
+  return matchesSize(boxDimensions(mesh), CONTAINER_SIZE)
+    && material?.isMeshStandardMaterial === true
+    && material.color;
+}
+
+function isContainerRibs(mesh) {
+  if (!mesh?.isMesh || mesh.isInstancedMesh || !mesh.material) return false;
+  const material = Array.isArray(mesh.material) ? null : mesh.material;
+  return matchesSize(boxDimensions(mesh), RIB_SIZE)
+    && material?.wireframe === true;
+}
+
+function disposeDetachedMesh(mesh) {
+  mesh.geometry?.dispose?.();
+  const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+  for (const material of materials) material?.dispose?.();
+}
+
+function batchContainerYards(world) {
+  const shellsByColor = new Map();
+  const ribs = [];
+
+  // Container-yard pieces are direct children of the Harbor world. Restricting the
+  // scan to direct children plus exact source dimensions prevents accidental batching
+  // of start gates, buildings or ship geometry that merely happen to be box-shaped.
+  for (const child of [...world.children]) {
+    if (isContainerShell(child)) {
+      const color = child.material.color.getHex(THREE.SRGBColorSpace);
+      if (!shellsByColor.has(color)) shellsByColor.set(color, []);
+      child.updateMatrix();
+      shellsByColor.get(color).push(child);
+    } else if (isContainerRibs(child)) {
+      child.updateMatrix();
+      ribs.push(child);
+    }
+  }
+
+  const shellCount = [...shellsByColor.values()].reduce((total, entries) => total + entries.length, 0);
+  if (!shellCount) return Object.freeze({ shells: 0, ribs: 0, drawGroups: 0 });
+
+  const containerGeometry = new THREE.BoxGeometry(
+    CONTAINER_SIZE.width,
+    CONTAINER_SIZE.height,
+    CONTAINER_SIZE.depth
+  );
+
+  let drawGroups = 0;
+  for (const [color, entries] of shellsByColor) {
+    const sourceMaterial = entries[0].material;
+    const material = new THREE.MeshStandardMaterial({
+      color,
+      roughness: sourceMaterial.roughness,
+      metalness: sourceMaterial.metalness
+    });
+    const batch = new THREE.InstancedMesh(containerGeometry, material, entries.length);
+    batch.name = `Harbor container batch ${color.toString(16).padStart(6, '0')}`;
+    for (let index = 0; index < entries.length; index += 1) {
+      batch.setMatrixAt(index, entries[index].matrix);
+    }
+    batch.instanceMatrix.needsUpdate = true;
+    batch.castShadow = true;
+    batch.receiveShadow = true;
+    world.add(batch);
+    drawGroups += 1;
+  }
+
+  if (ribs.length) {
+    const ribGeometry = new THREE.BoxGeometry(RIB_SIZE.width, RIB_SIZE.height, RIB_SIZE.depth);
+    const sourceMaterial = ribs[0].material;
+    const ribMaterial = new THREE.MeshBasicMaterial({
+      color: sourceMaterial.color?.getHex?.(THREE.SRGBColorSpace) ?? 0x08090a,
+      wireframe: true,
+      transparent: true,
+      opacity: sourceMaterial.opacity,
+      depthWrite: sourceMaterial.depthWrite
+    });
+    const ribBatch = new THREE.InstancedMesh(ribGeometry, ribMaterial, ribs.length);
+    ribBatch.name = 'Harbor container rib batch';
+    for (let index = 0; index < ribs.length; index += 1) ribBatch.setMatrixAt(index, ribs[index].matrix);
+    ribBatch.instanceMatrix.needsUpdate = true;
+    world.add(ribBatch);
+    drawGroups += 1;
+  }
+
+  for (const entries of shellsByColor.values()) {
+    for (const mesh of entries) {
+      world.remove(mesh);
+      disposeDetachedMesh(mesh);
+    }
+  }
+  for (const mesh of ribs) {
+    world.remove(mesh);
+    disposeDetachedMesh(mesh);
+  }
+
+  return Object.freeze({ shells: shellCount, ribs: ribs.length, drawGroups });
+}
+
+export function installHarborWorld(options) {
+  const world = installHarborWorldR81(options);
+  const batching = batchContainerYards(world);
+  world.name = 'TURN Harbor r82';
+  world.userData.turnHarborArtDirection = Object.freeze({
+    ...(world.userData.turnHarborArtDirection || {}),
+    version: 'r82',
+    containerDrawCallBatching: batching,
+    gameplayGeometryUnchanged: true,
+    noIndependentAnimationLoop: true
+  });
+  return world;
+}

--- a/turn/vehicle/emergency-livery-models.js
+++ b/turn/vehicle/emergency-livery-models.js
@@ -39,12 +39,16 @@ const EMERGENCY_LIVERY_BY_ID = Object.freeze({
 export { preloadCarModels, recolorCarVisual };
 
 export async function createCarVisual(options = {}) {
-  const root = await createBaseCarVisual(options);
+  const lotGridVisual = Math.abs(Number(options.targetLength) - LOT_TARGET_LENGTH) < 0.001;
+  // TURN's contour treatment is a second, enlarged back-face mesh for every
+  // source mesh. Keep that strong silhouette for the player and the large
+  // selected-car viewer, but do not double draw calls for all 15 Lot cars or
+  // for translucent rivals/ghosts where the outline adds little readability.
+  const outline = options.outline !== false && !options.ghost && !lotGridVisual;
+  const root = await createBaseCarVisual({ ...options, outline });
   const livery = EMERGENCY_LIVERY_BY_ID[root?.userData?.turnCarId];
   if (livery) applyFixedEmergencyLivery(root, livery, Boolean(options.ghost));
-  if (Math.abs(Number(options.targetLength) - LOT_TARGET_LENGTH) < 0.001) {
-    installLotUnselectedTint(root);
-  }
+  if (lotGridVisual) installLotUnselectedTint(root);
   return root;
 }
 

--- a/turn/vehicle/emergency-livery-models.js
+++ b/turn/vehicle/emergency-livery-models.js
@@ -39,15 +39,12 @@ const EMERGENCY_LIVERY_BY_ID = Object.freeze({
 export { preloadCarModels, recolorCarVisual };
 
 export async function createCarVisual(options = {}) {
-  const lotGridVisual = Math.abs(Number(options.targetLength) - LOT_TARGET_LENGTH) < 0.001;
-  // TURN's contour treatment is a second, enlarged back-face mesh for every
-  // source mesh. Keep it for gameplay cars/ghosts and the large selected-car
-  // viewer, but do not double draw calls for all 15 tiny Lot-grid cars.
-  const outline = options.outline !== false && !lotGridVisual;
-  const root = await createBaseCarVisual({ ...options, outline });
+  const root = await createBaseCarVisual(options);
   const livery = EMERGENCY_LIVERY_BY_ID[root?.userData?.turnCarId];
   if (livery) applyFixedEmergencyLivery(root, livery, Boolean(options.ghost));
-  if (lotGridVisual) installLotUnselectedTint(root);
+  if (Math.abs(Number(options.targetLength) - LOT_TARGET_LENGTH) < 0.001) {
+    installLotUnselectedTint(root);
+  }
   return root;
 }
 

--- a/turn/vehicle/emergency-livery-models.js
+++ b/turn/vehicle/emergency-livery-models.js
@@ -41,10 +41,9 @@ export { preloadCarModels, recolorCarVisual };
 export async function createCarVisual(options = {}) {
   const lotGridVisual = Math.abs(Number(options.targetLength) - LOT_TARGET_LENGTH) < 0.001;
   // TURN's contour treatment is a second, enlarged back-face mesh for every
-  // source mesh. Keep that strong silhouette for the player and the large
-  // selected-car viewer, but do not double draw calls for all 15 Lot cars or
-  // for translucent rivals/ghosts where the outline adds little readability.
-  const outline = options.outline !== false && !options.ghost && !lotGridVisual;
+  // source mesh. Keep it for gameplay cars/ghosts and the large selected-car
+  // viewer, but do not double draw calls for all 15 tiny Lot-grid cars.
+  const outline = options.outline !== false && !lotGridVisual;
   const root = await createBaseCarVisual({ ...options, outline });
   const livery = EMERGENCY_LIVERY_BY_ID[root?.userData?.turnCarId];
   if (livery) applyFixedEmergencyLivery(root, livery, Boolean(options.ghost));

--- a/turn/world-assets.js
+++ b/turn/world-assets.js
@@ -62,7 +62,8 @@ function prepareModel(source, {
   outline = false,
   castShadow = true,
   tint = null,
-  tintAmount = 0.75
+  tintAmount = 0.75,
+  suppressAutoOutline = false
 } = {}) {
   const model = source.clone(true);
   const tintColor = tint == null ? null : new THREE.Color(tint);
@@ -83,6 +84,10 @@ function prepareModel(source, {
 
     node.castShadow = castShadow;
     node.receiveShadow = true;
+    // world-art-pass.js uses this marker to avoid adding a second enlarged
+    // back-face mesh. Repeated vegetation keeps its native silhouette instead
+    // of doubling its draw calls for the entire race.
+    if (suppressAutoOutline) node.userData.turnOutlined = true;
   });
 
   model.updateMatrixWorld(true);
@@ -132,7 +137,8 @@ function placeAlongTrack({
   stretch = null,
   tint = null,
   tintAmount = 0.75,
-  groundSink = 0
+  groundSink = 0,
+  suppressAutoOutline = false
 }) {
   const { sample, position } = trackPosition(samples, index, side, trackWidth, distance);
   const model = prepareModel(source, {
@@ -141,7 +147,8 @@ function placeAlongTrack({
     outline,
     castShadow,
     tint,
-    tintAmount
+    tintAmount,
+    suppressAutoOutline
   });
   model.position.add(position);
   model.position.y -= groundSink;
@@ -181,7 +188,8 @@ function placeTreeBelt({ world, samples, trackWidth, trees, tallTrees }) {
       targetHeight,
       groundSink: targetHeight * 0.07,
       castShadow: i % 3 === 0,
-      rotationOffset: random * Math.PI * 2
+      rotationOffset: random * Math.PI * 2,
+      suppressAutoOutline: true
     });
   }
 }


### PR DESCRIPTION
## Goal

Make TURN stay cool, responsive and sonically reliable during sustained play—especially the 10–20 minute window where production has shown device heating, music glitching and eventual loss of all audio—without changing driving physics, vehicle balance, accessibility behavior or the approved song.

## Main findings

The review found several real long-session costs rather than one single culprit:

1. **Persistent Web Audio automation could grow for the life of the session.** Reused engine/DBE AudioParams were receiving new scheduled automation around 30 times per second without first bounding the previous timeline.
2. **Short-lived audio graphs were not always explicitly disconnected.** In particular, the generated music creates thousands of oscillator/buffer + Gain/Filter branches over a long session; source nodes ended, but WebKit was left to reclaim still-connected silent downstream branches.
3. **iOS/WebKit AudioContext interruption lacked a robust recovery path.** A temporarily suspended/interrupted central context could remain silent while gameplay continued.
4. **Mobile GPU defaults were unnecessarily close to desktop quality.** Touch hardware paid a higher DPR, shadow resolution and shadow-refresh cost than needed for this visual style.
5. **Menu/reward 3D surfaces kept rendering more often than useful.** The Lot used two WebGL renderers; Trophy Road previews were decorative but continuously animated.
6. **TURN contours are real extra geometry/draw calls.** Repeated cars, ghosts and Countryside vegetation were paying for duplicate enlarged back-face meshes where the visual benefit was small.
7. **Harbor container yards used many independent meshes/materials for identical boxes.** The same scenery can be retained with a handful of instanced draw groups.
8. **Some app-wide polling kept waking JavaScript while no race was active.** Achievement sampling and the independent Bella bootstrap were examples.
9. **Bella could keep a third AudioContext alive in ordinary sessions.** Its directional meow only needs that context during an eligible Countryside Fire Truck run.
10. **Nested cache identities could defeat lifecycle fixes on installed iOS PWAs.** The review therefore follows the actual production import chain rather than assuming changed source bytes are enough.

## Audio robustness

### Central game / Drive By Ear graph
- bounds repeated AudioParam automation instead of indefinitely appending scheduled events
- adds defensive fallback behavior for Web Audio implementations without the preferred automation API
- explicitly cleans up pace-note and transient cue graphs after completion
- reuses short transient noise buffers instead of allocating a new noise buffer for every cue
- adds bounded diagnostics for active transient sources and recovery attempts
- adds throttled AudioContext recovery for WebKit state interruption, page restore and visibility changes
- keeps intentional background suspension
- keeps the central audio update rate at 30 Hz

### Drive By Ear helpers
- applies the same bounded automation discipline to the organic ribbon and recovery guidance voices
- keeps DBE behavior, balance semantics and auditory cues unchanged

### Racing music
The **composition and sound design are unchanged**: BPM 120, default volume 50%, arrangement `C C T T B T`, lead/bass transpositions, chorus oscillator/filter/envelope values and all note data remain exactly as approved.

The source now adds lifecycle-only graph teardown:
- every generated chorus/lead/bass/arp/kick/snare/hat graph is tracked
- downstream Gain/Filter nodes are explicitly disconnected when its source ends
- MUSIC OFF/background stop also releases active graph branches immediately

Because the source bytes changed, the content fingerprint correctly changed from the old song blob to:

`/turn/audio/racing-music-v3.js?revision=blob-8319c3923e0a`

Production and TURN LAB use the same fingerprint, and CI derives the expected URL from the actual Git blob so stale music routing cannot pass unnoticed.

A lightweight music-health layer checks for unexpected context interruption and recovers through the existing public music API. It does not create another synth graph or change the song.

### Bella world sound
- Bella's small separate AudioContext is now created/resumed only during a visible Countryside Fire Truck run with other sounds enabled
- it suspends again when that eligibility ends and closes on disposal
- the independent Bella bootstrap now imports the same robustness behavior instead of reinstalling the older lifecycle
- the old fixed 120 ms startup polling loop is replaced by bounded back-off retries
- the outer bootstrap URL itself is cache-busted so installed Safari cannot legally reuse the old bytes

## GPU / thermal work

### Touch-device production profile
Desktop quality remains the established baseline. Touch/coarse-pointer hardware now defaults to:
- DPR ceiling **1.25**
- shadow map **512 px**
- shadow-map refresh capped at **30 Hz** while gameplay/rendering itself can remain at 60 Hz

The shadow cadence piggybacks the existing renderer call; it adds no timer or animation loop. Diagnostic performance parameters can still deliberately restore heavier settings for A/B comparison.

### High-refresh and covered rendering
- caps guarded WebGL animation delivery at roughly 60 Hz on 90/120 Hz displays
- skips the main race renderer while Home fully covers it
- retains existing route/runtime pause handling
- does not change physics fixed-step behavior

### The Lot
- overview + selected-car rendering capped at 30 fps
- both renderers inherit the production DPR cap
- WebGL contexts are explicitly released when leaving
- cloned viewer materials are disposed without disposing shared cached car geometry
- background Lot cars no longer create duplicate contour shells
- the large selected-car 3D viewer keeps the outline where it materially contributes to TURN's look
- existing freeze-safe Lot observer behavior is untouched

### Trophy Road
- decorative 3D preview rendering capped at 30 fps
- inherits DPR cap
- WebGL context is released when disposed
- small rotating preview models omit duplicate contour shells

### Race-world contours
Contours remain part of TURN's art direction; this is selective rather than a global removal.
- player car keeps its outline
- ghosts/rivals omit the duplicate contour geometry
- the 58-object Countryside tree belt opts out of the broad auto-outline pass
- late beauty-pass forest clusters have already-created contour shells stripped and remain marked so compatibility sweeps cannot recreate them
- important start-area flags, garages, buildings and other intentional silhouettes can keep explicit outlines

### Harbor draw-call batching
New `harbor-world-r82.js` keeps the existing Harbor art/gameplay geometry but batches the container yards:
- identical container shells are grouped by paint color into `THREE.InstancedMesh` batches
- container rib/wireframe geometry is one instanced batch
- established container shadows remain
- replaced per-container geometry/materials are disposed
- no independent loop is added

Cliffside and Midnight City were reviewed and already make strong use of instancing/sparse lighting; they were left alone rather than changed for the sake of changing them. Airport was reviewed too; some small decorative batching opportunities remain, but they are lower-value and higher routing/cache risk than the work above, so this PR deliberately stops before speculative micro-optimisation.

## CPU / lifecycle work

- achievement 100 ms sampling now runs only while gameplay/lap state requires it and stops on Home/Lot/background
- repeated replay sampling keeps its existing one-sample cache
- current HUD map rendering already caches its static track layer and updates dynamic markers at 30 Hz; no unnecessary rewrite was made
- existing bounded spatial track search remains covered by performance tests
- no new always-on timers/RAF loops were introduced by the optimisation systems

## Cache / installed-PWA robustness

Fresh module identities are carried through the actual production dependency graph for the changed runtime layers, including:
- performance profile
- central/DBE audio helpers
- covered rendering
- Lot route
- Trophy Road preview
- world bootstrap/shared world assets
- achievement lifecycle facade/runtime
- Bella behavior + independent bootstrap
- Harbor r82
- racing music content fingerprint

TURN LAB is restored to its complete production-runtime document and carries the same relevant robustness routes as production.

## Regression coverage

The full TURN workflow now includes a dedicated long-session lifecycle regression covering:
- race-scoped achievement polling
- touch shadow cadence with no extra loop
- repeated-tree contour suppression/stripping
- Harbor instancing
- Bella on-demand AudioContext and bounded bootstrap
- production/LAB cache routes

The racing-music regression additionally verifies:
- the exact runtime import specifier maps to a fingerprint derived from the real music file bytes
- all approved musical constants/data remain intact
- every generated voice family participates in explicit graph teardown
- MUSIC OFF still removes scheduler/source work and suspends the music context

Existing audio, DBE, pace-note, Lot, Trophy Road, physics, accessibility, viewport, release and track regressions remain in the full suite.

## Current validation

Latest full TURN regression suite: **66/66 steps green**.
All five additional TURN workflows are also green.

The code/diff audit is complete. No release/version bump, driving-physics change, perk/balance change, progression change or accessibility feature removal is included.

## Before merge: real-device soak

Keep this PR unmerged until it has been exercised on the actual iPhone for at least 15–20 minutes, ideally including repeated:

`Home → The Lot → Race → Home → The Lot → Race`

Please specifically observe:
- device temperature compared with current production
- music continuity / absence of crackle or glitching
- game/DBE audio continuing to work after sustained play
- no obvious visual regression from DPR/shadow/contour changes
- Harbor appearance
- Home/Lot/Trophy Road transitions
- background/foreground audio recovery

If the soak is clean, this should be suitable to merge as the TURN robustness/optimisation upgrade.