### PR TITLE
Separate developer activity in TURN stats

### DIFF
--- a/turn-tests/telemetry-production.mjs
+++ b/turn-tests/telemetry-production.mjs
@@ -25,15 +25,21 @@ assert.match(client, /turn:lap-invalid/);
 assert.match(client, /navigator\.sendBeacon/);
 assert.match(client, /keepalive: true/);
 assert.match(client, /credentials: 'omit'/);
-assert.doesNotMatch(client, /localStorage|sessionStorage|document\.cookie|indexedDB/i,
-  'Gameplay telemetry must not create a persistent analytics identifier');
+assert.match(client, /turn\.telemetry\.developer\.v1/);
+assert.match(client, /developer: isDeveloperDevice\(\)/);
+assert.match(client, /localStorage\.getItem\(DEVELOPER_STORAGE_KEY\) === '1'/);
+assert.doesNotMatch(client, /localStorage\.setItem|sessionStorage|document\.cookie|indexedDB/i,
+  'Gameplay telemetry must not create a persistent player or session identifier');
 assert.doesNotMatch(client, /requestAnimationFrame|setInterval|devicemotion|pointermove|mousemove/,
   'Telemetry must remain event-driven and stay out of the racing/rendering loops');
 
 assert.match(about, /installTurnTelemetry\(\)/);
+assert.match(about, /telemetry\/client\.js\?revision=r2/);
 assert.match(about, /<details class="turn-about-privacy">/);
 assert.match(about, /<summary>PRIVACY &amp; USAGE STATISTICS<\/summary>/);
 assert.match(about, /no analytics cookie and creates no persistent analytics identifier/i);
+assert.match(about, /developer yes\/no flag/i);
+assert.match(about, /same local yes\/no marker used by every developer device/i);
 assert.match(about, /does not include your name, challenge name, challenge link or ID, replay, driving path, control inputs/i);
 assert.match(about, /private developer dashboard/i);
 assert.match(about, /anonymous daily aggregate statistics in Cloudflare D1/i);
