### PR TITLE
Improve TURN screen reader quality

### DIFF
--- a/turn/tracks/countryside-bella-rescue-hotfix-r176.js
+++ b/turn/tracks/countryside-bella-rescue-hotfix-r176.js
@@ -1,11 +1,51 @@
 import { installBellaRescueBehavior } from './countryside-bella-rescue-r173.js?revision=r164-long-session-robustness';
 
 const RETRY_DELAYS_MS = Object.freeze([250, 350, 500, 700, 900, 1200, 1600, 2200, 3000, 4000]);
+const spatialRuntimeCache = new WeakMap();
 
 function bellaRoot(runtime) {
   return runtime?.world?.children?.find?.(
     (child) => child?.userData?.turnEasterEgg === 'save-bella'
   ) || null;
+}
+
+function correctedSpatialRuntime(runtime) {
+  if (!runtime || typeof Proxy !== 'function') return runtime;
+  const cached = spatialRuntimeCache.get(runtime);
+  if (cached) return cached;
+
+  // Bella's meow uses Web Audio's stereo panner, where negative is left and positive
+  // is right. TURN's existing rescue behavior receives the opposite sign from the
+  // runtime right-vector convention, so the cue was exactly mirrored. Keep the fix
+  // local to Bella instead of changing the shared vehicle/camera coordinate system.
+  const proxy = new Proxy(runtime, {
+    get(target, property) {
+      if (property === 'getRight') {
+        return () => {
+          const right = typeof target.getRight === 'function' ? target.getRight() : null;
+          if (right) {
+            return {
+              x: -Number(right.x || 0),
+              y: -Number(right.y || 0),
+              z: -Number(right.z || 0)
+            };
+          }
+
+          const heading = Number(target.state?.heading) || 0;
+          return {
+            x: -Math.cos(heading),
+            y: 0,
+            z: Math.sin(heading)
+          };
+        };
+      }
+
+      const value = Reflect.get(target, property, target);
+      return typeof value === 'function' ? value.bind(target) : value;
+    }
+  });
+  spatialRuntimeCache.set(runtime, proxy);
+  return proxy;
 }
 
 function reinstall(runtime) {
@@ -14,8 +54,8 @@ function reinstall(runtime) {
 
   root.userData.turnBellaDisposeRescueBehavior?.();
   root.userData.turnBellaRescueBehaviorInstalled = false;
-  installBellaRescueBehavior({ root, runtime });
-  root.userData.turnBellaRescueBootstrap = 'r164-long-session-robustness';
+  installBellaRescueBehavior({ root, runtime: correctedSpatialRuntime(runtime) });
+  root.userData.turnBellaRescueBootstrap = 'r172-screen-reader-quality';
   return true;
 }
 

--- a/turn/ui/startup-screen-reader-handoff-r529.js
+++ b/turn/ui/startup-screen-reader-handoff-r529.js
@@ -173,10 +173,17 @@
     if (node?.querySelectorAll) candidates.push(...node.querySelectorAll('.turn-achievement-toast'));
 
     for (const toast of candidates) {
-      toast.removeAttribute('role');
-      toast.removeAttribute('aria-live');
-      toast.removeAttribute('aria-atomic');
-      toast.setAttribute('aria-hidden', 'true');
+      if (toast.dataset.turnSrToastManaged !== 'true') {
+        toast.dataset.turnSrToastManaged = 'true';
+        toast.removeAttribute('role');
+        toast.removeAttribute('aria-live');
+        toast.removeAttribute('aria-atomic');
+        toast.setAttribute('aria-hidden', 'true');
+        const observer = new MutationObserver(() => {
+          queueMicrotask(() => announceToastIfVisible(toast));
+        });
+        observer.observe(toast, { attributes: true, attributeFilter: ['hidden', 'aria-label'] });
+      }
       queueMicrotask(() => announceToastIfVisible(toast));
     }
   }
@@ -453,6 +460,9 @@
     scanAccessibilityTargets(document);
     discoveryObserver?.disconnect();
     discoveryObserver = null;
