### PR TITLE
Use TURN road color for curb contours

### DIFF
--- a/turn/tracks/contextual-road-edges.js
+++ b/turn/tracks/contextual-road-edges.js
@@ -1,5 +1,5 @@
 const COLOR_EPSILON = 1e-4;
-const INK = 0x08090a;
+const TURN_ROAD = 0x44494f;
 const TURN_PROFILE_YELLOW = 0xffbd12;
 
 export const ROAD_EDGE_COLORS = Object.freeze({
@@ -125,9 +125,9 @@ function installOuterContourFromEdge(edge, samples, trackWidth, trackId, contour
   }
   positions.needsUpdate = true;
 
-  const ink = hexToLinearRgb(INK);
+  const road = hexToLinearRgb(TURN_ROAD);
   for (let index = 0; index < colors.count; index += 1) {
-    colors.setXYZ(index, ink.r, ink.g, ink.b);
+    colors.setXYZ(index, road.r, road.g, road.b);
   }
   colors.needsUpdate = true;
   mesh.geometry.computeVertexNormals?.();

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -11,7 +11,8 @@ import { installHarborWorld } from './harbor-world.js';
 // Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10
 import { installMidnightCityWorld } from './midnight-city-world-r11.js?build=20260802-r11';
 import { isForgivingTrackSurface } from './airport-runoff.js?build=20260722-r52';
-import './contextual-road-edges.js?revision=r512';
+import './contextual-road-edges.js?revision=r509';
+import './road-contour-color-r512.js?revision=r512';
 
 const WORLD_INSTALLERS = Object.freeze({
   countryside({ initialWorld }) {

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -11,7 +11,7 @@ import { installHarborWorld } from './harbor-world.js';
 // Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10
 import { installMidnightCityWorld } from './midnight-city-world-r11.js?build=20260802-r11';
 import { isForgivingTrackSurface } from './airport-runoff.js?build=20260722-r52';
-import './contextual-road-edges.js?revision=r509';
+import './contextual-road-edges.js?revision=r512';
 
 const WORLD_INSTALLERS = Object.freeze({
   countryside({ initialWorld }) {

--- a/turn/tracks/road-contour-color-r512.js
+++ b/turn/tracks/road-contour-color-r512.js
@@ -1,0 +1,49 @@
+const TURN_ROAD = 0x44494f;
+const road = hexToLinearRgb(TURN_ROAD);
+
+function applyRoadContourColor(world) {
+  if (!world?.traverse) return 0;
+  let changed = 0;
+
+  world.traverse((node) => {
+    if (!node?.userData?.turnContextualRoadContour) return;
+    const colors = node.geometry?.getAttribute?.('color');
+    if (!colors || colors.itemSize < 3) return;
+
+    for (let index = 0; index < colors.count; index += 1) {
+      colors.setXYZ(index, road.r, road.g, road.b);
+    }
+    colors.needsUpdate = true;
+    changed += 1;
+  });
+
+  return changed;
+}
+
+function styleActiveTrack() {
+  const runtime = globalThis.__turnRuntime;
+  applyRoadContourColor(runtime?.activeWorld);
+}
+
+function bootstrap() {
+  if (globalThis.__turnRuntime?.activeWorld) {
+    applyRoadContourColor(globalThis.__turnRuntime.activeWorld);
+  }
+  window.addEventListener('turn:track-changed', styleActiveTrack);
+}
+
+function hexToLinearRgb(hex) {
+  return {
+    r: srgbToLinear(((hex >> 16) & 0xff) / 255),
+    g: srgbToLinear(((hex >> 8) & 0xff) / 255),
+    b: srgbToLinear((hex & 0xff) / 255)
+  };
+}
+
+function srgbToLinear(channel) {
+  return channel < 0.04045
+    ? channel / 12.92
+    : ((channel + 0.055) / 1.055) ** 2.4;
+}
+
+if (typeof window !== 'undefined') bootstrap();


### PR DESCRIPTION
## What changed
- replaces the black curb/road-edge contour on Airport, Cliffside and Harbor with TURN's shared road colour `#44494f`
- keeps the solid edge colours themselves unchanged: Airport/Harbor profile yellow, Cliffside white
- preserves contour width, placement, geometry, collision and physics
- leaves track-card previews and Midnight City unchanged

## Shipping detail
The existing contextual edge module now paints newly created contours with TURN road colour. A tiny cache-busted follow-up module also recolours an already-cached r509 contour, so devices that have the previous black treatment cached still get the new colour immediately.

This is an art-direction-only polish change.