### PR TITLE
Fix TURN Music Tracker header overflow

### DIFF
--- a/turn/audio/music/index.html
+++ b/turn/audio/music/index.html
@@ -8,7 +8,7 @@
   <title>TURN Music Tracker</title>
   <link rel="stylesheet" href="../../design-tokens.css?revision=r162-social-sharing">
   <link rel="stylesheet" href="../../design-semantic.css?revision=r162-social-sharing">
-  <link rel="stylesheet" href="./tracker.css?revision=r188-design-system">
+  <link rel="stylesheet" href="./tracker.css?revision=r189-layout-containment">
 </head>
 <body>
   <header class="app-header">

--- a/turn/audio/music/tracker.css
+++ b/turn/audio/music/tracker.css
@@ -5,9 +5,19 @@
 }
 
 * { box-sizing: border-box; }
-html { background: var(--turn-ink); }
+html {
+  max-width: 100%;
+  overflow-x: hidden;
+  overflow-x: clip;
+  background: var(--turn-ink);
+}
 body {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
   margin: 0;
+  overflow-x: hidden;
+  overflow-x: clip;
   background: var(--turn-ink);
   color: var(--turn-paper);
   font-weight: 800;
@@ -46,6 +56,7 @@ h2 {
 h3 { margin-bottom: var(--turn-space-2); }
 
 .app-header {
+  overflow: clip;
   border-bottom: var(--turn-border-heavy) solid var(--turn-ink);
   background: linear-gradient(145deg, var(--turn-blue-500), var(--turn-green-500));
   color: var(--turn-ink);
@@ -54,15 +65,17 @@ h3 { margin-bottom: var(--turn-space-2); }
 main,
 footer {
   width: min(var(--tracker-width), calc(100% - 2rem));
+  max-width: calc(100% - 2rem);
   margin-inline: auto;
 }
 .app-header-inner {
-  display: flex;
-  justify-content: space-between;
-  align-items: end;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
   gap: var(--turn-space-8);
   padding: clamp(2rem, 7vw, 5rem) 0 var(--turn-space-8);
 }
+.app-header-inner > * { min-width: 0; }
 .lede {
   max-width: 62ch;
   margin-bottom: 0;
@@ -83,7 +96,8 @@ footer {
   text-transform: uppercase;
 }
 .back-link {
-  flex: 0 0 auto;
+  justify-self: end;
+  max-width: 100%;
   padding: 10px 16px;
   border: var(--turn-border-default) solid var(--turn-ink);
   border-radius: var(--turn-radius-pill);
@@ -100,9 +114,11 @@ main {
   gap: var(--turn-space-6);
   padding: var(--turn-space-8) 0 var(--turn-space-12);
 }
+main > * { min-width: 0; }
 
 .panel,
 .tracker-disclosure {
+  min-width: 0;
   border: var(--turn-border-default) solid var(--turn-ink);
   border-radius: var(--turn-radius-default);
   background: var(--turn-surface-page);
@@ -117,6 +133,7 @@ main {
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
   gap: var(--turn-space-3);
+  min-width: 0;
   min-height: 68px;
   padding: 12px 16px;
   background: var(--turn-disclosure-trigger);
@@ -152,6 +169,7 @@ main {
   line-height: 1.05;
 }
 .disclosure-panel {
+  min-width: 0;
   padding: clamp(16px, 3vw, 24px);
   border-top: var(--turn-border-compact) solid var(--turn-ink);
   background: var(--turn-disclosure-panel);
@@ -188,6 +206,7 @@ main {
 }
 .source-card,
 .entry-pad {
+  min-width: 0;
   border: var(--turn-border-compact) solid var(--turn-ink);
   border-radius: var(--turn-radius-compact);
   background: var(--turn-surface-raised);
@@ -198,6 +217,7 @@ main {
 
 label {
   display: grid;
+  min-width: 0;
   gap: var(--turn-space-1);
   color: var(--turn-ink);
   font-size: .82rem;
@@ -207,6 +227,7 @@ input,
 select,
 textarea {
   width: 100%;
+  min-width: 0;
   min-height: 46px;
   padding: 9px 11px;
   border: var(--turn-border-compact) solid var(--turn-ink);
@@ -227,7 +248,7 @@ textarea {
   flex-wrap: wrap;
 }
 .button-row { margin-top: var(--turn-space-2); }
-.grow { flex: 1 1 16rem; }
+.grow { flex: 1 1 16rem; min-width: 0; }
 
 .button,
 .demo-button,
@@ -279,7 +300,7 @@ textarea {
   padding-top: var(--turn-space-4);
   border-top: var(--turn-border-micro) solid var(--turn-ink);
 }
-.arrangement { display: flex; gap: var(--turn-space-2); }
+.arrangement { display: flex; min-width: 0; gap: var(--turn-space-2); }
 .arrangement select {
   width: 4rem;
   min-height: 52px;
@@ -301,7 +322,7 @@ textarea {
 .instrument-demos { display: grid; gap: var(--turn-space-3); }
 .demo-group {
   display: grid;
-  grid-template-columns: 8rem 1fr;
+  grid-template-columns: 8rem minmax(0, 1fr);
   gap: var(--turn-space-3);
   align-items: start;
 }
@@ -311,7 +332,7 @@ textarea {
   letter-spacing: .1em;
   text-transform: uppercase;
 }
-.demo-buttons { display: flex; flex-wrap: wrap; gap: var(--turn-space-2); }
+.demo-buttons { display: flex; min-width: 0; flex-wrap: wrap; gap: var(--turn-space-2); }
 .demo-button { background: var(--turn-action-utility); }
 .demo-button.active { background: var(--turn-yellow-400); }
 
@@ -399,7 +420,11 @@ textarea {
 }
 
 .tracker-scroll {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   overflow-x: auto;
+  overscroll-behavior-inline: contain;
   border: var(--turn-border-default) solid var(--turn-ink);
   border-radius: var(--turn-radius-default);
   background: var(--turn-white);
@@ -512,7 +537,11 @@ footer {
 }
 
 @media (max-width: 760px) {
-  .app-header-inner,
+  .app-header-inner {
+    grid-template-columns: minmax(0, 1fr);
+    align-items: start;
+  }
+  .app-header-inner .back-link { justify-self: start; }
   .tracker-heading { align-items: start; flex-direction: column; }
   .source-grid,
   .meta-grid,
@@ -533,7 +562,7 @@ footer {
   .tracker-disclosure > summary { grid-template-columns: auto minmax(0, 1fr); }
   .status-pill { grid-column: 2; justify-self: start; }
   .arrangement { width: 100%; }
-  .arrangement select { flex: 1; width: auto; }
+  .arrangement select { flex: 1; width: auto; min-width: 0; }
   .entry-pad-head { align-items: start; flex-direction: column; }
 }
 


### PR DESCRIPTION
## Summary
- Contain page-level horizontal overflow while preserving the tracker table’s own horizontal scroller.
- Change the header shell from flex to a minmax grid so the title/lede and Back to TURN action cannot force the viewport wider.
- Add `min-width: 0` containment to the main grid, panels, disclosures, form controls and tracker wrapper.
- Stack the header cleanly at the existing mobile breakpoint.
- Cache-bust the tracker stylesheet with `r189-layout-containment`.

No music, tracker behavior, or game runtime code is changed.