### PR TITLE
Fix Countryside curb contour at the source

### DIFF
--- a/turn-tests/release-production.mjs
+++ b/turn-tests/release-production.mjs
@@ -16,7 +16,9 @@ const [
   installGateCss,
   orientationGuardCss,
   liveSteering,
-  menuFontCss
+  menuFontCss,
+  worldArtPass,
+  renderWorld
 ] = await Promise.all([
   loadReleaseDefinition(),
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
@@ -30,7 +32,9 @@ const [
   fs.readFile(new URL('../turn/install-gate.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/orientation-guard.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/live-steering-setting.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/m8-menu-font-fix.css', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/m8-menu-font-fix.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/world-art-pass.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/render/world.js', import.meta.url), 'utf8')
 ]);
 
 await checkReleaseFiles();
@@ -127,6 +131,15 @@ assert.match(app, /installM8HomeNavigation\(\)/);
 assert.match(app, /installM8HomeFixedLayout\(\)/);
 assert.ok(app.indexOf('installTurnPlatform(webPlatform)') < app.indexOf("withBuild('./main.js')"));
 assert.ok(app.indexOf("withBuild('./main.js')") < app.indexOf('installM8HomeNavigation()'));
+
+assert.match(worldArtPass, /const TURN_ROAD = 0x44494f/,
+  'Countryside world art must share the TURN road color token for its curb contour');
+assert.match(worldArtPass, /function addRoadOuterContour[\s\S]*color: TURN_ROAD/,
+  'Countryside curb contour must be created in road color instead of black');
+assert.doesNotMatch(worldArtPass, /function addRoadOuterContour[\s\S]{0,180}color: INK/,
+  'Countryside curb contour must never regress to the generic ink outline color');
+assert.match(renderWorld, /world-art-pass\.js\?revision=r514-road-contour/,
+  'The fixed Countryside art pass needs its own URL revision so installed PWAs do not reuse the old black contour module');
 
 for (const anchor of [
   "from '/turn/race/game-state.js'",

--- a/turn/render/world.js
+++ b/turn/render/world.js
@@ -13,7 +13,7 @@ function moduleUrl(relativePath) {
 async function loadWorldModules() {
   const [beauty, art, identity, intensity, scenery, bella, bellaFinal, bellaRescue] = await Promise.all([
     import(moduleUrl('../world-beauty.js')),
-    import(moduleUrl('../world-art-pass.js')),
+    import(moduleUrl('../world-art-pass.js?revision=r514-road-contour')),
     import(moduleUrl('../track-identity.js')),
     import(moduleUrl('../section-intensity.js')),
     import(moduleUrl('../tracks/countryside-scenery-r177.js?revision=r177-lake-cleanup-traffic')),

--- a/turn/world-art-pass.js
+++ b/turn/world-art-pass.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 
 const TAU = Math.PI * 2;
 const INK = 0x08090a;
+const TURN_ROAD = 0x44494f;
 const OUTLINE_MATERIAL = new THREE.MeshBasicMaterial({
   color: INK,
   side: THREE.BackSide
@@ -352,7 +353,7 @@ function addLakeIsland(world, center) {
 }
 
 function addRoadOuterContour(world, samples, trackWidth) {
-  const material = new THREE.MeshBasicMaterial({ color: INK, side: THREE.DoubleSide });
+  const material = new THREE.MeshBasicMaterial({ color: TURN_ROAD, side: THREE.DoubleSide });
   for (const side of [-1, 1]) {
     const inner = [];
     const outer = [];


### PR DESCRIPTION
## What changed
- fixes the remaining black COUNTRYSIDE road-edge contour **where it is actually created**, in `world-art-pass.js`
- creates that outer ribbon directly in TURN road/track color `#44494f` instead of generic ink black
- cache-busts the Countryside art-pass import so installed PWAs cannot keep serving the old black version
- adds a release regression that fails if the Countryside road contour is created as black again or if the cache-bust is removed

## Why #513 did not hold
COUNTRYSIDE's outer ribbon is generated asynchronously by the older world art pass. The previous runtime recolor tried to find that ribbon after creation, which was still timing-dependent. This removes the timing dependency entirely: the source mesh is now born in the correct color.

The white road-edge line remains unchanged. Airport, Cliffside, Harbor, track cards, collisions and physics are untouched.