### PR TITLE
Give POSTAL a clear visual hierarchy and primary CTA

### DIFF
--- a/postal/hierarchy.css
+++ b/postal/hierarchy.css
@@ -1,0 +1,180 @@
+/* Visual hierarchy pass: keep the live world dominant and reserve strong action styling for what needs the player now. */
+
+/* 1. Utility/status information should read as supporting chrome, not competing actions. */
+.status-strip {
+  top: calc(61px + var(--safe-top));
+  gap: 5px;
+}
+.metric {
+  min-height: 47px;
+  padding: 6px 9px;
+  border-radius: 13px;
+  background: rgba(8, 33, 32, .66);
+  box-shadow: none;
+}
+.metric strong {
+  margin-top: 3px;
+  font-size: .94rem;
+}
+.metric-note { bottom: 7px; }
+.metric-issues {
+  background: rgba(8, 33, 32, .72);
+}
+.metric-issues strong { color: #ffb0a8; }
+.metric-issues .metric-note { color: #fff; opacity: .5; }
+.badge {
+  background: var(--red);
+  color: #fff;
+}
+
+/* 2. Location/context is important, but should not become another dashboard panel. */
+.world-context {
+  top: calc(114px + var(--safe-top));
+  border-color: rgba(255, 255, 255, .42);
+  background: rgba(247, 242, 232, .82);
+  box-shadow: 0 8px 22px rgba(8, 29, 27, .14);
+}
+.world-heading {
+  min-height: 60px;
+  padding: 9px 11px 7px;
+}
+.world-heading h1 {
+  font-size: 1.16rem;
+  letter-spacing: -.025em;
+}
+.level-kicker { opacity: .82; }
+.city-switcher { gap: 4px; padding: 0 7px 7px; }
+.city-chip {
+  min-height: 35px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, .52);
+  color: rgba(16, 42, 41, .78);
+}
+.city-chip[aria-pressed="true"] {
+  background: var(--ink);
+  color: #fff;
+  box-shadow: inset 0 -3px 0 var(--yellow);
+}
+
+/* 3. The live exception is the primary CTA. One yellow action surface, one clear verb. */
+.event-ribbon.primary-cta {
+  min-height: 64px;
+  padding: 9px 11px;
+  gap: 10px;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  border: 2px solid rgba(16, 42, 41, .18);
+  border-radius: 17px;
+  background: var(--yellow);
+  color: var(--ink);
+  box-shadow: 0 12px 30px rgba(7, 29, 28, .32), inset 0 1px rgba(255, 255, 255, .45);
+}
+.event-ribbon.primary-cta[data-kind="critical"],
+.event-ribbon.primary-cta[data-kind="warning"] {
+  background: var(--yellow);
+  border-color: rgba(16, 42, 41, .22);
+}
+.event-ribbon.primary-cta[data-kind="info"] {
+  background: rgba(247, 242, 232, .96);
+}
+.primary-cta .event-signal {
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  background: rgba(16, 42, 41, .1);
+}
+.primary-cta .event-signal i {
+  background: var(--orange);
+  box-shadow: 0 0 0 5px rgba(223, 120, 71, .15);
+}
+.primary-cta[data-kind="critical"] .event-signal {
+  background: rgba(185, 67, 59, .12);
+}
+.primary-cta[data-kind="critical"] .event-signal i {
+  background: var(--red);
+}
+.primary-cta .event-copy small {
+  color: rgba(16, 42, 41, .62);
+  font-size: .5rem;
+}
+.primary-cta .event-copy strong {
+  font-size: .75rem;
+  line-height: 1.15;
+}
+.event-command {
+  min-width: 74px;
+  display: grid;
+  justify-items: end;
+  gap: 2px;
+  color: var(--ink);
+}
+.event-command strong {
+  font-size: .64rem;
+  font-weight: 1000;
+  letter-spacing: .045em;
+  line-height: 1;
+}
+.event-command span {
+  font-size: 1.35rem;
+  font-weight: 900;
+  line-height: .75;
+}
+
+/* 4. Operations are secondary choices. They should be easy to find, but not look like the next required move. */
+.quick-actions {
+  grid-template-columns: 1fr 1.15fr;
+  gap: 5px;
+}
+.quick-action,
+.quick-action-focus {
+  min-height: 52px;
+  border-color: rgba(255, 255, 255, .35);
+  background: rgba(247, 242, 232, .9);
+  box-shadow: 0 5px 14px rgba(7, 29, 28, .15);
+}
+.quick-action-focus {
+  border-left: 4px solid var(--yellow);
+}
+.action-icon {
+  width: 31px;
+  height: 31px;
+  border-radius: 10px;
+}
+.action-icon svg { width: 21px; height: 21px; }
+.quick-action small { opacity: .48; }
+
+/* 5. Scale navigation is persistent navigation, visually below the action layer. */
+.level-switcher {
+  background: rgba(7, 29, 28, .79);
+  box-shadow: 0 8px 24px rgba(4, 18, 17, .24);
+}
+.level-tab { min-height: 53px; }
+.level-tab[aria-pressed="true"] {
+  background: rgba(255, 255, 255, .94);
+  color: var(--ink);
+  box-shadow: inset 0 -3px 0 var(--yellow);
+}
+
+/* Brand and help remain recognisable but do not steal the first glance from the game state. */
+.brand-mark {
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+}
+.brand strong { font-size: .86rem; }
+.brand div > span { opacity: .64; }
+.compact-btn { box-shadow: 0 4px 11px rgba(20, 15, 12, .14); }
+
+@media (max-height: 735px) and (orientation: portrait) {
+  .status-strip { top: calc(54px + var(--safe-top)); }
+  .metric { min-height: 43px; }
+  .world-context { top: calc(102px + var(--safe-top)); }
+  .event-ribbon.primary-cta { min-height: 57px; }
+  .quick-action { min-height: 47px; }
+  .level-tab { min-height: 47px; }
+}
+
+@media (max-width: 355px) {
+  .event-command { min-width: 60px; }
+  .event-command strong { font-size: .56rem; }
+  .primary-cta .event-copy strong { font-size: .69rem; }
+}

--- a/postal/index.html
+++ b/postal/index.html
@@ -8,6 +8,7 @@
   <meta name="description" content="Run a living Swedish parcel network from depot floor to national linehaul.">
   <title>POSTAL — Every promise has a path</title>
   <link rel="stylesheet" href="./styles.css">
+  <link rel="stylesheet" href="./hierarchy.css">
   <script type="importmap">
     {
       "imports": {
@@ -108,10 +109,10 @@
         </section>
 
         <div class="lower-controls">
-          <button id="event-ribbon" class="event-ribbon" type="button" data-kind="warning">
+          <button id="event-ribbon" class="event-ribbon primary-cta" type="button" data-kind="warning">
             <span class="event-signal" aria-hidden="true"><i></i></span>
-            <span class="event-copy"><small>NEEDS YOU</small><strong id="event-text">Customer complaint: USA → Timrå</strong></span>
-            <span class="event-arrow" aria-hidden="true">›</span>
+            <span class="event-copy"><small id="event-kicker">NEEDS YOU</small><strong id="event-text">Customer complaint: USA → Timrå</strong></span>
+            <span class="event-command" aria-hidden="true"><strong id="event-cta-label">INVESTIGATE</strong><span>›</span></span>
           </button>
 
           <div class="quick-actions" aria-label="Operations">

--- a/postal/runtime/visuals-ui-core.js
+++ b/postal/runtime/visuals-ui-core.js
@@ -135,13 +135,24 @@ function updateUI(force = false) {
     return Boolean(pkg?.issue || pkg?.complaint);
   }) || simulation.events[0];
   if (top) {
+    const pkg = top.packageId ? simulation.packages.get(top.packageId) : null;
+    const packageNeedsAction = Boolean(pkg?.issue || pkg?.complaint);
+    const urgent = top.kind === 'critical';
+    const warning = top.kind === 'warning';
+    const ctaLabel = packageNeedsAction ? 'INVESTIGATE' : urgent || warning ? 'REVIEW' : 'OPEN';
+    const kickerText = urgent ? 'URGENT · NEEDS YOU' : warning ? 'NEEDS YOU' : 'NETWORK UPDATE';
+
     app.eventText.textContent = top.title;
-    app.eventRibbon.dataset.kind = top.kind;
+    app.eventRibbon.dataset.kind = urgent ? 'critical' : warning ? 'warning' : 'info';
     app.eventRibbon.dataset.packageId = top.packageId || '';
-    const kicker = $('.event-copy small');
-    if (kicker) kicker.textContent = top.kind === 'critical' ? 'URGENT · NEEDS YOU' : top.kind === 'warning' ? 'NEEDS YOU' : 'NETWORK UPDATE';
+    app.eventRibbon.setAttribute('aria-label', `${ctaLabel}: ${top.title}`);
+    $('#event-kicker').textContent = kickerText;
+    $('#event-cta-label').textContent = ctaLabel;
     app.eventRibbon.hidden = false;
-  } else app.eventRibbon.hidden = true;
+  } else {
+    app.eventRibbon.hidden = true;
+    app.eventRibbon.removeAttribute('aria-label');
+  }
 }
 
 function formatGameClock(sec) {

--- a/postal/tests/hierarchy.test.mjs
+++ b/postal/tests/hierarchy.test.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, '..');
+const html = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
+const hierarchy = fs.readFileSync(path.join(root, 'hierarchy.css'), 'utf8');
+const ui = fs.readFileSync(path.join(root, 'runtime', 'visuals-ui-core.js'), 'utf8');
+
+assert.match(html, /href="\.\/styles\.css"[\s\S]*href="\.\/hierarchy\.css"/, 'Hierarchy overrides must load after the base styles');
+assert.match(html, /id="event-ribbon"[^>]*class="[^"]*primary-cta/, 'The live exception needs an explicit primary CTA class');
+assert.match(html, /id="event-cta-label">INVESTIGATE</, 'The primary CTA needs an action verb in its visible label');
+assert.match(hierarchy, /\.event-ribbon\.primary-cta[\s\S]*background:\s*var\(--yellow\)/, 'Primary CTA should own the brand action color');
+assert.match(hierarchy, /\.quick-action,[\s\S]*\.quick-action-focus[\s\S]*background:\s*rgba\(247, 242, 232/, 'Secondary operations should be visually quieter than the CTA');
+assert.match(hierarchy, /\.metric-issues[\s\S]*background:\s*rgba\(8, 33, 32/, 'Issue count should be status, not a competing red action card');
+assert.match(ui, /ctaLabel\s*=\s*packageNeedsAction\s*\?\s*'INVESTIGATE'/, 'Actionable package exceptions should announce INVESTIGATE');
+assert.match(ui, /setAttribute\('aria-label', `\$\{ctaLabel\}: \$\{top\.title\}`\)/, 'The CTA accessible name should include both action and subject');
+
+console.log('POSTAL hierarchy CTA tests passed');


### PR DESCRIPTION
## Why

POSTAL currently gives similar visual weight to status, configuration, navigation and the thing that actually needs the player. In particular, Team Focus owns the strongest yellow treatment while a live exception reads more like a notification than an action.

## What changes

- turns the live exception ribbon into the single unmistakable **primary CTA**;
- gives actionable parcel problems an explicit **INVESTIGATE** verb, with REVIEW/OPEN fallbacks for non-package events;
- includes that action in the CTA's accessible name (`Investigate: …`), not only visually;
- demotes Team Focus and Find Package to secondary operation controls;
- makes the red issue metric a status indicator instead of a competing action block;
- quiets the metric strip, city switcher and level navigation so the 3D world gets more visual breathing room;
- keeps urgency signalled with red/orange within the CTA without making destructive red the primary action color;
- adds a UI contract test for the hierarchy and CTA semantics.

No simulation or game-mechanics changes.