### PR TITLE
Lower MAYDAY wreck and align medical entrance

### DIFF
--- a/turn-lab/tests/emergency-vehicles-production.mjs
+++ b/turn-lab/tests/emergency-vehicles-production.mjs
@@ -120,13 +120,14 @@ assert.doesNotMatch(index, /syncFixedLiveryRail|emergencyVehicleNames/,
 
 assert.match(airportWorldR56, /airport-world-r53\.js/,
   'The MAYDAY layer must preserve the current real-aircraft Airport world');
-assert.match(airportWorldR56, /airport-emergency-r494\.js/);
+assert.match(airportWorldR56, /airport-emergency-r494\.js\?revision=r495-playtest/,
+  'The r495 playtest must cache-bust the corrected MAYDAY layer');
 assert.match(airportWorldR56, /removeMedicalBayJetBridge\(world\)/,
   'The jet bridge in front of the medical H sign must remain removed');
 assert.match(airportWorldR56, /nearly\(node\.position\?\.x, -52\)/);
 assert.match(airportWorldR56, /nearly\(node\.position\?\.z, -32\)/);
-assert.match(trackRegistry, /airport-world-r56\.js\?build=20260815-r494/,
-  'Production Airport must cache-bust the r494 MAYDAY layer');
+assert.match(trackRegistry, /airport-world-r56\.js\?build=20260815-r495/,
+  'Production Airport must cache-bust the r495 MAYDAY layer');
 assert.match(trackRegistry, /airport\(\{ scene, samples, trackWidth, runtime \}\)/,
   'Airport world installation must receive the live TURN runtime');
 
@@ -172,7 +173,7 @@ assert.match(airportEmergency, /setTimeout\(revealCrashVisuals, 120\)/,
 assert.doesNotMatch(airportEmergency, /aircraftMount\.add\(aircraft\)/,
   'The finish path must not reparent the live overflight B787');
 assert.match(airportEmergency, /WRECK_GROUND_Y - bounds\.min\.y/,
-  'The tilted wreck must first be fitted to measured geometry before the deliberate r494 penetration');
+  'The tilted wreck must first be fitted to measured geometry before deliberate penetration');
 assert.match(airportEmergency, /playMaydayCrashSound\(\);[\s\S]*session\.crashActive = true/,
   'The impact must be requested before crash-state work');
 assert.match(airportEmergency, /maydayInfoPlate\(\);[\s\S]*prepareMaydayAudio\(\)/,
@@ -209,22 +210,28 @@ assert.match(airportEmergency, /clearsOnPageReload: true/);
 assert.doesNotMatch(airportEmergency, /localStorage|sessionStorage/);
 
 assert.match(maydayPolish, /airport-emergency-r493\.js\?revision=r493/,
-  'r494 should stay a small corrective layer over the already-tested MAYDAY event');
+  'The corrective layer should stay small over the already-tested MAYDAY event');
 assert.match(maydayPolish, /cameraRight\.set\(1, 0, 0\)\.applyQuaternion\(camera\.quaternion\)/,
-  'Stereo direction must use actual camera screen-right, not TURN physics handedness');
+  'Stereo direction must keep using actual camera screen-right');
 assert.match(maydayPolish, /-Number\(physicsRight\.x \|\| 0\)/,
-  'The no-camera fallback must invert the physics right vector for screen-relative stereo');
-assert.match(maydayPolish, /const WRECK_PENETRATION_Y = 2\.47/,
-  'The wreck should be lowered by half the effective r492 hard-coded sink');
-assert.match(maydayPolish, /4\.8 \* cos20 \* cos20/,
-  'The wreck-depth calculation must remain documented from the previous playtest geometry');
+  'The no-camera fallback must retain corrected screen-relative handedness');
+assert.match(maydayPolish, /const WRECK_PENETRATION_Y = 4\.40/,
+  'The wreck should move substantially back toward the r492 depth after playtesting');
+assert.match(maydayPolish, /2\.47 \+ \(4\.94 - 2\.47\) \* 0\.78 = 4\.3966/,
+  'The wreck depth must document the requested 78-percent interpolation from r494 toward r492');
 assert.match(maydayPolish, /mount\.position\.y -= WRECK_PENETRATION_Y/);
 assert.match(maydayPolish, /Airport MAYDAY medical entrance/,
   'The medical bay needs a permanent facade entrance beside the H sign');
