### PR TITLE
Share stronger night spotlight across MOUNTAIN and MIDNIGHT CITY

### DIFF
--- a/.github/workflows/turn-mountain-visual-smoke.yml
+++ b/.github/workflows/turn-mountain-visual-smoke.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'turn/tracks/mountain-*'
+      - 'turn/tracks/night-player-spotlight-*'
       - 'turn/assets/scenery/mountain/**'
       - 'turn-lab/mountain-visual.html'
       - 'turn-tests/mountain-visual-smoke.mjs'
@@ -16,6 +17,7 @@ on:
       - feature/mountain-track
     paths:
       - 'turn/tracks/mountain-*'
+      - 'turn/tracks/night-player-spotlight-*'
       - 'turn/assets/scenery/mountain/**'
       - 'turn-lab/mountain-visual.html'
       - 'turn-tests/mountain-visual-smoke.mjs'
@@ -38,7 +40,7 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Validate MOUNTAIN spotlight contract
+      - name: Validate shared night spotlight contract
         run: node turn-tests/mountain-spotlight-headlight-production.mjs
 
       - name: Install Playwright Chromium

--- a/turn-tests/midnight-city-lighting-production.mjs
+++ b/turn-tests/midnight-city-lighting-production.mjs
@@ -68,6 +68,9 @@ assert.doesNotMatch(signParkSource, /requestAnimationFrame|setAnimationLoop|setI
 
 await fs.access(new URL('../turn/LILYA.PNG', import.meta.url));
 assert.match(easterEggSource, /installMidnightCityWorld as installMidnightCityWorldR7/);
+assert.match(easterEggSource, /installNightPlayerSpotlight\(options\.runtime\?\.playerCar, options\.runtime\)/);
+assert.match(easterEggSource, /sharedNightSpotlight: Boolean\(playerSpotlight\)/);
+assert.match(easterEggSource, /hiddenLilyaAddsDynamicLights: false/);
 assert.match(easterEggSource, /new URL\('\.\.\/LILYA\.PNG', import\.meta\.url\)\.href/);
 assert.match(easterEggSource, /x: -500\.70[\s\S]*y: 11\.96[\s\S]*z: 40\.20/);
 assert.match(easterEggSource, /maxWidth: 46[\s\S]*maxHeight: 21/);
@@ -97,11 +100,11 @@ assert.match(easterEggSource, /gameplayGeometryUnchanged: true/);
 assert.doesNotMatch(
   easterEggSource,
   /requestAnimationFrame|setAnimationLoop|setInterval|setTimeout|new THREE\.PointLight|new THREE\.SpotLight/,
-  'The hidden portrait must use the existing render loop without adding timers or lights'
+  'The hidden portrait itself must use the existing render loop without adding timers or inline lights'
 );
 
-assert.match(registrySource, /midnight-city-world-r11\.js\?build=20260802-r11/);
+assert.match(registrySource, /midnight-city-world-r11\.js\?build=20260818-r560-shared-spotlight/);
 assert.match(registrySource, /'midnight-city'\(\{ scene, samples, trackWidth, runtime \}\)/);
 assert.match(registrySource, /installMidnightCityWorld\(\{ scene, samples, trackWidth, runtime \}\)/);
 
-console.log('TURN Midnight City lighting, scenery and wrong-way-only lazy LILYA placement passed.');
+console.log('TURN Midnight City lighting, shared night spotlight, scenery and wrong-way-only lazy LILYA placement passed.');

--- a/turn-tests/mountain-spotlight-headlight-production.mjs
+++ b/turn-tests/mountain-spotlight-headlight-production.mjs
@@ -1,31 +1,43 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [headlight, world, registry] = await Promise.all([
+const [sharedHeadlight, mountainWrapper, world, midnight, registry] = await Promise.all([
+  fs.readFile(new URL('../turn/tracks/night-player-spotlight-r560.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/tracks/mountain-player-headlight-r8.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/tracks/mountain-world-r3.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/tracks/midnight-city-world-r11.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/tracks/registry.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(headlight, /new THREE\.SpotLight\(/,
-  'MOUNTAIN headlight experiment must use a real SpotLight');
-assert.equal((headlight.match(/new THREE\.SpotLight\(/g) || []).length, 1,
-  'MOUNTAIN should use one central spotlight rather than two expensive lamps');
-assert.match(headlight, /light\.castShadow = false/,
-  'The experimental headlight must never allocate a dynamic shadow map');
-assert.match(headlight, /target\.position\.set\(0, -0\.15, -44\)/,
-  'The spotlight target should live far ahead of the car so its inherited road pitch drives the beam');
-assert.match(headlight, /rig\.add\(light, target\)/,
+assert.match(sharedHeadlight, /new THREE\.SpotLight\(/,
+  'Night-track headlights must use a real SpotLight');
+assert.equal((sharedHeadlight.match(/new THREE\.SpotLight\(/g) || []).length, 1,
+  'MOUNTAIN and MIDNIGHT CITY must share one central spotlight rig rather than duplicate lights');
+assert.match(sharedHeadlight, /intensity: 840/,
+  'The shared spotlight should use the approved stronger intensity');
+assert.match(sharedHeadlight, /distance: 66/,
+  'The shared spotlight should use the approved longer range');
+assert.match(sharedHeadlight, /new Set\(\['midnight-city', 'mountain'\]\)/,
+  'Exactly the two night tracks should share the same spotlight configuration');
+assert.match(sharedHeadlight, /light\.castShadow = false/,
+  'The shared headlight must never allocate a dynamic shadow map');
+assert.match(sharedHeadlight, /targetLocal: Object\.freeze\(\{ x: 0, y: -0\.15, z: -54 \}\)/,
+  'The stronger spotlight target should remain ahead of the car so inherited road pitch drives the beam');
+assert.match(sharedHeadlight, /rig\.add\(light, target\)/,
   'Light and target must share the player-car transform');
-assert.match(headlight, /event\.detail\?\.trackId/,
-  'The MOUNTAIN-only spotlight must switch off on other tracks');
-assert.doesNotMatch(headlight, /PlaneGeometry|BufferGeometry|CircleGeometry|requestAnimationFrame|setAnimationLoop/,
-  'The spotlight solution must not reintroduce visible projected beam geometry or its own animation loop');
+assert.doesNotMatch(sharedHeadlight, /PlaneGeometry|BufferGeometry|CircleGeometry|requestAnimationFrame|setAnimationLoop/,
+  'The spotlight solution must not reintroduce projected beam geometry or its own animation loop');
 
+assert.match(mountainWrapper, /installNightPlayerSpotlight\(playerCar, runtime\)/,
+  'MOUNTAIN must delegate to the shared night-track spotlight implementation');
 assert.match(world, /installMountainSpotlightHeadlight\(runtime\?\.playerCar, runtime\)/,
-  'The MOUNTAIN world must attach the spotlight to the production player car');
-assert.match(world, /single-warm-shadowless-spotlight-car-child-following-existing-road-pitch/);
-assert.match(registry, /mountain-world-r3\.js\?revision=r8-shadowless-spotlight/,
-  'Production must cache-bust to the spotlight experiment');
+  'The MOUNTAIN world must attach the shared spotlight to the production player car');
+assert.match(midnight, /installNightPlayerSpotlight\(options\.runtime\?\.playerCar, options\.runtime\)/,
+  'MIDNIGHT CITY must install the exact same shared spotlight rig');
+assert.match(midnight, /shared-warm-shadowless-spotlight-identical-to-mountain/);
+assert.match(registry, /mountain-world-r3\.js\?revision=r560-shared-night-spotlight/,
+  'Production must cache-bust MOUNTAIN to the shared spotlight revision');
+assert.match(registry, /midnight-city-world-r11\.js\?build=20260818-r560-shared-spotlight/,
+  'Production must cache-bust MIDNIGHT CITY to the shared spotlight revision');
 
-console.log('TURN MOUNTAIN shadowless spotlight headlight contract passed.');
+console.log('TURN shared MOUNTAIN + MIDNIGHT CITY shadowless spotlight contract passed.');

--- a/turn/tracks/midnight-city-world-r11.js
+++ b/turn/tracks/midnight-city-world-r11.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { signalSecretAchievement } from '../achievements/secret-events.js?revision=r157-hidden-achievements';
 import { installMidnightCityWorld as installMidnightCityWorldR7 } from './midnight-city-world-r7.js?base=20260801-r7';
+import { installNightPlayerSpotlight } from './night-player-spotlight-r560.js';
 
 const LILYA_TEXTURE_URL = new URL('../LILYA.PNG', import.meta.url).href;
 
@@ -23,8 +24,10 @@ export function installMidnightCityWorld(options) {
   const world = installMidnightCityWorldR7(options);
   const portrait = installHiddenLilyaPortrait(world);
   const lazyLoadArmed = armWrongWayTextureLoad(world, portrait, options);
+  const playerSpotlight = installNightPlayerSpotlight(options.runtime?.playerCar, options.runtime);
 
   world.name = 'TURN Midnight City r11';
+  world.userData.turnPlayerLightRig = playerSpotlight;
   world.userData.turnMidnightCityArtDirection = Object.freeze({
     ...(world.userData.turnMidnightCityArtDirection || {}),
     version: 'r11',
@@ -38,7 +41,11 @@ export function installMidnightCityWorld(options) {
     hiddenLilyaMipmaps: false,
     hiddenLilyaFitsFacade: true,
     gameplayGeometryUnchanged: true,
-    noDynamicLightsAdded: true,
+    playerVisibilityLight: playerSpotlight
+      ? 'shared-warm-shadowless-spotlight-identical-to-mountain'
+      : 'unavailable-without-player-car',
+    sharedNightSpotlight: Boolean(playerSpotlight),
+    hiddenLilyaAddsDynamicLights: false,
     noIndependentAnimationLoop: true
   });
 

--- a/turn/tracks/mountain-player-headlight-r8.js
+++ b/turn/tracks/mountain-player-headlight-r8.js
@@ -1,69 +1,7 @@
-import * as THREE from 'three';
+import { installNightPlayerSpotlight } from './night-player-spotlight-r560.js';
 
-const TRACK_ID = 'mountain';
-const RIG_NAME = 'TURN Mountain spotlight headlight r8';
-const TARGET_NAME = 'TURN Mountain spotlight target r8';
-const LIGHT_NAME = 'TURN Mountain warm spotlight headlight r8';
-const HEADLIGHT_COLOR = 0xffe3b3;
-
-// One real, shadowless light rather than projected beam geometry. Because both
-// the lamp and its target are children of the player-car transform, TURN's
-// existing road pitch/yaw/roll automatically carries the headlight with the car
-// on MOUNTAIN's steep grades.
+// Keep the MOUNTAIN-facing API stable while using the exact same physical
+// spotlight rig and configuration as MIDNIGHT CITY.
 export function installMountainSpotlightHeadlight(playerCar, runtime) {
-  if (!playerCar) return null;
-
-  let rig = playerCar.getObjectByName?.(RIG_NAME);
-  if (rig) return rig;
-
-  rig = new THREE.Group();
-  rig.name = RIG_NAME;
-
-  const target = new THREE.Object3D();
-  target.name = TARGET_NAME;
-  target.position.set(0, -0.15, -44);
-
-  const light = new THREE.SpotLight(
-    HEADLIGHT_COLOR,
-    650,
-    54,
-    THREE.MathUtils.degToRad(14),
-    0.78,
-    2
-  );
-  light.name = LIGHT_NAME;
-  light.position.set(0, 1.05, -1.65);
-  light.target = target;
-  light.castShadow = false;
-
-  rig.add(light, target);
-  playerCar.add(rig);
-
-  const syncTrackVisibility = (trackId = runtime?.trackId) => {
-    rig.visible = trackId === TRACK_ID;
-  };
-  syncTrackVisibility();
-
-  if (!rig.userData.turnTrackVisibilityListener) {
-    globalThis.addEventListener?.('turn:track-changed', (event) => {
-      syncTrackVisibility(event.detail?.trackId);
-    });
-    rig.userData.turnTrackVisibilityListener = true;
-  }
-
-  rig.userData.turnTrackVisibility = TRACK_ID;
-  rig.userData.turnMountainHeadlight = Object.freeze({
-    type: 'SpotLight',
-    count: 1,
-    shadows: false,
-    color: HEADLIGHT_COLOR,
-    intensity: light.intensity,
-    distance: light.distance,
-    angleDegrees: 14,
-    penumbra: light.penumbra,
-    decay: light.decay,
-    targetLocal: Object.freeze({ x: 0, y: -0.15, z: -44 })
-  });
-
-  return rig;
+  return installNightPlayerSpotlight(playerCar, runtime);
 }

--- a/turn/tracks/mountain-world-r3.js
+++ b/turn/tracks/mountain-world-r3.js
@@ -8,7 +8,7 @@ import { installMountainR4DriverFacingWaterfall } from './mountain-world-r4-wate
 import { installMountainR5SuburbanVillage } from './mountain-world-r5-suburban-village.js';
 import { installMountainR6Night } from './mountain-world-r6-night.js';
 import { installMountainR7SkyFix } from './mountain-world-r7-sky.js';
-import { installMountainSpotlightHeadlight } from './mountain-player-headlight-r8.js';
+import { installMountainSpotlightHeadlight } from './mountain-player-headlight-r8.js?revision=r560-shared-night-spotlight';
 
 const MOUNTAIN_VILLAGE_BENCHES = new Set([
   'Mountain village bench r4',
@@ -54,9 +54,9 @@ export function installMountainWorld({ scene, samples, trackWidth = 27, runtime 
   world.name = 'TURN Mountain r3';
   scene.add(world);
 
-  // Unlike the earlier projected wedges, this is one real shadowless light.
-  // It and its target are children of the player car, so the existing vehicle
-  // pitch follows MOUNTAIN's grade without any terrain-specific per-frame work.
+  // One real shadowless light shared with MIDNIGHT CITY. The lamp and target
+  // are children of the player car, so TURN's existing vehicle pitch carries
+  // the beam naturally over MOUNTAIN's grades without terrain-specific work.
   const playerHeadlightRig = installMountainSpotlightHeadlight(runtime?.playerCar, runtime);
   world.userData.turnMountainPlayerHeadlightRig = playerHeadlightRig;
 
@@ -80,7 +80,7 @@ export function installMountainWorld({ scene, samples, trackWidth = 27, runtime 
   world.userData.turnMountainTerrainHeightAt = terrainContext.terrainHeightAt;
   world.userData.turnMountainArtDirection = Object.freeze({
     version: 'r3',
-    visualPolish: 'r8-shadowless-player-spotlight-plus-r7-horizon-sky-plus-r6-night-plus-r5-suburban-village-plus-r4-waterfall-landmarks',
+    visualPolish: 'r560-shared-night-spotlight-plus-r7-horizon-sky-plus-r6-night-plus-r5-suburban-village-plus-r4-waterfall-landmarks',
     ground: 'continuous-snow-and-granite-terrain-body',
     roadEdge: 'white-with-black-outer-contour',
     roadbed: 'opaque-and-terrain-supported',
@@ -96,7 +96,7 @@ export function installMountainWorld({ scene, samples, trackWidth = 27, runtime 
     moon: 'same-depth-star-plane-child-sharing-yaw-pitch-roll-and-parallax',
     moonlight: 'cool-hemisphere-and-directional-track-atmosphere-plus-static-blue-hill-fill',
     playerVisibilityLight: playerHeadlightRig
-      ? 'single-warm-shadowless-spotlight-car-child-following-existing-road-pitch'
+      ? 'shared-warm-shadowless-spotlight-identical-to-midnight-city'
       : 'static-moonlight-only-when-no-player-car-is-present',
     streetlights: 'warm-static-halos-plus-midnight-city-style-ground-pools-and-local-fill',
     houseWindows: 'warm-emissive-looking-panels-on-every-suburban-house-with-limited-local-spill',

--- a/turn/tracks/night-player-spotlight-r560.js
+++ b/turn/tracks/night-player-spotlight-r560.js
@@ -1,0 +1,100 @@
+import * as THREE from 'three';
+
+const NIGHT_TRACK_IDS = new Set(['midnight-city', 'mountain']);
+const RIG_NAME = 'TURN shared night spotlight r560';
+const TARGET_NAME = 'TURN shared night spotlight target r560';
+const LIGHT_NAME = 'TURN shared warm spotlight headlight r560';
+const LEGACY_MIDNIGHT_RIG_NAME = 'TURN Midnight City player light rig';
+const HEADLIGHT_COLOR = 0xffe3b3;
+
+// One configuration for both night tracks. This is deliberately a little more
+// assertive than the first MOUNTAIN experiment while keeping the same cheap
+// contract: one real light, finite range, no shadow map and no beam geometry.
+export const NIGHT_SPOTLIGHT_CONFIG = Object.freeze({
+  color: HEADLIGHT_COLOR,
+  intensity: 840,
+  distance: 66,
+  angleDegrees: 14,
+  penumbra: 0.78,
+  decay: 2,
+  lightLocal: Object.freeze({ x: 0, y: 1.05, z: -1.65 }),
+  targetLocal: Object.freeze({ x: 0, y: -0.15, z: -54 })
+});
+
+export function installNightPlayerSpotlight(playerCar, runtime) {
+  if (!playerCar) return null;
+
+  removeLegacyMidnightPlayerLighting(playerCar);
+
+  let rig = playerCar.getObjectByName?.(RIG_NAME);
+  if (!rig) {
+    rig = new THREE.Group();
+    rig.name = RIG_NAME;
+
+    const target = new THREE.Object3D();
+    target.name = TARGET_NAME;
+    target.position.set(
+      NIGHT_SPOTLIGHT_CONFIG.targetLocal.x,
+      NIGHT_SPOTLIGHT_CONFIG.targetLocal.y,
+      NIGHT_SPOTLIGHT_CONFIG.targetLocal.z
+    );
+
+    const light = new THREE.SpotLight(
+      NIGHT_SPOTLIGHT_CONFIG.color,
+      NIGHT_SPOTLIGHT_CONFIG.intensity,
+      NIGHT_SPOTLIGHT_CONFIG.distance,
+      THREE.MathUtils.degToRad(NIGHT_SPOTLIGHT_CONFIG.angleDegrees),
+      NIGHT_SPOTLIGHT_CONFIG.penumbra,
+      NIGHT_SPOTLIGHT_CONFIG.decay
+    );
+    light.name = LIGHT_NAME;
+    light.position.set(
+      NIGHT_SPOTLIGHT_CONFIG.lightLocal.x,
+      NIGHT_SPOTLIGHT_CONFIG.lightLocal.y,
+      NIGHT_SPOTLIGHT_CONFIG.lightLocal.z
+    );
+    light.target = target;
+    light.castShadow = false;
+
+    rig.add(light, target);
+    playerCar.add(rig);
+
+    rig.userData.turnNightSpotlight = Object.freeze({
+      type: 'SpotLight',
+      count: 1,
+      tracks: Object.freeze([...NIGHT_TRACK_IDS]),
+      shadows: false,
+      ...NIGHT_SPOTLIGHT_CONFIG
+    });
+  }
+
+  const syncTrackVisibility = (trackId = runtime?.trackId) => {
+    rig.visible = NIGHT_TRACK_IDS.has(trackId);
+  };
+  syncTrackVisibility();
+
+  if (!rig.userData.turnTrackVisibilityListener) {
+    globalThis.addEventListener?.('turn:track-changed', (event) => {
+      syncTrackVisibility(event.detail?.trackId);
+    });
+    rig.userData.turnTrackVisibilityListener = true;
+  }
+
+  return rig;
+}
+
+function removeLegacyMidnightPlayerLighting(playerCar) {
+  const legacyRig = playerCar.getObjectByName?.(LEGACY_MIDNIGHT_RIG_NAME);
+  if (!legacyRig) return;
+
+  for (const child of [...legacyRig.children]) {
+    legacyRig.remove(child);
+    child.geometry?.dispose?.();
+    if (Array.isArray(child.material)) {
+      for (const material of child.material) material?.dispose?.();
+    } else {
+      child.material?.dispose?.();
+    }
+  }
+  legacyRig.parent?.remove(legacyRig);
+}

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -8,10 +8,10 @@ import {
 import { installAirportWorld } from './airport-world-r56.js?build=20260815-r498';
 import { installCliffsideWorld } from './cliffside-world.js';
 import { installHarborWorld } from './harbor-world.js';
-// Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10
-import { installMidnightCityWorld } from './midnight-city-world-r11.js?build=20260802-r11';
-// Historical MOUNTAIN regression markers: mountain-world-r3.js?revision=r3-continuous-terrain-v1, mountain-world-r3.js?revision=r6-night-treatment
-import { installMountainWorld } from './mountain-world-r3.js?revision=r8-shadowless-spotlight';
+// Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10, midnight-city-world-r11.js?build=20260802-r11
+import { installMidnightCityWorld } from './midnight-city-world-r11.js?build=20260818-r560-shared-spotlight';
+// Historical MOUNTAIN regression markers: mountain-world-r3.js?revision=r3-continuous-terrain-v1, mountain-world-r3.js?revision=r6-night-treatment, mountain-world-r3.js?revision=r8-shadowless-spotlight
+import { installMountainWorld } from './mountain-world-r3.js?revision=r560-shared-night-spotlight';
 import { isForgivingTrackSurface } from './airport-runoff.js?build=20260722-r52';
 import './contextual-road-edges.js?revision=r518-signature-yellow';
 import './road-contour-color-r512.js?revision=r513-countryside';


### PR DESCRIPTION
Follow-up to the successful MOUNTAIN SpotLight experiment.

- use one shared physical spotlight configuration for both MOUNTAIN and MIDNIGHT CITY
- increase intensity from 650 to 840 and range from 54 m to 66 m
- keep the same 14° cone, soft penumbra, inverse-square decay and `castShadow = false`
- reuse one player-car rig across both night tracks rather than maintaining two implementations
- remove MIDNIGHT CITY's legacy player fill/projected-wedge rig when the shared spotlight is installed
- keep the spotlight hidden on all non-night tracks
- cache-bust both production night worlds
- extend regression coverage so the two tracks cannot drift to different headlight configurations

No terrain raycasts, beam geometry, shadow maps or independent animation loop are added.