### PR TITLE
Tighten The Lot sticky race action spacing

### DIFF
--- a/turn-lab/tests/lot-layout-production.mjs
+++ b/turn-lab/tests/lot-layout-production.mjs
@@ -142,6 +142,11 @@ assert.match(
 );
 assert.match(
   layoutCss,
+  /\.lot-card-actions \{[\s\S]*margin: 1px -6px -3px;[\s\S]*padding: 0 6px 3px;[\s\S]*background: transparent;/,
+  'The sticky Race This Car shell must stay close to the button instead of masking stats with a broad opaque band'
+);
+assert.match(
+  layoutCss,
   /@media \(max-height: 520px\)[\s\S]*--lot-viewbox-min-height: 140px;[\s\S]*--lot-side-gap: 7px/,
   'Short tablet landscapes must keep the card budget aligned with the compact viewer and gap'
 );
@@ -175,4 +180,4 @@ assert.match(legend, /role', 'dialog'/);
 assert.match(legend, /name\.textContent = entry\.label/);
 assert.match(legend, /description\.textContent = entry\.description/);
 
-console.log(`TURN ${release.id} compact optimized Lot layout, bounded details card, car-owned named perks and accessibility contract passed.`);
+console.log(`TURN ${release.id} compact optimized Lot layout, bounded details card, compact sticky race action, car-owned named perks and accessibility contract passed.`);

--- a/turn/garage/lot-layout-r60.css
+++ b/turn/garage/lot-layout-r60.css
@@ -152,13 +152,19 @@
   -webkit-overflow-scrolling: touch;
 }
 
+/*
+  Keep the sticky action footprint close to the button itself. The negative
+  edge margins reclaim most of the card padding while the transparent shell
+  avoids masking stats as they pass behind the sticky action during scrolling.
+*/
 .lot-card-actions {
   position: sticky;
   z-index: 2;
   bottom: 0;
   grid-template-columns: 1fr;
-  margin-top: 4px;
-  background: rgb(255 248 232 / 0.98);
+  margin: 1px -6px -3px;
+  padding: 0 6px 3px;
+  background: transparent;
 }
 
 .lot-race {
@@ -257,7 +263,8 @@
   }
 
   .lot-card-actions {
-    margin-top: 3px;
+    margin: 1px -5px -3px;
+    padding: 0 5px 3px;
   }
 }
 
@@ -310,6 +317,7 @@
   }
 
   .lot-card-actions {
-    margin-top: 2px;
+    margin: 1px -5px -2px;
+    padding: 0 5px 2px;
   }
 }


### PR DESCRIPTION
## Follow-up to #443
The sticky `RACE THIS CAR` action now stays visible, but tester screenshots show that the sticky shell itself reserves/paints more space around the button than necessary and can visually cover the lower attribute rows while scrolling.

## Change
- keep the button sticky and fully reachable
- shrink the sticky shell to a 1px top gap and a very small bottom inset
- reclaim most of the surrounding card padding with controlled negative edge margins
- make the sticky shell transparent so only the actual button masks content while stats scroll behind it
- tighten the same spacing further on short iPhone/iPad landscape heights

The button size itself is unchanged, so the touch target remains intact.

## Regression
The Lot layout regression now explicitly protects the compact sticky shell and transparent background in addition to the viewport-bounded card contract from #443.