### PR TITLE
Aim shared night headlights lower

### DIFF
--- a/turn-tests/mountain-spotlight-headlight-production.mjs
+++ b/turn-tests/mountain-spotlight-headlight-production.mjs
@@ -21,27 +21,27 @@ assert.match(sharedHeadlight, /new Set\(\['midnight-city', 'mountain'\]\)/,
   'Exactly the two night tracks should share the same spotlight configuration');
 assert.match(sharedHeadlight, /light\.castShadow = false/,
   'The shared headlight must never allocate a dynamic shadow map');
-assert.match(sharedHeadlight, /targetLocal: Object\.freeze\(\{ x: 0, y: -0\.15, z: -54 \}\)/,
-  'The spotlight target should remain ahead of the car so inherited road pitch drives the beam');
+assert.match(sharedHeadlight, /targetLocal: Object\.freeze\(\{ x: 0, y: -1\.5, z: -54 \}\)/,
+  'The shared spotlight should aim lower so flat and downhill roads meet the useful cone sooner');
 assert.match(sharedHeadlight, /rig\.add\(light, target\)/,
   'Light and target must share the player-car transform');
 assert.doesNotMatch(sharedHeadlight, /PlaneGeometry|BufferGeometry|CircleGeometry|requestAnimationFrame|setAnimationLoop/,
   'The spotlight solution must not reintroduce projected beam geometry or its own animation loop');
 
-assert.match(mountainWrapper, /night-player-spotlight-r560\.js\?revision=r561-200m/,
-  'MOUNTAIN must cache-bust to the 200 m shared spotlight configuration');
+assert.match(mountainWrapper, /night-player-spotlight-r560\.js\?revision=r563-lower-target/,
+  'MOUNTAIN must cache-bust to the lower shared spotlight aim');
 assert.match(mountainWrapper, /installNightPlayerSpotlight\(playerCar, runtime\)/,
   'MOUNTAIN must delegate to the shared night-track spotlight implementation');
 assert.match(world, /installMountainSpotlightHeadlight\(runtime\?\.playerCar, runtime\)/,
   'The MOUNTAIN world must attach the shared spotlight to the production player car');
-assert.match(midnight, /night-player-spotlight-r560\.js\?revision=r561-200m/,
-  'MIDNIGHT CITY must cache-bust to the exact same 200 m shared spotlight configuration');
+assert.match(midnight, /night-player-spotlight-r560\.js\?revision=r563-lower-target/,
+  'MIDNIGHT CITY must cache-bust to the exact same lower shared spotlight aim');
 assert.match(midnight, /installNightPlayerSpotlight\(options\.runtime\?\.playerCar, options\.runtime\)/,
   'MIDNIGHT CITY must install the exact same shared spotlight rig');
 assert.match(midnight, /shared-warm-shadowless-spotlight-identical-to-mountain/);
-assert.match(registry, /mountain-world-r3\.js\?revision=r561-200m-headlight/,
-  'Production must cache-bust MOUNTAIN to the 200 m headlight revision');
-assert.match(registry, /midnight-city-world-r11\.js\?build=20260818-r561-200m-headlight/,
-  'Production must cache-bust MIDNIGHT CITY to the 200 m headlight revision');
+assert.match(registry, /mountain-world-r3\.js\?revision=r563-lower-headlight-target/,
+  'Production must cache-bust MOUNTAIN to the lower headlight target revision');
+assert.match(registry, /midnight-city-world-r11\.js\?build=20260818-r563-lower-headlight-target/,
+  'Production must cache-bust MIDNIGHT CITY to the lower headlight target revision');
 
-console.log('TURN shared MOUNTAIN + MIDNIGHT CITY 200 m shadowless spotlight contract passed.');
+console.log('TURN shared MOUNTAIN + MIDNIGHT CITY lower-aim 200 m shadowless spotlight contract passed.');

--- a/turn/tracks/midnight-city-world-r11.js
+++ b/turn/tracks/midnight-city-world-r11.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { signalSecretAchievement } from '../achievements/secret-events.js?revision=r157-hidden-achievements';
 import { installMidnightCityWorld as installMidnightCityWorldR7 } from './midnight-city-world-r7.js?base=20260801-r7';
-import { installNightPlayerSpotlight } from './night-player-spotlight-r560.js?revision=r561-200m';
+import { installNightPlayerSpotlight } from './night-player-spotlight-r560.js?revision=r563-lower-target';
 
 const LILYA_TEXTURE_URL = new URL('../LILYA.PNG', import.meta.url).href;
 const MIDNIGHT_HEADLIGHT_ROAD = 0x292e38;

