### PR TITLE
Stop skid marks bridging across gaps and track changes

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -158,6 +158,7 @@
   <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260811-r164-r168-shared-about-credits"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
   <script type="module" src="./app.js?build=20260811-r164-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r164-long-session-robustness-post-soak"></script>
+  <script type="module" src="./render/skid-continuity-r198.js?revision=r198-skid-continuity"></script>
   <script type="module" src="./accessibility/color-accessibility-r163.js?build=20260811-r164-paint-basics"></script>
   <script type="module" src="./achievements/chromatic-camouflage-r183.js?revision=r183-production"></script>
   <script type="module" src="./social/your-turn-share-bootstrap.js?revision=r2"></script>

--- a/turn-tests/skid-ring-buffer-production.mjs
+++ b/turn-tests/skid-ring-buffer-production.mjs
@@ -1,14 +1,20 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [releaseSource, index, main] = await Promise.all([
+const [releaseSource, index, labIndex, main, continuity] = await Promise.all([
   fs.readFile(new URL('../turn/release.json', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/main.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn-lab/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/main.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/render/skid-continuity-r198.js', import.meta.url), 'utf8')
 ]);
 
 const release = JSON.parse(releaseSource);
 assert.match(index, new RegExp(`TURN v${release.version.replaceAll('.', '\\.')} · Build ${release.id.replaceAll('.', '\\.')}`));
+assert.match(index, /render\/skid-continuity-r198\.js\?revision=r198-skid-continuity/,
+  'Production TURN must load the fresh skid continuity renderer');
+assert.match(labIndex, /render\/skid-continuity-r198\.js\?revision=r198-skid-continuity/,
+  'TURN LAB must exercise the same skid continuity renderer as production');
 
 const declarations = section(main, 'const SKID_HISTORY_CAPACITY', '\nconst smokePool');
 assert.match(declarations, /SKID_HISTORY_CAPACITY = 90/, 'Skid history must preserve the previous 90 sample pairs');
@@ -42,6 +48,31 @@ assert.match(ringSection, /skidGeometry\.setDrawRange\(0, cursor\)/);
 assert.doesNotMatch(ringSection, /\.clone\(\)|\.unshift\(|\.map\(/, 'The skid update path must allocate no vectors or small history arrays');
 assert.doesNotMatch(ringSection, /requestAnimationFrame|setAnimationLoop|setInterval|setTimeout/, 'The ring buffer must remain inside the existing scene update');
 
+assert.match(continuity, /legacySkidLine\.visible = false/,
+  'The old renderer must be hidden so the corrected geometry is the only visible skid layer');
+assert.match(continuity, /new Uint8Array\(SKID_HISTORY_CAPACITY\)/,
+  'Continuity must be stored in a fixed allocation alongside the existing ring-buffer model');
+assert.match(continuity, /skidHistoryConnections\[skidHistoryStart\] = connectToPrevious \? 1 : 0/,
+  'Every new skid sample must explicitly declare whether it connects to the previous sample');
+assert.match(continuity, /skidHistoryConnections\[skidHistoryStart\] = 0/,
+  'Non-skidding frames must age the history without creating a drawable connection');
+assert.match(continuity, /const connectToPrevious = skidStrokeActive/,
+  'A new skid stroke must not connect back to an older stroke after grip returns');
+assert.match(continuity, /latestSkidDistanceSquared\(0, skidLeftWheel\) <= SKID_MAX_CONTINUOUS_GAP_SQUARED/,
+  'Even an active skid must reject an implausibly large position jump');
+assert.match(continuity, /if \(!skidHistoryConnections\[sampleIndex\]\) continue/,
+  'Rendering must skip breaks instead of drawing across them');
+assert.match(continuity, /clearIfCarJumped\(\)/,
+  'Track, training-part and restart teleports must clear stale skid history before repainting');
+assert.match(continuity, /addEventListener\('turn:track-changed', clearSkids\)/,
+  'Changing tracks must clear skid history immediately');
+assert.match(continuity, /event\.detail\?\.reason === 'race-reset'/,
+  'Restarting a race must clear skid history immediately');
+assert.match(continuity, /skidLine\.onBeforeRender = updateSkids/,
+  'The corrected renderer must stay inside the existing render loop rather than adding another animation loop');
+assert.doesNotMatch(continuity, /requestAnimationFrame|setAnimationLoop|setInterval|setTimeout/,
+  'The continuity fix must not add another timer or animation loop');
+
 const simulation = createRingSimulation(3);
 simulation.push([1, 2, 3, 4, 5, 6]);
 simulation.push([7, 8, 9, 10, 11, 12]);
@@ -58,7 +89,22 @@ assert.deepEqual(simulation.samples(), [
   [7, 8, 9, 10, 11, 12]
 ], 'A full ring must overwrite only the oldest sample');
 
-console.log(`TURN ${release.id} fixed skid history ring buffer passed.`);
+const continuitySimulation = createContinuitySimulation(6);
+const a = [1, 1, 1, 2, 2, 2];
+const b = [3, 3, 3, 4, 4, 4];
+const c = [20, 20, 20, 21, 21, 21];
+const d = [22, 22, 22, 23, 23, 23];
+continuitySimulation.push(a, false);
+continuitySimulation.push(b, true);
+continuitySimulation.repeatGap();
+continuitySimulation.push(c, false);
+continuitySimulation.push(d, true);
+assert.deepEqual(continuitySimulation.segments(), [
+  [d, c],
+  [b, a]
+], 'Separate skid bursts must remain visible as separate strokes without a bridge across the gap');
+
+console.log(`TURN ${release.id} fixed skid history and continuity regression passed.`);
 
 function section(source, startMarker, endMarker) {
   const start = source.indexOf(startMarker);
@@ -94,6 +140,40 @@ function createRingSimulation(capacity) {
         const slot = (start + offset) % capacity;
         return Array.from(values.slice(slot * stride, slot * stride + stride));
       });
+    }
+  };
+}
+
+function createContinuitySimulation(capacity) {
+  const values = Array.from({ length: capacity }, () => null);
+  const connections = new Uint8Array(capacity);
+  let start = 0;
+  let count = 0;
+
+  function insert(sample, connected) {
+    start = (start - 1 + capacity) % capacity;
+    values[start] = sample;
+    connections[start] = connected ? 1 : 0;
+    count = Math.min(capacity, count + 1);
+  }
+
+  return {
+    push(sample, connected) {
+      insert(sample, connected);
+    },
+    repeatGap() {
+      if (!count) return;
+      insert(values[start], false);
+    },
+    segments() {
+      const segments = [];
+      for (let offset = 0; offset < count - 1; offset += 1) {
+        const current = (start + offset) % capacity;
+        const previous = (start + offset + 1) % capacity;
+        if (!connections[current]) continue;
+        segments.push([values[current], values[previous]]);
+      }
+      return segments;
     }
   };
 }

--- a/turn/index.html
+++ b/turn/index.html
@@ -169,6 +169,7 @@
   <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260811-r164-r168-shared-about-credits"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
   <script type="module" src="./app.js?build=20260811-r164-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r420-music-warm-r426-loading-copy-r164-long-session-robustness-post-soak"></script>
+  <script type="module" src="./render/skid-continuity-r198.js?revision=r198-skid-continuity"></script>
   <script type="module" src="./input/qe-drive-controls-bootstrap.js?revision=r418-qe"></script>
   <script type="module" src="./ui/r411-race-controls.js?revision=r411"></script>
   <script type="module" src="./accessibility/color-accessibility-r163.js?build=20260811-r164-paint-basics"></script>

--- a/turn/render/skid-continuity-r198.js
+++ b/turn/render/skid-continuity-r198.js
@@ -1,0 +1,198 @@
+import * as THREE from 'three';
+
+const REVISION = 'r198-skid-continuity';
+const SKID_HISTORY_CAPACITY = 90;
+const SKID_WHEEL_COUNT = 2;
+const SKID_COMPONENT_COUNT = 3;
+const SKID_SAMPLE_STRIDE = SKID_WHEEL_COUNT * SKID_COMPONENT_COUNT;
+const SKID_MAX_DRAW_VERTICES = 120;
+const SKID_POSITION_CAPACITY = 360;
+const SKID_MAX_CONTINUOUS_GAP = 18;
+const SKID_MAX_CONTINUOUS_GAP_SQUARED = SKID_MAX_CONTINUOUS_GAP * SKID_MAX_CONTINUOUS_GAP;
+
+let installed = false;
+
+export function installSkidContinuity(runtime = globalThis.__turnRuntime) {
+  if (installed) return globalThis.__turnSkidContinuity || null;
+  if (!runtime?.world || !runtime?.state || !runtime?.getForward || !runtime?.getRight) return null;
+
+  const legacySkidLine = findLegacySkidLine(runtime.world);
+  if (!legacySkidLine) {
+    console.warn('TURN: skid continuity could not find the legacy skid renderer.');
+    return null;
+  }
+
+  installed = true;
+  legacySkidLine.visible = false;
+  legacySkidLine.userData.turnSkidLegacyDisabled = true;
+
+  const skidGeometry = new THREE.BufferGeometry();
+  const skidPositions = new Float32Array(SKID_POSITION_CAPACITY * SKID_COMPONENT_COUNT);
+  skidGeometry.setAttribute('position', new THREE.BufferAttribute(skidPositions, SKID_COMPONENT_COUNT));
+  skidGeometry.setDrawRange(0, 0);
+
+  const skidLine = new THREE.LineSegments(skidGeometry, legacySkidLine.material.clone());
+  skidLine.frustumCulled = false;
+  skidLine.renderOrder = legacySkidLine.renderOrder;
+  skidLine.userData.turnSkidContinuity = REVISION;
+  runtime.world.add(skidLine);
+
+  const skidHistory = new Float32Array(SKID_HISTORY_CAPACITY * SKID_SAMPLE_STRIDE);
+  const skidHistoryConnections = new Uint8Array(SKID_HISTORY_CAPACITY);
+  let skidHistoryStart = 0;
+  let skidHistoryCount = 0;
+  let skidStrokeActive = false;
+  let lastPositionValid = false;
+  let lastPositionX = 0;
+  let lastPositionY = 0;
+  let lastPositionZ = 0;
+
+  const skidLateral = new THREE.Vector3();
+  const skidRearCenter = new THREE.Vector3();
+  const skidLeftWheel = new THREE.Vector3();
+  const skidRightWheel = new THREE.Vector3();
+
+  function clearSkids() {
+    skidHistoryStart = 0;
+    skidHistoryCount = 0;
+    skidStrokeActive = false;
+    lastPositionValid = false;
+    skidGeometry.setDrawRange(0, 0);
+  }
+
+  function writeSkidPoint(sampleIndex, wheel, point) {
+    const offset = (sampleIndex * SKID_WHEEL_COUNT + wheel) * SKID_COMPONENT_COUNT;
+    skidHistory[offset] = point.x;
+    skidHistory[offset + 1] = point.y;
+    skidHistory[offset + 2] = point.z;
+  }
+
+  function pushSkidSample(leftWheel, rightWheel, connectToPrevious) {
+    skidHistoryStart = (skidHistoryStart - 1 + SKID_HISTORY_CAPACITY) % SKID_HISTORY_CAPACITY;
+    writeSkidPoint(skidHistoryStart, 0, leftWheel);
+    writeSkidPoint(skidHistoryStart, 1, rightWheel);
+    skidHistoryConnections[skidHistoryStart] = connectToPrevious ? 1 : 0;
+    skidHistoryCount = Math.min(SKID_HISTORY_CAPACITY, skidHistoryCount + 1);
+  }
+
+  function repeatLatestSkidSample() {
+    if (!skidHistoryCount) return;
+    const previousStart = skidHistoryStart;
+    skidHistoryStart = (skidHistoryStart - 1 + SKID_HISTORY_CAPACITY) % SKID_HISTORY_CAPACITY;
+    const previousOffset = previousStart * SKID_SAMPLE_STRIDE;
+    const nextOffset = skidHistoryStart * SKID_SAMPLE_STRIDE;
+    for (let component = 0; component < SKID_SAMPLE_STRIDE; component += 1) {
+      skidHistory[nextOffset + component] = skidHistory[previousOffset + component];
+    }
+    skidHistoryConnections[skidHistoryStart] = 0;
+    skidHistoryCount = Math.min(SKID_HISTORY_CAPACITY, skidHistoryCount + 1);
+  }
+
+  function latestSkidDistanceSquared(wheel, point) {
+    if (!skidHistoryCount) return Infinity;
+    const offset = (skidHistoryStart * SKID_WHEEL_COUNT + wheel) * SKID_COMPONENT_COUNT;
+    const dx = point.x - skidHistory[offset];
+    const dy = point.y - skidHistory[offset + 1];
+    const dz = point.z - skidHistory[offset + 2];
+    return dx * dx + dy * dy + dz * dz;
+  }
+
+  function copySkidVertex(sampleOffset, wheel, vertexIndex) {
+    const sampleIndex = (skidHistoryStart + sampleOffset) % SKID_HISTORY_CAPACITY;
+    const sourceOffset = (sampleIndex * SKID_WHEEL_COUNT + wheel) * SKID_COMPONENT_COUNT;
+    const targetOffset = vertexIndex * SKID_COMPONENT_COUNT;
+    skidPositions[targetOffset] = skidHistory[sourceOffset];
+    skidPositions[targetOffset + 1] = skidHistory[sourceOffset + 1];
+    skidPositions[targetOffset + 2] = skidHistory[sourceOffset + 2];
+  }
+
+  function clearIfCarJumped() {
+    const position = runtime.state.position;
+    if (lastPositionValid) {
+      const dx = position.x - lastPositionX;
+      const dy = position.y - lastPositionY;
+      const dz = position.z - lastPositionZ;
+      if (dx * dx + dy * dy + dz * dz > SKID_MAX_CONTINUOUS_GAP_SQUARED) clearSkids();
+    }
+    lastPositionX = position.x;
+    lastPositionY = position.y;
+    lastPositionZ = position.z;
+    lastPositionValid = true;
+  }
+
+  function updateSkids() {
+    const state = runtime.state;
+    if (!state.running) {
+      if (skidHistoryCount || skidStrokeActive || lastPositionValid) clearSkids();
+      return;
+    }
+
+    clearIfCarJumped();
+
+    if (state.driftAmount > 0.34 && state.speed > 21) {
+      skidLateral.copy(runtime.getRight());
+      skidRearCenter.copy(state.position).addScaledVector(runtime.getForward(), -2.0);
+      skidLeftWheel.copy(skidRearCenter).addScaledVector(skidLateral, -1.25);
+      skidRightWheel.copy(skidRearCenter).addScaledVector(skidLateral, 1.25);
+      skidLeftWheel.y = state.position.y + 0.05;
+      skidRightWheel.y = state.position.y + 0.05;
+
+      const connectToPrevious = skidStrokeActive
+        && latestSkidDistanceSquared(0, skidLeftWheel) <= SKID_MAX_CONTINUOUS_GAP_SQUARED
+        && latestSkidDistanceSquared(1, skidRightWheel) <= SKID_MAX_CONTINUOUS_GAP_SQUARED;
+      pushSkidSample(skidLeftWheel, skidRightWheel, connectToPrevious);
+      skidStrokeActive = true;
+    } else {
+      repeatLatestSkidSample();
+      skidStrokeActive = false;
+    }
+
+    let cursor = 0;
+    for (let sample = 0; sample < skidHistoryCount - 1 && cursor < SKID_MAX_DRAW_VERTICES; sample += 1) {
+      const sampleIndex = (skidHistoryStart + sample) % SKID_HISTORY_CAPACITY;
+      if (!skidHistoryConnections[sampleIndex]) continue;
+      for (let wheel = 0; wheel < SKID_WHEEL_COUNT; wheel += 1) {
+        copySkidVertex(sample, wheel, cursor);
+        cursor += 1;
+        copySkidVertex(sample + 1, wheel, cursor);
+        cursor += 1;
+      }
+    }
+    skidGeometry.attributes.position.needsUpdate = true;
+    skidGeometry.setDrawRange(0, cursor);
+  }
+
+  skidLine.onBeforeRender = updateSkids;
+  globalThis.addEventListener('turn:track-changed', clearSkids);
+  globalThis.addEventListener('turn:ui-state-change', (event) => {
+    if (event.detail?.reason === 'race-reset' || event.detail?.running === false) clearSkids();
+  });
+
+  const api = Object.freeze({ revision: REVISION, clear: clearSkids, line: skidLine });
+  globalThis.__turnSkidContinuity = api;
+  return api;
+}
+
+function findLegacySkidLine(world) {
+  return world.children.find((child) => {
+    const position = child.geometry?.getAttribute?.('position');
+    return child.isLineSegments
+      && child.frustumCulled === false
+      && child.material?.isLineBasicMaterial === true
+      && child.material?.transparent === true
+      && Math.abs(Number(child.material.opacity) - 0.52) < 0.0001
+      && position?.count === SKID_POSITION_CAPACITY;
+  }) || null;
+}
+
+function installWhenReady() {
+  if (globalThis.__turnRuntime) {
+    installSkidContinuity(globalThis.__turnRuntime);
+    return;
+  }
+  globalThis.addEventListener('turn:runtime-ready', (event) => {
+    installSkidContinuity(event.detail || globalThis.__turnRuntime);
+  }, { once: true });
+}
+
+installWhenReady();


### PR DESCRIPTION
Fixes the long-standing skid-mark connector visible in the supplied recordings, especially in Drive By Ear 101 and after separated drift bursts.

Root cause: the legacy fixed skid ring intentionally duplicates the latest sample on every non-skidding frame so old marks age out without allocations. When skidding starts again, the renderer still treats the newest sample and that duplicated old endpoint as adjacent, drawing one giant LineSegments bridge across the intervening drive/teleport/track.

This PR adds a continuity-aware skid renderer that preserves the existing visual thresholds, wheel offsets, 90-sample ageing model and 120-vertex draw budget, while explicitly storing whether each newest sample may connect to the previous one. Non-skidding samples age history but mark a break. Track/race resets clear the history, and an 18-unit discontinuity guard also catches training-part/restart teleports even if they happen between skid-active frames.

The existing legacy skid line is hidden; the replacement updates through `LineSegments.onBeforeRender`, so this does not add another requestAnimationFrame/timer loop. Production TURN and TURN LAB load the fresh r198 module directly, avoiding cache ambiguity.

Regression coverage now verifies separate skid bursts stay separate, track/race changes clear stale history, large jumps cannot connect, the old renderer is hidden, and no extra animation loop is introduced.