### PR TITLE
Show car color cues before Paintjob unlock

### DIFF
--- a/turn-lab/tests/color-accessibility-production.mjs
+++ b/turn-lab/tests/color-accessibility-production.mjs
@@ -139,8 +139,17 @@ assert.match(paintGateSource, /button\.className = 'lot-paint-lock-button'/,
 assert.match(paintGateSource, /button\.addEventListener\('click', showLockedPaintInfo\)/,
   'The lock button may own its own click listener without becoming an ancestor of the color input');
 
-assert.doesNotMatch(runtimeSource, /describeColorCue|lot-color-control|input\[type="color"\]|onPaintValueChange|replaceWith/,
-  'The Color Cues runtime must not post-process paint controls');
+assert.match(runtimeSource, /getVehicleDefaultColor/,
+  'The selected-car cue must have a factory-colour fallback before Paintjob is unlocked');
+assert.match(runtimeSource, /lot-selected-car-color-cue/,
+  'The Lot must expose a selected-car colour cue independently of paint controls');
+assert.match(runtimeSource, /CAR COLOR ·/);
+assert.match(runtimeSource, /input\[type="color"\]/,
+  'Once Paintjob is available, the selected-car cue may read the current native paint value');
+assert.match(runtimeSource, /attributeFilter: \['aria-checked'\]/,
+  'Car colour cues must update for mouse, touch, keyboard and 3D car selection');
+assert.doesNotMatch(runtimeSource, /replaceWith|showPicker\(|focusNativeColorInput|input\.click\(/,
+  'Color Cues must read native paint state without replacing or proxying the native control');
 assert.match(runtimeSource, /Color cues/);
 assert.match(runtimeSource, /TRACK COLOR ·/);
 assert.doesNotMatch(runtimeSource, /setInterval|setAnimationLoop/);
@@ -148,10 +157,12 @@ assert.doesNotMatch(runtimeSource, /setInterval|setAnimationLoop/);
 assert.match(cueCssSource, /data-turn-color-cues='on'/);
 assert.match(cueCssSource, /track-card-color-cue/);
 assert.match(cueCssSource, /lot-color-cue/);
+assert.match(cueCssSource, /lot-selected-car-color-cue/,
+  'The selected-car cue must remain visible in The Lot even while the paint controls are Trophy Road locked');
 assert.match(cueCssSource, /repeating-linear-gradient/);
 
 assert.match(historySource, /native HTML color input/i);
 assert.doesNotMatch(historySource, /native paint activation bridge|assistive-technology bridge/i,
   'Current release history must not claim an activation bridge that no longer exists');
 
-console.log(`TURN ${release.version} ${release.id} HTML-first native color input and six-track color-cue regression passed.`);
+console.log(`TURN ${release.version} ${release.id} HTML-first native color input, pre-Paintjob car cue and six-track color-cue regression passed.`);

--- a/turn/accessibility/color-accessibility-r163.js
+++ b/turn/accessibility/color-accessibility-r163.js
@@ -124,7 +124,8 @@ function installLotCarColorCues() {
       description.after(cue);
     }
 
-    cue.textContent = `CAR COLOR · ${describeColorCue(selectedLotBodyColor(screen, carId)).toUpperCase()}`;
+    const text = `CAR COLOR · ${describeColorCue(selectedLotBodyColor(screen, carId)).toUpperCase()}`;
+    if (cue.textContent !== text) cue.textContent = text;
     bindLotColorCueUpdates(screen);
   }
 }

--- a/turn/accessibility/color-accessibility-r163.js
+++ b/turn/accessibility/color-accessibility-r163.js
@@ -1,12 +1,17 @@
 import {
   applyColorCuesState,
+  describeColorCue,
   loadColorCuesEnabled,
   saveColorCuesEnabled,
   trackColorCue
 } from './color-cues.js?revision=r163';
+import {
+  getVehicleDefaultColor
+} from '../vehicle/catalog.js?build=20260804-r157-factory-colors';
 
 const RUNTIME_ID = 'color-cues-r163';
 let scheduled = false;
+const lotCueBindings = new Map();
 
 function settingsStatus(dialog) {
   return dialog.querySelector('.m8-settings-status');
@@ -68,10 +73,68 @@ function installTrackColorCues() {
   }
 }
 
+function selectedLotCarId(screen) {
+  return screen.querySelector('.lot-car-option[aria-checked="true"]')?.dataset.carId || '';
+}
+
+function selectedLotBodyColor(screen, carId) {
+  const bodyControl = [...screen.querySelectorAll('.lot-color-control')]
+    .find((control) => String(control.dataset.paintLabel || '').toLowerCase() === 'body');
+  const input = bodyControl?.querySelector('input[type="color"]');
+  return input?.value || getVehicleDefaultColor(carId);
+}
+
+function bindLotColorCueUpdates(screen) {
+  if (lotCueBindings.has(screen)) return;
+  const picker = screen.querySelector('.lot-car-picker');
+  const selectionObserver = new MutationObserver(scheduleSync);
+  if (picker) {
+    selectionObserver.observe(picker, {
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['aria-checked']
+    });
+  }
+  const handleInput = (event) => {
+    if (event.target?.matches?.('input[type="color"]')) scheduleSync();
+  };
+  screen.addEventListener('input', handleInput);
+  lotCueBindings.set(screen, { selectionObserver, handleInput });
+}
+
+function cleanupLotColorCueBindings() {
+  for (const [screen, binding] of lotCueBindings) {
+    if (screen.isConnected) continue;
+    binding.selectionObserver.disconnect();
+    screen.removeEventListener('input', binding.handleInput);
+    lotCueBindings.delete(screen);
+  }
+}
+
+function installLotCarColorCues() {
+  for (const screen of document.querySelectorAll('.lot-screen')) {
+    const description = screen.querySelector('.lot-car-description');
+    const carId = selectedLotCarId(screen);
+    if (!description || !carId) continue;
+
+    let cue = screen.querySelector('.lot-selected-car-color-cue');
+    if (!cue) {
+      cue = document.createElement('span');
+      cue.className = 'turn-color-cue lot-color-cue lot-selected-car-color-cue';
+      description.after(cue);
+    }
+
+    cue.textContent = `CAR COLOR · ${describeColorCue(selectedLotBodyColor(screen, carId)).toUpperCase()}`;
+    bindLotColorCueUpdates(screen);
+  }
+}
+
 function sync() {
   scheduled = false;
+  cleanupLotColorCueBindings();
   installColorCueSetting();
   installTrackColorCues();
+  installLotCarColorCues();
 }
 
 function scheduleSync() {
@@ -95,6 +158,11 @@ export function installColorAccessibility() {
     disconnect() {
       observer.disconnect();
       globalThis.removeEventListener('turn:home-ready', scheduleSync);
+      for (const [screen, binding] of lotCueBindings) {
+        binding.selectionObserver.disconnect();
+        screen.removeEventListener('input', binding.handleInput);
+      }
+      lotCueBindings.clear();
       globalThis.__turnColorAccessibility = null;
     }
   });

--- a/turn/accessibility/color-cues-r163.css
+++ b/turn/accessibility/color-cues-r163.css
@@ -58,10 +58,26 @@ html[data-turn-color-cues='on'] .turn-color-cue {
   content: '';
 }
 
+.lot-selected-car-color-cue {
+  width: max-content;
+  max-width: 100%;
+  margin-top: 5px;
+  padding: 3px 7px;
+  border: 2px solid var(--ink, #08090a);
+  border-radius: 999px;
+  background: rgb(255 248 232 / 0.94);
+  color: var(--ink, #08090a);
+}
+
 @media (max-height: 520px) {
   .lot-color-cue { font-size: 0.36rem; }
 }
 
 @media (max-height: 430px) {
   .lot-color-cue { font-size: 0.33rem; }
+
+  .lot-selected-car-color-cue {
+    margin-top: 3px;
+    padding: 2px 5px;
+  }
 }


### PR DESCRIPTION
Fixes the Color Cues / Chromatic Camouflage dependency mismatch.

When **Color cues** is enabled, The Lot now shows a persistent selected-car cue such as `CAR COLOR · YELLOW` even while PAINTJOB is still Trophy Road locked. The cue:

- falls back to each car’s factory colour before paint controls are available
- works for fixed-livery vehicles too
- follows car selection from touch/mouse, keyboard and 3D selection
- follows the native body-colour input after PAINTJOB is unlocked
- remains a read-only enhancement and does not replace, proxy or restyle the native colour input

The existing per-paint-control cues remain unchanged after PAINTJOB unlock.

Regression coverage now explicitly verifies the pre-PAINTJOB factory-colour fallback and that the native colour control remains untouched.