### PR TITLE
Make cold-start loading status informative and accessible

### DIFF
--- a/turn-lab/tests/startup-loading-accessibility.mjs
+++ b/turn-lab/tests/startup-loading-accessibility.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const root = process.cwd();
+const source = await fs.readFile(path.join(root, 'turn/app.js'), 'utf8');
+
+assert.match(source, /copy\.setAttribute\('role', 'status'\)/);
+assert.match(source, /copy\.setAttribute\('aria-live', 'polite'\)/);
+assert.match(source, /copy\.setAttribute\('aria-atomic', 'true'\)/,
+  'Startup status updates should be announced atomically');
+assert.match(source, /gate\.setAttribute\('aria-busy', 'true'\)/);
+assert.match(source, /document\.documentElement\.setAttribute\('aria-busy', 'true'\)/);
+assert.match(source, /gate\.setAttribute\('aria-busy', 'false'\)/);
+assert.match(source, /document\.documentElement\.setAttribute\('aria-busy', 'false'\)/);
+assert.match(source, /scheduleStatus\(4000, 'This might take a minute on a new installation…'\)/);
+assert.match(source, /scheduleStatus\(10000, 'Still loading TURN\. First start can take a little longer\.'\)/);
+assert.match(source, /scheduleStatus\(20000, 'Still loading TURN\. The game will open as soon as it is ready\.'\)/);
+assert.match(source, /spinner\.setAttribute\('aria-hidden', 'true'\)/,
+  'Indeterminate visual spinner should stay decorative rather than expose a fake percentage');
+assert.doesNotMatch(source, /turn-startup-spinner[\s\S]{0,300}role[^\n]*progressbar/,
+  'TURN should not claim measurable loading progress when no percentage is available');
+assert.match(source, /intro\.replaceChildren\(\s*makeHiddenHook\('button', 'motionButton'\),\s*makeHiddenHook\('button', 'manualButton'\),\s*makeHiddenHook\('p', 'status'\)\s*\)/,
+  'Cold-start accessibility changes must preserve the legacy launch compatibility hooks');

--- a/turn/app.js
+++ b/turn/app.js
@@ -63,16 +63,24 @@ function installStartupCover() {
   const copy = gate.querySelector('.install-copy');
   const card = gate.querySelector('.install-card');
   const guide = gate.querySelector('.install-guide');
+  const statusTimers = [];
   guide?.setAttribute('hidden', '');
   if (title) title.textContent = 'LOADING';
   if (copy) {
-    copy.textContent = 'YOU’LL BE RACING IN NO TIME';
+    // WAI-ARIA status messages should live in an established polite live region. Keep
+    // the same node present throughout startup, make updates atomic, and update only
+    // its text so VoiceOver and other screen readers hear progress without focus moves.
     copy.setAttribute('role', 'status');
     copy.setAttribute('aria-live', 'polite');
+    copy.setAttribute('aria-atomic', 'true');
+    copy.textContent = 'YOU’LL BE RACING IN NO TIME';
   }
   if (card && !card.querySelector('.turn-startup-spinner')) {
     const spinner = document.createElement('div');
     spinner.className = 'turn-startup-spinner';
+    // TURN cannot currently measure trustworthy percent progress. Keep the visual
+    // spinner decorative rather than exposing a fake progressbar value; the status
+    // region above carries the meaningful indeterminate progress updates.
     spinner.setAttribute('aria-hidden', 'true');
     card.appendChild(spinner);
   }
@@ -80,10 +88,31 @@ function installStartupCover() {
   gate.hidden = false;
   gate.classList.add('turn-startup-loading');
   gate.style.setProperty('display', 'grid');
+  gate.setAttribute('aria-busy', 'true');
+  document.documentElement.setAttribute('aria-busy', 'true');
   document.documentElement.classList.add('turn-startup-pending');
+
+  const scheduleStatus = (delay, text) => {
+    if (!copy) return;
+    statusTimers.push(globalThis.setTimeout(() => {
+      if (!gate.classList.contains('turn-startup-loading')) return;
+      copy.textContent = text;
+    }, delay));
+  };
+
+  // A cold/new installation can spend noticeably longer fetching and compiling the
+  // module graph. Acknowledge that delay instead of leaving the initial optimistic copy
+  // frozen indefinitely, then keep providing low-frequency polite status updates.
+  scheduleStatus(4000, 'This might take a minute on a new installation…');
+  scheduleStatus(10000, 'Still loading TURN. First start can take a little longer.');
+  scheduleStatus(20000, 'Still loading TURN. The game will open as soon as it is ready.');
 
   return Object.freeze({
     finish() {
+      for (const timer of statusTimers) globalThis.clearTimeout(timer);
+      if (copy) copy.textContent = 'TURN is ready.';
+      gate.setAttribute('aria-busy', 'false');
+      document.documentElement.setAttribute('aria-busy', 'false');
       document.documentElement.classList.remove('turn-startup-pending');
       document.documentElement.classList.add('turn-home-ready');
       gate.classList.remove('turn-startup-loading');
@@ -128,9 +157,10 @@ function retireLegacyStartPanel() {
   intro.hidden = true;
   intro.replaceChildren(
     makeHiddenHook('button', 'motionButton'),
-    makeHiddenHook('button', 'manualButton'),
     makeHiddenHook('p', 'status')
   );
+  intro.prepend(makeHiddenHook('button', 'manualButton'));
+  intro.prepend(makeHiddenHook('button', 'motionButton'));
   document.documentElement.dataset.turnLegacyStart = 'retired';
   return intro;
 }

--- a/turn/app.js
+++ b/turn/app.js
@@ -157,10 +157,9 @@ function retireLegacyStartPanel() {
   intro.hidden = true;
   intro.replaceChildren(
     makeHiddenHook('button', 'motionButton'),
+    makeHiddenHook('button', 'manualButton'),
     makeHiddenHook('p', 'status')
   );
-  intro.prepend(makeHiddenHook('button', 'manualButton'));
-  intro.prepend(makeHiddenHook('button', 'motionButton'));
   document.documentElement.dataset.turnLegacyStart = 'retired';
   return intro;
 }


### PR DESCRIPTION
## What changed

- keeps the existing visual loading screen and spinner
- after 4 seconds, changes the copy to acknowledge a slow first/new-install start: **“This might take a minute on a new installation…”**
- adds further low-frequency status updates at 10 and 20 seconds so a long cold start never becomes a silent frozen-looking screen
- keeps one established `role="status"` live region and makes updates explicitly atomic
- marks the loading region/document `aria-busy="true"` until Home is ready, then clears it
- leaves the visual spinner decorative instead of inventing a percentage TURN cannot actually measure

## Accessibility basis
This follows the WAI-ARIA status/live-region pattern: loading messages are polite, atomic updates and the busy state stays set while the interface is still being prepared. No focus is moved and no assertive interruptions are introduced.

## Regression coverage
Adds a focused contract for live-region semantics, busy state, timed copy, the decorative spinner and preservation of the legacy launch hooks.

This PR improves the experience of a long cold start; it does not claim to solve the underlying startup duration itself.