### PR TITLE
Finish MOUNTAIN accessibility and track card polish

### DIFF
--- a/turn-tests/track-select-visuals-production.mjs
+++ b/turn-tests/track-select-visuals-production.mjs
@@ -31,6 +31,7 @@ assert.equal(tracks.airport.accent, '#ffd43b', 'Airport keeps its established ru
 assert.equal(tracks.cliffside.accent, '#26c7c3', 'Cliffside keeps its blue-green ocean identity');
 assert.equal(tracks.harbor.accent, '#ff8f3d', 'Harbor needs a distinct rust-orange dock identity');
 assert.equal(tracks['midnight-city'].accent, '#9d7cff', 'Midnight City keeps its established violet identity');
+assert.equal(tracks.mountain.accent, '#4dabf7', 'Mountain keeps its established alpine-blue identity');
 assert.equal(tracks.harbor.difficulty, 'HARD');
 assert.equal(new Set(TRACK_DEFINITIONS.map((track) => track.accent)).size, TRACK_DEFINITIONS.length, 'Every playable track needs a distinct accent');
 
@@ -53,6 +54,11 @@ assert.match(
   postcardCss,
   /\.track-card-midnight-city[\s\S]*--track-card-paper: #e3dcff[\s\S]*--track-card-fold: #cfc2f4/,
   'Unselected Midnight City must have a visible pastel violet card rather than inheriting the blue page background'
+);
+assert.match(
+  postcardCss,
+  /\.track-card-mountain[\s\S]*--track-card-paper: #d7efff[\s\S]*--track-card-fold: #b9dced/,
+  'Unselected Mountain must use a light alpine-blue paper and the same folded-corner treatment as the other tracks'
 );
 assert.match(postcardCss, /\.track-card-preview::after[\s\S]*repeating-linear-gradient/, 'Every preview gets the small track-coloured curb motif');
 assert.match(postcardCss, /\.track-card-cliffside \.track-card-preview[\s\S]*#4ba8c8/, 'Cliffside preview must retain visible ocean blue');
@@ -98,7 +104,7 @@ assert.match(chooserSource, /card\.setAttribute\('aria-pressed', String\(selecte
 assert.match(chooserSource, /CONTINUE TO \$\{track\?\.name\.toUpperCase\(\)/, 'Continue copy remains the explicit textual confirmation');
 assert.match(chooserSource, /track-card-choice-marker/, 'The radio-style marker remains the extra visual choice indicator');
 
-console.log(`TURN ${release.id} five distinct track palettes and readable postcard previews passed.`);
+console.log(`TURN ${release.id} six distinct track palettes and readable postcard previews passed.`);
 
 function contrastRatio(foreground, background) {
   const light = Math.max(relativeLuminance(foreground), relativeLuminance(background));

--- a/turn/track-select-r77.css
+++ b/turn/track-select-r77.css
@@ -28,6 +28,11 @@
   --track-card-fold: #cfc2f4;
 }
 
+.track-card-mountain {
+  --track-card-paper: #d7efff;
+  --track-card-fold: #b9dced;
+}
+
 .track-card:not(.is-selected):not(.is-locked) {
   background:
     linear-gradient(135deg, rgb(255 255 255 / 0.34) 0 16%, transparent 16% 76%, var(--track-card-fold) 76% 100%),

--- a/turn/tracks/mountain-world-r3.js
+++ b/turn/tracks/mountain-world-r3.js
@@ -84,6 +84,7 @@ export function installMountainWorld({ scene, samples, trackWidth = 27, runtime 
     villageSquare: 'winter-market-no-fountain',
     nightSky: 'local-star-field-skydome-with-separate-moon-sprite',
     skyBehavior: 'flat-star-backdrop-with-world-up-roll-lock-and-world-yaw-uv-lock-with-gentle-drag',
+    reducedMotionSky: 'solid-deep-blue-track-background-with-moon-retained-and-parallax-suppressed',
     celestialLayer: 'r7-reparents-the-r6-moon-onto-the-star-plane-at-the-same-depth',
     moon: 'same-depth-star-plane-child-sharing-yaw-pitch-roll-and-parallax',
     moonlight: 'cool-hemisphere-and-directional-track-atmosphere-plus-static-blue-hill-fill',

--- a/turn/tracks/mountain-world-r7-sky.js
+++ b/turn/tracks/mountain-world-r7-sky.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 
-const REVISION = 'r7-world-yaw-uv-raised-moon-celestial-layer-cut-snap';
+const REVISION = 'r7-world-yaw-uv-raised-moon-celestial-layer-cut-snap-reduced-motion';
 const SKY_NAME = 'Mountain star field skydome r6';
 const MOON_NAME = 'Mountain full moon sprite r6';
 const SKY_DISTANCE = 840;
@@ -12,6 +12,7 @@ const SKY_PITCH_PARALLAX = 0.025;
 const SKY_CAMERA_CUT_DISTANCE = 48;
 const SKY_CAMERA_CUT_HEADING = Math.PI / 8;
 const LEGACY_MOON_DISTANCE = 810;
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
 const TAU = Math.PI * 2;
 
 // The moon is now a literal part of the same visual celestial layer as the
@@ -65,8 +66,30 @@ function worldLockSky(sky) {
     offsetU: null,
     offsetV: null,
     coverHeight: null,
-    cameraCutCount: 0
+    cameraCutCount: 0,
+    reducedMotion: false
   };
+
+  const reducedMotionMedia = globalThis.matchMedia?.(REDUCED_MOTION_QUERY) || null;
+  const applyReducedMotionPreference = () => {
+    motion.reducedMotion = reducedMotionMedia?.matches === true;
+
+    // Under prefers-reduced-motion, do not present the moving star field at
+    // all. The track's existing scene.background is the solid deep-blue night
+    // colour, so making this backdrop transparent reveals that colour while
+    // still letting its child moon render normally.
+    sky.material.transparent = motion.reducedMotion;
+    sky.material.opacity = motion.reducedMotion ? 0 : 1;
+    sky.material.needsUpdate = true;
+    sky.userData.turnMountainReducedMotionSky = motion.reducedMotion
+      ? 'solid-track-background-with-moon-only'
+      : 'animated-star-field';
+  };
+  applyReducedMotionPreference();
+  reducedMotionMedia?.addEventListener?.('change', applyReducedMotionPreference);
+  if (!reducedMotionMedia?.addEventListener) {
+    reducedMotionMedia?.addListener?.(applyReducedMotionPreference);
+  }
 
   sky.onBeforeRender = (_renderer, _scene, camera) => {
     camera.getWorldDirection(forward);
@@ -98,7 +121,10 @@ function worldLockSky(sky) {
     const cameraCut = hasPreviousCameraPose
       && (headingJump >= SKY_CAMERA_CUT_HEADING || positionJump >= SKY_CAMERA_CUT_DISTANCE);
 
-    if (motion.visualHeading === null || cameraCut) {
+    // Reduced-motion users keep the moon as a world landmark, but get none of
+    // the deliberate sky drag/parallax. Snap celestial heading directly to the
+    // camera heading and suppress the extra position/pitch drift.
+    if (motion.visualHeading === null || cameraCut || motion.reducedMotion) {
       motion.visualHeading = heading;
       if (cameraCut) motion.cameraCutCount += 1;
     } else {
@@ -113,8 +139,10 @@ function worldLockSky(sky) {
     const visibleU = Math.max(0.01, horizontalFov / TAU * SKY_HORIZONTAL_TILES);
     const baseU = 0.5 - visibleU * 0.5;
     const yawU = -motion.visualHeading / TAU * SKY_HORIZONTAL_TILES;
-    motion.positionU = (camera.position.x - camera.position.z) * SKY_POSITION_PARALLAX;
-    motion.pitchV = forward.y * SKY_PITCH_PARALLAX;
+    motion.positionU = motion.reducedMotion
+      ? 0
+      : (camera.position.x - camera.position.z) * SKY_POSITION_PARALLAX;
+    motion.pitchV = motion.reducedMotion ? 0 : forward.y * SKY_PITCH_PARALLAX;
     motion.visibleU = visibleU;
     motion.offsetU = baseU + yawU + motion.positionU;
     motion.offsetV = motion.pitchV;
@@ -134,6 +162,7 @@ function worldLockSky(sky) {
   sky.userData.turnMountainSkyHorizontalTiles = SKY_HORIZONTAL_TILES;
   sky.userData.turnMountainSkyYawCatchup = SKY_YAW_CATCHUP;
   sky.userData.turnMountainSkyCameraCuts = 'snap-large-camera-jumps-without-parallax-roll';
+  sky.userData.turnMountainReducedMotionPolicy = 'hide-star-field-show-solid-track-background-keep-moon';
   return motion;
 }
 
@@ -221,6 +250,7 @@ export function installMountainR7SkyFix(world) {
     skyCameraCuts: 'snap-large-camera-jumps-so-loading-cuts-are-not-animated',
     skyHorizontalTiles: SKY_HORIZONTAL_TILES,
     skyYawCatchup: SKY_YAW_CATCHUP,
+    reducedMotionSky: 'solid-track-background-with-moon-only-and-no-deliberate-sky-parallax',
     moonRepositioned: moonSkyLocked,
     moonSkyLock: 'literal-star-plane-child-with-shared-xyz-transform-and-fixed-uv-anchor',
     moonDistance: SKY_DISTANCE,


### PR DESCRIPTION
Final MOUNTAIN polish:

- honor `prefers-reduced-motion: reduce` by hiding the moving star field and revealing the track's existing solid deep-blue background instead
- keep the moon visible as the only celestial landmark
- suppress the deliberate sky yaw/position/pitch parallax in reduced-motion mode so the moon remains world-anchored without the extra drag effect
- react if the OS motion preference changes while TURN is open
- give the unselected MOUNTAIN track card its own light alpine-blue paper/fold variables so it gets the same pastel folded-corner treatment as the other track cards
- add track-card regression coverage for the sixth palette

Selected MOUNTAIN card styling is unchanged. No handling, geometry, village lighting, moon asset, or normal-motion sky behavior changes.