### PR TITLE
Polish TURN Music Tracker UX

### DIFF
--- a/turn/audio/music/index.html
+++ b/turn/audio/music/index.html
@@ -1,7 +1,194 @@
 <!doctype html>
-<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="theme-color" content="#08090a"><title>TURN Music Tracker</title><link rel="stylesheet" href="./tracker.css?revision=r187-music-tracker"></head><body><header class="app-header"><div><p class="eyebrow">TURN · MUSIC V2</p><h1>Music Tracker</h1><p class="lede">Compose against the real TURN instrument bank and hear changes immediately — no commits required.</p></div><a class="back-link" href="/turn/">Back to TURN</a></header><main>
-<section class="panel"><div class="section-heading"><div><p class="eyebrow">SOURCE</p><h2>Import / export</h2></div><p id="draftStatus" class="status-pill" role="status">Ready</p></div><div class="source-grid"><div class="source-card"><h3>Existing TURN song</h3><div class="inline-fields"><label class="grow"><span>Song</span><select id="songSelect"></select></label><button id="loadSongButton" class="button secondary" type="button">Load</button></div></div><div class="source-card"><h3>URL</h3><label><span>TURN song .js URL</span><input id="songUrl" type="url" placeholder="https://…/song.js"></label><button id="loadUrlButton" class="button secondary" type="button">Fetch &amp; parse</button><p class="hint">Remote source is parsed as text, never executed. GitHub blob URLs are converted to raw URLs automatically.</p></div><div class="source-card source-card-wide"><h3>Clipboard / pasted source</h3><textarea id="pasteSource" rows="5" spellcheck="false" placeholder="Paste a TURN song module here…"></textarea><div class="button-row"><button id="readClipboardButton" class="button secondary" type="button">Read clipboard</button><button id="loadPasteButton" class="button secondary" type="button">Load pasted source</button><button id="newSongButton" class="button ghost" type="button">New blank song</button></div></div><div class="source-card source-card-wide"><h3>Export</h3><div class="inline-fields"><label class="grow"><span>Filename</span><input id="filenameInput" type="text" value="new-song.js"></label><button id="copySourceButton" class="button secondary" type="button">Copy .js</button><button id="downloadSourceButton" class="button primary" type="button">Download .js</button></div><textarea id="exportPreview" rows="7" spellcheck="false" readonly aria-label="Generated TURN song JavaScript"></textarea></div></div></section>
-<section class="panel"><div class="section-heading"><div><p class="eyebrow">SONG</p><h2>Metadata &amp; arrangement</h2></div></div><div class="meta-grid"><label><span>ID</span><input id="metaId" type="text" value="new-song"></label><label><span>Name</span><input id="metaName" type="text" value="New TURN Song"></label><label><span>BPM</span><input id="metaBpm" type="number" min="70" max="180" value="120"></label><label><span>Key</span><input id="metaKey" type="text" value="C major"></label><label class="wide"><span>Style</span><input id="metaStyle" type="text"></label><label><span>Swing</span><input id="metaSwing" type="number" min="0" max="0.24" step="0.01" value="0"></label></div><div class="arrangement-wrap"><div><h3>Six-part arrangement</h3><p class="hint">T = tune · B = bridge · C = chorus</p></div><div id="arrangementControls" class="arrangement"></div><output id="arrangementText" class="arrangement-code">TTTBCC</output></div></section>
-<section class="panel"><div class="section-heading"><div><p class="eyebrow">SOUND BANK</p><h2>Instrument demos</h2></div><p id="demoStatus" class="hint" aria-live="polite">Push an instrument repeatedly: DO · RE · MI · FA · SOL · LA · TI · DO.</p></div><div id="instrumentDemos" class="instrument-demos"></div></section>
-<section class="panel tracker-panel"><div class="section-heading tracker-heading"><div><p class="eyebrow">TRACKER</p><h2>Part builder</h2></div><div class="transport"><button id="playSongButton" class="button play" type="button">▶ Song</button><button class="button play part-play" data-part="tune" type="button">▶ T</button><button class="button play part-play" data-part="bridge" type="button">▶ B</button><button class="button play part-play" data-part="chorus" type="button">▶ C</button><button id="stopButton" class="button stop" type="button">■ Stop</button></div></div><div class="tracker-toolbar"><fieldset class="channels"><legend>Channels</legend><label><input type="checkbox" data-channel="lead" checked> Lead</label><label><input type="checkbox" data-channel="bass" checked> Bass</label><label><input type="checkbox" data-channel="arp" checked> Arp</label><label><input type="checkbox" data-channel="drums" checked> Drums</label></fieldset><label class="loop-toggle"><input id="loopPlayback" type="checkbox" checked> Loop playback</label><p id="playStatus" class="play-status" aria-live="polite">Stopped</p></div><div class="part-tabs" role="tablist"><button class="part-tab active" data-part="tune" type="button">T · Tune</button><button class="part-tab" data-part="bridge" type="button">B · Bridge</button><button class="part-tab" data-part="chorus" type="button">C · Chorus</button></div><div class="part-settings"><label><span>Lead</span><select id="leadVoice"></select></label><label><span>Bass</span><select id="bassVoice"></select></label><label><span>Arp / texture</span><select id="arpVoice"></select></label><label><span>Drums</span><select id="drumKit"></select></label></div><div class="bar-toolbar"><button id="prevBarButton" class="button ghost" type="button">← Previous bar</button><strong id="barPosition">Bar 1 / 4</strong><button id="nextBarButton" class="button ghost" type="button">Next bar →</button><button id="addBarButton" class="button ghost" type="button">+ Bar</button><button id="removeBarButton" class="button ghost" type="button">− Bar</button><button id="copyBarButton" class="button ghost" type="button">Copy bar</button><button id="pasteBarButton" class="button ghost" type="button">Paste bar</button><button id="clearBarButton" class="button ghost danger-text" type="button">Clear bar</button></div><label class="harmony-field"><span>Harmony / chord for this bar</span><input id="barHarmony" type="text" placeholder="e.g. Em7"></label><div class="tracker-help"><span><kbd>↑</kbd><kbd>↓</kbd><kbd>←</kbd><kbd>→</kbd> move</span><span><kbd>Enter</kbd> advance</span><span><kbd>-</kbd> rest</span><span><kbd>=</kbd> tie</span><span>Piano keys: <kbd>Z</kbd>…<kbd>M</kbd> and <kbd>Q</kbd>…<kbd>U</kbd></span><span>Rows use tracker-style hex numbering.</span></div><div class="tracker-scroll" tabindex="0"><div class="tracker-grid tracker-grid-head"><div>ROW</div><div>LEAD</div><div>BASS</div><div>ARP</div><div>DRUMS</div></div><div id="trackerGrid"></div></div><div class="entry-pad"><div class="entry-pad-head"><div><h3>Quick entry</h3><p id="selectedCellLabel" class="hint">Lead · row 00</p></div><label id="octaveControl"><span>Octave</span><input id="entryOctave" type="number" min="0" max="8" value="5"></label></div><div id="noteButtons" class="note-buttons"></div><div id="drumButtons" class="note-buttons" hidden></div></div><details class="validation-panel"><summary>Validation</summary><pre id="validationOutput">Ready.</pre></details></section>
-</main><footer>TURN Music Tracker is a development utility. It uses the same generated Web Audio instruments as the game and stores an autosaved draft in this browser only.</footer><script type="module" src="./tracker.js?revision=r187-music-tracker"></script></body></html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#08090a">
+  <meta name="robots" content="noindex">
+  <title>TURN Music Tracker</title>
+  <link rel="stylesheet" href="../../design-tokens.css?revision=r162-social-sharing">
+  <link rel="stylesheet" href="../../design-semantic.css?revision=r162-social-sharing">
+  <link rel="stylesheet" href="./tracker.css?revision=r188-design-system">
+</head>
+<body>
+  <header class="app-header">
+    <div class="app-header-inner">
+      <div>
+        <p class="eyebrow">TURN · MUSIC V2</p>
+        <h1>Music Tracker</h1>
+        <p class="lede">Compose against the real TURN instrument bank and hear changes immediately — no commits required.</p>
+      </div>
+      <a class="back-link" href="/turn/" data-turn-navigation-action>Back to TURN</a>
+    </div>
+  </header>
+
+  <main>
+    <details class="tracker-disclosure">
+      <summary>
+        <span class="disclosure-symbol" aria-hidden="true"></span>
+        <span class="disclosure-title"><small>SOURCE</small><strong>Import / export</strong></span>
+        <span id="draftStatus" class="status-pill" role="status">Ready</span>
+      </summary>
+      <div class="disclosure-panel">
+        <div class="source-grid">
+          <div class="source-card">
+            <h3>Existing TURN song</h3>
+            <div class="inline-fields">
+              <label class="grow"><span>Song</span><select id="songSelect"></select></label>
+              <button id="loadSongButton" class="button secondary" type="button">Load</button>
+            </div>
+          </div>
+          <div class="source-card">
+            <h3>URL</h3>
+            <label><span>TURN song .js URL</span><input id="songUrl" type="url" placeholder="https://…/song.js"></label>
+            <button id="loadUrlButton" class="button secondary" type="button">Fetch &amp; parse</button>
+            <p class="hint">Remote source is parsed as text, never executed. GitHub blob URLs are converted to raw URLs automatically.</p>
+          </div>
+          <div class="source-card source-card-wide">
+            <h3>Clipboard / pasted source</h3>
+            <textarea id="pasteSource" rows="5" spellcheck="false" placeholder="Paste a TURN song module here…"></textarea>
+            <div class="button-row">
+              <button id="readClipboardButton" class="button secondary" type="button">Read clipboard</button>
+              <button id="loadPasteButton" class="button secondary" type="button">Load pasted source</button>
+              <button id="newSongButton" class="button ghost" type="button">New blank song</button>
+            </div>
+          </div>
+          <div class="source-card source-card-wide">
+            <h3>Export</h3>
+            <div class="inline-fields">
+              <label class="grow"><span>Filename</span><input id="filenameInput" type="text" value="new-song.js"></label>
+              <button id="copySourceButton" class="button secondary" type="button">Copy .js</button>
+              <button id="downloadSourceButton" class="button primary" type="button">Download .js</button>
+            </div>
+            <textarea id="exportPreview" rows="7" spellcheck="false" readonly aria-label="Generated TURN song JavaScript"></textarea>
+          </div>
+        </div>
+      </div>
+    </details>
+
+    <details class="tracker-disclosure">
+      <summary>
+        <span class="disclosure-symbol" aria-hidden="true"></span>
+        <span class="disclosure-title"><small>SONG</small><strong>Metadata &amp; arrangement</strong></span>
+      </summary>
+      <div class="disclosure-panel">
+        <div class="meta-grid">
+          <label><span>ID</span><input id="metaId" type="text" value="new-song"></label>
+          <label><span>Name</span><input id="metaName" type="text" value="New TURN Song"></label>
+          <label><span>BPM</span><input id="metaBpm" type="number" min="70" max="180" value="120"></label>
+          <label><span>Key</span><input id="metaKey" type="text" value="C major"></label>
+          <label class="wide"><span>Style</span><input id="metaStyle" type="text"></label>
+          <label><span>Swing</span><input id="metaSwing" type="number" min="0" max="0.24" step="0.01" value="0"></label>
+        </div>
+        <div class="arrangement-wrap">
+          <div>
+            <h3>Six-part arrangement</h3>
+            <p class="hint">T = tune · B = bridge · C = chorus</p>
+          </div>
+          <div id="arrangementControls" class="arrangement"></div>
+          <output id="arrangementText" class="arrangement-code">TTTBCC</output>
+        </div>
+      </div>
+    </details>
+
+    <details class="tracker-disclosure">
+      <summary>
+        <span class="disclosure-symbol" aria-hidden="true"></span>
+        <span class="disclosure-title"><small>SOUND BANK</small><strong>Instrument demos</strong></span>
+      </summary>
+      <div class="disclosure-panel">
+        <p id="demoStatus" class="hint demo-status" aria-live="polite">Push an instrument repeatedly: DO · RE · MI · FA · SOL · LA · TI · DO.</p>
+        <div id="instrumentDemos" class="instrument-demos"></div>
+      </div>
+    </details>
+
+    <section class="panel tracker-panel" aria-labelledby="partBuilderHeading">
+      <div class="section-heading tracker-heading">
+        <div>
+          <p class="eyebrow">TRACKER</p>
+          <h2 id="partBuilderHeading">Part builder</h2>
+        </div>
+        <div class="transport">
+          <button id="playSongButton" class="button play" type="button">▶ Song</button>
+          <button class="button play part-play" data-part="tune" type="button">▶ T</button>
+          <button class="button play part-play" data-part="bridge" type="button">▶ B</button>
+          <button class="button play part-play" data-part="chorus" type="button">▶ C</button>
+          <button id="stopButton" class="button stop" type="button">■ Stop</button>
+        </div>
+      </div>
+
+      <div class="tracker-toolbar">
+        <fieldset class="channels">
+          <legend>Channels</legend>
+          <label><input type="checkbox" data-channel="lead" checked> Lead</label>
+          <label><input type="checkbox" data-channel="bass" checked> Bass</label>
+          <label><input type="checkbox" data-channel="arp" checked> Arp</label>
+          <label><input type="checkbox" data-channel="drums" checked> Drums</label>
+        </fieldset>
+        <label class="loop-toggle"><input id="loopPlayback" type="checkbox" checked> Loop playback</label>
+        <p id="playStatus" class="play-status" aria-live="polite">Stopped</p>
+      </div>
+
+      <div class="part-tabs" role="tablist" aria-label="Song parts">
+        <button class="part-tab active" data-part="tune" type="button" role="tab">T · Tune</button>
+        <button class="part-tab" data-part="bridge" type="button" role="tab">B · Bridge</button>
+        <button class="part-tab" data-part="chorus" type="button" role="tab">C · Chorus</button>
+      </div>
+
+      <div class="part-settings">
+        <label><span>Lead</span><select id="leadVoice"></select></label>
+        <label><span>Bass</span><select id="bassVoice"></select></label>
+        <label><span>Arp / texture</span><select id="arpVoice"></select></label>
+        <label><span>Drums</span><select id="drumKit"></select></label>
+      </div>
+
+      <div class="bar-toolbar">
+        <button id="prevBarButton" class="button ghost" type="button">← Previous bar</button>
+        <strong id="barPosition">Bar 1 / 4</strong>
+        <button id="nextBarButton" class="button ghost" type="button">Next bar →</button>
+        <button id="addBarButton" class="button ghost" type="button">+ Bar</button>
+        <button id="removeBarButton" class="button ghost" type="button">− Bar</button>
+        <button id="copyBarButton" class="button ghost" type="button">Copy bar</button>
+        <button id="pasteBarButton" class="button ghost" type="button">Paste bar</button>
+        <button id="clearBarButton" class="button danger" type="button">Clear bar</button>
+      </div>
+
+      <label class="harmony-field"><span>Harmony / chord for this bar</span><input id="barHarmony" type="text" placeholder="e.g. Em7"></label>
+
+      <div class="tracker-instruction" id="trackerInstruction">
+        Select a tracker cell, then enter its value with NOTE ENTRY below. Every note, rest or tie advances to the next row automatically.
+      </div>
+
+      <div class="tracker-scroll" aria-describedby="trackerInstruction">
+        <div class="tracker-grid tracker-grid-head" aria-hidden="true"><div>ROW</div><div>LEAD</div><div>BASS</div><div>ARP</div><div>DRUMS</div></div>
+        <div id="trackerGrid"></div>
+      </div>
+
+      <div class="entry-pad" aria-labelledby="noteEntryHeading">
+        <div class="entry-pad-head">
+          <div>
+            <p class="eyebrow">INPUT</p>
+            <h3 id="noteEntryHeading">Note entry</h3>
+            <p id="selectedCellLabel" class="hint">Lead · row 00</p>
+          </div>
+          <label id="octaveControl"><span>Octave</span><input id="entryOctave" type="number" min="0" max="8" value="5"></label>
+        </div>
+        <div id="noteButtons" class="note-buttons"></div>
+        <div id="drumButtons" class="note-buttons" hidden></div>
+        <div class="entry-navigation">
+          <button id="entryPrevButton" class="button ghost" type="button">↑ Previous row</button>
+          <button id="entryNextButton" class="button ghost" type="button">Next row ↓</button>
+        </div>
+      </div>
+
+      <details class="validation-panel">
+        <summary>Validation</summary>
+        <pre id="validationOutput">Ready.</pre>
+      </details>
+    </section>
+  </main>
+
+  <footer>TURN Music Tracker is a development utility. It uses the same generated Web Audio instruments as the game and stores an autosaved draft in this browser only.</footer>
+  <script type="module" src="./tracker.js?revision=r188-design-system"></script>
+</body>
+</html>

