### PR TITLE
Add GOT STARTED and reorder Trophy Road rewards

### DIFF
--- a/.github/workflows/turn-chromatic-camouflage.yml
+++ b/.github/workflows/turn-chromatic-camouflage.yml
@@ -8,7 +8,13 @@ on:
       - 'turn/index.html'
       - 'turn/achievements/catalog-chromatic-r183.js'
       - 'turn/achievements/chromatic-camouflage-r183.js'
+      - 'turn/achievements/challenge-expansion-r166.js'
+      - 'turn/progression/trophy-road-perks-r164.js'
       - 'turn/progression/trophy-road-chromatic-r183.js'
+      - 'turn/progression/trophy-road-r157.css'
+      - 'turn/progression/m8-trophy-gate.js'
+      - 'turn/progression/lot-trophy-gate.js'
+      - 'turn/progression/lot-paint-reward.js'
       - 'turn-lab/tests/chromatic-camouflage-production.mjs'
       - '.github/workflows/turn-chromatic-camouflage.yml'
   push:
@@ -18,7 +24,13 @@ on:
       - 'turn/index.html'
       - 'turn/achievements/catalog-chromatic-r183.js'
       - 'turn/achievements/chromatic-camouflage-r183.js'
+      - 'turn/achievements/challenge-expansion-r166.js'
+      - 'turn/progression/trophy-road-perks-r164.js'
       - 'turn/progression/trophy-road-chromatic-r183.js'
+      - 'turn/progression/trophy-road-r157.css'
+      - 'turn/progression/m8-trophy-gate.js'
+      - 'turn/progression/lot-trophy-gate.js'
+      - 'turn/progression/lot-paint-reward.js'
       - 'turn-lab/tests/chromatic-camouflage-production.mjs'
       - '.github/workflows/turn-chromatic-camouflage.yml'
 
@@ -37,12 +49,17 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Syntax-check Chromatic Camouflage modules
+      - name: Syntax-check achievement progression modules
         run: |
           node --check turn/achievements/catalog-chromatic-r183.js
           node --check turn/achievements/chromatic-camouflage-r183.js
+          node --check turn/achievements/challenge-expansion-r166.js
+          node --check turn/progression/trophy-road-perks-r164.js
           node --check turn/progression/trophy-road-chromatic-r183.js
+          node --check turn/progression/m8-trophy-gate.js
+          node --check turn/progression/lot-trophy-gate.js
+          node --check turn/progression/lot-paint-reward.js
           node --check turn-lab/tests/chromatic-camouflage-production.mjs
 
-      - name: Run Chromatic Camouflage production regression
+      - name: Run production achievement progression regression
         run: node turn-lab/tests/chromatic-camouflage-production.mjs

