### PR TITLE
Fix clipped modal kicker headings

### DIFF
--- a/turn/home-feedback-r135.css
+++ b/turn/home-feedback-r135.css
@@ -1,5 +1,15 @@
 @import url('./design-semantic.css?revision=r140-difficulty-system');
 
+/* Keep the small modal kicker fully inside its own line box. iOS Safari can
+   clip the lower half of these heavy, letter-spaced labels at the compact
+   UI baseline unless the inline span gets explicit block geometry. */
+.m8-dialog-head > div > span {
+  display: block;
+  line-height: 1.35;
+  padding-block: 0.14em;
+  overflow: visible;
+}
+
 .m8-home-fixed-layout .m8-feedback-button {
   align-self: auto;
   display: block;


### PR DESCRIPTION
Fixes the small uppercase kicker above modal titles (for example QUICK GUIDE, YOUR PROGRESS, THE GAME and FROM FIRST PROTOTYPE TO TODAY) being vertically clipped in iOS Safari at the current UI baseline.

The shared M8 modal-header kicker now gets its own block line box with explicit line-height, a small amount of vertical breathing room and visible overflow. This applies consistently to Settings, How to Play, Drive By Ear 101, Give Feedback, Achievements, About and TURN History without changing their main headings or dialog layout.