### PR TITLE
Fix post-optimisation soak notes

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Run TURN NEXT motion safe-zone regression
         run: node turn-tests/motion-safe-zone-production.mjs
 
+      - name: Run post-optimisation soak regression
+        run: node turn-tests/post-soak-production.mjs
+
       - name: Run production race and replay regression tests
         run: node turn-tests/race-production.mjs
 

--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -71,7 +71,7 @@
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/achievements/trophy-road-showcase.js?revision=r160-reward-detail-sync": "/turn/achievements/trophy-road-showcase.js?revision=r164-long-session-robustness",
-        "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",
+        "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-post-soak",
         "/turn/render/covered-rendering.js?build=20260811-r164": "/turn/render/covered-rendering.js?build=20260811-r164&revision=r164-long-session-robustness",
         "./garage/lot-accessibility-r118.js?build=20260729-r118": "./garage/lot-accessibility-r118.js?build=20260811-r164&revision=r163-voiceover-first-lot-focus",
         "./garage/lot-enhancement-runtime.js?revision=r163-native-picker-parent-click&build=20260809-r163": "./garage/lot-enhancement-runtime.js?build=20260811-r164&revision=r164-perk-observer-hotfix",
@@ -149,7 +149,7 @@
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button" aria-label="Restart the current lap from the start line">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
   <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260811-r164-r168-shared-about-credits"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
-  <script type="module" src="./app.js?build=20260811-r164-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r164-long-session-robustness"></script>
+  <script type="module" src="./app.js?build=20260811-r164-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r164-long-session-robustness-post-soak"></script>
   <script type="module" src="./accessibility/color-accessibility-r163.js?build=20260811-r164-paint-basics"></script>
   <script type="module" src="./achievements/chromatic-camouflage-r183.js?revision=r183-production"></script>
   <script type="module" src="./social/your-turn-share-bootstrap.js?revision=r2"></script>

--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -66,6 +66,7 @@
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
+        "/turn/input/motion.js": "/turn/input/motion.js?revision=r164-ipad-motion-profile",
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
         "/turn/audio/racing-music-v2.js?build=20260811-r164-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=blob-8319c3923e0a",
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
@@ -117,7 +118,7 @@
         <h1 id="installTitle">TURN LAB</h1>
         <p class="install-copy">The current production game with a viewport flight recorder. Production TURN is not modified.</p>
         <div class="install-actions">
-          <button id="installTurnButton" class="install-primary" type="button">Install TURN LAB</button>
+          <button id="installTurnButton" type="button">Install TURN LAB</button>
           <p class="install-note" id="installNote">Install this separate Home Screen app to reproduce the intermittent iOS viewport strip.</p>
           <button class="install-secondary" id="playBrowserButton" type="button">Play in browser anyway</button>
         </div>

--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -118,7 +118,7 @@
         <h1 id="installTitle">TURN LAB</h1>
         <p class="install-copy">The current production game with a viewport flight recorder. Production TURN is not modified.</p>
         <div class="install-actions">
-          <button id="installTurnButton" type="button">Install TURN LAB</button>
+          <button id="installTurnButton" class="install-primary" type="button">Install TURN LAB</button>
           <p class="install-note" id="installNote">Install this separate Home Screen app to reproduce the intermittent iOS viewport strip.</p>
           <button class="install-secondary" id="playBrowserButton" type="button">Play in browser anyway</button>
         </div>

--- a/turn-tests/post-soak-production.mjs
+++ b/turn-tests/post-soak-production.mjs
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import {
+  resolveMotionSteeringProfile,
+  updateMotionInputState
+} from '../turn/input/motion.js';
+import {
   FUTURE_RACER_CAR_PERK_DESCRIPTION,
   FUTURE_RACER_REWARD_PERK_DESCRIPTION,
   vehiclePerkPresentation
@@ -26,6 +30,8 @@ const [
   fs.readFile(new URL('../turn-lab/index.html', import.meta.url), 'utf8')
 ]);
 
+const toRadians = (degrees) => degrees * Math.PI / 180;
+
 // Spectate must use the same elevation model as ordinary rivals. Cliffside is
 // the regression case: replay coordinates are X/Z only, while track progress
 // supplies the authoritative road Y and pitch.
