### PR TITLE
Fix collapsed POSTAL character rigs

### DIFF
--- a/postal/main.mjs
+++ b/postal/main.mjs
@@ -1,8 +1,10 @@
 import * as THREE_NS from 'three';
 import { GLTFLoader as GLTFLoader_NS } from 'three/addons/loaders/GLTFLoader.js';
+import { clone as cloneSkeleton_NS } from 'three/addons/utils/SkeletonUtils.js';
 
 globalThis.THREE = THREE_NS;
 globalThis.GLTFLoader = GLTFLoader_NS;
+globalThis.cloneSkeleton = cloneSkeleton_NS;
 
 const scripts = [
   './runtime/model-data.js', './runtime/model-core.js', './runtime/model-flow.js', './runtime/model-ops.js',

--- a/postal/main.mjs
+++ b/postal/main.mjs
@@ -8,7 +8,7 @@ globalThis.cloneSkeleton = cloneSkeleton_NS;
 
 const scripts = [
   './runtime/model-data.js', './runtime/model-core.js', './runtime/model-flow.js', './runtime/model-ops.js',
-  './runtime/app-foundation.js', './runtime/scene-depot.js', './runtime/scene-region.js', './runtime/scene-sweden.js',
+  './runtime/app-foundation.js', './runtime/skin-clone-fix.js', './runtime/scene-depot.js', './runtime/scene-region.js', './runtime/scene-sweden.js',
   './runtime/visuals-ui-core.js', './runtime/ui-sheets.js', './runtime/interaction-boot.js'
 ];
 

--- a/postal/runtime/skin-clone-fix.js
+++ b/postal/runtime/skin-clone-fix.js
@@ -1,0 +1,49 @@
+'use strict';
+
+// Three.js Object3D.clone() does not rebind SkinnedMesh skeletons to the cloned
+// bone hierarchy. Kenney Mini Characters are skinned rigs, so ordinary cloning
+// makes their body parts collapse around the root. Keep the fast existing path
+// for static scenery and use SkeletonUtils.clone() only when a GLB is skinned.
+const cloneStaticAsset = cloneAsset;
+
+cloneAsset = function cloneAssetWithSkinning(key, { target = 1, position = [0, 0, 0], rotation = [0, 0, 0], shadow = true } = {}) {
+  const src = assets.get(key);
+  if (!src) return null;
+
+  let hasSkinnedMesh = false;
+  src.traverse(obj => {
+    if (obj.isSkinnedMesh) hasSkinnedMesh = true;
+  });
+  if (!hasSkinnedMesh) return cloneStaticAsset(key, { target, position, rotation, shadow });
+
+  const clone = cloneSkeleton(src);
+  clone.traverse(obj => {
+    if (obj.isMesh) {
+      obj.castShadow = shadow;
+      obj.receiveShadow = shadow;
+      obj.userData.keepGeometry = true;
+      obj.userData.keepMaterial = true;
+    }
+  });
+
+  // Measure after the skeleton has been rebound, otherwise the bounding box is
+  // based on the broken shared rig and character placement/scaling is wrong too.
+  clone.updateMatrixWorld(true);
+  const box = new THREE.Box3().setFromObject(clone);
+  const size = new THREE.Vector3();
+  box.getSize(size);
+  const max = Math.max(size.x, size.y, size.z) || 1;
+  clone.scale.setScalar(target / max);
+  clone.updateMatrixWorld(true);
+
+  const scaledBox = new THREE.Box3().setFromObject(clone);
+  const center = new THREE.Vector3();
+  scaledBox.getCenter(center);
+  clone.position.set(-center.x, -scaledBox.min.y, -center.z);
+
+  const root = new THREE.Group();
+  root.position.set(...position);
+  root.rotation.set(...rotation);
+  root.add(clone);
+  return root;
+};

--- a/postal/tests/character-rendering.test.mjs
+++ b/postal/tests/character-rendering.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, '..');
+const main = fs.readFileSync(path.join(root, 'main.mjs'), 'utf8');
+const foundation = fs.readFileSync(path.join(root, 'runtime', 'app-foundation.js'), 'utf8');
+const skinFix = fs.readFileSync(path.join(root, 'runtime', 'skin-clone-fix.js'), 'utf8');
+
+assert.match(main, /SkeletonUtils\.js/, 'Skinned characters need Three.js SkeletonUtils');
+assert.match(main, /globalThis\.cloneSkeleton\s*=\s*cloneSkeleton_NS/);
+const foundationIndex = main.indexOf('./runtime/app-foundation.js');
+const fixIndex = main.indexOf('./runtime/skin-clone-fix.js');
+const depotIndex = main.indexOf('./runtime/scene-depot.js');
+assert.ok(foundationIndex >= 0 && fixIndex > foundationIndex && depotIndex > fixIndex,
+  'Skin clone fix must load after asset setup and before depot workers are instantiated');
+
+assert.match(skinFix, /obj\.isSkinnedMesh/);
+assert.match(skinFix, /cloneSkeleton\(src\)/,
+  'Skinned GLTFs must rebind skeletons instead of using Object3D.clone');
+assert.match(skinFix, /updateMatrixWorld\(true\)/,
+  'Bounding boxes must be measured from the rebound skeleton');
+
+const models = [...foundation.matchAll(/\.\/assets\/kenney\/characters\/(character-(?:female|male)-[a-f]\.glb)/g)]
+  .map(match => match[1]);
+assert.equal(new Set(models).size, 9, 'All nine depot workers should use distinct Mini Character models');
+
+for (const filename of new Set(models)) {
+  const glbPath = path.join(root, 'assets', 'kenney', 'characters', filename);
+  const glb = fs.readFileSync(glbPath);
+  assert.equal(glb.toString('ascii', 0, 4), 'glTF');
+  const jsonLength = glb.readUInt32LE(12);
+  const json = JSON.parse(glb.subarray(20, 20 + jsonLength).toString('utf8').replace(/\0+$/g, ''));
+  assert.ok((json.skins || []).length > 0, `${filename} should contain a skinned rig`);
+}
+
+console.log('POSTAL character rendering contract passed');


### PR DESCRIPTION
The screenshot exposed a real Three.js rigging bug rather than another bad asset selection.

POSTAL already vendors the correct Kenney Mini Characters and assigns nine distinct models across Sundsvall, Stockholm and Göteborg. However, `cloneAsset()` was cloning every GLTF with ordinary `Object3D.clone(true)`. That does not correctly rebind a `SkinnedMesh` to its cloned bone hierarchy, so the character body collapses around the skeleton root and appears as the squashed figure in the mobile screenshot.

This PR:
- imports Three.js `SkeletonUtils.clone()`;
- detects skinned GLTFs and uses the skeleton-aware clone path only for those assets;
- keeps the existing faster static clone path for buildings, roads, trucks, etc.;
- recalculates character bounds only after the cloned skeleton is rebound;
- adds a regression test proving all nine worker files contain skins and the skeleton-aware path loads before depot construction.

No gameplay/simulation changes.