### PR TITLE
Revive TURN LAB with connected roadtrip world prototype

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -1,12 +1,12 @@
 <!doctype html>
-<!-- TURN LAB viewport diagnostics. Runtime source: production TURN 2026.08.18-r175. -->
+<!-- TURN LAB connected-world experiment. Runtime source: production TURN 2026.08.18-r175. -->
 <html lang="en" data-turn-deployment="lab"><head>
   <base href="/turn/">
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no, shrink-to-fit=no">
   <meta name="theme-color" content="#08090a">
   <meta name="application-name" content="TURN LAB">
-  <meta name="description" content="TURN LAB runs the current production TURN runtime with temporary installed-app viewport diagnostics.">
+  <meta name="description" content="TURN LAB runs isolated experiments on the current production TURN runtime. This build prototypes a connected six-track roadtrip world.">
   <meta name="robots" content="noindex,nofollow">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="mobile-web-app-capable" content="yes">
@@ -20,13 +20,13 @@
       cacheKey: '20260818-r175'
     });
     globalThis.__TURN_LAB_SOURCE__ = Object.freeze({
-      commit: '3f35e821240773aa6dfd52bb0ad8d787db79d782',
-      purpose: 'viewport-flight-recorder-r1'
+      runtime: 'production TURN 2026.08.18-r175',
+      purpose: 'roadtrip-world-r1'
     });
   </script>
   <link rel="icon" href="/turn/TURNicon.PNG?icon=20260803-profile-512" type="image/png" sizes="512x512">
   <link rel="apple-touch-icon" href="/turn/TURNicon.PNG?icon=20260803-profile-512" sizes="512x512">
-  <link rel="manifest" href="/turn-lab/site.webmanifest?revision=viewport-flight-recorder-r1">
+  <link rel="manifest" href="/turn-lab/site.webmanifest?revision=roadtrip-world-r1">
   <link rel="stylesheet" href="./styles.css?build=20260818-r175-native-html">
   <link rel="stylesheet" href="./vertical-drive.css?build=20260818-r175">
   <link rel="stylesheet" href="./hud-tuning.css?build=20260818-r175">
@@ -56,8 +56,8 @@
   <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260818-r175-menu-font-v3">
   <link rel="stylesheet" href="./home-header-r425.css?revision=r425-header-boundary">
   <link rel="stylesheet" href="./home-track-row-gap-r200.css?revision=r200-match-horizontal-gap">
-  <script src="/turn-lab/lab-bootstrap.js?revision=viewport-flight-recorder-r1"></script>
-  <script src="/turn-lab/viewport-diagnostics.js?revision=viewport-flight-recorder-r1"></script>
+  <link rel="stylesheet" href="/turn-lab/roadtrip-world-r1.css?revision=r1">
+  <script src="/turn-lab/lab-bootstrap.js?revision=roadtrip-world-r1"></script>
   <script src="./pwa-usable-viewport-r181.js?revision=r181-usable-web-layer"></script>
   <script src="./motion-safe-zone.js?build=20260818-r175"></script>
   <script src="./orientation-compat.js?build=20260818-r175&revision=r163-voiceover-native-picker-events"></script>
@@ -124,12 +124,12 @@
     <div class="install-shell">
       <div class="install-art" aria-hidden="true"><img class="install-icon" src="./TURNicon.PNG?icon=20260803-profile-512" alt=""></div>
       <div class="install-card">
-        <span class="install-kicker">TURN LAB · production TURN 1.9.1 r175</span>
+        <span class="install-kicker">TURN LAB · ROADTRIP WORLD R1 · production engine r175</span>
         <h1 id="installTitle">TURN LAB</h1>
-        <p class="install-copy">The current production game with a viewport flight recorder. Production TURN is not modified.</p>
+        <p class="install-copy">Six tracks. Two roads out of each. Drive the current TURN engine through the connected-world experiment without touching production TURN.</p>
         <div class="install-actions">
           <button id="installTurnButton" class="install-primary" type="button">Install TURN LAB</button>
-          <p class="install-note" id="installNote">Install this separate Home Screen app to reproduce the intermittent iOS viewport strip.</p>
+          <p class="install-note" id="installNote">TURN LAB has separate saves. Install it as a separate Home Screen app, or test the roadtrip in this browser.</p>
           <button class="install-secondary" id="playBrowserButton" type="button">Play in browser anyway</button>
         </div>
       </div>
@@ -161,6 +161,7 @@
   <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260818-r175-r168-shared-about-credits"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
   <script type="module" src="./app.js?build=20260818-r175-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r164-long-session-robustness-post-soak-r199-card-gap-rim"></script>
+  <script type="module" src="/turn-lab/roadtrip-world-r1.js?revision=r1"></script>
   <script type="module" src="./render/skid-continuity-r198.js?revision=r198-skid-continuity"></script>
   <script type="module" src="./accessibility/color-accessibility-r163.js?build=20260818-r175-paint-basics"></script>
   <script type="module" src="./achievements/chromatic-camouflage-r183.js?revision=r183-production"></script>

--- a/turn-lab/lab-bootstrap.js
+++ b/turn-lab/lab-bootstrap.js
@@ -60,12 +60,7 @@
 
   document.documentElement.classList.toggle('turn-standalone', isStandalone);
   document.documentElement.classList.toggle('turn-browser', !isStandalone);
