### PR TITLE
Try a real shadowless spotlight for MOUNTAIN headlights

### DIFF
--- a/.github/workflows/turn-mountain-visual-smoke.yml
+++ b/.github/workflows/turn-mountain-visual-smoke.yml
@@ -9,6 +9,7 @@ on:
       - 'turn/assets/scenery/mountain/**'
       - 'turn-lab/mountain-visual.html'
       - 'turn-tests/mountain-visual-smoke.mjs'
+      - 'turn-tests/mountain-spotlight-headlight-production.mjs'
       - '.github/workflows/turn-mountain-visual-smoke.yml'
   push:
     branches:
@@ -18,6 +19,7 @@ on:
       - 'turn/assets/scenery/mountain/**'
       - 'turn-lab/mountain-visual.html'
       - 'turn-tests/mountain-visual-smoke.mjs'
+      - 'turn-tests/mountain-spotlight-headlight-production.mjs'
       - '.github/workflows/turn-mountain-visual-smoke.yml'
 
 permissions:
@@ -35,6 +37,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24'
+
+      - name: Validate MOUNTAIN spotlight contract
+        run: node turn-tests/mountain-spotlight-headlight-production.mjs
 
       - name: Install Playwright Chromium
         run: |

--- a/turn-tests/mountain-spotlight-headlight-production.mjs
+++ b/turn-tests/mountain-spotlight-headlight-production.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const [headlight, world, registry] = await Promise.all([
+  fs.readFile(new URL('../turn/tracks/mountain-player-headlight-r8.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/tracks/mountain-world-r3.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/tracks/registry.js', import.meta.url), 'utf8')
+]);
+
+assert.match(headlight, /new THREE\.SpotLight\(/,
+  'MOUNTAIN headlight experiment must use a real SpotLight');
+assert.equal((headlight.match(/new THREE\.SpotLight\(/g) || []).length, 1,
+  'MOUNTAIN should use one central spotlight rather than two expensive lamps');
+assert.match(headlight, /light\.castShadow = false/,
+  'The experimental headlight must never allocate a dynamic shadow map');
+assert.match(headlight, /target\.position\.set\(0, -0\.15, -44\)/,
+  'The spotlight target should live far ahead of the car so its inherited road pitch drives the beam');
+assert.match(headlight, /rig\.add\(light, target\)/,
+  'Light and target must share the player-car transform');
+assert.match(headlight, /event\.detail\?\.trackId/,
+  'The MOUNTAIN-only spotlight must switch off on other tracks');
+assert.doesNotMatch(headlight, /PlaneGeometry|BufferGeometry|CircleGeometry|requestAnimationFrame|setAnimationLoop/,
+  'The spotlight solution must not reintroduce visible projected beam geometry or its own animation loop');
+
+assert.match(world, /installMountainSpotlightHeadlight\(runtime\?\.playerCar, runtime\)/,
+  'The MOUNTAIN world must attach the spotlight to the production player car');
+assert.match(world, /single-warm-shadowless-spotlight-car-child-following-existing-road-pitch/);
+assert.match(registry, /mountain-world-r3\.js\?revision=r8-shadowless-spotlight/,
+  'Production must cache-bust to the spotlight experiment');
+
+console.log('TURN MOUNTAIN shadowless spotlight headlight contract passed.');

--- a/turn/tracks/mountain-player-headlight-r8.js
+++ b/turn/tracks/mountain-player-headlight-r8.js
@@ -1,0 +1,69 @@
+import * as THREE from 'three';
+
+const TRACK_ID = 'mountain';
+const RIG_NAME = 'TURN Mountain spotlight headlight r8';
+const TARGET_NAME = 'TURN Mountain spotlight target r8';
+const LIGHT_NAME = 'TURN Mountain warm spotlight headlight r8';
+const HEADLIGHT_COLOR = 0xffe3b3;
+
+// One real, shadowless light rather than projected beam geometry. Because both
+// the lamp and its target are children of the player-car transform, TURN's
+// existing road pitch/yaw/roll automatically carries the headlight with the car
+// on MOUNTAIN's steep grades.
+export function installMountainSpotlightHeadlight(playerCar, runtime) {
+  if (!playerCar) return null;
+
+  let rig = playerCar.getObjectByName?.(RIG_NAME);
+  if (rig) return rig;
+
+  rig = new THREE.Group();
+  rig.name = RIG_NAME;
+
+  const target = new THREE.Object3D();
+  target.name = TARGET_NAME;
+  target.position.set(0, -0.15, -44);
+
+  const light = new THREE.SpotLight(
+    HEADLIGHT_COLOR,
+    650,
+    54,
+    THREE.MathUtils.degToRad(14),
+    0.78,
+    2
+  );
+  light.name = LIGHT_NAME;
+  light.position.set(0, 1.05, -1.65);
+  light.target = target;
+  light.castShadow = false;
+
+  rig.add(light, target);
+  playerCar.add(rig);
+
+  const syncTrackVisibility = (trackId = runtime?.trackId) => {
+    rig.visible = trackId === TRACK_ID;
+  };
+  syncTrackVisibility();
+
+  if (!rig.userData.turnTrackVisibilityListener) {
+    globalThis.addEventListener?.('turn:track-changed', (event) => {
+      syncTrackVisibility(event.detail?.trackId);
+    });
+    rig.userData.turnTrackVisibilityListener = true;
+  }
+
+  rig.userData.turnTrackVisibility = TRACK_ID;
+  rig.userData.turnMountainHeadlight = Object.freeze({
+    type: 'SpotLight',
+    count: 1,
+    shadows: false,
+    color: HEADLIGHT_COLOR,
+    intensity: light.intensity,
+    distance: light.distance,
+    angleDegrees: 14,
+    penumbra: light.penumbra,
+    decay: light.decay,
+    targetLocal: Object.freeze({ x: 0, y: -0.15, z: -44 })
+  });
+
+  return rig;
+}

--- a/turn/tracks/mountain-world-r3.js
+++ b/turn/tracks/mountain-world-r3.js
@@ -8,6 +8,7 @@ import { installMountainR4DriverFacingWaterfall } from './mountain-world-r4-wate
 import { installMountainR5SuburbanVillage } from './mountain-world-r5-suburban-village.js';
 import { installMountainR6Night } from './mountain-world-r6-night.js';
 import { installMountainR7SkyFix } from './mountain-world-r7-sky.js';
+import { installMountainSpotlightHeadlight } from './mountain-player-headlight-r8.js';
 
 const MOUNTAIN_VILLAGE_BENCHES = new Set([
   'Mountain village bench r4',
@@ -53,6 +54,12 @@ export function installMountainWorld({ scene, samples, trackWidth = 27, runtime 
   world.name = 'TURN Mountain r3';
   scene.add(world);
 
+  // Unlike the earlier projected wedges, this is one real shadowless light.
+  // It and its target are children of the player car, so the existing vehicle
+  // pitch follows MOUNTAIN's grade without any terrain-specific per-frame work.
+  const playerHeadlightRig = installMountainSpotlightHeadlight(runtime?.playerCar, runtime);
+  world.userData.turnMountainPlayerHeadlightRig = playerHeadlightRig;
+
   const terrainContext = installMountainTerrain(world, samples, trackWidth);
   installMountainR3Polish(world, samples, trackWidth);
   const sceneryReady = installMountainScenery(world, samples, trackWidth, terrainContext);
@@ -73,7 +80,7 @@ export function installMountainWorld({ scene, samples, trackWidth = 27, runtime 
   world.userData.turnMountainTerrainHeightAt = terrainContext.terrainHeightAt;
   world.userData.turnMountainArtDirection = Object.freeze({
     version: 'r3',
-    visualPolish: 'r7-horizon-sky-plus-r6-night-plus-r5-suburban-village-plus-r4-waterfall-landmarks',
+    visualPolish: 'r8-shadowless-player-spotlight-plus-r7-horizon-sky-plus-r6-night-plus-r5-suburban-village-plus-r4-waterfall-landmarks',
     ground: 'continuous-snow-and-granite-terrain-body',
     roadEdge: 'white-with-black-outer-contour',
     roadbed: 'opaque-and-terrain-supported',
@@ -88,7 +95,9 @@ export function installMountainWorld({ scene, samples, trackWidth = 27, runtime 
     celestialLayer: 'r7-reparents-the-r6-moon-onto-the-star-plane-at-the-same-depth',
     moon: 'same-depth-star-plane-child-sharing-yaw-pitch-roll-and-parallax',
     moonlight: 'cool-hemisphere-and-directional-track-atmosphere-plus-static-blue-hill-fill',
-    playerVisibilityLight: 'none-car-headlights-removed-in-favor-of-static-moonlight',
+    playerVisibilityLight: playerHeadlightRig
+      ? 'single-warm-shadowless-spotlight-car-child-following-existing-road-pitch'
+      : 'static-moonlight-only-when-no-player-car-is-present',
     streetlights: 'warm-static-halos-plus-midnight-city-style-ground-pools-and-local-fill',
     houseWindows: 'warm-emissive-looking-panels-on-every-suburban-house-with-limited-local-spill',
     waterfallLight: 'cool-moonlit-emissive-water-surfaces',

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -10,8 +10,8 @@ import { installCliffsideWorld } from './cliffside-world.js';
 import { installHarborWorld } from './harbor-world.js';
 // Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10
 import { installMidnightCityWorld } from './midnight-city-world-r11.js?build=20260802-r11';
-// Historical MOUNTAIN regression marker: mountain-world-r3.js?revision=r3-continuous-terrain-v1
-import { installMountainWorld } from './mountain-world-r3.js?revision=r6-night-treatment';
+// Historical MOUNTAIN regression markers: mountain-world-r3.js?revision=r3-continuous-terrain-v1, mountain-world-r3.js?revision=r6-night-treatment
+import { installMountainWorld } from './mountain-world-r3.js?revision=r8-shadowless-spotlight';
 import { isForgivingTrackSurface } from './airport-runoff.js?build=20260722-r52';
 import './contextual-road-edges.js?revision=r518-signature-yellow';
 import './road-contour-color-r512.js?revision=r513-countryside';


### PR DESCRIPTION
Replaces the failed projected-headlight idea with a deliberately small real-light experiment on MOUNTAIN.

- one warm-white Three.js `SpotLight`, not two fake beam meshes
- mounted to the player car with its target as a sibling in the same rig, so TURN's existing player-car road pitch/yaw/roll automatically carries the beam uphill and downhill
- broad 14° cone with soft penumbra, finite 54 m range and inverse-square decay
- `castShadow = false`, so no dynamic shadow-map pass
- MOUNTAIN-only; the rig switches off as soon as another track is activated
- no village on/off logic, terrain raycasts, projected geometry, or independent animation loop
- keeps the static moonlit hill fill from the previous simplification
- adds a focused CI contract ensuring this stays one shadowless spotlight and doesn't regress back to projected beam geometry

This is intentionally an experiment: if the physical light looks wrong on-device, it can be removed cleanly without touching the rest of the finished MOUNTAIN night treatment.