### PR TITLE
Normalize TURN UI to the intended 75% Safari baseline

### DIFF
--- a/turn/audio/music/index.html
+++ b/turn/audio/music/index.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="../../design-semantic.css?revision=r162-social-sharing">
   <link rel="stylesheet" href="./tracker.css?revision=r189-layout-containment">
   <link rel="stylesheet" href="./tracker-workflow.css?revision=r192-safari-interaction">
+  <script src="../../ui/page-zoom-baseline-r193.js?revision=r193-canonical-75"></script>
 </head>
 <body>
   <header class="app-header">

--- a/turn/index.html
+++ b/turn/index.html
@@ -66,6 +66,7 @@
   <link rel="stylesheet" href="./accessibility/color-cues-r163.css?build=20260811-r164-accessible-paint">
   <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260811-r164-menu-font-v3">
   <link rel="stylesheet" href="./home-header-r425.css?revision=r425-header-boundary">
+  <script src="./ui/page-zoom-baseline-r193.js?revision=r193-canonical-75"></script>
   <script src="./install-gate.js?build=20260811-r164-social-browser"></script>
   <script src="./pwa-usable-viewport-r181.js?revision=r181-usable-web-layer"></script>
   <script src="./motion-safe-zone.js?build=20260811-r164"></script>

--- a/turn/stats/index.html
+++ b/turn/stats/index.html
@@ -9,6 +9,7 @@
   <link rel="icon" href="../TURNicon.PNG" type="image/png">
   <link rel="stylesheet" href="../design-tokens.css?build=20260808-r162">
   <link rel="stylesheet" href="./stats.css?revision=r1">
+  <script src="../ui/page-zoom-baseline-r193.js?revision=r193-canonical-75"></script>
 </head>
 <body>
   <main class="stats-shell">