-  document.documentElement.dataset.turnLab = 'viewport-flight-recorder-r1';
-
-  const repairScript = document.createElement('script');
-  repairScript.src = '/turn-lab/viewport-repair-r7.js?revision=r7-staged-autorepair';
-  repairScript.async = true;
-  document.head.appendChild(repairScript);
+  document.documentElement.dataset.turnLab = 'roadtrip-world-r1';
 
   let releaseBrowserLaunch = null;
   let browserReleased = false;
@@ -100,7 +95,7 @@
       guideSteps.innerHTML = `
         <div class="install-step"><div class="install-step-number" aria-hidden="true">1</div><div><strong>Open Safari’s Share menu</strong><span>Use the Share button while TURN LAB is open.</span></div></div>
         <div class="install-step"><div class="install-step-number" aria-hidden="true">2</div><div><strong>Choose Add to Home Screen</strong><span>Keep the separate TURN LAB name so production TURN remains untouched.</span></div></div>
-        <div class="install-step"><div class="install-step-number" aria-hidden="true">3</div><div><strong>Launch TURN LAB from its icon</strong><span>The viewport recorder starts before the production TURN runtime.</span></div></div>`;
+        <div class="install-step"><div class="install-step-number" aria-hidden="true">3</div><div><strong>Launch TURN LAB from its icon</strong><span>LAB keeps its own saves and loads the connected-world experiment on top of the production TURN engine.</span></div></div>`;
       guide.hidden = false;
     });
     browserButton.addEventListener('click', () => {

--- a/turn-lab/roadtrip-world-r1.css
+++ b/turn-lab/roadtrip-world-r1.css
@@ -1,0 +1,85 @@
+html[data-turn-deployment="lab"] .turn-lab-roadtrip-status {
+  position: fixed;
+  z-index: 78;
+  left: 50%;
+  top: max(10px, env(safe-area-inset-top));
+  transform: translateX(-50%);
+  max-width: min(72vw, 560px);
+  box-sizing: border-box;
+  padding: 8px 12px;
+  border: 2px solid #08090a;
+  border-radius: 10px;
+  background: rgba(8, 9, 10, 0.9);
+  color: #fff8e8;
+  font: 800 13px/1.2 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  letter-spacing: 0.035em;
+  text-align: center;
+  text-transform: uppercase;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+html[data-turn-deployment="lab"] .turn-lab-roadtrip-status.is-visible {
+  opacity: 1;
+}
+
+html[data-turn-deployment="lab"] .turn-lab-roadtrip-status strong {
+  color: #ffd43b;
+}
+
+html[data-turn-deployment="lab"] .turn-lab-roadtrip-transition {
+  position: fixed;
+  z-index: 2147483000;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  box-sizing: border-box;
+  padding: 24px;
+  background: #08090a;
+  color: #fff8e8;
+  font: 900 clamp(22px, 5vw, 44px)/1 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  letter-spacing: 0.045em;
+  text-align: center;
+  text-transform: uppercase;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 120ms ease, visibility 0s linear 120ms;
+}
+
+html[data-turn-deployment="lab"] .turn-lab-roadtrip-transition.is-active {
+  opacity: 1;
+  visibility: visible;
+  transition: opacity 120ms ease;
+}
+
+html[data-turn-deployment="lab"] .turn-lab-roadtrip-transition small {
+  display: block;
+  margin-top: 10px;
+  color: #ffd43b;
+  font-size: 0.38em;
+  letter-spacing: 0.11em;
+}
+
+html[data-turn-deployment="lab"]::after {
+  content: "TURN LAB · ROADTRIP";
+  position: fixed;
+  z-index: 77;
+  right: max(8px, env(safe-area-inset-right));
+  bottom: max(6px, env(safe-area-inset-bottom));
+  padding: 4px 7px;
+  border-radius: 6px;
+  background: rgba(8, 9, 10, 0.72);
+  color: rgba(255, 248, 232, 0.72);
+  font: 800 9px/1 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  letter-spacing: 0.08em;
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html[data-turn-deployment="lab"] .turn-lab-roadtrip-status,
+  html[data-turn-deployment="lab"] .turn-lab-roadtrip-transition {
+    transition: none;
+  }
+}

--- a/turn-lab/roadtrip-world-r1.js
+++ b/turn-lab/roadtrip-world-r1.js
@@ -1,0 +1,544 @@
+import * as THREE from 'three';
+import { activateTrack } from '/turn/tracks/track-manager.js?source=20260729-r118-m8';
+import { trackSurfaceY, trackPitch } from '/turn/tracks/elevation.js?build=20260725-r67';
+
+const TRACKS = Object.freeze({
+  countryside: Object.freeze({ label: 'COUNTRYSIDE', accent: 0xff4fa3 }),
+  airport: Object.freeze({ label: 'AIRPORT', accent: 0xffd43b }),
+  cliffside: Object.freeze({ label: 'CLIFFSIDE', accent: 0x26c7c3 }),
+  harbor: Object.freeze({ label: 'HARBOR', accent: 0xff8f3d }),
+  'midnight-city': Object.freeze({ label: 'MIDNIGHT CITY', accent: 0x9d7cff }),
+  mountain: Object.freeze({ label: 'MOUNTAIN', accent: 0x4dabf7 })
+});
+
+const CONNECTIONS = Object.freeze([
+  Object.freeze({
+    id: 'harbor-cliffside',
+    a: Object.freeze({ trackId: 'harbor', progress: 0.935 }),
+    b: Object.freeze({ trackId: 'cliffside', progress: 0.860 })
+  }),
+  Object.freeze({
+    id: 'cliffside-mountain',
+    a: Object.freeze({ trackId: 'cliffside', progress: 0.934 }),
+    b: Object.freeze({ trackId: 'mountain', progress: 0.850 })
+  }),
+  Object.freeze({
+    id: 'mountain-countryside',
+    a: Object.freeze({ trackId: 'mountain', progress: 0.927 }),
+    b: Object.freeze({ trackId: 'countryside', progress: 0.840 })
+  }),
+  Object.freeze({
+    id: 'countryside-midnight-city',
+    a: Object.freeze({ trackId: 'countryside', progress: 0.900 }),
+    b: Object.freeze({ trackId: 'midnight-city', progress: 0.830 })
+  }),
+  Object.freeze({
+    id: 'midnight-city-airport',
+    a: Object.freeze({ trackId: 'midnight-city', progress: 0.890 }),
+    b: Object.freeze({ trackId: 'airport', progress: 0.850 })
+  }),
+  Object.freeze({
+    id: 'airport-harbor',
+    a: Object.freeze({ trackId: 'airport', progress: 0.931 }),
+    b: Object.freeze({ trackId: 'harbor', progress: 0.860 })
+  })
+]);
+
+const LAP_CHECKPOINTS = Object.freeze([
+  0.08, 0.16, 0.24, 0.32, 0.40, 0.48,
+  0.56, 0.64, 0.72, 0.80, 0.88, 0.94
+]);
+
+const BRANCH_WIDTH = 10;
+const BRANCH_VISUAL_LENGTH = 30;
+const PORTAL_DISTANCE_FROM_CENTER = 19;
+const PORTAL_TRIGGER_RADIUS = 5.5;
+const PORTAL_HINT_RADIUS = 54;
+const ARRIVAL_ADVANCE_SAMPLES = 8;
+const TRANSITION_LOCK_MS = 2400;
+
+const reusableCenter = new THREE.Vector3();
+const reusableDirection = new THREE.Vector3();
+const reusableCross = new THREE.Vector3();
+const reusableArrivalVelocity = new THREE.Vector3();
+
+function waitForRuntime() {
+  if (globalThis.__turnRuntime) return Promise.resolve(globalThis.__turnRuntime);
+  return new Promise((resolve) => {
+    window.addEventListener('turn:runtime-ready', (event) => {
+      resolve(event.detail || globalThis.__turnRuntime);
+    }, { once: true });
+  });
+}
+
+function labelFor(trackId) {
+  return TRACKS[trackId]?.label || String(trackId || '').toUpperCase();
+}
+
+function otherEnd(connection, trackId) {
+  if (connection.a.trackId === trackId) return { local: connection.a, remote: connection.b };
+  if (connection.b.trackId === trackId) return { local: connection.b, remote: connection.a };
+  return null;
+}
+
+function portalsForTrack(trackId) {
+  return CONNECTIONS
+    .map((connection) => {
+      const ends = otherEnd(connection, trackId);
+      if (!ends) return null;
+      return {
+        connectionId: connection.id,
+        trackId,
+        progress: ends.local.progress,
+        destinationTrackId: ends.remote.trackId,
+        destinationProgress: ends.remote.progress
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.progress - b.progress);
+}
+
+function requiredCheckpointCount(progress) {
+  return LAP_CHECKPOINTS.filter((checkpoint) => checkpoint < progress - 0.005).length;
+}
+
+function portalIsEligible(runtime, portal) {
+  const state = runtime.state;
+  return Boolean(
+    state.running
+    && state.lapActive
+    && !state.lapInvalid
+    && state.lapCheckpointIndex >= requiredCheckpointCount(portal.progress)
+  );
+}
+
+function sampleAtProgress(samples, progress) {
+  if (!Array.isArray(samples) || !samples.length) return null;
+  const wrapped = ((Number(progress) % 1) + 1) % 1;
+  const index = Math.round(wrapped * samples.length) % samples.length;
+  return { sample: samples[index], index };
+}
+
+function computeTrackCenter(samples) {
+  reusableCenter.set(0, 0, 0);
+  if (!samples.length) return reusableCenter;
+  for (const sample of samples) reusableCenter.add(sample.point);
+  reusableCenter.multiplyScalar(1 / samples.length);
+  return reusableCenter;
+}
+
+function outwardDirection(sample, center) {
+  reusableDirection.copy(sample.normal || new THREE.Vector3(1, 0, 0));
+  reusableDirection.y = 0;
+  if (reusableDirection.lengthSq() < 0.0001) {
+    reusableDirection.set(-sample.tangent.z, 0, sample.tangent.x);
+  }
+  reusableDirection.normalize();
+  const fromCenterX = sample.point.x - center.x;
+  const fromCenterZ = sample.point.z - center.z;
+  if (fromCenterX * reusableDirection.x + fromCenterZ * reusableDirection.z < 0) {
+    reusableDirection.multiplyScalar(-1);
+  }
+  return reusableDirection.clone();
+}
+
+function disposeObject(root) {
+  root?.traverse?.((node) => {
+    node.geometry?.dispose?.();
+    const materials = Array.isArray(node.material) ? node.material : [node.material];
+    for (const material of materials) {
+      if (!material) continue;
+      material.map?.dispose?.();
+      material.dispose?.();
+    }
+  });
+  root?.removeFromParent?.();
+}
+
+function makeLabelTexture(text, accent) {
+  const canvas = document.createElement('canvas');
+  canvas.width = 512;
+  canvas.height = 144;
+  const context = canvas.getContext('2d');
+  context.fillStyle = '#08090a';
+  context.fillRect(0, 0, canvas.width, canvas.height);
+  context.strokeStyle = `#${accent.toString(16).padStart(6, '0')}`;
+  context.lineWidth = 12;
+  context.strokeRect(6, 6, canvas.width - 12, canvas.height - 12);
+  context.fillStyle = '#fff8e8';
+  context.font = '900 50px system-ui, -apple-system, sans-serif';
+  context.textAlign = 'center';
+  context.textBaseline = 'middle';
+  context.fillText(text, canvas.width / 2, canvas.height / 2 + 2);
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.minFilter = THREE.LinearFilter;
+  return texture;
+}
+
+function buildPortalVisual(runtime, portal, center) {
+  const sampleResult = sampleAtProgress(runtime.samples, portal.progress);
+  if (!sampleResult?.sample) return null;
+
+  const { sample, index } = sampleResult;
+  const direction = outwardDirection(sample, center);
+  const cross = reusableCross.copy(sample.tangent);
+  cross.y = 0;
+  if (cross.lengthSq() < 0.0001) cross.set(direction.z, 0, -direction.x);
+  cross.normalize();
+
+  const group = new THREE.Group();
+  group.name = `TURN LAB roadtrip ${portal.trackId} to ${portal.destinationTrackId}`;
+
+  const roadStart = sample.point.clone().addScaledVector(direction, runtime.trackWidth * 0.24);
+  const roadEnd = sample.point.clone().addScaledVector(direction, runtime.trackWidth * 0.5 + BRANCH_VISUAL_LENGTH);
+  const roadVector = roadEnd.clone().sub(roadStart);
+  roadVector.y = 0;
+  const roadLength = Math.max(1, roadVector.length());
+  const roadDirection = roadVector.clone().normalize();
+  const roadMidpoint = roadStart.clone().add(roadEnd).multiplyScalar(0.5);
+  roadMidpoint.y = sample.point.y + 0.16;
+
+  const asphalt = new THREE.MeshStandardMaterial({
+    color: 0x3e4348,
+    roughness: 0.98,
+    metalness: 0,
+    side: THREE.DoubleSide
+  });
+  const road = new THREE.Mesh(new THREE.BoxGeometry(BRANCH_WIDTH, 0.16, roadLength), asphalt);
+  road.position.copy(roadMidpoint);
+  road.quaternion.setFromUnitVectors(new THREE.Vector3(0, 0, 1), roadDirection);
+  road.receiveShadow = true;
+  group.add(road);
+
+  const curbGeometry = new THREE.BoxGeometry(0.72, 0.24, roadLength);
+  const curbMaterials = [
+    new THREE.MeshStandardMaterial({ color: 0xe63946, roughness: 0.9 }),
+    new THREE.MeshStandardMaterial({ color: 0xfff8e8, roughness: 0.9 })
+  ];
+  for (const side of [-1, 1]) {
+    const curb = new THREE.Mesh(curbGeometry, curbMaterials[side > 0 ? 0 : 1]);
+    curb.position.copy(roadMidpoint).addScaledVector(cross, side * (BRANCH_WIDTH / 2 + 0.25));
+    curb.position.y += 0.08;
+    curb.quaternion.copy(road.quaternion);
+    curb.receiveShadow = true;
+    group.add(curb);
+  }
+
+  const destinationAccent = TRACKS[portal.destinationTrackId]?.accent ?? 0xffd43b;
+  const gateMaterial = new THREE.MeshStandardMaterial({
+    color: destinationAccent,
+    emissive: destinationAccent,
+    emissiveIntensity: 0.12,
+    roughness: 0.62,
+    metalness: 0.12
+  });
+  const gateCenter = sample.point.clone().addScaledVector(direction, PORTAL_DISTANCE_FROM_CENTER);
+  gateCenter.y = sample.point.y + 0.18;
+
+  const postGeometry = new THREE.BoxGeometry(0.72, 4.6, 0.72);
+  for (const side of [-1, 1]) {
+    const post = new THREE.Mesh(postGeometry, gateMaterial);
+    post.position.copy(gateCenter).addScaledVector(cross, side * (BRANCH_WIDTH / 2 - 0.65));
+    post.position.y += 2.3;
+    post.castShadow = true;
+    group.add(post);
+  }
+
+  const beam = new THREE.Mesh(new THREE.BoxGeometry(BRANCH_WIDTH - 0.6, 0.7, 0.72), gateMaterial);
+  beam.position.copy(gateCenter);
+  beam.position.y += 4.55;
+  beam.quaternion.setFromUnitVectors(new THREE.Vector3(1, 0, 0), cross);
+  beam.castShadow = true;
+  group.add(beam);
+
+  const labelTexture = makeLabelTexture(`TO ${labelFor(portal.destinationTrackId)}`, destinationAccent);
+  const label = new THREE.Sprite(new THREE.SpriteMaterial({
+    map: labelTexture,
+    transparent: true,
+    depthTest: true,
+    depthWrite: false
+  }));
+  label.position.copy(gateCenter).addScaledVector(direction, -1.2);
+  label.position.y += 6.8;
+  label.scale.set(17, 4.8, 1);
+  group.add(label);
+
+  runtime.scene.add(group);
+
+  return {
+    ...portal,
+    sampleIndex: index,
+    sample,
+    direction,
+    cross: cross.clone(),
+    gateCenter,
+    group,
+    gateMaterial,
+    eligible: false
+  };
+}
+
+function installDomUi() {
+  const status = document.createElement('div');
+  status.className = 'turn-lab-roadtrip-status';
+  status.id = 'turnLabRoadtripStatus';
+  status.setAttribute('role', 'status');
+  status.setAttribute('aria-live', 'polite');
+  status.setAttribute('aria-atomic', 'true');
+
+  const transition = document.createElement('div');
+  transition.className = 'turn-lab-roadtrip-transition';
+  transition.id = 'turnLabRoadtripTransition';
+  transition.setAttribute('role', 'status');
+  transition.setAttribute('aria-live', 'polite');
+  transition.setAttribute('aria-atomic', 'true');
+
+  document.body.append(status, transition);
+  return { status, transition };
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
+function announceMessage(text, duration = 1900) {
+  const message = document.querySelector('#message');
+  if (!message) return;
+  message.textContent = text;
+  message.classList.add('show');
+  window.setTimeout(() => message.classList.remove('show'), duration);
+}
+
+const runtime = await waitForRuntime();
+const ui = installDomUi();
+let activeTrackId = globalThis.__turnGetTrackId?.() || runtime.trackId || runtime.state.trackId || 'countryside';
+let portalVisuals = [];
+let transitioning = false;
+let transitionLockedUntil = 0;
+let lastStatusText = '';
+let visitedTracks = new Set([activeTrackId]);
+let transitionCount = 0;
+
+function clearPortals() {
+  for (const portal of portalVisuals) disposeObject(portal.group);
+  portalVisuals = [];
+}
+
+function rebuildPortals(trackId = activeTrackId) {
+  clearPortals();
+  activeTrackId = trackId;
+  const center = computeTrackCenter(runtime.samples).clone();
+  portalVisuals = portalsForTrack(trackId)
+    .map((portal) => buildPortalVisual(runtime, portal, center))
+    .filter(Boolean);
+}
+
+function setStatus(text, visible) {
+  if (text !== lastStatusText) {
+    ui.status.textContent = text;
+    lastStatusText = text;
+  }
+  ui.status.classList.toggle('is-visible', Boolean(visible));
+}
+
+function updateGateState(portal) {
+  const eligible = portalIsEligible(runtime, portal);
+  if (eligible === portal.eligible) return eligible;
+  portal.eligible = eligible;
+  portal.gateMaterial.emissiveIntensity = eligible ? 0.95 : 0.08;
+  portal.gateMaterial.opacity = eligible ? 1 : 0.62;
+  portal.gateMaterial.transparent = !eligible;
+  portal.gateMaterial.needsUpdate = true;
+  return eligible;
+}
+
+function nearestPortal() {
+  let nearest = null;
+  let distance = Infinity;
+  for (const portal of portalVisuals) {
+    const nextDistance = runtime.state.position.distanceTo(portal.gateCenter);
+    if (nextDistance < distance) {
+      nearest = portal;
+      distance = nextDistance;
+    }
+  }
+  return { portal: nearest, distance };
+}
+
+function reciprocalPortal(destinationTrackId, connectionId) {
+  return portalsForTrack(destinationTrackId)
+    .find((portal) => portal.connectionId === connectionId) || null;
+}
+
+async function travel(portal) {
+  if (transitioning || performance.now() < transitionLockedUntil) return;
+  transitioning = true;
+  transitionLockedUntil = performance.now() + TRANSITION_LOCK_MS;
+
+  const fromTrackId = activeTrackId;
+  const toTrackId = portal.destinationTrackId;
+  const destinationPortal = reciprocalPortal(toTrackId, portal.connectionId);
+  const wasRunning = runtime.state.running;
+  const carriedSpeed = Math.max(12, Math.min(
+    Number(runtime.state.speed) || 0,
+    (Number(runtime.maxSpeed) || 88) * 1.15
+  ));
+
+  ui.transition.innerHTML = `${labelFor(fromTrackId)} → ${labelFor(toTrackId)}<small>ROADTRIP</small>`;
+  ui.transition.classList.add('is-active');
+  setStatus('', false);
+  runtime.state.running = false;
+
+  window.dispatchEvent(new CustomEvent('turn:roadtrip-transition-start', {
+    detail: { fromTrackId, toTrackId, connectionId: portal.connectionId, speed: carriedSpeed }
+  }));
+
+  try {
+    await sleep(120);
+    await activateTrack(toTrackId);
+
+    const arrivalProgress = destinationPortal?.progress ?? 0.86;
+    const baseResult = sampleAtProgress(runtime.samples, arrivalProgress);
+    const arrivalIndex = baseResult
+      ? (baseResult.index + ARRIVAL_ADVANCE_SAMPLES) % runtime.samples.length
+      : runtime.samples.length - 24;
+    const arrival = runtime.samples[arrivalIndex];
+    const state = runtime.state;
+
+    state.position.copy(arrival.point);
+    state.position.y = trackSurfaceY(arrival);
+    state.surfacePitch = trackPitch(arrival);
+    state.heading = Math.atan2(arrival.tangent.x, arrival.tangent.z);
+    reusableArrivalVelocity.copy(arrival.tangent).normalize().multiplyScalar(carriedSpeed);
+    state.velocity.copy(reusableArrivalVelocity);
+    state.speed = carriedSpeed;
+    state.driftAmount = 0;
+    state.offRoad = false;
+    state.nearestTrackIndex = arrivalIndex;
+    state.progress = arrivalIndex / runtime.samples.length;
+    state.lastProgress = state.progress;
+    state.trackDistance = Number(arrival.distance) || 0;
+    state.lapActive = false;
+    state.lapCheckpointIndex = 0;
+    state.lapInvalid = false;
+    state.lapStartedAt = 0;
+    state.lapElapsed = 0;
+    state.lapPreviousPosition = { x: state.position.x, z: state.position.z };
+    state.recording = [];
+    state.running = wasRunning;
+
+    runtime.playerCar.position.copy(state.position);
+    runtime.playerCar.rotation.x = state.surfacePitch;
+    runtime.playerCar.rotation.y = state.heading + Math.PI;
+    runtime.cameraPosition?.copy?.(state.position);
+    runtime.cameraTarget?.copy?.(state.position);
+
+    activeTrackId = toTrackId;
+    visitedTracks.add(toTrackId);
+    transitionCount += 1;
+    rebuildPortals(toTrackId);
+
+    const arrivalText = `${labelFor(toTrackId)} · FROM ${labelFor(fromTrackId)}`;
+    announceMessage(arrivalText, 2200);
+    window.dispatchEvent(new CustomEvent('turn:roadtrip-transition-complete', {
+      detail: {
+        fromTrackId,
+        toTrackId,
+        connectionId: portal.connectionId,
+        arrivalProgress: state.progress,
+        speed: carriedSpeed,
+        transitionCount,
+        visitedTrackIds: [...visitedTracks]
+      }
+    }));
+
+    await sleep(160);
+  } catch (error) {
+    console.error('TURN LAB: roadtrip transition failed.', error);
+    runtime.state.running = wasRunning;
+    announceMessage('ROADTRIP TRANSITION FAILED', 2400);
+  } finally {
+    ui.transition.classList.remove('is-active');
+    transitioning = false;
+  }
+}
+
+function update() {
+  const currentTrackId = globalThis.__turnGetTrackId?.() || runtime.trackId || runtime.state.trackId;
+  if (currentTrackId && currentTrackId !== activeTrackId && !transitioning) {
+    rebuildPortals(currentTrackId);
+  }
+
+  if (!runtime.state.running || transitioning) {
+    setStatus('', false);
+    requestAnimationFrame(update);
+    return;
+  }
+
+  for (const portal of portalVisuals) updateGateState(portal);
+  const { portal, distance } = nearestPortal();
+
+  if (!portal || distance > PORTAL_HINT_RADIUS) {
+    setStatus('', false);
+    requestAnimationFrame(update);
+    return;
+  }
+
+  const eligible = portalIsEligible(runtime, portal);
+  const destination = labelFor(portal.destinationTrackId);
+  if (eligible) {
+    setStatus(`↔ ${destination} · TAKE THE EXIT`, true);
+  } else {
+    const needed = requiredCheckpointCount(portal.progress);
+    const completed = Math.min(needed, Number(runtime.state.lapCheckpointIndex) || 0);
+    const reason = runtime.state.lapInvalid
+      ? 'LAP VOID'
+      : !runtime.state.lapActive
+        ? 'CROSS START / FINISH FIRST'
+        : `ROUTE ${completed}/${needed}`;
+    setStatus(`${destination} · EXIT LOCKED · ${reason}`, true);
+  }
+
+  if (
+    eligible
+    && distance <= PORTAL_TRIGGER_RADIUS
+    && performance.now() >= transitionLockedUntil
+    && Math.abs(Number(runtime.state.speed) || 0) > 3
+  ) {
+    void travel(portal);
+  }
+
+  requestAnimationFrame(update);
+}
+
+window.addEventListener('turn:track-changed', (event) => {
+  const trackId = event.detail?.trackId;
+  if (!trackId || transitioning) return;
+  rebuildPortals(trackId);
+});
+
+rebuildPortals(activeTrackId);
+requestAnimationFrame(update);
+
+globalThis.__turnLabRoadtrip = Object.freeze({
+  connections: CONNECTIONS,
+  getActiveTrackId: () => activeTrackId,
+  getPortals: () => portalVisuals.map((portal) => ({
+    connectionId: portal.connectionId,
+    trackId: portal.trackId,
+    progress: portal.progress,
+    destinationTrackId: portal.destinationTrackId,
+    destinationProgress: portal.destinationProgress,
+    eligible: portalIsEligible(runtime, portal)
+  })),
+  getSession: () => ({
+    transitionCount,
+    visitedTrackIds: [...visitedTracks]
+  })
+});
+
+document.documentElement.dataset.turnLabExperiment = 'roadtrip-world-r1';
+window.dispatchEvent(new CustomEvent('turn:roadtrip-ready', {
+  detail: { trackId: activeTrackId, connections: CONNECTIONS.length }
+}));

--- a/turn-lab/site.webmanifest
+++ b/turn-lab/site.webmanifest
@@ -2,7 +2,7 @@
   "id": "/turn-lab/",
   "name": "TURN LAB",
   "short_name": "TURN LAB",
-  "description": "Temporary installed-app viewport diagnostics for the current production TURN runtime.",
+  "description": "TURN LAB runs isolated experiments on the current TURN engine. This build prototypes a connected six-track roadtrip world.",
   "start_url": "/turn-lab/",
   "scope": "/turn-lab/",
   "display": "standalone",

--- a/turn-tests/viewport-coverage-production.mjs
+++ b/turn-tests/viewport-coverage-production.mjs
@@ -106,26 +106,28 @@ assert.match(
   new RegExp(`TURN v${release.version.replaceAll('.', '\\.')} · Build ${release.id.replaceAll('.', '\\.')}`)
 );
 
-// TURN LAB is a deployed diagnostic shell around the exact current production runtime.
+// TURN LAB is a deployed isolated experiment shell around the exact current production runtime.
 assert.match(labIndex, /<base href="\/turn\/">/,
   'TURN LAB must resolve all ordinary game assets from the current production TURN tree');
 assert.deepEqual(importMap(labIndex), importMap(index),
-  'TURN LAB must use the exact production import-map graph so viewport tests exercise current TURN code');
+  'TURN LAB must use the exact production import-map graph so experiments exercise current TURN code');
 assert.match(labIndex, new RegExp(`version: '${release.version.replaceAll('.', '\\.')}'`));
 assert.match(labIndex, new RegExp(`id: '${release.id.replaceAll('.', '\\.')}'`));
 assert.match(labIndex, new RegExp(`cacheKey: '${release.cacheKey}'`));
 assert.ok(
-  labIndex.indexOf('/turn-lab/lab-bootstrap.js') < labIndex.indexOf('/turn-lab/viewport-diagnostics.js'),
-  'LAB storage and standalone detection must exist before the flight recorder starts'
-);
-assert.ok(
-  labIndex.indexOf('/turn-lab/viewport-diagnostics.js') < labIndex.indexOf('pwa-usable-viewport-r181.js'),
-  'The flight recorder must observe the page before the production PWA viewport boundary mutates it'
+  labIndex.indexOf('/turn-lab/lab-bootstrap.js') < labIndex.indexOf('pwa-usable-viewport-r181.js'),
+  'LAB storage isolation and standalone detection must exist before production viewport setup'
 );
 assert.ok(
   labIndex.indexOf('pwa-usable-viewport-r181.js') < labIndex.indexOf('app.js?build='),
   'LAB must preserve the production PWA-boundary-before-runtime ordering'
 );
