### PR TITLE
Replace race curbs with contextual road edges

### DIFF
--- a/turn-lab/tests/multi-track-production.mjs
+++ b/turn-lab/tests/multi-track-production.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import { createTrackSpatialIndex, findNearestTrackBruteForce } from '../../turn/race/track-spatial-index.js';
 import { AIRPORT_HAIRPIN_RUNOFF_ZONES, isForgivingTrackSurface } from '../../turn/tracks/airport-runoff.js';
+import { applyContextualRoadEdges, ROAD_EDGE_COLORS } from '../../turn/tracks/contextual-road-edges.js';
 import {
   TRACK_DEFINITIONS,
   TRACK_PLACEHOLDERS,
@@ -44,6 +45,54 @@ assert.equal(getTrackStorageRevision('midnight-city'), 'midnight-city-r2');
 assert.equal(getTrackFreeRoamDistance('midnight-city'), 34);
 assert.equal(getTrackStorageRevision('future-track'), 'future-track');
 assert.equal(getTrackFreeRoamDistance('future-track'), 170);
+
+assert.deepEqual(
+  ROAD_EDGE_COLORS,
+  {
+    countryside: '#ffffff',
+    airport: '#ffd43b',
+    cliffside: '#ffffff',
+    harbor: '#f5c542'
+  },
+  'Road-like tracks must use one contextual edge color instead of alternating race curbs'
+);
+
+const contextualEdgeCases = [
+  ['countryside', [0xe63946, 0xfff8e8]],
+  ['airport', [0xff5f67, 0xfff8e8]],
+  ['cliffside', [0xff5f67, 0xfff8e8]],
+  ['harbor', [0xf5c542, 0x08090a]]
+];
+for (const [trackId, sourcePalette] of contextualEdgeCases) {
+  const edgeColors = mockVertexColors(sourcePalette);
+  const roadColors = mockVertexColors([0x34383d, 0x4a4f55]);
+  const edge = {
+    geometry: { getAttribute(name) { return name === 'color' ? edgeColors : null; } },
+    userData: {}
+  };
+  const road = {
+    geometry: { getAttribute(name) { return name === 'color' ? roadColors : null; } },
+    userData: {}
+  };
+  const world = {
+    traverse(callback) {
+      callback(edge);
+      callback(road);
+    }
+  };
+
+  assert.equal(applyContextualRoadEdges(world, trackId), 1, `${trackId} must recolor exactly its alternating edge mesh`);
+  assert.equal(edge.userData.turnContextualRoadEdge, trackId);
+  assert.equal(road.userData.turnContextualRoadEdge, undefined, `${trackId} must not recolor the asphalt vertex gradient`);
+
+  const target = linearRgb(Number.parseInt(ROAD_EDGE_COLORS[trackId].slice(1), 16));
+  for (let index = 0; index < edgeColors.count; index += 1) {
+    assert.ok(Math.abs(edgeColors.getX(index) - target.r) < 1e-4);
+    assert.ok(Math.abs(edgeColors.getY(index) - target.g) < 1e-4);
+    assert.ok(Math.abs(edgeColors.getZ(index) - target.b) < 1e-4);
+  }
+}
+assert.equal(ROAD_EDGE_COLORS['midnight-city'], undefined, 'Midnight City already owns a solid street-edge treatment and must remain unchanged');
 
 const midnightLength = closedPolylineLength(MIDNIGHT_CITY_CONTROL_POINTS);
 const harborLength = closedPolylineLength(HARBOR_CONTROL_POINTS);
@@ -133,6 +182,7 @@ assert.match(definitions, /fogNear: 250[\s\S]*fogFar: 880/);
 assert.match(definitions, /id: 'track-6-tba'[\s\S]*locked: true/);
 assert.match(catalog, /MIDNIGHT_CITY_CONTROL_POINTS\.map/);
 assert.match(registry, /midnight-city-world-r9\.js\?build=20260802-r9/);
+assert.match(registry, /contextual-road-edges\.js\?revision=r507/);
 assert.match(registry, /definition\.sampleCount \|\| sampleCount/);
 assert.doesNotMatch(manager, /nextTrackId === 'midnight-city'/, 'The generic track manager must not gain a Midnight City special case');
 assert.match(manager, /lighting\.hemisphereIntensity \?\? 2\.7/);
@@ -211,4 +261,38 @@ function segmentsProperlyIntersect(a, b, c, d) {
 
 function orientation(a, b, c) {
   return (b[0] - a[0]) * (c[2] - a[2]) - (b[2] - a[2]) * (c[0] - a[0]);
+}
+
+function mockVertexColors(hexes) {
+  const values = [];
+  for (const hex of hexes) {
+    const color = linearRgb(hex);
+    values.push(color.r, color.g, color.b);
+  }
+
+  return {
+    itemSize: 3,
+    count: hexes.length,
+    needsUpdate: false,
+    getX(index) { return values[index * 3]; },
+    getY(index) { return values[index * 3 + 1]; },
+    getZ(index) { return values[index * 3 + 2]; },
+    setXYZ(index, r, g, b) {
+      values[index * 3] = r;
+      values[index * 3 + 1] = g;
+      values[index * 3 + 2] = b;
+    }
+  };
+}
+
+function linearRgb(hex) {
+  const linear = (channel) => {
+    const value = channel / 255;
+    return value < 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+  };
+  return {
+    r: linear((hex >> 16) & 0xff),
+    g: linear((hex >> 8) & 0xff),
+    b: linear(hex & 0xff)
+  };
 }

--- a/turn/tracks/contextual-road-edges.js
+++ b/turn/tracks/contextual-road-edges.js
@@ -33,8 +33,8 @@ export function applyContextualRoadEdges(world, trackId) {
   if (!world?.traverse || !style) return 0;
   if (styledWorlds.get(world) === trackId) return 0;
 
-  const source = style.source.map(hexToRgb);
-  const target = hexToRgb(style.target);
+  const source = style.source.map(hexToLinearRgb);
+  const target = hexToLinearRgb(style.target);
   let changed = 0;
 
   world.traverse((node) => {
@@ -83,12 +83,18 @@ function matchesAlternatingPalette(attribute, palette) {
   return seen.every(Boolean);
 }
 
-function hexToRgb(hex) {
+function hexToLinearRgb(hex) {
   return {
-    r: ((hex >> 16) & 0xff) / 255,
-    g: ((hex >> 8) & 0xff) / 255,
-    b: (hex & 0xff) / 255
+    r: srgbToLinear(((hex >> 16) & 0xff) / 255),
+    g: srgbToLinear(((hex >> 8) & 0xff) / 255),
+    b: srgbToLinear((hex & 0xff) / 255)
   };
+}
+
+function srgbToLinear(channel) {
+  return channel < 0.04045
+    ? channel / 12.92
+    : ((channel + 0.055) / 1.055) ** 2.4;
 }
 
 function styleInitialCountryside(runtime) {

--- a/turn/tracks/contextual-road-edges.js
+++ b/turn/tracks/contextual-road-edges.js
@@ -1,0 +1,116 @@
+const COLOR_EPSILON = 1e-4;
+
+export const ROAD_EDGE_COLORS = Object.freeze({
+  countryside: '#ffffff',
+  airport: '#ffd43b',
+  cliffside: '#ffffff',
+  harbor: '#f5c542'
+});
+
+const EDGE_STYLES = Object.freeze({
+  countryside: Object.freeze({
+    source: Object.freeze([0xe63946, 0xfff8e8]),
+    target: 0xffffff
+  }),
+  airport: Object.freeze({
+    source: Object.freeze([0xff5f67, 0xfff8e8]),
+    target: 0xffd43b
+  }),
+  cliffside: Object.freeze({
+    source: Object.freeze([0xff5f67, 0xfff8e8]),
+    target: 0xffffff
+  }),
+  harbor: Object.freeze({
+    source: Object.freeze([0xf5c542, 0x08090a]),
+    target: 0xf5c542
+  })
+});
+
+const styledWorlds = new WeakMap();
+
+export function applyContextualRoadEdges(world, trackId) {
+  const style = EDGE_STYLES[trackId];
+  if (!world?.traverse || !style) return 0;
+  if (styledWorlds.get(world) === trackId) return 0;
+
+  const source = style.source.map(hexToRgb);
+  const target = hexToRgb(style.target);
+  let changed = 0;
+
+  world.traverse((node) => {
+    const colors = node?.geometry?.getAttribute?.('color');
+    if (!colors || colors.itemSize < 3 || colors.count < 2) return;
+    if (!matchesAlternatingPalette(colors, source)) return;
+
+    for (let index = 0; index < colors.count; index += 1) {
+      colors.setXYZ(index, target.r, target.g, target.b);
+    }
+    colors.needsUpdate = true;
+    node.userData ||= {};
+    node.userData.turnContextualRoadEdge = trackId;
+    changed += 1;
+  });
+
+  styledWorlds.set(world, trackId);
+  return changed;
+}
+
+function matchesAlternatingPalette(attribute, palette) {
+  const seen = new Array(palette.length).fill(false);
+
+  for (let index = 0; index < attribute.count; index += 1) {
+    const r = attribute.getX(index);
+    const g = attribute.getY(index);
+    const b = attribute.getZ(index);
+    let match = -1;
+
+    for (let paletteIndex = 0; paletteIndex < palette.length; paletteIndex += 1) {
+      const color = palette[paletteIndex];
+      if (
+        Math.abs(r - color.r) <= COLOR_EPSILON
+        && Math.abs(g - color.g) <= COLOR_EPSILON
+        && Math.abs(b - color.b) <= COLOR_EPSILON
+      ) {
+        match = paletteIndex;
+        break;
+      }
+    }
+
+    if (match < 0) return false;
+    seen[match] = true;
+  }
+
+  return seen.every(Boolean);
+}
+
+function hexToRgb(hex) {
+  return {
+    r: ((hex >> 16) & 0xff) / 255,
+    g: ((hex >> 8) & 0xff) / 255,
+    b: (hex & 0xff) / 255
+  };
+}
+
+function styleInitialCountryside(runtime) {
+  applyContextualRoadEdges(runtime?.world, 'countryside');
+}
+
+function styleActiveTrack(event) {
+  const trackId = event?.detail?.trackId;
+  const runtime = globalThis.__turnRuntime;
+  const world = runtime?.activeWorld || (trackId === 'countryside' ? runtime?.world : null);
+  applyContextualRoadEdges(world, trackId);
+}
+
+function bootstrap() {
+  if (globalThis.__turnRuntime) styleInitialCountryside(globalThis.__turnRuntime);
+  else {
+    window.addEventListener('turn:runtime-ready', (event) => {
+      styleInitialCountryside(event.detail || globalThis.__turnRuntime);
+    }, { once: true });
+  }
+
+  window.addEventListener('turn:track-changed', styleActiveTrack);
+}
+
+if (typeof window !== 'undefined') bootstrap();

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -11,6 +11,7 @@ import { installHarborWorld } from './harbor-world.js';
 // Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10
 import { installMidnightCityWorld } from './midnight-city-world-r11.js?build=20260802-r11';
 import { isForgivingTrackSurface } from './airport-runoff.js?build=20260722-r52';
+import './contextual-road-edges.js?revision=r507';
 
 const WORLD_INSTALLERS = Object.freeze({
   countryside({ initialWorld }) {


### PR DESCRIPTION
## What changed
- removes the alternating race-track curb treatment from the **drivable 3D worlds** without changing track geometry
- keeps the existing edge width/placement, so this is a color-only visual polish pass
- uses contextual solid edge colors:
  - **Countryside:** white
  - **Airport:** yellow
  - **Cliffside:** white
  - **Harbor:** yellow
- leaves **Midnight City** alone because it already uses a solid street/sidewalk edge treatment rather than alternating race curbs
- deliberately leaves the stylised striped track previews on the Home track cards unchanged

## Implementation
The four older worlds build their edge strips as vertex-colored meshes. A small track styling layer recognises only those exact two-color curb palettes and collapses them to the contextual single color when each world becomes active. It does not touch asphalt gradients, start/finish markings, runway markings, scenery, collision, track width, records, pace notes or physics.

## Regression coverage
The multi-track regression now verifies the per-track edge palette, proves only the alternating edge mesh is recolored (not the asphalt vertex gradient), and pins Midnight City as intentionally unchanged.

This should be an intentionally low-risk art-direction change: no gameplay geometry and no track-card preview changes.