### PR TITLE
Increase Airport ground surface contrast

### DIFF
--- a/turn-lab/tests/procedural-surface-polish-production.mjs
+++ b/turn-lab/tests/procedural-surface-polish-production.mjs
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [surfaceSource, registry] = await Promise.all([
+const [surfaceSource, airportContrastSource, registry] = await Promise.all([
   fs.readFile(new URL('../../turn/tracks/procedural-surface-polish-r522.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/tracks/airport-surface-contrast-r525.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/tracks/registry.js', import.meta.url), 'utf8')
 ]);
 
@@ -38,7 +39,15 @@ assert.doesNotMatch(surfaceSource, /new THREE\.InstancedMesh/, 'The replacement 
 assert.match(surfaceSource, /const wheelBands = \[0\.27, 0\.36, 0\.64, 0\.73\]/, 'Road polish must retain subtle wheel-path wear');
 assert.match(surfaceSource, /maxAlpha: 0\.16/, 'Surface contrast must retain the stronger but still restrained lightness range');
 assert.match(surfaceSource, /return finishTexture\(canvas, 1, 6\);/, 'Closed road texture repeat must use an integer repeat count so the loop seam is continuous');
+
+assert.match(airportContrastSource, /new Set\(\['airport-grass', 'airport-concrete'\]\)/, 'Airport contrast pass must target only Airport ground textures');
+assert.match(airportContrastSource, /contrast: 1\.6/, 'Airport ground texture range must be visibly wider than the base procedural pass');
+assert.match(airportContrastSource, /darken: 0\.055/, 'Airport ground treatment must shift slightly darker overall');
+assert.match(airportContrastSource, /trackId !== 'airport'/, 'Airport contrast pass must not alter Harbor, Cliffside, Countryside or Midnight City');
+assert.doesNotMatch(airportContrastSource, /new THREE\.|InstancedMesh|requestAnimationFrame|setInterval/, 'Airport contrast must not add geometry, draw calls or a frame loop');
+
 assert.match(registry, /procedural-surface-polish-r522\.js\?revision=r524-procedural-surfaces-contrast-r171/);
+assert.match(registry, /airport-surface-contrast-r525\.js\?revision=r525-airport-ground-contrast/);
 assert.doesNotMatch(registry, /ground-detail-polish-r521/, 'The old scattered Airport/Harbor ground-detail pass must no longer load');
 
 console.log('TURN procedural surface polish contract passed.');

--- a/turn/tracks/airport-surface-contrast-r525.js
+++ b/turn/tracks/airport-surface-contrast-r525.js
@@ -1,0 +1,100 @@
+const REVISION = 'r525-airport-ground-contrast';
+const AIRPORT_TEXTURE_KEYS = new Set(['airport-grass', 'airport-concrete']);
+const processedTextures = new WeakSet();
+
+export const AIRPORT_SURFACE_CONTRAST = Object.freeze({
+  contrast: 1.6,
+  pivot: 0.92,
+  darken: 0.055
+});
+
+function currentTrackId(runtime, fallback = '') {
+  return globalThis.__turnGetTrackId?.() || runtime?.trackId || fallback;
+}
+
+function activeWorld(runtime, trackId) {
+  return runtime?.activeWorld || (trackId === 'countryside' ? runtime?.world : null);
+}
+
+function materialList(material) {
+  return Array.isArray(material) ? material : [material];
+}
+
+function clampByte(value) {
+  return Math.max(0, Math.min(255, Math.round(value)));
+}
+
+function retoneAirportTexture(texture) {
+  if (!texture || processedTextures.has(texture)) return false;
+  const canvas = texture.image;
+  if (!canvas || typeof canvas.getContext !== 'function') return false;
+  const context = canvas.getContext('2d');
+  if (!context || typeof context.getImageData !== 'function') return false;
+
+  const width = Number(canvas.width) || 0;
+  const height = Number(canvas.height) || 0;
+  if (!width || !height) return false;
+
+  const image = context.getImageData(0, 0, width, height);
+  const data = image.data;
+  const pivot = AIRPORT_SURFACE_CONTRAST.pivot * 255;
+  const darken = AIRPORT_SURFACE_CONTRAST.darken * 255;
+  const contrast = AIRPORT_SURFACE_CONTRAST.contrast;
+
+  for (let index = 0; index < data.length; index += 4) {
+    data[index] = clampByte((data[index] - pivot) * contrast + pivot - darken);
+    data[index + 1] = clampByte((data[index + 1] - pivot) * contrast + pivot - darken);
+    data[index + 2] = clampByte((data[index + 2] - pivot) * contrast + pivot - darken);
+  }
+
+  context.putImageData(image, 0, 0);
+  texture.needsUpdate = true;
+  processedTextures.add(texture);
+  return true;
+}
+
+export function applyAirportSurfaceContrast(world) {
+  if (!world?.traverse) return 0;
+  let changed = 0;
+
+  world.traverse((node) => {
+    const textureKey = node?.userData?.turnProceduralGroundTexture;
+    if (!AIRPORT_TEXTURE_KEYS.has(textureKey)) return;
+
+    let nodeChanged = false;
+    for (const material of materialList(node.material)) {
+      if (retoneAirportTexture(material?.map)) nodeChanged = true;
+    }
+
+    if (!nodeChanged) return;
+    node.userData.turnAirportSurfaceContrast = REVISION;
+    changed += 1;
+  });
+
+  if (changed > 0) {
+    world.userData.turnAirportSurfaceContrast = REVISION;
+  }
+  return changed;
+}
+
+function polishRuntime(runtime, fallbackTrackId = '') {
+  if (!runtime) return;
+  const trackId = currentTrackId(runtime, fallbackTrackId);
+  if (trackId !== 'airport') return;
+  applyAirportSurfaceContrast(activeWorld(runtime, trackId));
+}
+
+function bootstrap() {
+  if (globalThis.__turnRuntime) polishRuntime(globalThis.__turnRuntime);
+  else {
+    window.addEventListener('turn:runtime-ready', (event) => {
+      polishRuntime(event.detail || globalThis.__turnRuntime);
+    }, { once: true });
+  }
+
+  window.addEventListener('turn:track-changed', (event) => {
+    polishRuntime(globalThis.__turnRuntime, event?.detail?.trackId || '');
+  });
+}
+
+if (typeof window !== 'undefined' && typeof document !== 'undefined') bootstrap();

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -16,6 +16,7 @@ import './road-contour-color-r512.js?revision=r513-countryside';
 import './start-area-polish-r519.js?revision=r519-start-area-consistency-v2';
 import './airport-start-banner-r520.js?revision=r520-signature-yellow';
 import './procedural-surface-polish-r522.js?revision=r524-procedural-surfaces-contrast-r171';
+import './airport-surface-contrast-r525.js?revision=r525-airport-ground-contrast';
 
 const WORLD_INSTALLERS = Object.freeze({
   countryside({ initialWorld }) {


### PR DESCRIPTION
## What changed
Makes the AIRPORT procedural ground treatment easier to see without touching the road treatment that already reads well.

- AIRPORT ground textures are shifted slightly darker overall
- tonal separation is increased substantially so the broad procedural fields survive the very bright Airport lighting
- affects only the existing `airport-grass` and `airport-concrete` CanvasTextures
- HARBOR, CLIFFSIDE, COUNTRYSIDE and MIDNIGHT CITY are unchanged

## Performance
This retunes the two existing 512×512 Airport CanvasTextures once when Airport becomes active. It does not add geometry, materials, draw calls, texture downloads, animation loops or per-frame work. The one-time cost is a pixel pass over roughly 0.5 million pixels, after which the same existing GPU textures are used normally.

## QA
Extends the procedural-surface contract so the stronger Airport-only contrast and registry loading stay explicit.

This is intentionally a visual trial only: TURN remains v1.8.5 / r171 until the result is approved.