### PR TITLE
Force music off during DBE 101

### DIFF
--- a/.github/workflows/turn-dbe-training-tests.yml
+++ b/.github/workflows/turn-dbe-training-tests.yml
@@ -8,6 +8,7 @@ on:
       - 'turn/training/**'
       - 'turn/m8-home-fixed-layout.js'
       - 'turn-tests/drive-by-ear-training-production.mjs'
+      - 'turn-tests/dbe-training-music-silence-production.mjs'
       - 'eslint.config.mjs'
       - '.github/workflows/turn-dbe-training-tests.yml'
   push:
@@ -17,6 +18,7 @@ on:
       - 'turn/training/**'
       - 'turn/m8-home-fixed-layout.js'
       - 'turn-tests/drive-by-ear-training-production.mjs'
+      - 'turn-tests/dbe-training-music-silence-production.mjs'
       - 'eslint.config.mjs'
       - '.github/workflows/turn-dbe-training-tests.yml'
 
@@ -36,10 +38,13 @@ jobs:
           node-version: '24'
 
       - name: Syntax-check training modules
-        run: find turn/training -type f -name '*.js' -print0 | xargs -0 -n1 node --check && node --check turn-tests/drive-by-ear-training-production.mjs
+        run: find turn/training -type f -name '*.js' -print0 | xargs -0 -n1 node --check && node --check turn-tests/drive-by-ear-training-production.mjs && node --check turn-tests/dbe-training-music-silence-production.mjs
 
       - name: Lint training modules
