### PR TITLE
Add per-track winner and safety achievements

### DIFF
--- a/turn-lab/tests/chromatic-camouflage-production.mjs
+++ b/turn-lab/tests/chromatic-camouflage-production.mjs
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises';
 import {
   ACHIEVEMENTS,
   TRACK_IDS,
+  TRACK_NAMES,
   getAchievement
 } from '../../turn/achievements/catalog-chromatic-r183.js';
 import {
@@ -24,8 +25,8 @@ const release = JSON.parse(releaseSource);
 
 const achievement = getAchievement(CHROMATIC_CAMOUFLAGE_ID);
 const mayday = getAchievement('golden-hour');
-assert.equal(ACHIEVEMENTS.length, 31,
-  'Production TURN should expose the existing 29 achievements plus MAYDAY and Chromatic Camouflage');
+assert.equal(ACHIEVEMENTS.length, 43,
+  'Production TURN should expose 31 existing achievements plus twelve per-track racing achievements');
 assert.equal(achievement?.title, 'CHROMATIC CAMOUFLAGE');
 assert.equal(achievement?.hidden, true);
 assert.equal(achievement?.category, 'exploration');
@@ -42,11 +43,26 @@ assert.equal(mayday?.lockedDescription, '');
 assert.match(mayday?.description || '', /Ambulance/);
 assert.match(mayday?.description || '', /Airport MAYDAY/);
 assert.match(mayday?.description || '', /30 seconds/);
+
+for (const trackId of TRACK_IDS) {
+  const trackName = TRACK_NAMES[trackId];
+  const winner = getAchievement(`${trackId}-winner`);
+  const safety = getAchievement(`${trackId}-safety`);
+  assert.equal(winner?.title, `${trackName.toUpperCase()} WINNER`);
+  assert.equal(winner?.category, 'racing');
+  assert.equal(winner?.trophies, 50);
+  assert.match(winner?.description || '', /four saved rivals/i);
+  assert.equal(safety?.title, `${trackName.toUpperCase()} SAFETY`);
+  assert.equal(safety?.category, 'racing');
+  assert.equal(safety?.trophies, 50);
+  assert.match(safety?.description || '', /without going off-road/i);
+}
+
 assert.equal(
   ACHIEVEMENTS.reduce((total, item) => total + item.trophies, 0),
-  1875
+  2475
 );
-assert.equal(TROPHY_ROAD_MAX_THRESHOLD, 1875);
+assert.equal(TROPHY_ROAD_MAX_THRESHOLD, 2475);
 assert.deepEqual(TRACK_IDS, [
   'countryside', 'airport', 'cliffside', 'harbor', 'midnight-city', 'mountain'
 ], 'Every-track achievements must include the sixth production track');
@@ -117,10 +133,10 @@ assert.ok(
 assert.match(indexSource, /catalog-chromatic-r183\.js/,
   'Production must route the achievement store and view through the production achievement catalog');
 assert.match(indexSource, /trophy-road-chromatic-r183\.js/,
-  'Production must expose the expanded 1875-trophy road maximum');
+  'Production must expose the expanded 2475-trophy road maximum');
 assert.match(indexSource, /chromatic-camouflage-r183\.js/,
   'Production must install the hidden achievement evaluator');
 assert.doesNotMatch(indexSource, /airport-runway/,
   'The TURN NEXT Airport prototype must not enter the production TURN entry point');
 
-console.log(`TURN ${release.version} production six-track Chromatic Camouflage achievement regression passed.`);
+console.log(`TURN ${release.version} production six-track achievement regression passed.`);

--- a/turn-lab/tests/chromatic-camouflage-production.mjs
+++ b/turn-lab/tests/chromatic-camouflage-production.mjs
@@ -11,6 +11,10 @@ import {
   matchesTrackColor,
   qualifyingChromaticCamouflage
 } from '../../turn/achievements/chromatic-camouflage-r183.js';
+import {
+  CHALLENGE_PROGRESS_STORAGE_KEY,
+  installAchievementChallengeExpansion
+} from '../../turn/achievements/challenge-expansion-r166.js';
 import { TROPHY_ROAD_MAX_THRESHOLD } from '../../turn/progression/trophy-road-chromatic-r183.js';
 
 const [releaseSource, indexSource] = await Promise.all([
@@ -57,6 +61,47 @@ for (const trackId of TRACK_IDS) {
   assert.equal(safety?.trophies, 50);
   assert.match(safety?.description || '', /without going off-road/i);
 }
+
+const challengeMemory = new Map([[
+  CHALLENGE_PROGRESS_STORAGE_KEY,
+  JSON.stringify({ armyTracks: ['airport'], cleanTracks: ['harbor'] })
+]]);
+const challengeStorage = {
+  getItem: (key) => challengeMemory.get(key) ?? null,
+  setItem: (key, value) => challengeMemory.set(key, value)
+};
+const challengeUnlocks = [];
+const challengeRuntime = {
+  state: {
+    trackId: 'countryside',
+    vehicleId: 'sedan',
+    competitorLaps: [{}, {}, {}, {}],
+    offRoad: false
+  }
+};
+const challengeApi = installAchievementChallengeExpansion({
+  runtime: challengeRuntime,
+  achievements: {
+    unlock(id, context) {
+      challengeUnlocks.push({ id, context });
+      return { id };
+    }
+  },
+  storage: challengeStorage
+});
+assert.ok(challengeUnlocks.some(({ id }) => id === 'airport-winner'),
+  'Stored all-track progress should backfill the corresponding WINNER achievement');
+assert.ok(challengeUnlocks.some(({ id }) => id === 'harbor-safety'),
+  'Stored all-track progress should backfill the corresponding SAFETY achievement');
+challengeUnlocks.length = 0;
+challengeApi.beginLap();
+challengeApi.completeLap({ position: 1, total: 5, time: 20 });
+assert.deepEqual(
+  challengeUnlocks.map(({ id }) => id),
+  ['countryside-winner', 'countryside-safety'],
+  'One qualifying lap should award both track-specific achievements immediately'
+);
+challengeApi.disconnect();
 
 assert.equal(
   ACHIEVEMENTS.reduce((total, item) => total + item.trophies, 0),

--- a/turn/achievements/catalog-chromatic-r183.js
+++ b/turn/achievements/catalog-chromatic-r183.js
@@ -21,16 +21,59 @@ const GOLDEN_HOUR = Object.freeze({
   icon: 'siren'
 });
 
-const firstTimeTrialIndex = base.ACHIEVEMENTS.findIndex(
+const SAFETY_TARGET_LABELS = Object.freeze({
+  countryside: '0:30',
+  airport: '0:30',
+  cliffside: '0:30',
+  harbor: '1:00',
+  'midnight-city': '2:00',
+  mountain: '1:50'
+});
+
+export const TRACK_WINNER_ACHIEVEMENTS = Object.freeze(
+  base.TRACK_IDS.map((trackId) => Object.freeze({
+    id: `${trackId}-winner`,
+    category: base.CATEGORY.RACING,
+    trophies: 50,
+    title: `${base.TRACK_NAMES[trackId].toUpperCase()} WINNER`,
+    description: `Finish first against four saved rivals on ${base.TRACK_NAMES[trackId]}.`,
+    icon: 'rival'
+  }))
+);
+
+export const TRACK_SAFETY_ACHIEVEMENTS = Object.freeze(
+  base.TRACK_IDS.map((trackId) => Object.freeze({
+    id: `${trackId}-safety`,
+    category: base.CATEGORY.RACING,
+    trophies: 50,
+    title: `${base.TRACK_NAMES[trackId].toUpperCase()} SAFETY`,
+    description: `Finish ${base.TRACK_NAMES[trackId]} without going off-road in under ${SAFETY_TARGET_LABELS[trackId]}.`,
+    icon: 'route'
+  }))
+);
+
+const expandedBaseAchievements = base.ACHIEVEMENTS.flatMap((achievement) => {
+  if (achievement.id === 'an-army-of-me') {
+    return [...TRACK_WINNER_ACHIEVEMENTS, achievement];
+  }
+  if (achievement.id === 'on-course-of-course') {
+    return [...TRACK_SAFETY_ACHIEVEMENTS, achievement];
+  }
+  return [achievement];
+});
+
+const firstTimeTrialIndex = expandedBaseAchievements.findIndex(
   (achievement) => achievement.category === base.CATEGORY.TIME_TRIALS
 );
-const insertionIndex = firstTimeTrialIndex >= 0 ? firstTimeTrialIndex : base.ACHIEVEMENTS.length;
+const insertionIndex = firstTimeTrialIndex >= 0
+  ? firstTimeTrialIndex
+  : expandedBaseAchievements.length;
 
 export const ACHIEVEMENTS = Object.freeze([
-  ...base.ACHIEVEMENTS.slice(0, insertionIndex),
+  ...expandedBaseAchievements.slice(0, insertionIndex),
   GOLDEN_HOUR,
   CHROMATIC_CAMOUFLAGE,
-  ...base.ACHIEVEMENTS.slice(insertionIndex)
+  ...expandedBaseAchievements.slice(insertionIndex)
 ]);
 
 export const VEHICLE_NAMES = Object.freeze({

--- a/turn/achievements/challenge-expansion-r166.js
+++ b/turn/achievements/challenge-expansion-r166.js
@@ -40,6 +40,22 @@ export function qualifiesForCleanLap(attempt, detail) {
     && seconds < target;
 }
 
+function winnerAchievementId(trackId) {
+  return `${trackId}-winner`;
+}
+
+function safetyAchievementId(trackId) {
+  return `${trackId}-safety`;
+}
+
+function achievementContext(trackId, vehicleId = '', time = null) {
+  return {
+    trackId,
+    vehicleId,
+    time: Number.isFinite(Number(time)) ? Number(time) : null
+  };
+}
+
 function loadProgress(storage = globalThis.localStorage) {
   try {
     const raw = storage?.getItem?.(CHALLENGE_PROGRESS_STORAGE_KEY);
@@ -81,6 +97,21 @@ export function installAchievementChallengeExpansion({
   const progress = loadProgress(storage);
   let currentLap = null;
 
+  function unlockStoredTrackAchievements() {
+    for (const trackId of progress.armyTracks) {
+      achievements.unlock(winnerAchievementId(trackId), achievementContext(trackId));
+    }
+    for (const trackId of progress.cleanTracks) {
+      achievements.unlock(safetyAchievementId(trackId), achievementContext(trackId));
+    }
+    if (allTracksComplete(progress.armyTracks)) {
+      achievements.unlock('an-army-of-me', achievementContext(''));
+    }
+    if (allTracksComplete(progress.cleanTracks)) {
+      achievements.unlock('on-course-of-course', achievementContext(''));
+    }
+  }
+
   function beginLap() {
     const state = runtime.state;
     currentLap = {
@@ -104,26 +135,21 @@ export function installAchievementChallengeExpansion({
     resetLap();
     if (!attempt || !TRACK_IDS.includes(attempt.trackId)) return;
 
+    const context = achievementContext(attempt.trackId, attempt.vehicleId, detail?.time);
     let changed = false;
     if (qualifiesForArmyLap(attempt, detail)) {
+      achievements.unlock(winnerAchievementId(attempt.trackId), context);
       changed = addTrack(progress, 'armyTracks', attempt.trackId) || changed;
       if (allTracksComplete(progress.armyTracks)) {
-        achievements.unlock('an-army-of-me', {
-          trackId: attempt.trackId,
-          vehicleId: attempt.vehicleId,
-          time: Number(detail?.time)
-        });
+        achievements.unlock('an-army-of-me', context);
       }
     }
 
     if (qualifiesForCleanLap(attempt, detail)) {
+      achievements.unlock(safetyAchievementId(attempt.trackId), context);
       changed = addTrack(progress, 'cleanTracks', attempt.trackId) || changed;
       if (allTracksComplete(progress.cleanTracks)) {
-        achievements.unlock('on-course-of-course', {
-          trackId: attempt.trackId,
-          vehicleId: attempt.vehicleId,
-          time: Number(detail?.time)
-        });
+        achievements.unlock('on-course-of-course', context);
       }
     }
 
@@ -142,6 +168,7 @@ export function installAchievementChallengeExpansion({
   const handleLapResult = (event) => completeLap(event.detail || {});
   const handleLapInvalid = () => resetLap();
 
+  unlockStoredTrackAchievements();
   globalThis.addEventListener?.('turn:ui-state-change', handleUiState);
   globalThis.addEventListener?.('turn:lap-result', handleLapResult);
   globalThis.addEventListener?.('turn:lap-invalid', handleLapInvalid);

--- a/turn/progression/trophy-road-chromatic-r183.js
+++ b/turn/progression/trophy-road-chromatic-r183.js
@@ -7,7 +7,7 @@ import {
 
 export * from './trophy-road.js?revision=r164-vintage-rally-perks';
 
-export const TROPHY_ROAD_MAX_THRESHOLD = 1875;
+export const TROPHY_ROAD_MAX_THRESHOLD = 2475;
 
 export const TROPHY_ROAD_REWARDS = Object.freeze(BASE_TROPHY_ROAD_REWARDS.map((reward) => {
   if (reward.id !== 'future-racer') return reward;


### PR DESCRIPTION
## What changed

Adds the missing stepping-stone achievements so players can earn trophies from tracks they already have access to instead of needing the full 1000-trophy track set first.

### WINNER line — 50 trophies each
- COUNTRYSIDE WINNER
- AIRPORT WINNER
- CLIFFSIDE WINNER
- HARBOR WINNER
- MIDNIGHT CITY WINNER
- MOUNTAIN WINNER

Each unlocks by finishing first against four saved rivals on that track. **AN ARMY OF ME** remains the all-six-tracks master achievement.

### SAFETY line — 50 trophies each
- COUNTRYSIDE SAFETY
- AIRPORT SAFETY
- CLIFFSIDE SAFETY
- HARBOR SAFETY
- MIDNIGHT CITY SAFETY
- MOUNTAIN SAFETY

Each uses the existing clean-lap rule for its track: never go off-road and finish below that track's current clean-lap target. **ON COURSE, OF COURSE** remains the all-six-tracks master achievement.

## Existing players

The existing challenge-progress record is reused. If a player already completed qualifying tracks before this update, the corresponding per-track achievements are backfilled automatically instead of making them repeat those runs.

## Progression impact

- +12 achievements
- +600 available trophies
- production collection: 43 achievements
- production trophy total: 2475
- reward thresholds themselves are unchanged; MOUNTAIN remains the 1000-trophy unlock

Regression coverage now verifies the production catalog, 50-trophy values, immediate per-track unlocks, stored-progress backfill, and the updated trophy total.