### PR TITLE
Push Airport overflight into distant background

### DIFF
--- a/turn/tracks/airport-world-r53.js
+++ b/turn/tracks/airport-world-r53.js
@@ -48,10 +48,10 @@ const EXTRA_AIRCRAFT = Object.freeze([
   Object.freeze({
     name: 'Airport B787 Overflight',
     model: 'b787',
-    targetLength: 54,
-    // Keep the static overflight far out near the horizon: distant enough to read as
-    // background air traffic, but low enough to enter normal race-camera fields of view.
-    position: [360, 100, -420],
+    targetLength: 40,
+    // Push the static aircraft deep into the hangar-side corner of the world. The smaller
+    // apparent size and greater camera distance reduce parallax so it reads as far-away traffic.
+    position: [520, 110, -560],
     rotation: -0.72,
     bank: -0.08,
     airborne: true
@@ -156,6 +156,9 @@ function prepareAircraftAsset(source, {
     const clones = materials.map((entry) => {
       const clone = entry.clone();
       if ('roughness' in clone) clone.roughness = Math.max(clone.roughness ?? 0.72, 0.62);
+      // The distant airborne aircraft intentionally sits beyond the scene's normal fog range.
+      // Keep it visible as a tiny silhouette rather than letting linear fog erase it completely.
+      if (airborne) clone.fog = false;
       return clone;
     });
     node.material = Array.isArray(node.material) ? clones : clones[0];
@@ -176,7 +179,8 @@ function prepareAircraftAsset(source, {
           depthWrite: false,
           polygonOffset: true,
           polygonOffsetFactor: 1,
-          polygonOffsetUnits: 1
+          polygonOffsetUnits: 1,
+          fog: !airborne
         })
       );
       outlineNode.scale.setScalar(airborne ? 1.012 : 1.018);

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -5,7 +5,7 @@ import {
   createTrackRuntime,
   normalizeTrackId
 } from './catalog.js';
-import { installAirportWorld } from './airport-world-r53.js?build=20260814-r55';
+import { installAirportWorld } from './airport-world-r53.js?build=20260814-r56';
 import { installCliffsideWorld } from './cliffside-world.js';
 import { installHarborWorld } from './harbor-world.js';
 // Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10


### PR DESCRIPTION
## What changed

- Moves the static B787 farther into the hangar-side corner of Airport, continuing the visual line away from the player suggested in testing.
- Reduces its rendered size from 54 to 40 units so it reads as genuinely distant air traffic.
- Disables scene fog only on the airborne aircraft materials/outline. This is necessary because the new position sits beyond TURN's normal 700-unit fog range; without it the aircraft would be completely erased rather than appearing as a faint distant object.
- Leaves all parked/runway aircraft exactly as they are.
- Bumps the Airport cache key to `r56`.

## Why

The previous static placement was still close enough that camera movement produced conspicuous accelerating parallax, making the aircraft look as though it were flying toward the player. This version uses substantially greater physical distance plus smaller apparent size to reduce that effect.

## Scope

Visual-only. No track geometry, physics, collision, controls, URLs, or gameplay changes.