### PR TITLE
Polish the BEGINNER-FRIENDLY speech bubble

### DIFF
--- a/turn-lab/tests/lot-layout-production.mjs
+++ b/turn-lab/tests/lot-layout-production.mjs
@@ -62,8 +62,8 @@ assert.ok(
 );
 
 assert.match(wrapper, /export async function showEnhancedLot/);
-assert.match(wrapper, /lot-r10\.js\?build=20260809-r163-native-html&revision=r588-canonical-attributes/,
-  'The wrapper must load the canonical-attribute Lot implementation under a fresh URL');
+assert.match(wrapper, /lot-r10\.js\?build=20260809-r163-native-html&revision=r589-beginner-bubble/,
+  'The wrapper must load the polished beginner-bubble Lot implementation under a fresh URL');
 assert.match(wrapper, /lot-enhancement-runtime\.js\?revision=r588-canonical-attributes/,
   'The wrapper must load the canonical-attribute accessibility bundle');
 assert.match(wrapper, /const removeEnhancements = enhanceLotNow\(\)/);
@@ -143,8 +143,20 @@ assert.match(lot, /function makeLockMarker\(\)/);
 assert.match(lot, /classList\.contains\('is-trophy-locked'\)/,
   '3D lock markers must follow the existing Trophy Road gate');
 assert.match(lot, /function makeBeginnerFriendlyMarker\(\)/);
-assert.match(lot, /ctx\.font = '900 38px system-ui, sans-serif'/,
-  'The beginner guide must use the larger physical-device-tested type size');
+assert.match(lot, /sprite\.scale\.set\(5\.7, 3\.15, 1\)/,
+  'The polished speech bubble must preserve the reference-like wider rounded silhouette');
+assert.match(lot, /canvas\.width = 720/,
+  'The beginner bubble must use a high-resolution texture for crisp 3D rendering');
+assert.match(lot, /canvas\.height = 400/);
+assert.match(lot, /ctx\.scale\(scale, scale\)/);
+assert.match(lot, /const radius = 34/,
+  'The speech bubble must keep the strongly rounded reference corners');
+assert.match(lot, /ctx\.lineTo\(tailRight, bottom\)[\s\S]*ctx\.lineTo\(tailTipX, tailTipY\)[\s\S]*ctx\.lineTo\(tailLeft, bottom\)/,
+  'The pointer must be part of the same continuous silhouette instead of a separate triangle');
+assert.match(lot, /ctx\.lineWidth = 10/,
+  'The speech bubble must retain the heavy black outline from the reference');
+assert.match(lot, /ctx\.font = '700 37px system-ui, sans-serif'/,
+  'The beginner guide must use the cleaner, slightly lighter reference-like type');
 assert.match(lot, /BEGINNER-/);
 assert.match(lot, /FRIENDLY/);
 assert.match(lot, /showBeginnerGuide = !hasTriedTrainingCar\(\)/);
@@ -229,4 +241,4 @@ assert.match(legend, /role', 'dialog'/);
 assert.match(legend, /name\.textContent = entry\.label/);
 assert.match(legend, /description\.textContent = entry\.description/);
 
-console.log(`TURN ${release.id} redesigned full-colour Lot, stable 5x3 order, canonical attributes, selection marker, progression locks, larger beginner guide and accessibility contract passed.`);
+console.log(`TURN ${release.id} redesigned full-colour Lot, stable 5x3 order, canonical attributes, selection marker, progression locks, polished beginner guide and accessibility contract passed.`);

--- a/turn/garage/lot-r10.js
+++ b/turn/garage/lot-r10.js
@@ -197,7 +197,7 @@ export function showTheLot({ initialSelection } = {}) {
         const beginnerMarker = makeBeginnerFriendlyMarker();
         // Keep the guide inside the car grid rather than the left hardware-safe area.
         // The bubble sits above/right of the Training Car and its tail points back left.
-        beginnerMarker.position.set(x + 2.45, 4.7, z + 0.65);
+        beginnerMarker.position.set(x + 2.0, 4.85, z + 0.65);
         lot.add(beginnerMarker);
       }
 
@@ -787,7 +787,7 @@ function makeBeginnerFriendlyMarker() {
     depthWrite: false
   });
   const sprite = new THREE.Sprite(material);
-  sprite.scale.set(5.5, 2.75, 1);
+  sprite.scale.set(5.7, 3.15, 1);
   sprite.renderOrder = 121;
   return sprite;
 }
