### PR TITLE
Make About dialogs heading-first in r172

### DIFF
--- a/turn-tests/about-history-production.mjs
+++ b/turn-tests/about-history-production.mjs
@@ -31,8 +31,8 @@ const [
 
 const release = JSON.parse(releaseSource);
 
-assert.match(productionEntry, new RegExp(`about-history-bootstrap-r165\\.js\\?build=${escapeRegex(release.cacheKey)}-r168-shared-about-credits`),
-  'The public website must load the shared-credit browser-aware About implementation directly with the current release cache identity');
+assert.match(productionEntry, new RegExp(`about-history-bootstrap-r165\\.js\\?build=${escapeRegex(release.cacheKey)}-r534-heading-first-about`),
+  'The public website must load the heading-first browser-aware About implementation directly with the current release cache identity');
 assert.ok(
   productionEntry.indexOf('about-history-bootstrap-r165.js') < productionEntry.indexOf('./app.js?build='),
   'Website About must load before the game module waits for explicit browser launch'
@@ -51,6 +51,14 @@ assert.match(productionEntry, /Install TURN as a home screen web app for the bes
 assert.match(bootstrap, /CHANGELOG[\s\S]*CURRENT_RELEASE[\s\S]*DEVELOPMENT_HISTORY/);
 assert.match(bootstrap, new RegExp(`about-history\\.js\\?build=${escapeRegex(release.cacheKey)}`),
   'History data must use the current release cache identity');
+assert.match(bootstrap, /function focusDialogHeading\(dialog\)/,
+  'Dialog opening must have a heading-first focus path');
+assert.match(bootstrap, /heading\.setAttribute\('tabindex', '-1'\)/,
+  'Dialog headings must be programmatically focusable without entering the normal tab order');
+assert.match(bootstrap, /focusDialogHeading\(dialog\);/,
+  'Opening About and History dialogs must focus the labelled heading rather than the close button');
+assert.doesNotMatch(bootstrap, /querySelector\('\[data-dialog-close\]'\)\?\.focus/,
+  'Initial dialog focus must not be forced to Close');
 assert.match(bootstrap, /return \[\.\.\.CHANGELOG\]\.reverse\(\)\.map\(/,
   'The changelog must render newest entries first without mutating its source data');
 assert.match(bootstrap, /const INSTALL_NOTE[\s\S]*Install TURN as a home screen web app for the best fullscreen experience\. You can also play here, but it is not recommended\./);

--- a/turn/index.html
+++ b/turn/index.html
@@ -167,7 +167,7 @@
   </div>
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button" aria-label="Restart the current lap from the start line">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
-  <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260817-r172-r168-shared-about-credits"></script>
+  <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260817-r172-r534-heading-first-about"></script>
   <script src="./ui/startup-screen-reader-handoff-r529.js?build=20260817-r172&revision=r530-screen-reader-quality"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
   <script type="module" src="./app.js?build=20260817-r172-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r420-music-warm-r426-loading-copy-r164-long-session-robustness-post-soak-r199-card-gap-rim-r518-landmark-framing-ground-layering"></script>

--- a/turn/ui/about-history-bootstrap-r165.js
+++ b/turn/ui/about-history-bootstrap-r165.js
@@ -2,7 +2,7 @@ import {
   CHANGELOG,
   CURRENT_RELEASE,
   DEVELOPMENT_HISTORY
-} from '../content/about-history.js?build=20260817-r171';
+} from '../content/about-history.js?build=20260817-r172';
 import { aboutTurnHtml } from '../content/about-turn.js?revision=r1';
 
 const REVISION = 'r165-browser-about';
@@ -28,17 +28,26 @@ function installStylesheet(path, dataAttribute) {
   document.head.appendChild(link);
 }
 
+function focusDialogHeading(dialog) {
+  const labelledBy = String(dialog.getAttribute('aria-labelledby') || '').trim().split(/\s+/)[0];
+  const heading = (labelledBy && document.getElementById(labelledBy))
+    || dialog.querySelector('h1, h2, h3, [role="heading"]');
+  if (!heading || !dialog.contains(heading)) return;
+  if (!heading.hasAttribute('tabindex')) heading.setAttribute('tabindex', '-1');
+  try {
+    heading.focus({ preventScroll: true });
+  } catch (_) {
+    heading.focus?.();
+  }
+}
+
 function openDialog(dialog, trigger) {
   dialog.__turnReturnFocus = trigger;
   const card = dialog.querySelector('.m8-dialog-card');
   if (card) card.scrollTop = 0;
   if (typeof dialog.showModal === 'function') dialog.showModal();
   else dialog.setAttribute('open', '');
-  try {
-    dialog.querySelector('[data-dialog-close]')?.focus({ preventScroll: true });
-  } catch (_) {
-    dialog.querySelector('[data-dialog-close]')?.focus?.();
-  }
+  focusDialogHeading(dialog);
 }
 
 function closeDialog(dialog) {


### PR DESCRIPTION
## What changed

- refreshes the About/history data import from r171 to the current r172 cache identity
- changes About and History dialog opening so their labelled heading receives initial focus instead of Close
- makes the heading programmatically focusable with `tabindex=-1` without adding it to normal tab order
- cache-busts the public About bootstrap with a fresh r172 URL so already-loaded r172 clients do not retain the stale module
- extends the About/dialog regression to require heading-first initial focus and forbid close-first focus

## Why

The r172 regression suite exposed a stale r171 history import. While fixing it, this also removes the source-level close-first focus behavior that directly contradicted the screen-reader quality pass.
