### PR TITLE
Stop accidental Safari zoom in TURN Music Tracker

### DIFF
--- a/turn/audio/music/index.html
+++ b/turn/audio/music/index.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="../../design-tokens.css?revision=r162-social-sharing">
   <link rel="stylesheet" href="../../design-semantic.css?revision=r162-social-sharing">
   <link rel="stylesheet" href="./tracker.css?revision=r189-layout-containment">
-  <link rel="stylesheet" href="./tracker-workflow.css?revision=r191-primary-workflow">
+  <link rel="stylesheet" href="./tracker-workflow.css?revision=r192-safari-interaction">
 </head>
 <body>
   <header class="app-header">

--- a/turn/audio/music/tracker-workflow.css
+++ b/turn/audio/music/tracker-workflow.css
@@ -6,10 +6,21 @@
   padding: 7px 12px;
 }
 
+button,
+[role="button"] {
+  touch-action: manipulation;
+}
+
 input,
 select {
   min-height: 44px;
   padding-block: 7px;
+}
+
+input,
+select,
+textarea {
+  font-size: 16px;
 }
 
 .arrangement select { min-height: 44px; }


### PR DESCRIPTION
Keeps rapid tracker button taps from being interpreted as double-tap zoom in iOS Safari, and raises form-control text to 16px so focusing inputs does not trigger Safari's automatic input zoom. Pinch zoom remains available; the viewport is not locked. Also cache-busts the tracker workflow stylesheet.