@@ -830,37 +830,57 @@ function getLockBadgeTexture() {
 function getBeginnerBadgeTexture() {
   if (beginnerBadgeTexture) return beginnerBadgeTexture;
   const canvas = document.createElement('canvas');
-  canvas.width = 360;
-  canvas.height = 190;
+  canvas.width = 720;
+  canvas.height = 400;
   const ctx = canvas.getContext('2d');
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const scale = 2;
+  const width = canvas.width / scale;
+  const height = canvas.height / scale;
+  ctx.scale(scale, scale);
+  ctx.clearRect(0, 0, width, height);
 
-  roundedRectPath(ctx, 17, 15, 326, 128, 13);
-  ctx.fillStyle = '#fff8e8';
-  ctx.fill();
-  ctx.strokeStyle = '#08090a';
-  ctx.lineWidth = 9;
-  ctx.stroke();
+  // Draw the body and pointer as one continuous silhouette. Besides matching the
+  // reference more closely, this removes the horizontal seam created by the old
+  // rounded-rectangle-plus-triangle construction.
+  const left = 10;
+  const top = 10;
+  const right = 350;
+  const bottom = 146;
+  const radius = 34;
+  const tailLeft = 83;
+  const tailRight = 133;
+  const tailTipX = 108;
+  const tailTipY = 191;
 
-  // Bottom-left speech-bubble tail: the label can live safely to the right of
-  // the Training Car while still visually pointing back to it.
   ctx.beginPath();
-  ctx.moveTo(72, 142);
-  ctx.lineTo(128, 142);
-  ctx.lineTo(48, 181);
+  ctx.moveTo(left + radius, top);
+  ctx.lineTo(right - radius, top);
+  ctx.quadraticCurveTo(right, top, right, top + radius);
+  ctx.lineTo(right, bottom - radius);
+  ctx.quadraticCurveTo(right, bottom, right - radius, bottom);
+  ctx.lineTo(tailRight, bottom);
+  ctx.lineTo(tailTipX, tailTipY);
+  ctx.lineTo(tailLeft, bottom);
+  ctx.lineTo(left + radius, bottom);
+  ctx.quadraticCurveTo(left, bottom, left, bottom - radius);
+  ctx.lineTo(left, top + radius);
+  ctx.quadraticCurveTo(left, top, left + radius, top);
   ctx.closePath();
+
   ctx.fillStyle = '#fff8e8';
   ctx.fill();
   ctx.strokeStyle = '#08090a';
-  ctx.lineWidth = 8;
+  ctx.lineWidth = 10;
+  ctx.lineJoin = 'round';
+  ctx.lineCap = 'round';
   ctx.stroke();
 
   ctx.fillStyle = '#08090a';
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
-  ctx.font = '900 38px system-ui, sans-serif';
-  ctx.fillText('BEGINNER-', 180, 55);
-  ctx.fillText('FRIENDLY', 180, 103);
+  ctx.font = '700 37px system-ui, sans-serif';
+  ctx.fillText('BEGINNER-', 180, 58);
+  ctx.fillText('FRIENDLY', 180, 108);
 
   beginnerBadgeTexture = new THREE.CanvasTexture(canvas);
   beginnerBadgeTexture.colorSpace = THREE.SRGBColorSpace;

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -11,7 +11,7 @@ import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
 let originalLotPromise = null;
 function loadOriginalLot() {
   if (!originalLotPromise) {
-    originalLotPromise = import('./lot-r10.js?build=20260809-r163-native-html&revision=r588-canonical-attributes');
+    originalLotPromise = import('./lot-r10.js?build=20260809-r163-native-html&revision=r589-beginner-bubble');
   }
   return originalLotPromise;
 }


### PR DESCRIPTION
## What changed

- Redrew the BEGINNER-FRIENDLY marker to match the supplied reference more closely.
- Uses one continuous rounded speech-bubble silhouette, so the pointer has no visible seam.
- Increased corner radius and outline weight.
- Uses a 2x canvas texture for crisper rendering in the 3D Lot.
- Slightly lightened the type weight and adjusted spacing/proportions.
- Kept the marker in the same safe area over the Training Car, with a small position/scale adjustment so the longer pointer still lands on the car.
- Added regression coverage for the integrated pointer, rounded silhouette, high-resolution texture and cache-busted Lot route.

No vehicle stats, physics, progression or Training Car behavior changed.