### PR TITLE
Fix ABOUT modal action labels

### DIFF
--- a/turn-tests/about-history-production.mjs
+++ b/turn-tests/about-history-production.mjs
@@ -91,10 +91,12 @@ assert.match(bootstrap, /aboutDialog\.showModal\(\)/,
   'Closing the reader should restore the source About dialog');
 assert.match(bootstrap, /historyButton\.focus\(\{ preventScroll: true \}\)/,
   'Focus should return to the History and Changelog action inside the restored About dialog');
-assert.match(bootstrap, /HISTORY &amp; CHANGELOG/);
+assert.match(bootstrap, /<span>HISTORY AND<br>CHANGELOG<\/span>/,
+  'The About history action must use the intended two-line label');
 assert.match(bootstrap, /href="\/turn\/design\.html"/,
   'The About action must open the main TURN design system');
-assert.match(bootstrap, />DESIGN SYSTEM<\/a>/);
+assert.match(bootstrap, /<span>DESIGN<br>SYSTEM<\/span>/,
+  'The Design System action must use the intended two-line label');
 assert.match(bootstrap, /installStylesheet\('\.\.\/m8-home\.css/);
 assert.match(bootstrap, /installStylesheet\('\.\.\/dialog-system-r163\.css/);
 assert.match(bootstrap, /installStylesheet\('\.\.\/about-history-r163\.css/);

--- a/turn/about-history-r163.css
+++ b/turn/about-history-r163.css
@@ -1,3 +1,4 @@
+/* ABOUT action buttons share one visual contract: two lines, equal height and equal type scale. */
 .m8-about-dialog {
   --turn-dialog-inline-size: min(660px, calc(100vw - 32px));
 }

--- a/turn/about-history-r163.css
+++ b/turn/about-history-r163.css
@@ -35,27 +35,34 @@
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   gap: 12px;
+  align-items: stretch;
   margin-top: 16px;
 }
 
 .m8-about-history,
 .m8-about-design-system {
+  box-sizing: border-box;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 48px;
-  padding: 10px 15px;
+  min-height: 72px;
+  padding: 12px 18px;
   border: 4px solid var(--m8-ink);
   border-radius: 999px;
   color: var(--m8-ink);
   box-shadow: 5px 5px 0 var(--m8-ink);
   font: inherit;
-  font-size: 0.82rem;
+  font-size: clamp(1rem, 1.8vw, 1.16rem);
   font-weight: 950;
-  line-height: 1.05;
-  letter-spacing: 0.035em;
+  line-height: 1.08;
+  letter-spacing: 0.02em;
   text-align: center;
   text-decoration: none;
+}
+
+.m8-about-history > span,
+.m8-about-design-system > span {
+  display: block;
 }
 
 .m8-about-history {

--- a/turn/ui/about-history-bootstrap-r165.js
+++ b/turn/ui/about-history-bootstrap-r165.js
@@ -211,8 +211,8 @@ function compactAboutDialog(aboutDialog, historyDialog, tabs) {
   content.innerHTML = `
     ${aboutTurnHtml()}
     <div class="m8-about-actions turn-dialog__actions">
-      <button class="m8-about-history" type="button" aria-haspopup="dialog">HISTORY &amp; CHANGELOG</button>
-      <a class="m8-about-design-system" href="/turn/design.html" target="_blank" rel="noreferrer">DESIGN SYSTEM</a>
+      <button class="m8-about-history" type="button" aria-haspopup="dialog"><span>HISTORY AND<br>CHANGELOG</span></button>
+      <a class="m8-about-design-system" href="/turn/design.html" target="_blank" rel="noreferrer"><span>DESIGN<br>SYSTEM</span></a>
     </div>`;
 
   const historyButton = content.querySelector('.m8-about-history');


### PR DESCRIPTION
Aligns the two ABOUT TURN actions with the supplied reference:

- `HISTORY AND` / `CHANGELOG`
- `DESIGN` / `SYSTEM`
- both actions use the same two-line treatment
- increases action typography from the undersized 0.82rem treatment to a responsive 1rem–1.16rem range
- increases minimum action height to 72px and explicitly stretches both grid items to the same row height
- keeps the existing two-column layout, colors, shadows and interaction behavior
- updates the production About regression expectations

The separate stale icon regression caused by the newly supplied icon has now been fixed and merged in #578. This PR does not modify the icon or release/build identity.