### PR TITLE
Turn POSTAL into a hands-on delivery rush

### DIFF
--- a/postal/README.md
+++ b/postal/README.md
@@ -1,39 +1,46 @@
 # POSTAL
 
-A portrait-first, pausable real-time logistics game spanning parcel, depot, regional, national and international flows.
+A portrait-first, real-time “diner dash” management game about keeping package promises moving through a living Swedish delivery network.
 
-## Core loop
+## Player loop
 
-- Choose one operational focus: late parcels, complaints, express or international.
-- Workers automatically pull the highest-value parcel that matches that focus.
-- Regional trucks deliver locally or feed the national handoff.
-- National linehaul connects Sundsvall, Stockholm and Göteborg.
-- International transports handle both outbound and inbound parcels at Sweden's gateways.
-- Exceptions and complaints require parcel-level investigation; resolved parcels re-enter the live system and can be watched all the way to delivery.
+1. **Read the live package rail.** Every active package remains visible at Depot, Region and Sweden scales, with carrier, route, deadline, location and a multi-stop breadcrumb.
+2. **Select the pressure point.** The package itself reveals the next useful verb: sort, scan, reroute, load, send or follow.
+3. **Shape each depot.** Sundsvall, Stockholm and Göteborg keep independent team focuses for late, complaint, express or international work.
+4. **Choose departures.** Regional and national trucks never leave automatically. The player trades deadline protection against load efficiency.
+5. **Build flow.** EXPRESS RUN, DEADLINE SAVE, SMART LOAD and FULL LOAD departures award points and can extend a dispatch chain.
 
-## Demo detective cases
+## First morning
 
-- `US-77104`: USA → Timrå, stuck in Stockholm after a missing scan.
-- `GBG-23018`: Mölndal → Uppsala, sorted to the wrong dock in Göteborg.
-- `SOR-48219`: Söråker → Denmark, demonstrating local → national → international flow.
+The first day is an interactive shift, not an onboarding dialog:
 
-## Assets
+- Select and sort one DLH package from Söråker to Timrå.
+- Load its regional truck and choose when it leaves.
+- Meet a four-carrier intake wave and set Sundsvall’s focus.
+- Find the Chicago → Timrå package in Stockholm, repair its missing scan and keep it visible through national and regional handoffs.
+- Finish with a scored first-morning summary, then open the full incoming flow.
 
-- Nine distinct **Kenney Mini Characters** give Sundsvall, Stockholm and Göteborg their own named depot teams; the old Factory Kit alien operators are no longer loaded.
-- Supplied **City Kit (Suburban)**, **City Kit (Commercial)** and **City Kit (Industrial)** buildings give each region its own readable miniature identity.
-- **City Kit (Roads) 2.0** supplies the modular crossroads, crossings, straights, road ends, lights and work-zone props used by the depot and region dioramas.
-- Factory Kit equipment provides the cutaway depot shell, conveyors, scanner, control panels, parcels and floor signage.
-- The postal truck remains the existing Kenney Car Kit model shared with TURN.
-- Sweden uses Natural Earth Admin 0 Countries 1:110m public-domain geometry.
-- Three.js is retained in `vendor/` with its existing license file.
+## Carrier rhythms
 
-The UI is a single full-height portrait stage: game information and controls are layered around the 3D world instead of shrinking it into a dashboard card. A one-time morning briefing introduces the open-ended shift, while persistent INCOMING, ISSUES, focus, detective, help and zoom controls keep every core action discoverable. A non-WebGL fallback preserves package investigation and operational controls on constrained devices.
+- **NORDPOST** — steady mixed domestic baseline.
+- **DLH** — small, urgent express decisions.
+- **BRUNG** — frequent local bursts.
+- **STÄNKER** — bulky national and international cages.
+
+## Visual system
+
+- Nine distinct **Kenney Mini Characters** give every depot its own named team; skinned rigs are cloned through Three.js `SkeletonUtils` so they render correctly.
+- **City Kit Suburban, Commercial and Industrial** buildings give every region a readable miniature identity.
+- Correctly aligned **City Kit Roads** match the truck routes, while tree clusters frame the playable center instead of adding central clutter.
+- **Factory Kit** conveyors, scanners, parcels, loading equipment and depot modules make the sorting floor legible.
+- The selected package is marked in the 3D depot and its active route is highlighted in Region and Sweden views.
+- Compact non-modal sheets preserve the world above them; the direct action remains in the main HUD.
 
 ## Validation
-
-Run the pure simulation tests with:
 
 ```sh
 node postal/tests/model.test.mjs
 node postal/tests/ui-contract.test.mjs
+node postal/tests/character-rendering.test.mjs
+node postal/tests/hierarchy.test.mjs
 ```

--- a/postal/assets/ATTRIBUTION.md
+++ b/postal/assets/ATTRIBUTION.md
@@ -19,6 +19,7 @@ The CC0 license files shipped inside the user-supplied archives are the source o
 ## Existing CC0 Kenney assets retained
 
 - **Car Kit 3.1** — postal truck, shared from TURN's existing vendored assets.
+- **City nature clusters** — retained Kenney grass-and-tree miniatures frame the outer edges of regional dioramas.
 
 ## Sweden geometry
 

--- a/postal/hierarchy.css
+++ b/postal/hierarchy.css
@@ -1,180 +1,341 @@
-/* Visual hierarchy pass: keep the live world dominant and reserve strong action styling for what needs the player now. */
+/* POSTAL control hierarchy: world first, packages always visible, one decisive CTA. */
+.world-shade {
+  background:
+    linear-gradient(180deg, rgba(7, 29, 28, .72) 0, rgba(7, 29, 28, .3) 16%, transparent 31%),
+    linear-gradient(0deg, rgba(7, 29, 28, .82) 0, rgba(7, 29, 28, .36) 19%, transparent 36%),
+    radial-gradient(circle at 50% 44%, transparent 43%, rgba(10, 43, 40, .08) 100%);
+}
 
-/* 1. Utility/status information should read as supporting chrome, not competing actions. */
+.topbar {
+  top: calc(5px + var(--safe-top));
+  min-height: 42px;
+}
+.brand-mark { width: 36px; height: 36px; border-radius: 11px; }
+.brand strong { font-size: .82rem; }
+.brand div > span { margin-top: 2px; font-size: .57rem; opacity: .6; }
+.clock,
+.compact-btn { min-height: 38px; border-radius: 12px; }
+.help-btn { width: 38px; }
+
 .status-strip {
-  top: calc(61px + var(--safe-top));
-  gap: 5px;
+  top: calc(51px + var(--safe-top));
+  gap: 4px;
 }
 .metric {
-  min-height: 47px;
-  padding: 6px 9px;
-  border-radius: 13px;
-  background: rgba(8, 33, 32, .66);
+  min-height: 40px;
+  padding: 5px 8px;
+  border-radius: 12px;
+  background: rgba(7, 29, 28, .73);
   box-shadow: none;
 }
