### PR TITLE
Improve The Lot attributes and small text

### DIFF
--- a/turn-lab/tests/lot-pwa-color-scroll-boundary.mjs
+++ b/turn-lab/tests/lot-pwa-color-scroll-boundary.mjs
@@ -1,12 +1,13 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [boundary, runtime, screenReader, perk, showroomCss] = await Promise.all([
+const [boundary, runtime, screenReader, perk, showroomCss, layout] = await Promise.all([
   fs.readFile(new URL('../../turn/garage/lot-card-scroll-boundary.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-enhancement-runtime.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-screen-reader-r202.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-perk-disclosure.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/garage/lot-showroom-experiment.css', import.meta.url), 'utf8')
+  fs.readFile(new URL('../../turn/garage/lot-showroom-experiment.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-layout-r60.js', import.meta.url), 'utf8')
 ]);
 
 // COLOR is intentionally moved into .lot-card for the requested semantic order.
@@ -27,24 +28,32 @@ assert.match(boundary, /\.lot-showroom \.lot-card-info-scroll\s*\{[\s\S]*overflo
 assert.match(boundary, /-webkit-overflow-scrolling:\s*touch/,
   'The inner information scroller must retain native iOS momentum scrolling');
 
-// The wrapper must contain every variable-height information node, especially perk copy,
-// while COLOR and RACE stay as card siblings outside the scroll layer.
+// The wrapper must contain every variable-height information node, especially perk copy
+// and the visible ATTRIBUTES row, while COLOR and RACE stay as card siblings outside it.
 for (const selector of [
   "'.lot-car-title'",
   "'.lot-car-description'",
   "'.lot-perk-disclosure'",
+  "'.lot-attributes-row'",
   "'.lot-stats'",
   "'.lot-stats-help'"
 ]) {
   assert.match(boundary, new RegExp(`card\\.querySelector\\(${selector.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')}\\)`));
 }
-assert.match(boundary, /for \(const node of \[title, description, perk, stats, statsHelp\]\)/);
+assert.match(boundary, /for \(const node of \[title, description, perk, attributes, stats, statsHelp\]\)/,
+  'ATTRIBUTES must move with the variable-height car information rather than becoming a fixed descendant');
 assert.doesNotMatch(boundary, /lot-colors|lot-race/,
   'COLOR and RACE must never be moved into the inner scroll region');
 
+// ATTRIBUTES is visual structure only; it must not add a new heading between
+// CAR INFORMATION and RACE, while the existing help button remains semantic.
+assert.match(layout, /label\.textContent = 'ATTRIBUTES'/);
+assert.match(layout, /label\.setAttribute\('aria-hidden', 'true'\)/);
+assert.match(layout, /attributesRow\.appendChild\(infoButton\)/);
+
 // The production enhancement lifecycle must install the boundary after perk/stat/layout
 // construction, before the later screen-reader pass moves COLOR into the card.
-assert.match(runtime, /lot-card-scroll-boundary\.js\?revision=r208-pwa-scroll-boundary/);
+assert.match(runtime, /lot-card-scroll-boundary\.js\?revision=r213-attributes-typography/);
 assert.match(runtime, /installLotCardScrollBoundary: scrollBoundary\.installLotCardScrollBoundary/);
 const installOrder = runtime.match(/const removePerkDisclosure[\s\S]*?const removeAccessibility = installLotAccessibility\(scope\);/)?.[0] || '';
 assert.ok(installOrder, 'Lot enhancement installation order must remain inspectable');

--- a/turn/garage/lot-card-scroll-boundary.js
+++ b/turn/garage/lot-card-scroll-boundary.js
@@ -43,6 +43,7 @@ export function installLotCardScrollBoundary(root = document.body) {
   const title = card.querySelector('.lot-car-title');
   const description = card.querySelector('.lot-car-description');
   const perk = card.querySelector('.lot-perk-disclosure');
+  const attributes = card.querySelector('.lot-attributes-row');
   const stats = card.querySelector('.lot-stats');
   const statsHelp = card.querySelector('.lot-stats-help');
   if (!title || !description || !stats) return () => {};
@@ -52,7 +53,7 @@ export function installLotCardScrollBoundary(root = document.body) {
   const scroll = document.createElement('div');
   scroll.className = 'lot-card-info-scroll';
   card.insertBefore(scroll, title);
-  for (const node of [title, description, perk, stats, statsHelp]) {
+  for (const node of [title, description, perk, attributes, stats, statsHelp]) {
     if (node?.parentElement === card) scroll.appendChild(node);
   }
 

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -22,10 +22,10 @@ export function prepareLotEnhancements() {
 
   enhancementPreparation = Promise.all([
     import('./lot-stat-legend.js?build=20260724-r59'),
-    import('./lot-layout-r60.js?build=20260729-r116'),
+    import('./lot-layout-r60.js?build=20260729-r116&revision=r213-attributes-typography'),
     import('./lot-accessibility-r118.js?build=20260729-r118&revision=r588-canonical-attributes'),
     import('./lot-perk-disclosure.js?revision=r203-idempotent'),
-    import('./lot-card-scroll-boundary.js?revision=r208-pwa-scroll-boundary'),
+    import('./lot-card-scroll-boundary.js?revision=r213-attributes-typography'),
     import('../progression/lot-trophy-gate.js?revision=r585-visible-locks'),
     import('../progression/lot-paint-reward.js?revision=r206-pwa-color')
   ]).then(([

--- a/turn/garage/lot-info-typography-r213.css
+++ b/turn/garage/lot-info-typography-r213.css
@@ -1,0 +1,154 @@
+/* Readability pass for THE LOT after the compact r212 information-panel fit.
+   Future Racer remains the height-budget acceptance case. */
+
+/* The old SELECTED CAR eyebrow stays in source for legacy compatibility, but the
+   showroom no longer spends visible space on it. */
+.lot-showroom .lot-car-title {
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0;
+  padding-bottom: 4px;
+}
+
+.lot-showroom .lot-car-title > span {
+  display: none;
+}
+
+.lot-showroom .lot-car-title strong {
+  grid-column: 1;
+  grid-row: 1;
+  font-size: clamp(1.24rem, 2.65vw, 1.98rem);
+  line-height: .94;
+}
+
+.lot-showroom .lot-car-description {
+  margin: 5px 0 2px;
+  font-size: clamp(.56rem, 1vw, .68rem);
+  line-height: 1.2;
+}
+
+.lot-showroom .lot-perk-copy {
+  font-size: clamp(.51rem, .9vw, .62rem);
+  line-height: 1.18;
+}
+
+/* Visual section label only: screen-reader heading navigation intentionally stays
+   CAR INFORMATION (H3) -> RACE (H2). The adjacent info button remains semantic. */
+.lot-showroom .lot-attributes-row {
+  display: flex;
+  min-width: 0;
+  min-height: 22px;
+  margin: 4px 0 1px;
+  align-items: center;
+  gap: 7px;
+}
+
+.lot-showroom .lot-attributes-label {
+  color: var(--ink, #08090a);
+  font-size: clamp(.49rem, .82vw, .57rem);
+  font-weight: 950;
+  line-height: 1;
+  letter-spacing: .09em;
+}
+
+.lot-showroom .lot-stats-help {
+  flex: 0 0 23px;
+  width: 23px;
+  height: 23px;
+  margin: 0;
+  font-size: .76rem;
+}
+
+.lot-showroom .lot-stats {
+  gap: 2px;
+  margin: 1px 0 2px;
+}
+
+.lot-showroom .lot-stat {
+  grid-template-columns: 88px minmax(0, 1fr);
+  gap: 6px;
+}
+
+.lot-showroom .lot-stat > span {
+  font-size: clamp(.46rem, .78vw, .53rem);
+  line-height: 1;
+  letter-spacing: .045em;
+}
+
+.lot-showroom .lot-stat i {
+  height: 8px;
+}
+
+.lot-showroom .lot-race {
+  font-size: clamp(.68rem, 1.2vw, .86rem);
+}
+
+/* Raise the floor on the genuinely tiny supporting text around the showroom. */
+.lot-showroom .lot-heading p {
+  font-size: clamp(.58rem, 1.08vw, .76rem);
+}
+
+.lot-showroom .lot-progress-summary strong {
+  font-size: .66rem;
+}
+
+.lot-showroom .lot-progress-summary small {
+  font-size: .48rem;
+}
+
+.lot-showroom .lot-back {
+  font-size: .62rem;
+}
+
+.lot-showroom .lot-viewbox-head span,
+.lot-showroom .lot-viewbox-head b {
+  font-size: .44rem;
+}
+
+.lot-showroom .lot-car-option-name {
+  font-size: clamp(.5rem, .84vw, .61rem);
+}
+
+.lot-showroom .lot-car-picker-help {
+  font-size: .42rem;
+}
+
+@media (max-height: 520px) {
+  .lot-showroom .lot-car-title strong {
+    font-size: clamp(1.16rem, 2.45vw, 1.78rem);
+  }
+
+  .lot-showroom .lot-car-description {
+    font-size: clamp(.52rem, .95vw, .63rem);
+    line-height: 1.17;
+  }
+
+  .lot-showroom .lot-perk-copy {
+    font-size: clamp(.48rem, .86vw, .58rem);
+    line-height: 1.15;
+  }
+
+  .lot-showroom .lot-attributes-row {
+    min-height: 20px;
+    margin-top: 3px;
+    gap: 6px;
+  }
+
+  .lot-showroom .lot-attributes-label {
+    font-size: clamp(.46rem, .76vw, .53rem);
+  }
+
+  .lot-showroom .lot-stats-help {
+    flex-basis: 21px;
+    width: 21px;
+    height: 21px;
+    font-size: .7rem;
+  }
+
+  .lot-showroom .lot-stat > span {
+    font-size: clamp(.44rem, .73vw, .5rem);
+  }
+
+  .lot-showroom .lot-car-option-name {
+    font-size: clamp(.48rem, .8vw, .58rem);
+  }
+}

--- a/turn/garage/lot-layout-r60.js
+++ b/turn/garage/lot-layout-r60.js
@@ -85,17 +85,38 @@ export function installLotLayout(root = document.body) {
   screen.classList.remove('is-view-closed');
 
   // The showroom owns its large-scale placement in its lazy-loaded stylesheet.
-  // Keep this enhancement layer focused on copy and stat-help semantics so it
-  // cannot reintroduce the legacy floating action geometry.
+  // Give ATTRIBUTES a stable visual row beside the existing stat-help action,
+  // without introducing another semantic heading between CAR INFORMATION and RACE.
   if (screen.classList.contains('lot-showroom')) {
     attributesHeading.replaceChildren(document.createTextNode('SELECTED CAR'));
-    if (infoButton) {
+
+    const stats = screen.querySelector('.lot-stats');
+    let attributesRow = screen.querySelector('.lot-attributes-row');
+    if (stats && !attributesRow) {
+      attributesRow = document.createElement('div');
+      attributesRow.className = 'lot-attributes-row';
+
+      const label = document.createElement('span');
+      label.className = 'lot-attributes-label';
+      label.textContent = 'ATTRIBUTES';
+      label.setAttribute('aria-hidden', 'true');
+      attributesRow.appendChild(label);
+      stats.insertAdjacentElement('beforebegin', attributesRow);
+    }
+
+    if (infoButton && attributesRow) {
       infoButton.textContent = 'i';
       infoButton.setAttribute('aria-label', 'What do the attributes mean?');
       infoButton.setAttribute('title', 'What do the attributes mean?');
-      attributesHeading.appendChild(infoButton);
+      attributesRow.appendChild(infoButton);
     }
-    return () => {};
+
+    return () => {
+      if (infoButton?.isConnected && attributesHeading.isConnected) {
+        attributesHeading.appendChild(infoButton);
+      }
+      attributesRow?.remove();
+    };
   }
 
   installBottomActionStyles();

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -1,7 +1,7 @@
 import {
   enhanceLotNow,
   prepareLotEnhancements
-} from './lot-enhancement-runtime.js?revision=r208-pwa-scroll-boundary&build=20260804-r157';
+} from './lot-enhancement-runtime.js?revision=r213-attributes-typography&build=20260804-r157';
 import { installLotPwaColorSwatches } from './lot-pwa-color-swatch.js?revision=r206-pwa-color';
 import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r52';
 import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
@@ -30,6 +30,7 @@ const SHOWROOM_STYLE_ID = 'turn-lot-showroom-r200';
 const SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r209-polish';
 const SHOWROOM_THUMBNAIL_STYLE_ID = 'turn-lot-thumbnail-r211-composition';
 const SHOWROOM_INFO_STYLE_ID = 'turn-lot-info-r212-fit';
+const SHOWROOM_TYPOGRAPHY_STYLE_ID = 'turn-lot-info-r213-typography';
 let showroomStylePromise = null;
 let originalLotPromise = null;
 let originalLotModule = null;
@@ -75,6 +76,10 @@ function prepareShowroomStyles() {
     prepareStylesheet(
       SHOWROOM_INFO_STYLE_ID,
       './lot-info-panel-r212.css?revision=r212-future-racer-fit'
+    ),
+    prepareStylesheet(
+      SHOWROOM_TYPOGRAPHY_STYLE_ID,
+      './lot-info-typography-r213.css?revision=r213-attributes-readable-type'
     )
   ]);
   return showroomStylePromise;


### PR DESCRIPTION
## Summary
- add a visible ATTRIBUTES row immediately above the vehicle stats
- move the existing stat info button beside ATTRIBUTES without adding another screen-reader heading
- keep the row inside the existing inner information scroll boundary so the robust standalone-iOS COLOR structure remains intact
- modestly increase the car description, perk copy, stat labels and Race This Car label while preserving Future Racer as the height-budget stress case
- raise the font-size floor for other genuinely tiny showroom text: carousel car names, browse hint, 3D preview chips, progress summary secondary line, subtitle and Back label
- retain the compact r212 action footprint and all existing car-selection/PWA/accessibility behavior

## Thumbnail clarification
The r211 1.45x thumbnail zoom is a generic `.lot-car-option-thumbnail` rule and already applies to every vehicle, not only Training Car.