### PR TITLE
Reverse MOUNTAIN sky yaw direction

### DIFF
--- a/turn-tests/track-intro-camera-production.mjs
+++ b/turn-tests/track-intro-camera-production.mjs
@@ -29,8 +29,10 @@ assert.match(mountainSkySource, /const SKY_YAW_CATCHUP = 0\.14/,
   'MOUNTAIN sky should retain a small heading drag instead of snapping');
 assert.match(mountainSkySource, /const heading = Math\.atan2\(forward\.x, forward\.z\)/,
   'MOUNTAIN sky UVs must derive from world heading');
-assert.match(mountainSkySource, /const yawU = visualHeading \/ TAU \* SKY_HORIZONTAL_TILES/,
-  'MOUNTAIN star texture must rotate through UV space with world yaw');
+assert.match(mountainSkySource, /const yawU = -visualHeading \/ TAU \* SKY_HORIZONTAL_TILES/,
+  'MOUNTAIN star texture must move opposite camera yaw so the distant sky appears world-fixed');
+assert.doesNotMatch(mountainSkySource, /const yawU = visualHeading \/ TAU \* SKY_HORIZONTAL_TILES/,
+  'MOUNTAIN sky must not rotate in the same direction as camera yaw');
 assert.match(mountainSkySource, /sky\.up\.set\(0, 1, 0\)/,
   'MOUNTAIN stars must keep world-up so they roll with the rendered horizon');
 assert.match(mountainSkySource, /sky\.lookAt\(camera\.position\)/,
@@ -139,7 +141,7 @@ bodyClasses.add('turn-track-intro');
 scene.onBeforeRender();
 assert.equal(calls.some((call) => call[0] === 'position'), false, 'Tracks without a showcase preset keep their established framing');
 
-console.log('TURN Midnight City and Mountain track intros use deliberate cinematic showcase angles with a world-yaw-locked MOUNTAIN sky and raised moon.');
+console.log('TURN Midnight City and Mountain track intros use deliberate cinematic showcase angles with an inverse-yaw world-locked MOUNTAIN sky and raised moon.');
 
 function projectDirectionToScreen({ direction, position, target, fov, aspect }) {
   const forward = normalize(subtract(target, position));

--- a/turn/tracks/mountain-world-r7-sky.js
+++ b/turn/tracks/mountain-world-r7-sky.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 
-const REVISION = 'r7-world-yaw-uv-raised-moon';
+const REVISION = 'r7-world-yaw-uv-raised-moon-direction-fix';
 const SKY_NAME = 'Mountain star field skydome r6';
 const MOON_NAME = 'Mountain full moon sprite r6';
 const SKY_DISTANCE = 840;
@@ -62,10 +62,9 @@ function worldLockSky(sky) {
     sky.lookAt(camera.position);
 
     // Four copies of the compact star field represent one 360-degree turn.
-    // Heading therefore moves the sampled UV region by exactly four texture
-    // widths over a full rotation: the stars are effectively fixed to world Y
-    // instead of to the phone screen. A small catch-up lag gives the distant
-    // sky the requested gentle drag while still settling on the world heading.
+    // Heading therefore moves the sampled UV region in the opposite direction
+    // to camera yaw, exactly as a fixed distant sky should appear when the car
+    // turns. A small catch-up lag gives the requested gentle parallax drag.
     const heading = Math.atan2(forward.x, forward.z);
     if (visualHeading === null) visualHeading = heading;
     visualHeading += shortestAngle(visualHeading, heading) * SKY_YAW_CATCHUP;
@@ -74,7 +73,7 @@ function worldLockSky(sky) {
     const horizontalFov = 2 * Math.atan(Math.tan(verticalFov / 2) * camera.aspect);
     const visibleU = Math.max(0.01, horizontalFov / TAU * SKY_HORIZONTAL_TILES);
     const baseU = 0.5 - visibleU * 0.5;
-    const yawU = visualHeading / TAU * SKY_HORIZONTAL_TILES;
+    const yawU = -visualHeading / TAU * SKY_HORIZONTAL_TILES;
     const positionU = (camera.position.x - camera.position.z) * SKY_POSITION_PARALLAX;
     texture.repeat.set(visibleU, 1);
     texture.offset.set(
@@ -90,7 +89,7 @@ function worldLockSky(sky) {
     sky.updateMatrixWorld(true);
   };
 
-  sky.userData.turnMountainSkyLock = 'world-yaw-via-uv-with-world-up-roll-lock';
+  sky.userData.turnMountainSkyLock = 'world-yaw-via-inverse-uv-with-world-up-roll-lock';
   sky.userData.turnMountainSkyHorizontalTiles = SKY_HORIZONTAL_TILES;
   sky.userData.turnMountainSkyYawCatchup = SKY_YAW_CATCHUP;
   return true;
@@ -117,7 +116,7 @@ export function installMountainR7SkyFix(world) {
   world.userData.turnMountainR7Sky = Object.freeze({
     revision: REVISION,
     horizonLockedSky,
-    skyYawLock: 'world-space-y-axis-via-four-tile-uv-rotation',
+    skyYawLock: 'world-space-y-axis-via-inverse-four-tile-uv-rotation',
     skyGeometry: 'camera-facing-flat-backdrop',
     skyParallax: 'yaw-catchup-plus-subtle-position-and-pitch-drag',
     skyHorizontalTiles: SKY_HORIZONTAL_TILES,


### PR DESCRIPTION
Device video confirms the MOUNTAIN star field is now rotating around the correct world Y axis, but its horizontal motion is inverted.

This follow-up keeps the current horizon lock, parallax drag, moon placement and loading camera unchanged, and only reverses the star UV yaw direction so a camera turn makes the distant sky appear fixed in world space rather than counter-rotating with the turn.

Regression coverage now explicitly requires inverse UV yaw and rejects the previous same-direction mapping.