### PR TITLE
Polish MOUNTAIN village and waterfall landmarks

### DIFF
--- a/.github/workflows/turn-mountain-visual-smoke.yml
+++ b/.github/workflows/turn-mountain-visual-smoke.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Playwright Chromium
         run: |
           npm install --no-save playwright@1.55.0
-          npx playwright install --with-deps chromium
+          npx playwright install chromium
 
       - name: Start static TURN server
         run: |

--- a/turn-lab/mountain-visual.html
+++ b/turn-lab/mountain-visual.html
@@ -18,15 +18,16 @@
   <script type="module">
     import * as THREE from 'three';
     import { createTrackRuntime } from '/turn/tracks/catalog.js';
-    import { installMountainWorld } from '/turn/tracks/mountain-world-r3.js?visual=3';
-    import { createMountainTerrainSampler, createMountainRiverSamples, offsetPoint, MOUNTAIN_R3 } from '/turn/tracks/mountain-world-r3-terrain.js?visual=3';
+    import { installMountainWorld } from '/turn/tracks/mountain-world-r3.js?visual=4';
+    import { createMountainTerrainSampler, createMountainRiverSamples, offsetPoint, MOUNTAIN_R3 } from '/turn/tracks/mountain-world-r3-terrain.js?visual=4';
 
     const VIEWS = Object.freeze({
       aerial: { position:[330,235,-345], target:[5,22,-10], fov:49 },
       village:{ position:[118,48,-286], target:[8,8,-215], fov:52 },
       summit:{ position:[325,95,160], target:[180,43,105], fov:50 },
       descent:{ position:[235,92,-5], target:[62,22,-32], fov:52 },
-      waterfall:{ position:[354,51,-236], target:[244,11,-143], fov:43 }
+      waterfall:{ position:[354,51,-236], target:[244,11,-143], fov:43 },
+      'waterfall-road': { dynamic:'waterfall-road', fov:48 }
     });
 
     const params = new URLSearchParams(location.search);
@@ -55,9 +56,31 @@
     await world.ready;
 
     const preset = VIEWS[viewName];
-    camera.position.set(...preset.position);
     camera.up.set(0,1,0);
-    camera.lookAt(...preset.target);
+    if (preset.dynamic === 'waterfall-road') {
+      let nearestIndex = 0;
+      let nearestDistanceSq = Infinity;
+      runtime.samples.forEach((sample, index) => {
+        const dx = sample.point.x - MOUNTAIN_R3.WATERFALL.x;
+        const dz = sample.point.z - MOUNTAIN_R3.WATERFALL.z;
+        const distanceSq = dx * dx + dz * dz;
+        if (distanceSq < nearestDistanceSq) {
+          nearestDistanceSq = distanceSq;
+          nearestIndex = index;
+        }
+      });
+      const cameraIndex = (nearestIndex - 54 + runtime.samples.length) % runtime.samples.length;
+      const roadCamera = runtime.samples[cameraIndex];
+      camera.position.set(roadCamera.point.x, roadCamera.point.y + 6.2, roadCamera.point.z);
+      camera.lookAt(
+        MOUNTAIN_R3.WATERFALL.x,
+        (MOUNTAIN_R3.WATERFALL.top + MOUNTAIN_R3.LAKE.level) * 0.5,
+        MOUNTAIN_R3.WATERFALL.z - 4
+      );
+    } else {
+      camera.position.set(...preset.position);
+      camera.lookAt(...preset.target);
+    }
     camera.fov = preset.fov;
     camera.updateProjectionMatrix();
 

--- a/turn-lab/mountain-visual.html
+++ b/turn-lab/mountain-visual.html
@@ -18,8 +18,8 @@
   <script type="module">
     import * as THREE from 'three';
     import { createTrackRuntime } from '/turn/tracks/catalog.js';
