### PR TITLE
Fix Airport aircraft ground and sky height

### DIFF
--- a/turn/tracks/airport-world-r53.js
+++ b/turn/tracks/airport-world-r53.js
@@ -20,7 +20,9 @@ const PARKED_AIRCRAFT = Object.freeze([
     name: 'Airport A320',
     model: 'a320',
     targetLength: 37,
-    position: [-145, 0.35, -22],
+    // The source model's lowest geometry is not its intended wheel contact plane.
+    // Give it explicit apron clearance so the fuselage/engines do not sink into the ground.
+    position: [-145, 2.4, -22],
     rotation: 0.1,
     clearance: 30
   }),
@@ -28,7 +30,7 @@ const PARKED_AIRCRAFT = Object.freeze([
     name: 'Airport B737',
     model: 'b737',
     targetLength: 36,
-    position: [78, 0.35, -8],
+    position: [78, 2.3, -8],
     rotation: -0.2,
     clearance: 30
   })
@@ -39,7 +41,7 @@ const EXTRA_AIRCRAFT = Object.freeze([
     name: 'Airport A380 Runway',
     model: 'a380',
     targetLength: 66,
-    position: [35, 0.3, -228],
+    position: [35, 4.2, -228],
     rotation: Math.PI / 2,
     clearance: 44
   }),
@@ -47,7 +49,9 @@ const EXTRA_AIRCRAFT = Object.freeze([
     name: 'Airport B787 Overflight',
     model: 'b787',
     targetLength: 54,
-    position: [-35, 118, 52],
+    // Keep the static overflight far enough away that it reads as distant air traffic,
+    // rather than as a nearby aircraft that ought to be visibly moving.
+    position: [-360, 320, 360],
     rotation: -0.72,
     bank: -0.08,
     airborne: true
@@ -79,7 +83,9 @@ export function installAirportWorld(options) {
     realAircraftModels: true,
     amvLabAircraftModels: true,
     runwayHeavy: true,
-    highAltitudeOverflight: true
+    highAltitudeOverflight: true,
+    correctedAircraftGroundClearance: true,
+    distantStaticOverflight: true
   });
 
   return world;

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -5,7 +5,7 @@ import {
   createTrackRuntime,
   normalizeTrackId
 } from './catalog.js';
-import { installAirportWorld } from './airport-world-r53.js?build=20260814-r53';
+import { installAirportWorld } from './airport-world-r53.js?build=20260814-r54';
 import { installCliffsideWorld } from './cliffside-world.js';
 import { installHarborWorld } from './harbor-world.js';
 // Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10


### PR DESCRIPTION
## What changed

- Raises the parked A320 and B737 so their fuselages/engines no longer intersect the apron.
- Raises the runway A380 by a larger model-specific amount.
- Moves the static B787 overflight much higher and much farther away horizontally, so it reads as distant air traffic and its lack of animation is not conspicuous.
- Bumps the Airport module build query from `r53` to `r54` so clients do not keep the first aircraft placement from cache.

## Scope

This is a visual-only follow-up to #467. No track geometry, physics, collision, controls, URLs, or gameplay behavior changes.