### PR TITLE
Extend shared night headlights to 200 m

### DIFF
--- a/turn-tests/mountain-spotlight-headlight-production.mjs
+++ b/turn-tests/mountain-spotlight-headlight-production.mjs
@@ -13,31 +13,35 @@ assert.match(sharedHeadlight, /new THREE\.SpotLight\(/,
   'Night-track headlights must use a real SpotLight');
 assert.equal((sharedHeadlight.match(/new THREE\.SpotLight\(/g) || []).length, 1,
   'MOUNTAIN and MIDNIGHT CITY must share one central spotlight rig rather than duplicate lights');
-assert.match(sharedHeadlight, /intensity: 840/,
-  'The shared spotlight should use the approved stronger intensity');
-assert.match(sharedHeadlight, /distance: 66/,
-  'The shared spotlight should use the approved longer range');
+assert.match(sharedHeadlight, /intensity: 2200/,
+  'The shared spotlight should use the approved racing-speed intensity');
+assert.match(sharedHeadlight, /distance: 200/,
+  'The shared spotlight should use the approved 200 m racing-speed range');
 assert.match(sharedHeadlight, /new Set\(\['midnight-city', 'mountain'\]\)/,
   'Exactly the two night tracks should share the same spotlight configuration');
 assert.match(sharedHeadlight, /light\.castShadow = false/,
   'The shared headlight must never allocate a dynamic shadow map');
 assert.match(sharedHeadlight, /targetLocal: Object\.freeze\(\{ x: 0, y: -0\.15, z: -54 \}\)/,
-  'The stronger spotlight target should remain ahead of the car so inherited road pitch drives the beam');
+  'The spotlight target should remain ahead of the car so inherited road pitch drives the beam');
 assert.match(sharedHeadlight, /rig\.add\(light, target\)/,
   'Light and target must share the player-car transform');
 assert.doesNotMatch(sharedHeadlight, /PlaneGeometry|BufferGeometry|CircleGeometry|requestAnimationFrame|setAnimationLoop/,
   'The spotlight solution must not reintroduce projected beam geometry or its own animation loop');
 
+assert.match(mountainWrapper, /night-player-spotlight-r560\.js\?revision=r561-200m/,
+  'MOUNTAIN must cache-bust to the 200 m shared spotlight configuration');
 assert.match(mountainWrapper, /installNightPlayerSpotlight\(playerCar, runtime\)/,
   'MOUNTAIN must delegate to the shared night-track spotlight implementation');
 assert.match(world, /installMountainSpotlightHeadlight\(runtime\?\.playerCar, runtime\)/,
   'The MOUNTAIN world must attach the shared spotlight to the production player car');
+assert.match(midnight, /night-player-spotlight-r560\.js\?revision=r561-200m/,
+  'MIDNIGHT CITY must cache-bust to the exact same 200 m shared spotlight configuration');
 assert.match(midnight, /installNightPlayerSpotlight\(options\.runtime\?\.playerCar, options\.runtime\)/,
   'MIDNIGHT CITY must install the exact same shared spotlight rig');
 assert.match(midnight, /shared-warm-shadowless-spotlight-identical-to-mountain/);
-assert.match(registry, /mountain-world-r3\.js\?revision=r560-shared-night-spotlight/,
-  'Production must cache-bust MOUNTAIN to the shared spotlight revision');
-assert.match(registry, /midnight-city-world-r11\.js\?build=20260818-r560-shared-spotlight/,
-  'Production must cache-bust MIDNIGHT CITY to the shared spotlight revision');
+assert.match(registry, /mountain-world-r3\.js\?revision=r561-200m-headlight/,
+  'Production must cache-bust MOUNTAIN to the 200 m headlight revision');
+assert.match(registry, /midnight-city-world-r11\.js\?build=20260818-r561-200m-headlight/,
+  'Production must cache-bust MIDNIGHT CITY to the 200 m headlight revision');
 
-console.log('TURN shared MOUNTAIN + MIDNIGHT CITY shadowless spotlight contract passed.');
+console.log('TURN shared MOUNTAIN + MIDNIGHT CITY 200 m shadowless spotlight contract passed.');

--- a/turn/tracks/midnight-city-world-r11.js
+++ b/turn/tracks/midnight-city-world-r11.js
@@ -40,10 +40,12 @@ export function installMidnightCityWorld(options) {
     hiddenLilyaDiscoveryHoldMs: LILYA_DISCOVERY_HOLD_MS,
     hiddenLilyaMipmaps: false,
     hiddenLilyaFitsFacade: true,
+    gameplayGeometryUnchanged: true,
     playerVisibilityLight: playerSpotlight
       ? 'shared-warm-shadowless-spotlight-identical-to-mountain'
-      : 'none-when-no-player-car-is-present',
-    gameplayGeometryUnchanged: true,
+      : 'unavailable-without-player-car',
+    sharedNightSpotlight: Boolean(playerSpotlight),
+    hiddenLilyaAddsDynamicLights: false,
     noIndependentAnimationLoop: true
   });
 

--- a/turn/tracks/midnight-city-world-r11.js
+++ b/turn/tracks/midnight-city-world-r11.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { signalSecretAchievement } from '../achievements/secret-events.js?revision=r157-hidden-achievements';
 import { installMidnightCityWorld as installMidnightCityWorldR7 } from './midnight-city-world-r7.js?base=20260801-r7';