--- a/turn/ui/page-zoom-baseline-r193.js
+++ b/turn/ui/page-zoom-baseline-r193.js
@@ -1,0 +1,327 @@
+(() => {
+  'use strict';
+
+  const SCALE = 0.75;
+  const SCALE_ATTRIBUTE = 'data-turn-ui-baseline-scale';
+  const NORMALIZED_ATTRIBUTE = 'data-turn-ui-baseline-normalized';
+  const ABSOLUTE_LENGTH_UNITS = new Set(['px', 'rem']);
+  const processedSheets = new WeakSet();
+  const pendingLinks = new WeakSet();
+
+  const diagnostics = {
+    scale: SCALE,
+    stylesheets: 0,
+    rules: 0,
+    declarations: 0,
+    mediaQueries: 0,
+    htmlLengths: 0,
+    protectedFormControls: 0,
+    inaccessibleStylesheets: 0
+  };
+
+  function formatNumber(value) {
+    const rounded = Math.round((value + Number.EPSILON) * 10000) / 10000;
+    if (Object.is(rounded, -0) || Math.abs(rounded) < 0.00005) return '0';
+    return String(rounded);
+  }
+
+  function startsUrlFunction(source, index) {
+    return source.slice(index, index + 4).toLowerCase() === 'url(';
+  }
+
+  function copyFunctionVerbatim(source, start) {
+    let index = start;
+    let depth = 0;
+    let quote = '';
+    for (; index < source.length; index += 1) {
+      const char = source[index];
+      if (quote) {
+        if (char === '\\') {
+          index += 1;
+          continue;
+        }
+        if (char === quote) quote = '';
+        continue;
+      }
+      if (char === '"' || char === "'") {
+        quote = char;
+        continue;
+      }
+      if (char === '(') depth += 1;
+      if (char === ')') {
+        depth -= 1;
+        if (depth === 0) return source.slice(start, index + 1);
+      }
+    }
+    return source.slice(start);
+  }
+
+  function scaleAbsoluteLengths(source) {
+    const text = String(source ?? '');
+    let result = '';
+    let index = 0;
+    let quote = '';
+
+    while (index < text.length) {
+      const char = text[index];
+
+      if (quote) {
+        result += char;
+        if (char === '\\' && index + 1 < text.length) {
+          result += text[index + 1];
+          index += 2;
+          continue;
+        }
+        if (char === quote) quote = '';
+        index += 1;
+        continue;
+      }
+
+      if (char === '"' || char === "'") {
+        quote = char;
+        result += char;
+        index += 1;
+        continue;
+      }
+
+      if (startsUrlFunction(text, index)) {
+        const verbatim = copyFunctionVerbatim(text, index);
+        result += verbatim;
+        index += verbatim.length;
+        continue;
+      }
+
+      const previous = index > 0 ? text[index - 1] : '';
+      const canStartNumber = !previous || !/[A-Za-z0-9_-]/.test(previous);
+      if (canStartNumber) {
+        const match = text.slice(index).match(/^(-?(?:\d+(?:\.\d*)?|\.\d+))(px|rem)\b/i);
+        if (match && ABSOLUTE_LENGTH_UNITS.has(match[2].toLowerCase())) {
+          const scaled = Number(match[1]) * SCALE;
+          result += `${formatNumber(scaled)}${match[2]}`;
+          index += match[0].length;
+          continue;
+        }
+      }
+
+      result += char;
+      index += 1;
+    }
+
+    return result;
+  }
+
+  function selectorTargetsRoot(selectorText) {
+    const selector = String(selectorText || '');
+    return selector.split(',').some((part) => {
+      const trimmed = part.trim();
+      return trimmed === ':root' || trimmed === 'html' || /^html(?:[.#[:]|\s|>|\+|~)/.test(trimmed);
+    });
+  }
+
+  function scaleStyleDeclaration(style, selectorText = '') {
+    if (!style) return;
+    const properties = Array.from({ length: style.length }, (_, index) => style.item(index)).filter(Boolean);
+    for (const property of properties) {
+      const value = style.getPropertyValue(property);
+      if (property === 'font-size' && selectorTargetsRoot(selectorText)) continue;
+      const nextValue = scaleAbsoluteLengths(value);
+      if (nextValue === value) continue;
+      const priority = style.getPropertyPriority(property);
+      style.setProperty(property, nextValue, priority);
+      diagnostics.declarations += 1;
+    }
+  }
+
+  function scaleRule(rule) {
+    if (!rule) return;
+    diagnostics.rules += 1;
+
+    if (rule.media?.mediaText) {
+      const currentMedia = rule.media.mediaText;
+      const nextMedia = scaleAbsoluteLengths(currentMedia);
+      if (nextMedia !== currentMedia) {
+        try {
+          rule.media.mediaText = nextMedia;
+          diagnostics.mediaQueries += 1;
+        } catch {
+          // A browser may expose a read-only MediaList for a particular rule.
+          // The declaration rules inside it are still safe to normalize.
+        }
+      }
+    }
+
+    if (rule.style) scaleStyleDeclaration(rule.style, rule.selectorText || '');
+
+    if (rule.styleSheet) {
+      processStylesheet(rule.styleSheet);
+    }
+
+    if (rule.cssRules) {
+      for (const childRule of Array.from(rule.cssRules)) scaleRule(childRule);
+    }
+  }
+
+  function processStylesheet(sheet) {
+    if (!sheet || processedSheets.has(sheet)) return;
+    let rules;
+    try {
+      rules = sheet.cssRules;
+    } catch {
+      diagnostics.inaccessibleStylesheets += 1;
+      return;
+    }
+    processedSheets.add(sheet);
+    diagnostics.stylesheets += 1;
+    for (const rule of Array.from(rules || [])) scaleRule(rule);
+    const owner = sheet.ownerNode;
+    if (owner?.setAttribute) owner.setAttribute(NORMALIZED_ATTRIBUTE, '');
+  }
+
+  function processStylesheetNode(node) {
+    if (!(node instanceof Element)) return;
+    if (node.matches('style')) {
+      processStylesheet(node.sheet);
+      return;
+    }
+    if (node.matches('link[rel~="stylesheet"]')) {
+      if (node.sheet) {
+        processStylesheet(node.sheet);
+        return;
+      }
+      if (pendingLinks.has(node)) return;
+      pendingLinks.add(node);
+      node.addEventListener('load', () => {
+        pendingLinks.delete(node);
+        processStylesheet(node.sheet);
+      }, { once: true });
+    }
+  }
+
+  function processStylesheetTree(root) {
+    if (!(root instanceof Element)) return;
+    processStylesheetNode(root);
+    for (const node of root.querySelectorAll('style, link[rel~="stylesheet"]')) {
+      processStylesheetNode(node);
+    }
+  }
+
+  function scaleNumericHtmlLength(element, attributeName) {
+    const raw = element.getAttribute(attributeName);
+    if (!raw || !/^-?(?:\d+(?:\.\d*)?|\.\d+)(?:px)?$/i.test(raw.trim())) return;
+    const unit = /px$/i.test(raw.trim()) ? 'px' : '';
+    const value = Number.parseFloat(raw);
+    const next = `${formatNumber(value * SCALE)}${unit}`;
+    if (next === raw) return;
+    element.setAttribute(attributeName, next);
+    diagnostics.htmlLengths += 1;
+  }
+
+  function normalizePresentationalLengths(root) {
+    if (!(root instanceof Element)) return;
+    const candidates = root.matches('svg[width], svg[height], img[width], img[height]')
+      ? [root]
+      : [];
+    candidates.push(...root.querySelectorAll('svg[width], svg[height], img[width], img[height]'));
+    for (const element of candidates) {
+      if (element.dataset.turnUiLengthNormalized === 'true') continue;
+      scaleNumericHtmlLength(element, 'width');
+      scaleNumericHtmlLength(element, 'height');
+      element.dataset.turnUiLengthNormalized = 'true';
+    }
+  }
+
+  const NON_TEXT_INPUT_TYPES = new Set([
+    'button', 'checkbox', 'color', 'file', 'hidden', 'image',
+    'radio', 'range', 'reset', 'submit'
+  ]);
+
+  function protectFormControl(control) {
+    if (!(control instanceof Element)) return;
+    if (control.matches('input') && NON_TEXT_INPUT_TYPES.has((control.getAttribute('type') || 'text').toLowerCase())) {
+      return;
+    }
+    const size = Number.parseFloat(getComputedStyle(control).fontSize);
+    if (!Number.isFinite(size) || size >= 16) return;
+    control.style.setProperty('font-size', '16px', 'important');
+    control.dataset.turnSafariTextZoomProtected = 'true';
+    diagnostics.protectedFormControls += 1;
+  }
+
+  function protectFormControls(root) {
+    if (!(root instanceof Element)) return;
+    if (root.matches('input, select, textarea')) protectFormControl(root);
+    for (const control of root.querySelectorAll('input, select, textarea')) protectFormControl(control);
+  }
+
+  function normalizeTree(root) {
+    processStylesheetTree(root);
+    normalizePresentationalLengths(root);
+    protectFormControls(root);
+  }
+
+  function normalizeExistingDocument() {
+    for (const sheet of Array.from(document.styleSheets)) processStylesheet(sheet);
+    normalizePresentationalLengths(document.documentElement);
+    protectFormControls(document.documentElement);
+  }
+
+  globalThis.__turnPageZoomBaselineTest = Object.freeze({
+    scale: SCALE,
+    scaleAbsoluteLengths,
+    formatNumber,
+    selectorTargetsRoot
+  });
+
+  if (typeof document === 'undefined' || typeof Element === 'undefined') return;
+
+  document.documentElement.setAttribute(SCALE_ATTRIBUTE, String(SCALE));
+  normalizeExistingDocument();
+
+  const observer = new MutationObserver((records) => {
+    for (const record of records) {
+      if (record.type === 'childList') {
+        if (record.target instanceof Element && record.target.matches('style') && record.target.sheet) {
+          processedSheets.delete(record.target.sheet);
+          processStylesheet(record.target.sheet);
+        }
+        for (const node of record.addedNodes) {
+          if (node instanceof Element) {
+            normalizeTree(node);
+          } else if (node.parentElement?.matches?.('style') && node.parentElement.sheet) {
+            processedSheets.delete(node.parentElement.sheet);
+            processStylesheet(node.parentElement.sheet);
+          }
+        }
+        continue;
+      }
+
+      if (record.type === 'characterData') {
+        const style = record.target.parentElement?.closest?.('style');
+        if (style?.sheet) {
+          processedSheets.delete(style.sheet);
+          processStylesheet(style.sheet);
+        }
+      }
+    }
+  });
+
+  observer.observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+    characterData: true
+  });
+
+  const settle = () => {
+    normalizeExistingDocument();
+    globalThis.__turnPageZoomBaselineDiagnostics = Object.freeze({ ...diagnostics });
+    window.dispatchEvent(new CustomEvent('turn:ui-baseline-normalized', {
+      detail: globalThis.__turnPageZoomBaselineDiagnostics
+    }));
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', settle, { once: true });
+  } else {
+    queueMicrotask(settle);
+  }
+})();

