### PR TITLE
Polish The Lot thumbnails, perks and color lock

### DIFF
--- a/turn-lab/tests/paint-lock-observer-production.mjs
+++ b/turn-lab/tests/paint-lock-observer-production.mjs
@@ -33,15 +33,23 @@ assert.doesNotMatch(paintGate, /colors\.addEventListener\(['"]keydown['"]/,
 assert.doesNotMatch(paintGate, /colors\.setAttribute\('role', 'button'\)|colors\.tabIndex\s*=/,
   'The paint group must keep its real group semantics instead of becoming a faux button');
 assert.match(paintGate, /button = document\.createElement\('button'\)/,
-  'Locked Paintjob feedback should use a real button');
+  'Locked color feedback should use a real button');
 assert.match(paintGate, /button\.type = 'button'/);
 assert.match(paintGate, /button\.className = 'lot-paint-lock-button'/);
 assert.match(paintGate, /button\.addEventListener\('click', showLockedPaintInfo\)/,
   'The lock explanation belongs directly to the lock button, not an ancestor of paint inputs');
+assert.match(paintGate, /label\.className = 'lot-color-visible-label'/,
+  'The paint control must identify itself visibly as COLOR');
+assert.match(paintGate, /label\.textContent = 'COLOR'/);
+assert.match(paintGate, /label\.setAttribute\('aria-hidden', 'true'\)/,
+  'The visual COLOR label must not duplicate the screen-reader group name');
 assert.match(paintGate, /lot-paint-lock-copy/);
-assert.match(paintGate, /<strong>PAINTJOB<\/strong>/);
+assert.match(paintGate, /copy\.innerHTML = `<strong>\$\{threshold\} 🏆<\/strong><small>TO UNLOCK<\/small>`/,
+  'Locked color must show the Trophy Road requirement next to its swatch');
+assert.match(paintGate, /Color locked\. Car color controls unlock at \$\{threshold\} trophies on Trophy Road\./,
+  'The lock button must make clear that color is locked, not the selected car');
 assert.doesNotMatch(paintGate, /<i>•<\/i>|<b>LOCKED<\/b>/,
-  'Visible lock-status copy must not crowd out the Paintjob label');
+  'The compact color control must not add redundant decorative lock-status copy');
 assert.match(paintGate, /function contrastingInk\(hexColor\)/);
 assert.match(paintGate, /luminance > 0\.18 \? '#08090a' : '#fffdf6'/,
   'The lock glyph must use whichever TURN ink gives the stronger colour contrast');
@@ -85,8 +93,8 @@ assert.match(lotGate, /if \(lastAnnouncedCarId\) dismissVisibleUnlockNotice\(\);
   'Leaving The Lot must not leave a vehicle lock notice behind');
 
 assert.match(lotRuntime, /lot-trophy-gate\.js\?revision=r164-vintage-rally-perks/);
-assert.match(lotRuntime, /lot-paint-reward\.js\?revision=r164-perks/);
-assert.match(lotRuntime, /lot-perk-disclosure\.js\?revision=r164-vintage-rally-perks/);
+assert.match(lotRuntime, /lot-paint-reward\.js\?revision=r203-color-label/);
+assert.match(lotRuntime, /lot-perk-disclosure\.js\?revision=r203-idempotent/);
 
 assert.match(perkPresentation, /getCarDefinition\(vehicleId\)\?\.perk/,
   'Inline perk identity must be read from the selected car itself');
@@ -109,4 +117,4 @@ assert.match(
   new RegExp(`app\\.js\\?build=${release.cacheKey}-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click`)
 );
 
-console.log('TURN Lot lock feedback, car-owned perk observer safety and native paint ancestry regressions passed.');
+console.log('TURN Lot color lock feedback, car-owned perk observer safety and native paint ancestry regressions passed.');

--- a/turn-tests/m8-lot-selection-production.mjs
+++ b/turn-tests/m8-lot-selection-production.mjs
@@ -1,14 +1,28 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [m8Home, showroom, showroomCss, showroomCleanupCss, wrapper, accessibility, screenReaderPass] = await Promise.all([
+const [
+  m8Home,
+  showroom,
+  showroomCss,
+  showroomCleanupCss,
+  wrapper,
+  accessibility,
+  screenReaderPass,
+  perkDisclosure,
+  paintReward,
+  enhancementRuntime
+] = await Promise.all([
   fs.readFile(new URL('../turn/m8-home.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/garage/lot-showroom-experiment.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/garage/lot-showroom-experiment.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/garage/lot-showroom-cleanup-r201.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/garage/lot-track-select.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/garage/lot-accessibility-r118.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/garage/lot-screen-reader-r202.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/garage/lot-screen-reader-r202.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/garage/lot-perk-disclosure.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/progression/lot-paint-reward.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/garage/lot-enhancement-runtime.js', import.meta.url), 'utf8')
 ]);
 
 assert.match(
@@ -57,8 +71,10 @@ assert.match(wrapper, /lot-showroom-experiment\.js\?revision=r200-production-can
   'The production wrapper must lazy-load the current showroom implementation');
 assert.match(wrapper, /lot-showroom-experiment\.css\?revision=r200-production-candidate/,
   'The showroom stylesheet must have its own cache identity');
-assert.match(wrapper, /lot-showroom-cleanup-r201\.css\?revision=r201-loading-cleanup/,
-  'The production wrapper must preload the small showroom polish layer before mount');
+assert.match(wrapper, /lot-showroom-cleanup-r201\.css\?revision=r203-thumbnail-color-polish/,
+  'The production wrapper must preload the current showroom polish layer with a fresh cache identity');
+assert.match(wrapper, /SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r203-polish'/,
+  'The polish stylesheet link must not reuse the previous cached link identity');
 assert.match(wrapper, /link\.addEventListener\('load', resolve/,
   'The Lot must wait for its showroom stylesheets before mounting to avoid a layout flash');
 
@@ -107,11 +123,6 @@ assert.match(
 );
 assert.match(showroomCss, /\.lot-showroom \.lot-color-control input\[type='color'\]/,
   'Unlocked paint must remain a native colour input presented as a swatch');
-assert.match(
-  showroomCss,
-  /\.lot-showroom \.lot-paint-lock-copy[\s\S]*clip-path: inset\(50%\)/,
-  'The locked PAINTJOB explanation must remain accessible without occupying visible showroom space'
-);
 assert.match(showroomCss, /\.lot-showroom \.lot-car-option\.has-3d-thumbnail \.lot-car-option-thumbnail \{ opacity: 1; \}/,
   'Cards must progressively replace their lightweight fallback with the real model thumbnail');
 
@@ -132,6 +143,40 @@ assert.match(
 );
 assert.doesNotMatch(showroomCleanupCss, /lot-car-secondary/,
   'The loading placeholder should stay deliberately abstract instead of trying to mimic the finished car');
+assert.match(
+  showroomCleanupCss,
+  /\.lot-showroom \.lot-car-option-thumbnail\s*\{[\s\S]*object-fit: contain;[\s\S]*object-position: center;/,
+  'Rendered 20:9 car thumbnails must preserve their intrinsic aspect ratio instead of stretching with responsive cards'
+);
+assert.match(showroomCleanupCss, /\.lot-showroom \.lot-color-visible-label[\s\S]*font-weight: 950/,
+  'The floating paint swatch must have a visible COLOR label');
+assert.match(
+  showroomCleanupCss,
+  /\.lot-showroom \.lot-paint-lock-copy[\s\S]*position: static !important;[\s\S]*clip-path: none !important;/,
+  'Locked color must show its unlock requirement beside the swatch instead of hiding all explanatory copy'
+);
+
+assert.match(perkDisclosure, /const activeDisclosures = new WeakMap\(\)/,
+  'Perk disclosure must keep one active installer per Lot screen');
+assert.match(perkDisclosure, /const active = activeDisclosures\.get\(screen\);[\s\S]*if \(active\) return active\.release;/,
+  'A second enhancement pass must reuse the existing perk disclosure rather than append another copy');
+assert.match(perkDisclosure, /querySelectorAll\('\.lot-perk-disclosure'\)[\s\S]*stale\.remove\(\)/,
+  'Any stale duplicate perk block from an older install must be removed before mounting the canonical copy');
+assert.match(perkDisclosure, /activeDisclosures\.delete\(screen\)/,
+  'Perk disclosure idempotency state must be released with the Lot');
+
+assert.match(paintReward, /label\.className = 'lot-color-visible-label'/,
+  'Paint gating must create a real visible COLOR label rather than relying on generated CSS content');
+assert.match(paintReward, /label\.setAttribute\('aria-hidden', 'true'\)/,
+  'The visual COLOR label must not duplicate the named Choose color group for screen readers');
+assert.match(paintReward, /`<strong>\$\{threshold\} 🏆<\/strong><small>TO UNLOCK<\/small>`/,
+  'Locked paint must display its Trophy Road unlock requirement next to the swatch');
+assert.match(paintReward, /`Color locked\. Car color controls unlock at \$\{threshold\} trophies on Trophy Road\.`/,
+  'The locked color button must explain specifically that color, not the whole car, is locked');
+assert.match(enhancementRuntime, /lot-perk-disclosure\.js\?revision=r203-idempotent/,
+  'The fixed perk installer must receive a fresh module cache identity');
+assert.match(enhancementRuntime, /lot-paint-reward\.js\?revision=r203-color-label/,
+  'The clarified color gate must receive a fresh module cache identity');
 
 // The established accessibility layer stays available for legacy Lot compatibility.
 assert.match(accessibility, /screen\.classList\.contains\('lot-showroom'\)/,
@@ -185,4 +230,4 @@ assert.match(screenReaderPass, /input\.setAttribute\('aria-label', `\$\{label\} 
 assert.match(screenReaderPass, /bottom: calc\(var\(--lot-picker-height, 122px\) \+ 12px\)/,
   'Moving the colour controls semantically must preserve their floating position over the 3D view');
 
-console.log('TURN M8 Home now enters a production showroom with H1 THE LOT, H2 CHOOSE CAR, H3 CAR INFORMATION, grouped colour controls and H2 RACE; duplicate car/stat/color announcements are removed while the visual showroom remains unchanged.');
+console.log('TURN M8 Lot keeps proportional 3D thumbnails, one perk disclosure, a visibly labelled COLOR control with unlock info, and the H1/H2/H3/H2 screen-reader structure.');

--- a/turn-tests/post-soak-production.mjs
+++ b/turn-tests/post-soak-production.mjs
@@ -159,7 +159,7 @@ assert.equal(
   'Other vehicle perk copy must remain untouched'
 );
 assert.match(lotPerk, /vehiclePerkPresentation\(vehicleId, getCarDefinition\(vehicleId\)\?\.perk\)/);
-assert.match(lotRuntime, /lot-perk-disclosure\.js\?revision=r164-post-soak/);
+assert.match(lotRuntime, /lot-perk-disclosure\.js\?revision=r203-idempotent/);
 assert.match(trophyWrapper, /FUTURE_RACER_REWARD_PERK_DESCRIPTION/);
 assert.match(trophyWrapper, /reward\.id !== 'future-racer'/);
 

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -21,9 +21,9 @@ export function prepareLotEnhancements() {
     import('./lot-stat-legend.js?build=20260724-r59'),
     import('./lot-layout-r60.js?build=20260729-r116'),
     import('./lot-accessibility-r118.js?build=20260729-r118&revision=r588-canonical-attributes'),
-    import('./lot-perk-disclosure.js?revision=r164-post-soak'),
+    import('./lot-perk-disclosure.js?revision=r203-idempotent'),
     import('../progression/lot-trophy-gate.js?revision=r585-visible-locks'),
-    import('../progression/lot-paint-reward.js?revision=r164-perks')
+    import('../progression/lot-paint-reward.js?revision=r203-color-label')
   ]).then(([
     statLegend,
     layout,

--- a/turn/garage/lot-perk-disclosure.js
+++ b/turn/garage/lot-perk-disclosure.js
@@ -2,6 +2,7 @@ import { getCarDefinition } from '../vehicle/catalog.js?revision=r164-vintage-ra
 import { vehiclePerkPresentation } from '../vehicle/perk-presentation.js?revision=r164-post-soak';
 
 const STYLE_ID = 'turn-lot-perk-inline-styles';
+const activeDisclosures = new WeakMap();
 
 function installStyles() {
   if (document.getElementById(STYLE_ID)) return;
@@ -44,6 +45,14 @@ export function installLotPerkDisclosure(root = document.body) {
   const description = card?.querySelector?.('.lot-car-description');
   const picker = screen?.querySelector?.('.lot-car-picker');
   if (!screen || !card || !description || !picker) return () => {};
+
+  const active = activeDisclosures.get(screen);
+  if (active) return active.release;
+
+  // A Lot can be enhanced through both the prepared route and the long-lived
+  // enhancement runtime. Keep the perk presentation idempotent even if those
+  // paths overlap, and clean up any stale duplicate left by an older install.
+  for (const stale of card.querySelectorAll('.lot-perk-disclosure')) stale.remove();
 
   installStyles();
 
@@ -90,8 +99,15 @@ export function installLotPerkDisclosure(root = document.body) {
   });
   sync();
 
-  return () => {
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
     observer.disconnect();
     perk.remove();
+    activeDisclosures.delete(screen);
   };
+
+  activeDisclosures.set(screen, { release });
+  return release;
 }

--- a/turn/garage/lot-showroom-cleanup-r201.css
+++ b/turn/garage/lot-showroom-cleanup-r201.css
@@ -24,3 +24,69 @@
 .lot-showroom .lot-car-option-fallback i:nth-child(3) {
   display: none;
 }
+
+/* The captured thumbnail canvas has a fixed 20:9 intrinsic ratio. Let it letterbox
+   inside responsive cards instead of stretching it to each card's current ratio. */
+.lot-showroom .lot-car-option-thumbnail {
+  object-fit: contain;
+  object-position: center;
+}
+
+/* Make the floating paint control read as COLOR first, lock state second. */
+.lot-showroom .lot-color-visible-label {
+  flex: 0 0 auto;
+  align-self: center;
+  color: var(--ink, #08090a);
+  font-size: .42rem;
+  font-weight: 950;
+  letter-spacing: .09em;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.lot-showroom .lot-paint-lock-button {
+  grid-template-columns: auto auto;
+  width: auto;
+  min-width: 0;
+  padding: 0;
+  gap: 7px;
+  align-items: center;
+  justify-items: start;
+}
+
+.lot-showroom .lot-paint-lock-copy {
+  position: static !important;
+  display: grid;
+  width: auto !important;
+  height: auto !important;
+  margin: 0 !important;
+  padding: 0 3px 0 0 !important;
+  overflow: visible !important;
+  clip: auto !important;
+  clip-path: none !important;
+  border: 0 !important;
+  gap: 1px;
+  color: var(--ink, #08090a);
+  line-height: 1;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.lot-showroom .lot-paint-lock-copy strong {
+  font-size: .42rem;
+  font-weight: 950;
+  letter-spacing: .04em;
+}
+
+.lot-showroom .lot-paint-lock-copy small {
+  font-size: .31rem;
+  font-weight: 900;
+  letter-spacing: .06em;
+}
+
+@media (max-height: 520px) {
+  .lot-showroom .lot-color-visible-label { font-size: .36rem; }
+  .lot-showroom .lot-paint-lock-button { gap: 5px; }
+  .lot-showroom .lot-paint-lock-copy strong { font-size: .36rem; }
+  .lot-showroom .lot-paint-lock-copy small { font-size: .27rem; }
+}

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -14,7 +14,7 @@ import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
 // Keep the showroom implementation and its CSS out of TURN's initial module graph.
 // Choosing or activating a track gives us a natural warmup window for these resources.
 const SHOWROOM_STYLE_ID = 'turn-lot-showroom-r200';
-const SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r201-cleanup';
+const SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r203-polish';
 let showroomStylePromise = null;
 let originalLotPromise = null;
 let originalLotModule = null;
@@ -51,7 +51,7 @@ function prepareShowroomStyles() {
     ),
     prepareStylesheet(
       SHOWROOM_CLEANUP_STYLE_ID,
-      './lot-showroom-cleanup-r201.css?revision=r201-loading-cleanup'
+      './lot-showroom-cleanup-r201.css?revision=r203-thumbnail-color-polish'
     )
   ]);
   return showroomStylePromise;

--- a/turn/progression/lot-paint-reward.js
+++ b/turn/progression/lot-paint-reward.js
@@ -87,6 +87,22 @@ export function gateLotPaintNow(root = document.body) {
     icon.style.setProperty('--lot-paint-lock-foreground', contrastingInk(bodyColour));
   }
 
+  function ensureVisibleLabel(car) {
+    let label = colors.querySelector('.lot-color-visible-label');
+    if (!car || car.fixedLivery) {
+      label?.remove();
+      return null;
+    }
+    if (!label) {
+      label = document.createElement('span');
+      label.className = 'lot-color-visible-label';
+      label.textContent = 'COLOR';
+      label.setAttribute('aria-hidden', 'true');
+      colors.prepend(label);
+    }
+    return label;
+  }
+
   function ensureLockButton(carId) {
     let button = colors.querySelector('.lot-paint-lock-button');
     if (!button) {
@@ -105,7 +121,9 @@ export function gateLotPaintNow(root = document.body) {
 
       button.append(icon, copy);
       button.addEventListener('click', showLockedPaintInfo);
-      colors.prepend(button);
+      const label = colors.querySelector('.lot-color-visible-label');
+      if (label) label.insertAdjacentElement('afterend', button);
+      else colors.prepend(button);
     }
 
     const threshold = reward()?.threshold || 900;
@@ -135,6 +153,7 @@ export function gateLotPaintNow(root = document.body) {
       const changedCar = Boolean(carId) && carId !== lastCarId;
       const controls = [...colors.querySelectorAll('.lot-color-control:not(.lot-fixed-livery)')];
 
+      ensureVisibleLabel(car);
       if (car && !car.fixedLivery && (!paintUnlocked || changedCar)) forceFactoryPaint(carId);
 
       const locked = Boolean(car && !car.fixedLivery && !paintUnlocked);
@@ -185,6 +204,7 @@ export function gateLotPaintNow(root = document.body) {
     window.removeEventListener('storage', handleStorage);
     raceButton.removeEventListener('click', sync, { capture: true });
     removeLockPresentation();
+    colors.querySelector('.lot-color-visible-label')?.remove();
     for (const control of colors.querySelectorAll('.lot-color-control')) {
       control.hidden = false;
       const input = control.querySelector('input');

--- a/turn/progression/lot-paint-reward.js
+++ b/turn/progression/lot-paint-reward.js
@@ -77,7 +77,7 @@ export function gateLotPaintNow(root = document.body) {
   function showLockedPaintInfo() {
     showTrophyUnlockNotice({
       reward: reward(),
-      itemName: 'Vehicle paint controls'
+      itemName: 'Car color'
     });
   }
 
@@ -94,25 +94,28 @@ export function gateLotPaintNow(root = document.body) {
       button.type = 'button';
       button.className = 'lot-paint-lock-button';
 
-      const copy = document.createElement('span');
-      copy.className = 'lot-paint-lock-copy';
-      copy.innerHTML = '<strong>PAINTJOB</strong>';
-
       const icon = document.createElement('span');
       icon.className = 'lot-paint-lock';
       icon.setAttribute('aria-hidden', 'true');
       icon.innerHTML = LOCK_ICON;
 
-      button.append(copy, icon);
+      const copy = document.createElement('span');
+      copy.className = 'lot-paint-lock-copy';
+      copy.setAttribute('aria-hidden', 'true');
+
+      button.append(icon, copy);
       button.addEventListener('click', showLockedPaintInfo);
       colors.prepend(button);
     }
 
     const threshold = reward()?.threshold || 900;
+    const copy = button.querySelector('.lot-paint-lock-copy');
+    if (copy) copy.innerHTML = `<strong>${threshold} 🏆</strong><small>TO UNLOCK</small>`;
     button.setAttribute(
       'aria-label',
-      `Paintjob locked. Vehicle paint controls unlock at ${threshold} trophies on Trophy Road.`
+      `Color locked. Car color controls unlock at ${threshold} trophies on Trophy Road.`
     );
+    button.title = `Color unlocks at ${threshold} trophies`;
     applyLockColour(button.querySelector('.lot-paint-lock'), carId);
     return button;
   }


### PR DESCRIPTION
## Summary
- preserve the fixed 20:9 aspect ratio of rendered 3D car thumbnails so responsive cards letterbox instead of stretching the cars
- make the perk disclosure idempotent per Lot screen and clean stale duplicates before mounting the canonical copy
- add a visible COLOR label to the floating swatch while keeping the existing screen-reader group name
- when PAINTJOB is locked, show the car-colored swatch plus the actual Trophy Road requirement beside it (`N 🏆 / TO UNLOCK`)
- clarify the locked control's accessible name as color being locked, not the car
- bump the affected stylesheet/perk/paint cache identities

## Accessibility
The visible COLOR label is `aria-hidden` because the semantic control group is already named `Choose color`. Locked color retains one explicit button name explaining the trophy requirement. The H1 THE LOT → H2 CHOOSE CAR → H3 CAR INFORMATION → H2 RACE structure from #599 is unchanged.

## Regression coverage
The production M8 Lot contract now guards proportional thumbnail rendering, one perk disclosure per screen, visible-but-nonduplicating COLOR labeling, visible unlock copy, and the new cache identities.