### PR TITLE
Rebalance time trial trophy rewards

### DIFF
--- a/turn-lab/tests/chromatic-camouflage-production.mjs
+++ b/turn-lab/tests/chromatic-camouflage-production.mjs
@@ -62,6 +62,17 @@ for (const trackId of TRACK_IDS) {
   assert.match(safety?.description || '', /without going off-road/i);
 }
 
+const timeTrialAchievements = ACHIEVEMENTS.filter((item) => (
+  item.category === 'time-trials' && item.id !== 'faster-than-the-dev'
+));
+assert.equal(timeTrialAchievements.length, 6);
+for (const timeTrial of timeTrialAchievements) {
+  assert.equal(timeTrial.trophies, 75,
+    `${timeTrial.title} should award 75 trophies`);
+}
+assert.equal(getAchievement('faster-than-the-dev')?.trophies, 300,
+  'FASTER THAN THE DEV should award 300 trophies');
+
 const challengeMemory = new Map([[
   CHALLENGE_PROGRESS_STORAGE_KEY,
   JSON.stringify({ armyTracks: ['airport'], cleanTracks: ['harbor'] })
@@ -105,9 +116,9 @@ challengeApi.disconnect();
 
 assert.equal(
   ACHIEVEMENTS.reduce((total, item) => total + item.trophies, 0),
-  2475
+  2975
 );
-assert.equal(TROPHY_ROAD_MAX_THRESHOLD, 2475);
+assert.equal(TROPHY_ROAD_MAX_THRESHOLD, 2975);
 assert.deepEqual(TRACK_IDS, [
   'countryside', 'airport', 'cliffside', 'harbor', 'midnight-city', 'mountain'
 ], 'Every-track achievements must include the sixth production track');
@@ -178,7 +189,7 @@ assert.ok(
 assert.match(indexSource, /catalog-chromatic-r183\.js/,
   'Production must route the achievement store and view through the production achievement catalog');
 assert.match(indexSource, /trophy-road-chromatic-r183\.js/,
-  'Production must expose the expanded 2475-trophy road maximum');
+  'Production must expose the expanded 2975-trophy road maximum');
 assert.match(indexSource, /chromatic-camouflage-r183\.js/,
   'Production must install the hidden achievement evaluator');
 assert.doesNotMatch(indexSource, /airport-runway/,

--- a/turn/achievements/catalog-chromatic-r183.js
+++ b/turn/achievements/catalog-chromatic-r183.js
@@ -52,7 +52,15 @@ export const TRACK_SAFETY_ACHIEVEMENTS = Object.freeze(
   }))
 );
 
-const expandedBaseAchievements = base.ACHIEVEMENTS.flatMap((achievement) => {
+const rebalancedBaseAchievements = base.ACHIEVEMENTS.map((achievement) => {
+  if (achievement.category !== base.CATEGORY.TIME_TRIALS) return achievement;
+  return Object.freeze({
+    ...achievement,
+    trophies: achievement.id === 'faster-than-the-dev' ? 300 : 75
+  });
+});
+
+const expandedBaseAchievements = rebalancedBaseAchievements.flatMap((achievement) => {
   if (achievement.id === 'an-army-of-me') {
     return [...TRACK_WINNER_ACHIEVEMENTS, achievement];
   }

--- a/turn/progression/trophy-road-chromatic-r183.js
+++ b/turn/progression/trophy-road-chromatic-r183.js
@@ -7,7 +7,7 @@ import {
 
 export * from './trophy-road.js?revision=r164-vintage-rally-perks';
 
-export const TROPHY_ROAD_MAX_THRESHOLD = 2475;
+export const TROPHY_ROAD_MAX_THRESHOLD = 2975;
 
 export const TROPHY_ROAD_REWARDS = Object.freeze(BASE_TROPHY_ROAD_REWARDS.map((reward) => {
   if (reward.id !== 'future-racer') return reward;


### PR DESCRIPTION
Raise the production time-trial rewards to better match their difficulty and progression value:

- each track SPRINT / time trial: 25 → 75 trophies
- FASTER THAN THE DEV: 100 → 300 trophies

This adds 500 available trophies overall, taking production TURN from 2475 to 2975 total trophies. Trophy Road reward thresholds themselves are unchanged; only the available-achievement maximum is updated.

Regression coverage verifies all six time trials award 75, the master awards 300, and the production trophy total/max stays synchronized.