### PR TITLE
Synchronize About release data with r172

### DIFF
--- a/turn/content/about-history.js
+++ b/turn/content/about-history.js
@@ -364,6 +364,6 @@ export const CHANGELOG = Object.freeze([
 
 export const CURRENT_RELEASE = Object.freeze({
   version: '1.8.5',
-  build: '2026.08.17-r171',
-  note: 'TURN 1.8.5 adds the latest visual-consistency pass, including lightweight Airport and Harbor ground detail, while preserving racing behaviour.'
+  build: '2026.08.17-r172',
+  note: 'TURN 1.8.5 build r172 adds a screen-reader quality pass for startup guidance, speech priority, non-visual onboarding, dialog focus and directional audio while preserving racing behaviour.'
 });


### PR DESCRIPTION
## What changed

- updates `CURRENT_RELEASE.build` in TURN history from r171 to canonical r172
- updates the current-release note to describe the screen-reader quality pass now shipped in r172

## Why

The full regression suite reached the About data contract after the dialog/cache fixes and correctly found the history data itself still advertising r171.