+assert.match(maydayPolish, /const MEDICAL_WINDOW_X = 12\.5/,
+  'The medical entrance should use the actual adjacent window centreline');
+assert.match(maydayPolish, /const MEDICAL_WINDOW_Z = 12\.25/);
+assert.match(maydayPolish, /const replacedWindow = terminal\.children\.find/,
+  'The door should replace the existing terminal window instead of overlaying it');
+assert.match(maydayPolish, /terminal\.remove\(replacedWindow\)/);
 assert.match(maydayPolish, /new THREE\.BoxGeometry\(6\.8, 7\.4, 0\.72\)/,
-  'The medical entrance must be large enough to read as a door from the apron');
-assert.match(maydayPolish, /entrance\.position\.set\(9\.2, 0, 12\.68\)/,
-  'The door should sit immediately beside the H sign toward the responder Ambulance');
+  'The medical entrance should keep the approved playtest proportions');
+assert.match(maydayPolish, /entrance\.position\.set\(MEDICAL_WINDOW_X, 0, 12\.68\)/,
+  'The door should align exactly with the window bay it replaces');
 
 assert.match(maydayAudio, /export function playMaydayCrashSound/);
 assert.match(maydayAudio, /playDistortedNoise\(now \+ 0\.015, 3\.05/,
@@ -262,4 +269,4 @@ assert.match(audio, /emergencySirenFrequency/);
 assert.match(audio, /sirenActive = boostActive/);
 assert.match(license, /Creative Commons CC0 1\.0 Universal/);
 
-console.log('TURN emergency vehicles and MAYDAY r494 stereo/scenery fixes passed.');
+console.log('TURN emergency vehicles and MAYDAY r495 depth/door fixes passed.');

--- a/turn/tracks/airport-emergency-r494.js
+++ b/turn/tracks/airport-emergency-r494.js
@@ -11,15 +11,18 @@ const TERMINAL_NAME = 'TURN International Terminal';
 const PREPARED_WRECK_NAME = 'Airport B787 Prepared Wreck';
 const MEDICAL_DOOR_NAME = 'Airport MAYDAY medical entrance';
 
-// r492 intentionally pushed the live B787 down by 4.8 local units while its mount sat
-// another 0.7 units low. With the wreck pitched and rolled 20 degrees, that 4.8-unit
-// local-Y move contributed about 4.24 world-Y units (4.8 * cos20 * cos20), for an
-// effective deliberate sink of about 4.94 units. r493 removed all penetration and
-// ground-fit the lowest geometry. Split those two playtest extremes: lower the fitted
-// wreck by half the old effective sink, 2.47 world units.
-const WRECK_PENETRATION_Y = 2.47;
+// r492 effectively lowered the wreck by about 4.94 world-Y units: the aircraft-local
+// -4.8 Y offset contributes about 4.24 after the 20-degree pitch/roll, plus the mount's
+// -0.7 Y. r494 used 2.47, exactly halfway between r493's ground fit and r492. Playtesting
+// still showed the fuselage clearly above ground, while r492 was closer but slightly too low.
+// Move 78% of the remaining 2.47-unit gap back toward r492:
+// 2.47 + (4.94 - 2.47) * 0.78 = 4.3966 -> 4.40 world units.
+const WRECK_PENETRATION_Y = 4.40;
 const WRECK_FIND_INTERVAL_MS = 120;
 const WRECK_FIND_ATTEMPTS = 160;
+const MEDICAL_WINDOW_X = 12.5;
+const MEDICAL_WINDOW_Y = 8.7;
+const MEDICAL_WINDOW_Z = 12.25;
 
 export function installAirportEmergency(options = {}) {
   const runtime = options.runtime || globalThis.__turnRuntime;
@@ -120,7 +123,7 @@ function installWreckPenetration(world, runtime) {
 
   world.userData.turnMaydayR494WreckPenetration = Object.freeze({
     amount: WRECK_PENETRATION_Y,
-    basis: 'half of the r492 effective hard-coded vertical sink after 20-degree pitch/roll'
+    basis: '78 percent of the remaining distance from r494 back toward the r492 wreck depth'
   });
 }
 
@@ -129,9 +132,22 @@ function installMedicalEntrance(world) {
   const terminal = world.getObjectByName(TERMINAL_NAME);
   if (!terminal) return;
 
+  // The terminal windows are facade overlays rather than holes in the wall. Remove the
+  // north-facing window in this exact bay, then put the medical entrance on its centreline
+  // so the door genuinely replaces the window instead of floating between two bays.
+  const replacedWindow = terminal.children.find((node) => (
+    node?.isGroup
+    && nearly(node.position?.x, MEDICAL_WINDOW_X)
+    && nearly(node.position?.y, MEDICAL_WINDOW_Y)
+    && nearly(node.position?.z, MEDICAL_WINDOW_Z)
+    && node.children?.length === 2
+  ));
+  if (replacedWindow) terminal.remove(replacedWindow);
+
   const entrance = new THREE.Group();
   entrance.name = MEDICAL_DOOR_NAME;
   entrance.userData.turnAirportMedicalEntrance = true;
+  entrance.userData.turnReplacesTerminalWindow = true;
 
   const ink = new THREE.MeshBasicMaterial({ color: 0x08090a, toneMapped: false });
   const cream = new THREE.MeshStandardMaterial({ color: 0xfff8e8, roughness: 0.88 });
@@ -171,8 +187,10 @@ function installMedicalEntrance(world) {
     node.receiveShadow = true;
   });
 
-  // The H occupies the central north-facing window. Put the entrance immediately to
-  // its right, toward the responder Ambulance, replacing the adjacent window visually.
-  entrance.position.set(9.2, 0, 12.68);
+  entrance.position.set(MEDICAL_WINDOW_X, 0, 12.68);
   terminal.add(entrance);
+}
+
+function nearly(value, expected) {
+  return Math.abs(Number(value) - expected) < 0.01;
 }

--- a/turn/tracks/airport-world-r56.js
+++ b/turn/tracks/airport-world-r56.js
@@ -1,5 +1,5 @@
 import { installAirportWorld as installAirportWorldR53 } from './airport-world-r53.js?build=20260814-r57';
-import { installAirportEmergency } from './airport-emergency-r494.js?revision=r494-playtest';
+import { installAirportEmergency } from './airport-emergency-r494.js?revision=r495-playtest';
 
 export function installAirportWorld(options = {}) {
   const world = installAirportWorldR53(options);
@@ -26,7 +26,8 @@ export function installAirportWorld(options = {}) {
     continuousEmergencyAudio: true,
     screenRelativeEmergencyAudio: true,
     partiallyEmbeddedCrashWreck: true,
-    medicalEntranceDoor: true
+    medicalEntranceDoor: true,
+    medicalEntranceReplacesWindow: true
   });
   return world;
 }

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -5,7 +5,7 @@ import {
   createTrackRuntime,
   normalizeTrackId
 } from './catalog.js';
-import { installAirportWorld } from './airport-world-r56.js?build=20260815-r494';
+import { installAirportWorld } from './airport-world-r56.js?build=20260815-r495';
 import { installCliffsideWorld } from './cliffside-world.js';
 import { installHarborWorld } from './harbor-world.js';
 // Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10


### PR DESCRIPTION
## Playtest adjustments
- keep the corrected camera-relative MAYDAY stereo unchanged
- move the B787 wreck **78% of the remaining way from r494 back toward the r492 depth**
- r492's effective deliberate sink was about 4.94 world-Y units; r494 used 2.47; r495 therefore uses `2.47 + (4.94 - 2.47) × 0.78 = 4.3966`, rounded to **4.40**
- replace the adjacent north terminal window with the approved medical double door instead of placing the door between window bays
- align the door to that window's actual centreline at local X = 12.5
- cache-bust the Airport layer and update regression coverage

## Scope
No changes to MAYDAY audio, triggers, timing, responder placement, or achievement logic.