### PR TITLE
Reuse canonical lock icon in The Lot

### DIFF
--- a/turn-lab/tests/lot-layout-production.mjs
+++ b/turn-lab/tests/lot-layout-production.mjs
@@ -62,8 +62,8 @@ assert.ok(
 );
 
 assert.match(wrapper, /export async function showEnhancedLot/);
-assert.match(wrapper, /lot-r10\.js\?build=20260809-r163-native-html&revision=r589-beginner-bubble/,
-  'The wrapper must load the polished beginner-bubble Lot implementation under a fresh URL');
+assert.match(wrapper, /lot-r10\.js\?build=20260809-r163-native-html&revision=r590-canonical-lock-icon/,
+  'The wrapper must load the canonical-lock Lot implementation under a fresh URL');
 assert.match(wrapper, /lot-enhancement-runtime\.js\?revision=r588-canonical-attributes/,
   'The wrapper must load the canonical-attribute accessibility bundle');
 assert.match(wrapper, /const removeEnhancements = enhanceLotNow\(\)/);
@@ -142,6 +142,12 @@ assert.match(lot, /turnLotPadPointer/,
 assert.match(lot, /function makeLockMarker\(\)/);
 assert.match(lot, /classList\.contains\('is-trophy-locked'\)/,
   '3D lock markers must follow the existing Trophy Road gate');
+assert.match(lot, /import \{ LOCK_ICON \} from '\.\.\/progression\/trophy-road\.js/,
+  'The Lot must reuse the canonical Trophy Road lock icon instead of drawing a second lock shape');
+assert.match(lot, /LOCK_ICON[\s\S]*new THREE\.TextureLoader\(\)\.load/,
+  'The canonical lock SVG must be rasterized directly into the 3D lock badge texture');
+assert.doesNotMatch(lot, /ctx\.arc\(80, 64, 34/,
+  'The old hand-drawn 3D padlock must not return');
 assert.match(lot, /function makeBeginnerFriendlyMarker\(\)/);
 assert.match(lot, /sprite\.scale\.set\(5\.7, 3\.15, 1\)/,
   'The polished speech bubble must preserve the reference-like wider rounded silhouette');

--- a/turn/garage/lot-r10.js
+++ b/turn/garage/lot-r10.js
@@ -13,6 +13,7 @@ import {
 import { createCarVisual, recolorCarVisual } from '../vehicle/car-models.js?build=20260720-r22';
 import { recordPerformanceFrame } from '../performance-monitor.js?build=20260720-r20';
 import { describeColorCue } from '../accessibility/color-cues.js?revision=r163';
+import { LOCK_ICON } from '../progression/trophy-road.js?revision=r166-bella-records';
 import {
   hasTriedTrainingCar,
   installTrainingCarGuide,
@@ -794,35 +795,24 @@ function makeBeginnerFriendlyMarker() {
 
 function getLockBadgeTexture() {
   if (lockBadgeTexture) return lockBadgeTexture;
-  const canvas = document.createElement('canvas');
-  canvas.width = 160;
-  canvas.height = 160;
-  const ctx = canvas.getContext('2d');
-  ctx.clearRect(0, 0, 160, 160);
 
-  ctx.lineCap = 'round';
-  ctx.lineJoin = 'round';
-  ctx.strokeStyle = '#08090a';
-  ctx.lineWidth = 11;
-  ctx.beginPath();
-  ctx.arc(80, 64, 34, Math.PI, 0);
-  ctx.lineTo(114, 86);
-  ctx.stroke();
+  const icon = LOCK_ICON
+    .replace(/^<svg[^>]*>/, '')
+    .replace(/<\/svg>$/, '');
+  const svg = `
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
+      <rect x="18" y="18" width="124" height="124" rx="28"
+        fill="#ffd43b" stroke="#08090a" stroke-width="10"/>
+      <g transform="translate(40 40) scale(3.333333)"
+        fill="none" stroke="#08090a" stroke-width="2.4"
+        stroke-linecap="round" stroke-linejoin="round">
+        ${icon}
+      </g>
+    </svg>`;
 
-  roundedRectPath(ctx, 30, 72, 100, 70, 14);
-  ctx.fillStyle = '#ffd43b';
-  ctx.fill();
-  ctx.strokeStyle = '#08090a';
-  ctx.lineWidth = 9;
-  ctx.stroke();
-
-  ctx.fillStyle = '#08090a';
-  ctx.beginPath();
-  ctx.arc(80, 104, 9, 0, Math.PI * 2);
-  ctx.fill();
-  ctx.fillRect(76, 108, 8, 18);
-
-  lockBadgeTexture = new THREE.CanvasTexture(canvas);
+  lockBadgeTexture = new THREE.TextureLoader().load(
+    `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
+  );
   lockBadgeTexture.colorSpace = THREE.SRGBColorSpace;
   return lockBadgeTexture;
 }
@@ -885,21 +875,6 @@ function getBeginnerBadgeTexture() {
   beginnerBadgeTexture = new THREE.CanvasTexture(canvas);
   beginnerBadgeTexture.colorSpace = THREE.SRGBColorSpace;
   return beginnerBadgeTexture;
-}
-
-function roundedRectPath(ctx, x, y, width, height, radius) {
-  const r = Math.min(radius, width / 2, height / 2);
-  ctx.beginPath();
-  ctx.moveTo(x + r, y);
-  ctx.lineTo(x + width - r, y);
-  ctx.quadraticCurveTo(x + width, y, x + width, y + r);
-  ctx.lineTo(x + width, y + height - r);
-  ctx.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
-  ctx.lineTo(x + r, y + height);
-  ctx.quadraticCurveTo(x, y + height, x, y + height - r);
-  ctx.lineTo(x, y + r);
-  ctx.quadraticCurveTo(x, y, x + r, y);
-  ctx.closePath();
 }
 
 function findCarId(object) {

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -11,7 +11,7 @@ import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
 let originalLotPromise = null;
 function loadOriginalLot() {
   if (!originalLotPromise) {
-    originalLotPromise = import('./lot-r10.js?build=20260809-r163-native-html&revision=r589-beginner-bubble');
+    originalLotPromise = import('./lot-r10.js?build=20260809-r163-native-html&revision=r590-canonical-lock-icon');
   }
   return originalLotPromise;
 }


### PR DESCRIPTION
## Summary
- replace the separately hand-drawn 3D Lot padlock with TURN’s existing canonical `LOCK_ICON`
- keep the yellow outlined badge and current locked-car placement, but rasterize the same SVG used by Trophy Road notices, selected-car state and the disabled race action
- remove the duplicate canvas padlock drawing
- cache-bust the on-demand Lot module and guard the canonical icon reuse in the Lot regression

## Why
The locked-car marker and the unlock notice were using two near-identical but different lock drawings. This makes the lock beside the cars use the existing TURN lock icon shown in the notice.

## Validation
The full TURN regression suite will run on this PR, including the focused Lot layout contract.