### PR TITLE
Normalize MOUNTAIN sky on iPad aspect ratios

### DIFF
--- a/.github/workflows/turn-mountain-visual-smoke.yml
+++ b/.github/workflows/turn-mountain-visual-smoke.yml
@@ -10,6 +10,7 @@ on:
       - 'turn/assets/scenery/mountain/**'
       - 'turn-lab/mountain-visual.html'
       - 'turn-tests/mountain-visual-smoke.mjs'
+      - 'turn-tests/mountain-sky-aspect-production.mjs'
       - 'turn-tests/mountain-spotlight-headlight-production.mjs'
       - '.github/workflows/turn-mountain-visual-smoke.yml'
   push:
@@ -21,6 +22,7 @@ on:
       - 'turn/assets/scenery/mountain/**'
       - 'turn-lab/mountain-visual.html'
       - 'turn-tests/mountain-visual-smoke.mjs'
+      - 'turn-tests/mountain-sky-aspect-production.mjs'
       - 'turn-tests/mountain-spotlight-headlight-production.mjs'
       - '.github/workflows/turn-mountain-visual-smoke.yml'
 
@@ -42,6 +44,9 @@ jobs:
 
       - name: Validate shared night spotlight contract
         run: node turn-tests/mountain-spotlight-headlight-production.mjs
+
+      - name: Validate phone and iPad sky aspect contract
+        run: node turn-tests/mountain-sky-aspect-production.mjs
 
       - name: Install Playwright Chromium
         run: |

--- a/.github/workflows/turn-mountain-visual-smoke.yml
+++ b/.github/workflows/turn-mountain-visual-smoke.yml
@@ -11,6 +11,7 @@ on:
       - 'turn-lab/mountain-visual.html'
       - 'turn-tests/mountain-visual-smoke.mjs'
       - 'turn-tests/mountain-sky-aspect-production.mjs'
+      - 'turn-tests/mountain-sky-visual-ipad.mjs'
       - 'turn-tests/mountain-spotlight-headlight-production.mjs'
       - '.github/workflows/turn-mountain-visual-smoke.yml'
   push:
@@ -23,6 +24,7 @@ on:
       - 'turn-lab/mountain-visual.html'
       - 'turn-tests/mountain-visual-smoke.mjs'
       - 'turn-tests/mountain-sky-aspect-production.mjs'
+      - 'turn-tests/mountain-sky-visual-ipad.mjs'
       - 'turn-tests/mountain-spotlight-headlight-production.mjs'
       - '.github/workflows/turn-mountain-visual-smoke.yml'
 
@@ -66,6 +68,9 @@ jobs:
 
       - name: Render and validate fixed MOUNTAIN cameras
         run: node turn-tests/mountain-visual-smoke.mjs
+
+      - name: Capture MOUNTAIN sky at iPad 4:3
+        run: node turn-tests/mountain-sky-visual-ipad.mjs
 
       - name: Upload MOUNTAIN visual inspection frames
         if: always()

