### PR TITLE
Describe track driving character in loading intros

### DIFF
--- a/turn-lab/tests/track-intro-driving-descriptions.mjs
+++ b/turn-lab/tests/track-intro-driving-descriptions.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const root = process.cwd();
+const turnDir = path.join(root, 'turn');
+const [intro, definitions] = await Promise.all([
+  fs.readFile(path.join(turnDir, 'ui/track-intro.js'), 'utf8'),
+  fs.readFile(path.join(turnDir, 'tracks/definitions.js'), 'utf8')
+]);
+
+assert.match(intro, /track-intro-description/);
+assert.match(intro, /`Driving: \$\{track\.description\}`/,
+  'Track loading status should announce the driving-character description');
+assert.match(intro, /role', 'status'/);
+assert.match(intro, /aria-live', 'polite'/);
+assert.match(intro, /aria-atomic', 'true'/);
+assert.match(intro, /clip:rect\(0 0 0 0\)/,
+  'Driving description should be available to assistive technology without adding visual loading-screen clutter');
+
+for (const expected of [
+  'Fast, flowing and forgiving.',
+  'Runway speed. Apron precision.',
+  'Linked curves. Mountain rhythm. Ocean flow.',
+  'Switchbacks. Container canyons. Quayside speed.',
+  'District avenues. Neon corners. A full-city endurance lap.'
+]) {
+  assert.ok(definitions.includes(expected), `Missing driving description: ${expected}`);
+}

--- a/turn/ui/track-intro.js
+++ b/turn/ui/track-intro.js
@@ -13,6 +13,7 @@ export async function showTrackIntro(trackId) {
 
   intro.querySelector('.track-intro-meta').textContent = meta;
   intro.querySelector('.track-intro-name').textContent = track.name;
+  intro.querySelector('.track-intro-description').textContent = `Driving: ${track.description}`;
   intro.hidden = false;
   intro.setAttribute('aria-hidden', 'false');
   intro.classList.remove('is-visible');
@@ -50,6 +51,7 @@ function ensureTrackIntro() {
     <div class="track-intro-card">
       <span class="track-intro-meta"></span>
       <h2 class="track-intro-name"></h2>
+      <p class="track-intro-description" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0"></p>
     </div>
   `;
   document.body.appendChild(intro);


### PR DESCRIPTION
## What changed

- adds an assistive-technology description to each track intro/loading screen
- reuses the track catalog’s existing driving-character copy rather than inventing a separate accessibility-only description set
- keeps the extra description visually hidden so the established loading-screen composition is unchanged
- includes the description in the existing polite, atomic track-intro status region

## Spoken examples
- Countryside: **Driving: Fast, flowing and forgiving.**
- Airport: **Driving: Runway speed. Apron precision.**
- Cliffside: **Driving: Linked curves. Mountain rhythm. Ocean flow.**
- Harbor: **Driving: Switchbacks. Container canyons. Quayside speed.**
- Midnight City: **Driving: District avenues. Neon corners. A full-city endurance lap.**

This is the semantic equivalent of alt text for TURN’s rendered track loading view: it describes what the player needs to know about the driving rather than trying to narrate decorative scenery.

## Regression coverage
Adds a focused contract that all five driving descriptions remain available through the track-intro live region.