--- a/turn/tracks/mountain-player-headlight-r8.js
+++ b/turn/tracks/mountain-player-headlight-r8.js
@@ -1,4 +1,4 @@
-import { installNightPlayerSpotlight } from './night-player-spotlight-r560.js?revision=r561-200m';
+import { installNightPlayerSpotlight } from './night-player-spotlight-r560.js?revision=r563-lower-target';
 
 // Keep the MOUNTAIN-facing API stable while using the exact same physical
 // spotlight rig and configuration as MIDNIGHT CITY.

--- a/turn/tracks/night-player-spotlight-r560.js
+++ b/turn/tracks/night-player-spotlight-r560.js
@@ -7,9 +7,10 @@ const LIGHT_NAME = 'TURN shared warm spotlight headlight r560';
 const LEGACY_MIDNIGHT_RIG_NAME = 'TURN Midnight City player light rig';
 const HEADLIGHT_COLOR = 0xffe3b3;
 
-// One configuration for both night tracks. The longer 200 m reach is tuned for
-// TURN's racing speeds, while the performance contract remains deliberately
-// small: one real light, no shadow map, no beam geometry and no extra loop.
+// One configuration for both night tracks. The 200 m reach is tuned for TURN's
+// racing speeds, while the lower target makes the useful part of the cone meet
+// flatter/downhill road surfaces sooner. The performance contract stays small:
+// one real light, no shadow map, no beam geometry and no extra loop.
 export const NIGHT_SPOTLIGHT_CONFIG = Object.freeze({
   color: HEADLIGHT_COLOR,
   intensity: 2200,
@@ -18,7 +19,7 @@ export const NIGHT_SPOTLIGHT_CONFIG = Object.freeze({
   penumbra: 0.78,
   decay: 2,
   lightLocal: Object.freeze({ x: 0, y: 1.05, z: -1.65 }),
-  targetLocal: Object.freeze({ x: 0, y: -0.15, z: -54 })
+  targetLocal: Object.freeze({ x: 0, y: -1.5, z: -54 })
 });
 
 export function installNightPlayerSpotlight(playerCar, runtime) {

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -8,10 +8,10 @@ import {
 import { installAirportWorld } from './airport-world-r56.js?build=20260815-r498';
 import { installCliffsideWorld } from './cliffside-world.js';
 import { installHarborWorld } from './harbor-world.js';
-// Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10, midnight-city-world-r11.js?build=20260802-r11, midnight-city-world-r11.js?build=20260818-r560-shared-spotlight, midnight-city-world-r11.js?build=20260818-r561-200m-headlight
-import { installMidnightCityWorld } from './midnight-city-world-r11.js?build=20260818-r562-road-headlight-response';
-// Historical MOUNTAIN regression markers: mountain-world-r3.js?revision=r3-continuous-terrain-v1, mountain-world-r3.js?revision=r6-night-treatment, mountain-world-r3.js?revision=r8-shadowless-spotlight, mountain-world-r3.js?revision=r560-shared-night-spotlight
-import { installMountainWorld } from './mountain-world-r3.js?revision=r561-200m-headlight';
+// Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10, midnight-city-world-r11.js?build=20260802-r11, midnight-city-world-r11.js?build=20260818-r560-shared-spotlight, midnight-city-world-r11.js?build=20260818-r561-200m-headlight, midnight-city-world-r11.js?build=20260818-r562-road-headlight-response
+import { installMidnightCityWorld } from './midnight-city-world-r11.js?build=20260818-r563-lower-headlight-target';
+// Historical MOUNTAIN regression markers: mountain-world-r3.js?revision=r3-continuous-terrain-v1, mountain-world-r3.js?revision=r6-night-treatment, mountain-world-r3.js?revision=r8-shadowless-spotlight, mountain-world-r3.js?revision=r560-shared-night-spotlight, mountain-world-r3.js?revision=r561-200m-headlight
+import { installMountainWorld } from './mountain-world-r3.js?revision=r563-lower-headlight-target';
 import { isForgivingTrackSurface } from './airport-runoff.js?build=20260722-r52';
 import './contextual-road-edges.js?revision=r518-signature-yellow';
 import './road-contour-color-r512.js?revision=r513-countryside';


### PR DESCRIPTION
Small follow-up to the shared MOUNTAIN + MIDNIGHT CITY spotlight after device comparison.

- keep one exact shared spotlight configuration on both night tracks
- keep intensity 2200, range 200 m, 14° cone, penumbra 0.78, decay 2 and no shadows
- lower the shared target from y=-0.15 to y=-1.5 at the same 54 m forward distance
- this makes flat and downhill road surfaces meet the useful part of the cone sooner, without adding any lights, geometry, raycasts, shadows or per-frame work
- cache-bust both production night-track paths
- update the shared spotlight contract test

The MOUNTAIN uphill/downhill comparison strongly points to beam incidence/aim rather than road color as the main visual difference.