### PR TITLE
Lower MAYDAY wreck another four units

### DIFF
--- a/turn-lab/tests/emergency-vehicles-production.mjs
+++ b/turn-lab/tests/emergency-vehicles-production.mjs
@@ -124,14 +124,14 @@ assert.doesNotMatch(index, /syncFixedLiveryRail|emergencyVehicleNames/,
 
 assert.match(airportWorldR56, /airport-world-r53\.js/,
   'The MAYDAY layer must preserve the current real-aircraft Airport world');
-assert.match(airportWorldR56, /airport-emergency-r497\.js\?revision=r497-depth-fire-cache/,
-  'The r497 playtest must cache-bust the final wreck/fire calibration layer');
+assert.match(airportWorldR56, /airport-emergency-r497\.js\?revision=r498-wreck-depth-cache/,
+  'The r498 playtest must cache-bust the revised wreck depth');
 assert.match(airportWorldR56, /removeMedicalBayJetBridge\(world\)/,
   'The jet bridge in front of the medical H sign must remain removed');
 assert.match(airportWorldR56, /nearly\(node\.position\?\.x, -52\)/);
 assert.match(airportWorldR56, /nearly\(node\.position\?\.z, -32\)/);
-assert.match(trackRegistry, /airport-world-r56\.js\?build=20260815-r497/,
-  'Production Airport must cache-bust the r497 MAYDAY layer');
+assert.match(trackRegistry, /airport-world-r56\.js\?build=20260815-r498/,
+  'Production Airport must cache-bust the r498 MAYDAY layer');
 assert.match(trackRegistry, /airport\(\{ scene, samples, trackWidth, runtime \}\)/,
   'Airport world installation must receive the live TURN runtime');
 
@@ -251,14 +251,14 @@ assert.match(maydayHud, /unlocked\.includes\('golden-hour'\)/,
 
 assert.match(maydayFinal, /airport-emergency-r496\.js\?revision=r497-depth-fire/,
   'r497 must preserve and cache-bust the approved r496 HUD behavior');
-assert.match(maydayFinal, /const TARGET_WRECK_PENETRATION_Y = 12\.0/,
-  'The latest playtest should lower the B787 a modest final 1.5 world units');
+assert.match(maydayFinal, /const TARGET_WRECK_PENETRATION_Y = 16\.0/,
+  'The r498 playtest should lower the B787 another four world units from the tested r497 result');
 assert.match(maydayFinal, /const FIRE_SCALE = 1\.7/,
-  'The crash fire should be materially larger against the full-scale B787');
+  'The crash fire should remain materially larger against the full-scale B787');
 assert.match(maydayFinal, /fire\.scale\.setScalar\(FIRE_SCALE\)/,
   'The larger fire should reuse the existing layered animated fire group');
 assert.match(maydayFinal, /mount\.position\.y -= EXTRA_WRECK_PENETRATION_Y/,
-  'The final wreck calibration should layer only the additional 1.5-unit correction');
+  'The final wreck calibration should apply the revised 16-unit target');
 
 assert.match(maydayAudio, /export function playMaydayCrashSound/);
 assert.match(maydayAudio, /playDistortedNoise\(now \+ 0\.015, 3\.05/,
@@ -296,4 +296,4 @@ assert.match(audio, /emergencySirenFrequency/);
 assert.match(audio, /sirenActive = boostActive/);
 assert.match(license, /Creative Commons CC0 1\.0 Universal/);
 
-console.log('TURN emergency vehicles and MAYDAY r497 depth/fire calibration passed.');
+console.log('TURN emergency vehicles and MAYDAY r498 wreck-depth calibration passed.');

--- a/turn/tracks/airport-emergency-r497.js
+++ b/turn/tracks/airport-emergency-r497.js
@@ -9,10 +9,9 @@ const AMBULANCE_ID = 'ambulance';
 const PREPARED_WRECK_NAME = 'Airport B787 Prepared Wreck';
 const FIRE_NAME = 'Airport MAYDAY fire';
 const R496_TARGET_PENETRATION_Y = 10.5;
-// The latest r496 playtest is close, but the fuselage still reads slightly suspended
-// from several approach angles. Add a modest final 1.5 world units rather than making
-// another large correction.
-const TARGET_WRECK_PENETRATION_Y = 12.0;
+// The r497 playtest is close, but the fuselage still reads too high above the ground.
+// Lower it another 4 world units from the tested 12-unit result.
+const TARGET_WRECK_PENETRATION_Y = 16.0;
 const EXTRA_WRECK_PENETRATION_Y = TARGET_WRECK_PENETRATION_Y - R496_TARGET_PENETRATION_Y;
 // The original layered flame works well up close but is too small relative to the
 // full-scale 62-unit B787. Scaling the existing fire group keeps the same animation,
@@ -88,6 +87,6 @@ function installFinalWreckDepth(world, runtime) {
     basePenetration: R496_TARGET_PENETRATION_Y,
     targetPenetration: TARGET_WRECK_PENETRATION_Y,
     additionalPenetration: EXTRA_WRECK_PENETRATION_Y,
-    basis: 'small final playtest correction after r496; lowers the wreck another 1.5 world units'
+    basis: 'r498 playtest correction; lowers the tested r497 wreck another 4 world units'
   });
 }

--- a/turn/tracks/airport-world-r56.js
+++ b/turn/tracks/airport-world-r56.js
@@ -1,5 +1,5 @@
 import { installAirportWorld as installAirportWorldR53 } from './airport-world-r53.js?build=20260814-r57';
-import { installAirportEmergency } from './airport-emergency-r497.js?revision=r497-depth-fire-cache';
+import { installAirportEmergency } from './airport-emergency-r497.js?revision=r498-wreck-depth-cache';
 
 export function installAirportWorld(options = {}) {
   const world = installAirportWorldR53(options);

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -5,7 +5,7 @@ import {
   createTrackRuntime,
   normalizeTrackId
 } from './catalog.js';
-import { installAirportWorld } from './airport-world-r56.js?build=20260815-r497';
+import { installAirportWorld } from './airport-world-r56.js?build=20260815-r498';
 import { installCliffsideWorld } from './cliffside-world.js';
 import { installHarborWorld } from './harbor-world.js';
 // Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10


### PR DESCRIPTION
## Playtest calibration
- lower the MAYDAY B787 wreck another **4 world units** from the tested r497 result
- total deliberate penetration changes **12.0 → 16.0**
- keep the enlarged **1.7×** crash fire from r497 unchanged

## Kept unchanged
- MAYDAY danger-red HUD above Boost
- stereo guidance and rescue audio
- crash/medical triggers, 30-second transfer, responders and medical entrance
- all other Airport art and gameplay

Airport/world imports are cache-busted to r498 and the emergency regression pins the 16-unit target.