### PR TITLE
Fix secondary emergency livery layering

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -136,6 +136,9 @@ jobs:
       - name: Run emergency vehicle regression
         run: node turn-lab/tests/emergency-vehicles-production.mjs
 
+      - name: Run emergency livery layering regression
+        run: node turn-lab/tests/emergency-livery-layering-production.mjs
+
       - name: Run DRIFT handling contract regression
         run: node turn-lab/tests/vehicle-drift-production.mjs
 

--- a/turn-lab/tests/emergency-livery-layering-production.mjs
+++ b/turn-lab/tests/emergency-livery-layering-production.mjs
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const source = await fs.readFile(new URL('../../turn/vehicle/emergency-livery-models.js', import.meta.url), 'utf8');
+
+assert.match(source, /candidates\.push\(\{ node, material, explicit \}\)/,
+  'Emergency livery placement must retain the body mesh that owns each paint material');
+assert.match(source, /function boundsForLiverySurface\(records\)/,
+  'Secondary accents must derive a body-surface envelope rather than use total vehicle width');
+assert.match(source, /bounds\.expandByObject\(node\)/,
+  'The livery surface envelope must be measured from the actual paintable body meshes');
+assert.match(source, /const surfaceBounds = bodyBounds \|\| bounds/,
+  'The full model bounds may be used only as a defensive fallback');
+assert.match(source, /const surfaceGap = Math\.max\(0\.006, surfaceSize\.x \* 0\.002\)/,
+  'Secondary geometry must keep a small physical gap outside the body surface');
+assert.match(source, /left: surfaceBounds\.min\.x - sideDepth \* 0\.5 - surfaceGap/);
+assert.match(source, /right: surfaceBounds\.max\.x \+ sideDepth \* 0\.5 \+ surfaceGap/);
+assert.match(source, /panel\.position\.set\(direction < 0 \? sideX\.left : sideX\.right, y, z\)/,
+  'Left and right accents must be placed fully outside their respective body surfaces');
+assert.doesNotMatch(source, /size\.x \* 0\.405/,
+  'The old in-body accent placement that caused angle-dependent occlusion must not return');
+assert.match(source, /turnEmergencyLiverySurfaceGap/,
+  'The resolved surface gap should remain inspectable on the visual for diagnostics');
+
+console.log('Emergency livery layering regression passed.');

--- a/turn/vehicle/emergency-livery-models.js
+++ b/turn/vehicle/emergency-livery-models.js
@@ -64,7 +64,7 @@ function applyFixedEmergencyLivery(root, livery, ghost) {
       if (!material?.color || isProtectedPart(node, material)) continue;
       const explicit = isExplicitBodyPart(node, material);
       if (explicit) explicitCount += 1;
-      candidates.push({ material, explicit });
+      candidates.push({ node, material, explicit });
     }
   });
 
@@ -79,7 +79,8 @@ function applyFixedEmergencyLivery(root, livery, ghost) {
     material.needsUpdate = true;
   }
 
-  installSecondaryAccent(root, model, secondary, livery.accent);
+  const bodyBounds = boundsForLiverySurface(records);
+  installSecondaryAccent(root, model, secondary, livery.accent, bodyBounds);
   root.userData.turnEmergencyLivery = Object.freeze({
     primary: livery.primary.fallback,
     secondary: livery.secondary.fallback,
@@ -87,15 +88,42 @@ function applyFixedEmergencyLivery(root, livery, ghost) {
   });
 }
 
-function installSecondaryAccent(root, model, color, accent) {
+function boundsForLiverySurface(records) {
+  const bounds = new THREE.Box3();
+  const nodes = new Set();
+  for (const { node } of records) {
+    if (!node || nodes.has(node)) continue;
+    nodes.add(node);
+    bounds.expandByObject(node);
+  }
+  return bounds.isEmpty() ? null : bounds;
+}
+
+function installSecondaryAccent(root, model, color, accent, bodyBounds = null) {
   model.updateMatrixWorld(true);
   const bounds = new THREE.Box3().setFromObject(model);
   const size = bounds.getSize(new THREE.Vector3());
   const center = bounds.getCenter(new THREE.Vector3());
   if (!Number.isFinite(size.x) || size.x <= 0 || size.z <= 0) return;
 
+  // The secondary livery is a real mesh, so its inner face must live outside the
+  // painted body surface. The previous 0.405 * total-width placement put these
+  // panels inside the vehicle volume; polygon offset cannot prevent another mesh
+  // from occluding geometry that is physically behind it as the car rotates.
+  // Derive the side surface from the paintable body meshes (not wheels/mirrors),
+  // then leave a tiny physical air gap. This is stable at every viewing angle.
+  const surfaceBounds = bodyBounds || bounds;
+  const surfaceSize = surfaceBounds.getSize(new THREE.Vector3());
+  const sideDepth = Math.max(0.012, surfaceSize.x * 0.004);
+  const surfaceGap = Math.max(0.006, surfaceSize.x * 0.002);
+  const sideX = Object.freeze({
+    left: surfaceBounds.min.x - sideDepth * 0.5 - surfaceGap,
+    right: surfaceBounds.max.x + sideDepth * 0.5 + surfaceGap
+  });
+
   const group = new THREE.Group();
   group.userData.turnEmergencyLiveryAccent = true;
+  group.userData.turnEmergencyLiverySurfaceGap = surfaceGap;
   const material = new THREE.MeshStandardMaterial({
     color: 0xffffff,
     roughness: 0.78,
@@ -106,14 +134,13 @@ function installSecondaryAccent(root, model, color, accent) {
   });
   setThreeColor(material.color, color);
 
-  const sideDepth = Math.max(0.028, size.x * 0.014);
-  const sideX = size.x * 0.405;
   const addSidePair = ({ length, height, y, z }) => {
     for (const direction of [-1, 1]) {
       const panel = new THREE.Mesh(new THREE.BoxGeometry(sideDepth, height, length), material);
-      panel.position.set(center.x + direction * sideX, y, z);
+      panel.position.set(direction < 0 ? sideX.left : sideX.right, y, z);
       panel.castShadow = false;
       panel.receiveShadow = true;
+      panel.userData.turnEmergencyLiverySide = direction < 0 ? 'left' : 'right';
       group.add(panel);
     }
   };


### PR DESCRIPTION
## Summary
- fix angle-dependent clipping/flicker of the secondary colors added to Fire Truck, Ambulance and Police Car
- measure the actual paintable body-mesh bounds instead of positioning secondary panels inside the overall vehicle width
- place each secondary accent fully outside the corresponding left/right body surface with a tiny physical gap
- retain the existing livery colors, proportions, fixed-livery behavior and emergency light system
- add a focused emergency-livery layering regression to prevent the old in-body placement from returning

## Root cause
The added secondary panels were centered at `size.x * 0.405` from the vehicle center. That is only about 81% of the half-width, so the accent geometry physically occupied the body volume. As the vehicle rotated, normal depth testing caused the body mesh to alternately occlude/reveal the stripe/panel. Polygon offset cannot reliably fix geometry that is actually behind another surface.

## Fix
The livery layer now retains the paintable body nodes, builds a body-only bounding envelope, and places the left/right accent meshes outside `surfaceBounds.min.x` / `surfaceBounds.max.x` by half the thin accent depth plus a small surface gap.