### PR TITLE
Enlarge Training Car guide and refresh Rally Racer attributes

### DIFF
--- a/turn-lab/tests/lot-layout-production.mjs
+++ b/turn-lab/tests/lot-layout-production.mjs
@@ -62,10 +62,10 @@ assert.ok(
 );
 
 assert.match(wrapper, /export async function showEnhancedLot/);
-assert.match(wrapper, /lot-r10\.js\?build=20260809-r163-native-html&revision=r585-lot-order-locks-guide/,
-  'The wrapper must load the redesigned Lot implementation under a fresh URL');
-assert.match(wrapper, /lot-enhancement-runtime\.js\?revision=r585-lot-redesign/,
-  'The wrapper must load the refreshed Lot enhancement bundle');
+assert.match(wrapper, /lot-r10\.js\?build=20260809-r163-native-html&revision=r587-rally-attributes-guide-type/,
+  'The wrapper must load the refreshed Rally/guide Lot implementation under a fresh URL');
+assert.match(wrapper, /lot-enhancement-runtime\.js\?revision=r587-rally-attributes/,
+  'The wrapper must load the refreshed Rally accessibility bundle');
 assert.match(wrapper, /const removeEnhancements = enhanceLotNow\(\)/);
 assert.match(wrapper, /await chooseTrackBeforeLot\(\)/);
 assert.doesNotMatch(wrapper, /installLotLayout|installLotStatLegend|installLotAccessibility/);
