### PR TITLE
Stabilize TURN horizon at very low speeds

### DIFF
--- a/turn-tests/motion-safe-zone-production.mjs
+++ b/turn-tests/motion-safe-zone-production.mjs
@@ -5,6 +5,8 @@ import {
   updateMotionInputState
 } from '../turn/input/motion.js';
 import {
+  applyLowSpeedHorizonDeadZone,
+  resolveLowSpeedHorizonDeadZone,
   resolveSensorCameraRollLimit,
   updateRaceCameraState
 } from '../turn/render/camera.js';
@@ -45,6 +47,31 @@ approximately(resolveSensorCameraRollLimit(), toRadians(24));
 approximately(resolveSteeringRollLimit(toRadians(14), { steeringDegrees: 0 }), toRadians(14));
 approximately(resolveSensorCameraRollLimit({ horizonDegrees: 90 }), toRadians(18));
 
+// Horizon stabilization is deliberately limited to first-impression / crawling
+// speeds. It is fully active through 5 km/h, fades linearly, and is completely
+// absent from 25 km/h upward so real corners retain today's direct camera feel.
+approximately(resolveLowSpeedHorizonDeadZone(0), toRadians(1.25));
+approximately(resolveLowSpeedHorizonDeadZone(5 / 3.6), toRadians(1.25));
+approximately(resolveLowSpeedHorizonDeadZone(15 / 3.6), toRadians(0.625));
+approximately(resolveLowSpeedHorizonDeadZone(25 / 3.6), 0);
+approximately(resolveLowSpeedHorizonDeadZone(58 / 3.6), 0);
+approximately(resolveLowSpeedHorizonDeadZone(-5 / 3.6), toRadians(1.25));
+approximately(
+  applyLowSpeedHorizonDeadZone(toRadians(1), toRadians(24), 0),
+  0,
+  1e-9
+);
+approximately(
+  applyLowSpeedHorizonDeadZone(toRadians(24), toRadians(24), 0),
+  toRadians(24),
+  1e-9
+);
+approximately(
+  applyLowSpeedHorizonDeadZone(toRadians(1), toRadians(24), 25 / 3.6),
+  toRadians(1),
+  1e-9
+);
+
 const steeringState = {
   sensorMode: true,
   roll: 0,
@@ -66,7 +93,7 @@ steeringState.steering = 0;
 updateMotionInputState({ state: steeringState, dt: 1, maxSteerRoll: toRadians(14) });
 assert.ok(steeringState.steering > 0.999, 'Steering must saturate at the canonical -24-degree boundary');
 
-function measuredCameraRoll(rollDegrees, configuration) {
+function measuredCameraRoll(rollDegrees, configuration, speedKmh = 0) {
   globalThis.__TURN_MOTION_SAFE_ZONE__ = configuration;
   let rotation = null;
   const camera = {
@@ -78,7 +105,7 @@ function measuredCameraRoll(rollDegrees, configuration) {
     updateProjectionMatrix() {}
   };
   const state = {
-    speed: 0,
+    speed: speedKmh / 3.6,
     velocity: { dot() { return 0; } },
     position: { x: 0, y: 0, z: 0 },
     nearestTrackIndex: 0,
@@ -104,6 +131,17 @@ function measuredCameraRoll(rollDegrees, configuration) {
 approximately(measuredCameraRoll(32, globalThis.__TURN_MOTION_SAFE_ZONE__), toRadians(-24), 1e-9);
 approximately(measuredCameraRoll(-32, globalThis.__TURN_MOTION_SAFE_ZONE__), toRadians(24), 1e-9);
 approximately(measuredCameraRoll(32, undefined), toRadians(-18), 1e-9);
+approximately(measuredCameraRoll(1, globalThis.__TURN_MOTION_SAFE_ZONE__, 0), 0, 1e-9);
+approximately(
+  measuredCameraRoll(1, globalThis.__TURN_MOTION_SAFE_ZONE__, 25),
+  toRadians(-1),
+  1e-9
+);
+approximately(
+  measuredCameraRoll(1, globalThis.__TURN_MOTION_SAFE_ZONE__, 58),
+  toRadians(-1),
+  1e-9
+);
 
 assert.equal(steeringLimitVisualOpacity({ active: false }), 0);
 approximately(steeringLimitVisualOpacity({ active: true, intensity: 0 }), 0.08);
@@ -205,4 +243,4 @@ for (const removedPath of [
 if (previousConfiguration === undefined) delete globalThis.__TURN_MOTION_SAFE_ZONE__;
 else globalThis.__TURN_MOTION_SAFE_ZONE__ = previousConfiguration;
 
-console.log('Canonical TURN 24-degree safe zone, inertial warning and NEXT wrapper passed.');
+console.log('Canonical TURN 24-degree safe zone, low-speed horizon stabilization, inertial warning and NEXT wrapper passed.');

--- a/turn/render/camera.js
+++ b/turn/render/camera.js
@@ -1,5 +1,8 @@
 const DEFAULT_MAX_SENSOR_CAMERA_ROLL = 18 * Math.PI / 180;
 const MAX_CONFIGURED_SAFE_ZONE_DEGREES = 45;
+const LOW_SPEED_HORIZON_DEAD_ZONE = 1.25 * Math.PI / 180;
+const LOW_SPEED_HORIZON_FULL_STABILIZATION_SPEED = 5 / 3.6;
+const LOW_SPEED_HORIZON_RELEASE_SPEED = 25 / 3.6;
 
 export function resolveSensorCameraRollLimit(
   configuration = globalThis.__TURN_MOTION_SAFE_ZONE__
@@ -13,6 +16,39 @@ export function resolveSensorCameraRollLimit(
     return configuredDegrees * Math.PI / 180;
   }
   return DEFAULT_MAX_SENSOR_CAMERA_ROLL;
+}
+
+export function resolveLowSpeedHorizonDeadZone(speed) {
+  const speedMagnitude = Math.abs(Number(speed) || 0);
+  if (speedMagnitude <= LOW_SPEED_HORIZON_FULL_STABILIZATION_SPEED) {
+    return LOW_SPEED_HORIZON_DEAD_ZONE;
+  }
+  if (speedMagnitude >= LOW_SPEED_HORIZON_RELEASE_SPEED) return 0;
+
+  const releaseProgress = (
+    speedMagnitude - LOW_SPEED_HORIZON_FULL_STABILIZATION_SPEED
+  ) / (
+    LOW_SPEED_HORIZON_RELEASE_SPEED - LOW_SPEED_HORIZON_FULL_STABILIZATION_SPEED
+  );
+  return LOW_SPEED_HORIZON_DEAD_ZONE * (1 - releaseProgress);
+}
+
+export function applyLowSpeedHorizonDeadZone(relativeRoll, maxRoll, speed) {
+  const limit = Math.max(0, Number(maxRoll) || 0);
+  if (!limit) return 0;
+
+  const guardedRoll = clamp(Number(relativeRoll) || 0, -limit, limit);
+  const deadZone = Math.min(limit, resolveLowSpeedHorizonDeadZone(speed));
+  if (!deadZone) return guardedRoll;
+
+  const magnitude = Math.abs(guardedRoll);
+  if (magnitude <= deadZone) return 0;
+
+  // Remove only the low-speed neutral jitter range, then stretch the remaining
+  // response so intentional full tilt still reaches the existing camera limit.
+  const activeRange = Math.max(0.000001, limit - deadZone);
+  const remappedMagnitude = (magnitude - deadZone) / activeRange * limit;
+  return Math.sign(guardedRoll) * remappedMagnitude;
 }
 
 export function updateRaceCameraState({
@@ -77,7 +113,12 @@ export function updateRaceCameraState({
     const relativeRoll = normalizeAngle(state.roll - neutralRoll);
     const maxSensorCameraRoll = resolveSensorCameraRollLimit();
     const guardedRoll = clamp(relativeRoll, -maxSensorCameraRoll, maxSensorCameraRoll);
-    camera.rotateZ(-guardedRoll);
+    const stabilizedRoll = applyLowSpeedHorizonDeadZone(
+      guardedRoll,
+      maxSensorCameraRoll,
+      state.speed
+    );
+    camera.rotateZ(-stabilizedRoll);
   }
 
   camera.fov = lerp(camera.fov, 68 + speedRatio * 14, Math.min(1, dt * 4.5));


### PR DESCRIPTION
## What changed
- add a 1.25° visual horizon dead zone at 0–5 km/h
- fade that dead zone linearly to zero between 5 and 25 km/h
- keep the existing horizon response completely unchanged from 25 km/h upward
- preserve the existing full camera-roll limit even while stabilization is active
- treat reverse speed by magnitude as well

## Why
Tiny sensor movement is most visible and annoying while stopped or crawling, especially at the starting grid. The stabilization disappears well below the measured ~58 km/h Airport hairpin speed so braking into real corners keeps immediate camera feedback.

## Performance
This reuses the existing per-frame speed and roll values and adds only a few scalar arithmetic/branch operations. No extra listeners, timers, animation loops, allocations, DOM work, or rendering passes.

## Validation
Extended the canonical motion safe-zone regression to cover 0, 5, 15, 25 and 58 km/h behavior, full-roll preservation, reverse-speed handling, and direct camera response at/above the release threshold.