### PR TITLE
Reveal POSTAL progressively and add a calm score

### DIFF
--- a/postal/README.md
+++ b/postal/README.md
@@ -19,6 +19,7 @@ The first day is an interactive shift, not an onboarding dialog:
 - Meet a four-carrier intake wave and set Sundsvall’s focus.
 - Find the Chicago → Timrå package in Stockholm, repair its missing scan and keep it visible through national and regional handoffs.
 - Finish with a scored first-morning summary, then open the full incoming flow.
+- The interface reveals route, pressure, focus, city and search controls only when the shift introduces them; the live package rail, current action, help, pause and music remain available throughout.
 
 ## Carrier rhythms
 
@@ -35,6 +36,7 @@ The first day is an interactive shift, not an onboarding dialog:
 - **Factory Kit** conveyors, scanners, parcels, loading equipment and depot modules make the sorting floor legible.
 - The selected package is marked in the 3D depot and its active route is highlighted in Region and Sweden views.
 - Compact non-modal sheets preserve the world above them; the direct action remains in the main HUD.
+- “Morning Routes” is a calm procedural score built from TURN’s Web Audio music engine modules. It starts after the first interaction and its persistent music control fully suspends the engine when switched off.
 
 ## Validation
 

--- a/postal/hierarchy.css
+++ b/postal/hierarchy.css
@@ -10,12 +10,42 @@
   top: calc(5px + var(--safe-top));
   min-height: 42px;
 }
+.topbar-actions { gap: 4px; }
 .brand-mark { width: 36px; height: 36px; border-radius: 11px; }
 .brand strong { font-size: .82rem; }
 .brand div > span { margin-top: 2px; font-size: .57rem; opacity: .6; }
 .clock,
 .compact-btn { min-height: 38px; border-radius: 12px; }
-.help-btn { width: 38px; }
+.help-btn,
+.music-btn { width: 38px; padding: 0; }
+.music-btn {
+  position: relative;
+  overflow: hidden;
+  background: rgba(7, 29, 28, .68);
+  color: var(--yellow);
+  font-size: .92rem;
+}
+.music-btn[aria-pressed="true"] { background: rgba(7, 29, 28, .72); }
+.music-btn[aria-pressed="false"] { color: rgba(255,255,255,.62); }
+.music-btn[aria-pressed="false"]::after {
+  content: "";
+  position: absolute;
+  width: 22px;
+  height: 2px;
+  border-radius: 2px;
+  background: currentColor;
+  transform: rotate(-45deg);
+}
+.music-btn:disabled { opacity: .5; }
+
+.first-day-pending [data-tutorial-reveal],
+[data-tutorial-reveal][hidden] { display: none !important; }
+.tutorial-just-revealed { animation: tutorialReveal .58s cubic-bezier(.2,.82,.2,1); }
+@keyframes tutorialReveal {
+  0% { opacity: 0; transform: translateY(10px) scale(.97); }
+  62% { opacity: 1; transform: translateY(-2px) scale(1.01); }
+  100% { opacity: 1; transform: translateY(0) scale(1); }
+}
 
 .status-strip {
   top: calc(51px + var(--safe-top));
@@ -329,6 +359,14 @@
   .live-package-card { flex-basis: 163px; }
 }
 
