### PR TITLE
Calibrate MAYDAY wreck and move alerts above boost

### DIFF
--- a/turn-lab/tests/emergency-vehicles-production.mjs
+++ b/turn-lab/tests/emergency-vehicles-production.mjs
@@ -55,6 +55,7 @@ const [
   maydayAudio,
   airportEmergency,
   maydayPolish,
+  maydayHud,
   airportWorldR56,
   trackRegistry,
   license,
@@ -72,6 +73,7 @@ const [
   fs.readFile(path.join(turnDir, 'audio/mayday-audio-r493.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'tracks/airport-emergency-r493.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'tracks/airport-emergency-r494.js'), 'utf8'),
+  fs.readFile(path.join(turnDir, 'tracks/airport-emergency-r496.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'tracks/airport-world-r56.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'tracks/registry.js'), 'utf8'),
   fs.readFile(path.join(turnDir, 'assets/cars/KENNEY-CAR-KIT.md'), 'utf8'),
@@ -120,14 +122,14 @@ assert.doesNotMatch(index, /syncFixedLiveryRail|emergencyVehicleNames/,
 
 assert.match(airportWorldR56, /airport-world-r53\.js/,
   'The MAYDAY layer must preserve the current real-aircraft Airport world');
-assert.match(airportWorldR56, /airport-emergency-r494\.js\?revision=r495-playtest/,
-  'The r495 playtest must cache-bust the corrected MAYDAY layer');
+assert.match(airportWorldR56, /airport-emergency-r496\.js\?revision=r496-hud-cache/,
+  'The r496 playtest must cache-bust the calibrated MAYDAY HUD layer');
 assert.match(airportWorldR56, /removeMedicalBayJetBridge\(world\)/,
   'The jet bridge in front of the medical H sign must remain removed');
 assert.match(airportWorldR56, /nearly\(node\.position\?\.x, -52\)/);
 assert.match(airportWorldR56, /nearly\(node\.position\?\.z, -32\)/);
-assert.match(trackRegistry, /airport-world-r56\.js\?build=20260815-r495/,
-  'Production Airport must cache-bust the r495 MAYDAY layer');
+assert.match(trackRegistry, /airport-world-r56\.js\?build=20260815-r496/,
+  'Production Airport must cache-bust the r496 MAYDAY layer');
 assert.match(trackRegistry, /airport\(\{ scene, samples, trackWidth, runtime \}\)/,
   'Airport world installation must receive the live TURN runtime');
 
@@ -192,7 +194,7 @@ assert.match(airportEmergency, /renderScene\.onBeforeRender = function airportEm
 assert.match(airportEmergency, /PATIENT ON BOARD · MEDICAL BAY · 30 SECONDS/);
 assert.doesNotMatch(airportEmergency, /FOLLOW THE SIRENS/);
 assert.match(airportEmergency, /\.turn-mayday-info-plate[\s\S]*top: max\(16px, calc\(env\(safe-area-inset-top\) \+ 10px\)\)[\s\S]*border: 3px solid #08090a[\s\S]*box-shadow: 5px 5px 0 #08090a/,
-  'MAYDAY instructions should retain the blank-screen info-plate treatment');
+  'The base MAYDAY info plate should retain the established card treatment');
 assert.match(airportEmergency, /new THREE\.BoxGeometry\(10\.4, 6\.4, 0\.65\)/,
   'The terminal H plate should cover the window it occupies');
 assert.match(airportEmergency, /sign\.position\.set\(0, 8\.7, 12\.72\)/);
@@ -210,15 +212,13 @@ assert.match(airportEmergency, /clearsOnPageReload: true/);
 assert.doesNotMatch(airportEmergency, /localStorage|sessionStorage/);
 
 assert.match(maydayPolish, /airport-emergency-r493\.js\?revision=r493/,
-  'The corrective layer should stay small over the already-tested MAYDAY event');
+  'The corrected stereo and medical-door layer must remain underneath r496');
 assert.match(maydayPolish, /cameraRight\.set\(1, 0, 0\)\.applyQuaternion\(camera\.quaternion\)/,
   'Stereo direction must keep using actual camera screen-right');
 assert.match(maydayPolish, /-Number\(physicsRight\.x \|\| 0\)/,
   'The no-camera fallback must retain corrected screen-relative handedness');
 assert.match(maydayPolish, /const WRECK_PENETRATION_Y = 4\.40/,
-  'The wreck should move substantially back toward the r492 depth after playtesting');
-assert.match(maydayPolish, /2\.47 \+ \(4\.94 - 2\.47\) \* 0\.78 = 4\.3966/,
-  'The wreck depth must document the requested 78-percent interpolation from r494 toward r492');
+  'r496 should build from the r495 measured baseline rather than rewriting it');
 assert.match(maydayPolish, /mount\.position\.y -= WRECK_PENETRATION_Y/);
 assert.match(maydayPolish, /Airport MAYDAY medical entrance/,
   'The medical bay needs a permanent facade entrance beside the H sign');
@@ -232,6 +232,22 @@ assert.match(maydayPolish, /new THREE\.BoxGeometry\(6\.8, 7\.4, 0\.72\)/,
   'The medical entrance should keep the approved playtest proportions');
 assert.match(maydayPolish, /entrance\.position\.set\(MEDICAL_WINDOW_X, 0, 12\.68\)/,
   'The door should align exactly with the window bay it replaces');
+
+assert.match(maydayHud, /airport-emergency-r494\.js\?revision=r496-hud-depth/,
+  'r496 must explicitly cache-bust its calibrated parent layer');
+assert.match(maydayHud, /const TARGET_WRECK_PENETRATION_Y = 10\.5/,
+  'The B787 should use the calibrated halfway-buried depth from the latest screenshots');
+assert.match(maydayHud, /62 \* sin\(20deg\) \/ 2 = 10\.6/,
+  'The calibration should stay tied to the 62-unit aircraft and 20-degree pitch');
+assert.match(maydayHud, /mount\.position\.y -= EXTRA_WRECK_PENETRATION_Y/,
+  'r496 must apply only the additional depth beyond the r494 baseline');
+assert.match(maydayHud, /var\(--turn-action-danger, #ff6b6b\)/,
+  'MAYDAY instructions and unlock toast must use the danger design token');
+assert.match(maydayHud, /bottom: calc\(clamp\(92px, 20vh, 150px\) \+ 38px\)/,
+  'MAYDAY messages should sit immediately above the boost HUD');
+assert.match(maydayHud, /turn:achievements-updated/);
+assert.match(maydayHud, /unlocked\.includes\('golden-hour'\)/,
+  'Only the MAYDAY unlock should receive the danger achievement-toast treatment');
 
 assert.match(maydayAudio, /export function playMaydayCrashSound/);
 assert.match(maydayAudio, /playDistortedNoise\(now \+ 0\.015, 3\.05/,
@@ -269,4 +285,4 @@ assert.match(audio, /emergencySirenFrequency/);
 assert.match(audio, /sirenActive = boostActive/);
 assert.match(license, /Creative Commons CC0 1\.0 Universal/);
 
-console.log('TURN emergency vehicles and MAYDAY r495 depth/door fixes passed.');
+console.log('TURN emergency vehicles and MAYDAY r496 calibration/HUD fixes passed.');

--- a/turn/tracks/airport-emergency-r496.js
+++ b/turn/tracks/airport-emergency-r496.js
@@ -1,19 +1,32 @@
 import {
   AIRPORT_EMERGENCY_CONFIG,
   installAirportEmergency as installAirportEmergencyR494
-} from './airport-emergency-r494.js?revision=r496-hud';
+} from './airport-emergency-r494.js?revision=r496-hud-depth';
 
 export { AIRPORT_EMERGENCY_CONFIG };
 
 const STYLE_ID = 'turn-mayday-r496-style';
 const TOAST_CLASS = 'is-mayday-alert';
+const AMBULANCE_ID = 'ambulance';
+const PREPARED_WRECK_NAME = 'Airport B787 Prepared Wreck';
+const R494_PENETRATION_Y = 4.40;
+// The wreck is 62 world units long and pitched 20 degrees. Half of its nose-to-tail
+// vertical swing is about 62 * sin(20deg) / 2 = 10.6 units. The latest playtest still
+// reads as airborne at 4.40, while r492 was visibly too deep. 10.5 puts the fuselage
+// intersection near the intended halfway-buried pose without returning to r492's extreme.
+const TARGET_WRECK_PENETRATION_Y = 10.5;
+const EXTRA_WRECK_PENETRATION_Y = TARGET_WRECK_PENETRATION_Y - R494_PENETRATION_Y;
+const WRECK_FIND_INTERVAL_MS = 120;
+const WRECK_FIND_ATTEMPTS = 160;
 let resetTimer = 0;
 let listenerInstalled = false;
 
 export function installAirportEmergency(options = {}) {
+  const runtime = options.runtime || globalThis.__turnRuntime;
   const installation = installAirportEmergencyR494(options);
   installHudStyle();
   installAchievementToastHook();
+  installWreckCalibration(options.world, runtime);
   return installation;
 }
 
@@ -60,5 +73,59 @@ function installAchievementToastHook() {
       toast.classList.remove(TOAST_CLASS);
       resetTimer = 0;
     }, 5200);
+  });
+}
+
+function installWreckCalibration(world, runtime) {
+  if (!world || world.userData.turnMaydayR496WreckCalibration) return;
+
+  let timer = 0;
+  let attempts = 0;
+  let applied = false;
+
+  const tryApply = () => {
+    timer = 0;
+    if (applied) return;
+
+    const wreck = world.getObjectByName(PREPARED_WRECK_NAME);
+    const mount = wreck?.parent;
+    if (
+      wreck
+      && mount
+      && mount.userData.turnMaydayR494DepthApplied
+      && !mount.userData.turnMaydayR496DepthApplied
+    ) {
+      mount.position.y -= EXTRA_WRECK_PENETRATION_Y;
+      mount.userData.turnMaydayR496DepthApplied = true;
+      world.updateMatrixWorld(true);
+      applied = true;
+      return;
+    }
+
+    attempts += 1;
+    if (
+      attempts < WRECK_FIND_ATTEMPTS
+      && String(runtime?.state?.vehicleId || '').toLowerCase() === AMBULANCE_ID
+    ) {
+      timer = globalThis.setTimeout(tryApply, WRECK_FIND_INTERVAL_MS);
+    }
+  };
+
+  const arm = () => {
+    if (applied || timer) return;
+    if (String(runtime?.state?.vehicleId || '').toLowerCase() !== AMBULANCE_ID) return;
+    attempts = 0;
+    timer = globalThis.setTimeout(tryApply, 0);
+  };
+
+  globalThis.addEventListener?.('turn:ui-state-change', arm);
+  globalThis.addEventListener?.('turn:track-changed', arm);
+  arm();
+
+  world.userData.turnMaydayR496WreckCalibration = Object.freeze({
+    basePenetration: R494_PENETRATION_Y,
+    targetPenetration: TARGET_WRECK_PENETRATION_Y,
+    additionalPenetration: EXTRA_WRECK_PENETRATION_Y,
+    basis: 'half of the 62-unit B787 nose-to-tail vertical swing at 20 degrees, calibrated against the r492 and r495 playtests'
   });
 }