--- a/yourturn/index.html
+++ b/yourturn/index.html
@@ -45,6 +45,7 @@
   <link rel="stylesheet" href="/yourturn/growing-challenge.css?revision=r2">
   <link rel="stylesheet" href="/yourturn/about-links.css?revision=r2">
   <link rel="stylesheet" href="/yourturn/r411.css?revision=r411">
+  <script src="/turn/ui/page-zoom-baseline-r193.js?revision=r193-canonical-75"></script>
 
   <script src="/yourturn/storage-bootstrap.js?revision=r2"></script>
   <script type="importmap">


### PR DESCRIPTION
## Why
TURN was designed and device-tested on iPhone with Safari Page Zoom set to 75%. The same setting also affects the installed PWA. At normal 100% page zoom, fixed UI lengths, typography, borders, spacing and responsive breakpoints therefore render substantially larger than the intended design, while viewport-filling Three.js geometry remains essentially unchanged.

We now have matched 75% and 100% screenshots from the same iPhone, same PWA install/session and same orientation covering Home, The Lot, race HUD, Settings and Achievements, plus a wider 75% golden set covering loading, rotate, dialogs, track intro and race states.

## Approach
This PR establishes the old 75%-zoom appearance as TURN's canonical UI baseline at normal 100% browser zoom.

