### PR TITLE
Highlight the selected Music Tracker part play button

### DIFF
--- a/turn-tests/music-tracker-mobile-sheet.mjs
+++ b/turn-tests/music-tracker-mobile-sheet.mjs
@@ -1,11 +1,12 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [index, workflow, tools, toolsCss] = await Promise.all([
+const [index, workflow, tools, toolsCss, activePartPlay] = await Promise.all([
   fs.readFile(new URL('../turn/audio/music/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/audio/music/tracker-workflow.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/audio/music/tracker-column-octave.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/audio/music/tracker-column-octave.css', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/audio/music/tracker-column-octave.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/audio/music/tracker-active-part-play-r207.js', import.meta.url), 'utf8')
 ]);
 
 assert.match(index, /tracker-workflow\.css\?revision=r205-mobile-sheet-fit/,
@@ -52,4 +53,19 @@ assert.match(toolsCss, /\.column-tools-actions-three/,
 assert.match(toolsCss, /@media \(max-width: 760px\)[\s\S]*grid-template-columns: 1fr/,
   'Column tools should stack cleanly on phones');
 
-console.log('TURN Music Tracker mobile sheet and column tools regression passed.');
+assert.match(index, /tracker-active-part-play-r207\.js\?revision=r207-active-part-play/,
+  'Music Tracker must load the active-part playback affordance with a fresh module identity');
+assert.match(activePartPlay, /\.part-tab\[data-part\]/,
+  'Active playback styling should follow the selected tracker part');
+assert.match(activePartPlay, /\.part-play\[data-part\]/,
+  'Only part playback buttons should be restyled');
+assert.match(activePartPlay, /button\.classList\.toggle\('primary', active\)/,
+  'The selected part playback button should use TURN primary styling');
+assert.match(activePartPlay, /button\.classList\.toggle\('play', !active\)/,
+  'Inactive part playback buttons should retain normal game-action styling');
+assert.match(activePartPlay, /button\.setAttribute\('aria-current', 'true'\)/,
+  'The selected part playback button should expose its current relationship semantically');
+assert.match(activePartPlay, /attributeFilter: \['class', 'aria-selected'\]/,
+  'The affordance should stay synchronized when tracker rendering changes the selected part');
+
+console.log('TURN Music Tracker mobile sheet, column tools and active part playback regression passed.');

--- a/turn/audio/music/index.html
+++ b/turn/audio/music/index.html
@@ -208,5 +208,6 @@
   <script type="module" src="./tracker.js?revision=r196-song-recovery"></script>
   <script type="module" src="./tracker-column-octave.js?revision=r206-column-tools"></script>
   <script type="module" src="./tracker-bar-shortcuts.js?revision=r191-primary-workflow"></script>
+  <script type="module" src="./tracker-active-part-play-r207.js?revision=r207-active-part-play"></script>
 </body>
 </html>

--- a/turn/audio/music/tracker-active-part-play-r207.js
+++ b/turn/audio/music/tracker-active-part-play-r207.js
@@ -1,0 +1,30 @@
+const partTabs = [...document.querySelectorAll('.part-tab[data-part]')];
+const partPlayButtons = [...document.querySelectorAll('.part-play[data-part]')];
+
+function selectedPart() {
+  const selected = partTabs.find((tab) => tab.classList.contains('active') || tab.getAttribute('aria-selected') === 'true');
+  return selected?.dataset.part || 'tune';
+}
+
+function renderActivePartPlayButton() {
+  const part = selectedPart();
+  partPlayButtons.forEach((button) => {
+    const active = button.dataset.part === part;
+    button.classList.toggle('primary', active);
+    button.classList.toggle('play', !active);
+    if (active) button.setAttribute('aria-current', 'true');
+    else button.removeAttribute('aria-current');
+  });
+}
+
+renderActivePartPlayButton();
+
+const observer = new MutationObserver(renderActivePartPlayButton);
+partTabs.forEach((tab) => observer.observe(tab, {
+  attributes: true,
+  attributeFilter: ['class', 'aria-selected']
+}));
+
+document.querySelector('.part-tabs')?.addEventListener('click', () => {
+  requestAnimationFrame(renderActivePartPlayButton);
+});


### PR DESCRIPTION
Small Music Tracker QoL polish based on the latest mobile mockup.

- the play button matching the selected T / B / C tracker part now uses TURN primary styling
- the other two part play buttons keep the regular game-action styling
- Song and Stop are left unchanged
- the highlight follows the selected part tab, including tracker re-renders/imports
- the selected part play button also exposes `aria-current="true"`
- fresh r207 module URL avoids Safari/PWA cache ambiguity
- extends the existing Music Tracker regression coverage