### PR TITLE
Apply Lot bay polish to the active M8 path

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -127,6 +127,9 @@ jobs:
       - name: Run production garage regression
         run: node turn-lab/tests/garage-production.mjs
 
+      - name: Run M8 Lot selection entry regression
+        run: node turn-tests/m8-lot-selection-production.mjs
+
       - name: Run compact Lot layout regression
         run: node turn-lab/tests/lot-layout-production.mjs
 
@@ -237,7 +240,6 @@ jobs:
 
       - name: Run Cliffside containment regression
         run: node turn-tests/cliffside-containment-production.mjs
-
       - name: Run full viewport coverage regression
         run: node turn-tests/viewport-coverage-production.mjs
 

--- a/turn-tests/m8-lot-selection-production.mjs
+++ b/turn-tests/m8-lot-selection-production.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const [m8Home, lot, trainingGuide, selectionBay, wrapper] = await Promise.all([
+  fs.readFile(new URL('../turn/m8-home.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/garage/lot-r10.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/garage/training-car-guide.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/garage/lot-selection-bay.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/garage/lot-track-select.js', import.meta.url), 'utf8')
+]);
+
+assert.match(
+  m8Home,
+  /import \{ showTheLot \} from '\/turn\/garage\/lot-r10\.js\?source=20260729-r118-m8';/,
+  'The active M8 Home route must remain covered even when it imports lot-r10 directly'
+);
+assert.match(
+  m8Home,
+  /const lotPromise = showTheLot\(\{ initialSelection: selectedVehicle\(runtime\) \}\);/,
+  'M8 must still enter the canonical Lot from continueToTrack()'
+);
+
+const canonicalBootstrap = lot.indexOf('installTrainingCarGuide();');
+const firstPadConstruction = lot.indexOf('const platform = makeParkingPad(car.id === selectedCarId);');
+assert.ok(canonicalBootstrap >= 0, 'lot-r10 must run its synchronous Lot-entry bootstrap');
+assert.ok(firstPadConstruction >= 0, 'lot-r10 must construct the selectable parking pads');
+assert.ok(
+  canonicalBootstrap < firstPadConstruction,
+  'The canonical Lot-entry bootstrap must run before any selected parking pad is built'
+);
+
+assert.match(
+  trainingGuide,
+  /import \{ installLotSelectionBayPolish \} from '\.\/lot-selection-bay\.js\?revision=r594-m8-entry';/,
+  'The canonical Lot-entry bootstrap must include the selected-bay presentation'
+);
+assert.ok(
+  trainingGuide.indexOf('installLotSelectionBayPolish();') < trainingGuide.indexOf('if (installed)'),
+  'Bay polish must be installed on every Lot entry, not only the first Training Car guide install'
+);
+
+assert.match(selectionBay, /const PARKING_WHITE = 0xfff8e8;/);
+assert.match(selectionBay, /const SELECTED_ASPHALT = 0x62676b;/);
+assert.match(selectionBay, /leftLegacyEdge\.visible = false/,
+  'The selector must reuse the persistent parking-space side stripes');
+assert.match(selectionBay, /rightLegacyEdge\.visible = false/);
+assert.match(selectionBay, /pointerOutline\.material\.visible = false/,
+  'The old floating selection arrow outline must stay suppressed');
+assert.match(selectionBay, /pointer\.material\.visible = false/,
+  'The old floating selection arrow must stay suppressed');
+
+assert.doesNotMatch(
+  wrapper,
+  /installLotSelectionBayPolish/,
+  'Bay polish must no longer depend on the legacy Lot wrapper that M8 bypasses'
+);
+
+console.log('TURN M8 canonical Lot entry now receives the connected white selected-bay treatment.');

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -2,7 +2,6 @@ import {
   enhanceLotNow,
   prepareLotEnhancements
 } from './lot-enhancement-runtime.js?revision=r588-canonical-attributes&build=20260804-r157';
-import { installLotSelectionBayPolish } from './lot-selection-bay.js?revision=r593-connected-bay';
 import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r52';
 import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
 
@@ -39,13 +38,9 @@ export async function showEnhancedLot(options = {}) {
     prepareLotEnhancements()
   ]);
 
-  // The original Lot builds all 15 parking pads synchronously inside showTheLot().
-  // Install a temporary construction hook only for that moment so the selected bay
-  // can reuse the existing parking stripes without forking the garage renderer.
-  const restoreSelectionBayPolish = installLotSelectionBayPolish();
+  // lot-r10 now applies the selected-bay polish from its own synchronous entry
+  // bootstrap, so every caller—including M8 Home—gets the same presentation.
   const lotResult = showOriginalLot(options);
-  restoreSelectionBayPolish();
-
   const removeEnhancements = enhanceLotNow();
   try {
     return await lotResult;

--- a/turn/garage/training-car-guide.js
+++ b/turn/garage/training-car-guide.js
@@ -1,3 +1,5 @@
+import { installLotSelectionBayPolish } from './lot-selection-bay.js?revision=r594-m8-entry';
+
 export const TRAINING_CAR_ID = 'classic';
 export const TRAINING_CAR_TRIED_STORAGE_KEY = 'turn-training-car-tried-v1';
 
@@ -20,6 +22,13 @@ export function markTrainingCarTried(storage = globalThis.localStorage) {
 }
 
 export function installTrainingCarGuide() {
+  // lot-r10 calls this synchronously at the start of every showTheLot() invocation,
+  // before any parking pads are constructed. Use that canonical entry boundary so
+  // both the active M8 Home route and the older wrapper route receive the same bay
+  // treatment. The temporary Three.js construction hook restores itself after all
+  // 15 pads have been created.
+  installLotSelectionBayPolish();
+
   if (installed) return globalThis.__turnTrainingCarGuide;
   installed = true;
 


### PR DESCRIPTION
## Problem
PR #593 applied the selected-car bay treatment only from `lot-track-select.js`. The active M8 Home does not use that wrapper: it imports `/turn/garage/lot-r10.js?source=20260729-r118-m8` directly, so the primary production path could still construct the old yellow pad + floating arrow.

## Fix
Make the bay treatment part of the canonical synchronous `lot-r10` entry path instead of the optional wrapper path:

- `lot-r10` already calls `installTrainingCarGuide()` at the beginning of every `showTheLot()` invocation, before any parking pads are created;
- that canonical Lot-entry bootstrap now installs the temporary `installLotSelectionBayPolish()` construction hook on **every** Lot open;
- the hook still restores itself after all 15 pads are built;
- remove the duplicate wrapper-only installation from `lot-track-select.js`.

This means M8 Home, the legacy wrapper flow and any other caller of canonical `showTheLot()` all receive the same connected cream-white bay, lighter asphalt fill and no floating arrow.

## Regression
Add `turn-tests/m8-lot-selection-production.mjs` and run it in the main TURN workflow. It explicitly verifies:

- M8 still imports and calls canonical `lot-r10` directly;
- the canonical Lot bootstrap runs before first parking-pad construction;
- bay polish is installed on every Lot entry, before the one-time Training Car listener guard;
- persistent parking stripes are reused and the arrow materials stay suppressed;
- the wrapper no longer owns the visual treatment.

This directly covers the production-path gap reported in review.