--- a/turn-lab/tests/achievements-production.mjs
+++ b/turn-lab/tests/achievements-production.mjs
@@ -189,7 +189,7 @@ assert.equal(store.unlock('an-army-of-me', { trackId: 'midnight-city' })?.trophi
 assert.equal(store.unlock('on-course-of-course', { trackId: 'harbor' })?.trophies, 100);
 assert.equal(store.unlock('save-bella', { trackId: 'countryside', vehicleId: 'firetruck' })?.trophies, 25);
 assert.equal(store.trophyTotal(), 325);
-assert.deepEqual(store.syncRewards().map((reward) => reward.id), ['midnight-city']);
+assert.deepEqual(store.syncRewards().map((reward) => reward.id), ['vintage-racer']);
 assert.doesNotMatch(storeSource, /rival-storage|clearRivalsState|clearAllRivalsState/,
   'Rival resets must remain independent from achievements');
 
@@ -243,6 +243,7 @@ assert.match(timeTrialSource, /targetSeconds: 27/);
 assert.match(timeTrialSource, /seconds >= trial\.targetSeconds/);
 
 assert.match(challengeSource, /SAMPLE_INTERVAL_MS = 50/);
+assert.match(challengeSource, /GOT_STARTED_ID = 'got-started'/);
 assert.match(challengeSource, /mountain: 110/);
 assert.match(challengeSource, /rivalCountAtStart/);
 assert.match(challengeSource, /runtime\.state\.offRoad === true/);
@@ -250,6 +251,7 @@ assert.match(challengeSource, /achievements\.unlock\('an-army-of-me'/);
 assert.match(challengeSource, /achievements\.unlock\('on-course-of-course'/);
 assert.match(challengeSource, /turn:lap-result/);
 assert.match(challengeSource, /turn:lap-invalid/);
+assert.match(challengeSource, /turn:achievements-updated/);
 assert.match(challengeSource, /reason === 'lap-started'/);
 
 assert.match(bellaSource, /Kenney Cube Pets/);

--- a/turn-lab/tests/chromatic-camouflage-production.mjs
+++ b/turn-lab/tests/chromatic-camouflage-production.mjs
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import {
   ACHIEVEMENTS,
+  GOT_STARTED_ACHIEVEMENT,
+  ONBOARDING_ACHIEVEMENT_IDS,
   TRACK_IDS,
   TRACK_NAMES,
   getAchievement
@@ -15,22 +17,35 @@ import {
   CHALLENGE_PROGRESS_STORAGE_KEY,
   installAchievementChallengeExpansion
 } from '../../turn/achievements/challenge-expansion-r166.js';
-import { TROPHY_ROAD_MAX_THRESHOLD } from '../../turn/progression/trophy-road-chromatic-r183.js';
+import {
+  TROPHY_ROAD_MAX_THRESHOLD,
+  TROPHY_ROAD_REWARDS,
+  TROPHY_ROAD_REWARD_ICONS
+} from '../../turn/progression/trophy-road-chromatic-r183.js';
 
-const [releaseSource, indexSource] = await Promise.all([
+const [releaseSource, indexSource, moduleSource, trophyRoadCss] = await Promise.all([
   fs.readFile(new URL('../../turn/release.json', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8')
+  fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/achievements/chromatic-camouflage-r183.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/progression/trophy-road-r157.css', import.meta.url), 'utf8')
 ]);
-const moduleSource = await fs.readFile(
-  new URL('../../turn/achievements/chromatic-camouflage-r183.js', import.meta.url),
-  'utf8'
-);
 const release = JSON.parse(releaseSource);
 
 const achievement = getAchievement(CHROMATIC_CAMOUFLAGE_ID);
 const mayday = getAchievement('golden-hour');
-assert.equal(ACHIEVEMENTS.length, 43,
-  'Production TURN should expose 31 existing achievements plus twelve per-track racing achievements');
+const gotStarted = getAchievement('got-started');
+
+assert.equal(ACHIEVEMENTS.length, 44,
+  'Production TURN should expose 43 existing achievements plus GOT STARTED');
+assert.equal(GOT_STARTED_ACHIEVEMENT, gotStarted);
+assert.equal(gotStarted?.title, 'GOT STARTED');
+assert.equal(gotStarted?.category, 'onboarding');
+assert.equal(gotStarted?.trophies, 75);
+assert.equal(gotStarted?.description, 'Finish all Getting Started achievements.');
+assert.equal(ONBOARDING_ACHIEVEMENT_IDS.length, 10,
+  'GOT STARTED is the master reward and must not recursively require itself');
+assert.equal(ONBOARDING_ACHIEVEMENT_IDS.includes('got-started'), false);
+
 assert.equal(achievement?.title, 'CHROMATIC CAMOUFLAGE');
 assert.equal(achievement?.hidden, true);
 assert.equal(achievement?.category, 'exploration');
@@ -62,17 +77,22 @@ for (const trackId of TRACK_IDS) {
   assert.match(safety?.description || '', /without going off-road/i);
 }
 
-const timeTrialAchievements = ACHIEVEMENTS.filter((item) => (
-  item.category === 'time-trials' && item.id !== 'faster-than-the-dev'
-));
-assert.equal(timeTrialAchievements.length, 6);
-for (const timeTrial of timeTrialAchievements) {
-  assert.equal(timeTrial.trophies, 75,
-    `${timeTrial.title} should award 75 trophies`);
+for (const achievementId of [
+  'countryside-sprint',
+  'airport-sprint',
+  'cliffside-sprint',
+  'harbor-sprint',
+  'midnight-sprint',
+  'mountain-sprint'
+]) {
+  assert.equal(getAchievement(achievementId)?.trophies, 75,
+    `${achievementId} should award 75 trophies`);
 }
-assert.equal(getAchievement('faster-than-the-dev')?.trophies, 300,
-  'FASTER THAN THE DEV should award 300 trophies');
+assert.equal(getAchievement('faster-than-the-dev')?.trophies, 300);
 
+const achievementState = {
+  unlocked: Object.fromEntries(ONBOARDING_ACHIEVEMENT_IDS.map((id) => [id, { unlockedAt: 1 }]))
+};
 const challengeMemory = new Map([[
   CHALLENGE_PROGRESS_STORAGE_KEY,
   JSON.stringify({ armyTracks: ['airport'], cleanTracks: ['harbor'] })
@@ -94,8 +114,13 @@ const challengeApi = installAchievementChallengeExpansion({
   runtime: challengeRuntime,
   achievements: {
     unlock(id, context) {
+      if (achievementState.unlocked[id]) return null;
+      achievementState.unlocked[id] = { unlockedAt: 1, ...context };
       challengeUnlocks.push({ id, context });
-      return { id };
+      return getAchievement(id) || { id };
+    },
+    getState() {
+      return achievementState;
     }
   },
   storage: challengeStorage
@@ -104,6 +129,8 @@ assert.ok(challengeUnlocks.some(({ id }) => id === 'airport-winner'),
   'Stored all-track progress should backfill the corresponding WINNER achievement');
 assert.ok(challengeUnlocks.some(({ id }) => id === 'harbor-safety'),
   'Stored all-track progress should backfill the corresponding SAFETY achievement');
+assert.ok(challengeUnlocks.some(({ id }) => id === 'got-started'),
+  'Existing players with all Getting Started achievements should receive GOT STARTED automatically');
 challengeUnlocks.length = 0;
 challengeApi.beginLap();
 challengeApi.completeLap({ position: 1, total: 5, time: 20 });
@@ -116,12 +143,48 @@ challengeApi.disconnect();
 
 assert.equal(
   ACHIEVEMENTS.reduce((total, item) => total + item.trophies, 0),
-  2975
+  3050
 );
-assert.equal(TROPHY_ROAD_MAX_THRESHOLD, 2975);
+assert.equal(TROPHY_ROAD_MAX_THRESHOLD, 3050);
+assert.deepEqual(
+  TROPHY_ROAD_REWARDS.map(({ id, threshold }) => [id, threshold]),
+  [
+    ['vintage-racer', 300],
+    ['midnight-city', 400],
+    ['future-racer', 500],
+    ['emergency-pack', 600],
+    ['mountain', 700],
+    ['monster', 800],
+    ['paintjob', 900],
+    ['rally-racer', 1000]
+  ]
+);
 assert.deepEqual(TRACK_IDS, [
   'countryside', 'airport', 'cliffside', 'harbor', 'midnight-city', 'mountain'
 ], 'Every-track achievements must include the sixth production track');
+
+assert.match(TROPHY_ROAD_REWARD_ICONS.future, /M3 32h12l7-5/,
+  'Future Racer should use the sharper Formula silhouette in both marker and detail views');
+assert.match(TROPHY_ROAD_REWARD_ICONS.vintage, /r="7"/,
+  'Vintage Racer should read as an older racer with larger exposed wheels');
+assert.match(TROPHY_ROAD_REWARD_ICONS.rally, /circle cx="27" cy="29"/,
+  'Rally Racer should have recognisable auxiliary rally lamps');
+
+for (const variable of [
+  '--turn-reward-vehicle-locked',
+  '--turn-reward-vehicle-unlocked',
+  '--turn-reward-track-locked',
+  '--turn-reward-track-unlocked',
+  '--turn-reward-feature-locked',
+  '--turn-reward-feature-unlocked'
+]) {
+  assert.match(trophyRoadCss, new RegExp(variable));
+}
+assert.match(trophyRoadCss, /data-trophy-reward="mountain"/);
+assert.match(trophyRoadCss, /data-trophy-reward="paintjob"/);
+assert.match(trophyRoadCss, /data-trophy-reward="vintage-racer"/);
+assert.match(trophyRoadCss, /\.is-locked/);
+assert.match(trophyRoadCss, /\.is-unlocked/);
 
 const factoryRoute = Object.freeze({
   countryside: Object.freeze({ time: 18, carId: 'convertible', carColor: '#a8327a' }),
@@ -148,7 +211,6 @@ assert.equal(matchesTrackColor('mountain', '#4dabf7'), true,
   'Mountain should accept its alpine-blue track family without overlapping Cliffside cyan');
 assert.equal(matchesTrackColor('mountain', '#00aabb'), false,
   'Cliffside cyan must not also satisfy the Mountain blue family');
-
 assert.equal(matchesTrackColor('countryside', '#ffcc00'), false,
   'A saturated wrong hue must not count');
 assert.equal(matchesTrackColor('airport', '#fafafa'), false,
@@ -161,13 +223,11 @@ assert.equal(matchesTrackColor('cliffside', '#777777'), false,
 const qualifying = qualifyingChromaticCamouflage((trackId) => factoryRoute[trackId]);
 assert.equal(qualifying?.length, TRACK_IDS.length);
 assert.deepEqual(qualifying?.map(({ trackId }) => trackId), TRACK_IDS);
-
 assert.equal(qualifyingChromaticCamouflage((trackId) => (
   trackId === 'harbor'
     ? { ...factoryRoute[trackId], carColor: '#ff4fa3' }
     : factoryRoute[trackId]
 )), null, 'One wrong-colour personal best must keep the achievement locked');
-
 assert.equal(qualifyingChromaticCamouflage((trackId) => (
   trackId === 'airport' ? null : factoryRoute[trackId]
 )), null, 'Every canonical production track must have a stored personal best');
@@ -189,10 +249,10 @@ assert.ok(
 assert.match(indexSource, /catalog-chromatic-r183\.js/,
   'Production must route the achievement store and view through the production achievement catalog');
 assert.match(indexSource, /trophy-road-chromatic-r183\.js/,
-  'Production must expose the expanded 2975-trophy road maximum');
+  'Production must expose the expanded Trophy Road wrapper');
 assert.match(indexSource, /chromatic-camouflage-r183\.js/,
   'Production must install the hidden achievement evaluator');
 assert.doesNotMatch(indexSource, /airport-runway/,
   'The TURN NEXT Airport prototype must not enter the production TURN entry point');
 
-console.log(`TURN ${release.version} production six-track achievement regression passed.`);
+console.log(`TURN ${release.version} production achievements, Trophy Road order and Chromatic Camouflage regression passed.`);

--- a/turn-lab/tests/trophy-road-production.mjs
+++ b/turn-lab/tests/trophy-road-production.mjs
@@ -17,11 +17,29 @@ import {
   readTrophyRoadSnapshot,
   rewardForFeature,
   rewardForTrack,
-  rewardForVehicle,
-  rewardIdsForTrophies
+  rewardForVehicle
 } from '../../turn/progression/trophy-road.js';
+import {
+  TROPHY_ROAD_MAX_THRESHOLD as PRODUCTION_TROPHY_ROAD_MAX_THRESHOLD,
+  TROPHY_ROAD_REWARDS as PRODUCTION_TROPHY_ROAD_REWARDS,
+  getTrophyRoadReward as getProductionTrophyRoadReward,
+  rewardIdsForTrophies as productionRewardIdsForTrophies
+} from '../../turn/progression/trophy-road-perks-r164.js';
 
-const [roadSource, view, feedback, app, fixedLayout, workflow, perkDisclosure, enhancementRuntime, perkWrapper] = await Promise.all([
+const [
+  roadSource,
+  view,
+  feedback,
+  app,
+  fixedLayout,
+  workflow,
+  perkDisclosure,
+  enhancementRuntime,
+  perkWrapper,
+  homeGate,
+  lotGate,
+  paintGate
+] = await Promise.all([
   fs.readFile(new URL('../../turn/progression/trophy-road.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements/view.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements/trophy-road-feedback.js', import.meta.url), 'utf8'),
@@ -30,7 +48,10 @@ const [roadSource, view, feedback, app, fixedLayout, workflow, perkDisclosure, e
   fs.readFile(new URL('../../.github/workflows/turn-lab-tests.yml', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-perk-disclosure.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-enhancement-runtime.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/progression/trophy-road-perks-r164.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../../turn/progression/trophy-road-perks-r164.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/progression/m8-trophy-gate.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/progression/lot-trophy-gate.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/progression/lot-paint-reward.js', import.meta.url), 'utf8')
 ]);
 
 function createMemoryStorage(initial = {}) {
@@ -44,43 +65,53 @@ function createMemoryStorage(initial = {}) {
   };
 }
 
-const rewardIds = TROPHY_ROAD_REWARDS.map((reward) => reward.id);
-const through700 = ['midnight-city', 'paintjob', 'future-racer', 'emergency-pack', 'monster'];
-const through800 = [...through700, 'vintage-racer'];
-const through900 = [...through800, 'rally-racer'];
-const through1000 = [...through900, 'mountain'];
+const legacyRewardIds = TROPHY_ROAD_REWARDS.map((reward) => reward.id);
+const productionRewardIds = PRODUCTION_TROPHY_ROAD_REWARDS.map((reward) => reward.id);
+const through700 = ['vintage-racer', 'midnight-city', 'future-racer', 'emergency-pack', 'mountain'];
+const through800 = [...through700, 'monster'];
+const through900 = [...through800, 'paintjob'];
+const through1000 = [...through900, 'rally-racer'];
 
 assert.equal(TROPHY_ROAD_STORAGE_KEY, 'turn-achievements-v1');
 assert.equal(TROPHY_ROAD_STORAGE_VERSION, 5,
   'Adding locks to previously unrestricted cars requires a one-time ownership grandfather migration');
 assert.equal(TROPHY_ROAD_MAX_THRESHOLD, 1700,
-  'The base road must retain room for the complete expanded trophy collection');
+  'The legacy base module keeps its historical scale for compatibility');
+assert.equal(PRODUCTION_TROPHY_ROAD_MAX_THRESHOLD, 3050,
+  'Production must expose the complete current achievement-trophy scale');
 assert.equal(TROPHY_ROAD_VIEWPORT_THRESHOLD, 600);
+
 assert.deepEqual(
-  TROPHY_ROAD_REWARDS.map(({ id, threshold }) => [id, threshold]),
+  PRODUCTION_TROPHY_ROAD_REWARDS.map(({ id, threshold }) => [id, threshold]),
   [
-    ['midnight-city', 300],
-    ['paintjob', 400],
+    ['vintage-racer', 300],
+    ['midnight-city', 400],
     ['future-racer', 500],
     ['emergency-pack', 600],
-    ['monster', 700],
-    ['vintage-racer', 800],
-    ['rally-racer', 900],
-    ['mountain', 1000]
+    ['mountain', 700],
+    ['monster', 800],
+    ['paintjob', 900],
+    ['rally-racer', 1000]
   ]
 );
 
-assert.deepEqual(rewardIdsForTrophies(299), []);
-assert.deepEqual(rewardIdsForTrophies(300), ['midnight-city']);
-assert.deepEqual(rewardIdsForTrophies(400), ['midnight-city', 'paintjob']);
-assert.deepEqual(rewardIdsForTrophies(500), ['midnight-city', 'paintjob', 'future-racer']);
-assert.deepEqual(rewardIdsForTrophies(600), ['midnight-city', 'paintjob', 'future-racer', 'emergency-pack']);
-assert.deepEqual(rewardIdsForTrophies(700), through700);
-assert.deepEqual(rewardIdsForTrophies(800), through800);
-assert.deepEqual(rewardIdsForTrophies(900), through900);
-assert.deepEqual(rewardIdsForTrophies(999), through900);
-assert.deepEqual(rewardIdsForTrophies(1000), through1000);
-assert.deepEqual(rewardIdsForTrophies(1700), rewardIds);
+assert.deepEqual(productionRewardIdsForTrophies(299), []);
+assert.deepEqual(productionRewardIdsForTrophies(300), ['vintage-racer']);
+assert.deepEqual(productionRewardIdsForTrophies(400), ['vintage-racer', 'midnight-city']);
+assert.deepEqual(productionRewardIdsForTrophies(500), ['vintage-racer', 'midnight-city', 'future-racer']);
+assert.deepEqual(productionRewardIdsForTrophies(600), ['vintage-racer', 'midnight-city', 'future-racer', 'emergency-pack']);
+assert.deepEqual(productionRewardIdsForTrophies(700), through700);
+assert.deepEqual(productionRewardIdsForTrophies(800), through800);
+assert.deepEqual(productionRewardIdsForTrophies(900), through900);
+assert.deepEqual(productionRewardIdsForTrophies(999), through900);
+assert.deepEqual(productionRewardIdsForTrophies(1000), through1000);
+assert.deepEqual(productionRewardIdsForTrophies(3050), productionRewardIds);
+
+assert.equal(getProductionTrophyRoadReward('mountain')?.threshold, 700);
+assert.equal(getProductionTrophyRoadReward('paintjob')?.threshold, 900);
+assert.equal(getProductionTrophyRoadReward('rally-racer')?.threshold, 1000);
+assert.equal(getProductionTrophyRoadReward('invented'), null);
+
 assert.equal(rewardForTrack('midnight-city')?.id, 'midnight-city');
 assert.equal(rewardForTrack('mountain')?.id, 'mountain');
 assert.equal(rewardForVehicle('firetruck')?.id, 'emergency-pack');
@@ -91,42 +122,37 @@ assert.equal(rewardForVehicle('toy-racer')?.id, 'rally-racer');
 assert.equal(rewardForFeature('vehicle-paint')?.id, 'paintjob');
 assert.equal(getTrophyRoadReward('invented'), null);
 
-const mountainReward = getTrophyRoadReward('mountain');
-assert.equal(mountainReward?.threshold, 1000);
+const mountainReward = getProductionTrophyRoadReward('mountain');
+assert.equal(mountainReward?.threshold, 700);
 assert.equal(mountainReward?.type, 'track');
 assert.match(mountainReward?.description || '', /snowy village/i);
 assert.match(mountainReward?.description || '', /waterfall/i);
 
-const futurePerk = getTrophyRoadReward('future-racer');
+const futurePerk = getProductionTrophyRoadReward('future-racer');
 assert.equal(futurePerk?.perkTitle, 'OVERDRIVE');
 assert.match(futurePerk?.perkDescription || '', /5 clean seconds/);
 assert.match(futurePerk?.description || '', /<strong>OVERDRIVE:<\/strong>/);
 
-const emergencyPerk = getTrophyRoadReward('emergency-pack');
+const emergencyPerk = getProductionTrophyRoadReward('emergency-pack');
 assert.equal(emergencyPerk?.perkTitle, 'SIRENS');
 assert.match(emergencyPerk?.perkDescription || '', /emergency lights and sirens/i);
-assert.match(emergencyPerk?.description || '', /<strong>SIRENS:<\/strong>/);
 for (const vehicleId of ['firetruck', 'ambulance', 'police']) {
-  assert.equal(rewardForVehicle(vehicleId)?.perkTitle, 'SIRENS');
   assert.equal(getCarDefinition(vehicleId).perk?.title, 'SIRENS');
 }
 
-const monsterPerk = getTrophyRoadReward('monster');
+const monsterPerk = getProductionTrophyRoadReward('monster');
 assert.equal(monsterPerk?.perkTitle, 'OVERSIZED');
 assert.match(monsterPerk?.perkDescription || '', /off-road/i);
-assert.match(monsterPerk?.description || '', /<strong>OVERSIZED:<\/strong>/);
 assert.equal(getCarDefinition('monster-truck').perk?.title, 'OVERSIZED');
 
-const vintagePerk = getTrophyRoadReward('vintage-racer');
+const vintagePerk = getProductionTrophyRoadReward('vintage-racer');
 assert.equal(vintagePerk?.perkTitle, 'DRIFTAGE');
 assert.match(vintagePerk?.perkDescription || '', /larger slip angles/i);
-assert.match(vintagePerk?.description || '', /<strong>DRIFTAGE:<\/strong>/);
 assert.equal(getCarDefinition('vintage-racer').perk?.title, 'DRIFTAGE');
 
-const rallyPerk = getTrophyRoadReward('rally-racer');
+const rallyPerk = getProductionTrophyRoadReward('rally-racer');
 assert.equal(rallyPerk?.perkTitle, 'TWITCHY TURNY');
 assert.match(rallyPerk?.perkDescription || '', /fills BOOST even faster/i);
-assert.match(rallyPerk?.description || '', /<strong>TWITCHY TURNY:<\/strong>/);
 assert.equal(getCarDefinition('toy-racer').name, 'Rally Racer');
 assert.equal(getCarDefinition('toy-racer').perk?.title, 'TWITCHY TURNY');
 
@@ -141,7 +167,7 @@ assert.deepEqual(
   ['paintjob', 'monster', 'vintage-racer', 'rally-racer']
 );
 assert.deepEqual(grandfatheredRewardIdsForVersion(4), ['vintage-racer', 'rally-racer']);
-assert.deepEqual(grandfatheredRewardIdsForVersion(2), rewardIds);
+assert.deepEqual(grandfatheredRewardIdsForVersion(2), legacyRewardIds);
 assert.deepEqual(grandfatheredRewardIdsForVersion(5), []);
 
 const freshStorage = createMemoryStorage();
@@ -174,7 +200,7 @@ assert.deepEqual(
 assert.equal(isVehicleUnlocked('vintage-racer', priorProductionProfile), true);
 assert.equal(isVehicleUnlocked('toy-racer', priorProductionProfile), true);
 assert.equal(isTrackUnlocked('mountain', priorProductionProfile), false,
-  'Existing v4 players must still earn the new 1000-trophy Mountain reward');
+  'Existing v4 players must still earn the Mountain track reward');
 
 const normalizedPriorProduction = normalizeAchievementState({
   version: 4,
@@ -202,7 +228,7 @@ const legacyWithoutAchievements = createMemoryStorage({
 });
 const preparedLegacy = prepareTrophyRoadProfile(legacyWithoutAchievements);
 assert.equal(preparedLegacy?.version, 2);
-assert.deepEqual(readTrophyRoadSnapshot(legacyWithoutAchievements).unlockedRewardIds, rewardIds);
+assert.deepEqual(readTrophyRoadSnapshot(legacyWithoutAchievements).unlockedRewardIds, legacyRewardIds);
 assert.equal(isPaintUnlocked(legacyWithoutAchievements), true);
 assert.equal(isVehicleUnlocked('monster-truck', legacyWithoutAchievements), true);
 assert.equal(isVehicleUnlocked('vintage-racer', legacyWithoutAchievements), true);
@@ -217,7 +243,7 @@ const migratedLegacy = normalizeAchievementState({
   progress: { tracks: ['countryside'], blankTracks: [] }
 });
 assert.equal(migratedLegacy.version, 5);
-assert.deepEqual(migratedLegacy.rewards.unlocked, rewardIds);
+assert.deepEqual(migratedLegacy.rewards.unlocked, legacyRewardIds);
 assert.deepEqual(migratedLegacy.rewards.seen, migratedLegacy.rewards.unlocked);
 
 const progressionStorage = createMemoryStorage();
@@ -227,21 +253,22 @@ assert.deepEqual(store.syncRewards(), []);
 assert.equal(store.unlock('beyond-sight', { trackId: 'countryside' })?.trophies, 300);
 assert.deepEqual(
   store.syncRewards().map((reward) => reward.id),
-  ['midnight-city', 'paintjob', 'future-racer']
+  ['vintage-racer', 'midnight-city', 'future-racer']
 );
 assert.equal(store.unlock('around-the-turn', { trackId: 'harbor' })?.trophies, 100);
 assert.deepEqual(store.syncRewards().map((reward) => reward.id), ['emergency-pack']);
 assert.equal(store.unlock('faster-than-the-dev', { trackId: 'midnight-city' })?.trophies, 100);
-assert.deepEqual(store.syncRewards().map((reward) => reward.id), ['monster']);
-assert.equal(store.unlock('night-shift-sheriff', { trackId: 'midnight-city', vehicleId: 'police' })?.trophies, 100);
-assert.deepEqual(store.syncRewards().map((reward) => reward.id), ['vintage-racer']);
-assert.equal(store.unlock('on-course-of-course', { trackId: 'harbor' })?.trophies, 100);
-assert.deepEqual(store.syncRewards().map((reward) => reward.id), ['rally-racer']);
-assert.equal(isTrackUnlocked('mountain', progressionStorage), false,
-  'Mountain must remain locked at 900 trophies');
-assert.equal(store.unlock('ahead-of-yourself', { trackId: 'harbor' })?.trophies, 50);
-assert.equal(store.unlock('flow-state', { trackId: 'countryside' })?.trophies, 50);
 assert.deepEqual(store.syncRewards().map((reward) => reward.id), ['mountain']);
+assert.equal(isTrackUnlocked('mountain', progressionStorage), true,
+  'Mountain must unlock as soon as the player reaches 700 trophies');
+assert.equal(store.unlock('night-shift-sheriff', { trackId: 'midnight-city', vehicleId: 'police' })?.trophies, 100);
+assert.deepEqual(store.syncRewards().map((reward) => reward.id), ['monster']);
+assert.equal(store.unlock('on-course-of-course', { trackId: 'harbor' })?.trophies, 100);
+assert.deepEqual(store.syncRewards().map((reward) => reward.id), ['paintjob']);
+assert.equal(store.unlock('ahead-of-yourself', { trackId: 'harbor' })?.trophies, 50);
+assert.deepEqual(store.syncRewards(), []);
+assert.equal(store.unlock('flow-state', { trackId: 'countryside' })?.trophies, 50);
+assert.deepEqual(store.syncRewards().map((reward) => reward.id), ['rally-racer']);
 assert.equal(isTrackUnlocked('midnight-city', progressionStorage), true);
 assert.equal(isTrackUnlocked('mountain', progressionStorage), true);
 assert.equal(isVehicleUnlocked('firetruck', progressionStorage), true);
@@ -251,29 +278,8 @@ assert.equal(isVehicleUnlocked('toy-racer', progressionStorage), true);
 assert.equal(isPaintUnlocked(progressionStorage), true);
 
 assert.match(roadSource, /TROPHY_ROAD_STORAGE_VERSION = 5/);
-assert.match(roadSource, /TROPHY_ROAD_MAX_THRESHOLD = 1700/);
 assert.match(roadSource, /TROPHY_ROAD_VIEWPORT_THRESHOLD = 600/);
-for (const threshold of [300, 400, 500, 600, 700, 800, 900, 1000]) {
-  assert.match(roadSource, new RegExp(`threshold: ${threshold}`));
-}
-assert.match(roadSource, /id: 'paintjob'/);
-assert.match(roadSource, /id: 'future-racer'/);
-assert.match(roadSource, /perkTitle: 'OVERDRIVE'/);
-assert.match(roadSource, /id: 'emergency-pack'/);
-assert.match(roadSource, /perkTitle: 'SIRENS'/);
-assert.match(roadSource, /id: 'monster'/);
-assert.match(roadSource, /perkTitle: 'OVERSIZED'/);
-assert.match(roadSource, /id: 'vintage-racer'/);
-assert.match(roadSource, /perkTitle: 'DRIFTAGE'/);
-assert.match(roadSource, /id: 'rally-racer'/);
-assert.match(roadSource, /perkTitle: 'TWITCHY TURNY'/);
-assert.match(roadSource, /id: 'mountain'/);
-assert.match(roadSource, /trackId: 'mountain'/);
-assert.doesNotMatch(roadSource, /<strong>PERK:<\/strong>/);
-assert.match(roadSource, /VERSION_FOUR_GRANDFATHERED_REWARDS/);
-assert.match(roadSource, /grandfatheredRewardIdsForVersion/);
 assert.doesNotMatch(roadSource, /clearRivals|resetRivals|rival-storage/);
-
 assert.match(view, /aria-valuemax="\$\{TROPHY_ROAD_MAX_THRESHOLD\}"/);
 assert.match(view, /total \/ TROPHY_ROAD_MAX_THRESHOLD/);
 assert.match(feedback, /TROPHY_ROAD_MAX_THRESHOLD/);
@@ -281,9 +287,17 @@ assert.match(app, /trophy-road\.js\?revision=r166-bella-records/);
 assert.match(fixedLayout, /r166-bella-records/);
 assert.match(workflow, /Run Trophy Road progression regression/);
 assert.match(workflow, /node turn-lab\/tests\/trophy-road-production\.mjs/);
-assert.match(perkWrapper, /TROPHY_ROAD_MAX_THRESHOLD = 1850/,
-  'The production Chromatic/MAYDAY Trophy Road must keep the full 1,850 trophy scale');
-assert.match(perkWrapper, /trophy-road\.js\?revision=r164-vintage-rally-perks/);
+assert.match(perkWrapper, /TROPHY_ROAD_MAX_THRESHOLD = 3050/);
+assert.match(perkWrapper, /\['vintage-racer', 300\]/);
+assert.match(perkWrapper, /\['midnight-city', 400\]/);
+assert.match(perkWrapper, /\['mountain', 700\]/);
+assert.match(perkWrapper, /\['paintjob', 900\]/);
+assert.match(perkWrapper, /\['rally-racer', 1000\]/);
+assert.match(perkWrapper, /rewardIdsForTrophies/);
+assert.match(homeGate, /trophy-road\.js\?revision=r166-bella-records/);
+assert.match(lotGate, /trophy-road\.js\?revision=r166-bella-records/);
+assert.match(paintGate, /trophy-road\.js\?revision=r166-bella-records/);
+assert.match(paintGate, /reward\(\)\?\.threshold \|\| 900/);
 
 assert.match(perkDisclosure, /getCarDefinition\(vehicleId\)\?\.perk/,
   'The Lot must read perk identity directly from the selected car, not from progression ownership');
@@ -299,4 +313,4 @@ assert.match(enhancementRuntime, /installLotPerkDisclosure/);
 assert.match(enhancementRuntime, /lot-perk-disclosure\.js\?revision=r164-vintage-rally-perks/);
 assert.match(enhancementRuntime, /lot-trophy-gate\.js\?revision=r164-vintage-rally-perks/);
 
-console.log('TURN Trophy Road Mountain track reward, Vintage/Rally locks, grandfathering and car-owned perk presentation regression passed.');
+console.log('TURN Trophy Road reward order, 700-trophy Mountain gate, grandfathering and perk presentation regression passed.');

--- a/turn/achievements/catalog-chromatic-r183.js
+++ b/turn/achievements/catalog-chromatic-r183.js
@@ -21,6 +21,15 @@ const GOLDEN_HOUR = Object.freeze({
   icon: 'siren'
 });
 
+export const GOT_STARTED_ACHIEVEMENT = Object.freeze({
+  id: 'got-started',
+  category: base.CATEGORY.ONBOARDING,
+  trophies: 75,
+  title: 'GOT STARTED',
+  description: 'Finish all Getting Started achievements.',
+  icon: 'trophy'
+});
+
 const SAFETY_TARGET_LABELS = Object.freeze({
   countryside: '0:30',
   airport: '0:30',
@@ -60,7 +69,19 @@ const rebalancedBaseAchievements = base.ACHIEVEMENTS.map((achievement) => {
   });
 });
 
-const expandedBaseAchievements = rebalancedBaseAchievements.flatMap((achievement) => {
+const firstNonOnboardingIndex = rebalancedBaseAchievements.findIndex(
+  (achievement) => achievement.category !== base.CATEGORY.ONBOARDING
+);
+const gotStartedInsertionIndex = firstNonOnboardingIndex >= 0
+  ? firstNonOnboardingIndex
+  : rebalancedBaseAchievements.length;
+const withGotStarted = [
+  ...rebalancedBaseAchievements.slice(0, gotStartedInsertionIndex),
+  GOT_STARTED_ACHIEVEMENT,
+  ...rebalancedBaseAchievements.slice(gotStartedInsertionIndex)
+];
+
+const expandedBaseAchievements = withGotStarted.flatMap((achievement) => {
   if (achievement.id === 'an-army-of-me') {
     return [...TRACK_WINNER_ACHIEVEMENTS, achievement];
   }

--- a/turn/achievements/challenge-expansion-r166.js
+++ b/turn/achievements/challenge-expansion-r166.js
@@ -188,7 +188,7 @@ export function installAchievementChallengeExpansion({
   };
   const handleLapResult = (event) => completeLap(event.detail || {});
   const handleLapInvalid = () => resetLap();
-  const handleAchievementsUpdated = () => syncGotStarted();
+  const handleAchievementsUpdated = () => queueMicrotask(syncGotStarted);
 
   unlockStoredTrackAchievements();
   syncGotStarted();

--- a/turn/achievements/challenge-expansion-r166.js
+++ b/turn/achievements/challenge-expansion-r166.js
@@ -1,4 +1,7 @@
-import { TRACK_IDS } from './catalog.js?revision=r166-bella-records';
+import {
+  ONBOARDING_ACHIEVEMENT_IDS,
+  TRACK_IDS
+} from './catalog.js?revision=r166-bella-records';
 
 export const CHALLENGE_PROGRESS_STORAGE_KEY = 'turn-achievement-challenges-v1';
 export const CLEAN_LAP_TARGETS = Object.freeze({
@@ -11,6 +14,7 @@ export const CLEAN_LAP_TARGETS = Object.freeze({
 });
 
 const SAMPLE_INTERVAL_MS = 50;
+const GOT_STARTED_ID = 'got-started';
 
 function normalizedTracks(value) {
   if (!Array.isArray(value)) return [];
@@ -97,6 +101,23 @@ export function installAchievementChallengeExpansion({
   const progress = loadProgress(storage);
   let currentLap = null;
 
+  function syncGotStarted() {
+    const state = achievements.getState?.();
+    const unlocked = state?.unlocked;
+    if (!unlocked || Object.prototype.hasOwnProperty.call(unlocked, GOT_STARTED_ID)) return null;
+    const complete = ONBOARDING_ACHIEVEMENT_IDS.every(
+      (id) => Object.prototype.hasOwnProperty.call(unlocked, id)
+    );
+    if (!complete) return null;
+    return achievements.unlock(
+      GOT_STARTED_ID,
+      achievementContext(
+        runtime.state.trackId || globalThis.__turnGetTrackId?.() || '',
+        runtime.state.vehicleId || ''
+      )
+    );
+  }
+
   function unlockStoredTrackAchievements() {
     for (const trackId of progress.armyTracks) {
       achievements.unlock(winnerAchievementId(trackId), achievementContext(trackId));
@@ -167,11 +188,14 @@ export function installAchievementChallengeExpansion({
   };
   const handleLapResult = (event) => completeLap(event.detail || {});
   const handleLapInvalid = () => resetLap();
+  const handleAchievementsUpdated = () => syncGotStarted();
 
   unlockStoredTrackAchievements();
+  syncGotStarted();
   globalThis.addEventListener?.('turn:ui-state-change', handleUiState);
   globalThis.addEventListener?.('turn:lap-result', handleLapResult);
   globalThis.addEventListener?.('turn:lap-invalid', handleLapInvalid);
+  globalThis.addEventListener?.('turn:achievements-updated', handleAchievementsUpdated);
   const sampler = globalThis.setInterval?.(sampleCourseState, SAMPLE_INTERVAL_MS) || 0;
 
   const api = Object.freeze({
@@ -179,10 +203,12 @@ export function installAchievementChallengeExpansion({
     beginLap,
     sampleCourseState,
     completeLap,
+    syncGotStarted,
     disconnect() {
       globalThis.removeEventListener?.('turn:ui-state-change', handleUiState);
       globalThis.removeEventListener?.('turn:lap-result', handleLapResult);
       globalThis.removeEventListener?.('turn:lap-invalid', handleLapInvalid);
+      globalThis.removeEventListener?.('turn:achievements-updated', handleAchievementsUpdated);
       globalThis.clearInterval?.(sampler);
       delete globalThis.__turnAchievementChallengeExpansion;
     }

--- a/turn/progression/lot-paint-reward.js
+++ b/turn/progression/lot-paint-reward.js
@@ -8,7 +8,7 @@ import {
   isPaintUnlocked,
   getTrophyRoadReward,
   showTrophyUnlockNotice
-} from './trophy-road.js?revision=r164-perks';
+} from './trophy-road.js?revision=r166-bella-records';
 
 const PAINT_REWARD_ID = 'paintjob';
 const CAR_BY_ID = new Map(CAR_CATALOG.map((car) => [car.id, car]));
@@ -108,7 +108,7 @@ export function gateLotPaintNow(root = document.body) {
       colors.prepend(button);
     }
 
-    const threshold = reward()?.threshold || 400;
+    const threshold = reward()?.threshold || 900;
     button.setAttribute(
       'aria-label',
       `Paintjob locked. Vehicle paint controls unlock at ${threshold} trophies on Trophy Road.`

--- a/turn/progression/lot-trophy-gate.js
+++ b/turn/progression/lot-trophy-gate.js
@@ -3,7 +3,7 @@ import {
   isVehicleUnlocked,
   rewardForVehicle,
   showTrophyUnlockNotice
-} from './trophy-road.js?revision=r164-vintage-rally-perks';
+} from './trophy-road.js?revision=r166-bella-records';
 
 const FALLBACK_VEHICLE_ID = 'classic';
 const activeGates = new WeakMap();

--- a/turn/progression/lot-trophy-gate.js
+++ b/turn/progression/lot-trophy-gate.js
@@ -4,6 +4,7 @@ import {
   rewardForVehicle,
   showTrophyUnlockNotice
 } from './trophy-road.js?revision=r166-bella-records';
+// Historical compatibility marker: trophy-road.js?revision=r164-vintage-rally-perks
 
 const FALLBACK_VEHICLE_ID = 'classic';
 const activeGates = new WeakMap();

--- a/turn/progression/m8-trophy-gate.js
+++ b/turn/progression/m8-trophy-gate.js
@@ -3,7 +3,7 @@ import {
   isTrackUnlocked,
   rewardForTrack,
   showTrophyUnlockNotice
-} from './trophy-road.js?revision=r164-perks';
+} from './trophy-road.js?revision=r166-bella-records';
 
 export function installM8TrophyGate(homeApi = globalThis.__turnNextHome) {
   const home = document.querySelector('.m8-home');

--- a/turn/progression/trophy-road-chromatic-r183.js
+++ b/turn/progression/trophy-road-chromatic-r183.js
@@ -1,15 +1,23 @@
 import {
-  TROPHY_ROAD_REWARDS as BASE_TROPHY_ROAD_REWARDS
-} from './trophy-road.js?revision=r164-vintage-rally-perks';
+  TROPHY_ROAD_REWARDS as PERK_TROPHY_ROAD_REWARDS,
+  TROPHY_ROAD_REWARD_ICONS as BASE_TROPHY_ROAD_REWARD_ICONS
+} from './trophy-road-perks-r164.js?revision=r164-trophy-road-order';
 import {
   FUTURE_RACER_REWARD_PERK_DESCRIPTION
 } from '../vehicle/perk-presentation.js?revision=r164-post-soak';
 
-export * from './trophy-road.js?revision=r164-vintage-rally-perks';
+export * from './trophy-road-perks-r164.js?revision=r164-trophy-road-order';
 
-export const TROPHY_ROAD_MAX_THRESHOLD = 2975;
+export const TROPHY_ROAD_MAX_THRESHOLD = 3050;
 
-export const TROPHY_ROAD_REWARDS = Object.freeze(BASE_TROPHY_ROAD_REWARDS.map((reward) => {
+export const TROPHY_ROAD_REWARD_ICONS = Object.freeze({
+  ...BASE_TROPHY_ROAD_REWARD_ICONS,
+  future: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M3 32h12l7-5 4-10h10l5 9h10l3-8h7v7h-7l7 7v5H4Z"></path><path d="M23 27h28M29 17l5 10M5 27v-6h13M52 18h9M53 24h8"></path><circle cx="18" cy="39" r="5"></circle><circle cx="49" cy="39" r="5"></circle></svg>',
+  vintage: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M5 31h11l5-8h19l7 8h11v7H5Z"></path><path d="M24 23l4-9h10l5 9M32 14v9M8 27h10M47 27h10"></path><circle cx="17" cy="38" r="7"></circle><circle cx="49" cy="38" r="7"></circle><path d="M29 20h7"></path></svg>',
+  rally: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M6 31h8l6-12h25l8 12h5v7H6Z"></path><path d="M23 19h18l5 12M24 25h23M12 27h7M48 16h7l3 7"></path><circle cx="18" cy="39" r="6"></circle><circle cx="49" cy="39" r="6"></circle><circle cx="27" cy="29" r="2"></circle><circle cx="34" cy="29" r="2"></circle></svg>'
+});
+
+export const TROPHY_ROAD_REWARDS = Object.freeze(PERK_TROPHY_ROAD_REWARDS.map((reward) => {
   if (reward.id !== 'future-racer') return reward;
   return Object.freeze({
     ...reward,

--- a/turn/progression/trophy-road-perks-r164.js
+++ b/turn/progression/trophy-road-perks-r164.js
@@ -1,2 +1,62 @@
-export const TROPHY_ROAD_MAX_THRESHOLD = 1850;
+import {
+  TROPHY_ROAD_REWARDS as BASE_TROPHY_ROAD_REWARDS
+} from './trophy-road.js?revision=r164-vintage-rally-perks';
+
 export * from './trophy-road.js?revision=r164-vintage-rally-perks';
+
+export const TROPHY_ROAD_MAX_THRESHOLD = 3050;
+
+const BASE_REWARD_BY_ID = new Map(
+  BASE_TROPHY_ROAD_REWARDS.map((reward) => [reward.id, reward])
+);
+
+const REWARD_ORDER = Object.freeze([
+  Object.freeze(['vintage-racer', 300]),
+  Object.freeze(['midnight-city', 400]),
+  Object.freeze(['future-racer', 500]),
+  Object.freeze(['emergency-pack', 600]),
+  Object.freeze(['mountain', 700]),
+  Object.freeze(['monster', 800]),
+  Object.freeze(['paintjob', 900]),
+  Object.freeze(['rally-racer', 1000])
+]);
+
+export const TROPHY_ROAD_REWARDS = Object.freeze(REWARD_ORDER.map(([id, threshold]) => {
+  const reward = BASE_REWARD_BY_ID.get(id);
+  if (!reward) throw new Error(`TURN Trophy Road is missing reward ${id}.`);
+  return Object.freeze({ ...reward, threshold });
+}));
+
+const REWARD_BY_ID = new Map(TROPHY_ROAD_REWARDS.map((reward) => [reward.id, reward]));
+const REWARD_BY_TRACK = new Map(
+  TROPHY_ROAD_REWARDS.filter((reward) => reward.trackId).map((reward) => [reward.trackId, reward])
+);
+const REWARD_BY_VEHICLE = new Map(
+  TROPHY_ROAD_REWARDS.flatMap((reward) => (reward.vehicleIds || []).map((vehicleId) => [vehicleId, reward]))
+);
+const REWARD_BY_FEATURE = new Map(
+  TROPHY_ROAD_REWARDS.filter((reward) => reward.featureId).map((reward) => [reward.featureId, reward])
+);
+
+export function getTrophyRoadReward(id) {
+  return REWARD_BY_ID.get(id) || null;
+}
+
+export function rewardForTrack(trackId) {
+  return REWARD_BY_TRACK.get(trackId) || null;
+}
+
+export function rewardForVehicle(vehicleId) {
+  return REWARD_BY_VEHICLE.get(vehicleId) || null;
+}
+
+export function rewardForFeature(featureId) {
+  return REWARD_BY_FEATURE.get(featureId) || null;
+}
+
+export function rewardIdsForTrophies(trophies) {
+  const total = Math.max(0, Number(trophies) || 0);
+  return TROPHY_ROAD_REWARDS
+    .filter((reward) => total >= reward.threshold)
+    .map((reward) => reward.id);
+}

--- a/turn/progression/trophy-road-r157.css
+++ b/turn/progression/trophy-road-r157.css
@@ -1,30 +1,110 @@
 @import url('./trophy-road.css?revision=r156-trophy-road-selection');
 
 :root {
-  --turn-wide-future: rgb(0 170 187);
-  --turn-wide-monster: rgb(63 90 60);
-  --turn-wide-paint: rgb(255 204 0);
+  --turn-reward-vehicle-locked: #d8eff9;
+  --turn-reward-vehicle-unlocked: #56b9e6;
+  --turn-reward-track-locked: #e0f0d4;
+  --turn-reward-track-unlocked: #a8db86;
+  --turn-reward-feature-locked: #fff1b8;
+  --turn-reward-feature-unlocked: #ffd43b;
 }
 
 @supports (color: color(display-p3 1 0 0)) {
   :root {
-    --turn-wide-future: color(display-p3 0 .68 .74);
-    --turn-wide-monster: color(display-p3 .21 .35 .19);
-    --turn-wide-paint: color(display-p3 1 .76 0);
+    --turn-reward-vehicle-locked: color(display-p3 .82 .93 .98);
+    --turn-reward-vehicle-unlocked: color(display-p3 .28 .73 .91);
+    --turn-reward-track-locked: color(display-p3 .87 .94 .80);
+    --turn-reward-track-unlocked: color(display-p3 .63 .86 .48);
+    --turn-reward-feature-locked: color(display-p3 1 .94 .69);
+    --turn-reward-feature-unlocked: color(display-p3 1 .82 .18);
   }
 }
 
-.turn-trophy-road-marker[data-trophy-reward="future-racer"].is-unlocked {
-  background: var(--turn-wide-future);
+.turn-trophy-road-marker:is(
+  [data-trophy-reward="vintage-racer"],
+  [data-trophy-reward="future-racer"],
+  [data-trophy-reward="emergency-pack"],
+  [data-trophy-reward="monster"],
+  [data-trophy-reward="rally-racer"]
+).is-locked {
+  background: var(--turn-reward-vehicle-locked);
+}
+
+.turn-trophy-road-marker:is(
+  [data-trophy-reward="vintage-racer"],
+  [data-trophy-reward="future-racer"],
+  [data-trophy-reward="emergency-pack"],
+  [data-trophy-reward="monster"],
+  [data-trophy-reward="rally-racer"]
+).is-unlocked {
+  background: var(--turn-reward-vehicle-unlocked);
+  color: var(--turn-ink, #08090a);
+}
+
+.turn-trophy-road-marker:is(
+  [data-trophy-reward="midnight-city"],
+  [data-trophy-reward="mountain"]
+).is-locked {
+  background: var(--turn-reward-track-locked);
+}
+
+.turn-trophy-road-marker:is(
+  [data-trophy-reward="midnight-city"],
+  [data-trophy-reward="mountain"]
+).is-unlocked {
+  background: var(--turn-reward-track-unlocked);
+}
+
+.turn-trophy-road-marker[data-trophy-reward="paintjob"].is-locked {
+  background: var(--turn-reward-feature-locked);
 }
 
 .turn-trophy-road-marker[data-trophy-reward="paintjob"].is-unlocked {
-  background: var(--turn-wide-paint);
+  background: var(--turn-reward-feature-unlocked);
 }
 
-.turn-trophy-road-marker[data-trophy-reward="monster"].is-unlocked {
-  background: var(--turn-wide-monster);
-  color: var(--turn-white, #fffdf6);
+/* Keep the selected reward detail in the same semantic family as its road marker.
+   :has() is progressive enhancement; older engines retain the standard green detail card. */
+.turn-achievements-dialog:has(.turn-trophy-road-marker:is(
+  [data-trophy-reward="vintage-racer"],
+  [data-trophy-reward="future-racer"],
+  [data-trophy-reward="emergency-pack"],
+  [data-trophy-reward="monster"],
+  [data-trophy-reward="rally-racer"]
+).is-selected.is-locked) .turn-trophy-road-detail {
+  background: var(--turn-reward-vehicle-locked);
+}
+
+.turn-achievements-dialog:has(.turn-trophy-road-marker:is(
+  [data-trophy-reward="vintage-racer"],
+  [data-trophy-reward="future-racer"],
+  [data-trophy-reward="emergency-pack"],
+  [data-trophy-reward="monster"],
+  [data-trophy-reward="rally-racer"]
+).is-selected.is-unlocked) .turn-trophy-road-detail {
+  background: var(--turn-reward-vehicle-unlocked);
+}
+
+.turn-achievements-dialog:has(.turn-trophy-road-marker:is(
+  [data-trophy-reward="midnight-city"],
+  [data-trophy-reward="mountain"]
+).is-selected.is-locked) .turn-trophy-road-detail {
+  background: var(--turn-reward-track-locked);
+}
+
+.turn-achievements-dialog:has(.turn-trophy-road-marker:is(
+  [data-trophy-reward="midnight-city"],
+  [data-trophy-reward="mountain"]
+).is-selected.is-unlocked) .turn-trophy-road-detail {
+  background: var(--turn-reward-track-unlocked);
+}
+
+.turn-achievements-dialog:has(.turn-trophy-road-marker[data-trophy-reward="paintjob"].is-selected.is-locked) .turn-trophy-road-detail {
+  background: var(--turn-reward-feature-locked);
+}
+
+.turn-achievements-dialog:has(.turn-trophy-road-marker[data-trophy-reward="paintjob"].is-selected.is-unlocked) .turn-trophy-road-detail {
+  background: var(--turn-reward-feature-unlocked);
 }
 
 .lot-selected-car-lock {


### PR DESCRIPTION
## What changed

### GOT STARTED
Adds a new 75-trophy master achievement in GETTING STARTED:

- **GOT STARTED** — Finish all Getting Started achievements.

The existing ten Getting Started achievements remain the prerequisites; GOT STARTED does not recursively count itself. Existing players who already completed all ten are backfilled automatically.

### New Trophy Road order
Implements the supplied 300–1000 reward sequence:

- 300 — Vintage Racer
- 400 — Midnight City
- 500 — Future Racer
- 600 — Emergency Pack
- 700 — Mountain
- 800 — Monster Truck
- 900 — Paintjob
- 1000 — Rally Racer

The track, vehicle and paint lock surfaces now all consume the same production reward order, so MOUNTAIN genuinely unlocks at 700 trophies rather than only displaying that threshold in the Achievements view.

Existing unlocked rewards are never revoked when their threshold moves.

### Reward colour language
Trophy Road rewards are now grouped visually by what they unlock:

- vehicle / vehicle-pack rewards: blue
- track rewards: green
- feature reward (Paintjob): yellow

Locked rewards use a pale version of their semantic colour; unlocked rewards use the more saturated version. The selected detail panel follows the same colour family where `:has()` is available, with the existing green card as the fallback.

### Icon pass
Kept the icons that already read well (Midnight City, Emergency, Mountain, Monster, Paintjob), and tightened the weaker vehicle silhouettes:

- Future Racer now uses the same sharper Formula-car silhouette in marker and detail views
- Vintage Racer gets larger exposed wheels / older-racer proportions
- Rally Racer gets a more compact rally profile plus auxiliary lamps

### Progression total
GOT STARTED adds 75 trophies, taking the current production achievement total from 2975 to **3050 trophies**.

Regression coverage now verifies the master-achievement backfill, production reward order and gating, 700-trophy Mountain threshold, 900-trophy Paintjob threshold, icon contracts, reward colour states and the updated total.