### PR TITLE
Simplify The Lot loading placeholders

### DIFF
--- a/turn-tests/m8-lot-selection-production.mjs
+++ b/turn-tests/m8-lot-selection-production.mjs
@@ -1,10 +1,11 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [m8Home, showroom, showroomCss, wrapper, accessibility] = await Promise.all([
+const [m8Home, showroom, showroomCss, showroomCleanupCss, wrapper, accessibility] = await Promise.all([
   fs.readFile(new URL('../turn/m8-home.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/garage/lot-showroom-experiment.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/garage/lot-showroom-experiment.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/garage/lot-showroom-cleanup-r201.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/garage/lot-track-select.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/garage/lot-accessibility-r118.js', import.meta.url), 'utf8')
 ]);
@@ -47,8 +48,10 @@ assert.match(wrapper, /lot-showroom-experiment\.js\?revision=r200-production-can
   'The production wrapper must lazy-load the current showroom implementation');
 assert.match(wrapper, /lot-showroom-experiment\.css\?revision=r200-production-candidate/,
   'The showroom stylesheet must have its own cache identity');
+assert.match(wrapper, /lot-showroom-cleanup-r201\.css\?revision=r201-loading-cleanup/,
+  'The production wrapper must preload the small showroom polish layer before mount');
 assert.match(wrapper, /link\.addEventListener\('load', resolve/,
-  'The Lot must wait for its showroom stylesheet before mounting to avoid a legacy-layout flash');
+  'The Lot must wait for its showroom stylesheets before mounting to avoid a layout flash');
 
 assert.match(showroom, /overlay\.className = 'lot-screen lot-showroom'/,
   'The production car selector must mount with the stable showroom state hook');
@@ -103,6 +106,24 @@ assert.match(
 assert.match(showroomCss, /\.lot-showroom \.lot-car-option\.has-3d-thumbnail \.lot-car-option-thumbnail \{ opacity: 1; \}/,
   'Cards must progressively replace their lightweight fallback with the real model thumbnail');
 
+assert.match(
+  showroomCleanupCss,
+  /\.lot-showroom \.lot-viewbox::before\s*\{[\s\S]*content: none;[\s\S]*display: none;/,
+  'The 3D hero view must not carry the redundant decorative TURN sign'
+);
+assert.match(
+  showroomCleanupCss,
+  /\.lot-showroom \.lot-car-option-fallback i:first-child[\s\S]*background: var\(--lot-car-color/,
+  'Thumbnail loading fallback must be a simple block using the car body colour'
+);
+assert.match(
+  showroomCleanupCss,
+  /\.lot-showroom \.lot-car-option-fallback i:nth-child\(2\),[\s\S]*i:nth-child\(3\)[\s\S]*display: none;/,
+  'Thumbnail loading fallback must not draw wheels or other hand-drawn car details'
+);
+assert.doesNotMatch(showroomCleanupCss, /lot-car-secondary/,
+  'The loading placeholder should stay deliberately abstract instead of trying to mimic the finished car');
+
 assert.match(accessibility, /screen\.classList\.contains\('lot-showroom'\)/,
   'Accessibility behavior must explicitly recognize the visible showroom radio rail');
 assert.match(accessibility, /if \(!preserveVisualOrder && selectedCarId/,
@@ -112,4 +133,4 @@ assert.match(accessibility, /aria-setsize/);
 assert.match(accessibility, /describeVehicleStats\(car\.stats\)/,
   'Screen-reader vehicle summaries must still use the same canonical attributes as the visible panel');
 
-console.log('TURN M8 Home now enters a prepared production showroom Lot with compact paint, yaw-only level car rotation, real 3D car thumbnails, bounded rendering and stable accessible card order.');
+console.log('TURN M8 Home now enters a prepared production showroom Lot with compact paint, yaw-only level car rotation, simple colour-block loading placeholders, real 3D car thumbnails, bounded rendering and stable accessible card order.');

--- a/turn/garage/lot-showroom-cleanup-r201.css
+++ b/turn/garage/lot-showroom-cleanup-r201.css
@@ -1,0 +1,26 @@
+/* Small production polish layered over the showroom base stylesheet. */
+
+/* Keep the hero view clean: the page title already identifies TURN. */
+.lot-showroom .lot-viewbox::before {
+  content: none;
+  display: none;
+}
+
+/* While real 3D thumbnails are rendered, show only a simple colour swatch shape. */
+.lot-showroom .lot-car-option-fallback i:first-child {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 56%;
+  height: 28%;
+  border: 2px solid var(--ink, #08090a);
+  border-radius: 5px;
+  transform: translate(-50%, -50%);
+  background: var(--lot-car-color, #8ce99a);
+  box-shadow: 0 3px 0 rgb(8 9 10 / .14);
+}
+
+.lot-showroom .lot-car-option-fallback i:nth-child(2),
+.lot-showroom .lot-car-option-fallback i:nth-child(3) {
+  display: none;
+}

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -12,32 +12,46 @@ import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
 // its existing Race This Car motion-access gate can bind immediately after mount.
 
 // Keep the showroom implementation and its CSS out of TURN's initial module graph.
-// Choosing or activating a track gives us a natural warmup window for both resources.
+// Choosing or activating a track gives us a natural warmup window for these resources.
 const SHOWROOM_STYLE_ID = 'turn-lot-showroom-r200';
+const SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r201-cleanup';
 let showroomStylePromise = null;
 let originalLotPromise = null;
 let originalLotModule = null;
 
-function prepareShowroomStyles() {
-  if (showroomStylePromise) return showroomStylePromise;
-  showroomStylePromise = new Promise((resolve) => {
-    const existing = document.getElementById(SHOWROOM_STYLE_ID);
+function prepareStylesheet(id, relativeUrl) {
+  return new Promise((resolve) => {
+    const existing = document.getElementById(id);
     if (existing) {
       resolve();
       return;
     }
 
     const link = document.createElement('link');
-    link.id = SHOWROOM_STYLE_ID;
+    link.id = id;
     link.rel = 'stylesheet';
-    link.href = new URL('./lot-showroom-experiment.css?revision=r200-production-candidate', import.meta.url).href;
+    link.href = new URL(relativeUrl, import.meta.url).href;
     link.addEventListener('load', resolve, { once: true });
     link.addEventListener('error', () => {
-      console.warn('TURN: showroom stylesheet could not be loaded.');
+      console.warn(`TURN: showroom stylesheet could not be loaded: ${relativeUrl}`);
       resolve();
     }, { once: true });
     document.head.appendChild(link);
   });
+}
+
+function prepareShowroomStyles() {
+  if (showroomStylePromise) return showroomStylePromise;
+  showroomStylePromise = Promise.all([
+    prepareStylesheet(
+      SHOWROOM_STYLE_ID,
+      './lot-showroom-experiment.css?revision=r200-production-candidate'
+    ),
+    prepareStylesheet(
+      SHOWROOM_CLEANUP_STYLE_ID,
+      './lot-showroom-cleanup-r201.css?revision=r201-loading-cleanup'
+    )
+  ]);
   return showroomStylePromise;
 }
 


### PR DESCRIPTION
## Summary
- replace the temporary hand-drawn car fallback in THE LOT rail with one simple rectangle in the car body colour
- remove the redundant decorative TURN sign from the 3D hero view
- keep real 3D thumbnails, locks, selection states and renderer behavior unchanged
- add focused regression coverage for both polish details

This is a presentation-only follow-up to #597.