### PR TITLE
Give MOUNTAIN a track-card map background

### DIFF
--- a/turn-tests/track-select-visuals-production.mjs
+++ b/turn-tests/track-select-visuals-production.mjs
@@ -64,6 +64,21 @@ assert.match(postcardCss, /\.track-card-preview::after[\s\S]*repeating-linear-gr
 assert.match(postcardCss, /\.track-card-cliffside \.track-card-preview[\s\S]*#4ba8c8/, 'Cliffside preview must retain visible ocean blue');
 assert.match(postcardCss, /\.track-card-harbor \.track-card-preview[\s\S]*#287f9f/, 'Harbor preview must retain visible quay water');
 assert.match(postcardCss, /\.track-card-harbor \.track-card-preview[\s\S]*#c95b35[\s\S]*#167b82[\s\S]*#f5c542/, 'Harbor postcard must read as a colourful container yard');
+assert.match(
+  postcardCss,
+  /\.track-card-mountain \.track-card-preview \{[\s\S]*radial-gradient\(circle at 18% 20%, #fff8e8[\s\S]*#101832[\s\S]*#1c2c42/,
+  'Mountain must have its own moonlit night background behind the route map'
+);
+assert.match(
+  postcardCss,
+  /\.track-card-mountain \.track-card-preview::before[\s\S]*#e1edf5[\s\S]*#516a82[\s\S]*#405a72[\s\S]*#263b50/,
+  'Mountain must have layered snow-capped alpine silhouettes behind the route map'
+);
+assert.match(
+  postcardCss,
+  /\.track-card-mountain \.track-preview-road[\s\S]*stroke: #738797/,
+  'Mountain road geometry must remain readable against the dark postcard background'
+);
 
 const countrysideDepth = depthCss.match(/\.track-card-countryside \.track-card-preview \{([\s\S]*?)\n\}/)?.[1] || '';
 const firstHill = countrysideDepth.indexOf('radial-gradient(ellipse');

--- a/turn/track-select-r77.css
+++ b/turn/track-select-r77.css
@@ -108,6 +108,38 @@
     linear-gradient(180deg, #b9e0e5 0 38%, #a8a79d 38% 72%, #287f9f 72% 100%);
 }
 
+/* MOUNTAIN previously fell back to the generic green preview behind its route map.
+   Keep the actual SVG course map on top, but give it a compact static version of the
+   track's night identity: moon, sparse stars and layered snow-capped silhouettes. */
+.track-card-mountain .track-card-preview {
+  background:
+    radial-gradient(circle at 18% 20%, #fff8e8 0 6.5%, #cfe3f7 7% 9%, transparent 9.5%),
+    radial-gradient(circle at 42% 15%, #eef7ff 0 0.8%, transparent 1.2%),
+    radial-gradient(circle at 69% 24%, #eef7ff 0 0.7%, transparent 1.1%),
+    radial-gradient(circle at 84% 12%, #eef7ff 0 0.6%, transparent 1%),
+    linear-gradient(180deg, #101832 0 58%, #1c2c42 58% 100%);
+}
+
+.track-card-mountain .track-card-preview::before {
+  content: "";
+  position: absolute;
+  z-index: 0;
+  inset: 28% -4% clamp(7px, 1.1vh, 11px);
+  background:
+    linear-gradient(138deg, transparent 0 45%, #e1edf5 45.5% 49%, #516a82 49.5% 74%, transparent 74.5%) 0 100% / 58% 100% no-repeat,
+    linear-gradient(222deg, transparent 0 42%, #d7e7f2 42.5% 46%, #405a72 46.5% 75%, transparent 75.5%) 100% 100% / 64% 92% no-repeat,
+    linear-gradient(180deg, transparent 0 63%, #263b50 63% 100%);
+  pointer-events: none;
+}
+
+.track-card-mountain .track-preview-road {
+  stroke: #738797;
+}
+
+.track-card-mountain .track-preview-line {
+  stroke-width: 7;
+}
+
 .track-card-locked .track-card-preview {
   background:
     repeating-linear-gradient(135deg, rgb(255 255 255 / 0.12) 0 9px, transparent 9px 18px),


### PR DESCRIPTION
## What changed

- Give the MOUNTAIN track card its own static postcard background instead of the generic green preview.
- Match the finished track's visual identity with a deep blue night sky, moon, sparse stars and layered snow-capped mountain silhouettes.
- Keep the real MOUNTAIN route SVG on top of the background and lighten its road stroke for readability against the darker scene.
- Preserve the existing blue track accent, folded-corner card treatment and curb motif.
- Add regression coverage so MOUNTAIN cannot silently fall back to the generic preview again.

No track geometry, physics, music, loading behavior or selection behavior changed.