### PR TITLE
Simplify The Lot selected-car bay

### DIFF
--- a/turn/garage/lot-selection-bay.js
+++ b/turn/garage/lot-selection-bay.js
@@ -1,0 +1,85 @@
+import * as THREE from 'three';
+
+const EXPECTED_PAD_COUNT = 15;
+const BAY_WIDTH = 8.1;
+const BAY_DEPTH = 5.8;
+const FILL_WIDTH = 7.92;
+const FILL_DEPTH = 5.58;
+const CONNECTOR_THICKNESS = 0.14;
+const PARKING_WHITE = 0xfff8e8;
+const SELECTED_ASPHALT = 0x62676b;
+
+function replacePlaneGeometry(mesh, width, depth) {
+  if (!mesh?.isMesh) return;
+  mesh.geometry?.dispose?.();
+  mesh.geometry = new THREE.PlaneGeometry(width, depth);
+}
+
+function polishParkingPad(pad) {
+  const fill = pad?.userData?.turnLotPadFill;
+  const border = pad?.userData?.turnLotPadBorder;
+  const pointerOutline = pad?.userData?.turnLotPadPointerOutline;
+  const pointer = pad?.userData?.turnLotPadPointer;
+  if (!fill?.isMesh || !border?.isGroup) return false;
+
+  // The ordinary parking stripes already provide the left and right edges. Keep the
+  // selection physically part of that parking-space language: a subtle lighter patch
+  // of asphalt, then only the two missing white cross-lines that close the bay.
+  replacePlaneGeometry(fill, FILL_WIDTH, FILL_DEPTH);
+  fill.material?.color?.setHex?.(SELECTED_ASPHALT);
+  if (fill.material) {
+    fill.material.transparent = true;
+    fill.material.opacity = 0.55;
+    fill.material.depthWrite = false;
+    fill.material.needsUpdate = true;
+  }
+
+  const edges = [...border.children];
+  const [nearConnector, farConnector, leftLegacyEdge, rightLegacyEdge] = edges;
+  for (const connector of [nearConnector, farConnector]) {
+    replacePlaneGeometry(connector, BAY_WIDTH, CONNECTOR_THICKNESS);
+    connector.material?.color?.setHex?.(PARKING_WHITE);
+    if (connector.material) connector.material.needsUpdate = true;
+  }
+
+  // The persistent Lot ground already draws these two side stripes at exactly the
+  // bay boundaries. Hiding the duplicate selector edges lets those lines simply join
+  // the new cross-lines instead of drawing a second boxed frame over them.
+  if (leftLegacyEdge) leftLegacyEdge.visible = false;
+  if (rightLegacyEdge) rightLegacyEdge.visible = false;
+
+  // Selection is the connected parking bay itself. Do not retain the old floating
+  // yellow pointer; setParkingPadSelected() may toggle the mesh, so suppress its
+  // material rather than relying on mesh.visible.
+  if (pointerOutline?.material) pointerOutline.material.visible = false;
+  if (pointer?.material) pointer.material.visible = false;
+
+  return true;
+}
+
+export function installLotSelectionBayPolish() {
+  const prototype = THREE.Object3D.prototype;
+  const originalAdd = prototype.add;
+  let polished = 0;
+  let restored = false;
+
+  function restore() {
+    if (restored) return;
+    restored = true;
+    if (prototype.add === patchedAdd) prototype.add = originalAdd;
+  }
+
+  function patchedAdd(...objects) {
+    const result = originalAdd.apply(this, objects);
+    for (const object of objects) {
+      if (!object?.userData?.turnLotPadFill) continue;
+      if (!polishParkingPad(object)) continue;
+      polished += 1;
+      if (polished >= EXPECTED_PAD_COUNT) restore();
+    }
+    return result;
+  }
+
+  prototype.add = patchedAdd;
+  return restore;
+}

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -2,6 +2,7 @@ import {
   enhanceLotNow,
   prepareLotEnhancements
 } from './lot-enhancement-runtime.js?revision=r588-canonical-attributes&build=20260804-r157';
+import { installLotSelectionBayPolish } from './lot-selection-bay.js?revision=r593-connected-bay';
 import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r52';
 import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
 
@@ -37,9 +38,19 @@ export async function showEnhancedLot(options = {}) {
     loadOriginalLot(),
     prepareLotEnhancements()
   ]);
-  const lotResult = showOriginalLot(options);
-  const removeEnhancements = enhanceLotNow();
 
+  // The original Lot builds all 15 parking pads synchronously inside showTheLot().
+  // Install a temporary construction hook only for that moment so the selected bay
+  // can reuse the existing parking stripes without forking the garage renderer.
+  const restoreSelectionBayPolish = installLotSelectionBayPolish();
+  let lotResult;
+  try {
+    lotResult = showOriginalLot(options);
+  } finally {
+    restoreSelectionBayPolish();
+  }
+
+  const removeEnhancements = enhanceLotNow();
   try {
     return await lotResult;
   } finally {

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -43,12 +43,8 @@ export async function showEnhancedLot(options = {}) {
   // Install a temporary construction hook only for that moment so the selected bay
   // can reuse the existing parking stripes without forking the garage renderer.
   const restoreSelectionBayPolish = installLotSelectionBayPolish();
-  let lotResult;
-  try {
-    lotResult = showOriginalLot(options);
-  } finally {
-    restoreSelectionBayPolish();
-  }
+  const lotResult = showOriginalLot(options);
+  restoreSelectionBayPolish();
 
   const removeEnhancements = enhanceLotNow();
   try {


### PR DESCRIPTION
## Visual change
Replace the yellow selected-car platform + floating arrow with the parking-space treatment from the supplied mockup:

- reuse the Lot’s existing cream-white parking stripes as the left/right sides of the selected bay;
- add only the two white cross-lines needed to connect that parking space into a rectangle;
- use a subtle lighter-asphalt fill inside the resulting shape;
- remove the floating selection arrow entirely;
- keep all cars in their full factory colours and preserve the existing selected-car lift/scale cue.

## Implementation
The existing Lot renderer remains canonical. A tiny self-restoring construction adapter styles the 15 parking-pad objects as they are created, then restores Three.js `Object3D.add` immediately; it does not remain installed during rendering or affect race scenes.

No car order, lock state, beginner guide, paint, attributes, progression, accessibility semantics, or race behavior changes.