### PR TITLE
Fix emergency vehicle player marker colors

### DIFF
--- a/turn/ui/player-marker-r428.js
+++ b/turn/ui/player-marker-r428.js
@@ -13,8 +13,11 @@ const MARKER_SIZE_MIN_PX = 17;
 const MARKER_SIZE_MAX_PX = 23;
 const FALLBACK_ROOF_HEIGHT = 1.8;
 const FALLBACK_MARKER_COLOR = '#38d9ff';
-const FIXED_LIVERY_MARKER_COLOR = '#ffcc00';
-const FIXED_LIVERY_VEHICLE_IDS = new Set(['firetruck', 'police', 'ambulance']);
+const FIXED_LIVERY_MARKER_COLORS = Object.freeze({
+  firetruck: '#d92d20',
+  police: '#0b0d10',
+  ambulance: '#f8f9fa'
+});
 
 function clamp(value, min, max) {
   return Math.min(max, Math.max(min, value));
@@ -147,7 +150,8 @@ export function playerMarkerAutoActive(distance) {
 
 export function playerMarkerColor(runtime) {
   const carId = runtime?.playerCar?.userData?.turnCarId || runtime?.state?.vehicleId;
-  if (FIXED_LIVERY_VEHICLE_IDS.has(carId)) return FIXED_LIVERY_MARKER_COLOR;
+  const fixedLiveryColor = FIXED_LIVERY_MARKER_COLORS[carId];
+  if (fixedLiveryColor) return fixedLiveryColor;
 
   const color = runtime?.playerCar?.userData?.turnCarColor || runtime?.state?.vehicleColor;
   return typeof color === 'string' && color.trim() ? color.trim() : FALLBACK_MARKER_COLOR;

--- a/turn/ui/r411-race-controls.js
+++ b/turn/ui/r411-race-controls.js
@@ -1,4 +1,4 @@
-import './player-marker-r428.js?revision=r431';
+import './player-marker-r428.js?revision=r432';
 
 function installStyles() {
   if (document.querySelector('#turn-r411-race-control-styles')) return;


### PR DESCRIPTION
## What changed
- Keeps the final 20 px player-marker roof clearance.
- Corrects the three fixed-livery emergency markers to match the vehicles themselves:
  - Fire Truck → red `#d92d20`
  - Police Car → near-black `#0b0d10`
  - Ambulance → white `#f8f9fa`
- Normal cars still use the selected paint color.
- Auto activation, size, outline, roof anchoring, exit grace, and 20 Hz proximity sampling are unchanged.

This corrects the previous yellow special case; the fixed-livery vehicles should use their actual livery primary color rather than the stored/custom paint selection.