### PR TITLE
Synchronize TURN NEXT parity with r172

### DIFF
--- a/turn-next/index.html
+++ b/turn-next/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- TURN 2026.08.17-r171 release identity -->
+<!-- TURN 2026.08.17-r172 release identity -->
 <html lang="en" data-turn-deployment="next"><head>
   <base href="/turn/">
   <meta charset="utf-8">
@@ -29,104 +29,104 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-title" content="TURN NEXT">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <title>TURN NEXT · Source TURN v1.8.5 · Build 2026.08.17-r171</title>
+  <title>TURN NEXT · Source TURN v1.8.5 · Build 2026.08.17-r172</title>
   <script>
     globalThis.__TURN_BUILD__ = Object.freeze({
       version: '1.8.5',
-      id: '2026.08.17-r171',
-      cacheKey: '20260817-r171'
+      id: '2026.08.17-r172',
+      cacheKey: '20260817-r172'
     });
   </script>
-  <script src="/turn-next/storage-bootstrap.js?source=20260817-r171"></script>
+  <script src="/turn-next/storage-bootstrap.js?source=20260817-r172"></script>
   <link rel="icon" href="./TURNicon.PNG?icon=20260803-profile-512" type="image/png" sizes="512x512">
   <link rel="apple-touch-icon" href="./TURNicon.PNG?icon=20260803-profile-512" sizes="512x512">
-  <link rel="manifest" href="/turn-next/site.webmanifest?source=20260817-r171-icon-20260803-profile-512-m8.5">
-  <link rel="stylesheet" href="./styles.css?build=20260817-r171">
-  <link rel="stylesheet" href="./vertical-drive.css?build=20260817-r171">
-  <link rel="stylesheet" href="./hud-tuning.css?build=20260817-r171">
-  <link rel="stylesheet" href="./install-gate.css?build=20260817-r171-social-browser">
-  <link rel="stylesheet" href="./gameplay-features.css?build=20260817-r171">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260817-r171">
-  <link rel="stylesheet" href="./position-hud-r83.css?build=20260817-r171">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260817-r171">
-  <link rel="stylesheet" href="./in-game-menu.css?build=20260817-r171">
-  <link rel="stylesheet" href="./spectate-v3.css?build=20260817-r171">
-  <link rel="stylesheet" href="./manual-steering.css?build=20260817-r171">
-  <link rel="stylesheet" href="./orientation-guard.css?build=20260817-r171-home-portrait">
-  <link rel="stylesheet" href="./lap-result-toast.css?build=20260817-r171">
-  <link rel="stylesheet" href="./rival-onboarding.css?build=20260817-r171">
-  <link rel="stylesheet" href="./track-select.css?build=20260817-r171">
-  <link rel="stylesheet" href="./track-select-r54.css?build=20260817-r171">
-  <link rel="stylesheet" href="./track-select-r61.css?build=20260817-r171">
-  <link rel="stylesheet" href="./track-select-r77.css?build=20260817-r171">
-  <link rel="stylesheet" href="./track-select-r78.css?build=20260817-r171">
-  <link rel="stylesheet" href="./track-select-r79.css?build=20260817-r171">
-  <link rel="stylesheet" href="./track-intro.css?build=20260817-r171">
-  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260817-r171">
-  <link rel="stylesheet" href="./garage/lot-stat-legend.css?build=20260817-r171">
-  <link rel="stylesheet" href="./garage/lot-layout-r60.css?build=20260817-r171">
-  <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260817-r171-menu-font-v3">
-  <link rel="stylesheet" href="/turn-next/identity.css?source=20260817-r171-m8.5-logo">
-  <script defer src="/turn-next/identity.js?source=20260817-r171-m8.5-logo"></script>
-  <script src="./install-gate.js?build=20260817-r171-social-browser"></script>
+  <link rel="manifest" href="/turn-next/site.webmanifest?source=20260817-r172-icon-20260803-profile-512-m8.5">
+  <link rel="stylesheet" href="./styles.css?build=20260817-r172">
+  <link rel="stylesheet" href="./vertical-drive.css?build=20260817-r172">
+  <link rel="stylesheet" href="./hud-tuning.css?build=20260817-r172">
+  <link rel="stylesheet" href="./install-gate.css?build=20260817-r172-social-browser">
+  <link rel="stylesheet" href="./gameplay-features.css?build=20260817-r172">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260817-r172">
+  <link rel="stylesheet" href="./position-hud-r83.css?build=20260817-r172">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260817-r172">
+  <link rel="stylesheet" href="./in-game-menu.css?build=20260817-r172">
+  <link rel="stylesheet" href="./spectate-v3.css?build=20260817-r172">
+  <link rel="stylesheet" href="./manual-steering.css?build=20260817-r172">
+  <link rel="stylesheet" href="./orientation-guard.css?build=20260817-r172-home-portrait">
+  <link rel="stylesheet" href="./lap-result-toast.css?build=20260817-r172">
+  <link rel="stylesheet" href="./rival-onboarding.css?build=20260817-r172">
+  <link rel="stylesheet" href="./track-select.css?build=20260817-r172">
+  <link rel="stylesheet" href="./track-select-r54.css?build=20260817-r172">
+  <link rel="stylesheet" href="./track-select-r61.css?build=20260817-r172">
+  <link rel="stylesheet" href="./track-select-r77.css?build=20260817-r172">
+  <link rel="stylesheet" href="./track-select-r78.css?build=20260817-r172">
+  <link rel="stylesheet" href="./track-select-r79.css?build=20260817-r172">
+  <link rel="stylesheet" href="./track-intro.css?build=20260817-r172">
+  <link rel="stylesheet" href="./garage/lot-r10.css?build=20260817-r172">
+  <link rel="stylesheet" href="./garage/lot-stat-legend.css?build=20260817-r172">
+  <link rel="stylesheet" href="./garage/lot-layout-r60.css?build=20260817-r172">
+  <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260817-r172-menu-font-v3">
+  <link rel="stylesheet" href="/turn-next/identity.css?source=20260817-r172-m8.5-logo">
+  <script defer src="/turn-next/identity.js?source=20260817-r172-m8.5-logo"></script>
+  <script src="./install-gate.js?build=20260817-r172-social-browser"></script>
   <script src="./pwa-usable-viewport-r181.js?revision=r181-usable-web-layer"></script>