--- a/turn/tracks/airport-emergency-r496.js
+++ b/turn/tracks/airport-emergency-r496.js
@@ -1,0 +1,64 @@
+import {
+  AIRPORT_EMERGENCY_CONFIG,
+  installAirportEmergency as installAirportEmergencyR494
+} from './airport-emergency-r494.js?revision=r496-hud';
+
+export { AIRPORT_EMERGENCY_CONFIG };
+
+const STYLE_ID = 'turn-mayday-r496-style';
+const TOAST_CLASS = 'is-mayday-alert';
+let resetTimer = 0;
+let listenerInstalled = false;
+
+export function installAirportEmergency(options = {}) {
+  const installation = installAirportEmergencyR494(options);
+  installHudStyle();
+  installAchievementToastHook();
+  return installation;
+}
+
+function installHudStyle() {
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = `
+    .turn-mayday-info-plate,
+    .turn-achievement-toast.${TOAST_CLASS} {
+      top: auto !important;
+      bottom: calc(clamp(92px, 20vh, 150px) + 38px);
+      background: var(--turn-action-danger, #ff6b6b) !important;
+      color: var(--turn-ink, #08090a);
+    }
+    .turn-achievement-toast.${TOAST_CLASS} {
+      transform: translate(-50%, 130%);
+    }
+    .turn-achievement-toast.${TOAST_CLASS}.is-visible {
+      transform: translate(-50%, 0);
+    }
+    @media (max-height: 430px) {
+      .turn-mayday-info-plate,
+      .turn-achievement-toast.${TOAST_CLASS} {
+        top: auto !important;
+        bottom: 106px;
+      }
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+function installAchievementToastHook() {
+  if (listenerInstalled) return;
+  listenerInstalled = true;
+  globalThis.addEventListener?.('turn:achievements-updated', (event) => {
+    const unlocked = Array.isArray(event.detail?.unlocked) ? event.detail.unlocked : [];
+    if (!unlocked.includes('golden-hour')) return;
+    const toast = document.querySelector('.turn-achievement-toast:not(.turn-trophy-reward-toast)');
+    if (!toast) return;
+    toast.classList.add(TOAST_CLASS);
+    globalThis.clearTimeout(resetTimer);
+    resetTimer = globalThis.setTimeout(() => {
+      toast.classList.remove(TOAST_CLASS);
+      resetTimer = 0;
+    }, 5200);
+  });
+}

--- a/turn/tracks/airport-world-r56.js
+++ b/turn/tracks/airport-world-r56.js
@@ -1,5 +1,5 @@
 import { installAirportWorld as installAirportWorldR53 } from './airport-world-r53.js?build=20260814-r57';
-import { installAirportEmergency } from './airport-emergency-r494.js?revision=r495-playtest';
+import { installAirportEmergency } from './airport-emergency-r496.js?revision=r496-hud-cache';
 
 export function installAirportWorld(options = {}) {
   const world = installAirportWorldR53(options);
@@ -27,7 +27,9 @@ export function installAirportWorld(options = {}) {
     screenRelativeEmergencyAudio: true,
     partiallyEmbeddedCrashWreck: true,
     medicalEntranceDoor: true,
-    medicalEntranceReplacesWindow: true
+    medicalEntranceReplacesWindow: true,
+    maydayDangerHud: true,
+    maydayHudAboveBoost: true
   });
   return world;
 }

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -5,7 +5,7 @@ import {
   createTrackRuntime,
   normalizeTrackId
 } from './catalog.js';
-import { installAirportWorld } from './airport-world-r56.js?build=20260815-r495';
+import { installAirportWorld } from './airport-world-r56.js?build=20260815-r496';
 import { installCliffsideWorld } from './cliffside-world.js';
 import { installHarborWorld } from './harbor-world.js';
 // Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10


### PR DESCRIPTION
## Playtest calibration
- keep the corrected camera-relative stereo, medical door, responder placement, 30-second transfer, and achievement logic unchanged
- calibrate the B787 against the latest screenshots instead of interpolating the old root offsets
- the wreck is 62 world units long and pitched 20°, so half its nose-to-tail vertical swing is about `62 × sin(20°) / 2 = 10.6` world units
- r495's geometry-ground-fit + 4.40 penetration still reads clearly airborne; r496 targets **10.5 total penetration**, adding 6.1 units after the r495 layer has applied

## MAYDAY HUD
- MAYDAY instructions use the design-system danger token `--turn-action-danger`
- place the instructions immediately above the boost bar instead of the top HUD
- when **MAYDAY!** itself unlocks, its achievement toast gets the same danger-red treatment and boost-adjacent position; other achievement/reward toasts are unchanged

## Delivery
- route Airport through a cache-busted r496 wrapper and pin the new behavior in the emergency regression

No changes to MAYDAY audio, stereo guidance, triggers, timing, responder positions, or achievement qualification.