--- a/turn-tests/mountain-sky-aspect-production.mjs
+++ b/turn-tests/mountain-sky-aspect-production.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const [skySource, worldSource, registrySource] = await Promise.all([
+  fs.readFile(new URL('../turn/tracks/mountain-world-r7-sky.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/tracks/mountain-world-r3.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/tracks/registry.js', import.meta.url), 'utf8')
+]);
+
+assert.match(skySource, /const SKY_REFERENCE_ASPECT = 1536 \/ 709/,
+  'The approved wide-phone MOUNTAIN sky composition must remain the visual reference');
+assert.match(skySource, /const visiblePlaneX = Math\.max\(1e-6, Math\.min\(1, visibleWidth \/ \(coverHeight \* SKY_IMAGE_ASPECT\)\)\)/,
+  'Sky sampling must know how much of the overscanned 2:1 plane is actually visible horizontally');
+assert.match(skySource, /const visiblePlaneY = Math\.max\(1e-6, Math\.min\(1, visibleHeight \/ coverHeight\)\)/,
+  'Sky sampling must know how much of the overscanned plane is actually visible vertically');
+assert.match(skySource, /const repeatU = visibleU \* REFERENCE_SKY_COVERAGE\.x \/ visiblePlaneX/,
+  'Horizontal UV repeat must compensate for aspect-dependent plane overhang');
+assert.match(skySource, /const repeatV = REFERENCE_SKY_COVERAGE\.y \/ visiblePlaneY/,
+  'Vertical UV repeat must preserve the established star scale across aspect ratios');
+assert.match(skySource, /texture\.repeat\.set\(repeatU, repeatV\)/,
+  'The compensated UV repeat must be applied to the live star texture');
+assert.match(skySource, /const localU = \(anchorU - skyMotion\.offsetU\) \/ skyMotion\.repeatU/,
+  'The moon must invert the aspect-corrected horizontal star transform');
+assert.match(skySource, /const localV = \(MOON_SKY_ANCHOR_V - skyMotion\.offsetV\) \/ skyMotion\.repeatV/,
+  'The moon must invert the aspect-corrected vertical star transform');
+assert.match(worldSource, /mountain-world-r7-sky\.js\?revision=r177-ipad-aspect-normalization/,
+  'MOUNTAIN must cache-bust the corrected sky module');
+assert.match(registrySource, /mountain-world-r3\.js\?revision=r177-ipad-sky-aspect/,
+  'Production must cache-bust the MOUNTAIN world wrapper containing the corrected sky dependency');
+
+const phone = skySampling({ fov: 68, aspect: 1536 / 709 });
+const ipad9 = skySampling({ fov: 68, aspect: 4 / 3 });
+
+// The visible horizontal texture span should scale only with horizontal FOV.
+// Before this fix the 4:3 viewport saw just ~0.59 texture widths versus ~1.18
+// on the phone: the hidden 2:1-plane overhang nearly doubled the apparent zoom
+// and yaw travel. The normalized transform restores one angular texel scale.
+const phoneAngularScale = phone.visibleTextureU / phone.horizontalFov;
+const ipadAngularScale = ipad9.visibleTextureU / ipad9.horizontalFov;
+assert.ok(Math.abs(phoneAngularScale - ipadAngularScale) < 1e-12,
+  `Phone/iPad horizontal star scale diverged: ${phoneAngularScale} vs ${ipadAngularScale}`);
+assert.ok(ipad9.visibleTextureU > 0.88 && ipad9.visibleTextureU < 0.90,
+  `4:3 iPad should see about 0.89 star-texture widths at 68° FOV, got ${ipad9.visibleTextureU}`);
+
+// Vertical FOV is identical on both devices, so the apparent vertical texture
+// scale should also remain identical rather than changing with plane coverage.
+assert.ok(Math.abs(phone.visibleTextureV - ipad9.visibleTextureV) < 1e-12,
+  `Phone/iPad vertical star scale diverged: ${phone.visibleTextureV} vs ${ipad9.visibleTextureV}`);
+
+// Preserve the approved phone appearance exactly: the reference aspect must
+// retain the old repeat values (visibleU horizontally, 1 vertically).
+assert.ok(Math.abs(phone.repeatU - phone.visibleU) < 1e-12,
+  'Reference phone horizontal sampling must remain visually unchanged');
+assert.ok(Math.abs(phone.repeatV - 1) < 1e-12,
+  'Reference phone vertical sampling must remain visually unchanged');
+
+console.log('TURN MOUNTAIN sky aspect normalization preserves the phone composition and fixes 4:3 iPad sampling.');
+
+function skySampling({ fov, aspect }) {
+  const skyImageAspect = 2;
+  const skyHorizontalTiles = 4;
+  const overscan = 1.05;
+  const referenceAspect = 1536 / 709;
+  const verticalFov = fov * Math.PI / 180;
+  const horizontalFov = 2 * Math.atan(Math.tan(verticalFov / 2) * aspect);
+  const visibleU = horizontalFov / (Math.PI * 2) * skyHorizontalTiles;
+  const coverage = planeCoverage(aspect, skyImageAspect, overscan);
+  const referenceCoverage = planeCoverage(referenceAspect, skyImageAspect, overscan);
+  const repeatU = visibleU * referenceCoverage.x / coverage.x;
+  const repeatV = referenceCoverage.y / coverage.y;
+  return {
+    horizontalFov,
+    visibleU,
+    repeatU,
+    repeatV,
+    visibleTextureU: repeatU * coverage.x,
+    visibleTextureV: repeatV * coverage.y
+  };
+}
+
+function planeCoverage(aspect, skyImageAspect, overscan) {
+  const coverHeightInVisibleHeights = Math.max(1, aspect / skyImageAspect) * overscan;
+  return {
+    x: Math.min(1, aspect / (coverHeightInVisibleHeights * skyImageAspect)),
+    y: Math.min(1, 1 / coverHeightInVisibleHeights)
+  };
+}

