### PR TITLE
Fix PWA Lot COLOR clipping on reward cars

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -184,6 +184,9 @@ jobs:
       - name: Run Lot paint observer freeze regression
         run: node turn-lab/tests/paint-lock-observer-production.mjs
 
+      - name: Run Lot PWA COLOR scroll-boundary regression
+        run: node turn-lab/tests/lot-pwa-color-scroll-boundary.mjs
+
       - name: Run production sound foundation regression
         run: node turn-lab/tests/audio-foundation-production.mjs
 
@@ -240,6 +243,7 @@ jobs:
 
       - name: Run Cliffside containment regression
         run: node turn-tests/cliffside-containment-production.mjs
+
       - name: Run full viewport coverage regression
         run: node turn-tests/viewport-coverage-production.mjs
 

--- a/turn-lab/tests/lot-pwa-color-scroll-boundary.mjs
+++ b/turn-lab/tests/lot-pwa-color-scroll-boundary.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const [boundary, runtime, screenReader, perk, showroomCss] = await Promise.all([
+  fs.readFile(new URL('../../turn/garage/lot-card-scroll-boundary.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-enhancement-runtime.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-screen-reader-r202.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-perk-disclosure.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-showroom-experiment.css', import.meta.url), 'utf8')
+]);
+
+// COLOR is intentionally moved into .lot-card for the requested semantic order.
+assert.match(screenReader, /card\.insertBefore\(colors, raceHeading\)/,
+  'The screen-reader pass must keep COLOR between Car information and Race in DOM order');
+
+// Reward cars have perk copy, which can make the information panel genuinely scroll.
+assert.match(perk, /description\.after\(perk\)/,
+  'Perk copy must remain part of car information rather than the floating COLOR control');
+assert.match(showroomCss, /\.lot-showroom \.lot-card\s*\{[\s\S]*overflow-y:\s*auto/,
+  'The base showroom still documents the historical card-level scroll behavior this compatibility layer overrides');
+
+// Standalone iOS must never have the fixed COLOR control inside the active scrolling ancestor.
+assert.match(boundary, /\.lot-showroom\.lot-card-scroll-boundary \.lot-card\s*\{[\s\S]*overflow:\s*visible/,
+  'The card itself must stop being the scrolling/clipping ancestor');
+assert.match(boundary, /\.lot-showroom \.lot-card-info-scroll\s*\{[\s\S]*overflow-y:\s*auto/,
+  'Only the inner car-information region may scroll');
+assert.match(boundary, /-webkit-overflow-scrolling:\s*touch/,
+  'The inner information scroller must retain native iOS momentum scrolling');
+
+// The wrapper must contain every variable-height information node, especially perk copy,
+// while COLOR and RACE stay as card siblings outside the scroll layer.
+for (const selector of [
+  "'.lot-car-title'",
+  "'.lot-car-description'",
+  "'.lot-perk-disclosure'",
+  "'.lot-stats'",
+  "'.lot-stats-help'"
+]) {
+  assert.match(boundary, new RegExp(`card\\.querySelector\\(${selector.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')}\\)`));
+}
+assert.match(boundary, /for \(const node of \[title, description, perk, stats, statsHelp\]\)/);
+assert.doesNotMatch(boundary, /lot-colors|lot-race/,
+  'COLOR and RACE must never be moved into the inner scroll region');
+
+// The production enhancement lifecycle must install the boundary after perk/stat/layout
+// construction, before the later screen-reader pass moves COLOR into the card.
+assert.match(runtime, /lot-card-scroll-boundary\.js\?revision=r208-pwa-scroll-boundary/);
+assert.match(runtime, /installLotCardScrollBoundary: scrollBoundary\.installLotCardScrollBoundary/);
+const installOrder = runtime.match(/const removePerkDisclosure[\s\S]*?const removeAccessibility = installLotAccessibility\(scope\);/)?.[0] || '';
+assert.ok(installOrder, 'Lot enhancement installation order must remain inspectable');
+assert.ok(installOrder.indexOf('removePerkDisclosure') < installOrder.indexOf('removeCardScrollBoundary'));
+assert.ok(installOrder.indexOf('removeStatLegend') < installOrder.indexOf('removeCardScrollBoundary'));
+assert.ok(installOrder.indexOf('removeLayout') < installOrder.indexOf('removeCardScrollBoundary'));
+assert.ok(installOrder.indexOf('removeCardScrollBoundary') < installOrder.indexOf('removeAccessibility'));
+
+// Cleanup must restore the original DOM before the showroom is removed.
+assert.match(boundary, /while \(scroll\.firstChild\) card\.insertBefore\(scroll\.firstChild, scroll\)/);
+assert.match(boundary, /screen\.classList\.remove\('lot-card-scroll-boundary'\)/);
+assert.match(runtime, /removeAccessibility\(\);[\s\S]*removeCardScrollBoundary\(\);/);
+
+console.log('TURN Lot standalone-PWA COLOR scroll-boundary regression passed.');

--- a/turn/garage/lot-card-scroll-boundary.js
+++ b/turn/garage/lot-card-scroll-boundary.js
@@ -1,0 +1,73 @@
+const STYLE_ID = 'turn-lot-card-scroll-boundary-r208-style';
+const activeBoundaries = new WeakMap();
+
+function findLotScreen(root) {
+  if (root?.matches?.('.lot-screen')) return root;
+  return root?.querySelector?.('.lot-screen') || null;
+}
+
+function installStyle() {
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = `
+    /* The screen-reader pass places COLOR inside .lot-card for semantic order.
+       Do not make that same ancestor the scrolling box: standalone iOS can clip
+       fixed-position descendants of an actively scrolling overflow container. */
+    .lot-showroom.lot-card-scroll-boundary .lot-card {
+      overflow: visible;
+      overscroll-behavior: auto;
+    }
+
+    .lot-showroom .lot-card-info-scroll {
+      min-width: 0;
+      min-height: 0;
+      flex: 1 1 auto;
+      overflow-x: hidden;
+      overflow-y: auto;
+      overscroll-behavior: contain;
+      -webkit-overflow-scrolling: touch;
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+export function installLotCardScrollBoundary(root = document.body) {
+  const screen = findLotScreen(root);
+  const card = screen?.querySelector('.lot-card');
+  if (!screen?.classList.contains('lot-showroom') || !card) return () => {};
+
+  const existing = activeBoundaries.get(screen);
+  if (existing) return existing.release;
+
+  const title = card.querySelector('.lot-car-title');
+  const description = card.querySelector('.lot-car-description');
+  const perk = card.querySelector('.lot-perk-disclosure');
+  const stats = card.querySelector('.lot-stats');
+  const statsHelp = card.querySelector('.lot-stats-help');
+  if (!title || !description || !stats) return () => {};
+
+  installStyle();
+
+  const scroll = document.createElement('div');
+  scroll.className = 'lot-card-info-scroll';
+  card.insertBefore(scroll, title);
+  for (const node of [title, description, perk, stats, statsHelp]) {
+    if (node?.parentElement === card) scroll.appendChild(node);
+  }
+
+  screen.classList.add('lot-card-scroll-boundary');
+
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
+    while (scroll.firstChild) card.insertBefore(scroll.firstChild, scroll);
+    scroll.remove();
+    screen.classList.remove('lot-card-scroll-boundary');
+    activeBoundaries.delete(screen);
+  };
+
+  activeBoundaries.set(screen, { release });
+  return release;
+}

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -25,6 +25,7 @@ export function prepareLotEnhancements() {
     import('./lot-layout-r60.js?build=20260729-r116'),
     import('./lot-accessibility-r118.js?build=20260729-r118&revision=r588-canonical-attributes'),
     import('./lot-perk-disclosure.js?revision=r203-idempotent'),
+    import('./lot-card-scroll-boundary.js?revision=r208-pwa-scroll-boundary'),
     import('../progression/lot-trophy-gate.js?revision=r585-visible-locks'),
     import('../progression/lot-paint-reward.js?revision=r206-pwa-color')
   ]).then(([
@@ -32,6 +33,7 @@ export function prepareLotEnhancements() {
     layout,
     accessibility,
     perkDisclosure,
+    scrollBoundary,
     trophyGate,
     paintGate
   ]) => {
@@ -40,6 +42,7 @@ export function prepareLotEnhancements() {
       installLotLayout: layout.installLotLayout,
       installLotAccessibility: accessibility.installLotAccessibility,
       installLotPerkDisclosure: perkDisclosure.installLotPerkDisclosure,
+      installLotCardScrollBoundary: scrollBoundary.installLotCardScrollBoundary,
       gateLotNow: trophyGate.gateLotNow,
       gateLotPaintNow: paintGate.gateLotPaintNow
     });
@@ -72,9 +75,8 @@ function installLotEntryClickGuard(screen) {
 
     // A VoiceOver double-tap that opens a full-screen route can leave a second
     // hit-test activation behind in standalone iOS landscape. Race This Car is
-    // mounted in almost the same screen region as Home RACE, so keep only this
-    // newly mounted action out of that finishing gesture. The paint picker is a
-    // sibling of .lot-card and therefore has no click-listener ancestor added.
+    // mounted in almost the same screen region as Home RACE, so keep only that
+    // newly mounted action out of the finishing gesture.
     event.preventDefault();
     event.stopImmediatePropagation();
   };
@@ -119,7 +121,8 @@ export function enhanceLotNow(root = document.body) {
     installLotPerkDisclosure,
     installLotStatLegend,
     installLotLayout,
-    installLotAccessibility
+    installLotAccessibility,
+    installLotCardScrollBoundary
   } = enhancementBundle;
   const scope = screen.parentElement || document.body;
   const removeEntryClickGuard = installLotEntryClickGuard(screen);
@@ -128,6 +131,7 @@ export function enhanceLotNow(root = document.body) {
   const removePerkDisclosure = installLotPerkDisclosure(scope);
   const removeStatLegend = installLotStatLegend(scope);
   const removeLayout = installLotLayout(scope);
+  const removeCardScrollBoundary = installLotCardScrollBoundary(scope);
   const removeAccessibility = installLotAccessibility(scope);
   let released = false;
 
@@ -135,6 +139,7 @@ export function enhanceLotNow(root = document.body) {
     if (released) return;
     released = true;
     removeAccessibility();
+    removeCardScrollBoundary();
     removeLayout();
     removeStatLegend();
     removePerkDisclosure();

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -1,7 +1,7 @@
 import {
   enhanceLotNow,
   prepareLotEnhancements
-} from './lot-enhancement-runtime.js?revision=r206-pwa-color&build=20260804-r157';
+} from './lot-enhancement-runtime.js?revision=r208-pwa-scroll-boundary&build=20260804-r157';
 import { installLotPwaColorSwatches } from './lot-pwa-color-swatch.js?revision=r206-pwa-color';
 import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r52';
 import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
@@ -10,6 +10,7 @@ import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
 // lot-r10.js?build=20260809-r163-native-html&revision=r590-canonical-lock-icon
 // lot-enhancement-runtime.js?revision=r588-canonical-attributes
 // lot-enhancement-runtime.js?revision=r205-color-baseline
+// lot-enhancement-runtime.js?revision=r206-pwa-color
 // lot-showroom-experiment.js?revision=r200-production-candidate
 // export async function showEnhancedLot
 // SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r203-polish'


### PR DESCRIPTION
## Summary
- fix standalone-iOS/PWA COLOR areas disappearing specifically on Trophy Road vehicles by removing `.lot-card` itself as the scrolling ancestor
- add a dedicated inner `.lot-card-info-scroll` region for variable-height car information, including perk copy and the stats help control
- keep COLOR and RACE outside that scrolling layer while preserving the requested screen-reader order (`CAR INFORMATION` → `Choose color` group → `RACE`)
- wire the new boundary into the existing Lot enhancement lifecycle under a fresh r208 runtime identity
- add a focused regression to pin the PWA scroll-boundary contract

## Root cause
The screen-reader pass intentionally moves the real COLOR controls into `.lot-card` so they occur after CAR INFORMATION and before RACE in DOM order. `.lot-card` was also the `overflow-y:auto` scrolling container. Every Trophy Road vehicle currently has perk copy; on those cars the information panel becomes tall enough to activate scrolling. Standalone iOS can clip/not paint the visually fixed COLOR descendant of that active overflow container, while Safari browser renders it correctly. This fits the observed matrix: reward/perk cars only, regardless of car lock, PAINTJOB, or COLOR CUES.

## Fix
The card is no longer the scroll container. A new inner information wrapper owns vertical scrolling and contains title, description, perk, stats, and stats help. COLOR and RACE remain card siblings outside it, so standalone WebKit no longer has to paint the fixed COLOR UI through an active scrolling ancestor.