+@media (max-width: 390px) {
+  .pause-btn { width: 38px; padding: 0; }
+  #pause-label { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0); }
+}
+
+html[data-tutorial-phase="package"] .world-context,
+html[data-tutorial-phase="route"] .world-context { top: calc(51px + var(--safe-top)); }
+
 @media (orientation: landscape) and (max-height: 620px) {
   .package-console { height: 92px; }
   .package-rail { height: 61px; }
@@ -337,5 +375,6 @@
 
 @media (prefers-reduced-motion: reduce) {
   .action-dock[data-tone="tutorial"] .dock-button-primary,
-  .live-package-card.tutorial-target { animation: none; }
+  .live-package-card.tutorial-target,
+  .tutorial-just-revealed { animation: none; }
 }

--- a/postal/index.html
+++ b/postal/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="first-day-pending">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
@@ -63,6 +63,9 @@
               <svg aria-hidden="true" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"></circle><path d="M12 7v5l3 2"></path></svg>
               <span id="clock">07:00</span>
             </span>
+            <button id="music-btn" class="compact-btn music-btn" type="button" aria-pressed="true" aria-label="Turn music off" title="Turn music off">
+              <span aria-hidden="true">♫</span>
+            </button>
             <button id="help-btn" class="compact-btn help-btn" type="button" aria-label="How to play">
               <span aria-hidden="true">?</span>
             </button>
@@ -73,7 +76,7 @@
           </div>
         </header>
 
-        <section class="status-strip" aria-label="Network status">
+        <section class="status-strip" data-tutorial-reveal="status" aria-label="Network status">
           <div class="metric metric-ontime">
             <span class="metric-label">ON TIME</span>
             <strong id="metric-ontime">100%</strong>
@@ -100,7 +103,7 @@
               <p id="level-subtitle">People sort. Packages move. You decide what matters.</p>
             </div>
           </div>
-          <nav class="city-switcher" aria-label="City">
+          <nav class="city-switcher" data-tutorial-reveal="cities" aria-label="City">
             <button class="city-chip" type="button" data-city="sundsvall" aria-pressed="true"><span>SUN</span>Sundsvall</button>
             <button class="city-chip" type="button" data-city="stockholm" aria-pressed="false"><span>STO</span>Stockholm</button>
             <button class="city-chip" type="button" data-city="goteborg" aria-pressed="false"><span>GBG</span>Göteborg</button>
@@ -130,10 +133,10 @@
                 <span id="package-console-summary">Loading the network…</span>
               </div>
               <div class="package-tools" aria-label="Package tools">
-                <button id="focus-btn" class="package-tool focus-tool" type="button">
+                <button id="focus-btn" class="package-tool focus-tool" data-tutorial-reveal="focus" type="button">
                   <small>FOCUS</small><strong id="focus-value">SUN · LATE</strong>
                 </button>
-                <button id="find-btn" class="package-tool find-tool" type="button" aria-label="Find a package">
+                <button id="find-btn" class="package-tool find-tool" data-tutorial-reveal="find" type="button" aria-label="Find a package">
                   <svg aria-hidden="true" viewBox="0 0 24 24"><circle cx="10.5" cy="10.5" r="6"></circle><path d="m15 15 5 5"></path></svg>
                   <span>FIND</span>
                 </button>
@@ -142,7 +145,7 @@
             <div id="package-rail" class="package-rail" role="list" aria-label="Packages across the whole network"></div>
           </section>
 
-          <nav class="level-switcher" aria-label="Network level">
+          <nav class="level-switcher" data-tutorial-reveal="levels" aria-label="Network level">
             <button class="level-tab" type="button" data-level="depot" aria-pressed="true">
               <svg aria-hidden="true" viewBox="0 0 24 24"><path d="M3 10h18v10H3zM6 10V6h12v4M7 14h3v6M14 14h3v2h-3z"></path></svg>
               <span><small>ZOOMED IN</small>DEPOT</span>

--- a/postal/main.mjs
+++ b/postal/main.mjs
@@ -24,3 +24,10 @@ function loadClassic(src) {
 }
 
 for (const src of scripts) await loadClassic(src);
+
+try {
+  const { installPostalMusic } = await import('./music.mjs');
+  globalThis.__postalMusic = installPostalMusic({ button: document.querySelector('#music-btn') });
+} catch (error) {
+  console.warn('POSTAL music could not start.', error);
+}

--- a/postal/music.mjs
+++ b/postal/music.mjs
@@ -1,0 +1,327 @@
+import { createToneRuntime } from '../turn/audio/music/tone-runtime.js?revision=r184-score-v2';
+import { createDrumRuntime } from '../turn/audio/music/drum-runtime.js?revision=r184-score-v2';
+import { bars, makeSection, makeSong } from '../turn/audio/music/song-tools.js?revision=r186-note-ties';
+
+const TUNE = makeSection({
+  name: 'tune',
+  leadVoice: 'organ', bassVoice: 'drone', arpVoice: 'glass', drumKit: 'brush',
+  lead: bars(
+    'G5 - - - B5 - - - D6 - - - B5 - - -',
+    'A5 - - - F#5 - - - D6 - - - A5 - - -',
+    'G5 - - - E5 - - - B5 - - - G5 - - -',
+    'E5 - - - G5 - - - B5 - - - D6 - - -'
+  ),
+  bass: bars(
+    'G2 - - - D3 - - - G2 - - - D3 - - -',
+    'F#2 - - - A2 - - - D3 - - - A2 - - -',
+    'E2 - - - B2 - - - E3 - - - B2 - - -',
+    'C2 - - - G2 - - - C3 - - - D3 - - -'
+  ),
+  arp: bars(
+    'G4 - B4 - D5 - B4 - G5 - D5 - B4 - D5 -',
+    'F#4 - A4 - D5 - A4 - F#5 - D5 - A4 - D5 -',
+    'E4 - G4 - B4 - G4 - E5 - B4 - G4 - B4 -',
+    'C4 - E4 - G4 - E4 - C5 - G4 - D5 - G4 -'
+  ),
+  drums: bars(
+    'K - - - R - - - - - - - R - - -',
+    '- - - - R - - - K - - - R - - -',
+    'K - - - R - - - - - - - R - - -',
+    '- - - - R - - - K - - - R - - -'
+  )
+});
+
+const CHORUS = makeSection({
+  name: 'chorus',
+  leadVoice: 'bell', bassVoice: 'drone', arpVoice: 'soft', drumKit: 'brush',
+  lead: bars(
+    'B5 - - - D6 - - - G6 - - - D6 - - -',
+    'A5 - - - D6 - - - F#6 - - - E6 - - -',
+    'G5 - - - B5 - - - E6 - - - B5 - - -',
+    'A5 - - - D6 - - - F#6 - - - D6 - - -'
+  ),
+  bass: bars(
+    'E2 - - - B2 - - - E3 - - - B2 - - -',
+    'C2 - - - G2 - - - C3 - - - G2 - - -',
+    'G2 - - - D3 - - - G3 - - - D3 - - -',
+    'D2 - - - A2 - - - D3 - - - A2 - - -'
+  ),
+  arp: bars(
+    'E4 - B4 - G4 - B4 - E5 - B4 - G4 - B4 -',
+    'C4 - G4 - E4 - G4 - C5 - G4 - E4 - G4 -',
+    'G4 - D5 - B4 - D5 - G5 - D5 - B4 - D5 -',
+    'D4 - A4 - F#4 - A4 - D5 - A4 - F#4 - A4 -'
+  ),
+  drums: bars(
+    'K - - - R - - - - - - - R - - -',
+    '- - - - R - - - K - - - R - - -',
+    'K - - - R - - - - - - - R - - -',
+    '- - - - R - - - K - - - R - - -'
+  )
+});
+
+const BRIDGE = makeSection({
+  name: 'bridge',
+  leadVoice: 'organ', bassVoice: 'drone', arpVoice: 'organ', drumKit: 'brush',
+  lead: bars(
+    'C6 - - - B5 - - - G5 - - - E5 - - -',
+    'A5 - - - F#5 - - - D5 - - - F#5 - - -',
+    'B5 - - - G5 - - - E5 - - - G5 - - -',
+    'A5 - - - D6 - - - B5 - - - G5 - - -'
+  ),
+  bass: bars(
+    'C2 - - - G2 - - - C3 - - - G2 - - -',
+    'D2 - - - A2 - - - D3 - - - A2 - - -',
+    'E2 - - - B2 - - - E3 - - - B2 - - -',
+    'G2 - - - D3 - - - G3 - - - D3 - - -'
+  ),
+  arp: bars(
+    'C4 - - E4 - - G4 - - E4 - - G4 - - -',
+    'D4 - - F#4 - - A4 - - F#4 - - A4 - - -',
+    'E4 - - G4 - - B4 - - G4 - - B4 - - -',
+    'G4 - - B4 - - D5 - - B4 - - D5 - - -'
+  ),
+  drums: bars(
+    '- - R - - - R - - - R - - - R -',
+    '- - R - - - R - - - R - - - R -',
+    '- - R - - - R - - - R - - - R -',
+    '- - R - - - R - - - R - - - R -'
+  )
+});
+
+export const POSTAL_SONG = makeSong({
+  id: 'morning-routes',
+  name: 'Morning Routes',
+  bpm: 78,
+  key: 'G major / E minor',
+  style: 'calm Scandinavian logistics score',
+  swing: 0.08,
+  sections: [TUNE, CHORUS, BRIDGE],
+  arrangement: ['tune', 'tune', 'chorus', 'tune', 'bridge', 'chorus']
+});
+
+const AudioContextClass = globalThis.AudioContext || globalThis.webkitAudioContext;
+const STORAGE_KEY = 'postal-music-volume-v1';
+const LAST_VOLUME_KEY = 'postal-music-last-volume-v1';
+const DEFAULT_VOLUME = 48;
+const DESIGNED_MASTER_GAIN = 0.28;
+const STEPS_PER_BEAT = 4;
+const LOOKAHEAD_MS = 25;
+const SCHEDULE_AHEAD_SECONDS = 0.12;
+const NOTE_INDEX = Object.freeze({
+  C: 0, 'C#': 1, Db: 1, D: 2, 'D#': 3, Eb: 3, E: 4, F: 5,
+  'F#': 6, Gb: 6, G: 7, 'G#': 8, Ab: 8, A: 9, 'A#': 10, Bb: 10, B: 11
+});
+
+let installed = false;
+let context = null;
+let masterGain = null;
+let tones = null;
+let drums = null;
+let schedulerTimer = 0;
+let currentSection = 0;
+let currentStep = 0;
+let nextStepTime = 0;
+let playing = false;
+let musicButton = null;
+let musicVolume = readStoredNumber(STORAGE_KEY, DEFAULT_VOLUME);
+let lastNonZeroVolume = readStoredNumber(LAST_VOLUME_KEY, DEFAULT_VOLUME);
+const stepSeconds = (60 / POSTAL_SONG.bpm) / STEPS_PER_BEAT;
+const supported = Boolean(AudioContextClass && typeof globalThis.GainNode === 'function');
+
+function clamp(value, min, max, fallback = min) {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.max(min, Math.min(max, value));
+}
+
+function readStoredNumber(key, fallback) {
+  try {
+    const stored = globalThis.localStorage?.getItem(key);
+    if (stored == null || stored === '') return fallback;
+    const value = Number(stored);
+    return Number.isFinite(value) ? clamp(value, 0, 100, fallback) : fallback;
+  } catch { return fallback; }
+}
+
+function writeStoredNumber(key, value) {
+  try { globalThis.localStorage?.setItem(key, String(Math.round(value))); }
+  catch {}
+}
+
+function noteToFrequency(note) {
+  const match = /^([A-G](?:#|b)?)(-?\d+)$/.exec(note);
+  if (!match) return 440;
+  const midi = NOTE_INDEX[match[1]] + (Number(match[2]) + 1) * 12;
+  return 440 * Math.pow(2, (midi - 69) / 12);
+}
+
+function makeNoiseBuffer() {
+  const buffer = context.createBuffer(1, context.sampleRate, context.sampleRate);
+  const channel = buffer.getChannelData(0);
+  for (let index = 0; index < channel.length; index += 1) channel[index] = Math.random() * 2 - 1;
+  return buffer;
+}
+
+function ensureGraph() {
+  if (context || !supported) return Boolean(context);
+  try { context = new AudioContextClass({ latencyHint: 'playback' }); }
+  catch { context = new AudioContextClass(); }
+
+  masterGain = new GainNode(context, { gain: 0 });
+  const compressor = context.createDynamicsCompressor();
+  compressor.threshold.value = -16;
+  compressor.knee.value = 22;
+  compressor.ratio.value = 2.2;
+  compressor.attack.value = 0.025;
+  compressor.release.value = 0.4;
+  masterGain.connect(compressor);
+  compressor.connect(context.destination);
+
+  const noiseBuffer = makeNoiseBuffer();
+  tones = createToneRuntime({ context, masterGain, noteToFrequency, getStepSeconds: () => stepSeconds });
+  drums = createDrumRuntime({ context, masterGain, noiseBuffer });
+  return true;
+}
+
+function activeSection() {
+  return POSTAL_SONG.arrangement[currentSection];
+}
+
+function scheduleStep(step, time) {
+  const section = activeSection();
+  tones?.playLead(section.lead[step], time, section.leadVoice);
+  tones?.playBass(section.bass[step], time, section.bassVoice);
+  tones?.playArp(section.arp[step], time, section.arpVoice);
+  drums?.play(section.drums[step], time, section.drumKit);
+}
+
+function advanceStep() {
+  const completedStep = currentStep;
+  currentStep += 1;
+  if (currentStep >= activeSection().lead.length) {
+    currentStep = 0;
+    currentSection = (currentSection + 1) % POSTAL_SONG.arrangement.length;
+  }
+  const swing = POSTAL_SONG.swing;
+  nextStepTime += stepSeconds * (completedStep % 2 === 0 ? 1 + swing : 1 - swing);
+}
+
+function scheduler() {
+  if (!playing || !context || context.state !== 'running') return;
+  while (nextStepTime < context.currentTime + SCHEDULE_AHEAD_SECONDS) {
+    scheduleStep(currentStep, nextStepTime);
+    advanceStep();
+  }
+  schedulerTimer = globalThis.setTimeout(scheduler, LOOKAHEAD_MS);
+}
+
+function clearScheduler() {
+  globalThis.clearTimeout(schedulerTimer);
+  schedulerTimer = 0;
+}
+
+function applyVolume() {
+  if (!masterGain || !context) return;
+  const gain = musicVolume > 0 ? DESIGNED_MASTER_GAIN * (musicVolume / 100) : 0;
+  const now = context.currentTime;
+  masterGain.gain.cancelScheduledValues(now);
+  masterGain.gain.setTargetAtTime(gain, now, 0.08);
+}
+
+function syncButton() {
+  if (!musicButton) return;
+  const enabled = supported && musicVolume > 0;
+  musicButton.disabled = !supported;
+  musicButton.setAttribute('aria-pressed', String(enabled));
+  musicButton.setAttribute('aria-label', supported ? `Turn music ${enabled ? 'off' : 'on'}` : 'Music is not supported on this device');
+  musicButton.title = musicButton.getAttribute('aria-label');
+}
+
+async function startPlayback({ restart = false } = {}) {
+  if (!supported || musicVolume <= 0 || document.visibilityState === 'hidden') return false;
+  if (!ensureGraph()) return false;
+  if (restart) { currentSection = 0; currentStep = 0; }
+  try { if (context.state !== 'running') await context.resume(); }
+  catch { return false; }
+  if (context.state !== 'running') return false;
+  applyVolume();
+  if (!playing) {
+    playing = true;
+    nextStepTime = context.currentTime + 0.06;
+    scheduler();
+  }
+  return true;
+}
+
+async function stopPlayback({ reset = false } = {}) {
+  playing = false;
+  clearScheduler();
+  tones?.stop();
+  drums?.stop();
+  if (reset) { currentSection = 0; currentStep = 0; }
+  if (!context) return;
+  applyVolume();
+  try { if (context.state === 'running') await context.suspend(); }
+  catch {}
+}
+
+function setVolume(nextVolume, { restart = false } = {}) {
+  const previous = musicVolume;
+  musicVolume = clamp(Number(nextVolume), 0, 100, DEFAULT_VOLUME);
+  if (musicVolume > 0) {
+    lastNonZeroVolume = musicVolume;
+    writeStoredNumber(LAST_VOLUME_KEY, lastNonZeroVolume);
+  }
+  writeStoredNumber(STORAGE_KEY, musicVolume);
+  syncButton();
+  if (musicVolume <= 0) void stopPlayback({ reset: true });
+  else if (previous <= 0 || restart || !playing) void startPlayback({ restart: previous <= 0 || restart });
+  else applyVolume();
+  return musicVolume;
+}
+
+function toggleMusic() {
+  if (musicVolume > 0) return setVolume(0);
+  return setVolume(clamp(lastNonZeroVolume || DEFAULT_VOLUME, 1, 100, DEFAULT_VOLUME), { restart: true });
+}
+
+function announceMusic() {
+  const live = document.querySelector('#live-region');
+  if (live) live.textContent = musicVolume > 0 ? `Music on. ${POSTAL_SONG.name}.` : 'Music off.';
+}
+
+function handleActivation() {
+  if (musicVolume > 0 && !playing) void startPlayback();
+}
+
+function handleVisibilityChange() {
+  if (document.visibilityState === 'hidden') void stopPlayback();
+  else if (musicVolume > 0) void startPlayback();
+}
+
+export function installPostalMusic({ button = document.querySelector('#music-btn') } = {}) {
+  if (installed) return globalThis.__postalMusic;
+  installed = true;
+  musicButton = button;
+  syncButton();
+  musicButton?.addEventListener('click', () => { toggleMusic(); announceMusic(); });
+  document.addEventListener('pointerdown', handleActivation, { capture: true, passive: true });
+  document.addEventListener('keydown', handleActivation, { capture: true });
+  document.addEventListener('visibilitychange', handleVisibilityChange, { passive: true });
+  globalThis.addEventListener('pagehide', () => void stopPlayback(), { passive: true });
+
+  const api = Object.freeze({
+    name: POSTAL_SONG.name,
+    bpm: POSTAL_SONG.bpm,
+    get enabled() { return musicVolume > 0; },
+    get playing() { return playing; },
+    get volume() { return musicVolume; },
+    get state() { return context?.state || 'not-created'; },
+    setVolume,
+    toggle: toggleMusic,
+    start: () => startPlayback(),
+    stop: () => setVolume(0)
+  });
+  globalThis.__postalMusic = api;
+  return api;
+}

--- a/postal/runtime/interaction-boot.js
+++ b/postal/runtime/interaction-boot.js
@@ -288,6 +288,7 @@ function bindUI() {
 
 async function boot() {
   bindUI();
+  syncTutorialInterface();
   resizeRenderer();
   if (renderer) await preloadAssets();
   buildScene();

--- a/postal/runtime/tutorial.js
+++ b/postal/runtime/tutorial.js
@@ -1,6 +1,14 @@
 'use strict';
 let firstDayCelebration = false;
 let tutorialLastStage = simulation.tutorialStage;
+let tutorialInterfaceReady = false;
+const tutorialInterfaceElements = Object.freeze({
+  status: $('.status-strip'),
+  levels: $('.level-switcher'),
+  focus: $('#focus-btn'),
+  cities: $('.city-switcher'),
+  find: $('#find-btn')
+});
 
 function tutorialIsActive() {
   return simulation.firstDay && simulation.tutorialStage !== 'complete';
@@ -8,6 +16,41 @@ function tutorialIsActive() {
 
 function persistFirstDayComplete() {
   try { localStorage.setItem(FIRST_DAY_KEY, 'complete'); } catch {}
+}
+
+function tutorialInterfacePhase() {
+  if (!tutorialIsActive()) return 'complete';
+  if (['select-package', 'watch-sort'].includes(simulation.tutorialStage)) return 'package';
+  if (['load-local', 'send-local', 'local-driving'].includes(simulation.tutorialStage)) return 'route';
+  if (simulation.tutorialStage === 'choose-focus') return 'operations';
+  return 'network';
+}
+
+function syncTutorialInterface() {
+  const phase = tutorialInterfacePhase();
+  const visible = new Set(
+    phase === 'package' ? []
+      : phase === 'route' ? ['levels']
+      : phase === 'operations' ? ['levels', 'status', 'focus']
+      : Object.keys(tutorialInterfaceElements)
+  );
+
+  for (const [feature, element] of Object.entries(tutorialInterfaceElements)) {
+    if (!element) continue;
+    const shouldShow = visible.has(feature);
+    const wasHidden = element.hidden;
+    element.hidden = !shouldShow;
+    element.inert = !shouldShow;
+    if (shouldShow && wasHidden && tutorialInterfaceReady && !prefersReducedMotion) {
+      element.classList.remove('tutorial-just-revealed');
+      requestAnimationFrame(() => element.classList.add('tutorial-just-revealed'));
+      setTimeout(() => element.classList.remove('tutorial-just-revealed'), 700);
+    }
+  }
+
+  document.documentElement.dataset.tutorialPhase = phase;
+  document.documentElement.classList.remove('first-day-pending');
+  tutorialInterfaceReady = true;
 }
 
 function handleTutorialFocusChosen(cityId) {
@@ -105,13 +148,13 @@ function tutorialInstruction() {
       ? ['FIRST PACKAGE', 'DLH · Söråker → Timrå', 'Send it into the highlighted Express sort.', 'SORT EXPRESS', 'start-tutorial-sort']
       : ['FIRST PACKAGE', 'Tap the yellow DLH package', 'Packages stay here while you change depot or scale.', 'SELECT DLH', 'select-suggested'],
     'watch-sort': ['SORTING', 'Leo is moving your package', 'Watch its card change when it reaches the regional dock.', 'WATCH', 'watch'],
-    'load-local': ['TRUCK READY', 'Timrå route is waiting', 'Load the package, then choose when the truck leaves.', 'LOAD TRUCK', 'load-package'],
+    'load-local': ['REGION VIEW', 'Timrå route is waiting', 'The level bar now follows packages from depot floor to the roads.', 'LOAD TRUCK', 'load-package'],
     'send-local': ['YOUR DECISION', 'Timrå truck loaded', 'Leaving early protects DLH; waiting improves utilisation.', 'SEND TO TIMRÅ', 'dispatch-truck'],
     'local-driving': ['ON THE ROAD', 'Follow the DLH package', 'The first delivery will unlock a four-carrier wave.', 'FOLLOW', 'follow'],
-    'choose-focus': ['FOUR CARRIERS', 'Set Sundsvall’s team focus', 'Every depot keeps its own priority.', 'SET SUN FOCUS', 'open-focus'],
+    'choose-focus': ['NETWORK PRESSURE', 'Set Sundsvall’s team focus', 'LIVE and ISSUES now show pressure. Every depot keeps its own priority.', 'SET SUN FOCUS', 'open-focus'],
     'select-chicago': selectedPackageId === 'US-77104'
       ? ['MISSING SCAN', 'Chicago → Timrå', 'The breadcrumb shows where it stopped and what comes next.', 'SCAN CAGE', 'scan-cage']
-      : ['NETWORK CASE', 'Find Chicago → Timrå', 'It remains visible even though it is in Stockholm.', 'SELECT PACKAGE', 'select-suggested'],
+      : ['CITY TOOLS', 'Find Chicago → Timrå', 'FIND and the city switcher trace work anywhere without losing the package rail.', 'SELECT PACKAGE', 'select-suggested'],
     'watch-chicago-sort': ['FOUND IN STOCKHOLM', 'DLH package is sorting', 'Next: send it north on national linehaul.', 'WATCH', 'watch'],
     'load-national': ['NATIONAL HANDOFF', 'Stockholm → Sundsvall', 'Put the package on the northbound linehaul.', 'LOAD LINEHAUL', 'load-package'],
     'send-national': ['YOUR DECISION', 'Northbound linehaul loaded', 'Send it when the load is worth the deadline risk.', 'SEND TO SUNDSVALL', 'dispatch-truck'],

--- a/postal/runtime/ui-sheets.js
+++ b/postal/runtime/ui-sheets.js
@@ -12,6 +12,7 @@ function showBriefingSheet() {
       <span class="eyebrow">PACKAGES ARE THE CONTROLS</span>
       <h3>See it. Select it. Send it.</h3>
       <p>The live rail stays on screen at Depot, Region and Sweden. Select a package to reveal its next physical handoff.</p>
+      <p class="hint">On your first morning, the rest of the interface appears as each tool becomes useful. Help, pause and music always remain available.</p>
     </div>
     <div class="briefing-steps">
       <article><span aria-hidden="true">1</span><div><strong>Select a package</strong><p>Its route breadcrumb and next action remain visible while you move through the network.</p></div></article>

--- a/postal/runtime/visuals-ui-core.js
+++ b/postal/runtime/visuals-ui-core.js
@@ -307,6 +307,7 @@ function updateUI(force = false) {
   if (!force && now - lastUiUpdate < 300) return;
   lastUiUpdate = now;
   updateFirstDayTutorial();
+  syncTutorialInterface();
   const m = simulation.getMetrics();
   if (simulation.stats.received > lastReceivedCount) app.incoming.classList.add('new-arrival');
   lastReceivedCount = simulation.stats.received;

--- a/postal/sw.js
+++ b/postal/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'postal-packages-are-controls-2026-08-16-v3';
+const CACHE = 'postal-progressive-music-2026-08-16-v4';
 self.addEventListener('install', event => { self.skipWaiting(); });
 self.addEventListener('activate', event => {
   event.waitUntil((async () => {

--- a/postal/tests/hierarchy.test.mjs
+++ b/postal/tests/hierarchy.test.mjs
@@ -13,6 +13,10 @@ const interaction = fs.readFileSync(path.join(root, 'runtime', 'interaction-boot
 assert.match(html, /href="\.\/styles\.css"[\s\S]*href="\.\/hierarchy\.css"/, 'Hierarchy overrides must load after the base styles');
 assert.match(html, /id="action-dock"[\s\S]*id="action-primary"/, 'The contextual next action must remain visible above the package rail');
 assert.match(html, /id="package-console"|class="package-console"[\s\S]*id="package-rail"/, 'The live package rail must be persistent HUD, not sheet content');
+assert.doesNotMatch(html.match(/<section id="action-dock"[^>]*>/)?.[0] || '', /data-tutorial-reveal/, 'The tutorial must never hide the current action');
+assert.doesNotMatch(html.match(/<section class="package-console"[^>]*>/)?.[0] || '', /data-tutorial-reveal/, 'The tutorial must never hide live packages');
+assert.match(hierarchy, /\.first-day-pending \[data-tutorial-reveal\][\s\S]*display:\s*none !important/, 'Unintroduced controls must not flash before tutorial state loads');
+assert.match(hierarchy, /\.tutorial-just-revealed[\s\S]*tutorialReveal/, 'New controls need a legible visual entrance');
 assert.match(hierarchy, /\.dock-button-primary[\s\S]*background:\s*var\(--yellow\)/, 'Yellow belongs to the direct executable action');
 assert.match(hierarchy, /\.level-tab\[aria-pressed="true"\][\s\S]*background:\s*rgba\(255,255,255/, 'Navigation must be quieter than the CTA');
 assert.match(hierarchy, /\.metric-issues[\s\S]*background:\s*rgba\(7, 29, 28/, 'Issue count should be status, not a competing red action card');

--- a/postal/tests/music.test.mjs
+++ b/postal/tests/music.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { POSTAL_SONG } from '../music.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const source = fs.readFileSync(path.resolve(here, '..', 'music.mjs'), 'utf8');
+
+assert.equal(POSTAL_SONG.name, 'Morning Routes');
+assert.ok(POSTAL_SONG.bpm >= 70 && POSTAL_SONG.bpm <= 90, 'The management score should stay calm rather than race-paced');
+assert.equal(POSTAL_SONG.arrangement.length, 6, 'The score needs a full tune/chorus/bridge loop');
+assert.deepEqual(new Set(POSTAL_SONG.sections.map(section => section.name)), new Set(['tune', 'chorus', 'bridge']));
+
+for (const section of POSTAL_SONG.sections) {
+  assert.equal(section.lead.length, section.bass.length);
+  assert.equal(section.lead.length, section.arp.length);
+  assert.equal(section.lead.length, section.drums.length);
+  assert.equal(section.drumKit, 'brush', 'POSTAL should use TURN’s gentlest percussion kit');
+  assert.equal(section.bassVoice, 'drone', 'POSTAL should use a soft sustained foundation');
+}
+
+assert.match(source, /const DEFAULT_VOLUME = 48/, 'Music should start gently but be on by default');
+assert.match(source, /musicVolume <= 0[\s\S]*stopPlayback\(\{ reset: true \}\)/, 'Music OFF must stop the scheduler and audio sources');
+assert.match(source, /context\.suspend\(\)/, 'An inactive music engine must release processing work');
+
+console.log('POSTAL calm music contract passed');

--- a/postal/tests/ui-contract.test.mjs
+++ b/postal/tests/ui-contract.test.mjs
@@ -8,6 +8,8 @@ const root = path.resolve(here, '..');
 const html = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
 const css = fs.readFileSync(path.join(root, 'styles.css'), 'utf8');
 const hierarchy = fs.readFileSync(path.join(root, 'hierarchy.css'), 'utf8');
+const main = fs.readFileSync(path.join(root, 'main.mjs'), 'utf8');
+const music = fs.readFileSync(path.join(root, 'music.mjs'), 'utf8');
 const foundation = fs.readFileSync(path.join(root, 'runtime', 'app-foundation.js'), 'utf8');
 const interaction = fs.readFileSync(path.join(root, 'runtime', 'interaction-boot.js'), 'utf8');
 const tutorial = fs.readFileSync(path.join(root, 'runtime', 'tutorial.js'), 'utf8');
@@ -17,7 +19,7 @@ const ids = [...html.matchAll(/\sid="([^"]+)"/g)].map(match => match[1]);
 assert.equal(new Set(ids).size, ids.length, 'HTML IDs must be unique');
 
 for (const id of [
-  'scene', 'scene-fallback', 'pause-btn', 'help-btn', 'incoming-btn', 'clock',
+  'scene', 'scene-fallback', 'pause-btn', 'help-btn', 'music-btn', 'incoming-btn', 'clock',
   'metric-ontime', 'metric-flow', 'metric-issues', 'focus-btn', 'find-btn',
   'action-dock', 'action-primary', 'action-details', 'package-rail', 'flow-feedback', 'sheet'
 ]) assert.ok(ids.includes(id), `Missing required UI hook #${id}`);
@@ -26,6 +28,7 @@ assert.match(html, /<canvas[^>]+aria-label=/, 'The interactive scene needs an ac
 assert.match(html, /<dialog[^>]+aria-labelledby="sheet-title"/, 'The bottom sheet needs an accessible name');
 assert.match(html, /id="package-rail"[^>]+role="list"/, 'The persistent package rail needs list semantics');
 assert.match(html, /id="action-primary"[^>]*>SELECT</, 'The direct action must be visible in the main HUD');
+assert.match(html, /id="music-btn"[^>]+aria-pressed="true"/, 'Music needs an always-available accessible toggle');
 assert.doesNotMatch(html, /scene-help-btn|event-ribbon/, 'Retired duplicate and event-only controls must stay removed');
 
 assert.doesNotMatch(foundation, /oopi\.glb/i, 'Alien workers must not return');
@@ -36,6 +39,10 @@ assert.match(interaction, /app\.packageRail\.addEventListener\('click'/);
 assert.match(interaction, /simulation\.dispatchTruck/);
 assert.doesNotMatch(interaction, /showBriefingSheet\(\{\s*firstRun|needsFirstShiftBriefing/, 'The first day must be played, not opened as a modal briefing');
 assert.match(tutorial, /select-package[\s\S]*choose-focus[\s\S]*select-chicago[\s\S]*send-national[\s\S]*send-timra/);
+assert.match(tutorial, /function syncTutorialInterface\(\)[\s\S]*phase === 'package'[\s\S]*phase === 'route'[\s\S]*phase === 'operations'/, 'First-day controls must reveal in meaningful stages');
+for (const feature of ['status', 'levels', 'focus', 'cities', 'find']) assert.match(html, new RegExp(`data-tutorial-reveal="${feature}"`), `Missing progressive ${feature} control`);
+assert.match(main, /installPostalMusic/, 'POSTAL must install its score without blocking game boot');
+assert.match(music, /\.\.\/turn\/audio\/music\/tone-runtime\.js[\s\S]*\.\.\/turn\/audio\/music\/drum-runtime\.js/, 'POSTAL music must reuse TURN audio engine modules');
 assert.match(region, /function roadRotationFor\(dx, dz\)[\s\S]*Math\.atan2\(dx, dz\)/, 'Road tiles must derive orientation from their route vector');
 assert.match(region, /const REGION_ROAD_CCW_OFFSET = Math\.PI \/ 2/, 'Every region road tile needs the requested quarter-turn counterclockwise');
 assert.match(region, /function addRoadTile\([\s\S]*rotation \+ REGION_ROAD_CCW_OFFSET/, 'The counterclockwise offset must apply to every region road asset');


### PR DESCRIPTION
## What changed
- turn the first morning into four progressive interface phases: package, route, operations, and full network
- keep the live package rail, contextual CTA, help, pause, clock, and music available throughout
- reveal each new control with concise in-context copy and a reduced-motion-safe entrance
- compose **Morning Routes**, a calm 78 BPM procedural score using TURN’s existing tone, instrument, drum, and song modules
- add an accessible persistent music toggle; OFF clears scheduled notes, stops sources, and suspends Web Audio processing
- preserve a compact top bar on narrow portrait screens

## Validation
- `node --check postal/main.mjs postal/music.mjs postal/sw.js`
- `node --check postal/runtime/*.js`
- `node --test postal/tests/*.test.mjs` (5/5 passing)
- `git diff --check`