### PR TITLE
Fit all Music Tracker lanes on mobile

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -187,6 +187,9 @@ jobs:
       - name: Run Music Tracker demo feedback regression
         run: node turn-tests/music-tracker-demo-feedback.mjs
 
+      - name: Run Music Tracker mobile sheet regression
+        run: node turn-tests/music-tracker-mobile-sheet.mjs
+
       - name: Run sustained music note tie regression
         run: node turn-tests/racing-music-note-ties.mjs
 

--- a/turn-tests/music-tracker-mobile-sheet.mjs
+++ b/turn-tests/music-tracker-mobile-sheet.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const [index, workflow] = await Promise.all([
+  fs.readFile(new URL('../turn/audio/music/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/audio/music/tracker-workflow.css', import.meta.url), 'utf8')
+]);
+
+assert.match(index, /tracker-workflow\.css\?revision=r205-mobile-sheet-fit/,
+  'Music Tracker must cache-bust the mobile sheet layout');
+assert.match(workflow, /@media \(max-width: 760px\)[\s\S]*?\.tracker-grid,[\s\S]*?\.tracker-row\s*\{[\s\S]*?grid-template-columns: 2\.8rem repeat\(3, minmax\(0, 1fr\)\) 4\.4rem;/,
+  'Phone layouts should fit row + lead + bass + arp + drums into the available sheet width');
+assert.match(workflow, /\.tracker-grid,[\s\S]*?\.tracker-row\s*\{[\s\S]*?min-width: 0;/,
+  'Phone layouts must override the desktop 650px tracker minimum width');
+assert.match(workflow, /@media \(max-width: 520px\)[\s\S]*?grid-template-columns: 2\.45rem repeat\(3, minmax\(0, 1fr\)\) 3\.8rem;/,
+  'Narrow phones should keep the drums lane visible with a tighter proportional sheet');
+assert.doesNotMatch(workflow, /@media \(max-width: 760px\)[\s\S]*?\.tracker-scroll\s*\{[^}]*overflow-x:\s*hidden/,
+  'Horizontal scrolling remains available as a fallback on unusually narrow displays');
+
+console.log('TURN Music Tracker mobile sheet regression passed.');

--- a/turn/audio/music/index.html
+++ b/turn/audio/music/index.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="../../design-tokens.css?revision=r162-social-sharing">
   <link rel="stylesheet" href="../../design-semantic.css?revision=r162-social-sharing">
   <link rel="stylesheet" href="./tracker.css?revision=r189-layout-containment">
-  <link rel="stylesheet" href="./tracker-workflow.css?revision=r192-safari-interaction">
+  <link rel="stylesheet" href="./tracker-workflow.css?revision=r205-mobile-sheet-fit">
   <link rel="stylesheet" href="./tracker-demo-feedback-r204.css?revision=r204-local-demo-feedback">
   <script src="../../ui/page-zoom-baseline-r193.js?revision=r193-canonical-75"></script>
 </head>

--- a/turn/audio/music/tracker-workflow.css
+++ b/turn/audio/music/tracker-workflow.css
@@ -142,6 +142,29 @@ body .column-octave-controls .octave-shift {
     width: 100%;
     margin-left: 0;
   }
+
+  /* On phones the sheet is the primary control surface. Keep all four lanes visible
+     instead of inheriting the desktop tracker's 650px minimum width. */
+  .tracker-grid,
+  .tracker-row {
+    grid-template-columns: 2.8rem repeat(3, minmax(0, 1fr)) 4.4rem;
+    min-width: 0;
+  }
+
+  .tracker-grid-head > div,
+  body .column-select-button {
+    min-width: 0;
+    padding-inline: 6px;
+  }
+
+  body .column-select-button {
+    gap: 4px;
+  }
+
+  .step-cell {
+    min-width: 0;
+    padding-inline: 6px;
+  }
 }
 
 @media (max-width: 520px) {
@@ -153,10 +176,24 @@ body .column-octave-controls .octave-shift {
     padding-inline: 10px;
   }
 
+  .tracker-grid,
+  .tracker-row {
+    grid-template-columns: 2.45rem repeat(3, minmax(0, 1fr)) 3.8rem;
+  }
+
   .tracker-grid-head > div,
   body .column-select-button {
     min-height: 32px;
-    padding-block: 4px;
+    padding: 4px;
+  }
+
+  body .column-select-button {
+    gap: 2px;
+  }
+
+  body .column-select-button small {
+    padding-inline: 3px;
+    font-size: .52rem;
   }
 
   .row-number,
@@ -165,7 +202,8 @@ body .column-octave-controls .octave-shift {
   }
 
   .step-cell {
-    padding-block: 2px;
+    padding: 2px 4px;
+    font-size: .78rem;
   }
 
   .entry-pad {


### PR DESCRIPTION
Polishes the mobile tracker sheet based on the iPhone screenshots.

- removes the desktop 650px minimum width from the tracker grid on phone layouts
- keeps ROW + LEAD + BASS + ARP + DRUMS visible at once by using tighter proportional columns
- gives DRUMS its own compact but fully visible lane instead of hiding it offscreen
- tightens header/cell padding on narrow phones without changing the existing row heights
- keeps horizontal scrolling available as a fallback on unusually narrow displays rather than disabling it
- cache-busts the tracker workflow stylesheet with r205
- adds a dedicated mobile sheet regression and runs it in the full TURN suite