### PR TITLE
Move Airport overflight to lower-right distance

### DIFF
--- a/turn/tracks/airport-world-r53.js
+++ b/turn/tracks/airport-world-r53.js
@@ -48,10 +48,10 @@ const EXTRA_AIRCRAFT = Object.freeze([
   Object.freeze({
     name: 'Airport B787 Overflight',
     model: 'b787',
-    targetLength: 40,
-    // Push the static aircraft deep into the hangar-side corner of the world. The smaller
-    // apparent size and greater camera distance reduce parallax so it reads as far-away traffic.
-    position: [520, 110, -560],
+    targetLength: 22,
+    // The minimap maps +X to the right and +Z downward. Put the static overflight deep in
+    // the lower-right world quadrant, high and small enough to read like distant traffic.
+    position: [620, 190, 560],
     rotation: -0.72,
     bank: -0.08,
     airborne: true

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -5,7 +5,7 @@ import {
   createTrackRuntime,
   normalizeTrackId
 } from './catalog.js';
-import { installAirportWorld } from './airport-world-r53.js?build=20260814-r56';
+import { installAirportWorld } from './airport-world-r53.js?build=20260814-r57';
 import { installCliffsideWorld } from './cliffside-world.js';
 import { installHarborWorld } from './harbor-world.js';
 // Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10


### PR DESCRIPTION
## What changed

- Moves the static B787 from the upper-right world quadrant to the **lower-right** Airport quadrant, matching the minimap orientation (+X right, +Z down).
- Raises the aircraft from y=110 to y=190.
- Reduces its target size from 40 to 22 so it reads like the tiny distant aircraft shown in testing.
- Leaves every ground aircraft unchanged.
- Bumps the Airport cache key to `r57`.

## Scope

Visual-only follow-up. No track geometry, physics, collision, controls, URLs, or gameplay behavior changes.