### PR TITLE
Narrow The Lot thumbnail cards

### DIFF
--- a/turn/garage/lot-showroom-cleanup-r201.css
+++ b/turn/garage/lot-showroom-cleanup-r201.css
@@ -25,6 +25,19 @@
   display: none;
 }
 
+/* The mockup's carousel cards are about 1.55:1. Keep the established rail height
+   and derive card width from that ratio so the thumbnails stay consistently
+   narrower across landscape viewport sizes without changing their content. */
+.lot-showroom .lot-car-option,
+.lot-showroom .lot-car-option:focus-visible {
+  box-sizing: border-box;
+  flex: 0 0 auto;
+  width: auto;
+  min-width: 0;
+  height: 100%;
+  aspect-ratio: 1.55 / 1;
+}
+
 /* The captured thumbnail canvas has a fixed 20:9 intrinsic ratio. Let it letterbox
    inside responsive cards instead of stretching it to each card's current ratio. */
 .lot-showroom .lot-car-option-thumbnail {

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -14,7 +14,7 @@ import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
 // Keep the showroom implementation and its CSS out of TURN's initial module graph.
 // Choosing or activating a track gives us a natural warmup window for these resources.
 const SHOWROOM_STYLE_ID = 'turn-lot-showroom-r200';
-const SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r203-polish';
+const SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r204-thumbnail-ratio';
 let showroomStylePromise = null;
 let originalLotPromise = null;
 let originalLotModule = null;
@@ -51,7 +51,7 @@ function prepareShowroomStyles() {
     ),
     prepareStylesheet(
       SHOWROOM_CLEANUP_STYLE_ID,
-      './lot-showroom-cleanup-r201.css?revision=r203-thumbnail-color-polish'
+      './lot-showroom-cleanup-r201.css?revision=r204-narrow-thumbnail-ratio'
     )
   ]);
   return showroomStylePromise;

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -14,7 +14,7 @@ import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
 // Keep the showroom implementation and its CSS out of TURN's initial module graph.
 // Choosing or activating a track gives us a natural warmup window for these resources.
 const SHOWROOM_STYLE_ID = 'turn-lot-showroom-r200';
-const SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r204-thumbnail-ratio';
+const SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r203-polish';
 let showroomStylePromise = null;
 let originalLotPromise = null;
 let originalLotModule = null;
@@ -51,7 +51,7 @@ function prepareShowroomStyles() {
     ),
     prepareStylesheet(
       SHOWROOM_CLEANUP_STYLE_ID,
-      './lot-showroom-cleanup-r201.css?revision=r204-narrow-thumbnail-ratio'
+      './lot-showroom-cleanup-r201.css?revision=r203-thumbnail-color-polish-ratio155'
     )
   ]);
   return showroomStylePromise;


### PR DESCRIPTION
## Summary
- match the carousel card proportion to the supplied mockup at approximately 1.55:1
- keep the existing carousel height and derive width from the ratio
- leave thumbnail content, car rendering, labels, padding, borders, locks and accessibility behavior unchanged
- retain `object-fit: contain` so the rendered 3D canvases remain undistorted inside the narrower cards
- cache-bust only the existing Lot polish stylesheet URL

## Scope
This is intentionally a ratio-only visual adjustment. The supplied screenshots measure roughly 1.55:1 for the mockup cards versus about 2.2:1 in the current screenshot.