### PR TITLE
Finish MAYDAY medical-bay polish

### DIFF
--- a/turn-lab/tests/emergency-vehicles-production.mjs
+++ b/turn-lab/tests/emergency-vehicles-production.mjs
@@ -155,7 +155,7 @@ assert.match(airportEmergency, /\[7\.0, 65, 2\.0, 4\.9\]/,
 
 assert.match(airportEmergency, /preloadCarModels\(\['firetruck', 'ambulance'\]\)/,
   'Ambulance Airport runs should preload both medical responder models');
-assert.doesNotMatch(airportEmergency, /requestIdleCallback/,
+assert.doesNotMatch(airportEmergency, /globalThis\.requestIdleCallback\s*\(/,
   'iOS must not defer responder preparation until the finish line');
 assert.match(airportEmergency, /renderer\.compileAsync\(staging, camera\)/,
   'MAYDAY-only materials should be asynchronously shader-warmed before the crash reveal');

--- a/turn-lab/tests/emergency-vehicles-production.mjs
+++ b/turn-lab/tests/emergency-vehicles-production.mjs
@@ -68,8 +68,8 @@ const [
   fs.readFile(path.join(turnDir, 'garage/lot-track-select.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'ui/gameplay-controls.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'audio/audio-system.js'), 'utf8'),
-  fs.readFile(path.join(turnDir, 'audio/mayday-audio-r491.js'), 'utf8'),
-  fs.readFile(path.join(turnDir, 'tracks/airport-emergency-r491.js'), 'utf8'),
+  fs.readFile(path.join(turnDir, 'audio/mayday-audio-r492.js'), 'utf8'),
+  fs.readFile(path.join(turnDir, 'tracks/airport-emergency-r492.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'tracks/airport-world-r56.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'tracks/registry.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'assets/cars/KENNEY-CAR-KIT.md'), 'utf8'),
@@ -118,16 +118,16 @@ assert.doesNotMatch(index, /syncFixedLiveryRail|emergencyVehicleNames/,
 
 assert.match(airportWorldR56, /airport-world-r53\.js/,
   'The MAYDAY layer must preserve the current real-aircraft Airport world');
-assert.match(airportWorldR56, /airport-emergency-r491\.js/);
-assert.match(trackRegistry, /airport-world-r56\.js/,
-  'Production Airport must route through the MAYDAY playtest-fix wrapper');
+assert.match(airportWorldR56, /airport-emergency-r492\.js/);
+assert.match(trackRegistry, /airport-world-r56\.js\?build=20260815-r492/,
+  'Production Airport must cache-bust the r492 MAYDAY layer');
 assert.match(trackRegistry, /airport\(\{ scene, samples, trackWidth, runtime \}\)/,
   'Airport world installation must receive the live TURN runtime');
 assert.match(airportEmergency, /export const AIRPORT_EMERGENCY_CONFIG/);
 assert.match(airportEmergency, /vehicleId: AMBULANCE_ID/);
 assert.match(airportEmergency, /TRANSFER_LIMIT_MS = 30_000/);
 assert.match(airportEmergency, /MEDICAL_RADIUS = 42/,
-  'The terminal medical bay should be broad enough to trigger around either responder');
+  'The terminal medical bay should remain forgiving');
 assert.match(airportEmergency, /crashActive !== true/,
   'The Airport crash should happen only once per page session');
 assert.match(airportEmergency, /trackId === AIRPORT_TRACK_ID/,
@@ -145,32 +145,53 @@ assert.match(airportEmergency, /world\.getObjectByName\(OVERFLIGHT_NAME\)/,
   'The plane seen in the sky should become the physical wreck rather than a substitute');
 assert.match(airportEmergency, /aircraftMount\.rotation\.x = THREE\.MathUtils\.degToRad\(-20\)/);
 assert.match(airportEmergency, /aircraftMount\.rotation\.y = Math\.PI/,
-  'The wreck nose-tail direction must be reversed from the r490 playtest');
+  'The wreck nose-tail direction must remain reversed after playtesting');
 assert.match(airportEmergency, /aircraftMount\.rotation\.z = THREE\.MathUtils\.degToRad\(20\)/);
 assert.match(airportEmergency, /makeFlameTongue/,
-  'The crash fire should use layered bent flame geometry instead of two large cones');
+  'The improved layered crash fire must remain in place');
 assert.match(airportEmergency, /THREE\.AdditiveBlending/);
 assert.match(airportEmergency, /\[7\.0, 65, 2\.0, 4\.9\]/,
   'The smoke column should stay tall above the full-scale wreck');
+
 assert.match(airportEmergency, /preloadCarModels\(\['firetruck', 'ambulance'\]\)/,
-  'Airport + Ambulance should prewarm both medical responder models before lap one finishes');
-assert.match(airportEmergency, /requestIdleCallback/,
-  'Responder preparation should move away from the finish-line critical path');
+  'Ambulance Airport runs should preload both medical responder models');
+assert.doesNotMatch(airportEmergency, /requestIdleCallback/,
+  'iOS must not defer responder preparation until the finish line');
+assert.match(airportEmergency, /renderer\.compileAsync\(staging, camera\)/,
+  'MAYDAY-only materials should be asynchronously shader-warmed before the crash reveal');
+assert.match(airportEmergency, /setTimeout\(revealCrashVisuals, 120\)/,
+  'Crash scene reparenting and reveal should happen after the lap transition frame');
 assert.match(airportEmergency, /playMaydayCrashSound\(\);[\s\S]*session\.crashActive = true/,
-  'The impact must be requested before any crash-scene or responder work');
+  'The impact must be requested before crash-state work');
+
 assert.match(airportEmergency, /carId: 'firetruck'/,
   'The medical bay needs a Fire Truck responder');
 assert.match(airportEmergency, /carId: 'ambulance'/,
   'The medical bay needs an Ambulance responder too');
-assert.match(airportEmergency, /horizontalDistanceSquared\(position, placement\.firetruckPoint\)/);
-assert.match(airportEmergency, /horizontalDistanceSquared\(position, placement\.ambulancePoint\)/,
-  'Approaching either responder must count as reaching the medical bay');
+assert.match(airportEmergency, /const medicalPoint = ambulancePoint\.clone\(\)/,
+  'The medical trigger must be centred on the responder Ambulance, not inside the terminal');
+assert.match(airportEmergency, /function isInsideMedicalBay\(position\)[\s\S]*placement\.medicalPoint/);
+assert.doesNotMatch(airportEmergency, /isInsideMedicalBay\(position\)[\s\S]{0,220}placement\.firetruckPoint/,
+  'The transfer zone should be one understandable Ambulance-centred target, not a hidden union of zones');
+assert.match(airportEmergency, /renderScene\.onBeforeRender = function airportEmergencyFrame/,
+  'MAYDAY logic must run at scene level even after the wreck leaves the camera frustum');
+assert.doesNotMatch(airportEmergency, /renderAnchor\.onBeforeRender/,
+  'Medical transfer and siren updates must not depend on the crash fire still being rendered');
+
+assert.match(airportEmergency, /PATIENT ON BOARD · MEDICAL BAY · 30 SECONDS/,
+  'The instruction should describe the objective without explicitly telling players to follow sirens');
+assert.doesNotMatch(airportEmergency, /FOLLOW THE SIRENS/);
+assert.match(airportEmergency, /\.turn-mayday-info-plate[\s\S]*top: max\(16px, calc\(env\(safe-area-inset-top\) \+ 10px\)\)[\s\S]*border: 3px solid #08090a[\s\S]*box-shadow: 5px 5px 0 #08090a/,
+  'MAYDAY instructions should use the same fixed info-plate treatment as blank-screen info');
+assert.match(airportEmergency, /new THREE\.BoxGeometry\(10\.4, 6\.4, 0\.65\)/,
+  'The terminal H plate should cover the window it occupies');
+assert.match(airportEmergency, /sign\.position\.set\(0, 8\.7, 12\.72\)/,
+  'The H plate should be centred on the terminal window');
+
 assert.match(airportEmergency, /pulseMaydayResponderSiren/,
   'The medical responders must provide positioned audible sirens');
 assert.match(airportEmergency, /pulseMaydayFire/,
   'The crash site must retain positioned audible fire guidance');
-assert.match(airportEmergency, /#message\.turn-mayday-message[\s\S]*31vh/,
-  'MAYDAY instructions must sit below the top lap HUD');
 assert.match(airportEmergency, /marker\.textContent = kind === 'medical' \? 'H' : '🔥'/,
   'The minimap must switch from the crash marker to the terminal medical marker during transport');
 assert.match(airportEmergency, /sessionPersistent: true/);
@@ -179,7 +200,13 @@ assert.doesNotMatch(airportEmergency, /localStorage|sessionStorage/,
   'The crash must persist only for the current page session and reset when TURN starts again');
 
 assert.match(maydayAudio, /export function playMaydayCrashSound/);
+assert.match(maydayAudio, /playDistortedNoise/,
+  'The crash impact should use a distorted low rumble rather than a short fail-like transient');
+assert.match(maydayAudio, /2\.45/,
+  'The crash rumble should be substantially slowed\/lengthened');
 assert.match(maydayAudio, /export function pulseMaydayResponderSiren/);
+assert.match(maydayAudio, /0\.58/,
+  'Responder siren pulses should overlap enough to sound continuous');
 assert.match(maydayAudio, /createStereoPanner/,
   'MAYDAY responder audio should preserve left\/right direction when supported');
 assert.match(maydayAudio, /__turnAudioPreferences\?\.getSettings/,
@@ -204,4 +231,4 @@ assert.match(audio, /emergencySirenFrequency/);
 assert.match(audio, /sirenActive = boostActive/);
 assert.match(license, /Creative Commons CC0 1\.0 Universal/);
 
-console.log('TURN emergency vehicles and MAYDAY playtest fixes passed.');
+console.log('TURN emergency vehicles and MAYDAY r492 playtest fixes passed.');

--- a/turn/audio/mayday-audio-r492.js
+++ b/turn/audio/mayday-audio-r492.js
@@ -1,0 +1,223 @@
+const AudioContextClass = globalThis.AudioContext || globalThis.webkitAudioContext;
+
+let context = null;
+let masterGain = null;
+let noiseBuffer = null;
+let prepared = false;
+let distortionCurve = null;
+
+export function prepareMaydayAudio() {
+  if (prepared || !AudioContextClass) return;
+  prepared = true;
+
+  const unlockFromGesture = () => {
+    void unlock();
+  };
+  document.addEventListener('pointerdown', unlockFromGesture, { capture: true, passive: true });
+  document.addEventListener('keydown', unlockFromGesture, { capture: true });
+}
+
+export function playMaydayCrashSound() {
+  withReady(() => {
+    const now = context.currentTime;
+
+    // About four times the duration and roughly one quarter of the bright transient
+    // pitch from r491: this should read as a distant aircraft impact/rumble rather
+    // than TURN's familiar short bump/fail family of cues.
+    playTone(58, 17, 2.25, 0.13, 'sine', now);
+    playTone(138, 24, 1.3, 0.052, 'square', now + 0.03);
+    playDistortedNoise(now + 0.015, 2.45, 0.11, 55, 720, 0.9);
+    playTone(46, 26, 1.45, 0.075, 'triangle', now + 0.48);
+    playNoiseBurst(now + 0.62, 1.55, 0.05, 70, 460, 0.96);
+  });
+}
+
+export function pulseMaydayFire({ pan = 0, intensity = 0.6 } = {}) {
+  withReady(() => {
+    const now = context.currentTime;
+    const level = clamp(Number(intensity) || 0.6, 0.25, 1);
+    const stereo = clamp(Number(pan) || 0, -0.96, 0.96);
+    playNoiseBurst(now, 0.28, 0.025 + level * 0.022, 210, 1650, 0.98, stereo);
+    playNoiseBurst(now + 0.085, 0.15, 0.015 + level * 0.014, 620, 2800, 0.84, stereo);
+  });
+}
+
+export function pulseMaydayResponderSiren({ service = 'ambulance', pan = 0, high = false } = {}) {
+  withReady(() => {
+    const now = context.currentTime;
+    const stereo = clamp(Number(pan) || 0, -0.96, 0.96);
+    const pair = service === 'firetruck' ? [430, 570] : [610, 820];
+    const start = high ? pair[1] : pair[0];
+    const end = high ? pair[0] : pair[1];
+    const level = service === 'firetruck' ? 0.068 : 0.062;
+
+    // Long enough to overlap the 540 ms pulse cadence slightly, so the responder
+    // actually reads as an ongoing siren rather than isolated notification beeps.
+    playTone(start, end, 0.58, level, 'triangle', now, stereo);
+    playTone(start * 1.5, end * 1.5, 0.58, level * 0.28, 'sine', now, stereo);
+  });
+}
+
+function withReady(callback) {
+  if (!audioEnabled()) return;
+  void unlock().then((ready) => {
+    if (ready && audioEnabled()) callback();
+  });
+}
+
+async function unlock() {
+  if (!AudioContextClass) return false;
+  ensureContext();
+  if (!context) return false;
+  if (context.state === 'running') return true;
+  try {
+    await context.resume();
+  } catch (_) {
+    return false;
+  }
+  return context.state === 'running';
+}
+
+function ensureContext() {
+  if (context || !AudioContextClass) return;
+  try {
+    context = new AudioContextClass({ latencyHint: 'interactive' });
+  } catch (_) {
+    context = new AudioContextClass();
+  }
+
+  masterGain = context.createGain();
+  masterGain.gain.value = 0.66;
+  masterGain.connect(context.destination);
+  noiseBuffer = makeNoiseBuffer(context, 2.8);
+  distortionCurve = makeDistortionCurve(85);
+}
+
+function audioEnabled() {
+  const settings = globalThis.__turnAudioPreferences?.getSettings?.();
+  return settings?.audioEnabled !== false;
+}
+
+function playTone(startHz, endHz, duration, level, type, startAt, pan = 0) {
+  const oscillator = context.createOscillator();
+  const gain = context.createGain();
+  const panner = createStereoPanner(pan);
+  const endAt = startAt + duration;
+
+  oscillator.type = type;
+  oscillator.frequency.setValueAtTime(Math.max(1, startHz), startAt);
+  oscillator.frequency.exponentialRampToValueAtTime(Math.max(1, endHz), endAt);
+  gain.gain.setValueAtTime(0.0001, startAt);
+  gain.gain.exponentialRampToValueAtTime(Math.max(0.0002, level), startAt + Math.min(0.03, duration * 0.16));
+  gain.gain.exponentialRampToValueAtTime(0.0001, endAt);
+
+  oscillator.connect(gain);
+  gain.connect(panner);
+  panner.connect(masterGain);
+  oscillator.addEventListener('ended', () => disconnect(oscillator, gain, panner), { once: true });
+  oscillator.start(startAt);
+  oscillator.stop(endAt + 0.02);
+}
+
+function playNoiseBurst(startAt, duration, level, lowHz, highHz, roughness, pan = 0) {
+  if (!noiseBuffer) return;
+  const source = context.createBufferSource();
+  const filter = context.createBiquadFilter();
+  const gain = context.createGain();
+  const panner = createStereoPanner(pan);
+  const endAt = startAt + duration;
+
+  source.buffer = noiseBuffer;
+  source.loop = true;
+  filter.type = 'bandpass';
+  filter.frequency.setValueAtTime(Math.max(40, highHz), startAt);
+  filter.frequency.exponentialRampToValueAtTime(Math.max(40, lowHz), endAt);
+  filter.Q.value = 0.45 + clamp(Number(roughness) || 0.8, 0, 1) * 0.65;
+  gain.gain.setValueAtTime(0.0001, startAt);
+  gain.gain.exponentialRampToValueAtTime(Math.max(0.0002, level), startAt + Math.min(0.025, duration * 0.12));
+  gain.gain.exponentialRampToValueAtTime(0.0001, endAt);
+
+  source.connect(filter);
+  filter.connect(gain);
+  gain.connect(panner);
+  panner.connect(masterGain);
+  source.addEventListener('ended', () => disconnect(source, filter, gain, panner), { once: true });
+  source.start(startAt);
+  source.stop(endAt + 0.02);
+}
+
+function playDistortedNoise(startAt, duration, level, lowHz, highHz, roughness) {
+  if (!noiseBuffer) return;
+  const source = context.createBufferSource();
+  const filter = context.createBiquadFilter();
+  const shaper = context.createWaveShaper();
+  const gain = context.createGain();
+  const endAt = startAt + duration;
+
+  source.buffer = noiseBuffer;
+  source.loop = true;
+  filter.type = 'lowpass';
+  filter.frequency.setValueAtTime(Math.max(40, highHz), startAt);
+  filter.frequency.exponentialRampToValueAtTime(Math.max(40, lowHz), endAt);
+  filter.Q.value = 0.5 + clamp(Number(roughness) || 0.8, 0, 1) * 0.8;
+  shaper.curve = distortionCurve;
+  shaper.oversample = '2x';
+  gain.gain.setValueAtTime(0.0001, startAt);
+  gain.gain.exponentialRampToValueAtTime(Math.max(0.0002, level), startAt + 0.035);
+  gain.gain.exponentialRampToValueAtTime(0.0001, endAt);
+
+  source.connect(filter);
+  filter.connect(shaper);
+  shaper.connect(gain);
+  gain.connect(masterGain);
+  source.addEventListener('ended', () => disconnect(source, filter, shaper, gain), { once: true });
+  source.start(startAt);
+  source.stop(endAt + 0.02);
+}
+
+function createStereoPanner(pan) {
+  if (typeof context.createStereoPanner === 'function') {
+    const node = context.createStereoPanner();
+    node.pan.value = clamp(Number(pan) || 0, -1, 1);
+    return node;
+  }
+  const gain = context.createGain();
+  gain.gain.value = 1;
+  return gain;
+}
+
+function makeNoiseBuffer(audioContext, seconds) {
+  const frames = Math.max(1, Math.floor(audioContext.sampleRate * seconds));
+  const buffer = audioContext.createBuffer(1, frames, audioContext.sampleRate);
+  const data = buffer.getChannelData(0);
+  let previous = 0;
+  for (let index = 0; index < frames; index += 1) {
+    const white = Math.random() * 2 - 1;
+    previous = previous * 0.82 + white * 0.18;
+    data[index] = previous * 0.78 + white * 0.22;
+  }
+  return buffer;
+}
+
+function makeDistortionCurve(amount) {
+  const samples = 512;
+  const curve = new Float32Array(samples);
+  const k = Math.max(1, Number(amount) || 50);
+  for (let index = 0; index < samples; index += 1) {
+    const x = index * 2 / (samples - 1) - 1;
+    curve[index] = ((3 + k) * x * 20 * Math.PI / 180) / (Math.PI + k * Math.abs(x));
+  }
+  return curve;
+}
+
+function disconnect(...nodes) {
+  for (const node of nodes) {
+    try {
+      node.disconnect();
+    } catch (_) {}
+  }
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}

--- a/turn/tracks/airport-emergency-r492.js
+++ b/turn/tracks/airport-emergency-r492.js
@@ -1,0 +1,880 @@
+import * as THREE from 'three';
+import {
+  createCarVisual,
+  preloadCarModels
+} from '../vehicle/car-models.js?build=20260720-r19';
+import { signalSecretAchievement } from '../achievements/secret-events.js?revision=r174-bella-siren-zone';
+import {
+  prepareMaydayAudio,
+  playMaydayCrashSound,
+  pulseMaydayFire,
+  pulseMaydayResponderSiren
+} from '../audio/mayday-audio-r492.js?revision=r492';
+
+const AIRPORT_TRACK_ID = 'airport';
+const AMBULANCE_ID = 'ambulance';
+const TRANSFER_LIMIT_MS = 30_000;
+const PICKUP_RADIUS = 24;
+const MEDICAL_RADIUS = 42;
+const PICKUP_RADIUS_SQUARED = PICKUP_RADIUS * PICKUP_RADIUS;
+const MEDICAL_RADIUS_SQUARED = MEDICAL_RADIUS * MEDICAL_RADIUS;
+const CRASH_REFERENCE = Object.freeze({ x: 192, z: 70 });
+const CRASH_OUTSIDE_REFERENCE = Object.freeze({ x: 235, z: 108 });
+const TERMINAL_NAME = 'TURN International Terminal';
+const OVERFLIGHT_NAME = 'Airport B787 Overflight';
+const OVERFLIGHT_TARGET_LENGTH = 22;
+const WRECK_TARGET_LENGTH = 62;
+const WRECK_SCALE = WRECK_TARGET_LENGTH / OVERFLIGHT_TARGET_LENGTH;
+const MAP_STYLE_ID = 'turn-airport-emergency-map-style-r492';
+const MAP_MARKER_ID = 'turn-airport-emergency-map-marker';
+const MAYDAY_INFO_ID = 'turn-mayday-info-plate';
+const FIRE_GUIDE_INTERVAL_MS = 950;
+const RESPONDER_SIREN_INTERVAL_MS = 540;
+
+export const AIRPORT_EMERGENCY_CONFIG = Object.freeze({
+  trackId: AIRPORT_TRACK_ID,
+  vehicleId: AMBULANCE_ID,
+  transferLimitMs: TRANSFER_LIMIT_MS,
+  pickupRadius: PICKUP_RADIUS,
+  medicalRadius: MEDICAL_RADIUS,
+  wreckTargetLength: WRECK_TARGET_LENGTH
+});
+
+const session = {
+  crashActive: false,
+  resolved: false,
+  phase: 'idle',
+  transferStartedAt: 0,
+  transferDeadline: 0,
+  crashAircraftMounted: false,
+  nextAircraftCheckAt: 0,
+  nextGuideCueAt: 0,
+  guidePulseIndex: 0
+};
+
+let installation = null;
+
+export function qualifiesForAirportCrash(detail, {
+  trackId = '',
+  vehicleId = '',
+  crashActive = false
+} = {}) {
+  return crashActive !== true
+    && trackId === AIRPORT_TRACK_ID
+    && vehicleId === AMBULANCE_ID
+    && detail?.valid === true
+    && Number.isFinite(Number(detail?.time))
+    && Number(detail.time) > 5;
+}
+
+export function installAirportEmergency({ world, samples, runtime = globalThis.__turnRuntime } = {}) {
+  if (installation) return installation;
+  if (!world || !Array.isArray(samples) || !samples.length || !runtime?.state) return null;
+
+  const placement = emergencyPlacement(world, samples);
+  installMaydayUiStyle();
+  installMedicalSign(world, placement);
+  prepareMaydayAudio();
+
+  const {
+    scene: crashScene,
+    aircraftMount,
+    fireRecords
+  } = makeCrashScene();
+  crashScene.position.copy(placement.crashPoint);
+  crashScene.rotation.y = placement.crashYaw;
+  crashScene.visible = false;
+  world.add(crashScene);
+
+  const mapMarker = installMapMarker(samples);
+  let respondersPromise = null;
+  let responderVisuals = [];
+  let renderWarmPromise = null;
+  let crashRevealTimer = 0;
+
+  function activeTrackId() {
+    return runtime.state.trackId || globalThis.__turnGetTrackId?.() || '';
+  }
+
+  function playerPosition() {
+    return runtime.playerCar?.position || runtime.state.position || null;
+  }
+
+  function syncMapMarker() {
+    if (!mapMarker) return;
+    if (activeTrackId() !== AIRPORT_TRACK_ID || !session.crashActive || session.resolved) {
+      mapMarker.hide();
+      return;
+    }
+    mapMarker.show(
+      session.phase === 'transport' ? placement.medicalPoint : placement.crashPoint,
+      session.phase === 'transport' ? 'medical' : 'crash'
+    );
+  }
+
+  function syncResponders() {
+    for (const responder of responderVisuals) responder.visual.visible = session.crashActive;
+  }
+
+  function prepareResponders() {
+    if (respondersPromise) return respondersPromise;
+    respondersPromise = preloadCarModels(['firetruck', 'ambulance'])
+      .then(() => Promise.all([
+        makeResponder({
+          carId: 'firetruck',
+          color: '#d92d20',
+          secondaryColor: '#ffcc00',
+          name: 'Airport MAYDAY medical fire truck',
+          position: placement.firetruckPoint,
+          yaw: placement.responderYaw
+        }),
+        makeResponder({
+          carId: 'ambulance',
+          color: '#f8f9fa',
+          secondaryColor: '#d92d20',
+          name: 'Airport MAYDAY medical ambulance',
+          position: placement.ambulancePoint,
+          yaw: placement.responderYaw
+        })
+      ]))
+      .then((records) => {
+        responderVisuals = records.filter(Boolean);
+        for (const responder of responderVisuals) {
+          responder.visual.visible = session.crashActive;
+          world.add(responder.visual);
+        }
+        syncResponders();
+        void precompileEmergencyVisuals();
+        return responderVisuals;
+      })
+      .catch((error) => {
+        console.info('TURN: MAYDAY medical responders unavailable; the medical bay and audible guide remain active.', error);
+        responderVisuals = [];
+        return responderVisuals;
+      });
+    return respondersPromise;
+  }
+
+  function precompileEmergencyVisuals() {
+    if (renderWarmPromise) return renderWarmPromise;
+    const renderer = runtime.renderer;
+    const camera = runtime.camera;
+    if (typeof renderer?.compileAsync !== 'function' || !camera) return Promise.resolve(false);
+
+    const staging = new THREE.Scene();
+    const crashClone = crashScene.clone(true);
+    crashClone.visible = true;
+    staging.add(crashClone);
+    for (const responder of responderVisuals) {
+      const clone = responder.visual.clone(true);
+      clone.visible = true;
+      staging.add(clone);
+    }
+
+    renderWarmPromise = renderer.compileAsync(staging, camera)
+      .then(() => true)
+      .catch(() => false);
+    return renderWarmPromise;
+  }
+
+  function startResponderPrewarm() {
+    if (runtime.state.vehicleId !== AMBULANCE_ID) return;
+    // Do the GLTF/network work as soon as the Ambulance race is staged. The previous
+    // requestIdleCallback could wait until the first lap was nearly over on iOS.
+    globalThis.setTimeout(() => {
+      void prepareResponders();
+      void precompileEmergencyVisuals();
+    }, 0);
+  }
+
+  function mountOverflightAsWreck(now = performance.now()) {
+    if (!session.crashActive || session.crashAircraftMounted || now < session.nextAircraftCheckAt) return;
+    session.nextAircraftCheckAt = now + 250;
+    const aircraft = world.getObjectByName(OVERFLIGHT_NAME);
+    if (!aircraft) return;
+
+    aircraft.position.set(0, -4.8, 0);
+    aircraft.scale.multiplyScalar(WRECK_SCALE);
+    aircraftMount.add(aircraft);
+    aircraft.visible = true;
+    session.crashAircraftMounted = true;
+  }
+
+  function revealCrashVisuals() {
+    crashRevealTimer = 0;
+    crashScene.visible = true;
+    mountOverflightAsWreck(0);
+    syncResponders();
+  }
+
+  function triggerCrash() {
+    if (session.crashActive) return;
+
+    // Keep the finish-line event itself cheap: sound, state and instruction happen now;
+    // scene reveal/reparenting happens just after the lap transition has rendered.
+    playMaydayCrashSound();
+
+    session.crashActive = true;
+    session.resolved = false;
+    session.phase = 'waiting';
+    session.transferStartedAt = 0;
+    session.transferDeadline = 0;
+    session.crashAircraftMounted = false;
+    session.nextAircraftCheckAt = 0;
+    session.nextGuideCueAt = 0;
+    session.guidePulseIndex = 0;
+    syncMapMarker();
+    showMessage('MAYDAY · AIRPORT CRASH REPORTED', 2400);
+    publishState('crash');
+
+    if (respondersPromise) void respondersPromise.then(syncResponders);
+    else globalThis.setTimeout(() => void prepareResponders(), 500);
+
+    globalThis.clearTimeout(crashRevealTimer);
+    crashRevealTimer = globalThis.setTimeout(revealCrashVisuals, 120);
+  }
+
+  function beginTransfer(now) {
+    session.phase = 'transport';
+    session.transferStartedAt = now;
+    session.transferDeadline = now + TRANSFER_LIMIT_MS;
+    session.nextGuideCueAt = 0;
+    session.guidePulseIndex = 0;
+    syncMapMarker();
+    globalThis.__turnAudio?.cue?.('ui-confirm');
+    showMessage('PATIENT ON BOARD · MEDICAL BAY · 30 SECONDS', 2800);
+    publishState('pickup');
+  }
+
+  function failTransfer() {
+    session.phase = 'waiting';
+    session.transferStartedAt = 0;
+    session.transferDeadline = 0;
+    session.nextGuideCueAt = 0;
+    session.guidePulseIndex = 0;
+    syncMapMarker();
+    globalThis.__turnAudio?.cue?.('ui-back');
+    showMessage('TRANSFER MISSED · RETURN TO THE CRASH', 2300);
+    publishState('retry');
+  }
+
+  function completeTransfer(now) {
+    const transferSeconds = Math.max(0, (now - session.transferStartedAt) / 1000);
+    session.phase = 'resolved';
+    session.resolved = true;
+    session.transferDeadline = 0;
+    session.nextGuideCueAt = Infinity;
+    syncMapMarker();
+    globalThis.__turnAudio?.cue?.('ui-confirm');
+    showMessage('PATIENT DELIVERED · MAYDAY!', 2100);
+    signalSecretAchievement('golden-hour', {
+      trackId: AIRPORT_TRACK_ID,
+      vehicleId: AMBULANCE_ID,
+      time: transferSeconds,
+      rescueConfirmed: true
+    });
+    publishState('resolved');
+  }
+
+  function updateAudibleGuide(now, state, position) {
+    if (now < session.nextGuideCueAt) return;
+
+    if (session.phase === 'waiting') {
+      const distance = Math.sqrt(horizontalDistanceSquared(position, placement.crashPoint));
+      pulseMaydayFire({
+        pan: positionalPan(state, position, placement.crashPoint),
+        intensity: THREE.MathUtils.clamp(1 - distance / 280, 0.3, 1)
+      });
+      session.nextGuideCueAt = now + FIRE_GUIDE_INTERVAL_MS;
+      return;
+    }
+
+    if (session.phase === 'transport') {
+      const firetruckTurn = session.guidePulseIndex % 2 === 0;
+      const source = firetruckTurn ? placement.firetruckPoint : placement.ambulancePoint;
+      pulseMaydayResponderSiren({
+        service: firetruckTurn ? 'firetruck' : 'ambulance',
+        pan: positionalPan(state, position, source),
+        high: Math.floor(session.guidePulseIndex / 2) % 2 === 1
+      });
+      session.guidePulseIndex += 1;
+      session.nextGuideCueAt = now + RESPONDER_SIREN_INTERVAL_MS;
+    }
+  }
+
+  function isInsideMedicalBay(position) {
+    return horizontalDistanceSquared(position, placement.medicalPoint) <= MEDICAL_RADIUS_SQUARED;
+  }
+
+  function updateEmergencyFrame() {
+    if (!session.crashActive) return;
+    const now = performance.now();
+    if (crashScene.visible) {
+      mountOverflightAsWreck(now);
+      updateFire(fireRecords, now);
+    }
+
+    if (session.phase === 'transport' && now > session.transferDeadline) {
+      failTransfer();
+      return;
+    }
+
+    const state = runtime.state;
+    if (activeTrackId() !== AIRPORT_TRACK_ID || state.running !== true) return;
+    const position = playerPosition();
+    if (!position) return;
+
+    if (session.phase === 'waiting' || session.phase === 'transport') {
+      updateAudibleGuide(now, state, position);
+    }
+
+    if (session.phase === 'waiting') {
+      const sirenActive = state.vehicleId === AMBULANCE_ID && globalThis.__turnBoostActive === true;
+      if (!sirenActive || horizontalDistanceSquared(position, placement.crashPoint) > PICKUP_RADIUS_SQUARED) return;
+      beginTransfer(now);
+      return;
+    }
+
+    if (
+      session.phase === 'transport'
+      && state.vehicleId === AMBULANCE_ID
+      && isInsideMedicalBay(position)
+    ) {
+      completeTransfer(now);
+    }
+  }
+
+  // Do not hang rescue logic from a crash-site mesh: once the wreck leaves the camera
+  // frustum Three.js stops calling that mesh's onBeforeRender. Scene-level rendering
+  // keeps the sirens and medical trigger alive all the way to the terminal.
+  const renderScene = runtime.scene || world.parent;
+  const previousSceneBeforeRender = renderScene?.onBeforeRender;
+  if (renderScene) {
+    renderScene.onBeforeRender = function airportEmergencyFrame(...args) {
+      previousSceneBeforeRender?.call(this, ...args);
+      updateEmergencyFrame();
+    };
+  }
+
+  const onLapResult = (event) => {
+    if (!qualifiesForAirportCrash(event.detail, {
+      trackId: activeTrackId(),
+      vehicleId: runtime.state.vehicleId,
+      crashActive: session.crashActive
+    })) return;
+    triggerCrash();
+  };
+
+  const onUiState = () => {
+    if (!session.crashActive && runtime.state.vehicleId === AMBULANCE_ID) startResponderPrewarm();
+    syncMapMarker();
+    syncResponders();
+  };
+
+  globalThis.addEventListener?.('turn:lap-result', onLapResult);
+  globalThis.addEventListener?.('turn:track-changed', onUiState);
+  globalThis.addEventListener?.('turn:ui-state-change', onUiState);
+
+  world.userData.turnAirportEmergency = Object.freeze({
+    achievementId: 'golden-hour',
+    achievementTitle: 'MAYDAY!',
+    requiredVehicle: AMBULANCE_ID,
+    transferSeconds: TRANSFER_LIMIT_MS / 1000,
+    crashPoint: placement.crashPoint.clone(),
+    medicalPoint: placement.medicalPoint.clone(),
+    sessionPersistent: true,
+    clearsOnPageReload: true,
+    realAircraftWreck: 'reuses the Airport B787 overflight at full scale with reversed nose-tail orientation',
+    medicalResponders: 'prewarmed Fire Truck and Ambulance with flashing lights and positioned audible sirens',
+    audibleGuidance: 'positioned fire audio at the wreck and responder sirens at the terminal medical bay'
+  });
+
+  installation = Object.freeze({
+    getState() {
+      return Object.freeze({
+        crashActive: session.crashActive,
+        resolved: session.resolved,
+        phase: session.phase,
+        transferDeadline: session.transferDeadline,
+        crashAircraftMounted: session.crashAircraftMounted
+      });
+    },
+    triggerCrash,
+    crashPoint: placement.crashPoint.clone(),
+    medicalPoint: placement.medicalPoint.clone()
+  });
+  globalThis.__turnAirportEmergency = installation;
+
+  startResponderPrewarm();
+  syncMapMarker();
+  return installation;
+}
+
+async function makeResponder({ carId, color, secondaryColor, name, position, yaw }) {
+  const visual = await createCarVisual({
+    carId,
+    color,
+    secondaryColor,
+    targetLength: 8.4,
+    outline: true
+  });
+  visual.name = name;
+  visual.position.copy(position);
+  visual.rotation.y = yaw;
+  visual.visible = false;
+  visual.traverse((node) => {
+    if (node.isMesh) node.castShadow = false;
+  });
+  installResponderLightOverride(visual);
+  return { service: carId, visual };
+}
+
+function emergencyPlacement(world, samples) {
+  const crashSample = nearestSample(samples, CRASH_REFERENCE.x, CRASH_REFERENCE.z);
+  const sideA = crashSample.point.clone().addScaledVector(crashSample.normal, 34);
+  const sideB = crashSample.point.clone().addScaledVector(crashSample.normal, -34);
+  const outside = new THREE.Vector3(CRASH_OUTSIDE_REFERENCE.x, 0, CRASH_OUTSIDE_REFERENCE.z);
+  const crashPoint = sideA.distanceToSquared(outside) <= sideB.distanceToSquared(outside) ? sideA : sideB;
+  crashPoint.y = 0.3;
+
+  const terminal = world.getObjectByName(TERMINAL_NAME) || null;
+  let firetruckPoint = new THREE.Vector3(-74, 0.2, -35);
+  let ambulancePoint = new THREE.Vector3(-42, 0.2, -35);
+  let responderYaw = Math.PI / 2;
+
+  if (terminal) {
+    terminal.updateMatrixWorld(true);
+    firetruckPoint = terminal.localToWorld(new THREE.Vector3(-16, 0.2, 28));
+    ambulancePoint = terminal.localToWorld(new THREE.Vector3(16, 0.2, 28));
+    const centre = terminal.localToWorld(new THREE.Vector3(0, 0.2, 28));
+    const localForward = terminal.localToWorld(new THREE.Vector3(0, 0.2, 38));
+    responderYaw = Math.atan2(
+      localForward.x - centre.x,
+      localForward.z - centre.z
+    ) + Math.PI / 2;
+  }
+
+  const medicalPoint = ambulancePoint.clone();
+  medicalPoint.y = 0.3;
+
+  return {
+    terminal,
+    crashPoint,
+    medicalPoint,
+    firetruckPoint,
+    ambulancePoint,
+    responderYaw,
+    crashYaw: Math.atan2(crashSample.tangent.x, crashSample.tangent.z) + 0.62
+  };
+}
+
+function nearestSample(samples, x, z) {
+  let nearest = samples[0];
+  let best = Infinity;
+  for (const sample of samples) {
+    const dx = sample.point.x - x;
+    const dz = sample.point.z - z;
+    const distance = dx * dx + dz * dz;
+    if (distance >= best) continue;
+    best = distance;
+    nearest = sample;
+  }
+  return nearest;
+}
+
+function horizontalDistanceSquared(a, b) {
+  const dx = Number(a.x) - Number(b.x);
+  const dz = Number(a.z) - Number(b.z);
+  return dx * dx + dz * dz;
+}
+
+function positionalPan(state, listenerPosition, sourcePosition) {
+  const dx = Number(sourcePosition.x) - Number(listenerPosition.x);
+  const dz = Number(sourcePosition.z) - Number(listenerPosition.z);
+  const length = Math.max(0.001, Math.hypot(dx, dz));
+  const heading = Number(state?.heading) || 0;
+  const rightX = Math.cos(heading);
+  const rightZ = -Math.sin(heading);
+  return THREE.MathUtils.clamp((dx / length) * rightX + (dz / length) * rightZ, -0.96, 0.96);
+}
+
+function installMedicalSign(world, placement) {
+  const sign = makeMedicalSign();
+  if (placement.terminal) {
+    // Match the north-window centre exactly and cover the whole window rather than
+    // looking like a small sign floating on top of it.
+    sign.position.set(0, 8.7, 12.72);
+    placement.terminal.add(sign);
+    return sign;
+  }
+  sign.position.copy(placement.medicalPoint).setY(8.7);
+  world.add(sign);
+  return sign;
+}
+
+function makeMedicalSign() {
+  const sign = new THREE.Group();
+  sign.name = 'Airport terminal medical H';
+  sign.userData.turnAirportMedical = true;
+
+  const panel = outlinedPrimitive(
+    new THREE.BoxGeometry(10.4, 6.4, 0.65),
+    new THREE.MeshStandardMaterial({ color: 0xfff8e8, roughness: 0.86 }),
+    1.045
+  );
+  sign.add(panel);
+
+  const red = new THREE.MeshBasicMaterial({ color: 0xd92d20, toneMapped: false });
+  const left = new THREE.Mesh(new THREE.BoxGeometry(1.3, 5.0, 0.3), red);
+  const right = left.clone();
+  const middle = new THREE.Mesh(new THREE.BoxGeometry(4.9, 1.25, 0.3), red);
+  left.position.set(-1.8, 0, 0.49);
+  right.position.set(1.8, 0, 0.49);
+  middle.position.set(0, 0, 0.49);
+  sign.add(left, right, middle);
+  return sign;
+}
+
+function makeCrashScene() {
+  const root = new THREE.Group();
+  root.name = 'Airport MAYDAY crash site';
+  root.userData.turnAirportCrashSite = true;
+
+  const aircraftMount = new THREE.Group();
+  aircraftMount.name = 'Airport B787 wreck mount';
+  aircraftMount.position.y = -0.7;
+  aircraftMount.rotation.x = THREE.MathUtils.degToRad(-20);
+  aircraftMount.rotation.y = Math.PI;
+  aircraftMount.rotation.z = THREE.MathUtils.degToRad(20);
+  root.add(aircraftMount);
+
+  const dark = new THREE.MeshStandardMaterial({ color: 0x34383d, roughness: 0.94 });
+  const concrete = new THREE.MeshStandardMaterial({ color: 0x737b82, roughness: 0.98 });
+  const debris = [
+    [-13, 0.7, -8, 5.2, 2.3, 0.35],
+    [-8, 0.6, 7, 4.2, 2.6, -0.6],
+    [-2, 0.8, -10, 6.1, 2.4, 0.9],
+    [5, 0.6, 9, 4.7, 2.7, -0.25],
+    [10, 0.75, -6, 5.8, 2.2, 0.5],
+    [14, 0.65, 4, 4.4, 3.0, -0.8],
+    [-16, 0.55, 2, 3.9, 2.8, 0.15],
+    [1, 0.55, 13, 4.8, 2.4, 0.72]
+  ];
+  for (const [x, y, z, width, depth, rotation] of debris) {
+    const chunk = outlinedPrimitive(
+      new THREE.BoxGeometry(width, 1.0, depth),
+      Math.abs(rotation) > 0.5 ? concrete : dark,
+      1.04
+    );
+    chunk.position.set(x, y, z);
+    chunk.rotation.set(0.16, rotation, 0.18);
+    root.add(chunk);
+  }
+
+  const fireGroup = new THREE.Group();
+  fireGroup.name = 'Airport MAYDAY fire';
+  fireGroup.position.set(3.2, 0.8, 1.2);
+  root.add(fireGroup);
+
+  const ember = new THREE.Mesh(
+    new THREE.IcosahedronGeometry(3.6, 1),
+    new THREE.MeshBasicMaterial({
+      color: 0xff5c22,
+      transparent: true,
+      opacity: 0.9,
+      blending: THREE.AdditiveBlending,
+      depthWrite: false,
+      toneMapped: false
+    })
+  );
+  ember.scale.set(1.25, 0.55, 1.0);
+  ember.position.y = 1.1;
+  fireGroup.add(ember);
+
+  const tongueSpecs = [
+    [2.8, 11.8, -0.4, 0.1, -1.1, 0.25, 0xd92d20, 0.86],
+    [2.2, 9.4, 1.8, -0.6, 0.8, -0.35, 0xff6b22, 0.92],
+    [1.9, 8.0, -2.0, 0.8, -0.5, 0.55, 0xff922b, 0.96],
+    [1.45, 6.8, 0.25, 1.9, 0.35, 0.2, 0xffcc00, 0.98],
+    [1.2, 5.5, 0.7, -1.8, -0.25, -0.35, 0xffe066, 0.98]
+  ];
+  const fireRecords = [];
+  tongueSpecs.forEach(([radius, height, x, z, bendX, bendZ, color, opacity], index) => {
+    const tongue = makeFlameTongue(radius, height, bendX, bendZ, color, opacity);
+    tongue.position.set(x, height * 0.48, z);
+    tongue.rotation.y = index * 0.73;
+    fireGroup.add(tongue);
+    fireRecords.push({
+      mesh: tongue,
+      baseX: tongue.scale.x,
+      baseY: tongue.scale.y,
+      phase: index * 1.17
+    });
+  });
+
+  const smokeGeometry = new THREE.DodecahedronGeometry(2.5, 0);
+  const smokeMaterials = [0x34383d, 0x46515b, 0x59636f, 0x69737d].map((color, index) => (
+    new THREE.MeshBasicMaterial({
+      color,
+      transparent: true,
+      opacity: 0.78 - index * 0.08,
+      depthWrite: false
+    })
+  ));
+  const smoke = [
+    [2.8, 10, 1.2, 1.5],
+    [1.0, 15, 1.8, 2.0],
+    [3.8, 20, 0.5, 2.4],
+    [0.2, 26, 2.2, 2.8],
+    [4.5, 32, 1.0, 3.2],
+    [1.2, 39, 2.8, 3.6],
+    [5.6, 47, 1.4, 4.0],
+    [2.2, 56, 3.1, 4.5],
+    [7.0, 65, 2.0, 4.9]
+  ];
+  smoke.forEach(([x, y, z, scale], index) => {
+    const cloud = new THREE.Mesh(smokeGeometry, smokeMaterials[index % smokeMaterials.length]);
+    cloud.position.set(x, y, z);
+    cloud.scale.set(scale, scale * 0.92, scale);
+    root.add(cloud);
+  });
+
+  return {
+    scene: root,
+    aircraftMount,
+    fireRecords
+  };
+}
+
+function makeFlameTongue(radius, height, bendX, bendZ, color, opacity) {
+  const geometry = new THREE.ConeGeometry(radius, height, 7, 3, false);
+  const positions = geometry.attributes.position;
+  for (let index = 0; index < positions.count; index += 1) {
+    const y = positions.getY(index);
+    const t = THREE.MathUtils.clamp((y + height / 2) / height, 0, 1);
+    const bend = t * t;
+    positions.setX(index, positions.getX(index) + bendX * bend);
+    positions.setZ(index, positions.getZ(index) + bendZ * bend);
+  }
+  positions.needsUpdate = true;
+  geometry.computeVertexNormals();
+  return new THREE.Mesh(
+    geometry,
+    new THREE.MeshBasicMaterial({
+      color,
+      transparent: true,
+      opacity,
+      blending: THREE.AdditiveBlending,
+      depthWrite: false,
+      toneMapped: false
+    })
+  );
+}
+
+function updateFire(records, now) {
+  const seconds = now / 1000;
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index];
+    const flicker = Math.sin(seconds * (8.2 + index * 0.7) + record.phase);
+    const sway = Math.sin(seconds * (4.1 + index * 0.35) + record.phase * 0.7);
+    record.mesh.scale.y = record.baseY * (0.94 + flicker * 0.075);
+    record.mesh.scale.x = record.baseX * (1.0 - flicker * 0.035);
+    record.mesh.rotation.z = sway * 0.045;
+  }
+}
+
+function installResponderLightOverride(root) {
+  const rig = root?.userData?.turnEmergencyLightRig;
+  if (!rig?.lamps?.length) return;
+  for (const record of rig.lamps) {
+    record.lamp.onBeforeRender = () => updateResponderLights(rig);
+  }
+}
+
+function updateResponderLights(rig) {
+  const now = performance.now();
+  if (now === rig.lastFrameAt) return;
+  rig.lastFrameAt = now;
+  const active = session.crashActive && !session.resolved;
+  const phase = (now % rig.periodMs) / rig.periodMs;
+  const firstOn = phase < 0.5;
+
+  for (const record of rig.lamps) {
+    const on = record.index === 0 ? firstOn : !firstOn;
+    record.lamp.visible = true;
+    record.halo.visible = active && on;
+    record.wideHalo.visible = active && !rig.reducedMotion && on;
+    record.material.opacity = active ? (on ? 1 : 0.08) : 0;
+    record.haloMaterial.opacity = active && on ? (rig.reducedMotion ? 0.42 : 0.68) : 0;
+    record.wideHaloMaterial.opacity = active && on ? 0.26 : 0;
+    record.pointLight.intensity = active && on ? (rig.reducedMotion ? 70 : 110) : 0;
+  }
+}
+
+function outlinedPrimitive(geometry, fillMaterial, scale = 1.04) {
+  const group = new THREE.Group();
+  const outline = new THREE.Mesh(
+    geometry,
+    new THREE.MeshBasicMaterial({ color: 0x08090a, side: THREE.BackSide, toneMapped: false })
+  );
+  outline.scale.setScalar(scale);
+  const fill = new THREE.Mesh(geometry, fillMaterial);
+  fill.castShadow = false;
+  fill.receiveShadow = true;
+  group.add(outline, fill);
+  return group;
+}
+
+function installMaydayUiStyle() {
+  if (document.getElementById(MAP_STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = MAP_STYLE_ID;
+  style.textContent = `
+    .map-wrap { position: relative; }
+    #${MAP_MARKER_ID} {
+      position: absolute;
+      z-index: 4;
+      width: clamp(20px, 4.8vh, 29px);
+      height: clamp(20px, 4.8vh, 29px);
+      transform: translate(-50%, -50%);
+      display: grid;
+      place-items: center;
+      box-sizing: border-box;
+      border: 3px solid #08090a;
+      border-radius: 50%;
+      background: #fff8e8;
+      font: 900 clamp(12px, 2.8vh, 18px)/1 system-ui, sans-serif;
+      pointer-events: none;
+    }
+    #${MAP_MARKER_ID}[hidden] { display: none; }
+    #${MAP_MARKER_ID}.is-medical { color: #d92d20; }
+    #${MAP_MARKER_ID}.is-crash { color: #08090a; }
+    .turn-mayday-info-plate {
+      position: fixed;
+      left: 50%;
+      top: max(16px, calc(env(safe-area-inset-top) + 10px));
+      z-index: 2147482999;
+      width: min(620px, calc(100vw - 32px));
+      margin: 0;
+      padding: 10px 14px;
+      border: 3px solid #08090a;
+      border-radius: 14px;
+      background: var(--paper, #fffdf6);
+      color: #08090a;
+      box-shadow: 5px 5px 0 #08090a;
+      transform: translateX(-50%);
+      text-align: center;
+      font-size: clamp(0.72rem, 1.7vw, 0.92rem);
+      font-weight: 900;
+      line-height: 1.25;
+      pointer-events: none;
+    }
+    .turn-mayday-info-plate[hidden] { display: none; }
+    @media (max-height: 430px) {
+      .turn-mayday-info-plate {
+        top: max(10px, calc(env(safe-area-inset-top) + 6px));
+        width: min(700px, calc(100vw - 20px));
+        padding: 7px 11px;
+        font-size: 0.7rem;
+      }
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+function installMapMarker(samples) {
+  const canvas = document.querySelector?.('#map');
+  const wrap = canvas?.closest?.('.map-wrap');
+  if (!canvas || !wrap) return null;
+
+  let marker = document.getElementById(MAP_MARKER_ID);
+  if (!marker) {
+    marker = document.createElement('span');
+    marker.id = MAP_MARKER_ID;
+    marker.setAttribute('aria-hidden', 'true');
+    marker.hidden = true;
+    wrap.appendChild(marker);
+  }
+
+  const project = createMapProjection(samples, canvas);
+  return {
+    hide() {
+      marker.hidden = true;
+    },
+    show(worldPoint, kind) {
+      const point = project(worldPoint);
+      marker.style.left = `${point.xPercent}%`;
+      marker.style.top = `${point.yPercent}%`;
+      marker.classList.toggle('is-medical', kind === 'medical');
+      marker.classList.toggle('is-crash', kind !== 'medical');
+      marker.textContent = kind === 'medical' ? 'H' : '🔥';
+      marker.hidden = false;
+    }
+  };
+}
+
+function createMapProjection(samples, canvas) {
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minZ = Infinity;
+  let maxZ = -Infinity;
+  for (const sample of samples) {
+    minX = Math.min(minX, sample.point.x);
+    maxX = Math.max(maxX, sample.point.x);
+    minZ = Math.min(minZ, sample.point.z);
+    maxZ = Math.max(maxZ, sample.point.z);
+  }
+
+  const pad = 20;
+  const width = canvas.width - pad * 2;
+  const height = canvas.height - pad * 2;
+  const scale = Math.min(width / (maxX - minX), height / (maxZ - minZ));
+  const contentWidth = (maxX - minX) * scale;
+  const contentHeight = (maxZ - minZ) * scale;
+  const offsetX = (canvas.width - contentWidth) / 2;
+  const offsetY = (canvas.height - contentHeight) / 2;
+
+  return (point) => ({
+    xPercent: (offsetX + (point.x - minX) * scale) / canvas.width * 100,
+    yPercent: (offsetY + (point.z - minZ) * scale) / canvas.height * 100
+  });
+}
+
+function maydayInfoPlate() {
+  let plate = document.getElementById(MAYDAY_INFO_ID);
+  if (plate) return plate;
+  plate = document.createElement('p');
+  plate.id = MAYDAY_INFO_ID;
+  plate.className = 'turn-mayday-info-plate';
+  plate.hidden = true;
+  plate.setAttribute('role', 'status');
+  plate.setAttribute('aria-live', 'polite');
+  plate.setAttribute('aria-atomic', 'true');
+  document.body.appendChild(plate);
+  return plate;
+}
+
+function showMessage(text, duration = 1800) {
+  const plate = maydayInfoPlate();
+  const token = `${performance.now()}-${Math.random()}`;
+  plate.dataset.turnMaydayMessage = token;
+  plate.textContent = text;
+  plate.hidden = false;
+  window.setTimeout(() => {
+    if (plate.dataset.turnMaydayMessage !== token || plate.textContent !== text) return;
+    plate.hidden = true;
+    delete plate.dataset.turnMaydayMessage;
+  }, duration);
+}
+
+function publishState(reason) {
+  globalThis.dispatchEvent?.(new CustomEvent('turn:airport-emergency', {
+    detail: {
+      reason,
+      crashActive: session.crashActive,
+      resolved: session.resolved,
+      phase: session.phase,
+      transferDeadline: session.transferDeadline
+    }
+  }));
+}

--- a/turn/tracks/airport-world-r56.js
+++ b/turn/tracks/airport-world-r56.js
@@ -1,5 +1,5 @@
 import { installAirportWorld as installAirportWorldR53 } from './airport-world-r53.js?build=20260814-r57';
-import { installAirportEmergency } from './airport-emergency-r491.js?revision=r491-playtest';
+import { installAirportEmergency } from './airport-emergency-r492.js?revision=r492-playtest';
 
 export function installAirportWorld(options = {}) {
   const world = installAirportWorldR53(options);
@@ -17,7 +17,9 @@ export function installAirportWorld(options = {}) {
     maydayPlaytestFixes: true,
     prewarmedMedicalResponders: true,
     positionedResponderSirens: true,
-    broadMedicalBay: true
+    broadMedicalBay: true,
+    responderCentredMedicalBay: true,
+    sceneLevelEmergencyLoop: true
   });
   return world;
 }

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -5,7 +5,7 @@ import {
   createTrackRuntime,
   normalizeTrackId
 } from './catalog.js';
-import { installAirportWorld } from './airport-world-r56.js?build=20260815-r491';
+import { installAirportWorld } from './airport-world-r56.js?build=20260815-r492';
 import { installCliffsideWorld } from './cliffside-world.js';
 import { installHarborWorld } from './harbor-world.js';
 // Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10


### PR DESCRIPTION
## What changed
- move the medical transfer zone out of the terminal and centre its forgiving 42-unit radius on the responder Ambulance
- keep the Fire Truck + Ambulance together as the visible destination and enlarge the terminal H plate to cover its window
- restore the simpler transfer instruction: **PATIENT ON BOARD · MEDICAL BAY · 30 SECONDS** (no explicit “follow the sirens” hint)
- render MAYDAY instructions in a fixed info plate using the same size/position/treatment as the blank-screen info plate so lap UI cannot cover them
- move the MAYDAY update loop from the crash-fire mesh to the scene-level render hook; this keeps medical-zone checks and responder sirens running after the wreck leaves the camera frustum
- lengthen/lower/distort the crash impact into a ~2.5 s distant rumble instead of a short fail-like bump
- make the responder siren pulses louder and slightly overlapping for a continuous emergency-service sound

## Finish-line freeze
- start responder model preparation immediately when an Ambulance race is staged instead of waiting for `requestIdleCallback`
- asynchronously precompile MAYDAY-only materials with `renderer.compileAsync` where supported
- remove responder preparation from the finish-line critical path
- defer the actual crash-scene reveal/B787 reparent by 120 ms so lap-result rendering can complete first

## Root cause fixed
The responder sirens and medical trigger were updated from the crash-site mesh’s `onBeforeRender`. Once the wreck left the camera frustum, Three.js stopped calling that callback. r492 moves the lightweight rescue update to the scene render hook, so navigation audio and transfer detection continue all the way to the terminal.

## Validation
Regression coverage now pins the Ambulance-centred medical zone, scene-level update loop, restored copy, blank-info-style plate, larger H sign, immediate prewarm/async shader warmup, deferred crash reveal, and the slower distorted crash sound.