--- a/turn-tests/mountain-sky-visual-ipad.mjs
+++ b/turn-tests/mountain-sky-visual-ipad.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { chromium } from 'playwright';
+
+const baseUrl = process.env.TURN_VISUAL_BASE_URL || 'http://127.0.0.1:8000';
+const outputDir = process.env.TURN_VISUAL_OUTPUT || 'mountain-visual-artifact';
+await fs.mkdir(outputDir, { recursive: true });
+
+const browser = await chromium.launch({
+  headless: true,
+  args: ['--use-gl=angle', '--use-angle=swiftshader', '--enable-webgl', '--ignore-gpu-blocklist']
+});
+const context = await browser.newContext({ viewport: { width: 1024, height: 768 }, deviceScaleFactor: 1 });
+const page = await context.newPage();
+const browserErrors = [];
+page.on('pageerror', (error) => browserErrors.push(`pageerror: ${error.message}`));
+page.on('console', (message) => {
+  const text = message.text();
+  if (message.type() === 'error' || /failed to load|mountain .* failed/i.test(text)) {
+    browserErrors.push(`console ${message.type()}: ${text}`);
+  }
+});
+
+try {
+  const response = await page.goto(`${baseUrl}/turn-lab/mountain-visual.html?view=aerial`, {
+    waitUntil: 'networkidle',
+    timeout: 60_000
+  });
+  assert.equal(response?.ok(), true, '4:3 MOUNTAIN visual page must load successfully');
+  await page.waitForFunction(() => globalThis.__mountainVisualReady === true, null, { timeout: 60_000 });
+  await page.screenshot({ path: path.join(outputDir, 'aerial-ipad-4x3.png'), fullPage: true });
+} finally {
+  await browser.close();
+}
+
+assert.deepEqual(browserErrors, [], `4:3 MOUNTAIN sky produced browser errors:\n${browserErrors.join('\n')}`);
+console.log('TURN MOUNTAIN 4:3 iPad sky visual frame captured.');