-import { installNightPlayerSpotlight } from './night-player-spotlight-r560.js';
+import { installNightPlayerSpotlight } from './night-player-spotlight-r560.js?revision=r561-200m';
 
 const LILYA_TEXTURE_URL = new URL('../LILYA.PNG', import.meta.url).href;
 
@@ -40,12 +40,10 @@ export function installMidnightCityWorld(options) {
     hiddenLilyaDiscoveryHoldMs: LILYA_DISCOVERY_HOLD_MS,
     hiddenLilyaMipmaps: false,
     hiddenLilyaFitsFacade: true,
-    gameplayGeometryUnchanged: true,
     playerVisibilityLight: playerSpotlight
       ? 'shared-warm-shadowless-spotlight-identical-to-mountain'
-      : 'unavailable-without-player-car',
-    sharedNightSpotlight: Boolean(playerSpotlight),
-    hiddenLilyaAddsDynamicLights: false,
+      : 'none-when-no-player-car-is-present',
+    gameplayGeometryUnchanged: true,
     noIndependentAnimationLoop: true
   });
 

--- a/turn/tracks/mountain-player-headlight-r8.js
+++ b/turn/tracks/mountain-player-headlight-r8.js
@@ -1,4 +1,4 @@
-import { installNightPlayerSpotlight } from './night-player-spotlight-r560.js';
+import { installNightPlayerSpotlight } from './night-player-spotlight-r560.js?revision=r561-200m';
 
 // Keep the MOUNTAIN-facing API stable while using the exact same physical
 // spotlight rig and configuration as MIDNIGHT CITY.

--- a/turn/tracks/night-player-spotlight-r560.js
+++ b/turn/tracks/night-player-spotlight-r560.js
@@ -7,13 +7,13 @@ const LIGHT_NAME = 'TURN shared warm spotlight headlight r560';
 const LEGACY_MIDNIGHT_RIG_NAME = 'TURN Midnight City player light rig';
 const HEADLIGHT_COLOR = 0xffe3b3;
 
-// One configuration for both night tracks. This is deliberately a little more
-// assertive than the first MOUNTAIN experiment while keeping the same cheap
-// contract: one real light, finite range, no shadow map and no beam geometry.
+// One configuration for both night tracks. The longer 200 m reach is tuned for
+// TURN's racing speeds, while the performance contract remains deliberately
+// small: one real light, no shadow map, no beam geometry and no extra loop.
 export const NIGHT_SPOTLIGHT_CONFIG = Object.freeze({
   color: HEADLIGHT_COLOR,
-  intensity: 840,
-  distance: 66,
+  intensity: 2200,
+  distance: 200,
   angleDegrees: 14,
   penumbra: 0.78,
   decay: 2,

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -8,10 +8,10 @@ import {
 import { installAirportWorld } from './airport-world-r56.js?build=20260815-r498';
 import { installCliffsideWorld } from './cliffside-world.js';
 import { installHarborWorld } from './harbor-world.js';
-// Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10, midnight-city-world-r11.js?build=20260802-r11
-import { installMidnightCityWorld } from './midnight-city-world-r11.js?build=20260818-r560-shared-spotlight';
-// Historical MOUNTAIN regression markers: mountain-world-r3.js?revision=r3-continuous-terrain-v1, mountain-world-r3.js?revision=r6-night-treatment, mountain-world-r3.js?revision=r8-shadowless-spotlight
-import { installMountainWorld } from './mountain-world-r3.js?revision=r560-shared-night-spotlight';
+// Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10, midnight-city-world-r11.js?build=20260802-r11, midnight-city-world-r11.js?build=20260818-r560-shared-spotlight
+import { installMidnightCityWorld } from './midnight-city-world-r11.js?build=20260818-r561-200m-headlight';
+// Historical MOUNTAIN regression markers: mountain-world-r3.js?revision=r3-continuous-terrain-v1, mountain-world-r3.js?revision=r6-night-treatment, mountain-world-r3.js?revision=r8-shadowless-spotlight, mountain-world-r3.js?revision=r560-shared-night-spotlight
+import { installMountainWorld } from './mountain-world-r3.js?revision=r561-200m-headlight';
 import { isForgivingTrackSurface } from './airport-runoff.js?build=20260722-r52';
 import './contextual-road-edges.js?revision=r518-signature-yellow';
 import './road-contour-color-r512.js?revision=r513-countryside';


### PR DESCRIPTION
Tunes the single shared MOUNTAIN + MIDNIGHT CITY spotlight for TURN's racing speeds while preserving the performance-conscious implementation.

- one exact configuration for both night tracks
- increase intensity from 840 to 2200
- increase finite range from 66 m to 200 m
- keep the same 14° cone, 0.78 penumbra and inverse-square decay
- keep `castShadow = false`
- still one real light total: no duplicate lamps, beam geometry, terrain raycasts or independent animation loop
- cache-bust both production night-track paths so the tuning reaches installed clients
- update the shared contract test so MOUNTAIN and MIDNIGHT CITY cannot drift apart

This is intentionally the next performance-conscious step before device testing on the iPad 9. If the longer influence range proves too expensive there, the shared config gives us one place to dial it back.