### PR TITLE
Use TURN palette for The Lot carousel

### DIFF
--- a/turn/garage/lot-carousel-palette-r210.css
+++ b/turn/garage/lot-carousel-palette-r210.css
@@ -1,0 +1,56 @@
+/* Lighter TURN palette for THE LOT car carousel only. */
+
+.lot-showroom .lot-car-picker-shell {
+  border-bottom-color: #79c8ea;
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / .5), transparent 42%),
+    #d9f3ff;
+  box-shadow: 0 4px 0 rgb(30 80 112 / .12);
+}
+
+.lot-showroom .lot-car-picker {
+  scrollbar-color: var(--yellow, #ffd43b) #bfe6f7;
+}
+
+.lot-showroom .lot-car-option,
+.lot-showroom .lot-car-option:focus-visible {
+  border-color: #a9cddd;
+  background: var(--paper, #fff8e8);
+  color: #102a43;
+  box-shadow: 0 3px 0 rgb(16 42 67 / .14);
+}
+
+.lot-showroom .lot-car-option-preview {
+  background:
+    radial-gradient(ellipse at 50% 82%, rgb(255 255 255 / .48), transparent 56%),
+    linear-gradient(180deg, #aee5fb 0 66%, #d8e1e5 66% 100%);
+}
+
+.lot-showroom .lot-car-option-name {
+  color: #102a43;
+}
+
+.lot-showroom .lot-car-option[aria-checked='true'] {
+  border-color: var(--yellow, #ffd43b);
+  background: var(--paper, #fff8e8);
+  color: #102a43;
+  box-shadow:
+    0 0 0 3px var(--cyan, #38d9ff),
+    0 3px 0 rgb(16 42 67 / .16);
+}
+
+.lot-showroom .lot-car-option:focus-visible {
+  border-color: var(--yellow, #ffd43b);
+  outline: 3px solid var(--cyan, #38d9ff);
+  outline-offset: 2px;
+}
+
+.lot-showroom .lot-car-option-lock {
+  border-color: #102a43;
+  color: #102a43;
+  box-shadow: 2px 2px 0 rgb(16 42 67 / .28);
+}
+
+.lot-showroom .lot-car-option.is-trophy-locked .lot-car-option-preview {
+  filter: grayscale(.2) brightness(.9);
+}

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -28,6 +28,7 @@ import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
 // Choosing or activating a track gives us a natural warmup window for these resources.
 const SHOWROOM_STYLE_ID = 'turn-lot-showroom-r200';
 const SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r209-polish';
+const SHOWROOM_CAROUSEL_STYLE_ID = 'turn-lot-carousel-r210-palette';
 let showroomStylePromise = null;
 let originalLotPromise = null;
 let originalLotModule = null;
@@ -65,6 +66,10 @@ function prepareShowroomStyles() {
     prepareStylesheet(
       SHOWROOM_CLEANUP_STYLE_ID,
       './lot-showroom-cleanup-r201.css?revision=r209-picker-above-showroom'
+    ),
+    prepareStylesheet(
+      SHOWROOM_CAROUSEL_STYLE_ID,
+      './lot-carousel-palette-r210.css?revision=r210-turn-palette'
     )
   ]);
   return showroomStylePromise;


### PR DESCRIPTION
## Summary
- recolor only THE LOT car carousel toward the lighter TURN palette from the visual concept
- replace the dark rail with pale cyan
- use cream cards, pale-blue thumbnail skies, light gray-blue ground and deep navy text/borders
- use yellow + cyan together for the selected card
- retain the existing yellow Trophy Road lock, lock filtering, thumbnail layout, card ratio and all carousel interaction/accessibility behavior
- load the palette as an isolated r210 stylesheet so the rest of the showroom is untouched

## Scope
Pure presentation change. No changes to car order, selection logic, Trophy Road, COLOR, PAINTJOB, PWA layout, screen-reader semantics or thumbnail rendering.