### PR TITLE
Simplify ABOUT modal to history action

### DIFF
--- a/turn-tests/about-history-production.mjs
+++ b/turn-tests/about-history-production.mjs
@@ -93,10 +93,8 @@ assert.match(bootstrap, /historyButton\.focus\(\{ preventScroll: true \}\)/,
   'Focus should return to the History and Changelog action inside the restored About dialog');
 assert.match(bootstrap, /<span>HISTORY AND<br>CHANGELOG<\/span>/,
   'The About history action must use the intended two-line label');
-assert.match(bootstrap, /href="\/turn\/design\.html"/,
-  'The About action must open the main TURN design system');
-assert.match(bootstrap, /<span>DESIGN<br>SYSTEM<\/span>/,
-  'The Design System action must use the intended two-line label');
+assert.doesNotMatch(bootstrap, /m8-about-design-system|href="\/turn\/design\.html"|<span>DESIGN<br>SYSTEM<\/span>/,
+  'The About dialog must not expose a Design System action');
 assert.match(bootstrap, /installStylesheet\('\.\.\/m8-home\.css/);
 assert.match(bootstrap, /installStylesheet\('\.\.\/dialog-system-r163\.css/);
 assert.match(bootstrap, /installStylesheet\('\.\.\/about-history-r163\.css/);
@@ -154,7 +152,8 @@ assert.match(historyCss, /\.turn-history-card[\s\S]*overflow: hidden !important/
 assert.match(historyCss, /\.turn-history-panel[\s\S]*overflow-y: auto/);
 assert.match(historyCss, /\.m8-about-summary[\s\S]*font-size: 0\.8rem !important/,
   'About supporting copy must be compact enough for short landscape viewports');
-assert.match(historyCss, /\.m8-about-actions[\s\S]*grid-template-columns/);
+assert.match(historyCss, /\.m8-about-actions[\s\S]*grid-template-columns: 1fr/,
+  'The sole About action must span the full available width');
 
 assert.match(designReference, /TURN DIALOGS/);
 assert.match(designReference, /Standardize the shell, not the content/);

--- a/turn/about-history-r163.css
+++ b/turn/about-history-r163.css
@@ -1,4 +1,4 @@
-/* ABOUT action buttons share one visual contract: two lines, equal height and equal type scale. */
+/* ABOUT keeps one prominent full-width History and Changelog action. */
 .m8-about-dialog {
   --turn-dialog-inline-size: min(660px, calc(100vw - 32px));
 }
@@ -34,7 +34,7 @@
 
 .m8-about-actions {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  grid-template-columns: 1fr;
   gap: 12px;
   align-items: stretch;
   margin-top: 16px;

--- a/turn/ui/about-history-bootstrap-r165.js
+++ b/turn/ui/about-history-bootstrap-r165.js
@@ -212,7 +212,6 @@ function compactAboutDialog(aboutDialog, historyDialog, tabs) {
     ${aboutTurnHtml()}
     <div class="m8-about-actions turn-dialog__actions">
       <button class="m8-about-history" type="button" aria-haspopup="dialog"><span>HISTORY AND<br>CHANGELOG</span></button>
-      <a class="m8-about-design-system" href="/turn/design.html" target="_blank" rel="noreferrer"><span>DESIGN<br>SYSTEM</span></a>
     </div>`;
 
   const historyButton = content.querySelector('.m8-about-history');


### PR DESCRIPTION
Removes the Design System action from ABOUT TURN and lets the remaining HISTORY AND / CHANGELOG action span the full modal width.

Also updates the ABOUT regression so the removed Design System link stays removed and the single-column action layout is protected.