### PR TITLE
Wait for landscape before non-visual onboarding

### DIFF
--- a/turn-tests/long-session-lifecycle-production.mjs
+++ b/turn-tests/long-session-lifecycle-production.mjs
@@ -167,8 +167,10 @@ assert.match(
 );
 assert.match(screenReaderCoordinator, /navigation\.innerHTML = `[\s\S]*Non-visual onboarding[\s\S]*Drive By Ear 101/,
   'Home accessibility shortcuts must put Non-visual onboarding before Drive By Ear 101');
-assert.match(screenReaderCoordinator, /speak\(`\$\{readyMessage\} \$\{NON_VISUAL_ONBOARDING_MESSAGE\}`, \{ priority: 'assertive' \}\)/,
-  'The one-time non-visual onboarding must be assertive enough to be noticed');
+assert.match(screenReaderCoordinator, /function scheduleNonVisualOnboarding\(\)[\s\S]*if \(viewportIsPortrait\(\)\) return;[\s\S]*speak\(`TURN is ready\. \$\{NON_VISUAL_ONBOARDING_MESSAGE\}`, \{ priority: 'assertive' \}\)/,
+  'The one-time non-visual onboarding must remain assertive but wait until landscape is confirmed');
+assert.match(screenReaderCoordinator, /if \(viewportIsPortrait\(\)\) \{\s*speak\('TURN is ready\. Rotate your device to landscape\.', \{ priority: 'assertive' \}\);\s*\} else \{\s*scheduleNonVisualOnboarding\(\);/,
+  'Portrait startup must not append the non-visual onboarding before the OS landscape announcement has cleared');
 assert.match(screenReaderCoordinator, /summary\.setAttribute\('aria-hidden', 'true'\)/,
   'Track cards must expose their composed button name once rather than repeating the visible summary');
 assert.match(screenReaderCoordinator, /window\.addEventListener\('turn:dbe-training-stage-started'/,

--- a/turn-tests/startup-and-unread-production.mjs
+++ b/turn-tests/startup-and-unread-production.mjs
@@ -1,13 +1,14 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [releaseSource, index, nextIndex, app, fixedLayout, unreadMarkers] = await Promise.all([
+const [releaseSource, index, nextIndex, app, fixedLayout, unreadMarkers, screenReaderCoordinator] = await Promise.all([
   fs.readFile(new URL('../turn/release.json', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-next/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/achievements/unread-markers.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/achievements/unread-markers.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/ui/startup-screen-reader-handoff-r529.js', import.meta.url), 'utf8')
 ]);
 
 const release = JSON.parse(releaseSource);
@@ -53,6 +54,17 @@ assert.ok(
   'The loading cover must remain above the early Countryside frame until Home is complete'
 );
 
+assert.match(screenReaderCoordinator, /const LANDSCAPE_SETTLE_MS = 1200/,
+  'Automatic non-visual onboarding must leave a short quiet window after landscape settles');
+assert.match(screenReaderCoordinator, /function installLandscapeWatch\(\)[\s\S]*window\.addEventListener\('resize', handleLandscapeCandidate[\s\S]*window\.addEventListener\('orientationchange', handleLandscapeCandidate[\s\S]*visualViewport\?\.addEventListener\('resize', handleLandscapeCandidate/,
+  'The onboarding coordinator must react to both viewport and OS orientation transitions');
+assert.match(screenReaderCoordinator, /function scheduleNonVisualOnboarding\(\)[\s\S]*if \(viewportIsPortrait\(\)\) return;[\s\S]*window\.setTimeout\([\s\S]*viewportIsPortrait\(\)\) return;[\s\S]*speak\(`TURN is ready\. \$\{NON_VISUAL_ONBOARDING_MESSAGE\}`/,
+  'The onboarding itself must only enter the live region after landscape remains confirmed');
+assert.match(screenReaderCoordinator, /if \(viewportIsPortrait\(\)\) \{\s*speak\('TURN is ready\. Rotate your device to landscape\.', \{ priority: 'assertive' \}\);\s*\} else \{\s*scheduleNonVisualOnboarding\(\);/,
+  'Portrait Home may request rotation, but must not append the onboarding before landscape');
+assert.doesNotMatch(screenReaderCoordinator, /speak\(`\$\{readyMessage\} \$\{NON_VISUAL_ONBOARDING_MESSAGE\}`/,
+  'The old portrait-ready plus onboarding utterance must not return');
+
 assert.match(fixedLayout, /achievements\/unread-markers\.js\?build=\$\{buildKey\}-r159-unread-cards/);
 assert.match(fixedLayout, /installAchievementUnreadMarkers\(achievements\)/);
 assert.match(fixedLayout, /achievementUnreadMarkers,/);
@@ -67,7 +79,7 @@ assert.match(unreadMarkers, /Newly unlocked achievement\./);
 assert.match(unreadMarkers, /new MutationObserver\(queueDecoration\)/);
 assert.match(unreadMarkers, /listObserver\.observe\(list, \{ childList: true \}\)/);
 
-console.log(`TURN ${release.version} startup cover, screen-reader follow-up cache contracts, refreshed Bella graph, fixed Home viewport, spoken training labels and unread achievement markers passed.`);
+console.log(`TURN ${release.version} startup cover, landscape-gated screen-reader onboarding, refreshed Bella graph, fixed Home viewport, spoken training labels and unread achievement markers passed.`);
 
 function escapeRegex(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/turn/ui/startup-screen-reader-handoff-r529.js
+++ b/turn/ui/startup-screen-reader-handoff-r529.js
@@ -2,6 +2,7 @@
   const STATUS_ID = 'turn-screen-reader-status';
   const SKIP_STYLE_ID = 'turn-screen-reader-skip-link-styles';
   const TRAINING_SPEECH_CHANNEL = 'dbe-training';
+  const LANDSCAPE_SETTLE_MS = 1200;
   const NON_VISUAL_ONBOARDING_MESSAGE = 'Non-visual onboarding. To race, choose a track on Home, then choose a car. For a guided introduction to Drive By Ear and non-visual gameplay, choose Drive By Ear one oh one. The first two links on Home let you replay this introduction or jump directly to Drive By Ear one oh one.';
   const MENU_GLYPHS = new Set(['…', '⋮', '☰']);
   const TRAINING_START_MESSAGES = Object.freeze({
@@ -19,6 +20,9 @@
   let positionAnnouncer = null;
   let pendingPosition = '';
   let homeReadyHandled = false;
+  let onboardingTimer = 0;
+  let onboardingAnnounced = false;
+  let landscapeWatchInstalled = false;
   let externalPriorityTimer = 0;
   let externalPriorityUntil = 0;
   let discoveryObserver = null;
@@ -28,6 +32,50 @@
     const width = viewport?.width || window.innerWidth || document.documentElement.clientWidth;
     const height = viewport?.height || window.innerHeight || document.documentElement.clientHeight;
     return height > width;
+  }
+
+  function clearOnboardingTimer() {
+    window.clearTimeout(onboardingTimer);
+    onboardingTimer = 0;
+  }
+
+  function removeLandscapeWatch() {
+    if (!landscapeWatchInstalled) return;
+    landscapeWatchInstalled = false;
+    window.removeEventListener('resize', handleLandscapeCandidate);
+    window.removeEventListener('orientationchange', handleLandscapeCandidate);
+    window.visualViewport?.removeEventListener('resize', handleLandscapeCandidate);
+  }
+
+  function scheduleNonVisualOnboarding() {
+    if (!homeReadyHandled || onboardingAnnounced) return;
+    clearOnboardingTimer();
+    if (viewportIsPortrait()) return;
+
+    onboardingTimer = window.setTimeout(() => {
+      onboardingTimer = 0;
+      if (!homeReadyHandled || onboardingAnnounced || viewportIsPortrait()) return;
+      onboardingAnnounced = true;
+      removeLandscapeWatch();
+      speak(`TURN is ready. ${NON_VISUAL_ONBOARDING_MESSAGE}`, { priority: 'assertive' });
+    }, LANDSCAPE_SETTLE_MS);
+  }
+
+  function handleLandscapeCandidate() {
+    if (!homeReadyHandled || onboardingAnnounced) return;
+    if (viewportIsPortrait()) {
+      clearOnboardingTimer();
+      return;
+    }
+    scheduleNonVisualOnboarding();
+  }
+
+  function installLandscapeWatch() {
+    if (landscapeWatchInstalled || onboardingAnnounced) return;
+    landscapeWatchInstalled = true;
+    window.addEventListener('resize', handleLandscapeCandidate, { passive: true });
+    window.addEventListener('orientationchange', handleLandscapeCandidate, { passive: true });
+    window.visualViewport?.addEventListener('resize', handleLandscapeCandidate, { passive: true });
   }
 
   function ensureStatusRegion() {
@@ -601,10 +649,12 @@
       }
     }
 
-    const readyMessage = viewportIsPortrait()
-      ? 'TURN is ready. Rotate your device to landscape.'
-      : 'TURN is ready.';
-    speak(`${readyMessage} ${NON_VISUAL_ONBOARDING_MESSAGE}`, { priority: 'assertive' });
+    installLandscapeWatch();
+    if (viewportIsPortrait()) {
+      speak('TURN is ready. Rotate your device to landscape.', { priority: 'assertive' });
+    } else {
+      scheduleNonVisualOnboarding();
+    }
   }, { once: true });
 
   window.addEventListener('turn:track-changed', () => {


### PR DESCRIPTION
## What changed

- keeps the portrait startup announcement limited to “TURN is ready. Rotate your device to landscape.”
- waits until the viewport is actually landscape before announcing the non-visual onboarding
- debounces orientation/viewport changes for 1.2 seconds so VoiceOver’s OS-level “Landscape” announcement can finish first
- removes the temporary orientation listeners once onboarding has been announced
- keeps the Home “Non-visual onboarding” skip link available for replay
- adds startup regression coverage so portrait startup cannot append the onboarding again

## Why

Real VoiceOver testing showed that iOS announces “Landscape” when the device rotates, interrupting TURN’s automatic non-visual onboarding. The onboarding is important enough that it should start only after the orientation transition has settled.