### PR TITLE
Correct MAYDAY stereo, wreck depth, and medical entrance

### DIFF
--- a/turn-lab/tests/emergency-vehicles-production.mjs
+++ b/turn-lab/tests/emergency-vehicles-production.mjs
@@ -54,6 +54,7 @@ const [
   audio,
   maydayAudio,
   airportEmergency,
+  maydayPolish,
   airportWorldR56,
   trackRegistry,
   license,
@@ -70,6 +71,7 @@ const [
   fs.readFile(path.join(turnDir, 'audio/audio-system.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'audio/mayday-audio-r493.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'tracks/airport-emergency-r493.js'), 'utf8'),
+  fs.readFile(path.join(turnDir, 'tracks/airport-emergency-r494.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'tracks/airport-world-r56.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'tracks/registry.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'assets/cars/KENNEY-CAR-KIT.md'), 'utf8'),
@@ -118,13 +120,13 @@ assert.doesNotMatch(index, /syncFixedLiveryRail|emergencyVehicleNames/,
 
 assert.match(airportWorldR56, /airport-world-r53\.js/,
   'The MAYDAY layer must preserve the current real-aircraft Airport world');
-assert.match(airportWorldR56, /airport-emergency-r493\.js/);
+assert.match(airportWorldR56, /airport-emergency-r494\.js/);
 assert.match(airportWorldR56, /removeMedicalBayJetBridge\(world\)/,
-  'The jet bridge in front of the medical H sign must be removed');
+  'The jet bridge in front of the medical H sign must remain removed');
 assert.match(airportWorldR56, /nearly\(node\.position\?\.x, -52\)/);
 assert.match(airportWorldR56, /nearly\(node\.position\?\.z, -32\)/);
-assert.match(trackRegistry, /airport-world-r56\.js\?build=20260815-r493/,
-  'Production Airport must cache-bust the r493 MAYDAY layer');
+assert.match(trackRegistry, /airport-world-r56\.js\?build=20260815-r494/,
+  'Production Airport must cache-bust the r494 MAYDAY layer');
 assert.match(trackRegistry, /airport\(\{ scene, samples, trackWidth, runtime \}\)/,
   'Airport world installation must receive the live TURN runtime');
 
@@ -170,7 +172,7 @@ assert.match(airportEmergency, /setTimeout\(revealCrashVisuals, 120\)/,
 assert.doesNotMatch(airportEmergency, /aircraftMount\.add\(aircraft\)/,
   'The finish path must not reparent the live overflight B787');
 assert.match(airportEmergency, /WRECK_GROUND_Y - bounds\.min\.y/,
-  'The tilted wreck must be fitted to measured geometry rather than sunk with a hard-coded negative offset');
+  'The tilted wreck must first be fitted to measured geometry before the deliberate r494 penetration');
 assert.match(airportEmergency, /playMaydayCrashSound\(\);[\s\S]*session\.crashActive = true/,
   'The impact must be requested before crash-state work');
 assert.match(airportEmergency, /maydayInfoPlate\(\);[\s\S]*prepareMaydayAudio\(\)/,
@@ -194,8 +196,7 @@ assert.match(airportEmergency, /new THREE\.BoxGeometry\(10\.4, 6\.4, 0\.65\)/,
   'The terminal H plate should cover the window it occupies');
 assert.match(airportEmergency, /sign\.position\.set\(0, 8\.7, 12\.72\)/);
 
-assert.match(airportEmergency, /runtime\?\.getRight\?\.\(\)/,
-  'Directional MAYDAY audio must use TURN\'s canonical vehicle right vector when available');
+assert.match(airportEmergency, /runtime\?\.getRight\?\.\(\)/);
 assert.match(airportEmergency, /updateMaydayFire\(\{[\s\S]*placement\.crashPoint/,
   'The continuous fire source must point at the exact crash trigger');
 assert.match(airportEmergency, /updateMaydayResponderSiren\(\{[\s\S]*placement\.medicalPoint/,
@@ -206,6 +207,24 @@ assert.match(airportEmergency, /marker\.textContent = kind === 'medical' \? 'H' 
 assert.match(airportEmergency, /sessionPersistent: true/);
 assert.match(airportEmergency, /clearsOnPageReload: true/);
 assert.doesNotMatch(airportEmergency, /localStorage|sessionStorage/);
+
+assert.match(maydayPolish, /airport-emergency-r493\.js\?revision=r493/,
+  'r494 should stay a small corrective layer over the already-tested MAYDAY event');
+assert.match(maydayPolish, /cameraRight\.set\(1, 0, 0\)\.applyQuaternion\(camera\.quaternion\)/,
+  'Stereo direction must use actual camera screen-right, not TURN physics handedness');
+assert.match(maydayPolish, /-Number\(physicsRight\.x \|\| 0\)/,
+  'The no-camera fallback must invert the physics right vector for screen-relative stereo');
+assert.match(maydayPolish, /const WRECK_PENETRATION_Y = 2\.47/,
+  'The wreck should be lowered by half the effective r492 hard-coded sink');
+assert.match(maydayPolish, /4\.8 \* cos20 \* cos20/,
+  'The wreck-depth calculation must remain documented from the previous playtest geometry');
+assert.match(maydayPolish, /mount\.position\.y -= WRECK_PENETRATION_Y/);
+assert.match(maydayPolish, /Airport MAYDAY medical entrance/,
+  'The medical bay needs a permanent facade entrance beside the H sign');
+assert.match(maydayPolish, /new THREE\.BoxGeometry\(6\.8, 7\.4, 0\.72\)/,
+  'The medical entrance must be large enough to read as a door from the apron');
+assert.match(maydayPolish, /entrance\.position\.set\(9\.2, 0, 12\.68\)/,
+  'The door should sit immediately beside the H sign toward the responder Ambulance');
 
 assert.match(maydayAudio, /export function playMaydayCrashSound/);
 assert.match(maydayAudio, /playDistortedNoise\(now \+ 0\.015, 3\.05/,
@@ -220,7 +239,7 @@ assert.match(maydayAudio, /responderSirenTone\.type = 'triangle'/);
 assert.match(maydayAudio, /responderSirenHarmonic\.type = 'sine'/);
 assert.match(maydayAudio, /responderSirenFilter\.frequency\.value = 1800/);
 assert.match(maydayAudio, /createStereoPanner/,
-  'MAYDAY world audio should preserve left\/right direction when supported');
+  'MAYDAY world audio should preserve left/right direction when supported');
 assert.match(maydayAudio, /__turnAudioPreferences\?\.getSettings/,
   'The supplemental rescue audio must respect TURN audio-off preferences');
 
@@ -243,4 +262,4 @@ assert.match(audio, /emergencySirenFrequency/);
 assert.match(audio, /sirenActive = boostActive/);
 assert.match(license, /Creative Commons CC0 1\.0 Universal/);
 
-console.log('TURN emergency vehicles and MAYDAY r493 playtest fixes passed.');
+console.log('TURN emergency vehicles and MAYDAY r494 stereo/scenery fixes passed.');

--- a/turn/tracks/airport-emergency-r494.js
+++ b/turn/tracks/airport-emergency-r494.js
@@ -1,0 +1,178 @@
+import * as THREE from 'three';
+import {
+  AIRPORT_EMERGENCY_CONFIG,
+  installAirportEmergency as installAirportEmergencyR493
+} from './airport-emergency-r493.js?revision=r493';
+
+export { AIRPORT_EMERGENCY_CONFIG };
+
+const AMBULANCE_ID = 'ambulance';
+const TERMINAL_NAME = 'TURN International Terminal';
+const PREPARED_WRECK_NAME = 'Airport B787 Prepared Wreck';
+const MEDICAL_DOOR_NAME = 'Airport MAYDAY medical entrance';
+
+// r492 intentionally pushed the live B787 down by 4.8 local units while its mount sat
+// another 0.7 units low. With the wreck pitched and rolled 20 degrees, that 4.8-unit
+// local-Y move contributed about 4.24 world-Y units (4.8 * cos20 * cos20), for an
+// effective deliberate sink of about 4.94 units. r493 removed all penetration and
+// ground-fit the lowest geometry. Split those two playtest extremes: lower the fitted
+// wreck by half the old effective sink, 2.47 world units.
+const WRECK_PENETRATION_Y = 2.47;
+const WRECK_FIND_INTERVAL_MS = 120;
+const WRECK_FIND_ATTEMPTS = 160;
+
+export function installAirportEmergency(options = {}) {
+  const runtime = options.runtime || globalThis.__turnRuntime;
+  const world = options.world;
+  const audioRuntime = makeScreenRelativeRuntime(runtime);
+
+  const installation = installAirportEmergencyR493({
+    ...options,
+    runtime: audioRuntime
+  });
+
+  if (world) {
+    installMedicalEntrance(world);
+    installWreckPenetration(world, runtime);
+  }
+
+  return installation;
+}
+
+function makeScreenRelativeRuntime(runtime) {
+  if (!runtime) return runtime;
+
+  const view = Object.create(runtime);
+  const cameraRight = new THREE.Vector3();
+  const fallbackRight = new THREE.Vector3();
+
+  Object.defineProperty(view, 'getRight', {
+    configurable: true,
+    value() {
+      // Web Audio pan must describe the source relative to what the player actually sees.
+      // TURN's physics getRight() has the opposite handedness from camera screen-right:
+      // when the camera looks along +Z, screen-right is -X. Use camera local +X so the
+      // channel assignment also remains correct through camera follow lag and drifting.
+      const camera = runtime.camera;
+      if (camera?.quaternion) {
+        cameraRight.set(1, 0, 0).applyQuaternion(camera.quaternion);
+        cameraRight.y = 0;
+        if (cameraRight.lengthSq() > 0.000001) return cameraRight.normalize();
+      }
+
+      const physicsRight = runtime.getRight?.();
+      if (physicsRight) {
+        fallbackRight.set(
+          -Number(physicsRight.x || 0),
+          0,
+          -Number(physicsRight.z || 0)
+        );
+        if (fallbackRight.lengthSq() > 0.000001) return fallbackRight.normalize();
+      }
+
+      return fallbackRight.set(-1, 0, 0);
+    }
+  });
+
+  return view;
+}
+
+function installWreckPenetration(world, runtime) {
+  if (world.userData.turnMaydayR494WreckPenetration) return;
+
+  let timer = 0;
+  let attempts = 0;
+  let applied = false;
+
+  const tryApply = () => {
+    timer = 0;
+    if (applied) return;
+
+    const wreck = world.getObjectByName(PREPARED_WRECK_NAME);
+    const mount = wreck?.parent;
+    if (wreck && mount && !mount.userData.turnMaydayR494DepthApplied) {
+      mount.position.y -= WRECK_PENETRATION_Y;
+      mount.userData.turnMaydayR494DepthApplied = true;
+      world.updateMatrixWorld(true);
+      applied = true;
+      return;
+    }
+
+    attempts += 1;
+    if (
+      attempts < WRECK_FIND_ATTEMPTS
+      && String(runtime?.state?.vehicleId || '').toLowerCase() === AMBULANCE_ID
+    ) {
+      timer = globalThis.setTimeout(tryApply, WRECK_FIND_INTERVAL_MS);
+    }
+  };
+
+  const arm = () => {
+    if (applied || timer) return;
+    if (String(runtime?.state?.vehicleId || '').toLowerCase() !== AMBULANCE_ID) return;
+    attempts = 0;
+    timer = globalThis.setTimeout(tryApply, 0);
+  };
+
+  globalThis.addEventListener?.('turn:ui-state-change', arm);
+  globalThis.addEventListener?.('turn:track-changed', arm);
+  arm();
+
+  world.userData.turnMaydayR494WreckPenetration = Object.freeze({
+    amount: WRECK_PENETRATION_Y,
+    basis: 'half of the r492 effective hard-coded vertical sink after 20-degree pitch/roll'
+  });
+}
+
+function installMedicalEntrance(world) {
+  if (world.getObjectByName(MEDICAL_DOOR_NAME)) return;
+  const terminal = world.getObjectByName(TERMINAL_NAME);
+  if (!terminal) return;
+
+  const entrance = new THREE.Group();
+  entrance.name = MEDICAL_DOOR_NAME;
+  entrance.userData.turnAirportMedicalEntrance = true;
+
+  const ink = new THREE.MeshBasicMaterial({ color: 0x08090a, toneMapped: false });
+  const cream = new THREE.MeshStandardMaterial({ color: 0xfff8e8, roughness: 0.88 });
+  const dark = new THREE.MeshStandardMaterial({ color: 0x39434d, roughness: 0.76 });
+  const glass = new THREE.MeshStandardMaterial({ color: 0x55c7df, roughness: 0.34, metalness: 0.04 });
+  const red = new THREE.MeshBasicMaterial({ color: 0xd92d20, toneMapped: false });
+
+  const frame = new THREE.Mesh(new THREE.BoxGeometry(6.8, 7.4, 0.72), ink);
+  frame.position.y = 3.7;
+  entrance.add(frame);
+
+  const surround = new THREE.Mesh(new THREE.BoxGeometry(6.25, 6.85, 0.82), cream);
+  surround.position.set(0, 3.7, 0.08);
+  entrance.add(surround);
+
+  for (const side of [-1, 1]) {
+    const leaf = new THREE.Mesh(new THREE.BoxGeometry(2.72, 6.25, 0.44), dark);
+    leaf.position.set(side * 1.47, 3.45, 0.58);
+    entrance.add(leaf);
+
+    const windowPane = new THREE.Mesh(new THREE.BoxGeometry(2.08, 2.18, 0.16), glass);
+    windowPane.position.set(side * 1.47, 4.72, 0.86);
+    entrance.add(windowPane);
+
+    const handle = new THREE.Mesh(new THREE.BoxGeometry(0.22, 0.72, 0.18), red);
+    handle.position.set(side * 0.36, 2.72, 0.91);
+    entrance.add(handle);
+  }
+
+  const threshold = new THREE.Mesh(new THREE.BoxGeometry(6.7, 0.28, 1.35), red);
+  threshold.position.set(0, 0.18, 0.48);
+  entrance.add(threshold);
+
+  entrance.traverse((node) => {
+    if (!node.isMesh) return;
+    node.castShadow = false;
+    node.receiveShadow = true;
+  });
+
+  // The H occupies the central north-facing window. Put the entrance immediately to
+  // its right, toward the responder Ambulance, replacing the adjacent window visually.
+  entrance.position.set(9.2, 0, 12.68);
+  terminal.add(entrance);
+}

--- a/turn/tracks/airport-world-r56.js
+++ b/turn/tracks/airport-world-r56.js
@@ -1,5 +1,5 @@
 import { installAirportWorld as installAirportWorldR53 } from './airport-world-r53.js?build=20260814-r57';
-import { installAirportEmergency } from './airport-emergency-r493.js?revision=r493-playtest';
+import { installAirportEmergency } from './airport-emergency-r494.js?revision=r494-playtest';
 
 export function installAirportWorld(options = {}) {
   const world = installAirportWorldR53(options);
@@ -23,7 +23,10 @@ export function installAirportWorld(options = {}) {
     sceneLevelEmergencyLoop: true,
     clearMedicalSignSightline: true,
     prebuiltCrashWreck: true,
-    continuousEmergencyAudio: true
+    continuousEmergencyAudio: true,
+    screenRelativeEmergencyAudio: true,
+    partiallyEmbeddedCrashWreck: true,
+    medicalEntranceDoor: true
   });
   return world;
 }

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -5,7 +5,7 @@ import {
   createTrackRuntime,
   normalizeTrackId
 } from './catalog.js';
-import { installAirportWorld } from './airport-world-r56.js?build=20260815-r493';
+import { installAirportWorld } from './airport-world-r56.js?build=20260815-r494';
 import { installCliffsideWorld } from './cliffside-world.js';
 import { installHarborWorld } from './harbor-world.js';
 // Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10


### PR DESCRIPTION
## What changed
- fix MAYDAY left/right guidance by using the camera's actual screen-right basis instead of TURN's physics `getRight()` handedness
- keep the existing exact sound origins: crash trigger for fire and Ambulance-centred medical trigger for the responder siren
- lower the r493 ground-fitted B787 wreck by 2.47 world units so it is partially embedded rather than fully above ground
- add a permanent double medical entrance immediately beside the H sign, toward the responder Ambulance
- cache-bust the Airport MAYDAY layer to r494 and extend the emergency regression

## Stereo analysis
The uploaded screen recording confirms a handedness inversion rather than a distance problem. Around 12–13 s the visible crash is to screen-right while the fire-dominant band is roughly 4.7–5.8 dB louder in the left channel. Around 18–20 s the crash is far to screen-left while the right channel is roughly 14–19 dB louder. TURN's physics `getRight()` returns +X when heading +Z, but a Three.js camera looking +Z has screen-right at -X. r494 derives local +X directly from the live camera quaternion, so panning follows what the player actually sees even through camera lag/drift.

## Wreck-depth calculation
r492 used an aircraft-local Y offset of -4.8 plus a mount offset of -0.7. With 20° pitch and roll, the local offset contributes about `4.8 × cos(20°) × cos(20°) = 4.24` world-Y units; combined with the mount that is about 4.94 units of deliberate sink. r493 removed penetration entirely. r494 splits those two playtest extremes and lowers the fitted wreck by half: **2.47 world units**.

## Regression
Coverage pins the r494 route/cache-bust, camera-relative stereo basis and inverted physics fallback, calculated 2.47-unit penetration, and medical entrance placement/dimensions.