### PR TITLE
Match Countryside curb contour to road color

### DIFF
--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -12,7 +12,7 @@ import { installHarborWorld } from './harbor-world.js';
 import { installMidnightCityWorld } from './midnight-city-world-r11.js?build=20260802-r11';
 import { isForgivingTrackSurface } from './airport-runoff.js?build=20260722-r52';
 import './contextual-road-edges.js?revision=r509';
-import './road-contour-color-r512.js?revision=r512';
+import './road-contour-color-r512.js?revision=r513-countryside';
 
 const WORLD_INSTALLERS = Object.freeze({
   countryside({ initialWorld }) {

--- a/turn/tracks/road-contour-color-r512.js
+++ b/turn/tracks/road-contour-color-r512.js
@@ -1,4 +1,8 @@
+const TURN_INK = 0x08090a;
 const TURN_ROAD = 0x44494f;
+const COUNTRYSIDE_CONTOUR_Y = 0.158;
+const COUNTRYSIDE_CONTOUR_TOLERANCE = 0.012;
+const INITIAL_RETRY_DELAYS_MS = Object.freeze([0, 180, 520, 1200, 2400, 4200]);
 const road = hexToLinearRgb(TURN_ROAD);
 
 function applyRoadContourColor(world) {
@@ -6,30 +10,69 @@ function applyRoadContourColor(world) {
   let changed = 0;
 
   world.traverse((node) => {
-    if (!node?.userData?.turnContextualRoadContour) return;
-    const colors = node.geometry?.getAttribute?.('color');
-    if (!colors || colors.itemSize < 3) return;
+    if (node?.userData?.turnContextualRoadContour) {
+      const colors = node.geometry?.getAttribute?.('color');
+      if (!colors || colors.itemSize < 3) return;
 
-    for (let index = 0; index < colors.count; index += 1) {
-      colors.setXYZ(index, road.r, road.g, road.b);
+      for (let index = 0; index < colors.count; index += 1) {
+        colors.setXYZ(index, road.r, road.g, road.b);
+      }
+      colors.needsUpdate = true;
+      changed += 1;
+      return;
     }
-    colors.needsUpdate = true;
+
+    if (!isCountrysideRoadContour(node)) return;
+    const materials = Array.isArray(node.material) ? node.material : [node.material];
+    let recolored = false;
+    for (const material of materials) {
+      if (material?.color?.getHex?.() !== TURN_INK) continue;
+      material.color.setHex(TURN_ROAD);
+      material.needsUpdate = true;
+      recolored = true;
+    }
+    if (!recolored) return;
+
+    node.userData ||= {};
+    node.userData.turnContextualRoadContour = 'countryside';
     changed += 1;
   });
 
   return changed;
 }
 
-function styleActiveTrack() {
+function isCountrysideRoadContour(node) {
+  if (!node?.isMesh || !node.userData?.turnNoAutoOutline) return false;
+  const positions = node.geometry?.getAttribute?.('position');
+  if (!positions || positions.itemSize < 3 || positions.count < 6) return false;
+
+  node.geometry.computeBoundingBox?.();
+  const bounds = node.geometry.boundingBox;
+  if (!bounds) return false;
+  return Math.abs(bounds.min.y - COUNTRYSIDE_CONTOUR_Y) <= COUNTRYSIDE_CONTOUR_TOLERANCE
+    && Math.abs(bounds.max.y - COUNTRYSIDE_CONTOUR_Y) <= COUNTRYSIDE_CONTOUR_TOLERANCE;
+}
+
+function styleCurrentWorld() {
   const runtime = globalThis.__turnRuntime;
-  applyRoadContourColor(runtime?.activeWorld);
+  applyRoadContourColor(runtime?.activeWorld || runtime?.world);
+}
+
+function scheduleInitialPasses() {
+  for (const delay of INITIAL_RETRY_DELAYS_MS) {
+    window.setTimeout(styleCurrentWorld, delay);
+  }
 }
 
 function bootstrap() {
-  if (globalThis.__turnRuntime?.activeWorld) {
-    applyRoadContourColor(globalThis.__turnRuntime.activeWorld);
-  }
-  window.addEventListener('turn:track-changed', styleActiveTrack);
+  styleCurrentWorld();
+  scheduleInitialPasses();
+  window.addEventListener('turn:runtime-ready', scheduleInitialPasses, { once: true });
+  window.addEventListener('turn:home-ready', styleCurrentWorld);
+  window.addEventListener('turn:track-changed', () => {
+    styleCurrentWorld();
+    window.setTimeout(styleCurrentWorld, 0);
+  });
 }
 
 function hexToLinearRgb(hex) {


### PR DESCRIPTION
## What changed
- fixes the remaining **black** outer curb contour on **COUNTRYSIDE**
- recolors it to the same TURN road/track color used by the other contextual curb contours: `#44494f`
- keeps the white COUNTRYSIDE edge itself unchanged
- preserves geometry, width, collision and physics

## Why this needed a follow-up
COUNTRYSIDE's contour predates the newer contextual road-edge system and is created asynchronously by the older world art pass, so PR #512's tagged-contour recolor did not catch it. This update recognizes that legacy road ribbon specifically and retries briefly during startup so the later-created contour is recolored reliably.

The newer Airport / Cliffside / Harbor contour behavior remains unchanged.