+    window.clearTimeout(externalPriorityTimer);
+    externalPriorityTimer = 0;
+    externalPriorityUntil = 0;
 
     const loadingCopy = document.querySelector('#installGate .install-copy');
     if (loadingCopy) {

--- a/turn/ui/startup-screen-reader-handoff-r529.js
+++ b/turn/ui/startup-screen-reader-handoff-r529.js
@@ -16,6 +16,9 @@
   let pendingPosition = '';
   let homeReadyHandled = false;
   let trainingAnnouncementToken = 0;
+  let externalPriorityTimer = 0;
+  let externalPriorityUntil = 0;
+  let discoveryObserver = null;
 
   function viewportIsPortrait() {
     const viewport = window.visualViewport;
@@ -53,13 +56,36 @@
     return Math.min(9500, Math.max(2400, 900 + words * 380));
   }
 
+  function externalSpeechActive() {
+    return performance.now() < externalPriorityUntil;
+  }
+
+  function positionSpeechBlocked() {
+    return speaking || speechQueue.length > 0 || externalSpeechActive();
+  }
+
   function setPositionSpeechEnabled(enabled) {
     if (!positionAnnouncer) return;
     positionAnnouncer.setAttribute('aria-live', enabled ? 'polite' : 'off');
   }
 
+  function reservePositionForSpeech(message) {
+    const normalized = String(message || '').trim();
+    if (!normalized || !positionAnnouncer) return;
+    const now = performance.now();
+    externalPriorityUntil = Math.max(externalPriorityUntil, now + speechDurationMs(normalized));
+    window.clearTimeout(externalPriorityTimer);
+    externalPriorityTimer = window.setTimeout(() => {
+      externalPriorityTimer = 0;
+      externalPriorityUntil = 0;
+      if (!speaking) flushPendingPosition();
+    }, Math.max(0, externalPriorityUntil - now));
+    setPositionSpeechEnabled(false);
+  }
+
   function flushPendingPosition() {
     if (!positionAnnouncer) return;
+    if (positionSpeechBlocked()) return;
     setPositionSpeechEnabled(true);
     const message = String(pendingPosition || positionAnnouncer.textContent || '').trim();
     pendingPosition = '';
@@ -67,7 +93,7 @@
 
     positionAnnouncer.textContent = '';
     requestAnimationFrame(() => {
-      if (speaking || !positionAnnouncer) {
+      if (positionSpeechBlocked() || !positionAnnouncer) {
         pendingPosition = message;
         return;
       }
@@ -78,6 +104,12 @@
   function playNextSpeech() {
     window.clearTimeout(speechTimer);
     speechTimer = 0;
+
+    if (externalSpeechActive()) {
+      setPositionSpeechEnabled(false);
+      speechTimer = window.setTimeout(playNextSpeech, Math.max(80, externalPriorityUntil - performance.now()));
+      return;
+    }
 
     const next = speechQueue.shift();
     if (!next) {
@@ -102,7 +134,7 @@
   function speak(message) {
     const normalized = String(message || '').trim();
     if (!normalized) return;
-    const tail = speechQueue.at(-1);
+    const tail = speechQueue[speechQueue.length - 1];
     if (tail === normalized) return;
     if (speaking && document.getElementById(STATUS_ID)?.textContent === normalized) return;
     speechQueue.push(normalized);
@@ -119,10 +151,10 @@
 
     positionAnnouncer = announcer;
     announcer.dataset.turnSrPriorityManaged = 'true';
-    setPositionSpeechEnabled(!speaking);
+    setPositionSpeechEnabled(!positionSpeechBlocked());
     const observer = new MutationObserver(() => {
       const text = String(announcer.textContent || '').trim();
-      if (speaking && text) pendingPosition = text;
+      if (positionSpeechBlocked() && text) pendingPosition = text;
     });
     observer.observe(announcer, { childList: true, characterData: true, subtree: true });
   }
@@ -159,7 +191,7 @@
 
   function focusDialogHeading(dialog) {
     if (!dialog || dialog.hidden) return;
-    if (dialog instanceof HTMLDialogElement && !dialog.open) return;
+    if (globalThis.HTMLDialogElement && dialog instanceof globalThis.HTMLDialogElement && !dialog.open) return;
     const heading = headingForDialog(dialog);
     if (!heading) return;
     if (!heading.hasAttribute('tabindex')) heading.setAttribute('tabindex', '-1');
@@ -209,7 +241,7 @@
 
   function replaceMenuGlyphText(root) {
     if (!root || !document.createTreeWalker) return;
-    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    const walker = document.createTreeWalker(root, globalThis.NodeFilter?.SHOW_TEXT || 4);
     const textNodes = [];
     while (walker.nextNode()) textNodes.push(walker.currentNode);
 
@@ -338,49 +370,73 @@
     return TRAINING_START_MESSAGES[runtimeId] ? runtimeId : '';
   }
 
-  function installGlobalObserver() {
-    if (typeof MutationObserver !== 'function' || !document.body) return;
-    const observer = new MutationObserver((mutations) => {
-      for (const mutation of mutations) {
-        if (mutation.type === 'childList') {
-          for (const node of mutation.addedNodes) {
-            if (!(node instanceof Element)) continue;
-            preparePositionAnnouncer(node);
-            prepareAchievementToast(node);
-            prepareBalanceSlider(node);
-            normalizeMenuButtons(node);
-          }
-        }
+  function externalLiveRegionReadable(live) {
+    if (!live || live.id === STATUS_ID || live === positionAnnouncer) return false;
+    if (live.getAttribute('aria-live') === 'off') return false;
+    if (live.closest('[hidden], [aria-hidden="true"]')) return false;
+    const closedDialog = live.closest('dialog');
+    if (closedDialog && !closedDialog.open) return false;
+    return true;
+  }
 
-        if (mutation.type === 'attributes') {
-          const target = mutation.target;
-          if (target?.matches?.('.turn-achievement-toast')) {
-            prepareAchievementToast(target);
-            queueMicrotask(() => announceToastIfVisible(target));
-          }
-          if (
-            mutation.attributeName === 'hidden'
-            && target?.matches?.('[role="dialog"]')
-            && !target.hidden
-          ) {
-            queueMicrotask(() => focusDialogHeading(target));
-          }
-          if (
-            mutation.attributeName === 'open'
-            && target instanceof HTMLDialogElement
-            && target.open
-          ) {
-            queueMicrotask(() => focusDialogHeading(target));
-          }
+  function prepareExternalLiveRegions(node = document) {
+    const selector = '[aria-live], [role="status"], [role="alert"]';
+    const candidates = [];
+    if (node?.matches?.(selector)) candidates.push(node);
+    if (node?.querySelectorAll) candidates.push(...node.querySelectorAll(selector));
+
+    for (const live of candidates) {
+      if (!live || live.id === STATUS_ID || live === positionAnnouncer) continue;
+      if (live.dataset.turnSrExternalPriority === 'true') continue;
+      live.dataset.turnSrExternalPriority = 'true';
+      const observer = new MutationObserver(() => {
+        if (!externalLiveRegionReadable(live)) return;
+        const message = String(live.textContent || '').trim();
+        if (message) reservePositionForSpeech(message);
+      });
+      observer.observe(live, { childList: true, characterData: true, subtree: true });
+    }
+  }
+
+  function prepareDialogOpenTracking(node = document) {
+    const dialogs = [];
+    if (node?.matches?.('dialog, [role="dialog"]')) dialogs.push(node);
+    if (node?.querySelectorAll) dialogs.push(...node.querySelectorAll('dialog, [role="dialog"]'));
+
+    for (const dialog of dialogs) {
+      if (dialog.dataset.turnSrHeadingTracked === 'true') continue;
+      dialog.dataset.turnSrHeadingTracked = 'true';
+      const observer = new MutationObserver(() => {
+        const nativeOpen = globalThis.HTMLDialogElement
+          && dialog instanceof globalThis.HTMLDialogElement
+          && dialog.open;
+        const roleDialogOpen = dialog.getAttribute('role') === 'dialog' && !dialog.hidden;
+        if (nativeOpen || roleDialogOpen) queueMicrotask(() => focusDialogHeading(dialog));
+      });
+      observer.observe(dialog, { attributes: true, attributeFilter: ['open', 'hidden'] });
+    }
+  }
+
+  function scanAccessibilityTargets(node = document) {
+    preparePositionAnnouncer(node);
+    prepareAchievementToast(node);
+    prepareBalanceSlider(node);
+    normalizeMenuButtons(node);
+    prepareDialogOpenTracking(node);
+    prepareExternalLiveRegions(node);
+  }
+
+  function installDiscoveryObserver() {
+    if (typeof MutationObserver !== 'function' || !document.body) return;
+    discoveryObserver = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        for (const node of mutation.addedNodes || []) {
+          if (!(node instanceof Element)) continue;
+          scanAccessibilityTargets(node);
         }
       }
     });
-    observer.observe(document.body, {
-      childList: true,
-      subtree: true,
-      attributes: true,
-      attributeFilter: ['hidden', 'open', 'aria-label']
-    });
+    discoveryObserver.observe(document.body, { childList: true, subtree: true });
   }
 
   installDialogHeadingFocus();
@@ -388,14 +444,15 @@
   prepareInstallInstructions();
   normalizeMenuButtons();
   suppressDuplicateStartupReady();
-  preparePositionAnnouncer(document);
-  prepareAchievementToast(document);
-  prepareBalanceSlider(document);
-  installGlobalObserver();
+  scanAccessibilityTargets(document);
+  installDiscoveryObserver();
 
   document.addEventListener('turn:home-ready', () => {
     if (homeReadyHandled) return;
     homeReadyHandled = true;
+    scanAccessibilityTargets(document);
+    discoveryObserver?.disconnect();
+    discoveryObserver = null;
 
     const loadingCopy = document.querySelector('#installGate .install-copy');
     if (loadingCopy) {
@@ -413,11 +470,16 @@
   }, { once: true });
 
   window.addEventListener('turn:track-changed', (event) => {
+    scanAccessibilityTargets(document);
     const trackId = String(event.detail?.trackId || '');
     if (event.detail?.training === true && TRAINING_START_MESSAGES[trackId]) {
       announceTrainingWhenRunning(trackId);
     }
   });
+
+  for (const eventName of ['turn:ui-state-change', 'turn:achievements-updated', 'turn:trophy-road-updated']) {
+    window.addEventListener(eventName, () => scanAccessibilityTargets(document));
+  }
 
   document.addEventListener('click', (event) => {
     const restart = event.target?.closest?.('#resetButton, [data-training-race-restart]');

--- a/turn/ui/startup-screen-reader-handoff-r529.js
+++ b/turn/ui/startup-screen-reader-handoff-r529.js
@@ -1,5 +1,21 @@
 (() => {
-  const STATUS_ID = 'turn-startup-handoff-status';
+  const STATUS_ID = 'turn-screen-reader-status';
+  const MENU_GLYPHS = new Set(['…', '⋮', '☰']);
+  const TRAINING_START_MESSAGES = Object.freeze({
+    'dbe-training-1': 'Part one, Find the ribbon. Steer toward the warm guiding hum and keep it centred.',
+    'dbe-training-2': 'Part two, Listen ahead. Follow the guiding hum and listen for one right pace note, then a broader two-BIP left.',
+    'dbe-training-3': 'Part three, Leave and return. You start off-road. Use gravel and the warm recovery hum to rejoin, then listen for one right pace note.',
+    'dbe-training-4': 'Part four, Trust the sequence. Listen for BIP BIP BEEP in the left ear before the long tight left.',
+    'dbe-training-5': 'Part five, Drive by ear. Combine the guiding hum with the right-left pace-note sequence, and recover by sound if you leave the road.'
+  });
+
+  let speechQueue = [];
+  let speaking = false;
+  let speechTimer = 0;
+  let positionAnnouncer = null;
+  let pendingPosition = '';
+  let homeReadyHandled = false;
+  let trainingAnnouncementToken = 0;
 
   function viewportIsPortrait() {
     const viewport = window.visualViewport;
@@ -32,17 +48,381 @@
     return status;
   }
 
-  const status = ensureStatusRegion();
+  function speechDurationMs(message) {
+    const words = String(message || '').trim().split(/\s+/).filter(Boolean).length;
+    return Math.min(9500, Math.max(2400, 900 + words * 380));
+  }
 
-  document.addEventListener('turn:home-ready', () => {
-    // The loading surface is hidden synchronously when Home becomes ready. Announce
-    // completion from a persistent live region outside that surface, then include the
-    // next required action only when the player is actually holding the device upright.
+  function setPositionSpeechEnabled(enabled) {
+    if (!positionAnnouncer) return;
+    positionAnnouncer.setAttribute('aria-live', enabled ? 'polite' : 'off');
+  }
+
+  function flushPendingPosition() {
+    if (!positionAnnouncer) return;
+    setPositionSpeechEnabled(true);
+    const message = String(pendingPosition || positionAnnouncer.textContent || '').trim();
+    pendingPosition = '';
+    if (!message) return;
+
+    positionAnnouncer.textContent = '';
+    requestAnimationFrame(() => {
+      if (speaking || !positionAnnouncer) {
+        pendingPosition = message;
+        return;
+      }
+      positionAnnouncer.textContent = message;
+    });
+  }
+
+  function playNextSpeech() {
+    window.clearTimeout(speechTimer);
+    speechTimer = 0;
+
+    const next = speechQueue.shift();
+    if (!next) {
+      speaking = false;
+      flushPendingPosition();
+      return;
+    }
+
+    speaking = true;
+    setPositionSpeechEnabled(false);
+    const status = ensureStatusRegion();
     status.textContent = '';
     requestAnimationFrame(() => {
-      status.textContent = viewportIsPortrait()
-        ? 'TURN is ready. Rotate your device to landscape.'
-        : 'TURN is ready.';
+      status.textContent = next;
+      speechTimer = window.setTimeout(() => {
+        status.textContent = '';
+        playNextSpeech();
+      }, speechDurationMs(next));
     });
+  }
+
+  function speak(message) {
+    const normalized = String(message || '').trim();
+    if (!normalized) return;
+    const tail = speechQueue.at(-1);
+    if (tail === normalized) return;
+    if (speaking && document.getElementById(STATUS_ID)?.textContent === normalized) return;
+    speechQueue.push(normalized);
+    if (!speaking) playNextSpeech();
+  }
+
+  globalThis.__turnScreenReaderSpeak = speak;
+
+  function preparePositionAnnouncer(node) {
+    const announcer = node?.matches?.('.race-position-announcer')
+      ? node
+      : node?.querySelector?.('.race-position-announcer');
+    if (!announcer || announcer.dataset.turnSrPriorityManaged === 'true') return;
+
+    positionAnnouncer = announcer;
+    announcer.dataset.turnSrPriorityManaged = 'true';
+    setPositionSpeechEnabled(!speaking);
+    const observer = new MutationObserver(() => {
+      const text = String(announcer.textContent || '').trim();
+      if (speaking && text) pendingPosition = text;
+    });
+    observer.observe(announcer, { childList: true, characterData: true, subtree: true });
+  }
+
+  function announceToastIfVisible(toast) {
+    if (!toast || toast.hidden) return;
+    const message = String(toast.getAttribute('aria-label') || '').trim();
+    if (!message || toast.dataset.turnSrAnnouncedLabel === message) return;
+    toast.dataset.turnSrAnnouncedLabel = message;
+    speak(message);
+  }
+
+  function prepareAchievementToast(node) {
+    const candidates = [];
+    if (node?.matches?.('.turn-achievement-toast')) candidates.push(node);
+    if (node?.querySelectorAll) candidates.push(...node.querySelectorAll('.turn-achievement-toast'));
+
+    for (const toast of candidates) {
+      toast.removeAttribute('role');
+      toast.removeAttribute('aria-live');
+      toast.removeAttribute('aria-atomic');
+      toast.setAttribute('aria-hidden', 'true');
+      queueMicrotask(() => announceToastIfVisible(toast));
+    }
+  }
+
+  function headingForDialog(dialog) {
+    if (!dialog) return null;
+    const labelledBy = String(dialog.getAttribute('aria-labelledby') || '').trim().split(/\s+/)[0];
+    const labelled = labelledBy ? document.getElementById(labelledBy) : null;
+    if (labelled && dialog.contains(labelled)) return labelled;
+    return dialog.querySelector('h1, h2, h3, [role="heading"]');
+  }
+
+  function focusDialogHeading(dialog) {
+    if (!dialog || dialog.hidden) return;
+    if (dialog instanceof HTMLDialogElement && !dialog.open) return;
+    const heading = headingForDialog(dialog);
+    if (!heading) return;
+    if (!heading.hasAttribute('tabindex')) heading.setAttribute('tabindex', '-1');
+    try {
+      heading.focus({ preventScroll: true });
+    } catch (_) {
+      heading.focus?.();
+    }
+  }
+
+  function installDialogHeadingFocus() {
+    const prototype = globalThis.HTMLDialogElement?.prototype;
+    const originalShowModal = prototype?.showModal;
+    if (prototype && typeof originalShowModal === 'function' && !originalShowModal.__turnHeadingFirst) {
+      function showModalHeadingFirst(...args) {
+        const result = originalShowModal.apply(this, args);
+        queueMicrotask(() => focusDialogHeading(this));
+        return result;
+      }
+      showModalHeadingFirst.__turnHeadingFirst = true;
+      showModalHeadingFirst.__turnOriginal = originalShowModal;
+      try {
+        prototype.showModal = showModalHeadingFirst;
+      } catch (_) {}
+    }
+  }
+
+  function moveInstallReleaseInfoToEnd() {
+    const card = document.querySelector('#installGate .install-card');
+    const actions = card?.querySelector('.install-actions');
+    const kicker = card?.querySelector('.install-kicker');
+    if (!card || !actions || !kicker || kicker.dataset.turnSrReordered === 'true') return;
+    actions.after(kicker);
+    kicker.dataset.turnSrReordered = 'true';
+  }
+
+  function menuKey(symbol) {
+    const key = document.createElement('kbd');
+    key.className = 'install-menu-key';
+    key.setAttribute('aria-label', 'Menu');
+    const glyph = document.createElement('span');
+    glyph.setAttribute('aria-hidden', 'true');
+    glyph.textContent = symbol;
+    key.appendChild(glyph);
+    return key;
+  }
+
+  function replaceMenuGlyphText(root) {
+    if (!root || !document.createTreeWalker) return;
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    const textNodes = [];
+    while (walker.nextNode()) textNodes.push(walker.currentNode);
+
+    for (const textNode of textNodes) {
+      if (textNode.parentElement?.closest('kbd')) continue;
+      const text = textNode.nodeValue || '';
+      if (![...MENU_GLYPHS].some((glyph) => text.includes(glyph))) continue;
+
+      const fragment = document.createDocumentFragment();
+      let buffer = '';
+      for (const character of text) {
+        if (MENU_GLYPHS.has(character)) {
+          if (buffer) fragment.appendChild(document.createTextNode(buffer));
+          fragment.appendChild(menuKey(character));
+          buffer = '';
+        } else {
+          buffer += character;
+        }
+      }
+      if (buffer) fragment.appendChild(document.createTextNode(buffer));
+      textNode.replaceWith(fragment);
+    }
+  }
+
+  function normalizeMenuButtons(root = document) {
+    const buttons = root?.matches?.('button') ? [root] : [...(root?.querySelectorAll?.('button') || [])];
+    for (const button of buttons) {
+      const label = String(button.textContent || '').trim();
+      if (MENU_GLYPHS.has(label)) button.setAttribute('aria-label', 'Menu');
+    }
+  }
+
+  function prepareInstallInstructions() {
+    const steps = document.querySelector('#installSteps');
+    if (!steps || steps.dataset.turnSrMenuKeys === 'true') return;
+    steps.dataset.turnSrMenuKeys = 'true';
+    replaceMenuGlyphText(steps);
+    normalizeMenuButtons(steps);
+    const observer = new MutationObserver(() => {
+      replaceMenuGlyphText(steps);
+      normalizeMenuButtons(steps);
+    });
+    observer.observe(steps, { childList: true, subtree: true });
+  }
+
+  function balanceValueText(slider) {
+    const value = Math.max(0, Math.min(100, Math.round(Number(slider?.value) || 0)));
+    if (value < 45) return `${100 - value}% other sounds`;
+    if (value > 55) return `${value}% Drive By Ear`;
+    return 'Balanced';
+  }
+
+  function prepareBalanceSlider(node = document) {
+    const slider = node?.matches?.('#m8AudioBalance')
+      ? node
+      : node?.querySelector?.('#m8AudioBalance');
+    if (!slider || slider.dataset.turnSrAccessibleBalance === 'true') return;
+
+    slider.dataset.turnSrAccessibleBalance = 'true';
+    slider.removeAttribute('aria-describedby');
+    if (!slider.hasAttribute('aria-label')) slider.setAttribute('aria-label', 'Sound balance');
+    const output = document.querySelector('#m8AudioBalanceValue');
+    output?.setAttribute('aria-hidden', 'true');
+
+    const sync = () => slider.setAttribute('aria-valuetext', balanceValueText(slider));
+    sync();
+    slider.addEventListener('input', () => queueMicrotask(sync));
+    slider.addEventListener('change', () => {
+      sync();
+      const status = slider.closest('.m8-settings-dialog')?.querySelector('.m8-settings-status');
+      queueMicrotask(() => {
+        if (status?.textContent?.startsWith('Sound balance:')) status.textContent = '';
+      });
+    });
+  }
+
+  function suppressDuplicateStartupReady() {
+    const copy = document.querySelector('#installGate .install-copy');
+    if (!copy || copy.dataset.turnSrReadyGuard === 'true') return;
+    copy.dataset.turnSrReadyGuard = 'true';
+
+    const suppress = () => {
+      if (!/^TURN is ready\.?$/i.test(String(copy.textContent || '').trim())) return;
+      copy.setAttribute('aria-live', 'off');
+      copy.removeAttribute('role');
+      copy.textContent = '';
+    };
+    const observer = new MutationObserver(suppress);
+    observer.observe(copy, { childList: true, characterData: true, subtree: true });
+  }
+
+  function trainingMessage(trackId) {
+    const base = TRAINING_START_MESSAGES[trackId];
+    if (!base) return '';
+    if (trackId !== 'dbe-training-1') return base;
+
+    const steeringMode = globalThis.__turnHome?.getSteeringMode?.();
+    const steering = steeringMode === 'manual'
+      ? 'Use the on-screen steering control to steer.'
+      : 'Turn the device like a steering wheel to steer.';
+    return `${base} ${steering} Hold Gas to move. Brake is separate; Drift and Boost are in the drive area.`;
+  }
+
+  function announceTrainingWhenRunning(trackId) {
+    const token = ++trainingAnnouncementToken;
+    let attempts = 0;
+    const check = () => {
+      if (token !== trainingAnnouncementToken) return;
+      const runtime = globalThis.__turnRuntime;
+      const activeTrack = String(runtime?.state?.trackId || runtime?.trackId || '');
+      if (runtime?.state?.running === true && activeTrack === trackId) {
+        speak(trainingMessage(trackId));
+        return;
+      }
+      attempts += 1;
+      if (attempts < 60) window.setTimeout(check, 100);
+    };
+    window.setTimeout(check, 100);
+  }
+
+  function currentTrainingTrackId() {
+    const state = globalThis.__turnDriveByEarTraining?.getState?.();
+    const stageId = state?.stageId;
+    if (stageId) return stageId;
+    const runtimeId = String(globalThis.__turnRuntime?.state?.trackId || '');
+    return TRAINING_START_MESSAGES[runtimeId] ? runtimeId : '';
+  }
+
+  function installGlobalObserver() {
+    if (typeof MutationObserver !== 'function' || !document.body) return;
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        if (mutation.type === 'childList') {
+          for (const node of mutation.addedNodes) {
+            if (!(node instanceof Element)) continue;
+            preparePositionAnnouncer(node);
+            prepareAchievementToast(node);
+            prepareBalanceSlider(node);
+            normalizeMenuButtons(node);
+          }
+        }
+
+        if (mutation.type === 'attributes') {
+          const target = mutation.target;
+          if (target?.matches?.('.turn-achievement-toast')) {
+            prepareAchievementToast(target);
+            queueMicrotask(() => announceToastIfVisible(target));
+          }
+          if (
+            mutation.attributeName === 'hidden'
+            && target?.matches?.('[role="dialog"]')
+            && !target.hidden
+          ) {
+            queueMicrotask(() => focusDialogHeading(target));
+          }
+          if (
+            mutation.attributeName === 'open'
+            && target instanceof HTMLDialogElement
+            && target.open
+          ) {
+            queueMicrotask(() => focusDialogHeading(target));
+          }
+        }
+      }
+    });
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['hidden', 'open', 'aria-label']
+    });
+  }
+
+  installDialogHeadingFocus();
+  moveInstallReleaseInfoToEnd();
+  prepareInstallInstructions();
+  normalizeMenuButtons();
+  suppressDuplicateStartupReady();
+  preparePositionAnnouncer(document);
+  prepareAchievementToast(document);
+  prepareBalanceSlider(document);
+  installGlobalObserver();
+
+  document.addEventListener('turn:home-ready', () => {
+    if (homeReadyHandled) return;
+    homeReadyHandled = true;
+
+    const loadingCopy = document.querySelector('#installGate .install-copy');
+    if (loadingCopy) {
+      loadingCopy.setAttribute('aria-live', 'off');
+      loadingCopy.removeAttribute('role');
+      if (/^TURN is ready\.?$/i.test(String(loadingCopy.textContent || '').trim())) {
+        loadingCopy.textContent = '';
+      }
+    }
+
+    speak(viewportIsPortrait()
+      ? 'TURN is ready. Rotate your device to landscape.'
+      : 'TURN is ready.');
+    speak('To race, choose a track on Home, then choose a car. For an introduction to Drive By Ear and non-visual gameplay, choose Drive By Ear 101 on Home.');
   }, { once: true });
+
+  window.addEventListener('turn:track-changed', (event) => {
+    const trackId = String(event.detail?.trackId || '');
+    if (event.detail?.training === true && TRAINING_START_MESSAGES[trackId]) {
+      announceTrainingWhenRunning(trackId);
+    }
+  });
+
+  document.addEventListener('click', (event) => {
+    const restart = event.target?.closest?.('#resetButton, [data-training-race-restart]');
+    if (!restart || !document.body.classList.contains('turn-dbe-training-active')) return;
+    const trackId = currentTrainingTrackId();
+    if (trackId) window.setTimeout(() => speak(trainingMessage(trackId)), 180);
+  }, true);
 })();


### PR DESCRIPTION
## What changed

- makes the startup completion announcement one-shot and orientation-aware
- gives live game messages priority over race-position updates; position is now polite and coalesced until other speech is finished
- announces achievement and Trophy Road toasts once instead of letting multiple live-region mutations repeat them
- moves install-page release/About information after the primary content and actions in the live DOM
- exposes browser menu glyphs as `kbd` references named “Menu”
- gives the Sound balance range an accessible `aria-valuetext` instead of repeatedly describing its output
- focuses modal headings when dialogs open instead of forcing focus to Close first
- adds screen-reader-only Home onboarding for racing vs Drive By Ear 101
- adds short spoken goals at the start/restart of every Drive By Ear 101 part, with steering/control guidance in part 1
- corrects Bella’s meow stereo direction without changing TURN’s shared coordinate system

## Why

This is a focused VoiceOver/screen-reader quality pass. The main root problem was competing live regions: race position was assertive while achievements, lap/status messages and tutorial guidance were lower priority. The new coordinator makes position the fallback announcement and reserves it while other live speech is active.

## Validation

- both changed JavaScript files pass `node --check`
- branch is based directly on current `main` and contains only the two intended runtime files
- accessibility discovery observer disconnects at Home; race-time priority monitoring is scoped to actual live regions rather than the whole DOM
