### PR TITLE
Set CLIFFSIDE SPRINT target to 15 seconds

### DIFF
--- a/turn/achievements/time-trials.js
+++ b/turn/achievements/time-trials.js
@@ -16,9 +16,9 @@ export const TIME_TRIALS = Object.freeze([
   Object.freeze({
     id: 'cliffside-sprint',
     trackId: 'cliffside',
-    targetSeconds: 16,
+    targetSeconds: 15,
     title: 'CLIFFSIDE SPRINT',
-    description: 'Finish Cliffside in under 16 seconds.'
+    description: 'Finish Cliffside in under 15 seconds.'
   }),
   Object.freeze({
     id: 'harbor-sprint',


### PR DESCRIPTION
Updates the CLIFFSIDE SPRINT achievement from under 16 seconds to under 15 seconds.

Changes:
- `targetSeconds`: 16 → 15
- Achievement description: “under 16 seconds” → “under 15 seconds”

No other time-trial thresholds are changed.