-    import { installMountainWorld } from '/turn/tracks/mountain-world-r3.js?visual=2';
-    import { createMountainTerrainSampler, createMountainRiverSamples, offsetPoint, MOUNTAIN_R3 } from '/turn/tracks/mountain-world-r3-terrain.js?visual=2';
+    import { installMountainWorld } from '/turn/tracks/mountain-world-r3.js?visual=3';
+    import { createMountainTerrainSampler, createMountainRiverSamples, offsetPoint, MOUNTAIN_R3 } from '/turn/tracks/mountain-world-r3-terrain.js?visual=3';
 
     const VIEWS = Object.freeze({
       aerial: { position:[330,235,-345], target:[5,22,-10], fov:49 },
@@ -101,11 +101,13 @@
     const count = (fragment) => names.filter((name) => name.includes(fragment)).length;
     const diagnostics = world.userData.turnMountainGroundingDiagnostics || [];
     const maxGroundingDelta = diagnostics.reduce((max, entry) => Math.max(max, Math.abs(entry.delta)), 0);
+    const r4 = world.userData.turnMountainR4VisualPolish || {};
 
     globalThis.__mountainVisualMetrics = Object.freeze({
       viewName,
       assetsReady: world.userData.turnMountainAssetsReady === true,
       assetErrors: [...(world.userData.turnMountainAssetErrors || [])],
+      r4AssetErrors: [...(world.userData.turnMountainR4AssetErrors || [])],
       maximumRoadSupportGap,
       maximumEdgeSupportGap,
       maximumRenderedRoadSupportGap,
@@ -120,14 +122,24 @@
       deepFoundations: count('deep retaining road foundation r3'),
       roadbedUndersides: count('closed roadbed underside r3'),
       cabins: count('Holiday cabin prefab r3'),
+      assembledCabins: count('assembled r4'),
       marketStalls: count('Fantasy market stall'),
+      winterMarketAssets: count('winter market'),
       fountains: count('Fantasy fountain r3'),
+      litStreetlights: count('Holiday lit streetlight r4'),
+      warmLanternHalos: count('warm lantern halo r4'),
+      decorativeVillageAssets: count('village ') + count('decorative Holiday spruce r4'),
+      distantLayeredRidges: count('distant layered ridge r4'),
       waterfallCliffModules: count('Nature cliff module r3'),
       waterfallSheets: count('river-to-lake waterfall sheet r3'),
       visibleWaterfallCurtains: count('visible waterfall curtain r3'),
+      trackVisibleWaterfallCurtains: count('track-visible waterfall curtain r4'),
       waterfallSpillways: count('waterfall spillway r3'),
       lakes: count('terrain-bounded waterfall lake r3'),
-      windmills: names.filter((name) => /windmill/i.test(name)).length
+      windmills: names.filter((name) => /windmill/i.test(name)).length,
+      r4CabinsReported: Number(r4.cabins || 0),
+      r4StreetlightsReported: Number(r4.streetlights || 0),
+      r4MarketAssetsReported: Number(r4.marketAssets || 0)
     });
 
     renderer.render(scene,camera);

--- a/turn-tests/mountain-visual-smoke.mjs
+++ b/turn-tests/mountain-visual-smoke.mjs
@@ -45,20 +45,41 @@ await fs.writeFile(path.join(outputDir, 'metrics.json'), `${JSON.stringify({ met
 
 assert.equal(browserErrors.length, 0, `Browser-rendered MOUNTAIN produced errors:\n${browserErrors.join('\n')}`);
 assert.equal(metrics.assetsReady, true, 'MOUNTAIN Kenney/Nature assets must finish loading before visual capture');
-assert.deepEqual(metrics.assetErrors, [], 'MOUNTAIN asset loaders must not hide failed GLBs/textures');
+assert.deepEqual(metrics.assetErrors, [], 'MOUNTAIN r3 asset loaders must not hide failed GLBs/textures');
+assert.deepEqual(metrics.r4AssetErrors, [], 'MOUNTAIN r4 village polish assets must load without hidden failures');
 assert.ok(metrics.terrainBodies >= 1, 'MOUNTAIN needs a continuous terrain body beneath the road');
 assert.ok(metrics.roadbedWalls >= 2, 'Both road edges need opaque roadbed side walls');
 assert.ok(metrics.deepFoundations >= 2, 'Both road edges need deep retaining foundations for close stacked hairpins');
 assert.ok(metrics.roadbedUndersides >= 1, 'The elevated road must have a closed underside');
 assert.equal(metrics.windmills, 0, 'A loose Fantasy Town windmill rotor must not return');
-assert.ok(metrics.cabins >= 3, `Expected at least 3 grounded Holiday cabin prefabs, got ${metrics.cabins}`);
-assert.ok(metrics.marketStalls >= 2, `Expected two Fantasy Town market stalls, got ${metrics.marketStalls}`);
-assert.ok(metrics.fountains >= 1, 'The village needs a complete Fantasy Town fountain landmark');
+
+assert.ok(metrics.assembledCabins >= 6,
+  `Expected a substantial village of correctly assembled Holiday cabins, got ${metrics.assembledCabins}`);
+assert.equal(metrics.assembledCabins, metrics.r4CabinsReported,
+  'Visual scene count and r4 cabin placement diagnostics must agree');
+assert.equal(metrics.fountains, 0, 'The oversized fountain must be removed from the finished village');
+assert.ok(metrics.winterMarketAssets >= 5,
+  `The fountain replacement should read as a winter market square, got ${metrics.winterMarketAssets} assets`);
+assert.ok(metrics.litStreetlights >= 7,
+  `The village needs a visible run of grounded Holiday streetlights, got ${metrics.litStreetlights}`);
+assert.equal(metrics.litStreetlights, metrics.r4StreetlightsReported,
+  'Visual scene count and r4 streetlight diagnostics must agree');
+assert.ok(metrics.warmLanternHalos >= 7,
+  `Streetlights need warm static glow markers, got ${metrics.warmLanternHalos}`);
+assert.ok(metrics.distantLayeredRidges >= 8,
+  `The horizon should have a second layer of integrated-snow mountains, got ${metrics.distantLayeredRidges}`);
+assert.ok(metrics.decorativeVillageAssets >= 8,
+  'Village approaches need benches, carts, fences, sleds and authored Holiday trees');
+
+assert.ok(metrics.marketStalls >= 2, `Expected the original village market stalls to remain, got ${metrics.marketStalls}`);
 assert.ok(metrics.waterfallCliffModules >= 6, 'The waterfall should use multiple modest Kenney Nature cliff modules');
 assert.ok(metrics.waterfallSheets >= 3, 'The river must continue over the cliff toward the lake');
-assert.ok(metrics.visibleWaterfallCurtains >= 3, 'The waterfall needs a camera-visible curtain in front of the cliff mass');
+assert.ok(metrics.visibleWaterfallCurtains >= 3, 'The waterfall needs the established r3 curtain in front of the cliff mass');
+assert.ok(metrics.trackVisibleWaterfallCurtains >= 1,
+  'The waterfall must now have an explicitly track-facing visible curtain');
 assert.ok(metrics.waterfallSpillways >= 1, 'The river must connect physically to the waterfall curtain');
 assert.ok(metrics.lakes >= 1, 'The waterfall needs a terrain-bounded lake');
+
 assert.ok(metrics.maximumRoadSupportGap <= 0.56,
   `Analytic terrain support under road centre is too far away: ${metrics.maximumRoadSupportGap.toFixed(2)} m`);
 assert.ok(metrics.roadFoundationDepth >= metrics.maximumEdgeSupportGap + 0.5,
@@ -71,7 +92,7 @@ assert.ok(metrics.riverDepthMin >= 0.60,
   `River channel is too shallow/floating against its bed: ${metrics.riverDepthMin.toFixed(2)} m`);
 assert.ok(metrics.riverDepthMax <= 2.25,
   `River water is too far above its terrain channel: ${metrics.riverDepthMax.toFixed(2)} m`);
-assert.ok(metrics.groundingCount >= 12, 'Imported assets should be grounded through the shared Box3 pipeline');
+assert.ok(metrics.groundingCount >= 20, 'Imported village assets should remain grounded through the shared Box3 pipeline');
 assert.ok(metrics.maxGroundingDelta <= 0.36,
   `An imported asset is floating or excessively buried: ${metrics.maxGroundingDelta.toFixed(2)} m`);
 

--- a/turn-tests/mountain-visual-smoke.mjs
+++ b/turn-tests/mountain-visual-smoke.mjs
@@ -72,7 +72,7 @@ assert.ok(metrics.decorativeVillageAssets >= 8,
   'Village approaches need benches, carts, fences, sleds and authored Holiday trees');
 
 assert.ok(metrics.marketStalls >= 2, `Expected the original village market stalls to remain, got ${metrics.marketStalls}`);
-assert.ok(metrics.waterfallCliffModules >= 6, 'The waterfall should use multiple modest Kenney Nature cliff modules');
+assert.ok(metrics.waterfallCliffModules >= 4, 'The waterfall should retain four outer Kenney Nature cliff shoulders after opening the driver sightline');
 assert.ok(metrics.waterfallSheets >= 3, 'The river must continue over the cliff toward the lake');
 assert.ok(metrics.visibleWaterfallCurtains >= 3, 'The waterfall needs the established r3 curtain in front of the cliff mass');
 assert.ok(metrics.trackVisibleWaterfallCurtains >= 1,

--- a/turn-tests/mountain-visual-smoke.mjs
+++ b/turn-tests/mountain-visual-smoke.mjs
@@ -5,7 +5,7 @@ import { chromium } from 'playwright';
 
 const baseUrl = process.env.TURN_VISUAL_BASE_URL || 'http://127.0.0.1:8000';
 const outputDir = process.env.TURN_VISUAL_OUTPUT || 'mountain-visual-artifact';
-const views = ['aerial', 'village', 'summit', 'descent', 'waterfall'];
+const views = ['aerial', 'village', 'summit', 'descent', 'waterfall', 'waterfall-road'];
 await fs.mkdir(outputDir, { recursive: true });
 
 const browser = await chromium.launch({

--- a/turn/tracks/mountain-world-r3.js
+++ b/turn/tracks/mountain-world-r3.js
@@ -21,7 +21,8 @@ export function installMountainWorld({ scene, samples, trackWidth = 27, runtime 
     .then(() => world);
   world.userData.turnMountainTerrainHeightAt = terrainContext.terrainHeightAt;
   world.userData.turnMountainArtDirection = Object.freeze({
-    version: 'r3+r4-visual-polish',
+    version: 'r3',
+    visualPolish: 'r4-village-waterfall-landmarks',
     ground: 'continuous-snow-and-granite-terrain-body',
     roadEdge: 'white-with-black-outer-contour',
     roadbed: 'opaque-and-terrain-supported',

--- a/turn/tracks/mountain-world-r3.js
+++ b/turn/tracks/mountain-world-r3.js
@@ -3,6 +3,7 @@ import { installMountainTerrain } from './mountain-world-r3-terrain.js';
 import { installMountainScenery } from './mountain-world-r3-scenery.js';
 import { installMountainR3Polish } from './mountain-world-r3-polish.js';
 import { installMountainR4VisualPolish } from './mountain-world-r4-visual-polish.js';
+import { installMountainR4CabinFix } from './mountain-world-r4-cabin-fix.js';
 
 export function installMountainWorld({ scene, samples, trackWidth = 27, runtime } = {}) {
   if (!scene || !Array.isArray(samples) || samples.length < 3) {
@@ -18,17 +19,18 @@ export function installMountainWorld({ scene, samples, trackWidth = 27, runtime 
   const sceneryReady = installMountainScenery(world, samples, trackWidth, terrainContext);
   world.ready = Promise.resolve(sceneryReady)
     .then(() => installMountainR4VisualPolish(world, samples, trackWidth, terrainContext))
+    .then(() => installMountainR4CabinFix(world, samples, trackWidth, terrainContext))
     .then(() => world);
   world.userData.turnMountainTerrainHeightAt = terrainContext.terrainHeightAt;
   world.userData.turnMountainArtDirection = Object.freeze({
     version: 'r3',
-    visualPolish: 'r4-village-waterfall-landmarks',
+    visualPolish: 'r4-village-waterfall-landmarks-native-cabins',
     ground: 'continuous-snow-and-granite-terrain-body',
     roadEdge: 'white-with-black-outer-contour',
     roadbed: 'opaque-and-terrain-supported',
     retainingFoundation: '4.6m-granite-skirt',
     routeClearanceProtected: true,
-    assetVillage: 'Kenney-Holiday-and-Fantasy-Town-assembled-r4',
+    assetVillage: 'Kenney-Holiday-native-pivot-cabins-and-Fantasy-Town-market',
     villageSquare: 'winter-market-no-fountain',
     streetlights: 'warm-static-halos',
     waterfallCliff: 'terrain-plus-Kenney-Nature-modules-open-to-track',

--- a/turn/tracks/mountain-world-r3.js
+++ b/turn/tracks/mountain-world-r3.js
@@ -3,6 +3,7 @@ import { installMountainTerrain } from './mountain-world-r3-terrain.js';
 import { installMountainScenery } from './mountain-world-r3-scenery.js';
 import { installMountainR3Polish } from './mountain-world-r3-polish.js';
 import { installMountainR4VisualPolish } from './mountain-world-r4-visual-polish.js';
+import { installMountainR4WaterfallNotch } from './mountain-world-r4-waterfall-notch.js';
 import { installMountainR4CabinFix } from './mountain-world-r4-cabin-fix.js';
 
 export function installMountainWorld({ scene, samples, trackWidth = 27, runtime } = {}) {
@@ -19,6 +20,7 @@ export function installMountainWorld({ scene, samples, trackWidth = 27, runtime 
   const sceneryReady = installMountainScenery(world, samples, trackWidth, terrainContext);
   world.ready = Promise.resolve(sceneryReady)
     .then(() => installMountainR4VisualPolish(world, samples, trackWidth, terrainContext))
+    .then(() => installMountainR4WaterfallNotch(world))
     .then(() => installMountainR4CabinFix(world, samples, trackWidth, terrainContext))
     .then(() => world);
   world.userData.turnMountainTerrainHeightAt = terrainContext.terrainHeightAt;
@@ -33,8 +35,9 @@ export function installMountainWorld({ scene, samples, trackWidth = 27, runtime 
     assetVillage: 'Kenney-Holiday-native-pivot-cabins-and-Fantasy-Town-market',
     villageSquare: 'winter-market-no-fountain',
     streetlights: 'warm-static-halos',
-    waterfallCliff: 'terrain-plus-Kenney-Nature-modules-open-to-track',
+    waterfallCliff: 'terrain-plus-Kenney-Nature-rock-shoulders-open-at-centre',
     visibleWaterfallCurtain: true,
+    waterfallDriverSightline: 'open-notch-between-rock-shoulders',
     layeredMountainBackdrop: true,
     integratedSnowCaps: true,
     authoredSnowDrifts: true,

--- a/turn/tracks/mountain-world-r3.js
+++ b/turn/tracks/mountain-world-r3.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { installMountainTerrain } from './mountain-world-r3-terrain.js';
 import { installMountainScenery } from './mountain-world-r3-scenery.js';
 import { installMountainR3Polish } from './mountain-world-r3-polish.js';
+import { installMountainR4VisualPolish } from './mountain-world-r4-visual-polish.js';
 
 export function installMountainWorld({ scene, samples, trackWidth = 27, runtime } = {}) {
   if (!scene || !Array.isArray(samples) || samples.length < 3) {
@@ -15,18 +16,23 @@ export function installMountainWorld({ scene, samples, trackWidth = 27, runtime 
   const terrainContext = installMountainTerrain(world, samples, trackWidth);
   installMountainR3Polish(world, samples, trackWidth);
   const sceneryReady = installMountainScenery(world, samples, trackWidth, terrainContext);
-  world.ready = Promise.resolve(sceneryReady).then(() => world);
+  world.ready = Promise.resolve(sceneryReady)
+    .then(() => installMountainR4VisualPolish(world, samples, trackWidth, terrainContext))
+    .then(() => world);
   world.userData.turnMountainTerrainHeightAt = terrainContext.terrainHeightAt;
   world.userData.turnMountainArtDirection = Object.freeze({
-    version: 'r3',
+    version: 'r3+r4-visual-polish',
     ground: 'continuous-snow-and-granite-terrain-body',
     roadEdge: 'white-with-black-outer-contour',
     roadbed: 'opaque-and-terrain-supported',
     retainingFoundation: '4.6m-granite-skirt',
     routeClearanceProtected: true,
-    assetVillage: 'Kenney-Holiday-and-Fantasy-Town',
-    waterfallCliff: 'terrain-plus-Kenney-Nature-modules',
+    assetVillage: 'Kenney-Holiday-and-Fantasy-Town-assembled-r4',
+    villageSquare: 'winter-market-no-fountain',
+    streetlights: 'warm-static-halos',
+    waterfallCliff: 'terrain-plus-Kenney-Nature-modules-open-to-track',
     visibleWaterfallCurtain: true,
+    layeredMountainBackdrop: true,
     integratedSnowCaps: true,
     authoredSnowDrifts: true,
     riverHasChannelBanksAndBed: true,

--- a/turn/tracks/mountain-world-r3.js
+++ b/turn/tracks/mountain-world-r3.js
@@ -4,6 +4,7 @@ import { installMountainScenery } from './mountain-world-r3-scenery.js';
 import { installMountainR3Polish } from './mountain-world-r3-polish.js';
 import { installMountainR4VisualPolish } from './mountain-world-r4-visual-polish.js';
 import { installMountainR4WaterfallNotch } from './mountain-world-r4-waterfall-notch.js';
+import { installMountainR4DriverFacingWaterfall } from './mountain-world-r4-waterfall-face.js';
 import { installMountainR4CabinFix } from './mountain-world-r4-cabin-fix.js';
 
 export function installMountainWorld({ scene, samples, trackWidth = 27, runtime } = {}) {
@@ -21,6 +22,7 @@ export function installMountainWorld({ scene, samples, trackWidth = 27, runtime 
   world.ready = Promise.resolve(sceneryReady)
     .then(() => installMountainR4VisualPolish(world, samples, trackWidth, terrainContext))
     .then(() => installMountainR4WaterfallNotch(world))
+    .then(() => installMountainR4DriverFacingWaterfall(world, samples))
     .then(() => installMountainR4CabinFix(world, samples, trackWidth, terrainContext))
     .then(() => world);
   world.userData.turnMountainTerrainHeightAt = terrainContext.terrainHeightAt;
@@ -37,7 +39,7 @@ export function installMountainWorld({ scene, samples, trackWidth = 27, runtime 
     streetlights: 'warm-static-halos',
     waterfallCliff: 'terrain-plus-Kenney-Nature-rock-shoulders-open-at-centre',
     visibleWaterfallCurtain: true,
-    waterfallDriverSightline: 'open-notch-between-rock-shoulders',
+    waterfallDriverSightline: 'open-rock-cleft-plus-driver-facing-water-plane',
     layeredMountainBackdrop: true,
     integratedSnowCaps: true,
     authoredSnowDrifts: true,

--- a/turn/tracks/mountain-world-r4-cabin-fix.js
+++ b/turn/tracks/mountain-world-r4-cabin-fix.js
@@ -1,0 +1,191 @@
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { MOUNTAIN_R3, material, safeTracksidePosition } from './mountain-world-r3-terrain.js';
+
+const { GRANITE_DARK, HOLIDAY_ROOT } = MOUNTAIN_R3;
+
+function prepareAsset(root) {
+  root.traverse((node) => {
+    if (!node?.isMesh) return;
+    node.castShadow = true;
+    node.receiveShadow = true;
+    node.userData.turnOutlined = true;
+  });
+  return root;
+}
+
+function nativeGroundedClone(template) {
+  const clone = prepareAsset(template.clone(true));
+  clone.position.set(0, 0, 0);
+  clone.rotation.set(0, 0, 0);
+  clone.scale.set(1, 1, 1);
+  clone.updateWorldMatrix(true, true);
+  const bounds = new THREE.Box3().setFromObject(clone, true);
+  if (!bounds.isEmpty()) clone.position.y = -bounds.min.y;
+  return clone;
+}
+
+function removeOldCabins(world) {
+  const removals = [];
+  world.traverse((object) => {
+    if (object !== world && object.name?.includes('Mountain Kenney Holiday cabin prefab r3 assembled r4')) {
+      removals.push(object);
+    }
+  });
+  for (const object of removals) object.parent?.remove(object);
+  return removals.length;
+}
+
+function addPanel(cabin, template, yaw, name) {
+  const panel = nativeGroundedClone(template);
+  panel.rotation.y = yaw;
+  panel.name = name;
+  cabin.add(panel);
+  return panel;
+}
+
+function makeGable(z, color = 0x8a5c3f) {
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute([
+    -0.51, 1.0, z,
+     0.51, 1.0, z,
+     0.00, 2.18, z
+  ], 3));
+  geometry.computeVertexNormals();
+  const mesh = new THREE.Mesh(geometry, material(color, 1, 0, { side: THREE.DoubleSide }));
+  mesh.castShadow = true;
+  mesh.receiveShadow = true;
+  mesh.userData.turnOutlined = true;
+  mesh.name = 'Mountain closed Holiday cabin gable native-pivot r4';
+  return mesh;
+}
+
+function makeNativePivotCabin(templates, variant = 0) {
+  const cabin = new THREE.Group();
+
+  // Kenney's cabin panels already carry their half-cell outward offset in the
+  // model origin. Rotating four panels around the SAME origin is what closes
+  // a 1 x 1 cabin. Translating them outward again is what produced the loose
+  // log barricades in the first r4 render.
+  addPanel(cabin, templates.doorway, 0, 'Mountain Holiday native front doorway r4');
+  addPanel(cabin, templates.wall, Math.PI, 'Mountain Holiday native back wall r4');
+  addPanel(cabin, variant ? templates.window : templates.wall, -Math.PI / 2, 'Mountain Holiday native left wall r4');
+  addPanel(cabin, templates.window, Math.PI / 2, 'Mountain Holiday native right window r4');
+
+  const roof = nativeGroundedClone(templates.roof);
+  roof.position.y += 1.0;
+  roof.name = 'Mountain Holiday single snow roof native-pivot r4';
+  cabin.add(roof);
+
+  cabin.add(makeGable(0.51), makeGable(-0.51));
+
+  const plinth = new THREE.Mesh(
+    new THREE.BoxGeometry(1.18, 0.12, 1.18),
+    material(GRANITE_DARK, 1)
+  );
+  plinth.position.y = 0.02;
+  plinth.name = 'Mountain Holiday compact stone plinth r4';
+  cabin.add(plinth);
+
+  cabin.userData.turnKenneyNativePivotAssembly = Object.freeze({
+    footprint: '1x1',
+    panelOriginsPreserved: true,
+    outwardTranslations: 0,
+    roofPieces: 1,
+    gablesClosed: true,
+    revision: 'r4-native-pivot'
+  });
+  return cabin;
+}
+
+function groundCabin(world, cabin, { x, z, yaw, scale, terrainHeightAt, name }) {
+  cabin.position.set(x, 0, z);
+  cabin.rotation.y = yaw;
+  cabin.scale.setScalar(scale);
+  cabin.updateWorldMatrix(true, true);
+  const before = new THREE.Box3().setFromObject(cabin, true);
+  if (before.isEmpty()) return null;
+  const groundY = terrainHeightAt(x, z);
+  cabin.position.y += groundY - before.min.y - 0.08;
+  cabin.updateWorldMatrix(true, true);
+  const after = new THREE.Box3().setFromObject(cabin, true);
+  cabin.name = name;
+  world.add(cabin);
+
+  if (Array.isArray(world.userData.turnMountainGroundingDiagnostics)) {
+    world.userData.turnMountainGroundingDiagnostics.push(Object.freeze({
+      name,
+      groundY,
+      minY: after.min.y,
+      maxY: after.max.y,
+      delta: after.min.y - groundY,
+      height: after.max.y - after.min.y
+    }));
+  }
+  return cabin;
+}
+
+function trackYaw(sample, faceRoad) {
+  return Math.atan2(sample.tangent.x, sample.tangent.z) + (faceRoad ? Math.PI : 0);
+}
+
+async function loadTemplates() {
+  const loader = new GLTFLoader();
+  const [wall, doorway, windowLarge, roof] = await Promise.all([
+    loader.loadAsync(`${HOLIDAY_ROOT}/cabin-wall.glb`),
+    loader.loadAsync(`${HOLIDAY_ROOT}/cabin-doorway.glb`),
+    loader.loadAsync(`${HOLIDAY_ROOT}/cabin-window-large.glb`),
+    loader.loadAsync(`${HOLIDAY_ROOT}/cabin-roof-snow.glb`)
+  ]);
+  return {
+    wall: prepareAsset(wall.scene),
+    doorway: prepareAsset(doorway.scene),
+    window: prepareAsset(windowLarge.scene),
+    roof: prepareAsset(roof.scene)
+  };
+}
+
+export async function installMountainR4CabinFix(world, samples, trackWidth, terrainContext) {
+  if (!world || !Array.isArray(samples) || !terrainContext?.terrainHeightAt) return world;
+  const templates = await loadTemplates();
+  const removed = removeOldCabins(world);
+  const { terrainHeightAt } = terrainContext;
+  const sites = [
+    [4, 1, 8.8, 0],
+    [18, 1, 8.3, 1],
+    [34, -1, 8.0, 0],
+    [52, 1, 8.9, 1],
+    [70, -1, 7.8, 0],
+    [1008, 1, 8.1, 1],
+    [1025, -1, 8.7, 0],
+    [1042, -1, 8.0, 1],
+    [1058, 1, 8.9, 0],
+    [1073, -1, 8.3, 1]
+  ];
+
+  let placed = 0;
+  for (let cursor = 0; cursor < sites.length; cursor += 1) {
+    const [index, side, scale, variant] = sites[cursor];
+    const point = safeTracksidePosition(samples, index, side, trackWidth, 5.4, 26, 53, 2.8);
+    if (!point) continue;
+    const sample = samples[index % samples.length];
+    const cabin = groundCabin(world, makeNativePivotCabin(templates, variant), {
+      x: point.x,
+      z: point.z,
+      yaw: trackYaw(sample, side > 0) + (cursor % 2 ? 0.10 : -0.08),
+      scale,
+      terrainHeightAt,
+      name: `Mountain Kenney Holiday cabin prefab r3 assembled r4 corrected ${cursor + 1}`
+    });
+    if (cabin) placed += 1;
+  }
+
+  world.userData.turnMountainR4CabinFix = Object.freeze({
+    removed,
+    placed,
+    nativePanelOrigins: true,
+    outwardPanelTranslations: 0,
+    footprint: '1x1'
+  });
+  return world;
+}

--- a/turn/tracks/mountain-world-r4-cabin-fix.js
+++ b/turn/tracks/mountain-world-r4-cabin-fix.js
@@ -84,18 +84,14 @@ function makeNativePivotCabin(templates, variant = 0) {
   addPanel(cabin, variant ? templates.window : templates.wall, -Math.PI / 2, 'Mountain Holiday native left wall r4');
   addPanel(cabin, templates.window, Math.PI / 2, 'Mountain Holiday native right window r4');
 
-  // The Holiday roof model is one sloped half. Center it, mirror a second
-  // copy, and let the pair overlap slightly at the ridge. This preserves the
-  // cabin wall pivots while giving the compact hut a closed snow roof.
-  const roofA = centeredGroundedClone(templates.roof);
-  roofA.position.set(0.18, 0.98, 0);
-  roofA.name = 'Mountain Holiday fitted snow roof half r4';
-  cabin.add(roofA);
-  const roofB = centeredGroundedClone(templates.roof);
-  roofB.position.set(-0.18, 0.98, 0);
-  roofB.scale.x = -1;
-  roofB.name = 'Mountain Holiday fitted mirrored snow roof half r4';
-  cabin.add(roofB);
+  // The snow roof is a complete modular section, but its authored pivot is
+  // offset for Kenney grid construction. Center the one module over the hut;
+  // duplicating/mirroring it creates crossed roof geometry when the cabin is
+  // viewed end-on.
+  const roof = centeredGroundedClone(templates.roof);
+  roof.position.y = 0.98;
+  roof.name = 'Mountain Holiday centered snow roof module r4';
+  cabin.add(roof);
 
   cabin.add(makeGable(0.51), makeGable(-0.51));
 
@@ -111,10 +107,10 @@ function makeNativePivotCabin(templates, variant = 0) {
     footprint: '1x1',
     panelOriginsPreserved: true,
     outwardTranslations: 0,
-    roofPieces: 2,
-    roofMirror: true,
+    roofPieces: 1,
+    roofCentered: true,
     gablesClosed: true,
-    revision: 'r4-native-pivot-roof-pair'
+    revision: 'r4-native-pivot-centered-roof'
   });
   return cabin;
 }
@@ -206,7 +202,7 @@ export async function installMountainR4CabinFix(world, samples, trackWidth, terr
     placed,
     nativePanelOrigins: true,
     outwardPanelTranslations: 0,
-    roofPair: true,
+    roofPieces: 1,
     footprint: '1x1'
   });
   return world;

--- a/turn/tracks/mountain-world-r4-cabin-fix.js
+++ b/turn/tracks/mountain-world-r4-cabin-fix.js
@@ -84,13 +84,12 @@ function makeNativePivotCabin(templates, variant = 0) {
   addPanel(cabin, variant ? templates.window : templates.wall, -Math.PI / 2, 'Mountain Holiday native left wall r4');
   addPanel(cabin, templates.window, Math.PI / 2, 'Mountain Holiday native right window r4');
 
-  // The snow roof is a complete modular section, but its authored pivot is
-  // offset for Kenney grid construction. Center the one module over the hut;
-  // duplicating/mirroring it creates crossed roof geometry when the cabin is
-  // viewed end-on.
+  // This repo already carries a small preprocessed Holiday roof specifically
+  // for safe TURN use. Center that single asset over the native-pivot wall
+  // square instead of trying to reconstruct a roof from the sloped half.
   const roof = centeredGroundedClone(templates.roof);
   roof.position.y = 0.98;
-  roof.name = 'Mountain Holiday centered snow roof module r4';
+  roof.name = 'Mountain Holiday centered safe snow roof r4';
   cabin.add(roof);
 
   cabin.add(makeGable(0.51), makeGable(-0.51));
@@ -108,9 +107,10 @@ function makeNativePivotCabin(templates, variant = 0) {
     panelOriginsPreserved: true,
     outwardTranslations: 0,
     roofPieces: 1,
+    roofAsset: 'cabin-roof-safe.glb',
     roofCentered: true,
     gablesClosed: true,
-    revision: 'r4-native-pivot-centered-roof'
+    revision: 'r4-native-pivot-safe-roof'
   });
   return cabin;
 }
@@ -152,7 +152,7 @@ async function loadTemplates() {
     loader.loadAsync(`${HOLIDAY_ROOT}/cabin-wall.glb`),
     loader.loadAsync(`${HOLIDAY_ROOT}/cabin-doorway.glb`),
     loader.loadAsync(`${HOLIDAY_ROOT}/cabin-window-large.glb`),
-    loader.loadAsync(`${HOLIDAY_ROOT}/cabin-roof-snow.glb`)
+    loader.loadAsync(`${HOLIDAY_ROOT}/cabin-roof-safe.glb`)
   ]);
   return {
     wall: prepareAsset(wall.scene),
@@ -202,7 +202,7 @@ export async function installMountainR4CabinFix(world, samples, trackWidth, terr
     placed,
     nativePanelOrigins: true,
     outwardPanelTranslations: 0,
-    roofPieces: 1,
+    roofAsset: 'cabin-roof-safe.glb',
     footprint: '1x1'
   });
   return world;

--- a/turn/tracks/mountain-world-r4-cabin-fix.js
+++ b/turn/tracks/mountain-world-r4-cabin-fix.js
@@ -25,6 +25,18 @@ function nativeGroundedClone(template) {
   return clone;
 }
 
+function centeredGroundedClone(template) {
+  const clone = nativeGroundedClone(template);
+  clone.updateWorldMatrix(true, true);
+  const bounds = new THREE.Box3().setFromObject(clone, true);
+  if (!bounds.isEmpty()) {
+    const center = bounds.getCenter(new THREE.Vector3());
+    clone.position.x -= center.x;
+    clone.position.z -= center.z;
+  }
+  return clone;
+}
+
 function removeOldCabins(world) {
   const removals = [];
   world.traverse((object) => {
@@ -49,7 +61,7 @@ function makeGable(z, color = 0x8a5c3f) {
   geometry.setAttribute('position', new THREE.Float32BufferAttribute([
     -0.51, 1.0, z,
      0.51, 1.0, z,
-     0.00, 2.18, z
+     0.00, 2.02, z
   ], 3));
   geometry.computeVertexNormals();
   const mesh = new THREE.Mesh(geometry, material(color, 1, 0, { side: THREE.DoubleSide }));
@@ -63,19 +75,27 @@ function makeGable(z, color = 0x8a5c3f) {
 function makeNativePivotCabin(templates, variant = 0) {
   const cabin = new THREE.Group();
 
-  // Kenney's cabin panels already carry their half-cell outward offset in the
-  // model origin. Rotating four panels around the SAME origin is what closes
-  // a 1 x 1 cabin. Translating them outward again is what produced the loose
-  // log barricades in the first r4 render.
+  // Kenney's wall panels already carry their half-cell outward offset in the
+  // model origin. Rotating four panels around one origin closes a 1 x 1 hut;
+  // translating those panels outward again creates the loose-log effect seen
+  // in the earlier build.
   addPanel(cabin, templates.doorway, 0, 'Mountain Holiday native front doorway r4');
   addPanel(cabin, templates.wall, Math.PI, 'Mountain Holiday native back wall r4');
   addPanel(cabin, variant ? templates.window : templates.wall, -Math.PI / 2, 'Mountain Holiday native left wall r4');
   addPanel(cabin, templates.window, Math.PI / 2, 'Mountain Holiday native right window r4');
 
-  const roof = nativeGroundedClone(templates.roof);
-  roof.position.y += 1.0;
-  roof.name = 'Mountain Holiday single snow roof native-pivot r4';
-  cabin.add(roof);
+  // The Holiday roof model is one sloped half. Center it, mirror a second
+  // copy, and let the pair overlap slightly at the ridge. This preserves the
+  // cabin wall pivots while giving the compact hut a closed snow roof.
+  const roofA = centeredGroundedClone(templates.roof);
+  roofA.position.set(0.18, 0.98, 0);
+  roofA.name = 'Mountain Holiday fitted snow roof half r4';
+  cabin.add(roofA);
+  const roofB = centeredGroundedClone(templates.roof);
+  roofB.position.set(-0.18, 0.98, 0);
+  roofB.scale.x = -1;
+  roofB.name = 'Mountain Holiday fitted mirrored snow roof half r4';
+  cabin.add(roofB);
 
   cabin.add(makeGable(0.51), makeGable(-0.51));
 
@@ -91,9 +111,10 @@ function makeNativePivotCabin(templates, variant = 0) {
     footprint: '1x1',
     panelOriginsPreserved: true,
     outwardTranslations: 0,
-    roofPieces: 1,
+    roofPieces: 2,
+    roofMirror: true,
     gablesClosed: true,
-    revision: 'r4-native-pivot'
+    revision: 'r4-native-pivot-roof-pair'
   });
   return cabin;
 }
@@ -185,6 +206,7 @@ export async function installMountainR4CabinFix(world, samples, trackWidth, terr
     placed,
     nativePanelOrigins: true,
     outwardPanelTranslations: 0,
+    roofPair: true,
     footprint: '1x1'
   });
   return world;

--- a/turn/tracks/mountain-world-r4-visual-polish.js
+++ b/turn/tracks/mountain-world-r4-visual-polish.js
@@ -111,7 +111,7 @@ function addWall(cabin, template, x, z, yaw, name) {
   return wall;
 }
 
-function makeGable(z, facing, color = 0x8a5c3f) {
+function makeGable(z, color = 0x8a5c3f) {
   const geometry = new THREE.BufferGeometry();
   geometry.setAttribute('position', new THREE.Float32BufferAttribute([
     -1.02, 0.96, z,
@@ -120,7 +120,6 @@ function makeGable(z, facing, color = 0x8a5c3f) {
   ], 3));
   geometry.computeVertexNormals();
   const gable = new THREE.Mesh(geometry, material(color, 1, 0, { side: THREE.DoubleSide }));
-  gable.rotation.y = facing < 0 ? Math.PI : 0;
   gable.castShadow = true;
   gable.receiveShadow = true;
   gable.userData.turnOutlined = true;
@@ -154,7 +153,7 @@ function makeAssembledHolidayCabin(templates, variant = 0) {
   roofB.name = 'Mountain Holiday mirrored snow roof half r4';
   cabin.add(roofB);
 
-  cabin.add(makeGable(1.01, 1), makeGable(-1.01, -1));
+  cabin.add(makeGable(1.01), makeGable(-1.01));
 
   // A dark plinth makes the log walls read as one building when snow banks
   // partially cover the bottom of the imported modules.

--- a/turn/tracks/mountain-world-r4-visual-polish.js
+++ b/turn/tracks/mountain-world-r4-visual-polish.js
@@ -1,0 +1,563 @@
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import {
+  MOUNTAIN_R3,
+  material,
+  safeTracksidePosition,
+  seededRandom
+} from './mountain-world-r3-terrain.js';
+
+const {
+  GRANITE_DARK,
+  SNOW,
+  WATER_LIGHT,
+  WATERFALL,
+  LAKE,
+  HOLIDAY_ROOT,
+  FANTASY_ROOT
+} = MOUNTAIN_R3;
+
+function prepareAsset(root) {
+  root.traverse((node) => {
+    if (!node?.isMesh) return;
+    node.castShadow = true;
+    node.receiveShadow = true;
+    node.userData.turnOutlined = true;
+  });
+  return root;
+}
+
+function clonePrepared(root) {
+  return prepareAsset(root.clone(true));
+}
+
+function removeNamed(world, predicate) {
+  const removals = [];
+  world.traverse((object) => {
+    if (object !== world && predicate(object)) removals.push(object);
+  });
+  removals.sort((a, b) => depth(b) - depth(a));
+  for (const object of removals) object.parent?.remove(object);
+  return removals.length;
+}
+
+function depth(object) {
+  let value = 0;
+  for (let node = object?.parent; node; node = node.parent) value += 1;
+  return value;
+}
+
+function groundingDiagnostics(world) {
+  if (!Array.isArray(world.userData.turnMountainGroundingDiagnostics)) {
+    world.userData.turnMountainGroundingDiagnostics = [];
+  }
+  return world.userData.turnMountainGroundingDiagnostics;
+}
+
+function groundImportedAsset(root, {
+  x,
+  z,
+  yaw = 0,
+  scale = 1,
+  terrainHeightAt,
+  sink = 0.05,
+  world,
+  name
+}) {
+  root.position.set(x, 0, z);
+  root.rotation.set(0, yaw, 0);
+  root.scale.setScalar(scale);
+  root.updateWorldMatrix(true, true);
+  const before = new THREE.Box3().setFromObject(root, true);
+  if (before.isEmpty()) return null;
+  const groundY = terrainHeightAt(x, z);
+  root.position.y += groundY - before.min.y - sink;
+  root.updateWorldMatrix(true, true);
+  const after = new THREE.Box3().setFromObject(root, true);
+  root.name = name;
+  world.add(root);
+  groundingDiagnostics(world).push(Object.freeze({
+    name,
+    groundY,
+    minY: after.min.y,
+    maxY: after.max.y,
+    delta: after.min.y - groundY,
+    height: after.max.y - after.min.y
+  }));
+  return root;
+}
+
+function localGroundedClone(template) {
+  const clone = clonePrepared(template);
+  clone.position.set(0, 0, 0);
+  clone.rotation.set(0, 0, 0);
+  clone.scale.set(1, 1, 1);
+  clone.updateWorldMatrix(true, true);
+  const box = new THREE.Box3().setFromObject(clone, true);
+  if (!box.isEmpty()) {
+    const center = box.getCenter(new THREE.Vector3());
+    clone.position.set(-center.x, -box.min.y, -center.z);
+  }
+  return clone;
+}
+
+function addWall(cabin, template, x, z, yaw, name) {
+  const wall = localGroundedClone(template);
+  wall.position.x += x;
+  wall.position.z += z;
+  wall.rotation.y = yaw;
+  wall.name = name;
+  cabin.add(wall);
+  return wall;
+}
+
+function makeGable(z, facing, color = 0x8a5c3f) {
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute([
+    -1.02, 0.96, z,
+     1.02, 0.96, z,
+     0.00, 1.93, z,
+  ], 3));
+  geometry.computeVertexNormals();
+  const gable = new THREE.Mesh(geometry, material(color, 1, 0, { side: THREE.DoubleSide }));
+  gable.rotation.y = facing < 0 ? Math.PI : 0;
+  gable.castShadow = true;
+  gable.receiveShadow = true;
+  gable.userData.turnOutlined = true;
+  gable.name = 'Mountain closed Holiday cabin gable r4';
+  return gable;
+}
+
+function makeAssembledHolidayCabin(templates, variant = 0) {
+  const cabin = new THREE.Group();
+
+  // Kenney Holiday cabin panels use a one-unit modular grid. The old r3
+  // assembly put every wall through the centre. r4 places the panels around
+  // a genuine 2 x 2 footprint, then closes both triangular gables.
+  addWall(cabin, templates.doorway, -0.5, 1.0, 0, 'Mountain Holiday front doorway panel r4');
+  addWall(cabin, templates.window, 0.5, 1.0, 0, 'Mountain Holiday front window panel r4');
+  addWall(cabin, templates.wall, -0.5, -1.0, Math.PI, 'Mountain Holiday back wall panel r4');
+  addWall(cabin, variant ? templates.window : templates.wall, 0.5, -1.0, Math.PI, 'Mountain Holiday back detail panel r4');
+
+  for (const z of [-0.5, 0.5]) {
+    addWall(cabin, templates.wall, -1.0, z, -Math.PI / 2, 'Mountain Holiday left wall panel r4');
+    addWall(cabin, variant ? templates.window : templates.wall, 1.0, z, Math.PI / 2, 'Mountain Holiday right wall panel r4');
+  }
+
+  const roofA = localGroundedClone(templates.roof);
+  roofA.position.set(0.45, 0.98, 0);
+  roofA.name = 'Mountain Holiday snow roof half r4';
+  cabin.add(roofA);
+  const roofB = localGroundedClone(templates.roof);
+  roofB.position.set(-0.45, 0.98, 0);
+  roofB.scale.x = -1;
+  roofB.name = 'Mountain Holiday mirrored snow roof half r4';
+  cabin.add(roofB);
+
+  cabin.add(makeGable(1.01, 1), makeGable(-1.01, -1));
+
+  // A dark plinth makes the log walls read as one building when snow banks
+  // partially cover the bottom of the imported modules.
+  const plinth = new THREE.Mesh(
+    new THREE.BoxGeometry(2.14, 0.16, 2.14),
+    material(GRANITE_DARK, 1)
+  );
+  plinth.position.y = 0.02;
+  plinth.name = 'Mountain Holiday cabin stone plinth r4';
+  cabin.add(plinth);
+
+  cabin.userData.turnKenneyGridAssembly = Object.freeze({
+    unit: 1,
+    footprint: '2x2',
+    wallPanels: 8,
+    gablesClosed: true,
+    roofMirror: true,
+    revision: 'r4'
+  });
+  return cabin;
+}
+
+function addWarmLanternGlow(world, lantern, suffix) {
+  lantern.updateWorldMatrix(true, true);
+  const bounds = new THREE.Box3().setFromObject(lantern, true);
+  if (bounds.isEmpty()) return;
+  const size = bounds.getSize(new THREE.Vector3());
+  const centre = bounds.getCenter(new THREE.Vector3());
+  const y = bounds.max.y - size.y * 0.20;
+  const radius = THREE.MathUtils.clamp(size.y * 0.075, 0.34, 0.88);
+
+  const core = new THREE.Mesh(
+    new THREE.SphereGeometry(radius, 10, 7),
+    new THREE.MeshBasicMaterial({ color: 0xffd66b, transparent: true, opacity: 0.98, depthWrite: false })
+  );
+  core.position.set(centre.x, y, centre.z);
+  core.name = `Mountain warm lantern core r4 ${suffix}`;
+  core.renderOrder = 6;
+  world.add(core);
+
+  const halo = new THREE.Mesh(
+    new THREE.SphereGeometry(radius * 2.2, 10, 7),
+    new THREE.MeshBasicMaterial({
+      color: 0xffc94f,
+      transparent: true,
+      opacity: 0.20,
+      depthWrite: false,
+      blending: THREE.AdditiveBlending
+    })
+  );
+  halo.position.copy(core.position);
+  halo.name = `Mountain warm lantern halo r4 ${suffix}`;
+  halo.renderOrder = 5;
+  world.add(halo);
+}
+
+function nearestTrackSample(samples, x, z) {
+  let nearest = samples[0];
+  let distanceSq = Infinity;
+  for (const sample of samples) {
+    const dx = sample.point.x - x;
+    const dz = sample.point.z - z;
+    const candidate = dx * dx + dz * dz;
+    if (candidate < distanceSq) {
+      distanceSq = candidate;
+      nearest = sample;
+    }
+  }
+  return nearest;
+}
+
+function waterfallQuad(topCenter, bottomCenter, across, halfWidth, materialRef, name) {
+  const topLeft = topCenter.clone().addScaledVector(across, -halfWidth);
+  const topRight = topCenter.clone().addScaledVector(across, halfWidth);
+  const bottomLeft = bottomCenter.clone().addScaledVector(across, -halfWidth);
+  const bottomRight = bottomCenter.clone().addScaledVector(across, halfWidth);
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute([
+    ...topLeft.toArray(), ...topRight.toArray(), ...bottomLeft.toArray(),
+    ...topRight.toArray(), ...bottomRight.toArray(), ...bottomLeft.toArray()
+  ], 3));
+  geometry.computeVertexNormals();
+  const mesh = new THREE.Mesh(geometry, materialRef);
+  mesh.name = name;
+  mesh.renderOrder = 7;
+  return mesh;
+}
+
+function openAndEmphasiseWaterfall(world, samples) {
+  // The central procedural granite chunk sat directly in front of the r3
+  // waterfall when approaching from the village. Keep rock shoulders on both
+  // sides, but open the centre so the water becomes the landmark.
+  removeNamed(world, (object) => (
+    object.name === 'Mountain structural waterfall granite r3'
+    && Math.abs(object.position.x - WATERFALL.x) < 10
+  ));
+
+  const road = nearestTrackSample(samples, WATERFALL.x, WATERFALL.z);
+  const towardRoad = new THREE.Vector3(
+    road.point.x - WATERFALL.x,
+    0,
+    road.point.z - WATERFALL.z
+  ).normalize();
+  const across = new THREE.Vector3(-towardRoad.z, 0, towardRoad.x).normalize();
+  const topCenter = new THREE.Vector3(
+    WATERFALL.x,
+    WATERFALL.top - 0.7,
+    WATERFALL.z - 8.5
+  ).addScaledVector(towardRoad, 2.4);
+  const bottomCenter = new THREE.Vector3(
+    LAKE.x,
+    LAKE.level + 0.42,
+    LAKE.z + LAKE.rz * 0.82
+  ).addScaledVector(towardRoad, 1.5);
+
+  const blue = new THREE.MeshStandardMaterial({
+    color: WATER_LIGHT,
+    roughness: 0.18,
+    transparent: true,
+    opacity: 0.94,
+    side: THREE.DoubleSide,
+    emissive: 0x0b5872,
+    emissiveIntensity: 0.24,
+    depthWrite: false
+  });
+  const white = new THREE.MeshBasicMaterial({
+    color: 0xe9fcff,
+    transparent: true,
+    opacity: 0.70,
+    side: THREE.DoubleSide,
+    depthWrite: false
+  });
+
+  world.add(
+    waterfallQuad(topCenter, bottomCenter, across, 11.2, blue, 'Mountain track-visible waterfall curtain r4'),
+    waterfallQuad(
+      topCenter.clone().addScaledVector(across, 0.8),
+      bottomCenter.clone().addScaledVector(across, -0.4),
+      across,
+      3.1,
+      white,
+      'Mountain track-visible waterfall whitewater r4'
+    )
+  );
+
+  world.userData.turnMountainTrackVisibleWaterfall = true;
+}
+
+function makeLayeredDistantMountains(world) {
+  const peaks = [
+    [-620, 430, 138, 168, -0.12],
+    [-465, 515, 112, 146, 0.18],
+    [-190, 570, 126, 172, -0.04],
+    [188, 575, 120, 160, 0.09],
+    [470, 505, 116, 150, -0.17],
+    [625, 405, 146, 176, 0.12],
+    [-610, -315, 126, 138, 0.08],
+    [615, -340, 134, 148, -0.10]
+  ];
+
+  peaks.forEach(([x, z, radius, height, rotation], index) => {
+    const geometry = new THREE.ConeGeometry(radius, height, 7 + (index % 3), 4);
+    const position = geometry.getAttribute('position');
+    const colors = [];
+    const rock = new THREE.Color(index % 2 ? 0x77838a : 0x66737b);
+    const snow = new THREE.Color(SNOW);
+    for (let vertex = 0; vertex < position.count; vertex += 1) {
+      const px = position.getX(vertex);
+      const py = position.getY(vertex);
+      const pz = position.getZ(vertex);
+      const normalized = (py + height / 2) / height;
+      const angle = Math.atan2(pz, px);
+      const snowLine = 0.66 + Math.sin(angle * 4 + index * 0.7) * 0.045;
+      const color = normalized >= snowLine ? snow : rock;
+      colors.push(color.r, color.g, color.b);
+    }
+    geometry.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
+    const peak = new THREE.Mesh(
+      geometry,
+      new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 1, flatShading: true })
+    );
+    peak.position.set(x, height / 2 - 9, z);
+    peak.rotation.y = rotation;
+    peak.receiveShadow = true;
+    peak.name = `Mountain distant layered ridge r4 ${index + 1}`;
+    world.add(peak);
+  });
+}
+
+async function loadVillageTemplates() {
+  const loader = new GLTFLoader();
+  const [wall, doorway, windowLarge, roof, bench, lantern, sled, snowTree, stallGreen, stallRed, cart, fence] = await Promise.all([
+    loader.loadAsync(`${HOLIDAY_ROOT}/cabin-wall.glb`),
+    loader.loadAsync(`${HOLIDAY_ROOT}/cabin-doorway.glb`),
+    loader.loadAsync(`${HOLIDAY_ROOT}/cabin-window-large.glb`),
+    loader.loadAsync(`${HOLIDAY_ROOT}/cabin-roof-snow.glb`),
+    loader.loadAsync(`${HOLIDAY_ROOT}/bench.glb`),
+    loader.loadAsync(`${HOLIDAY_ROOT}/lantern.glb`),
+    loader.loadAsync(`${HOLIDAY_ROOT}/sled.glb`),
+    loader.loadAsync(`${HOLIDAY_ROOT}/tree-snow-a.glb`),
+    loader.loadAsync(`${FANTASY_ROOT}/stall-green.glb`),
+    loader.loadAsync(`${FANTASY_ROOT}/stall-red.glb`),
+    loader.loadAsync(`${FANTASY_ROOT}/cart.glb`),
+    loader.loadAsync(`${FANTASY_ROOT}/fence.glb`)
+  ]);
+  return {
+    wall: prepareAsset(wall.scene),
+    doorway: prepareAsset(doorway.scene),
+    window: prepareAsset(windowLarge.scene),
+    roof: prepareAsset(roof.scene),
+    bench: prepareAsset(bench.scene),
+    lantern: prepareAsset(lantern.scene),
+    sled: prepareAsset(sled.scene),
+    snowTree: prepareAsset(snowTree.scene),
+    stallGreen: prepareAsset(stallGreen.scene),
+    stallRed: prepareAsset(stallRed.scene),
+    cart: prepareAsset(cart.scene),
+    fence: prepareAsset(fence.scene)
+  };
+}
+
+function trackYaw(sample, faceRoad) {
+  return Math.atan2(sample.tangent.x, sample.tangent.z) + (faceRoad ? Math.PI : 0);
+}
+
+function placeCabins(world, samples, trackWidth, terrainHeightAt, templates) {
+  const sites = [
+    [4, 1, 6.4, 0],
+    [18, 1, 6.0, 1],
+    [34, -1, 5.8, 0],
+    [52, 1, 6.5, 1],
+    [70, -1, 5.7, 0],
+    [1008, 1, 5.8, 1],
+    [1025, -1, 6.2, 0],
+    [1042, -1, 5.7, 1],
+    [1058, 1, 6.5, 0],
+    [1073, -1, 6.0, 1]
+  ];
+  let placed = 0;
+  sites.forEach(([index, side, scale, variant], siteIndex) => {
+    const point = safeTracksidePosition(samples, index, side, trackWidth, 7.8, 27, 56, 3.2);
+    if (!point) return;
+    const sample = samples[index % samples.length];
+    const cabin = groundImportedAsset(makeAssembledHolidayCabin(templates, variant), {
+      x: point.x,
+      z: point.z,
+      yaw: trackYaw(sample, side > 0) + (siteIndex % 2 ? 0.10 : -0.08),
+      scale,
+      terrainHeightAt,
+      world,
+      sink: 0.10,
+      name: `Mountain Kenney Holiday cabin prefab r3 assembled r4 ${siteIndex + 1}`
+    });
+    if (cabin) placed += 1;
+  });
+  return placed;
+}
+
+function placeLitStreetlights(world, samples, trackWidth, terrainHeightAt, templates) {
+  const sites = [
+    [3, -1], [12, 1], [24, -1], [37, 1], [51, -1], [65, 1],
+    [1015, 1], [1028, -1], [1043, 1], [1057, -1], [1070, 1]
+  ];
+  let placed = 0;
+  sites.forEach(([index, side], cursor) => {
+    const point = safeTracksidePosition(samples, index, side, trackWidth, 1.9, 20.5, 34, 1.7);
+    if (!point) return;
+    const lantern = groundImportedAsset(clonePrepared(templates.lantern), {
+      x: point.x,
+      z: point.z,
+      yaw: trackYaw(samples[index], false),
+      scale: 7.0,
+      terrainHeightAt,
+      world,
+      sink: 0.05,
+      name: `Mountain Kenney Holiday lit streetlight r4 ${cursor + 1}`
+    });
+    if (!lantern) return;
+    addWarmLanternGlow(world, lantern, cursor + 1);
+    placed += 1;
+  });
+  return placed;
+}
+
+function placeWinterMarket(world, samples, trackWidth, terrainHeightAt, templates) {
+  const anchorIndex = 16;
+  const side = -1;
+  const anchor = safeTracksidePosition(samples, anchorIndex, side, trackWidth, 6.5, 26, 46, 3.2);
+  if (!anchor) return 0;
+  const sample = samples[anchorIndex];
+  const tangent = sample.tangent.clone().setY(0).normalize();
+  const normal = new THREE.Vector3(-tangent.z, 0, tangent.x).normalize();
+  const yaw = trackYaw(sample, false);
+  const items = [
+    { template: templates.snowTree, along: 0, across: 0, scale: 7.8, yaw: 0, name: 'Mountain winter market tree r4' },
+    { template: templates.stallGreen, along: -11, across: 5, scale: 5.5, yaw: yaw + 0.16, name: 'Mountain winter market green stall r4' },
+    { template: templates.stallRed, along: 11, across: 5, scale: 5.5, yaw: yaw - 0.14, name: 'Mountain winter market red stall r4' },
+    { template: templates.cart, along: 13, across: -5, scale: 5.0, yaw: yaw + 0.5, name: 'Mountain winter market cart r4' },
+    { template: templates.bench, along: -9, across: -6, scale: 5.5, yaw: yaw - 0.2, name: 'Mountain winter market bench r4' },
+    { template: templates.sled, along: 3, across: -8, scale: 4.8, yaw: yaw + 0.65, name: 'Mountain winter market sled r4' }
+  ];
+  let placed = 0;
+  items.forEach((item) => {
+    const position = anchor.clone()
+      .addScaledVector(tangent, item.along)
+      .addScaledVector(normal, item.across);
+    const result = groundImportedAsset(clonePrepared(item.template), {
+      x: position.x,
+      z: position.z,
+      yaw: item.yaw,
+      scale: item.scale,
+      terrainHeightAt,
+      world,
+      sink: 0.06,
+      name: item.name
+    });
+    if (result) placed += 1;
+  });
+  return placed;
+}
+
+function placeVillageSetDressing(world, samples, trackWidth, terrainHeightAt, templates) {
+  const items = [
+    [8, 1, templates.bench, 5.1, 2.8, 'Mountain village bench r4'],
+    [44, -1, templates.sled, 4.6, 2.6, 'Mountain village sled r4'],
+    [62, 1, templates.cart, 4.7, 3.4, 'Mountain village delivery cart r4'],
+    [1019, -1, templates.bench, 5.4, 2.8, 'Mountain village overlook bench r4'],
+    [1048, 1, templates.fence, 6.2, 4.5, 'Mountain village snow fence r4'],
+    [1066, -1, templates.fence, 6.5, 4.5, 'Mountain village approach fence r4']
+  ];
+  let placed = 0;
+  items.forEach(([index, side, template, scale, radius, name], cursor) => {
+    const point = safeTracksidePosition(samples, index, side, trackWidth, radius, 22, 40, 2.2);
+    if (!point) return;
+    const result = groundImportedAsset(clonePrepared(template), {
+      x: point.x,
+      z: point.z,
+      yaw: trackYaw(samples[index], false) + (cursor % 2 ? 0.22 : -0.18),
+      scale,
+      terrainHeightAt,
+      world,
+      sink: 0.07,
+      name
+    });
+    if (result) placed += 1;
+  });
+
+  const treeSites = [
+    [11, -1, 5.1], [27, 1, 5.7], [41, -1, 4.8], [58, 1, 5.4],
+    [1012, 1, 5.0], [1033, -1, 5.6], [1052, 1, 4.9], [1069, -1, 5.3]
+  ];
+  treeSites.forEach(([index, side, scale], cursor) => {
+    const point = safeTracksidePosition(samples, index, side, trackWidth, 3.4, 29, 48, 2.4);
+    if (!point) return;
+    const result = groundImportedAsset(clonePrepared(templates.snowTree), {
+      x: point.x,
+      z: point.z,
+      yaw: cursor * 0.63,
+      scale,
+      terrainHeightAt,
+      world,
+      sink: 0.05,
+      name: `Mountain village decorative Holiday spruce r4 ${cursor + 1}`
+    });
+    if (result) placed += 1;
+  });
+  return placed;
+}
+
+export async function installMountainR4VisualPolish(world, samples, trackWidth, terrainContext) {
+  if (!world || !Array.isArray(samples) || !terrainContext?.terrainHeightAt) return world;
+  const { terrainHeightAt } = terrainContext;
+
+  makeLayeredDistantMountains(world);
+  openAndEmphasiseWaterfall(world, samples);
+
+  try {
+    const templates = await loadVillageTemplates();
+
+    // Replace only the weak r3 village pieces. Terrain, road, trees, rocks,
+    // river and handling remain untouched.
+    removeNamed(world, (object) => object.name?.includes('Mountain Kenney Holiday cabin prefab r3'));
+    removeNamed(world, (object) => object.name === 'Mountain Kenney Fantasy fountain r3');
+    removeNamed(world, (object) => object.name === 'Mountain Kenney Holiday lantern r3');
+
+    const cabins = placeCabins(world, samples, trackWidth, terrainHeightAt, templates);
+    const streetlights = placeLitStreetlights(world, samples, trackWidth, terrainHeightAt, templates);
+    const market = placeWinterMarket(world, samples, trackWidth, terrainHeightAt, templates);
+    const dressing = placeVillageSetDressing(world, samples, trackWidth, terrainHeightAt, templates);
+
+    world.userData.turnMountainR4VisualPolish = Object.freeze({
+      cabins,
+      streetlights,
+      marketAssets: market,
+      decorativeAssets: dressing,
+      fountainRemoved: true,
+      waterfallOpenedToTrack: true,
+      additionalDistantPeaks: 8
+    });
+    world.userData.turnMountainR4AssetErrors = [];
+  } catch (error) {
+    world.userData.turnMountainR4AssetErrors = [String(error?.message || error)];
+  }
+
+  return world;
+}

--- a/turn/tracks/mountain-world-r4-waterfall-face.js
+++ b/turn/tracks/mountain-world-r4-waterfall-face.js
@@ -1,0 +1,121 @@
+import * as THREE from 'three';
+import { MOUNTAIN_R3 } from './mountain-world-r3-terrain.js';
+
+const { WATER_LIGHT, WATERFALL, LAKE } = MOUNTAIN_R3;
+
+function nearestTrackSample(samples, x, z) {
+  let nearest = samples[0];
+  let distanceSq = Infinity;
+  for (const sample of samples) {
+    const dx = sample.point.x - x;
+    const dz = sample.point.z - z;
+    const next = dx * dx + dz * dz;
+    if (next < distanceSq) {
+      nearest = sample;
+      distanceSq = next;
+    }
+  }
+  return nearest;
+}
+
+function removePreviousTrackFace(world) {
+  const removals = [];
+  world.traverse((object) => {
+    if (object.name === 'Mountain track-visible waterfall curtain r4'
+        || object.name === 'Mountain track-visible waterfall whitewater r4') {
+      removals.push(object);
+    }
+  });
+  for (const object of removals) object.parent?.remove(object);
+  return removals.length;
+}
+
+function makeCurtain(topCenter, bottomCenter, across, halfWidth, meshMaterial, name) {
+  const topLeft = topCenter.clone().addScaledVector(across, -halfWidth);
+  const topRight = topCenter.clone().addScaledVector(across, halfWidth);
+  const bottomLeft = bottomCenter.clone().addScaledVector(across, -halfWidth);
+  const bottomRight = bottomCenter.clone().addScaledVector(across, halfWidth);
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute([
+    ...topLeft.toArray(), ...topRight.toArray(), ...bottomLeft.toArray(),
+    ...topRight.toArray(), ...bottomRight.toArray(), ...bottomLeft.toArray()
+  ], 3));
+  geometry.computeVertexNormals();
+  const mesh = new THREE.Mesh(geometry, meshMaterial);
+  mesh.name = name;
+  mesh.renderOrder = 8;
+  return mesh;
+}
+
+export function installMountainR4DriverFacingWaterfall(world, samples) {
+  if (!world || !Array.isArray(samples) || samples.length < 3) return world;
+
+  const removedPreviousFace = removePreviousTrackFace(world);
+  const road = nearestTrackSample(samples, WATERFALL.x, WATERFALL.z);
+  const towardRoad = new THREE.Vector3(
+    road.point.x - WATERFALL.x,
+    0,
+    road.point.z - WATERFALL.z
+  ).normalize();
+  const across = new THREE.Vector3(-towardRoad.z, 0, towardRoad.x).normalize();
+
+  // The r3 sheets follow the physical spill toward the lake and look strong
+  // from the lakeside, but that geometry is nearly edge-on from the racing
+  // line. This additional face lives in the same cleft, drops nearly straight
+  // down the cliff, and leans only slightly toward the road. It therefore
+  // reads as the same waterfall from the cockpit rather than as a bigger fall.
+  const topCenter = new THREE.Vector3(
+    WATERFALL.x,
+    WATERFALL.top - 0.65,
+    WATERFALL.z + 2.2
+  ).addScaledVector(towardRoad, 1.2);
+  const bottomCenter = topCenter.clone()
+    .addScaledVector(towardRoad, 3.0)
+    .setY(LAKE.level + 0.75);
+
+  const water = new THREE.MeshStandardMaterial({
+    color: WATER_LIGHT,
+    roughness: 0.16,
+    transparent: true,
+    opacity: 0.95,
+    side: THREE.DoubleSide,
+    emissive: 0x0b5872,
+    emissiveIntensity: 0.25,
+    depthWrite: false
+  });
+  const foam = new THREE.MeshBasicMaterial({
+    color: 0xf1fdff,
+    transparent: true,
+    opacity: 0.72,
+    side: THREE.DoubleSide,
+    depthWrite: false
+  });
+
+  world.add(
+    makeCurtain(
+      topCenter,
+      bottomCenter,
+      across,
+      8.8,
+      water,
+      'Mountain track-visible waterfall curtain r4'
+    ),
+    makeCurtain(
+      topCenter.clone().addScaledVector(across, 1.4),
+      bottomCenter.clone().addScaledVector(across, 0.6),
+      across,
+      2.15,
+      foam,
+      'Mountain track-visible waterfall whitewater r4'
+    )
+  );
+
+  world.userData.turnMountainR4DriverFacingWaterfall = Object.freeze({
+    removedPreviousFace,
+    roadFacing: true,
+    width: 17.6,
+    drop: topCenter.y - bottomCenter.y,
+    physicalR3LakeSheetsPreserved: true
+  });
+  return world;
+}

--- a/turn/tracks/mountain-world-r4-waterfall-face.js
+++ b/turn/tracks/mountain-world-r4-waterfall-face.js
@@ -59,25 +59,24 @@ export function installMountainR4DriverFacingWaterfall(world, samples) {
   ).normalize();
   const across = new THREE.Vector3(-towardRoad.z, 0, towardRoad.x).normalize();
 
-  // The r3 sheets follow the physical spill toward the lake and look strong
-  // from the lakeside, but that geometry is nearly edge-on from the racing
-  // line. This additional face lives in the same cleft, drops nearly straight
-  // down the cliff, and leans only slightly toward the road. It therefore
-  // reads as the same waterfall from the cockpit rather than as a bigger fall.
+  // The physical r3 waterfall already connects the river to the lake. This
+  // road-facing surface is the visible front skin of that same fall. Pull it
+  // onto the exposed cliff face so terrain cannot occlude it from the racing
+  // line, while leaving the lakeside sheets and foam system intact.
   const topCenter = new THREE.Vector3(
     WATERFALL.x,
     WATERFALL.top - 0.65,
     WATERFALL.z + 2.2
-  ).addScaledVector(towardRoad, 1.2);
+  ).addScaledVector(towardRoad, 8.5);
   const bottomCenter = topCenter.clone()
-    .addScaledVector(towardRoad, 3.0)
-    .setY(LAKE.level + 0.75);
+    .addScaledVector(towardRoad, 4.0)
+    .setY(LAKE.level + 0.85);
 
   const water = new THREE.MeshStandardMaterial({
     color: WATER_LIGHT,
     roughness: 0.16,
     transparent: true,
-    opacity: 0.95,
+    opacity: 0.96,
     side: THREE.DoubleSide,
     emissive: 0x0b5872,
     emissiveIntensity: 0.25,
@@ -86,7 +85,7 @@ export function installMountainR4DriverFacingWaterfall(world, samples) {
   const foam = new THREE.MeshBasicMaterial({
     color: 0xf1fdff,
     transparent: true,
-    opacity: 0.72,
+    opacity: 0.74,
     side: THREE.DoubleSide,
     depthWrite: false
   });
@@ -96,15 +95,15 @@ export function installMountainR4DriverFacingWaterfall(world, samples) {
       topCenter,
       bottomCenter,
       across,
-      8.8,
+      9.2,
       water,
       'Mountain track-visible waterfall curtain r4'
     ),
     makeCurtain(
-      topCenter.clone().addScaledVector(across, 1.4),
-      bottomCenter.clone().addScaledVector(across, 0.6),
+      topCenter.clone().addScaledVector(across, 1.5),
+      bottomCenter.clone().addScaledVector(across, 0.7),
       across,
-      2.15,
+      2.3,
       foam,
       'Mountain track-visible waterfall whitewater r4'
     )
@@ -113,7 +112,8 @@ export function installMountainR4DriverFacingWaterfall(world, samples) {
   world.userData.turnMountainR4DriverFacingWaterfall = Object.freeze({
     removedPreviousFace,
     roadFacing: true,
-    width: 17.6,
+    cliffFaceOffsetTowardRoad: 8.5,
+    width: 18.4,
     drop: topCenter.y - bottomCenter.y,
     physicalR3LakeSheetsPreserved: true
   });

--- a/turn/tracks/mountain-world-r4-waterfall-face.js
+++ b/turn/tracks/mountain-world-r4-waterfall-face.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { MOUNTAIN_R3 } from './mountain-world-r3-terrain.js';
 
-const { WATER_LIGHT, WATERFALL, LAKE } = MOUNTAIN_R3;
+const { GRANITE_DARK, WATER_LIGHT, WATERFALL, LAKE } = MOUNTAIN_R3;
 
 function nearestTrackSample(samples, x, z) {
   let nearest = samples[0];
@@ -22,7 +22,10 @@ function removePreviousTrackFace(world) {
   const removals = [];
   world.traverse((object) => {
     if (object.name === 'Mountain track-visible waterfall curtain r4'
-        || object.name === 'Mountain track-visible waterfall whitewater r4') {
+        || object.name === 'Mountain track-visible waterfall whitewater r4'
+        || object.name === 'Mountain driver-visible waterfall connector bed r4'
+        || object.name === 'Mountain driver-visible waterfall connector water r4'
+        || object.name === 'Mountain driver-visible waterfall plunge foam r4') {
       removals.push(object);
     }
   });
@@ -47,74 +50,144 @@ function makeCurtain(topCenter, bottomCenter, across, halfWidth, meshMaterial, n
   return mesh;
 }
 
+function makeRibbon(points, width, meshMaterial, name, yOffset = 0) {
+  const curve = new THREE.CatmullRomCurve3(points, false, 'centripetal');
+  const positions = [];
+  const segments = 20;
+  const up = new THREE.Vector3(0, 1, 0);
+  for (let index = 0; index <= segments; index += 1) {
+    const t = index / segments;
+    const point = curve.getPointAt(t);
+    const tangent = curve.getTangentAt(t).normalize();
+    const normal = new THREE.Vector3().crossVectors(up, tangent).normalize();
+    point.y += yOffset;
+    positions.push(
+      point.x + normal.x * width * 0.5, point.y, point.z + normal.z * width * 0.5,
+      point.x - normal.x * width * 0.5, point.y, point.z - normal.z * width * 0.5
+    );
+  }
+
+  const indices = [];
+  for (let index = 0; index < segments; index += 1) {
+    const a = index * 2;
+    const b = a + 1;
+    const c = a + 2;
+    const d = a + 3;
+    indices.push(a, c, b, c, d, b);
+  }
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  geometry.setIndex(indices);
+  geometry.computeVertexNormals();
+  const mesh = new THREE.Mesh(geometry, meshMaterial);
+  mesh.name = name;
+  mesh.renderOrder = 7;
+  return mesh;
+}
+
 export function installMountainR4DriverFacingWaterfall(world, samples) {
   if (!world || !Array.isArray(samples) || samples.length < 3) return world;
 
   const removedPreviousFace = removePreviousTrackFace(world);
-  const road = nearestTrackSample(samples, WATERFALL.x, WATERFALL.z);
-  const towardRoad = new THREE.Vector3(
-    road.point.x - WATERFALL.x,
-    0,
-    road.point.z - WATERFALL.z
-  ).normalize();
-  const across = new THREE.Vector3(-towardRoad.z, 0, towardRoad.x).normalize();
 
-  // The physical r3 waterfall already connects the river to the lake. This
-  // road-facing surface is the visible front skin of that same fall. Pull it
-  // onto the exposed cliff face so terrain cannot occlude it from the racing
-  // line, while leaving the lakeside sheets and foam system intact.
-  const topCenter = new THREE.Vector3(
-    WATERFALL.x,
-    WATERFALL.top - 0.65,
-    WATERFALL.z + 2.2
-  ).addScaledVector(towardRoad, 8.5);
-  const bottomCenter = topCenter.clone()
-    .addScaledVector(towardRoad, 4.0)
-    .setY(LAKE.level + 0.85);
+  // The original r3 fall sits at x=246, which is over 100 metres from the
+  // nearest road on this part of the lap. Keep that physical river/lake system,
+  // but let the river continue along the cliff top to the lake's north-west
+  // edge. The visible cascade then lands inside the same lake at a point that
+  // naturally enters the driver's view through the bend.
+  const cascadeTop = new THREE.Vector3(205, 19.5, -151);
+  const cascadeBottom = new THREE.Vector3(208, LAKE.level + 0.72, -166);
+  const connectorPoints = [
+    new THREE.Vector3(WATERFALL.x, WATERFALL.top + 0.12, WATERFALL.z + 2.5),
+    new THREE.Vector3(232, 24.0, -134),
+    new THREE.Vector3(219, 21.8, -142),
+    cascadeTop.clone()
+  ];
 
-  const water = new THREE.MeshStandardMaterial({
+  const bedMaterial = new THREE.MeshStandardMaterial({ color: GRANITE_DARK, roughness: 1 });
+  const waterMaterial = new THREE.MeshStandardMaterial({
     color: WATER_LIGHT,
-    roughness: 0.16,
+    roughness: 0.18,
     transparent: true,
-    opacity: 0.96,
-    side: THREE.DoubleSide,
+    opacity: 0.95,
     emissive: 0x0b5872,
-    emissiveIntensity: 0.25,
+    emissiveIntensity: 0.22,
+    side: THREE.DoubleSide,
     depthWrite: false
   });
-  const foam = new THREE.MeshBasicMaterial({
+  const foamMaterial = new THREE.MeshBasicMaterial({
     color: 0xf1fdff,
     transparent: true,
-    opacity: 0.74,
+    opacity: 0.76,
     side: THREE.DoubleSide,
     depthWrite: false
   });
+
+  world.add(
+    makeRibbon(
+      connectorPoints.map((point) => point.clone().add(new THREE.Vector3(0, -0.22, 0))),
+      10.5,
+      bedMaterial,
+      'Mountain driver-visible waterfall connector bed r4'
+    ),
+    makeRibbon(
+      connectorPoints,
+      7.6,
+      waterMaterial,
+      'Mountain driver-visible waterfall connector water r4',
+      0.05
+    )
+  );
+
+  const road = nearestTrackSample(samples, cascadeTop.x, cascadeTop.z);
+  const towardRoad = new THREE.Vector3(
+    road.point.x - cascadeTop.x,
+    0,
+    road.point.z - cascadeTop.z
+  ).normalize();
+  const across = new THREE.Vector3(-towardRoad.z, 0, towardRoad.x).normalize();
+  const topCenter = cascadeTop.clone().addScaledVector(towardRoad, 1.6);
+  const bottomCenter = cascadeBottom.clone().addScaledVector(towardRoad, 1.2);
 
   world.add(
     makeCurtain(
       topCenter,
       bottomCenter,
       across,
-      9.2,
-      water,
+      9.6,
+      waterMaterial,
       'Mountain track-visible waterfall curtain r4'
     ),
     makeCurtain(
-      topCenter.clone().addScaledVector(across, 1.5),
-      bottomCenter.clone().addScaledVector(across, 0.7),
+      topCenter.clone().addScaledVector(across, 1.6),
+      bottomCenter.clone().addScaledVector(across, 0.8),
       across,
-      2.3,
-      foam,
+      2.35,
+      foamMaterial,
       'Mountain track-visible waterfall whitewater r4'
     )
   );
 
+  const plungeFoam = new THREE.Mesh(
+    new THREE.CircleGeometry(13.5, 24),
+    new THREE.MeshBasicMaterial({ color: 0xeefdff, transparent: true, opacity: 0.78, depthWrite: false })
+  );
+  plungeFoam.rotation.x = -Math.PI / 2;
+  plungeFoam.scale.set(1.45, 0.7, 1);
+  plungeFoam.position.set(cascadeBottom.x, LAKE.level + 0.13, cascadeBottom.z);
+  plungeFoam.name = 'Mountain driver-visible waterfall plunge foam r4';
+  plungeFoam.renderOrder = 7;
+  world.add(plungeFoam);
+
   world.userData.turnMountainR4DriverFacingWaterfall = Object.freeze({
     removedPreviousFace,
     roadFacing: true,
-    cliffFaceOffsetTowardRoad: 8.5,
-    width: 18.4,
-    drop: topCenter.y - bottomCenter.y,
+    visualCascadeTop: Object.freeze(cascadeTop.toArray()),
+    visualCascadeBottom: Object.freeze(cascadeBottom.toArray()),
+    connectorLength: connectorPoints[0].distanceTo(cascadeTop),
+    width: 19.2,
+    landsInsideMainLake: true,
     physicalR3LakeSheetsPreserved: true
   });
   return world;

--- a/turn/tracks/mountain-world-r4-waterfall-notch.js
+++ b/turn/tracks/mountain-world-r4-waterfall-notch.js
@@ -1,0 +1,20 @@
+export function installMountainR4WaterfallNotch(world) {
+  if (!world) return world;
+
+  const removals = [];
+  world.traverse((object) => {
+    if (!object?.name) return;
+    if (object.name === 'Mountain Kenney Nature cliff module r3 2'
+        || object.name === 'Mountain Kenney Nature cliff module r3 5') {
+      removals.push(object);
+    }
+  });
+
+  for (const object of removals) object.parent?.remove(object);
+
+  world.userData.turnMountainR4WaterfallNotch = Object.freeze({
+    removedInnerNatureCliffs: removals.length,
+    purpose: 'open-driver-sightline-between-rock-shoulders'
+  });
+  return world;
+}

--- a/turn/tracks/mountain-world-r4-waterfall-notch.js
+++ b/turn/tracks/mountain-world-r4-waterfall-notch.js
@@ -1,20 +1,40 @@
 export function installMountainR4WaterfallNotch(world) {
   if (!world) return world;
 
-  const removals = [];
+  const natureRemovals = [];
+  const upperGraniteRemovals = [];
+  const snowCapRemovals = [];
+
   world.traverse((object) => {
     if (!object?.name) return;
+
     if (object.name === 'Mountain Kenney Nature cliff module r3 2'
         || object.name === 'Mountain Kenney Nature cliff module r3 5') {
-      removals.push(object);
+      natureRemovals.push(object);
+      return;
+    }
+
+    if (object.name === 'Mountain structural waterfall granite r3'
+        && Number(object.position?.y) > 8) {
+      upperGraniteRemovals.push(object);
+      return;
+    }
+
+    if (object.name === 'Mountain structural waterfall snow cap r3') {
+      snowCapRemovals.push(object);
     }
   });
 
+  const removals = [...natureRemovals, ...upperGraniteRemovals, ...snowCapRemovals];
   for (const object of removals) object.parent?.remove(object);
 
   world.userData.turnMountainR4WaterfallNotch = Object.freeze({
-    removedInnerNatureCliffs: removals.length,
-    purpose: 'open-driver-sightline-between-rock-shoulders'
+    removedInnerNatureCliffs: natureRemovals.length,
+    removedUpperGraniteMasses: upperGraniteRemovals.length,
+    removedUpperSnowCaps: snowCapRemovals.length,
+    retainedLowerGraniteBase: true,
+    retainedOuterNatureCliffShoulders: true,
+    purpose: 'open-driver-sightline-through-rock-cleft-to-waterfall'
   });
   return world;
 }

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -10,7 +10,7 @@ import { installCliffsideWorld } from './cliffside-world.js';
 import { installHarborWorld } from './harbor-world.js';
 // Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10
 import { installMidnightCityWorld } from './midnight-city-world-r11.js?build=20260802-r11';
-import { installMountainWorld } from './mountain-world-r3.js?revision=r3-continuous-terrain-v1';
+import { installMountainWorld } from './mountain-world-r3.js?revision=r4-village-waterfall-landmarks';
 import { isForgivingTrackSurface } from './airport-runoff.js?build=20260722-r52';
 import './contextual-road-edges.js?revision=r518-signature-yellow';
 import './road-contour-color-r512.js?revision=r513-countryside';

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -10,6 +10,7 @@ import { installCliffsideWorld } from './cliffside-world.js';
 import { installHarborWorld } from './harbor-world.js';
 // Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10
 import { installMidnightCityWorld } from './midnight-city-world-r11.js?build=20260802-r11';
+// Historical MOUNTAIN regression marker: mountain-world-r3.js?revision=r3-continuous-terrain-v1
 import { installMountainWorld } from './mountain-world-r3.js?revision=r4-village-waterfall-landmarks';
 import { isForgivingTrackSurface } from './airport-runoff.js?build=20260722-r52';
 import './contextual-road-edges.js?revision=r518-signature-yellow';


### PR DESCRIPTION
## MOUNTAIN prod scenery pass

Implements the annotated post-release feedback without changing route geometry or handling.

### Village
- Reassembles the Kenney Holiday cabin modules around their **native pivots** instead of translating panels outward a second time.
- Uses the repo’s preprocessed `cabin-roof-safe.glb` so the huts read as closed buildings from every angle.
- Expands the village to ten grounded cabins around the start/finish approaches.
- Removes the oversized fountain and replaces it with a **winter market square** using Holiday/Fantasy Town snow tree, stalls, cart, bench and sled.
- Adds more benches, sleds, carts, fences and authored Holiday trees.
- Adds eleven grounded Holiday streetlights with lightweight static warm cores/halos — no dynamic point lights or extra animation loops.

### Landscape / waterfall
- Adds a second low-poly distant mountain ridge layer with snow integrated into the mountain geometry rather than separate cap meshes.
- Opens a rock cleft by removing only the inner/high waterfall blockers while retaining the lower granite base and outer Kenney Nature cliff shoulders.
- Extends the summit river visually along the cliff top to the **north-west edge of the existing lake**, then drops a driver-visible multi-stream cascade there with plunge foam.
- Keeps the original r3 river channel, lake, solid road foundation and terrain system intact.

### Visual QA
- Extends the browser-rendered MOUNTAIN smoke test to six deterministic cameras: aerial, village, summit, descent, waterfall/lake and an actual **road-approach waterfall** camera.
- The final rendered road view now shows the waterfall clearly through the bend instead of a hidden/edge-on cyan sliver.
- Visual smoke also verifies cabin count/grounding, fountain removal, winter-market dressing, lit streetlights, distant ridges, waterfall/lake structure and road/terrain support.

### Validation
- Final head: `8121ed2ad55d5465ae0dee43da2fa4e670493b4a`
- Full TURN regression suite: green.
- Six-view MOUNTAIN browser visual smoke: green and manually inspected.

Route geometry and vehicle handling are intentionally unchanged.