### PR TITLE
Turn MOUNTAIN into a moonlit night track

### DIFF
--- a/turn-lab/mountain-visual.html
+++ b/turn-lab/mountain-visual.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>TURN MOUNTAIN visual smoke</title>
   <style>
-    html,body{margin:0;width:100%;height:100%;overflow:hidden;background:#71cff1}
+    html,body{margin:0;width:100%;height:100%;overflow:hidden;background:#06132c}
     canvas{display:block;width:100%;height:100%}
     #label{position:fixed;left:12px;bottom:10px;padding:6px 9px;border:2px solid #08090a;border-radius:8px;background:#fff8e8;color:#08090a;font:700 13px/1.1 system-ui,sans-serif;letter-spacing:.06em;text-transform:uppercase;z-index:2}
   </style>
@@ -18,8 +18,8 @@
   <script type="module">
     import * as THREE from 'three';
     import { createTrackRuntime } from '/turn/tracks/catalog.js';
-    import { installMountainWorld } from '/turn/tracks/mountain-world-r3.js?visual=5';
-    import { createMountainTerrainSampler, createMountainRiverSamples, offsetPoint, MOUNTAIN_R3 } from '/turn/tracks/mountain-world-r3-terrain.js?visual=5';
+    import { installMountainWorld } from '/turn/tracks/mountain-world-r3.js?visual=6';
+    import { createMountainTerrainSampler, createMountainRiverSamples, offsetPoint, MOUNTAIN_R3 } from '/turn/tracks/mountain-world-r3-terrain.js?visual=6';
 
     const VIEWS = Object.freeze({
       aerial: { position:[330,235,-345], target:[5,22,-10], fov:49 },
@@ -35,8 +35,8 @@
     document.querySelector('#label').textContent = `MOUNTAIN · ${viewName}`;
 
     const scene = new THREE.Scene();
-    scene.background = new THREE.Color(0x71cff1);
-    scene.fog = new THREE.Fog(0xc6e0ea, 410, 1180);
+    scene.background = new THREE.Color(0x06132c);
+    scene.fog = new THREE.Fog(0x172744, 430, 1250);
     const camera = new THREE.PerspectiveCamera(50, innerWidth / innerHeight, 0.1, 1800);
     const renderer = new THREE.WebGLRenderer({ antialias:true, preserveDrawingBuffer:true, powerPreference:'low-power' });
     renderer.setPixelRatio(1);
@@ -45,10 +45,10 @@
     renderer.shadowMap.enabled = false;
     document.body.prepend(renderer.domElement);
 
-    scene.add(new THREE.HemisphereLight(0xd8f1ff, 0x617455, 1.18));
-    const sun = new THREE.DirectionalLight(0xfff2d4, 1.26);
-    sun.position.set(-160, 240, -110);
-    scene.add(sun);
+    scene.add(new THREE.HemisphereLight(0x5a78a8, 0x07101b, 0.56));
+    const moonlight = new THREE.DirectionalLight(0xb8d7ff, 0.92);
+    moonlight.position.set(-90, 150, 70);
+    scene.add(moonlight);
 
     const runtime = createTrackRuntime('mountain', 1080);
     const trackWidth = 27;
@@ -126,6 +126,7 @@
     const maxGroundingDelta = diagnostics.reduce((max, entry) => Math.max(max, Math.abs(entry.delta)), 0);
     const r4 = world.userData.turnMountainR4VisualPolish || {};
     const r5 = world.userData.turnMountainR5SuburbanVillage || {};
+    const r6 = world.userData.turnMountainR6Night || {};
 
     globalThis.__mountainVisualMetrics = Object.freeze({
       viewName,
@@ -133,6 +134,7 @@
       assetErrors: [...(world.userData.turnMountainAssetErrors || [])],
       r4AssetErrors: [...(world.userData.turnMountainR4AssetErrors || [])],
       r5AssetErrors: [...(world.userData.turnMountainR5AssetErrors || [])],
+      r6AssetErrors: [...(world.userData.turnMountainR6AssetErrors || [])],
       maximumRoadSupportGap,
       maximumEdgeSupportGap,
       maximumRenderedRoadSupportGap,
@@ -154,6 +156,11 @@
       fountains: count('Fantasy fountain r3'),
       litStreetlights: count('Holiday lit streetlight r4'),
       warmLanternHalos: count('warm lantern halo r4'),
+      nightStreetlightFills: count('Mountain warm streetlight fill r6'),
+      starSkydomes: count('Mountain star field skydome r6'),
+      moonSprites: count('Mountain full moon sprite r6'),
+      warmHouseWindowMeshes: count('Mountain warm house windows r6'),
+      warmHouseWindowHaloMeshes: count('Mountain warm house window halos r6'),
       decorativeVillageAssets: count('village ') + count('decorative Holiday spruce r4'),
       distantLayeredRidges: count('distant layered ridge r4'),
       waterfallCliffModules: count('Nature cliff module r3'),
@@ -169,7 +176,15 @@
       r5SuburbanReported: Number(r5.placed || 0),
       r5RemovedCabins: Number(r5.removedAssembledCabins || 0),
       r5PaletteMode: String(r5.paletteMode || ''),
-      r5RequestedTypes: [...(r5.requestedTypes || [])]
+      r5RequestedTypes: [...(r5.requestedTypes || [])],
+      r6StarSky: r6.starSky === true,
+      r6Moon: r6.moon === true,
+      r6StreetLightPoolCount: Number(r6.streetLightPoolCount || 0),
+      r6StreetLightPointLightCount: Number(r6.streetLightPointLightCount || 0),
+      r6LitHouseCount: Number(r6.litHouseCount || 0),
+      r6WindowPanelCount: Number(r6.windowPanelCount || 0),
+      r6HouseSpillLightCount: Number(r6.houseSpillLightCount || 0),
+      r6MoonlitWaterMaterials: Number(r6.moonlitWaterMaterials || 0)
     });
 
     renderer.render(scene,camera);

--- a/turn-tests/mountain-track-production.mjs
+++ b/turn-tests/mountain-track-production.mjs
@@ -8,10 +8,11 @@ import { TROPHY_ROAD_REWARDS, rewardForTrack } from '../turn/progression/trophy-
 import { TRACK_COLOR_CUES } from '../turn/accessibility/color-cues.js';
 import { TRACK_COLOR_RULES } from '../turn/achievements/chromatic-camouflage-r183.js';
 
-const [world, terrain, scenery, registry, trophyGate, kenneyAssets, visualPage, visualSmoke, visualWorkflow] = await Promise.all([
+const [world, terrain, scenery, night, registry, trophyGate, kenneyAssets, visualPage, visualSmoke, visualWorkflow] = await Promise.all([
   fs.readFile(new URL('../turn/tracks/mountain-world-r3.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/tracks/mountain-world-r3-terrain.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/tracks/mountain-world-r3-scenery.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/tracks/mountain-world-r6-night.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/tracks/registry.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/progression/m8-trophy-gate.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/assets/KENNEY-ASSETS.md', import.meta.url), 'utf8'),
@@ -36,6 +37,14 @@ assert.ok(closedLength(MOUNTAIN_CONTROL_POINTS) > 1500);
 assert.equal(findProperIntersections(MOUNTAIN_CONTROL_POINTS).length, 0);
 assert.ok(maximumTurn(MOUNTAIN_CONTROL_POINTS) < 100);
 
+assert.equal(definition.sky, 0x06132c, 'MOUNTAIN should use the deep-blue night fallback sky');
+assert.equal(definition.fog, 0x172744, 'MOUNTAIN fog should stay cool and moonlit');
+assert.equal(definition.lighting.hemisphereSky, 0x5a78a8);
+assert.equal(definition.lighting.hemisphereGround, 0x07101b);
+assert.equal(definition.lighting.hemisphereIntensity, 0.56);
+assert.equal(definition.lighting.directionalColor, 0xb8d7ff);
+assert.equal(definition.lighting.directionalIntensity, 0.92);
+
 const reward = rewardForTrack('mountain');
 assert.equal(reward?.id, 'mountain');
 assert.equal(reward?.threshold, 1000);
@@ -57,14 +66,48 @@ assert.deepEqual(
 assert.equal(TRACK_COLOR_CUES.mountain, 'blue');
 assert.deepEqual(TRACK_COLOR_RULES.mountain, { hueMin: 206, hueMax: 230, name: 'blue' });
 
-assert.match(registry, /mountain-world-r3\.js\?revision=r3-continuous-terrain-v1/);
+assert.match(registry, /mountain-world-r3\.js\?revision=r3-continuous-terrain-v1/,
+  'Keep the historical continuous-terrain regression marker');
+assert.match(registry, /mountain-world-r3\.js\?revision=r6-night-treatment/,
+  'Production must cache-bust to the MOUNTAIN night world revision');
 assert.match(world, /version: 'r3'/);
 assert.match(world, /continuous-snow-and-granite-terrain-body/);
 assert.match(world, /roadbed: 'opaque-and-terrain-supported'/);
 assert.match(world, /riverHasChannelBanksAndBed: true/);
 assert.match(world, /boundingBoxGroundedAssets: true/);
+assert.match(world, /installMountainR6Night/);
+assert.match(world, /nightSky: 'local-star-field-skydome-with-separate-moon-sprite'/);
+assert.match(world, /streetlights: 'warm-static-halos-plus-midnight-city-style-ground-pools-and-local-fill'/);
+assert.match(world, /houseWindows: 'warm-emissive-looking-panels-on-every-suburban-house-with-limited-local-spill'/);
+assert.match(world, /waterfallLight: 'cool-moonlit-emissive-water-surfaces'/);
 assert.match(world, /world\.ready = Promise\.resolve/);
 assert.doesNotMatch(world, /setAnimationLoop|requestAnimationFrame|setInterval/);
+
+assert.match(night, /mountain-night-sky\.jpg/);
+assert.match(night, /mountain-moon\.png/);
+assert.match(night, /Mountain star field skydome r6/);
+assert.match(night, /Mountain full moon sprite r6/);
+assert.match(night, /new THREE\.CircleGeometry\(11\.5, 24\)/,
+  'MOUNTAIN streetlight pools should reuse the established Midnight City footprint');
+assert.match(night, /new THREE\.PointLight\(WARM_LIGHT, 8\.4, 66, 1\.65\)/);
+assert.match(night, /Mountain warm house windows r6/);
+assert.match(night, /Mountain warm house window halos r6/);
+assert.match(night, /new THREE\.InstancedMesh/,
+  'Night windows and light pools must stay batched rather than becoming individual meshes');
+assert.match(night, /strengthenMoonlitWater/);
+assert.doesNotMatch(night, /setAnimationLoop|requestAnimationFrame|setInterval/,
+  'The night treatment must remain render-driven with no independent loop');
+
+const nightSkyAsset = await fs.readFile(new URL('../turn/assets/mountain/mountain-night-sky.jpg', import.meta.url));
+assert.equal(nightSkyAsset[0], 0xff, 'MOUNTAIN star field must remain a JPEG');
+assert.equal(nightSkyAsset[1], 0xd8, 'MOUNTAIN star field must remain a JPEG');
+assert.ok(nightSkyAsset.length < 20_000,
+  `MOUNTAIN star field should stay deliberately compact, got ${nightSkyAsset.length} bytes`);
+const moonAsset = await fs.readFile(new URL('../turn/assets/mountain/mountain-moon.png', import.meta.url));
+assert.deepEqual([...moonAsset.subarray(0, 8)], [0x89,0x50,0x4e,0x47,0x0d,0x0a,0x1a,0x0a],
+  'MOUNTAIN moon must remain a transparent-capable PNG');
+assert.ok(moonAsset.length < 10_000,
+  `MOUNTAIN moon should stay deliberately compact, got ${moonAsset.length} bytes`);
 
 assert.match(terrain, /Mountain continuous terrain body r3/);
 assert.match(terrain, /createMountainTerrainSampler/);
@@ -148,17 +191,21 @@ assert.match(kenneyAssets, /Fantasy Town/i);
 assert.match(kenneyAssets, /Nature Kit/i);
 assert.match(kenneyAssets, /bounding/i);
 assert.match(visualPage, /__mountainVisualMetrics/);
+assert.match(visualPage, /r6WindowPanelCount/);
 for (const view of ['aerial', 'village', 'summit', 'descent', 'waterfall']) {
   assert.match(visualPage, new RegExp(`${view}:`));
   assert.match(visualSmoke, new RegExp(`['"]${view}['"]`));
 }
+assert.match(visualSmoke, /r6StarSky/);
+assert.match(visualSmoke, /r6StreetLightPoolCount/);
+assert.match(visualSmoke, /r6WindowPanelCount/);
 assert.match(visualSmoke, /maximumRenderedRoadSupportGap/);
 assert.match(visualSmoke, /maxGroundingDelta/);
 assert.match(visualWorkflow, /playwright@1\.55\.0/);
 assert.match(visualWorkflow, /upload-artifact@v4/);
 assert.match(visualWorkflow, /mountain-visual-smoke/);
 
-console.log(`TURN MOUNTAIN r3 production contract passed: ${closedLength(MOUNTAIN_CONTROL_POINTS).toFixed(0)} control units, continuous terrain, grounded Kenney village and browser visual QA.`);
+console.log(`TURN MOUNTAIN r3 production contract passed: ${closedLength(MOUNTAIN_CONTROL_POINTS).toFixed(0)} control units, continuous terrain, grounded Kenney village and moonlit night treatment.`);
 
 function parseGlbJson(buffer, label) {
   assert.ok(Buffer.isBuffer(buffer), `${label} must be read as binary data`);

--- a/turn-tests/mountain-visual-smoke.mjs
+++ b/turn-tests/mountain-visual-smoke.mjs
@@ -48,6 +48,7 @@ assert.equal(metrics.assetsReady, true, 'MOUNTAIN Kenney/Nature assets must fini
 assert.deepEqual(metrics.assetErrors, [], 'MOUNTAIN r3 asset loaders must not hide failed GLBs/textures');
 assert.deepEqual(metrics.r4AssetErrors, [], 'MOUNTAIN r4 village polish assets must load without hidden failures');
 assert.deepEqual(metrics.r5AssetErrors, [], 'MOUNTAIN r5 Suburban houses and recolored palette must load without hidden failures');
+assert.deepEqual(metrics.r6AssetErrors, [], 'MOUNTAIN r6 star field and moon assets must load without hidden failures');
 assert.ok(metrics.terrainBodies >= 1, 'MOUNTAIN needs a continuous terrain body beneath the road');
 assert.ok(metrics.roadbedWalls >= 2, 'Both road edges need opaque roadbed side walls');
 assert.ok(metrics.deepFoundations >= 2, 'Both road edges need deep retaining foundations for close stacked hairpins');
@@ -79,6 +80,29 @@ assert.ok(metrics.distantLayeredRidges >= 8,
   `The horizon should have a second layer of integrated-snow mountains, got ${metrics.distantLayeredRidges}`);
 assert.ok(metrics.decorativeVillageAssets >= 8,
   'Village approaches need benches, carts, fences, sleds and authored Holiday trees');
+
+assert.equal(metrics.r6StarSky, true, 'MOUNTAIN night treatment must install the generated star field');
+assert.equal(metrics.r6Moon, true, 'MOUNTAIN night treatment must install the separate generated moon');
+assert.equal(metrics.starSkydomes, 1, 'MOUNTAIN should render exactly one camera-centred star skydome');
+assert.equal(metrics.moonSprites, 1, 'MOUNTAIN should render exactly one distant moon sprite');
+assert.equal(metrics.r6StreetLightPoolCount, metrics.litStreetlights,
+  'Every MOUNTAIN streetlight should receive a Midnight City-style warm ground pool');
+assert.equal(metrics.r6StreetLightPointLightCount, metrics.litStreetlights,
+  'Every MOUNTAIN streetlight should receive one short-range non-shadow light');
+assert.equal(metrics.nightStreetlightFills, metrics.litStreetlights,
+  'Scene point-light count must agree with the r6 night diagnostics');
+assert.equal(metrics.r6LitHouseCount, metrics.suburbanHouses,
+  'Every final Suburban house should participate in the night window treatment');
+assert.ok(metrics.r6WindowPanelCount >= metrics.r6LitHouseCount * 2,
+  `Every house needs multiple warm windows, got ${metrics.r6WindowPanelCount} panels for ${metrics.r6LitHouseCount} houses`);
+assert.equal(metrics.warmHouseWindowMeshes, 1,
+  'House window cores should remain one cheap instanced draw-call layer');
+assert.equal(metrics.warmHouseWindowHaloMeshes, 1,
+  'House window halos should remain one cheap instanced draw-call layer');
+assert.ok(metrics.r6HouseSpillLightCount >= 3,
+  `A few houses should cast real local warmth onto the snow, got ${metrics.r6HouseSpillLightCount}`);
+assert.ok(metrics.r6MoonlitWaterMaterials >= 1,
+  'The waterfall should receive a cool moonlit emissive treatment');
 
 assert.ok(metrics.marketStalls >= 2, `Expected the original village market stalls to remain, got ${metrics.marketStalls}`);
 assert.ok(metrics.waterfallCliffModules >= 4, 'The waterfall should retain four outer Kenney Nature cliff shoulders after opening the driver sightline');

--- a/turn/tracks/definitions.js
+++ b/turn/tracks/definitions.js
@@ -133,16 +133,16 @@ const TRACKS = [
       boundaryMinimumRecoverySpeed: 5.5,
       colliders: []
     },
-    sky: 0x71cff1,
-    fog: 0xc6e0ea,
-    fogNear: 360,
-    fogFar: 1180,
+    sky: 0x06132c,
+    fog: 0x172744,
+    fogNear: 430,
+    fogFar: 1250,
     lighting: {
-      hemisphereSky: 0xd8f1ff,
-      hemisphereGround: 0x617455,
-      hemisphereIntensity: 1.04,
-      directionalColor: 0xfff2d4,
-      directionalIntensity: 1.16
+      hemisphereSky: 0x5a78a8,
+      hemisphereGround: 0x07101b,
+      hemisphereIntensity: 0.56,
+      directionalColor: 0xb8d7ff,
+      directionalIntensity: 0.92
     }
   }
 ];

--- a/turn/tracks/mountain-world-r3.js
+++ b/turn/tracks/mountain-world-r3.js
@@ -6,6 +6,7 @@ import { installMountainR4VisualPolish } from './mountain-world-r4-visual-polish
 import { installMountainR4WaterfallNotch } from './mountain-world-r4-waterfall-notch.js';
 import { installMountainR4DriverFacingWaterfall } from './mountain-world-r4-waterfall-face.js';
 import { installMountainR5SuburbanVillage } from './mountain-world-r5-suburban-village.js';
+import { installMountainR6Night } from './mountain-world-r6-night.js';
 
 const MOUNTAIN_VILLAGE_BENCHES = new Set([
   'Mountain village bench r4',
@@ -40,12 +41,13 @@ export function installMountainWorld({ scene, samples, trackWidth = 27, runtime 
     .then(() => installMountainR5SuburbanVillage(world, samples, trackWidth, terrainContext))
     .then(() => {
       faceMountainVillageBenchesTowardTrack(world);
-      return world;
-    });
+      return installMountainR6Night(world, samples, trackWidth, terrainContext);
+    })
+    .then(() => world);
   world.userData.turnMountainTerrainHeightAt = terrainContext.terrainHeightAt;
   world.userData.turnMountainArtDirection = Object.freeze({
     version: 'r3',
-    visualPolish: 'r5-suburban-village-plus-r4-waterfall-landmarks',
+    visualPolish: 'r6-night-plus-r5-suburban-village-plus-r4-waterfall-landmarks',
     ground: 'continuous-snow-and-granite-terrain-body',
     roadEdge: 'white-with-black-outer-contour',
     roadbed: 'opaque-and-terrain-supported',
@@ -54,7 +56,11 @@ export function installMountainWorld({ scene, samples, trackWidth = 27, runtime 
     assetVillage: 'Kenney-City-Kit-Suburban-complete-buildings-A-G-M-N-U',
     villagePalette: 'dark-brown-walls-and-snow-white-roofs',
     villageSquare: 'winter-market-no-fountain',
-    streetlights: 'warm-static-halos',
+    nightSky: 'local-star-field-skydome-with-separate-moon-sprite',
+    moonlight: 'cool-hemisphere-and-directional-track-atmosphere',
+    streetlights: 'warm-static-halos-plus-midnight-city-style-ground-pools-and-local-fill',
+    houseWindows: 'warm-emissive-looking-panels-on-every-suburban-house-with-limited-local-spill',
+    waterfallLight: 'cool-moonlit-emissive-water-surfaces',
     waterfallCliff: 'terrain-plus-Kenney-Nature-rock-shoulders-open-at-centre',
     visibleWaterfallCurtain: true,
     waterfallDriverSightline: 'open-rock-cleft-plus-driver-facing-water-plane',

--- a/turn/tracks/mountain-world-r6-night.js
+++ b/turn/tracks/mountain-world-r6-night.js
@@ -9,7 +9,8 @@ const WINDOW_LIGHT = 0xffc766;
 const MOON_BLUE = 0xaed3ff;
 const STREETLIGHT_PREFIX = 'Mountain Kenney Holiday lit streetlight r4';
 const HOUSE_PREFIX = 'Mountain Kenney Suburban house r5';
-const SKY_RADIUS = 840;
+const SKY_DISTANCE = 840;
+const SKY_IMAGE_ASPECT = 2;
 const MOON_DISTANCE = 810;
 const MOON_SIZE = 174;
 
@@ -34,30 +35,40 @@ async function loadNightTexture(url, options) {
 }
 
 function installStarSky(world, texture) {
-  // The deliberately tiny 512x256 source is tiled at its native 2:1 aspect
-  // rather than stretched once around all 360 degrees. This keeps individual
-  // stars crisp enough on mobile while retaining the very small download.
-  texture.wrapS = THREE.RepeatWrapping;
-  texture.wrapT = THREE.RepeatWrapping;
-  texture.repeat.set(4, 2);
-  texture.offset.set(0.11, 0.07);
+  // The generated asset is intentionally a tiny flat 2:1 star field rather
+  // than a large equirectangular panorama. Keep it crisp by using it as a
+  // distant camera-facing backdrop with cover sizing, instead of magnifying it
+  // around an entire 360-degree sphere.
+  texture.wrapS = THREE.ClampToEdgeWrapping;
+  texture.wrapT = THREE.ClampToEdgeWrapping;
   texture.needsUpdate = true;
 
   const sky = new THREE.Mesh(
-    new THREE.SphereGeometry(SKY_RADIUS, 40, 20),
+    new THREE.PlaneGeometry(1, 1),
     new THREE.MeshBasicMaterial({
       map: texture,
-      side: THREE.BackSide,
+      side: THREE.DoubleSide,
       depthWrite: false,
+      depthTest: true,
       fog: false,
       toneMapped: false
     })
   );
+  // Keep the established diagnostic name even though r6 now uses a flat
+  // camera-centred backdrop rather than stretching the tiny texture as a dome.
   sky.name = 'Mountain star field skydome r6';
   sky.frustumCulled = false;
   sky.renderOrder = -100;
+  const forward = new THREE.Vector3();
   sky.onBeforeRender = (_renderer, _scene, camera) => {
-    sky.position.copy(camera.position);
+    camera.getWorldDirection(forward);
+    sky.position.copy(camera.position).addScaledVector(forward, SKY_DISTANCE);
+    sky.quaternion.copy(camera.quaternion);
+
+    const visibleHeight = 2 * SKY_DISTANCE * Math.tan(THREE.MathUtils.degToRad(camera.fov) / 2);
+    const visibleWidth = visibleHeight * camera.aspect;
+    const coverHeight = Math.max(visibleHeight, visibleWidth / SKY_IMAGE_ASPECT) * 1.03;
+    sky.scale.set(coverHeight * SKY_IMAGE_ASPECT, coverHeight, 1);
     sky.updateMatrixWorld(true);
   };
   world.add(sky);

--- a/turn/tracks/mountain-world-r6-night.js
+++ b/turn/tracks/mountain-world-r6-night.js
@@ -35,6 +35,7 @@ async function loadNightTexture(url, options) {
 function installStarSky(world, texture) {
   texture.wrapS = THREE.RepeatWrapping;
   texture.wrapT = THREE.ClampToEdgeWrapping;
+  texture.needsUpdate = true;
 
   const sky = new THREE.Mesh(
     new THREE.SphereGeometry(SKY_RADIUS, 40, 20),
@@ -259,6 +260,7 @@ function installHouseWindowGlow(world, samples) {
     geometry,
     new THREE.MeshBasicMaterial({
       color: WINDOW_LIGHT,
+      depthWrite: false,
       side: THREE.DoubleSide,
       toneMapped: false
     }),
@@ -289,7 +291,6 @@ function installHouseWindowGlow(world, samples) {
     marker.updateMatrix();
     core.setMatrixAt(index, marker.matrix);
 
-    marker.position.y += 0.015;
     marker.scale.set(spec.width * 1.65, spec.height * 1.55, 1);
     marker.updateMatrix();
     halo.setMatrixAt(index, marker.matrix);

--- a/turn/tracks/mountain-world-r6-night.js
+++ b/turn/tracks/mountain-world-r6-night.js
@@ -1,0 +1,381 @@
+import * as THREE from 'three';
+
+const REVISION = 'r6-night-treatment';
+const SKY_TEXTURE_URL = new URL('../assets/mountain/mountain-night-sky.jpg', import.meta.url).href;
+const MOON_TEXTURE_URL = new URL('../assets/mountain/mountain-moon.png', import.meta.url).href;
+const WARM_LIGHT = 0xffd27a;
+const WINDOW_LIGHT = 0xffc766;
+const MOON_BLUE = 0xaed3ff;
+const STREETLIGHT_PREFIX = 'Mountain Kenney Holiday lit streetlight r4';
+const HOUSE_PREFIX = 'Mountain Kenney Suburban house r5';
+const SKY_RADIUS = 840;
+const MOON_DISTANCE = 810;
+const MOON_SIZE = 174;
+
+// Chosen from the established MOUNTAIN aerial showcase camera so the moon
+// lands at roughly 23% from the left and 19% from the top, matching the night
+// art-direction mockup. Keeping this as a world-space direction makes the moon
+// behave like a distant celestial object while the camera moves around the lap.
+const MOON_DIRECTION = new THREE.Vector3(-0.286712, -0.135528, 0.948382).normalize();
+
+function configureColorTexture(texture, { mipmaps = true } = {}) {
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.generateMipmaps = mipmaps;
+  texture.minFilter = mipmaps ? THREE.LinearMipmapLinearFilter : THREE.LinearFilter;
+  texture.magFilter = THREE.LinearFilter;
+  texture.needsUpdate = true;
+  return texture;
+}
+
+async function loadNightTexture(url, options) {
+  const texture = await new THREE.TextureLoader().loadAsync(url);
+  return configureColorTexture(texture, options);
+}
+
+function installStarSky(world, texture) {
+  texture.wrapS = THREE.RepeatWrapping;
+  texture.wrapT = THREE.ClampToEdgeWrapping;
+
+  const sky = new THREE.Mesh(
+    new THREE.SphereGeometry(SKY_RADIUS, 40, 20),
+    new THREE.MeshBasicMaterial({
+      map: texture,
+      side: THREE.BackSide,
+      depthWrite: false,
+      fog: false,
+      toneMapped: false
+    })
+  );
+  sky.name = 'Mountain star field skydome r6';
+  sky.frustumCulled = false;
+  sky.renderOrder = -100;
+  sky.onBeforeRender = (_renderer, _scene, camera) => {
+    sky.position.copy(camera.position);
+    sky.updateMatrixWorld(true);
+  };
+  world.add(sky);
+  return sky;
+}
+
+function installMoon(world, texture) {
+  const material = new THREE.SpriteMaterial({
+    map: texture,
+    color: 0xffffff,
+    transparent: true,
+    alphaTest: 0.025,
+    depthTest: true,
+    depthWrite: false,
+    fog: false,
+    toneMapped: false
+  });
+  const moon = new THREE.Sprite(material);
+  moon.name = 'Mountain full moon sprite r6';
+  moon.scale.set(MOON_SIZE, MOON_SIZE, 1);
+  moon.frustumCulled = false;
+  moon.onBeforeRender = (_renderer, _scene, camera) => {
+    moon.position.copy(camera.position).addScaledVector(MOON_DIRECTION, MOON_DISTANCE);
+    moon.updateMatrixWorld(true);
+  };
+  world.add(moon);
+  return moon;
+}
+
+function collectNamed(world, prefix) {
+  const result = [];
+  world.traverse((object) => {
+    if (object.name?.startsWith(prefix)) result.push(object);
+  });
+  return result;
+}
+
+function installStreetlightPoolsAndFill(world, terrainHeightAt) {
+  const streetlights = collectNamed(world, STREETLIGHT_PREFIX);
+  if (!streetlights.length) return { pools: null, poolCount: 0, pointLightCount: 0 };
+
+  const poolGeometry = new THREE.CircleGeometry(11.5, 24);
+  const poolMaterial = new THREE.MeshBasicMaterial({
+    color: WARM_LIGHT,
+    transparent: true,
+    opacity: 0.13,
+    depthWrite: false,
+    blending: THREE.AdditiveBlending,
+    side: THREE.DoubleSide,
+    toneMapped: false
+  });
+  const pools = new THREE.InstancedMesh(poolGeometry, poolMaterial, streetlights.length);
+  pools.name = 'Mountain street-light snow pools r6';
+  pools.frustumCulled = false;
+
+  const marker = new THREE.Object3D();
+  const bounds = new THREE.Box3();
+  const center = new THREE.Vector3();
+  const size = new THREE.Vector3();
+  let cursor = 0;
+
+  for (const streetlight of streetlights) {
+    streetlight.updateWorldMatrix(true, true);
+    bounds.setFromObject(streetlight, true);
+    if (bounds.isEmpty()) continue;
+    bounds.getCenter(center);
+    bounds.getSize(size);
+
+    const groundY = typeof terrainHeightAt === 'function'
+      ? terrainHeightAt(center.x, center.z)
+      : bounds.min.y;
+    marker.position.set(center.x, groundY + 0.16, center.z);
+    marker.rotation.set(-Math.PI / 2, 0, 0);
+    marker.scale.set(1, 1, 1);
+    marker.updateMatrix();
+    pools.setMatrixAt(cursor, marker.matrix);
+
+    const light = new THREE.PointLight(WARM_LIGHT, 8.4, 66, 1.65);
+    light.name = `Mountain warm streetlight fill r6 ${cursor + 1}`;
+    light.position.set(center.x, bounds.max.y - size.y * 0.20, center.z);
+    light.castShadow = false;
+    world.add(light);
+    cursor += 1;
+  }
+
+  pools.count = cursor;
+  pools.instanceMatrix.needsUpdate = true;
+  world.add(pools);
+  return { pools, poolCount: cursor, pointLightCount: cursor };
+}
+
+function localBounds(object) {
+  object.updateWorldMatrix(true, true);
+  const inverseRoot = object.matrixWorld.clone().invert();
+  const result = new THREE.Box3();
+  let hasBounds = false;
+
+  object.traverse((node) => {
+    if (!node?.isMesh || !node.geometry) return;
+    if (!node.geometry.boundingBox) node.geometry.computeBoundingBox();
+    if (!node.geometry.boundingBox) return;
+    const nodeBox = node.geometry.boundingBox.clone();
+    const relativeMatrix = inverseRoot.clone().multiply(node.matrixWorld);
+    nodeBox.applyMatrix4(relativeMatrix);
+    if (!hasBounds) {
+      result.copy(nodeBox);
+      hasBounds = true;
+    } else {
+      result.union(nodeBox);
+    }
+  });
+
+  return hasBounds ? result : null;
+}
+
+function worldCorners(object, box) {
+  const corners = [];
+  for (const x of [box.min.x, box.max.x]) {
+    for (const y of [box.min.y, box.max.y]) {
+      for (const z of [box.min.z, box.max.z]) {
+        corners.push(object.localToWorld(new THREE.Vector3(x, y, z)));
+      }
+    }
+  }
+  return corners;
+}
+
+function nearestTrackSample(samples, x, z) {
+  let nearest = samples[0];
+  let distanceSq = Infinity;
+  for (const sample of samples) {
+    const dx = sample.point.x - x;
+    const dz = sample.point.z - z;
+    const next = dx * dx + dz * dz;
+    if (next < distanceSq) {
+      nearest = sample;
+      distanceSq = next;
+    }
+  }
+  return nearest;
+}
+
+function makeWindowSpecs(house, samples, houseIndex) {
+  const box = localBounds(house);
+  if (!box) return [];
+  const corners = worldCorners(house, box);
+  const center = corners.reduce((sum, point) => sum.add(point), new THREE.Vector3()).multiplyScalar(1 / corners.length);
+  const sample = nearestTrackSample(samples, center.x, center.z);
+  if (!sample) return [];
+
+  const towardRoad = new THREE.Vector3(sample.point.x - center.x, 0, sample.point.z - center.z);
+  if (towardRoad.lengthSq() < 1e-6) return [];
+  towardRoad.normalize();
+  const alongFacade = new THREE.Vector3(towardRoad.z, 0, -towardRoad.x).normalize();
+
+  let roadExtent = 0;
+  let alongExtent = 0;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (const corner of corners) {
+    const delta = corner.clone().sub(center);
+    roadExtent = Math.max(roadExtent, Math.abs(delta.dot(towardRoad)));
+    alongExtent = Math.max(alongExtent, Math.abs(delta.dot(alongFacade)));
+    minY = Math.min(minY, corner.y);
+    maxY = Math.max(maxY, corner.y);
+  }
+
+  const facadeWidth = alongExtent * 2;
+  const height = maxY - minY;
+  if (facadeWidth < 2 || height < 3) return [];
+
+  const columns = THREE.MathUtils.clamp(Math.floor(facadeWidth / 2.45), 2, 3);
+  const windowWidth = THREE.MathUtils.clamp(facadeWidth / (columns * 2.05), 0.7, 1.18);
+  const windowHeight = THREE.MathUtils.clamp(height * 0.085, 0.68, 0.95);
+  const yaw = Math.atan2(towardRoad.x, towardRoad.z);
+  const facadeCenter = center.clone().addScaledVector(towardRoad, roadExtent + 0.075);
+  const rows = [0.31];
+  if (height >= 9.6 && houseIndex % 2 === 0) rows.push(0.52);
+
+  const specs = [];
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
+    const count = rowIndex === 0 ? columns : Math.max(2, columns - 1);
+    const spread = Math.min(facadeWidth * 0.68, (count - 1) * 2.05);
+    for (let column = 0; column < count; column += 1) {
+      const along = count === 1 ? 0 : THREE.MathUtils.lerp(-spread / 2, spread / 2, column / (count - 1));
+      const position = facadeCenter.clone().addScaledVector(alongFacade, along);
+      position.y = minY + height * rows[rowIndex];
+      specs.push({
+        position,
+        yaw,
+        width: windowWidth,
+        height: windowHeight
+      });
+    }
+  }
+  return specs;
+}
+
+function installHouseWindowGlow(world, samples) {
+  const houses = collectNamed(world, HOUSE_PREFIX);
+  const specs = houses.flatMap((house, index) => makeWindowSpecs(house, samples, index));
+  if (!specs.length) return { core: null, halo: null, windowCount: 0, houseCount: houses.length, spillLightCount: 0 };
+
+  const geometry = new THREE.PlaneGeometry(1, 1);
+  const core = new THREE.InstancedMesh(
+    geometry,
+    new THREE.MeshBasicMaterial({
+      color: WINDOW_LIGHT,
+      side: THREE.DoubleSide,
+      toneMapped: false
+    }),
+    specs.length
+  );
+  core.name = 'Mountain warm house windows r6';
+
+  const halo = new THREE.InstancedMesh(
+    geometry,
+    new THREE.MeshBasicMaterial({
+      color: WINDOW_LIGHT,
+      transparent: true,
+      opacity: 0.18,
+      depthWrite: false,
+      blending: THREE.AdditiveBlending,
+      side: THREE.DoubleSide,
+      toneMapped: false
+    }),
+    specs.length
+  );
+  halo.name = 'Mountain warm house window halos r6';
+
+  const marker = new THREE.Object3D();
+  specs.forEach((spec, index) => {
+    marker.position.copy(spec.position);
+    marker.rotation.set(0, spec.yaw, 0);
+    marker.scale.set(spec.width, spec.height, 1);
+    marker.updateMatrix();
+    core.setMatrixAt(index, marker.matrix);
+
+    marker.position.y += 0.015;
+    marker.scale.set(spec.width * 1.65, spec.height * 1.55, 1);
+    marker.updateMatrix();
+    halo.setMatrixAt(index, marker.matrix);
+  });
+
+  core.instanceMatrix.needsUpdate = true;
+  halo.instanceMatrix.needsUpdate = true;
+  core.frustumCulled = false;
+  halo.frustumCulled = false;
+  world.add(core, halo);
+
+  // A small number of real local lights provide warm spill on nearby snow and
+  // timber while every house still gets cheap emissive-looking window panels.
+  let spillLightCount = 0;
+  houses.forEach((house, index) => {
+    if (index % 3 !== 0) return;
+    const box = new THREE.Box3().setFromObject(house, true);
+    if (box.isEmpty()) return;
+    const center = box.getCenter(new THREE.Vector3());
+    const light = new THREE.PointLight(WINDOW_LIGHT, 2.8, 25, 1.85);
+    light.name = `Mountain house window spill r6 ${index + 1}`;
+    light.position.set(center.x, box.min.y + (box.max.y - box.min.y) * 0.36, center.z);
+    light.castShadow = false;
+    world.add(light);
+    spillLightCount += 1;
+  });
+
+  return { core, halo, windowCount: specs.length, houseCount: houses.length, spillLightCount };
+}
+
+function strengthenMoonlitWater(world) {
+  let count = 0;
+  world.traverse((object) => {
+    if (!object?.isMesh || !/waterfall|connector water/i.test(object.name || '')) return;
+    const materials = Array.isArray(object.material) ? object.material : [object.material];
+    const replacements = materials.map((material) => {
+      if (!material?.isMeshStandardMaterial) return material;
+      const clone = material.clone();
+      clone.emissive = new THREE.Color(MOON_BLUE).multiplyScalar(0.34);
+      clone.emissiveIntensity = Math.max(Number(clone.emissiveIntensity) || 0, 0.46);
+      clone.needsUpdate = true;
+      count += 1;
+      return clone;
+    });
+    object.material = Array.isArray(object.material) ? replacements : replacements[0];
+  });
+  return count;
+}
+
+export async function installMountainR6Night(world, samples, _trackWidth, terrainContext) {
+  if (!world || !Array.isArray(samples) || !samples.length) return world;
+
+  const errors = [];
+  let starSky = null;
+  let moon = null;
+
+  const [skyResult, moonResult] = await Promise.allSettled([
+    loadNightTexture(SKY_TEXTURE_URL),
+    loadNightTexture(MOON_TEXTURE_URL, { mipmaps: false })
+  ]);
+
+  if (skyResult.status === 'fulfilled') starSky = installStarSky(world, skyResult.value);
+  else errors.push(`star field: ${String(skyResult.reason?.message || skyResult.reason)}`);
+
+  if (moonResult.status === 'fulfilled') moon = installMoon(world, moonResult.value);
+  else errors.push(`moon: ${String(moonResult.reason?.message || moonResult.reason)}`);
+
+  const streetlights = installStreetlightPoolsAndFill(world, terrainContext?.terrainHeightAt);
+  const windows = installHouseWindowGlow(world, samples);
+  const moonlitWaterMaterials = strengthenMoonlitWater(world);
+
+  world.userData.turnMountainR6Night = Object.freeze({
+    revision: REVISION,
+    starSky: Boolean(starSky),
+    moon: Boolean(moon),
+    moonDirection: Object.freeze(MOON_DIRECTION.toArray()),
+    moonDistance: MOON_DISTANCE,
+    moonSize: MOON_SIZE,
+    streetLightPoolCount: streetlights.poolCount,
+    streetLightPointLightCount: streetlights.pointLightCount,
+    litHouseCount: windows.houseCount,
+    windowPanelCount: windows.windowCount,
+    houseSpillLightCount: windows.spillLightCount,
+    moonlitWaterMaterials,
+    noIndependentAnimationLoop: true
+  });
+  world.userData.turnMountainR6AssetErrors = errors;
+  return world;
+}

--- a/turn/tracks/mountain-world-r6-night.js
+++ b/turn/tracks/mountain-world-r6-night.js
@@ -4,6 +4,7 @@ const REVISION = 'r6-night-treatment';
 const SKY_TEXTURE_URL = new URL('../assets/mountain/mountain-night-sky.jpg', import.meta.url).href;
 const MOON_TEXTURE_URL = new URL('../assets/mountain/mountain-moon.png', import.meta.url).href;
 const WARM_LIGHT = 0xffd27a;
+const STREET_POOL_LIGHT = 0xffb000;
 const WINDOW_LIGHT = 0xffc766;
 const MOON_BLUE = 0xaed3ff;
 const STREETLIGHT_PREFIX = 'Mountain Kenney Holiday lit streetlight r4';
@@ -16,7 +17,7 @@ const MOON_SIZE = 174;
 // lands at roughly 23% from the left and 19% from the top, matching the night
 // art-direction mockup. Keeping this as a world-space direction makes the moon
 // behave like a distant celestial object while the camera moves around the lap.
-const MOON_DIRECTION = new THREE.Vector3(-0.286712, -0.135528, 0.948382).normalize();
+const MOON_DIRECTION = new THREE.Vector3(-0.353323, -0.140080, 0.924954).normalize();
 
 function configureColorTexture(texture, { mipmaps = true } = {}) {
   texture.colorSpace = THREE.SRGBColorSpace;
@@ -33,8 +34,13 @@ async function loadNightTexture(url, options) {
 }
 
 function installStarSky(world, texture) {
+  // The deliberately tiny 512x256 source is tiled at its native 2:1 aspect
+  // rather than stretched once around all 360 degrees. This keeps individual
+  // stars crisp enough on mobile while retaining the very small download.
   texture.wrapS = THREE.RepeatWrapping;
-  texture.wrapT = THREE.ClampToEdgeWrapping;
+  texture.wrapT = THREE.RepeatWrapping;
+  texture.repeat.set(4, 2);
+  texture.offset.set(0.11, 0.07);
   texture.needsUpdate = true;
 
   const sky = new THREE.Mesh(
@@ -95,9 +101,9 @@ function installStreetlightPoolsAndFill(world, terrainHeightAt) {
 
   const poolGeometry = new THREE.CircleGeometry(11.5, 24);
   const poolMaterial = new THREE.MeshBasicMaterial({
-    color: WARM_LIGHT,
+    color: STREET_POOL_LIGHT,
     transparent: true,
-    opacity: 0.13,
+    opacity: 0.18,
     depthWrite: false,
     blending: THREE.AdditiveBlending,
     side: THREE.DoubleSide,

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -11,7 +11,7 @@ import { installHarborWorld } from './harbor-world.js';
 // Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10
 import { installMidnightCityWorld } from './midnight-city-world-r11.js?build=20260802-r11';
 // Historical MOUNTAIN regression marker: mountain-world-r3.js?revision=r3-continuous-terrain-v1
-import { installMountainWorld } from './mountain-world-r3.js?revision=r5-suburban-village';
+import { installMountainWorld } from './mountain-world-r3.js?revision=r6-night-treatment';
 import { isForgivingTrackSurface } from './airport-runoff.js?build=20260722-r52';
 import './contextual-road-edges.js?revision=r518-signature-yellow';
 import './road-contour-color-r512.js?revision=r513-countryside';


### PR DESCRIPTION
First full MOUNTAIN night treatment, based on the supplied mockup and the lighting research.

- use the compact generated star-field asset as a camera-centred skydome
- place the generated moon as a separate distant sprite, positioned to match the aerial mockup composition
- change MOUNTAIN atmosphere to cool blue moonlight and night fog
- reuse Midnight City's warm additive ground-circle technique under every existing village streetlight
- give each streetlight a short-range, non-shadow-casting warm fill light
- give every final Suburban house warm road-facing window panels, batched into two instanced layers, with only a few real local spill lights
- strengthen the waterfall's cool emissive response so it reads under moonlight
- keep route, terrain, handling, village geometry and progression unchanged
- extend production and browser visual smoke contracts for the night assets and lighting layers

The implementation deliberately keeps the expensive lighting bounded: no new shadows, one instanced pool layer, two instanced window layers, and no independent animation loop.