### PR TITLE
Orchestrate the TURN menu theme with score v2

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -68,7 +68,7 @@
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/turn/input/motion.js": "/turn/input/motion.js?revision=r164-ipad-motion-profile",
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
-        "/turn/audio/racing-music-v2.js?build=20260811-r164-racing-music-warm-v2": "/turn/audio/racing-music-v5.js?revision=r184-score-v2",
+        "/turn/audio/racing-music-v2.js?build=20260811-r164-racing-music-warm-v2": "/turn/audio/racing-music-v5.js?revision=r185-menu-orchestration",
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/achievements/trophy-road-showcase.js?revision=r160-reward-detail-sync": "/turn/achievements/trophy-road-showcase.js?revision=r164-long-session-robustness",

--- a/turn-tests/racing-music-production.mjs
+++ b/turn-tests/racing-music-production.mjs
@@ -54,39 +54,56 @@ function importMapImports(source) {
 
 const release = JSON.parse(releaseSource);
 const musicSpecifier = `/turn/audio/racing-music-v2.js?build=${release.cacheKey}-racing-music-warm-v2`;
-const expectedMusicTarget = '/turn/audio/racing-music-v5.js?revision=r184-score-v2';
+const expectedMusicTarget = '/turn/audio/racing-music-v5.js?revision=r185-menu-orchestration';
 const productionImports = importMapImports(index);
 const labImports = importMapImports(labIndex);
 
 assert.match(homeLayout, /audio\/racing-music-v2\.js\?build=\$\{buildKey\}-racing-music-warm-v2/,
   'Home keeps the established release-derived compatibility specifier');
 assert.equal(productionImports[musicSpecifier], expectedMusicTarget,
-  'Production must route the compatibility specifier to the fresh score-v5 URL');
+  'Production must route the compatibility specifier to the fresh menu-orchestration URL');
 assert.equal(labImports[musicSpecifier], expectedMusicTarget,
-  'TURN LAB must exercise the same score-v5 engine');
+  'TURN LAB must exercise the same menu-orchestrated score-v5 engine');
 assert.doesNotMatch(index, /racing-music-v4\.js\?revision=track-songbook-20260813-v1/,
   'Production must not retain the stale score-v4 cache target');
 assert.doesNotMatch(labIndex, /racing-music-v4\.js\?revision=track-songbook-20260813-v1/,
   'TURN LAB must not retain the stale score-v4 cache target');
 
-for (const moduleName of ['songbook', 'tone-runtime', 'drum-runtime', 'instrument-bank', 'music-controls']) {
+assert.match(engine, /music\/songbook\.js\?revision=r185-menu-orchestration/,
+  'score-v5 must reload the songbook for the orchestrated menu theme');
+for (const moduleName of ['tone-runtime', 'drum-runtime', 'instrument-bank', 'music-controls']) {
   assert.match(engine, new RegExp(`music/${moduleName}\\.js\\?revision=r184-score-v2`),
-    `score-v5 must load ${moduleName} through the fresh music revision`);
+    `score-v5 must keep ${moduleName} on the current instrument-library revision`);
 }
 assert.match(engine, /music-controls\.css\?revision=r184-score-v2/,
-  'Music control CSS must also be cache-busted with the score');
+  'Music control CSS stays on the current score revision');
+assert.match(songbookSource, /menu-theme\.js\?revision=r185-menu-orchestration/,
+  'The songbook must not serve a cached pre-v2 menu theme');
 for (const trackFile of ['countryside', 'airport', 'cliffside', 'harbor', 'midnight-city']) {
   assert.match(songbookSource, new RegExp(`${trackFile}\\.js\\?revision=r184-score-v2`),
-    `${trackFile} must load through the fresh score revision`);
+    `${trackFile} must keep the approved score-v2 revision`);
 }
 
 assert.equal(MENU_SONG.id, 'menu');
 assert.equal(MENU_SONG.name, 'TURN Theme');
 assert.equal(MENU_SONG.bpm, 120, 'The approved UI theme stays at 120 BPM');
+assert.equal(MENU_SONG.key, 'E minor', 'The established menu theme keeps its tonal identity');
+assert.equal(MENU_SONG.style, 'warm arcade title anthem');
 assert.deepEqual(MENU_SONG.form, ['chorus', 'chorus', 'tune', 'tune', 'bridge', 'tune'],
   'The established UI theme keeps its C C T T B T form');
+assert.match(menuSource, /song-tools\.js\?revision=r185-menu-orchestration/,
+  'The menu theme must use the score-v2 section schema rather than its stale legacy import');
 assert.match(menuSource, /'E5', null, 'G5', 'B5', 'D6'/,
   'The established menu melody remains intact');
+const menuPalettes = Object.fromEntries(MENU_SONG.sections.map((section) => [
+  section.name,
+  `${section.leadVoice}/${section.bassVoice}/${section.arpVoice}/${section.drumKit}`
+]));
+assert.deepEqual(menuPalettes, {
+  tune: 'brass/warm/mandolin/classic',
+  bridge: 'reed/warm/organ/cinematic',
+  chorus: 'whistle/warm/glass/night'
+}, 'The same TURN theme notes must be re-orchestrated through three distinct score-v2 palettes');
 
 const expectedTrackIds = ['countryside', 'airport', 'cliffside', 'harbor', 'midnight-city'];
 assert.deepEqual(Object.keys(TRACK_SONGS), expectedTrackIds);

