### PR TITLE
Move The Lot actions out of the details rail

### DIFF
--- a/turn/garage/lot-layout-r60.js
+++ b/turn/garage/lot-layout-r60.js
@@ -1,11 +1,96 @@
+const BOTTOM_ACTION_STYLE_ID = 'turn-lot-bottom-actions-r196';
+
+function installBottomActionStyles() {
+  if (document.getElementById(BOTTOM_ACTION_STYLE_ID)) return;
+
+  const style = document.createElement('style');
+  style.id = BOTTOM_ACTION_STYLE_ID;
+  style.textContent = `
+    /*
+      The Lot's narrow right rail is for car information only. Primary
+      navigation sits over the open canvas instead, which gives descriptions,
+      perks and stats the full rail height without sacrificing the 3D preview.
+      The buttons remain in their original DOM locations so existing click,
+      focus and VoiceOver wiring keeps working unchanged.
+    */
+    .lot-side {
+      top: max(12px, env(safe-area-inset-top));
+    }
+
+    .lot-card-actions {
+      position: fixed;
+      z-index: 6;
+      right: calc(var(--lot-rail-width) + max(28px, env(safe-area-inset-right)));
+      bottom: max(24px, env(safe-area-inset-bottom));
+      width: clamp(160px, 20vw, 240px);
+      margin: 0;
+      padding: 0;
+      background: transparent;
+    }
+
+    .lot-race {
+      min-height: 56px;
+    }
+
+    .lot-back {
+      top: auto;
+      right: auto;
+      left: max(24px, env(safe-area-inset-left));
+      bottom: max(24px, env(safe-area-inset-bottom));
+      width: auto;
+      height: auto;
+      min-width: 144px;
+      min-height: 56px;
+      padding: 8px 18px;
+      border-radius: 999px;
+      font-size: 0.8rem;
+      letter-spacing: 0.04em;
+    }
+
+    @media (max-height: 520px) {
+      .lot-side {
+        top: max(10px, env(safe-area-inset-top));
+      }
+
+      .lot-card-actions {
+        right: calc(var(--lot-rail-width) + max(18px, env(safe-area-inset-right)));
+        bottom: max(18px, env(safe-area-inset-bottom));
+      }
+
+      .lot-back {
+        left: max(18px, env(safe-area-inset-left));
+        bottom: max(18px, env(safe-area-inset-bottom));
+      }
+    }
+
+    @media (max-height: 430px) {
+      .lot-card-actions {
+        width: clamp(140px, 20vw, 210px);
+      }
+    }
+  `;
+  document.head.appendChild(style);
+}
+
 export function installLotLayout(root = document.body) {
   const screen = root.querySelector('.lot-screen');
   const attributesHeading = screen?.querySelector('.lot-car-title > span');
   const infoButton = screen?.querySelector('.lot-stats-help');
+  const headingCopy = screen?.querySelector('.lot-heading > p');
+  const backButton = screen?.querySelector('.lot-back');
+  const raceButton = screen?.querySelector('.lot-race');
 
   if (!screen || !attributesHeading) return () => {};
 
+  installBottomActionStyles();
   screen.classList.remove('is-view-closed');
+
+  if (headingCopy) headingCopy.textContent = 'Choose your car';
+  if (backButton) {
+    backButton.textContent = '< BACK';
+    backButton.setAttribute('aria-label', 'Back to track selection');
+  }
+  if (raceButton) raceButton.textContent = 'RACE!';
 
   attributesHeading.replaceChildren(document.createTextNode('ATTRIBUTES'));
   if (infoButton) {


### PR DESCRIPTION
## Why
The Lot's right-hand rail is the tightest vertical part of the screen. The car preview, paint controls, attributes, descriptions/perks and `RACE THIS CAR` currently all compete for the same height, while the close action also reserves space above the rail.

This follows the supplied layout mockup only; it deliberately does **not** copy the mockup's patchy background colours.

## Changes
- Reclaims the top-right space by turning the circular close control into a bottom-left `< BACK` action.
- Moves the race action visually out of the attributes card to the bottom-right of the open lot/canvas area and shortens its visible label to `RACE!`.
- Moves the right-side preview/details rail up to the top safe area now that it no longer has to clear the close button.
- Changes the Lot helper line to `Choose your car`.
- Leaves the race button in its existing DOM/card hierarchy even though it is visually fixed over the canvas. That preserves the current click guard, focus handling, VoiceOver behaviour and race wiring without duplicating interaction logic.
- Keeps all existing colours unchanged.

## Page-zoom baseline
The new runtime style is inserted through the existing Lot layout enhancer. TURN's page-zoom normalizer already observes dynamic `<style>` elements, so the new fixed lengths and compact breakpoints receive the same canonical 0.75 normalization as the rest of TURN.

## Expected result
The right rail now spends its height on the 3D preview, paint and car information instead of navigation buttons, giving long descriptions/perks substantially more room and making the layout more resilient on short landscape viewports.