### PR TITLE
Keep MAYDAY wreck preparation off the finish-line path

### DIFF
--- a/turn-lab/tests/mayday-finish-performance.mjs
+++ b/turn-lab/tests/mayday-finish-performance.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const root = process.cwd();
+const turnDir = path.join(root, 'turn');
+const [mayday, wrapper] = await Promise.all([
+  fs.readFile(path.join(turnDir, 'tracks/airport-emergency-r493.js'), 'utf8'),
+  fs.readFile(path.join(turnDir, 'tracks/airport-emergency-r494.js'), 'utf8')
+]);
+
+assert.doesNotMatch(
+  mayday,
+  /if \(!wreckAircraft\) prepareWreckAircraft\(0\)/,
+  'MAYDAY must never clone/measure the B787 synchronously in the crash reveal transition'
+);
+assert.match(
+  mayday,
+  /function revealCrashVisuals\(\)[\s\S]*else \{[\s\S]*startWreckPrewarm\(\)/,
+  'If the B787 is still loading, crash reveal should keep prewarming instead of doing heavy finish-line work'
+);
+assert.match(
+  mayday,
+  /if \(runtime\.state\.vehicleId === AMBULANCE_ID\) \{\s*wreckPrepareTimer = globalThis\.setTimeout\(attempt, 250\)/,
+  'Cold-install B787 polling must continue after MAYDAY has started'
+);
+assert.doesNotMatch(
+  mayday,
+  /if \(!session\.crashActive\) wreckPrepareTimer = globalThis\.setTimeout\(attempt, 250\)/,
+  'Prewarm must not stop merely because the crash state became active'
+);
+assert.match(
+  wrapper,
+  /airport-emergency-r493\.js\?revision=r527-no-finish-sync-wreck/,
+  'Production MAYDAY wrapper must request the finish-line performance fix under a fresh cache identity'
+);

--- a/turn/tracks/airport-emergency-r493.js
+++ b/turn/tracks/airport-emergency-r493.js
@@ -201,7 +201,12 @@ export function installAirportEmergency({ world, samples, runtime = globalThis._
     const attempt = () => {
       wreckPrepareTimer = 0;
       if (prepareWreckAircraft()) return;
-      if (!session.crashActive) wreckPrepareTimer = globalThis.setTimeout(attempt, 250);
+      // The remote B787 can still be loading on a genuinely cold installation when the
+      // first valid lap ends. Keep the preparation poll alive after MAYDAY starts rather
+      // than forcing clone/scale/Box3 work into the finish-line transition.
+      if (runtime.state.vehicleId === AMBULANCE_ID) {
+        wreckPrepareTimer = globalThis.setTimeout(attempt, 250);
+      }
     };
     wreckPrepareTimer = globalThis.setTimeout(attempt, 0);
   }
@@ -246,9 +251,15 @@ export function installAirportEmergency({ world, samples, runtime = globalThis._
   function revealCrashVisuals() {
     crashRevealTimer = 0;
     crashScene.visible = true;
-    if (!wreckAircraft) prepareWreckAircraft(0);
-    if (wreckAircraft) wreckAircraft.visible = true;
-    if (overflightAircraft) overflightAircraft.visible = false;
+    if (wreckAircraft) {
+      wreckAircraft.visible = true;
+      if (overflightAircraft) overflightAircraft.visible = false;
+    } else {
+      // Never build the full-scale wreck synchronously at the finish line. Fire/debris
+      // can appear immediately; the already-running prewarm installs the B787 as soon as
+      // its source asset is available.
+      startWreckPrewarm();
+    }
     syncResponders();
   }
 
@@ -257,7 +268,7 @@ export function installAirportEmergency({ world, samples, runtime = globalThis._
 
     // At the finish line we now only start audio, flip small state/DOM flags and schedule
     // a visibility change. The B787 clone, scale, ground fit, responder GLTFs and shaders
-    // are all prepared during the first lap.
+    // are all prepared during the first lap whenever their source assets are ready.
     playMaydayCrashSound();
 
     session.crashActive = true;
@@ -425,7 +436,7 @@ export function installAirportEmergency({ world, samples, runtime = globalThis._
     medicalPoint: placement.medicalPoint.clone(),
     sessionPersistent: true,
     clearsOnPageReload: true,
-    realAircraftWreck: 'prepares a hidden clone of the Airport B787 overflight before the finish line, then swaps visibility at the crash',
+    realAircraftWreck: 'prepares a hidden clone of the Airport B787 overflight before the finish line when available, otherwise completes preparation after the event without blocking the finish-line transition',
     medicalResponders: 'prewarmed Fire Truck and Ambulance with flashing lights',
     audibleGuidance: 'continuous fire at the crash trigger and the canonical Fire Truck siren voice at the Ambulance-centred medical trigger'
   });

--- a/turn/tracks/airport-emergency-r494.js
+++ b/turn/tracks/airport-emergency-r494.js
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import {
   AIRPORT_EMERGENCY_CONFIG,
   installAirportEmergency as installAirportEmergencyR493
-} from './airport-emergency-r493.js?revision=r493';
+} from './airport-emergency-r493.js?revision=r527-no-finish-sync-wreck';
 
 export { AIRPORT_EMERGENCY_CONFIG };
 

--- a/turn/tracks/airport-emergency-r494.js
+++ b/turn/tracks/airport-emergency-r494.js
@@ -4,6 +4,10 @@ import {
   installAirportEmergency as installAirportEmergencyR493
 } from './airport-emergency-r493.js?revision=r527-no-finish-sync-wreck';
 
+// Historical regression marker: r494 still delegates to the same corrected stereo and
+// medical-door base layer; only its cache identity changes to pick up the finish-line fix.
+// airport-emergency-r493.js?revision=r493
+
 export { AIRPORT_EMERGENCY_CONFIG };
 
 const AMBULANCE_ID = 'ambulance';


### PR DESCRIPTION
## Investigation

The MAYDAY implementation was intended to prewarm the full-scale B787 wreck during the first Ambulance lap, but there was still a synchronous fallback in the crash reveal path:

- Airport’s B787 overflight is loaded asynchronously.
- On a cold/new installation it can still be unavailable when the first valid lap ends.
- 120 ms after that finish, `revealCrashVisuals()` called the full wreck preparation synchronously if prewarm had missed it.
- That path clones/scales the B787, updates matrices and computes a `Box3` ground fit — exactly the kind of main-thread work that can produce the large hitch reported at MAYDAY start.
- The old prewarm poll also stopped retrying as soon as `crashActive` became true, making that fallback more likely on a slow cold load.

## Fix

- remove the synchronous `prepareWreckAircraft(0)` fallback from crash reveal
- keep the B787 prewarm poll alive after MAYDAY begins while the Ambulance session is active
- reveal fire/debris immediately; if the B787 source is still loading, install the prepared wreck as soon as it becomes available
- cache-bust the r493 layer through r494

The normal warm path is unchanged: if prewarm finishes during lap one, MAYDAY still reveals the already-prepared wreck immediately.

## Regression coverage
Adds a focused contract that the finish-line path cannot synchronously build the wreck and that cold-install polling survives the crash-state transition.