### PR TITLE
Lift MIDNIGHT CITY asphalt for shared headlights

### DIFF
--- a/turn-tests/midnight-city-lighting-production.mjs
+++ b/turn-tests/midnight-city-lighting-production.mjs
@@ -70,6 +70,11 @@ await fs.access(new URL('../turn/LILYA.PNG', import.meta.url));
 assert.match(easterEggSource, /installMidnightCityWorld as installMidnightCityWorldR7/);
 assert.match(easterEggSource, /installNightPlayerSpotlight\(options\.runtime\?\.playerCar, options\.runtime\)/);
 assert.match(easterEggSource, /sharedNightSpotlight: Boolean\(playerSpotlight\)/);
+assert.match(easterEggSource, /const MIDNIGHT_HEADLIGHT_ROAD = 0x292e38/,
+  'MIDNIGHT CITY asphalt should be lifted enough to reflect the shared spotlight without changing the light config');
+assert.match(easterEggSource, /liftRoadForSharedHeadlight\(world\)/);
+assert.match(easterEggSource, /material\.color\.setHex\(MIDNIGHT_HEADLIGHT_ROAD\)/);
+assert.match(easterEggSource, /headlightRoadReflectance: headlightRoadLifted/);
 assert.match(easterEggSource, /hiddenLilyaAddsDynamicLights: false/);
 assert.match(easterEggSource, /new URL\('\.\.\/LILYA\.PNG', import\.meta\.url\)\.href/);
 assert.match(easterEggSource, /x: -500\.70[\s\S]*y: 11\.96[\s\S]*z: 40\.20/);
@@ -103,8 +108,8 @@ assert.doesNotMatch(
   'The hidden portrait itself must use the existing render loop without adding timers or inline lights'
 );
 
-assert.match(registrySource, /midnight-city-world-r11\.js\?build=20260818-r560-shared-spotlight/);
+assert.match(registrySource, /midnight-city-world-r11\.js\?build=20260818-r562-road-headlight-response/);
 assert.match(registrySource, /'midnight-city'\(\{ scene, samples, trackWidth, runtime \}\)/);
 assert.match(registrySource, /installMidnightCityWorld\(\{ scene, samples, trackWidth, runtime \}\)/);
 
-console.log('TURN Midnight City lighting, shared night spotlight, scenery and wrong-way-only lazy LILYA placement passed.');
+console.log('TURN Midnight City lighting, shared night spotlight, road reflectance, scenery and wrong-way-only lazy LILYA placement passed.');

--- a/turn/tracks/midnight-city-world-r11.js
+++ b/turn/tracks/midnight-city-world-r11.js
@@ -4,6 +4,7 @@ import { installMidnightCityWorld as installMidnightCityWorldR7 } from './midnig
 import { installNightPlayerSpotlight } from './night-player-spotlight-r560.js?revision=r561-200m';
 
 const LILYA_TEXTURE_URL = new URL('../LILYA.PNG', import.meta.url).href;
+const MIDNIGHT_HEADLIGHT_ROAD = 0x292e38;
 
 const LILYA_WALL = Object.freeze({
   x: -500.70,
@@ -22,6 +23,7 @@ const LILYA_DISCOVERY_HOLD_MS = 650;
 
 export function installMidnightCityWorld(options) {
   const world = installMidnightCityWorldR7(options);
+  const headlightRoadLifted = liftRoadForSharedHeadlight(world);
   const portrait = installHiddenLilyaPortrait(world);
   const lazyLoadArmed = armWrongWayTextureLoad(world, portrait, options);
   const playerSpotlight = installNightPlayerSpotlight(options.runtime?.playerCar, options.runtime);
@@ -45,11 +47,29 @@ export function installMidnightCityWorld(options) {
       ? 'shared-warm-shadowless-spotlight-identical-to-mountain'
       : 'unavailable-without-player-car',
     sharedNightSpotlight: Boolean(playerSpotlight),
+    headlightRoadReflectance: headlightRoadLifted
+      ? 'asphalt-lifted-to-292e38-for-shared-spotlight-readability'
+      : 'race-road-not-found',
     hiddenLilyaAddsDynamicLights: false,
     noIndependentAnimationLoop: true
   });
 
   return world;
+}
+
+function liftRoadForSharedHeadlight(world) {
+  const road = world.getObjectByName('Midnight City race road');
+  if (!road?.isMesh) return false;
+
+  const materials = Array.isArray(road.material) ? road.material : [road.material];
+  let changed = false;
+  for (const material of materials) {
+    if (!material?.isMeshStandardMaterial || !material.color) continue;
+    material.color.setHex(MIDNIGHT_HEADLIGHT_ROAD);
+    material.needsUpdate = true;
+    changed = true;
+  }
+  return changed;
 }
 
 function installHiddenLilyaPortrait(world) {

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -8,8 +8,8 @@ import {
 import { installAirportWorld } from './airport-world-r56.js?build=20260815-r498';
 import { installCliffsideWorld } from './cliffside-world.js';
 import { installHarborWorld } from './harbor-world.js';
-// Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10, midnight-city-world-r11.js?build=20260802-r11, midnight-city-world-r11.js?build=20260818-r560-shared-spotlight
-import { installMidnightCityWorld } from './midnight-city-world-r11.js?build=20260818-r561-200m-headlight';
+// Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10, midnight-city-world-r11.js?build=20260802-r11, midnight-city-world-r11.js?build=20260818-r560-shared-spotlight, midnight-city-world-r11.js?build=20260818-r561-200m-headlight
+import { installMidnightCityWorld } from './midnight-city-world-r11.js?build=20260818-r562-road-headlight-response';
 // Historical MOUNTAIN regression markers: mountain-world-r3.js?revision=r3-continuous-terrain-v1, mountain-world-r3.js?revision=r6-night-treatment, mountain-world-r3.js?revision=r8-shadowless-spotlight, mountain-world-r3.js?revision=r560-shared-night-spotlight
 import { installMountainWorld } from './mountain-world-r3.js?revision=r561-200m-headlight';
 import { isForgivingTrackSurface } from './airport-runoff.js?build=20260722-r52';


### PR DESCRIPTION
Small visual follow-up to the shared 200 m night spotlight.

- keep the exact same shared headlight configuration on MOUNTAIN and MIDNIGHT CITY
- lift only MIDNIGHT CITY race-road material to `#292e38` at world install time
- no additional lights, geometry, raycasts, shadows, or animation work
- cache-bust the production MIDNIGHT CITY world
- add regression coverage for the road reflectance treatment

The goal is to make the existing shared spotlight read on MIDNIGHT CITY as clearly as it does on MOUNTAIN without increasing lighting cost.