### PR TITLE
Make The Lot COLOR UI state-driven

### DIFF
--- a/turn-lab/tests/paint-lock-observer-production.mjs
+++ b/turn-lab/tests/paint-lock-observer-production.mjs
@@ -7,6 +7,7 @@ const [
   paintCss,
   showroomCleanupCss,
   lotRuntime,
+  lotWrapper,
   perkPresentation,
   app,
   index,
@@ -17,6 +18,7 @@ const [
   fs.readFile(new URL('../../turn/progression/trophy-road-r157.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-showroom-cleanup-r201.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-enhancement-runtime.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-track-select.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-perk-disclosure.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
@@ -26,159 +28,164 @@ const [
 const release = JSON.parse(releaseSource);
 const syncBody = paintGate.match(/function sync\(\) \{([\s\S]*?)\n  \}\n\n  const observer/ )?.[1] || '';
 assert.ok(syncBody, 'The paint gate must expose a bounded synchronization function');
-assert.match(paintGate, /observer\.observe\(picker,/,
-  'Paint synchronization must observe the car picker rather than the whole Lot screen');
-assert.doesNotMatch(paintGate, /observer\.observe\(screen,/,
-  'The lock presentation must not be inside the picker observer target');
-assert.match(syncBody, /if \(locked\) ensureLockButton\(carId\);[\s\S]*else removeLockPresentation\(\)/,
-  'Paint synchronization must keep the compact lock control only while paint is actually locked');
-assert.doesNotMatch(syncBody, /lot-paint-lock[\s\S]*remove\(\);[\s\S]*if \(locked\)/,
-  'A synchronization pass must never remove and immediately recreate its own lock control');
-assert.match(paintGate, /try \{[\s\S]*\} finally \{[\s\S]*syncing = false/,
-  'The synchronization guard must always be released');
 
-assert.match(paintGate, /function mutationTouchesPaintControl\(mutation\)/,
-  'The paint gate must distinguish showroom control replacement from its own presentation mutations');
-assert.match(
-  paintGate,
-  /mutations\.some\(mutationTouchesPaintControl\)\) sync\(\)/,
-  'Replacing native color controls must immediately resynchronize the locked swatch'
-);
-assert.match(
-  paintGate,
-  /controlObserver\.observe\(colors, \{ childList: true \}\)/,
-  'The control replacement observer must stay direct-child-only rather than observing the paint subtree'
-);
+// --- Stable baseline and explicit state model ---------------------------------
+assert.match(paintGate, /function selectedCarIsLocked\(screen\)/,
+  'CAR lock state must be modeled independently from paint state');
+assert.match(syncBody, /const carLocked = selectedCarIsLocked\(screen\)/);
+assert.match(syncBody, /const freeColor = Boolean\(car && !car\.fixedLivery\)/,
+  'Vehicle free/fixed color must be an explicit state dimension');
+assert.match(syncBody, /const paintLocked = Boolean\(freeColor && !paintUnlocked\)/,
+  'PAINTJOB lock must depend on paintability and PAINTJOB only, never car lock');
 assert.doesNotMatch(
-  paintGate,
-  /controlObserver\.observe\(colors, \{[^}]*subtree:\s*true/,
-  'Paint rebuild recovery must not observe descendants and recreate a self-trigger loop'
+  syncBody.match(/const paintLocked[^\n]*/)?.[0] || '',
+  /carLocked/,
+  'A locked vehicle must still expose the same COLOR baseline'
 );
-assert.match(paintGate, /controlObserver\.disconnect\(\)/,
-  'The focused color-control observer must be released with THE LOT');
+assert.match(syncBody, /colors\.dataset\.vehicleColorMode = car\?\.fixedLivery \? 'fixed' : 'free'/);
+assert.match(syncBody, /colors\.dataset\.paintState = car\?\.fixedLivery \? 'fixed' : \(paintUnlocked \? 'editable' : 'locked'\)/);
+assert.match(syncBody, /colors\.dataset\.carState = carLocked \? 'locked' : 'unlocked'/);
+assert.match(syncBody, /colors\.hidden = false/,
+  'The COLOR component must remain visible for every selected vehicle state');
+assert.match(syncBody, /colors\.removeAttribute\('aria-hidden'\)/,
+  'Fixed-livery showroom markup must not be allowed to remove COLOR from the final interface');
+assert.match(syncBody, /screen\.classList\.toggle\('lot-color-baseline-active', Boolean\(car\)\)/);
 
-assert.doesNotMatch(paintGate, /colors\.addEventListener\(['"]click['"]/,
-  'The paint container must never be a click-listener ancestor of the native color input');
-assert.doesNotMatch(paintGate, /colors\.addEventListener\(['"]keydown['"]/,
-  'The paint container must not emulate button keyboard behavior');
-assert.doesNotMatch(paintGate, /colors\.setAttribute\('role', 'button'\)|colors\.tabIndex\s*=/,
-  'The paint group must keep its real group semantics instead of becoming a faux button');
-assert.match(paintGate, /button = document\.createElement\('button'\)/,
-  'Locked color feedback should use a real button');
-assert.match(paintGate, /button\.type = 'button'/);
-assert.match(paintGate, /button\.className = 'lot-paint-lock-button'/);
-assert.match(paintGate, /button\.addEventListener\('click', showLockedPaintInfo\)/,
-  'The lock explanation belongs directly to the lock button, not an ancestor of paint inputs');
-assert.match(paintGate, /label\.className = 'lot-color-visible-label'/,
-  'The paint control must identify itself visibly as COLOR');
+// --- One visible COLOR label and swatch for every vehicle ----------------------
+assert.match(paintGate, /function ensureVisibleLabel\(car\)/);
+assert.match(paintGate, /label\.className = 'lot-color-visible-label'/);
 assert.match(paintGate, /label\.textContent = 'COLOR'/);
 assert.match(paintGate, /label\.setAttribute\('aria-hidden', 'true'\)/,
-  'The visual COLOR label must not duplicate the screen-reader group name');
-assert.match(paintGate, /lot-paint-lock-copy/);
-assert.match(paintGate, /copy\.innerHTML = `<strong>\$\{threshold\} 🏆<\/strong><small>TO UNLOCK<\/small>`/,
-  'Locked color must show the Trophy Road requirement next to its swatch');
+  'The visual COLOR label must not duplicate the named screen-reader group');
+assert.doesNotMatch(
+  paintGate.match(/function ensureVisibleLabel\(car\) \{([\s\S]*?)\n  \}/)?.[1] || '',
+  /fixedLivery[\s\S]*remove/,
+  'Fixed-livery cars must keep the same visible COLOR label as paintable cars'
+);
+
+assert.match(paintGate, /function ensureFixedColorDisplay\(car\)/,
+  'Set-color vehicles must receive a display-only swatch rather than an empty COLOR area');
+assert.match(paintGate, /swatch\.className = 'lot-fixed-color-display'/);
+assert.match(paintGate, /getVehicleDefaultColor\(car\.id\)/);
+assert.match(paintGate, /getVehicleDefaultSecondaryColor\(car\.id\)/,
+  'Fixed emergency liveries must expose their canonical secondary color too');
+assert.match(paintGate, /swatch\.classList\.toggle\('is-two-tone'/,
+  'Two-color fixed liveries must remain represented inside the same swatch footprint');
+assert.match(paintGate, /Fixed car colors\./,
+  'The display-only fixed swatch must still carry a useful accessible description');
+
+// --- TURN-owned visual face over native color input ----------------------------
+assert.match(paintGate, /function applyNativeSwatchFace\(control\)/);
+assert.match(paintGate, /control\.classList\.add\('has-turn-color-swatch'\)/);
+assert.match(paintGate, /control\.style\.setProperty\('--lot-color-swatch', input\.value\)/,
+  'The visible free-color swatch must be driven by the actual native input value');
+assert.match(
+  showroomCleanupCss,
+  /\.lot-showroom \.lot-color-control\.has-turn-color-swatch::before\s*\{[\s\S]*background: var\(--lot-color-swatch/,
+  'TURN must paint the visible swatch itself instead of relying on the browser color-input skin'
+);
+assert.match(
+  showroomCleanupCss,
+  /\.lot-showroom \.lot-color-control\.has-turn-color-swatch input\[type='color'\][\s\S]*opacity: 0/,
+  'The native color input must stay interactive but no longer be responsible for visible paint'
+);
+assert.match(
+  showroomCleanupCss,
+  /\.lot-showroom \.lot-color-control\.has-turn-color-swatch:focus-within::before[\s\S]*outline:/,
+  'Keyboard focus must remain visible on the TURN-owned swatch face'
+);
+assert.match(showroomCleanupCss, /\.lot-showroom \.lot-color-control\[hidden\][\s\S]*display: none !important/,
+  'PAINTJOB locking must reliably hide the native editable control despite author display rules');
+
+// --- PAINTJOB locked/unlocked ---------------------------------------------------
+assert.match(syncBody, /if \(freeColor && \(!paintUnlocked \|\| changedCar\)\) forceFactoryPaint\(carId\)/,
+  'Before PAINTJOB unlock, paintable vehicles must display their factory color');
+assert.match(syncBody, /control\.hidden = paintLocked/);
+assert.match(syncBody, /input\.disabled = paintLocked/);
+assert.match(syncBody, /if \(paintLocked\) ensureLockButton\(carId\);[\s\S]*else removeLockPresentation\(\)/,
+  'Free-color vehicles must turn the same swatch slot into a lock only while PAINTJOB is locked');
+assert.match(paintGate, /button\.className = 'lot-paint-lock-button'/);
 assert.match(paintGate, /Color locked\. Car color controls unlock at \$\{threshold\} trophies on Trophy Road\./,
-  'The lock button must make clear that color is locked, not the selected car');
-assert.doesNotMatch(paintGate, /<i>•<\/i>|<b>LOCKED<\/b>/,
-  'The compact color control must not add redundant decorative lock-status copy');
+  'The lock must describe COLOR, not imply that the vehicle itself is locked');
+assert.match(paintGate, /applyLockColour\(button\.querySelector\('\.lot-paint-lock'\), carId\)/,
+  'The locked swatch must still visibly represent the selected car factory color');
 assert.match(paintGate, /function contrastingInk\(hexColor\)/);
 assert.match(paintGate, /luminance > 0\.18 \? '#08090a' : '#fffdf6'/,
-  'The lock glyph must use whichever TURN ink gives the stronger colour contrast');
-assert.match(paintGate, /--lot-paint-lock-background/);
-assert.match(paintGate, /--lot-paint-lock-foreground/);
-assert.match(paintGate, /getVehicleDefaultColor\(carId\)/,
-  'The locked swatch must represent the selected car factory colour');
+  'The lock glyph must retain readable contrast over every car color');
 
+// --- COLOR CUES on/off, always in the same swatch-side slot --------------------
 assert.match(paintGate, /import \{ describeColorCue \} from '\.\.\/accessibility\/color-cues\.js\?revision=r163'/,
-  'The visual swatch-side cue must use the same canonical color naming as COLOR CUES');
-assert.match(paintGate, /function ensureVisualColorCue\(car\)/,
-  'The paint layer must own a visual cue that stays associated with its swatch');
-assert.match(
-  paintGate,
-  /cue\.className = 'turn-color-cue lot-color-cue lot-paint-color-cue'/,
-  'The swatch-side cue must obey the global COLOR CUES on/off state'
-);
+  'The visual cue must use the canonical COLOR CUES color naming');
+assert.match(paintGate, /function ensureVisualColorCue\(car\)/);
+assert.match(paintGate, /cue\.className = 'turn-color-cue lot-color-cue lot-paint-color-cue'/,
+  'The fixed swatch-side cue must obey the global COLOR CUES on/off CSS state');
 assert.match(paintGate, /cue\.setAttribute\('aria-hidden', 'true'\)/,
-  'The swatch-side copy is visual-only because the canonical selected-car cue remains semantic');
-assert.match(
-  paintGate,
-  /cue\.textContent = `CAR COLOR · \$\{describeColorCue\(bodyColorValue\(car\.id\)\)\.toUpperCase\(\)\}`/,
-  'The visual cue must always describe the actual body swatch color'
-);
-assert.match(paintGate, /const hasPaintControl = Boolean\(car && !car\.fixedLivery\)/,
-  'Only genuinely paintable cars may suppress the information-panel visual cue');
-assert.match(paintGate, /screen\.classList\.toggle\('lot-has-paint-control', hasPaintControl\)/);
+  'The new cue is visual-only because the existing selected-car cue remains semantic');
+assert.match(paintGate, /cue\.textContent = `CAR COLOR · \$\{colorCueDescription\(car\)\}`/);
+assert.match(paintGate, /if \(car\.fixedLivery\)[\s\S]*getVehicleDefaultSecondaryColor\(car\.id\)/,
+  'Fixed emergency liveries must get COLOR CUES in the same place, including their second color');
+assert.match(paintGate, /if \(car\.secondaryPaint\)/,
+  'Free-color vehicles with a secondary paint part must keep that extra color in the cue');
+assert.match(syncBody, /ensureVisualColorCue\(car\)/,
+  'Every selected-car state must finish by populating the same cue slot');
 assert.match(paintGate, /colors\.addEventListener\('input', handlePaintInput\)/,
-  'Unlocked native color changes must refresh the swatch-side cue immediately');
-assert.match(paintGate, /colors\.removeEventListener\('input', handlePaintInput\)/);
-
+  'Unlocked native color changes must update the TURN-owned swatch and cue immediately');
+assert.match(paintGate, /applyNativeSwatchFace\(event\.target\.closest\('\.lot-color-control'\)\)/);
 assert.match(
   showroomCleanupCss,
-  /\.lot-showroom \.lot-paint-color-cue\s*\{[\s\S]*font-size: clamp\(\.52rem, 1vw, \.68rem\)/,
-  'The visible Lot color cue must be substantially larger than the old tiny annotation'
+  /\.lot-showroom \.lot-paint-color-cue\s*\{[\s\S]*font-size: clamp\(\.56rem, 1\.08vw, \.72rem\)/,
+  'The swatch-side COLOR CUE must stay large enough to read'
 );
 assert.match(
   showroomCleanupCss,
-  /\.lot-showroom \.lot-paint-color-cue::before[\s\S]*repeating-linear-gradient/,
-  'The enlarged cue must keep the redundant pattern signal as well as text'
-);
-assert.match(
-  showroomCleanupCss,
-  /\.lot-showroom\.lot-has-paint-control \.lot-card \.lot-selected-car-color-cue[\s\S]*clip-path: inset\(50%\)/,
-  'For paintable cars the old semantic cue must remain accessible without being drawn twice'
+  /\.lot-showroom\.lot-color-baseline-active \.lot-card \.lot-selected-car-color-cue[\s\S]*clip-path: inset\(50%\)/,
+  'The old semantic cue must remain accessible without being visually duplicated for any car type'
 );
 
+// --- Observer safety ------------------------------------------------------------
+assert.match(paintGate, /observer\.observe\(picker,/,
+  'Paint synchronization must stay scoped to the car picker rather than the whole Lot screen');
+assert.doesNotMatch(paintGate, /observer\.observe\(screen,/,
+  'The COLOR presentation must never observe the screen subtree that contains its own writes');
+assert.match(paintGate, /attributeFilter: \['aria-checked', 'class'\]/,
+  'Selection and car-lock changes must both refresh the explicit state model');
+assert.match(paintGate, /function mutationTouchesPaintControl\(mutation\)/,
+  'The paint gate must distinguish showroom control replacement from its own presentation mutations');
+assert.match(paintGate, /mutations\.some\(mutationTouchesPaintControl\)\) sync\(\)/,
+  'Replacing native color controls must immediately resynchronize the baseline');
+assert.match(paintGate, /controlObserver\.observe\(colors, \{ childList: true \}\)/,
+  'The rebuild observer must stay direct-child-only');
+assert.doesNotMatch(paintGate, /controlObserver\.observe\(colors, \{[^}]*subtree:\s*true/,
+  'The color rebuild recovery must not recreate the old self-triggering observer loop');
+assert.match(paintGate, /try \{[\s\S]*\} finally \{[\s\S]*syncing = false/,
+  'The synchronization guard must always be released');
+assert.match(paintGate, /controlObserver\.disconnect\(\)/);
+
+// Keep native form semantics: no faux-button wrapper around editable color controls.
+assert.doesNotMatch(paintGate, /colors\.addEventListener\(['"]click['"]/,
+  'The COLOR container must never become a click-listener ancestor that hijacks native input behavior');
+assert.doesNotMatch(paintGate, /colors\.addEventListener\(['"]keydown['"]/);
+assert.doesNotMatch(paintGate, /colors\.setAttribute\('role', 'button'\)|colors\.tabIndex\s*=/);
+
+// Established Trophy Road / perk contracts remain intact.
 assert.match(paintCss, /\.lot-colors\.is-paint-locked[\s\S]*min-height: 54px/);
-assert.match(
-  paintCss,
-  /\.lot-viewbox-with-paint \.lot-colors\.is-paint-locked \{[\s\S]*position: absolute;[\s\S]*bottom: 0;/,
-  'The locked Paintjob treatment must occupy the reserved bottom rail rather than cover the 3D viewer'
-);
-assert.doesNotMatch(
-  paintCss.match(/\.lot-colors\.is-paint-locked\s*\{([\s\S]*?)\}/)?.[1] || '',
-  /position: relative/,
-  'The generic locked state must not override the absolute bottom-rail placement'
-);
-const paintLockButtonRule = paintCss.match(/\.lot-paint-lock-button\s*\{([\s\S]*?)\}/)?.[1] || '';
-assert.ok(paintLockButtonRule, 'The real locked Paintjob button must have its own layout rule');
-assert.match(paintLockButtonRule, /grid-template-columns: minmax\(0, 1fr\) auto/);
-assert.match(paintLockButtonRule, /width: 100%/);
-const paintLockRule = paintCss.match(/\.lot-paint-lock\s*\{([\s\S]*?)\}/)?.[1] || '';
-assert.ok(paintLockRule, 'The compact paint lock must have its own CSS rule');
-assert.match(paintLockRule, /width: 36px/);
-assert.match(paintLockRule, /height: 36px/);
-assert.match(paintLockRule, /background: var\(--lot-paint-lock-background/);
-assert.match(paintLockRule, /color: var\(--lot-paint-lock-foreground/);
-assert.match(paintLockRule, /border: 2px solid var\(--turn-ink/,
-  'The swatch keeps the TURN black outline even when the lock glyph needs white contrast');
-assert.doesNotMatch(paintLockRule, /width: 100%/);
-
 assert.match(lotGate, /function dismissVisibleUnlockNotice\(\)/);
 assert.match(lotGate, /\.turn-unlock-notice\.is-visible/);
-assert.match(lotGate, /notice\.classList\.remove\('is-visible'\)/);
 assert.match(lotGate, /trophy-road\.js\?revision=r164-vintage-rally-perks/);
-assert.match(lotGate, /if \(lastAnnouncedCarId\) dismissVisibleUnlockNotice\(\)/,
-  'Selecting an available vehicle after a locked one must remove the stale lock notice');
-assert.match(lotGate, /if \(lastAnnouncedCarId\) dismissVisibleUnlockNotice\(\);[\s\S]*raceButton\.classList\.remove/,
-  'Leaving The Lot must not leave a vehicle lock notice behind');
-
 assert.match(lotRuntime, /lot-trophy-gate\.js\?revision=r164-vintage-rally-perks/);
-assert.match(lotRuntime, /lot-paint-reward\.js\?revision=r204-color-control-rebuild/);
+assert.match(lotRuntime, /lot-paint-reward\.js\?revision=r205-color-baseline/,
+  'The baseline color state model must receive a fresh module cache identity');
 assert.match(lotRuntime, /lot-perk-disclosure\.js\?revision=r203-idempotent/);
+assert.match(lotWrapper, /lot-enhancement-runtime\.js\?revision=r205-color-baseline/,
+  'The showroom wrapper must not reuse a cached enhancement runtime');
+assert.match(lotWrapper, /SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r205-polish'/);
+assert.match(lotWrapper, /lot-showroom-cleanup-r201\.css\?revision=r205-color-baseline/);
 
 assert.match(perkPresentation, /getCarDefinition\(vehicleId\)\?\.perk/,
-  'Inline perk identity must be read from the selected car itself');
-assert.doesNotMatch(perkPresentation, /rewardForVehicle|trophy-road/,
-  'Inline perk presentation must not become a progression entitlement');
-assert.match(
-  perkPresentation,
-  /observer\.observe\(picker, \{[\s\S]*subtree: true,[\s\S]*attributes: true,[\s\S]*attributeFilter: \['aria-checked'\][\s\S]*\}\);/,
-  'Inline perk synchronization must remain scoped to selected-car radio state'
-);
+  'Inline perk identity must remain car-owned');
 assert.doesNotMatch(perkPresentation, /observer\.observe\(screen,/,
-  'Inline perk presentation must never observe the DOM subtree that contains its own copy');
-assert.doesNotMatch(perkPresentation, /childList:\s*true|characterData:\s*true/,
-  'Inline perk presentation must not reintroduce the self-triggering DOM/text observer that froze The Lot');
+  'Perk presentation must not reintroduce its old self-triggering observer');
+assert.doesNotMatch(perkPresentation, /childList:\s*true|characterData:\s*true/);
 
 assert.match(app, /trophy-road-r157\.css\?revision=r163-native-picker-parent-click/);
 assert.match(app, /lot-enhancement-runtime\.js\?revision=r163-native-picker-parent-click/);
@@ -187,4 +194,4 @@ assert.match(
   new RegExp(`app\\.js\\?build=${release.cacheKey}-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click`)
 );
 
-console.log('TURN Lot color swatch rebuild, enlarged swatch-side cue, observer safety and native paint ancestry regressions passed.');
+console.log('TURN Lot COLOR baseline state matrix, browser-independent swatches, cue placement and observer safety regressions passed.');

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -1,6 +1,7 @@
 // Historical regression marker: lot-perk-disclosure.js?revision=r164-vintage-rally-perks
 // Historical regression marker: lot-trophy-gate.js?revision=r164-vintage-rally-perks
 // Historical regression marker: lot-paint-reward.js?revision=r164-perks
+// Historical regression marker: lot-paint-reward.js?revision=r203-color-label
 // Historical regression marker: lot-paint-reward.js?revision=r204-color-control-rebuild
 // Historical regression marker: lot-accessibility-r118.js?build=20260729-r118
 

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -1,7 +1,7 @@
 // Historical regression marker: lot-perk-disclosure.js?revision=r164-vintage-rally-perks
 // Historical regression marker: lot-trophy-gate.js?revision=r164-vintage-rally-perks
 // Historical regression marker: lot-paint-reward.js?revision=r164-perks
-// Historical regression marker: lot-paint-reward.js?revision=r203-color-label
+// Historical regression marker: lot-paint-reward.js?revision=r204-color-control-rebuild
 // Historical regression marker: lot-accessibility-r118.js?build=20260729-r118
 
 // Historical regression markers for the established enhancement layers:
@@ -24,7 +24,7 @@ export function prepareLotEnhancements() {
     import('./lot-accessibility-r118.js?build=20260729-r118&revision=r588-canonical-attributes'),
     import('./lot-perk-disclosure.js?revision=r203-idempotent'),
     import('../progression/lot-trophy-gate.js?revision=r585-visible-locks'),
-    import('../progression/lot-paint-reward.js?revision=r204-color-control-rebuild')
+    import('../progression/lot-paint-reward.js?revision=r205-color-baseline')
   ]).then(([
     statLegend,
     layout,

--- a/turn/garage/lot-showroom-cleanup-r201.css
+++ b/turn/garage/lot-showroom-cleanup-r201.css
@@ -69,7 +69,7 @@
   white-space: nowrap;
 }
 
-/* Make the floating paint control read as COLOR first, lock state second. */
+/* COLOR is one stable component for every selected car. */
 .lot-showroom .lot-color-visible-label {
   flex: 0 0 auto;
   align-self: center;
@@ -79,6 +79,66 @@
   letter-spacing: .09em;
   line-height: 1;
   white-space: nowrap;
+}
+
+/* Never rely on WebKit's internal <input type=color> swatch for visible colour.
+   iOS can leave the input tappable while failing to paint its internal swatch after
+   repeated DOM replacement. TURN owns the square; the native input remains the real
+   interactive/accessibility control invisibly on top of it. */
+.lot-showroom .lot-color-control[hidden] {
+  display: none !important;
+}
+
+.lot-showroom .lot-color-control.has-turn-color-swatch::before {
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  box-sizing: border-box;
+  border: 2px solid var(--ink, #08090a);
+  border-radius: 10px;
+  background: var(--lot-color-swatch, #ffcc00);
+  content: '';
+  pointer-events: none;
+}
+
+.lot-showroom .lot-color-control.has-turn-color-swatch input[type='color'] {
+  position: absolute;
+  z-index: 2;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.lot-showroom .lot-color-control.has-turn-color-swatch:focus-within::before {
+  outline: 4px solid var(--cyan, #38d9ff);
+  outline-offset: 2px;
+}
+
+/* Fixed-livery vehicles use the exact same COLOR slot. Their swatch is display-only
+   because PAINTJOB never changes an ambulance/police/fire livery. A diagonal split
+   communicates the two canonical livery colours without inventing another control. */
+.lot-showroom .lot-fixed-color-display {
+  display: block;
+  flex: 0 0 42px;
+  width: 42px;
+  min-width: 42px;
+  height: 42px;
+  min-height: 42px;
+  box-sizing: border-box;
+  border: 2px solid var(--ink, #08090a);
+  border-radius: 10px;
+  background: var(--lot-fixed-primary, #ffcc00);
+}
+
+.lot-showroom .lot-fixed-color-display.is-two-tone {
+  background: linear-gradient(
+    135deg,
+    var(--lot-fixed-primary, #ffcc00) 0 48%,
+    var(--lot-fixed-secondary, #fffdf6) 52% 100%
+  );
 }
 
 .lot-showroom .lot-paint-lock-button {
@@ -121,21 +181,21 @@
   letter-spacing: .06em;
 }
 
-/* COLOR CUES gets a large visual copy beside the real swatch/lock. The original
-   selected-car cue in CAR INFORMATION stays in the accessibility tree but is
-   visually hidden for paintable cars so the same message is not drawn twice. */
+/* COLOR CUES owns one fixed visual slot beside the swatch in every state: editable,
+   PAINTJOB locked, fixed livery, car locked or car unlocked. The older selected-car
+   cue stays in the accessibility tree but is never drawn a second time in the card. */
 .lot-showroom .lot-paint-color-cue {
   flex: 0 1 auto;
   align-self: center;
-  max-width: min(44vw, 230px);
+  max-width: min(46vw, 250px);
   margin: 0 2px 0 3px;
-  padding: 4px 8px;
+  padding: 5px 9px;
   overflow: hidden;
   border: 2px solid var(--ink, #08090a);
   border-radius: 999px;
   background: rgb(255 248 232 / .94);
   color: var(--ink, #08090a);
-  font-size: clamp(.52rem, 1vw, .68rem);
+  font-size: clamp(.56rem, 1.08vw, .72rem);
   font-weight: 950;
   letter-spacing: .045em;
   line-height: 1;
@@ -154,7 +214,7 @@
   content: '';
 }
 
-.lot-showroom.lot-has-paint-control .lot-card .lot-selected-car-color-cue {
+.lot-showroom.lot-color-baseline-active .lot-card .lot-selected-car-color-cue {
   position: absolute !important;
   width: 1px !important;
   height: 1px !important;
@@ -181,15 +241,15 @@
   .lot-showroom .lot-paint-lock-copy strong { font-size: .36rem; }
   .lot-showroom .lot-paint-lock-copy small { font-size: .27rem; }
   .lot-showroom .lot-paint-color-cue {
-    max-width: min(40vw, 200px);
-    padding: 3px 6px;
-    font-size: .48rem;
+    max-width: min(42vw, 215px);
+    padding: 4px 7px;
+    font-size: .5rem;
   }
 }
 
 @media (max-height: 430px) {
   .lot-showroom .lot-paint-color-cue {
-    max-width: min(36vw, 176px);
-    font-size: .44rem;
+    max-width: min(38vw, 190px);
+    font-size: .46rem;
   }
 }

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -1,7 +1,7 @@
 import {
   enhanceLotNow,
   prepareLotEnhancements
-} from './lot-enhancement-runtime.js?revision=r588-canonical-attributes&build=20260804-r157';
+} from './lot-enhancement-runtime.js?revision=r205-color-baseline&build=20260804-r157';
 import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r52';
 import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
 
@@ -10,13 +10,15 @@ import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
 // export async function showEnhancedLot
 // SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r203-polish'
 // lot-showroom-cleanup-r201.css?revision=r203-thumbnail-color-polish
+// SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r204-polish'
+// lot-showroom-cleanup-r201.css?revision=r204-color-swatch-cue
 // The actual prepared M8 entry below is deliberately synchronous after warmup so
 // its existing Race This Car motion-access gate can bind immediately after mount.
 
 // Keep the showroom implementation and its CSS out of TURN's initial module graph.
 // Choosing or activating a track gives us a natural warmup window for these resources.
 const SHOWROOM_STYLE_ID = 'turn-lot-showroom-r200';
-const SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r204-polish';
+const SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r205-polish';
 let showroomStylePromise = null;
 let originalLotPromise = null;
 let originalLotModule = null;
@@ -53,7 +55,7 @@ function prepareShowroomStyles() {
     ),
     prepareStylesheet(
       SHOWROOM_CLEANUP_STYLE_ID,
-      './lot-showroom-cleanup-r201.css?revision=r204-color-swatch-cue'
+      './lot-showroom-cleanup-r201.css?revision=r205-color-baseline'
     )
   ]);
   return showroomStylePromise;

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -7,6 +7,7 @@ import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
 
 // Historical production regression markers while the showroom replaces this loader:
 // lot-r10.js?build=20260809-r163-native-html&revision=r590-canonical-lock-icon
+// lot-enhancement-runtime.js?revision=r588-canonical-attributes
 // export async function showEnhancedLot
 // SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r203-polish'
 // lot-showroom-cleanup-r201.css?revision=r203-thumbnail-color-polish

--- a/turn/progression/lot-paint-reward.js
+++ b/turn/progression/lot-paint-reward.js
@@ -20,8 +20,16 @@ function findLotScreen(root) {
   return root?.querySelector?.('.lot-screen') || null;
 }
 
+function selectedCarButton(screen) {
+  return screen.querySelector('.lot-car-option[aria-checked="true"]');
+}
+
 function selectedCarId(screen) {
-  return screen.querySelector('.lot-car-option[aria-checked="true"]')?.dataset.carId || '';
+  return selectedCarButton(screen)?.dataset.carId || '';
+}
+
+function selectedCarIsLocked(screen) {
+  return selectedCarButton(screen)?.classList.contains('is-trophy-locked') === true;
 }
 
 function setInputValue(input, value) {
@@ -66,11 +74,22 @@ export function gateLotPaintNow(root = document.body) {
   let lastCarId = selectedCarId(screen);
   let paintWasUnlocked = isPaintUnlocked();
 
+  function paintControl(label = 'body') {
+    return [...colors.querySelectorAll('.lot-color-control')]
+      .find((control) => String(control.dataset.paintLabel || '').toLowerCase() === label.toLowerCase());
+  }
+
   function bodyColorValue(carId) {
-    const body = [...colors.querySelectorAll('.lot-color-control')]
-      .find((control) => control.dataset.paintLabel?.toLowerCase() === 'body')
-      ?.querySelector('input[type="color"]');
-    return body?.value || getVehicleDefaultColor(carId);
+    return paintControl('body')?.querySelector('input[type="color"]')?.value
+      || getVehicleDefaultColor(carId);
+  }
+
+  function secondaryColorValue(car) {
+    if (!car) return '';
+    const secondaryControl = [...colors.querySelectorAll('.lot-color-control')]
+      .find((control) => String(control.dataset.paintLabel || '').toLowerCase() !== 'body');
+    return secondaryControl?.querySelector('input[type="color"]')?.value
+      || getVehicleDefaultSecondaryColor(car.id);
   }
 
   function forceFactoryPaint(carId) {
@@ -96,15 +115,9 @@ export function gateLotPaintNow(root = document.body) {
     });
   }
 
-  function applyLockColour(icon, carId) {
-    const bodyColour = getVehicleDefaultColor(carId);
-    icon.style.setProperty('--lot-paint-lock-background', bodyColour);
-    icon.style.setProperty('--lot-paint-lock-foreground', contrastingInk(bodyColour));
-  }
-
   function ensureVisibleLabel(car) {
     let label = colors.querySelector('.lot-color-visible-label');
-    if (!car || car.fixedLivery) {
+    if (!car) {
       label?.remove();
       return null;
     }
@@ -116,6 +129,63 @@ export function gateLotPaintNow(root = document.body) {
       colors.prepend(label);
     }
     return label;
+  }
+
+  function applyNativeSwatchFace(control) {
+    if (!control) return;
+    const input = control.querySelector('input[type="color"]');
+    if (!input) return;
+    control.classList.add('has-turn-color-swatch');
+    control.style.setProperty('--lot-color-swatch', input.value);
+  }
+
+  function syncNativeSwatchFaces() {
+    for (const control of colors.querySelectorAll('.lot-color-control')) {
+      applyNativeSwatchFace(control);
+    }
+  }
+
+  function removeFixedColorDisplay() {
+    colors.querySelector('.lot-fixed-color-display')?.remove();
+  }
+
+  function ensureFixedColorDisplay(car) {
+    let swatch = colors.querySelector('.lot-fixed-color-display');
+    if (!car?.fixedLivery) {
+      swatch?.remove();
+      return null;
+    }
+
+    if (!swatch) {
+      swatch = document.createElement('span');
+      swatch.className = 'lot-fixed-color-display';
+      swatch.setAttribute('role', 'img');
+      const label = colors.querySelector('.lot-color-visible-label');
+      if (label) label.insertAdjacentElement('afterend', swatch);
+      else colors.prepend(swatch);
+    }
+
+    const primary = getVehicleDefaultColor(car.id);
+    const secondary = getVehicleDefaultSecondaryColor(car.id);
+    const primaryName = describeColorCue(primary);
+    const secondaryName = describeColorCue(secondary);
+    swatch.style.setProperty('--lot-fixed-primary', primary);
+    swatch.style.setProperty('--lot-fixed-secondary', secondary);
+    swatch.classList.toggle('is-two-tone', secondary.toLowerCase() !== primary.toLowerCase());
+    swatch.setAttribute(
+      'aria-label',
+      secondary.toLowerCase() !== primary.toLowerCase()
+        ? `Fixed car colors. ${primaryName} and ${secondaryName}.`
+        : `Fixed car color. ${primaryName}.`
+    );
+    swatch.title = 'Fixed vehicle colors';
+    return swatch;
+  }
+
+  function applyLockColour(icon, carId) {
+    const bodyColour = getVehicleDefaultColor(carId);
+    icon.style.setProperty('--lot-paint-lock-background', bodyColour);
+    icon.style.setProperty('--lot-paint-lock-foreground', contrastingInk(bodyColour));
   }
 
   function ensureLockButton(carId) {
@@ -153,9 +223,30 @@ export function gateLotPaintNow(root = document.body) {
     return button;
   }
 
+  function removeLockPresentation() {
+    colors.querySelector('.lot-paint-lock-button')?.remove();
+  }
+
+  function colorCueDescription(car) {
+    if (!car) return '';
+    const primary = describeColorCue(bodyColorValue(car.id)).toUpperCase();
+
+    if (car.fixedLivery) {
+      const secondary = describeColorCue(getVehicleDefaultSecondaryColor(car.id)).toUpperCase();
+      return secondary === primary ? primary : `${primary} + ${secondary}`;
+    }
+
+    if (car.secondaryPaint) {
+      const secondary = describeColorCue(secondaryColorValue(car)).toUpperCase();
+      return `${primary} + ${car.secondaryPaint.label.toUpperCase()} ${secondary}`;
+    }
+
+    return primary;
+  }
+
   function ensureVisualColorCue(car) {
     let cue = colors.querySelector('.lot-paint-color-cue');
-    if (!car || car.fixedLivery) {
+    if (!car) {
       cue?.remove();
       return null;
     }
@@ -164,13 +255,9 @@ export function gateLotPaintNow(root = document.body) {
       cue.className = 'turn-color-cue lot-color-cue lot-paint-color-cue';
       cue.setAttribute('aria-hidden', 'true');
     }
-    cue.textContent = `CAR COLOR · ${describeColorCue(bodyColorValue(car.id)).toUpperCase()}`;
+    cue.textContent = `CAR COLOR · ${colorCueDescription(car)}`;
     if (cue.parentElement !== colors || cue !== colors.lastElementChild) colors.append(cue);
     return cue;
-  }
-
-  function removeLockPresentation() {
-    colors.querySelector('.lot-paint-lock-button')?.remove();
   }
 
   function sync() {
@@ -182,24 +269,41 @@ export function gateLotPaintNow(root = document.body) {
       const car = CAR_BY_ID.get(carId);
       const paintUnlocked = isPaintUnlocked();
       const changedCar = Boolean(carId) && carId !== lastCarId;
+      const carLocked = selectedCarIsLocked(screen);
+      const freeColor = Boolean(car && !car.fixedLivery);
       const controls = [...colors.querySelectorAll('.lot-color-control:not(.lot-fixed-livery)')];
-      const hasPaintControl = Boolean(car && !car.fixedLivery);
 
-      screen.classList.toggle('lot-has-paint-control', hasPaintControl);
+      colors.hidden = false;
+      colors.removeAttribute('aria-hidden');
+      screen.classList.toggle('lot-color-baseline-active', Boolean(car));
+      colors.dataset.vehicleColorMode = car?.fixedLivery ? 'fixed' : 'free';
+      colors.dataset.paintState = car?.fixedLivery ? 'fixed' : (paintUnlocked ? 'editable' : 'locked');
+      colors.dataset.carState = carLocked ? 'locked' : 'unlocked';
+
       ensureVisibleLabel(car);
-      if (hasPaintControl && (!paintUnlocked || changedCar)) forceFactoryPaint(carId);
+      syncNativeSwatchFaces();
 
-      const locked = Boolean(hasPaintControl && !paintUnlocked);
-      colors.classList.toggle('is-paint-locked', locked);
+      if (freeColor && (!paintUnlocked || changedCar)) forceFactoryPaint(carId);
+
+      const paintLocked = Boolean(freeColor && !paintUnlocked);
+      colors.classList.toggle('is-paint-locked', paintLocked);
 
       for (const control of controls) {
-        control.hidden = locked;
+        control.hidden = paintLocked;
         const input = control.querySelector('input');
-        if (input) input.disabled = locked;
+        if (input) input.disabled = paintLocked;
+        applyNativeSwatchFace(control);
       }
 
-      if (locked) ensureLockButton(carId);
-      else removeLockPresentation();
+      if (car?.fixedLivery) {
+        removeLockPresentation();
+        ensureFixedColorDisplay(car);
+      } else {
+        removeFixedColorDisplay();
+        if (paintLocked) ensureLockButton(carId);
+        else removeLockPresentation();
+      }
+
       ensureVisualColorCue(car);
 
       if (!paintWasUnlocked && paintUnlocked) {
@@ -214,20 +318,19 @@ export function gateLotPaintNow(root = document.body) {
   }
 
   const observer = new MutationObserver(sync);
-  // Selection remains the primary signal. Keep this observer scoped to the picker,
-  // never the whole Lot screen.
+  // Selection and car-lock state are independent inputs to the COLOR baseline.
+  // Keep this observer scoped to the picker rather than the Lot screen.
   observer.observe(picker, {
     childList: true,
     subtree: true,
     attributes: true,
-    attributeFilter: ['aria-checked']
+    attributeFilter: ['aria-checked', 'class']
   });
 
-  // The showroom replaces the native color controls whenever a different car is
-  // selected. That replacement can remove the injected COLOR label and locked swatch
-  // after the picker mutation has already been observed. Watch only direct child-list
-  // changes that actually add/remove .lot-color-control nodes. Our own label/button/cue
-  // mutations are ignored, so this cannot create the old self-observer feedback loop.
+  // The showroom replaces native color controls whenever a different paintable car
+  // is selected. Watch only direct child-list changes that actually add/remove those
+  // controls. Our own label, fixed-display, lock and cue mutations are ignored, so
+  // this cannot recreate the old self-observer feedback loop.
   const controlObserver = new MutationObserver((mutations) => {
     if (mutations.some(mutationTouchesPaintControl)) sync();
   });
@@ -235,6 +338,7 @@ export function gateLotPaintNow(root = document.body) {
 
   const handlePaintInput = (event) => {
     if (!event.target?.matches?.('input[type="color"]')) return;
+    applyNativeSwatchFace(event.target.closest('.lot-color-control'));
     const car = CAR_BY_ID.get(selectedCarId(screen));
     ensureVisualColorCue(car);
   };
@@ -256,15 +360,21 @@ export function gateLotPaintNow(root = document.body) {
     window.removeEventListener('storage', handleStorage);
     raceButton.removeEventListener('click', sync, { capture: true });
     removeLockPresentation();
+    removeFixedColorDisplay();
     colors.querySelector('.lot-color-visible-label')?.remove();
     colors.querySelector('.lot-paint-color-cue')?.remove();
     for (const control of colors.querySelectorAll('.lot-color-control')) {
       control.hidden = false;
+      control.classList.remove('has-turn-color-swatch');
+      control.style.removeProperty('--lot-color-swatch');
       const input = control.querySelector('input');
       if (input) input.disabled = false;
     }
     colors.classList.remove('is-paint-locked');
-    screen.classList.remove('lot-has-paint-control');
+    delete colors.dataset.vehicleColorMode;
+    delete colors.dataset.paintState;
+    delete colors.dataset.carState;
+    screen.classList.remove('lot-color-baseline-active');
     delete screen.dataset.turnPaintUnlocked;
     activeGates.delete(screen);
   };


### PR DESCRIPTION
## Summary
- replace the fragile native iOS color-input visual with a TURN-owned swatch face while retaining the real native input for interaction/accessibility
- make COLOR a permanent showroom component across PAINTJOB locked/unlocked, car locked/unlocked, COLOR CUES on/off, and free/fixed vehicle color
- give fixed emergency liveries the same COLOR slot using a display-only two-tone swatch rather than removing the component
- keep car lock orthogonal to color visibility; it is modeled but never used to hide COLOR
- keep PAINTJOB lock orthogonal to fixed liveries; fixed colors do not receive a misleading unlock lock
- place the COLOR CUES text in one stable swatch-side slot for every vehicle type and describe both colors for fixed two-tone liveries
- preserve the existing semantic selected-car cue while visually suppressing its duplicate in the information card
- retain direct-child-only paint-control rebuild observation to avoid the old mutation-observer feedback loop

## Root causes addressed
1. The showroom deliberately removed all color controls for `fixedLivery` cars, so the presence of COLOR depended on implementation rather than UI state.
2. Paintable cars relied on WebKit's internal `<input type=color>` swatch after `appearance:none`; on iOS that internal swatch can disappear after repeated DOM replacement while the input remains tappable.

## State contract
- COLOR CUES: only toggles cue visibility, never component structure
- PAINTJOB: switches a free-color swatch between locked and editable states
- CAR lock: affects race entitlement elsewhere, never COLOR visibility
- VEHICLE color mode: free = native editable/locked swatch; fixed = display-only canonical livery swatch

## Regression coverage
The existing paint observer production regression now pins the full state matrix, TURN-owned swatch rendering, fixed-livery behavior, cue placement, cache identities, and observer safety.