### PR TITLE
Finish Airport aircraft positioning

### DIFF
--- a/turn/tracks/airport-world-r53.js
+++ b/turn/tracks/airport-world-r53.js
@@ -30,7 +30,7 @@ const PARKED_AIRCRAFT = Object.freeze([
     name: 'Airport B737',
     model: 'b737',
     targetLength: 36,
-    position: [78, 2.3, -8],
+    position: [78, 4.1, -8],
     rotation: -0.2,
     clearance: 30
   })
@@ -49,9 +49,9 @@ const EXTRA_AIRCRAFT = Object.freeze([
     name: 'Airport B787 Overflight',
     model: 'b787',
     targetLength: 54,
-    // Keep the static overflight far enough away that it reads as distant air traffic,
-    // rather than as a nearby aircraft that ought to be visibly moving.
-    position: [-360, 320, 360],
+    // Keep the static overflight far out near the horizon: distant enough to read as
+    // background air traffic, but low enough to enter normal race-camera fields of view.
+    position: [360, 100, -420],
     rotation: -0.72,
     bank: -0.08,
     airborne: true

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -5,7 +5,7 @@ import {
   createTrackRuntime,
   normalizeTrackId
 } from './catalog.js';
-import { installAirportWorld } from './airport-world-r53.js?build=20260814-r54';
+import { installAirportWorld } from './airport-world-r53.js?build=20260814-r55';
 import { installCliffsideWorld } from './cliffside-world.js';
 import { installHarborWorld } from './harbor-world.js';
 // Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10


### PR DESCRIPTION
## What changed

- Raises only the remaining sunken B737, leaving the A320 and A380 placements unchanged.
- Repositions the static B787 from an excessively high sky position to a distant near-horizon location: far enough away to read as background air traffic, but low enough to enter normal Airport race-camera views.
- Bumps the Airport module cache key to `r55` so clients receive the updated placement.

## Scope

Visual-only follow-up. No track geometry, physics, collision, controls, URLs, or gameplay behavior changes.