### PR TITLE
Move The Lot car picker above showroom content

### DIFF
--- a/turn/garage/lot-showroom-cleanup-r201.css
+++ b/turn/garage/lot-showroom-cleanup-r201.css
@@ -249,6 +249,61 @@
   white-space: nowrap !important;
 }
 
+/* Keep horizontal car browsing away from the OS home/app-switch gesture zone.
+   The screen-reader pass already places CHOOSE CAR before the showroom content
+   in DOM order; align the visual layout with that structure as well. */
+.lot-showroom {
+  --lot-content-bottom: max(14px, env(safe-area-inset-bottom));
+}
+
+.lot-showroom::before {
+  inset:
+    calc(var(--lot-header-height) + var(--lot-picker-height))
+    var(--lot-info-width)
+    var(--lot-content-bottom)
+    0;
+}
+
+.lot-showroom .lot-car-picker-shell {
+  top: var(--lot-header-height);
+  right: 0;
+  bottom: auto;
+  left: 0;
+  height: var(--lot-picker-height);
+  padding:
+    9px
+    max(14px, env(safe-area-inset-right))
+    9px
+    max(14px, env(safe-area-inset-left));
+  border-top: 0;
+  border-bottom: 4px solid var(--ink, #08090a);
+  box-shadow: 0 4px 0 rgb(255 255 255 / .08);
+}
+
+.lot-showroom .lot-side {
+  top: calc(var(--lot-header-height) + var(--lot-picker-height));
+  bottom: var(--lot-content-bottom);
+}
+
+/* The carousel itself already communicates horizontal browsing through its
+   partially visible cards. Keep the tiny visual helper out of the header/preview
+   boundary; screen readers retain the full hidden instructions. */
+.lot-showroom .lot-car-picker-help {
+  display: none;
+}
+
+/* COLOR is semantically inside the card but visually anchored over the preview.
+   The screen-reader pass injects its positioning after this stylesheet, so the
+   bottom override is intentionally important. It no longer depends on picker height. */
+.lot-showroom.lot-screen-reader-structured .lot-colors,
+.lot-showroom.lot-screen-reader-structured .lot-colors.is-paint-locked {
+  bottom: calc(var(--lot-content-bottom) + 12px) !important;
+}
+
+.lot-showroom .lot-loading {
+  bottom: calc(var(--lot-content-bottom) + 12px);
+}
+
 @media (max-height: 520px) {
   .lot-showroom .lot-car-option,
   .lot-showroom .lot-car-option:focus-visible {
@@ -273,6 +328,17 @@
     max-width: min(42vw, 215px);
     padding: 4px 7px;
     font-size: .5rem;
+  }
+  .lot-showroom .lot-car-picker-shell {
+    padding-top: 7px;
+    padding-bottom: 7px;
+  }
+  .lot-showroom.lot-screen-reader-structured .lot-colors,
+  .lot-showroom.lot-screen-reader-structured .lot-colors.is-paint-locked {
+    bottom: calc(var(--lot-content-bottom) + 8px) !important;
+  }
+  .lot-showroom .lot-loading {
+    bottom: calc(var(--lot-content-bottom) + 8px);
   }
 }
 

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -19,13 +19,15 @@ import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
 // lot-showroom-cleanup-r201.css?revision=r204-color-swatch-cue
 // SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r205-polish'
 // lot-showroom-cleanup-r201.css?revision=r205-color-baseline
+// SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r206-polish'
+// lot-showroom-cleanup-r201.css?revision=r206-pwa-color
 // The actual prepared M8 entry below is deliberately synchronous after warmup so
 // its existing Race This Car motion-access gate can bind immediately after mount.
 
 // Keep the showroom implementation and its CSS out of TURN's initial module graph.
 // Choosing or activating a track gives us a natural warmup window for these resources.
 const SHOWROOM_STYLE_ID = 'turn-lot-showroom-r200';
-const SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r206-polish';
+const SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r209-polish';
 let showroomStylePromise = null;
 let originalLotPromise = null;
 let originalLotModule = null;
@@ -62,7 +64,7 @@ function prepareShowroomStyles() {
     ),
     prepareStylesheet(
       SHOWROOM_CLEANUP_STYLE_ID,
-      './lot-showroom-cleanup-r201.css?revision=r206-pwa-color'
+      './lot-showroom-cleanup-r201.css?revision=r209-picker-above-showroom'
     )
   ]);
   return showroomStylePromise;


### PR DESCRIPTION
## Summary
- move the horizontal CHOOSE CAR rail from the bottom home/app-switch gesture area to a full-width row directly below THE LOT header
- place the 3D preview and car information below the rail so visual order matches the existing semantic order: CHOOSE CAR → CAR INFORMATION/COLOR → RACE
- reserve `env(safe-area-inset-bottom)` for the preview/info region instead of putting horizontal scrolling in it
- re-anchor the floating COLOR control and loading indicator to the lower content safe area rather than the old bottom carousel height
- hide the redundant tiny visual swipe helper; screen-reader instructions remain unchanged
- give the polish stylesheet a fresh r209 cache identity

## Scope
No changes to car selection behavior, Trophy Road, PAINTJOB, COLOR CUES, thumbnail rendering, or screen-reader heading structure. The robust r208 inner CAR INFORMATION scroll boundary remains unchanged.