### PR TITLE
Recover TURN Music Tracker after direct song edits

### DIFF
--- a/turn-tests/racing-music-production.mjs
+++ b/turn-tests/racing-music-production.mjs
@@ -1,11 +1,12 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [index, labIndex, releaseSource, homeLayout, engine, songbookSource, songToolsSource,
+const [index, labIndex, trackerIndex, releaseSource, homeLayout, engine, songbookSource, songToolsSource,
   toneRuntime, drumRuntime, leadVoicesSource, bassVoicesSource, arpVoicesSource,
   drumKitsSource] = await Promise.all([
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-lab/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/audio/music/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/release.json', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/audio/racing-music-v5.js', import.meta.url), 'utf8'),
@@ -36,15 +37,23 @@ const release = JSON.parse(releaseSource);
 const musicSpecifier = `/turn/audio/racing-music-v2.js?build=${release.cacheKey}-racing-music-warm-v2`;
 const productionImports = importMapImports(index);
 const labImports = importMapImports(labIndex);
+const trackerImports = importMapImports(trackerIndex);
 assert.equal(productionImports[musicSpecifier], '/turn/audio/racing-music-v5.js?revision=r185-menu-orchestration');
 assert.equal(labImports[musicSpecifier], '/turn/audio/racing-music-v5.js?revision=r185-menu-orchestration');
 assert.match(homeLayout, /audio\/racing-music-v2\.js\?build=\$\{buildKey\}-racing-music-warm-v2/);
 assert.match(engine, /music\/songbook\.js\?revision=r185-menu-orchestration/);
+assert.equal(
+  trackerImports['./songbook.js?revision=r185-menu-orchestration'],
+  './songbook.js?revision=r196-user-scores-repair',
+  'Music Tracker must bypass stale songbook modules after direct score edits'
+);
+assert.match(trackerIndex, /tracker\.js\?revision=r196-song-recovery/,
+  'Music Tracker entry must get a fresh module identity after a broken song import');
 
 // Creative score files are intentionally user-editable. Cache-bust their direct imports whenever
 // the checked-in scores change so installed Safari PWAs do not keep stale song modules.
 for (const songFile of ['menu-theme', 'countryside', 'airport', 'cliffside', 'harbor', 'midnight-city']) {
-  assert.match(songbookSource, new RegExp(`${songFile}\\.js\\?revision=r194-user-scores`),
+  assert.match(songbookSource, new RegExp(`${songFile}\\.js\\?revision=r196-user-scores-repair`),
     `${songFile} must use the current user-score cache revision`);
 }
 

--- a/turn/audio/music/airport.js
+++ b/turn/audio/music/airport.js
@@ -90,5 +90,5 @@ const CHORUS = makeSection({
 export const AIRPORT_SONG = makeSong({
   id: 'airport', name: 'TURN Theme', bpm: 128, key: 'E minor',
   style: 'warm arcade title anthem', swing: 0.1,
-  sections: [TUNE, BRIDGE, CHORUS], arrangement: ['tune', 'tune', 'bridge', 'tune', 'chorus ', 'chorus']
+  sections: [TUNE, BRIDGE, CHORUS], arrangement: ['tune', 'tune', 'bridge', 'tune', 'chorus', 'chorus']
 });

--- a/turn/audio/music/cliffside.js
+++ b/turn/audio/music/cliffside.js
@@ -90,5 +90,5 @@ const CHORUS = makeSection({
 export const CLIFFSIDE_SONG = makeSong({
   id: 'cliffside', name: 'TURN Theme', bpm: 120, key: 'E minor',
   style: 'warm arcade title anthem', swing: 0.2,
-  sections: [TUNE, BRIDGE, CHORUS], arrangement: ['tune', 'tune', 'bridge', 'tune', 'chorus ', 'chorus']
+  sections: [TUNE, BRIDGE, CHORUS], arrangement: ['tune', 'tune', 'bridge', 'tune', 'chorus', 'chorus']
 });

--- a/turn/audio/music/countryside.js
+++ b/turn/audio/music/countryside.js
@@ -90,5 +90,5 @@ const CHORUS = makeSection({
 export const COUNTRYSIDE_SONG = makeSong({
   id: 'countryside', name: 'TURN Theme', bpm: 112, key: 'E minor',
   style: 'warm arcade title anthem', swing: 0.24,
-  sections: [TUNE, BRIDGE, CHORUS], arrangement: ['tune', 'tune', 'bridge', 'tune', 'chorus ', 'chorus']
+  sections: [TUNE, BRIDGE, CHORUS], arrangement: ['tune', 'tune', 'bridge', 'tune', 'chorus', 'chorus']
 });

--- a/turn/audio/music/harbor.js
+++ b/turn/audio/music/harbor.js
@@ -90,5 +90,5 @@ const CHORUS = makeSection({
 export const HARBOR_SONG = makeSong({
   id: 'harbor', name: 'TURN Theme', bpm: 132, key: 'E minor',
   style: 'warm arcade title anthem', swing: 0.05,
-  sections: [TUNE, BRIDGE, CHORUS], arrangement: ['tune', 'tune', 'bridge', 'tune', 'chorus ', 'chorus']
+  sections: [TUNE, BRIDGE, CHORUS], arrangement: ['tune', 'tune', 'bridge', 'tune', 'chorus', 'chorus']
 });

--- a/turn/audio/music/index.html
+++ b/turn/audio/music/index.html
@@ -195,7 +195,14 @@
   </main>
 
   <footer>TURN Music Tracker is a development utility. It uses the same generated Web Audio instruments as the game and stores an autosaved draft in this browser only.</footer>
-  <script type="module" src="./tracker.js?revision=r188-design-system"></script>
+  <script type="importmap">
+    {
+      "imports": {
+        "./songbook.js?revision=r185-menu-orchestration": "./songbook.js?revision=r196-user-scores-repair"
+      }
+    }
+  </script>
+  <script type="module" src="./tracker.js?revision=r196-song-recovery"></script>
   <script type="module" src="./tracker-column-octave.js?revision=r190-column-octave"></script>
   <script type="module" src="./tracker-bar-shortcuts.js?revision=r191-primary-workflow"></script>
 </body>

--- a/turn/audio/music/midnight-city.js
+++ b/turn/audio/music/midnight-city.js
@@ -90,5 +90,5 @@ const CHORUS = makeSection({
 export const MIDNIGHT_CITY_SONG = makeSong({
   id: 'midnight-city', name: 'TURN Theme', bpm: 128, key: 'E minor',
   style: 'warm arcade title anthem', swing: 0,
-  sections: [TUNE, BRIDGE, CHORUS], arrangement: ['tune', 'tune', 'bridge', 'tune', 'chorus ', 'chorus']
+  sections: [TUNE, BRIDGE, CHORUS], arrangement: ['tune', 'tune', 'bridge', 'tune', 'chorus', 'chorus']
 });

--- a/turn/audio/music/songbook.js
+++ b/turn/audio/music/songbook.js
@@ -1,9 +1,9 @@
-import { MENU_SONG } from './menu-theme.js?revision=r194-user-scores';
-import { COUNTRYSIDE_SONG } from './countryside.js?revision=r194-user-scores';
-import { AIRPORT_SONG } from './airport.js?revision=r194-user-scores';
-import { CLIFFSIDE_SONG } from './cliffside.js?revision=r194-user-scores';
-import { HARBOR_SONG } from './harbor.js?revision=r194-user-scores';
-import { MIDNIGHT_CITY_SONG } from './midnight-city.js?revision=r194-user-scores';
+import { MENU_SONG } from './menu-theme.js?revision=r196-user-scores-repair';
+import { COUNTRYSIDE_SONG } from './countryside.js?revision=r196-user-scores-repair';
+import { AIRPORT_SONG } from './airport.js?revision=r196-user-scores-repair';
+import { CLIFFSIDE_SONG } from './cliffside.js?revision=r196-user-scores-repair';
+import { HARBOR_SONG } from './harbor.js?revision=r196-user-scores-repair';
+import { MIDNIGHT_CITY_SONG } from './midnight-city.js?revision=r196-user-scores-repair';
 
 export { MENU_SONG };
 


### PR DESCRIPTION
Fixes the empty Music Tracker song selector after the latest direct score edits.

Root cause was not the selector itself: all five track files currently referenced `chorus ` (with a trailing space) in their six-part arrangement. `makeSong()` correctly rejected that unknown section, which caused the shared songbook module to fail during import; because the tracker imports the whole songbook before wiring its UI, the selector never received any options.

This PR:
- corrects the five malformed `chorus ` arrangement tokens without changing any notes, instruments, tempos or other score content
- moves all direct song imports to a fresh `r196-user-scores-repair` cache identity
- gives the Music Tracker an import-map bridge from its old songbook specifier to the fresh songbook, plus a fresh tracker entry URL for Safari/module-cache recovery
- extends the generated-music regression to verify the tracker cache bridge and current direct-song revision, while continuing to validate that every song can actually instantiate

The latest main regression failure already pinpoints the same root cause: `TURN music countryside references unknown section chorus .`