### PR TITLE
Use The Lot info panel space more evenly

### DIFF
--- a/turn-lab/tests/lot-pwa-color-scroll-boundary.mjs
+++ b/turn-lab/tests/lot-pwa-color-scroll-boundary.mjs
@@ -28,6 +28,13 @@ assert.match(boundary, /\.lot-showroom \.lot-card-info-scroll\s*\{[\s\S]*overflo
 assert.match(boundary, /-webkit-overflow-scrolling:\s*touch/,
   'The inner information scroller must retain native iOS momentum scrolling');
 
+// When the information is shorter than its viewport, do not dump all spare height
+// below the stat table. Keep the Race action anchored while sharing that room between
+// the visible information sections. With negative free space, space-between naturally
+// collapses back to normal packed flow and the same container can scroll.
+assert.match(boundary, /\.lot-showroom \.lot-card-info-scroll\s*\{[\s\S]*display:\s*flex;[\s\S]*flex-direction:\s*column;[\s\S]*justify-content:\s*space-between;[\s\S]*gap:\s*2px;/,
+  'Spare car-information height must be distributed between sections instead of accumulating below the stats');
+
 // The wrapper must contain every variable-height information node, especially perk copy
 // and the visible ATTRIBUTES row, while COLOR and RACE stay as card siblings outside it.
 for (const selector of [
@@ -53,7 +60,7 @@ assert.match(layout, /attributesRow\.appendChild\(infoButton\)/);
 
 // The production enhancement lifecycle must install the boundary after perk/stat/layout
 // construction, before the later screen-reader pass moves COLOR into the card.
-assert.match(runtime, /lot-card-scroll-boundary\.js\?revision=r213-attributes-typography/);
+assert.match(runtime, /lot-card-scroll-boundary\.js\?revision=r215-info-space/);
 assert.match(runtime, /installLotCardScrollBoundary: scrollBoundary\.installLotCardScrollBoundary/);
 const installOrder = runtime.match(/const removePerkDisclosure[\s\S]*?const removeAccessibility = installLotAccessibility\(scope\);/)?.[0] || '';
 assert.ok(installOrder, 'Lot enhancement installation order must remain inspectable');

--- a/turn/garage/lot-card-scroll-boundary.js
+++ b/turn/garage/lot-card-scroll-boundary.js
@@ -1,4 +1,4 @@
-const STYLE_ID = 'turn-lot-card-scroll-boundary-r208-style';
+const STYLE_ID = 'turn-lot-card-scroll-boundary-r215-style';
 const activeBoundaries = new WeakMap();
 
 function findLotScreen(root) {
@@ -23,6 +23,10 @@ function installStyle() {
       min-width: 0;
       min-height: 0;
       flex: 1 1 auto;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      gap: 2px;
       overflow-x: hidden;
       overflow-y: auto;
       overscroll-behavior: contain;

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -25,7 +25,7 @@ export function prepareLotEnhancements() {
     import('./lot-layout-r60.js?build=20260729-r116&revision=r213-attributes-typography'),
     import('./lot-accessibility-r118.js?build=20260729-r118&revision=r588-canonical-attributes'),
     import('./lot-perk-disclosure.js?revision=r203-idempotent'),
-    import('./lot-card-scroll-boundary.js?revision=r213-attributes-typography'),
+    import('./lot-card-scroll-boundary.js?revision=r215-info-space'),
     import('../progression/lot-trophy-gate.js?revision=r585-visible-locks'),
     import('../progression/lot-paint-reward.js?revision=r206-pwa-color')
   ]).then(([
@@ -163,7 +163,6 @@ export function installLotEnhancementRuntime(root = document.body) {
   const sync = () => {
     const nextScreen = findLotScreen(root);
     if (nextScreen === currentScreen) return;
-
     preparationGeneration += 1;
     const generation = preparationGeneration;
     releaseCurrent();

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -1,7 +1,7 @@
 import {
   enhanceLotNow,
   prepareLotEnhancements
-} from './lot-enhancement-runtime.js?revision=r214-future-racer-fit&build=20260804-r157';
+} from './lot-enhancement-runtime.js?revision=r215-info-space&build=20260804-r157';
 import { installLotPwaColorSwatches } from './lot-pwa-color-swatch.js?revision=r206-pwa-color';
 import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r52';
 import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
@@ -11,6 +11,7 @@ import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
 // lot-enhancement-runtime.js?revision=r588-canonical-attributes
 // lot-enhancement-runtime.js?revision=r205-color-baseline
 // lot-enhancement-runtime.js?revision=r206-pwa-color
+// lot-enhancement-runtime.js?revision=r214-future-racer-fit
 // lot-showroom-experiment.js?revision=r200-production-candidate
 // export async function showEnhancedLot
 // SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r203-polish'


### PR DESCRIPTION
## Summary
- keep the current Future Racer typography and ATTRIBUTES layout unchanged
- fix the real source of the large blank block between the stat table and RACE THIS CAR
- retain the PWA-safe inner car-information scroll boundary, but make it a vertical flex layout using `justify-content: space-between`
- distribute spare height between title, description, perk, ATTRIBUTES and stats instead of accumulating it below BOOST TANK
- keep RACE THIS CAR anchored at the bottom
- preserve normal overflow behavior when the information genuinely needs to scroll
- refresh the Lot enhancement cache identity and strengthen the PWA boundary regression for this spacing contract

Future Racer remains the acceptance case.