@@ -49,14 +55,21 @@ assert.doesNotMatch(privacyCss, /--turn-disclosure-trigger|background:\s*var\(--
 assert.match(statsHtml, /<meta name="robots" content="noindex,nofollow,noarchive">/);
 assert.match(statsHtml, /PRIVATE · ENKEL\.DESIGN/);
 assert.match(statsHtml, /PLAY SESSIONS/);
-assert.match(statsHtml, /does not assign a persistent analytics identifier/);
+assert.match(statsHtml, /data-audience="players" aria-pressed="true">PLAYERS/);
+assert.match(statsHtml, /data-audience="developer">DEVELOPER/);
+assert.match(statsHtml, /MARK AS DEVELOPER/);
+assert.match(statsHtml, /older activity cannot be separated/i);
 assert.doesNotMatch(productionIndex, /href=["'][^"']*\/turn\/stats|href=["'][^"']*stats\//i,
   'The private dashboard must not be linked into public TURN navigation');
 assert.match(statsJs, /location\.hash\.slice\(1\)/,
   'The private key must stay in the URL fragment so GitHub Pages never receives it');
 assert.match(statsJs, /Authorization: `Bearer \$\{statsKey\}`/);
-assert.doesNotMatch(statsJs, /localStorage|sessionStorage|document\.cookie/i,
-  'The private dashboard must not persist its bearer key into browser storage');
+assert.match(statsJs, /turn\.telemetry\.developer\.v1/);
+assert.match(statsJs, /localStorage\.setItem\(DEVELOPER_STORAGE_KEY, '1'\)/);
+assert.match(statsJs, /localStorage\.removeItem\(DEVELOPER_STORAGE_KEY\)/);
+assert.doesNotMatch(statsJs, /localStorage\.(?:setItem|getItem)\([^\n]*statsKey|sessionStorage|document\.cookie/i,
+  'The private dashboard must never persist its bearer key into browser storage');
+assert.match(statsJs, /audience/);
 assert.match(statsJs, /renderFavourite\('Track', tracks, races\)/);
 assert.match(statsJs, /renderFavourite\('Car', cars, races\)/);
 assert.match(statsJs, /YOUR TURN play sessions/);
@@ -70,10 +83,16 @@ assert.doesNotMatch(workerConfig, /analytics_engine_datasets|"binding": "ANALYTI
   'Private stats must deploy using the already-proven D1 binding only');
 assert.match(workerRouter, /handleTelemetryRoute/);
 assert.match(workerTelemetry, /'play_session'[\s\S]*'race_start'[\s\S]*'lap_complete'[\s\S]*'lap_invalid'/);
-assert.match(workerTelemetry, /CREATE TABLE IF NOT EXISTS turn_telemetry_daily/);
-assert.doesNotMatch(workerTelemetry, /INSERT INTO turn_telemetry_(?:event|raw|session)|session_hash TEXT|player_id TEXT/i,
+assert.match(workerTelemetry, /CREATE TABLE IF NOT EXISTS turn_telemetry_daily_v2/);
+assert.match(workerTelemetry, /developer INTEGER NOT NULL/);
+assert.match(workerTelemetry, /developer: Boolean\(value\.developer\)/);
+assert.match(workerTelemetry, /STATS_AUDIENCES/);
+assert.match(workerTelemetry, /audience === 'players'/);
+assert.match(workerTelemetry, /UNION ALL/,
+  'ALL stats must retain the original aggregate history while including new cohort-separated data');
+assert.doesNotMatch(workerTelemetry, /INSERT INTO turn_telemetry_(?:event|raw|session)|session_hash TEXT|player_id TEXT|installation_id TEXT/i,
   'D1 must keep daily aggregate usage only, not persistent player/session histories');
 assert.match(workerTelemetry, /Authorization/);
 assert.match(workerTelemetry, /stats_unauthorized/);
 
-console.log('TURN private event-driven telemetry, privacy disclosure and stats dashboard regression passed.');
+console.log('TURN developer-filtered private telemetry, privacy disclosure and stats dashboard regression passed.');

--- a/turn/content/about-turn.js
+++ b/turn/content/about-turn.js
@@ -1,4 +1,4 @@
-import { installTurnTelemetry } from '../telemetry/client.js?revision=r1';
+import { installTurnTelemetry } from '../telemetry/client.js?revision=r2';
 
 installTurnTelemetry();
 installSharedAboutStyles();
@@ -22,9 +22,9 @@ export function aboutTurnHtml() {
         <summary>PRIVACY &amp; USAGE STATISTICS</summary>
         <div class="turn-about-privacy-copy">
           <p>TURN sends a few anonymous gameplay events to Cloudflare after a race starts so enkel.design can see whether the game is being played, which tracks and cars are used, and where the game may need improvement.</p>
-          <p>The events can include TURN or YOUR TURN, app build, track, car, motion or manual steering, browser or installed web app, Drive By Ear and blank-screen state, valid or void laps and lap time.</p>
+          <p>The events can include TURN or YOUR TURN, app build, track, car, motion or manual steering, browser or installed web app, Drive By Ear and blank-screen state, valid or void laps and lap time. Devices explicitly marked as developer in the private dashboard also send a developer yes/no flag so test activity can be excluded from player statistics.</p>
           <p>TURN’s analytics payload does not include your name, challenge name, challenge link or ID, replay, driving path, control inputs, advertising identifiers, IP address or precise location. Cloudflare processes normal network request information while carrying the events, but TURN does not add that information to its gameplay statistics.</p>
-          <p>TURN sets no analytics cookie and creates no persistent analytics identifier. A random identifier exists only in memory for the current page load so events from that one play session can be grouped; it disappears when the page is closed or reloaded.</p>
+          <p>TURN sets no analytics cookie and creates no persistent analytics identifier. A random identifier exists only in memory for the current page load so events from that one play session can be grouped; it disappears when the page is closed or reloaded. A device marked as developer stores only the same local yes/no marker used by every developer device, not a unique identifier.</p>
           <p>TURN keeps anonymous daily aggregate statistics in Cloudflare D1 for the private developer dashboard. It does not keep raw gameplay-event histories in that database. The statistics are not public and are not used for advertising.</p>
         </div>
       </details>

--- a/turn/stats/index.html
+++ b/turn/stats/index.html
@@ -8,7 +8,7 @@
   <title>TURN private usage stats</title>
   <link rel="icon" href="../TURNicon.PNG" type="image/png">
   <link rel="stylesheet" href="../design-tokens.css?build=20260808-r162">
-  <link rel="stylesheet" href="./stats.css?revision=r1">
+  <link rel="stylesheet" href="./stats.css?revision=r2">
   <script src="../ui/page-zoom-baseline-r193.js?revision=r193-canonical-75"></script>
 </head>
 <body>
@@ -36,8 +36,8 @@
     </section>
 
     <section id="statsDashboard" hidden>
-      <div class="stats-toolbar" aria-label="Statistics period">
-        <div>
+      <div class="stats-toolbar">
+        <div aria-label="Statistics period">
           <span class="toolbar-label">PERIOD</span>
           <div class="range-tabs" id="rangeTabs">
             <button type="button" data-days="1">24H</button>
@@ -47,10 +47,28 @@
             <button type="button" data-days="3650">ALL</button>
           </div>
         </div>
+        <div aria-label="Statistics audience">
+          <span class="toolbar-label">VIEW</span>
+          <div class="range-tabs audience-tabs" id="audienceTabs">
+            <button type="button" data-audience="players" aria-pressed="true">PLAYERS</button>
+            <button type="button" data-audience="all">ALL</button>
+            <button type="button" data-audience="developer">DEVELOPER</button>
+          </div>
+        </div>
         <div class="updated" id="statsUpdated" aria-live="polite"></div>
       </div>
 
-      <p class="privacy-note"><strong>PLAY SESSIONS</strong> means one page load that actually starts a race. TURN deliberately does not assign a persistent analytics identifier, so this dashboard does not pretend to count unique people.</p>
+      <p class="privacy-note" id="statsCohortNote"><strong>PLAYERS</strong> excludes telemetry from devices you mark as developer below. Developer separation starts with this update; older activity cannot be separated and therefore appears only in <strong>ALL</strong>.</p>
+
+      <section class="developer-device" aria-labelledby="developerDeviceTitle">
+        <div>
+          <span class="toolbar-label" id="developerDeviceTitle">THIS DEVICE</span>
+          <strong id="developerDeviceState">PLAYER</strong>
+          <small id="developerDeviceDescription">Future TURN activity from this browser is included in PLAYERS.</small>
+        </div>
+        <button id="toggleDeveloperDevice" type="button" aria-pressed="false">MARK AS DEVELOPER</button>
+        <p class="device-status" id="developerDeviceStatus" role="status" aria-live="polite"></p>
+      </section>
 
       <section class="metric-grid" aria-label="Headline statistics">
         <article class="metric"><span>PLAY SESSIONS</span><strong id="metricSessions">–</strong></article>
@@ -94,6 +112,6 @@
       </footer>
     </section>
   </main>
-  <script type="module" src="./stats.js?revision=r1"></script>
+  <script type="module" src="./stats.js?revision=r2"></script>
 </body>
 </html>

--- a/turn/stats/stats.css
+++ b/turn/stats/stats.css
@@ -89,6 +89,7 @@ input:focus-visible {
 .stats-access,
 .stats-toolbar,
 .privacy-note,
+.developer-device,
 .metric,
 .feature-card,
 .panel,
@@ -126,6 +127,7 @@ input:focus-visible {
 .key-row input,
 .key-row button,
 .range-tabs button,
+#toggleDeveloperDevice,
 #forgetKey {
   min-height: 48px;
   border: 4px solid var(--turn-ink, #08090a);
@@ -156,6 +158,7 @@ input:focus-visible {
 
 .stats-toolbar {
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   gap: 18px;
   align-items: end;
@@ -182,8 +185,13 @@ input:focus-visible {
   background: var(--turn-pink-500, #ff4fa3);
 }
 
+.audience-tabs button[aria-pressed="true"] {
+  background: var(--turn-blue-100, #bdeeff);
+}
+
 .updated {
   max-width: 30ch;
+  margin-left: auto;
   font-size: 0.78rem;
   text-align: right;
 }
@@ -195,6 +203,48 @@ input:focus-visible {
   background: var(--turn-paper, #fff8e8);
   font-size: 0.86rem;
   line-height: 1.45;
+}
+
+.developer-device {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px 18px;
+  align-items: center;
+  margin-top: 18px;
+  padding: 16px;
+  border-radius: 18px;
+  background: var(--turn-blue-100, #bdeeff);
+}
+
+.developer-device strong {
+  display: block;
+  margin-top: 3px;
+  font-size: clamp(1.4rem, 4vw, 2.2rem);
+  line-height: 1;
+}
+
+.developer-device small {
+  display: block;
+  max-width: 64ch;
+  margin-top: 6px;
+  font-size: 0.78rem;
+}
+
+#toggleDeveloperDevice {
+  padding: 8px 14px;
+  background: var(--turn-paper, #fff8e8);
+  box-shadow: 4px 4px 0 var(--turn-ink, #08090a);
+}
+
+#toggleDeveloperDevice[aria-pressed="true"] {
+  background: var(--turn-orange-100, #ffd0ae);
+}
+
+.device-status {
+  grid-column: 1 / -1;
+  min-height: 1.2em;
+  margin: 0;
+  font-size: 0.78rem;
 }
 
 .metric-grid {
@@ -380,7 +430,9 @@ input:focus-visible {
   .key-row { grid-template-columns: 1fr; }
   .stats-toolbar,
   .stats-footer { align-items: stretch; flex-direction: column; }
-  .updated { max-width: none; text-align: left; }
+  .updated { max-width: none; margin-left: 0; text-align: left; }
+  .developer-device { grid-template-columns: 1fr; }
+  .device-status { grid-column: 1; }
   .favourites-grid { grid-template-columns: 1fr; }
 }
 

--- a/turn/stats/stats.js
+++ b/turn/stats/stats.js
@@ -1,4 +1,5 @@
 const STATS_ENDPOINT = 'https://turn-challenges.erik-jansson-ux.workers.dev/v1/stats';
+const DEVELOPER_STORAGE_KEY = 'turn.telemetry.developer.v1';
 
 const TRACKS = Object.freeze([
   ['countryside', 'Countryside'],
@@ -32,11 +33,18 @@ const keyForm = document.querySelector('#statsKeyForm');
 const keyInput = document.querySelector('#statsKey');
 const accessStatus = document.querySelector('#statsAccessStatus');
 const rangeTabs = document.querySelector('#rangeTabs');
+const audienceTabs = document.querySelector('#audienceTabs');
 const updated = document.querySelector('#statsUpdated');
 const forgetKey = document.querySelector('#forgetKey');
+const cohortNote = document.querySelector('#statsCohortNote');
+const developerDeviceState = document.querySelector('#developerDeviceState');
+const developerDeviceDescription = document.querySelector('#developerDeviceDescription');
+const developerDeviceStatus = document.querySelector('#developerDeviceStatus');
+const toggleDeveloperDevice = document.querySelector('#toggleDeveloperDevice');
 
 let statsKey = keyFromFragment();
 let activeDays = 30;
+let activeAudience = 'players';
 let requestSequence = 0;
 
 keyForm.addEventListener('submit', (event) => {
@@ -44,7 +52,7 @@ keyForm.addEventListener('submit', (event) => {
   const key = keyInput.value.trim();
   if (!key) return;
   setKey(key);
-  void loadStats(activeDays);
+  void loadStats(activeDays, activeAudience);
 });
 
 rangeTabs.addEventListener('click', (event) => {
@@ -52,10 +60,29 @@ rangeTabs.addEventListener('click', (event) => {
   if (!button) return;
   const days = Number(button.dataset.days) || 30;
   activeDays = days;
-  for (const candidate of rangeTabs.querySelectorAll('button[data-days]')) {
-    candidate.setAttribute('aria-pressed', String(candidate === button));
+  setPressedButton(rangeTabs, button);
+  void loadStats(days, activeAudience);
+});
+
+audienceTabs.addEventListener('click', (event) => {
+  const button = event.target.closest('button[data-audience]');
+  if (!button) return;
+  const audience = String(button.dataset.audience || 'players');
+  activeAudience = ['players', 'all', 'developer'].includes(audience) ? audience : 'players';
+  setPressedButton(audienceTabs, button);
+  void loadStats(activeDays, activeAudience);
+});
+
+toggleDeveloperDevice.addEventListener('click', () => {
+  const nextValue = !isDeveloperDevice();
+  if (!setDeveloperDevice(nextValue)) {
+    developerDeviceStatus.textContent = 'This browser did not allow the developer marker to be saved.';
+    return;
   }
-  void loadStats(days);
+  renderDeveloperDevice();
+  developerDeviceStatus.textContent = nextValue
+    ? 'Marked as developer. Future TURN telemetry from this browser will be excluded from PLAYERS.'
+    : 'Developer marker removed. Future TURN telemetry from this browser will be included in PLAYERS.';
 });
 
 forgetKey.addEventListener('click', () => {
@@ -68,17 +95,22 @@ forgetKey.addEventListener('click', () => {
   keyInput.focus();
 });
 
-if (statsKey) void loadStats(activeDays);
+renderDeveloperDevice();
+if (statsKey) void loadStats(activeDays, activeAudience);
 else keyInput.focus();
 
-async function loadStats(days) {
+async function loadStats(days, audience) {
   if (!statsKey) return;
   const sequence = ++requestSequence;
   accessStatus.textContent = 'Loading private statistics…';
   updated.textContent = 'Loading…';
 
   try {
-    const response = await fetch(`${STATS_ENDPOINT}?days=${encodeURIComponent(days)}`, {
+    const query = new URLSearchParams({
+      days: String(days),
+      audience
+    });
+    const response = await fetch(`${STATS_ENDPOINT}?${query}`, {
       method: 'GET',
       mode: 'cors',
       credentials: 'omit',
@@ -139,12 +171,27 @@ function renderStats(stats) {
 
   const generatedAt = Number(stats.generatedAt) || Date.now();
   const range = Number(stats.rangeDays) === 3650 ? 'all recorded time' : `${Number(stats.rangeDays) || 30} days`;
-  updated.textContent = `${range} · refreshed ${formatDateTime(generatedAt)}`;
+  const audience = statsAudienceLabel(stats.audience);
+  updated.textContent = `${audience} · ${range} · refreshed ${formatDateTime(generatedAt)}`;
+
+  cohortNote.innerHTML = stats.audience === 'all'
+    ? '<strong>ALL</strong> combines the original unseparated history with new player and developer aggregates. Old activity cannot be retrospectively assigned to either cohort.'
+    : `<strong>${escapeHtml(audience)}</strong> contains only activity recorded after developer separation shipped. It does not guess who generated older aggregate statistics.`;
 
   const lastAt = Number(stats.lastActivityAt) || 0;
   text('#lastActivity', lastAt
-    ? `Last recorded gameplay: ${formatDateTime(lastAt)}`
-    : 'No recorded gameplay in this period yet.');
+    ? `Last recorded ${audience.toLowerCase()} gameplay: ${formatDateTime(lastAt)}`
+    : `No recorded ${audience.toLowerCase()} gameplay in this period yet.`);
+}
+
+function renderDeveloperDevice() {
+  const developer = isDeveloperDevice();
+  developerDeviceState.textContent = developer ? 'DEVELOPER' : 'PLAYER';
+  developerDeviceDescription.textContent = developer
+    ? 'Future TURN activity from this browser is excluded from PLAYERS and appears under DEVELOPER.'
+    : 'Future TURN activity from this browser is included in PLAYERS.';
+  toggleDeveloperDevice.textContent = developer ? 'REMOVE DEVELOPER MARKER' : 'MARK AS DEVELOPER';
+  toggleDeveloperDevice.setAttribute('aria-pressed', String(developer));
 }
 
 function renderFavourite(kind, rows, raceCount) {
@@ -239,6 +286,30 @@ function countMap(rows = []) {
   return new Map(rows.map((row) => [String(row.id), Number(row.count) || 0]));
 }
 
+function setPressedButton(container, activeButton) {
+  for (const candidate of container.querySelectorAll('button')) {
+    candidate.setAttribute('aria-pressed', String(candidate === activeButton));
+  }
+}
+
+function isDeveloperDevice() {
+  try {
+    return localStorage.getItem(DEVELOPER_STORAGE_KEY) === '1';
+  } catch (_) {
+    return false;
+  }
+}
+
+function setDeveloperDevice(value) {
+  try {
+    if (value) localStorage.setItem(DEVELOPER_STORAGE_KEY, '1');
+    else localStorage.removeItem(DEVELOPER_STORAGE_KEY);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
 function setKey(value) {
   statsKey = String(value || '').trim();
   if (!statsKey) return;
@@ -249,6 +320,12 @@ function keyFromFragment() {
   const raw = location.hash.slice(1);
   if (!raw) return '';
   try { return decodeURIComponent(raw).trim(); } catch (_) { return raw.trim(); }
+}
+
+function statsAudienceLabel(value) {
+  if (value === 'developer') return 'DEVELOPER';
+  if (value === 'all') return 'ALL';
+  return 'PLAYERS';
 }
 
 function text(selector, value) {

--- a/turn/telemetry/client.js
+++ b/turn/telemetry/client.js
@@ -1,7 +1,8 @@
 const TELEMETRY_ENDPOINT = 'https://turn-challenges.erik-jansson-ux.workers.dev/v1/telemetry';
-const CLIENT_VERSION = 1;
+const CLIENT_VERSION = 2;
 const FLUSH_DELAY_MS = 120;
 const MAX_BATCH = 8;
+const DEVELOPER_STORAGE_KEY = 'turn.telemetry.developer.v1';
 
 let installed = false;
 let playSessionSent = false;
@@ -21,7 +22,8 @@ export function installTurnTelemetry() {
     version: CLIENT_VERSION,
     record: queueEvent,
     flush: flushQueue,
-    sessionId
+    sessionId,
+    isDeveloperDevice
   });
   globalThis.__turnTelemetry = api;
 
@@ -72,6 +74,7 @@ function queueEvent(event, extra = {}) {
     installed: isInstalledWebApp(),
     driveByEar: audio.dbeEnabled === true,
     blank: document.documentElement.classList.contains('turn-screen-blanked'),
+    developer: isDeveloperDevice(),
     occurredAt: Date.now(),
     value: Number(extra.value) || 0,
     reason: String(extra.reason || '')
@@ -132,6 +135,14 @@ function isInstalledWebApp() {
     || navigator.standalone === true
     || globalThis.matchMedia?.('(display-mode: standalone)').matches === true
     || globalThis.matchMedia?.('(display-mode: fullscreen)').matches === true;
+}
+
+function isDeveloperDevice() {
+  try {
+    return localStorage.getItem(DEVELOPER_STORAGE_KEY) === '1';
+  } catch (_) {
+    return false;
+  }
 }
 
 function createSessionId() {

--- a/workers/turn-challenges/README.md
+++ b/workers/turn-challenges/README.md
@@ -18,10 +18,10 @@ There is intentionally no update or delete API for challenge snapshots. Two peop
 ## Private usage statistics
 
 - `POST /v1/telemetry` — accepts a small batch of allow-listed gameplay events from TURN/YOUR TURN.
-- `GET /v1/stats?days=30` — returns anonymous aggregate statistics to the private dashboard after bearer-key authentication.
+- `GET /v1/stats?days=30&audience=players` — returns anonymous aggregate statistics to the private dashboard after bearer-key authentication. `audience` can be `players`, `developer` or `all`; omitted/invalid values preserve the legacy `all` behavior.
 - D1 stores daily aggregate counts only. It does not store player IDs, page-session IDs or raw gameplay-event histories.
 
-TURN does not create an analytics cookie or persistent analytics identifier. A random page-session identifier exists only in browser memory and is never written to D1. Telemetry starts only after a race actually starts and is event-driven rather than frame-driven.
+TURN does not create an analytics cookie or persistent analytics identifier. A random page-session identifier exists only in browser memory and is never written to D1. Telemetry starts only after a race actually starts and is event-driven rather than frame-driven. Devices explicitly marked from the private dashboard store a local developer yes/no marker; that shared boolean is not unique to a device or person.
 
 Current event types are deliberately small:
 
@@ -30,14 +30,15 @@ Current event types are deliberately small:
 - `lap_complete`
 - `lap_invalid`
 
-Dimensions are limited to product surface, build, track, car, steering mode, browser/installed web app, Drive By Ear state, blank-screen state, lap time and invalid-lap reason. Names, challenge IDs/links, replay data, driving paths, control streams and precise location are not part of the analytics payload.
+Dimensions are limited to product surface, build, track, car, steering mode, browser/installed web app, Drive By Ear state, blank-screen state, developer yes/no, lap time and invalid-lap reason. Names, challenge IDs/links, replay data, driving paths, control streams and precise location are not part of the analytics payload.
 
-The private dashboard is a static page under `/turn/stats/`. It is `noindex`, unlinked from TURN and protected at the API layer by a bearer key whose plaintext is not committed to the repository.
+The private dashboard is a static page under `/turn/stats/`. It is `noindex`, unlinked from TURN and protected at the API layer by a bearer key whose plaintext is not committed to the repository. The `PLAYERS` view excludes developer-marked devices; `DEVELOPER` shows only those devices; `ALL` combines the original unseparated history with the newer cohort-separated aggregates.
 
 ## Storage and safety boundaries
 
 - D1 binding: `DB`.
 - Tables are created lazily with `CREATE TABLE IF NOT EXISTS`; deployment does not require a separate migration step.
+- The original `turn_telemetry_daily` table remains read-only legacy history. New events are written to `turn_telemetry_daily_v2`, whose primary key adds the developer boolean so player and developer activity never collapse into one daily aggregate.
 - Exact duplicate challenge payloads reuse the same snapshot ID; different challenge generations get different immutable snapshots.
 - Browser writes are accepted only with an `Origin` of `https://enkel.design` (or `https://www.enkel.design`). This is an origin guard, not user authentication.
 - Request and decompressed-payload limits protect the challenge store from accidental oversized writes.

--- a/workers/turn-challenges/src/telemetry.js
+++ b/workers/turn-challenges/src/telemetry.js
@@ -1,4 +1,4 @@
-const TELEMETRY_API_VERSION = 1;
+const TELEMETRY_API_VERSION = 2;
 const MAX_BODY_BYTES = 16 * 1024;
 const MAX_EVENTS_PER_REQUEST = 8;
 const STATS_KEY_SHA256 = '18379b62d01eb7c33cf5bc56a9076268425a43eb17797a9bb4129306044c9803';
@@ -8,6 +8,7 @@ const TELEMETRY_EVENTS = new Set([
   'lap_complete',
   'lap_invalid'
 ]);
+const STATS_AUDIENCES = new Set(['players', 'all', 'developer']);
 const ALLOWED_ORIGINS = new Set([
   'https://enkel.design',
   'https://www.enkel.design'
@@ -54,7 +55,8 @@ export async function handleTelemetryRoute(request, env = {}, ctx = null) {
       requireAllowedOrigin(request, { allowMissing: true });
       await requireStatsKey(request);
       const days = normalizeDays(url.searchParams.get('days'));
-      const stats = await loadStats(env.DB, days);
+      const audience = normalizeAudience(url.searchParams.get('audience'));
+      const stats = await loadStats(env.DB, days, audience);
       return jsonResponse(stats, 200, request);
     }
 
@@ -94,7 +96,8 @@ async function recordTelemetryEvents(env, events) {
           event.value,
           event.installed ? 1 : 0,
           event.driveByEar ? 1 : 0,
-          event.blank ? 1 : 0
+          event.blank ? 1 : 0,
+          event.developer ? 1 : 0
         ]
       });
     } catch (error) {
@@ -107,14 +110,14 @@ async function recordTelemetryEvents(env, events) {
 async function upsertAggregate(db, event) {
   const day = new Date(event.occurredAt).toISOString().slice(0, 10);
   await db.prepare(`
-    INSERT INTO turn_telemetry_daily (
+    INSERT INTO turn_telemetry_daily_v2 (
       day, event, surface, track_id, car_id, steering,
-      installed, drive_by_ear, blank_screen,
+      installed, drive_by_ear, blank_screen, developer,
       count, value_sum, last_at
-    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 1, ?10, ?11)
+    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 1, ?11, ?12)
     ON CONFLICT (
       day, event, surface, track_id, car_id, steering,
-      installed, drive_by_ear, blank_screen
+      installed, drive_by_ear, blank_screen, developer
     ) DO UPDATE SET
       count = count + 1,
       value_sum = value_sum + excluded.value_sum,
@@ -129,14 +132,16 @@ async function upsertAggregate(db, event) {
     event.installed ? 1 : 0,
     event.driveByEar ? 1 : 0,
     event.blank ? 1 : 0,
+    event.developer ? 1 : 0,
     event.value,
     event.occurredAt
   ).run();
 }
 
-async function loadStats(db, days) {
+async function loadStats(db, days, audience) {
   await ensureTelemetrySchema(db);
   const sinceDay = utcDay(Date.now() - (days - 1) * 86_400_000);
+  const source = statsSource(audience);
   const [
     totalsRows,
     trackRows,
@@ -151,59 +156,59 @@ async function loadStats(db, days) {
   ] = await Promise.all([
     allRows(db.prepare(`
       SELECT event, SUM(count) AS count, SUM(value_sum) AS value_sum
-      FROM turn_telemetry_daily
+      FROM ${source}
       WHERE day >= ?1
       GROUP BY event
     `).bind(sinceDay)),
     allRows(db.prepare(`
       SELECT track_id AS id, SUM(count) AS count
-      FROM turn_telemetry_daily
+      FROM ${source}
       WHERE day >= ?1 AND event = 'race_start' AND track_id <> ''
       GROUP BY track_id ORDER BY count DESC
     `).bind(sinceDay)),
     allRows(db.prepare(`
       SELECT car_id AS id, SUM(count) AS count
-      FROM turn_telemetry_daily
+      FROM ${source}
       WHERE day >= ?1 AND event = 'race_start' AND car_id <> ''
       GROUP BY car_id ORDER BY count DESC
     `).bind(sinceDay)),
     allRows(db.prepare(`
       SELECT surface AS id, SUM(count) AS count
-      FROM turn_telemetry_daily
+      FROM ${source}
       WHERE day >= ?1 AND event = 'play_session'
       GROUP BY surface ORDER BY count DESC
     `).bind(sinceDay)),
     allRows(db.prepare(`
       SELECT steering AS id, SUM(count) AS count
-      FROM turn_telemetry_daily
+      FROM ${source}
       WHERE day >= ?1 AND event = 'race_start' AND steering <> ''
       GROUP BY steering ORDER BY count DESC
     `).bind(sinceDay)),
     allRows(db.prepare(`
       SELECT installed AS id, SUM(count) AS count
-      FROM turn_telemetry_daily
+      FROM ${source}
       WHERE day >= ?1 AND event = 'race_start'
       GROUP BY installed ORDER BY count DESC
     `).bind(sinceDay)),
     allRows(db.prepare(`
       SELECT drive_by_ear AS id, SUM(count) AS count
-      FROM turn_telemetry_daily
+      FROM ${source}
       WHERE day >= ?1 AND event = 'race_start'
       GROUP BY drive_by_ear ORDER BY count DESC
     `).bind(sinceDay)),
     allRows(db.prepare(`
       SELECT blank_screen AS id, SUM(count) AS count
-      FROM turn_telemetry_daily
+      FROM ${source}
       WHERE day >= ?1 AND event = 'lap_complete'
       GROUP BY blank_screen ORDER BY count DESC
     `).bind(sinceDay)),
     allRows(db.prepare(`
       SELECT track_id AS id, SUM(count) AS count, SUM(value_sum) AS value_sum
-      FROM turn_telemetry_daily
+      FROM ${source}
       WHERE day >= ?1 AND event = 'lap_complete' AND track_id <> ''
       GROUP BY track_id ORDER BY count DESC
     `).bind(sinceDay)),
-    db.prepare('SELECT MAX(last_at) AS last_at FROM turn_telemetry_daily WHERE day >= ?1').bind(sinceDay).first()
+    db.prepare(`SELECT MAX(last_at) AS last_at FROM ${source} WHERE day >= ?1`).bind(sinceDay).first()
   ]);
 
   const totals = Object.fromEntries(totalsRows.map((row) => [
@@ -213,6 +218,8 @@ async function loadStats(db, days) {
   return {
     version: TELEMETRY_API_VERSION,
     rangeDays: days,
+    audience,
+    includesLegacyUnseparatedStats: audience === 'all',
     sinceDay,
     generatedAt: Date.now(),
     lastActivityAt: Number(lastRow?.last_at) || 0,
@@ -235,6 +242,24 @@ async function loadStats(db, days) {
       average: Number(row.count) > 0 ? (Number(row.value_sum) || 0) / Number(row.count) : 0
     }))
   };
+}
+
+function statsSource(audience) {
+  const columns = [
+    'day', 'event', 'surface', 'track_id', 'car_id', 'steering',
+    'installed', 'drive_by_ear', 'blank_screen', 'count', 'value_sum', 'last_at'
+  ].join(', ');
+  if (audience === 'developer') {
+    return `(SELECT ${columns} FROM turn_telemetry_daily_v2 WHERE developer = 1)`;
+  }
+  if (audience === 'players') {
+    return `(SELECT ${columns} FROM turn_telemetry_daily_v2 WHERE developer = 0)`;
+  }
+  return `(
+    SELECT ${columns} FROM turn_telemetry_daily
+    UNION ALL
+    SELECT ${columns} FROM turn_telemetry_daily_v2
+  )`;
 }
 
 function normalizeTelemetryEvent(value) {
@@ -262,6 +287,7 @@ function normalizeTelemetryEvent(value) {
     installed: Boolean(value.installed),
     driveByEar: Boolean(value.driveByEar),
     blank: Boolean(value.blank),
+    developer: Boolean(value.developer),
     value: finiteNumber(value.value, 0, 600),
     occurredAt: finiteInteger(value.occurredAt, Date.now() - 86_400_000, Date.now() + 300_000, Date.now())
   });
@@ -289,6 +315,27 @@ async function ensureTelemetrySchema(db) {
       PRIMARY KEY (
         day, event, surface, track_id, car_id, steering,
         installed, drive_by_ear, blank_screen
+      )
+    )
+  `).run();
+  await db.prepare(`
+    CREATE TABLE IF NOT EXISTS turn_telemetry_daily_v2 (
+      day TEXT NOT NULL,
+      event TEXT NOT NULL,
+      surface TEXT NOT NULL,
+      track_id TEXT NOT NULL,
+      car_id TEXT NOT NULL,
+      steering TEXT NOT NULL,
+      installed INTEGER NOT NULL,
+      drive_by_ear INTEGER NOT NULL,
+      blank_screen INTEGER NOT NULL,
+      developer INTEGER NOT NULL,
+      count INTEGER NOT NULL DEFAULT 0,
+      value_sum REAL NOT NULL DEFAULT 0,
+      last_at INTEGER NOT NULL,
+      PRIMARY KEY (
+        day, event, surface, track_id, car_id, steering,
+        installed, drive_by_ear, blank_screen, developer
       )
     )
   `).run();
@@ -369,6 +416,11 @@ function normalizeDays(value) {
   const days = Math.round(Number(value) || 30);
   if ([1, 7, 30, 90, 3650].includes(days)) return days;
   return 30;
+}
+
+function normalizeAudience(value) {
+  const audience = String(value || 'players').trim().toLowerCase();
+  return STATS_AUDIENCES.has(audience) ? audience : 'players';
 }
 
 function utcDay(timestamp) {

--- a/workers/turn-challenges/src/telemetry.js
+++ b/workers/turn-challenges/src/telemetry.js
@@ -419,8 +419,8 @@ function normalizeDays(value) {
 }
 
 function normalizeAudience(value) {
-  const audience = String(value || 'players').trim().toLowerCase();
-  return STATS_AUDIENCES.has(audience) ? audience : 'players';
+  const audience = String(value || 'all').trim().toLowerCase();
+  return STATS_AUDIENCES.has(audience) ? audience : 'all';
 }
 
 function utcDay(timestamp) {

--- a/workers/turn-challenges/test/telemetry.test.js
+++ b/workers/turn-challenges/test/telemetry.test.js
@@ -40,9 +40,9 @@ class FakeStatement {
     if (this.sql.startsWith('CREATE TABLE IF NOT EXISTS turn_telemetry_daily')) {
       return { success: true, meta: { changes: 0 } };
     }
-    if (this.sql.startsWith('INSERT INTO turn_telemetry_daily')) {
-      const [day, event, surface, trackId, carId, steering, installed, driveByEar, blank, value, lastAt] = this.values;
-      const key = [day, event, surface, trackId, carId, steering, installed, driveByEar, blank].join('|');
+    if (this.sql.startsWith('INSERT INTO turn_telemetry_daily_v2')) {
+      const [day, event, surface, trackId, carId, steering, installed, driveByEar, blank, developer, value, lastAt] = this.values;
+      const key = [day, event, surface, trackId, carId, steering, installed, driveByEar, blank, developer].join('|');
       const existing = this.db.rows.get(key) || { count: 0, value_sum: 0, last_at: 0 };
       this.db.rows.set(key, {
         day,
@@ -54,6 +54,7 @@ class FakeStatement {
         installed,
         drive_by_ear: driveByEar,
         blank_screen: blank,
+        developer,
         count: existing.count + 1,
         value_sum: existing.value_sum + value,
         last_at: Math.max(existing.last_at, lastAt)
@@ -76,6 +77,7 @@ function event(overrides = {}) {
     installed: true,
     driveByEar: true,
     blank: false,
+    developer: false,
     occurredAt: Date.now(),
     value: 0,
     reason: '',
@@ -94,7 +96,7 @@ function post(events, origin = ORIGIN) {
   });
 }
 
-await test('accepts a small gameplay batch and writes aggregate plus Analytics Engine point', async () => {
+await test('accepts a small gameplay batch and writes cohort aggregate plus Analytics Engine point', async () => {
   const DB = new FakeD1();
   const ANALYTICS = new FakeAnalytics();
   const response = await handleTelemetryRoute(post([
@@ -114,13 +116,14 @@ await test('accepts a small gameplay batch and writes aggregate plus Analytics E
   assert.equal(point.blobs[2], 'countryside');
   assert.equal(point.blobs[3], 'classic');
   assert.equal(point.blobs[4], 'motion');
+  assert.equal(point.doubles[4], 0);
   assert.match(point.indexes[0], /^[a-f0-9]{64}$/);
   assert.notEqual(point.indexes[0], event().session, 'The ephemeral page-session ID must be hashed before Analytics Engine');
   assert.equal(JSON.stringify(point).includes('ERIK'), false);
   assert.equal(JSON.stringify(point).includes('challenge'), false);
 });
 
-await test('aggregates repeated events without keeping page-session identifiers in D1', async () => {
+await test('aggregates repeated player events without keeping page-session identifiers in D1', async () => {
   const DB = new FakeD1();
   const ANALYTICS = new FakeAnalytics();
   const first = event({ event: 'race_start' });
@@ -130,8 +133,24 @@ await test('aggregates repeated events without keeping page-session identifiers 
   assert.equal(DB.rows.size, 1);
   const [row] = DB.rows.values();
   assert.equal(row.count, 2);
+  assert.equal(row.developer, 0);
   assert.equal(Object.hasOwn(row, 'session'), false);
   assert.equal(Object.hasOwn(row, 'session_hash'), false);
+});
+
+await test('keeps developer and player activity in separate daily aggregates', async () => {
+  const DB = new FakeD1();
+  const ANALYTICS = new FakeAnalytics();
+  await handleTelemetryRoute(post([
+    event({ event: 'race_start', developer: false }),
+    event({ event: 'race_start', session: 'zT8mQ2pR6vN4cK7sL1xF5B', developer: true })
+  ]), { DB, ANALYTICS });
+
+  assert.equal(DB.rows.size, 2);
+  const cohorts = [...DB.rows.values()].map((row) => row.developer).sort();
+  assert.deepEqual(cohorts, [0, 1]);
+  assert.equal(ANALYTICS.points[0].doubles[4], 0);
+  assert.equal(ANALYTICS.points[1].doubles[4], 1);
 });
 
 await test('rejects telemetry writes outside enkel.design', async () => {
@@ -145,7 +164,7 @@ await test('rejects telemetry writes outside enkel.design', async () => {
 
 await test('keeps the private stats endpoint closed without a dashboard key', async () => {
   const response = await handleTelemetryRoute(new Request(
-    'https://turn-challenges.example/v1/stats?days=30',
+    'https://turn-challenges.example/v1/stats?days=30&audience=players',
     { headers: { Origin: ORIGIN } }
   ), { DB: new FakeD1() });
   assert.equal(response.status, 401);


### PR DESCRIPTION
## Summary
- add a private-dashboard marker that tags the current browser as developer without creating a persistent player identifier
- split new D1 daily telemetry aggregates by developer yes/no while retaining the original aggregate table as read-only legacy history
- make PLAYERS the dashboard default, with ALL and DEVELOPER views
- keep omitted/legacy stats API requests on ALL for rollout compatibility
- update the in-game privacy disclosure and Worker documentation
- extend telemetry regression tests for the developer cohort boundary

## Privacy boundary
The marker is a single local boolean shared by every developer-marked browser. TURN still creates no persistent analytics/player identifier and D1 still stores only daily aggregates, not raw events or page-session IDs.

## Historical behavior
Older aggregate activity cannot be separated retrospectively. ALL retains that history; PLAYERS and DEVELOPER only contain cohort-separated events recorded after this ships.

## Validation
GitHub Actions should run both the TURN static telemetry regression and the Worker contract/dry-run checks on this PR.