### PR TITLE
Disable text selection across TURN except information surfaces

### DIFF
--- a/turn-tests/form-disclosure-system.mjs
+++ b/turn-tests/form-disclosure-system.mjs
@@ -1,12 +1,13 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [app, tokens, components, guide, design] = await Promise.all([
+const [app, tokens, components, guide, design, selectionPolicy] = await Promise.all([
   fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/design-tokens.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/settings-components-r141.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/ui/how-to-play-guide.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/design.html', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/design.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/drive-pad.css', import.meta.url), 'utf8')
 ]);
 
 assert.match(app, /settings-components-r141\.css\?revision=r141-form-disclosure/);
@@ -49,6 +50,35 @@ assert.ok(
   'The disclosure state symbol must precede and sit beside its summary label'
 );
 
+assert.match(
+  selectionPolicy,
+  /body,\s*body \*[\s\S]*-webkit-user-select: none !important;[\s\S]*user-select: none !important;[\s\S]*-webkit-touch-callout: none !important;/,
+  'TURN must suppress selection and the iOS text callout by default across the app'
+);
+for (const allowedSurface of [
+  '.m8-how-dialog .m8-guide-grid',
+  '.turn-dbe-training-dialog .m8-dialog-card',
+  '.m8-home-build',
+  '.install-kicker',
+  '.m8-about-content',
+  '.turn-history-panel',
+  '.turn-history-release',
+  '.turn-achievements-content',
+  '.m8-feedback-content'
+]) {
+  assert.ok(selectionPolicy.includes(`body ${allowedSurface}`), `Missing selection allowlist surface ${allowedSurface}`);
+}
+assert.match(
+  selectionPolicy,
+  /-webkit-user-select: text !important;[\s\S]*user-select: text !important;[\s\S]*-webkit-touch-callout: default !important;/,
+  'Allowed information surfaces must restore text selection and the native iOS text callout'
+);
+assert.doesNotMatch(
+  selectionPolicy,
+  /#game,\s*#hud,\s*#controls,\s*#message/,
+  'The old race-only selection guard must not remain as the policy boundary'
+);
+
 for (const specimen of [
   'Native form controls',
   'Legend and heading elements share one floating card-title treatment',
@@ -66,4 +96,4 @@ assert.match(design, /<input type="radio" name="designSteering" checked>/);
 assert.match(design, /<input type="checkbox" checked>/);
 assert.match(design, /<details class="disclosure-sample"[^>]*>[\s\S]*<summary><span class="disclosure-symbol" aria-hidden="true"><\/span><span>Explore the Drive By Ear sounds<\/span><\/summary>/);
 
-console.log('TURN native form controls, headings and disclosure system passed.');
+console.log('TURN native form controls, selection policy, headings and disclosure system passed.');

--- a/turn/drive-pad.css
+++ b/turn/drive-pad.css
@@ -1,20 +1,41 @@
 /*
- * Keep browser text-selection gestures out of the live race surface. On iOS a
- * sustained driving touch can otherwise open the Copy / Look Up / Translate
- * callout. This stays deliberately local to gameplay so document text and the
- * native color input in The Lot keep normal browser interaction.
+ * TURN is gesture-first. Prevent browser text selection and the iOS Copy /
+ * Look Up / Translate callout throughout the app, then opt the deliberately
+ * readable/copyable information surfaces back in below.
  */
-#game,
-#hud,
-#controls,
-#message,
-#game *,
-#hud *,
-#controls *,
-#message * {
-  -webkit-user-select: none;
-  user-select: none;
-  -webkit-touch-callout: none;
+body,
+body * {
+  -webkit-user-select: none !important;
+  user-select: none !important;
+  -webkit-touch-callout: none !important;
+}
+
+/*
+ * Selection allowlist: How to Play + Drive By Ear help/training, visible
+ * version information, About, History/Changelog, Achievements and Give
+ * Feedback. Keep controls and the rest of the game gesture-only.
+ */
+body .m8-how-dialog .m8-guide-grid,
+body .m8-how-dialog .m8-guide-grid *,
+body .turn-dbe-training-dialog .m8-dialog-card,
+body .turn-dbe-training-dialog .m8-dialog-card *,
+body .m8-home-build,
+body .m8-home-build *,
+body .install-kicker,
+body .install-kicker *,
+body .m8-about-content,
+body .m8-about-content *,
+body .turn-history-panel,
+body .turn-history-panel *,
+body .turn-history-release,
+body .turn-history-release *,
+body .turn-achievements-content,
+body .turn-achievements-content *,
+body .m8-feedback-content,
+body .m8-feedback-content * {
+  -webkit-user-select: text !important;
+  user-select: text !important;
+  -webkit-touch-callout: default !important;
 }
 
 .pedals {


### PR DESCRIPTION
Make TURN gesture-first by disabling browser text selection and the iOS Copy / Look Up / Translate callout across the whole app.

Selection is explicitly restored only for:
- How to Play / Drive By Ear help and training
- visible version/build information
- About
- History / Changelog
- Achievements
- Give Feedback

This replaces the previous race-only boundary, which could still leave selectable UI outside `#game/#hud/#controls/#message` during races. Added regression coverage for the allowlist and iOS callout policy.