### PR TITLE
Give The Lot a screen-reader-first semantic structure

### DIFF
--- a/turn-tests/m8-lot-selection-production.mjs
+++ b/turn-tests/m8-lot-selection-production.mjs
@@ -1,13 +1,14 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [m8Home, showroom, showroomCss, showroomCleanupCss, wrapper, accessibility] = await Promise.all([
+const [m8Home, showroom, showroomCss, showroomCleanupCss, wrapper, accessibility, screenReaderPass] = await Promise.all([
   fs.readFile(new URL('../turn/m8-home.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/garage/lot-showroom-experiment.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/garage/lot-showroom-experiment.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/garage/lot-showroom-cleanup-r201.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/garage/lot-track-select.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/garage/lot-accessibility-r118.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/garage/lot-accessibility-r118.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/garage/lot-screen-reader-r202.js', import.meta.url), 'utf8')
 ]);
 
 assert.match(
@@ -39,11 +40,19 @@ assert.match(wrapper, /export async function prepareEnhancedLot/,
 assert.match(wrapper, /let originalLotModule = null/);
 assert.match(wrapper, /originalLotModule = module/,
   'Warmup must retain the resolved showroom module for synchronous mounting');
+assert.match(wrapper, /lot-screen-reader-r202\.js\?revision=r202-heading-structure/,
+  'The production wrapper must preload the showroom-specific screen reader pass');
+assert.match(wrapper, /screenReaderPassModule = module/,
+  'The prepared accessibility pass must be retained for synchronous showroom mounting');
 assert.match(wrapper, /function mountEnhancedLot\(options\)/,
   'Prepared callers must have a synchronous showroom mount path');
+assert.match(wrapper, /const removeEnhancements = enhanceLotNow\(\);[\s\S]*const removeScreenReaderPass = installLotScreenReaderPass\(\);/,
+  'The semantic pass must run after established Trophy Road, paint, perk and layout enhancements have produced their final DOM');
+assert.match(wrapper, /removeScreenReaderPass\(\);[\s\S]*removeEnhancements\(\);/,
+  'Showroom semantic cleanup must release before the underlying enhancement bundle');
 assert.match(wrapper, /export function showEnhancedLot/);
-assert.match(wrapper, /if \(originalLotModule\) return mountEnhancedLot\(options\)/,
-  'M8 must not cross another asynchronous boundary once the showroom has been prepared');
+assert.match(wrapper, /if \(originalLotModule && screenReaderPassModule\) return mountEnhancedLot\(options\)/,
+  'M8 must not cross another asynchronous boundary once the showroom and semantic pass have been prepared');
 assert.match(wrapper, /lot-showroom-experiment\.js\?revision=r200-production-candidate/,
   'The production wrapper must lazy-load the current showroom implementation');
 assert.match(wrapper, /lot-showroom-experiment\.css\?revision=r200-production-candidate/,
@@ -94,7 +103,7 @@ assert.match(
 assert.match(
   showroomCss,
   /\.lot-showroom \.lot-viewbox-with-paint \.lot-colors\.is-paint-locked[\s\S]*bottom: 12px;[\s\S]*left: 12px;/,
-  'Locked PAINTJOB must remain a compact floating control inside the 3D preview'
+  'Locked PAINTJOB must retain the compact floating-control styling'
 );
 assert.match(showroomCss, /\.lot-showroom \.lot-color-control input\[type='color'\]/,
   'Unlocked paint must remain a native colour input presented as a swatch');
@@ -124,13 +133,56 @@ assert.match(
 assert.doesNotMatch(showroomCleanupCss, /lot-car-secondary/,
   'The loading placeholder should stay deliberately abstract instead of trying to mimic the finished car');
 
+// The established accessibility layer stays available for legacy Lot compatibility.
 assert.match(accessibility, /screen\.classList\.contains\('lot-showroom'\)/,
-  'Accessibility behavior must explicitly recognize the visible showroom radio rail');
-assert.match(accessibility, /if \(!preserveVisualOrder && selectedCarId/,
-  'VoiceOver support must preserve stable visual DOM order in the showroom while retaining the legacy hidden-radio behavior elsewhere');
+  'Accessibility behavior must still recognize the visible showroom radio rail');
 assert.match(accessibility, /aria-posinset/);
 assert.match(accessibility, /aria-setsize/);
-assert.match(accessibility, /describeVehicleStats\(car\.stats\)/,
-  'Screen-reader vehicle summaries must still use the same canonical attributes as the visible panel');
 
-console.log('TURN M8 Home now enters a prepared production showroom Lot with compact paint, yaw-only level car rotation, simple colour-block loading placeholders, real 3D car thumbnails, bounded rendering and stable accessible card order.');
+// The showroom-specific pass owns the final non-visual information architecture.
+assert.match(screenReaderPass, /makeHeading\(2, 'lot-sr-choose-car', 'Choose car'\)/,
+  'The Lot must expose CHOOSE CAR as the first H2');
+assert.match(screenReaderPass, /makeHeading\(3, 'lot-sr-car-information', 'Car information'\)/,
+  'Selected vehicle detail must be introduced by H3 CAR INFORMATION');
+assert.match(screenReaderPass, /makeHeading\(2, 'lot-sr-race', 'Race'\)/,
+  'RACE must be the next H2 after CAR INFORMATION');
+assert.doesNotMatch(screenReaderPass, /makeHeading\([^\n]*Choose (?:car )?colou?r/i,
+  'CHOOSE COLOR must not become another heading between CAR INFORMATION and RACE');
+assert.match(screenReaderPass, /colors\.setAttribute\('role', 'group'\);[\s\S]*colors\.setAttribute\('aria-label', 'Choose color'\)/,
+  'Colour controls must be a named control group rather than a heading');
+assert.match(screenReaderPass, /card\.insertBefore\(colors, raceHeading\)/,
+  'The actual colour controls must follow car information and precede RACE in DOM order');
+assert.match(screenReaderPass, /side\.insertAdjacentElement\('beforebegin', pickerShell\)/,
+  'The CHOOSE CAR section must precede CAR INFORMATION in DOM order without changing the absolute visual layout');
+assert.match(screenReaderPass, /screen\.removeAttribute\('aria-labelledby'\)/,
+  'The full-screen section must not duplicate THE LOT as a named region and an H1');
+assert.match(screenReaderPass, /headingPitch\?\.setAttribute\('aria-hidden', 'true'\)/,
+  'The decorative CHOOSE YOUR RIDE tagline must not duplicate the CHOOSE CAR section name');
+assert.match(screenReaderPass, /progressSummary\?\.removeAttribute\('aria-live'\)/,
+  'Availability decoration must not repeatedly announce itself while Trophy Road classes settle');
+assert.match(screenReaderPass, /carDescription\.removeAttribute\('aria-hidden'\);[\s\S]*stats\.removeAttribute\('aria-hidden'\)/,
+  'CAR INFORMATION must expose the real visible description and stat rows once instead of a duplicate hidden summary');
+assert.match(screenReaderPass, /button\.removeAttribute\('aria-labelledby'\);[\s\S]*button\.setAttribute\('aria-label', conciseCarLabel\(button\)\)/,
+  'Car radios must use concise names instead of hidden labels containing the description and all six stats');
+assert.doesNotMatch(screenReaderPass, /describeVehicleStats/,
+  'The car picker must not repeat all vehicle stats before CAR INFORMATION');
+assert.match(screenReaderPass, /raceSummary\.textContent = `\$\{carName\} on \$\{trackName\}`/,
+  'RACE must state the selected car and selected track before the action');
+assert.match(screenReaderPass, /raceButton\.removeAttribute\('aria-label'\);[\s\S]*raceButton\.setAttribute\('aria-describedby', descriptions\.join\(' '\)\)/,
+  'RACE THIS CAR must keep its visible button name while car/track and lock information are descriptions');
+assert.match(screenReaderPass, /event\.detail === 0\) queueInformationFocus\(\)/,
+  'Screen-reader or keyboard activation of a car must move focus to CAR INFORMATION');
+assert.match(screenReaderPass, /\['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End'\]/,
+  'Arrow-key car selection must also move focus to CAR INFORMATION');
+assert.match(screenReaderPass, /infoHeading\.tabIndex = -1/,
+  'CAR INFORMATION must support programmatic focus without adding an extra Tab stop');
+assert.match(screenReaderPass, /cycle\.tabIndex = -1;[\s\S]*cycle\.setAttribute\('aria-hidden', 'true'\)/,
+  'Redundant visual previous/next buttons must not add duplicate non-visual navigation stops');
+assert.match(screenReaderPass, /lot-color-name'\)\?\.setAttribute\('aria-hidden', 'true'\)/,
+  'Hidden visual colour labels must not be read separately from their native colour input');
+assert.match(screenReaderPass, /input\.setAttribute\('aria-label', `\$\{label\} color\. \$\{cue\}\.`\)/,
+  'Each native colour input must expose one concise label including the non-visual colour cue');
+assert.match(screenReaderPass, /bottom: calc\(var\(--lot-picker-height, 122px\) \+ 12px\)/,
+  'Moving the colour controls semantically must preserve their floating position over the 3D view');
+
+console.log('TURN M8 Home now enters a production showroom with H1 THE LOT, H2 CHOOSE CAR, H3 CAR INFORMATION, grouped colour controls and H2 RACE; duplicate car/stat/color announcements are removed while the visual showroom remains unchanged.');

--- a/turn/garage/lot-screen-reader-r202.js
+++ b/turn/garage/lot-screen-reader-r202.js
@@ -1,0 +1,321 @@
+import { getCarDefinition } from '../vehicle/catalog.js?build=20260720-r20&revision=r588-canonical-attributes';
+import { TRACK_CATALOG } from '../tracks/catalog.js?build=20260818-r175';
+import { describeColorCue } from '../accessibility/color-cues.js?revision=r163';
+
+const STYLE_ID = 'turn-lot-screen-reader-r202-style';
+const activePasses = new WeakMap();
+
+function findLotScreen(root) {
+  if (root?.matches?.('.lot-screen')) return root;
+  return root?.querySelector?.('.lot-screen') || null;
+}
+
+function installStructureStyle() {
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = `
+    /* The real colour controls live after CAR INFORMATION in DOM order, while
+       remaining visually anchored over the lower-left of the 3D showroom. */
+    .lot-showroom.lot-screen-reader-structured .lot-colors,
+    .lot-showroom.lot-screen-reader-structured .lot-colors.is-paint-locked {
+      position: fixed;
+      z-index: 7;
+      right: auto;
+      bottom: calc(var(--lot-picker-height, 122px) + 12px);
+      left: max(26px, calc(env(safe-area-inset-left) + 26px));
+    }
+
+    @media (max-height: 520px) {
+      .lot-showroom.lot-screen-reader-structured .lot-colors,
+      .lot-showroom.lot-screen-reader-structured .lot-colors.is-paint-locked {
+        bottom: calc(var(--lot-picker-height, 102px) + 8px);
+        left: max(22px, calc(env(safe-area-inset-left) + 22px));
+      }
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+function makeHeading(level, id, text) {
+  const heading = document.createElement(`h${level}`);
+  heading.id = id;
+  heading.className = 'lot-a11y-only';
+  heading.textContent = text;
+  return heading;
+}
+
+function selectedCarButton(carPicker) {
+  return carPicker.querySelector('.lot-car-option[aria-checked="true"]')
+    || carPicker.querySelector('.lot-car-option[tabindex="0"]')
+    || carPicker.querySelector('.lot-car-option');
+}
+
+function selectedTrackName() {
+  const homeTrackId = globalThis.__turnNextHome?.getSelectedTrackId?.();
+  const runtimeTrackId = globalThis.__turnRuntime?.state?.trackId;
+  const trackId = homeTrackId || runtimeTrackId || '';
+  const track = TRACK_CATALOG.find((entry) => entry.id === trackId);
+  if (track?.name) return track.name;
+  if (!trackId) return 'selected track';
+  return String(trackId).replace(/[-_]+/g, ' ');
+}
+
+function conciseCarLabel(button) {
+  const car = getCarDefinition(button.dataset.carId);
+  const base = button.dataset.lotBaseLabel || car?.name || button.textContent.trim() || 'Car';
+  if (!button.classList.contains('is-trophy-locked')) return base;
+  const threshold = button.dataset.trophyLockLabel;
+  return threshold
+    ? `${base} Locked. Unlocks at ${threshold.toLowerCase()} on Trophy Road.`
+    : `${base} Locked on Trophy Road.`;
+}
+
+function focusWithoutScroll(element) {
+  if (!element) return;
+  try {
+    element.focus({ preventScroll: true });
+  } catch (_) {
+    element.focus();
+  }
+}
+
+export function installLotScreenReaderPass(root = document.body) {
+  const screen = findLotScreen(root);
+  if (!screen?.classList.contains('lot-showroom')) return () => {};
+
+  const current = activePasses.get(screen);
+  if (current) return current.release;
+
+  const lotTitle = screen.querySelector('#lot-title');
+  const headingPitch = screen.querySelector('.lot-heading-copy > p');
+  const progressSummary = screen.querySelector('.lot-progress-summary');
+  const pickerShell = screen.querySelector('.lot-car-picker-shell');
+  const carPicker = screen.querySelector('.lot-car-picker');
+  const side = screen.querySelector('.lot-side');
+  const card = screen.querySelector('.lot-card');
+  const carTitle = card?.querySelector('.lot-car-title');
+  const carDescription = card?.querySelector('.lot-car-description');
+  const stats = card?.querySelector('.lot-stats');
+  const statsHelp = card?.querySelector('.lot-stats-help');
+  const colors = screen.querySelector('.lot-colors');
+  const raceActions = card?.querySelector('.lot-card-actions');
+  const raceButton = raceActions?.querySelector('.lot-race');
+
+  if (!lotTitle || !pickerShell || !carPicker || !side || !card || !carTitle
+      || !carDescription || !stats || !colors || !raceActions || !raceButton) {
+    return () => {};
+  }
+
+  installStructureStyle();
+  screen.classList.add('lot-screen-reader-structured');
+
+  // A named <section> plus its H1 caused an unnecessary extra "region" reading.
+  // The full-screen route is already unambiguously introduced by THE LOT.
+  screen.removeAttribute('aria-labelledby');
+  headingPitch?.setAttribute('aria-hidden', 'true');
+  progressSummary?.removeAttribute('aria-live');
+
+  // Remove the older injected semantic duplicates before constructing the simpler
+  // showroom outline. Its observers may keep their detached nodes updated, but no
+  // duplicate labels or headings remain in the accessibility tree.
+  screen.querySelector('#lot-choose-car-heading')?.remove();
+  screen.querySelector('#lot-paint-heading')?.remove();
+  screen.querySelector('#lot-car-info-heading')?.remove();
+  screen.querySelector('[data-lot-a11y="car-descriptions"]')?.remove();
+  screen.querySelector('[data-lot-a11y="selected-car-summary"]')?.remove();
+
+  carDescription.removeAttribute('aria-hidden');
+  stats.removeAttribute('aria-hidden');
+
+  // Absolute positioning makes this DOM reorder visually neutral. It gives heading
+  // navigation the intended H1 THE LOT -> H2 CHOOSE CAR -> H3 CAR INFORMATION -> H2 RACE outline.
+  side.insertAdjacentElement('beforebegin', pickerShell);
+
+  const chooseCarHeading = makeHeading(2, 'lot-sr-choose-car', 'Choose car');
+  const chooseCarInstructions = document.createElement('p');
+  chooseCarInstructions.id = 'lot-sr-choose-car-instructions';
+  chooseCarInstructions.className = 'lot-a11y-only';
+  chooseCarInstructions.textContent = 'Swipe through the cars, or use the left and right arrow keys for the previous or next car. Selecting a car moves to Car information.';
+  pickerShell.prepend(chooseCarHeading, chooseCarInstructions);
+  carPicker.setAttribute('aria-labelledby', chooseCarHeading.id);
+  carPicker.setAttribute('aria-describedby', chooseCarInstructions.id);
+  carPicker.setAttribute('aria-orientation', 'horizontal');
+  carPicker.removeAttribute('aria-label');
+
+  const infoHeading = makeHeading(3, 'lot-sr-car-information', 'Car information');
+  infoHeading.tabIndex = -1;
+  card.prepend(infoHeading);
+  card.setAttribute('role', 'none');
+  card.removeAttribute('aria-labelledby');
+  carTitle.querySelector(':scope > span')?.setAttribute('aria-hidden', 'true');
+
+  const raceHeading = makeHeading(2, 'lot-sr-race', 'Race');
+  const raceSummary = document.createElement('p');
+  raceSummary.id = 'lot-sr-race-summary';
+  raceSummary.className = 'lot-a11y-only';
+  const raceLockDescription = document.createElement('p');
+  raceLockDescription.id = 'lot-sr-race-lock-description';
+  raceLockDescription.className = 'lot-a11y-only';
+  raceActions.before(raceHeading, raceSummary, raceLockDescription);
+
+  // CHOOSE COLOR is deliberately a named group rather than another heading. This
+  // keeps heading navigation from CAR INFORMATION going directly to RACE.
+  card.insertBefore(colors, raceHeading);
+  colors.setAttribute('role', 'group');
+  colors.setAttribute('aria-label', 'Choose color');
+  colors.removeAttribute('aria-labelledby');
+
+  // The arrow buttons are redundant for non-visual users: the radio group already
+  // exposes the same previous/next operation with arrow keys. Keep them as pointer
+  // controls without adding two extra stops before CAR INFORMATION.
+  for (const cycle of screen.querySelectorAll('.lot-cycle')) {
+    cycle.tabIndex = -1;
+    cycle.setAttribute('aria-hidden', 'true');
+  }
+
+  const buttons = [...carPicker.querySelectorAll('.lot-car-option')];
+  const visibleOrder = buttons.map((button) => button.dataset.carId).filter(Boolean);
+
+  function syncCarRadios() {
+    for (const button of buttons) {
+      const index = visibleOrder.indexOf(button.dataset.carId);
+      button.removeAttribute('aria-labelledby');
+      button.setAttribute('aria-label', conciseCarLabel(button));
+      if (index >= 0) {
+        button.setAttribute('aria-posinset', String(index + 1));
+        button.setAttribute('aria-setsize', String(visibleOrder.length));
+      }
+    }
+
+    const selected = selectedCarButton(carPicker);
+    for (const button of buttons) button.tabIndex = button === selected ? 0 : -1;
+  }
+
+  function syncColorControls() {
+    colors.removeAttribute('aria-labelledby');
+    if (colors.getAttribute('aria-hidden') !== 'true') colors.setAttribute('aria-label', 'Choose color');
+
+    for (const control of colors.querySelectorAll('.lot-color-control')) {
+      const input = control.querySelector('input[type="color"]');
+      if (!input) continue;
+      control.querySelector('.lot-color-name')?.setAttribute('aria-hidden', 'true');
+      const label = control.dataset.paintLabel || 'Car';
+      const cue = describeColorCue(input.value);
+      input.setAttribute('aria-label', `${label} color. ${cue}.`);
+    }
+  }
+
+  function syncRaceContext() {
+    const selected = selectedCarButton(carPicker);
+    const car = getCarDefinition(selected?.dataset.carId);
+    const carName = car?.name || selected?.textContent.trim() || 'Selected car';
+    const trackName = selectedTrackName();
+    raceSummary.textContent = `${carName} on ${trackName}`;
+
+    const locked = raceButton.dataset.trophyLocked === 'true'
+      || selected?.classList.contains('is-trophy-locked');
+    const descriptions = [raceSummary.id];
+    if (locked) {
+      const threshold = selected?.dataset.trophyLockLabel;
+      raceLockDescription.textContent = threshold
+        ? `${carName} is locked. Unlocks at ${threshold.toLowerCase()} on Trophy Road.`
+        : `${carName} is locked on Trophy Road.`;
+      descriptions.push(raceLockDescription.id);
+    } else {
+      raceLockDescription.textContent = '';
+    }
+
+    // The visible label is the accessible name. Car/track context and lock status
+    // are descriptions, avoiding "Race the X / Race this car" duplicate naming.
+    raceButton.removeAttribute('aria-label');
+    raceButton.setAttribute('aria-describedby', descriptions.join(' '));
+  }
+
+  function syncAll() {
+    syncCarRadios();
+    syncColorControls();
+    syncRaceContext();
+  }
+
+  syncAll();
+
+  let focusFrame = 0;
+  function queueInformationFocus() {
+    if (focusFrame) cancelAnimationFrame(focusFrame);
+    focusFrame = requestAnimationFrame(() => {
+      focusFrame = 0;
+      focusWithoutScroll(infoHeading);
+    });
+  }
+
+  function handlePickerClick(event) {
+    const button = event.target?.closest?.('.lot-car-option');
+    if (!button || !carPicker.contains(button)) return;
+    // VoiceOver/keyboard activation dispatches a synthetic click with detail 0.
+    // Pointer users keep their direct manipulation focus where they touched.
+    if (event.detail === 0) queueInformationFocus();
+  }
+
+  function handlePickerKeydown(event) {
+    if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End'].includes(event.key)) {
+      queueInformationFocus();
+    }
+  }
+
+  function handleColorInput(event) {
+    if (event.target?.matches?.('input[type="color"]')) syncColorControls();
+  }
+
+  carPicker.addEventListener('click', handlePickerClick);
+  carPicker.addEventListener('keydown', handlePickerKeydown);
+  colors.addEventListener('input', handleColorInput);
+
+  const selectionObserver = new MutationObserver(syncAll);
+  selectionObserver.observe(carPicker, {
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['aria-checked', 'class', 'data-trophy-lock-label']
+  });
+
+  const colorObserver = new MutationObserver(syncColorControls);
+  colorObserver.observe(colors, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['aria-hidden', 'hidden']
+  });
+
+  const raceObserver = new MutationObserver(syncRaceContext);
+  raceObserver.observe(raceButton, {
+    attributes: true,
+    attributeFilter: ['disabled', 'data-trophy-locked']
+  });
+
+  const handleTrophyUpdate = syncAll;
+  window.addEventListener('turn:trophy-road-updated', handleTrophyUpdate);
+
+  if (!screen.contains(document.activeElement)) {
+    lotTitle.tabIndex = -1;
+    focusWithoutScroll(lotTitle);
+  }
+
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
+    if (focusFrame) cancelAnimationFrame(focusFrame);
+    selectionObserver.disconnect();
+    colorObserver.disconnect();
+    raceObserver.disconnect();
+    carPicker.removeEventListener('click', handlePickerClick);
+    carPicker.removeEventListener('keydown', handlePickerKeydown);
+    colors.removeEventListener('input', handleColorInput);
+    window.removeEventListener('turn:trophy-road-updated', handleTrophyUpdate);
+    screen.classList.remove('lot-screen-reader-structured');
+    activePasses.delete(screen);
+  };
+
+  activePasses.set(screen, { release });
+  return release;
+}

--- a/turn/garage/lot-screen-reader-r202.js
+++ b/turn/garage/lot-screen-reader-r202.js
@@ -97,7 +97,6 @@ export function installLotScreenReaderPass(root = document.body) {
   const carTitle = card?.querySelector('.lot-car-title');
   const carDescription = card?.querySelector('.lot-car-description');
   const stats = card?.querySelector('.lot-stats');
-  const statsHelp = card?.querySelector('.lot-stats-help');
   const colors = screen.querySelector('.lot-colors');
   const raceActions = card?.querySelector('.lot-card-actions');
   const raceButton = raceActions?.querySelector('.lot-race');
@@ -278,12 +277,13 @@ export function installLotScreenReaderPass(root = document.body) {
     attributeFilter: ['aria-checked', 'class', 'data-trophy-lock-label']
   });
 
+  // Child replacement is enough to catch car changes and paint lock/unlock changes.
+  // Do not observe descendant aria-hidden attributes: syncColorControls sets those
+  // itself, which would otherwise create a recursive MutationObserver loop.
   const colorObserver = new MutationObserver(syncColorControls);
   colorObserver.observe(colors, {
     childList: true,
-    subtree: true,
-    attributes: true,
-    attributeFilter: ['aria-hidden', 'hidden']
+    subtree: true
   });
 
   const raceObserver = new MutationObserver(syncRaceContext);

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -18,6 +18,8 @@ const SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r201-cleanup';
 let showroomStylePromise = null;
 let originalLotPromise = null;
 let originalLotModule = null;
+let screenReaderPassPromise = null;
+let screenReaderPassModule = null;
 
 function prepareStylesheet(id, relativeUrl) {
   return new Promise((resolve) => {
@@ -66,22 +68,39 @@ function loadOriginalLot() {
   return originalLotPromise;
 }
 
+function loadScreenReaderPass() {
+  if (!screenReaderPassPromise) {
+    screenReaderPassPromise = import('./lot-screen-reader-r202.js?revision=r202-heading-structure')
+      .then((module) => {
+        screenReaderPassModule = module;
+        return module;
+      });
+  }
+  return screenReaderPassPromise;
+}
+
 export async function prepareEnhancedLot() {
   await Promise.all([
     loadOriginalLot(),
+    loadScreenReaderPass(),
     prepareShowroomStyles(),
     prepareLotEnhancements()
   ]);
 }
 
 function mountEnhancedLot(options) {
-  if (!originalLotModule) {
-    throw new Error('TURN: showroom was mounted before its module finished preparing.');
+  if (!originalLotModule || !screenReaderPassModule) {
+    throw new Error('TURN: showroom was mounted before its modules finished preparing.');
   }
   const { showTheLot: showOriginalLot } = originalLotModule;
+  const { installLotScreenReaderPass } = screenReaderPassModule;
   const lotResult = showOriginalLot(options);
   const removeEnhancements = enhanceLotNow();
-  return Promise.resolve(lotResult).finally(removeEnhancements);
+  const removeScreenReaderPass = installLotScreenReaderPass();
+  return Promise.resolve(lotResult).finally(() => {
+    removeScreenReaderPass();
+    removeEnhancements();
+  });
 }
 
 export async function showTheLot(options = {}) {
@@ -96,6 +115,6 @@ export async function showTheLot(options = {}) {
 }
 
 export function showEnhancedLot(options = {}) {
-  if (originalLotModule) return mountEnhancedLot(options);
+  if (originalLotModule && screenReaderPassModule) return mountEnhancedLot(options);
   return prepareEnhancedLot().then(() => mountEnhancedLot(options));
 }


### PR DESCRIPTION
## Summary
- add a showroom-specific screen reader pass after the established Lot/Trophy Road/paint/perk enhancements
- expose heading navigation as H1 THE LOT → H2 CHOOSE CAR → H3 CAR INFORMATION → H2 RACE
- treat CHOOSE COLOR as a named control group instead of another heading, so next-heading navigation from CAR INFORMATION lands on RACE
- move the real colour controls after car information in DOM order while keeping the swatch visually floating over the 3D view
- keep only the selected car in the roving Tab stop and preserve left/right arrow car selection
- move screen-reader/keyboard focus to CAR INFORMATION after a car is selected
- announce RACE context as “<car> on <track>” before the RACE THIS CAR button

## Duplicate-reading audit / fixes
- remove the old hidden per-car label that repeated description + all six stats in the picker
- remove the duplicate hidden selected-car summary and expose the real visible description/stat rows once
- remove the redundant named-region reading of THE LOT
- hide the decorative CHOOSE YOUR RIDE tagline from AT because CHOOSE CAR now names the section
- stop the availability badge from acting as a live region while Trophy Road classes settle
- remove the redundant non-visual previous/next 3D-view buttons; the radio group already provides arrow navigation
- keep native colour inputs but collapse their hidden label/cue fragments into one concise accessible name
- keep RACE THIS CAR as the button name; car/track/lock information is supplied through descriptions instead of a competing aria-label

## Visual behavior
No intentional visual redesign. The compact paint swatch remains floating over the lower-left of the 3D showroom even though its DOM location moves into the semantic information flow.

## Validation
Final head passed the full TURN regression suite. The M8 Lot production regression now explicitly guards the final heading outline, focus contract, duplicate-reading removals, colour-group semantics, race context, non-recursive colour observers, and preservation of the floating swatch.