### PR TITLE
Refine solid road edges with TURN yellow and black contours

### DIFF
--- a/turn-lab/tests/multi-track-production.mjs
+++ b/turn-lab/tests/multi-track-production.mjs
@@ -2,7 +2,11 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import { createTrackSpatialIndex, findNearestTrackBruteForce } from '../../turn/race/track-spatial-index.js';
 import { AIRPORT_HAIRPIN_RUNOFF_ZONES, isForgivingTrackSurface } from '../../turn/tracks/airport-runoff.js';
-import { applyContextualRoadEdges, ROAD_EDGE_COLORS } from '../../turn/tracks/contextual-road-edges.js';
+import {
+  applyContextualRoadEdges,
+  ROAD_EDGE_COLORS,
+  ROAD_EDGE_CONTOURS
+} from '../../turn/tracks/contextual-road-edges.js';
 import {
   TRACK_DEFINITIONS,
   TRACK_PLACEHOLDERS,
@@ -50,12 +54,21 @@ assert.deepEqual(
   ROAD_EDGE_COLORS,
   {
     countryside: '#ffffff',
-    airport: '#ffd43b',
+    airport: '#ffbd12',
     cliffside: '#ffffff',
-    harbor: '#f5c542'
+    harbor: '#ffbd12'
   },
-  'Road-like tracks must use one contextual edge color instead of alternating race curbs'
+  'Airport and Harbor must use TURN profile yellow while road-like tracks keep one solid contextual edge color'
 );
+assert.deepEqual(
+  Object.keys(ROAD_EDGE_CONTOURS),
+  ['airport', 'cliffside', 'harbor'],
+  'Airport, Cliffside and Harbor must gain the Countryside-style black outer contour only'
+);
+for (const [trackId, contour] of Object.entries(ROAD_EDGE_CONTOURS)) {
+  assert.ok(contour.edgeWidth > 1.5, `${trackId} contour must begin outside its colored road edge`);
+  assert.ok(contour.contourWidth >= 0.5 && contour.contourWidth <= 0.8, `${trackId} black contour must stay visually subordinate to the colored edge`);
+}
 
 const contextualEdgeCases = [
   ['countryside', [0xe63946, 0xfff8e8]],
@@ -93,6 +106,8 @@ for (const [trackId, sourcePalette] of contextualEdgeCases) {
   }
 }
 assert.equal(ROAD_EDGE_COLORS['midnight-city'], undefined, 'Midnight City already owns a solid street-edge treatment and must remain unchanged');
+assert.equal(ROAD_EDGE_CONTOURS.countryside, undefined, 'Countryside already owns its black outer contour and must not get a duplicate');
+assert.equal(ROAD_EDGE_CONTOURS['midnight-city'], undefined, 'Midnight City must keep its own street-edge construction');
 
 const midnightLength = closedPolylineLength(MIDNIGHT_CITY_CONTROL_POINTS);
 const harborLength = closedPolylineLength(HARBOR_CONTROL_POINTS);
@@ -182,7 +197,7 @@ assert.match(definitions, /fogNear: 250[\s\S]*fogFar: 880/);
 assert.match(definitions, /id: 'track-6-tba'[\s\S]*locked: true/);
 assert.match(catalog, /MIDNIGHT_CITY_CONTROL_POINTS\.map/);
 assert.match(registry, /midnight-city-world-r9\.js\?build=20260802-r9/);
-assert.match(registry, /contextual-road-edges\.js\?revision=r507/);
+assert.match(registry, /contextual-road-edges\.js\?revision=r509/);
 assert.match(registry, /definition\.sampleCount \|\| sampleCount/);
 assert.doesNotMatch(manager, /nextTrackId === 'midnight-city'/, 'The generic track manager must not gain a Midnight City special case');
 assert.match(manager, /lighting\.hemisphereIntensity \?\? 2\.7/);

--- a/turn/tracks/contextual-road-edges.js
+++ b/turn/tracks/contextual-road-edges.js
@@ -1,5 +1,3 @@
-import * as THREE from 'three';
-
 const COLOR_EPSILON = 1e-4;
 const INK = 0x08090a;
 const TURN_PROFILE_YELLOW = 0xffbd12;
@@ -12,9 +10,9 @@ export const ROAD_EDGE_COLORS = Object.freeze({
 });
 
 export const ROAD_EDGE_CONTOURS = Object.freeze({
-  airport: Object.freeze({ edgeWidth: 1.75, contourWidth: 0.62, heightOffset: 0.197 }),
-  cliffside: Object.freeze({ edgeWidth: 1.65, contourWidth: 0.62, heightOffset: 0.162 }),
-  harbor: Object.freeze({ edgeWidth: 1.8, contourWidth: 0.62, heightOffset: 0.207 })
+  airport: Object.freeze({ edgeWidth: 1.75, contourWidth: 0.62 }),
+  cliffside: Object.freeze({ edgeWidth: 1.65, contourWidth: 0.62 }),
+  harbor: Object.freeze({ edgeWidth: 1.8, contourWidth: 0.62 })
 });
 
 const EDGE_STYLES = Object.freeze({
@@ -47,6 +45,7 @@ export function applyContextualRoadEdges(world, trackId, {
   if (!world?.traverse || !style) return 0;
 
   let changed = 0;
+  const matchingEdges = [];
   if (styledWorlds.get(world) !== trackId) {
     const source = style.source.map(hexToLinearRgb);
     const target = hexToLinearRgb(style.target);
@@ -56,6 +55,7 @@ export function applyContextualRoadEdges(world, trackId, {
       if (!colors || colors.itemSize < 3 || colors.count < 2) return;
       if (!matchesAlternatingPalette(colors, source)) return;
 
+      matchingEdges.push(node);
       for (let index = 0; index < colors.count; index += 1) {
         colors.setXYZ(index, target.r, target.g, target.b);
       }
@@ -72,73 +72,82 @@ export function applyContextualRoadEdges(world, trackId, {
   if (
     contour
     && !outlinedWorlds.has(world)
+    && matchingEdges.length
     && Array.isArray(samples)
     && samples.length > 2
-    && typeof world.add === 'function'
   ) {
-    installOuterContour(world, samples, Number(trackWidth) || 27, trackId, contour);
+    for (const edge of matchingEdges) {
+      installOuterContourFromEdge(edge, samples, Number(trackWidth) || 27, trackId, contour);
+    }
     outlinedWorlds.add(world);
   }
 
   return changed;
 }
 
-function installOuterContour(world, samples, trackWidth, trackId, contour) {
-  const group = new THREE.Group();
-  group.name = `TURN ${trackId} outer road contours`;
-  group.userData.turnContextualRoadContour = trackId;
+function installOuterContourFromEdge(edge, samples, trackWidth, trackId, contour) {
+  if (!edge?.clone || !edge.geometry?.clone) return false;
+  const sourcePositions = edge.geometry.getAttribute?.('position');
+  const sourceColors = edge.geometry.getAttribute?.('color');
+  if (!sourcePositions || !sourceColors || sourcePositions.count < 6) return false;
 
-  for (const side of [-1, 1]) {
-    const positions = [];
-    const indices = [];
-    const halfTrack = trackWidth / 2;
-    const innerDistance = halfTrack + contour.edgeWidth - 0.04;
-    const outerDistance = halfTrack + contour.edgeWidth + contour.contourWidth;
+  const mesh = edge.clone(false);
+  mesh.geometry = edge.geometry.clone();
+  mesh.material = cloneMaterial(edge.material);
+  mesh.name = `TURN ${trackId} outer road contour`;
+  mesh.receiveShadow = true;
+  mesh.castShadow = false;
+  mesh.userData = { ...(edge.userData || {}), turnContextualRoadContour: trackId };
 
-    for (let index = 0; index <= samples.length; index += 1) {
-      const sample = samples[index % samples.length];
-      if (!sample?.point || !sample?.normal) continue;
+  const positions = mesh.geometry.getAttribute('position');
+  const colors = mesh.geometry.getAttribute('color');
+  const firstSample = samples[0];
+  const firstX = sourcePositions.getX(0) - Number(firstSample?.point?.x || 0);
+  const firstZ = sourcePositions.getZ(0) - Number(firstSample?.point?.z || 0);
+  const sideDot = firstX * Number(firstSample?.normal?.x || 0)
+    + firstZ * Number(firstSample?.normal?.z || 0);
+  const side = sideDot >= 0 ? 1 : -1;
+  const halfTrack = trackWidth / 2;
+  const innerDistance = halfTrack + contour.edgeWidth - 0.04;
+  const outerDistance = halfTrack + contour.edgeWidth + contour.contourWidth;
+  const segmentCount = Math.min(samples.length, Math.floor(positions.count / 6));
 
-      const inner = sample.point.clone()
-        .addScaledVector(sample.normal, side * innerDistance);
-      const outer = sample.point.clone()
-        .addScaledVector(sample.normal, side * outerDistance);
-      inner.y = sample.point.y + contour.heightOffset;
-      outer.y = sample.point.y + contour.heightOffset;
-      positions.push(inner.x, inner.y, inner.z, outer.x, outer.y, outer.z);
-    }
-
-    const rowCount = positions.length / 6;
-    for (let index = 0; index < rowCount - 1; index += 1) {
-      const a = index * 2;
-      const b = a + 1;
-      const c = a + 2;
-      const d = a + 3;
-      indices.push(a, c, b, b, c, d);
-    }
-
-    if (!indices.length) continue;
-    const geometry = new THREE.BufferGeometry();
-    geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
-    geometry.setIndex(indices);
-    geometry.computeVertexNormals();
-
-    const mesh = new THREE.Mesh(
-      geometry,
-      new THREE.MeshStandardMaterial({
-        color: INK,
-        roughness: 0.94,
-        metalness: 0,
-        side: THREE.DoubleSide
-      })
-    );
-    mesh.name = `TURN ${trackId} outer road contour ${side}`;
-    mesh.receiveShadow = true;
-    mesh.userData.turnContextualRoadContour = trackId;
-    group.add(mesh);
+  for (let segment = 0; segment < segmentCount; segment += 1) {
+    const current = samples[segment];
+    const next = samples[(segment + 1) % samples.length];
+    const base = segment * 6;
+    setContourVertex(positions, sourcePositions, base, current, side, innerDistance);
+    setContourVertex(positions, sourcePositions, base + 1, current, side, outerDistance);
+    setContourVertex(positions, sourcePositions, base + 2, next, side, innerDistance);
+    setContourVertex(positions, sourcePositions, base + 3, current, side, outerDistance);
+    setContourVertex(positions, sourcePositions, base + 4, next, side, outerDistance);
+    setContourVertex(positions, sourcePositions, base + 5, next, side, innerDistance);
   }
+  positions.needsUpdate = true;
 
-  if (group.children.length) world.add(group);
+  const ink = hexToLinearRgb(INK);
+  for (let index = 0; index < colors.count; index += 1) {
+    colors.setXYZ(index, ink.r, ink.g, ink.b);
+  }
+  colors.needsUpdate = true;
+  mesh.geometry.computeVertexNormals?.();
+
+  const parent = edge.parent;
+  parent?.add?.(mesh);
+  return Boolean(parent);
+}
+
+function setContourVertex(attribute, sourceAttribute, index, sample, side, distance) {
+  if (!sample?.point || !sample?.normal || index >= attribute.count) return;
+  const x = Number(sample.point.x) + Number(sample.normal.x) * side * distance;
+  const z = Number(sample.point.z) + Number(sample.normal.z) * side * distance;
+  const y = sourceAttribute.getY(index) - 0.008;
+  attribute.setXYZ(index, x, y, z);
+}
+
+function cloneMaterial(material) {
+  if (Array.isArray(material)) return material.map((entry) => entry?.clone?.() || entry);
+  return material?.clone?.() || material;
 }
 
 function matchesAlternatingPalette(attribute, palette) {

--- a/turn/tracks/contextual-road-edges.js
+++ b/turn/tracks/contextual-road-edges.js
@@ -1,10 +1,20 @@
+import * as THREE from 'three';
+
 const COLOR_EPSILON = 1e-4;
+const INK = 0x08090a;
+const TURN_PROFILE_YELLOW = 0xffbd12;
 
 export const ROAD_EDGE_COLORS = Object.freeze({
   countryside: '#ffffff',
-  airport: '#ffd43b',
+  airport: '#ffbd12',
   cliffside: '#ffffff',
-  harbor: '#f5c542'
+  harbor: '#ffbd12'
+});
+
+export const ROAD_EDGE_CONTOURS = Object.freeze({
+  airport: Object.freeze({ edgeWidth: 1.75, contourWidth: 0.62, heightOffset: 0.197 }),
+  cliffside: Object.freeze({ edgeWidth: 1.65, contourWidth: 0.62, heightOffset: 0.162 }),
+  harbor: Object.freeze({ edgeWidth: 1.8, contourWidth: 0.62, heightOffset: 0.207 })
 });
 
 const EDGE_STYLES = Object.freeze({
@@ -14,7 +24,7 @@ const EDGE_STYLES = Object.freeze({
   }),
   airport: Object.freeze({
     source: Object.freeze([0xff5f67, 0xfff8e8]),
-    target: 0xffd43b
+    target: TURN_PROFILE_YELLOW
   }),
   cliffside: Object.freeze({
     source: Object.freeze([0xff5f67, 0xfff8e8]),
@@ -22,37 +32,113 @@ const EDGE_STYLES = Object.freeze({
   }),
   harbor: Object.freeze({
     source: Object.freeze([0xf5c542, 0x08090a]),
-    target: 0xf5c542
+    target: TURN_PROFILE_YELLOW
   })
 });
 
 const styledWorlds = new WeakMap();
+const outlinedWorlds = new WeakSet();
 
-export function applyContextualRoadEdges(world, trackId) {
+export function applyContextualRoadEdges(world, trackId, {
+  samples,
+  trackWidth = 27
+} = {}) {
   const style = EDGE_STYLES[trackId];
   if (!world?.traverse || !style) return 0;
-  if (styledWorlds.get(world) === trackId) return 0;
 
-  const source = style.source.map(hexToLinearRgb);
-  const target = hexToLinearRgb(style.target);
   let changed = 0;
+  if (styledWorlds.get(world) !== trackId) {
+    const source = style.source.map(hexToLinearRgb);
+    const target = hexToLinearRgb(style.target);
 
-  world.traverse((node) => {
-    const colors = node?.geometry?.getAttribute?.('color');
-    if (!colors || colors.itemSize < 3 || colors.count < 2) return;
-    if (!matchesAlternatingPalette(colors, source)) return;
+    world.traverse((node) => {
+      const colors = node?.geometry?.getAttribute?.('color');
+      if (!colors || colors.itemSize < 3 || colors.count < 2) return;
+      if (!matchesAlternatingPalette(colors, source)) return;
 
-    for (let index = 0; index < colors.count; index += 1) {
-      colors.setXYZ(index, target.r, target.g, target.b);
-    }
-    colors.needsUpdate = true;
-    node.userData ||= {};
-    node.userData.turnContextualRoadEdge = trackId;
-    changed += 1;
-  });
+      for (let index = 0; index < colors.count; index += 1) {
+        colors.setXYZ(index, target.r, target.g, target.b);
+      }
+      colors.needsUpdate = true;
+      node.userData ||= {};
+      node.userData.turnContextualRoadEdge = trackId;
+      changed += 1;
+    });
 
-  styledWorlds.set(world, trackId);
+    styledWorlds.set(world, trackId);
+  }
+
+  const contour = ROAD_EDGE_CONTOURS[trackId];
+  if (
+    contour
+    && !outlinedWorlds.has(world)
+    && Array.isArray(samples)
+    && samples.length > 2
+    && typeof world.add === 'function'
+  ) {
+    installOuterContour(world, samples, Number(trackWidth) || 27, trackId, contour);
+    outlinedWorlds.add(world);
+  }
+
   return changed;
+}
+
+function installOuterContour(world, samples, trackWidth, trackId, contour) {
+  const group = new THREE.Group();
+  group.name = `TURN ${trackId} outer road contours`;
+  group.userData.turnContextualRoadContour = trackId;
+
+  for (const side of [-1, 1]) {
+    const positions = [];
+    const indices = [];
+    const halfTrack = trackWidth / 2;
+    const innerDistance = halfTrack + contour.edgeWidth - 0.04;
+    const outerDistance = halfTrack + contour.edgeWidth + contour.contourWidth;
+
+    for (let index = 0; index <= samples.length; index += 1) {
+      const sample = samples[index % samples.length];
+      if (!sample?.point || !sample?.normal) continue;
+
+      const inner = sample.point.clone()
+        .addScaledVector(sample.normal, side * innerDistance);
+      const outer = sample.point.clone()
+        .addScaledVector(sample.normal, side * outerDistance);
+      inner.y = sample.point.y + contour.heightOffset;
+      outer.y = sample.point.y + contour.heightOffset;
+      positions.push(inner.x, inner.y, inner.z, outer.x, outer.y, outer.z);
+    }
+
+    const rowCount = positions.length / 6;
+    for (let index = 0; index < rowCount - 1; index += 1) {
+      const a = index * 2;
+      const b = a + 1;
+      const c = a + 2;
+      const d = a + 3;
+      indices.push(a, c, b, b, c, d);
+    }
+
+    if (!indices.length) continue;
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+    geometry.setIndex(indices);
+    geometry.computeVertexNormals();
+
+    const mesh = new THREE.Mesh(
+      geometry,
+      new THREE.MeshStandardMaterial({
+        color: INK,
+        roughness: 0.94,
+        metalness: 0,
+        side: THREE.DoubleSide
+      })
+    );
+    mesh.name = `TURN ${trackId} outer road contour ${side}`;
+    mesh.receiveShadow = true;
+    mesh.userData.turnContextualRoadContour = trackId;
+    group.add(mesh);
+  }
+
+  if (group.children.length) world.add(group);
 }
 
 function matchesAlternatingPalette(attribute, palette) {
@@ -105,7 +191,10 @@ function styleActiveTrack(event) {
   const trackId = event?.detail?.trackId;
   const runtime = globalThis.__turnRuntime;
   const world = runtime?.activeWorld || (trackId === 'countryside' ? runtime?.world : null);
-  applyContextualRoadEdges(world, trackId);
+  applyContextualRoadEdges(world, trackId, {
+    samples: runtime?.samples,
+    trackWidth: runtime?.trackWidth
+  });
 }
 
 function bootstrap() {

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -11,7 +11,7 @@ import { installHarborWorld } from './harbor-world.js';
 // Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10
 import { installMidnightCityWorld } from './midnight-city-world-r11.js?build=20260802-r11';
 import { isForgivingTrackSurface } from './airport-runoff.js?build=20260722-r52';
-import './contextual-road-edges.js?revision=r507';
+import './contextual-road-edges.js?revision=r509';
 
 const WORLD_INSTALLERS = Object.freeze({
   countryside({ initialWorld }) {


### PR DESCRIPTION
## What changed
- switches the solid **Airport** and **Harbor** road edges from the brighter yellows to TURN's profile/header yellow `#ffbd12` (`--turn-yellow-600` / `--m8-yellow`)
- keeps **Countryside** and **Cliffside** white
- adds a narrow **black outer contour** to Airport, Cliffside and Harbor, matching the visual treatment already seen on Countryside
- contours sit outside the colored/white road edge only; they do not change the drivable road width, collision or physics
- leaves Midnight City unchanged
- leaves the stylised striped track-card previews unchanged

## Implementation
The existing contextual edge layer still recolors only the known curb vertex palettes. For Airport, Cliffside and Harbor it now adds one static outer ribbon per side using the active track samples. The contour is deliberately narrow (0.62 world units) and slightly under the colored edge to avoid seams/z-fighting.

This adds only two static meshes to the active world and no animation/update loop.

## Regression coverage
- pins Airport + Harbor to TURN profile yellow
- pins the contour to Airport / Cliffside / Harbor only
- keeps Countryside from receiving a duplicate contour
- keeps Midnight City untouched
- cache-busts the contextual styling layer