+assert.ok(
+  labIndex.indexOf('app.js?build=') < labIndex.indexOf('/turn-lab/roadtrip-world-r1.js'),
+  'LAB experiments must layer on top of the initialized production runtime rather than replace it'
+);
+assert.doesNotMatch(labIndex, /\/turn-lab\/viewport-diagnostics\.js/,
+  'Retired viewport recording must not run automatically in the revived general-purpose LAB shell');
 
 assert.equal(labManifest.id, '/turn-lab/');
 assert.equal(labManifest.start_url, '/turn-lab/');
@@ -133,19 +135,22 @@ assert.equal(labManifest.scope, '/turn-lab/');
 assert.equal(labManifest.display, 'standalone');
 assert.deepEqual(labManifest.display_override, ['standalone']);
 assert.equal(labManifest.orientation, 'any',
-  'TURN LAB deliberately removes the landscape manifest lock for the real-device startup-orientation experiment');
+  'TURN LAB must allow its normal rotate UI to handle startup orientation independently of the manifest');
 
 assert.match(labBootstrap, /LOCAL_PREFIX = 'turn-lab:'/,
   'LAB local storage must stay in its own namespace');
 assert.match(labBootstrap, /SESSION_PREFIX = 'turn-lab-session:'/,
   'LAB session storage must stay in its own namespace');
 assert.doesNotMatch(labBootstrap, /seed|COPY_ONCE|turn-personal-rivals/,
-  'The fresh viewport lab must not seed or modify production TURN save data');
+  'The isolated LAB must not seed or modify production TURN save data');
 assert.match(labBootstrap, /__turnLaunchReady/,
   'LAB must preserve the production startup gate contract');
