### PR TITLE
Reuse MIDNIGHT CITY headlights on MOUNTAIN

### DIFF
--- a/turn/tracks/mountain-world-r3.js
+++ b/turn/tracks/mountain-world-r3.js
@@ -8,11 +8,14 @@ import { installMountainR4DriverFacingWaterfall } from './mountain-world-r4-wate
 import { installMountainR5SuburbanVillage } from './mountain-world-r5-suburban-village.js';
 import { installMountainR6Night } from './mountain-world-r6-night.js';
 import { installMountainR7SkyFix } from './mountain-world-r7-sky.js';
+import { installProjectedHeadlightsForTrack } from './projected-player-headlights.js';
 
 const MOUNTAIN_VILLAGE_BENCHES = new Set([
   'Mountain village bench r4',
   'Mountain village overlook bench r4'
 ]);
+const MOUNTAIN_PLAYER_LIGHT_RIG_NAME = 'TURN Mountain player light rig';
+const MOUNTAIN_HEADLIGHT_PROJECTION_NAME = 'Mountain projected headlights';
 
 function faceMountainVillageBenchesTowardTrack(world) {
   world.traverse((object) => {
@@ -31,6 +34,17 @@ export function installMountainWorld({ scene, samples, trackWidth = 27, runtime 
   const world = new THREE.Group();
   world.name = 'TURN Mountain r3';
   scene.add(world);
+
+  // Reuse MIDNIGHT CITY's deliberately cheap night-driving treatment exactly:
+  // one short-range fill plus two additive projected road wedges. No SpotLights,
+  // shadows or independent animation are added.
+  const playerLightRig = installProjectedHeadlightsForTrack(runtime?.playerCar, {
+    trackId: 'mountain',
+    rigName: MOUNTAIN_PLAYER_LIGHT_RIG_NAME,
+    label: 'Mountain',
+    projectionName: MOUNTAIN_HEADLIGHT_PROJECTION_NAME
+  });
+  world.userData.turnPlayerLightRig = playerLightRig;
 
   const terrainContext = installMountainTerrain(world, samples, trackWidth);
   installMountainR3Polish(world, samples, trackWidth);
@@ -63,6 +77,7 @@ export function installMountainWorld({ scene, samples, trackWidth = 27, runtime 
     celestialLayer: 'r7-reparents-the-r6-moon-onto-the-star-plane-at-the-same-depth',
     moon: 'same-depth-star-plane-child-sharing-yaw-pitch-roll-and-parallax',
     moonlight: 'cool-hemisphere-and-directional-track-atmosphere',
+    playerVisibilityLight: 'MIDNIGHT CITY short-range fill plus projected unlit headlights',
     streetlights: 'warm-static-halos-plus-midnight-city-style-ground-pools-and-local-fill',
     houseWindows: 'warm-emissive-looking-panels-on-every-suburban-house-with-limited-local-spill',
     waterfallLight: 'cool-moonlit-emissive-water-surfaces',

--- a/turn/tracks/projected-player-headlights.js
+++ b/turn/tracks/projected-player-headlights.js
@@ -1,0 +1,111 @@
+import * as THREE from 'three';
+
+const PLAYER_FILL = 0xffe3b3;
+
+/**
+ * Shared night-driving headlight treatment first established for MIDNIGHT CITY:
+ * one short-range local fill plus two cheap additive road-projection wedges.
+ * The wedges are deliberately unlit geometry rather than SpotLights, keeping
+ * the visual reach without adding shadow/render cost.
+ */
+export function populateProjectedHeadlightRig(rig, {
+  label = 'Night track',
+  projectionName = `${label} projected headlights`
+} = {}) {
+  if (!rig) return null;
+
+  for (const child of [...rig.children]) {
+    rig.remove(child);
+    child.geometry?.dispose?.();
+    child.material?.dispose?.();
+  }
+
+  const fill = new THREE.PointLight(PLAYER_FILL, 3.1, 17, 2);
+  fill.name = `${label} player visibility fill`;
+  fill.position.set(0, 2.55, 0.45);
+  fill.castShadow = false;
+  rig.add(fill);
+
+  const headlights = new THREE.Group();
+  headlights.name = projectionName;
+  headlights.add(
+    makeHeadlightWedge({
+      nearWidth: 3.8,
+      farWidth: 17,
+      nearZ: -1.7,
+      farZ: -38,
+      opacity: 0.075
+    }),
+    makeHeadlightWedge({
+      nearWidth: 2.5,
+      farWidth: 9.5,
+      nearZ: -1.4,
+      farZ: -28,
+      opacity: 0.14
+    })
+  );
+  rig.add(headlights);
+  rig.userData.turnProjectedHeadlights = 'midnight-city-shared-solution';
+  return rig;
+}
+
+export function installProjectedHeadlightsForTrack(playerCar, {
+  trackId,
+  rigName,
+  label,
+  projectionName
+} = {}) {
+  if (!playerCar || !trackId || !rigName) return null;
+
+  let rig = playerCar.getObjectByName?.(rigName);
+  if (!rig) {
+    rig = new THREE.Group();
+    rig.name = rigName;
+    playerCar.add(rig);
+  }
+
+  populateProjectedHeadlightRig(rig, { label, projectionName });
+  rig.visible = true;
+  rig.userData.turnTrackVisibility = trackId;
+
+  if (!rig.userData.turnTrackVisibilityListener) {
+    const onTrackChanged = (event) => {
+      rig.visible = event.detail?.trackId === trackId;
+    };
+    globalThis.addEventListener?.('turn:track-changed', onTrackChanged);
+    rig.userData.turnTrackVisibilityListener = true;
+  }
+
+  return rig;
+}
+
+function makeHeadlightWedge({ nearWidth, farWidth, nearZ, farZ, opacity }) {
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute([
+    -nearWidth / 2, 0.24, nearZ,
+    nearWidth / 2, 0.24, nearZ,
+    -farWidth / 2, 0.24, farZ,
+    farWidth / 2, 0.24, farZ
+  ], 3));
+  geometry.setIndex([0, 2, 1, 1, 2, 3]);
+  geometry.computeVertexNormals();
+
+  const beam = new THREE.Mesh(
+    geometry,
+    new THREE.MeshBasicMaterial({
+      color: PLAYER_FILL,
+      transparent: true,
+      opacity,
+      depthWrite: false,
+      depthTest: true,
+      blending: THREE.AdditiveBlending,
+      side: THREE.DoubleSide,
+      toneMapped: false,
+      polygonOffset: true,
+      polygonOffsetFactor: -1,
+      polygonOffsetUnits: -2
+    })
+  );
+  beam.renderOrder = 5;
+  return beam;
+}


### PR DESCRIPTION
Adds headlights to MOUNTAIN using the established MIDNIGHT CITY night-driving treatment unchanged in behavior:

- one short-range warm player fill (`PointLight(0xffe3b3, 3.1, 17, 2)`)
- the same two additive projected road wedges (38/28-unit reach, same widths and opacities)
- no SpotLights, shadows, or independent animation loop
- rig is attached to the player car and visible only on MOUNTAIN, following the existing `turn:track-changed` lifecycle
- helper is isolated so the projection geometry/values stay reusable rather than becoming MOUNTAIN-specific

No handling, terrain, sky/moon, village lighting, or track geometry changes.