### PR TITLE
Set Truck/SUV colors and fix MOUNTAIN HARD tag

### DIFF
--- a/turn-lab/tests/vehicle-drift-production.mjs
+++ b/turn-lab/tests/vehicle-drift-production.mjs
@@ -97,10 +97,13 @@ assert.match(
   'Boost recharge must read the selected car tuning only while DRIFT is held'
 );
 
+const suv = CAR_CATALOG.find((car) => car.id === 'suv');
+assert.ok(suv, 'SUV must remain in the vehicle catalog');
+assert.equal(suv.defaultColor, '#0555aa', 'SUV factory paint must be #0555aa');
+
 const truck = CAR_CATALOG.find((car) => car.id === 'truck');
 assert.ok(truck, 'Truck must remain in the vehicle catalog');
-assert.equal(truck.defaultColor, '#8b5a2b',
-  'Truck must receive the former Vintage Racer factory colour');
+assert.equal(truck.defaultColor, '#ff7700', 'Truck factory paint must be #f70');
 
 assert.match(
   showcaseSource,

--- a/turn/design-semantic.css
+++ b/turn/design-semantic.css
@@ -46,6 +46,7 @@
 
 .track-card-harbor .track-card-difficulty,
 .track-card-midnight-city .track-card-difficulty,
+.track-card-mountain .track-card-difficulty,
 .track-card[data-track-difficulty="hard"] .track-card-difficulty {
   background: var(--turn-difficulty-hard) !important;
 }

--- a/turn/vehicle/catalog.js
+++ b/turn/vehicle/catalog.js
@@ -44,11 +44,11 @@ const DEFAULT_COLOR_BY_ID = Object.freeze({
   race: Object.freeze({ fallback: '#b93632', p3: Object.freeze([0.72, 0.12, 0.12]) }),
   'sedan-sports': Object.freeze({ fallback: '#5e3c87', p3: Object.freeze([0.36, 0.19, 0.56]) }),
   sedan: Object.freeze({ fallback: '#2b6a70', p3: Object.freeze([0.12, 0.41, 0.43]) }),
-  suv: Object.freeze({ fallback: '#7b4f2d', p3: Object.freeze([0.47, 0.25, 0.12]) }),
+  suv: Object.freeze({ fallback: '#0555aa', p3: Object.freeze([0.02, 0.333, 0.667]) }),
   firetruck: Object.freeze({ fallback: '#d92d20', p3: Object.freeze([0.82, 0.08, 0.04]) }),
   police: Object.freeze({ fallback: '#0b0d10', p3: Object.freeze([0.035, 0.045, 0.06]) }),
   ambulance: Object.freeze({ fallback: '#f8f9fa', p3: Object.freeze([0.95, 0.97, 0.98]) }),
-  truck: Object.freeze({ fallback: '#8b5a2b', p3: Object.freeze([0.52, 0.29, 0.12]) }),
+  truck: Object.freeze({ fallback: '#ff7700', p3: Object.freeze([1, 0.467, 0]) }),
   van: Object.freeze({ fallback: '#5d503f', p3: Object.freeze([0.34, 0.29, 0.21]) })
 });
 


### PR DESCRIPTION
Two small production visual fixes:

- Truck default paint: `#ff7700` (`#f70`)
- SUV default paint: `#0555aa`
- Keep the corresponding Display-P3 default specs aligned with those colors
- Add MOUNTAIN to the semantic HARD difficulty selector so its HARD pill uses the same `--turn-difficulty-hard` role as HARBOR and MIDNIGHT CITY

No gameplay, physics, layout, or runtime behavior changes.