### PR TITLE
Clarify iOS Safari Share step in install guide

### DIFF
--- a/turn/install-gate.js
+++ b/turn/install-gate.js
@@ -215,7 +215,15 @@
       : browserContext.name;
 
     if (browserContext.ios) {
-      const usesEllipsisMenu = ['safari', 'chrome', 'edge'].includes(targetId);
+      if (targetId === 'safari') {
+        return [
+          installStep(startNumber, 'In Safari, tap Share', 'If Share is not visible, tap … to open the menu, then choose Share.'),
+          installStep(startNumber + 1, 'Choose Add to Home Screen', 'Scroll down in the Share sheet if it is not visible.'),
+          installStep(startNumber + 2, `Open ${appName} from your Home Screen`, `From now on, ${appName} opens fullscreen like an app.`)
+        ].join('');
+      }
+
+      const usesEllipsisMenu = ['chrome', 'edge'].includes(targetId);
       const menuTitle = usesEllipsisMenu
         ? `In ${targetName}, tap …, then Share`
         : `In ${targetName}, open the menu, then Share`;


### PR DESCRIPTION
## What changed
- updates the iOS Safari install step to lead with **Share** instead of implying the three-dot menu is always required
- adds the fallback instruction: if Share is not visible, tap **…** to open the menu and choose Share
- leaves Chrome/Edge iOS instructions and all non-iOS install flows unchanged

## New Safari copy
**In Safari, tap Share**

_If Share is not visible, tap … to open the menu, then choose Share._

Copy-only change; no install behavior or layout changes.