-.metric strong {
-  margin-top: 3px;
-  font-size: .94rem;
-}
-.metric-note { bottom: 7px; }
-.metric-issues {
-  background: rgba(8, 33, 32, .72);
-}
-.metric-issues strong { color: #ffb0a8; }
-.metric-issues .metric-note { color: #fff; opacity: .5; }
-.badge {
-  background: var(--red);
-  color: #fff;
-}
+.metric strong { margin-top: 2px; font-size: .86rem; }
+.metric-label { font-size: .46rem; }
+.metric-note { right: 7px; bottom: 6px; font-size: .48rem; }
+.metric-track { left: 8px; right: 8px; bottom: 5px; height: 2px; }
+.metric-issues { background: rgba(7, 29, 28, .78); }
+.metric-issues strong { color: #ffaaa1; }
+.badge { top: 4px; right: 5px; background: var(--red); color: #fff; }
 
-/* 2. Location/context is important, but should not become another dashboard panel. */
 .world-context {
-  top: calc(114px + var(--safe-top));
+  top: calc(96px + var(--safe-top));
+  border-radius: 14px;
   border-color: rgba(255, 255, 255, .42);
-  background: rgba(247, 242, 232, .82);
-  box-shadow: 0 8px 22px rgba(8, 29, 27, .14);
+  background: rgba(247, 242, 232, .83);
+  box-shadow: 0 7px 18px rgba(8, 29, 27, .13);
 }
-.world-heading {
-  min-height: 60px;
-  padding: 9px 11px 7px;
-}
-.world-heading h1 {
-  font-size: 1.16rem;
-  letter-spacing: -.025em;
-}
-.level-kicker { opacity: .82; }
-.city-switcher { gap: 4px; padding: 0 7px 7px; }
+.world-heading { min-height: 39px; padding: 6px 9px 4px; }
+.level-kicker { margin-bottom: 1px; font-size: .44rem; opacity: .78; }
+.level-kicker i { width: 6px; height: 6px; }
+.world-heading h1 { font-size: .94rem; }
+.world-heading p { display: none; }
+.city-switcher { gap: 3px; padding: 0 4px 4px; }
 .city-chip {
-  min-height: 35px;
-  border-radius: 10px;
+  min-height: 30px;
+  padding: 4px 3px;
+  border-radius: 9px;
   background: rgba(255, 255, 255, .52);
-  color: rgba(16, 42, 41, .78);
+  color: rgba(16, 42, 41, .72);
+  font-size: .58rem;
 }
 .city-chip[aria-pressed="true"] {
   background: var(--ink);
   color: #fff;
-  box-shadow: inset 0 -3px 0 var(--yellow);
+  box-shadow: inset 0 -2px 0 var(--yellow);
 }
 
-/* 3. The live exception is the primary CTA. One yellow action surface, one clear verb. */
-.event-ribbon.primary-cta {
-  min-height: 64px;
-  padding: 9px 11px;
-  gap: 10px;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  border: 2px solid rgba(16, 42, 41, .18);
-  border-radius: 17px;
-  background: var(--yellow);
-  color: var(--ink);
-  box-shadow: 0 12px 30px rgba(7, 29, 28, .32), inset 0 1px rgba(255, 255, 255, .45);
-}
-.event-ribbon.primary-cta[data-kind="critical"],
-.event-ribbon.primary-cta[data-kind="warning"] {
-  background: var(--yellow);
-  border-color: rgba(16, 42, 41, .22);
-}
-.event-ribbon.primary-cta[data-kind="info"] {
-  background: rgba(247, 242, 232, .96);
-}
-.primary-cta .event-signal {
-  width: 38px;
-  height: 38px;
-  border-radius: 12px;
-  background: rgba(16, 42, 41, .1);
-}
-.primary-cta .event-signal i {
-  background: var(--orange);
-  box-shadow: 0 0 0 5px rgba(223, 120, 71, .15);
-}
-.primary-cta[data-kind="critical"] .event-signal {
-  background: rgba(185, 67, 59, .12);
-}
-.primary-cta[data-kind="critical"] .event-signal i {
-  background: var(--red);
-}
-.primary-cta .event-copy small {
-  color: rgba(16, 42, 41, .62);
-  font-size: .5rem;
-}
-.primary-cta .event-copy strong {
-  font-size: .75rem;
-  line-height: 1.15;
-}
-.event-command {
-  min-width: 74px;
+.flow-feedback {
+  position: absolute;
+  z-index: 18;
+  left: 50%;
+  top: 43%;
+  min-width: 148px;
+  padding: 9px 14px;
   display: grid;
-  justify-items: end;
-  gap: 2px;
+  justify-items: center;
+  gap: 1px;
+  border: 2px solid rgba(255,255,255,.82);
+  border-radius: 14px;
+  background: var(--yellow);
   color: var(--ink);
+  box-shadow: 0 12px 35px rgba(7,29,28,.34);
+  opacity: 0;
+  transform: translate(-50%, 10px) scale(.94);
+  pointer-events: none;
+  transition: opacity .2s ease, transform .24s cubic-bezier(.2,.8,.2,1);
 }
-.event-command strong {
-  font-size: .64rem;
-  font-weight: 1000;
-  letter-spacing: .045em;
-  line-height: 1;
-}
-.event-command span {
-  font-size: 1.35rem;
-  font-weight: 900;
-  line-height: .75;
-}
+.flow-feedback[hidden] { display: none; }
+.flow-feedback.is-showing { opacity: 1; transform: translate(-50%, 0) scale(1); }
+.flow-feedback strong { font-size: .7rem; font-weight: 1000; letter-spacing: .08em; }
+.flow-feedback span { font-size: .62rem; font-weight: 900; }
 
-/* 4. Operations are secondary choices. They should be easy to find, but not look like the next required move. */
-.quick-actions {
-  grid-template-columns: 1fr 1.15fr;
+.lower-controls { left: 6px; right: 6px; bottom: calc(5px + var(--safe-bottom)); gap: 4px; }
+
+.action-dock {
+  min-height: 58px;
+  padding: 6px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: stretch;
   gap: 5px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, .22);
+  border-radius: 15px;
+  background: rgba(7, 29, 28, .93);
+  color: #fff;
+  box-shadow: 0 9px 25px rgba(4, 18, 17, .3);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
 }
-.quick-action,
-.quick-action-focus {
-  min-height: 52px;
-  border-color: rgba(255, 255, 255, .35);
-  background: rgba(247, 242, 232, .9);
-  box-shadow: 0 5px 14px rgba(7, 29, 28, .15);
+.action-dock[data-tone="critical"] { border-color: rgba(255, 119, 106, .88); }
+.action-dock[data-tone="tutorial"] { border-color: var(--yellow); box-shadow: 0 0 0 2px rgba(243, 202, 82, .17), 0 9px 25px rgba(4, 18, 17, .3); }
+.action-dock[data-tone="success"] { border-color: var(--teal-bright); }
+.action-dock-copy { min-width: 0; align-self: center; display: grid; gap: 2px; padding: 0 4px; }
+.action-dock-copy small { color: var(--yellow); font-size: .45rem; font-weight: 1000; letter-spacing: .11em; }
+.action-dock-copy strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: .74rem; line-height: 1.06; }
+.action-dock-copy span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: rgba(255, 255, 255, .62); font-size: .55rem; }
+.dock-button {
+  min-width: 61px;
+  min-height: 46px;
+  padding: 5px 8px;
+  border: 1px solid rgba(255, 255, 255, .2);
+  border-radius: 11px;
+  font-size: .58rem;
+  font-weight: 1000;
+  letter-spacing: .035em;
 }
-.quick-action-focus {
-  border-left: 4px solid var(--yellow);
-}
-.action-icon {
-  width: 31px;
-  height: 31px;
-  border-radius: 10px;
-}
-.action-icon svg { width: 21px; height: 21px; }
-.quick-action small { opacity: .48; }
-
-/* 5. Scale navigation is persistent navigation, visually below the action layer. */
-.level-switcher {
-  background: rgba(7, 29, 28, .79);
-  box-shadow: 0 8px 24px rgba(4, 18, 17, .24);
-}
-.level-tab { min-height: 53px; }
-.level-tab[aria-pressed="true"] {
-  background: rgba(255, 255, 255, .94);
+.dock-button-secondary { background: rgba(255, 255, 255, .08); color: #fff; }
+.dock-button-primary {
+  min-width: 84px;
+  border-color: rgba(16, 42, 41, .24);
+  background: var(--yellow);
   color: var(--ink);
-  box-shadow: inset 0 -3px 0 var(--yellow);
+  box-shadow: inset 0 -3px rgba(16, 42, 41, .1), 0 5px 14px rgba(243, 202, 82, .18);
 }
+.dock-button-primary:disabled { background: #62716f; color: rgba(255,255,255,.66); box-shadow: none; }
+.action-dock[data-tone="tutorial"] .dock-button-primary:not(:disabled) { animation: tutorialCta 1.8s ease-in-out infinite; }
+@keyframes tutorialCta { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-2px); box-shadow: inset 0 -3px rgba(16,42,41,.1), 0 7px 18px rgba(243,202,82,.42); } }
 
-/* Brand and help remain recognisable but do not steal the first glance from the game state. */
-.brand-mark {
-  width: 38px;
-  height: 38px;
-  border-radius: 12px;
+.package-console {
+  height: 102px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, .18);
+  border-radius: 15px;
+  background: rgba(7, 29, 28, .9);
+  color: #fff;
+  box-shadow: 0 8px 22px rgba(4, 18, 17, .27);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
 }
-.brand strong { font-size: .86rem; }
-.brand div > span { opacity: .64; }
-.compact-btn { box-shadow: 0 4px 11px rgba(20, 15, 12, .14); }
+.package-console-header {
+  height: 32px;
+  padding: 3px 4px 3px 9px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  border-bottom: 1px solid rgba(255, 255, 255, .12);
+}
+.package-console-title { min-width: 0; display: flex; align-items: baseline; gap: 6px; }
+.package-console-title strong { flex: 0 0 auto; color: var(--yellow); font-size: .49rem; letter-spacing: .1em; }
+.package-console-title span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: rgba(255,255,255,.58); font-size: .51rem; }
+.package-tools { flex: 0 0 auto; display: flex; align-items: stretch; gap: 3px; height: 26px; }
+.package-tool {
+  min-width: 0;
+  border: 1px solid rgba(255, 255, 255, .15);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, .08);
+  color: #fff;
+}
+.focus-tool { width: 92px; padding: 2px 6px; display: grid; align-content: center; text-align: left; }
+.focus-tool small { font-size: .4rem; line-height: 1; opacity: .52; }
+.focus-tool strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: .52rem; }
+.find-tool { width: 39px; display: flex; align-items: center; justify-content: center; gap: 2px; font-size: .43rem; font-weight: 1000; }
+.find-tool svg { width: 13px; fill: none; stroke: currentColor; stroke-width: 2; }
+
+.package-rail {
+  height: 70px;
+  padding: 4px;
+  display: flex;
+  gap: 5px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-snap-type: x proximity;
+  scrollbar-width: none;
+  overscroll-behavior-inline: contain;
+}
+.package-rail::-webkit-scrollbar { display: none; }
+.live-package-card {
+  position: relative;
+  flex: 0 0 174px;
+  height: 62px;
+  padding: 5px 6px 4px 8px;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 2px;
+  overflow: hidden;
+  border: 2px solid transparent;
+  border-radius: 11px;
+  background: rgba(255,255,255,.95);
+  color: var(--ink);
+  text-align: left;
+  scroll-snap-align: center;
+  box-shadow: inset 4px 0 var(--carrier-color, var(--teal));
+}
+.live-package-card[aria-pressed="true"] {
+  border-color: var(--yellow);
+  background: #fffdf3;
+  box-shadow: inset 4px 0 var(--carrier-color, var(--teal)), 0 0 0 1px rgba(16,42,41,.5);
+}
+.live-package-card.critical { background: #fff3f1; }
+.live-package-card.warning .live-deadline { color: #8b3e16; }
+.live-package-card.tutorial-target { animation: packageTarget 1.7s ease-in-out infinite; }
+@keyframes packageTarget { 0%, 100% { box-shadow: inset 4px 0 var(--carrier-color), 0 0 0 1px rgba(243,202,82,.3); } 50% { box-shadow: inset 4px 0 var(--carrier-color), 0 0 0 3px var(--yellow); } }
+.carrier-nordpost { --carrier-color: #2865ad; }
+.carrier-dlh { --carrier-color: #e9bd20; }
+.carrier-brung { --carrier-color: #28956c; }
+.carrier-stanker,
+.carrier-st-nker { --carrier-color: #d84d43; }
+.carrier-nordpost .carrier-band { background: #2865ad; }
+.carrier-dlh .carrier-band { background: #e9bd20; }
+.carrier-brung .carrier-band { background: #28956c; }
+.carrier-st-nker .carrier-band { background: #d84d43; }
+.live-package-head { min-width: 0; display: grid; grid-template-columns: auto minmax(0,1fr) auto; align-items: center; gap: 4px; }
+.live-package-head strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: .57rem; }
+.carrier-flag {
+  min-width: 43px;
+  height: 15px;
+  padding: 0 3px;
+  display: grid;
+  place-items: center;
+  border-radius: 4px;
+  background: var(--carrier-color, var(--teal));
+  color: #fff;
+  font-size: .34rem;
+  font-weight: 1000;
+  letter-spacing: -.01em;
+}
+.carrier-dlh .carrier-flag { color: var(--ink); }
+.carrier-flag[data-pattern="bars"] { background-image: repeating-linear-gradient(90deg, rgba(255,255,255,.22) 0 2px, transparent 2px 5px); }
+.carrier-flag[data-pattern="arrow"] { background-image: linear-gradient(135deg, transparent 0 58%, rgba(16,42,41,.16) 58% 72%, transparent 72%); }
+.carrier-flag[data-pattern="dots"] { background-image: radial-gradient(rgba(255,255,255,.32) 1px, transparent 1px); background-size: 4px 4px; }
+.carrier-flag[data-pattern="stripe"] { background-image: repeating-linear-gradient(135deg, rgba(255,255,255,.25) 0 3px, transparent 3px 7px); }
+.live-deadline { font-size: .5rem; font-weight: 1000; font-variant-numeric: tabular-nums; }
+.live-deadline.is-soon { color: #a54818; }
+.live-deadline.is-late { color: var(--red); }
+.route-breadcrumb { min-width: 0; display: flex; align-items: center; padding-left: 1px; }
+.route-node { position: relative; flex: 1 1 auto; min-width: 0; display: flex; align-items: center; gap: 2px; color: rgba(16,42,41,.42); }
+.route-node::after { content: ""; height: 2px; flex: 1 1 auto; background: rgba(16,42,41,.16); }
+.route-node:last-child { flex: 0 0 auto; }
+.route-node:last-child::after { display: none; }
+.route-node i { width: 6px; height: 6px; flex: 0 0 auto; border: 1px solid currentColor; border-radius: 50%; background: #fff; }
+.route-node b { font-size: .39rem; font-weight: 1000; }
+.route-node.is-done,
+.route-node.is-current { color: var(--teal); }
+.route-node.is-done i { background: var(--teal); }
+.route-node.is-current i { border-color: var(--yellow); background: var(--yellow); box-shadow: 0 0 0 2px rgba(243,202,82,.28); }
+.live-package-foot { min-width: 0; display: flex; justify-content: space-between; gap: 4px; color: rgba(16,42,41,.62); font-size: .43rem; }
+.live-package-foot span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.live-package-foot span:first-child { font-weight: 900; color: var(--ink); }
+.rail-empty { flex: 1 0 100%; display: flex; align-items: center; justify-content: center; gap: 7px; color: rgba(255,255,255,.62); font-size: .58rem; }
+.rail-empty strong { color: var(--teal-bright); }
+
+.level-switcher {
+  padding: 3px;
+  border-radius: 14px;
+  background: rgba(7,29,28,.92);
+  box-shadow: 0 7px 19px rgba(4,18,17,.25);
+}
+.level-tab { min-height: 42px; padding: 4px 3px; border-radius: 10px; font-size: .59rem; }
+.level-tab svg { width: 18px; height: 18px; }
+.level-tab small { font-size: .38rem; }
+.level-tab[aria-pressed="true"] { background: rgba(255,255,255,.94); color: var(--ink); box-shadow: inset 0 -3px 0 var(--yellow); }
+
+.sheet[open] {
+  position: fixed;
+  z-index: 80;
+  inset: auto 5px calc(5px + var(--safe-bottom));
+  width: min(calc(100% - 10px), 680px);
+  max-height: min(56dvh, 570px);
+  margin: 0 auto;
+  border-radius: 22px 22px 16px 16px;
+  box-shadow: 0 18px 55px rgba(5,24,23,.4), 0 0 0 1px rgba(255,255,255,.36);
+}
+.sheet::backdrop { background: transparent; backdrop-filter: none; }
+.sheet-header { min-height: 52px; }
+.sheet-body { max-height: calc(min(56dvh, 570px) - 63px); }
+.sheet-close { width: 40px; height: 40px; }
+
+.carrier-guide { margin-top: 10px; display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 6px; }
+.carrier-guide-item { min-width: 0; padding: 7px; display: grid; grid-template-columns: auto minmax(0,1fr); align-items: center; gap: 7px; border: 1px solid var(--line); border-left: 4px solid var(--carrier-color); border-radius: 11px; background: #fff; }
+.carrier-guide-item > b { min-width: 31px; color: var(--carrier-color); font-size: .65rem; }
+.carrier-guide-item > span { min-width: 0; display: grid; gap: 1px; }
+.carrier-guide-item strong { font-size: .62rem; }
+.carrier-guide-item small { font-size: .53rem; line-height: 1.2; opacity: .62; }
+.truck-load-list { display: grid; gap: 6px; }
+.truck-load-row { width: 100%; min-height: 53px; padding: 7px 9px; display: grid; grid-template-columns: auto minmax(0,1fr) auto; align-items: center; gap: 8px; border: 1px solid var(--line); border-left: 5px solid var(--carrier-color); border-radius: 12px; background: #fff; text-align: left; }
+.truck-load-row[aria-pressed="true"] { background: #fff9db; border-color: var(--ink); }
+.truck-load-row > span:nth-child(2) { min-width: 0; display: grid; gap: 2px; }
+.truck-load-row strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: .69rem; }
+.truck-load-row small { font-size: .58rem; opacity: .62; }
+.load-check { width: 26px; height: 26px; display: grid; place-items: center; border-radius: 8px; background: var(--teal-soft); font-weight: 1000; }
+.truck-load-row[aria-pressed="true"] .load-check { background: var(--yellow); }
 
 @media (max-height: 735px) and (orientation: portrait) {
-  .status-strip { top: calc(54px + var(--safe-top)); }
-  .metric { min-height: 43px; }
-  .world-context { top: calc(102px + var(--safe-top)); }
-  .event-ribbon.primary-cta { min-height: 57px; }
-  .quick-action { min-height: 47px; }
-  .level-tab { min-height: 47px; }
+  .brand div > span { display: none; }
+  .topbar { top: calc(3px + var(--safe-top)); }
+  .status-strip { top: calc(47px + var(--safe-top)); }
+  .metric { min-height: 37px; }
+  .world-context { top: calc(89px + var(--safe-top)); }
+  .world-heading { min-height: 34px; padding-block: 4px 2px; }
+  .city-chip { min-height: 28px; }
+  .action-dock { min-height: 52px; }
+  .package-console { height: 91px; }
+  .package-console-header { height: 29px; }
+  .package-rail { height: 62px; }
+  .live-package-card { height: 54px; }
+  .live-package-foot { display: none; }
+  .level-tab { min-height: 39px; }
+  .sheet[open] { max-height: 53dvh; }
+  .sheet-body { max-height: calc(53dvh - 63px); }
 }
 
-@media (max-width: 355px) {
-  .event-command { min-width: 60px; }
-  .event-command strong { font-size: .56rem; }
-  .primary-cta .event-copy strong { font-size: .69rem; }
+@media (max-width: 370px) {
+  .brand div > span, .metric-note, .level-tab small, .action-dock-copy span { display: none; }
+  .action-dock { grid-template-columns: minmax(0, 1fr) auto auto; }
+  .dock-button { min-width: 54px; padding-inline: 6px; }
+  .dock-button-primary { min-width: 76px; }
+  .focus-tool { width: 80px; }
+  .package-console-title span { display: none; }
+  .live-package-card { flex-basis: 163px; }
+}
+
+@media (orientation: landscape) and (max-height: 620px) {
+  .package-console { height: 92px; }
+  .package-rail { height: 61px; }
+  .live-package-card { height: 53px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .action-dock[data-tone="tutorial"] .dock-button-primary,
+  .live-package-card.tutorial-target { animation: none; }
 }

--- a/postal/index.html
+++ b/postal/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#102a29">
   <meta name="color-scheme" content="light">
-  <meta name="description" content="Run a living Swedish parcel network from depot floor to national linehaul.">
+  <meta name="description" content="A portrait-first package delivery management game: sort the rush, send the trucks and keep every promise moving.">
   <title>POSTAL — Every promise has a path</title>
   <link rel="stylesheet" href="./styles.css">
   <link rel="stylesheet" href="./hierarchy.css">
@@ -80,9 +80,9 @@
             <i class="metric-track" aria-hidden="true"><b id="metric-ontime-bar"></b></i>
           </div>
           <button id="incoming-btn" class="metric metric-flow" type="button" aria-label="Open incoming packages">
-            <span class="metric-label">INCOMING</span>
+            <span class="metric-label">LIVE</span>
             <strong id="metric-flow">0</strong>
-            <span class="metric-note">depot floor</span>
+            <span class="metric-note">packages</span>
           </button>
           <button id="issues-btn" class="metric metric-issues" type="button" aria-label="Open network issues">
             <span class="metric-label">ISSUES</span>
@@ -99,7 +99,6 @@
               <h1 id="level-title">Sundsvall depot</h1>
               <p id="level-subtitle">People sort. Packages move. You decide what matters.</p>
             </div>
-            <button id="scene-help-btn" class="tap-hint" type="button" aria-label="What can I interact with in the scene?"><span aria-hidden="true">◎</span> What to tap</button>
           </div>
           <nav class="city-switcher" aria-label="City">
             <button class="city-chip" type="button" data-city="sundsvall" aria-pressed="true"><span>SUN</span>Sundsvall</button>
@@ -108,27 +107,40 @@
           </nav>
         </section>
 
-        <div class="lower-controls">
-          <button id="event-ribbon" class="event-ribbon primary-cta" type="button" data-kind="warning">
-            <span class="event-signal" aria-hidden="true"><i></i></span>
-            <span class="event-copy"><small id="event-kicker">NEEDS YOU</small><strong id="event-text">Customer complaint: USA → Timrå</strong></span>
-            <span class="event-command" aria-hidden="true"><strong id="event-cta-label">INVESTIGATE</strong><span>›</span></span>
-          </button>
+        <div id="flow-feedback" class="flow-feedback" role="status" aria-live="polite" aria-atomic="true" hidden>
+          <strong id="flow-feedback-grade">EXPRESS RUN</strong>
+          <span id="flow-feedback-points">+105</span>
+        </div>
 
-          <div class="quick-actions" aria-label="Operations">
-            <button id="focus-btn" class="quick-action quick-action-focus" type="button">
-              <span class="action-icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"></circle><circle cx="12" cy="12" r="3"></circle><path d="M12 2v3M22 12h-3M12 22v-3M2 12h3"></path></svg>
-              </span>
-              <span><small>TEAM FOCUS</small><strong id="focus-value">LATE</strong></span>
-            </button>
-            <button id="find-btn" class="quick-action" type="button">
-              <span class="action-icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24"><path d="M4 7.5 12 3l8 4.5v9L12 21l-8-4.5z"></path><path d="m4 7.5 8 4.5 8-4.5M12 12v9"></path><circle cx="17.5" cy="16.5" r="2.5"></circle><path d="m19.4 18.4 2 2"></path></svg>
-              </span>
-              <span><small>DETECTIVE</small><strong>FIND PACKAGE</strong></span>
-            </button>
-          </div>
+        <div class="lower-controls">
+          <section id="action-dock" class="action-dock" aria-label="Selected operation">
+            <div class="action-dock-copy">
+              <small id="action-kicker">NEXT ACTION</small>
+              <strong id="action-title">Select a live package</strong>
+              <span id="action-meta">Its route will light up across every view.</span>
+            </div>
+            <button id="action-details" class="dock-button dock-button-secondary" type="button" hidden>DETAILS</button>
+            <button id="action-primary" class="dock-button dock-button-primary" type="button">SELECT</button>
+          </section>
+
+          <section class="package-console" aria-labelledby="package-console-title">
+            <header class="package-console-header">
+              <div class="package-console-title">
+                <strong id="package-console-title">LIVE PACKAGES</strong>
+                <span id="package-console-summary">Loading the network…</span>
+              </div>
+              <div class="package-tools" aria-label="Package tools">
+                <button id="focus-btn" class="package-tool focus-tool" type="button">
+                  <small>FOCUS</small><strong id="focus-value">SUN · LATE</strong>
+                </button>
+                <button id="find-btn" class="package-tool find-tool" type="button" aria-label="Find a package">
+                  <svg aria-hidden="true" viewBox="0 0 24 24"><circle cx="10.5" cy="10.5" r="6"></circle><path d="m15 15 5 5"></path></svg>
+                  <span>FIND</span>
+                </button>
+              </div>
+            </header>
+            <div id="package-rail" class="package-rail" role="list" aria-label="Packages across the whole network"></div>
+          </section>
 
           <nav class="level-switcher" aria-label="Network level">
             <button class="level-tab" type="button" data-level="depot" aria-pressed="true">

--- a/postal/main.mjs
+++ b/postal/main.mjs
@@ -9,7 +9,7 @@ globalThis.cloneSkeleton = cloneSkeleton_NS;
 const scripts = [
   './runtime/model-data.js', './runtime/model-core.js', './runtime/model-flow.js', './runtime/model-ops.js',
   './runtime/app-foundation.js', './runtime/skin-clone-fix.js', './runtime/scene-depot.js', './runtime/scene-region.js', './runtime/scene-sweden.js',
-  './runtime/visuals-ui-core.js', './runtime/ui-sheets.js', './runtime/interaction-boot.js'
+  './runtime/tutorial.js', './runtime/visuals-ui-core.js', './runtime/ui-sheets.js', './runtime/interaction-boot.js'
 ];
 
 function loadClassic(src) {

--- a/postal/runtime/app-foundation.js
+++ b/postal/runtime/app-foundation.js
@@ -2,15 +2,25 @@
 const $ = (sel, root = document) => root.querySelector(sel);
 const $$ = (sel, root = document) => [...root.querySelectorAll(sel)];
 const prefersReducedMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
+const FIRST_DAY_KEY = 'postal-first-day-v3';
 
-const simulation = new PostalSimulation({ seed: 12 });
+function needsFirstDay() {
+  try { return localStorage.getItem(FIRST_DAY_KEY) !== 'complete'; }
+  catch { return true; }
+}
+
+const firstDayRequired = needsFirstDay();
+const simulation = new PostalSimulation({ seed: 12, firstDay: firstDayRequired });
 let currentLevel = 'depot';
 let currentCityId = 'sundsvall';
-let selectedPackageId = null;
+let selectedPackageId = firstDayRequired ? null : 'US-77104';
+let selectedTruckId = null;
 let visualTime = 0;
 let lastFrame = performance.now();
 let lastUiUpdate = 0;
 let lastReceivedCount = simulation.stats.received;
+let packageRailKey = '';
+let flowFeedbackTimer = 0;
 
 const app = {
   canvas: $('#scene'),
@@ -24,8 +34,17 @@ const app = {
   issueBadge: $('#issue-badge'),
   live: $('#live-region'),
   pause: $('#pause-btn'),
-  eventRibbon: $('#event-ribbon'),
-  eventText: $('#event-text'),
+  actionDock: $('#action-dock'),
+  actionKicker: $('#action-kicker'),
+  actionTitle: $('#action-title'),
+  actionMeta: $('#action-meta'),
+  actionPrimary: $('#action-primary'),
+  actionDetails: $('#action-details'),
+  packageRail: $('#package-rail'),
+  packageSummary: $('#package-console-summary'),
+  flowFeedback: $('#flow-feedback'),
+  flowFeedbackGrade: $('#flow-feedback-grade'),
+  flowFeedbackPoints: $('#flow-feedback-points'),
   sheet: $('#sheet'),
   sheetTitle: $('#sheet-title'),
   sheetBody: $('#sheet-body'),
@@ -91,6 +110,8 @@ const manifest = {
   suburbanL: './assets/kenney/city-suburban/building-type-l.glb',
   treeLarge: './assets/kenney/suburban/tree-large.glb',
   treeSmall: './assets/kenney/suburban/tree-small.glb',
+  treeCluster: './assets/city/grass-trees.glb',
+  treeClusterTall: './assets/city/grass-trees-tall.glb',
   commercialA: './assets/kenney/city-commercial/building-a.glb',
   commercialH: './assets/kenney/city-commercial/building-h.glb',
   skyscraper: './assets/kenney/city-commercial/building-skyscraper-a.glb',

--- a/postal/runtime/interaction-boot.js
+++ b/postal/runtime/interaction-boot.js
@@ -1,4 +1,149 @@
 'use strict';
+function packageView(pkg) {
+  const cityId = pkg.cityId || cityForPlace(pkg.destination.place) || cityForPlace(pkg.origin.place) || currentCityId;
+  if (['ready-local', 'transit-local'].includes(pkg.status)) return { cityId, level: 'region' };
+  if (['ready-national', 'transit-national', 'ready-international', 'ready-inbound', 'transit-international'].includes(pkg.status)) return { cityId, level: 'sweden' };
+  return { cityId, level: 'depot' };
+}
+
+function selectPackage(packageId, { navigate = true, announceSelection = true } = {}) {
+  const pkg = simulation.packages.get(packageId);
+  if (!pkg) return false;
+  selectedPackageId = packageId;
+  selectedTruckId = null;
+  packageRailKey = '';
+  if (navigate) {
+    const view = packageView(pkg);
+    currentCityId = view.cityId;
+    currentLevel = view.level;
+    buildScene();
+  } else if (currentLevel === 'depot' && pkg.cityId === currentCityId) {
+    syncDepotPackages(currentCityId);
+  }
+  updateUI(true);
+  app.packageRail.querySelector(`[data-select-package="${packageId}"]`)?.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth', block: 'nearest', inline: 'center' });
+  if (announceSelection) announce(`${pkg.carrier} package selected. ${pkg.origin.place} to ${pkg.destination.place}.`);
+  return true;
+}
+
+function selectTruck(truckId) {
+  const truck = simulation.findTruck(truckId);
+  if (!truck) return false;
+  selectedTruckId = truck.id;
+  packageRailKey = '';
+  updateUI(true);
+  const from = CITIES[truck.from]?.name || truck.from;
+  const to = CITIES[truck.to]?.name || truck.to;
+  announce(`${from} to ${to} truck selected. ${truck.state === 'waiting' ? 'Choose its load and departure.' : 'Truck is on the road.'}`);
+  return true;
+}
+
+function advanceTutorialAfterLoad(pkg, truck) {
+  if (!tutorialIsActive() || !pkg || !truck) return;
+  if (pkg.id === 'DAY1-1001' && truck.kind === 'regional') simulation.tutorialStage = 'send-local';
+  else if (pkg.id === 'US-77104' && truck.kind === 'national') simulation.tutorialStage = 'send-national';
+  else if (pkg.id === 'US-77104' && truck.kind === 'regional') simulation.tutorialStage = 'send-timra';
+}
+
+function resolveSelectedIssue(action, { reopen = false } = {}) {
+  const pkg = selectedPackageId ? simulation.packages.get(selectedPackageId) : null;
+  if (!pkg) return false;
+  const result = simulation.resolveIssue(pkg.id, action);
+  announce(result.message);
+  if (!result.ok) return false;
+  if (tutorialIsActive() && pkg.id === 'US-77104' && simulation.tutorialStage === 'select-chicago') {
+    simulation.tutorialStage = 'watch-chicago-sort';
+    closeSheet();
+  } else if (reopen) showPackage(pkg.id);
+  if (currentLevel === 'depot' && pkg.cityId === currentCityId) syncDepotPackages(currentCityId);
+  packageRailKey = '';
+  updateUI(true);
+  return true;
+}
+
+function dispatchSelectedTruck(truckId = selectedTruckId) {
+  const truck = simulation.findTruck(truckId);
+  if (!truck) return false;
+  const result = simulation.dispatchTruck(truck.id);
+  announce(result.message);
+  if (!result.ok) return false;
+  showFlowFeedback(result);
+  handleTutorialTruckDispatched(result.truck);
+  selectedTruckId = null;
+  packageRailKey = '';
+  closeSheet();
+  updateUI(true);
+  return true;
+}
+
+function showFlowFeedback(result) {
+  if (!result?.grade || !app.flowFeedback) return;
+  clearTimeout(flowFeedbackTimer);
+  app.flowFeedbackGrade.textContent = result.grade;
+  app.flowFeedbackPoints.textContent = `+${result.points}${result.chain > 1 ? ` · ${result.chain}× FLOW` : ''}`;
+  app.flowFeedback.hidden = false;
+  app.flowFeedback.classList.remove('is-showing');
+  requestAnimationFrame(() => app.flowFeedback.classList.add('is-showing'));
+  flowFeedbackTimer = setTimeout(() => {
+    app.flowFeedback.classList.remove('is-showing');
+    setTimeout(() => { app.flowFeedback.hidden = true; }, 240);
+  }, 1750);
+}
+
+function performDockAction(action) {
+  const pkg = selectedPackageId ? simulation.packages.get(selectedPackageId) : null;
+  if (action === 'select-suggested') {
+    const targetId = simulation.tutorialStage === 'select-package' ? 'DAY1-1001'
+      : simulation.tutorialStage === 'select-chicago' ? 'US-77104'
+      : simulation.getActivePackages(1)[0]?.id;
+    if (targetId) selectPackage(targetId);
+    return;
+  }
+  if (action === 'open-focus') { currentCityId = 'sundsvall'; showFocusSheet(); return; }
+  if (action === 'start-tutorial-sort') {
+    if (simulation.startFirstDaySort(selectedPackageId)) {
+      announce('DLH package released to Express sort. Watch Leo move it.');
+      if (currentLevel === 'depot') syncDepotPackages(currentCityId);
+      packageRailKey = '';
+      updateUI(true);
+    }
+    return;
+  }
+  if (['scan-cage', 'reroute', 'reprint', 'rescan'].includes(action)) { resolveSelectedIssue(action); return; }
+  if (action === 'priority' && pkg) {
+    simulation.flagPriority(pkg.id);
+    packageRailKey = '';
+    updateUI(true);
+    announce(`${pkg.id} priority ${pkg.priorityFlag ? 'set' : 'cleared'}.`);
+    return;
+  }
+  if (action === 'load-package' && pkg) {
+    const result = simulation.planPackageOnTruck(pkg.id);
+    announce(result.message);
+    if (result.ok) {
+      selectedTruckId = result.truck.id;
+      advanceTutorialAfterLoad(pkg, result.truck);
+      packageRailKey = '';
+      updateUI(true);
+    }
+    return;
+  }
+  if (action === 'dispatch-truck') { dispatchSelectedTruck(); return; }
+  if (action === 'follow' && pkg) { selectPackage(pkg.id); return; }
+  if (action === 'details' && pkg) { showPackage(pkg.id); updateUI(true); return; }
+  if (action === 'edit-load' && selectedTruckId) { showTruck(selectedTruckId); updateUI(true); return; }
+  if (action === 'first-day-summary') { showFirstDaySummary(); return; }
+  if (action === 'dismiss-celebration') {
+    firstDayCelebration = false;
+    selectedPackageId = simulation.getActivePackages(1)[0]?.id || null;
+    packageRailKey = '';
+    updateUI(true);
+    announce('The full network is live. Keep the carrier promises moving.');
+    return;
+  }
+  if (action === 'watch') announce('The selected package is moving through the current operation.');
+}
+
 function onScenePointer(event) {
   const rect = app.canvas.getBoundingClientRect();
   pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
@@ -10,9 +155,9 @@ function onScenePointer(event) {
     while (obj && obj !== world) {
       if (obj.userData?.entityType) {
         const d = obj.userData;
-        if (d.entityType === 'package') showPackage(d.packageId);
+        if (d.entityType === 'package') selectPackage(d.packageId, { navigate: false });
         else if (d.entityType === 'worker') showWorker(d.workerId);
-        else if (d.entityType === 'truck') showTruck(d.truckId);
+        else if (d.entityType === 'truck') selectTruck(d.truckId);
         else if (d.entityType === 'transport') showTransport(d.transportId);
         else if (d.entityType === 'town') showTown(d.cityId, d.town);
         else if (d.entityType === 'city') showCity(d.cityId);
@@ -56,43 +201,70 @@ function bindUI() {
   app.pause.addEventListener('click', () => { simulation.togglePause(); updateUI(true); announce(simulation.paused ? 'Network paused.' : 'Network running.'); });
   app.incoming.addEventListener('click', showIncomingSheet);
   app.incoming.addEventListener('animationend', () => app.incoming.classList.remove('new-arrival'));
-  $('#help-btn').addEventListener('click', () => showBriefingSheet());
-  $('#scene-help-btn').addEventListener('click', () => showBriefingSheet());
+  $('#help-btn').addEventListener('click', showBriefingSheet);
   $('#focus-btn').addEventListener('click', showFocusSheet);
   $('#issues-btn').addEventListener('click', showIssuesSheet);
   $('#find-btn').addEventListener('click', showFindSheet);
-  app.eventRibbon.addEventListener('click', () => {
-    const packageId = app.eventRibbon.dataset.packageId;
-    if (packageId && simulation.packages.has(packageId)) showPackage(packageId);
-    else showIssuesSheet();
+  app.actionPrimary.addEventListener('click', () => performDockAction(app.actionPrimary.dataset.action));
+  app.actionDetails.addEventListener('click', () => performDockAction(app.actionDetails.dataset.action));
+  app.packageRail.addEventListener('click', event => {
+    const card = event.target.closest('[data-select-package]');
+    if (card) selectPackage(card.dataset.selectPackage);
   });
   app.sheetClose.addEventListener('click', closeSheet);
-  app.sheet.addEventListener('click', event => { if (event.target === app.sheet && !onboardingActive) closeSheet(); });
-  app.sheet.addEventListener('cancel', event => { if (onboardingActive) event.preventDefault(); });
+  app.sheet.addEventListener('click', event => { if (event.target === app.sheet) closeSheet(); });
+  app.sheet.addEventListener('cancel', event => { event.preventDefault(); closeSheet(); });
   app.canvas.addEventListener('pointerup', onScenePointer);
 
   app.sheetBody.addEventListener('click', event => {
-    const startShift = event.target.closest('[data-start-shift]');
-    if (startShift) { finishFirstShiftBriefing(); return; }
     const close = event.target.closest('[data-close-sheet]');
     if (close) { closeSheet(); return; }
     const focus = event.target.closest('[data-focus]');
     if (focus) {
-      simulation.setFocus(focus.dataset.focus); updateUI(true); showFocusSheet(); announce(`Priority set to ${focusLabel(simulation.focus)}.`); return;
+      const cityId = focus.dataset.focusCity || currentCityId;
+      const tutorialChoice = tutorialIsActive() && simulation.tutorialStage === 'choose-focus';
+      if (!simulation.setFocus(cityId, focus.dataset.focus)) return;
+      if (tutorialChoice) {
+        handleTutorialFocusChosen(cityId);
+        closeSheet();
+      } else showFocusSheet();
+      updateUI(true);
+      announce(`${CITIES[cityId].name} priority set to ${focusLabel(simulation.getFocus(cityId))}.`);
+      return;
     }
     const openPkg = event.target.closest('[data-open-package]');
-    if (openPkg) { showPackage(openPkg.dataset.openPackage); return; }
+    if (openPkg) { showPackage(openPkg.dataset.openPackage); updateUI(true); return; }
     const action = event.target.closest('[data-package-action]');
     if (action) {
       const id = action.dataset.packageId;
+      selectedPackageId = id;
+      selectedTruckId = null;
       if (action.dataset.packageAction === 'priority') {
-        simulation.flagPriority(id); showPackage(id); announce(`${id} priority updated.`); return;
+        simulation.flagPriority(id); showPackage(id); updateUI(true); announce(`${id} priority updated.`); return;
       }
-      const result = simulation.resolveIssue(id, action.dataset.packageAction);
-      announce(result.message);
-      showPackage(id); updateUI(true);
+      resolveSelectedIssue(action.dataset.packageAction, { reopen: true });
       return;
     }
+    const toggleLoad = event.target.closest('[data-toggle-truck-load]');
+    if (toggleLoad) {
+      selectedTruckId = toggleLoad.dataset.truckId;
+      const changed = simulation.toggleTruckLoad(selectedTruckId, toggleLoad.dataset.toggleTruckLoad);
+      const truck = simulation.findTruck(selectedTruckId);
+      const pkg = simulation.packages.get(toggleLoad.dataset.toggleTruckLoad);
+      if (changed && truck?.plannedLoad.includes(pkg?.id)) advanceTutorialAfterLoad(pkg, truck);
+      showTruck(selectedTruckId); updateUI(true); return;
+    }
+    const autoFill = event.target.closest('[data-auto-fill-truck]');
+    if (autoFill) {
+      selectedTruckId = autoFill.dataset.autoFillTruck;
+      simulation.autoFillTruck(selectedTruckId);
+      const truck = simulation.findTruck(selectedTruckId);
+      const pkg = selectedPackageId ? simulation.packages.get(selectedPackageId) : null;
+      if (truck?.plannedLoad.includes(pkg?.id)) advanceTutorialAfterLoad(pkg, truck);
+      showTruck(selectedTruckId); updateUI(true); announce('Truck filled with the highest-priority compatible packages.'); return;
+    }
+    const dispatch = event.target.closest('[data-dispatch-truck]');
+    if (dispatch) { selectedTruckId = dispatch.dataset.dispatchTruck; dispatchSelectedTruck(selectedTruckId); return; }
     const openRegion = event.target.closest('[data-open-region]');
     if (openRegion) { currentCityId = openRegion.dataset.openRegion; closeSheet(); if (currentLevel === 'region') buildScene(); else setLevel('region'); return; }
   });
@@ -107,7 +279,7 @@ function bindUI() {
   addEventListener('resize', resizeRenderer, { passive: true });
   document.addEventListener('visibilitychange', () => { lastFrame = performance.now(); });
   document.addEventListener('keydown', event => {
-    if (event.key === 'Escape' && app.sheet.open && !onboardingActive) closeSheet();
+    if (event.key === 'Escape' && app.sheet.open) closeSheet();
     if (event.code === 'Space' && !app.sheet.open && !['INPUT','BUTTON'].includes(document.activeElement?.tagName)) {
       event.preventDefault(); simulation.togglePause(); updateUI(true);
     }
@@ -115,8 +287,6 @@ function bindUI() {
 }
 
 async function boot() {
-  const firstRun = needsFirstShiftBriefing();
-  if (firstRun) simulation.paused = true;
   bindUI();
   resizeRenderer();
   if (renderer) await preloadAssets();
@@ -124,7 +294,6 @@ async function boot() {
   updateUI(true);
   app.loader.classList.add('is-done');
   setTimeout(() => app.loader.remove(), 420);
-  if (firstRun) showBriefingSheet({ firstRun: true });
   requestAnimationFrame(animate);
   if ('serviceWorker' in navigator) navigator.serviceWorker.register('./sw.js').catch(() => {});
 }

--- a/postal/runtime/model-core.js
+++ b/postal/runtime/model-core.js
@@ -1,10 +1,12 @@
 'use strict';
 class PostalSimulation {
-  constructor({ seed = 7 } = {}) {
+  constructor({ seed = 7, firstDay = false } = {}) {
     this.clock = 0;
     this.paused = false;
     this.speed = 1;
-    this.focus = 'late';
+    this.firstDay = Boolean(firstDay);
+    this.tutorialStage = this.firstDay ? 'select-package' : 'complete';
+    this.spawnEnabled = !this.firstDay;
     this.rngState = seed >>> 0;
     this.packages = new Map();
     this.cities = Object.fromEntries(CITY_IDS.map(id => [id, blankCityState(id)]));
@@ -28,10 +30,14 @@ class PostalSimulation {
     ];
     for (const t of this.internationalTransports) t.duration = 26;
     this.events = [];
-    this.stats = { received: 0, delivered: 0, lateDelivered: 0, complaintsResolved: 0, investigationsResolved: 0 };
+    this.stats = {
+      received: 0, delivered: 0, lateDelivered: 0, complaintsResolved: 0, investigationsResolved: 0,
+      dispatches: 0, dispatchedSpaces: 0, dispatchedCapacity: 0, score: 0, dispatchChain: 0
+    };
     this.spawnAccumulator = 0;
     this.incidentAccumulator = 0;
-    this._bootstrapDemo();
+    if (this.firstDay) this._bootstrapFirstDay();
+    else this._bootstrapDemo();
   }
 
   random() {
@@ -45,6 +51,7 @@ class PostalSimulation {
   }
 
   addPackage(spec) {
+    const carrier = carrierFor(spec.carrierId || spec.carrier || CARRIER_IDS[Math.floor(this.random() * CARRIER_IDS.length)]);
     const pkg = {
       id: spec.id || makePackageId(spec.prefix || 'PKG'),
       origin: spec.origin,
@@ -61,7 +68,12 @@ class PostalSimulation {
       priorityFlag: Boolean(spec.priorityFlag),
       international: spec.origin.country !== 'Sweden' || spec.destination.country !== 'Sweden',
       trace: spec.trace ? [...spec.trace] : [],
-      carrier: spec.carrier || ['NordPost', 'DLH', 'DB Stänker'][Math.floor(this.random() * 3)],
+      carrier: carrier.name,
+      carrierId: carrier.id,
+      carrierCode: carrier.code,
+      carrierTone: carrier.tone,
+      carrierPattern: carrier.pattern,
+      tutorialLock: Boolean(spec.tutorialLock),
       wait: 0,
       deliveredAt: null
     };
@@ -72,7 +84,26 @@ class PostalSimulation {
     return pkg;
   }
 
+  _bootstrapFirstDay() {
+    this.addPackage({
+      id: 'DAY1-1001',
+      origin: { place: 'Söråker', country: 'Sweden' },
+      destination: { place: 'Timrå', country: 'Sweden' },
+      cityId: 'sundsvall', location: 'Sundsvall terminal · inbound',
+      service: 'express', deadline: 120, carrierId: 'dlh', tutorialLock: true,
+      trace: [
+        { t: -9, label: 'Collected', place: 'Söråker' },
+        { t: -2, label: 'Arrived at depot', place: 'Sundsvall terminal' }
+      ]
+    });
+    this.addEvent('info', 'Your first DLH package is waiting', 'Select it in the live package rail.', 'DAY1-1001');
+  }
+
   _enqueue(pkg) {
+    if (!['ready-local', 'ready-national'].includes(pkg.status)) {
+      const managedTrucks = [...Object.values(this.cities).flatMap(city => city.regionalTrucks), ...this.nationalTrucks];
+      for (const truck of managedTrucks) truck.plannedLoad = truck.plannedLoad.filter(id => id !== pkg.id);
+    }
     for (const city of Object.values(this.cities)) {
       for (const queue of Object.values(city.queues)) {
         const i = queue.indexOf(pkg.id);
@@ -92,7 +123,7 @@ class PostalSimulation {
     this.addPackage({
       id: 'SOR-48219',
       origin: { place: 'Söråker', country: 'Sweden' }, destination: { place: 'Aarhus', country: 'Denmark' },
-      cityId: 'sundsvall', location: 'Sundsvall terminal', service: 'express', deadline: 72,
+      cityId: 'sundsvall', location: 'Sundsvall terminal', service: 'express', deadline: 72, carrierId: 'stanker',
       trace: [
         { t: -18, label: 'Collected', place: 'Söråker' },
         { t: -9, label: 'Arrived at regional depot', place: 'Sundsvall terminal' }
@@ -102,7 +133,7 @@ class PostalSimulation {
       id: 'US-77104',
       origin: { place: 'Chicago', country: 'USA' }, destination: { place: 'Timrå', country: 'Sweden' },
       cityId: 'stockholm', location: 'Stockholm terminal · inbound cage 14', service: 'express', deadline: 28,
-      status: 'held', issue: 'scan-gap', complaint: true,
+      status: 'held', issue: 'scan-gap', complaint: true, carrierId: 'dlh',
       issueDetail: 'No scan after customs release. Customer in Timrå says the parcel has not moved since yesterday.',
       trace: [
         { t: -96, label: 'Accepted', place: 'Chicago' },
@@ -116,7 +147,7 @@ class PostalSimulation {
       id: 'GBG-23018',
       origin: { place: 'Mölndal', country: 'Sweden' }, destination: { place: 'Uppsala', country: 'Sweden' },
       cityId: 'goteborg', location: 'Göteborg terminal · local dock', service: 'standard', deadline: 52,
-      status: 'held', issue: 'wrong-dock', issueDetail: 'Sorted to a local delivery dock even though Uppsala requires national handoff.',
+      status: 'held', issue: 'wrong-dock', carrierId: 'brung', issueDetail: 'Sorted to a local delivery dock even though Uppsala requires national handoff.',
       trace: [
         { t: -24, label: 'Collected', place: 'Mölndal' },
         { t: -15, label: 'Sorted', place: 'Göteborg terminal' },
@@ -126,23 +157,23 @@ class PostalSimulation {
     this.addPackage({
       id: 'STO-88402',
       origin: { place: 'Nacka', country: 'Sweden' }, destination: { place: 'Härnösand', country: 'Sweden' },
-      cityId: 'stockholm', location: 'Stockholm terminal', service: 'standard', deadline: 86
+      cityId: 'stockholm', location: 'Stockholm terminal', service: 'standard', deadline: 86, carrierId: 'nordpost'
     });
     this.addPackage({
       id: 'SUN-31391',
       origin: { place: 'Ånge', country: 'Sweden' }, destination: { place: 'Sundsvall', country: 'Sweden' },
-      cityId: 'sundsvall', location: 'Sundsvall terminal', service: 'standard', deadline: 61
+      cityId: 'sundsvall', location: 'Sundsvall terminal', service: 'standard', deadline: 61, carrierId: 'brung'
     });
     const morningIntake = [
-      ['SUN-10421', 'sundsvall', 'Söråker', 'Timrå', 'Sweden', 'standard', 74, 'NordPost'],
+      ['SUN-10421', 'sundsvall', 'Söråker', 'Timrå', 'Sweden', 'standard', 74, 'NORDPOST'],
       ['SUN-10422', 'sundsvall', 'Härnösand', 'Solna', 'Sweden', 'express', 46, 'DLH'],
-      ['SUN-10423', 'sundsvall', 'Ånge', 'Hamburg', 'Germany', 'standard', 108, 'DB Stänker'],
-      ['STO-20411', 'stockholm', 'Solna', 'Nacka', 'Sweden', 'standard', 68, 'NordPost'],
+      ['SUN-10423', 'sundsvall', 'Ånge', 'Hamburg', 'Germany', 'standard', 108, 'STÄNKER'],
+      ['STO-20411', 'stockholm', 'Solna', 'Nacka', 'Sweden', 'standard', 68, 'BRUNG'],
       ['STO-20412', 'stockholm', 'Uppsala', 'Borås', 'Sweden', 'express', 51, 'DLH'],
-      ['STO-20413', 'stockholm', 'Stockholm', 'Helsinki', 'Finland', 'standard', 112, 'DB Stänker'],
-      ['GBG-30411', 'goteborg', 'Kungsbacka', 'Mölndal', 'Sweden', 'standard', 64, 'NordPost'],
+      ['STO-20413', 'stockholm', 'Stockholm', 'Helsinki', 'Finland', 'standard', 112, 'STÄNKER'],
+      ['GBG-30411', 'goteborg', 'Kungsbacka', 'Mölndal', 'Sweden', 'standard', 64, 'BRUNG'],
       ['GBG-30412', 'goteborg', 'Borås', 'Sundsvall', 'Sweden', 'express', 49, 'DLH'],
-      ['GBG-30413', 'goteborg', 'Göteborg', 'København', 'Denmark', 'standard', 105, 'DB Stänker']
+      ['GBG-30413', 'goteborg', 'Göteborg', 'København', 'Denmark', 'standard', 105, 'STÄNKER']
     ];
     for (const [id, cityId, origin, destination, country, service, deadline, carrier] of morningIntake) {
       this.addPackage({
@@ -158,11 +189,14 @@ class PostalSimulation {
     this.addEvent('warning', 'Wrong dock in Göteborg', 'A parcel for Uppsala is sitting with local deliveries.', 'GBG-23018');
   }
 
-  setFocus(mode) {
-    if (!FOCUS_MODES.includes(mode)) return;
-    this.focus = mode;
-    this.addEvent('info', `Priority changed: ${mode}`, 'Workers now pull the highest-value matching parcels first.');
+  setFocus(cityId, mode) {
+    if (!this.cities[cityId] || !FOCUS_MODES.includes(mode)) return false;
+    this.cities[cityId].focus = mode;
+    this.addEvent('info', `${CITIES[cityId].name} focus: ${mode}`, 'That depot now pulls matching packages first.');
+    return true;
   }
+
+  getFocus(cityId) { return this.cities[cityId]?.focus || 'late'; }
 
   togglePause() { this.paused = !this.paused; }
 
@@ -182,13 +216,13 @@ class PostalSimulation {
     this._tickNationalTrucks(dt);
     this._tickInternational(dt);
 
-    if (this.spawnAccumulator > 3.4) {
-      this.spawnAccumulator -= 3.4;
+    if (this.spawnEnabled && this.spawnAccumulator > 5.8) {
+      this.spawnAccumulator -= 5.8;
       this._spawnRoutinePackage();
       this._spawnRoutinePackage();
       if (this.random() < 0.55) this._spawnRoutinePackage();
     }
-    if (this.incidentAccumulator > 42) {
+    if (this.spawnEnabled && this.incidentAccumulator > 42) {
       this.incidentAccumulator = 0;
       this._maybeCreateIncident();
     }

--- a/postal/runtime/model-data.js
+++ b/postal/runtime/model-data.js
@@ -35,6 +35,35 @@ const CITIES = {
 const CITY_IDS = Object.keys(CITIES);
 const FOCUS_MODES = ['late', 'complaints', 'express', 'international'];
 
+const CARRIERS = Object.freeze({
+  nordpost: Object.freeze({
+    id: 'nordpost', name: 'NORDPOST', code: 'NP', tone: 'blue', pattern: 'bars',
+    service: 'standard', deadline: 116, rhythm: 'Steady domestic flow'
+  }),
+  dlh: Object.freeze({
+    id: 'dlh', name: 'DLH', code: 'DLH', tone: 'yellow', pattern: 'arrow',
+    service: 'express', deadline: 57, rhythm: 'Small, urgent express loads'
+  }),
+  brung: Object.freeze({
+    id: 'brung', name: 'BRUNG', code: 'BRG', tone: 'green', pattern: 'dots',
+    service: 'standard', deadline: 82, rhythm: 'Frequent local bursts'
+  }),
+  stanker: Object.freeze({
+    id: 'stanker', name: 'STÄNKER', code: 'DBS', tone: 'red', pattern: 'stripe',
+    service: 'standard', deadline: 138, rhythm: 'Bulky national cages'
+  })
+});
+
+const CARRIER_IDS = Object.keys(CARRIERS);
+
+function carrierFor(value) {
+  const normalized = String(value || '').toLowerCase().replace(/[^a-zåäö]+/g, '');
+  return Object.values(CARRIERS).find(carrier => {
+    const names = [carrier.id, carrier.name, carrier.code].map(item => item.toLowerCase().replace(/[^a-zåäö]+/g, ''));
+    return names.includes(normalized);
+  }) || CARRIERS.nordpost;
+}
+
 const COUNTRY_CITY_HINTS = {
   Denmark: 'goteborg', Germany: 'goteborg', Netherlands: 'goteborg', Norway: 'goteborg',
   Finland: 'stockholm', USA: 'stockholm', 'United States': 'stockholm', UK: 'stockholm', France: 'goteborg'
@@ -127,7 +156,7 @@ function createWorker(cityId, index) {
 function createTruck(id, kind, from, to, capacity = 7) {
   return {
     id, kind, from, to, state: 'waiting', progress: 0, duration: kind === 'regional' ? 12 : 20,
-    load: [], capacity, departures: 0, wait: 0
+    load: [], plannedLoad: [], capacity, departures: 0, wait: 0
   };
 }
 
@@ -137,6 +166,7 @@ function blankCityState(cityId) {
   regional.unshift(createTruck(`${cityId}-r0`, 'regional', cityId, city.name, 5));
   return {
     cityId,
+    focus: 'late',
     queues: { arrived: [], readyLocal: [], readyNational: [], readyInternational: [], held: [] },
     workers: [0, 1, 2].map(i => createWorker(cityId, i)),
     regionalTrucks: regional,

--- a/postal/runtime/model-flow.js
+++ b/postal/runtime/model-flow.js
@@ -5,8 +5,8 @@ PostalSimulation.prototype._tickWorkers = function(dt) {
         if (!worker.packageId) {
           const candidates = city.queues.arrived
             .map(id => this.packages.get(id))
-            .filter(pkg => pkg && !pkg.issue)
-            .sort((a, b) => packageScore(b, this.focus, this.clock) - packageScore(a, this.focus, this.clock));
+            .filter(pkg => pkg && !pkg.issue && !pkg.tutorialLock)
+            .sort((a, b) => packageScore(b, city.focus, this.clock) - packageScore(a, city.focus, this.clock));
           const pkg = candidates[0];
           if (!pkg) {
             worker.task = 'Watching the inbound flow';
@@ -65,22 +65,6 @@ PostalSimulation.prototype._tickRegionalTrucks = function(dt) {
       for (const truck of city.regionalTrucks) {
         if (truck.state === 'waiting') {
           truck.wait += dt;
-          const queue = city.queues.readyLocal
-            .map(id => this.packages.get(id))
-            .filter(pkg => pkg && pkg.destination.place === truck.to)
-            .sort((a, b) => packageScore(b, this.focus, this.clock) - packageScore(a, this.focus, this.clock));
-          const urgent = queue.some(pkg => packageScore(pkg, this.focus, this.clock) > 90);
-          if (queue.length && (queue.length >= 2 || truck.wait > 8 || urgent)) {
-            truck.load = queue.slice(0, truck.capacity).map(p => p.id);
-            for (const id of truck.load) {
-              const pkg = this.packages.get(id);
-              pkg.status = 'transit-local';
-              pkg.location = `Truck to ${truck.to}`;
-              this._enqueue(pkg);
-              trace(pkg, this.clock, 'Loaded on regional truck', CITIES[city.cityId].hub);
-            }
-            truck.state = 'driving'; truck.progress = 0; truck.wait = 0; truck.departures += 1;
-          }
         } else {
           truck.progress += dt / truck.duration;
           if (truck.progress >= 1) {
@@ -90,6 +74,7 @@ PostalSimulation.prototype._tickRegionalTrucks = function(dt) {
               pkg.status = 'delivered'; pkg.location = pkg.destination.place; pkg.deliveredAt = this.clock;
               trace(pkg, this.clock, 'Delivered', pkg.destination.place);
               this.stats.delivered += 1;
+              if (pkg.complaint) this.stats.complaintsResolved += 1;
               if (pkg.deliveredAt > pkg.deadline) this.stats.lateDelivered += 1;
               city.delivered += 1;
             }
@@ -103,23 +88,8 @@ PostalSimulation.prototype._tickRegionalTrucks = function(dt) {
 
 PostalSimulation.prototype._tickNationalTrucks = function(dt) {
     for (const truck of this.nationalTrucks) {
-      const city = this.cities[truck.from];
       if (truck.state === 'waiting') {
         truck.wait += dt;
-        const candidates = city.queues.readyNational
-          .map(id => this.packages.get(id))
-          .filter(pkg => pkg && nextLegForPackage(pkg).to === truck.to)
-          .sort((a, b) => packageScore(b, this.focus, this.clock) - packageScore(a, this.focus, this.clock));
-        const urgent = candidates.some(pkg => packageScore(pkg, this.focus, this.clock) > 95);
-        if (candidates.length && (candidates.length >= 3 || truck.wait > 10 || urgent)) {
-          truck.load = candidates.slice(0, truck.capacity).map(p => p.id);
-          for (const id of truck.load) {
-            const pkg = this.packages.get(id);
-            pkg.status = 'transit-national'; pkg.location = `${CITIES[truck.from].name} → ${CITIES[truck.to].name}`;
-            this._enqueue(pkg); trace(pkg, this.clock, 'National linehaul departed', CITIES[truck.from].hub);
-          }
-          truck.state = 'driving'; truck.progress = 0; truck.wait = 0; truck.departures += 1;
-        }
       } else {
         truck.progress += dt / truck.duration;
         if (truck.progress >= 1) {
@@ -149,12 +119,12 @@ PostalSimulation.prototype._tickInternational = function(dt) {
         const candidates = inbound
           ? [...this.packages.values()]
               .filter(pkg => pkg.status === 'ready-inbound' && pkg.origin.country === truck.from && gatewayForCountry(pkg.origin.country) === truck.to)
-              .sort((a, b) => packageScore(b, this.focus, this.clock) - packageScore(a, this.focus, this.clock))
+              .sort((a, b) => packageScore(b, city.focus, this.clock) - packageScore(a, city.focus, this.clock))
           : city.queues.readyInternational
               .map(id => this.packages.get(id))
               .filter(pkg => pkg && pkg.destination.country === truck.to)
-              .sort((a, b) => packageScore(b, this.focus, this.clock) - packageScore(a, this.focus, this.clock));
-        const urgent = candidates.some(pkg => packageScore(pkg, this.focus, this.clock) > 95);
+              .sort((a, b) => packageScore(b, city.focus, this.clock) - packageScore(a, city.focus, this.clock));
+        const urgent = candidates.some(pkg => packageScore(pkg, city.focus, this.clock) > 95);
         if (candidates.length && (truck.wait > 9 || urgent)) {
           truck.load = candidates.slice(0, truck.capacity).map(p => p.id);
           for (const id of truck.load) {
@@ -182,6 +152,7 @@ PostalSimulation.prototype._tickInternational = function(dt) {
               pkg.status = 'delivered'; pkg.location = `${pkg.destination.place}, ${pkg.destination.country}`; pkg.deliveredAt = this.clock;
               trace(pkg, this.clock, 'Handed to destination network', pkg.location);
               this.stats.delivered += 1;
+              if (pkg.complaint) this.stats.complaintsResolved += 1;
               if (pkg.deliveredAt > pkg.deadline) this.stats.lateDelivered += 1;
             }
           }

--- a/postal/runtime/model-ops.js
+++ b/postal/runtime/model-ops.js
@@ -3,44 +3,283 @@ PostalSimulation.prototype._spawnRoutinePackage = function() {
     const cityId = CITY_IDS[Math.floor(this.random() * CITY_IDS.length)];
     const city = CITIES[cityId];
     const origin = city.towns[Math.floor(this.random() * city.towns.length)];
+    const carrierId = CARRIER_IDS[Math.floor(this.random() * CARRIER_IDS.length)];
+    const carrier = CARRIERS[carrierId];
     const roll = this.random();
-    const service = this.random() < 0.22 ? 'express' : 'standard';
-    if (roll < 0.18) {
+    const service = carrier.id === 'dlh' || (carrier.id === 'nordpost' && this.random() < .14) ? 'express' : carrier.service;
+
+    // Each carrier changes the shape of the queue, not only its paint.
+    // BRUNG stays local, DLH creates urgent single decisions, STÄNKER fills
+    // national vehicles, and NORDPOST supplies the steady mixed baseline.
+    if (carrier.id === 'brung') {
+      let destinationTown = city.towns[Math.floor(this.random() * city.towns.length)];
+      if (destinationTown === origin) destinationTown = city.name;
+      this.addPackage({
+        prefix: carrier.code, carrierId, origin: { place: origin, country: 'Sweden' },
+        destination: { place: destinationTown, country: 'Sweden' }, cityId, location: city.hub,
+        service, deadline: this.clock + carrier.deadline
+      });
+      return;
+    }
+
+    if (roll < (carrier.id === 'stanker' ? .08 : .18)) {
       const country = ['USA', 'Denmark', 'Germany', 'Finland'][Math.floor(this.random() * 4)];
       const originPlace = { USA: 'Chicago', Denmark: 'København', Germany: 'Hamburg', Finland: 'Helsinki' }[country];
       const targetId = CITY_IDS[Math.floor(this.random() * CITY_IDS.length)];
       const target = CITIES[targetId];
       const destination = { place: target.towns[Math.floor(this.random() * target.towns.length)], country: 'Sweden' };
       this.addPackage({
-        prefix: 'IN', origin: { place: originPlace, country }, destination,
+        prefix: carrier.code, carrierId, origin: { place: originPlace, country }, destination,
         cityId: null, location: `${originPlace} partner hub`, status: 'ready-inbound', service,
-        deadline: this.clock + (service === 'express' ? 82 : 145),
+        deadline: this.clock + carrier.deadline + 24,
         trace: [{ t: this.clock, label: 'Accepted by partner network', place: originPlace }]
       });
     } else {
       let destination;
-      if (roll < 0.36) {
+      if (carrier.id === 'stanker' && roll < .34) {
         const country = ['Denmark', 'Germany', 'Finland'][Math.floor(this.random() * 3)];
         destination = { place: country === 'Denmark' ? 'København' : country === 'Germany' ? 'Hamburg' : 'Helsinki', country };
       } else {
-        const targetId = CITY_IDS[Math.floor(this.random() * CITY_IDS.length)];
+        let targetId = CITY_IDS[Math.floor(this.random() * CITY_IDS.length)];
+        if (carrier.id === 'stanker' && targetId === cityId) targetId = CITY_IDS[(CITY_IDS.indexOf(cityId) + 1) % CITY_IDS.length];
         const target = CITIES[targetId];
         destination = { place: target.towns[Math.floor(this.random() * target.towns.length)], country: 'Sweden' };
       }
       this.addPackage({
-        prefix: city.short,
+        prefix: carrier.code, carrierId,
         origin: { place: origin, country: 'Sweden' }, destination,
         cityId, location: city.hub, service,
-        deadline: this.clock + (service === 'express' ? 60 : 115)
+        deadline: this.clock + carrier.deadline
       });
     }
 };
 
 
+PostalSimulation.prototype.focusForPackage = function(pkg) {
+    return this.cities[pkg?.cityId]?.focus || 'late';
+};
+
+
+PostalSimulation.prototype.getActivePackages = function(limit = 30) {
+    return [...this.packages.values()]
+      .filter(pkg => pkg.status !== 'delivered')
+      .sort((a, b) => {
+        const aSelected = a.priorityFlag ? 1 : 0;
+        const bSelected = b.priorityFlag ? 1 : 0;
+        return Number(Boolean(b.issue)) - Number(Boolean(a.issue)) || bSelected - aSelected ||
+          packageScore(b, this.focusForPackage(b), this.clock) - packageScore(a, this.focusForPackage(a), this.clock);
+      })
+      .slice(0, limit);
+};
+
+
+PostalSimulation.prototype.findTruck = function(truckId) {
+    return [...Object.values(this.cities).flatMap(city => city.regionalTrucks), ...this.nationalTrucks]
+      .find(truck => truck.id === truckId) || null;
+};
+
+
+PostalSimulation.prototype.eligiblePackagesForTruck = function(truckOrId) {
+    const truck = typeof truckOrId === 'string' ? this.findTruck(truckOrId) : truckOrId;
+    if (!truck || truck.state !== 'waiting') return [];
+    const city = this.cities[truck.from];
+    if (!city) return [];
+    const ids = truck.kind === 'regional' ? city.queues.readyLocal : city.queues.readyNational;
+    return ids.map(id => this.packages.get(id)).filter(pkg => {
+      if (!pkg) return false;
+      if (truck.kind === 'regional') return pkg.destination.place === truck.to;
+      return nextLegForPackage(pkg).to === truck.to;
+    }).sort((a, b) => packageScore(b, city.focus, this.clock) - packageScore(a, city.focus, this.clock));
+};
+
+
+PostalSimulation.prototype.truckForPackage = function(packageId) {
+    const pkg = this.packages.get(packageId);
+    if (!pkg || !pkg.cityId) return null;
+    if (pkg.status === 'ready-local') {
+      return this.cities[pkg.cityId].regionalTrucks.find(truck => truck.to === pkg.destination.place && truck.state === 'waiting') || null;
+    }
+    if (pkg.status === 'ready-national') {
+      const leg = nextLegForPackage(pkg);
+      return this.nationalTrucks.find(truck => truck.from === pkg.cityId && truck.to === leg.to && truck.state === 'waiting') || null;
+    }
+    return null;
+};
+
+
+PostalSimulation.prototype.planPackageOnTruck = function(packageId) {
+    const truck = this.truckForPackage(packageId);
+    if (!truck) return { ok: false, message: 'No compatible truck is ready yet.' };
+    const eligible = this.eligiblePackagesForTruck(truck);
+    if (!eligible.some(pkg => pkg.id === packageId)) return { ok: false, message: 'That package is not ready for this route.' };
+    for (const other of [...Object.values(this.cities).flatMap(city => city.regionalTrucks), ...this.nationalTrucks]) {
+      other.plannedLoad = other.plannedLoad.filter(id => id !== packageId);
+    }
+    if (!truck.plannedLoad.includes(packageId)) truck.plannedLoad.unshift(packageId);
+    truck.plannedLoad = truck.plannedLoad.slice(0, truck.capacity);
+    return { ok: true, truck, message: `${packageId} loaded for ${truck.to}.` };
+};
+
+
+PostalSimulation.prototype.toggleTruckLoad = function(truckId, packageId) {
+    const truck = this.findTruck(truckId);
+    if (!truck || truck.state !== 'waiting') return false;
+    const eligible = this.eligiblePackagesForTruck(truck);
+    if (!eligible.some(pkg => pkg.id === packageId)) return false;
+    const index = truck.plannedLoad.indexOf(packageId);
+    if (index >= 0) truck.plannedLoad.splice(index, 1);
+    else if (truck.plannedLoad.length < truck.capacity) truck.plannedLoad.push(packageId);
+    return true;
+};
+
+
+PostalSimulation.prototype.autoFillTruck = function(truckId) {
+    const truck = this.findTruck(truckId);
+    if (!truck || truck.state !== 'waiting') return [];
+    const eligible = this.eligiblePackagesForTruck(truck);
+    const kept = truck.plannedLoad.filter(id => eligible.some(pkg => pkg.id === id));
+    for (const pkg of eligible) {
+      if (kept.length >= truck.capacity) break;
+      if (!kept.includes(pkg.id)) kept.push(pkg.id);
+    }
+    truck.plannedLoad = kept;
+    return [...truck.plannedLoad];
+};
+
+
+PostalSimulation.prototype.dispatchTruck = function(truckId) {
+    const truck = this.findTruck(truckId);
+    if (!truck || truck.state !== 'waiting') return { ok: false, message: 'That truck is already on the road.' };
+    const eligibleIds = new Set(this.eligiblePackagesForTruck(truck).map(pkg => pkg.id));
+    const load = truck.plannedLoad.filter(id => eligibleIds.has(id)).slice(0, truck.capacity);
+    if (!load.length) return { ok: false, message: 'Load at least one matching package first.' };
+
+    const loadPackages = load.map(id => this.packages.get(id)).filter(Boolean);
+    const fillRatio = load.length / truck.capacity;
+    const protectsExpress = loadPackages.some(pkg => pkg.service === 'express');
+    const protectsDeadline = loadPackages.some(pkg => pkg.deadline - this.clock < 25);
+    const grade = fillRatio >= .8 ? 'FULL LOAD' : protectsDeadline ? 'DEADLINE SAVE' : protectsExpress ? 'EXPRESS RUN' : fillRatio >= .45 ? 'SMART LOAD' : 'EARLY RUN';
+    const points = load.length * 35 + (fillRatio >= .8 ? 180 : fillRatio >= .45 ? 90 : 0) + (protectsDeadline ? 120 : protectsExpress ? 70 : 0);
+    const chainMove = fillRatio >= .45 || protectsDeadline || protectsExpress;
+
+    truck.load = load;
+    truck.plannedLoad = [];
+    for (const id of load) {
+      const pkg = this.packages.get(id);
+      if (!pkg) continue;
+      if (truck.kind === 'regional') {
+        pkg.status = 'transit-local';
+        pkg.location = `${CITIES[truck.from].name} → ${truck.to}`;
+        trace(pkg, this.clock, 'Regional truck departed', CITIES[truck.from].hub);
+      } else {
+        pkg.status = 'transit-national';
+        pkg.location = `${CITIES[truck.from].name} → ${CITIES[truck.to].name}`;
+        trace(pkg, this.clock, 'National linehaul departed', CITIES[truck.from].hub);
+      }
+      this._enqueue(pkg);
+    }
+    truck.state = 'driving';
+    truck.progress = 0;
+    truck.wait = 0;
+    truck.departures += 1;
+    this.stats.dispatches += 1;
+    this.stats.dispatchedSpaces += load.length;
+    this.stats.dispatchedCapacity += truck.capacity;
+    this.stats.score += points;
+    this.stats.dispatchChain = chainMove ? this.stats.dispatchChain + 1 : 0;
+    this.addEvent('success', `${grade}: ${CITIES[truck.from].name} → ${CITIES[truck.to]?.name || truck.to}`, `${load.length}/${truck.capacity} spaces · +${points} points.`);
+    return {
+      ok: true, truck, load, grade, points, chain: this.stats.dispatchChain,
+      message: `${grade} · +${points}. Truck sent with ${load.length} package${load.length === 1 ? '' : 's'}.`
+    };
+};
+
+
+PostalSimulation.prototype.startFirstDaySort = function(packageId = 'DAY1-1001') {
+    const pkg = this.packages.get(packageId);
+    if (!this.firstDay || !pkg || this.tutorialStage !== 'select-package') return false;
+    const city = this.cities[pkg.cityId];
+    const worker = city?.workers.find(item => item.role === 'Express sort') || city?.workers[0];
+    if (!city || !worker || worker.packageId) return false;
+    const queueIndex = city.queues.arrived.indexOf(pkg.id);
+    if (queueIndex >= 0) city.queues.arrived.splice(queueIndex, 1);
+    pkg.tutorialLock = false;
+    pkg.priorityFlag = true;
+    pkg.status = 'sorting';
+    worker.packageId = pkg.id;
+    worker.progress = 0;
+    worker.total = 4.2;
+    worker.task = `Sorting ${pkg.id}`;
+    this.tutorialStage = 'watch-sort';
+    trace(pkg, this.clock, `${worker.name} started Express sort`, CITIES[pkg.cityId].hub);
+    return true;
+};
+
+
+PostalSimulation.prototype.releaseFirstDayWave = function() {
+    if (!this.firstDay || this.firstDayWaveReleased) return false;
+    this.firstDayWaveReleased = true;
+    const wave = [
+      ['DAY1-NP', 'NORDPOST', 'Ånge', 'Sundsvall', 'Sweden', 'standard', 112],
+      ['DAY1-DLH', 'DLH', 'Härnösand', 'Solna', 'Sweden', 'express', 62],
+      ['DAY1-BRG', 'BRUNG', 'Söråker', 'Timrå', 'Sweden', 'standard', 84],
+      ['DAY1-DBS', 'STÄNKER', 'Ånge', 'Göteborg', 'Sweden', 'standard', 136]
+    ];
+    for (const [id, carrier, origin, destination, country, service, margin] of wave) {
+      this.addPackage({
+        id, carrier, cityId: 'sundsvall', location: CITIES.sundsvall.hub, service,
+        deadline: this.clock + margin,
+        origin: { place: origin, country: 'Sweden' }, destination: { place: destination, country }
+      });
+    }
+    this.tutorialStage = 'choose-focus';
+    this.addEvent('info', 'Four carriers arrived together', 'Set Sundsvall’s focus before the queue grows.');
+    return true;
+};
+
+
+PostalSimulation.prototype.releaseChicagoCase = function() {
+    if (!this.firstDay || this.packages.has('US-77104')) return false;
+    this.addPackage({
+      id: 'US-77104', carrierId: 'dlh',
+      origin: { place: 'Chicago', country: 'USA' }, destination: { place: 'Timrå', country: 'Sweden' },
+      cityId: 'stockholm', location: 'Stockholm terminal · inbound cage 14', service: 'express',
+      deadline: this.clock + 92, status: 'held', issue: 'scan-gap', complaint: true,
+      issueDetail: 'No scan after customs release. The Timrå recipient is waiting.',
+      trace: [
+        { t: this.clock - 64, label: 'Accepted', place: 'Chicago' },
+        { t: this.clock - 42, label: 'Departed USA', place: 'Chicago air hub' },
+        { t: this.clock - 18, label: 'Customs cleared', place: 'Stockholm Arlanda' },
+        { t: this.clock - 9, label: 'Last scan', place: 'Inbound cage 14' }
+      ]
+    });
+    this.tutorialStage = 'select-chicago';
+    this.addEvent('critical', 'Chicago → Timrå stopped in Stockholm', 'Follow it across every handoff.', 'US-77104');
+    return true;
+};
+
+
+PostalSimulation.prototype.completeFirstDay = function() {
+    if (!this.firstDay) return false;
+    this.firstDay = false;
+    this.tutorialStage = 'complete';
+    this.spawnEnabled = true;
+    this.spawnAccumulator = 0;
+    this.addEvent('success', 'First morning complete', 'The whole network is now live.');
+    for (let i = 0; i < 4; i += 1) this._spawnRoutinePackage();
+    return true;
+};
+
+
 PostalSimulation.prototype._maybeCreateIncident = function() {
-    const candidates = [...this.packages.values()].filter(p => p.status !== 'delivered' && !p.issue && !p.status.startsWith('transit'));
+    const candidates = [...this.packages.values()].filter(p => p.status !== 'delivered' && !p.issue && !p.complaint && !p.status.startsWith('transit'));
     if (!candidates.length || this.random() > 0.68) return;
     const pkg = candidates[Math.floor(this.random() * candidates.length)];
+    if (this.random() < .28) {
+      pkg.complaint = true;
+      this.addEvent('warning', `Recipient is asking about ${pkg.id}`, 'Deliver it to clear the complaint; a complaints-focused depot will pull it forward.', pkg.id);
+      return;
+    }
     pkg.issue = this.random() < 0.5 ? 'label-damage' : 'missed-scan';
     pkg.issueDetail = pkg.issue === 'label-damage' ? 'The destination label is unreadable at the sort station.' : 'A required handoff scan is missing.';
     pkg.status = 'held';
@@ -60,15 +299,7 @@ PostalSimulation.prototype.resolveIssue = function(packageId, action) {
       'missed-scan': ['rescan'],
       'routing': ['reroute']
     };
-    if (!valid[issue]?.includes(action)) {
-      if (action === 'contact') {
-        pkg.complaint = false;
-        this.stats.complaintsResolved += 1;
-        this.addEvent('info', `Customer updated about ${pkg.id}`, 'Useful, but the parcel still needs an operational fix.', pkg.id);
-        return { ok: true, partial: true, message: 'Customer updated. The parcel is still held.' };
-      }
-      return { ok: false, message: 'That does not resolve the operational exception.' };
-    }
+    if (!valid[issue]?.includes(action)) return { ok: false, message: 'That does not resolve the operational exception.' };
 
     if (issue === 'scan-gap' && action === 'scan-cage') {
       pkg.location = 'Stockholm terminal · inbound cage 14';
@@ -108,14 +339,14 @@ PostalSimulation.prototype.findPackages = function(query) {
 
 PostalSimulation.prototype.getIssues = function() {
     return [...this.packages.values()]
-      .filter(pkg => pkg.issue || pkg.complaint)
-      .sort((a, b) => packageScore(b, this.focus, this.clock) - packageScore(a, this.focus, this.clock));
+      .filter(pkg => pkg.status !== 'delivered' && (pkg.issue || pkg.complaint))
+      .sort((a, b) => packageScore(b, this.focusForPackage(b), this.clock) - packageScore(a, this.focusForPackage(a), this.clock));
 };
 
 PostalSimulation.prototype.getIncomingPackages = function(cityId = null) {
     return [...this.packages.values()]
       .filter(pkg => CITY_IDS.includes(pkg.cityId) && (!cityId || pkg.cityId === cityId) && ['arrived', 'sorting', 'held'].includes(pkg.status))
-      .sort((a, b) => packageScore(b, this.focus, this.clock) - packageScore(a, this.focus, this.clock));
+      .sort((a, b) => packageScore(b, this.focusForPackage(b), this.clock) - packageScore(a, this.focusForPackage(a), this.clock));
 };
 
 
@@ -126,13 +357,21 @@ PostalSimulation.prototype.getMetrics = function() {
     const issues = active.filter(p => p.issue || p.complaint).length;
     const incoming = this.getIncomingPackages().length;
     const onTime = this.stats.delivered ? Math.round(100 * (this.stats.delivered - this.stats.lateDelivered) / this.stats.delivered) : 100;
-    return { active: active.length, incoming, late, dueSoon, issues, onTime, delivered: this.stats.delivered };
+    const utilisation = this.stats.dispatchedCapacity
+      ? Math.round(100 * this.stats.dispatchedSpaces / this.stats.dispatchedCapacity)
+      : 0;
+    return {
+      active: active.length, incoming, late, dueSoon, issues, onTime, delivered: this.stats.delivered, utilisation,
+      score: this.stats.score, chain: this.stats.dispatchChain
+    };
 };
 
 globalThis.PostalSimulation = PostalSimulation;
 globalThis.CITIES = CITIES;
 globalThis.CITY_IDS = CITY_IDS;
 globalThis.FOCUS_MODES = FOCUS_MODES;
+globalThis.CARRIERS = CARRIERS;
+globalThis.CARRIER_IDS = CARRIER_IDS;
 globalThis.packageScore = packageScore;
 globalThis.nextLegForPackage = nextLegForPackage;
-globalThis.POSTAL_MODEL = { PostalSimulation, CITIES, CITY_IDS, FOCUS_MODES, packageScore, nextLegForPackage, cityForPlace, gatewayForCountry, isInternationalPlace, makePackageId };
+globalThis.POSTAL_MODEL = { PostalSimulation, CITIES, CITY_IDS, FOCUS_MODES, CARRIERS, CARRIER_IDS, packageScore, nextLegForPackage, cityForPlace, gatewayForCountry, isInternationalPlace, makePackageId };

--- a/postal/runtime/scene-depot.js
+++ b/postal/runtime/scene-depot.js
@@ -4,6 +4,7 @@ const depotPalettes = {
   stockholm: { ground: 0xbacbd0, floor: 0xe9e7df, accent: 0x69a5c4, lane: 0x435f70 },
   goteborg: { ground: 0xb8c9b5, floor: 0xebe4d6, accent: 0xe37a47, lane: 0x4b6660 }
 };
+const carrierSceneColors = { nordpost: 0x2865ad, dlh: 0xf2c94c, brung: 0x28956c, stanker: 0xd84d43 };
 
 function buildDepotScene(cityId) {
   const palette = depotPalettes[cityId] || depotPalettes.sundsvall;
@@ -138,14 +139,16 @@ function createWorkerFallback(pos, i) {
 }
 
 function syncDepotPackages(cityId) {
-  for (const { mesh, issueRing } of viewState.packages.values()) {
+  for (const { mesh, issueRing, carrierPad, selectionRing } of viewState.packages.values()) {
     world.remove(mesh);
     if (issueRing) world.remove(issueRing);
+    if (carrierPad) world.remove(carrierPad);
+    if (selectionRing) world.remove(selectionRing);
   }
   viewState.packages.clear();
   const pkgs = [...simulation.packages.values()]
     .filter(pkg => pkg.cityId === cityId && !pkg.status.startsWith('transit') && pkg.status !== 'delivered')
-    .sort((a, b) => packageScore(b, simulation.focus, simulation.clock) - packageScore(a, simulation.focus, simulation.clock))
+    .sort((a, b) => packageScore(b, simulation.getFocus(cityId), simulation.clock) - packageScore(a, simulation.getFocus(cityId), simulation.clock))
     .slice(0, 16);
 
   pkgs.forEach((pkg, i) => {
@@ -174,6 +177,15 @@ function syncDepotPackages(cityId) {
     addUserData(mesh, { entityType: 'package', packageId: pkg.id });
     world.add(mesh);
 
+    const carrierPad = new THREE.Mesh(
+      new THREE.RingGeometry(.23, .31, 28),
+      new THREE.MeshBasicMaterial({ color: carrierSceneColors[pkg.carrierId] || 0x5d706e, transparent: true, opacity: .9, depthWrite: false })
+    );
+    carrierPad.rotation.x = -Math.PI / 2;
+    carrierPad.position.set(x, .202, z);
+    addUserData(carrierPad, { entityType: 'package', packageId: pkg.id });
+    world.add(carrierPad);
+
     let issueRing = null;
     if (held) {
       issueRing = new THREE.Mesh(new THREE.RingGeometry(.37, .46, 28), new THREE.MeshBasicMaterial({ color: 0xc53e36, transparent: true, opacity: .92, depthWrite: false }));
@@ -182,7 +194,18 @@ function syncDepotPackages(cityId) {
       addUserData(issueRing, { entityType: 'package', packageId: pkg.id });
       world.add(issueRing);
     }
-    viewState.packages.set(pkg.id, { mesh, issueRing, lane, base: new THREE.Vector3(x, mesh.position.y, z), baseY: mesh.position.y, offset: i * .47 });
+    let selectionRing = null;
+    if (pkg.id === selectedPackageId) {
+      selectionRing = new THREE.Mesh(
+        new THREE.RingGeometry(.49, .59, 32),
+        new THREE.MeshBasicMaterial({ color: 0xf2c94c, transparent: true, opacity: 1, depthWrite: false })
+      );
+      selectionRing.rotation.x = -Math.PI / 2;
+      selectionRing.position.set(x, .198, z);
+      addUserData(selectionRing, { entityType: 'package', packageId: pkg.id });
+      world.add(selectionRing);
+    }
+    viewState.packages.set(pkg.id, { mesh, issueRing, carrierPad, selectionRing, lane, base: new THREE.Vector3(x, mesh.position.y, z), baseY: mesh.position.y, offset: i * .47 });
   });
 }
 

--- a/postal/runtime/scene-region.js
+++ b/postal/runtime/scene-region.js
@@ -17,14 +17,16 @@ function buildRegionScene(cityId) {
   world.add(district);
 
   addRoadTile('roadCross', [0, .13, 0], 3.05, 0);
-  addRoadTile('roadCrossing', [3.02, .13, 0], 3.05, 0);
-  addRoadTile('roadStraight', [-3.02, .13, 0], 3.05, 0);
-  addRoadTile('roadStraight', [0, .13, 3.02], 3.05, Math.PI / 2);
-  addRoadTile('roadStraight', [0, .13, -3.02], 3.05, Math.PI / 2);
-  addRoadTile('roadEnd', [5.68, .13, 0], 3.05, Math.PI);
-  addRoadTile('roadEnd', [-5.68, .13, 0], 3.05, 0);
-  addRoadTile('roadEnd', [0, .13, 5.68], 3.05, -Math.PI / 2);
-  addRoadTile('roadEnd', [0, .13, -5.68], 3.05, Math.PI / 2);
+  // Kenney's straight tile points along local Z. Derive every rotation from
+  // the route vector so the painted lanes and moving trucks agree.
+  addRoadTile('roadCrossing', [3.02, .13, 0], 3.05, roadRotationFor(1, 0));
+  addRoadTile('roadStraight', [-3.02, .13, 0], 3.05, roadRotationFor(1, 0));
+  addRoadTile('roadStraight', [0, .13, 3.02], 3.05, roadRotationFor(0, 1));
+  addRoadTile('roadStraight', [0, .13, -3.02], 3.05, roadRotationFor(0, 1));
+  addRoadTile('roadEnd', [5.68, .13, 0], 3.05, roadRotationFor(1, 0));
+  addRoadTile('roadEnd', [-5.68, .13, 0], 3.05, roadRotationFor(-1, 0));
+  addRoadTile('roadEnd', [0, .13, 5.68], 3.05, roadRotationFor(0, 1));
+  addRoadTile('roadEnd', [0, .13, -5.68], 3.05, roadRotationFor(0, -1));
 
   const localCurve = new THREE.CatmullRomCurve3([
     new THREE.Vector3(-.2, .16, .2), new THREE.Vector3(1.8, .16, 1.7),
@@ -76,7 +78,9 @@ function buildRegionScene(cityId) {
   handoffLane.receiveShadow = true;
   world.add(handoffLane);
 
+  addSelectedRegionRoute(cityId);
   addRegionDetails(cityId);
+  addRegionEdgeNature(cityId);
 
   simulation.cities[cityId].regionalTrucks.forEach((truck, i) => {
     const curve = viewState.routeCurves.get(`${cityId}:${truck.to}`);
@@ -87,6 +91,10 @@ function buildRegionScene(cityId) {
     world.add(mesh);
     viewState.regionalTrucks.set(truck.id, { mesh, curve, offset: i * .035 });
   });
+}
+
+function roadRotationFor(dx, dz) {
+  return Math.atan2(dx, dz);
 }
 
 function addRoadTile(key, position, target, rotation) {
@@ -147,6 +155,56 @@ function addRegionDetails(cityId) {
       if (cone) world.add(cone);
     } else {
       const tree = cloneAsset(i % 2 ? 'treeSmall' : 'treeLarge', { target: .72, position: [x, .14, z] });
+      if (tree) world.add(tree);
+    }
+  });
+}
+
+function addSelectedRegionRoute(cityId) {
+  const pkg = selectedPackageId ? simulation.packages.get(selectedPackageId) : null;
+  if (!pkg || pkg.cityId !== cityId) return;
+  const destination = ['ready-national', 'transit-national'].includes(pkg.status) ? 'national'
+    : ['ready-local', 'transit-local'].includes(pkg.status) ? pkg.destination.place : null;
+  const curve = destination ? viewState.routeCurves.get(`${cityId}:${destination}`) : null;
+  if (!curve) return;
+  const material = new THREE.MeshStandardMaterial({ color: 0xf2c94c, emissive: 0x5c4300, emissiveIntensity: .55, roughness: .55 });
+  const highlight = new THREE.Mesh(new THREE.TubeGeometry(curve, 36, .21, 10, false), material);
+  highlight.position.y = .075;
+  highlight.receiveShadow = false;
+  world.add(highlight);
+  const pulse = new THREE.Mesh(
+    new THREE.SphereGeometry(.19, 18, 12),
+    new THREE.MeshBasicMaterial({ color: 0xffffff, transparent: true, opacity: .95, depthWrite: false })
+  );
+  world.add(pulse);
+  viewState.decorative.push({ kind: 'selectedRegionRoute', mesh: pulse, curve, offset: .08, speed: .12 });
+  const end = curve.getPoint(.995);
+  const marker = new THREE.Mesh(
+    new THREE.RingGeometry(.44, .57, 32),
+    new THREE.MeshBasicMaterial({ color: 0xf2c94c, transparent: true, opacity: .95, depthWrite: false })
+  );
+  marker.rotation.x = -Math.PI / 2;
+  marker.position.set(end.x, .27, end.z);
+  world.add(marker);
+  viewState.decorative.push({ kind: 'selectedRouteMarker', mesh: marker, offset: .3 });
+}
+
+function addRegionEdgeNature(cityId) {
+  const edgePoints = [
+    [-7.55, -1.5], [-7.35, 1.9], [-6.25, 5.2], [-3.3, 7.25], [.2, 7.55], [3.7, 7.05],
+    [6.65, 4.6], [7.55, 1.25], [7.25, -2.55], [5.25, -6.15], [1.8, -7.45], [-2.05, -7.35]
+  ];
+  const cityOffset = CITY_IDS.indexOf(cityId);
+  edgePoints.forEach(([x, z], index) => {
+    const tall = (index + cityOffset) % 3 === 0;
+    const cluster = cloneAsset(tall ? 'treeClusterTall' : 'treeCluster', {
+      target: tall ? 1.7 : 1.4,
+      position: [x, .04, z],
+      rotation: [0, ((index * 1.13) + cityOffset * .6) % (Math.PI * 2), 0]
+    });
+    if (cluster) world.add(cluster);
+    else {
+      const tree = cloneAsset(tall ? 'treeLarge' : 'treeSmall', { target: tall ? 1.15 : .9, position: [x, .12, z] });
       if (tree) world.add(tree);
     }
   });

--- a/postal/runtime/scene-sweden.js
+++ b/postal/runtime/scene-sweden.js
@@ -96,6 +96,8 @@ function buildSwedenScene() {
     viewState.decorative.push({ kind: 'routePulse', mesh: pulse, curve, offset: .15 + index * .18, speed: .025 });
   });
 
+  addSelectedSwedenRoute();
+
   simulation.nationalTrucks.forEach(truck => {
     const curve = viewState.routeCurves.get(`${truck.from}:${truck.to}`);
     if (!curve) return;
@@ -119,6 +121,49 @@ function buildSwedenScene() {
   const title = makeLabel(`SWEDEN · ${inFlow} PACKAGES IN FLOW`, { fg: '#fff', bg: 'rgba(16,42,41,.94)', scale: .57 });
   title.position.set(-2.4, 1.22, -5.5);
   world.add(title);
+}
+
+function selectedNetworkLeg(pkg) {
+  if (!pkg) return null;
+  if (pkg.status === 'ready-national') {
+    const leg = nextLegForPackage(pkg);
+    return leg?.to ? [pkg.cityId, leg.to] : null;
+  }
+  if (pkg.status === 'transit-national') {
+    const truck = simulation.nationalTrucks.find(item => item.load.includes(pkg.id));
+    return truck ? [truck.from, truck.to] : null;
+  }
+  if (pkg.status === 'ready-international') return [pkg.cityId, pkg.destination.country];
+  if (pkg.status === 'ready-inbound') return [pkg.origin.country, gatewayForCountry(pkg.origin.country)];
+  if (pkg.status === 'transit-international') {
+    const transport = simulation.internationalTransports.find(item => item.load.includes(pkg.id));
+    return transport ? [transport.from, transport.to] : null;
+  }
+  return null;
+}
+
+function addSelectedSwedenRoute() {
+  const pkg = selectedPackageId ? simulation.packages.get(selectedPackageId) : null;
+  const leg = selectedNetworkLeg(pkg);
+  if (!pkg || !leg) return;
+  const curve = viewState.routeCurves.get(`${leg[0]}:${leg[1]}`);
+  if (!curve) return;
+  const highlightMaterial = new THREE.MeshStandardMaterial({ color: 0xf2c94c, emissive: 0x5c4300, emissiveIntensity: .72, roughness: .48 });
+  const highlight = new THREE.Mesh(new THREE.TubeGeometry(curve, 48, .14, 10, false), highlightMaterial);
+  world.add(highlight);
+  const pulse = new THREE.Mesh(
+    new THREE.SphereGeometry(.15, 18, 12),
+    new THREE.MeshBasicMaterial({ color: 0xffffff, transparent: true, opacity: .96, depthWrite: false })
+  );
+  pulse.position.copy(curve.getPoint(.08));
+  world.add(pulse);
+  viewState.decorative.push({ kind: 'routePulse', mesh: pulse, curve, offset: .08, speed: .12 });
+  const label = makeLabel(`SELECTED · ${shortPlace(pkg.origin.place)} → ${shortPlace(pkg.destination.place)}`, {
+    fg: '#102a29', bg: 'rgba(242,201,76,.98)', scale: .43
+  });
+  label.position.copy(curve.getPoint(.52));
+  label.position.y += .48;
+  world.add(label);
 }
 
 function createTransportMarker(kind) {

--- a/postal/runtime/tutorial.js
+++ b/postal/runtime/tutorial.js
@@ -1,0 +1,126 @@
+'use strict';
+let firstDayCelebration = false;
+let tutorialLastStage = simulation.tutorialStage;
+
+function tutorialIsActive() {
+  return simulation.firstDay && simulation.tutorialStage !== 'complete';
+}
+
+function persistFirstDayComplete() {
+  try { localStorage.setItem(FIRST_DAY_KEY, 'complete'); } catch {}
+}
+
+function handleTutorialFocusChosen(cityId) {
+  if (!tutorialIsActive() || simulation.tutorialStage !== 'choose-focus' || cityId !== 'sundsvall') return;
+  simulation.releaseChicagoCase();
+  selectedPackageId = null;
+  selectedTruckId = null;
+  currentCityId = 'sundsvall';
+  currentLevel = 'depot';
+  buildScene();
+  announce('Good. Each depot keeps its own focus. A DLH package from Chicago now needs you.');
+}
+
+function handleTutorialTruckDispatched(truck) {
+  if (!tutorialIsActive() || !truck) return;
+  const pkg = selectedPackageId ? simulation.packages.get(selectedPackageId) : null;
+  if (!pkg || !truck.load.includes(pkg.id)) return;
+  if (pkg.id === 'DAY1-1001' && truck.kind === 'regional') {
+    simulation.tutorialStage = 'local-driving';
+    currentLevel = 'region';
+    buildScene();
+  } else if (pkg.id === 'US-77104' && truck.kind === 'national') {
+    simulation.tutorialStage = 'national-driving';
+    currentLevel = 'sweden';
+    buildScene();
+  } else if (pkg.id === 'US-77104' && truck.kind === 'regional') {
+    simulation.tutorialStage = 'timra-driving';
+    currentCityId = 'sundsvall';
+    currentLevel = 'region';
+    buildScene();
+  }
+}
+
+function updateFirstDayTutorial() {
+  if (!tutorialIsActive()) return;
+  const stage = simulation.tutorialStage;
+  const first = simulation.packages.get('DAY1-1001');
+  const chicago = simulation.packages.get('US-77104');
+
+  if (stage === 'watch-sort' && first?.status === 'ready-local') {
+    simulation.tutorialStage = 'load-local';
+    selectedPackageId = first.id;
+    currentCityId = 'sundsvall';
+    currentLevel = 'region';
+    buildScene();
+  } else if (stage === 'local-driving' && first?.status === 'delivered') {
+    simulation.releaseFirstDayWave();
+    selectedPackageId = null;
+    selectedTruckId = null;
+    currentLevel = 'depot';
+    buildScene();
+  } else if (stage === 'watch-chicago-sort' && chicago?.status === 'ready-national') {
+    simulation.tutorialStage = 'load-national';
+    selectedPackageId = chicago.id;
+    currentCityId = 'stockholm';
+    currentLevel = 'sweden';
+    buildScene();
+  } else if (stage === 'national-driving' && chicago?.cityId === 'sundsvall' && ['arrived', 'sorting'].includes(chicago.status)) {
+    simulation.tutorialStage = 'watch-sundsvall-sort';
+    currentCityId = 'sundsvall';
+    currentLevel = 'depot';
+    buildScene();
+  } else if (stage === 'watch-sundsvall-sort' && chicago?.status === 'ready-local') {
+    simulation.tutorialStage = 'load-timra';
+    selectedPackageId = chicago.id;
+    currentCityId = 'sundsvall';
+    currentLevel = 'region';
+    buildScene();
+  } else if (stage === 'timra-driving' && chicago?.status === 'delivered') {
+    simulation.completeFirstDay();
+    persistFirstDayComplete();
+    selectedTruckId = null;
+    firstDayCelebration = true;
+    announce('First morning complete. Every package stayed visible from Chicago to Timrå.');
+  }
+
+  if (tutorialLastStage !== simulation.tutorialStage) {
+    tutorialLastStage = simulation.tutorialStage;
+    packageRailKey = '';
+    updateUI(true);
+  }
+}
+
+function tutorialInstruction() {
+  if (firstDayCelebration) return {
+    kicker: 'FIRST MORNING COMPLETE',
+    title: 'The whole network is yours',
+    meta: 'Keep the four carriers flowing. New packages are arriving.',
+    action: 'KEEP OPERATING'
+  };
+  if (!tutorialIsActive()) return null;
+  const stage = simulation.tutorialStage;
+  const copy = {
+    'select-package': selectedPackageId === 'DAY1-1001'
+      ? ['FIRST PACKAGE', 'DLH · Söråker → Timrå', 'Send it into the highlighted Express sort.', 'SORT EXPRESS', 'start-tutorial-sort']
+      : ['FIRST PACKAGE', 'Tap the yellow DLH package', 'Packages stay here while you change depot or scale.', 'SELECT DLH', 'select-suggested'],
+    'watch-sort': ['SORTING', 'Leo is moving your package', 'Watch its card change when it reaches the regional dock.', 'WATCH', 'watch'],
+    'load-local': ['TRUCK READY', 'Timrå route is waiting', 'Load the package, then choose when the truck leaves.', 'LOAD TRUCK', 'load-package'],
+    'send-local': ['YOUR DECISION', 'Timrå truck loaded', 'Leaving early protects DLH; waiting improves utilisation.', 'SEND TO TIMRÅ', 'dispatch-truck'],
+    'local-driving': ['ON THE ROAD', 'Follow the DLH package', 'The first delivery will unlock a four-carrier wave.', 'FOLLOW', 'follow'],
+    'choose-focus': ['FOUR CARRIERS', 'Set Sundsvall’s team focus', 'Every depot keeps its own priority.', 'SET SUN FOCUS', 'open-focus'],
+    'select-chicago': selectedPackageId === 'US-77104'
+      ? ['MISSING SCAN', 'Chicago → Timrå', 'The breadcrumb shows where it stopped and what comes next.', 'SCAN CAGE', 'scan-cage']
+      : ['NETWORK CASE', 'Find Chicago → Timrå', 'It remains visible even though it is in Stockholm.', 'SELECT PACKAGE', 'select-suggested'],
+    'watch-chicago-sort': ['FOUND IN STOCKHOLM', 'DLH package is sorting', 'Next: send it north on national linehaul.', 'WATCH', 'watch'],
+    'load-national': ['NATIONAL HANDOFF', 'Stockholm → Sundsvall', 'Put the package on the northbound linehaul.', 'LOAD LINEHAUL', 'load-package'],
+    'send-national': ['YOUR DECISION', 'Northbound linehaul loaded', 'Send it when the load is worth the deadline risk.', 'SEND TO SUNDSVALL', 'dispatch-truck'],
+    'national-driving': ['ACROSS SWEDEN', 'Chicago → Stockholm → Sundsvall', 'The selected package remains in the rail.', 'FOLLOW', 'follow'],
+    'watch-sundsvall-sort': ['ARRIVED SUNDSVALL', 'One local handoff remains', 'The local team is preparing the Timrå route.', 'WATCH', 'watch'],
+    'load-timra': ['FINAL HANDOFF', 'Sundsvall → Timrå', 'Load the regional truck for the last leg.', 'LOAD TRUCK', 'load-package'],
+    'send-timra': ['FINAL DECISION', 'Timrå truck loaded', 'Complete the package’s four-stop journey.', 'SEND TO TIMRÅ', 'dispatch-truck'],
+    'timra-driving': ['LAST MILE', 'The package is almost home', 'Watch the route finish.', 'FOLLOW', 'follow']
+  }[stage];
+  if (!copy) return null;
+  return { kicker: copy[0], title: copy[1], meta: copy[2], action: copy[3], actionKey: copy[4] };
+}

--- a/postal/runtime/ui-sheets.js
+++ b/postal/runtime/ui-sheets.js
@@ -1,61 +1,40 @@
 'use strict';
-let onboardingActive = false;
-const FIRST_SHIFT_KEY = 'postal-first-shift-v2';
 
 function closeSheet() {
-  if (onboardingActive) return;
   if (app.sheet.open && typeof app.sheet.close === 'function') app.sheet.close();
   else app.sheet.removeAttribute('open');
   app.sheetClose.hidden = false;
 }
 
-function needsFirstShiftBriefing() {
-  try { return localStorage.getItem(FIRST_SHIFT_KEY) !== 'complete'; }
-  catch { return true; }
-}
-
-function finishFirstShiftBriefing() {
-  try { localStorage.setItem(FIRST_SHIFT_KEY, 'complete'); } catch {}
-  onboardingActive = false;
-  app.sheetClose.hidden = false;
-  if (app.sheet.open && typeof app.sheet.close === 'function') app.sheet.close();
-  else app.sheet.removeAttribute('open');
-  simulation.paused = false;
-  updateUI(true);
-  announce('Morning shift started. Incoming packages are ready.');
-}
-
-function showBriefingSheet({ firstRun = false } = {}) {
-  onboardingActive = firstRun;
-  app.sheetClose.hidden = firstRun;
-  const metrics = simulation.getMetrics();
-  const action = firstRun
-    ? '<button class="action-btn primary full briefing-start" data-start-shift>START THE MORNING SHIFT</button>'
-    : '<button class="action-btn primary full" data-close-sheet>BACK TO THE NETWORK</button>';
-  showSheet(firstRun ? 'Morning briefing' : 'How to run the network', `
+function showBriefingSheet() {
+  showSheet('How to run the network', `
     <div class="briefing-hero">
-      <span class="eyebrow">SHIFT 1 · 07:00</span>
-      <h3>Keep the morning moving</h3>
-      <p>${metrics.incoming} packages are already on depot floors. Your team sorts automatically; you decide what deserves attention.</p>
+      <span class="eyebrow">PACKAGES ARE THE CONTROLS</span>
+      <h3>See it. Select it. Send it.</h3>
+      <p>The live rail stays on screen at Depot, Region and Sweden. Select a package to reveal its next physical handoff.</p>
     </div>
     <div class="briefing-steps">
-      <article><span aria-hidden="true">1</span><div><strong>Watch INCOMING</strong><p>Open the depot queues, inspect any package and prioritise the ones that cannot wait.</p></div></article>
-      <article><span aria-hidden="true">2</span><div><strong>Resolve red ISSUES</strong><p>Read the scan trail, find what stopped the package and choose an operational fix.</p></div></article>
-      <article><span aria-hidden="true">3</span><div><strong>Zoom out before trouble spreads</strong><p>DEPOT shows people and parcels, REGION shows local trucks, and SWEDEN shows national and international flow.</p></div></article>
+      <article><span aria-hidden="true">1</span><div><strong>Select a package</strong><p>Its route breadcrumb and next action remain visible while you move through the network.</p></div></article>
+      <article><span aria-hidden="true">2</span><div><strong>Load and send trucks</strong><p>Leave early to protect a deadline or wait for a fuller, more efficient load.</p></div></article>
+      <article><span aria-hidden="true">3</span><div><strong>Give each depot a focus</strong><p>Sundsvall, Stockholm and Göteborg can prioritise different work.</p></div></article>
     </div>
-    <div class="interaction-key"><strong>Also interactive:</strong><span>workers</span><span>packages</span><span>trucks</span><span>towns</span><span>hubs</span></div>
-    ${action}
+    <div class="carrier-guide" aria-label="Carrier rhythms">
+      ${Object.values(CARRIERS).map(carrier => `<span class="carrier-guide-item carrier-${carrier.id}"><b>${carrier.code}</b><span><strong>${carrier.name}</strong><small>${carrier.rhythm}</small></span></span>`).join('')}
+    </div>
+    <button class="action-btn primary full" data-close-sheet>BACK TO THE NETWORK</button>
   `);
 }
 
 function showFocusSheet() {
+  const city = CITIES[currentCityId];
+  const currentFocus = simulation.getFocus(currentCityId);
   const buttons = FOCUS_MODES.map(mode => `
-    <button class="focus-option ${simulation.focus === mode ? 'is-active' : ''}" data-focus="${mode}" aria-pressed="${simulation.focus === mode}">
+    <button class="focus-option ${currentFocus === mode ? 'is-active' : ''}" data-focus="${mode}" data-focus-city="${currentCityId}" aria-pressed="${currentFocus === mode}">
       <span class="focus-option-icon" aria-hidden="true">${focusIcon(mode)}</span>
       <strong>${focusLabel(mode)}</strong>
       <small>${focusDescription(mode)}</small>
     </button>`).join('');
-  showSheet('Choose the team focus', `<p class="sheet-lede">The depot keeps moving. Your focus changes which packages every worker pulls first.</p><div class="focus-grid">${buttons}</div>`);
+  showSheet(`${city.name} team focus`, `<p class="sheet-lede">Only ${city.name} changes. The other depots keep their own priorities.</p><div class="focus-grid">${buttons}</div>`);
 }
 
 function focusIcon(mode) {
@@ -124,6 +103,8 @@ function showPackage(packageId) {
   const pkg = simulation.packages.get(packageId);
   if (!pkg) return;
   selectedPackageId = packageId;
+  selectedTruckId = null;
+  packageRailKey = '';
   const slack = Math.round(pkg.deadline - simulation.clock);
   const status = humanStatus(pkg.status);
   const issue = pkg.issue ? `<div class="exception-card"><span class="eyebrow">NEEDS YOU</span><strong>${issueTitle(pkg.issue)}</strong><p>${escapeHtml(pkg.issueDetail)}</p></div>` : '';
@@ -157,7 +138,6 @@ function packageActions(pkg) {
   else if (pkg.issue === 'wrong-dock' || pkg.issue === 'routing') list.push(btn('REROUTE', 'reroute', 'primary'));
   else if (pkg.issue === 'label-damage') list.push(btn('REPRINT LABEL', 'reprint', 'primary'));
   else if (pkg.issue === 'missed-scan') list.push(btn('RESCAN', 'rescan', 'primary'));
-  if (pkg.complaint) list.push(btn('CONTACT CUSTOMER', 'contact'));
   list.push(btn(pkg.priorityFlag ? 'CLEAR PRIORITY' : 'PRIORITISE', 'priority', pkg.priorityFlag ? 'secondary' : 'accent'));
   return list.join('');
 }
@@ -173,14 +153,14 @@ function showWorker(workerId) {
         <span class="entity-avatar" aria-hidden="true">${escapeHtml(worker.name.slice(0, 1))}</span>
         <div><span class="eyebrow">${escapeHtml(worker.role.toUpperCase())} · ${CITIES[worker.cityId].name.toUpperCase()}</span><h3>${escapeHtml(worker.task)}</h3></div>
       </div>
-      <p>${pkg ? `Working on <button class="inline-link" data-open-package="${pkg.id}">${pkg.id}</button> because it scores highest under <strong>${focusLabel(simulation.focus)}</strong>.` : `Ready for the next package. Current team focus: <strong>${focusLabel(simulation.focus)}</strong>.`}</p>
+      <p>${pkg ? `Working on <button class="inline-link" data-open-package="${pkg.id}">${pkg.id}</button> because it scores highest under <strong>${focusLabel(simulation.getFocus(worker.cityId))}</strong>.` : `Ready for the next package. Current depot focus: <strong>${focusLabel(simulation.getFocus(worker.cityId))}</strong>.`}</p>
       <div class="progress-rail" aria-label="Task ${progress}% complete"><i style="width:${progress}%"></i></div>
       <div class="mini-stats"><span><strong>${worker.handled}</strong> handled</span><span><strong>${progress}%</strong> current task</span></div>
     </div>`);
 }
 
 function findTruck(truckId) {
-  return [...Object.values(simulation.cities).flatMap(city => city.regionalTrucks), ...simulation.nationalTrucks].find(truck => truck.id === truckId);
+  return simulation.findTruck(truckId);
 }
 
 function capacityDots(load, capacity) {
@@ -190,18 +170,40 @@ function capacityDots(load, capacity) {
 function showTruck(truckId) {
   const truck = findTruck(truckId);
   if (!truck) return;
+  selectedTruckId = truck.id;
   const from = CITIES[truck.from]?.name || truck.from;
   const to = CITIES[truck.to]?.name || truck.to;
   const load = truck.load.map(id => simulation.packages.get(id)).filter(Boolean);
+  const eligible = simulation.eligiblePackagesForTruck(truck);
   const progress = truck.state === 'driving' ? Math.round(truck.progress * 100) : 0;
+  const waitingCopy = eligible.length
+    ? `${eligible.length} compatible package${eligible.length === 1 ? '' : 's'} waiting. Fill the truck, then decide whether the deadline or utilisation matters more.`
+    : 'No compatible packages are waiting for this route yet.';
+  const loadList = truck.state === 'driving'
+    ? (load.length ? load.map(pkg => packageRow(pkg)).join('') : '<p class="hint">No packages aboard right now.</p>')
+    : (eligible.length ? eligible.map(pkg => truckLoadRow(truck, pkg)).join('') : '<p class="hint">The dock is clear for this route.</p>');
+  const controls = truck.state === 'waiting' ? `<div class="sheet-actions">
+      <button class="action-btn secondary" data-auto-fill-truck="${truck.id}">AUTO-FILL</button>
+      <button class="action-btn primary" data-dispatch-truck="${truck.id}" ${truck.plannedLoad.length ? '' : 'disabled'}>SEND TO ${escapeHtml(String(to).toUpperCase())}</button>
+    </div>` : '';
   showSheet(truck.kind === 'national' ? 'National linehaul' : 'Regional truck', `
     <div class="entity-card">
       <div class="entity-card-layout"><span class="entity-avatar" aria-hidden="true">↗</span><div><span class="eyebrow">${truck.state.toUpperCase()}</span><h3>${escapeHtml(from)} → ${escapeHtml(to)}</h3></div></div>
-      <p>${truck.state === 'driving' ? `${progress}% through the route. Tap any package below to follow its whole journey.` : 'Waiting for a useful load or a deadline that forces departure.'}</p>
-      ${capacityDots(load.length, truck.capacity)}
-      <div class="mini-stats"><span><strong>${load.length}/${truck.capacity}</strong> load</span><span><strong>${truck.departures}</strong> runs</span></div>
+      <p>${truck.state === 'driving' ? `${progress}% through the route. The package rail remains live while it moves.` : waitingCopy}</p>
+      ${capacityDots(truck.state === 'driving' ? load.length : truck.plannedLoad.length, truck.capacity)}
+      <div class="mini-stats"><span><strong>${truck.state === 'driving' ? load.length : truck.plannedLoad.length}/${truck.capacity}</strong> load</span><span><strong>${truck.departures}</strong> runs</span></div>
     </div>
-    <div class="package-list">${load.length ? load.map(pkg => packageRow(pkg)).join('') : '<p class="hint">No packages aboard right now.</p>'}</div>`);
+    <div class="package-list truck-load-list">${loadList}</div>${controls}`);
+}
+
+function truckLoadRow(truck, pkg) {
+  const planned = truck.plannedLoad.includes(pkg.id);
+  const slack = Math.round(pkg.deadline - simulation.clock);
+  return `<button class="truck-load-row ${carrierClass(pkg.carrier)}" type="button" data-toggle-truck-load="${pkg.id}" data-truck-id="${truck.id}" aria-pressed="${planned}">
+    <span class="carrier-flag" data-pattern="${pkg.carrierPattern}">${escapeHtml(pkg.carrier)}</span>
+    <span><strong>${escapeHtml(pkg.origin.place)} → ${escapeHtml(pkg.destination.place)}</strong><small>${escapeHtml(pkg.id)} · ${slack < 0 ? `${Math.abs(slack)}m late` : `${slack}m left`}</small></span>
+    <span class="load-check" aria-hidden="true">${planned ? '✓' : '+'}</span>
+  </button>`;
 }
 
 function showTransport(transportId) {
@@ -216,7 +218,8 @@ function showTransport(transportId) {
 
 function showTown(cityId, town) {
   const packages = [...simulation.packages.values()].filter(pkg => pkg.destination.place === town && pkg.status !== 'delivered');
-  showSheet(town, `<div class="entity-card"><span class="eyebrow">${CITIES[cityId].name.toUpperCase()} REGION</span><h3>${packages.length} package${packages.length === 1 ? '' : 's'} heading here</h3><p>Regional trucks leave automatically when their load is worthwhile or a deadline forces the run.</p></div><div class="package-list">${packages.length ? packages.map(pkg => packageRow(pkg)).join('') : '<div class="empty-state"><span class="empty-state-icon" aria-hidden="true">✓</span><strong>Route clear</strong><p>Nothing is waiting for this town.</p></div>'}</div>`);
+  const ready = packages.filter(pkg => pkg.status === 'ready-local').length;
+  showSheet(town, `<div class="entity-card"><span class="eyebrow">${CITIES[cityId].name.toUpperCase()} REGION</span><h3>${packages.length} package${packages.length === 1 ? '' : 's'} heading here</h3><p>${ready ? `${ready} ready at the dock. Tap the route truck, load it and choose when it leaves.` : 'Packages will collect at the dock after sorting.'}</p></div><div class="package-list">${packages.length ? packages.map(pkg => packageRow(pkg)).join('') : '<div class="empty-state"><span class="empty-state-icon" aria-hidden="true">✓</span><strong>Route clear</strong><p>Nothing is waiting for this town.</p></div>'}</div>`);
 }
 
 function showCity(cityId) {
@@ -230,7 +233,15 @@ function showCity(cityId) {
 function showHandoff(cityId) {
   const city = simulation.cities[cityId];
   const packages = city.queues.readyNational.map(id => simulation.packages.get(id)).filter(Boolean);
-  showSheet('National handoff', `<p class="sheet-lede">Packages leave the region here. Sweden-level linehaul chooses the correct hub automatically.</p><div class="package-list">${packages.length ? packages.map(pkg => packageRow(pkg)).join('') : '<div class="empty-state"><span class="empty-state-icon" aria-hidden="true">✓</span><strong>Handoff clear</strong><p>No national packages are waiting.</p></div>'}</div>`);
+  showSheet('National handoff', `<p class="sheet-lede">Packages wait here until you load a compatible national linehaul and send it.</p><div class="package-list">${packages.length ? packages.map(pkg => packageRow(pkg)).join('') : '<div class="empty-state"><span class="empty-state-icon" aria-hidden="true">✓</span><strong>Handoff clear</strong><p>No national packages are waiting.</p></div>'}</div>`);
+}
+
+function showFirstDaySummary() {
+  const metrics = simulation.getMetrics();
+  showSheet('First morning complete', `
+    <div class="briefing-hero first-day-result"><span class="eyebrow">DAY 1 · NETWORK OPEN</span><h3>You kept the packages moving</h3><p>You sorted a live package, chose three truck departures, set one depot’s focus and followed Chicago → Timrå across Sweden.</p></div>
+    <div class="intake-summary"><span><strong>${metrics.score}</strong> points</span><span><strong>${metrics.onTime}%</strong> on time</span><span><strong>${metrics.utilisation}%</strong> truck use</span></div>
+    <button class="action-btn primary full" data-close-sheet>KEEP OPERATING</button>`);
 }
 
 function issueTitle(issue) {

--- a/postal/runtime/visuals-ui-core.js
+++ b/postal/runtime/visuals-ui-core.js
@@ -29,7 +29,7 @@ function updateDepotVisuals() {
       badge.position.z = mesh.position.z;
     }
   }
-  for (const { mesh, issueRing, lane, base, baseY, offset } of viewState.packages.values()) {
+  for (const { mesh, issueRing, selectionRing, lane, base, baseY, offset } of viewState.packages.values()) {
     mesh.position.y = baseY;
     if (!prefersReducedMotion && !simulation.paused) {
       mesh.position.y += Math.sin(visualTime * 2.2 + offset) * .025;
@@ -37,6 +37,11 @@ function updateDepotVisuals() {
       if (issueRing) {
         const pulse = 1 + Math.sin(visualTime * 4 + offset) * .08;
         issueRing.scale.setScalar(pulse);
+      }
+      if (selectionRing) {
+        const pulse = 1 + Math.sin(visualTime * 4.6 + offset) * .11;
+        selectionRing.scale.setScalar(pulse);
+        selectionRing.material.opacity = .78 + Math.sin(visualTime * 4.6 + offset) * .2;
       }
     }
   }
@@ -64,6 +69,16 @@ function updateRegionVisuals() {
     const item = viewState.regionalTrucks.get(truck.id); if (!item) continue;
     const t = truck.state === 'driving' ? Math.min(.995, truck.progress) : Math.min(.045 + item.offset, .16);
     orientAlongCurve(item.mesh, item.curve, t);
+  }
+  for (const item of viewState.decorative) {
+    if (item.kind === 'selectedRegionRoute') {
+      const t = prefersReducedMotion || simulation.paused ? item.offset : (visualTime * item.speed + item.offset) % 1;
+      item.mesh.position.copy(item.curve.getPoint(t));
+      item.mesh.position.y += .32;
+    } else if (item.kind === 'selectedRouteMarker' && !prefersReducedMotion && !simulation.paused) {
+      const pulse = 1 + Math.sin(visualTime * 4.2 + item.offset) * .12;
+      item.mesh.scale.setScalar(pulse);
+    }
   }
 }
 
@@ -104,20 +119,201 @@ function updateContextHeader() {
   app.viewport.dataset.level = currentLevel;
   app.viewport.dataset.city = currentCityId;
   $$('.level-tab').forEach(btn => btn.setAttribute('aria-pressed', String(btn.dataset.level === currentLevel)));
-  $$('.city-chip').forEach(btn => btn.setAttribute('aria-pressed', String(btn.dataset.city === currentCityId)));
+  $$('.city-chip').forEach(btn => {
+    const active = btn.dataset.city === currentCityId;
+    btn.setAttribute('aria-pressed', String(active));
+    btn.setAttribute('aria-label', `${CITIES[btn.dataset.city].name}, focus ${focusLabel(simulation.getFocus(btn.dataset.city))}`);
+  });
+}
+
+function shortPlace(place) {
+  const known = {
+    Chicago: 'CHI', Stockholm: 'STO', Sundsvall: 'SUN', Timrå: 'TMR', Göteborg: 'GBG',
+    Söråker: 'SÖR', Härnösand: 'HSD', Solna: 'SOL', Nacka: 'NAC', Uppsala: 'UPP',
+    Aarhus: 'AAR', København: 'CPH', Hamburg: 'HAM', Helsinki: 'HEL'
+  };
+  return known[place] || String(place || '').slice(0, 3).toUpperCase();
+}
+
+function packageRouteStops(pkg) {
+  const stops = [pkg.origin.place];
+  const originCity = cityForPlace(pkg.origin.place);
+  const destinationCity = cityForPlace(pkg.destination.place);
+  const gateway = pkg.origin.country !== 'Sweden' ? gatewayForCountry(pkg.origin.country)
+    : pkg.destination.country !== 'Sweden' ? gatewayForCountry(pkg.destination.country) : null;
+  const cityStops = [];
+  if (originCity) cityStops.push(CITIES[originCity].name);
+  else if (gateway) cityStops.push(CITIES[gateway].name);
+  if (destinationCity && !cityStops.includes(CITIES[destinationCity].name)) cityStops.push(CITIES[destinationCity].name);
+  for (const stop of cityStops) if (!stops.includes(stop) && stop !== pkg.destination.place) stops.push(stop);
+  if (!stops.includes(pkg.destination.place)) stops.push(pkg.destination.place);
+  return stops.slice(0, 4);
+}
+
+function packageRouteProgress(pkg, stops) {
+  if (pkg.status === 'delivered') return stops.length - 1;
+  const cityName = pkg.cityId ? CITIES[pkg.cityId]?.name : null;
+  const cityIndex = cityName ? stops.indexOf(cityName) : -1;
+  if (cityIndex >= 0) return cityIndex;
+  if (pkg.origin.country !== 'Sweden' && pkg.status !== 'ready-inbound') return Math.min(1, stops.length - 1);
+  return 0;
+}
+
+function packageRailCard(pkg) {
+  const selected = pkg.id === selectedPackageId;
+  const stops = packageRouteStops(pkg);
+  const progress = packageRouteProgress(pkg, stops);
+  const route = `${pkg.origin.place} → ${pkg.destination.place}`;
+  const attention = pkg.issue ? 'critical' : pkg.deadline - simulation.clock < 25 ? 'warning' : 'normal';
+  const tutorialTarget = tutorialIsActive() && (
+    (simulation.tutorialStage === 'select-package' && pkg.id === 'DAY1-1001') ||
+    (simulation.tutorialStage === 'select-chicago' && pkg.id === 'US-77104')
+  );
+  const nodes = stops.map((stop, index) => `<span class="route-node ${index < progress ? 'is-done' : index === progress ? 'is-current' : ''}"><i></i><b>${escapeHtml(shortPlace(stop))}</b></span>`).join('');
+  return `<button class="live-package-card ${carrierClass(pkg.carrier)} ${attention} ${tutorialTarget ? 'tutorial-target' : ''}" type="button" role="listitem" data-select-package="${pkg.id}" aria-pressed="${selected}" aria-label="${escapeHtml(pkg.carrier)}, ${escapeHtml(route)}, ${humanStatus(pkg.status)}, ${Math.max(0, Math.round(pkg.deadline - simulation.clock))} minutes remaining">
+    <span class="live-package-head"><span class="carrier-flag" data-pattern="${pkg.carrierPattern}">${escapeHtml(pkg.carrier)}</span><strong>${escapeHtml(route)}</strong><span class="live-deadline" data-package-deadline="${pkg.id}"></span></span>
+    <span class="route-breadcrumb" aria-hidden="true">${nodes}</span>
+    <span class="live-package-foot"><span>${escapeHtml(humanStatus(pkg.status))}</span><span>${escapeHtml(pkg.location)}</span></span>
+  </button>`;
+}
+
+function renderPackageRail(force = false) {
+  const packages = simulation.getActivePackages(40);
+  if (selectedPackageId) {
+    const selected = simulation.packages.get(selectedPackageId);
+    if (selected && selected.status !== 'delivered' && !packages.includes(selected)) packages.unshift(selected);
+  }
+  const key = packages.map(pkg => `${pkg.id}:${pkg.status}:${pkg.location}:${pkg.issue || ''}`).join('|') + `:${selectedPackageId || ''}:${simulation.tutorialStage}`;
+  if (force || key !== packageRailKey) {
+    const scrollLeft = app.packageRail.scrollLeft;
+    app.packageRail.innerHTML = packages.length
+      ? packages.map(packageRailCard).join('')
+      : '<div class="rail-empty"><strong>All clear</strong><span>New carrier arrivals are on the way.</span></div>';
+    app.packageRail.scrollLeft = scrollLeft;
+    packageRailKey = key;
+  }
+  const metrics = simulation.getMetrics();
+  app.packageSummary.textContent = `${packages.length} active · ${metrics.dueSoon} due · ${metrics.score} pts`;
+  app.packageRail.querySelectorAll('[data-package-deadline]').forEach(node => {
+    const pkg = simulation.packages.get(node.dataset.packageDeadline);
+    if (!pkg) return;
+    const slack = Math.round(pkg.deadline - simulation.clock);
+    node.textContent = slack < 0 ? `${Math.abs(slack)}m LATE` : `${slack}m`;
+    node.classList.toggle('is-late', slack < 0);
+    node.classList.toggle('is-soon', slack >= 0 && slack < 25);
+  });
+}
+
+function configureDock({ kicker, title, meta, primary, action, secondary = 'DETAILS', secondaryAction = 'details', disabled = false, tone = 'normal' }) {
+  app.actionKicker.textContent = kicker;
+  app.actionTitle.textContent = title;
+  app.actionMeta.textContent = meta;
+  app.actionPrimary.textContent = primary;
+  app.actionPrimary.dataset.action = action;
+  app.actionPrimary.disabled = disabled;
+  app.actionDetails.textContent = secondary;
+  app.actionDetails.dataset.action = secondaryAction;
+  app.actionDetails.hidden = !secondary;
+  app.actionDock.dataset.tone = tone;
+}
+
+function updateActionDock() {
+  const instruction = tutorialInstruction();
+  const truck = selectedTruckId ? simulation.findTruck(selectedTruckId) : null;
+  if (truck && truck.state === 'waiting') {
+    const from = CITIES[truck.from]?.name || truck.from;
+    const to = CITIES[truck.to]?.name || truck.to;
+    const eligible = simulation.eligiblePackagesForTruck(truck);
+    configureDock({
+      kicker: instruction?.kicker || (truck.kind === 'national' ? 'NATIONAL LINEHAUL' : 'REGIONAL TRUCK'),
+      title: instruction?.title || `${from} → ${to}`,
+      meta: instruction?.meta || `${truck.plannedLoad.length}/${truck.capacity} loaded · ${eligible.length} eligible · you choose departure`,
+      primary: instruction?.action || `SEND TO ${String(to).toUpperCase()}`,
+      action: 'dispatch-truck', secondary: 'EDIT LOAD', secondaryAction: 'edit-load',
+      disabled: truck.plannedLoad.length === 0, tone: truck.plannedLoad.length ? 'action' : 'normal'
+    });
+    return;
+  }
+
+  if (firstDayCelebration) {
+    configureDock({ ...instruction, primary: instruction.action, action: 'dismiss-celebration', secondary: 'SUMMARY', secondaryAction: 'first-day-summary', tone: 'success' });
+    return;
+  }
+
+  const pkg = selectedPackageId ? simulation.packages.get(selectedPackageId) : null;
+  if (!pkg) {
+    configureDock({
+      kicker: instruction?.kicker || 'PACKAGES ARE THE CONTROLS',
+      title: instruction?.title || 'Select a live package',
+      meta: instruction?.meta || 'Its next physical handoff will light up in the world.',
+      primary: instruction?.action || 'SELECT PACKAGE', action: instruction?.actionKey || 'select-suggested', secondary: '',
+      disabled: instruction?.actionKey === 'watch', tone: tutorialIsActive() ? 'tutorial' : 'normal'
+    });
+    return;
+  }
+
+  const slack = Math.round(pkg.deadline - simulation.clock);
+  const route = `${pkg.origin.place} → ${pkg.destination.place}`;
+  let action = 'details';
+  let primary = 'OPEN DETAILS';
+  let disabled = false;
+  let actionMeta = `${pkg.location} · ${slack < 0 ? `${Math.abs(slack)}m late` : `${slack}m left`}`;
+
+  if (tutorialIsActive() && pkg.id === 'DAY1-1001' && simulation.tutorialStage === 'select-package') {
+    action = 'start-tutorial-sort'; primary = 'SORT EXPRESS';
+  } else if (pkg.issue === 'scan-gap') {
+    action = 'scan-cage'; primary = 'SCAN CAGE';
+  } else if (pkg.issue === 'wrong-dock' || pkg.issue === 'routing') {
+    action = 'reroute'; primary = 'REROUTE';
+  } else if (pkg.issue === 'label-damage') {
+    action = 'reprint'; primary = 'REPRINT LABEL';
+  } else if (pkg.issue === 'missed-scan') {
+    action = 'rescan'; primary = 'RESCAN';
+  } else if (pkg.status === 'arrived') {
+    action = 'priority'; primary = pkg.priorityFlag ? 'PRIORITY SET' : 'PRIORITISE'; disabled = pkg.priorityFlag;
+  } else if (pkg.status === 'sorting') {
+    action = 'watch'; primary = 'SORTING…'; disabled = true;
+  } else if (pkg.status === 'ready-local' || pkg.status === 'ready-national') {
+    const routeTruck = simulation.truckForPackage(pkg.id);
+    if (routeTruck) {
+      action = 'load-package'; primary = pkg.status === 'ready-national' ? 'LOAD LINEHAUL' : 'LOAD TRUCK';
+    } else {
+      action = 'watch'; primary = 'TRUCK RETURNING'; disabled = true;
+      actionMeta = `${pkg.location} · its route vehicle is already on the road`;
+    }
+  } else if (pkg.status.startsWith('transit')) {
+    action = 'follow'; primary = 'FOLLOW ROUTE';
+  } else if (pkg.status === 'ready-international' || pkg.status === 'ready-inbound') {
+    action = 'watch'; primary = 'GATEWAY QUEUED'; disabled = true;
+    actionMeta = `${pkg.location} · partner transport is scheduled automatically`;
+  }
+
+  if (instruction) {
+    primary = instruction.action;
+    action = instruction.actionKey || action;
+    disabled = instruction.actionKey === 'watch' || disabled;
+  }
+  configureDock({
+    kicker: instruction?.kicker || `${pkg.carrier} · ${humanStatus(pkg.status).toUpperCase()}`,
+    title: instruction?.title || route,
+    meta: instruction?.meta || actionMeta,
+    primary, action, secondary: 'DETAILS', secondaryAction: 'details', disabled,
+    tone: pkg.issue ? 'critical' : instruction ? 'tutorial' : action === 'load-package' ? 'action' : 'normal'
+  });
 }
 
 function updateUI(force = false) {
   const now = performance.now();
   if (!force && now - lastUiUpdate < 300) return;
   lastUiUpdate = now;
+  updateFirstDayTutorial();
   const m = simulation.getMetrics();
   if (simulation.stats.received > lastReceivedCount) app.incoming.classList.add('new-arrival');
   lastReceivedCount = simulation.stats.received;
   app.metricOnTime.textContent = `${m.onTime}%`;
   $('#metric-ontime-bar').style.width = `${Math.max(2, m.onTime)}%`;
-  app.metricFlow.textContent = `${m.incoming}`;
-  app.incoming.setAttribute('aria-label', `Open ${m.incoming} incoming package${m.incoming === 1 ? '' : 's'} across all depots`);
+  app.metricFlow.textContent = `${m.active}`;
+  app.incoming.setAttribute('aria-label', `Open overview of ${m.active} live package${m.active === 1 ? '' : 's'}`);
   app.metricIssues.textContent = `${m.issues}`;
   app.issueBadge.textContent = String(m.issues);
   app.issueBadge.hidden = m.issues === 0;
@@ -126,33 +322,10 @@ function updateUI(force = false) {
   $('#pause-label').textContent = simulation.paused ? 'PLAY' : 'PAUSE';
   app.pause.setAttribute('aria-label', simulation.paused ? 'Resume network' : 'Pause network');
   app.pause.setAttribute('aria-pressed', String(simulation.paused));
-  $('#focus-value').textContent = focusLabel(simulation.focus);
-
-  const top = simulation.events.find(event => {
-    if (event.kind !== 'critical' && event.kind !== 'warning') return false;
-    if (!event.packageId) return true;
-    const pkg = simulation.packages.get(event.packageId);
-    return Boolean(pkg?.issue || pkg?.complaint);
-  }) || simulation.events[0];
-  if (top) {
-    const pkg = top.packageId ? simulation.packages.get(top.packageId) : null;
-    const packageNeedsAction = Boolean(pkg?.issue || pkg?.complaint);
-    const urgent = top.kind === 'critical';
-    const warning = top.kind === 'warning';
-    const ctaLabel = packageNeedsAction ? 'INVESTIGATE' : urgent || warning ? 'REVIEW' : 'OPEN';
-    const kickerText = urgent ? 'URGENT · NEEDS YOU' : warning ? 'NEEDS YOU' : 'NETWORK UPDATE';
-
-    app.eventText.textContent = top.title;
-    app.eventRibbon.dataset.kind = urgent ? 'critical' : warning ? 'warning' : 'info';
-    app.eventRibbon.dataset.packageId = top.packageId || '';
-    app.eventRibbon.setAttribute('aria-label', `${ctaLabel}: ${top.title}`);
-    $('#event-kicker').textContent = kickerText;
-    $('#event-cta-label').textContent = ctaLabel;
-    app.eventRibbon.hidden = false;
-  } else {
-    app.eventRibbon.hidden = true;
-    app.eventRibbon.removeAttribute('aria-label');
-  }
+  $('#focus-value').textContent = `${CITIES[currentCityId].short} · ${focusLabel(simulation.getFocus(currentCityId))}`;
+  renderPackageRail(force);
+  updateActionDock();
+  updateContextHeader();
 }
 
 function formatGameClock(sec) {
@@ -179,8 +352,8 @@ function setCity(cityId) {
 function showSheet(title, html, { onOpen } = {}) {
   app.sheetTitle.textContent = title;
   app.sheetBody.innerHTML = html;
-  if (typeof app.sheet.showModal === 'function') {
-    if (!app.sheet.open) app.sheet.showModal();
+  if (typeof app.sheet.show === 'function') {
+    if (!app.sheet.open) app.sheet.show();
   } else app.sheet.setAttribute('open','');
   onOpen?.();
 }

--- a/postal/sw.js
+++ b/postal/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'postal-onboarding-assets-2026-08-16-v2';
+const CACHE = 'postal-packages-are-controls-2026-08-16-v3';
 self.addEventListener('install', event => { self.skipWaiting(); });
 self.addEventListener('activate', event => {
   event.waitUntil((async () => {

--- a/postal/tests/hierarchy.test.mjs
+++ b/postal/tests/hierarchy.test.mjs
@@ -8,14 +8,18 @@ const root = path.resolve(here, '..');
 const html = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
 const hierarchy = fs.readFileSync(path.join(root, 'hierarchy.css'), 'utf8');
 const ui = fs.readFileSync(path.join(root, 'runtime', 'visuals-ui-core.js'), 'utf8');
+const interaction = fs.readFileSync(path.join(root, 'runtime', 'interaction-boot.js'), 'utf8');
 
 assert.match(html, /href="\.\/styles\.css"[\s\S]*href="\.\/hierarchy\.css"/, 'Hierarchy overrides must load after the base styles');
-assert.match(html, /id="event-ribbon"[^>]*class="[^"]*primary-cta/, 'The live exception needs an explicit primary CTA class');
-assert.match(html, /id="event-cta-label">INVESTIGATE</, 'The primary CTA needs an action verb in its visible label');
-assert.match(hierarchy, /\.event-ribbon\.primary-cta[\s\S]*background:\s*var\(--yellow\)/, 'Primary CTA should own the brand action color');
-assert.match(hierarchy, /\.quick-action,[\s\S]*\.quick-action-focus[\s\S]*background:\s*rgba\(247, 242, 232/, 'Secondary operations should be visually quieter than the CTA');
-assert.match(hierarchy, /\.metric-issues[\s\S]*background:\s*rgba\(8, 33, 32/, 'Issue count should be status, not a competing red action card');
-assert.match(ui, /ctaLabel\s*=\s*packageNeedsAction\s*\?\s*'INVESTIGATE'/, 'Actionable package exceptions should announce INVESTIGATE');
-assert.match(ui, /setAttribute\('aria-label', `\$\{ctaLabel\}: \$\{top\.title\}`\)/, 'The CTA accessible name should include both action and subject');
+assert.match(html, /id="action-dock"[\s\S]*id="action-primary"/, 'The contextual next action must remain visible above the package rail');
+assert.match(html, /id="package-console"|class="package-console"[\s\S]*id="package-rail"/, 'The live package rail must be persistent HUD, not sheet content');
+assert.match(hierarchy, /\.dock-button-primary[\s\S]*background:\s*var\(--yellow\)/, 'Yellow belongs to the direct executable action');
+assert.match(hierarchy, /\.level-tab\[aria-pressed="true"\][\s\S]*background:\s*rgba\(255,255,255/, 'Navigation must be quieter than the CTA');
+assert.match(hierarchy, /\.metric-issues[\s\S]*background:\s*rgba\(7, 29, 28/, 'Issue count should be status, not a competing red action card');
+assert.match(hierarchy, /\.live-package-card\[aria-pressed="true"\][\s\S]*border-color:\s*var\(--yellow\)/, 'Selected package must have obvious continuity across levels');
+assert.match(hierarchy, /\.package-rail[\s\S]*overflow-x:\s*auto/, 'Portrait package rail must scroll horizontally without shrinking cards');
+assert.match(ui, /pkg\.issue === 'scan-gap'[\s\S]*primary = 'SCAN CAGE'/, 'The package state must produce a concrete operational verb');
+assert.match(ui, /pkg\.status === 'ready-local' \|\| pkg\.status === 'ready-national'[\s\S]*action = 'load-package'/, 'Ready packages must expose loading in the main CTA');
+assert.match(interaction, /action === 'dispatch-truck'[\s\S]*dispatchSelectedTruck/, 'Truck departure must be a player action');
 
 console.log('POSTAL hierarchy CTA tests passed');

--- a/postal/tests/model.test.mjs
+++ b/postal/tests/model.test.mjs
@@ -11,7 +11,23 @@ context.globalThis = context;
 for (const name of ['model-data.js','model-core.js','model-flow.js','model-ops.js']) {
   vm.runInContext(fs.readFileSync(path.join(root, 'runtime', name), 'utf8'), context, { filename: name });
 }
-const { PostalSimulation, packageScore, nextLegForPackage } = context.POSTAL_MODEL;
+const { PostalSimulation, CARRIERS, packageScore, nextLegForPackage } = context.POSTAL_MODEL;
+
+function tickUntil(sim, predicate, maxTicks = 300, dt = .5) {
+  for (let i = 0; i < maxTicks && !predicate(); i += 1) sim.tick(dt);
+  assert.ok(predicate(), `Condition was not reached after ${maxTicks * dt} simulated seconds`);
+}
+
+function runManaged(sim, pkg, maxTicks = 1200) {
+  for (let i = 0; i < maxTicks && pkg.status !== 'delivered'; i += 1) {
+    if (pkg.status === 'ready-local' || pkg.status === 'ready-national') {
+      const planned = sim.planPackageOnTruck(pkg.id);
+      if (planned.ok) sim.dispatchTruck(planned.truck.id);
+    }
+    sim.tick(.5);
+  }
+  assert.equal(pkg.status, 'delivered', `${pkg.id} should complete with managed dispatches`);
+}
 
 {
   const crew = Object.values(context.CITIES).flatMap(city => city.crew);
@@ -23,21 +39,22 @@ const { PostalSimulation, packageScore, nextLegForPackage } = context.POSTAL_MOD
     assert.ok(sim.getIncomingPackages(cityId).length >= 4, `${cityId} should open with a visible intake queue`);
   }
   const openingTotal = sim.packages.size;
-  sim.paused = false;
-  for (let i = 0; i < 4; i++) sim.tick(1);
-  assert.ok(sim.packages.size >= openingTotal + 2, 'Incoming packages should arrive in visible waves');
+  tickUntil(sim, () => sim.packages.size >= openingTotal + 2, 20);
+}
+
+{
+  assert.deepEqual(Object.values(CARRIERS).map(carrier => carrier.name), ['NORDPOST', 'DLH', 'BRUNG', 'STÄNKER']);
+  assert.equal(new Set(Object.values(CARRIERS).map(carrier => carrier.rhythm)).size, 4);
+  assert.equal(CARRIERS.dlh.service, 'express');
+  assert.ok(CARRIERS.stanker.deadline > CARRIERS.brung.deadline);
 }
 
 {
   const sim = new PostalSimulation({ seed: 10 });
   const locationlessHold = sim.addPackage({
-    id: 'IN-HOLD',
-    origin: { place: 'Hamburg', country: 'Germany' },
-    destination: { place: 'Timrå', country: 'Sweden' },
-    cityId: null,
-    location: 'Hamburg partner hub',
-    status: 'held',
-    issue: 'missed-scan'
+    id: 'IN-HOLD', origin: { place: 'Hamburg', country: 'Germany' },
+    destination: { place: 'Timrå', country: 'Sweden' }, cityId: null,
+    location: 'Hamburg partner hub', status: 'held', issue: 'missed-scan'
   });
   assert.equal(locationlessHold.cityId, null);
   const incoming = sim.getIncomingPackages();
@@ -47,11 +64,10 @@ const { PostalSimulation, packageScore, nextLegForPackage } = context.POSTAL_MOD
 
 {
   const sim = new PostalSimulation({ seed: 1 });
-  sim.paused = false;
+  sim.spawnEnabled = false;
   const pkg = sim.packages.get('SOR-48219');
   assert.equal(nextLegForPackage(pkg).kind, 'national');
-  for (let i = 0; i < 900 && pkg.status !== 'delivered'; i++) sim.tick(.5);
-  assert.equal(pkg.status, 'delivered');
+  runManaged(sim, pkg);
   assert.match(pkg.location, /Aarhus/);
   assert.ok(pkg.trace.some(step => step.label === 'National linehaul departed'));
   assert.ok(pkg.trace.some(step => step.label === 'International departure'));
@@ -59,12 +75,10 @@ const { PostalSimulation, packageScore, nextLegForPackage } = context.POSTAL_MOD
 
 {
   const sim = new PostalSimulation({ seed: 2 });
-  sim.paused = false;
+  sim.spawnEnabled = false;
   const pkg = sim.packages.get('US-77104');
-  const result = sim.resolveIssue(pkg.id, 'scan-cage');
-  assert.equal(result.ok, true);
-  for (let i = 0; i < 900 && pkg.status !== 'delivered'; i++) sim.tick(.5);
-  assert.equal(pkg.status, 'delivered');
+  assert.equal(sim.resolveIssue(pkg.id, 'scan-cage').ok, true);
+  runManaged(sim, pkg);
   assert.equal(pkg.location, 'Timrå');
   assert.ok(pkg.trace.some(step => step.label === 'Manual cage scan found parcel'));
 }
@@ -76,17 +90,49 @@ const { PostalSimulation, packageScore, nextLegForPackage } = context.POSTAL_MOD
   const complaint = sim.packages.get('US-77104');
   complaint.issue = null; complaint.status = 'arrived'; sim._enqueue(complaint);
   const ordinary = sim.addPackage({ id:'TEST-ORD', origin:{place:'Solna',country:'Sweden'}, destination:{place:'Nacka',country:'Sweden'}, cityId:'stockholm', location:'Stockholm terminal', deadline: 500 });
-  sim.focus='complaints';
-  assert.ok(packageScore(complaint, sim.focus, sim.clock) > packageScore(ordinary, sim.focus, sim.clock));
-  sim.paused=false; sim.tick(.1);
-  assert.ok(city.workers.some(w => w.packageId === complaint.id));
+  assert.equal(sim.setFocus('stockholm', 'complaints'), true);
+  assert.equal(sim.getFocus('stockholm'), 'complaints');
+  assert.equal(sim.getFocus('sundsvall'), 'late', 'Depot focus must be isolated by city');
+  assert.ok(packageScore(complaint, sim.getFocus('stockholm'), sim.clock) > packageScore(ordinary, sim.getFocus('stockholm'), sim.clock));
+  sim.tick(.1);
+  assert.ok(city.workers.some(worker => worker.packageId === complaint.id));
+}
+
+{
+  const sim = new PostalSimulation({ seed: 12, firstDay: true });
+  const pkg = sim.packages.get('DAY1-1001');
+  assert.equal(sim.packages.size, 1, 'The first morning should begin with one readable decision');
+  assert.equal(pkg.tutorialLock, true);
+  assert.equal(sim.startFirstDaySort(), true);
+  assert.equal(sim.cities.sundsvall.workers.find(worker => worker.name === 'Leo').packageId, pkg.id, 'Leo should visibly perform the Express tutorial sort');
+  tickUntil(sim, () => pkg.status === 'ready-local', 30);
+  for (let i = 0; i < 40; i += 1) sim.tick(.5);
+  assert.equal(pkg.status, 'ready-local', 'Regional trucks must never auto-depart');
+  assert.equal(sim.cities.sundsvall.regionalTrucks.find(truck => truck.to === 'Timrå').departures, 0);
+  const planned = sim.planPackageOnTruck(pkg.id);
+  assert.equal(planned.ok, true);
+  const sent = sim.dispatchTruck(planned.truck.id);
+  assert.equal(sent.grade, 'EXPRESS RUN');
+  assert.ok(sent.points > 0);
+  tickUntil(sim, () => pkg.status === 'delivered', 40);
+  assert.equal(sim.releaseFirstDayWave(), true);
+  assert.equal(new Set([...sim.packages.values()].filter(item => item.status !== 'delivered').map(item => item.carrier)).size, 4);
+  sim.setFocus('sundsvall', 'express');
+  assert.equal(sim.releaseChicagoCase(), true);
+  const chicago = sim.packages.get('US-77104');
+  assert.equal(sim.resolveIssue(chicago.id, 'scan-cage').ok, true);
+  runManaged(sim, chicago);
+  const checkpoints = Array.from(chicago.trace).filter(step => /linehaul arrived|Delivered/.test(step.label)).map(step => step.place);
+  assert.deepEqual(checkpoints, ['Sundsvall terminal', 'Timrå']);
+  assert.equal(sim.completeFirstDay(), true);
+  assert.equal(sim.spawnEnabled, true);
+  assert.ok(sim.getMetrics().score > 0);
 }
 
 {
   const sim = new PostalSimulation({ seed: 4 });
-  sim.paused = false;
-  for (let i=0;i<600;i++) sim.tick(.5);
-  const queued=[];
+  for (let i = 0; i < 600; i += 1) sim.tick(.5);
+  const queued = [];
   for (const city of Object.values(sim.cities)) for (const queue of Object.values(city.queues)) queued.push(...queue);
   assert.equal(new Set(queued).size, queued.length);
   for (const id of queued) assert.ok(sim.packages.has(id));

--- a/postal/tests/ui-contract.test.mjs
+++ b/postal/tests/ui-contract.test.mjs
@@ -7,23 +7,41 @@ const here = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(here, '..');
 const html = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
 const css = fs.readFileSync(path.join(root, 'styles.css'), 'utf8');
+const hierarchy = fs.readFileSync(path.join(root, 'hierarchy.css'), 'utf8');
 const foundation = fs.readFileSync(path.join(root, 'runtime', 'app-foundation.js'), 'utf8');
+const interaction = fs.readFileSync(path.join(root, 'runtime', 'interaction-boot.js'), 'utf8');
+const tutorial = fs.readFileSync(path.join(root, 'runtime', 'tutorial.js'), 'utf8');
+const region = fs.readFileSync(path.join(root, 'runtime', 'scene-region.js'), 'utf8');
 
 const ids = [...html.matchAll(/\sid="([^"]+)"/g)].map(match => match[1]);
 assert.equal(new Set(ids).size, ids.length, 'HTML IDs must be unique');
 
-for (const id of ['scene', 'scene-fallback', 'pause-btn', 'help-btn', 'incoming-btn', 'clock', 'metric-ontime', 'metric-flow', 'metric-issues', 'focus-btn', 'find-btn', 'event-ribbon', 'sheet']) {
-  assert.ok(ids.includes(id), `Missing required UI hook #${id}`);
-}
+for (const id of [
+  'scene', 'scene-fallback', 'pause-btn', 'help-btn', 'incoming-btn', 'clock',
+  'metric-ontime', 'metric-flow', 'metric-issues', 'focus-btn', 'find-btn',
+  'action-dock', 'action-primary', 'action-details', 'package-rail', 'flow-feedback', 'sheet'
+]) assert.ok(ids.includes(id), `Missing required UI hook #${id}`);
 
 assert.match(html, /<canvas[^>]+aria-label=/, 'The interactive scene needs an accessible name');
 assert.match(html, /<dialog[^>]+aria-labelledby="sheet-title"/, 'The bottom sheet needs an accessible name');
+assert.match(html, /id="package-rail"[^>]+role="list"/, 'The persistent package rail needs list semantics');
+assert.match(html, /id="action-primary"[^>]*>SELECT</, 'The direct action must be visible in the main HUD');
+assert.doesNotMatch(html, /scene-help-btn|event-ribbon/, 'Retired duplicate and event-only controls must stay removed');
+
 assert.doesNotMatch(foundation, /oopi\.glb/i, 'Alien workers must not return');
 const characterModels = [...foundation.matchAll(/character-(?:female|male)-[a-f]\.glb/g)].map(match => match[0]);
 assert.equal(new Set(characterModels).size, 9, 'Each depot worker needs a distinct Mini Character model');
+assert.match(foundation, /treeClusterTall/);
+assert.match(interaction, /app\.packageRail\.addEventListener\('click'/);
+assert.match(interaction, /simulation\.dispatchTruck/);
+assert.doesNotMatch(interaction, /showBriefingSheet\(\{\s*firstRun|needsFirstShiftBriefing/, 'The first day must be played, not opened as a modal briefing');
+assert.match(tutorial, /select-package[\s\S]*choose-focus[\s\S]*select-chicago[\s\S]*send-national[\s\S]*send-timra/);
+assert.match(region, /function roadRotationFor\(dx, dz\)[\s\S]*Math\.atan2\(dx, dz\)/, 'Road tiles must derive orientation from their route vector');
+assert.match(region, /addRegionEdgeNature\(cityId\)/, 'Region edges need deliberate nature framing');
 assert.match(foundation, /city-kit-roads|kenney\/roads/);
 assert.match(css, /env\(safe-area-inset-top/);
 assert.match(css, /prefers-reduced-motion/);
+assert.match(hierarchy, /\.sheet\[open\][\s\S]*max-height:\s*min\(56dvh/, 'Information sheets must preserve a visible world above them');
 
 const assetPaths = [...foundation.matchAll(/['"](\.\/assets\/[^'"]+)['"]/g)].map(match => match[1]);
 assert.ok(assetPaths.length >= 30, 'The visual manifest should include the full diorama set');


### PR DESCRIPTION
## What changed

- makes packages the persistent controls at Depot, Region, and Sweden scales, with carrier identity, deadlines, location, and route breadcrumbs
- adds a playable first morning: sort DLH, manually load/send regional and national trucks, set a depot-specific focus, and guide Chicago → Stockholm → Sundsvall → Timrå
- restores NORDPOST, DLH, BRUNG, and STÄNKER as distinct visual and gameplay rhythms
- replaces automatic truck departures with player timing, load planning, dispatch grades, points, and flow chains
- raises visual hierarchy around the next executable action, highlights the selected package/route, fixes regional road orientation, and frames region edges with Kenney nature assets
- keeps the three depot teams distinct and preserves the skinned Kenney Mini Character rendering fix
- replaces modal onboarding and oversized information overlays with anchored tutorial CTAs and compact non-modal sheets

## Validation

- `node --check postal/main.mjs`
- `node --check postal/sw.js`
- `node --check postal/runtime/*.js`
- `node --test postal/tests/*.test.mjs` (4/4 passing)
- `git diff --check`
