### PR TITLE
Swap Race Car and Truck colors, retune Truck

### DIFF
--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -42,6 +42,14 @@ assert.deepEqual(
   trainingCar.stats,
   { speed: 1, acceleration: 1, control: 5, drift: 5, boostPower: 1, boostDuration: 5 }
 );
+assert.deepEqual(
+  truck.stats,
+  { speed: 3, acceleration: 2, control: 4, drift: 4, boostPower: 2, boostDuration: 3 }
+);
+assert.equal(race.defaultColor, '#ff7700');
+assert.deepEqual(race.defaultColorP3, [1, 0.467, 0]);
+assert.equal(truck.defaultColor, '#b93632');
+assert.deepEqual(truck.defaultColorP3, [0.72, 0.12, 0.12]);
 assert.equal(monsterTruck.visualScale, 0.83);
 assert.equal(sedan.tuning.topSpeedMultiplier, 1);
 assert.equal(sedan.tuning.accelerationMultiplier, 1);
@@ -59,11 +67,13 @@ assert.ok(race.tuning.controlMultiplier > sedan.tuning.controlMultiplier);
 assert.ok(race.tuning.driftDragAdd > sedan.tuning.driftDragAdd);
 assert.ok(race.tuning.driftStabilityMultiplier < sedan.tuning.driftStabilityMultiplier);
 assert.ok(race.tuning.boostDurationSeconds < sedan.tuning.boostDurationSeconds);
-assert.ok(truck.tuning.topSpeedMultiplier < sedan.tuning.topSpeedMultiplier);
+assert.equal(truck.tuning.topSpeedMultiplier, sedan.tuning.topSpeedMultiplier);
 assert.ok(truck.tuning.accelerationMultiplier < sedan.tuning.accelerationMultiplier);
+assert.ok(truck.tuning.controlMultiplier > sedan.tuning.controlMultiplier);
 assert.ok(truck.tuning.driftDragAdd < sedan.tuning.driftDragAdd);
 assert.ok(truck.tuning.driftStabilityMultiplier > sedan.tuning.driftStabilityMultiplier);
-assert.ok(truck.tuning.boostDurationSeconds > sedan.tuning.boostDurationSeconds);
+assert.ok(truck.tuning.boostPowerMultiplier < sedan.tuning.boostPowerMultiplier);
+assert.equal(truck.tuning.boostDurationSeconds, sedan.tuning.boostDurationSeconds);
 assert.notEqual(catalog.makeGhostColor('#ff4fa3'), '#ff4fa3');
 
 const easterEggSelection = {

--- a/turn-lab/tests/vehicle-drift-production.mjs
+++ b/turn-lab/tests/vehicle-drift-production.mjs
@@ -101,9 +101,13 @@ const suv = CAR_CATALOG.find((car) => car.id === 'suv');
 assert.ok(suv, 'SUV must remain in the vehicle catalog');
 assert.equal(suv.defaultColor, '#0555aa', 'SUV factory paint must be #0555aa');
 
+const raceCar = CAR_CATALOG.find((car) => car.id === 'race');
+assert.ok(raceCar, 'Race Car must remain in the vehicle catalog');
+assert.equal(raceCar.defaultColor, '#ff7700', 'Race Car factory paint must be the former Truck orange');
+
 const truck = CAR_CATALOG.find((car) => car.id === 'truck');
 assert.ok(truck, 'Truck must remain in the vehicle catalog');
-assert.equal(truck.defaultColor, '#ff7700', 'Truck factory paint must be #f70');
+assert.equal(truck.defaultColor, '#b93632', 'Truck factory paint must be the former Race Car red');
 
 assert.match(
   showcaseSource,

--- a/turn/vehicle/catalog.js
+++ b/turn/vehicle/catalog.js
@@ -41,14 +41,14 @@ const DEFAULT_COLOR_BY_ID = Object.freeze({
   'toy-racer': Object.freeze({ fallback: '#111111', p3: Object.freeze([0.067, 0.067, 0.067]) }),
   'monster-truck': Object.freeze({ fallback: '#3f5a3c', p3: Object.freeze([0.21, 0.35, 0.19]) }),
   'race-future': Object.freeze({ fallback: '#00aabb', p3: Object.freeze([0, 0.68, 0.74]) }),
-  race: Object.freeze({ fallback: '#b93632', p3: Object.freeze([0.72, 0.12, 0.12]) }),
+  race: Object.freeze({ fallback: '#ff7700', p3: Object.freeze([1, 0.467, 0]) }),
   'sedan-sports': Object.freeze({ fallback: '#5e3c87', p3: Object.freeze([0.36, 0.19, 0.56]) }),
   sedan: Object.freeze({ fallback: '#2b6a70', p3: Object.freeze([0.12, 0.41, 0.43]) }),
   suv: Object.freeze({ fallback: '#0555aa', p3: Object.freeze([0.02, 0.333, 0.667]) }),
   firetruck: Object.freeze({ fallback: '#d92d20', p3: Object.freeze([0.82, 0.08, 0.04]) }),
   police: Object.freeze({ fallback: '#0b0d10', p3: Object.freeze([0.035, 0.045, 0.06]) }),
   ambulance: Object.freeze({ fallback: '#f8f9fa', p3: Object.freeze([0.95, 0.97, 0.98]) }),
-  truck: Object.freeze({ fallback: '#ff7700', p3: Object.freeze([1, 0.467, 0]) }),
+  truck: Object.freeze({ fallback: '#b93632', p3: Object.freeze([0.72, 0.12, 0.12]) }),
   van: Object.freeze({ fallback: '#5d503f', p3: Object.freeze([0.34, 0.29, 0.21]) })
 });
 
@@ -129,7 +129,7 @@ const RAW_CARS = [
   ['firetruck', 'Fire Truck', 'car', { speed: 2, acceleration: 2, control: 4, drift: 4, boostPower: 1, boostDuration: 5 }, 1.10, 0, 0.66],
   ['police', 'Police Car', 'car', { speed: 4, acceleration: 3, control: 3, drift: 2, boostPower: 1, boostDuration: 5 }, 0.98, 0, 1.10],
   ['ambulance', 'Ambulance', 'car', { speed: 3, acceleration: 2, control: 3, drift: 4, boostPower: 1, boostDuration: 5 }, 1.05, 0, 0.78],
-  ['truck', 'Truck', 'car', { speed: 2, acceleration: 2, control: 3, drift: 5, boostPower: 1, boostDuration: 5 }, 1.12, 0, 0.68],
+  ['truck', 'Truck', 'car', { speed: 3, acceleration: 2, control: 4, drift: 4, boostPower: 2, boostDuration: 3 }, 1.12, 0, 0.68],
   ['van', 'Van', 'car', { speed: 2, acceleration: 3, control: 3, drift: 5, boostPower: 1, boostDuration: 4 }, 1.08, 0, 0.80]
 ];
 


### PR DESCRIPTION
Updates TURN’s vehicle catalog as requested:

- Race Car now uses the Truck’s previous orange default color.
- Truck now uses the Race Car’s previous red default color.
- Truck stats become 3 / 2 / 4 / 4 / 2 / 3 for Top Speed / Acceleration / Control / Drift / Boost Power / Boost Tank.
- The Truck remains on the standard 18-point vehicle stat budget.

No other vehicle tuning or visuals are changed.