--- a/turn/audio/music/tracker.css
+++ b/turn/audio/music/tracker.css
@@ -1,1 +1,547 @@
-:root{color-scheme:dark;--bg:#08090a;--panel:#111317;--panel2:#171a20;--line:#353a45;--text:#f5f7fa;--muted:#aeb5c0;--yellow:#ffd400;--orange:#ff8a00;--green:#35d07f;--red:#ff5c5c;--blue:#69a7ff;--focus:#fff2a6;font-family:ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}*{box-sizing:border-box}body{margin:0;background:radial-gradient(circle at top,#171a20 0,var(--bg) 32rem);color:var(--text)}button,input,select,textarea{font:inherit;color:inherit;border:1px solid var(--line);background:#0d0f12;border-radius:.65rem}button:focus-visible,input:focus-visible,select:focus-visible,textarea:focus-visible,[tabindex]:focus-visible{outline:3px solid var(--focus);outline-offset:2px}.app-header,main,footer{width:min(1180px,calc(100% - 2rem));margin-inline:auto}.app-header{display:flex;justify-content:space-between;gap:2rem;align-items:end;padding:2rem 0 1rem}h1,h2,h3,p{margin-top:0}h1{font-size:clamp(2rem,6vw,4.5rem);line-height:.9;margin-bottom:.7rem;letter-spacing:-.05em}h2{margin-bottom:.2rem}h3{font-size:1rem}.eyebrow{color:var(--yellow);font-size:.74rem;font-weight:900;letter-spacing:.14em;margin-bottom:.45rem}.lede,.hint{color:var(--muted)}.lede{max-width:65ch;margin-bottom:0}.back-link{color:var(--text);border:1px solid var(--line);border-radius:999px;padding:.65rem 1rem;text-decoration:none;white-space:nowrap}main{display:grid;gap:1rem;padding-bottom:2rem}.panel{background:var(--panel);border:1px solid var(--line);border-radius:1rem;padding:1rem;box-shadow:0 1rem 3rem #0005}.section-heading{display:flex;justify-content:space-between;align-items:start;gap:1rem;margin-bottom:1rem}.status-pill{border:1px solid var(--line);border-radius:999px;padding:.4rem .7rem;font-size:.85rem;color:var(--muted)}.status-pill.good{color:var(--green)}.status-pill.bad{color:var(--red)}.source-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.8rem}.source-card{background:var(--panel2);padding:.85rem;border-radius:.8rem;border:1px solid #292d35}.source-card-wide{grid-column:1/-1}label{display:grid;gap:.35rem;color:var(--muted);font-size:.82rem;font-weight:700}input,select,textarea{width:100%;padding:.62rem .7rem}textarea{resize:vertical;font:500 .82rem/1.45 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}.inline-fields,.button-row{display:flex;align-items:end;gap:.55rem;flex-wrap:wrap}.grow{flex:1 1 16rem}.button{min-height:2.5rem;padding:.55rem .85rem;font-weight:850;cursor:pointer}.button.primary{background:var(--yellow);color:#111;border-color:var(--yellow)}.button.secondary{background:#252a33}.button.ghost{background:transparent}.button.play{background:#173c2a;border-color:#2c9961}.button.stop{background:#43240e;border-color:#b86012}.danger-text{color:#ffaaaa}.hint{font-size:.82rem;margin:.45rem 0 0}.meta-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:.75rem}.meta-grid .wide{grid-column:span 2}.arrangement-wrap{margin-top:1rem;display:flex;align-items:end;gap:1rem;flex-wrap:wrap;padding-top:1rem;border-top:1px solid var(--line)}.arrangement{display:flex;gap:.35rem}.arrangement select{width:4rem;font-size:1.2rem;font-weight:900;text-align:center}.arrangement-code{font:900 1.4rem/1 ui-monospace,monospace;letter-spacing:.14em;color:var(--yellow)}.instrument-demos{display:grid;gap:.8rem}.demo-group{display:grid;grid-template-columns:8rem 1fr;gap:.7rem;align-items:start}.demo-group h3{margin:.65rem 0 0;text-transform:uppercase;color:var(--muted);letter-spacing:.08em}.demo-buttons{display:flex;flex-wrap:wrap;gap:.4rem}.demo-button{padding:.55rem .7rem;background:#1e2229;cursor:pointer}.demo-button.active{border-color:var(--yellow);color:var(--yellow)}.tracker-heading{align-items:center}.transport{display:flex;gap:.4rem;flex-wrap:wrap;justify-content:flex-end}.tracker-toolbar{display:flex;gap:1rem;align-items:center;flex-wrap:wrap;margin-bottom:.8rem}.channels{display:flex;gap:.75rem;border:1px solid var(--line);border-radius:.7rem;padding:.45rem .75rem .55rem}.channels legend{font-size:.72rem;color:var(--muted);padding-inline:.25rem}.channels label,.loop-toggle{display:flex;align-items:center;gap:.35rem;color:var(--text);font-size:.82rem}.channels input,.loop-toggle input{width:auto}.play-status{margin:0 0 0 auto;color:var(--muted);font:700 .8rem ui-monospace,monospace}.part-tabs{display:flex;gap:.35rem;margin:.8rem 0}.part-tab{padding:.65rem 1rem;cursor:pointer;font-weight:900;background:#171a20}.part-tab.active{background:var(--yellow);color:#111;border-color:var(--yellow)}.part-settings{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:.6rem}.bar-toolbar{display:flex;gap:.4rem;align-items:center;flex-wrap:wrap;margin-top:.8rem}.bar-toolbar strong{padding-inline:.35rem}.harmony-field{margin:.75rem 0;max-width:24rem}.tracker-help{display:flex;flex-wrap:wrap;gap:.45rem 1rem;color:var(--muted);font-size:.76rem;margin:.75rem 0}kbd{display:inline-block;min-width:1.35rem;padding:.1rem .25rem;border-radius:.3rem;border:1px solid #555c68;background:#171a20;text-align:center;color:var(--text)}.tracker-scroll{overflow-x:auto;border:1px solid var(--line);border-radius:.8rem;background:#090a0c}.tracker-grid,.tracker-row{display:grid;grid-template-columns:4.4rem repeat(3,minmax(8.5rem,1fr)) minmax(10rem,1.15fr);min-width:650px}.tracker-grid-head{position:sticky;top:0;z-index:2;background:#1b1f26;color:var(--muted);font:800 .72rem ui-monospace,monospace}.tracker-grid-head>div{padding:.55rem;border-right:1px solid #30343d}.tracker-row{border-top:1px solid #1e2228}.tracker-row.beat{border-top-color:#454b57}.tracker-row.current{background:#131821}.row-number{display:grid;place-items:center;color:#737c8a;font:800 .76rem ui-monospace,monospace;border-right:1px solid #2a2e35}.step-input{min-width:0;border-radius:0;border:0;border-right:1px solid #222730;padding:.48rem .55rem;background:transparent;font:800 .9rem ui-monospace,SFMono-Regular,Menlo,monospace}.step-input:focus{background:#262c35;outline-offset:-3px}.step-input.invalid{background:#4c161b}.entry-pad{margin-top:.8rem;padding:.8rem;background:var(--panel2);border-radius:.8rem;border:1px solid #292d35}.entry-pad-head{display:flex;align-items:end;justify-content:space-between;gap:1rem}.entry-pad-head h3{margin-bottom:0}#octaveControl{width:7rem}.note-buttons{display:flex;flex-wrap:wrap;gap:.4rem;margin-top:.7rem}.note-button{min-width:3rem;padding:.55rem .65rem;background:#242932;cursor:pointer;font:850 .82rem ui-monospace,monospace}.note-button.accidental{color:var(--blue)}.note-button.special{color:var(--yellow)}.validation-panel{margin-top:.8rem;border-top:1px solid var(--line);padding-top:.7rem}.validation-panel summary{cursor:pointer;color:var(--muted)}.validation-panel pre{white-space:pre-wrap;color:var(--muted);font-size:.78rem}footer{color:var(--muted);font-size:.8rem;padding:0 0 3rem}@media(max-width:760px){.app-header{align-items:start;flex-direction:column}.source-grid,.meta-grid,.part-settings{grid-template-columns:1fr 1fr}.meta-grid .wide{grid-column:1/-1}.demo-group{grid-template-columns:1fr}.tracker-heading{align-items:start;flex-direction:column}.transport{justify-content:flex-start}.play-status{margin-left:0}}@media(max-width:520px){.source-grid,.meta-grid,.part-settings{grid-template-columns:1fr}.source-card-wide,.meta-grid .wide{grid-column:auto}.arrangement{width:100%}.arrangement select{flex:1;width:auto}}@media(prefers-reduced-motion:reduce){*{scroll-behavior:auto!important}}
+:root {
+  font-family: Inter, ui-rounded, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color-scheme: light;
+  --tracker-width: 1180px;
+}
+
+* { box-sizing: border-box; }
+html { background: var(--turn-ink); }
+body {
+  margin: 0;
+  background: var(--turn-ink);
+  color: var(--turn-paper);
+  font-weight: 800;
+  line-height: 1.45;
+}
+
+button, input, select, textarea, summary { font: inherit; }
+button, input, select, textarea { color: var(--turn-ink); }
+button, summary { cursor: pointer; }
+button:disabled { cursor: not-allowed; opacity: .45; }
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+summary:focus-visible,
+.step-cell:focus-visible {
+  outline: 5px solid var(--turn-form-control-focus);
+  outline-offset: 4px;
+}
+
+h1, h2, h3, p { margin-top: 0; }
+h1 {
+  margin-bottom: var(--turn-space-3);
+  font-size: clamp(3rem, 8vw, 6rem);
+  line-height: .78;
+  letter-spacing: -.07em;
+}
+h2 {
+  margin-bottom: var(--turn-space-1);
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: .9;
+  letter-spacing: -.045em;
+}
+h3 { margin-bottom: var(--turn-space-2); }
+
+.app-header {
+  border-bottom: var(--turn-border-heavy) solid var(--turn-ink);
+  background: linear-gradient(145deg, var(--turn-blue-500), var(--turn-green-500));
+  color: var(--turn-ink);
+}
+.app-header-inner,
+main,
+footer {
+  width: min(var(--tracker-width), calc(100% - 2rem));
+  margin-inline: auto;
+}
+.app-header-inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: end;
+  gap: var(--turn-space-8);
+  padding: clamp(2rem, 7vw, 5rem) 0 var(--turn-space-8);
+}
+.lede {
+  max-width: 62ch;
+  margin-bottom: 0;
+  font-size: clamp(1rem, 2vw, 1.2rem);
+}
+.eyebrow {
+  display: inline-block;
+  margin-bottom: var(--turn-space-2);
+  padding: 6px 10px;
+  border: var(--turn-border-compact) solid var(--turn-ink);
+  border-radius: var(--turn-radius-pill);
+  background: var(--turn-yellow-400);
+  color: var(--turn-ink);
+  box-shadow: var(--turn-shadow-compact);
+  font-size: .72rem;
+  font-weight: 950;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+}
+.back-link {
+  flex: 0 0 auto;
+  padding: 10px 16px;
+  border: var(--turn-border-default) solid var(--turn-ink);
+  border-radius: var(--turn-radius-pill);
+  background: var(--turn-action-navigation);
+  color: var(--turn-ink);
+  box-shadow: var(--turn-shadow-default);
+  font-weight: 950;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+main {
+  display: grid;
+  gap: var(--turn-space-6);
+  padding: var(--turn-space-8) 0 var(--turn-space-12);
+}
+
+.panel,
+.tracker-disclosure {
+  border: var(--turn-border-default) solid var(--turn-ink);
+  border-radius: var(--turn-radius-default);
+  background: var(--turn-surface-page);
+  color: var(--turn-ink);
+  box-shadow: var(--turn-shadow-default);
+}
+.panel { padding: clamp(16px, 3vw, 28px); }
+
+.tracker-disclosure { overflow: hidden; }
+.tracker-disclosure > summary {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--turn-space-3);
+  min-height: 68px;
+  padding: 12px 16px;
+  background: var(--turn-disclosure-trigger);
+  list-style: none;
+}
+.tracker-disclosure > summary::-webkit-details-marker { display: none; }
+.disclosure-symbol {
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border: var(--turn-border-compact) solid var(--turn-ink);
+  border-radius: var(--turn-radius-circle);
+  background: var(--turn-disclosure-panel);
+  font-size: 1.4rem;
+  line-height: 1;
+}
+.disclosure-symbol::before { content: '+'; }
+.tracker-disclosure[open] .disclosure-symbol::before { content: '−'; }
+.disclosure-title {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+.disclosure-title small {
+  font-size: .7rem;
+  font-weight: 950;
+  letter-spacing: .14em;
+}
+.disclosure-title strong {
+  font-size: clamp(1.1rem, 2.5vw, 1.45rem);
+  font-weight: 950;
+  line-height: 1.05;
+}
+.disclosure-panel {
+  padding: clamp(16px, 3vw, 24px);
+  border-top: var(--turn-border-compact) solid var(--turn-ink);
+  background: var(--turn-disclosure-panel);
+}
+
+.status-pill {
+  padding: 6px 10px;
+  border: var(--turn-border-compact) solid var(--turn-ink);
+  border-radius: var(--turn-radius-pill);
+  background: var(--turn-paper);
+  box-shadow: var(--turn-shadow-compact);
+  font-size: .8rem;
+  font-weight: 950;
+  white-space: nowrap;
+}
+.status-pill.good { background: var(--turn-action-success); }
+.status-pill.bad { background: var(--turn-action-danger); }
+
+.section-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: start;
+  gap: var(--turn-space-4);
+  margin-bottom: var(--turn-space-4);
+}
+.tracker-heading { align-items: center; }
+.tracker-heading .eyebrow,
+.entry-pad .eyebrow { margin-bottom: var(--turn-space-2); }
+
+.source-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--turn-space-3);
+}
+.source-card,
+.entry-pad {
+  border: var(--turn-border-compact) solid var(--turn-ink);
+  border-radius: var(--turn-radius-compact);
+  background: var(--turn-surface-raised);
+  box-shadow: var(--turn-shadow-compact);
+}
+.source-card { padding: var(--turn-space-4); }
+.source-card-wide { grid-column: 1 / -1; }
+
+label {
+  display: grid;
+  gap: var(--turn-space-1);
+  color: var(--turn-ink);
+  font-size: .82rem;
+  font-weight: 900;
+}
+input,
+select,
+textarea {
+  width: 100%;
+  min-height: 46px;
+  padding: 9px 11px;
+  border: var(--turn-border-compact) solid var(--turn-ink);
+  border-radius: var(--turn-radius-compact);
+  background: var(--turn-white);
+  font-weight: 850;
+}
+textarea {
+  min-height: 7rem;
+  resize: vertical;
+  font: 700 .82rem/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.inline-fields,
+.button-row {
+  display: flex;
+  align-items: end;
+  gap: var(--turn-space-2);
+  flex-wrap: wrap;
+}
+.button-row { margin-top: var(--turn-space-2); }
+.grow { flex: 1 1 16rem; }
+
+.button,
+.demo-button,
+.note-button,
+.part-tab {
+  min-height: 46px;
+  padding: 8px 13px;
+  border: var(--turn-border-compact) solid var(--turn-ink);
+  border-radius: var(--turn-radius-compact);
+  background: var(--turn-action-utility);
+  box-shadow: var(--turn-shadow-compact);
+  color: var(--turn-ink);
+  font-weight: 950;
+}
+.button:active,
+.demo-button:active,
+.note-button:active,
+.part-tab:active,
+.step-cell:active { transform: translate(2px, 2px); box-shadow: 1px 1px 0 var(--turn-ink); }
+.button.primary {
+  border-radius: var(--turn-radius-pill);
+  background: var(--turn-action-primary);
+}
+.button.secondary { background: var(--turn-action-information); }
+.button.ghost { background: var(--turn-action-utility); }
+.button.play { background: var(--turn-action-game); }
+.button.stop { background: var(--turn-action-navigation); }
+.button.danger { background: var(--turn-action-danger); }
+
+.hint {
+  margin: var(--turn-space-2) 0 0;
+  color: color-mix(in srgb, var(--turn-ink) 72%, var(--turn-paper));
+  font-size: .82rem;
+}
+.demo-status { margin: 0 0 var(--turn-space-4); }
+
+.meta-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--turn-space-3);
+}
+.meta-grid .wide { grid-column: span 2; }
+.arrangement-wrap {
+  display: flex;
+  align-items: end;
+  gap: var(--turn-space-4);
+  flex-wrap: wrap;
+  margin-top: var(--turn-space-6);
+  padding-top: var(--turn-space-4);
+  border-top: var(--turn-border-micro) solid var(--turn-ink);
+}
+.arrangement { display: flex; gap: var(--turn-space-2); }
+.arrangement select {
+  width: 4rem;
+  min-height: 52px;
+  background: var(--turn-yellow-100);
+  font-size: 1.2rem;
+  font-weight: 950;
+  text-align: center;
+}
+.arrangement-code {
+  padding: 9px 12px;
+  border: var(--turn-border-compact) solid var(--turn-ink);
+  border-radius: var(--turn-radius-compact);
+  background: var(--turn-yellow-400);
+  box-shadow: var(--turn-shadow-compact);
+  font: 950 1.35rem/1 ui-monospace, monospace;
+  letter-spacing: .14em;
+}
+
+.instrument-demos { display: grid; gap: var(--turn-space-3); }
+.demo-group {
+  display: grid;
+  grid-template-columns: 8rem 1fr;
+  gap: var(--turn-space-3);
+  align-items: start;
+}
+.demo-group h3 {
+  margin: 12px 0 0;
+  font-size: .78rem;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+}
+.demo-buttons { display: flex; flex-wrap: wrap; gap: var(--turn-space-2); }
+.demo-button { background: var(--turn-action-utility); }
+.demo-button.active { background: var(--turn-yellow-400); }
+
+.transport {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--turn-space-2);
+  flex-wrap: wrap;
+}
+.tracker-toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--turn-space-4);
+  flex-wrap: wrap;
+  margin-bottom: var(--turn-space-3);
+}
+.channels {
+  display: flex;
+  gap: var(--turn-space-3);
+  padding: 8px 12px 10px;
+  border: var(--turn-border-compact) solid var(--turn-ink);
+  border-radius: var(--turn-radius-compact);
+  background: var(--turn-surface-raised);
+}
+.channels legend {
+  padding-inline: var(--turn-space-1);
+  font-size: .72rem;
+  font-weight: 950;
+}
+.channels label,
+.loop-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--turn-space-1);
+  font-size: .82rem;
+}
+.channels input,
+.loop-toggle input {
+  width: 28px;
+  min-height: 28px;
+  height: 28px;
+  margin: 0;
+  accent-color: var(--turn-form-control-selected);
+}
+.play-status {
+  margin: 0 0 0 auto;
+  font: 900 .8rem ui-monospace, monospace;
+}
+
+.part-tabs {
+  display: flex;
+  gap: var(--turn-space-2);
+  margin: var(--turn-space-4) 0;
+}
+.part-tab { background: var(--turn-blue-100); }
+.part-tab.active { background: var(--turn-action-primary); }
+.part-settings {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--turn-space-3);
+}
+.bar-toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--turn-space-2);
+  flex-wrap: wrap;
+  margin-top: var(--turn-space-4);
+}
+.bar-toolbar strong {
+  padding: 8px 10px;
+  border: var(--turn-border-compact) solid var(--turn-ink);
+  border-radius: var(--turn-radius-pill);
+  background: var(--turn-yellow-100);
+}
+.harmony-field {
+  max-width: 24rem;
+  margin: var(--turn-space-4) 0;
+}
+.tracker-instruction {
+  margin: var(--turn-space-4) 0 var(--turn-space-3);
+  padding: 10px 12px;
+  border-left: var(--turn-border-heavy) solid var(--turn-blue-500);
+  background: var(--turn-blue-100);
+  font-size: .84rem;
+}
+
+.tracker-scroll {
+  overflow-x: auto;
+  border: var(--turn-border-default) solid var(--turn-ink);
+  border-radius: var(--turn-radius-default);
+  background: var(--turn-white);
+  box-shadow: var(--turn-shadow-compact);
+}
+.tracker-grid,
+.tracker-row {
+  display: grid;
+  grid-template-columns: 4.2rem repeat(3, minmax(8rem, 1fr)) minmax(9rem, 1.1fr);
+  min-width: 650px;
+}
+.tracker-grid-head {
+  background: var(--turn-road);
+  color: var(--turn-paper);
+  font: 950 .72rem ui-monospace, monospace;
+  letter-spacing: .06em;
+}
+.tracker-grid-head > div {
+  padding: 10px;
+  border-right: var(--turn-border-micro) solid var(--turn-ink);
+}
+.tracker-row { border-top: var(--turn-border-micro) solid var(--turn-muted); }
+.tracker-row.beat { border-top: var(--turn-border-default) solid var(--turn-ink); }
+.row-number {
+  display: grid;
+  place-items: center;
+  border-right: var(--turn-border-micro) solid var(--turn-ink);
+  background: var(--turn-paper);
+  font: 950 .76rem ui-monospace, monospace;
+}
+.step-cell {
+  min-width: 0;
+  min-height: 42px;
+  padding: 7px 9px;
+  border: 0;
+  border-right: var(--turn-border-micro) solid var(--turn-ink);
+  border-radius: 0;
+  background: var(--turn-white);
+  box-shadow: none;
+  color: var(--turn-ink);
+  font: 900 .9rem ui-monospace, SFMono-Regular, Menlo, monospace;
+  text-align: left;
+}
+.step-cell:hover { background: var(--turn-blue-100); }
+.step-cell.selected {
+  background: var(--turn-yellow-400);
+  box-shadow: inset 0 0 0 var(--turn-border-compact) var(--turn-ink);
+}
+.step-cell.invalid { background: var(--turn-red-200); }
+
+.entry-pad {
+  margin-top: var(--turn-space-4);
+  padding: var(--turn-space-4);
+  background: var(--turn-yellow-100);
+}
+.entry-pad-head {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: var(--turn-space-4);
+}
+.entry-pad-head h3 {
+  margin-bottom: 0;
+  font-size: 1.4rem;
+}
+#octaveControl { width: 7rem; }
+.note-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--turn-space-2);
+  margin-top: var(--turn-space-3);
+}
+.note-button {
+  min-width: 3.1rem;
+  background: var(--turn-surface-raised);
+  font: 950 .84rem ui-monospace, monospace;
+}
+.note-button.accidental { background: var(--turn-blue-200); }
+.note-button.special { background: var(--turn-yellow-400); }
+.entry-navigation {
+  display: flex;
+  gap: var(--turn-space-2);
+  flex-wrap: wrap;
+  margin-top: var(--turn-space-3);
+  padding-top: var(--turn-space-3);
+  border-top: var(--turn-border-micro) solid var(--turn-ink);
+}
+
+.validation-panel {
+  margin-top: var(--turn-space-4);
+  border: var(--turn-border-compact) solid var(--turn-ink);
+  border-radius: var(--turn-radius-compact);
+  background: var(--turn-surface-raised);
+}
+.validation-panel summary {
+  padding: 9px 12px;
+  font-weight: 950;
+}
+.validation-panel pre {
+  margin: 0;
+  padding: 0 12px 12px;
+  white-space: pre-wrap;
+  font-size: .78rem;
+}
+
+footer {
+  padding: 0 0 var(--turn-space-12);
+  color: color-mix(in srgb, var(--turn-paper) 72%, var(--turn-ink));
+  font-size: .8rem;
+}
+
+@media (max-width: 760px) {
+  .app-header-inner,
+  .tracker-heading { align-items: start; flex-direction: column; }
+  .source-grid,
+  .meta-grid,
+  .part-settings { grid-template-columns: 1fr 1fr; }
+  .meta-grid .wide { grid-column: 1 / -1; }
+  .demo-group { grid-template-columns: 1fr; }
+  .transport { justify-content: flex-start; }
+  .play-status { margin-left: 0; }
+}
+
+@media (max-width: 520px) {
+  .app-header-inner { gap: var(--turn-space-4); }
+  .source-grid,
+  .meta-grid,
+  .part-settings { grid-template-columns: 1fr; }
+  .source-card-wide,
+  .meta-grid .wide { grid-column: auto; }
+  .tracker-disclosure > summary { grid-template-columns: auto minmax(0, 1fr); }
+  .status-pill { grid-column: 2; justify-self: start; }
+  .arrangement { width: 100%; }
+  .arrangement select { flex: 1; width: auto; }
+  .entry-pad-head { align-items: start; flex-direction: column; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * { scroll-behavior: auto !important; }
+  .button:active,
+  .demo-button:active,
+  .note-button:active,
+  .part-tab:active,
+  .step-cell:active { transform: none; }
+}

--- a/turn/audio/music/tracker.js
+++ b/turn/audio/music/tracker.js
@@ -1,29 +1,457 @@
 import { model, save, restore, fromSong, fromParsed, parseSource, rawURL, errors, source, validToken, SONGBOOK, LEAD_VOICES, BASS_VOICES, ARP_VOICES, DRUM_KITS, N, C, L, P, HITS } from './tracker-core.js?revision=r187-music-tracker';
 import { startPlayback, stopPlayback, isPlaying, renderDemos } from './tracker-audio.js?revision=r187-music-tracker';
-const $=id=>document.getElementById(id), PAD=['C','C#','D','D#','E','F','F#','G','G#','A','A#','B'], SN=PAD;
-const KEYS={z:0,s:1,x:2,d:3,c:4,v:5,g:6,b:7,h:8,n:9,j:10,m:11,q:12,'2':13,w:14,'3':15,e:16,r:17,'5':18,t:19,'6':20,y:21,'7':22,u:23};
-let clip=null;
-const s=()=>model.state, status=(m,k='')=>{ $('draftStatus').textContent=m;$('draftStatus').className=`status-pill${k?' '+k:''}` };
-function changed(doSave=true){const e=errors();$('validationOutput').textContent=e.length?e.join('\n'):'Ready.';$('exportPreview').value=source();if(e.length)status(`${e.length} validation issue${e.length===1?'':'s'}`,'bad');else if(doSave)status('Ready','good');if(doSave)save()}
-function renderMeta(){for(const [id,k] of [['metaId','id'],['metaName','name'],['metaBpm','bpm'],['metaKey','key'],['metaStyle','style'],['metaSwing','swing']])$(id).value=s().meta[k];$('filenameInput').value=s().filename}
-function renderArr(){const r=$('arrangementControls');r.replaceChildren();s().arrangement.forEach((v,i)=>{const x=document.createElement('select');x.setAttribute('aria-label',`Arrangement part ${i+1}`);N.forEach(n=>x.add(new Option(C[n],n,false,n===v)));x.onchange=()=>{s().arrangement[i]=x.value;renderArr();changed()};r.append(x)});$('arrangementText').value=s().arrangement.map(n=>C[n]).join('')}
-function renderPart(){document.querySelectorAll('.part-tab').forEach(b=>{const a=b.dataset.part===s().part;b.classList.toggle('active',a);b.setAttribute('aria-selected',String(a))});const p=s().parts[s().part];$('leadVoice').value=p.leadVoice;$('bassVoice').value=p.bassVoice;$('arpVoice').value=p.arpVoice;$('drumKit').value=p.drumKit;s().bar=Math.min(s().bar,model.barsIn(p)-1);$('barPosition').textContent=`Bar ${s().bar+1} / ${model.barsIn(p)}`;$('barHarmony').value=p.harmony[s().bar]||'';$('removeBarButton').disabled=model.barsIn(p)<=1}
-function renderGrid(){const root=$('trackerGrid'),p=s().parts[s().part];root.replaceChildren();for(let row=0;row<16;row++){const i=s().bar*16+row,d=document.createElement('div');d.className=`tracker-row${row%4===0?' beat':''}${row===s().sel.row?' current':''}`;const num=document.createElement('div');num.className='row-number';num.textContent=i.toString(16).toUpperCase().padStart(2,'0');d.append(num);for(const l of L){const x=document.createElement('input');x.className='step-input'+(validToken(l,p[l][i],i,p)?'':' invalid');x.dataset.lane=l;x.dataset.row=row;x.value=p[l][i]??'-';x.spellcheck=false;x.maxLength=l==='drums'?8:4;x.setAttribute('aria-label',`${s().part} bar ${s().bar+1} row ${num.textContent} ${l}`);x.onfocus=()=>{s().sel={lane:l,row};renderPad()};x.onchange=()=>commit(x,false);x.onkeydown=keyDown;d.append(x)}root.append(d)}renderPad()}
-function renderPad(){const pitched=P.includes(s().sel.lane);$('selectedCellLabel').textContent=`${C[s().part]} · ${s().sel.lane} · row ${model.step().toString(16).toUpperCase().padStart(2,'0')}`;$('octaveControl').hidden=!pitched;$('noteButtons').hidden=!pitched;$('drumButtons').hidden=pitched;if(pitched)$('entryOctave').value=s().oct[s().sel.lane]}
-function render(){renderMeta();renderArr();renderPart();renderGrid();document.querySelectorAll('[data-channel]').forEach(x=>x.checked=s().channels[x.dataset.channel]!==false);$('loopPlayback').checked=s().loop!==false;changed(false)}
-function commit(x,advance){const l=x.dataset.lane,row=+x.dataset.row,p=s().parts[s().part],i=s().bar*16+row;let v=x.value.trim();v=!v||v==='-'?null:v==='='?'=':l==='drums'?v.toUpperCase():v[0].toUpperCase()+v.slice(1);p[l][i]=v;x.value=v??'-';x.classList.toggle('invalid',!validToken(l,v,i,p));changed();if(advance)move(0,1)}
-function focus(l,row){s().sel={lane:l,row};requestAnimationFrame(()=>{const x=document.querySelector(`.step-input[data-lane="${l}"][data-row="${row}"]`);x?.focus();x?.select()})}
-function move(dl,dr){let li=L.indexOf(s().sel.lane)+dl,r=s().sel.row+dr;if(r<0&&s().bar>0){s().bar--;r=15;renderPart();renderGrid()}else if(r>15&&s().bar<model.barsIn()-1){s().bar++;r=0;renderPart();renderGrid()}r=Math.max(0,Math.min(15,r));focus(L[Math.max(0,Math.min(3,li))],r)}
-function keyDown(e){const x=e.currentTarget,l=x.dataset.lane;if(e.key==='ArrowUp'){e.preventDefault();move(0,-1)}else if(e.key==='ArrowDown'){e.preventDefault();move(0,1)}else if(e.key==='Enter'){e.preventDefault();commit(x,true)}else if(e.key==='-'||(e.key==='='&&l!=='drums')){e.preventDefault();x.value=e.key;commit(x,true)}else if(P.includes(l)&&!e.metaKey&&!e.ctrlKey&&!e.altKey&&KEYS[e.key.toLowerCase()]!=null){e.preventDefault();const z=KEYS[e.key.toLowerCase()],o=s().oct[l]+Math.floor(z/12);x.value=`${SN[z%12]}${o}`;commit(x,true)}else if(e.altKey&&e.key==='ArrowLeft'){e.preventDefault();move(-1,0)}else if(e.altKey&&e.key==='ArrowRight'){e.preventDefault();move(1,0)}}
-function quick(v){const x=document.querySelector(`.step-input[data-lane="${s().sel.lane}"][data-row="${s().sel.row}"]`);if(x){x.value=v;commit(x,true)}}
-function padButtons(){const a=$('noteButtons');PAD.forEach(n=>{const b=document.createElement('button');b.type='button';b.className='note-button'+(n.includes('#')?' accidental':'');b.textContent=n;b.onclick=()=>quick(`${n}${s().oct[s().sel.lane]}`);a.append(b)});[['REST','-'],['TIE','='],['CLEAR','']].forEach(([n,v])=>{const b=document.createElement('button');b.type='button';b.className='note-button special';b.textContent=n;b.onclick=()=>quick(v);a.append(b)});const d=$('drumButtons');HITS.forEach(h=>{const b=document.createElement('button');b.type='button';b.className='note-button';b.textContent=h;b.onclick=()=>{const p=s().parts[s().part],i=model.step(),set=new Set((p.drums[i]||'').split(''));set.has(h)?set.delete(h):set.add(h);p.drums[i]=HITS.filter(x=>set.has(x)).join('')||null;renderGrid();changed()};d.append(b)});const adv=document.createElement('button');adv.type='button';adv.className='note-button special';adv.textContent='ADVANCE ↓';adv.onclick=()=>move(0,1);d.append(adv)}
-function addBar(){const p=s().parts[s().part];if(model.barsIn(p)>=16)return status('Editor limit: 16 bars per part','bad');L.forEach(l=>p[l].push(...Array(16).fill(null)));p.harmony.push('');s().bar=model.barsIn(p)-1;renderPart();renderGrid();changed()}
-function removeBar(){const p=s().parts[s().part];if(model.barsIn(p)<=1)return;const i=s().bar*16;L.forEach(l=>p[l].splice(i,16));p.harmony.splice(s().bar,1);s().bar=Math.min(s().bar,model.barsIn(p)-1);renderPart();renderGrid();changed()}
-function copyBar(){const p=s().parts[s().part],i=s().bar*16;clip={harmony:p.harmony[s().bar],...Object.fromEntries(L.map(l=>[l,p[l].slice(i,i+16)]))};status('Bar copied','good')}
-function pasteBar(){if(!clip)return status('Copy a bar first','bad');const p=s().parts[s().part],i=s().bar*16;L.forEach(l=>p[l].splice(i,16,...clip[l]));p.harmony[s().bar]=clip.harmony;renderPart();renderGrid();changed()}
-function clearBar(){const p=s().parts[s().part],i=s().bar*16;L.forEach(l=>p[l].fill(null,i,i+16));p.harmony[s().bar]='';renderPart();renderGrid();changed()}
-function changeBar(d){s().bar=Math.max(0,Math.min(model.barsIn()-1,s().bar+d));s().sel.row=0;renderPart();renderGrid();save();if(isPlaying())startPlayback('part',s().part,s().bar).catch(e=>status(e.message,'bad'))}
-function voiceOptions(){for(const [id,lib] of [['leadVoice',LEAD_VOICES],['bassVoice',BASS_VOICES],['arpVoice',ARP_VOICES],['drumKit',DRUM_KITS]])Object.keys(lib).forEach(n=>$(id).add(new Option(n,n)))}
-function download(){if(errors().length)return status(errors()[0],'bad');const b=new Blob([source()],{type:'text/javascript'}),u=URL.createObjectURL(b),a=document.createElement('a');a.href=u;a.download=s().filename||`${model.slug(s().meta.id)}.js`;a.click();setTimeout(()=>URL.revokeObjectURL(u),1000)}
-function wire(){const sel=$('songSelect');SONGBOOK.forEach(x=>sel.add(new Option(`${x.name} · ${x.id}`,x.id)));$('loadSongButton').onclick=()=>{fromSong(SONGBOOK.find(x=>x.id===sel.value));render();save();status('Song loaded','good')};$('loadUrlButton').onclick=async()=>{try{status('Fetching…');const r=await fetch(rawURL($('songUrl').value),{credentials:'omit'});if(!r.ok)throw Error(`HTTP ${r.status}`);fromParsed(parseSource(await r.text()));render();save();status('URL imported','good')}catch(e){status(`Import failed: ${e.message}`,'bad')}};$('readClipboardButton').onclick=async()=>{try{const t=await navigator.clipboard.readText();$('pasteSource').value=t;fromParsed(parseSource(t));render();save();status('Clipboard imported','good')}catch(_){status('Clipboard read blocked; paste into the box instead.','bad')}};$('loadPasteButton').onclick=()=>{try{fromParsed(parseSource($('pasteSource').value));render();save();status('Pasted source imported','good')}catch(e){status(`Import failed: ${e.message}`,'bad')}};$('newSongButton').onclick=()=>{stopPlayback();model.fresh();render();save()};$('copySourceButton').onclick=async()=>{try{if(errors().length)throw Error(errors()[0]);await navigator.clipboard.writeText(source());status('Copied .js','good')}catch(e){status(e.message,'bad')}};$('downloadSourceButton').onclick=download;$('filenameInput').oninput=e=>{s().filename=e.target.value;save()};for(const [id,k,cast] of [['metaId','id',String],['metaName','name',String],['metaBpm','bpm',Number],['metaKey','key',String],['metaStyle','style',String],['metaSwing','swing',Number]])$(id).oninput=e=>{s().meta[k]=cast(e.target.value);changed()};document.querySelectorAll('.part-tab').forEach(b=>b.onclick=()=>{s().part=b.dataset.part;s().bar=0;s().sel.row=0;renderPart();renderGrid();save()});for(const [id,k] of [['leadVoice','leadVoice'],['bassVoice','bassVoice'],['arpVoice','arpVoice'],['drumKit','drumKit']])$(id).onchange=e=>{s().parts[s().part][k]=e.target.value;changed()};$('barHarmony').oninput=e=>{s().parts[s().part].harmony[s().bar]=e.target.value;changed()};$('prevBarButton').onclick=()=>changeBar(-1);$('nextBarButton').onclick=()=>changeBar(1);$('addBarButton').onclick=addBar;$('removeBarButton').onclick=removeBar;$('copyBarButton').onclick=copyBar;$('pasteBarButton').onclick=pasteBar;$('clearBarButton').onclick=clearBar;$('entryOctave').oninput=e=>{if(P.includes(s().sel.lane))s().oct[s().sel.lane]=+e.target.value};$('playSongButton').onclick=()=>startPlayback('song').catch(e=>status(e.message,'bad'));document.querySelectorAll('.part-play').forEach(b=>b.onclick=()=>startPlayback('part',b.dataset.part,b.dataset.part===s().part?s().bar:0).catch(e=>status(e.message,'bad')));$('stopButton').onclick=stopPlayback;$('loopPlayback').onchange=e=>{s().loop=e.target.checked;save()};document.querySelectorAll('[data-channel]').forEach(x=>x.onchange=()=>{s().channels[x.dataset.channel]=x.checked;save()})}
-voiceOptions();padButtons();renderDemos();restore();render();wire();
+
+const $ = (id) => document.getElementById(id);
+const PAD = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+let clip = null;
+
+const s = () => model.state;
+const status = (message, kind = '') => {
+  $('draftStatus').textContent = message;
+  $('draftStatus').className = `status-pill${kind ? ` ${kind}` : ''}`;
+};
+
+function changed(doSave = true) {
+  const currentErrors = errors();
+  $('validationOutput').textContent = currentErrors.length ? currentErrors.join('\n') : 'Ready.';
+  $('exportPreview').value = source();
+  if (currentErrors.length) status(`${currentErrors.length} validation issue${currentErrors.length === 1 ? '' : 's'}`, 'bad');
+  else if (doSave) status('Ready', 'good');
+  if (doSave) save();
+}
+
+function renderMeta() {
+  for (const [id, key] of [['metaId', 'id'], ['metaName', 'name'], ['metaBpm', 'bpm'], ['metaKey', 'key'], ['metaStyle', 'style'], ['metaSwing', 'swing']]) {
+    $(id).value = s().meta[key];
+  }
+  $('filenameInput').value = s().filename;
+}
+
+function renderArr() {
+  const root = $('arrangementControls');
+  root.replaceChildren();
+  s().arrangement.forEach((value, index) => {
+    const select = document.createElement('select');
+    select.setAttribute('aria-label', `Arrangement part ${index + 1}`);
+    N.forEach((name) => select.add(new Option(C[name], name, false, name === value)));
+    select.onchange = () => {
+      s().arrangement[index] = select.value;
+      renderArr();
+      changed();
+    };
+    root.append(select);
+  });
+  $('arrangementText').value = s().arrangement.map((name) => C[name]).join('');
+}
+
+function renderPart() {
+  document.querySelectorAll('.part-tab').forEach((button) => {
+    const active = button.dataset.part === s().part;
+    button.classList.toggle('active', active);
+    button.setAttribute('aria-selected', String(active));
+  });
+  const part = s().parts[s().part];
+  $('leadVoice').value = part.leadVoice;
+  $('bassVoice').value = part.bassVoice;
+  $('arpVoice').value = part.arpVoice;
+  $('drumKit').value = part.drumKit;
+  s().bar = Math.min(s().bar, model.barsIn(part) - 1);
+  $('barPosition').textContent = `Bar ${s().bar + 1} / ${model.barsIn(part)}`;
+  $('barHarmony').value = part.harmony[s().bar] || '';
+  $('removeBarButton').disabled = model.barsIn(part) <= 1;
+}
+
+function selectedCellSelector() {
+  return `.step-cell[data-lane="${s().sel.lane}"][data-row="${s().sel.row}"]`;
+}
+
+function focusSelectedCell() {
+  requestAnimationFrame(() => document.querySelector(selectedCellSelector())?.focus());
+}
+
+function selectCell(lane, row) {
+  s().sel = { lane, row };
+  renderGrid();
+  focusSelectedCell();
+}
+
+function renderGrid() {
+  const root = $('trackerGrid');
+  const part = s().parts[s().part];
+  root.replaceChildren();
+
+  for (let row = 0; row < 16; row += 1) {
+    const index = s().bar * 16 + row;
+    const line = document.createElement('div');
+    line.className = `tracker-row${row % 4 === 0 ? ' beat' : ''}`;
+
+    const rowNumber = document.createElement('div');
+    rowNumber.className = 'row-number';
+    rowNumber.textContent = index.toString(16).toUpperCase().padStart(2, '0');
+    line.append(rowNumber);
+
+    for (const lane of L) {
+      const value = part[lane][index];
+      const selected = s().sel.lane === lane && s().sel.row === row;
+      const cell = document.createElement('button');
+      cell.type = 'button';
+      cell.className = `step-cell${selected ? ' selected' : ''}${validToken(lane, value, index, part) ? '' : ' invalid'}`;
+      cell.dataset.lane = lane;
+      cell.dataset.row = String(row);
+      cell.textContent = value ?? '-';
+      cell.setAttribute('aria-pressed', String(selected));
+      cell.setAttribute('aria-label', `${s().part} bar ${s().bar + 1} row ${rowNumber.textContent} ${lane}: ${value ?? 'rest'}`);
+      cell.onclick = () => selectCell(lane, row);
+      line.append(cell);
+    }
+    root.append(line);
+  }
+
+  renderPad();
+}
+
+function renderPad() {
+  const pitched = P.includes(s().sel.lane);
+  const index = model.step();
+  const part = s().parts[s().part];
+  $('selectedCellLabel').textContent = `${C[s().part]} · ${s().sel.lane} · row ${index.toString(16).toUpperCase().padStart(2, '0')}`;
+  $('octaveControl').hidden = !pitched;
+  $('noteButtons').hidden = !pitched;
+  $('drumButtons').hidden = pitched;
+  if (pitched) $('entryOctave').value = s().oct[s().sel.lane];
+
+  const tieButton = document.querySelector('[data-entry="tie"]');
+  if (tieButton) tieButton.disabled = !pitched || !validToken(s().sel.lane, '=', index, part);
+}
+
+function render() {
+  renderMeta();
+  renderArr();
+  renderPart();
+  renderGrid();
+  document.querySelectorAll('[data-channel]').forEach((control) => {
+    control.checked = s().channels[control.dataset.channel] !== false;
+  });
+  $('loopPlayback').checked = s().loop !== false;
+  changed(false);
+}
+
+function moveSelection(delta) {
+  const part = s().parts[s().part];
+  let row = s().sel.row + delta;
+  let bar = s().bar;
+  if (row < 0 && bar > 0) {
+    bar -= 1;
+    row = 15;
+  } else if (row > 15 && bar < model.barsIn(part) - 1) {
+    bar += 1;
+    row = 0;
+  }
+  row = Math.max(0, Math.min(15, row));
+  s().bar = bar;
+  s().sel.row = row;
+  renderPart();
+  renderGrid();
+  save();
+  focusSelectedCell();
+}
+
+function setSelectedValue(value, { advance = true } = {}) {
+  const lane = s().sel.lane;
+  const part = s().parts[s().part];
+  const index = model.step();
+  if (!validToken(lane, value, index, part)) {
+    status(value === '=' ? 'A tie must immediately follow a note or another tie.' : 'That value is not valid here.', 'bad');
+    return;
+  }
+  part[lane][index] = value;
+  changed();
+  if (advance) moveSelection(1);
+  else renderGrid();
+}
+
+function toggleDrumHit(hit) {
+  const part = s().parts[s().part];
+  const index = model.step();
+  const set = new Set((part.drums[index] || '').split(''));
+  if (set.has(hit)) set.delete(hit);
+  else set.add(hit);
+  part.drums[index] = HITS.filter((item) => set.has(item)).join('') || null;
+  renderGrid();
+  changed();
+}
+
+function padButtons() {
+  const noteRoot = $('noteButtons');
+  PAD.forEach((note) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = `note-button${note.includes('#') ? ' accidental' : ''}`;
+    button.textContent = note;
+    button.onclick = () => setSelectedValue(`${note}${s().oct[s().sel.lane]}`);
+    noteRoot.append(button);
+  });
+
+  const rest = document.createElement('button');
+  rest.type = 'button';
+  rest.className = 'note-button special';
+  rest.textContent = 'REST −';
+  rest.onclick = () => setSelectedValue(null);
+  noteRoot.append(rest);
+
+  const tie = document.createElement('button');
+  tie.type = 'button';
+  tie.className = 'note-button special';
+  tie.dataset.entry = 'tie';
+  tie.textContent = 'TIE =';
+  tie.onclick = () => setSelectedValue('=');
+  noteRoot.append(tie);
+
+  const clear = document.createElement('button');
+  clear.type = 'button';
+  clear.className = 'note-button special';
+  clear.textContent = 'CLEAR';
+  clear.onclick = () => setSelectedValue(null, { advance: false });
+  noteRoot.append(clear);
+
+  const drumRoot = $('drumButtons');
+  HITS.forEach((hit) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'note-button';
+    button.textContent = hit;
+    button.onclick = () => toggleDrumHit(hit);
+    drumRoot.append(button);
+  });
+
+  const drumRest = document.createElement('button');
+  drumRest.type = 'button';
+  drumRest.className = 'note-button special';
+  drumRest.textContent = 'REST − ↓';
+  drumRest.onclick = () => setSelectedValue(null);
+  drumRoot.append(drumRest);
+
+  const drumClear = document.createElement('button');
+  drumClear.type = 'button';
+  drumClear.className = 'note-button special';
+  drumClear.textContent = 'CLEAR';
+  drumClear.onclick = () => setSelectedValue(null, { advance: false });
+  drumRoot.append(drumClear);
+}
+
+function addBar() {
+  const part = s().parts[s().part];
+  if (model.barsIn(part) >= 16) return status('Editor limit: 16 bars per part', 'bad');
+  L.forEach((lane) => part[lane].push(...Array(16).fill(null)));
+  part.harmony.push('');
+  s().bar = model.barsIn(part) - 1;
+  renderPart();
+  renderGrid();
+  changed();
+}
+
+function removeBar() {
+  const part = s().parts[s().part];
+  if (model.barsIn(part) <= 1) return;
+  const index = s().bar * 16;
+  L.forEach((lane) => part[lane].splice(index, 16));
+  part.harmony.splice(s().bar, 1);
+  s().bar = Math.min(s().bar, model.barsIn(part) - 1);
+  renderPart();
+  renderGrid();
+  changed();
+}
+
+function copyBar() {
+  const part = s().parts[s().part];
+  const index = s().bar * 16;
+  clip = {
+    harmony: part.harmony[s().bar],
+    ...Object.fromEntries(L.map((lane) => [lane, part[lane].slice(index, index + 16)]))
+  };
+  status('Bar copied', 'good');
+}
+
+function pasteBar() {
+  if (!clip) return status('Copy a bar first', 'bad');
+  const part = s().parts[s().part];
+  const index = s().bar * 16;
+  L.forEach((lane) => part[lane].splice(index, 16, ...clip[lane]));
+  part.harmony[s().bar] = clip.harmony;
+  renderPart();
+  renderGrid();
+  changed();
+}
+
+function clearBar() {
+  const part = s().parts[s().part];
+  const index = s().bar * 16;
+  L.forEach((lane) => part[lane].fill(null, index, index + 16));
+  part.harmony[s().bar] = '';
+  renderPart();
+  renderGrid();
+  changed();
+}
+
+function changeBar(delta) {
+  s().bar = Math.max(0, Math.min(model.barsIn() - 1, s().bar + delta));
+  s().sel.row = 0;
+  renderPart();
+  renderGrid();
+  save();
+  if (isPlaying()) startPlayback('part', s().part, s().bar).catch((error) => status(error.message, 'bad'));
+}
+
+function voiceOptions() {
+  for (const [id, library] of [['leadVoice', LEAD_VOICES], ['bassVoice', BASS_VOICES], ['arpVoice', ARP_VOICES], ['drumKit', DRUM_KITS]]) {
+    Object.keys(library).forEach((name) => $(id).add(new Option(name, name)));
+  }
+}
+
+function download() {
+  if (errors().length) return status(errors()[0], 'bad');
+  const blob = new Blob([source()], { type: 'text/javascript' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = s().filename || `${model.slug(s().meta.id)}.js`;
+  anchor.click();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+function wire() {
+  const songSelect = $('songSelect');
+  SONGBOOK.forEach((song) => songSelect.add(new Option(`${song.name} · ${song.id}`, song.id)));
+
+  $('loadSongButton').onclick = () => {
+    fromSong(SONGBOOK.find((song) => song.id === songSelect.value));
+    render();
+    save();
+    status('Song loaded', 'good');
+  };
+
+  $('loadUrlButton').onclick = async () => {
+    try {
+      status('Fetching…');
+      const response = await fetch(rawURL($('songUrl').value), { credentials: 'omit' });
+      if (!response.ok) throw Error(`HTTP ${response.status}`);
+      fromParsed(parseSource(await response.text()));
+      render();
+      save();
+      status('URL imported', 'good');
+    } catch (error) {
+      status(`Import failed: ${error.message}`, 'bad');
+    }
+  };
+
+  $('readClipboardButton').onclick = async () => {
+    try {
+      const text = await navigator.clipboard.readText();
+      $('pasteSource').value = text;
+      fromParsed(parseSource(text));
+      render();
+      save();
+      status('Clipboard imported', 'good');
+    } catch (_) {
+      status('Clipboard read blocked; paste into the box instead.', 'bad');
+    }
+  };
+
+  $('loadPasteButton').onclick = () => {
+    try {
+      fromParsed(parseSource($('pasteSource').value));
+      render();
+      save();
+      status('Pasted source imported', 'good');
+    } catch (error) {
+      status(`Import failed: ${error.message}`, 'bad');
+    }
+  };
+
+  $('newSongButton').onclick = () => {
+    stopPlayback();
+    model.fresh();
+    render();
+    save();
+  };
+
+  $('copySourceButton').onclick = async () => {
+    try {
+      if (errors().length) throw Error(errors()[0]);
+      await navigator.clipboard.writeText(source());
+      status('Copied .js', 'good');
+    } catch (error) {
+      status(error.message, 'bad');
+    }
+  };
+
+  $('downloadSourceButton').onclick = download;
+  $('filenameInput').oninput = (event) => {
+    s().filename = event.target.value;
+    save();
+  };
+
+  for (const [id, key, cast] of [['metaId', 'id', String], ['metaName', 'name', String], ['metaBpm', 'bpm', Number], ['metaKey', 'key', String], ['metaStyle', 'style', String], ['metaSwing', 'swing', Number]]) {
+    $(id).oninput = (event) => {
+      s().meta[key] = cast(event.target.value);
+      changed();
+    };
+  }
+
+  document.querySelectorAll('.part-tab').forEach((button) => {
+    button.onclick = () => {
+      s().part = button.dataset.part;
+      s().bar = 0;
+      s().sel.row = 0;
+      renderPart();
+      renderGrid();
+      save();
+    };
+  });
+
+  for (const [id, key] of [['leadVoice', 'leadVoice'], ['bassVoice', 'bassVoice'], ['arpVoice', 'arpVoice'], ['drumKit', 'drumKit']]) {
+    $(id).onchange = (event) => {
+      s().parts[s().part][key] = event.target.value;
+      changed();
+    };
+  }
+
+  $('barHarmony').oninput = (event) => {
+    s().parts[s().part].harmony[s().bar] = event.target.value;
+    changed();
+  };
+  $('prevBarButton').onclick = () => changeBar(-1);
+  $('nextBarButton').onclick = () => changeBar(1);
+  $('addBarButton').onclick = addBar;
+  $('removeBarButton').onclick = removeBar;
+  $('copyBarButton').onclick = copyBar;
+  $('pasteBarButton').onclick = pasteBar;
+  $('clearBarButton').onclick = clearBar;
+  $('entryPrevButton').onclick = () => moveSelection(-1);
+  $('entryNextButton').onclick = () => moveSelection(1);
+  $('entryOctave').oninput = (event) => {
+    if (P.includes(s().sel.lane)) s().oct[s().sel.lane] = Number(event.target.value);
+  };
+  $('playSongButton').onclick = () => startPlayback('song').catch((error) => status(error.message, 'bad'));
+  document.querySelectorAll('.part-play').forEach((button) => {
+    button.onclick = () => startPlayback('part', button.dataset.part, button.dataset.part === s().part ? s().bar : 0).catch((error) => status(error.message, 'bad'));
+  });
+  $('stopButton').onclick = stopPlayback;
+  $('loopPlayback').onchange = (event) => {
+    s().loop = event.target.checked;
+    save();
+  };
+  document.querySelectorAll('[data-channel]').forEach((control) => {
+    control.onchange = () => {
+      s().channels[control.dataset.channel] = control.checked;
+      save();
+    };
+  });
+}
+
+voiceOptions();
+padButtons();
+renderDemos();
+restore();
+render();
+wire();


### PR DESCRIPTION
## Summary
- Restyle `/turn/audio/music/` using TURN design-system tokens, semantic action colours, geometry and disclosure pattern.
- Collapse SOURCE / Import-export, SONG / Metadata-arrangement, and SOUND BANK / Instrument demos into native `<details>` disclosures.
- Remove direct tracker-cell typing and piano-key shortcuts; tracker cells are now selection buttons and all musical values are entered through **NOTE ENTRY**.
- Keep note/rest/tie auto-advance, drum-hit toggling, octave control, plus explicit previous/next-row controls.
- Preserve all existing import/export, playback, channel, bar, instrument-demo and autosave behavior.

No soundtrack or game-runtime files are changed.