-  <script src="./motion-safe-zone.js?build=20260817-r171"></script>
-  <script src="./orientation-compat.js?build=20260817-r171"></script>
-  <script src="./live-steering-setting.js?build=20260817-r171-live-steering"></script>
+  <script src="./motion-safe-zone.js?build=20260817-r172"></script>
+  <script src="./orientation-compat.js?build=20260817-r172"></script>
+  <script src="./live-steering-setting.js?build=20260817-r172-live-steering"></script>
   <script type="importmap">
     {
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
-        "/turn/race/game-state.js?build=20260805-r160": "/turn/race/game-state.js?build=20260817-r171",
-        "/turn/race/rival-storage.js?build=20260805-r160": "/turn/race/rival-storage.js?build=20260817-r171",
-        "/turn/race/replay-system.js?build=20260805-r160": "/turn/race/replay-system.js?build=20260817-r171",
+        "/turn/race/game-state.js?build=20260805-r160": "/turn/race/game-state.js?build=20260817-r172",
+        "/turn/race/rival-storage.js?build=20260805-r160": "/turn/race/rival-storage.js?build=20260817-r172",
+        "/turn/race/replay-system.js?build=20260805-r160": "/turn/race/replay-system.js?build=20260817-r172",
         "/turn/tracks/track-manager.js?build=20260805-r160": "/turn/tracks/track-manager.js?source=20260729-r118-m8",
         "/turn/tracks/catalog.js?build=20260805-r160": "/turn/tracks/catalog.js?source=20260729-r118-m8",
-        "/turn/tracks/definitions.js?build=20260805-r160": "/turn/tracks/definitions.js?build=20260817-r171",
+        "/turn/tracks/definitions.js?build=20260805-r160": "/turn/tracks/definitions.js?build=20260817-r172",
         "/turn/tracks/elevation.js?build=20260805-r160": "/turn/tracks/elevation.js?build=20260725-r67",
         "/turn/vehicle/catalog.js?build=20260805-r160": "/turn/vehicle/catalog.js?source=20260729-r118-m8",
-        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260817-r171",
-        "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260817-r171",
-        "./race/lap-system.js?build=20260720-r19": "./race/lap-system-r86.js?build=20260817-r171",
-        "./race/game-state.js": "./race/game-state.js?build=20260817-r171",
-        "./race/replay-system.js": "./race/replay-system.js?build=20260817-r171",
-        "./race/rival-storage.js?build=20260720-r19": "./race/rival-storage.js?build=20260817-r171",
-        "./race/rival-storage.js?build=20260722-r50": "./race/rival-storage.js?build=20260817-r171",
-        "./race/track-spatial-index.js?build=20260720-r19": "./race/track-spatial-index.js?build=20260817-r171",
-        "./performance-monitor.js?build=20260720-r19": "./performance-monitor.js?build=20260817-r171",
-        "./world-assets.js": "./world-assets.js?build=20260817-r171",
-        "./vehicle/physics.js?build=20260720-r19": "./vehicle/physics.js?build=20260817-r171",
-        "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260817-r171",
-        "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260817-r171",
-        "./vehicle/catalog.js?build=20260722-r42": "./vehicle/catalog.js?build=20260817-r171",
-        "./vehicle/car-models.js?build=20260720-r19": "./vehicle/emergency-livery-models.js?build=20260817-r171",
-        "./vehicle/car-models.js?build=20260720-r22": "./vehicle/emergency-livery-models.js?build=20260817-r171",
-        "./ui/race-announcements.js": "./ui/race-announcements.js?build=20260817-r171",
-        "./ui/track-select.js?build=20260722-r51": "./ui/track-select.js?build=20260817-r171",
-        "./ui/track-intro.js?build=20260725-r75": "./ui/track-intro.js?build=20260817-r171",
-        "./tracks/catalog.js?build=20260722-r50": "./tracks/catalog.js?build=20260817-r171",
-        "./tracks/catalog.js": "./tracks/catalog.js?build=20260817-r171",
-        "./tracks/cliffside-layout.js": "./tracks/cliffside-layout.js?build=20260817-r171",
-        "./tracks/cliffside-world.js": "./tracks/cliffside-world-r76.js?build=20260817-r171",
-        "./tracks/harbor-collision.js": "./tracks/harbor-collision.js?build=20260817-r171",
-        "./tracks/harbor-layout.js": "./tracks/harbor-layout.js?build=20260817-r171",
-        "./tracks/harbor-world.js": "./tracks/harbor-world-r81.js?build=20260817-r171",
-        "./tracks/definitions.js": "./tracks/definitions.js?build=20260817-r171",
-        "./tracks/elevation.js": "./tracks/elevation.js?build=20260817-r171",
-        "./tracks/pace-notes.js": "./tracks/pace-notes.js?build=20260817-r171",
-        "./tracks/registry.js": "./tracks/registry.js?build=20260817-r171",
-        "./tracks/track-manager.js?build=20260722-r52": "./tracks/track-manager.js?build=20260817-r171"
+        "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260817-r172",
+        "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260817-r172",
+        "./race/lap-system.js?build=20260720-r19": "./race/lap-system-r86.js?build=20260817-r172",
+        "./race/game-state.js": "./race/game-state.js?build=20260817-r172",
+        "./race/replay-system.js": "./race/replay-system.js?build=20260817-r172",
+        "./race/rival-storage.js?build=20260720-r19": "./race/rival-storage.js?build=20260817-r172",
+        "./race/rival-storage.js?build=20260722-r50": "./race/rival-storage.js?build=20260817-r172",
+        "./race/track-spatial-index.js?build=20260720-r19": "./race/track-spatial-index.js?build=20260817-r172",
+        "./performance-monitor.js?build=20260720-r19": "./performance-monitor.js?build=20260817-r172",
+        "./world-assets.js": "./world-assets.js?build=20260817-r172",
+        "./vehicle/physics.js?build=20260720-r19": "./vehicle/physics.js?build=20260817-r172",
+        "./vehicle/catalog.js?build=20260720-r19": "./vehicle/catalog.js?build=20260817-r172",
+        "./vehicle/catalog.js?build=20260720-r20": "./vehicle/catalog.js?build=20260817-r172",
+        "./vehicle/catalog.js?build=20260722-r42": "./vehicle/catalog.js?build=20260817-r172",
+        "./vehicle/car-models.js?build=20260720-r19": "./vehicle/emergency-livery-models.js?build=20260817-r172",
+        "./vehicle/car-models.js?build=20260720-r22": "./vehicle/emergency-livery-models.js?build=20260817-r172",
+        "./ui/race-announcements.js": "./ui/race-announcements.js?build=20260817-r172",
+        "./ui/track-select.js?build=20260722-r51": "./ui/track-select.js?build=20260817-r172",
+        "./ui/track-intro.js?build=20260725-r75": "./ui/track-intro.js?build=20260817-r172",
+        "./tracks/catalog.js?build=20260722-r50": "./tracks/catalog.js?build=20260817-r172",
+        "./tracks/catalog.js": "./tracks/catalog.js?build=20260817-r172",
+        "./tracks/cliffside-layout.js": "./tracks/cliffside-layout.js?build=20260817-r172",
+        "./tracks/cliffside-world.js": "./tracks/cliffside-world-r76.js?build=20260817-r172",
+        "./tracks/harbor-collision.js": "./tracks/harbor-collision.js?build=20260817-r172",
+        "./tracks/harbor-layout.js": "./tracks/harbor-layout.js?build=20260817-r172",
+        "./tracks/harbor-world.js": "./tracks/harbor-world-r81.js?build=20260817-r172",
+        "./tracks/definitions.js": "./tracks/definitions.js?build=20260817-r172",
+        "./tracks/elevation.js": "./tracks/elevation.js?build=20260817-r172",
+        "./tracks/pace-notes.js": "./tracks/pace-notes.js?build=20260817-r172",
+        "./tracks/registry.js": "./tracks/registry.js?build=20260817-r172",
+        "./tracks/track-manager.js?build=20260722-r52": "./tracks/track-manager.js?build=20260817-r172"
       }
     }
   </script>
 </head><body>
