### PR TITLE
Keep YOUR TURN on production TURN motion engine

### DIFF
--- a/.github/workflows/turn-challenge-tests.yml
+++ b/.github/workflows/turn-challenge-tests.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Run YOUR TURN recipient contract
         run: node turn-tests/yourturn-production.mjs
 
+      - name: Run YOUR TURN production engine parity
+        run: node turn-tests/yourturn-engine-parity-production.mjs
+
       - name: Run YOUR TURN r411 controls and maps regression
         run: node turn-tests/yourturn-r411-production.mjs
 

--- a/turn-tests/yourturn-engine-parity-production.mjs
+++ b/turn-tests/yourturn-engine-parity-production.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const [turnIndex, yourTurnIndex] = await Promise.all([
+  fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../yourturn/index.html', import.meta.url), 'utf8')
+]);
+
+function readImportMap(source, label) {
+  const match = source.match(/<script\s+type="importmap">\s*([\s\S]*?)\s*<\/script>/i);
+  assert.ok(match, `${label} must expose an import map`);
+  return JSON.parse(match[1]);
+}
+
+function canonicalScriptUrl(source, basename, baseUrl, label) {
+  const sources = [...source.matchAll(/<script\b[^>]*\bsrc="([^"]+)"[^>]*><\/script>/gi)]
+    .map((match) => match[1]);
+  const sourceUrl = sources.find((value) => new URL(value, baseUrl).pathname.endsWith(`/${basename}`));
+  assert.ok(sourceUrl, `${label} must load ${basename}`);
+  return new URL(sourceUrl, baseUrl).href;
+}
+
+const turnImportMap = readImportMap(turnIndex, 'TURN');
+const yourTurnImportMap = readImportMap(yourTurnIndex, 'YOUR TURN');
+const motionSpecifier = '/turn/input/motion.js';
+
+assert.equal(
+  yourTurnImportMap.imports?.[motionSpecifier],
+  turnImportMap.imports?.[motionSpecifier],
+  'YOUR TURN must resolve the canonical motion input module through the exact production TURN route'
+);
+assert.match(
+  yourTurnImportMap.imports?.[motionSpecifier] || '',
+  /ipad-motion-profile/,
+  'The shared production motion route must include the iPad steering profile cache bust'
+);
+
+for (const basename of ['motion-safe-zone.js', 'orientation-compat.js']) {
+  assert.equal(
+    canonicalScriptUrl(yourTurnIndex, basename, 'https://enkel.design/yourturn/', 'YOUR TURN'),
+    canonicalScriptUrl(turnIndex, basename, 'https://enkel.design/turn/', 'TURN'),
+    `YOUR TURN must load the exact production TURN ${basename} bootstrap URL`
+  );
+}
+
+assert.doesNotMatch(
+  yourTurnIndex,
+  /\/yourturn\/(?:input\/)?motion[^"']*\.js/i,
+  'YOUR TURN must not grow a challenge-specific copy of the motion steering engine'
+);
+
+console.log('YOUR TURN production motion/orientation parity contract passed.');

--- a/yourturn/index.html
+++ b/yourturn/index.html
@@ -47,12 +47,16 @@
   <link rel="stylesheet" href="/yourturn/r411.css?revision=r411">
   <script src="/turn/ui/page-zoom-baseline-r193.js?revision=r193-canonical-75"></script>
 
+  <!-- Keep the motion/orientation bootstrap identical to production TURN. -->
+  <script src="/turn/motion-safe-zone.js?build=20260818-r175"></script>
+  <script src="/turn/orientation-compat.js?build=20260818-r175&revision=r163-voiceover-native-picker-events"></script>
   <script src="/yourturn/storage-bootstrap.js?revision=r2"></script>
   <script type="importmap">
     {
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
+        "/turn/input/motion.js": "/turn/input/motion.js?revision=r164-ipad-motion-profile",
         "/yourturn/session.js?revision=r3": "/yourturn/session.js?revision=r7",
         "/yourturn/ui.js?revision=r3": "/yourturn/ui.js?revision=r10",
         "/yourturn/protocol.js?revision=r3": "/yourturn/protocol-social.js?revision=r1",


### PR DESCRIPTION
## Device result
The required iPad 9 A/B from #410 is now available: current production TURN is stable on the same iPad where YOUR TURN still shows the spontaneous steering/world-roll failure.

## Root cause
YOUR TURN already imports production `turn/main.js`, but its entry point had drifted away from TURN's motion bootstrap:

- production TURN configures the ±24° motion safe zone before the race runtime loads; YOUR TURN did not, so the shared input module could fall back to the legacy 14° steering range;
- production TURN loads the adaptive orientation compatibility layer; YOUR TURN did not;
- production TURN import-maps `/turn/input/motion.js` to the fresh `r164-ipad-motion-profile` URL added in #442; YOUR TURN did not, leaving it exposed to an older cached unversioned motion module.

That means the two products shared `main.js` without actually sharing the production steering environment.

## Fix
- load the exact production TURN `motion-safe-zone.js` URL in YOUR TURN;
- load the exact production TURN `orientation-compat.js` URL in YOUR TURN;
- route `/turn/input/motion.js` through the exact same production iPad-aware import-map target;
- add a CI parity contract that compares those critical motion/orientation routes between `turn/index.html` and `yourturn/index.html`, so future steering fixes cannot silently ship to TURN only.

The existing YOUR TURN portrait→landscape handoff, motion subscriber handling and final-centering timing are intentionally unchanged.

## Validation
Challenge CI now runs `turn-tests/yourturn-engine-parity-production.mjs` in addition to the existing recipient/device regressions.

Addresses #410. Keep #410 open until the patched build is physically re-tested on the iPad 9 in both landscape directions.