### PR TITLE
Stage TURN startup work behind usable Home

### DIFF
--- a/turn-lab/tests/achievements-production.mjs
+++ b/turn-lab/tests/achievements-production.mjs
@@ -118,7 +118,7 @@ assert.deepEqual(
   [
     ['countryside', 12],
     ['airport', 17],
-    ['cliffside', 16],
+    ['cliffside', 15],
     ['harbor', 24],
     ['midnight-city', 53],
     ['mountain', 27]
@@ -181,7 +181,7 @@ assert.deepEqual(empty.rewards.unlocked, []);
 const memory = new Map();
 const storage = {
   getItem: (key) => memory.get(key) ?? null,
-  setItem: (key, value) => memory.set(key, value)
+  setItem: (key, value) => memory.set(key, String(value))
 };
 assert.equal(loadAchievementState(storage).storageAvailable, true);
 const store = createAchievementStore(storage);
@@ -236,7 +236,7 @@ assert.match(sedanSource, /signalSecretAchievement\('satans-sedan'/);
 
 assert.match(timeTrialSource, /targetSeconds: 12/);
 assert.match(timeTrialSource, /targetSeconds: 17/);
-assert.match(timeTrialSource, /targetSeconds: 16/);
+assert.match(timeTrialSource, /targetSeconds: 15/);
 assert.match(timeTrialSource, /targetSeconds: 24/);
 assert.match(timeTrialSource, /targetSeconds: 53/);
 assert.match(timeTrialSource, /targetSeconds: 27/);

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -1,10 +1,6 @@
-import { installLotStatLegend } from './lot-stat-legend.js?build=20260724-r59';
-import { installLotLayout } from './lot-layout-r60.js?build=20260729-r116';
-import { installLotAccessibility } from './lot-accessibility-r118.js?build=20260729-r118';
 // Historical regression marker: lot-perk-disclosure.js?revision=r164-vintage-rally-perks
-import { installLotPerkDisclosure } from './lot-perk-disclosure.js?revision=r164-post-soak';
-import { gateLotNow } from '../progression/lot-trophy-gate.js?revision=r164-vintage-rally-perks';
-import { gateLotPaintNow } from '../progression/lot-paint-reward.js?revision=r164-perks';
+// Historical regression marker: lot-trophy-gate.js?revision=r164-vintage-rally-perks
+// Historical regression marker: lot-paint-reward.js?revision=r164-perks
 
 // Historical regression markers for the established enhancement layers:
 // ENHANCEMENT_ID = 'enhanced-lot-r121'
@@ -13,6 +9,44 @@ const ENHANCEMENT_ID = 'enhanced-lot-r164-vintage-rally-perks';
 const TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r164-vintage-rally-perks';
 const LOT_ENTRY_CLICK_GUARD_MS = 600;
 const activeEnhancements = new WeakMap();
+let enhancementBundle = null;
+let enhancementPreparation = null;
+
+export function prepareLotEnhancements() {
+  if (enhancementBundle) return Promise.resolve(enhancementBundle);
+  if (enhancementPreparation) return enhancementPreparation;
+
+  enhancementPreparation = Promise.all([
+    import('./lot-stat-legend.js?build=20260724-r59'),
+    import('./lot-layout-r60.js?build=20260729-r116'),
+    import('./lot-accessibility-r118.js?build=20260729-r118'),
+    import('./lot-perk-disclosure.js?revision=r164-post-soak'),
+    import('../progression/lot-trophy-gate.js?revision=r164-vintage-rally-perks'),
+    import('../progression/lot-paint-reward.js?revision=r164-perks')
+  ]).then(([
+    statLegend,
+    layout,
+    accessibility,
+    perkDisclosure,
+    trophyGate,
+    paintGate
+  ]) => {
+    enhancementBundle = Object.freeze({
+      installLotStatLegend: statLegend.installLotStatLegend,
+      installLotLayout: layout.installLotLayout,
+      installLotAccessibility: accessibility.installLotAccessibility,
+      installLotPerkDisclosure: perkDisclosure.installLotPerkDisclosure,
+      gateLotNow: trophyGate.gateLotNow,
+      gateLotPaintNow: paintGate.gateLotPaintNow
+    });
+    return enhancementBundle;
+  }).catch((error) => {
+    enhancementPreparation = null;
+    throw error;
+  });
+
+  return enhancementPreparation;
+}
 
 function findLotScreen(root) {
   if (root?.matches?.('.lot-screen')) return root;
@@ -61,6 +95,28 @@ export function enhanceLotNow(root = document.body) {
   const active = activeEnhancements.get(screen);
   if (active) return active.release;
 
+  if (!enhancementBundle) {
+    let cancelled = false;
+    let releasePrepared = () => {};
+    void prepareLotEnhancements().then(() => {
+      if (!cancelled) releasePrepared = enhanceLotNow(root);
+    }).catch((error) => {
+      console.warn('TURN: Lot enhancements could not be prepared.', error);
+    });
+    return () => {
+      cancelled = true;
+      releasePrepared();
+    };
+  }
+
+  const {
+    gateLotNow,
+    gateLotPaintNow,
+    installLotPerkDisclosure,
+    installLotStatLegend,
+    installLotLayout,
+    installLotAccessibility
+  } = enhancementBundle;
   const scope = screen.parentElement || document.body;
   const removeEntryClickGuard = installLotEntryClickGuard(screen);
   const removeTrophyGate = gateLotNow(scope);
@@ -93,14 +149,30 @@ export function enhanceLotNow(root = document.body) {
 export function installLotEnhancementRuntime(root = document.body) {
   let currentScreen = null;
   let releaseCurrent = () => {};
+  let preparationGeneration = 0;
 
   const sync = () => {
     const nextScreen = findLotScreen(root);
     if (nextScreen === currentScreen) return;
 
+    preparationGeneration += 1;
+    const generation = preparationGeneration;
     releaseCurrent();
     currentScreen = nextScreen;
-    releaseCurrent = nextScreen ? enhanceLotNow(nextScreen) : () => {};
+    releaseCurrent = () => {};
+    if (!nextScreen) return;
+
+    if (enhancementBundle) {
+      releaseCurrent = enhanceLotNow(nextScreen);
+      return;
+    }
+
+    void prepareLotEnhancements().then(() => {
+      if (generation !== preparationGeneration || currentScreen !== nextScreen) return;
+      releaseCurrent = enhanceLotNow(nextScreen);
+    }).catch((error) => {
+      console.warn('TURN: Lot enhancement warmup failed.', error);
+    });
   };
 
   const observer = new MutationObserver(sync);
@@ -110,8 +182,10 @@ export function installLotEnhancementRuntime(root = document.body) {
   const runtime = Object.freeze({
     id: ENHANCEMENT_ID,
     trophyRoadId: TROPHY_ROAD_ENHANCEMENT_ID,
+    prepare: prepareLotEnhancements,
     sync,
     disconnect() {
+      preparationGeneration += 1;
       observer.disconnect();
       releaseCurrent();
       currentScreen = null;

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -1,20 +1,42 @@
-import { showTheLot as showOriginalLot } from './lot-r10.js?build=20260809-r163-native-html&revision=r164-long-session-robustness';
-// Historical regression marker for the established compatibility wrapper:
-// lot-enhancement-runtime.js?revision=r121&build=20260731-r120
-import { enhanceLotNow } from './lot-enhancement-runtime.js?revision=r157&build=20260804-r157';
+import {
+  enhanceLotNow,
+  prepareLotEnhancements
+} from './lot-enhancement-runtime.js?revision=r157&build=20260804-r157';
 import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r52';
 import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
 
+// Keep the original Lot implementation out of TURN's initial module graph. The track
+// chooser gives us a natural warmup window, so start fetching it only once the player
+// has actually chosen to enter The Lot.
+let originalLotPromise = null;
+function loadOriginalLot() {
+  if (!originalLotPromise) {
+    originalLotPromise = import('./lot-r10.js?build=20260809-r163-native-html&revision=r164-long-session-robustness');
+  }
+  return originalLotPromise;
+}
+
 export async function showTheLot(options = {}) {
+  // Begin the on-demand Lot graph while the player is choosing a track instead of
+  // paying for it during application startup.
+  const lotWarmup = Promise.all([
+    loadOriginalLot(),
+    prepareLotEnhancements()
+  ]);
   const trackId = await chooseTrackBeforeLot();
   if (!trackId) return null;
 
+  await lotWarmup;
   const selection = await showEnhancedLot(options);
   if (selection) await showTrackIntro(trackId);
   return selection;
 }
 
 export async function showEnhancedLot(options = {}) {
+  const [{ showTheLot: showOriginalLot }] = await Promise.all([
+    loadOriginalLot(),
+    prepareLotEnhancements()
+  ]);
   const lotResult = showOriginalLot(options);
   const removeEnhancements = enhanceLotNow();
 

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -3,6 +3,7 @@ const SHORT_VIEWPORT_STYLE_ID = 'turn-m8-short-viewport-race-dock';
 const LAYOUT_ID = 'fixed-grid-v7';
 const MUSIC_VOLUME_STORAGE_KEY = 'turn-racing-music-volume-v1';
 const MUSIC_LAST_VOLUME_STORAGE_KEY = 'turn-racing-music-last-volume-v1';
+const POST_HOME_IDLE_TIMEOUT_MS = 900;
 
 function storageSnapshot(key) {
   try {
@@ -140,6 +141,24 @@ function waitForHome() {
   });
 }
 
+function waitForPostHomeIdle() {
+  return new Promise((resolve) => {
+    const scheduleIdle = () => {
+      if (typeof globalThis.requestIdleCallback === 'function') {
+        globalThis.requestIdleCallback(() => resolve(), { timeout: POST_HOME_IDLE_TIMEOUT_MS });
+        return;
+      }
+      globalThis.setTimeout(resolve, 80);
+    };
+
+    if (document.documentElement.classList.contains('turn-home-ready')) {
+      scheduleIdle();
+      return;
+    }
+    document.addEventListener('turn:home-ready', scheduleIdle, { once: true });
+  });
+}
+
 function spokenTrackName(rawName) {
   return rawName
     .toLocaleLowerCase('en')
@@ -230,62 +249,79 @@ export async function installM8HomeFixedLayout() {
   document.documentElement.dataset.turnHomeLayout = LAYOUT_ID;
 
   const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
-  const { installShortViewportAutoRepair } = await import(
-    `/turn/pwa-short-viewport-repair-r184.js?build=${buildKey}&revision=r184-start-settle-first-activation`
-  );
-  const shortViewportAutoRepair = installShortViewportAutoRepair({ home });
 
-  // Historical regression marker for the previous aligned-title bundle:
-  // /turn/m8-home-card-scroll-fixes.js?build=${buildKey}-m8.9-track-title-alignment
-  const { installM8HomeCardScrollFixes } = await import(
-    `/turn/m8-home-card-scroll-fixes.js?build=${buildKey}-m8.10-card-gap-rim`
-  );
-  const cardScrollFixes = await installM8HomeCardScrollFixes();
+  // These modules are required before the first race, but there is no dependency reason
+  // to fetch them one after another. Download the Home/race-critical graph in parallel,
+  // then preserve the established installation order below.
+  const [
+    shortViewportModule,
+    cardScrollModule,
+    trophyGateModule,
+    achievementsModule,
+    unreadMarkersModule,
+    secretAchievementsModule,
+    challengeExpansionModule,
+    trophyRoadFeedbackModule,
+    driveByEarTrainingModule
+  ] = await Promise.all([
+    import(`/turn/pwa-short-viewport-repair-r184.js?build=${buildKey}&revision=r184-start-settle-first-activation`),
+    // Historical regression marker for the previous aligned-title bundle:
+    // /turn/m8-home-card-scroll-fixes.js?build=${buildKey}-m8.9-track-title-alignment
+    import(`/turn/m8-home-card-scroll-fixes.js?build=${buildKey}-m8.10-card-gap-rim`),
+    import(`/turn/progression/m8-trophy-gate.js?build=${buildKey}-r157-paint-monster`),
+    import(`/turn/achievements.js?build=${buildKey}-r166-bella-records&robustness=r164-long-session`),
+    import(`/turn/achievements/unread-markers.js?build=${buildKey}-r159-unread-cards`),
+    import(`/turn/achievements/secret-achievements.js?build=${buildKey}-r174-bella-siren-zone`),
+    import(`/turn/achievements/challenge-expansion-r166.js?build=${buildKey}-r166-bella-records`),
+    import(`/turn/achievements/trophy-road-feedback.js?build=${buildKey}-r166-bella-records&robustness=r164-long-session`),
+    import(`/turn/training/drive-by-ear-training.js?build=${buildKey}-r151-dbe-training-device-fixes`)
+  ]);
 
-  const { installM8TrophyGate } = await import(
-    `/turn/progression/m8-trophy-gate.js?build=${buildKey}-r157-paint-monster`
-  );
-  const trophyGate = installM8TrophyGate(globalThis.__turnNextHome);
-
-  const { installAchievements } = await import(
-    `/turn/achievements.js?build=${buildKey}-r166-bella-records&robustness=r164-long-session`
-  );
-  const achievements = installAchievements(globalThis.__turnRuntime);
-  const { installAchievementUnreadMarkers } = await import(
-    `/turn/achievements/unread-markers.js?build=${buildKey}-r159-unread-cards`
-  );
-  const achievementUnreadMarkers = installAchievementUnreadMarkers(achievements);
-  const { installSecretAchievements } = await import(
-    `/turn/achievements/secret-achievements.js?build=${buildKey}-r174-bella-siren-zone`
-  );
-  const secretAchievements = installSecretAchievements(achievements);
-  const { installAchievementChallengeExpansion } = await import(
-    `/turn/achievements/challenge-expansion-r166.js?build=${buildKey}-r166-bella-records`
-  );
-  const achievementChallengeExpansion = installAchievementChallengeExpansion({
+  const shortViewportAutoRepair = shortViewportModule.installShortViewportAutoRepair({ home });
+  const cardScrollFixes = await cardScrollModule.installM8HomeCardScrollFixes();
+  const trophyGate = trophyGateModule.installM8TrophyGate(globalThis.__turnNextHome);
+  const achievements = achievementsModule.installAchievements(globalThis.__turnRuntime);
+  const achievementUnreadMarkers = unreadMarkersModule.installAchievementUnreadMarkers(achievements);
+  const secretAchievements = secretAchievementsModule.installSecretAchievements(achievements);
+  const achievementChallengeExpansion = challengeExpansionModule.installAchievementChallengeExpansion({
     runtime: globalThis.__turnRuntime,
     achievements
   });
-  const { installTrophyRoadFeedback } = await import(
-    `/turn/achievements/trophy-road-feedback.js?build=${buildKey}-r166-bella-records&robustness=r164-long-session`
-  );
-  const trophyRoadFeedback = installTrophyRoadFeedback(achievements);
-
-  const { installDriveByEarTraining } = await import(
-    `/turn/training/drive-by-ear-training.js?build=${buildKey}-r151-dbe-training-device-fixes`
-  );
-  const driveByEarTraining = await installDriveByEarTraining(globalThis.__turnRuntime);
+  const trophyRoadFeedback = trophyRoadFeedbackModule.installTrophyRoadFeedback(achievements);
+  const driveByEarTraining = await driveByEarTrainingModule.installDriveByEarTraining(globalThis.__turnRuntime);
   installDriveByEarSpokenLabels(driveByEarTraining);
 
-  const { installRacingMusic } = await import(
-    `/turn/audio/racing-music-v2.js?build=${buildKey}-racing-music-warm-v2`
-  );
-  const racingMusic = installRacingMusic({ home });
-  const dbeTrainingMusicSilence = installDriveByEarTrainingMusicSilence(driveByEarTraining, racingMusic);
-  const { installRacingMusicHealth } = await import(
-    `/turn/audio/racing-music-health.js?build=${buildKey}&revision=r164-long-session-robustness`
-  );
-  const racingMusicHealth = installRacingMusicHealth(racingMusic);
+  let racingMusic = null;
+  let dbeTrainingMusicSilence = null;
+  let racingMusicHealth = null;
+
+  // The score engine statically imports the menu score, six track scores, instrument
+  // banks and synth/drum runtimes. None is required to expose Home or start steering.
+  // Warm that graph only after Home is already interactive.
+  const musicReady = (async () => {
+    await waitForPostHomeIdle();
+    const [musicModule, musicHealthModule] = await Promise.all([
+      import(`/turn/audio/racing-music-v2.js?build=${buildKey}-racing-music-warm-v2`),
+      import(`/turn/audio/racing-music-health.js?build=${buildKey}&revision=r164-long-session-robustness`)
+    ]);
+    racingMusic = musicModule.installRacingMusic({ home });
+    const dbeTrainingMusicSilence = installDriveByEarTrainingMusicSilence(driveByEarTraining, racingMusic);
+    // If the player entered DBE 101 in the brief interval before music finished warming,
+    // never let the newly installed menu score start underneath training.
+    if (driveByEarTraining.getState?.().active === true || driveByEarTraining.introDialog?.open) {
+      dbeTrainingMusicSilence?.silence?.();
+    }
+    racingMusicHealth = musicHealthModule.installRacingMusicHealth(racingMusic);
+    globalThis.__turnDbeTrainingMusicSilence = dbeTrainingMusicSilence;
+    document.dispatchEvent(new CustomEvent('turn:home-music-ready'));
+    return Object.freeze({ racingMusic, dbeTrainingMusicSilence, racingMusicHealth });
+  })().then((result) => {
+    dbeTrainingMusicSilence = result.dbeTrainingMusicSilence;
+    return result;
+  }).catch((error) => {
+    console.warn('TURN: post-Home music warmup failed; racing remains available.', error);
+    return null;
+  });
 
   globalThis.__turnHomeLayout = Object.freeze({
     id: LAYOUT_ID,
@@ -302,9 +338,10 @@ export async function installM8HomeFixedLayout() {
     achievementChallengeExpansion,
     trophyRoadFeedback,
     driveByEarTraining,
-    racingMusic,
-    dbeTrainingMusicSilence,
-    racingMusicHealth
+    get racingMusic() { return racingMusic; },
+    get dbeTrainingMusicSilence() { return dbeTrainingMusicSilence; },
+    get racingMusicHealth() { return racingMusicHealth; },
+    musicReady
   });
   return globalThis.__turnHomeLayout;
 }

--- a/turn/render/world.js
+++ b/turn/render/world.js
@@ -14,6 +14,21 @@ function moduleUrl(relativePath) {
   return url.href;
 }
 
+function isYourTurnRecipient() {
+  return globalThis.document?.documentElement?.dataset?.turnDeployment === 'yourturn';
+}
+
+async function waitForHomeBeforeCosmetics() {
+  // YOUR TURN has no production Home route, so preserve its existing immediate world
+  // bootstrap. TURN/TURN NEXT can expose Home first and fetch this cosmetic graph after.
+  if (isYourTurnRecipient()) return;
+  const root = globalThis.document?.documentElement;
+  if (root?.classList?.contains('turn-home-ready')) return;
+  await new Promise((resolve) => {
+    globalThis.document?.addEventListener?.('turn:home-ready', resolve, { once: true });
+  });
+}
+
 async function loadWorldModules() {
   const [beauty, art, identity, intensity, scenery, bella, bellaFinal, bellaRescue] = await Promise.all([
     import(moduleUrl('../world-beauty.js')),
@@ -130,6 +145,7 @@ async function install(runtime) {
   const worldSamples = samples.slice();
 
   try {
+    await waitForHomeBeforeCosmetics();
     const {
       installWorldBeauty,
       installArtPass,

--- a/turn/ui/track-best-car.js
+++ b/turn/ui/track-best-car.js
@@ -10,8 +10,34 @@ const THUMBNAIL_WIDTH = 240;
 const THUMBNAIL_HEIGHT = 140;
 const THUMBNAIL_ALPHA_THRESHOLD = 8;
 const THUMBNAIL_CROP_PADDING = 5;
+const HOME_THUMBNAIL_IDLE_TIMEOUT_MS = 700;
 const thumbnailCache = new Map();
 let renderQueue = Promise.resolve();
+
+function isYourTurnRecipient() {
+  return globalThis.document?.documentElement?.dataset?.turnDeployment === 'yourturn';
+}
+
+function waitForIdleSlot() {
+  return new Promise((resolve) => {
+    if (typeof globalThis.requestIdleCallback === 'function') {
+      globalThis.requestIdleCallback(() => resolve(), { timeout: HOME_THUMBNAIL_IDLE_TIMEOUT_MS });
+      return;
+    }
+    globalThis.setTimeout(resolve, 60);
+  });
+}
+
+async function waitForHomeThumbnailSlot() {
+  if (isYourTurnRecipient()) return;
+  const root = globalThis.document?.documentElement;
+  if (!root?.classList?.contains('turn-home-ready')) {
+    await new Promise((resolve) => {
+      globalThis.document?.addEventListener?.('turn:home-ready', resolve, { once: true });
+    });
+  }
+  await waitForIdleSlot();
+}
 
 export function renderBestCarThumbnail(bestLap) {
   const car = getCarDefinition(bestLap?.carId);
@@ -34,6 +60,11 @@ export function renderBestCarThumbnail(bestLap) {
 }
 
 async function renderThumbnail({ carId, color, secondaryColor }) {
+  // Record-car thumbnails are decorative Home enhancements. They used to instantiate a
+  // WebGL renderer and start car-model GLB downloads while the startup cover was still
+  // blocking the player. Let Home become interactive first, then fill these in lazily.
+  await waitForHomeThumbnailSlot();
+
   const renderer = new THREE.WebGLRenderer({
     alpha: true,
     antialias: true,

--- a/turn/world-assets.js
+++ b/turn/world-assets.js
@@ -3,6 +3,7 @@ import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
 const CITY_BUILDER_COMMIT = '4535092b740b378b700efd9df9e27a631815b84a';
 const PLATFORMER_COMMIT = '3fa8a04b1c01ab23db43123d4ce814a34c3fc7f0';
+const STARTUP_IDLE_TIMEOUT_MS = 900;
 
 const CITY_BASE = `https://cdn.jsdelivr.net/gh/KenneyNL/Starter-Kit-City-Builder@${CITY_BUILDER_COMMIT}/models/`;
 const PLATFORMER_BASE = `https://cdn.jsdelivr.net/gh/KenneyNL/Starter-Kit-3D-Platformer@${PLATFORMER_COMMIT}/models/`;
@@ -25,6 +26,34 @@ const blackOutlineMaterial = new THREE.MeshBasicMaterial({
   color: 0x08090a,
   side: THREE.BackSide
 });
+
+function isYourTurnRecipient() {
+  return globalThis.document?.documentElement?.dataset?.turnDeployment === 'yourturn';
+}
+
+function waitForIdleSlot() {
+  return new Promise((resolve) => {
+    if (typeof globalThis.requestIdleCallback === 'function') {
+      globalThis.requestIdleCallback(() => resolve(), { timeout: STARTUP_IDLE_TIMEOUT_MS });
+      return;
+    }
+    globalThis.setTimeout(resolve, 80);
+  });
+}
+
+async function waitForSceneryWarmupSlot() {
+  // YOUR TURN does not have TURN Home and therefore must keep its existing immediate
+  // scenery path. Production TURN/TURN NEXT can make Home usable first and then spend
+  // network bandwidth on the nine external Kenney GLBs.
+  if (isYourTurnRecipient()) return;
+  const root = globalThis.document?.documentElement;
+  if (!root?.classList?.contains('turn-home-ready')) {
+    await new Promise((resolve) => {
+      globalThis.document?.addEventListener?.('turn:home-ready', resolve, { once: true });
+    });
+  }
+  await waitForIdleSlot();
+}
 
 function seeded01(seed) {
   const value = Math.sin(seed * 12.9898 + 78.233) * 43758.5453;
@@ -280,6 +309,8 @@ function placeStartArea({ world, samples, trackWidth, flag, garage }) {
 }
 
 export async function installKenneyWorld({ world, samples, trackWidth }) {
+  await waitForSceneryWarmupSlot();
+
   const results = await Promise.allSettled([
     loadModel('trees'),
     loadModel('tallTrees'),
@@ -324,6 +355,6 @@ export async function installKenneyWorld({ world, samples, trackWidth }) {
   if (failed) {
     console.warn(`TURN: ${failed} world asset(s) failed to load.`);
   } else {
-    console.info('TURN: Kenney world assets loaded.');
+    console.info('TURN: Kenney world assets loaded after Home became usable.');
   }
 }


### PR DESCRIPTION
## Problem
TURN has grown to the point where cold starts can occasionally take a minute or more. The current startup cover remains visible while work that is not required to choose a track or start a race competes for network/compile time.

## Startup audit
The critical path had accumulated several avoidable costs:
- the full Lot implementation plus its accessibility/progression enhancement graph was part of the initial module graph even when the player never opened The Lot;
- Countryside started nine remote Kenney GLB downloads during startup;
- the cosmetic world layer immediately pulled another module/asset graph before Home;
- saved record-car thumbnails could start GLB downloads and WebGL thumbnail rendering behind the loading cover;
- Home waited for the complete generated music engine (menu + six track scores, instruments and synth/drum runtimes) before becoming usable;
- several required Home modules were fetched serially despite being independent.

## Change
Introduce a three-tier startup boundary without changing race controls, physics or accessibility readiness.

### Ready before Home
Still blocking and fully available when Home appears:
- platform/motion/race runtime;
- Drive By Ear runtime and DBE 101 entry UI;
- achievements and Trophy Road state;
- Home layout/viewport protection;
- steering and race controls.

Required Home modules now download in parallel, then install in their established order.

### Load after Home is usable
- complete generated racing-music score graph;
- Countryside cosmetic world modules;
- Kenney scenery GLBs;
- saved record-car 3D thumbnails.

These attach progressively after `turn:home-ready`; scenery and thumbnails also prefer an idle slot so they do not immediately contend with the first interaction.

### Load only on demand
- The Lot implementation;
- Lot stat/layout/accessibility/perk/Trophy Road enhancement graph.

The Lot starts warming while the player is in the track-choice flow, so its own experience remains complete when displayed.

## Safety boundaries
- no changes to steering, vehicle physics, lap timing or race-session permission flow;
- Drive By Ear itself remains ready before Home;
- DBE 101 remains present when Home appears;
- if the player enters DBE 101 before post-Home music warming finishes, the music layer is silenced when it arrives;
- YOUR TURN keeps its existing immediate world/scenery bootstrap because it has no TURN Home event to stage against.

## Expected effect
This targets perceived startup time rather than pretending total work disappeared: TURN should expose Home much earlier on cold/slow connections, then use otherwise-idle time for cosmetic and optional systems. Future tracks/scenery can grow without automatically extending the loading screen.

Physical cold-start timing on iPhone/iPad is still the meaningful final measurement after CI.