### PR TITLE
Keep The Lot race action inside the viewport

### DIFF
--- a/turn-lab/tests/lot-layout-production.mjs
+++ b/turn-lab/tests/lot-layout-production.mjs
@@ -125,6 +125,31 @@ assert.doesNotMatch(layout, /MutationObserver|setAnimationLoop|requestAnimationF
 assert.match(layoutCss, /\.lot-a11y-only \{[\s\S]*clip-path: inset\(50%\)/);
 assert.match(layoutCss, /--lot-paint-rail-height: 54px/);
 assert.match(layoutCss, /min-height: clamp\(150px, 28vh, 230px\)/);
+assert.match(
+  layoutCss,
+  /\.lot-side \{[\s\S]*--lot-viewbox-min-height: clamp\(150px, 28vh, 230px\);[\s\S]*--lot-side-gap: 10px/,
+  'The details card must derive its viewport budget from the protected 3D preview and rail gap'
+);
+assert.match(
+  layoutCss,
+  /\.lot-card \{[\s\S]*max-height: calc\(100% - var\(--lot-viewbox-min-height\) - var\(--lot-side-gap\)\);[\s\S]*overflow-y: auto;[\s\S]*overscroll-behavior: contain/,
+  'Growing descriptions, perks and future detail rows must overflow inside the card rather than below the viewport'
+);
+assert.match(
+  layoutCss,
+  /\.lot-card-actions \{[\s\S]*position: sticky;[\s\S]*bottom: 0;/,
+  'Race This Car must remain visible at the bottom of a constrained details card'
+);
+assert.match(
+  layoutCss,
+  /@media \(max-height: 520px\)[\s\S]*--lot-viewbox-min-height: 140px;[\s\S]*--lot-side-gap: 7px/,
+  'Short tablet landscapes must keep the card budget aligned with the compact viewer and gap'
+);
+assert.match(
+  layoutCss,
+  /@media \(max-height: 430px\)[\s\S]*--lot-viewbox-min-height: 120px;[\s\S]*--lot-side-gap: 7px/,
+  'Short iPhone landscapes must keep the card budget aligned with the compact viewer and gap'
+);
 assert.match(layoutCss, /\.lot-viewbox-with-paint \.lot-colors \{[\s\S]*border-top: 3px solid var\(--ink\)/);
 assert.doesNotMatch(layoutCss, /\.lot-color-input|\.lot-color-preset/);
 assert.match(layoutCss, /\.lot-race \{[\s\S]*background: var\(--pink\)/);
@@ -150,4 +175,4 @@ assert.match(legend, /role', 'dialog'/);
 assert.match(legend, /name\.textContent = entry\.label/);
 assert.match(legend, /description\.textContent = entry\.description/);
 
-console.log(`TURN ${release.id} compact optimized Lot layout, car-owned named perks and accessibility contract passed.`);
+console.log(`TURN ${release.id} compact optimized Lot layout, bounded details card, car-owned named perks and accessibility contract passed.`);

--- a/turn/garage/lot-layout-r60.css
+++ b/turn/garage/lot-layout-r60.css
@@ -11,6 +11,11 @@
   white-space: nowrap !important;
 }
 
+.lot-side {
+  --lot-viewbox-min-height: clamp(150px, 28vh, 230px);
+  --lot-side-gap: 10px;
+}
+
 .lot-viewbox-with-paint {
   --lot-paint-rail-height: 54px;
   flex: 1 1 auto;
@@ -125,13 +130,35 @@
   flex-direction: column;
 }
 
+.lot-screen.is-super-sedan-unlocked .lot-side {
+  --lot-viewbox-min-height: clamp(132px, 22vh, 176px);
+}
+
 .lot-screen.is-super-sedan-unlocked .lot-viewbox-with-paint {
   min-height: clamp(132px, 22vh, 176px);
 }
 
+/*
+  The side rail is viewport-bounded. Copy can grow as cars gain perks, secrets,
+  translated labels or larger text, so the information card must yield before
+  it can push the primary action below the screen. The 3D panel keeps its
+  protected minimum; overflow stays inside the card as a last-resort fallback.
+*/
+.lot-card {
+  min-height: 0;
+  max-height: calc(100% - var(--lot-viewbox-min-height) - var(--lot-side-gap));
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
 .lot-card-actions {
+  position: sticky;
+  z-index: 2;
+  bottom: 0;
   grid-template-columns: 1fr;
   margin-top: 4px;
+  background: rgb(255 248 232 / 0.98);
 }
 
 .lot-race {
@@ -140,6 +167,8 @@
 
 @media (max-height: 520px) {
   .lot-side {
+    --lot-viewbox-min-height: 140px;
+    --lot-side-gap: 7px;
     top: max(62px, calc(env(safe-area-inset-top) + 54px));
     gap: 7px;
   }
@@ -152,6 +181,10 @@
   .lot-viewbox-with-paint {
     --lot-paint-rail-height: 50px;
     min-height: 140px;
+  }
+
+  .lot-screen.is-super-sedan-unlocked .lot-side {
+    --lot-viewbox-min-height: 112px;
   }
 
   .lot-screen.is-super-sedan-unlocked .lot-viewbox-with-paint {
@@ -229,10 +262,19 @@
 }
 
 @media (max-height: 430px) {
+  .lot-side {
+    --lot-viewbox-min-height: 120px;
+    --lot-side-gap: 7px;
+  }
+
   .lot-viewbox-with-paint {
     --lot-paint-rail-height: 47px;
     min-height: 120px;
     flex-basis: auto;
+  }
+
+  .lot-screen.is-super-sedan-unlocked .lot-side {
+    --lot-viewbox-min-height: 96px;
   }
 
   .lot-screen.is-super-sedan-unlocked .lot-viewbox-with-paint {


### PR DESCRIPTION
## Problem
A tester found that `RACE THIS CAR` can slip partly below the viewport when a car has both its normal description and an inline perk description. The previous Super Sedan fix handled one known tall-card case, but the underlying rail still allowed future detail content to grow beyond the fixed viewport.

## Fix
Make this a generic layout contract rather than another car-specific exception:

- keep the existing protected minimum height for the 3D/paint panel
- give the details card an explicit maximum height based on that protected preview plus the rail gap
- allow only the details card to scroll when copy genuinely exceeds the available space
- keep the `RACE THIS CAR` action sticky at the bottom of that bounded card, so the primary action remains in the viewport
- keep the existing short-landscape and Super Sedan preview minima in sync with the same card-height budget

This applies to ordinary descriptions, current/future perks, the Super Sedan notice, larger text, and other future detail rows without special-casing Rally Racer.

## Regression
Extend the compact Lot layout contract to require:

- a viewport-derived details-card height budget
- contained vertical overflow instead of rail overflow
- a sticky race action
- matching tablet/iPhone compact-height budgets

No vehicle tuning, progression, paint behavior, accessibility semantics, or race behavior changes.