@@ -49,6 +55,91 @@ assert.doesNotMatch(
   /if \(detail\.enteredHard\) \{\s*playLimitCue\(\);/,
   'Entering max steering must not beep immediately'
 );
+
+// iPadOS can identify either as iPad or as a touch-capable Mac. Only those
+// environments get damping. The established iPhone/default numbers are pinned
+// exactly so this compatibility fix cannot silently alter newer-iPhone feel.
+const defaultProfile = resolveMotionSteeringProfile({
+  navigator: {
+    userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 26_5 like Mac OS X) Mobile Safari',
+    platform: 'iPhone',
+    maxTouchPoints: 5
+  }
+});
+assert.equal(defaultProfile.id, 'default');
+assert.equal(defaultProfile.steeringEnterThreshold, toRadians(2.2));
+assert.equal(defaultProfile.steeringExitThreshold, toRadians(0.9));
+assert.equal(defaultProfile.rollFollowRate, 16);
+assert.equal(defaultProfile.pitchFollowRate, 12);
+assert.equal(defaultProfile.steeringResponseRate, 8.5);
+assert.equal(defaultProfile.steeringReleaseRate, 12);
+assert.equal(defaultProfile.curvePower, 1);
+
+const namedIPadProfile = resolveMotionSteeringProfile({
+  navigator: {
+    userAgent: 'Mozilla/5.0 (iPad; CPU OS 26_5 like Mac OS X) Mobile Safari',
+    platform: 'iPad',
+    maxTouchPoints: 5
+  }
+});
+const desktopIPadProfile = resolveMotionSteeringProfile({
+  navigator: {
+    userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit Mobile Safari',
+    platform: 'MacIntel',
+    maxTouchPoints: 5
+  }
+});
+for (const profile of [namedIPadProfile, desktopIPadProfile]) {
+  assert.equal(profile.id, 'ipad-damped');
+  assert.equal(profile.steeringEnterThreshold, toRadians(3.2));
+  assert.equal(profile.steeringExitThreshold, toRadians(1.4));
+  assert.equal(profile.rollFollowRate, 10.5);
+  assert.equal(profile.pitchFollowRate, 12);
+  assert.equal(profile.steeringResponseRate, 6.5);
+  assert.equal(profile.steeringReleaseRate, 10);
+  assert.equal(profile.curvePower, 1.22);
+}
+assert.equal(
+  resolveMotionSteeringProfile({
+    navigator: {
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) Safari',
+      platform: 'MacIntel',
+      maxTouchPoints: 0
+    }
+  }).id,
+  'default',
+  'An ordinary Mac must never be mistaken for an iPad'
+);
+
+function steeringAfterFrames(profile, targetDegrees, frames = 24) {
+  const state = {
+    sensorMode: true,
+    roll: 0,
+    targetRoll: toRadians(targetDegrees),
+    pitch: 0,
+    targetPitch: 0,
+    neutralRoll: 0,
+    steering: 0,
+    steeringEngaged: false,
+    tiltDrive: 0
+  };
+  for (let frame = 0; frame < frames; frame += 1) {
+    updateMotionInputState({
+      state,
+      dt: 1 / 60,
+      maxSteerRoll: toRadians(24),
+      steeringProfile: profile
+    });
+  }
+  return state.steering;
+}
+
+const defaultMidSteer = Math.abs(steeringAfterFrames(defaultProfile, 12));
+const ipadMidSteer = Math.abs(steeringAfterFrames(namedIPadProfile, 12));
+assert.ok(ipadMidSteer < defaultMidSteer * 0.8,
+  'The iPad profile must materially calm mid-range steering without changing the default profile');
+assert.ok(Math.abs(steeringAfterFrames(namedIPadProfile, 24, 120)) > 0.99,
+  'The iPad profile must still reach full steering at the canonical 24-degree limit');
 
 assert.equal(
   FUTURE_RACER_REWARD_PERK_DESCRIPTION,
@@ -79,10 +170,15 @@ for (const index of [productionIndex, labIndex]) {
     'Production and LAB must load the fresh Future Racer reward-copy wrapper'
   );
   assert.match(index, /app\.js\?build=[^"']*r164-long-session-robustness-post-soak/);
+  assert.match(
+    index,
+    /"\/turn\/input\/motion\.js": "\/turn\/input\/motion\.js\?revision=r164-ipad-motion-profile"/,
+    'Production and LAB must route the race core to the fresh iPad-aware motion module'
+  );
 }
 
 assert.match(app, /steering-limit-warning\.js\?revision=r164-post-soak/);
 assert.match(app, /lot-enhancement-runtime\.js\?revision=r164-post-soak/);
 assert.match(app, /spectate\.js\?revision=r164-elevation-aware/);
 
-console.log('TURN post-optimisation soak fixes passed.');
+console.log('TURN post-optimisation soak fixes and isolated iPad steering profile passed.');

--- a/turn-tests/post-soak-production.mjs
+++ b/turn-tests/post-soak-production.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import {
+  FUTURE_RACER_CAR_PERK_DESCRIPTION,
+  FUTURE_RACER_REWARD_PERK_DESCRIPTION,
+  vehiclePerkPresentation
+} from '../turn/vehicle/perk-presentation.js';
+
+const [
+  spectate,
+  steeringWarning,
+  lotPerk,
+  lotRuntime,
+  trophyWrapper,
+  app,
+  productionIndex,
+  labIndex
+] = await Promise.all([
+  fs.readFile(new URL('../turn/ui/spectate.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/ui/steering-limit-warning.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/garage/lot-perk-disclosure.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/garage/lot-enhancement-runtime.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/progression/trophy-road-chromatic-r183.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn-lab/index.html', import.meta.url), 'utf8')
+]);
+
+// Spectate must use the same elevation model as ordinary rivals. Cliffside is
+// the regression case: replay coordinates are X/Z only, while track progress
+// supplies the authoritative road Y and pitch.
+assert.match(spectate, /trackPitch, trackSampleAtProgress, trackSurfaceY/);
+assert.match(spectate, /trackSampleAtProgress\(runtime\.samples, frame\?\.p\)/);
+assert.match(spectate, /car\.position\.set\(frame\.x, trackSurfaceY\(surfaceSample\), frame\.z\)/);
+assert.match(spectate, /car\.rotation\.x = trackPitch\(surfaceSample\)/);
+assert.match(spectate, /desiredCamera\.y = surfaceY \+ 8\.6/);
+assert.match(spectate, /desiredTarget\.y = surfaceY \+ 2\.15/);
+assert.doesNotMatch(spectate, /car\.position\.set\(frame\.x, 0\.18, frame\.z\)/);
+assert.doesNotMatch(spectate, /new THREE\.Vector3\(frame\.x, 0\.18, frame\.z\)/);
+
+// The edge gradient stays immediate, but the informational sound/announcement
+// requires a sustained hard limit so incidental millisecond touches stay quiet.
+assert.match(steeringWarning, /HARD_LIMIT_CUE_HOLD_MS = 320/);
+assert.match(steeringWarning, /function scheduleHardCue\(side\)/);
+assert.match(steeringWarning, /if \(currentHardSide !== side\) return;/);
+assert.match(steeringWarning, /cancelPendingHardCue\(\);[\s\S]*scheduleSoftRelease/);
+assert.doesNotMatch(
+  steeringWarning,
+  /if \(detail\.enteredHard\) \{\s*playLimitCue\(\);/,
+  'Entering max steering must not beep immediately'
+);
+
+assert.equal(
+  FUTURE_RACER_REWARD_PERK_DESCRIPTION,
+  'After a few seconds of clean driving on-track the speed cap starts increasing. Going off-track resets it.'
+);
+assert.equal(
+  FUTURE_RACER_CAR_PERK_DESCRIPTION,
+  'A few seconds of staying on-track raises speed cap. Going off-track resets it.'
+);
+assert.equal(
+  vehiclePerkPresentation('race-future', { title: 'OVERDRIVE', description: 'old' }).description,
+  FUTURE_RACER_CAR_PERK_DESCRIPTION
+);
+assert.equal(
+  vehiclePerkPresentation('monster-truck', { title: 'OVERSIZED', description: 'unchanged' }).description,
+  'unchanged',
+  'Other vehicle perk copy must remain untouched'
+);
+assert.match(lotPerk, /vehiclePerkPresentation\(vehicleId, getCarDefinition\(vehicleId\)\?\.perk\)/);
+assert.match(lotRuntime, /lot-perk-disclosure\.js\?revision=r164-post-soak/);
+assert.match(trophyWrapper, /FUTURE_RACER_REWARD_PERK_DESCRIPTION/);
+assert.match(trophyWrapper, /reward\.id !== 'future-racer'/);
+
+for (const index of [productionIndex, labIndex]) {
+  assert.match(
+    index,
+    /\/turn\/progression\/trophy-road-chromatic-r183\.js\?revision=r183-post-soak/,
+    'Production and LAB must load the fresh Future Racer reward-copy wrapper'
+  );
+  assert.match(index, /app\.js\?build=[^"']*r164-long-session-robustness-post-soak/);
+}
+
+assert.match(app, /steering-limit-warning\.js\?revision=r164-post-soak/);
+assert.match(app, /lot-enhancement-runtime\.js\?revision=r164-post-soak/);
+assert.match(app, /spectate\.js\?revision=r164-elevation-aware/);
+
+console.log('TURN post-optimisation soak fixes passed.');

--- a/turn/app.js
+++ b/turn/app.js
@@ -238,7 +238,7 @@ audioPreferences.setDriveByEarEnabled(driveByEarEnabled);
 // }
 
 const { installSteeringLimitWarning } = await import(
-  withBuild('./ui/steering-limit-warning.js')
+  withBuild('./ui/steering-limit-warning.js?revision=r164-post-soak')
 );
 installSteeringLimitWarning();
 
@@ -272,7 +272,7 @@ installHarborHiddenFaceOrientation();
 // lot-enhancement-runtime.js?revision=r121&trophy-road=r154
 // lot-enhancement-runtime.js?revision=r121&trophy-road=r157
 const { installLotEnhancementRuntime } = await import(
-  withBuild('./garage/lot-enhancement-runtime.js?revision=r163-native-picker-parent-click')
+  withBuild('./garage/lot-enhancement-runtime.js?revision=r164-post-soak')
 );
 installLotEnhancementRuntime();
 
@@ -301,7 +301,7 @@ installTrackIntroCamera();
 // render/world.js?revision=r174-bella-siren-zone
 await Promise.all([
   import(withBuild('./render/world.js?revision=r164-long-session-robustness')),
-  import(withBuild('./ui/spectate.js')),
+  import(withBuild('./ui/spectate.js?revision=r164-elevation-aware')),
   import(withBuild('./ui/back-to-lot.js'))
 ]);
 

--- a/turn/app.js
+++ b/turn/app.js
@@ -271,6 +271,7 @@ installHarborHiddenFaceOrientation();
 // Historical regression markers for established Trophy Road Lot enhancement bundles:
 // lot-enhancement-runtime.js?revision=r121&trophy-road=r154
 // lot-enhancement-runtime.js?revision=r121&trophy-road=r157
+// lot-enhancement-runtime.js?revision=r163-native-picker-parent-click
 const { installLotEnhancementRuntime } = await import(
   withBuild('./garage/lot-enhancement-runtime.js?revision=r164-post-soak')
 );

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -1,6 +1,7 @@
 import { installLotStatLegend } from './lot-stat-legend.js?build=20260724-r59';
 import { installLotLayout } from './lot-layout-r60.js?build=20260729-r116';
 import { installLotAccessibility } from './lot-accessibility-r118.js?build=20260729-r118';
+// Historical regression marker: lot-perk-disclosure.js?revision=r164-vintage-rally-perks
 import { installLotPerkDisclosure } from './lot-perk-disclosure.js?revision=r164-post-soak';
 import { gateLotNow } from '../progression/lot-trophy-gate.js?revision=r164-vintage-rally-perks';
 import { gateLotPaintNow } from '../progression/lot-paint-reward.js?revision=r164-perks';

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -1,7 +1,7 @@
 import { installLotStatLegend } from './lot-stat-legend.js?build=20260724-r59';
 import { installLotLayout } from './lot-layout-r60.js?build=20260729-r116';
 import { installLotAccessibility } from './lot-accessibility-r118.js?build=20260729-r118';
-import { installLotPerkDisclosure } from './lot-perk-disclosure.js?revision=r164-vintage-rally-perks';
+import { installLotPerkDisclosure } from './lot-perk-disclosure.js?revision=r164-post-soak';
 import { gateLotNow } from '../progression/lot-trophy-gate.js?revision=r164-vintage-rally-perks';
 import { gateLotPaintNow } from '../progression/lot-paint-reward.js?revision=r164-perks';
 

--- a/turn/garage/lot-perk-disclosure.js
+++ b/turn/garage/lot-perk-disclosure.js
@@ -1,4 +1,5 @@
 import { getCarDefinition } from '../vehicle/catalog.js?revision=r164-vintage-rally-polish';
+import { vehiclePerkPresentation } from '../vehicle/perk-presentation.js?revision=r164-post-soak';
 
 const STYLE_ID = 'turn-lot-perk-inline-styles';
 
@@ -59,7 +60,7 @@ export function installLotPerkDisclosure(root = document.body) {
 
   function sync() {
     const vehicleId = selectedVehicleId(screen);
-    const vehiclePerk = getCarDefinition(vehicleId)?.perk;
+    const vehiclePerk = vehiclePerkPresentation(vehicleId, getCarDefinition(vehicleId)?.perk);
     const perkTitle = vehiclePerk?.title || '';
     const perkDescription = vehiclePerk?.description || '';
     const perkText = perkTitle && perkDescription

--- a/turn/index.html
+++ b/turn/index.html
@@ -81,7 +81,7 @@
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/achievements/trophy-road-showcase.js?revision=r160-reward-detail-sync": "/turn/achievements/trophy-road-showcase.js?revision=r164-long-session-robustness",
-        "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-production",
+        "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-post-soak",
         "/turn/render/covered-rendering.js?build=20260811-r164": "/turn/render/covered-rendering.js?build=20260811-r164&revision=r164-long-session-robustness",
         "./garage/lot-accessibility-r118.js?build=20260729-r118": "./garage/lot-accessibility-r118.js?build=20260811-r164&revision=r163-voiceover-first-lot-focus",
         "./garage/lot-enhancement-runtime.js?revision=r163-native-picker-parent-click&build=20260809-r163": "./garage/lot-enhancement-runtime.js?build=20260811-r164&revision=r164-perk-observer-hotfix",
@@ -159,7 +159,7 @@
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button" aria-label="Restart the current lap from the start line">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
   <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260811-r164-r168-shared-about-credits"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
-  <script type="module" src="./app.js?build=20260811-r164-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r420-music-warm-r426-loading-copy-r164-long-session-robustness"></script>
+  <script type="module" src="./app.js?build=20260811-r164-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r420-music-warm-r426-loading-copy-r164-long-session-robustness-post-soak"></script>
   <script type="module" src="./input/qe-drive-controls-bootstrap.js?revision=r418-qe"></script>
   <script type="module" src="./ui/r411-race-controls.js?revision=r411"></script>
   <script type="module" src="./accessibility/color-accessibility-r163.js?build=20260811-r164-paint-basics"></script>

--- a/turn/index.html
+++ b/turn/index.html
@@ -76,6 +76,7 @@
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
+        "/turn/input/motion.js": "/turn/input/motion.js?revision=r164-ipad-motion-profile",
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
         "/turn/audio/racing-music-v2.js?build=20260811-r164-racing-music-warm-v2": "/turn/audio/racing-music-v3.js?revision=blob-8319c3923e0a",
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",

--- a/turn/input/motion.js
+++ b/turn/input/motion.js
@@ -1,8 +1,45 @@
 import { getTurnPlatform } from '../platform/platform-context.js';
 
-const STEERING_ENTER_THRESHOLD = degToRad(2.2);
-const STEERING_EXIT_THRESHOLD = degToRad(0.9);
 const MAX_CONFIGURED_SAFE_ZONE_DEGREES = 45;
+
+const DEFAULT_STEERING_PROFILE = Object.freeze({
+  id: 'default',
+  steeringEnterThreshold: degToRad(2.2),
+  steeringExitThreshold: degToRad(0.9),
+  rollFollowRate: 16,
+  pitchFollowRate: 12,
+  steeringResponseRate: 8.5,
+  steeringReleaseRate: 12,
+  curvePower: 1
+});
+
+const IPAD_STEERING_PROFILE = Object.freeze({
+  id: 'ipad-damped',
+  steeringEnterThreshold: degToRad(3.2),
+  steeringExitThreshold: degToRad(1.4),
+  rollFollowRate: 10.5,
+  pitchFollowRate: 12,
+  steeringResponseRate: 6.5,
+  steeringReleaseRate: 10,
+  curvePower: 1.22
+});
+
+export function resolveMotionSteeringProfile(environment = globalThis) {
+  const navigatorRef = environment?.navigator || environment;
+  const userAgent = String(navigatorRef?.userAgent || '');
+  const platform = String(navigatorRef?.platform || '');
+  const maxTouchPoints = Math.max(0, Number(navigatorRef?.maxTouchPoints) || 0);
+  const reportsIPad = /\biPad\b/i.test(userAgent);
+  const reportsDesktopIPad = platform === 'MacIntel'
+    && maxTouchPoints > 1
+    && /\bMacintosh\b/i.test(userAgent);
+
+  return reportsIPad || reportsDesktopIPad
+    ? IPAD_STEERING_PROFILE
+    : DEFAULT_STEERING_PROFILE;
+}
+
+const ACTIVE_STEERING_PROFILE = resolveMotionSteeringProfile();
 
 export function motionPoseFromGravity(event) {
   const gravity = event?.accelerationIncludingGravity;
@@ -34,7 +71,12 @@ export function resolveSteeringRollLimit(
   return Number.isFinite(fallback) && fallback > 0 ? fallback : degToRad(14);
 }
 
-export function updateMotionInputState({ state, dt, maxSteerRoll }) {
+export function updateMotionInputState({
+  state,
+  dt,
+  maxSteerRoll,
+  steeringProfile = ACTIVE_STEERING_PROFILE
+}) {
   if (!state.sensorMode) {
     // Manual input is expressed in screen space (left = -1, right = +1), while
     // TURN's vehicle yaw convention uses the opposite sign.
@@ -43,8 +85,13 @@ export function updateMotionInputState({ state, dt, maxSteerRoll }) {
     return;
   }
 
-  state.roll += shortestAngle(state.roll, state.targetRoll) * Math.min(1, dt * 16);
-  state.pitch = lerp(state.pitch, state.targetPitch, Math.min(1, dt * 12));
+  state.roll += shortestAngle(state.roll, state.targetRoll)
+    * Math.min(1, dt * steeringProfile.rollFollowRate);
+  state.pitch = lerp(
+    state.pitch,
+    state.targetPitch,
+    Math.min(1, dt * steeringProfile.pitchFollowRate)
+  );
 
   const steeringRoll = normalizeAngle(state.roll - state.neutralRoll);
   const steeringMagnitude = Math.abs(steeringRoll);
@@ -53,24 +100,30 @@ export function updateMotionInputState({ state, dt, maxSteerRoll }) {
   state.steeringEngaged ??= false;
 
   if (state.steeringEngaged) {
-    if (steeringMagnitude < STEERING_EXIT_THRESHOLD) state.steeringEngaged = false;
-  } else if (steeringMagnitude > STEERING_ENTER_THRESHOLD) {
+    if (steeringMagnitude < steeringProfile.steeringExitThreshold) state.steeringEngaged = false;
+  } else if (steeringMagnitude > steeringProfile.steeringEnterThreshold) {
     state.steeringEngaged = true;
   }
 
   let desiredSteering = 0;
   if (state.steeringEngaged) {
-    const availableRoll = Math.max(0.001, steeringRollLimit - STEERING_EXIT_THRESHOLD);
+    const availableRoll = Math.max(
+      0.001,
+      steeringRollLimit - steeringProfile.steeringExitThreshold
+    );
     const linearSteer = clamp(
-      (steeringMagnitude - STEERING_EXIT_THRESHOLD) / availableRoll,
+      (steeringMagnitude - steeringProfile.steeringExitThreshold) / availableRoll,
       0,
       1
     );
-    const easedSteer = linearSteer * linearSteer * (3 - 2 * linearSteer);
+    const curvedSteer = Math.pow(linearSteer, steeringProfile.curvePower);
+    const easedSteer = curvedSteer * curvedSteer * (3 - 2 * curvedSteer);
     desiredSteering = -Math.sign(steeringRoll) * easedSteer;
   }
 
-  const steeringResponseRate = state.steeringEngaged ? 8.5 : 12;
+  const steeringResponseRate = state.steeringEngaged
+    ? steeringProfile.steeringResponseRate
+    : steeringProfile.steeringReleaseRate;
   const steeringResponse = 1 - Math.exp(-dt * steeringResponseRate);
   state.steering = lerp(state.steering, desiredSteering, steeringResponse);
 

--- a/turn/progression/trophy-road-chromatic-r183.js
+++ b/turn/progression/trophy-road-chromatic-r183.js
@@ -1,2 +1,46 @@
-export const TROPHY_ROAD_MAX_THRESHOLD = 1750;
+import {
+  TROPHY_ROAD_REWARDS as BASE_TROPHY_ROAD_REWARDS
+} from './trophy-road.js?revision=r164-vintage-rally-perks';
+import {
+  FUTURE_RACER_REWARD_PERK_DESCRIPTION
+} from '../vehicle/perk-presentation.js?revision=r164-post-soak';
+
 export * from './trophy-road.js?revision=r164-vintage-rally-perks';
+
+export const TROPHY_ROAD_MAX_THRESHOLD = 1750;
+
+export const TROPHY_ROAD_REWARDS = Object.freeze(BASE_TROPHY_ROAD_REWARDS.map((reward) => {
+  if (reward.id !== 'future-racer') return reward;
+  return Object.freeze({
+    ...reward,
+    perkDescription: FUTURE_RACER_REWARD_PERK_DESCRIPTION,
+    description: `Unlock the Future Racer: built for advanced time trials.<br><strong>OVERDRIVE:</strong> ${FUTURE_RACER_REWARD_PERK_DESCRIPTION}`
+  });
+}));
+
+const REWARD_BY_ID = new Map(TROPHY_ROAD_REWARDS.map((reward) => [reward.id, reward]));
+const REWARD_BY_TRACK = new Map(
+  TROPHY_ROAD_REWARDS.filter((reward) => reward.trackId).map((reward) => [reward.trackId, reward])
+);
+const REWARD_BY_VEHICLE = new Map(
+  TROPHY_ROAD_REWARDS.flatMap((reward) => (reward.vehicleIds || []).map((vehicleId) => [vehicleId, reward]))
+);
+const REWARD_BY_FEATURE = new Map(
+  TROPHY_ROAD_REWARDS.filter((reward) => reward.featureId).map((reward) => [reward.featureId, reward])
+);
+
+export function getTrophyRoadReward(id) {
+  return REWARD_BY_ID.get(id) || null;
+}
+
+export function rewardForTrack(trackId) {
+  return REWARD_BY_TRACK.get(trackId) || null;
+}
+
+export function rewardForVehicle(vehicleId) {
+  return REWARD_BY_VEHICLE.get(vehicleId) || null;
+}
+
+export function rewardForFeature(featureId) {
+  return REWARD_BY_FEATURE.get(featureId) || null;
+}

--- a/turn/ui/spectate.js
+++ b/turn/ui/spectate.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { GAME_MODE } from '../race/game-state.js';
 import { replayFrameAt } from '../race/replay-system.js';
+import { trackPitch, trackSampleAtProgress, trackSurfaceY } from '../tracks/elevation.js?build=20260811-r164';
 
 const spectate = {
   active: false,
@@ -38,6 +39,12 @@ function install(runtime) {
   installUi(runtime);
 }
 
+function replaySurfaceSample(runtime, frame) {
+  return trackSampleAtProgress(runtime.samples, frame?.p)
+    || runtime.findNearestTrack?.(frame)?.sample
+    || null;
+}
+
 function updateSpectatorScene(runtime, dt) {
   if (!spectate.active) return false;
 
@@ -73,8 +80,10 @@ function updateSpectatorScene(runtime, dt) {
       continue;
     }
 
+    const surfaceSample = replaySurfaceSample(runtime, frame);
     car.visible = true;
-    car.position.set(frame.x, 0.18, frame.z);
+    car.position.set(frame.x, trackSurfaceY(surfaceSample), frame.z);
+    car.rotation.x = trackPitch(surfaceSample);
     car.rotation.y = frame.h + Math.PI;
     car.rotation.z = -frame.s * 0.03;
     if (car === ghostCar) animateWheels(car, frame.s, 45, dt);
@@ -84,15 +93,17 @@ function updateSpectatorScene(runtime, dt) {
   const frame = lap ? replayFrameAt(lap, spectate.elapsed) : null;
   if (!frame) return true;
 
-  const focus = new THREE.Vector3(frame.x, 0.18, frame.z);
+  const surfaceSample = replaySurfaceSample(runtime, frame);
+  const surfaceY = trackSurfaceY(surfaceSample);
+  const focus = new THREE.Vector3(frame.x, surfaceY, frame.z);
   const forward = new THREE.Vector3(Math.sin(frame.h), 0, Math.cos(frame.h));
   const desiredCamera = focus.clone().addScaledVector(forward, -18.5);
-  desiredCamera.y = 8.6;
+  desiredCamera.y = surfaceY + 8.6;
   cameraPosition.lerp(desiredCamera, 1 - Math.exp(-dt * 7.2));
   camera.position.copy(cameraPosition);
 
   const desiredTarget = focus.clone().addScaledVector(forward, 13.5);
-  desiredTarget.y = 2.15;
+  desiredTarget.y = surfaceY + 2.15;
   cameraTarget.lerp(desiredTarget, 1 - Math.exp(-dt * 9));
   camera.up.set(0, 1, 0);
   camera.lookAt(cameraTarget);
@@ -261,7 +272,7 @@ function spectateDateLabel(lap, allLaps) {
   }
 
   const duplicateDate = allLaps.filter((other) => {
-    const otherHitAt = other?.hitAt == null ? NaN : Number(other.hitAt);
+    const otherHitAt = other?.hitAt == null ? NaN : Number(otherHitAt);
     return Number.isFinite(otherHitAt) && sameDate(new Date(otherHitAt), date);
   }).length > 1;
 

--- a/turn/ui/steering-limit-warning.js
+++ b/turn/ui/steering-limit-warning.js
@@ -1,4 +1,5 @@
 const LIMIT_EVENT = 'turn:steering-limit-feedback';
+const HARD_LIMIT_CUE_HOLD_MS = 320;
 const SECOND_TONE_DELAY_MS = 90;
 const MIN_VISIBLE_OPACITY = 0.08;
 const MIN_VISIBLE_GROWTH = 0.3;
@@ -50,6 +51,9 @@ export function installSteeringLimitWarning() {
 
   const announcedSides = { left: false, right: false };
   let audioTimer = 0;
+  let hardCueTimer = 0;
+  let pendingHardSide = null;
+  let currentHardSide = null;
   let animationFrame = 0;
   let previousFrameTime = 0;
 
@@ -146,10 +150,18 @@ export function installSteeringLimitWarning() {
     if (!animationFrame) animationFrame = window.requestAnimationFrame(animateVisuals);
   }
 
+  function cancelPendingHardCue() {
+    window.clearTimeout(hardCueTimer);
+    hardCueTimer = 0;
+    pendingHardSide = null;
+  }
+
   function resetRaceAnnouncements() {
     announcedSides.left = false;
     announcedSides.right = false;
     announcer.textContent = '';
+    currentHardSide = null;
+    cancelPendingHardCue();
   }
 
   function playLimitCue() {
@@ -170,12 +182,27 @@ export function installSteeringLimitWarning() {
     });
   }
 
+  function scheduleHardCue(side) {
+    if (pendingHardSide === side && hardCueTimer) return;
+    cancelPendingHardCue();
+    pendingHardSide = side;
+    hardCueTimer = window.setTimeout(() => {
+      hardCueTimer = 0;
+      pendingHardSide = null;
+      if (currentHardSide !== side) return;
+      playLimitCue();
+      announceLimit(side);
+    }, HARD_LIMIT_CUE_HOLD_MS);
+  }
+
   function handleLimitFeedback(event) {
     const detail = event.detail || {};
     const side = detail.side === 'left' || detail.side === 'right' ? detail.side : null;
     const now = currentTime();
 
     if (!detail.active || !side) {
+      currentHardSide = null;
+      cancelPendingHardCue();
       scheduleSoftRelease(states.left, now);
       scheduleSoftRelease(states.right, now);
       requestVisualAnimation();
@@ -188,9 +215,14 @@ export function installSteeringLimitWarning() {
     setHiddenTarget(inactiveState);
     requestVisualAnimation();
 
-    if (detail.enteredHard) {
-      playLimitCue();
-      announceLimit(side);
+    if (detail.hard) {
+      if (currentHardSide !== side || detail.enteredHard) {
+        currentHardSide = side;
+        scheduleHardCue(side);
+      }
+    } else {
+      currentHardSide = null;
+      cancelPendingHardCue();
     }
   }
 
@@ -201,6 +233,8 @@ export function installSteeringLimitWarning() {
     if (!event.detail?.running) {
       window.clearTimeout(audioTimer);
       audioTimer = 0;
+      currentHardSide = null;
+      cancelPendingHardCue();
       resetVisualsImmediately();
       announcer.textContent = '';
     }

--- a/turn/vehicle/perk-presentation.js
+++ b/turn/vehicle/perk-presentation.js
@@ -1,0 +1,14 @@
+export const FUTURE_RACER_REWARD_PERK_DESCRIPTION =
+  'After a few seconds of clean driving on-track the speed cap starts increasing. Going off-track resets it.';
+
+export const FUTURE_RACER_CAR_PERK_DESCRIPTION =
+  'A few seconds of staying on-track raises speed cap. Going off-track resets it.';
+
+export function vehiclePerkPresentation(vehicleId, perk) {
+  if (!perk) return null;
+  if (vehicleId !== 'race-future') return perk;
+  return Object.freeze({
+    ...perk,
+    description: FUTURE_RACER_CAR_PERK_DESCRIPTION
+  });
+}


### PR DESCRIPTION
## TURN post-optimisation soak follow-up

Corrective follow-up to #441 based on the successful iPhone production soak and the subsequent iPad 9 compatibility test.

### Cliffside spectate elevation
Spectate still had a pre-elevation flat-track assumption: replay cars were forced to `y = 0.18`, while the spectate camera and target also used absolute flat-world heights. Normal rivals already follow the track elevation model.

Fix:
- resolve each replay frame against the track sample/progress
- place spectated cars at `trackSurfaceY(...)`
- apply `trackPitch(...)` to the replay car
- position the chase camera and target relative to the current road height
- preserve nearest-track fallback for older/malformed replay frames

This fixes spectated cars/camera appearing below Cliffside terrain without changing replay data or race physics.

### Max-steering cue debounce
The steering thresholds and warning code were unchanged by #441. Historical review confirmed that the audible hard-limit cue has always fired immediately on entering the hard boundary.

Fix:
- visual edge feedback remains immediate
- hard-limit audio + screen-reader announcement now require **320 ms of continuous max steering**
- the pending cue is cancelled if steering eases below hard max, clears, or changes side
- sustained max steering still produces the established subtle cue
- the canonical 24° max steering/safe-zone boundary is unchanged

### iPad motion profile
The iPad 9 performance soak passed, but the recording showed noticeably more nervous motion steering than on the newer iPhone. WebKit does not reliably expose an exact iPad model; modern iPadOS may identify as either `iPad` or a touch-capable `MacIntel` device.

Rather than touching the established phone steering, the motion module now selects one of two explicit profiles:

**Default / iPhone profile — unchanged values**
- steering engage: 2.2°
- steering release: 0.9°
- roll follow: 16
- steering response: 8.5 / 12
- curve power: 1.0

**iPad-only damped profile**
- steering engage: 3.2°
- steering release: 1.4°
- roll follow: 10.5
- steering response: 6.5 / 10
- curve power: 1.22

The iPad profile adds a little more centre hysteresis, temporal damping and a softer mid-range response. It still reaches full steering at the same canonical **24°** boundary. Calibration, motion-axis mapping, vehicle physics, camera and the newer-iPhone/default steering path are not changed.

Detection is deliberately narrow: explicit `iPad`, or `MacIntel` + touch points + Macintosh UA. An ordinary Mac remains on the default path.

### Future Racer OVERDRIVE copy
Presentation-only copy update; OVERDRIVE mechanics are unchanged.

Trophy Road unlock info:
> **OVERDRIVE:** After a few seconds of clean driving on-track the speed cap starts increasing. Going off-track resets it.

The Lot car info:
> **OVERDRIVE:** A few seconds of staying on-track raises speed cap. Going off-track resets it.

Other vehicle perk copy remains unchanged.

### Cache safety
Fresh production/LAB routes are used for the changed app, steering warning, spectate, Lot perk, Trophy Road presentation and motion-input modules. Version/build remains TURN 1.8.0 r164.

### Regression coverage
`turn-tests/post-soak-production.mjs` is part of the full TURN workflow and covers:
- elevation-aware spectate cars + camera
- absence of the old flat `0.18` spectate placement
- sustained hard-limit debounce and cancellation
- exact new Future Racer copy in both contexts
- unchanged non-Future perk presentation
- iPad detection in both legacy `iPad` and modern desktop-UA forms
- ordinary Mac exclusion
- exact pinning of all established default/iPhone motion constants
- materially calmer iPad mid-range response
- full iPad steering still reached at 24°
- fresh production/LAB cache routes

No music/audio engine, optimisation profile, vehicle physics/balance, progression ownership, accessibility feature, or release-version changes are included.