--- a/turn/audio/music/menu-theme.js
+++ b/turn/audio/music/menu-theme.js
@@ -1,8 +1,12 @@
-import { makeSection, makeSong } from './song-tools.js?revision=r165-track-songbook-v1';
+import { makeSection, makeSong } from './song-tools.js?revision=r185-menu-orchestration';
 
-// The established TURN theme, moved intact out of the audio engine.
+// The established TURN theme: note-for-note intact, newly orchestrated through score v2.
 const TUNE = makeSection({
   name: 'tune',
+  leadVoice: 'brass',
+  bassVoice: 'warm',
+  arpVoice: 'mandolin',
+  drumKit: 'classic',
   lead: [
     'E5', null, 'G5', 'B5', 'D6', null, 'B5', 'G5',
     'E5', null, 'G5', 'A5', 'B5', 'D6', 'E6', null,
@@ -47,6 +51,10 @@ const TUNE = makeSection({
 
 const BRIDGE = makeSection({
   name: 'bridge',
+  leadVoice: 'reed',
+  bassVoice: 'warm',
+  arpVoice: 'organ',
+  drumKit: 'cinematic',
   lead: [
     'G5', null, 'B5', 'D6', 'G6', 'F#6', 'D6', 'B5',
     'A5', 'B5', 'D6', 'E6', 'D6', 'B5', 'G5', null,
@@ -91,7 +99,10 @@ const BRIDGE = makeSection({
 
 const CHORUS = makeSection({
   name: 'chorus',
-  leadVoice: 'flute',
+  leadVoice: 'whistle',
+  bassVoice: 'warm',
+  arpVoice: 'glass',
+  drumKit: 'night',
   lead: [
     'E4', 'E4', 'G4', 'G4', 'B4', 'B4', 'G4', 'G4',
     'E5', 'E5', 'B4', 'B4', 'G4', 'G4', 'B4', 'B4',
@@ -138,6 +149,8 @@ export const MENU_SONG = makeSong({
   id: 'menu',
   name: 'TURN Theme',
   bpm: 120,
+  key: 'E minor',
+  style: 'warm arcade title anthem',
   sections: [TUNE, BRIDGE, CHORUS],
   arrangement: ['chorus', 'chorus', 'tune', 'tune', 'bridge', 'tune']
 });

--- a/turn/audio/music/songbook.js
+++ b/turn/audio/music/songbook.js
@@ -1,4 +1,4 @@
-import { MENU_SONG } from './menu-theme.js?revision=r165-track-songbook-v1';
+import { MENU_SONG } from './menu-theme.js?revision=r185-menu-orchestration';
 import { COUNTRYSIDE_SONG } from './countryside.js?revision=r184-score-v2';
 import { AIRPORT_SONG } from './airport.js?revision=r184-score-v2';
 import { CLIFFSIDE_SONG } from './cliffside.js?revision=r184-score-v2';

--- a/turn/audio/racing-music-v5.js
+++ b/turn/audio/racing-music-v5.js
@@ -1,4 +1,4 @@
-import { MENU_SONG, SONGBOOK, songForTrack } from './music/songbook.js?revision=r184-score-v2';
+import { MENU_SONG, SONGBOOK, songForTrack } from './music/songbook.js?revision=r185-menu-orchestration';
 import { createToneRuntime } from './music/tone-runtime.js?revision=r184-score-v2';
 import { createDrumRuntime } from './music/drum-runtime.js?revision=r184-score-v2';
 import { LEAD_VOICES, BASS_VOICES, ARP_VOICES, DRUM_KITS } from './music/instrument-bank.js?revision=r184-score-v2';

--- a/turn/index.html
+++ b/turn/index.html
@@ -78,7 +78,7 @@
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/turn/input/motion.js": "/turn/input/motion.js?revision=r164-ipad-motion-profile",
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
-        "/turn/audio/racing-music-v2.js?build=20260811-r164-racing-music-warm-v2": "/turn/audio/racing-music-v5.js?revision=r184-score-v2",
+        "/turn/audio/racing-music-v2.js?build=20260811-r164-racing-music-warm-v2": "/turn/audio/racing-music-v5.js?revision=r185-menu-orchestration",
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r183-production",
         "/turn/achievements/trophy-road-showcase.js?revision=r160-reward-detail-sync": "/turn/achievements/trophy-road-showcase.js?revision=r164-long-session-robustness",


### PR DESCRIPTION
## Summary
- Keep the established TURN menu theme note-for-note, at the same 120 BPM and the same C C T T B T six-part form.
- Re-orchestrate each existing section through the score-v2 instrument library:
  - Chorus: whistle lead, warm bass, glass texture, night kit.
  - Tune: brass lead, warm bass, mandolin texture, classic kit.
  - Bridge: reed lead, warm bass, organ texture, cinematic kit.
- Keep the bass voice in its original octave while using contrasting lead, texture and percussion colors around it.
- Give the theme score-v2 metadata (`E minor`, `warm arcade title anthem`).
- Fix the menu theme's stale legacy `song-tools` revision so those v2 section voices actually reach the runtime.
- Cache-bust the production and TURN LAB music chain through `r185-menu-orchestration` so existing PWAs do not keep serving the pre-orchestrated menu module.
- Extend the racing-music regression contract to protect the menu palette, form, melody fingerprint and cache routing.

No race-track notes, arrangements or instrument palettes are changed.