### PR TITLE
Set Midnight Sprint target to 53 seconds

### DIFF
--- a/turn-lab/tests/achievements-production.mjs
+++ b/turn-lab/tests/achievements-production.mjs
@@ -117,7 +117,7 @@ assert.deepEqual(
     ['airport', 17],
     ['cliffside', 16],
     ['harbor', 24],
-    ['midnight-city', 55]
+    ['midnight-city', 53]
   ]
 );
 for (const trial of TIME_TRIALS) {
@@ -227,7 +227,7 @@ assert.match(timeTrialSource, /targetSeconds: 12/);
 assert.match(timeTrialSource, /targetSeconds: 17/);
 assert.match(timeTrialSource, /targetSeconds: 16/);
 assert.match(timeTrialSource, /targetSeconds: 24/);
-assert.match(timeTrialSource, /targetSeconds: 55/);
+assert.match(timeTrialSource, /targetSeconds: 53/);
 assert.match(timeTrialSource, /seconds >= trial\.targetSeconds/);
 
 assert.match(challengeSource, /SAMPLE_INTERVAL_MS = 50/);

--- a/turn/achievements/time-trials.js
+++ b/turn/achievements/time-trials.js
@@ -30,9 +30,9 @@ export const TIME_TRIALS = Object.freeze([
   Object.freeze({
     id: 'midnight-sprint',
     trackId: 'midnight-city',
-    targetSeconds: 55,
+    targetSeconds: 53,
     title: 'MIDNIGHT SPRINT',
-    description: 'Finish Midnight City in under 55 seconds.'
+    description: 'Finish Midnight City in under 53 seconds.'
   })
 ]);
 


### PR DESCRIPTION
## What changed
- lower MIDNIGHT SPRINT from under 55 seconds to under 53 seconds
- update the visible achievement copy to match
- update the canonical achievement regression to pin the new developer target

## Scope
This is intentionally a tiny data/copy change only. No achievement architecture, storage, audio, rendering, handling, or progression logic is changed.

Existing players who already unlocked MIDNIGHT SPRINT keep the stored unlock; new unlocks require a valid Midnight City lap under 53 seconds.