A shared early-running normalizer:
- multiplies fixed `px` and `rem` design lengths by `0.75`;
- does the same to fixed bounds inside `clamp()`, `calc()`, `min()` and `max()`;
- converts pixel media-query thresholds (for example `560px -> 420px`);
- leaves viewport-relative units (`vw`, `vh`, `dvw`, `dvh`), percentages, `fr`, Three.js/canvas sizing, world geometry and safe-area `env()` values alone;
- watches TURN's dynamically inserted same-origin stylesheets so Home, Settings, achievements, DBE 101, loading and other runtime UI receive the same conversion;
- preserves the root font-size while scaling `rem` values so typography is not double-scaled;
- keeps text-entry controls at Safari's 16px-safe focus size where needed, preserving the Music Tracker fix from #454;
- does **not** use CSS `zoom` or `transform: scale()`.

The normalizer is loaded by:
- TURN
- YOUR TURN
- private Stats
- Music Tracker

## Deliberately unchanged
- Three.js renderer/camera/world coordinates
- canvas backing dimensions and track-map drawing geometry
- physics, controls and audio
- viewport-relative geometry
- user browser zoom itself

This means 100% becomes the intended baseline, while a user choosing 125%, 150%, 200%, etc. can still enlarge the interface normally.

## Validation target
The supplied 75% screenshots are the visual goldens. In particular:
- Home should again show the intended compact track/menu composition and comfortable RACE clearance;
- The Lot information rail should match the compact 75% presentation with RACE THIS CAR comfortably available;
- race HUD/menu chrome should shrink while the 3D racing scene, drive pad and map geometry retain their intended viewport-relative scale;
- Settings and Achievements should match the 75% density rather than the oversized 100% screenshots;
- loading/rotate/dialog surfaces should follow the same baseline conversion.

## Status
Draft for CI and real-device calibration at Safari/PWA 100%. Do not merge until the matched iPhone screenshots have been checked against the 75% goldens.