### PR TITLE
Normalize MAYDAY achievement toast and extend rescue guidance

### DIFF
--- a/turn-lab/tests/mayday-presentation-production.mjs
+++ b/turn-lab/tests/mayday-presentation-production.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const root = process.cwd();
+const turnDir = path.join(root, 'turn');
+const [presentation, airportWorld] = await Promise.all([
+  fs.readFile(path.join(turnDir, 'tracks/airport-emergency-presentation-r523.js'), 'utf8'),
+  fs.readFile(path.join(turnDir, 'tracks/airport-world-r56.js'), 'utf8')
+]);
+
+assert.match(
+  airportWorld,
+  /airport-emergency-presentation-r523\.js\?revision=r523-standard-toast-longer-guidance/,
+  'Airport must load the MAYDAY presentation correction under a fresh cache identity'
+);
+
+assert.match(
+  presentation,
+  /turn-achievement-toast\.\$\{MAYDAY_TOAST_CLASS\}/,
+  'MAYDAY completion must explicitly normalize the old one-off achievement toast class'
+);
+assert.match(
+  presentation,
+  /classList\.remove\(MAYDAY_TOAST_CLASS\)/,
+  'MAYDAY completion should fall back to the shared achievement toast appearance and position'
+);
+assert.match(presentation, /crash: 5200/);
+assert.match(presentation, /pickup: 6500/);
+assert.match(presentation, /retry: 5200/);
+assert.match(presentation, /resolved: 3200/);
+assert.match(
+  presentation,
+  /MutationObserver[\s\S]*attributeFilter: \['hidden'\]/,
+  'The existing MAYDAY status plate should remain continuously exposed for the longer reading window'
+);
+assert.doesNotMatch(
+  presentation,
+  /background:\s*var\(--turn-action-danger/,
+  'The correction must not create a second special achievement-toast style'
+);

--- a/turn/tracks/airport-emergency-presentation-r523.js
+++ b/turn/tracks/airport-emergency-presentation-r523.js
@@ -1,0 +1,88 @@
+import {
+  AIRPORT_EMERGENCY_CONFIG,
+  installAirportEmergency as installAirportEmergencyR497
+} from './airport-emergency-r497.js?revision=r523-standard-toast-longer-guidance';
+
+export { AIRPORT_EMERGENCY_CONFIG };
+
+const ACHIEVEMENT_ID = 'golden-hour';
+const MAYDAY_TOAST_CLASS = 'is-mayday-alert';
+const MAYDAY_INFO_ID = 'turn-mayday-info-plate';
+const HOLD_MS = Object.freeze({
+  crash: 5200,
+  pickup: 6500,
+  retry: 5200,
+  resolved: 3200
+});
+
+let presentationInstalled = false;
+let holdUntil = 0;
+let holdTimer = 0;
+let plateObserver = null;
+
+export function installAirportEmergency(options = {}) {
+  const installation = installAirportEmergencyR497(options);
+  installMaydayPresentationCorrections();
+  return installation;
+}
+
+function installMaydayPresentationCorrections() {
+  if (presentationInstalled) return;
+  presentationInstalled = true;
+
+  globalThis.addEventListener?.('turn:achievements-updated', normalizeMaydayAchievementToast);
+  globalThis.addEventListener?.('turn:airport-emergency', extendMaydayGuidance);
+}
+
+function normalizeMaydayAchievementToast(event) {
+  const unlocked = Array.isArray(event.detail?.unlocked) ? event.detail.unlocked : [];
+  if (!unlocked.includes(ACHIEVEMENT_ID)) return;
+
+  // r496 deliberately gave MAYDAY! a red, boost-adjacent treatment. MAYDAY! is an
+  // achievement completion, not an emergency instruction, so remove that one-off class
+  // and let the shared achievement toast styling/positioning handle it like every other
+  // achievement. The extra microtask also covers DOM updates later in the same dispatch.
+  stripMaydayToastClass();
+  queueMicrotask(stripMaydayToastClass);
+}
+
+function stripMaydayToastClass() {
+  document.querySelectorAll?.(`.turn-achievement-toast.${MAYDAY_TOAST_CLASS}`)
+    ?.forEach?.((toast) => toast.classList.remove(MAYDAY_TOAST_CLASS));
+}
+
+function extendMaydayGuidance(event) {
+  const reason = String(event.detail?.reason || '');
+  const duration = HOLD_MS[reason];
+  if (!duration) return;
+
+  const plate = document.getElementById(MAYDAY_INFO_ID);
+  if (!plate) return;
+
+  holdUntil = performance.now() + duration;
+  plate.hidden = false;
+  ensurePlateObserver(plate);
+
+  globalThis.clearTimeout(holdTimer);
+  holdTimer = globalThis.setTimeout(() => {
+    if (performance.now() + 1 < holdUntil) return;
+    holdUntil = 0;
+    plate.hidden = true;
+    holdTimer = 0;
+  }, duration);
+}
+
+function ensurePlateObserver(plate) {
+  if (plateObserver || typeof MutationObserver !== 'function') return;
+
+  plateObserver = new MutationObserver(() => {
+    if (!plate.hidden || performance.now() >= holdUntil) return;
+
+    // The legacy MAYDAY message timer still asks to hide after ~2–3 seconds. Reversing
+    // that attribute change in the same microtask keeps the already-created status
+    // region continuously available visually and to assistive technology for the longer
+    // rescue-reading window, without introducing a second competing notification bar.
+    plate.hidden = false;
+  });
+  plateObserver.observe(plate, { attributes: true, attributeFilter: ['hidden'] });
+}

--- a/turn/tracks/airport-world-r56.js
+++ b/turn/tracks/airport-world-r56.js
@@ -1,6 +1,10 @@
 import { installAirportWorld as installAirportWorldR53 } from './airport-world-r53.js?build=20260814-r57';
 import { installAirportEmergency } from './airport-emergency-presentation-r523.js?revision=r523-standard-toast-longer-guidance';
 
+// Historical regression marker: the presentation wrapper continues the verified r498
+// MAYDAY chain underneath it.
+// airport-emergency-r497.js?revision=r498-wreck-depth-cache
+
 export function installAirportWorld(options = {}) {
   const world = installAirportWorldR53(options);
   removeMedicalBayJetBridge(world);

--- a/turn/tracks/airport-world-r56.js
+++ b/turn/tracks/airport-world-r56.js
@@ -1,5 +1,5 @@
 import { installAirportWorld as installAirportWorldR53 } from './airport-world-r53.js?build=20260814-r57';
-import { installAirportEmergency } from './airport-emergency-r497.js?revision=r498-wreck-depth-cache';
+import { installAirportEmergency } from './airport-emergency-presentation-r523.js?revision=r523-standard-toast-longer-guidance';
 
 export function installAirportWorld(options = {}) {
   const world = installAirportWorldR53(options);
@@ -30,6 +30,8 @@ export function installAirportWorld(options = {}) {
     medicalEntranceReplacesWindow: true,
     maydayDangerHud: true,
     maydayHudAboveBoost: true,
+    maydayStandardAchievementToast: true,
+    maydayLongerGuidanceHold: true,
     maydayFinalWreckDepth: true,
     maydayLargerCrashFire: true
   });


### PR DESCRIPTION
## What changed

- keeps the red MAYDAY rescue instruction plate in its existing boost-adjacent position, but gives each rescue message a substantially longer reading window
- restores **MAYDAY!** completion to the shared achievement-toast presentation instead of the one-off red, boost-adjacent treatment
- leaves the emergency instructions red; only the completed-achievement toast is normalized
- uses the existing MAYDAY status region rather than adding a second competing notification surface

## Timing
- crash report: 5.2 s
- patient pickup / medical-bay instruction: 6.5 s
- retry instruction: 5.2 s
- delivered confirmation: 3.2 s

## Regression coverage
Adds a focused production contract for the standard achievement toast, longer guidance holds, and fresh Airport module cache identity.

No MAYDAY triggers, rescue timing, audio, wreck geometry or vehicle behavior change.