-assert.match(labBootstrap, /viewport-repair-r7\.js\?revision=r7-staged-autorepair/,
-  'LAB must load the cache-busted staged lifecycle repair watchdog without modifying production TURN');
+assert.match(labBootstrap, /dataset\.turnLab = 'roadtrip-world-r1'/,
+  'The revived LAB shell must identify the active connected-world experiment');
+assert.doesNotMatch(labBootstrap, /viewport-repair-r7\.js/,
+  'The retired viewport repair watchdog must not run automatically in the revived LAB shell');
 
+// Keep the old diagnostic bench valid and available for targeted regressions even though LAB no longer auto-loads it.
 for (const requiredDiagnostic of [
   'screen.width',
   'screen.height',
@@ -162,15 +167,15 @@ for (const requiredDiagnostic of [
   'COLOR LAYERS',
   'COPY LOG'
 ]) {
-  assert.ok(labDiagnostics.includes(requiredDiagnostic), `TURN LAB recorder must include ${requiredDiagnostic}`);
+  assert.ok(labDiagnostics.includes(requiredDiagnostic), `TURN LAB archived recorder must include ${requiredDiagnostic}`);
 }
 assert.match(labDiagnostics, /MAX_SESSIONS = 8/,
-  'The recorder must retain several random good/bad cold launches for comparison');
+  'The archived recorder must retain several random good/bad cold launches for comparison');
 assert.match(labDiagnostics, /localStorage\.setItem\(STORAGE_KEY/,
-  'Viewport evidence must survive reloads and orientation cycles');
+  'Archived viewport evidence must survive reloads and orientation cycles when the recorder is invoked explicitly');
 
-// The repair bench remains LAB-only. Automatic mode waits for Home, watches later lifecycle events, and retries a failed pulse without looping forever.
-assert.doesNotThrow(() => new Function(labRepair), 'The LAB repair probe must remain valid JavaScript');
+// The old repair bench remains available as a LAB-only diagnostic tool, but is no longer part of normal LAB startup.
+assert.doesNotThrow(() => new Function(labRepair), 'The archived LAB repair probe must remain valid JavaScript');
 for (const requiredRepair of [
   "measureHeight('100dvh')",
   "measureHeight('100lvh')",
@@ -203,7 +208,7 @@ for (const requiredRepair of [
   'repairInFlight',
   'COPY REPAIR RESULT'
 ]) {
-  assert.ok(labRepair.includes(requiredRepair), `TURN LAB repair bench must include ${requiredRepair}`);
+  assert.ok(labRepair.includes(requiredRepair), `TURN LAB archived repair bench must include ${requiredRepair}`);
 }
 assert.doesNotMatch(labRepair, /AUTO_WATCHDOG_MS|performance\.now\(\) - startedAt >/,
   'Resume-time recovery must not expire just because the app has been alive longer than the cold-start window');
@@ -216,4 +221,4 @@ assert.match(labRepair, /if \(repairInFlight \|\| autoConfirmationTimer \|\| !do
 
 await import('./short-viewport-repair-production.mjs');
 
-console.log(`TURN ${release.id} usable iOS standalone viewport boundary and TURN LAB recorder/repair bench passed.`);
+console.log(`TURN ${release.id} usable iOS standalone viewport boundary, revived TURN LAB shell and archived diagnostic bench passed.`);


### PR DESCRIPTION
## What this does

Revives `/turn-lab/` as a general isolated experiment surface on top of the current production TURN engine and replaces the old viewport-flight-recorder startup role with the connected-world prototype.

### Connected world

Six canonical bidirectional connections:

- HARBOR ↔ CLIFFSIDE
- CLIFFSIDE ↔ MOUNTAIN
- MOUNTAIN ↔ COUNTRYSIDE
- COUNTRYSIDE ↔ MIDNIGHT CITY
- MIDNIGHT CITY ↔ AIRPORT
- AIRPORT ↔ HARBOR

Each active track gets two physical branch roads with destination-coloured gate/sign markers. The junctions are deliberately late in the lap (roughly 83–94%).

### Roadtrip integrity

Exits stay locked until the current lap is active, valid, and has passed TURN's existing ordered checkpoint chain far enough to reach that junction. This prevents reversing or spawning near an exit from counting as roadtrip progress.

When a gate is taken, LAB briefly masks the world swap, uses the existing shared `activateTrack()` manager, preserves current driving speed, spawns just beyond the reciprocal junction on the destination track in the normal race direction, and resets the destination lap to staged so the driver must cross start/finish and then race most of that track before another roadtrip exit unlocks.

Transition events and `globalThis.__turnLabRoadtrip` are exposed for later achievements/testing.

### LAB isolation

- Production `/turn/` runtime files are unchanged.
- LAB continues to prefix local/session storage, so experimental saves do not contaminate TURN.
- Old viewport diagnostic files remain in the repo but are no longer loaded by the LAB shell.
- The viewport regression now protects the revived LAB ordering/isolation contract while retaining tests for the archived diagnostic tools.
- Reduced-motion users get an instantaneous transition cover rather than an animated fade.

## Validation

- Full TURN regression suite run #1813: **passed**.
- Branch is current with `main` (0 commits behind at merge check).
- The first CI run exposed one stale LAB assertion that required the retired viewport recorder; the regression contract was corrected and the complete suite then passed.
- Production track-manager lifecycle, collision envelope and ordered checkpoint semantics were inspected before implementation.

## Needs live LAB QA

This is intentionally an experimental first pass. The main things to evaluate live are the exact physical branch placement against scenery/terrain, especially MOUNTAIN, and whether the short off-road turn onto each connector feels natural enough before connector roads become first-class driveable surfaces.