-  <aside class="turn-next-badge" role="note" aria-label="TURN NEXT test channel. Source TURN v1.8.0, build 2026.08.17-r171."><strong>TURN NEXT</strong><span>Source 2026.08.17-r171 · canonical runtime</span></aside>
+  <aside class="turn-next-badge" role="note" aria-label="TURN NEXT test channel. Source TURN v1.8.0, build 2026.08.17-r172."><strong>TURN NEXT</strong><span>Source 2026.08.17-r172 · canonical runtime</span></aside>
   <section class="install-gate" id="installGate" aria-labelledby="installTitle">
     <div class="install-shell">
       <div class="install-art" aria-hidden="true"><img class="install-icon" src="./TURNicon.PNG?icon=20260803-profile-512" alt=""></div>
       <div class="install-card">
-        <span class="install-kicker">TURN NEXT · Source TURN v1.8.5 · Build 2026.08.17-r171</span>
+        <span class="install-kicker">TURN NEXT · Source TURN v1.8.5 · Build 2026.08.17-r172</span>
         <h1 id="installTitle">TURN NEXT</h1>
         <p class="install-copy">TURN NEXT runs the canonical TURN game with separate test records.</p>
         <div class="install-actions">
@@ -149,6 +149,6 @@
   <div class="hud" id="hud" hidden><div class="topbar"><div class="stats"><div class="chip">speed<strong><span id="speed">0</span> km/h</strong></div><div class="chip">lap<strong id="lap">1</strong></div><div class="chip">time<strong id="lapTime">0:00.000</strong></div><div class="chip">best<strong id="bestTime">--:--.---</strong></div></div><div class="map-wrap"><canvas id="map" width="300" height="210" aria-label="Track map"></canvas></div></div><div class="message" id="message" role="status"></div><div class="tilt-drive" aria-hidden="true"><span><b>brake</b><b>gas</b></span><div class="tilt-track"><i class="tilt-needle" id="tiltNeedle"></i></div><small class="tilt-value" id="tiltValue">neutral</small></div></div>
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
-  <script type="module" src="/turn-next/app.js?source=20260817-r171-browser-consent-r166-bella-records"></script>
+  <script type="module" src="/turn-next/app.js?source=20260817-r172-browser-consent-r166-bella-records"></script>
   <script type="module" src="./ui/about-history-bootstrap.js?revision=r164-design-navigation"></script>
 </body></html>


### PR DESCRIPTION
## What changed

- updates only `turn-next/index.html` from TURN build r171 to r172
- synchronizes TURN NEXT source/build labels, storage/app source keys, asset build keys, and canonical-runtime import-map targets
- does not add the screen-reader pass to TURN NEXT or change TURN NEXT gameplay

## Why

The TURN regression suite after #531 correctly caught that TURN NEXT's parity entry still referenced r171. The canonical TURN r172 release itself verified successfully; this is the generated parity identity repair required by the repository checks.

## Expected regression result

`turn-next/scripts/build-parity-app.mjs --check` can now match TURN NEXT against `turn/release.json` at `2026.08.17-r172`, allowing the rest of the TURN regression suite to run.
