### PR TITLE
Remove legacy Countryside edge overlays

### DIFF
--- a/turn/render/world.js
+++ b/turn/render/world.js
@@ -14,7 +14,7 @@ async function loadWorldModules() {
   const [beauty, art, identity, intensity, scenery, bella, bellaFinal, bellaRescue] = await Promise.all([
     import(moduleUrl('../world-beauty.js')),
     import(moduleUrl('../world-art-pass.js?revision=r514-road-contour')),
-    import(moduleUrl('../track-identity.js')),
+    import(moduleUrl('../track-identity.js?revision=r515-road-edge-cleanup')),
     import(moduleUrl('../section-intensity.js')),
     import(moduleUrl('../tracks/countryside-scenery-r177.js?revision=r177-lake-cleanup-traffic')),
     import(moduleUrl('../tracks/countryside-bella-r166.js?revision=r168-bella-markings-eyes-foliage-r169-facing-palette-r170-eye-placement-r171-cute-eyes-r172-final-tune-r173-rescue-r174-siren-zone-r175-broad-rear-zone-r176-road-derived-zone')),

--- a/turn/track-identity.js
+++ b/turn/track-identity.js
@@ -73,6 +73,7 @@ function hideOldRoadContour(world) {
 }
 
 function addSectionEdges(world, samples, trackWidth) {
+  if (globalThis.__turnLegacySectionEdgesEnabled !== true) return;
   hideOldRoadContour(world);
   const sections = ZONES.length;
   const sectionLength = Math.floor(samples.length / sections);


### PR DESCRIPTION
## Root cause
The remaining black line was **not** the road contour changed in #512–#514. COUNTRYSIDE has a second, older styling layer in `track-identity.js` that explicitly draws:

- a black ribbon immediately outside the curb, and
- a solid colored zone ribbon immediately outside that.

Those two ribbons sit above the newer road-colored contour, so they kept visually covering it even after the contour itself was fixed.

## Fix
- disables that legacy black + colored section-edge overlay by default
- leaves the white COUNTRYSIDE curb/edge line intact
- leaves the newer TURN road-colored `#44494f` contour underneath intact
- keeps the themed landmarks, scenery tinting and section-intensity treatment
- cache-busts the `track-identity.js` import so the stale overlay is not reused

No collision, track geometry or physics changes.