-        run: npx --yes eslint@9.39.1 turn/training/*.js turn-tests/drive-by-ear-training-production.mjs
+        run: npx --yes eslint@9.39.1 turn/training/*.js turn-tests/drive-by-ear-training-production.mjs turn-tests/dbe-training-music-silence-production.mjs
 
       - name: Run Drive By Ear training regression
         run: node turn-tests/drive-by-ear-training-production.mjs
+
+      - name: Run DBE 101 music silence regression
+        run: node turn-tests/dbe-training-music-silence-production.mjs

--- a/turn-tests/dbe-training-music-silence-production.mjs
+++ b/turn-tests/dbe-training-music-silence-production.mjs
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const fixedLayout = await fs.readFile(
+  new URL('../turn/m8-home-fixed-layout.js', import.meta.url),
+  'utf8'
+);
+
+assert.match(fixedLayout, /const MUSIC_VOLUME_STORAGE_KEY = 'turn-racing-music-volume-v1'/);
+assert.match(fixedLayout, /const MUSIC_LAST_VOLUME_STORAGE_KEY = 'turn-racing-music-last-volume-v1'/);
+assert.match(fixedLayout, /function installDriveByEarTrainingMusicSilence\(training, racingMusic\)/);
+assert.match(
+  fixedLayout,
+  /volume: Number\.isFinite\(Number\(racingMusic\.volume\)\) \? Number\(racingMusic\.volume\) : 0/,
+  'DBE 101 must remember the in-memory music level before forcing silence'
+);
+assert.match(
+  fixedLayout,
+  /racingMusic\.setVolume\?\.\(0\);[\s\S]*restorePersistentMusicChoice\(temporary\)/,
+  'Training may set the running engine to zero only if the persisted preference is restored immediately'
+);
+assert.match(
+  fixedLayout,
+  /racingMusic\.setVolume\?\.\(snapshot\.volume\);[\s\S]*restorePersistentMusicChoice\(snapshot\)/,
+  'Leaving DBE 101 must restore both the running level and the exact stored preference'
+);
+assert.match(
+  fixedLayout,
+  /button\.addEventListener\('click', silence, \{ capture: true \}\)/,
+  'Every DBE 101 entry point must silence music before its normal click handler opens training'
+);
+assert.match(
+  fixedLayout,
+  /training\.introDialog\?\.addEventListener\('close',[\s\S]*training\.getState\?\.\(\)\.active !== true\) restore\(\)/,
+  'Cancelling the DBE 101 introduction must restore music when no training session started'
+);
+assert.match(
+  fixedLayout,
+  /addEventListener\('turn:dbe-training-stage-started', silence\)/,
+  'The exact-stage start event must provide a fallback guarantee that music is silent during driving'
+);
+assert.match(
+  fixedLayout,
+  /addEventListener\('turn:track-changed',[\s\S]*event\.detail\?\.training === true\) silence\(\);[\s\S]*else if \(temporary\) restore\(\)/,
+  'Training track changes keep music off and returning to a real track restores the prior state'
+);
+assert.match(fixedLayout, /const dbeTrainingMusicSilence = installDriveByEarTrainingMusicSilence\(driveByEarTraining, racingMusic\)/);
+assert.match(fixedLayout, /dbeTrainingMusicSilence,/);
+
+console.log('TURN DBE 101 temporary music silence regression passed.');

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -1,6 +1,89 @@
 const STYLE_ATTRIBUTE = 'data-turn-m8-fixed-home-styles';
 const SHORT_VIEWPORT_STYLE_ID = 'turn-m8-short-viewport-race-dock';
 const LAYOUT_ID = 'fixed-grid-v7';
+const MUSIC_VOLUME_STORAGE_KEY = 'turn-racing-music-volume-v1';
+const MUSIC_LAST_VOLUME_STORAGE_KEY = 'turn-racing-music-last-volume-v1';
+
+function storageSnapshot(key) {
+  try {
+    return Object.freeze({ available: true, value: globalThis.localStorage?.getItem(key) ?? null });
+  } catch (_) {
+    return Object.freeze({ available: false, value: null });
+  }
+}
+
+function restoreStorage(key, snapshot) {
+  if (!snapshot?.available) return;
+  try {
+    if (snapshot.value == null) globalThis.localStorage?.removeItem(key);
+    else globalThis.localStorage?.setItem(key, snapshot.value);
+  } catch (_) {}
+}
+
+function installDriveByEarTrainingMusicSilence(training, racingMusic) {
+  if (!training || !racingMusic || globalThis.__turnDbeTrainingMusicSilence) {
+    return globalThis.__turnDbeTrainingMusicSilence || null;
+  }
+
+  let temporary = null;
+
+  const restorePersistentMusicChoice = (snapshot) => {
+    restoreStorage(MUSIC_VOLUME_STORAGE_KEY, snapshot?.storedVolume);
+    restoreStorage(MUSIC_LAST_VOLUME_STORAGE_KEY, snapshot?.storedLastVolume);
+  };
+
+  const silence = () => {
+    if (temporary) return;
+    temporary = Object.freeze({
+      volume: Number.isFinite(Number(racingMusic.volume)) ? Number(racingMusic.volume) : 0,
+      storedVolume: storageSnapshot(MUSIC_VOLUME_STORAGE_KEY),
+      storedLastVolume: storageSnapshot(MUSIC_LAST_VOLUME_STORAGE_KEY)
+    });
+    racingMusic.setVolume?.(0);
+    // setVolume(0) intentionally updates the normal preference. DBE 101 is different:
+    // silence is temporary, so immediately put the player's persisted choice back.
+    restorePersistentMusicChoice(temporary);
+  };
+
+  const restore = () => {
+    if (!temporary) return;
+    const snapshot = temporary;
+    temporary = null;
+    racingMusic.setVolume?.(snapshot.volume);
+    restorePersistentMusicChoice(snapshot);
+  };
+
+  const entryButtons = [
+    training.entryPoints?.homeButton,
+    training.entryPoints?.howCallout?.querySelector?.('[data-turn-dbe-training-entry]'),
+    training.entryPoints?.settingsCallout?.querySelector?.('[data-turn-dbe-training-entry]'),
+    training.blankSuggestion?.dialog?.querySelector?.('[data-blank-training]')
+  ].filter(Boolean);
+
+  for (const button of entryButtons) {
+    button.addEventListener('click', silence, { capture: true });
+  }
+
+  training.introDialog?.addEventListener('close', () => {
+    queueMicrotask(() => {
+      if (training.getState?.().active !== true) restore();
+    });
+  });
+
+  globalThis.addEventListener('turn:dbe-training-stage-started', silence);
+  globalThis.addEventListener('turn:track-changed', (event) => {
+    if (event.detail?.training === true) silence();
+    else if (temporary) restore();
+  });
+
+  const api = Object.freeze({
+    silence,
+    restore,
+    get active() { return Boolean(temporary); }
+  });
+  globalThis.__turnDbeTrainingMusicSilence = api;
+  return api;
+}
 
 function installStylesheet() {
   if (document.querySelector(`link[${STYLE_ATTRIBUTE}]`)) return;
@@ -198,6 +281,7 @@ export async function installM8HomeFixedLayout() {
     `/turn/audio/racing-music-v2.js?build=${buildKey}-racing-music-warm-v2`
   );
   const racingMusic = installRacingMusic({ home });
+  const dbeTrainingMusicSilence = installDriveByEarTrainingMusicSilence(driveByEarTraining, racingMusic);
   const { installRacingMusicHealth } = await import(
     `/turn/audio/racing-music-health.js?build=${buildKey}&revision=r164-long-session-robustness`
   );
@@ -219,6 +303,7 @@ export async function installM8HomeFixedLayout() {
     trophyRoadFeedback,
     driveByEarTraining,
     racingMusic,
+    dbeTrainingMusicSilence,
     racingMusicHealth
   });
   return globalThis.__turnHomeLayout;


### PR DESCRIPTION
## What changed

- silences TURN music whenever the player enters Drive By Ear 101
- keeps music silent through the intro, every training part, between-part dialogs and completion
- restores the previous in-memory music level when training is cancelled or exited
- immediately restores the persisted music storage after forcing runtime volume to zero, so killing/reloading TURN during training cannot accidentally save Music OFF
- adds a dedicated regression and wires it into the DBE 101 workflow

## Why

DBE 101 teaches spatial guidance, pace notes, surface/status audio and spoken instructions. Music competes with exactly the signals the player is learning, so training should provide a controlled listening environment without changing the player's normal music preference.