### PR TITLE
Fix Midnight City road normals for physical headlights

### DIFF
--- a/turn-tests/midnight-city-lighting-production.mjs
+++ b/turn-tests/midnight-city-lighting-production.mjs
@@ -68,12 +68,24 @@ assert.doesNotMatch(signParkSource, /requestAnimationFrame|setAnimationLoop|setI
 
 await fs.access(new URL('../turn/LILYA.PNG', import.meta.url));
 assert.match(easterEggSource, /installMidnightCityWorld as installMidnightCityWorldR7/);
+assert.match(easterEggSource, /repairTrackSurfaceWinding\(world\)/,
+  'MIDNIGHT CITY must repair the original downward-facing road ribbon winding before installing the physical headlight');
+assert.match(easterEggSource, /const TRACK_SURFACE_NAME = \/\^Midnight City \(race road\|road edge\|sidewalk\)\//,
+  'The normal repair must stay scoped to the authored drive surface');
+assert.match(easterEggSource, /if \(faceNormal\.y >= 0\) return/,
+  'Already-correct upward surfaces must be left untouched');
+assert.match(easterEggSource, /index\.setX\(offset \+ 1, index\.getX\(offset \+ 2\)\)/,
+  'Downward triangles must have their winding reversed rather than using a double-sided material workaround');
+assert.match(easterEggSource, /geometry\.computeVertexNormals\(\)/,
+  'Repaired winding must regenerate lighting normals');
+assert.match(easterEggSource, /repairedDownwardSurfaceMeshes: surfaceNormals\.repaired/,
+  'Runtime diagnostics must expose how many inherited surface meshes needed repair');
 assert.match(easterEggSource, /installNightPlayerSpotlight\(options\.runtime\?\.playerCar, options\.runtime\)/);
 assert.match(easterEggSource, /sharedNightSpotlight: Boolean\(playerSpotlight\)/);
-assert.match(easterEggSource, /headlightRoadReflectance: 'original-midnight-city-road-material'/,
-  'MIDNIGHT CITY should keep its established road material and let the shared physical spotlight carry the headlight treatment');
-assert.doesNotMatch(easterEggSource, /MIDNIGHT_HEADLIGHT_ROAD|liftRoadForSharedHeadlight|material\.color\.setHex/,
-  'The discarded road-color workaround must not remain in the production night-track wrapper');
+assert.match(easterEggSource, /headlightRoadReflectance: 'original-midnight-city-road-material-with-upward-facing-surface-normals'/,
+  'MIDNIGHT CITY should keep its road material but expose an upward normal to the shared physical spotlight');
+assert.doesNotMatch(easterEggSource, /MIDNIGHT_HEADLIGHT_ROAD|liftRoadForSharedHeadlight|material\.color\.setHex|THREE\.DoubleSide[\s\S]*race road/,
+  'The road-normal repair must not regress to color lifting or a double-sided material workaround');
 assert.match(easterEggSource, /hiddenLilyaAddsDynamicLights: false/);
 assert.match(easterEggSource, /new URL\('\.\.\/LILYA\.PNG', import\.meta\.url\)\.href/);
 assert.match(easterEggSource, /x: -500\.70[\s\S]*y: 11\.96[\s\S]*z: 40\.20/);
@@ -104,11 +116,12 @@ assert.match(easterEggSource, /gameplayGeometryUnchanged: true/);
 assert.doesNotMatch(
   easterEggSource,
   /requestAnimationFrame|setAnimationLoop|setInterval|setTimeout|new THREE\.PointLight|new THREE\.SpotLight/,
-  'The hidden portrait itself must use the existing render loop without adding timers or inline lights'
+  'The hidden portrait and surface repair must use the existing render loop without adding timers or inline lights'
 );
 
-assert.match(registrySource, /midnight-city-world-r11\.js\?build=20260818-r174-night-headlight-tune/);
+assert.match(registrySource, /midnight-city-world-r11\.js\?build=20260819-r176-upward-road-normals/,
+  'Production must cache-bust the Midnight City wrapper that repairs inherited surface normals');
 assert.match(registrySource, /'midnight-city'\(\{ scene, samples, trackWidth, runtime \}\)/);
 assert.match(registrySource, /installMidnightCityWorld\(\{ scene, samples, trackWidth, runtime \}\)/);
 
-console.log('TURN Midnight City lighting, shared night spotlight, original road material, scenery and wrong-way-only lazy LILYA placement passed.');
+console.log('TURN Midnight City lighting, upward road normals, shared night spotlight, scenery and wrong-way-only lazy LILYA placement passed.');

--- a/turn-tests/mountain-spotlight-headlight-production.mjs
+++ b/turn-tests/mountain-spotlight-headlight-production.mjs
@@ -55,9 +55,11 @@ assert.match(midnight, /night-player-spotlight-r560\.js\?revision=r175-reconcile
 assert.match(midnight, /installNightPlayerSpotlight\(options\.runtime\?\.playerCar, options\.runtime\)/,
   'MIDNIGHT CITY must install the exact same shared spotlight rig');
 assert.match(midnight, /shared-warm-shadowless-spotlight-identical-to-mountain/);
+assert.match(midnight, /repairTrackSurfaceWinding\(world\)/,
+  'MIDNIGHT CITY must correct its inherited downward road normals before the shared spotlight is evaluated');
 assert.match(registry, /mountain-world-r3\.js\?revision=r175-reconcile-night-headlight/,
   'Production must cache-bust MOUNTAIN to the reconciled headlight revision');
-assert.match(registry, /midnight-city-world-r11\.js\?build=20260818-r175-reconcile-night-headlight/,
-  'Production must cache-bust MIDNIGHT CITY to the reconciled headlight revision');
+assert.match(registry, /midnight-city-world-r11\.js\?build=20260819-r176-upward-road-normals/,
+  'Production must cache-bust MIDNIGHT CITY to the upward road-normal repair');
 
 console.log('TURN shared MOUNTAIN + MIDNIGHT CITY reconciled 220 m shadowless spotlight contract passed.');

--- a/turn/tracks/midnight-city-world-r11.js
+++ b/turn/tracks/midnight-city-world-r11.js
@@ -19,9 +19,11 @@ const LILYA_MIN_VIEW_DOT = 0.56;
 const LILYA_MIN_FRONT_DOT = 0.12;
 const LILYA_MAX_TRACK_ALIGNMENT = -0.62;
 const LILYA_DISCOVERY_HOLD_MS = 650;
+const TRACK_SURFACE_NAME = /^Midnight City (race road|road edge|sidewalk)/;
 
 export function installMidnightCityWorld(options) {
   const world = installMidnightCityWorldR7(options);
+  const surfaceNormals = repairTrackSurfaceWinding(world);
   const portrait = installHiddenLilyaPortrait(world);
   const lazyLoadArmed = armWrongWayTextureLoad(world, portrait, options);
   const playerSpotlight = installNightPlayerSpotlight(options.runtime?.playerCar, options.runtime);
@@ -45,12 +47,55 @@ export function installMidnightCityWorld(options) {
       ? 'shared-warm-shadowless-spotlight-identical-to-mountain'
       : 'unavailable-without-player-car',
     sharedNightSpotlight: Boolean(playerSpotlight),
-    headlightRoadReflectance: 'original-midnight-city-road-material',
+    headlightRoadReflectance: 'original-midnight-city-road-material-with-upward-facing-surface-normals',
+    repairedDownwardSurfaceMeshes: surfaceNormals.repaired,
+    inspectedTrackSurfaceMeshes: surfaceNormals.inspected,
     hiddenLilyaAddsDynamicLights: false,
     noIndependentAnimationLoop: true
   });
 
   return world;
+}
+
+function repairTrackSurfaceWinding(world) {
+  let inspected = 0;
+  let repaired = 0;
+  const a = new THREE.Vector3();
+  const b = new THREE.Vector3();
+  const c = new THREE.Vector3();
+  const ab = new THREE.Vector3();
+  const ac = new THREE.Vector3();
+  const faceNormal = new THREE.Vector3();
+
+  world.traverse((node) => {
+    if (!node?.isMesh || !TRACK_SURFACE_NAME.test(node.name || '')) return;
+    const geometry = node.geometry;
+    const index = geometry?.index;
+    const position = geometry?.getAttribute?.('position');
+    if (!index || !position || index.count < 3) return;
+
+    inspected += 1;
+    a.fromBufferAttribute(position, index.getX(0));
+    b.fromBufferAttribute(position, index.getX(1));
+    c.fromBufferAttribute(position, index.getX(2));
+    ab.subVectors(b, a);
+    ac.subVectors(c, a);
+    faceNormal.crossVectors(ab, ac);
+    if (faceNormal.y >= 0) return;
+
+    for (let offset = 0; offset < index.count; offset += 3) {
+      const second = index.getX(offset + 1);
+      index.setX(offset + 1, index.getX(offset + 2));
+      index.setX(offset + 2, second);
+    }
+    index.needsUpdate = true;
+    geometry.computeVertexNormals();
+    geometry.getAttribute('normal').needsUpdate = true;
+    node.userData.turnMidnightSurfaceWinding = 'upward-r176';
+    repaired += 1;
+  });
+
+  return Object.freeze({ inspected, repaired });
 }
 
 function installHiddenLilyaPortrait(world) {

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -8,8 +8,8 @@ import {
 import { installAirportWorld } from './airport-world-r56.js?build=20260815-r498';
 import { installCliffsideWorld } from './cliffside-world.js';
 import { installHarborWorld } from './harbor-world.js';
-// Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10, midnight-city-world-r11.js?build=20260802-r11, midnight-city-world-r11.js?build=20260818-r560-shared-spotlight, midnight-city-world-r11.js?build=20260818-r561-200m-headlight, midnight-city-world-r11.js?build=20260818-r562-road-headlight-response, midnight-city-world-r11.js?build=20260818-r563-lower-headlight-target, midnight-city-world-r11.js?build=20260818-r174-night-headlight-tune
-import { installMidnightCityWorld } from './midnight-city-world-r11.js?build=20260818-r175-reconcile-night-headlight';
+// Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10, midnight-city-world-r11.js?build=20260802-r11, midnight-city-world-r11.js?build=20260818-r560-shared-spotlight, midnight-city-world-r11.js?build=20260818-r561-200m-headlight, midnight-city-world-r11.js?build=20260818-r562-road-headlight-response, midnight-city-world-r11.js?build=20260818-r563-lower-headlight-target, midnight-city-world-r11.js?build=20260818-r174-night-headlight-tune, midnight-city-world-r11.js?build=20260818-r175-reconcile-night-headlight
+import { installMidnightCityWorld } from './midnight-city-world-r11.js?build=20260819-r176-upward-road-normals';
 // Historical MOUNTAIN regression markers: mountain-world-r3.js?revision=r3-continuous-terrain-v1, mountain-world-r3.js?revision=r6-night-treatment, mountain-world-r3.js?revision=r8-shadowless-spotlight, mountain-world-r3.js?revision=r560-shared-night-spotlight, mountain-world-r3.js?revision=r561-200m-headlight, mountain-world-r3.js?revision=r563-lower-headlight-target, mountain-world-r3.js?revision=r174-night-headlight-tune
 import { installMountainWorld } from './mountain-world-r3.js?revision=r175-reconcile-night-headlight';
 import { isForgivingTrackSurface } from './airport-runoff.js?build=20260722-r52';


### PR DESCRIPTION
The shared spotlight was not the remaining problem. MIDNIGHT CITY's original ribbon builder orders the race-road vertices opposite to MOUNTAIN: the race-road triangles have downward-facing normals, so the physical spotlight is effectively lighting the wrong side of the surface. This dates back to the original Midnight City world and explains why repeated headlight-config changes barely changed the picture.

This repair runs once when the Midnight City world is installed, inspects only the race road / road edges / sidewalks, reverses triangle winding only where the first face normal points downward, and recomputes vertex normals. It keeps the existing road material and the existing single 2600 / 220 m shadowless shared spotlight: no extra lights, double-sided materials, raycasts, beam meshes or render loops. The Midnight City wrapper gets a fresh revision URL and regression coverage records the repair.