### PR TITLE
Replace MOUNTAIN cabins with Kenney Suburban houses

### DIFF
--- a/turn-lab/mountain-visual.html
+++ b/turn-lab/mountain-visual.html
@@ -18,8 +18,8 @@
   <script type="module">
     import * as THREE from 'three';
     import { createTrackRuntime } from '/turn/tracks/catalog.js';
-    import { installMountainWorld } from '/turn/tracks/mountain-world-r3.js?visual=4';
-    import { createMountainTerrainSampler, createMountainRiverSamples, offsetPoint, MOUNTAIN_R3 } from '/turn/tracks/mountain-world-r3-terrain.js?visual=4';
+    import { installMountainWorld } from '/turn/tracks/mountain-world-r3.js?visual=5';
+    import { createMountainTerrainSampler, createMountainRiverSamples, offsetPoint, MOUNTAIN_R3 } from '/turn/tracks/mountain-world-r3-terrain.js?visual=5';
 
     const VIEWS = Object.freeze({
       aerial: { position:[330,235,-345], target:[5,22,-10], fov:49 },
@@ -125,12 +125,14 @@
     const diagnostics = world.userData.turnMountainGroundingDiagnostics || [];
     const maxGroundingDelta = diagnostics.reduce((max, entry) => Math.max(max, Math.abs(entry.delta)), 0);
     const r4 = world.userData.turnMountainR4VisualPolish || {};
+    const r5 = world.userData.turnMountainR5SuburbanVillage || {};
 
     globalThis.__mountainVisualMetrics = Object.freeze({
       viewName,
       assetsReady: world.userData.turnMountainAssetsReady === true,
       assetErrors: [...(world.userData.turnMountainAssetErrors || [])],
       r4AssetErrors: [...(world.userData.turnMountainR4AssetErrors || [])],
+      r5AssetErrors: [...(world.userData.turnMountainR5AssetErrors || [])],
       maximumRoadSupportGap,
       maximumEdgeSupportGap,
       maximumRenderedRoadSupportGap,
@@ -146,6 +148,7 @@
       roadbedUndersides: count('closed roadbed underside r3'),
       cabins: count('Holiday cabin prefab r3'),
       assembledCabins: count('assembled r4'),
+      suburbanHouses: count('Mountain Kenney Suburban house r5'),
       marketStalls: count('Fantasy market stall'),
       winterMarketAssets: count('winter market'),
       fountains: count('Fantasy fountain r3'),
@@ -162,7 +165,11 @@
       windmills: names.filter((name) => /windmill/i.test(name)).length,
       r4CabinsReported: Number(r4.cabins || 0),
       r4StreetlightsReported: Number(r4.streetlights || 0),
-      r4MarketAssetsReported: Number(r4.marketAssets || 0)
+      r4MarketAssetsReported: Number(r4.marketAssets || 0),
+      r5SuburbanReported: Number(r5.placed || 0),
+      r5RemovedCabins: Number(r5.removedAssembledCabins || 0),
+      r5PaletteMode: String(r5.paletteMode || ''),
+      r5RequestedTypes: [...(r5.requestedTypes || [])]
     });
 
     renderer.render(scene,camera);

--- a/turn-tests/mountain-visual-smoke.mjs
+++ b/turn-tests/mountain-visual-smoke.mjs
@@ -47,16 +47,25 @@ assert.equal(browserErrors.length, 0, `Browser-rendered MOUNTAIN produced errors
 assert.equal(metrics.assetsReady, true, 'MOUNTAIN Kenney/Nature assets must finish loading before visual capture');
 assert.deepEqual(metrics.assetErrors, [], 'MOUNTAIN r3 asset loaders must not hide failed GLBs/textures');
 assert.deepEqual(metrics.r4AssetErrors, [], 'MOUNTAIN r4 village polish assets must load without hidden failures');
+assert.deepEqual(metrics.r5AssetErrors, [], 'MOUNTAIN r5 Suburban houses and recolored palette must load without hidden failures');
 assert.ok(metrics.terrainBodies >= 1, 'MOUNTAIN needs a continuous terrain body beneath the road');
 assert.ok(metrics.roadbedWalls >= 2, 'Both road edges need opaque roadbed side walls');
 assert.ok(metrics.deepFoundations >= 2, 'Both road edges need deep retaining foundations for close stacked hairpins');
 assert.ok(metrics.roadbedUndersides >= 1, 'The elevated road must have a closed underside');
 assert.equal(metrics.windmills, 0, 'A loose Fantasy Town windmill rotor must not return');
 
-assert.ok(metrics.assembledCabins >= 6,
-  `Expected a substantial village of correctly assembled Holiday cabins, got ${metrics.assembledCabins}`);
-assert.equal(metrics.assembledCabins, metrics.r4CabinsReported,
-  'Visual scene count and r4 cabin placement diagnostics must agree');
+assert.equal(metrics.assembledCabins, 0,
+  'The final MOUNTAIN village must not expose hand-assembled Holiday cabins');
+assert.ok(metrics.suburbanHouses >= 8,
+  `Expected a substantial village of complete Kenney City Kit Suburban houses, got ${metrics.suburbanHouses}`);
+assert.equal(metrics.suburbanHouses, metrics.r5SuburbanReported,
+  'Visual scene count and r5 Suburban placement diagnostics must agree');
+assert.deepEqual(metrics.r5RequestedTypes, ['a', 'g', 'm', 'n', 'u'],
+  'MOUNTAIN must use the requested A/G/M/N/U City Kit Suburban variants');
+assert.equal(metrics.r5PaletteMode, 'mountain-brown-snow',
+  'Suburban houses should use the MOUNTAIN dark-brown wall / snow-white roof palette');
+assert.ok(metrics.r5RemovedCabins >= 1,
+  'The Suburban pass must actively remove the old assembled cabin layer');
 assert.equal(metrics.fountains, 0, 'The oversized fountain must be removed from the finished village');
 assert.ok(metrics.winterMarketAssets >= 5,
   `The fountain replacement should read as a winter market square, got ${metrics.winterMarketAssets} assets`);

--- a/turn/tracks/mountain-world-r3.js
+++ b/turn/tracks/mountain-world-r3.js
@@ -5,7 +5,7 @@ import { installMountainR3Polish } from './mountain-world-r3-polish.js';
 import { installMountainR4VisualPolish } from './mountain-world-r4-visual-polish.js';
 import { installMountainR4WaterfallNotch } from './mountain-world-r4-waterfall-notch.js';
 import { installMountainR4DriverFacingWaterfall } from './mountain-world-r4-waterfall-face.js';
-import { installMountainR4CabinFix } from './mountain-world-r4-cabin-fix.js';
+import { installMountainR5SuburbanVillage } from './mountain-world-r5-suburban-village.js';
 
 export function installMountainWorld({ scene, samples, trackWidth = 27, runtime } = {}) {
   if (!scene || !Array.isArray(samples) || samples.length < 3) {
@@ -23,18 +23,19 @@ export function installMountainWorld({ scene, samples, trackWidth = 27, runtime 
     .then(() => installMountainR4VisualPolish(world, samples, trackWidth, terrainContext))
     .then(() => installMountainR4WaterfallNotch(world))
     .then(() => installMountainR4DriverFacingWaterfall(world, samples))
-    .then(() => installMountainR4CabinFix(world, samples, trackWidth, terrainContext))
+    .then(() => installMountainR5SuburbanVillage(world, samples, trackWidth, terrainContext))
     .then(() => world);
   world.userData.turnMountainTerrainHeightAt = terrainContext.terrainHeightAt;
   world.userData.turnMountainArtDirection = Object.freeze({
     version: 'r3',
-    visualPolish: 'r4-village-waterfall-landmarks-native-cabins',
+    visualPolish: 'r5-suburban-village-plus-r4-waterfall-landmarks',
     ground: 'continuous-snow-and-granite-terrain-body',
     roadEdge: 'white-with-black-outer-contour',
     roadbed: 'opaque-and-terrain-supported',
     retainingFoundation: '4.6m-granite-skirt',
     routeClearanceProtected: true,
-    assetVillage: 'Kenney-Holiday-native-pivot-cabins-and-Fantasy-Town-market',
+    assetVillage: 'Kenney-City-Kit-Suburban-complete-buildings-A-G-M-N-U',
+    villagePalette: 'dark-brown-walls-and-snow-white-roofs',
     villageSquare: 'winter-market-no-fountain',
     streetlights: 'warm-static-halos',
     waterfallCliff: 'terrain-plus-Kenney-Nature-rock-shoulders-open-at-centre',

--- a/turn/tracks/mountain-world-r5-suburban-village.js
+++ b/turn/tracks/mountain-world-r5-suburban-village.js
@@ -1,0 +1,249 @@
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { safeTracksidePosition } from './mountain-world-r3-terrain.js';
+
+const REVISION = 'r5-kenney-suburban-village';
+const ASSET_BASE = 'https://cdn.jsdelivr.net/gh/immaculate-lift-studio/CityCrafter3D@0831a1937a59562b6165ccfab30f64f35c957b6f/addons/citycrafter/assets/example_assets/kenney_city-kit-suburban_20/Models/GLB%20format/';
+const PALETTE_URL = `${ASSET_BASE}Textures/colormap.png`;
+const HOUSE_TYPES = Object.freeze(['a', 'g', 'm', 'n', 'u']);
+
+const SITES = Object.freeze([
+  Object.freeze({ index: 4, side: 1, type: 'a', height: 8.8, yaw: -0.08 }),
+  Object.freeze({ index: 18, side: 1, type: 'g', height: 9.4, yaw: 0.10 }),
+  Object.freeze({ index: 34, side: -1, type: 'm', height: 9.1, yaw: -0.06 }),
+  Object.freeze({ index: 52, side: 1, type: 'n', height: 10.5, yaw: 0.08 }),
+  Object.freeze({ index: 70, side: -1, type: 'u', height: 10.0, yaw: -0.10 }),
+  Object.freeze({ index: 1008, side: 1, type: 'u', height: 10.2, yaw: 0.08 }),
+  Object.freeze({ index: 1025, side: -1, type: 'n', height: 10.8, yaw: -0.06 }),
+  Object.freeze({ index: 1042, side: -1, type: 'm', height: 9.3, yaw: 0.07 }),
+  Object.freeze({ index: 1058, side: 1, type: 'g', height: 9.6, yaw: -0.08 }),
+  Object.freeze({ index: 1073, side: -1, type: 'a', height: 8.9, yaw: 0.06 })
+]);
+
+let palettePromise = null;
+
+function rgbToHsv(r, g, b) {
+  const rf = r / 255;
+  const gf = g / 255;
+  const bf = b / 255;
+  const max = Math.max(rf, gf, bf);
+  const min = Math.min(rf, gf, bf);
+  const delta = max - min;
+  let hue = 0;
+  if (delta > 1e-8) {
+    if (max === rf) hue = ((gf - bf) / delta) % 6;
+    else if (max === gf) hue = (bf - rf) / delta + 2;
+    else hue = (rf - gf) / delta + 4;
+    hue /= 6;
+    if (hue < 0) hue += 1;
+  }
+  return [hue, max <= 1e-8 ? 0 : delta / max, max];
+}
+
+function recolorPalettePixels(data) {
+  for (let offset = 0; offset < data.length; offset += 4) {
+    const r = data[offset];
+    const g = data[offset + 1];
+    const b = data[offset + 2];
+    const alpha = data[offset + 3];
+    if (!alpha || (r < 8 && g < 8 && b < 8)) continue;
+
+    const [hue, saturation, value] = rgbToHsv(r, g, b);
+
+    // City Kit Suburban uses a green family for its roofs. Turn that family
+    // into bright, slightly cool snow while preserving the palette shading.
+    if (hue >= 0.28 && hue <= 0.50 && saturation >= 0.22 && value >= 0.28) {
+      const shade = Math.round(210 + 45 * value);
+      data[offset] = Math.min(255, shade + 4);
+      data[offset + 1] = Math.min(255, shade + 6);
+      data[offset + 2] = Math.min(255, shade + 8);
+      continue;
+    }
+
+    // The houses' pale neutral wall family becomes dark-brown timber. Keep
+    // the value gradient so windows, eaves and wall facets still have depth.
+    if (saturation <= 0.22 && value >= 0.55) {
+      const blend = THREE.MathUtils.clamp((value - 0.55) / 0.45, 0, 1);
+      data[offset] = Math.round(THREE.MathUtils.lerp(66, 105, blend));
+      data[offset + 1] = Math.round(THREE.MathUtils.lerp(38, 64, blend));
+      data[offset + 2] = Math.round(THREE.MathUtils.lerp(22, 36, blend));
+    }
+  }
+}
+
+function loadImage(url) {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.crossOrigin = 'anonymous';
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error(`TURN: could not load Suburban palette ${url}`));
+    image.src = url;
+  });
+}
+
+async function createMountainPaletteUrl() {
+  if (palettePromise) return palettePromise;
+  palettePromise = (async () => {
+    if (typeof document === 'undefined') return PALETTE_URL;
+    const image = await loadImage(PALETTE_URL);
+    const canvas = document.createElement('canvas');
+    canvas.width = image.naturalWidth || image.width;
+    canvas.height = image.naturalHeight || image.height;
+    const context = canvas.getContext('2d', { willReadFrequently: true });
+    if (!context) return PALETTE_URL;
+    context.drawImage(image, 0, 0);
+    const pixels = context.getImageData(0, 0, canvas.width, canvas.height);
+    recolorPalettePixels(pixels.data);
+    context.putImageData(pixels, 0, 0);
+    return canvas.toDataURL('image/png');
+  })();
+  return palettePromise;
+}
+
+function createLoader(paletteUrl) {
+  const manager = new THREE.LoadingManager();
+  manager.setURLModifier((url) => /(?:^|\/)Textures\/colormap\.png(?:\?|$)/i.test(url) ? paletteUrl : url);
+  return new GLTFLoader(manager);
+}
+
+function prepareSource(root) {
+  root.traverse((node) => {
+    if (!node?.isMesh) return;
+    node.castShadow = true;
+    node.receiveShadow = true;
+    node.userData.turnOutlined = true;
+  });
+  return root;
+}
+
+function preparedBuilding(source, targetHeight) {
+  const building = prepareSource(source.clone(true));
+  building.position.set(0, 0, 0);
+  building.rotation.set(0, 0, 0);
+  building.scale.set(1, 1, 1);
+  building.updateWorldMatrix(true, true);
+
+  let bounds = new THREE.Box3().setFromObject(building, true);
+  if (bounds.isEmpty()) return null;
+  const size = bounds.getSize(new THREE.Vector3());
+  building.scale.setScalar(targetHeight / Math.max(0.001, size.y));
+  building.updateWorldMatrix(true, true);
+
+  bounds = new THREE.Box3().setFromObject(building, true);
+  const center = bounds.getCenter(new THREE.Vector3());
+  building.position.x -= center.x;
+  building.position.y -= bounds.min.y;
+  building.position.z -= center.z;
+  building.updateWorldMatrix(true, true);
+  return building;
+}
+
+function removeAssembledCabins(world) {
+  const removals = [];
+  world.traverse((object) => {
+    if (object === world || !object.name) return;
+    if (/Mountain .*Holiday.*cabin/i.test(object.name)
+        || /Mountain Kenney Holiday cabin prefab/i.test(object.name)) {
+      removals.push(object);
+    }
+  });
+  removals.sort((a, b) => objectDepth(b) - objectDepth(a));
+  for (const object of removals) object.parent?.remove(object);
+  return removals.length;
+}
+
+function objectDepth(object) {
+  let depth = 0;
+  for (let node = object?.parent; node; node = node.parent) depth += 1;
+  return depth;
+}
+
+function trackYaw(sample, side, adjustment) {
+  return Math.atan2(sample.tangent.x, sample.tangent.z)
+    + (side > 0 ? Math.PI : 0)
+    + adjustment;
+}
+
+function groundingDiagnostics(world) {
+  if (!Array.isArray(world.userData.turnMountainGroundingDiagnostics)) {
+    world.userData.turnMountainGroundingDiagnostics = [];
+  }
+  return world.userData.turnMountainGroundingDiagnostics;
+}
+
+function groundBuilding(world, building, spec, point, sample, terrainHeightAt) {
+  building.position.set(point.x, 0, point.z);
+  building.rotation.y = trackYaw(sample, spec.side, spec.yaw);
+  building.updateWorldMatrix(true, true);
+  const before = new THREE.Box3().setFromObject(building, true);
+  if (before.isEmpty()) return null;
+  const groundY = terrainHeightAt(point.x, point.z);
+  building.position.y += groundY - before.min.y - 0.06;
+  building.updateWorldMatrix(true, true);
+  const after = new THREE.Box3().setFromObject(building, true);
+  building.name = `Mountain Kenney Suburban house r5 type-${spec.type}`;
+  building.userData.turnKenneySuburbanAsset = `building-type-${spec.type}`;
+  building.userData.turnMountainVillageRevision = REVISION;
+  world.add(building);
+  groundingDiagnostics(world).push(Object.freeze({
+    name: building.name,
+    groundY,
+    minY: after.min.y,
+    maxY: after.max.y,
+    delta: after.min.y - groundY,
+    height: after.max.y - after.min.y
+  }));
+  return building;
+}
+
+async function loadSources() {
+  const paletteUrl = await createMountainPaletteUrl();
+  const loader = createLoader(paletteUrl);
+  const pairs = await Promise.all(HOUSE_TYPES.map(async (type) => {
+    const gltf = await loader.loadAsync(`${ASSET_BASE}building-type-${type}.glb`);
+    return [type, prepareSource(gltf.scene)];
+  }));
+  return { sourceByType: new Map(pairs), paletteUrl };
+}
+
+export async function installMountainR5SuburbanVillage(world, samples, trackWidth, terrainContext) {
+  if (!world || !Array.isArray(samples) || !terrainContext?.terrainHeightAt) return world;
+  const removed = removeAssembledCabins(world);
+  const errors = [];
+  let placed = 0;
+  let paletteMode = 'mountain-brown-snow';
+
+  try {
+    const { sourceByType, paletteUrl } = await loadSources();
+    if (paletteUrl === PALETTE_URL) paletteMode = 'original-fallback';
+
+    for (const spec of SITES) {
+      const source = sourceByType.get(spec.type);
+      if (!source) continue;
+      const building = preparedBuilding(source, spec.height);
+      if (!building) continue;
+      building.updateWorldMatrix(true, true);
+      const localBounds = new THREE.Box3().setFromObject(building, true);
+      const size = localBounds.getSize(new THREE.Vector3());
+      const radius = Math.max(size.x, size.z) * 0.56;
+      const point = safeTracksidePosition(samples, spec.index, spec.side, trackWidth, radius, 31, 64, 4.5);
+      if (!point) continue;
+      const sample = samples[spec.index % samples.length];
+      if (groundBuilding(world, building, spec, point, sample, terrainContext.terrainHeightAt)) placed += 1;
+    }
+  } catch (error) {
+    errors.push(String(error?.message || error));
+  }
+
+  world.userData.turnMountainR5SuburbanVillage = Object.freeze({
+    revision: REVISION,
+    removedAssembledCabins: removed,
+    placed,
+    requestedTypes: [...HOUSE_TYPES],
+    paletteMode,
+    source: 'Kenney City Kit Suburban',
+    completeBuildings: true
+  });
+  world.userData.turnMountainR5AssetErrors = errors;
+  return world;
+}

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -11,7 +11,7 @@ import { installHarborWorld } from './harbor-world.js';
 // Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10
 import { installMidnightCityWorld } from './midnight-city-world-r11.js?build=20260802-r11';
 // Historical MOUNTAIN regression marker: mountain-world-r3.js?revision=r3-continuous-terrain-v1
-import { installMountainWorld } from './mountain-world-r3.js?revision=r4-village-waterfall-landmarks';
+import { installMountainWorld } from './mountain-world-r3.js?revision=r5-suburban-village';
 import { isForgivingTrackSurface } from './airport-runoff.js?build=20260722-r52';
 import './contextual-road-edges.js?revision=r518-signature-yellow';
 import './road-contour-color-r512.js?revision=r513-countryside';


### PR DESCRIPTION
Replace the hand-assembled Holiday cabins in MOUNTAIN's finished scene with complete Kenney City Kit Suburban buildings using the requested A/G/M/N/U variants.

- reuse TURN's existing pinned Kenney Suburban source already used by CLIFFSIDE
- recolor the Suburban palette at load time to dark-brown walls and snow-white roofs
- keep the current village positions, winter market, lit streetlights, waterfall, terrain, route and handling
- remove assembled Holiday cabins from the final MOUNTAIN scene
- extend the six-view browser visual smoke test to require the complete Suburban village and requested five house variants
- bump the MOUNTAIN module revision so prod does not retain the old cabin layer