### PR TITLE
Refine r172 non-visual onboarding and DBE speech

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -68,6 +68,8 @@
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/turn/input/motion.js": "/turn/input/motion.js?revision=r164-ipad-motion-profile",
+        "/turn/race/session-orchestrator.js?source=20260729-r118-m8": "/turn/race/session-orchestrator.js?source=20260817-r172-screen-reader-followup",
+        "/turn/training/drive-by-ear-training.js?build=20260817-r172-r151-dbe-training-device-fixes": "/turn/training/drive-by-ear-training.js?build=20260817-r172&revision=r172-screen-reader-followup",
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
         "/turn/audio/audio-preferences.js?build=20260817-r172": "/turn/audio/audio-preferences.js?build=20260817-r172&revision=r197-audio-mix",
         "/turn/audio/racing-music-v2.js?build=20260817-r172-racing-music-warm-v2": "/turn/audio/racing-music-v5.js?revision=r197-audio-mix",

--- a/turn-tests/drive-by-ear-training-production.mjs
+++ b/turn-tests/drive-by-ear-training-production.mjs
@@ -9,16 +9,28 @@ import {
   TRAINING_STAGES
 } from '../turn/training/stages.js';
 
-const [training, view, css, fixedLayout] = await Promise.all([
+const [training, view, css, fixedLayout, sessionOrchestrator, index] = await Promise.all([
   fs.readFile(new URL('../turn/training/drive-by-ear-training.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/training/view.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/training/drive-by-ear-training.css', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/race/session-orchestrator.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8')
 ]);
 
 assert.match(fixedLayout, /training\/drive-by-ear-training\.js\?build=\$\{buildKey\}-r151-dbe-training-device-fixes/);
 assert.match(fixedLayout, /installDriveByEarTraining\(globalThis\.__turnRuntime\)/);
 assert.match(fixedLayout, /driveByEarTraining/);
+assert.match(
+  index,
+  /"\/turn\/training\/drive-by-ear-training\.js\?build=20260817-r172-r151-dbe-training-device-fixes": "\/turn\/training\/drive-by-ear-training\.js\?build=20260817-r172&revision=r172-screen-reader-followup"/,
+  'Production must map the established training import to the r172 screen-reader follow-up module identity'
+);
+assert.match(
+  index,
+  /"\/turn\/race\/session-orchestrator\.js\?source=20260729-r118-m8": "\/turn\/race\/session-orchestrator\.js\?source=20260817-r172-screen-reader-followup"/,
+  'Production must map the established race-session import to the start-announcement-aware module identity'
+);
 
 assert.equal(TRAINING_STAGES.length, 5, 'Training must contain exactly five authored parts');
 assert.equal(FINISH_PROGRESS, 0.94);
@@ -81,7 +93,7 @@ for (const stage of TRAINING_STAGES) {
   assertCourseHasSpace(stage);
 }
 
-assert.match(training, /const TRAINING_REVISION = 'r150-dbe-training-refinement'/);
+assert.match(training, /const TRAINING_REVISION = 'r172-screen-reader-followup'/);
 assert.match(training, /applySlipperyAssist\(sample, side/);
 assert.match(training, /1 - Math\.exp\(-profile\.damping \* dt\)/);
 assert.match(training, /tangential motion instead of stopping or snapping the car back onto the road/);
@@ -93,6 +105,31 @@ assert.match(training, /data-training-race-restart/);
 assert.match(training, /restartPart/);
 assert.match(training, /renderTrainingNavigation/);
 assert.match(training, /dataset\.trainingTarget/);
+
+assert.match(
+  sessionOrchestrator,
+  /async function startGame\(fullscreenPromise = Promise\.resolve\(false\), \{ announceStart = true \} = \{\}\)/,
+  'The shared race session must let training suppress the ordinary GO announcement without changing normal races'
+);
+assert.match(sessionOrchestrator, /if \(announceStart\) announce\('GO!'\)/);
+assert.match(
+  training,
+  /raceSession\.startGame\(fullscreenPromise \|\| Promise\.resolve\(false\), \{ announceStart: false \}\)/,
+  'DBE 101 must suppress the ordinary race-session GO so its instructions can come first'
+);
+assert.match(
+  training,
+  /runtime\.state\.suppressNextLapStartMessage = true/,
+  'DBE 101 must also suppress the lap-system GO at each staged/restarted training start'
+);
+assert.match(training, /function signalStageStarted\(\{ restarted = false \} = \{\}\)/);
+assert.match(training, /new CustomEvent\('turn:dbe-training-stage-started'/);
+assert.match(training, /stageId: session\.stage\.id/);
+assert.match(training, /stageIndex: session\.stageIndex/);
+assert.match(training, /signalStageStarted\(\);\s*return true;/,
+  'A part-start event must be emitted only after that exact stage has finished starting');
+assert.match(training, /signalStageStarted\(\{ restarted: true \}\)/,
+  'Restart must emit the same exact-stage start event rather than relying on click timing');
 
 assert.match(view, /homeButton\.textContent = 'DRIVE BY EAR 101'/);
 assert.doesNotMatch(view, /homeButton\.textContent = 'DRIVE BY EAR TRAINING'/);
@@ -136,7 +173,7 @@ assert.match(css, /data-training-race-restart/);
 assert.match(css, /\.turn-dbe-training-race-nav\[hidden\]/);
 assert.match(css, /@media \(prefers-reduced-motion: reduce\)/);
 
-console.log('TURN Drive By Ear 101 device cue mapping, modal position and linked sequence passed.');
+console.log('TURN Drive By Ear 101 exact-stage instructions, single GO sequencing and device cue mapping passed.');
 
 function assertCourseHasSpace(stage) {
   const points = stage.points.map(([x, z]) => ({ x, z }));

--- a/turn-tests/long-session-lifecycle-production.mjs
+++ b/turn-tests/long-session-lifecycle-production.mjs
@@ -87,8 +87,8 @@ assert.match(
 );
 assert.match(
   index,
-  new RegExp(`startup-screen-reader-handoff-r529\\.js\\?build=${escapeRegex(release.cacheKey)}&revision=r530-screen-reader-quality`),
-  'Production must bind the screen-reader coordinator to the current release cache identity'
+  new RegExp(`startup-screen-reader-handoff-r529\\.js\\?build=${escapeRegex(release.cacheKey)}&revision=r531-screen-reader-followup`),
+  'Production must bind the screen-reader coordinator follow-up to the current release cache identity'
 );
 
 // Touch hardware keeps 60 Hz gameplay but should not redraw the complete dynamic
@@ -150,15 +150,33 @@ assert.match(
   'The achievement facade must cache-bust the race-scoped sampler implementation'
 );
 
-// The screen-reader quality coordinator may discover dynamic live regions while Home
-// is being assembled, but it must not keep a document-wide observer or polling loop
-// alive for the rest of a long race session.
+// The screen-reader coordinator may discover dynamic live regions while Home is being
+// assembled, but it must not keep a document-wide observer or polling loop alive for
+// the rest of a long race session. The follow-up also protects the user-facing speech
+// contracts that depend on this coordinator.
 assert.match(screenReaderCoordinator, /discoveryObserver = new MutationObserver/);
 assert.match(screenReaderCoordinator, /discoveryObserver\.observe\(document\.body, \{ childList: true, subtree: true \}\)/);
 assert.match(screenReaderCoordinator, /discoveryObserver\?\.disconnect\(\);\s*discoveryObserver = null;/,
   'The broad accessibility discovery observer must disconnect once Home is ready');
 assert.doesNotMatch(screenReaderCoordinator, /setInterval/,
   'Screen-reader coordination must not add an independent polling interval');
+assert.match(
+  screenReaderCoordinator,
+  /return `\$\{dbe\}% Drive By Ear, \$\{other\}% other sounds\$\{balance\}`/,
+  'Sound balance must expose percentages at every slider position rather than repeating Balanced across a range'
+);
+assert.match(screenReaderCoordinator, /navigation\.innerHTML = `[\s\S]*Non-visual onboarding[\s\S]*Drive By Ear 101/,
+  'Home accessibility shortcuts must put Non-visual onboarding before Drive By Ear 101');
+assert.match(screenReaderCoordinator, /speak\(`\$\{readyMessage\} \$\{NON_VISUAL_ONBOARDING_MESSAGE\}`, \{ priority: 'assertive' \}\)/,
+  'The one-time non-visual onboarding must be assertive enough to be noticed');
+assert.match(screenReaderCoordinator, /summary\.setAttribute\('aria-hidden', 'true'\)/,
+  'Track cards must expose their composed button name once rather than repeating the visible summary');
+assert.match(screenReaderCoordinator, /window\.addEventListener\('turn:dbe-training-stage-started'/,
+  'Training speech must follow the exact stage-start event rather than the earlier track-swap event');
+assert.match(screenReaderCoordinator, /clearSpeechChannel\(TRAINING_SPEECH_CHANNEL\)/,
+  'Moving to another DBE part must cancel stale queued instructions');
+assert.match(screenReaderCoordinator, /speak\(`\$\{instructions\} Go!`, \{[\s\S]*priority: 'assertive'[\s\S]*channel: TRAINING_SPEECH_CHANNEL/,
+  'DBE instructions and the single GO cue must be one ordered assertive utterance');
 
 // Repeated vegetation is a poor place to spend a second draw call per source mesh.
 // Buildings/start landmarks may keep intentional contours; tree belts opt out before
@@ -244,4 +262,4 @@ assert.match(bellaBootstrap, /RETRY_DELAYS_MS = Object\.freeze/);
 assert.doesNotMatch(bellaBootstrap, /setInterval/,
   'The independent Bella bootstrap must use bounded startup retries rather than a fixed polling interval');
 
-console.log(`TURN ${release.id} long-session timers, touch shadows, accessibility observers, scenery batching/contours, cache and Bella audio lifecycle passed.`);
+console.log(`TURN ${release.id} long-session timers, touch shadows, accessibility observers, screen-reader speech contracts, scenery batching/contours, cache and Bella audio lifecycle passed.`);

--- a/turn-tests/startup-and-unread-production.mjs
+++ b/turn-tests/startup-and-unread-production.mjs
@@ -23,8 +23,8 @@ assert.ok(
 );
 assert.match(
   index,
-  new RegExp(`startup-screen-reader-handoff-r529\\.js\\?build=${escapedCacheKey}&revision=r530-screen-reader-quality`),
-  'The screen-reader quality coordinator must be bound to the current release cache identity'
+  new RegExp(`startup-screen-reader-handoff-r529\\.js\\?build=${escapedCacheKey}&revision=r531-screen-reader-followup`),
+  'The screen-reader follow-up coordinator must be bound to the current release cache identity'
 );
 assert.match(
   index,
@@ -67,7 +67,7 @@ assert.match(unreadMarkers, /Newly unlocked achievement\./);
 assert.match(unreadMarkers, /new MutationObserver\(queueDecoration\)/);
 assert.match(unreadMarkers, /listObserver\.observe\(list, \{ childList: true \}\)/);
 
-console.log(`TURN ${release.version} startup cover, screen-reader cache contracts, refreshed Bella graph, fixed Home viewport, spoken training labels and unread achievement markers passed.`);
+console.log(`TURN ${release.version} startup cover, screen-reader follow-up cache contracts, refreshed Bella graph, fixed Home viewport, spoken training labels and unread achievement markers passed.`);
 
 function escapeRegex(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/turn/index.html
+++ b/turn/index.html
@@ -79,6 +79,8 @@
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/turn/input/motion.js": "/turn/input/motion.js?revision=r164-ipad-motion-profile",
+        "/turn/race/session-orchestrator.js?source=20260729-r118-m8": "/turn/race/session-orchestrator.js?source=20260817-r172-screen-reader-followup",
+        "/turn/training/drive-by-ear-training.js?build=20260817-r172-r151-dbe-training-device-fixes": "/turn/training/drive-by-ear-training.js?build=20260817-r172&revision=r172-screen-reader-followup",
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
         "/turn/audio/audio-preferences.js?build=20260817-r172": "/turn/audio/audio-preferences.js?build=20260817-r172&revision=r197-audio-mix",
         "/turn/audio/racing-music-v2.js?build=20260817-r172-racing-music-warm-v2": "/turn/audio/racing-music-v5.js?revision=r197-audio-mix",
@@ -168,7 +170,7 @@
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button" aria-label="Restart the current lap from the start line">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
   <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260817-r172-r534-heading-first-about"></script>
-  <script src="./ui/startup-screen-reader-handoff-r529.js?build=20260817-r172&revision=r530-screen-reader-quality"></script>
+  <script src="./ui/startup-screen-reader-handoff-r529.js?build=20260817-r172&revision=r531-screen-reader-followup"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
   <script type="module" src="./app.js?build=20260817-r172-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r420-music-warm-r426-loading-copy-r164-long-session-robustness-post-soak-r199-card-gap-rim-r518-landmark-framing-ground-layering"></script>
   <script type="module" src="./render/skid-continuity-r198.js?revision=r198-skid-continuity"></script>

--- a/turn/race/session-orchestrator.js
+++ b/turn/race/session-orchestrator.js
@@ -144,7 +144,7 @@ export function createRaceSessionOrchestrator({
     return Object.freeze({ mode: 'manual', fullscreenPromise });
   }
 
-  async function startGame(fullscreenPromise = Promise.resolve(false)) {
+  async function startGame(fullscreenPromise = Promise.resolve(false), { announceStart = true } = {}) {
     phase = 'starting';
     state.running = true;
     state.lastFrame = clock();
@@ -173,7 +173,7 @@ export function createRaceSessionOrchestrator({
     resizeViewport();
     setTimer(resizeViewport, 300);
     setTimer(resizeViewport, 900);
-    announce('GO!');
+    if (announceStart) announce('GO!');
     phase = 'racing';
     return true;
   }

--- a/turn/training/drive-by-ear-training.js
+++ b/turn/training/drive-by-ear-training.js
@@ -25,7 +25,7 @@ import {
   updatePartDialog
 } from './view.js';
 
-const TRAINING_REVISION = 'r150-dbe-training-refinement';
+const TRAINING_REVISION = 'r172-screen-reader-followup';
 const AUDIO_ENABLED_STORAGE_KEY = 'turn-audio-enabled-v1';
 const AUDIO_BALANCE_STORAGE_KEY = 'turn-audio-balance-v1';
 const DRIVE_BY_EAR_STORAGE_KEY = 'turn-drive-by-ear-v1';
@@ -240,12 +240,13 @@ export async function installDriveByEarTraining(runtime = globalThis.__turnRunti
       runtime.openLot = leaveTraining;
 
       const fullscreenPromise = first ? session.preparedAccess?.fullscreenPromise : Promise.resolve(false);
-      await raceSession.startGame(fullscreenPromise || Promise.resolve(false));
+      await raceSession.startGame(fullscreenPromise || Promise.resolve(false), { announceStart: false });
       positionStageStart(stage);
       session.previousProgress = runtime.state.progress;
       session.previousPosition = snapshotPosition(runtime.state.position);
       session.lastFrameAt = globalThis.performance?.now?.() || 0;
       if (!session.frame) session.frame = requestAnimationFrame(trainingFrame);
+      signalStageStarted();
       return true;
     } finally {
       session.switching = false;
@@ -302,12 +303,24 @@ export async function installDriveByEarTraining(runtime = globalThis.__turnRunti
     runtime.state.lapInvalid = false;
     runtime.state.lapStartedAt = 0;
     runtime.state.lapElapsed = 0;
+    runtime.state.suppressNextLapStartMessage = true;
     runtime.state.lapPreviousPosition = { x: runtime.state.position.x, z: runtime.state.position.z };
     runtime.state.recording = [];
     runtime.playerCar.position.copy(runtime.state.position);
     runtime.playerCar.rotation.y = runtime.state.heading + Math.PI;
     runtime.setRacePosition?.(null, 1);
     session.previousPosition = snapshotPosition(runtime.state.position);
+  }
+
+  function signalStageStarted({ restarted = false } = {}) {
+    if (!session.active || !session.stage) return;
+    window.dispatchEvent(new CustomEvent('turn:dbe-training-stage-started', {
+      detail: Object.freeze({
+        stageId: session.stage.id,
+        stageIndex: session.stageIndex,
+        restarted
+      })
+    }));
   }
 
   function restartPart(event) {
@@ -320,6 +333,7 @@ export async function installDriveByEarTraining(runtime = globalThis.__turnRunti
     session.previousPosition = snapshotPosition(runtime.state.position);
     session.finishing = false;
     silencePaceNotes();
+    signalStageStarted({ restarted: true });
   }
 
   function trainingFrame(timestamp) {

--- a/turn/ui/startup-screen-reader-handoff-r529.js
+++ b/turn/ui/startup-screen-reader-handoff-r529.js
@@ -1,5 +1,8 @@
 (() => {
   const STATUS_ID = 'turn-screen-reader-status';
+  const SKIP_STYLE_ID = 'turn-screen-reader-skip-link-styles';
+  const TRAINING_SPEECH_CHANNEL = 'dbe-training';
+  const NON_VISUAL_ONBOARDING_MESSAGE = 'Non-visual onboarding. To race, choose a track on Home, then choose a car. For a guided introduction to Drive By Ear and non-visual gameplay, choose Drive By Ear one oh one. The first two links on Home let you replay this introduction or jump directly to Drive By Ear one oh one.';
   const MENU_GLYPHS = new Set(['…', '⋮', '☰']);
   const TRAINING_START_MESSAGES = Object.freeze({
     'dbe-training-1': 'Part one, Find the ribbon. Steer toward the warm guiding hum and keep it centred.',
@@ -11,11 +14,11 @@
 
   let speechQueue = [];
   let speaking = false;
+  let activeSpeech = null;
   let speechTimer = 0;
   let positionAnnouncer = null;
   let pendingPosition = '';
   let homeReadyHandled = false;
-  let trainingAnnouncementToken = 0;
   let externalPriorityTimer = 0;
   let externalPriorityUntil = 0;
   let discoveryObserver = null;
@@ -113,32 +116,58 @@
 
     const next = speechQueue.shift();
     if (!next) {
+      activeSpeech = null;
       speaking = false;
       flushPendingPosition();
       return;
     }
 
+    activeSpeech = next;
     speaking = true;
     setPositionSpeechEnabled(false);
     const status = ensureStatusRegion();
+    status.setAttribute('aria-live', next.priority);
     status.textContent = '';
     requestAnimationFrame(() => {
-      status.textContent = next;
+      if (activeSpeech !== next) return;
+      status.textContent = next.message;
       speechTimer = window.setTimeout(() => {
+        if (activeSpeech !== next) return;
         status.textContent = '';
+        activeSpeech = null;
         playNextSpeech();
-      }, speechDurationMs(next));
+      }, speechDurationMs(next.message));
     });
   }
 
-  function speak(message) {
+  function speak(message, { priority = 'polite', channel = '' } = {}) {
     const normalized = String(message || '').trim();
     if (!normalized) return;
+    const entry = Object.freeze({
+      message: normalized,
+      priority: priority === 'assertive' ? 'assertive' : 'polite',
+      channel: String(channel || '')
+    });
     const tail = speechQueue[speechQueue.length - 1];
-    if (tail === normalized) return;
-    if (speaking && document.getElementById(STATUS_ID)?.textContent === normalized) return;
-    speechQueue.push(normalized);
+    if (tail?.message === normalized && tail?.channel === entry.channel) return;
+    if (activeSpeech?.message === normalized && activeSpeech?.channel === entry.channel) return;
+    speechQueue.push(entry);
     if (!speaking) playNextSpeech();
+  }
+
+  function clearSpeechChannel(channel) {
+    const normalized = String(channel || '');
+    if (!normalized) return;
+    speechQueue = speechQueue.filter((entry) => entry.channel !== normalized);
+    if (activeSpeech?.channel !== normalized) return;
+
+    window.clearTimeout(speechTimer);
+    speechTimer = 0;
+    const status = document.getElementById(STATUS_ID);
+    if (status) status.textContent = '';
+    activeSpeech = null;
+    speaking = false;
+    requestAnimationFrame(playNextSpeech);
   }
 
   globalThis.__turnScreenReaderSpeak = speak;
@@ -295,10 +324,10 @@
   }
 
   function balanceValueText(slider) {
-    const value = Math.max(0, Math.min(100, Math.round(Number(slider?.value) || 0)));
-    if (value < 45) return `${100 - value}% other sounds`;
-    if (value > 55) return `${value}% Drive By Ear`;
-    return 'Balanced';
+    const dbe = Math.max(0, Math.min(100, Math.round(Number(slider?.value) || 0)));
+    const other = 100 - dbe;
+    const balance = dbe === 50 ? ', balanced' : '';
+    return `${dbe}% Drive By Ear, ${other}% other sounds${balance}`;
   }
 
   function prepareBalanceSlider(node = document) {
@@ -323,6 +352,128 @@
         if (status?.textContent?.startsWith('Sound balance:')) status.textContent = '';
       });
     });
+  }
+
+  function spokenCardText(rawText) {
+    return String(rawText || '')
+      .trim()
+      .toLocaleLowerCase('en')
+      .replace(/(^|\s)\p{L}/gu, (character) => character.toLocaleUpperCase('en'));
+  }
+
+  function prepareHomeTrackCards(node = document) {
+    const cards = [];
+    if (node?.matches?.('.m8-track-rail .track-card')) cards.push(node);
+    if (node?.querySelectorAll) cards.push(...node.querySelectorAll('.m8-track-rail .track-card'));
+
+    for (const card of cards) {
+      const summary = card.querySelector('.track-card-summary');
+      if (!summary) continue;
+
+      if (!card.disabled) {
+        const name = spokenCardText(card.querySelector('.track-card-name')?.textContent);
+        const difficulty = String(card.querySelector('.track-card-difficulty')?.textContent || '').trim().toLocaleLowerCase('en');
+        const time = String(card.querySelector('.track-card-best-time')?.textContent || '').trim();
+        const car = spokenCardText(card.querySelector('.track-card-best-car:not([hidden])')?.textContent);
+        const label = [`${name}, ${difficulty} track`];
+        if (time && !/^(?:--:--\.---|NO TIME YET)$/i.test(time)) {
+          label.push(`Best ${time}${car ? ` with ${car}` : ''}`);
+        } else {
+          label.push('No time yet');
+        }
+        card.setAttribute('aria-label', `${label.join('. ')}.`);
+      }
+
+      summary.setAttribute('aria-hidden', 'true');
+      card.dataset.turnSrSingleObject = 'true';
+    }
+  }
+
+  function installSkipLinkStyles() {
+    if (document.getElementById(SKIP_STYLE_ID)) return;
+    const style = document.createElement('style');
+    style.id = SKIP_STYLE_ID;
+    style.textContent = `
+      .turn-sr-skip-links {
+        position: fixed;
+        z-index: 100000;
+        top: 0;
+        left: max(8px, env(safe-area-inset-left));
+        display: flex;
+        gap: 8px;
+        padding: 8px;
+        transform: translateY(-140%);
+        transition: transform 80ms linear;
+      }
+      .turn-sr-skip-links:focus-within { transform: translateY(0); }
+      .turn-sr-skip-links a {
+        display: inline-block;
+        padding: 10px 12px;
+        border: 3px solid #08090a;
+        border-radius: 8px;
+        background: #fff8e8;
+        color: #08090a;
+        font: 900 14px/1.1 system-ui, sans-serif;
+        text-decoration: underline;
+      }
+      .turn-sr-onboarding-target {
+        position: fixed;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip-path: inset(50%);
+        white-space: nowrap;
+        border: 0;
+      }
+    `;
+    document.head.appendChild(style);
+  }
+
+  function installHomeSkipLinks() {
+    const home = document.querySelector('.m8-home');
+    const trainingButton = document.querySelector('.turn-dbe-training-home');
+    if (!home || !trainingButton || home.querySelector('.turn-sr-skip-links')) return;
+
+    installSkipLinkStyles();
+    trainingButton.id = trainingButton.id || 'turnDbeTrainingHome';
+
+    const navigation = document.createElement('nav');
+    navigation.className = 'turn-sr-skip-links';
+    navigation.setAttribute('aria-label', 'Accessibility shortcuts');
+    navigation.innerHTML = `
+      <a href="#turnNonVisualOnboarding">Non-visual onboarding</a>
+      <a href="#${trainingButton.id}">Drive By Ear 101</a>
+    `;
+
+    const onboardingTarget = document.createElement('div');
+    onboardingTarget.id = 'turnNonVisualOnboarding';
+    onboardingTarget.className = 'turn-sr-onboarding-target';
+    onboardingTarget.tabIndex = -1;
+    onboardingTarget.setAttribute('role', 'note');
+    onboardingTarget.setAttribute('aria-label', NON_VISUAL_ONBOARDING_MESSAGE);
+
+    const [onboardingLink, trainingLink] = navigation.querySelectorAll('a');
+    onboardingLink.addEventListener('click', (event) => {
+      event.preventDefault();
+      try {
+        onboardingTarget.focus({ preventScroll: true });
+      } catch (_) {
+        onboardingTarget.focus?.();
+      }
+    });
+    trainingLink.addEventListener('click', (event) => {
+      event.preventDefault();
+      try {
+        trainingButton.focus({ preventScroll: true });
+      } catch (_) {
+        trainingButton.focus?.();
+      }
+    });
+
+    home.prepend(onboardingTarget);
+    home.prepend(navigation);
   }
 
   function suppressDuplicateStartupReady() {
@@ -350,31 +501,6 @@
       ? 'Use the on-screen steering control to steer.'
       : 'Turn the device like a steering wheel to steer.';
     return `${base} ${steering} Hold Gas to move. Brake is separate; Drift and Boost are in the drive area.`;
-  }
-
-  function announceTrainingWhenRunning(trackId) {
-    const token = ++trainingAnnouncementToken;
-    let attempts = 0;
-    const check = () => {
-      if (token !== trainingAnnouncementToken) return;
-      const runtime = globalThis.__turnRuntime;
-      const activeTrack = String(runtime?.state?.trackId || runtime?.trackId || '');
-      if (runtime?.state?.running === true && activeTrack === trackId) {
-        speak(trainingMessage(trackId));
-        return;
-      }
-      attempts += 1;
-      if (attempts < 60) window.setTimeout(check, 100);
-    };
-    window.setTimeout(check, 100);
-  }
-
-  function currentTrainingTrackId() {
-    const state = globalThis.__turnDriveByEarTraining?.getState?.();
-    const stageId = state?.stageId;
-    if (stageId) return stageId;
-    const runtimeId = String(globalThis.__turnRuntime?.state?.trackId || '');
-    return TRAINING_START_MESSAGES[runtimeId] ? runtimeId : '';
   }
 
   function externalLiveRegionReadable(live) {
@@ -428,6 +554,7 @@
     preparePositionAnnouncer(node);
     prepareAchievementToast(node);
     prepareBalanceSlider(node);
+    prepareHomeTrackCards(node);
     normalizeMenuButtons(node);
     prepareDialogOpenTracking(node);
     prepareExternalLiveRegions(node);
@@ -458,6 +585,7 @@
     if (homeReadyHandled) return;
     homeReadyHandled = true;
     scanAccessibilityTargets(document);
+    installHomeSkipLinks();
     discoveryObserver?.disconnect();
     discoveryObserver = null;
     window.clearTimeout(externalPriorityTimer);
@@ -473,28 +601,28 @@
       }
     }
 
-    speak(viewportIsPortrait()
+    const readyMessage = viewportIsPortrait()
       ? 'TURN is ready. Rotate your device to landscape.'
-      : 'TURN is ready.');
-    speak('To race, choose a track on Home, then choose a car. For an introduction to Drive By Ear and non-visual gameplay, choose Drive By Ear 101 on Home.');
+      : 'TURN is ready.';
+    speak(`${readyMessage} ${NON_VISUAL_ONBOARDING_MESSAGE}`, { priority: 'assertive' });
   }, { once: true });
 
-  window.addEventListener('turn:track-changed', (event) => {
+  window.addEventListener('turn:track-changed', () => {
     scanAccessibilityTargets(document);
-    const trackId = String(event.detail?.trackId || '');
-    if (event.detail?.training === true && TRAINING_START_MESSAGES[trackId]) {
-      announceTrainingWhenRunning(trackId);
-    }
+  });
+
+  window.addEventListener('turn:dbe-training-stage-started', (event) => {
+    const trackId = String(event.detail?.stageId || '');
+    if (!TRAINING_START_MESSAGES[trackId]) return;
+    clearSpeechChannel(TRAINING_SPEECH_CHANNEL);
+    const instructions = trainingMessage(trackId);
+    speak(`${instructions} Go!`, {
+      priority: 'assertive',
+      channel: TRAINING_SPEECH_CHANNEL
+    });
   });
 
   for (const eventName of ['turn:ui-state-change', 'turn:achievements-updated', 'turn:trophy-road-updated']) {
     window.addEventListener(eventName, () => scanAccessibilityTargets(document));
   }
-
-  document.addEventListener('click', (event) => {
-    const restart = event.target?.closest?.('#resetButton, [data-training-race-restart]');
-    if (!restart || !document.body.classList.contains('turn-dbe-training-active')) return;
-    const trackId = currentTrainingTrackId();
-    if (trackId) window.setTimeout(() => speak(trainingMessage(trackId)), 180);
-  }, true);
 })();


### PR DESCRIPTION
## What changed

- makes Sound balance expose percentages at every slider position, including 50/50
- turns each Home track card into one accessibility object so its label and visible summary are not read separately, while preserving best-time/car information in the accessible name
- makes the startup non-visual onboarding assertive and adds two conventional Home skip links: Non-visual onboarding first, Drive By Ear 101 second
- moves DBE 101 speech to an exact `turn:dbe-training-stage-started` event emitted only after the selected part has actually started
- cancels stale training speech when moving between parts
- suppresses both shared race/lap GO announcements during DBE 101 and emits one atomic `instructions … Go!` announcement instead
- cache-busts the coordinator and maps the established training/session imports to fresh r172 module identities
- extends DBE 101 regression coverage for exact-stage speech and single-GO ownership

## Why

Real VoiceOver testing after r172 found repeated Balanced values near the midpoint, duplicate track-card speech, easy-to-miss onboarding, stale NEXT-part instructions and two GO announcements before the training instructions. This keeps the successful r172 behavior while making the non-visual path deterministic.
