### PR TITLE
Rotate every POSTAL region road tile counterclockwise

### DIFF
--- a/postal/runtime/scene-region.js
+++ b/postal/runtime/scene-region.js
@@ -4,6 +4,7 @@ const regionBuildingSets = {
   stockholm: ['commercialA', 'commercialH', 'skyscraper', 'commercialA'],
   goteborg: ['industrialB', 'industrialS', 'industrialT', 'industrialS']
 };
+const REGION_ROAD_CCW_OFFSET = Math.PI / 2;
 
 function buildRegionScene(cityId) {
   scene.background.set(cityId === 'stockholm' ? 0xd9e8ec : 0xddebe3);
@@ -98,7 +99,12 @@ function roadRotationFor(dx, dz) {
 }
 
 function addRoadTile(key, position, target, rotation) {
-  const road = cloneAsset(key, { target, position, rotation: [0, rotation, 0], shadow: false });
+  const road = cloneAsset(key, {
+    target,
+    position,
+    rotation: [0, rotation + REGION_ROAD_CCW_OFFSET, 0],
+    shadow: false
+  });
   if (road) world.add(road);
   else {
     const fallback = boxMesh([target, .06, target], 0x687674, [position[0], position[1], position[2]]);

--- a/postal/tests/ui-contract.test.mjs
+++ b/postal/tests/ui-contract.test.mjs
@@ -37,6 +37,8 @@ assert.match(interaction, /simulation\.dispatchTruck/);
 assert.doesNotMatch(interaction, /showBriefingSheet\(\{\s*firstRun|needsFirstShiftBriefing/, 'The first day must be played, not opened as a modal briefing');
 assert.match(tutorial, /select-package[\s\S]*choose-focus[\s\S]*select-chicago[\s\S]*send-national[\s\S]*send-timra/);
 assert.match(region, /function roadRotationFor\(dx, dz\)[\s\S]*Math\.atan2\(dx, dz\)/, 'Road tiles must derive orientation from their route vector');
+assert.match(region, /const REGION_ROAD_CCW_OFFSET = Math\.PI \/ 2/, 'Every region road tile needs the requested quarter-turn counterclockwise');
+assert.match(region, /function addRoadTile\([\s\S]*rotation \+ REGION_ROAD_CCW_OFFSET/, 'The counterclockwise offset must apply to every region road asset');
 assert.match(region, /addRegionEdgeNature\(cityId\)/, 'Region edges need deliberate nature framing');
 assert.match(foundation, /city-kit-roads|kenney\/roads/);
 assert.match(css, /env\(safe-area-inset-top/);


### PR DESCRIPTION
## What changed
- rotate every REGION road asset 90° counterclockwise through the shared tile renderer
- cover crossings, straight sections, marked crossings, and rounded road ends consistently
- add a regression check so future REGION road pieces inherit the same orientation

## Validation
- `node --check postal/main.mjs`
- `node --check postal/sw.js`
- `node --check postal/runtime/*.js`
- `node --test postal/tests/*.test.mjs` (4/4 passing)
- `git diff --check`