### PR TITLE
Refine The Lot thumbnail composition

### DIFF
--- a/turn/garage/lot-thumbnail-composition-r211.css
+++ b/turn/garage/lot-thumbnail-composition-r211.css
@@ -1,0 +1,14 @@
+/* Thumbnail composition only: keep the established black carousel treatment. */
+
+/* Split each thumbnail preview evenly between sky and grey ground. */
+.lot-showroom .lot-car-option-preview {
+  background:
+    radial-gradient(ellipse at 50% 82%, rgb(255 255 255 / .28), transparent 52%),
+    linear-gradient(180deg, #8ed8ff 0 50%, #5a6268 50% 100%);
+}
+
+/* The WebGL capture is transparent, so zoom the intact canvas rather than changing
+   camera/model geometry. This keeps every car undistorted while filling the card better. */
+.lot-showroom .lot-car-option-thumbnail {
+  transform: scale(1.45);
+}

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -28,6 +28,7 @@ import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
 // Choosing or activating a track gives us a natural warmup window for these resources.
 const SHOWROOM_STYLE_ID = 'turn-lot-showroom-r200';
 const SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r209-polish';
+const SHOWROOM_THUMBNAIL_STYLE_ID = 'turn-lot-thumbnail-r211-composition';
 let showroomStylePromise = null;
 let originalLotPromise = null;
 let originalLotModule = null;
@@ -65,6 +66,10 @@ function prepareShowroomStyles() {
     prepareStylesheet(
       SHOWROOM_CLEANUP_STYLE_ID,
       './lot-showroom-cleanup-r201.css?revision=r209-picker-above-showroom'
+    ),
+    prepareStylesheet(
+      SHOWROOM_THUMBNAIL_STYLE_ID,
+      './lot-thumbnail-composition-r211.css?revision=r211-half-ground-zoom'
     )
   ]);
   return showroomStylePromise;


### PR DESCRIPTION
## Summary
- keep the current black/charcoal THE LOT carousel and all existing card geometry
- make the thumbnail preview background exactly 50% sky / 50% grey ground
- increase the real 3D thumbnail presentation scale from 1.30x to 1.45x so cars fill the cards better
- keep the WebGL captures undistorted; this is presentation-only CSS
- load the tweak through a fresh r211 stylesheet identity so browser/PWA caches cannot retain the previous composition

## Scope
No changes to card size, carousel position/order, Trophy Road locks, selection behavior, COLOR/PAINTJOB, screen-reader semantics, PWA structure, or the thumbnail renderer itself.