--- a/turn-tests/mountain-spotlight-headlight-production.mjs
+++ b/turn-tests/mountain-spotlight-headlight-production.mjs
@@ -57,8 +57,8 @@ assert.match(midnight, /installNightPlayerSpotlight\(options\.runtime\?\.playerC
 assert.match(midnight, /shared-warm-shadowless-spotlight-identical-to-mountain/);
 assert.match(midnight, /repairTrackSurfaceWinding\(world\)/,
   'MIDNIGHT CITY must correct its inherited downward road normals before the shared spotlight is evaluated');
-assert.match(registry, /mountain-world-r3\.js\?revision=r175-reconcile-night-headlight/,
-  'Production must cache-bust MOUNTAIN to the reconciled headlight revision');
+assert.match(registry, /mountain-world-r3\.js\?revision=r177-ipad-sky-aspect/,
+  'Production must cache-bust MOUNTAIN through the iPad sky aspect correction without changing its shared headlight rig');
 assert.match(registry, /midnight-city-world-r11\.js\?build=20260819-r176-upward-road-normals/,
   'Production must cache-bust MIDNIGHT CITY to the upward road-normal repair');
 

--- a/turn-tests/track-intro-camera-production.mjs
+++ b/turn-tests/track-intro-camera-production.mjs
@@ -27,10 +27,16 @@ assert.match(mountainSkySource, /const SKY_HORIZONTAL_TILES = 4/,
   'MOUNTAIN yaw lock should map four star-field tiles to one world rotation');
 assert.match(mountainSkySource, /const SKY_YAW_CATCHUP = 0\.14/,
   'MOUNTAIN sky should retain a small heading drag instead of snapping');
+assert.match(mountainSkySource, /const SKY_REFERENCE_ASPECT = 1536 \/ 709/,
+  'The approved wide-phone composition should remain the sky-scale reference');
 assert.match(mountainSkySource, /const heading = Math\.atan2\(forward\.x, forward\.z\)/,
   'MOUNTAIN sky UVs must derive from world heading');
 assert.match(mountainSkySource, /const yawU = -motion\.visualHeading \/ TAU \* SKY_HORIZONTAL_TILES/,
   'MOUNTAIN star texture must move opposite camera yaw so the distant sky appears world-fixed');
+assert.match(mountainSkySource, /const repeatU = visibleU \* REFERENCE_SKY_COVERAGE\.x \/ visiblePlaneX/,
+  'MOUNTAIN horizontal star sampling must compensate for aspect-dependent plane overhang');
+assert.match(mountainSkySource, /const repeatV = REFERENCE_SKY_COVERAGE\.y \/ visiblePlaneY/,
+  'MOUNTAIN vertical star sampling must preserve the approved scale across aspect ratios');
 assert.match(mountainSkySource, /sky\.up\.set\(0, 1, 0\)/,
   'MOUNTAIN stars must keep world-up so they roll with the rendered horizon');
 assert.match(mountainSkySource, /sky\.lookAt\(camera\.position\)/,
@@ -46,10 +52,10 @@ assert.match(mountainSkySource, /const MOON_SKY_ANCHOR_V = 0\.783222/,
   'MOUNTAIN moon needs a stable vertical anchor in the star texture');
 assert.match(mountainSkySource, /sky\.add\(moonLayer\)/,
   'The moon must be a literal child of the star backdrop so it shares the same 3D transform and depth');
-assert.match(mountainSkySource, /const localU = \(anchorU - skyMotion\.offsetU\) \/ skyMotion\.visibleU/,
-  'The moon horizontal position must invert the exact star-field UV transform');
-assert.match(mountainSkySource, /const localV = MOON_SKY_ANCHOR_V - skyMotion\.offsetV/,
-  'The moon vertical position must invert the exact star-field pitch/parallax transform');
+assert.match(mountainSkySource, /const localU = \(anchorU - skyMotion\.offsetU\) \/ skyMotion\.repeatU/,
+  'The moon horizontal position must invert the exact aspect-corrected star-field UV transform');
+assert.match(mountainSkySource, /const localV = \(MOON_SKY_ANCHOR_V - skyMotion\.offsetV\) \/ skyMotion\.repeatV/,
+  'The moon vertical position must invert the exact aspect-corrected star-field UV transform');
 assert.match(mountainSkySource, /moonLayer\.position\.set\(localU - 0\.5, localV - 0\.5, 0\)/,
   'The moon must live on the exact same Z plane as the stars');
 assert.match(mountainSkySource, /apparentSize = legacySize \* SKY_DISTANCE \/ LEGACY_MOON_DISTANCE/,
@@ -156,30 +162,47 @@ function projectSkyAnchorToScreen({ anchorU, anchorV, position, target, fov, asp
   const skyDistance = 840;
   const skyImageAspect = 2;
   const horizontalTiles = 4;
+  const overscan = 1.05;
+  const referenceAspect = 1536 / 709;
   const forward = normalize(subtract(target, position));
   const heading = Math.atan2(forward[0], forward[2]);
   const verticalFov = fov * Math.PI / 180;
   const horizontalFov = 2 * Math.atan(Math.tan(verticalFov / 2) * aspect);
   const visibleU = horizontalFov / (Math.PI * 2) * horizontalTiles;
-  const baseU = 0.5 - visibleU * 0.5;
-  const yawU = -heading / (Math.PI * 2) * horizontalTiles;
-  const positionU = (position[0] - position[2]) * 0.00004;
-  const offsetU = baseU + yawU + positionU;
-  const offsetV = forward[1] * 0.025;
-  const centreSampleU = offsetU + visibleU * 0.5;
-  const equivalentAnchorU = anchorU
-    + Math.round((centreSampleU - anchorU) / horizontalTiles) * horizontalTiles;
-  const localU = (equivalentAnchorU - offsetU) / visibleU;
-  const localV = anchorV - offsetV;
 
   const visibleHeight = 2 * skyDistance * Math.tan(verticalFov / 2);
   const visibleWidth = visibleHeight * aspect;
-  const coverHeight = Math.max(visibleHeight, visibleWidth / skyImageAspect) * 1.05;
+  const coverHeight = Math.max(visibleHeight, visibleWidth / skyImageAspect) * overscan;
+  const visiblePlaneX = Math.min(1, visibleWidth / (coverHeight * skyImageAspect));
+  const visiblePlaneY = Math.min(1, visibleHeight / coverHeight);
+  const referenceCoverage = planeCoverage(referenceAspect, skyImageAspect, overscan);
+  const repeatU = visibleU * referenceCoverage.x / visiblePlaneX;
+  const repeatV = referenceCoverage.y / visiblePlaneY;
+  const baseU = 0.5 - repeatU * 0.5;
+  const baseV = 0.5 - repeatV * 0.5;
+  const yawU = -heading / (Math.PI * 2) * horizontalTiles;
+  const positionU = (position[0] - position[2]) * 0.00004;
+  const offsetU = baseU + yawU + positionU;
+  const offsetV = baseV + forward[1] * 0.025;
+  const centreSampleU = offsetU + repeatU * 0.5;
+  const equivalentAnchorU = anchorU
+    + Math.round((centreSampleU - anchorU) / horizontalTiles) * horizontalTiles;
+  const localU = (equivalentAnchorU - offsetU) / repeatU;
+  const localV = (anchorV - offsetV) / repeatV;
+
   const worldX = (localU - 0.5) * coverHeight * skyImageAspect;
   const worldY = (localV - 0.5) * coverHeight;
   const ndcX = worldX / (visibleWidth / 2);
   const ndcY = worldY / (visibleHeight / 2);
   return { x: (ndcX + 1) / 2, y: (1 - ndcY) / 2 };
+}
+
+function planeCoverage(aspect, skyImageAspect, overscan) {
+  const coverHeightInVisibleHeights = Math.max(1, aspect / skyImageAspect) * overscan;
+  return {
+    x: Math.min(1, aspect / (coverHeightInVisibleHeights * skyImageAspect)),
+    y: Math.min(1, 1 / coverHeightInVisibleHeights)
+  };
 }
 
 function subtract(a, b) {

--- a/turn/tracks/mountain-world-r3.js
+++ b/turn/tracks/mountain-world-r3.js
@@ -7,7 +7,7 @@ import { installMountainR4WaterfallNotch } from './mountain-world-r4-waterfall-n
 import { installMountainR4DriverFacingWaterfall } from './mountain-world-r4-waterfall-face.js';
 import { installMountainR5SuburbanVillage } from './mountain-world-r5-suburban-village.js';
 import { installMountainR6Night } from './mountain-world-r6-night.js';
-import { installMountainR7SkyFix } from './mountain-world-r7-sky.js';
+import { installMountainR7SkyFix } from './mountain-world-r7-sky.js?revision=r177-ipad-aspect-normalization';
 import { installMountainSpotlightHeadlight } from './mountain-player-headlight-r8.js?revision=r175-reconcile';
 
 const MOUNTAIN_VILLAGE_BENCHES = new Set([
@@ -80,7 +80,7 @@ export function installMountainWorld({ scene, samples, trackWidth = 27, runtime 
   world.userData.turnMountainTerrainHeightAt = terrainContext.terrainHeightAt;
   world.userData.turnMountainArtDirection = Object.freeze({
     version: 'r3',
-    visualPolish: 'r560-shared-night-spotlight-plus-r7-horizon-sky-plus-r6-night-plus-r5-suburban-village-plus-r4-waterfall-landmarks',
+    visualPolish: 'r177-ipad-aspect-normalized-r7-horizon-sky-plus-r6-night-plus-r5-suburban-village-plus-r4-waterfall-landmarks',
     ground: 'continuous-snow-and-granite-terrain-body',
     roadEdge: 'white-with-black-outer-contour',
     roadbed: 'opaque-and-terrain-supported',

--- a/turn/tracks/mountain-world-r7-sky.js
+++ b/turn/tracks/mountain-world-r7-sky.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 
-const REVISION = 'r7-world-yaw-uv-raised-moon-celestial-layer-cut-snap-reduced-motion';
+const REVISION = 'r7-world-yaw-uv-aspect-normalized-celestial-layer-cut-snap-reduced-motion';
 const SKY_NAME = 'Mountain star field skydome r6';
 const MOON_NAME = 'Mountain full moon sprite r6';
 const SKY_DISTANCE = 840;
@@ -11,6 +11,12 @@ const SKY_POSITION_PARALLAX = 0.00004;
 const SKY_PITCH_PARALLAX = 0.025;
 const SKY_CAMERA_CUT_DISTANCE = 48;
 const SKY_CAMERA_CUT_HEADING = Math.PI / 8;
+const SKY_OVERSCAN = 1.05;
+// The established phone composition was tuned and regression-tested at this
+// wide viewport. Treat its apparent star scale as canonical, then compensate
+// for how much of the fixed 2:1 sky plane is actually visible on other aspect
+// ratios (notably the iPad 9's 4:3 display).
+const SKY_REFERENCE_ASPECT = 1536 / 709;
 const LEGACY_MOON_DISTANCE = 810;
 const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
 const TAU = Math.PI * 2;
@@ -30,6 +36,17 @@ function shortestAngle(from, to) {
   while (delta < -Math.PI) delta += TAU;
   return delta;
 }
+
+function planeCoverageForAspect(aspect) {
+  const safeAspect = Math.max(0.1, Number(aspect) || SKY_REFERENCE_ASPECT);
+  const coverHeightInVisibleHeights = Math.max(1, safeAspect / SKY_IMAGE_ASPECT) * SKY_OVERSCAN;
+  return Object.freeze({
+    x: Math.min(1, safeAspect / (coverHeightInVisibleHeights * SKY_IMAGE_ASPECT)),
+    y: Math.min(1, 1 / coverHeightInVisibleHeights)
+  });
+}
+
+const REFERENCE_SKY_COVERAGE = planeCoverageForAspect(SKY_REFERENCE_ASPECT);
 
 function worldLockSky(sky) {
   const texture = sky.material?.map;
@@ -63,6 +80,10 @@ function worldLockSky(sky) {
     positionU: 0,
     pitchV: 0,
     visibleU: null,
+    repeatU: null,
+    repeatV: null,
+    visiblePlaneX: null,
+    visiblePlaneY: null,
     offsetU: null,
     offsetV: null,
     coverHeight: null,
@@ -137,23 +158,40 @@ function worldLockSky(sky) {
     const verticalFov = THREE.MathUtils.degToRad(camera.fov);
     const horizontalFov = 2 * Math.atan(Math.tan(verticalFov / 2) * camera.aspect);
     const visibleU = Math.max(0.01, horizontalFov / TAU * SKY_HORIZONTAL_TILES);
-    const baseU = 0.5 - visibleU * 0.5;
+
+    // The 2:1 plane deliberately over-covers the frustum so camera roll never
+    // reveals its edges. On a wide phone the viewport sees almost the whole
+    // plane width; on 4:3 iPad it sees only about two thirds. The old code used
+    // the same UV repeat regardless, so that hidden overhang effectively zoomed
+    // the stars and amplified yaw motion on iPad. Compensate by measuring the
+    // visible fraction of the plane and preserving the established wide-phone
+    // texture scale rather than detecting any particular device.
+    const visibleHeight = 2 * SKY_DISTANCE * Math.tan(verticalFov / 2);
+    const visibleWidth = visibleHeight * camera.aspect;
+    const coverHeight = Math.max(visibleHeight, visibleWidth / SKY_IMAGE_ASPECT) * SKY_OVERSCAN;
+    const visiblePlaneX = Math.max(1e-6, Math.min(1, visibleWidth / (coverHeight * SKY_IMAGE_ASPECT)));
+    const visiblePlaneY = Math.max(1e-6, Math.min(1, visibleHeight / coverHeight));
+    const repeatU = visibleU * REFERENCE_SKY_COVERAGE.x / visiblePlaneX;
+    const repeatV = REFERENCE_SKY_COVERAGE.y / visiblePlaneY;
+    const baseU = 0.5 - repeatU * 0.5;
+    const baseV = 0.5 - repeatV * 0.5;
     const yawU = -motion.visualHeading / TAU * SKY_HORIZONTAL_TILES;
+
     motion.positionU = motion.reducedMotion
       ? 0
       : (camera.position.x - camera.position.z) * SKY_POSITION_PARALLAX;
     motion.pitchV = motion.reducedMotion ? 0 : forward.y * SKY_PITCH_PARALLAX;
     motion.visibleU = visibleU;
+    motion.repeatU = repeatU;
+    motion.repeatV = repeatV;
+    motion.visiblePlaneX = visiblePlaneX;
+    motion.visiblePlaneY = visiblePlaneY;
     motion.offsetU = baseU + yawU + motion.positionU;
-    motion.offsetV = motion.pitchV;
-    texture.repeat.set(visibleU, 1);
+    motion.offsetV = baseV + motion.pitchV;
+    motion.coverHeight = coverHeight;
+    texture.repeat.set(repeatU, repeatV);
     texture.offset.set(motion.offsetU, motion.offsetV);
 
-    // Cover the camera frustum without stretching the texture around geometry.
-    const visibleHeight = 2 * SKY_DISTANCE * Math.tan(verticalFov / 2);
-    const visibleWidth = visibleHeight * camera.aspect;
-    const coverHeight = Math.max(visibleHeight, visibleWidth / SKY_IMAGE_ASPECT) * 1.05;
-    motion.coverHeight = coverHeight;
     sky.scale.set(coverHeight * SKY_IMAGE_ASPECT, coverHeight, 1);
     sky.updateMatrixWorld(true);
   };
@@ -161,6 +199,8 @@ function worldLockSky(sky) {
   sky.userData.turnMountainSkyLock = 'world-yaw-via-inverse-uv-with-world-up-roll-lock';
   sky.userData.turnMountainSkyHorizontalTiles = SKY_HORIZONTAL_TILES;
   sky.userData.turnMountainSkyYawCatchup = SKY_YAW_CATCHUP;
+  sky.userData.turnMountainSkyReferenceAspect = SKY_REFERENCE_ASPECT;
+  sky.userData.turnMountainSkyAspectPolicy = 'preserve-wide-phone-angular-star-scale-across-plane-overcoverage';
   sky.userData.turnMountainSkyCameraCuts = 'snap-large-camera-jumps-without-parallax-roll';
   sky.userData.turnMountainReducedMotionPolicy = 'hide-star-field-show-solid-track-background-keep-moon';
   return motion;
@@ -200,22 +240,23 @@ function lockMoonToSkyLayer(moon, sky, skyMotion) {
   sky.add(moonLayer);
 
   moonLayer.onBeforeRender = () => {
-    if (!Number.isFinite(skyMotion.visibleU)
+    if (!Number.isFinite(skyMotion.repeatU)
+      || !Number.isFinite(skyMotion.repeatV)
       || !Number.isFinite(skyMotion.offsetU)
       || !Number.isFinite(skyMotion.offsetV)) return;
 
     // Pick the equivalent anchor from the current 360-degree cycle. This keeps
     // one moon in the world rather than repeating it with every mirrored star
     // tile, while still bringing it back to the same place after a full turn.
-    const centreSampleU = skyMotion.offsetU + skyMotion.visibleU * 0.5;
+    const centreSampleU = skyMotion.offsetU + skyMotion.repeatU * 0.5;
     const anchorU = MOON_SKY_ANCHOR_U
       + Math.round((centreSampleU - MOON_SKY_ANCHOR_U) / MOON_WORLD_U_PERIOD) * MOON_WORLD_U_PERIOD;
 
     // Invert the exact texture transform used by the stars. The moon therefore
     // sits on one fixed point of the star field in X and Y; because it is also a
     // child of the sky plane, it inherits the same Z depth, pitch and roll.
-    const localU = (anchorU - skyMotion.offsetU) / skyMotion.visibleU;
-    const localV = MOON_SKY_ANCHOR_V - skyMotion.offsetV;
+    const localU = (anchorU - skyMotion.offsetU) / skyMotion.repeatU;
+    const localV = (MOON_SKY_ANCHOR_V - skyMotion.offsetV) / skyMotion.repeatV;
     moonLayer.position.set(localU - 0.5, localV - 0.5, 0);
 
     // Parent scaling makes the backdrop cover the viewport. Divide it back out
@@ -247,6 +288,8 @@ export function installMountainR7SkyFix(world) {
     skyYawLock: 'world-space-y-axis-via-inverse-four-tile-uv-rotation',
     skyGeometry: 'camera-facing-flat-backdrop',
     skyParallax: 'yaw-catchup-plus-subtle-position-and-pitch-drag',
+    skyAspectPolicy: 'wide-phone-reference-normalized-for-4x3-and-other-aspects',
+    skyReferenceAspect: SKY_REFERENCE_ASPECT,
     skyCameraCuts: 'snap-large-camera-jumps-so-loading-cuts-are-not-animated',
     skyHorizontalTiles: SKY_HORIZONTAL_TILES,
     skyYawCatchup: SKY_YAW_CATCHUP,

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -10,8 +10,8 @@ import { installCliffsideWorld } from './cliffside-world.js';
 import { installHarborWorld } from './harbor-world.js';
 // Historical regression markers: midnight-city-world-r9.js?build=20260802-r9, midnight-city-world-r10.js?build=20260802-r10, midnight-city-world-r11.js?build=20260802-r11, midnight-city-world-r11.js?build=20260818-r560-shared-spotlight, midnight-city-world-r11.js?build=20260818-r561-200m-headlight, midnight-city-world-r11.js?build=20260818-r562-road-headlight-response, midnight-city-world-r11.js?build=20260818-r563-lower-headlight-target, midnight-city-world-r11.js?build=20260818-r174-night-headlight-tune, midnight-city-world-r11.js?build=20260818-r175-reconcile-night-headlight
 import { installMidnightCityWorld } from './midnight-city-world-r11.js?build=20260819-r176-upward-road-normals';
-// Historical MOUNTAIN regression markers: mountain-world-r3.js?revision=r3-continuous-terrain-v1, mountain-world-r3.js?revision=r6-night-treatment, mountain-world-r3.js?revision=r8-shadowless-spotlight, mountain-world-r3.js?revision=r560-shared-night-spotlight, mountain-world-r3.js?revision=r561-200m-headlight, mountain-world-r3.js?revision=r563-lower-headlight-target, mountain-world-r3.js?revision=r174-night-headlight-tune
-import { installMountainWorld } from './mountain-world-r3.js?revision=r175-reconcile-night-headlight';
+// Historical MOUNTAIN regression markers: mountain-world-r3.js?revision=r3-continuous-terrain-v1, mountain-world-r3.js?revision=r6-night-treatment, mountain-world-r3.js?revision=r8-shadowless-spotlight, mountain-world-r3.js?revision=r560-shared-night-spotlight, mountain-world-r3.js?revision=r561-200m-headlight, mountain-world-r3.js?revision=r563-lower-headlight-target, mountain-world-r3.js?revision=r174-night-headlight-tune, mountain-world-r3.js?revision=r175-reconcile-night-headlight
+import { installMountainWorld } from './mountain-world-r3.js?revision=r177-ipad-sky-aspect';
 import { isForgivingTrackSurface } from './airport-runoff.js?build=20260722-r52';
 import './contextual-road-edges.js?revision=r518-signature-yellow';
 import './road-contour-color-r512.js?revision=r513-countryside';


### PR DESCRIPTION
Fix the MOUNTAIN star field on 4:3 displays such as iPad 9 without changing the approved wide-phone composition.

Root cause: the sky is a fixed 2:1 plane that deliberately over-covers the camera frustum. The UV yaw/scale math assumed the viewport saw the whole plane width. That is almost true on a ~2.16:1 phone, but on 4:3 iPad only about 63% of the plane width is visible. The hidden overhang therefore magnified both the star texture and the UV yaw motion.

Changes:
- compensate UV repeat for the fraction of the overscanned sky plane actually visible at the current aspect ratio
- preserve the current 1536/709 phone appearance as the visual reference
- keep moon positioning on the exact same corrected UV transform
- retain world-up horizon/roll lock, yaw drag, camera-cut snapping and reduced-motion behavior
- cache-bust the corrected MOUNTAIN sky path
- add a phone-vs-4:3 regression proving one consistent angular star scale
- run that regression in the MOUNTAIN visual-smoke workflow

No extra rendering passes, lights, geometry, timers or animation loops are added; this is a few arithmetic operations inside the existing sky onBeforeRender hook.