### PR TITLE
Raise player marker clearance

### DIFF
--- a/turn/ui/player-marker-r428.js
+++ b/turn/ui/player-marker-r428.js
@@ -7,7 +7,7 @@ const AUTO_ACTIVATION_RADIUS = REFERENCE_CAR_LENGTH * AUTO_ACTIVATION_DIAMETER_C
 const AUTO_ACTIVATION_RADIUS_SQUARED = AUTO_ACTIVATION_RADIUS * AUTO_ACTIVATION_RADIUS;
 const AUTO_EXIT_GRACE_MS = 220;
 const AUTO_CHECK_INTERVAL_MS = 50;
-const MARKER_GAP_PX = 8;
+const MARKER_GAP_PX = 14;
 const MARKER_SIZE_VIEWPORT_RATIO = 0.045;
 const MARKER_SIZE_MIN_PX = 17;
 const MARKER_SIZE_MAX_PX = 23;
@@ -97,9 +97,8 @@ function markerPose(runtime, rect, roofHeight) {
     upY /= upLength;
   }
 
-  // Standard overhead-marker treatment: anchor at the top of the vehicle silhouette,
-  // then leave one small, constant visual gap. This keeps the marker associated with
-  // the car without covering it, independent of FOV, speed or viewport height.
+  // Anchor from the model's bounds-derived roof and leave enough screen-space
+  // clearance for the triangle to remain distinct even inside a same-car pack.
   const centerGap = MARKER_GAP_PX + markerSizePixels(rect.height) * 0.5;
   const x = roofPoint.x + upX * centerGap;
   const y = roofPoint.y + upY * centerGap;

--- a/turn/ui/r411-race-controls.js
+++ b/turn/ui/r411-race-controls.js
@@ -1,4 +1,4 @@
-import './player-marker-r428.js?revision=r429';
+import './player-marker-r428.js?revision=r430';
 
 function installStyles() {
   if (document.querySelector('#turn-r411-race-control-styles')) return;


### PR DESCRIPTION
## What changed
- Keeps the existing bounds-derived roof anchor and all current Auto behavior.
- Raises the marker's **visual gap from 8 px to 14 px** above the detected vehicle roof.
- Leaves marker size, outline, player-car color, activation distance, 220 ms exit grace, and 20 Hz proximity sampling unchanged.

## Why
The same-model/same-color worst-case pack test showed that the 8 px gap could make the triangle read as part of the vehicle cluster. The roof detection itself was tracking the player correctly; it simply needed more separation. A 14 px gap is roughly 0.6 marker-heights at the current capped size, giving clear visual separation without making the marker feel detached.

This is intentionally a tiny visual tuning change with no additional per-frame work.