### PR TITLE
Announce TURN startup completion and required rotation

### DIFF
--- a/turn-lab/tests/startup-ready-orientation-announcement.mjs
+++ b/turn-lab/tests/startup-ready-orientation-announcement.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const root = process.cwd();
+const handoff = await fs.readFile(
+  path.join(root, 'turn/ui/startup-screen-reader-handoff-r529.js'),
+  'utf8'
+);
+const index = await fs.readFile(path.join(root, 'turn/index.html'), 'utf8');
+
+assert.match(handoff, /document\.addEventListener\('turn:home-ready'/,
+  'The ready announcement must use TURN\'s established Home-ready lifecycle event');
+assert.match(handoff, /status\.setAttribute\('role', 'status'\)/);
+assert.match(handoff, /status\.setAttribute\('aria-live', 'polite'\)/);
+assert.match(handoff, /status\.setAttribute\('aria-atomic', 'true'\)/);
+assert.match(handoff, /document\.body\.appendChild\(status\)/,
+  'The completion live region must persist outside the startup gate that gets hidden');
+assert.match(handoff, /TURN is ready\. Rotate your device to landscape\./,
+  'Portrait startup must announce both completion and the required orientation action');
+assert.match(handoff, /: 'TURN is ready\.';/,
+  'Landscape startup should announce completion without an unnecessary rotate instruction');
+assert.match(handoff, /height > width/,
+  'Orientation guidance should be based on the live viewport rather than assumed from device type');
+assert.match(index, /startup-screen-reader-handoff-r529\.js\?revision=r529-ready-orientation/,
+  'Production TURN must load the cache-revised startup handoff before app startup');

--- a/turn/index.html
+++ b/turn/index.html
@@ -168,6 +168,7 @@
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button" aria-label="Restart the current lap from the start line">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
   <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260817-r171-r168-shared-about-credits"></script>
+  <script src="./ui/startup-screen-reader-handoff-r529.js?revision=r529-ready-orientation"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
   <script type="module" src="./app.js?build=20260817-r171-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r420-music-warm-r426-loading-copy-r164-long-session-robustness-post-soak-r199-card-gap-rim-r518-landmark-framing-ground-layering"></script>
   <script type="module" src="./render/skid-continuity-r198.js?revision=r198-skid-continuity"></script>

--- a/turn/ui/startup-screen-reader-handoff-r529.js
+++ b/turn/ui/startup-screen-reader-handoff-r529.js
@@ -1,0 +1,48 @@
+(() => {
+  const STATUS_ID = 'turn-startup-handoff-status';
+
+  function viewportIsPortrait() {
+    const viewport = window.visualViewport;
+    const width = viewport?.width || window.innerWidth || document.documentElement.clientWidth;
+    const height = viewport?.height || window.innerHeight || document.documentElement.clientHeight;
+    return height > width;
+  }
+
+  function ensureStatusRegion() {
+    let status = document.getElementById(STATUS_ID);
+    if (status) return status;
+
+    status = document.createElement('div');
+    status.id = STATUS_ID;
+    status.setAttribute('role', 'status');
+    status.setAttribute('aria-live', 'polite');
+    status.setAttribute('aria-atomic', 'true');
+    status.style.cssText = [
+      'position:fixed',
+      'width:1px',
+      'height:1px',
+      'padding:0',
+      'margin:-1px',
+      'overflow:hidden',
+      'clip-path:inset(50%)',
+      'white-space:nowrap',
+      'border:0'
+    ].join(';');
+    document.body.appendChild(status);
+    return status;
+  }
+
+  const status = ensureStatusRegion();
+
+  document.addEventListener('turn:home-ready', () => {
+    // The loading surface is hidden synchronously when Home becomes ready. Announce
+    // completion from a persistent live region outside that surface, then include the
+    // next required action only when the player is actually holding the device upright.
+    status.textContent = '';
+    requestAnimationFrame(() => {
+      status.textContent = viewportIsPortrait()
+        ? 'TURN is ready. Rotate your device to landscape.'
+        : 'TURN is ready.';
+    });
+  }, { once: true });
+})();


### PR DESCRIPTION
## Problem

On a fresh/installed TURN launch with a screen reader, the startup live region announces loading and the longer cold-start updates, but the final handoff is silent.

The existing startup cover writes `TURN is ready.` and then immediately hides the entire install/loading gate. VoiceOver can therefore miss that final update. The portrait rotate panel is also a labelled visual surface that already exists in the DOM, so revealing it does not itself announce the required action.

## Fix

- add a persistent, visually hidden polite live region outside the startup gate
- listen to TURN's existing `turn:home-ready` lifecycle event
- when Home is ready in portrait, announce: **“TURN is ready. Rotate your device to landscape.”**
- when already landscape, announce only: **“TURN is ready.”**
- determine portrait/landscape from the live viewport rather than device type
- load the handoff script before the main TURN module so the live region exists before readiness can fire

No focus is moved, no assertive announcement is introduced, and the visual rotate panel is unchanged.

## Regression coverage

Adds a focused contract for:
- use of the established Home-ready event
- persistent `role=status` / polite / atomic semantics
- placement outside the startup gate
- portrait-specific rotate guidance
- landscape completion without redundant rotate guidance
- production script inclusion

This is an accessibility-only startup handoff fix; gameplay, motion, rendering, audio and progression are unchanged.