### PR TITLE
Smooth TURN horizon at very low speeds

### DIFF
--- a/turn-tests/motion-safe-zone-production.mjs
+++ b/turn-tests/motion-safe-zone-production.mjs
@@ -7,7 +7,9 @@ import {
 import {
   applyLowSpeedHorizonDeadZone,
   resolveLowSpeedHorizonDeadZone,
+  resolveLowSpeedHorizonStabilizationAmount,
   resolveSensorCameraRollLimit,
+  smoothLowSpeedHorizonRoll,
   updateRaceCameraState
 } from '../turn/render/camera.js';
 import {
@@ -48,8 +50,14 @@ approximately(resolveSteeringRollLimit(toRadians(14), { steeringDegrees: 0 }), t
 approximately(resolveSensorCameraRollLimit({ horizonDegrees: 90 }), toRadians(18));
 
 // Horizon stabilization is deliberately limited to first-impression / crawling
-// speeds. It is fully active through 5 km/h, fades linearly, and is completely
-// absent from 25 km/h upward so real corners retain today's direct camera feel.
+// speeds. Dead-zone suppression and temporal smoothing share the same fade: full
+// through 5 km/h and completely absent from 25 km/h upward.
+approximately(resolveLowSpeedHorizonStabilizationAmount(0), 1);
+approximately(resolveLowSpeedHorizonStabilizationAmount(5 / 3.6), 1);
+approximately(resolveLowSpeedHorizonStabilizationAmount(15 / 3.6), 0.5);
+approximately(resolveLowSpeedHorizonStabilizationAmount(25 / 3.6), 0);
+approximately(resolveLowSpeedHorizonStabilizationAmount(58 / 3.6), 0);
+approximately(resolveLowSpeedHorizonStabilizationAmount(-5 / 3.6), 1);
 approximately(resolveLowSpeedHorizonDeadZone(0), toRadians(1.25));
 approximately(resolveLowSpeedHorizonDeadZone(5 / 3.6), toRadians(1.25));
 approximately(resolveLowSpeedHorizonDeadZone(15 / 3.6), toRadians(0.625));
@@ -70,6 +78,36 @@ approximately(
   applyLowSpeedHorizonDeadZone(toRadians(1), toRadians(24), 25 / 3.6),
   toRadians(1),
   1e-9
+);
+
+const smoothingTarget = toRadians(10);
+const stoppedSmoothingStep = smoothLowSpeedHorizonRoll(0, smoothingTarget, 0, 1 / 60);
+const midSpeedSmoothingStep = smoothLowSpeedHorizonRoll(0, smoothingTarget, 15 / 3.6, 1 / 60);
+assert.ok(
+  stoppedSmoothingStep > 0 && stoppedSmoothingStep < smoothingTarget,
+  'Stopped horizon motion should ease toward deliberate tilt instead of stepping immediately'
+);
+assert.ok(
+  midSpeedSmoothingStep > stoppedSmoothingStep && midSpeedSmoothingStep < smoothingTarget,
+  'Temporal smoothing should fade progressively between 5 and 25 km/h'
+);
+approximately(
+  smoothLowSpeedHorizonRoll(0, smoothingTarget, 25 / 3.6, 1 / 60),
+  smoothingTarget,
+  1e-9
+);
+approximately(
+  smoothLowSpeedHorizonRoll(0, smoothingTarget, 58 / 3.6, 1 / 60),
+  smoothingTarget,
+  1e-9
+);
+let convergedRoll = 0;
+for (let frame = 0; frame < 60; frame += 1) {
+  convergedRoll = smoothLowSpeedHorizonRoll(convergedRoll, smoothingTarget, 0, 1 / 60);
+}
+assert.ok(
+  convergedRoll > smoothingTarget * 0.999,
+  'Low-speed smoothing must settle on the intentional target instead of reducing steering range'
 );
 
 const steeringState = {
@@ -243,4 +281,4 @@ for (const removedPath of [
 if (previousConfiguration === undefined) delete globalThis.__TURN_MOTION_SAFE_ZONE__;
 else globalThis.__TURN_MOTION_SAFE_ZONE__ = previousConfiguration;
 
-console.log('Canonical TURN 24-degree safe zone, low-speed horizon stabilization, inertial warning and NEXT wrapper passed.');
+console.log('Canonical TURN 24-degree safe zone, low-speed horizon dead zone and smoothing, inertial warning and NEXT wrapper passed.');

--- a/turn/render/camera.js
+++ b/turn/render/camera.js
@@ -3,6 +3,7 @@ const MAX_CONFIGURED_SAFE_ZONE_DEGREES = 45;
 const LOW_SPEED_HORIZON_DEAD_ZONE = 1.25 * Math.PI / 180;
 const LOW_SPEED_HORIZON_FULL_STABILIZATION_SPEED = 5 / 3.6;
 const LOW_SPEED_HORIZON_RELEASE_SPEED = 25 / 3.6;
+const LOW_SPEED_HORIZON_SMOOTHING_RATE = 10;
 
 export function resolveSensorCameraRollLimit(
   configuration = globalThis.__TURN_MOTION_SAFE_ZONE__
@@ -18,19 +19,20 @@ export function resolveSensorCameraRollLimit(
   return DEFAULT_MAX_SENSOR_CAMERA_ROLL;
 }
 
-export function resolveLowSpeedHorizonDeadZone(speed) {
+export function resolveLowSpeedHorizonStabilizationAmount(speed) {
   const speedMagnitude = Math.abs(Number(speed) || 0);
-  if (speedMagnitude <= LOW_SPEED_HORIZON_FULL_STABILIZATION_SPEED) {
-    return LOW_SPEED_HORIZON_DEAD_ZONE;
-  }
+  if (speedMagnitude <= LOW_SPEED_HORIZON_FULL_STABILIZATION_SPEED) return 1;
   if (speedMagnitude >= LOW_SPEED_HORIZON_RELEASE_SPEED) return 0;
 
-  const releaseProgress = (
+  return 1 - (
     speedMagnitude - LOW_SPEED_HORIZON_FULL_STABILIZATION_SPEED
   ) / (
     LOW_SPEED_HORIZON_RELEASE_SPEED - LOW_SPEED_HORIZON_FULL_STABILIZATION_SPEED
   );
-  return LOW_SPEED_HORIZON_DEAD_ZONE * (1 - releaseProgress);
+}
+
+export function resolveLowSpeedHorizonDeadZone(speed) {
+  return LOW_SPEED_HORIZON_DEAD_ZONE * resolveLowSpeedHorizonStabilizationAmount(speed);
 }
 
 export function applyLowSpeedHorizonDeadZone(relativeRoll, maxRoll, speed) {
@@ -49,6 +51,24 @@ export function applyLowSpeedHorizonDeadZone(relativeRoll, maxRoll, speed) {
   const activeRange = Math.max(0.000001, limit - deadZone);
   const remappedMagnitude = (magnitude - deadZone) / activeRange * limit;
   return Math.sign(guardedRoll) * remappedMagnitude;
+}
+
+export function smoothLowSpeedHorizonRoll(previousRoll, targetRoll, speed, dt) {
+  const target = Number(targetRoll) || 0;
+  const previous = Number(previousRoll);
+  const current = Number.isFinite(previous) ? previous : target;
+  const stabilizationAmount = resolveLowSpeedHorizonStabilizationAmount(speed);
+
+  // Normal racing takes the direct path: no extra Math.exp() and no visual lag.
+  if (stabilizationAmount <= 0) return target;
+
+  const elapsed = Math.max(0, Number(dt) || 0);
+  const smoothingResponse = 1 - Math.exp(-elapsed * LOW_SPEED_HORIZON_SMOOTHING_RATE);
+  const smoothedRoll = lerp(current, target, smoothingResponse);
+
+  // Fade the temporal smoothing out over the same 5–25 km/h interval as the
+  // dead zone, reaching the untouched direct response at 25 km/h.
+  return lerp(target, smoothedRoll, stabilizationAmount);
 }
 
 export function updateRaceCameraState({
@@ -118,7 +138,15 @@ export function updateRaceCameraState({
       maxSensorCameraRoll,
       state.speed
     );
-    camera.rotateZ(-stabilizedRoll);
+    state.horizonCameraRoll = smoothLowSpeedHorizonRoll(
+      state.horizonCameraRoll,
+      stabilizedRoll,
+      state.speed,
+      dt
+    );
+    camera.rotateZ(-state.horizonCameraRoll);
+  } else {
+    state.horizonCameraRoll = 0;
   }
 
   camera.fov = lerp(camera.fov, 68 + speedRatio * 14, Math.min(1, dt * 4.5));


### PR DESCRIPTION
## What changed
- keep the existing 1.25° low-speed horizon dead zone
- add lightweight temporal smoothing to the horizon only while the same low-speed stabilization is active
- use full smoothing through 5 km/h, fade it linearly together with the dead zone, and remove it completely at 25 km/h
- keep steering input untouched
- reset the tiny camera-only smoothing state when sensor mode is off

## Why
The dead zone removes sensor jitter near neutral, but the supplied low-speed test video still shows small quick horizon steps once movement passes the dead-zone boundary. A short horizon-only low-pass makes the stationary/launch presentation calmer without affecting real cornering.

## Performance
The extra exponential smoothing runs only below 25 km/h. At 25 km/h and above the helper takes the direct branch before `Math.exp()`, so normal racing has no added filter work or response lag. The implementation stores one numeric camera-roll value on existing race state and adds no listeners, timers, DOM work, allocations, or render passes.

## Validation
Extended the canonical motion safe-zone regression to pin the shared 0–5 / 5–25 / 25+ km/h fade, verify smoothing at stopped and mid speeds, verify direct response at 25 and 58 km/h, and verify that full intended roll remains reachable.