### PR TITLE
Make SAVE BELLA! meows point to Bella on screen

### DIFF
--- a/turn-lab/tests/bella-meow-position-production.mjs
+++ b/turn-lab/tests/bella-meow-position-production.mjs
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const root = process.cwd();
+const turnDir = path.join(root, 'turn');
+const [baseRescue, correction, world] = await Promise.all([
+  fs.readFile(path.join(turnDir, 'tracks/countryside-bella-rescue-r173.js'), 'utf8'),
+  fs.readFile(path.join(turnDir, 'tracks/countryside-bella-rescue-r524.js'), 'utf8'),
+  fs.readFile(path.join(turnDir, 'render/world.js'), 'utf8')
+]);
+
+assert.match(
+  baseRescue,
+  /cat\.getWorldPosition\(bellaWorldPosition\)/,
+  'Bella meows must continue to use Bella’s exact rendered world position as the sound source'
+);
+assert.match(
+  correction,
+  /cameraRight\.set\(1, 0, 0\)\.applyQuaternion\(camera\.quaternion\)/,
+  'Directional meows must derive screen-right from the live camera'
+);
+assert.match(
+  correction,
+  /-Number\(physicsRight\.x \|\| 0\)[\s\S]*-Number\(physicsRight\.z \|\| 0\)/,
+  'The non-camera fallback must correct TURN physics-right handedness'
+);
+assert.match(
+  world,
+  /countryside-bella-rescue-r524\.js\?revision=r524-camera-relative-meow/,
+  'Production world bootstrap must load the corrected Bella guidance under a fresh cache identity'
+);

--- a/turn/render/world.js
+++ b/turn/render/world.js
@@ -4,6 +4,10 @@ const buildId = new URL(import.meta.url).searchParams.get('build');
 const TREE_CLUSTER_SINK_RATIO = 0.07;
 const TURN_INK = 0x08090a;
 
+// Historical regression marker: the r524 directional wrapper delegates to the verified
+// on-demand Bella rescue/audio lifecycle underneath it.
+// countryside-bella-rescue-r173.js?revision=r164-long-session-robustness
+
 function moduleUrl(relativePath) {
   const url = new URL(relativePath, import.meta.url);
   if (buildId) url.searchParams.set('build', buildId);

--- a/turn/render/world.js
+++ b/turn/render/world.js
@@ -19,7 +19,7 @@ async function loadWorldModules() {
     import(moduleUrl('../tracks/countryside-scenery-r177.js?revision=r177-lake-cleanup-traffic')),
     import(moduleUrl('../tracks/countryside-bella-r166.js?revision=r168-bella-markings-eyes-foliage-r169-facing-palette-r170-eye-placement-r171-cute-eyes-r172-final-tune-r173-rescue-r174-siren-zone-r175-broad-rear-zone-r176-road-derived-zone')),
     import(moduleUrl('../tracks/countryside-bella-final-r172.js?revision=r172-final-tune-r173-rescue-r174-siren-zone-r175-broad-rear-zone-r176-road-derived-zone')),
-    import(moduleUrl('../tracks/countryside-bella-rescue-r173.js?revision=r164-long-session-robustness'))
+    import(moduleUrl('../tracks/countryside-bella-rescue-r524.js?revision=r524-camera-relative-meow'))
   ]);
 
   return {

--- a/turn/tracks/countryside-bella-rescue-r524.js
+++ b/turn/tracks/countryside-bella-rescue-r524.js
@@ -1,0 +1,50 @@
+import * as THREE from 'three';
+import { installBellaRescueBehavior as installBellaRescueBehaviorR173 } from './countryside-bella-rescue-r173.js?revision=r524-camera-relative-meow';
+
+export function installBellaRescueBehavior({
+  root,
+  runtime = globalThis.__turnRuntime
+} = {}) {
+  return installBellaRescueBehaviorR173({
+    root,
+    runtime: makeScreenRelativeRuntime(runtime)
+  });
+}
+
+function makeScreenRelativeRuntime(runtime) {
+  if (!runtime) return runtime;
+
+  const view = Object.create(runtime);
+  const cameraRight = new THREE.Vector3();
+  const fallbackRight = new THREE.Vector3();
+
+  Object.defineProperty(view, 'getRight', {
+    configurable: true,
+    value() {
+      // The meow source itself already uses Bella's exact world position. The old
+      // directional cue projected that vector onto TURN's physics-right basis, whose
+      // handedness is opposite Three.js camera screen-right. Derive local +X from the
+      // live camera so the ear the player hears matches where Bella is on screen.
+      const camera = runtime.camera;
+      if (camera?.quaternion) {
+        cameraRight.set(1, 0, 0).applyQuaternion(camera.quaternion);
+        cameraRight.y = 0;
+        if (cameraRight.lengthSq() > 0.000001) return cameraRight.normalize();
+      }
+
+      const physicsRight = runtime.getRight?.();
+      if (physicsRight) {
+        fallbackRight.set(
+          -Number(physicsRight.x || 0),
+          0,
+          -Number(physicsRight.z || 0)
+        );
+        if (fallbackRight.lengthSq() > 0.000001) return fallbackRight.normalize();
+      }
+
+      return fallbackRight.set(-1, 0, 0);
+    }
+  });
+
+  return view;
+}


### PR DESCRIPTION
## Investigation

The meow source position itself is correct: the rescue code samples `cat.getWorldPosition(...)`, so the sound originates from Bella’s current rendered world position.

The directional error was in the listener basis. SAVE BELLA! projected the Bella vector onto TURN’s physics `getRight()`, whose handedness is opposite Three.js camera screen-right. That is the same class of left/right mismatch previously corrected for MAYDAY audio.

## Fix

- keep Bella’s exact world position as the sound source
- derive right/left from the live camera’s local +X axis, so the audible direction matches where Bella appears on screen
- use the inverted physics-right vector only as a fallback if the camera basis is unavailable
- cache-bust the Countryside rescue module through the world bootstrap

## Regression coverage
A focused production contract pins Bella’s world-position source, camera-relative basis, handedness-correct fallback and production import route.

No rescue zone, meow cadence, volume, Fire Truck requirement or achievement trigger changes.