@@ -74,7 +74,7 @@ assert.match(enhancementRuntime, /ENHANCEMENT_ID = 'enhanced-lot-r164-vintage-ra
 assert.match(enhancementRuntime, /TROPHY_ROAD_ENHANCEMENT_ID = 'enhanced-lot-r164-vintage-rally-perks'/);
 assert.match(enhancementRuntime, /lot-perk-disclosure\.js\?revision=r164-vintage-rally-perks/);
 assert.match(enhancementRuntime, /lot-trophy-gate\.js\?revision=r585-visible-locks/);
-assert.match(enhancementRuntime, /lot-accessibility-r118\.js\?build=20260729-r118&revision=r585-visible-order/);
+assert.match(enhancementRuntime, /lot-accessibility-r118\.js\?build=20260729-r118&revision=r587-rally-attributes/);
 assert.match(enhancementRuntime, /activeEnhancements = new WeakMap\(\)/);
 assert.match(enhancementRuntime, /LOT_ENTRY_CLICK_GUARD_MS = 600/);
 assert.match(enhancementRuntime, /installLotPerkDisclosure\(scope\)/);
@@ -143,9 +143,15 @@ assert.match(lot, /function makeLockMarker\(\)/);
 assert.match(lot, /classList\.contains\('is-trophy-locked'\)/,
   '3D lock markers must follow the existing Trophy Road gate');
 assert.match(lot, /function makeBeginnerFriendlyMarker\(\)/);
+assert.match(lot, /ctx\.font = '900 38px system-ui, sans-serif'/,
+  'The beginner guide must use the larger physical-device-tested type size');
 assert.match(lot, /BEGINNER-/);
 assert.match(lot, /FRIENDLY/);
 assert.match(lot, /showBeginnerGuide = !hasTriedTrainingCar\(\)/);
+assert.match(lot, /const RALLY_RACER_DISPLAY_STATS = Object\.freeze\(\{[\s\S]*speed: 4,[\s\S]*acceleration: 5,[\s\S]*control: 5,[\s\S]*drift: 1,[\s\S]*boostPower: 2,[\s\S]*boostDuration: 1[\s\S]*\}\);/,
+  'The Rally Racer card must expose the current 4/5/5/1/2/1 profile');
+assert.match(lot, /car\.id === 'toy-racer' \? RALLY_RACER_DISPLAY_STATS : car\.stats/,
+  'The Rally Racer card must use the current profile even if an older cached catalog is present');
 
 assert.match(trainingGuide, /TRAINING_CAR_ID = 'classic'/);
 assert.match(trainingGuide, /TRAINING_CAR_TRIED_STORAGE_KEY = 'turn-training-car-tried-v1'/);
@@ -206,6 +212,8 @@ assert.match(accessibility, /button\.setAttribute\('aria-labelledby', descriptio
 assert.match(accessibility, /selectedSummary\.textContent = completeTextByCarId\.get\(selectedCarId\)/);
 assert.match(accessibility, /visibleOrder\.slice\(selectedIndex\)/,
   'VoiceOver order must rotate through the same stable order as the visible parking lot');
+assert.match(accessibility, /getLotDisplayStats\(car\)/,
+  'VoiceOver must announce the same Rally profile shown by the visible bars');
 assert.match(accessibility, /aria-posinset/);
 assert.match(accessibility, /aria-setsize/);
 assert.match(accessibility, /lotTitle\.focus\(\{ preventScroll: true \}\)/);
@@ -219,4 +227,4 @@ assert.match(legend, /role', 'dialog'/);
 assert.match(legend, /name\.textContent = entry\.label/);
 assert.match(legend, /description\.textContent = entry\.description/);
 
-console.log(`TURN ${release.id} redesigned full-colour Lot, stable 5x3 order, selection marker, progression locks, beginner guide and accessibility contract passed.`);
+console.log(`TURN ${release.id} redesigned full-colour Lot, stable 5x3 order, selection marker, progression locks, larger beginner guide, Rally profile and accessibility contract passed.`);

--- a/turn/garage/lot-accessibility-r118.js
+++ b/turn/garage/lot-accessibility-r118.js
@@ -9,6 +9,19 @@ const STAT_FIELDS = Object.freeze([
   Object.freeze({ key: 'boostDuration', label: 'Boost tank' })
 ]);
 
+const RALLY_RACER_DISPLAY_STATS = Object.freeze({
+  speed: 4,
+  acceleration: 5,
+  control: 5,
+  drift: 1,
+  boostPower: 2,
+  boostDuration: 1
+});
+
+function getLotDisplayStats(car) {
+  return car?.id === 'toy-racer' ? RALLY_RACER_DISPLAY_STATS : car?.stats;
+}
+
 export function installLotAccessibility(root = document.body) {
   const screen = root.querySelector('.lot-screen');
   const lotTitle = screen?.querySelector('#lot-title');
@@ -49,7 +62,7 @@ export function installLotAccessibility(root = document.body) {
     const description = document.createElement('span');
     description.id = `lot-${car.id}-complete-label`;
     const existingLabel = button.getAttribute('aria-label') || car.name;
-    const completeText = `${existingLabel} ${describeVehicleStats(car.stats)}`;
+    const completeText = `${existingLabel} ${describeVehicleStats(getLotDisplayStats(car))}`;
     description.textContent = completeText;
     descriptions.appendChild(description);
 

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -20,7 +20,7 @@ export function prepareLotEnhancements() {
   enhancementPreparation = Promise.all([
     import('./lot-stat-legend.js?build=20260724-r59'),
     import('./lot-layout-r60.js?build=20260729-r116'),
-    import('./lot-accessibility-r118.js?build=20260729-r118&revision=r585-visible-order'),
+    import('./lot-accessibility-r118.js?build=20260729-r118&revision=r587-rally-attributes'),
     import('./lot-perk-disclosure.js?revision=r164-post-soak'),
     import('../progression/lot-trophy-gate.js?revision=r585-visible-locks'),
     import('../progression/lot-paint-reward.js?revision=r164-perks')

--- a/turn/garage/lot-r10.js
+++ b/turn/garage/lot-r10.js
@@ -46,6 +46,19 @@ export const LOT_CAR_ORDER = Object.freeze([
 const CAR_BY_ID = new Map(CAR_CATALOG.map((car) => [car.id, car]));
 const LOT_CARS = Object.freeze(LOT_CAR_ORDER.map((id) => CAR_BY_ID.get(id)).filter(Boolean));
 
+// Rally Racer was rebalanced to this profile before the current release, but an older
+// cached Lot/catalog pair can still surface its previous 4/4/1/4/4/1 card. Keep the
+// player-facing card pinned to the current 18-point profile while the underlying race
+// tuning continues to come from the canonical vehicle definition.
+const RALLY_RACER_DISPLAY_STATS = Object.freeze({
+  speed: 4,
+  acceleration: 5,
+  control: 5,
+  drift: 1,
+  boostPower: 2,
+  boostDuration: 1
+});
+
 const CAR_DESCRIPTIONS = Object.freeze({
   convertible: 'A low, open-top sports car with a long bonnet and compact cabin.',
   classic: 'A small, upright classic car with rounded bodywork and a friendly shape.',
@@ -263,9 +276,10 @@ export function showTheLot({ initialSelection } = {}) {
 
     function updateSelectionUi({ refreshViewer = true } = {}) {
       const car = getCarDefinition(selectedCarId);
+      const displayStats = car.id === 'toy-racer' ? RALLY_RACER_DISPLAY_STATS : car.stats;
       title.textContent = car.name;
       description.textContent = CAR_DESCRIPTIONS[car.id] || 'A selectable car in The Lot.';
-      stats.replaceChildren(...makeStats(car.stats));
+      stats.replaceChildren(...makeStats(displayStats));
       raceButton.setAttribute('aria-label', `Race the ${car.name}`);
 
       for (const [carId, button] of carButtons) {
@@ -858,9 +872,9 @@ function getBeginnerBadgeTexture() {
   ctx.fillStyle = '#08090a';
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
-  ctx.font = '900 30px system-ui, sans-serif';
-  ctx.fillText('BEGINNER-', 180, 57);
-  ctx.fillText('FRIENDLY', 180, 101);
+  ctx.font = '900 38px system-ui, sans-serif';
+  ctx.fillText('BEGINNER-', 180, 55);
+  ctx.fillText('FRIENDLY', 180, 103);
 
   beginnerBadgeTexture = new THREE.CanvasTexture(canvas);
   beginnerBadgeTexture.colorSpace = THREE.SRGBColorSpace;

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -11,7 +11,7 @@ import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
 let originalLotPromise = null;
 function loadOriginalLot() {
   if (!originalLotPromise) {
-    originalLotPromise = import('./lot-r10.js?build=20260809-r163-native-html&revision=r585-lot-order-locks-guide');
+    originalLotPromise = import('./lot-r10.js?build=20260809-r163-native-html&revision=r587-rally-attributes-guide-type');
   }
   return originalLotPromise;
 }

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -1,7 +1,7 @@
 import {
   enhanceLotNow,
   prepareLotEnhancements
-} from './lot-enhancement-runtime.js?revision=r585-lot-redesign&build=20260804-r157';
+} from './lot-enhancement-runtime.js?revision=r587-rally-attributes&build=20260804-r157';
 import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r52';
 import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
 


### PR DESCRIPTION
## What changed

Two Lot follow-ups from physical-device review:

- increase the **BEGINNER-FRIENDLY** sign text from 30px to 38px while keeping the bubble footprint and safe right-side position essentially unchanged;
- make the Rally Racer card show its current intended 18-point profile rather than the older cached card values:
  - Top speed 4
  - Acceleration 5
  - Control 5
  - Drift 1
  - Boost power 2
  - Boost tank 1

The Rally Racer source/tuning already uses this current profile; the Lot now pins the displayed card to it so an older cached Lot/catalog pair cannot surface the previous 4/4/1/4/4/1 presentation.

The same Rally profile is used in the hidden VoiceOver car summary so visible and spoken attributes stay equivalent.

Fresh Lot and enhancement cache revisions are included so installed/PWA sessions receive the updated renderer and accessibility layer.