### PR TITLE
Build TURN UP over Midlanda and Söråker

### DIFF
--- a/.github/workflows/turnup-tests.yml
+++ b/.github/workflows/turnup-tests.yml
@@ -1,0 +1,36 @@
+name: TURN UP production tests
+
+on:
+  pull_request:
+    paths:
+      - 'turnup/**'
+      - 'turn-tests/turnup-production.mjs'
+      - '.github/workflows/turnup-tests.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'turnup/**'
+      - 'turn-tests/turnup-production.mjs'
+      - '.github/workflows/turnup-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  production-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Check module syntax
+        run: |
+          node --check turnup/app.mjs
+          node --check turnup/audio.mjs
+          node --check turnup/flight-model.mjs
+          node --check turnup/scene.mjs
+      - name: Test flight and production contracts
+        run: node turn-tests/turnup-production.mjs

--- a/turn-tests/turnup-production.mjs
+++ b/turn-tests/turnup-production.mjs
@@ -1,0 +1,171 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  FLIGHT_LIMITS,
+  checkpointReached,
+  controlFromAngle,
+  createFlightState,
+  degreesToRadians,
+  distanceBetween,
+  formatCourseTime,
+  headingToTarget,
+  metresPerSecondToKnots,
+  shortestAngle,
+  updateFlightState
+} from '../turnup/flight-model.mjs';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const read = (path) => readFile(resolve(repositoryRoot, path), 'utf8');
+const [html, app, scene, css, readme, icon] = await Promise.all([
+  read('turnup/index.html'),
+  read('turnup/app.mjs'),
+  read('turnup/scene.mjs'),
+  read('turnup/styles.css'),
+  read('turnup/README.md'),
+  read('turnup/icon.svg')
+]);
+
+const tests = [];
+function test(name, callback) {
+  tests.push({ name, callback });
+}
+
+function simulate(state, controls, seconds, step = 0.05) {
+  for (let elapsed = 0; elapsed < seconds; elapsed += step) {
+    updateFlightState(state, controls, Math.min(step, seconds - elapsed));
+  }
+  return state;
+}
+
+test('HTML exposes a mobile, accessible launch and fallback control surface', () => {
+  assert.match(html, /<html lang="en"/);
+  assert.match(html, /width=device-width, initial-scale=1, viewport-fit=cover/);
+  assert.doesNotMatch(html, /user-scalable\s*=\s*no/i);
+  assert.match(html, /TAKE OFF WITH TILT/);
+  assert.match(html, /FLY WITH BUTTONS/);
+  assert.match(html, /aria-live="polite"/);
+  assert.match(html, /id="targetNameValue"/);
+  assert.match(html, /prefers-reduced-motion|styles\.css/);
+});
+
+test('the import map pins production map and rendering dependencies', () => {
+  const importMapText = html.match(/<script type="importmap">([\s\S]*?)<\/script>/)?.[1];
+  assert.ok(importMapText, 'import map is present');
+  const imports = JSON.parse(importMapText).imports;
+  assert.equal(imports['maplibre-gl'].includes('maplibre-gl@6.5.0'), true);
+  assert.equal(imports.three.includes('three@0.184.0'), true);
+  assert.equal(imports['/turn/input/motion.js'], '/turn/input/motion.js?revision=r164-ipad-motion-profile');
+});
+
+test('TURN UP imports the canonical TURN platform and steering engine', () => {
+  assert.match(app, /from '\/turn\/platform\/web-platform\.js'/);
+  assert.match(app, /from '\/turn\/platform\/platform-context\.js'/);
+  assert.match(app, /motionPoseFromGravity/);
+  assert.match(app, /resolveMotionSteeringProfile/);
+  assert.match(app, /updateMotionInputState/);
+  assert.match(app, /controlFromAngle\(motionState\.pitch - motionState\.neutralPitch/);
+  assert.doesNotMatch(app, /DeviceMotionEvent\.requestPermission/);
+});
+
+test('the real Midlanda–Söråker course uses open 3D map infrastructure', () => {
+  assert.match(scene, /tiles\.openfreemap\.org\/styles\/liberty/);
+  assert.match(scene, /elevation-tiles-prod\/terrarium/);
+  assert.match(scene, /type: 'raster-dem'/);
+  assert.match(scene, /type: 'fill-extrusion'/);
+  assert.match(scene, /renderingMode: '3d'/);
+  assert.match(scene, /defaultProjectionData\.mainMatrix/);
+  assert.match(scene, /RUNWAY 16/);
+  assert.match(scene, /SÖRÅKER/);
+  assert.match(scene, /STRIND AREA/);
+  assert.match(scene, /17\.66/);
+  assert.match(scene, /maxBounds: \[\[17\.22, 62\.39\], \[17\.84, 62\.67\]\]/);
+});
+
+test('aircraft asset is immutable, attributed and has an offline visual fallback', () => {
+  assert.match(scene, /91d835e8e851b2317fe79af291c9fed6153fd525/);
+  assert.match(scene, /B737_nologo\.glb/);
+  assert.match(scene, /createFallbackAircraft/);
+  assert.match(html, /CC BY 4\.0/);
+  assert.match(readme, /AMV Lab/);
+});
+
+test('privacy and map credits are visible in the product', () => {
+  assert.match(html, /general Strind area/);
+  assert.match(html, /does not place a marker on a private home/);
+  assert.match(html, /OpenStreetMap contributors/);
+  assert.match(html, /AWS Registry of Open Data/);
+});
+
+test('TURN styling includes focus, contrast and reduced-motion treatment', () => {
+  assert.match(css, /@import url\('\/turn\/design-tokens\.css/);
+  assert.match(css, /:focus-visible/);
+  assert.match(css, /@media \(prefers-reduced-motion: reduce\)/);
+  assert.match(css, /@media \(prefers-contrast: more\)/);
+  assert.match(css, /@media \(forced-colors: active\)/);
+  assert.match(icon, /#38d9ff/);
+  assert.match(icon, /#ff4fa3/);
+});
+
+test('pitch control has a calm dead zone and a reversible response', () => {
+  assert.equal(controlFromAngle(degreesToRadians(1)), 0);
+  const standard = controlFromAngle(degreesToRadians(10));
+  const inverted = controlFromAngle(degreesToRadians(10), { invert: true });
+  assert.ok(standard > 0 && standard < 1);
+  assert.equal(inverted, -standard);
+  assert.equal(controlFromAngle(degreesToRadians(40)), 1);
+});
+
+test('flight model turns, climbs, dives and respects its envelope', () => {
+  const turn = simulate(createFlightState(), { turn: 1 }, 1);
+  assert.ok(turn.heading < 0);
+  assert.ok(Math.abs(turn.bank) <= FLIGHT_LIMITS.maximumBank);
+
+  const climb = simulate(createFlightState({ y: 100 }), { pitch: 1, thrust: true }, 2);
+  assert.ok(climb.position.y > 100);
+  assert.ok(climb.pitch <= FLIGHT_LIMITS.maximumPitch);
+  assert.ok(climb.throttle <= 1);
+
+  const dive = simulate(createFlightState({ y: 200 }), { pitch: -1 }, 2);
+  assert.ok(dive.position.y < 200);
+  assert.ok(dive.speed <= FLIGHT_LIMITS.maximumSpeed);
+});
+
+test('low airspeed produces a stall and measurable sink', () => {
+  const stalled = simulate(createFlightState({ y: 120, speed: 40, throttle: 0 }), {}, 1);
+  assert.equal(stalled.stalled, true);
+  assert.ok(stalled.verticalSpeed < 0);
+  assert.ok(stalled.position.y < 120);
+});
+
+test('navigation and course helpers remain deterministic', () => {
+  const position = { x: 0, y: 0, z: 0 };
+  const target = { x: 30, y: 0, z: -40 };
+  assert.equal(distanceBetween(position, target), 50);
+  assert.equal(checkpointReached(position, target, 50), true);
+  assert.equal(checkpointReached(position, target, 49.9), false);
+  assert.ok(headingToTarget(position, target) > 0);
+  assert.ok(Math.abs(shortestAngle(degreesToRadians(179), degreesToRadians(-179))) < degreesToRadians(3));
+  assert.equal(formatCourseTime(65.2), '1:05.20');
+  assert.equal(Math.round(metresPerSecondToKnots(100)), 194);
+});
+
+let failures = 0;
+for (const { name, callback } of tests) {
+  try {
+    await callback();
+    console.log(`✓ ${name}`);
+  } catch (error) {
+    failures += 1;
+    console.error(`✗ ${name}`);
+    console.error(error);
+  }
+}
+
+if (failures) {
+  console.error(`\n${failures} TURN UP production test${failures === 1 ? '' : 's'} failed.`);
+  process.exitCode = 1;
+} else {
+  console.log(`\n${tests.length} TURN UP production tests passed.`);
+}

--- a/turnup/README.md
+++ b/turnup/README.md
@@ -1,0 +1,37 @@
+# TURN UP
+
+TURN UP is a small motion-controlled flight game at `https://enkel.design/turnup/`. It reuses TURN's production web platform and steering engine, then adds calibrated pitch control for climbing and diving.
+
+The first route starts over Sundsvall–Timrå Airport (Midlanda), crosses Söråker and the general Strind area, continues east, then returns along the coast and Indalsälven. The course never identifies a private home.
+
+## Runtime
+
+- MapLibre GL JS 6.5 renders the vector map, 3D terrain, buildings and Three.js custom flight layer.
+- OpenFreeMap's Liberty style supplies OpenStreetMap/OpenMapTiles map data.
+- AWS Terrain Tiles supply Terrarium elevation data.
+- Three.js 0.184 renders gates and the aircraft.
+- `B737_nologo.glb` loads at runtime from AMV Lab's `aircraft-models` commit `91d835e8e851b2317fe79af291c9fed6153fd525` under CC BY 4.0. A lightweight local aircraft is used if the remote asset is unavailable.
+- TURN design tokens, platform adapters and canonical motion steering remain shared from `/turn/`.
+
+## Controls
+
+- Tilt left/right to bank using TURN's canonical motion profile.
+- Tilt the device's top edge up/down to climb or dive.
+- Hold Thrust or Air Brake to adjust speed.
+- Button, keyboard and switch-accessible controls are always available.
+
+Keyboard: arrows or W/A/S/D fly, Space/R adds thrust, Shift/F slows, C recalibrates and Escape pauses.
+
+## Test
+
+From the repository root:
+
+```sh
+node turn-tests/turnup-production.mjs
+```
+
+The production test checks the flight model, TURN integration contract, map/terrain sources, attribution, privacy copy and accessibility fallbacks.
+
+## Credits
+
+Map data © OpenStreetMap contributors, served through OpenFreeMap/OpenMapTiles. Terrain data is hosted through the AWS Registry of Open Data. Aircraft © AMV Lab contributors, CC BY 4.0.

--- a/turnup/app.mjs
+++ b/turnup/app.mjs
@@ -1,0 +1,688 @@
+import { createWebPlatform } from '/turn/platform/web-platform.js';
+import { installTurnPlatform } from '/turn/platform/platform-context.js';
+import {
+  motionPoseFromGravity,
+  resolveMotionSteeringProfile,
+  updateMotionInputState
+} from '/turn/input/motion.js';
+import { createFlightAudio } from './audio.mjs';
+import {
+  checkpointReached,
+  controlFromAngle,
+  createFlightState,
+  degreesToRadians,
+  distanceBetween,
+  formatCourseTime,
+  headingToTarget,
+  metresPerSecondToKnots,
+  radiansToDegrees,
+  shortestAngle,
+  updateFlightState
+} from './flight-model.mjs';
+import { COURSE_POINTS, createFlightScene } from './scene.mjs';
+
+const BUILD = '2026.08.22-r1';
+const BEST_TIME_KEY = 'turnup.bestCourseSeconds.v1';
+const SETTINGS_KEY = 'turnup.settings.v1';
+const reducedMotion = globalThis.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+
+const elements = {
+  body: document.body,
+  game: requireElement('#game'),
+  intro: requireElement('#intro'),
+  takeOff: requireElement('#takeOffButton'),
+  manualStart: requireElement('#manualStartButton'),
+  how: requireElement('#howButton'),
+  about: requireElement('#aboutButton'),
+  loadingStatus: requireElement('#loadingStatus'),
+  modelStatus: requireElement('#modelStatus'),
+  hud: requireElement('#hud'),
+  controls: requireElement('#controls'),
+  manualControls: requireElement('#manualControls'),
+  recalibrate: requireElement('#recalibrateButton'),
+  pause: requireElement('#pauseButton'),
+  gate: requireElement('#gateValue'),
+  altitude: requireElement('#altitudeValue'),
+  speed: requireElement('#speedValue'),
+  throttle: requireElement('#throttleValue'),
+  time: requireElement('#timeValue'),
+  targetName: requireElement('#targetNameValue'),
+  distance: requireElement('#distanceValue'),
+  courseNeedle: requireElement('#courseNeedle'),
+  attitude: requireElement('#attitudeIndicator'),
+  throttleFill: requireElement('#throttleFill'),
+  flightMessage: requireElement('#flightMessage'),
+  rotateTitle: requireElement('#rotateTitle'),
+  pauseDialog: requireElement('#pauseDialog'),
+  resume: requireElement('#resumeButton'),
+  restart: requireElement('#restartButton'),
+  switchControls: requireElement('#switchControlsButton'),
+  leave: requireElement('#leaveButton'),
+  soundToggle: requireElement('#soundToggle'),
+  invertPitch: requireElement('#invertPitchToggle'),
+  pauseMode: requireElement('#pauseMode'),
+  resultDialog: requireElement('#resultDialog'),
+  resultTime: requireElement('#resultTime'),
+  resultBest: requireElement('#resultBest'),
+  flyAgain: requireElement('#flyAgainButton'),
+  resultLeave: requireElement('#resultLeaveButton'),
+  howDialog: requireElement('#howDialog'),
+  howClose: requireElement('#howCloseButton'),
+  aboutDialog: requireElement('#aboutDialog'),
+  aboutClose: requireElement('#aboutCloseButton'),
+  thrust: requireElement('#thrustButton'),
+  airBrake: requireElement('#airBrakeButton'),
+  bankLeft: requireElement('#bankLeftButton'),
+  bankRight: requireElement('#bankRightButton'),
+  pitchUp: requireElement('#pitchUpButton'),
+  pitchDown: requireElement('#pitchDownButton'),
+  build: requireElement('#buildLabel')
+};
+
+const settings = loadSettings();
+elements.soundToggle.checked = settings.sound;
+elements.invertPitch.checked = settings.invertPitch;
+elements.build.textContent = `TURN UP · BUILD ${BUILD.toUpperCase()}`;
+
+const platform = createWebPlatform();
+installTurnPlatform(platform);
+const audio = createFlightAudio();
+if (!settings.sound) void audio.setEnabled(false);
+
+const steeringProfile = resolveMotionSteeringProfile();
+const motionState = {
+  sensorMode: true,
+  roll: 0,
+  targetRoll: 0,
+  neutralRoll: 0,
+  pitch: 0,
+  targetPitch: 0,
+  neutralPitch: 0,
+  steering: 0,
+  manualSteering: 0,
+  tiltDrive: 0,
+  steeringEngaged: false
+};
+
+let latestMotionPose = null;
+let pendingCalibration = true;
+let unsubscribeMotion = null;
+let motionPermissionGranted = false;
+let controlMode = platform.motion.isAvailable() ? 'tilt' : 'manual';
+let flightState = createFlightState();
+let flightScene = null;
+let gateIndex = 0;
+let playing = false;
+let paused = false;
+let animationFrame = 0;
+let previousFrameTime = 0;
+let messageTimer = 0;
+let crashCooldown = 0;
+let announcedStall = false;
+const activeKeys = new Set();
+const activePointers = new Set();
+const clickImpulseTimers = new Map();
+
+setLaunchEnabled(false);
+const slowLoadingTimer = globalThis.setTimeout(() => {
+  elements.loadingStatus.textContent = 'Still loading TURN UP. First start can take a little longer.';
+}, 5000);
+
+const scenePromise = createFlightScene(elements.game, {
+  reducedMotion,
+  onModelStatus(message) {
+    elements.modelStatus.textContent = message;
+  }
+}).then((scene) => {
+  flightScene = scene;
+  flightState = createFlightState(scene.startPose);
+  scene.render(flightState, 0);
+  setLaunchEnabled(true);
+  globalThis.clearTimeout(slowLoadingTimer);
+  elements.loadingStatus.textContent = platform.motion.isAvailable()
+    ? 'Ready. Take off with tilt controls or choose buttons.'
+    : 'Ready. Motion sensors are unavailable here, so button controls will be used.';
+  document.documentElement.dataset.turnUpReady = 'true';
+  return scene;
+}).catch((error) => {
+  console.error('TURN UP could not start.', error);
+  globalThis.clearTimeout(slowLoadingTimer);
+  elements.loadingStatus.textContent = 'TURN UP could not load. Check your connection and try again.';
+  setLaunchEnabled(false);
+  throw error;
+});
+
+elements.takeOff.addEventListener('click', () => startFlight('tilt'));
+elements.manualStart.addEventListener('click', () => startFlight('manual'));
+elements.how.addEventListener('click', () => openDialog(elements.howDialog));
+elements.about.addEventListener('click', () => openDialog(elements.aboutDialog));
+elements.howClose.addEventListener('click', () => elements.howDialog.close());
+elements.aboutClose.addEventListener('click', () => elements.aboutDialog.close());
+elements.pause.addEventListener('click', pauseFlight);
+elements.resume.addEventListener('click', resumeFlight);
+elements.restart.addEventListener('click', () => {
+  closeDialog(elements.pauseDialog);
+  resetCourse();
+  paused = false;
+  void audio.resume();
+});
+elements.switchControls.addEventListener('click', switchControlMode);
+elements.leave.addEventListener('click', leaveFlight);
+elements.flyAgain.addEventListener('click', () => {
+  closeDialog(elements.resultDialog);
+  resetCourse();
+  paused = false;
+  playing = true;
+  previousFrameTime = performance.now();
+  void audio.resume();
+});
+elements.resultLeave.addEventListener('click', leaveFlight);
+elements.recalibrate.addEventListener('click', () => calibrateMotion(true));
+elements.soundToggle.addEventListener('change', () => {
+  settings.sound = elements.soundToggle.checked;
+  saveSettings();
+  void audio.setEnabled(settings.sound);
+});
+elements.invertPitch.addEventListener('change', () => {
+  settings.invertPitch = elements.invertPitch.checked;
+  saveSettings();
+  announce(settings.invertPitch ? 'Pitch controls inverted.' : 'Pitch controls use the standard direction.');
+});
+
+bindHoldControl(elements.thrust, 'thrust');
+bindHoldControl(elements.airBrake, 'brake');
+bindHoldControl(elements.bankLeft, 'left');
+bindHoldControl(elements.bankRight, 'right');
+bindHoldControl(elements.pitchUp, 'up');
+bindHoldControl(elements.pitchDown, 'down');
+
+globalThis.addEventListener('keydown', onKeyDown, { passive: false });
+globalThis.addEventListener('keyup', onKeyUp, { passive: false });
+globalThis.addEventListener('resize', onResize, { passive: true });
+globalThis.screen?.orientation?.addEventListener?.('change', onResize);
+document.addEventListener('visibilitychange', () => {
+  if (document.hidden && playing && !paused) pauseFlight();
+});
+
+const portraitQuery = globalThis.matchMedia?.('(orientation: portrait)');
+portraitQuery?.addEventListener?.('change', (event) => {
+  if (playing && event.matches) {
+    elements.rotateTitle.focus();
+    announce('Rotate your device to landscape to keep flying.');
+  }
+});
+
+async function startFlight(requestedMode) {
+  setLaunchEnabled(false);
+  elements.loadingStatus.textContent = 'Preparing your flight…';
+  await scenePromise;
+
+  let resolvedMode = requestedMode;
+  if (requestedMode === 'tilt') {
+    resolvedMode = await prepareTiltControls() ? 'tilt' : 'manual';
+  } else {
+    void platform.display.requestFullscreen();
+    void platform.display.lockLandscape();
+  }
+
+  controlMode = resolvedMode;
+  motionState.sensorMode = resolvedMode === 'tilt';
+  applyControlModePresentation();
+  resetCourse();
+  elements.intro.hidden = true;
+  elements.intro.setAttribute('aria-hidden', 'true');
+  elements.hud.hidden = false;
+  elements.controls.hidden = false;
+  elements.body.classList.add('is-flying');
+  playing = true;
+  paused = false;
+  previousFrameTime = performance.now();
+  setLaunchEnabled(true);
+  void audio.start();
+
+  announce(resolvedMode === 'tilt'
+    ? `Flight started. Tilt left and right to bank. Tilt up or down to climb and dive. First gate: ${flightScene.getGate(0).label}.`
+    : `Flight started with button controls. First gate: ${flightScene.getGate(0).label}.`);
+  if (!animationFrame) animationFrame = requestAnimationFrame(frame);
+}
+
+async function prepareTiltControls() {
+  if (!platform.motion.isAvailable()) {
+    elements.loadingStatus.textContent = 'Motion sensors are unavailable. Using button controls.';
+    return false;
+  }
+
+  const permissionRequest = platform.motion.requestPermission();
+  const fullscreenRequest = platform.display.requestFullscreen();
+  const landscapeRequest = platform.display.lockLandscape();
+  const [permission] = await Promise.allSettled([
+    permissionRequest,
+    fullscreenRequest,
+    landscapeRequest
+  ]);
+
+  if (permission.status !== 'fulfilled') {
+    elements.loadingStatus.textContent = 'Motion access was not granted. Using button controls instead.';
+    announce('Motion access was not granted. Button controls are ready.');
+    return false;
+  }
+
+  motionPermissionGranted = true;
+  ensureMotionSubscription();
+  pendingCalibration = true;
+  return true;
+}
+
+function ensureMotionSubscription() {
+  if (unsubscribeMotion) return;
+  unsubscribeMotion = platform.motion.subscribe((event) => {
+    const pose = motionPoseFromGravity(event);
+    if (!pose) return;
+    latestMotionPose = pose;
+    motionState.targetRoll = pose.roll;
+    motionState.targetPitch = pose.pitch;
+    if (pendingCalibration) calibrateMotion(false);
+  });
+}
+
+function calibrateMotion(withAnnouncement) {
+  const pose = latestMotionPose;
+  if (!pose) {
+    pendingCalibration = true;
+    if (withAnnouncement) announce('Hold your device comfortably. Calibration will finish when motion data arrives.');
+    return false;
+  }
+
+  motionState.roll = pose.roll;
+  motionState.targetRoll = pose.roll;
+  motionState.neutralRoll = pose.roll;
+  motionState.pitch = pose.pitch;
+  motionState.targetPitch = pose.pitch;
+  motionState.neutralPitch = pose.pitch;
+  motionState.steering = 0;
+  motionState.steeringEngaged = false;
+  pendingCalibration = false;
+  if (withAnnouncement) announce('Flight controls recalibrated.');
+  return true;
+}
+
+function frame(now) {
+  animationFrame = requestAnimationFrame(frame);
+  if (!flightScene) return;
+
+  if (!playing || paused) {
+    flightScene.render(flightState, now / 1000);
+    previousFrameTime = now;
+    return;
+  }
+
+  const elapsed = Math.min(0.12, Math.max(0, (now - previousFrameTime) / 1000));
+  previousFrameTime = now;
+  const manual = readManualControls();
+  motionState.manualSteering = manual.steering;
+  motionState.sensorMode = controlMode === 'tilt';
+  updateMotionInputState({
+    state: motionState,
+    dt: Math.min(elapsed, 0.05),
+    maxSteerRoll: degreesToRadians(24),
+    steeringProfile
+  });
+
+  const pitchControl = controlMode === 'tilt'
+    ? controlFromAngle(motionState.pitch - motionState.neutralPitch, {
+      limitRadians: degreesToRadians(19),
+      deadZoneRadians: degreesToRadians(1.7),
+      invert: settings.invertPitch
+    })
+    : manual.pitch;
+
+  let remaining = elapsed;
+  while (remaining > 0) {
+    const step = Math.min(remaining, 0.05);
+    updateFlightState(flightState, {
+      turn: motionState.steering,
+      pitch: pitchControl,
+      thrust: manual.thrust,
+      brake: manual.brake
+    }, step);
+    remaining -= step;
+  }
+
+  crashCooldown = Math.max(0, crashCooldown - elapsed);
+  handleFlightEvents();
+  updateHud(pitchControl);
+  audio.update(flightState);
+  flightScene.render(flightState, now / 1000);
+}
+
+function handleFlightEvents() {
+  const groundElevation = flightScene.groundElevationAt(flightState.position);
+  const tooFar = Math.hypot(flightState.position.x, flightState.position.z) > 30000;
+  if ((
+    flightState.position.y < groundElevation + 10
+    || flightState.position.y > 1400
+    || tooFar
+  ) && !crashCooldown) {
+    respawnAtCurrentGate();
+    crashCooldown = 2.5;
+    audio.warning();
+    announce(tooFar
+      ? 'Returning you to the course.'
+      : 'Aircraft recovered at the last gate.');
+  }
+
+  if (flightState.stalled && !announcedStall) {
+    announcedStall = true;
+    elements.body.classList.add('is-stalling');
+    audio.warning();
+    announce('Stall warning. Lower the nose or add thrust.');
+  } else if (!flightState.stalled && announcedStall) {
+    announcedStall = false;
+    elements.body.classList.remove('is-stalling');
+    announce('Airspeed recovered.');
+  }
+
+  const target = flightScene.getGate(gateIndex);
+  if (target && checkpointReached(flightState.position, target, flightScene.gateRadius)) {
+    gateIndex += 1;
+    flightScene.setActiveGate(gateIndex);
+    audio.checkpoint();
+    if (gateIndex >= COURSE_POINTS.length) finishCourse();
+    else announce(`Gate ${gateIndex} clear. Next: ${flightScene.getGate(gateIndex).label}.`);
+  }
+}
+
+function finishCourse() {
+  paused = true;
+  const courseTime = flightState.elapsed;
+  const previousBest = loadBestTime();
+  const isBest = !Number.isFinite(previousBest) || courseTime < previousBest;
+  if (isBest) saveBestTime(courseTime);
+  elements.resultTime.textContent = formatCourseTime(courseTime);
+  elements.resultBest.textContent = isBest
+    ? 'New best flight!'
+    : `Best: ${formatCourseTime(previousBest)}`;
+  audio.complete();
+  announce(`Course complete in ${formatCourseTime(courseTime)}.`);
+  openDialog(elements.resultDialog);
+}
+
+function resetCourse() {
+  flightState = createFlightState(flightScene?.startPose || {});
+  gateIndex = 0;
+  crashCooldown = 0;
+  announcedStall = false;
+  elements.body.classList.remove('is-stalling');
+  flightScene?.setActiveGate(0);
+  if (controlMode === 'tilt') pendingCalibration = true;
+  updateHud(0);
+  flightScene?.render(flightState, performance.now() / 1000);
+}
+
+function respawnAtCurrentGate() {
+  const respawn = flightScene.getRespawnPose(gateIndex);
+  flightState = createFlightState({
+    ...respawn,
+    speed: Math.max(82, flightState.speed),
+    throttle: Math.max(0.7, flightState.throttle)
+  });
+}
+
+function pauseFlight() {
+  if (!playing || paused) return;
+  paused = true;
+  applyControlModePresentation();
+  void audio.suspend();
+  openDialog(elements.pauseDialog);
+}
+
+function resumeFlight() {
+  if (!playing) return;
+  closeDialog(elements.pauseDialog);
+  paused = false;
+  previousFrameTime = performance.now();
+  void audio.resume();
+  elements.pause.focus();
+}
+
+async function switchControlMode() {
+  if (controlMode === 'tilt') {
+    controlMode = 'manual';
+    motionState.sensorMode = false;
+    applyControlModePresentation();
+    announce('Button controls selected.');
+    return;
+  }
+
+  const ready = motionPermissionGranted || await prepareTiltControls();
+  if (!ready) {
+    controlMode = 'manual';
+    applyControlModePresentation();
+    return;
+  }
+  ensureMotionSubscription();
+  controlMode = 'tilt';
+  motionState.sensorMode = true;
+  pendingCalibration = true;
+  applyControlModePresentation();
+  announce('Tilt controls selected. Hold your device comfortably for calibration.');
+}
+
+function leaveFlight() {
+  closeDialog(elements.pauseDialog);
+  closeDialog(elements.resultDialog);
+  playing = false;
+  paused = false;
+  activeKeys.clear();
+  activePointers.clear();
+  elements.body.classList.remove('is-flying', 'is-stalling');
+  elements.hud.hidden = true;
+  elements.controls.hidden = true;
+  elements.intro.hidden = false;
+  elements.intro.setAttribute('aria-hidden', 'false');
+  resetCourse();
+  void audio.suspend();
+  setLaunchEnabled(true);
+  elements.takeOff.focus();
+}
+
+function applyControlModePresentation() {
+  const tilt = controlMode === 'tilt';
+  elements.manualControls.hidden = tilt;
+  elements.recalibrate.hidden = !tilt;
+  elements.switchControls.textContent = tilt ? 'Use button controls' : 'Use tilt controls';
+  elements.pauseMode.textContent = tilt ? 'Tilt controls' : 'Button controls';
+  elements.body.dataset.controlMode = controlMode;
+}
+
+function updateHud(pitchControl) {
+  if (!flightScene) return;
+  const target = flightScene.getGate(gateIndex);
+  elements.gate.textContent = gateIndex >= COURSE_POINTS.length
+    ? 'COMPLETE'
+    : `${gateIndex + 1} / ${COURSE_POINTS.length}`;
+  elements.altitude.textContent = `${Math.max(0, Math.round(flightState.position.y))} m`;
+  elements.speed.textContent = `${Math.round(metresPerSecondToKnots(flightState.speed))} kt`;
+  elements.throttle.textContent = `${Math.round(flightState.throttle * 100)}%`;
+  elements.time.textContent = formatCourseTime(flightState.elapsed);
+  elements.targetName.textContent = target?.label || 'COURSE COMPLETE';
+  elements.distance.textContent = target
+    ? `${Math.round(distanceBetween(flightState.position, target))} m`
+    : '—';
+  elements.throttleFill.style.setProperty('--throttle', `${Math.round(flightState.throttle * 100)}%`);
+  elements.attitude.style.setProperty('--bank-angle', `${-radiansToDegrees(flightState.bank)}deg`);
+  elements.attitude.style.setProperty('--pitch-offset', `${Math.round(pitchControl * 28)}px`);
+
+  if (target) {
+    const bearing = headingToTarget(flightState.position, target);
+    const relative = radiansToDegrees(shortestAngle(flightState.heading, bearing));
+    elements.courseNeedle.style.setProperty('--course-angle', `${relative}deg`);
+  }
+}
+
+function readManualControls() {
+  const left = controlActive('left', ['ArrowLeft', 'KeyA']);
+  const right = controlActive('right', ['ArrowRight', 'KeyD']);
+  const up = controlActive('up', ['ArrowUp', 'KeyW']);
+  const down = controlActive('down', ['ArrowDown', 'KeyS']);
+  return {
+    steering: Number(right) - Number(left),
+    pitch: Number(up) - Number(down),
+    thrust: controlActive('thrust', ['Space', 'KeyR']),
+    brake: controlActive('brake', ['ShiftLeft', 'ShiftRight', 'KeyF'])
+  };
+}
+
+function controlActive(pointerName, keyCodes) {
+  return activePointers.has(pointerName) || keyCodes.some((code) => activeKeys.has(code));
+}
+
+function bindHoldControl(button, controlName) {
+  const release = () => {
+    activePointers.delete(controlName);
+    button.classList.remove('is-down');
+  };
+  button.addEventListener('pointerdown', (event) => {
+    event.preventDefault();
+    activePointers.add(controlName);
+    button.classList.add('is-down');
+    button.setPointerCapture?.(event.pointerId);
+  });
+  button.addEventListener('pointerup', release);
+  button.addEventListener('pointercancel', release);
+  button.addEventListener('lostpointercapture', release);
+  button.addEventListener('click', () => {
+    // A short digital impulse makes activated buttons useful with switch control,
+    // keyboard emulation and screen readers that do not emit a sustained pointer.
+    activePointers.add(controlName);
+    globalThis.clearTimeout(clickImpulseTimers.get(controlName));
+    clickImpulseTimers.set(controlName, globalThis.setTimeout(() => {
+      activePointers.delete(controlName);
+      button.classList.remove('is-down');
+    }, 280));
+  });
+}
+
+function onKeyDown(event) {
+  if (!playing) return;
+  if (event.code === 'Escape') {
+    event.preventDefault();
+    if (paused && elements.pauseDialog.open) resumeFlight();
+    else pauseFlight();
+    return;
+  }
+  if (event.code === 'KeyC' && controlMode === 'tilt') {
+    event.preventDefault();
+    calibrateMotion(true);
+    return;
+  }
+  if (isFlightKey(event.code)) event.preventDefault();
+  activeKeys.add(event.code);
+}
+
+function onKeyUp(event) {
+  if (isFlightKey(event.code)) event.preventDefault();
+  activeKeys.delete(event.code);
+}
+
+function isFlightKey(code) {
+  return [
+    'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown',
+    'KeyA', 'KeyD', 'KeyW', 'KeyS', 'Space', 'KeyR', 'KeyF',
+    'ShiftLeft', 'ShiftRight'
+  ].includes(code);
+}
+
+function onResize() {
+  flightScene?.resize();
+  flightScene?.render(flightState, performance.now() / 1000);
+}
+
+function announce(message) {
+  globalThis.clearTimeout(messageTimer);
+  elements.flightMessage.textContent = '';
+  requestAnimationFrame(() => {
+    elements.flightMessage.textContent = message;
+    elements.flightMessage.classList.add('show');
+    messageTimer = globalThis.setTimeout(() => {
+      elements.flightMessage.classList.remove('show');
+    }, 3200);
+  });
+}
+
+function setLaunchEnabled(enabled) {
+  elements.takeOff.disabled = !enabled;
+  elements.manualStart.disabled = !enabled;
+}
+
+function openDialog(dialog) {
+  if (dialog.open) return;
+  if (typeof dialog.showModal === 'function') dialog.showModal();
+  else dialog.setAttribute('open', '');
+}
+
+function closeDialog(dialog) {
+  if (!dialog.open && !dialog.hasAttribute('open')) return;
+  if (typeof dialog.close === 'function') dialog.close();
+  else dialog.removeAttribute('open');
+}
+
+function loadBestTime() {
+  try {
+    const value = Number(localStorage.getItem(BEST_TIME_KEY));
+    return value > 0 ? value : Infinity;
+  } catch (_) {
+    return Infinity;
+  }
+}
+
+function saveBestTime(value) {
+  try {
+    localStorage.setItem(BEST_TIME_KEY, String(value));
+  } catch (_) {
+    // Progress remains available for the current flight when storage is restricted.
+  }
+}
+
+function loadSettings() {
+  const defaults = { sound: true, invertPitch: false };
+  try {
+    const saved = JSON.parse(localStorage.getItem(SETTINGS_KEY) || 'null');
+    return {
+      sound: typeof saved?.sound === 'boolean' ? saved.sound : defaults.sound,
+      invertPitch: typeof saved?.invertPitch === 'boolean'
+        ? saved.invertPitch
+        : defaults.invertPitch
+    };
+  } catch (_) {
+    return defaults;
+  }
+}
+
+function saveSettings() {
+  try {
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
+  } catch (_) {
+    // Settings remain active for this session when storage is restricted.
+  }
+}
+
+function requireElement(selector) {
+  const element = document.querySelector(selector);
+  if (!element) throw new Error(`TURN UP is missing ${selector}.`);
+  return element;
+}
+
+globalThis.__TURN_UP__ = Object.freeze({
+  build: BUILD,
+  source: 'TURN motion/platform engine + AMV Lab B737',
+  get state() {
+    return Object.freeze({
+      playing,
+      paused,
+      controlMode,
+      gateIndex,
+      aircraftSource: flightScene?.aircraftSource || 'loading'
+    });
+  }
+});

--- a/turnup/audio.mjs
+++ b/turnup/audio.mjs
@@ -1,0 +1,164 @@
+export function createFlightAudio() {
+  let context = null;
+  let master = null;
+  let engineOscillator = null;
+  let engineOvertone = null;
+  let engineFilter = null;
+  let engineGain = null;
+  let windSource = null;
+  let windFilter = null;
+  let windGain = null;
+  let enabled = true;
+
+  async function start() {
+    if (!enabled) return false;
+    ensureGraph();
+    if (context.state === 'suspended') await context.resume();
+    return true;
+  }
+
+  function ensureGraph() {
+    if (context) return;
+    const AudioContextType = globalThis.AudioContext || globalThis.webkitAudioContext;
+    if (!AudioContextType) return;
+
+    context = new AudioContextType();
+    master = context.createGain();
+    master.gain.value = 0.22;
+    master.connect(context.destination);
+
+    engineFilter = context.createBiquadFilter();
+    engineFilter.type = 'lowpass';
+    engineFilter.frequency.value = 620;
+    engineFilter.Q.value = 0.7;
+    engineGain = context.createGain();
+    engineGain.gain.value = 0.055;
+    engineFilter.connect(engineGain).connect(master);
+
+    engineOscillator = context.createOscillator();
+    engineOscillator.type = 'sawtooth';
+    engineOscillator.frequency.value = 56;
+    engineOscillator.connect(engineFilter);
+    engineOscillator.start();
+
+    engineOvertone = context.createOscillator();
+    engineOvertone.type = 'triangle';
+    engineOvertone.frequency.value = 112;
+    const overtoneGain = context.createGain();
+    overtoneGain.gain.value = 0.18;
+    engineOvertone.connect(overtoneGain).connect(engineFilter);
+    engineOvertone.start();
+
+    windFilter = context.createBiquadFilter();
+    windFilter.type = 'bandpass';
+    windFilter.frequency.value = 900;
+    windFilter.Q.value = 0.55;
+    windGain = context.createGain();
+    windGain.gain.value = 0.012;
+    windFilter.connect(windGain).connect(master);
+    windSource = context.createBufferSource();
+    windSource.buffer = createNoiseBuffer(context);
+    windSource.loop = true;
+    windSource.connect(windFilter);
+    windSource.start();
+  }
+
+  function update({ speed = 0, throttle = 0, stalled = false } = {}) {
+    if (!context || !enabled) return;
+    const now = context.currentTime;
+    const speedNormal = clamp((speed - 20) / 70, 0, 1);
+    const baseFrequency = 48 + throttle * 54 + speedNormal * 18;
+    engineOscillator.frequency.setTargetAtTime(baseFrequency, now, 0.08);
+    engineOvertone.frequency.setTargetAtTime(baseFrequency * 2.01, now, 0.08);
+    engineFilter.frequency.setTargetAtTime(420 + throttle * 760, now, 0.1);
+    engineGain.gain.setTargetAtTime(stalled ? 0.035 : 0.05 + throttle * 0.045, now, 0.08);
+    windFilter.frequency.setTargetAtTime(540 + speedNormal * 1450, now, 0.14);
+    windGain.gain.setTargetAtTime(0.006 + speedNormal * 0.045, now, 0.12);
+  }
+
+  function checkpoint() {
+    playNotes([523.25, 659.25, 783.99], 0.075, 0.06, 'square');
+  }
+
+  function complete() {
+    playNotes([392, 523.25, 659.25, 783.99], 0.12, 0.09, 'triangle');
+  }
+
+  function warning() {
+    playNotes([196, 164.81], 0.15, 0.07, 'sawtooth');
+  }
+
+  function playNotes(frequencies, spacing, volume, type) {
+    if (!enabled) return;
+    ensureGraph();
+    if (!context) return;
+    void context.resume();
+    const startAt = context.currentTime + 0.01;
+    for (let index = 0; index < frequencies.length; index += 1) {
+      const oscillator = context.createOscillator();
+      const gain = context.createGain();
+      const noteAt = startAt + index * spacing;
+      oscillator.type = type;
+      oscillator.frequency.value = frequencies[index];
+      gain.gain.setValueAtTime(0.0001, noteAt);
+      gain.gain.exponentialRampToValueAtTime(volume, noteAt + 0.012);
+      gain.gain.exponentialRampToValueAtTime(0.0001, noteAt + spacing * 1.7);
+      oscillator.connect(gain).connect(master);
+      oscillator.start(noteAt);
+      oscillator.stop(noteAt + spacing * 1.8);
+    }
+  }
+
+  async function setEnabled(nextEnabled) {
+    enabled = Boolean(nextEnabled);
+    if (!context) {
+      if (enabled) await start();
+      return enabled;
+    }
+    const now = context.currentTime;
+    master.gain.setTargetAtTime(enabled ? 0.22 : 0.0001, now, 0.025);
+    if (enabled && context.state === 'suspended') await context.resume();
+    return enabled;
+  }
+
+  async function suspend() {
+    if (context?.state === 'running') await context.suspend();
+  }
+
+  async function resume() {
+    if (enabled && context?.state === 'suspended') await context.resume();
+  }
+
+  function isEnabled() {
+    return enabled;
+  }
+
+  return Object.freeze({
+    start,
+    update,
+    checkpoint,
+    complete,
+    warning,
+    setEnabled,
+    suspend,
+    resume,
+    isEnabled
+  });
+}
+
+function createNoiseBuffer(context) {
+  const length = Math.max(1, Math.floor(context.sampleRate * 1.2));
+  const buffer = context.createBuffer(1, length, context.sampleRate);
+  const channel = buffer.getChannelData(0);
+  let previous = 0;
+  for (let index = 0; index < length; index += 1) {
+    const white = Math.random() * 2 - 1;
+    previous = previous * 0.78 + white * 0.22;
+    channel[index] = previous;
+  }
+  return buffer;
+}
+
+function clamp(value, minimum, maximum) {
+  return Math.min(maximum, Math.max(minimum, value));
+}

--- a/turnup/flight-model.mjs
+++ b/turnup/flight-model.mjs
@@ -1,0 +1,188 @@
+export const FLIGHT_LIMITS = Object.freeze({
+  minimumSpeed: 44,
+  stallSpeed: 57,
+  cruiseSpeed: 92,
+  maximumSpeed: 138,
+  maximumPitch: degreesToRadians(22),
+  maximumBank: degreesToRadians(42),
+  maximumTurnRate: degreesToRadians(31),
+  pitchResponseRate: 2.8,
+  bankResponseRate: 4.4,
+  throttleIncreaseRate: 0.34,
+  throttleDecreaseRate: 0.46
+});
+
+export const START_POSE = Object.freeze({
+  x: 0,
+  y: 72,
+  z: 185,
+  heading: 0,
+  pitch: degreesToRadians(2),
+  bank: 0,
+  speed: 91,
+  throttle: 0.7
+});
+
+export function createFlightState(overrides = {}) {
+  return {
+    position: {
+      x: finiteOr(overrides.x, START_POSE.x),
+      y: finiteOr(overrides.y, START_POSE.y),
+      z: finiteOr(overrides.z, START_POSE.z)
+    },
+    heading: finiteOr(overrides.heading, START_POSE.heading),
+    pitch: finiteOr(overrides.pitch, START_POSE.pitch),
+    bank: finiteOr(overrides.bank, START_POSE.bank),
+    speed: finiteOr(overrides.speed, START_POSE.speed),
+    throttle: clamp(finiteOr(overrides.throttle, START_POSE.throttle), 0, 1),
+    verticalSpeed: 0,
+    stalled: false,
+    elapsed: 0
+  };
+}
+
+export function updateFlightState(state, controls = {}, elapsedSeconds = 0) {
+  const dt = clamp(finiteOr(elapsedSeconds, 0), 0, 0.05);
+  if (!dt) return state;
+
+  const turn = clamp(finiteOr(controls.turn, 0), -1, 1);
+  const pitchControl = clamp(finiteOr(controls.pitch, 0), -1, 1);
+  const thrust = Boolean(controls.thrust);
+  const brake = Boolean(controls.brake);
+
+  if (thrust !== brake) {
+    const throttleRate = thrust
+      ? FLIGHT_LIMITS.throttleIncreaseRate
+      : -FLIGHT_LIMITS.throttleDecreaseRate;
+    state.throttle = clamp(state.throttle + throttleRate * dt, 0, 1);
+  }
+
+  const targetPitch = pitchControl * FLIGHT_LIMITS.maximumPitch;
+  const targetBank = turn * FLIGHT_LIMITS.maximumBank;
+  state.pitch = damp(state.pitch, targetPitch, FLIGHT_LIMITS.pitchResponseRate, dt);
+  state.bank = damp(state.bank, targetBank, FLIGHT_LIMITS.bankResponseRate, dt);
+
+  const targetSpeed = lerp(
+    FLIGHT_LIMITS.minimumSpeed,
+    FLIGHT_LIMITS.maximumSpeed,
+    state.throttle
+  );
+  state.speed = damp(state.speed, targetSpeed, 0.62, dt);
+
+  // Climbing trades speed for height while a dive recovers some of that energy.
+  const climbDemand = Math.max(0, Math.sin(state.pitch));
+  const diveRecovery = Math.max(0, -Math.sin(state.pitch));
+  state.speed += (diveRecovery * 8.2 - climbDemand * 6.4) * dt;
+  state.speed = clamp(state.speed, FLIGHT_LIMITS.minimumSpeed * 0.72, FLIGHT_LIMITS.maximumSpeed);
+
+  state.stalled = state.speed < FLIGHT_LIMITS.stallSpeed;
+  const speedRange = Math.max(1, FLIGHT_LIMITS.maximumSpeed - FLIGHT_LIMITS.stallSpeed);
+  const turnAuthority = clamp((state.speed - FLIGHT_LIMITS.minimumSpeed) / speedRange, 0.2, 1);
+  state.heading = wrapAngle(
+    state.heading - turn * FLIGHT_LIMITS.maximumTurnRate * turnAuthority * dt
+  );
+
+  const horizontalSpeed = Math.cos(state.pitch) * state.speed;
+  const aerodynamicClimb = Math.sin(state.pitch) * state.speed;
+  const stallSink = state.stalled
+    ? lerp(0, 23, clamp(
+      (FLIGHT_LIMITS.stallSpeed - state.speed)
+        / (FLIGHT_LIMITS.stallSpeed - FLIGHT_LIMITS.minimumSpeed * 0.72),
+      0,
+      1
+    ))
+    : 0;
+
+  state.verticalSpeed = aerodynamicClimb - stallSink;
+  state.position.x += Math.sin(state.heading) * horizontalSpeed * dt;
+  state.position.y += state.verticalSpeed * dt;
+  state.position.z -= Math.cos(state.heading) * horizontalSpeed * dt;
+  state.elapsed += dt;
+  return state;
+}
+
+export function controlFromAngle(deltaRadians, {
+  limitRadians = degreesToRadians(18),
+  deadZoneRadians = degreesToRadians(1.8),
+  invert = false,
+  curvePower = 1.12
+} = {}) {
+  const magnitude = Math.abs(finiteOr(deltaRadians, 0));
+  if (magnitude <= deadZoneRadians) return 0;
+
+  const available = Math.max(0.001, limitRadians - deadZoneRadians);
+  const linear = clamp((magnitude - deadZoneRadians) / available, 0, 1);
+  const curved = Math.pow(linear, curvePower);
+  const eased = curved * curved * (3 - 2 * curved);
+  const direction = Math.sign(deltaRadians) * (invert ? -1 : 1);
+  return direction * eased;
+}
+
+export function checkpointReached(position, checkpoint, radius = 34) {
+  if (!position || !checkpoint) return false;
+  const dx = finiteOr(position.x, 0) - finiteOr(checkpoint.x, 0);
+  const dy = finiteOr(position.y, 0) - finiteOr(checkpoint.y, 0);
+  const dz = finiteOr(position.z, 0) - finiteOr(checkpoint.z, 0);
+  return dx * dx + dy * dy + dz * dz <= radius * radius;
+}
+
+export function distanceBetween(position, target) {
+  if (!position || !target) return Infinity;
+  return Math.hypot(
+    finiteOr(position.x, 0) - finiteOr(target.x, 0),
+    finiteOr(position.y, 0) - finiteOr(target.y, 0),
+    finiteOr(position.z, 0) - finiteOr(target.z, 0)
+  );
+}
+
+export function headingToTarget(position, target) {
+  const dx = finiteOr(target?.x, 0) - finiteOr(position?.x, 0);
+  const dz = finiteOr(target?.z, 0) - finiteOr(position?.z, 0);
+  return Math.atan2(dx, -dz);
+}
+
+export function shortestAngle(from, to) {
+  return wrapAngle(finiteOr(to, 0) - finiteOr(from, 0));
+}
+
+export function formatCourseTime(seconds) {
+  const safe = Math.max(0, finiteOr(seconds, 0));
+  const minutes = Math.floor(safe / 60);
+  const remainder = safe - minutes * 60;
+  return `${minutes}:${remainder.toFixed(2).padStart(5, '0')}`;
+}
+
+export function metresPerSecondToKnots(value) {
+  return Math.max(0, finiteOr(value, 0)) * 1.943844;
+}
+
+export function radiansToDegrees(value) {
+  return finiteOr(value, 0) * 180 / Math.PI;
+}
+
+export function degreesToRadians(value) {
+  return finiteOr(value, 0) * Math.PI / 180;
+}
+
+export function clamp(value, minimum, maximum) {
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+function damp(current, target, responseRate, dt) {
+  return lerp(current, target, 1 - Math.exp(-responseRate * dt));
+}
+
+function lerp(start, end, amount) {
+  return start + (end - start) * amount;
+}
+
+function wrapAngle(angle) {
+  let value = angle;
+  while (value > Math.PI) value -= Math.PI * 2;
+  while (value < -Math.PI) value += Math.PI * 2;
+  return value;
+}
+
+function finiteOr(value, fallback) {
+  return Number.isFinite(value) ? value : fallback;
+}

--- a/turnup/icon.svg
+++ b/turnup/icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title description">
+  <title id="title">TURN UP</title>
+  <desc id="description">An aircraft banking upward in the TURN design style.</desc>
+  <rect x="5" y="5" width="118" height="118" rx="25" fill="#38d9ff" stroke="#08090a" stroke-width="10"/>
+  <path d="M24 80 54 66l9-42c1-6 9-6 11 0l3 34 25-12c4-2 9 0 11 4 2 5 0 9-5 11L77 77l-4 25 12 8H48l12-9-3-25-27 14c-5 2-10 0-12-5-1-4 1-8 6-10Z" fill="#fff8e8" stroke="#08090a" stroke-width="7" stroke-linejoin="round"/>
+  <path d="m83 26 12-12 12 12M95 15v25" fill="none" stroke="#ff4fa3" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/turnup/index.html
+++ b/turnup/index.html
@@ -1,0 +1,218 @@
+<!doctype html>
+<html lang="en" data-turn-deployment="turnup">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="theme-color" content="#38d9ff">
+  <meta name="application-name" content="TURN UP">
+  <meta name="apple-mobile-web-app-title" content="TURN UP">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="description" content="TURN UP is a motion-controlled flight game over Sundsvall–Timrå Airport, Söråker and the Strind area. Bank like TURN, then tilt up or down to climb and dive.">
+  <link rel="canonical" href="https://enkel.design/turnup/">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="TURN UP">
+  <meta property="og:title" content="TURN UP — Tilt. Climb. Fly.">
+  <meta property="og:description" content="A motion-controlled flight over Midlanda, Söråker and the Strind area, powered by the TURN engine.">
+  <meta property="og:url" content="https://enkel.design/turnup/">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="TURN UP — Tilt. Climb. Fly.">
+  <meta name="twitter:description" content="A motion-controlled flight over Midlanda, Söråker and the Strind area.">
+  <title>TURN UP</title>
+  <link rel="icon" href="./icon.svg" type="image/svg+xml">
+  <link rel="preconnect" href="https://tiles.openfreemap.org">
+  <link rel="preconnect" href="https://s3.amazonaws.com">
+  <link rel="preload" as="fetch" crossorigin href="https://raw.githubusercontent.com/amvlab/aircraft-models/91d835e8e851b2317fe79af291c9fed6153fd525/models/B737_nologo.glb">
+  <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@6.5.0/dist/maplibre-gl.css">
+  <link rel="stylesheet" href="./styles.css?build=20260822-r1">
+  <script type="importmap">
+    {
+      "imports": {
+        "maplibre-gl": "https://unpkg.com/maplibre-gl@6.5.0/dist/maplibre-gl.mjs",
+        "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
+        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
+        "/turn/input/motion.js": "/turn/input/motion.js?revision=r164-ipad-motion-profile"
+      }
+    }
+  </script>
+</head>
+<body>
+  <a class="skip-link" href="#intro">Skip to game controls</a>
+  <div id="game" aria-label="3D flight view over Sundsvall–Timrå Airport, Söråker and the Strind area"></div>
+
+  <main class="launch-panel" id="intro" aria-labelledby="gameTitle" aria-hidden="false">
+    <article class="launch-card">
+      <div class="launch-mark" aria-hidden="true">
+        <img src="./icon.svg" alt="">
+      </div>
+      <div class="launch-copy">
+        <span class="kicker">A TURN FLIGHT EXPERIMENT</span>
+        <h1 id="gameTitle"><span>TURN</span> UP</h1>
+        <p class="tagline">TILT. CLIMB. FLY.</p>
+        <p class="intro-copy">Bank left and right just like TURN. Tilt the top of your device up or down to climb and dive, then fly the gates across the real Midlanda–Söråker landscape.</p>
+        <p class="route-chip"><strong>FIRST ROUTE</strong> MIDLANDA <span aria-hidden="true">→</span> SÖRÅKER <span aria-hidden="true">→</span> STRIND AREA</p>
+        <div class="launch-actions">
+          <button class="primary" id="takeOffButton" type="button" disabled>TAKE OFF WITH TILT</button>
+          <button class="game-action" id="manualStartButton" type="button" disabled>FLY WITH BUTTONS</button>
+          <button class="utility-action" id="howButton" type="button">HOW TO FLY</button>
+        </div>
+        <p class="loading-status" id="loadingStatus" role="status" aria-live="polite" aria-atomic="true">Loading the TURN flight engine…</p>
+        <p class="model-status" id="modelStatus">Preparing the Midlanda map…</p>
+        <div class="launch-meta">
+          <span id="buildLabel">TURN UP</span>
+          <button id="aboutButton" type="button">ABOUT &amp; MAP CREDITS</button>
+        </div>
+      </div>
+    </article>
+  </main>
+
+  <section class="hud" id="hud" aria-label="Flight instruments" hidden>
+    <div class="topbar">
+      <div class="stats">
+        <div class="chip"><span>gate</span><strong id="gateValue">1 / 8</strong></div>
+        <div class="chip"><span>altitude</span><strong id="altitudeValue">78 m</strong></div>
+        <div class="chip"><span>airspeed</span><strong id="speedValue">177 kt</strong></div>
+        <div class="chip"><span>throttle</span><strong id="throttleValue">70%</strong></div>
+        <div class="chip optional-chip"><span>time</span><strong id="timeValue">0:00.00</strong></div>
+      </div>
+      <button class="pause-button" id="pauseButton" type="button" aria-label="Pause flight">PAUSE</button>
+    </div>
+
+    <div class="objective" aria-hidden="true">
+      <div class="course-dial">
+        <i id="courseNeedle"></i>
+      </div>
+      <div>
+        <span>NEXT GATE</span>
+        <b id="targetNameValue">RUNWAY 16</b>
+        <strong id="distanceValue">—</strong>
+      </div>
+    </div>
+
+    <div class="attitude" id="attitudeIndicator" aria-hidden="true">
+      <div class="attitude-world">
+        <div class="attitude-sky"></div>
+        <div class="attitude-ground"></div>
+        <i class="attitude-horizon"></i>
+      </div>
+      <div class="attitude-plane"><i></i><b></b><i></i></div>
+    </div>
+
+    <p class="flight-message" id="flightMessage" role="status" aria-live="polite" aria-atomic="true"></p>
+  </section>
+
+  <section class="flight-controls" id="controls" aria-label="Flight controls" hidden>
+    <div class="manual-controls" id="manualControls" aria-label="Bank and pitch controls" hidden>
+      <button id="pitchUpButton" class="direction up" type="button" aria-label="Pitch up">UP</button>
+      <button id="bankLeftButton" class="direction left" type="button" aria-label="Bank left">LEFT</button>
+      <button id="bankRightButton" class="direction right" type="button" aria-label="Bank right">RIGHT</button>
+      <button id="pitchDownButton" class="direction down" type="button" aria-label="Pitch down">DOWN</button>
+    </div>
+
+    <button class="recalibrate" id="recalibrateButton" type="button">RECALIBRATE</button>
+
+    <div class="throttle-controls" aria-label="Throttle controls">
+      <div class="throttle-meter" aria-hidden="true"><i id="throttleFill"></i></div>
+      <button class="air-brake" id="airBrakeButton" type="button">AIR BRAKE</button>
+      <button class="thrust" id="thrustButton" type="button">THRUST</button>
+    </div>
+  </section>
+
+  <section class="rotate-gate" aria-labelledby="rotateTitle">
+    <div class="rotate-card">
+      <div class="rotate-phone" aria-hidden="true"></div>
+      <h2 id="rotateTitle" tabindex="-1">ROTATE TO LANDSCAPE</h2>
+      <p>TURN UP needs the width for its flight view and controls.</p>
+    </div>
+  </section>
+
+  <dialog class="turn-dialog" id="howDialog" aria-labelledby="howTitle">
+    <article>
+      <header>
+        <div>
+          <span class="dialog-kicker">FLIGHT SCHOOL</span>
+          <h2 id="howTitle">HOW TO FLY</h2>
+        </div>
+        <button class="close-button" id="howCloseButton" type="button" aria-label="Close flight instructions">CLOSE</button>
+      </header>
+      <div class="instruction-grid">
+        <section>
+          <strong>1 · BANK</strong>
+          <p>Turn your device left or right exactly as you do in TURN. The aircraft banks into the turn.</p>
+        </section>
+        <section>
+          <strong>2 · CLIMB &amp; DIVE</strong>
+          <p>Tilt the top edge up to climb and down to dive. Recalibrate if your resting position changes. Invert pitch is available in Pause.</p>
+        </section>
+        <section>
+          <strong>3 · AIRSPEED</strong>
+          <p>Hold Thrust to speed up and Air Brake to slow down. If STALL appears, lower the nose or add thrust.</p>
+        </section>
+        <section>
+          <strong>4 · THE ROUTE</strong>
+          <p>Fly through the pink gate. Yellow gates show what comes later. The first course starts at Midlanda and stretches east past the Strind area.</p>
+        </section>
+      </div>
+      <p class="keyboard-help"><strong>KEYBOARD:</strong> Arrow keys or W/A/S/D fly · Space/R adds thrust · Shift/F slows · C recalibrates · Escape pauses.</p>
+    </article>
+  </dialog>
+
+  <dialog class="turn-dialog pause-dialog" id="pauseDialog" aria-labelledby="pauseTitle">
+    <article>
+      <header>
+        <div>
+          <span class="dialog-kicker">FLIGHT PAUSED</span>
+          <h2 id="pauseTitle">TURN UP</h2>
+        </div>
+        <span class="mode-pill" id="pauseMode">Tilt controls</span>
+      </header>
+      <fieldset>
+        <legend>SETTINGS</legend>
+        <label><input id="soundToggle" type="checkbox" checked> <span><strong>FLIGHT AUDIO</strong><small>Engine, wind and gate cues</small></span></label>
+        <label><input id="invertPitchToggle" type="checkbox"> <span><strong>INVERT PITCH</strong><small>Reverse the climb and dive direction</small></span></label>
+      </fieldset>
+      <div class="dialog-actions">
+        <button class="primary" id="resumeButton" type="button">RESUME FLIGHT</button>
+        <button class="game-action" id="switchControlsButton" type="button">USE BUTTON CONTROLS</button>
+        <button class="warning-action" id="restartButton" type="button">RESTART COURSE</button>
+        <button class="navigation-action" id="leaveButton" type="button">LEAVE FLIGHT</button>
+      </div>
+    </article>
+  </dialog>
+
+  <dialog class="turn-dialog result-dialog" id="resultDialog" aria-labelledby="resultTitle">
+    <article>
+      <span class="dialog-kicker">COURSE COMPLETE</span>
+      <h2 id="resultTitle">YOU TURNED UP.</h2>
+      <p class="result-time" id="resultTime">0:00.00</p>
+      <p class="result-best" id="resultBest">New best flight!</p>
+      <div class="dialog-actions">
+        <button class="primary" id="flyAgainButton" type="button">FLY AGAIN</button>
+        <button class="navigation-action" id="resultLeaveButton" type="button">LEAVE FLIGHT</button>
+      </div>
+    </article>
+  </dialog>
+
+  <dialog class="turn-dialog about-dialog" id="aboutDialog" aria-labelledby="aboutTitle">
+    <article>
+      <header>
+        <div>
+          <span class="dialog-kicker">OPEN FLIGHT</span>
+          <h2 id="aboutTitle">ABOUT TURN UP</h2>
+        </div>
+        <button class="close-button" id="aboutCloseButton" type="button" aria-label="Close about TURN UP">CLOSE</button>
+      </header>
+      <p>TURN UP is a small arcade flight simulator built from TURN’s production motion and platform engine. It uses the same iPad steering profile and adds a second tilt axis for pitch.</p>
+      <h3>REAL-WORLD MAP</h3>
+      <p>The Midlanda, Söråker and Strind-area landscape is rendered with <a href="https://maplibre.org/">MapLibre GL JS</a>, <a href="https://openfreemap.org/">OpenFreeMap</a>, <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>, OpenMapTiles and open terrain elevation tiles hosted through the <a href="https://registry.opendata.aws/terrain-tiles/">AWS Registry of Open Data</a>.</p>
+      <p>The route identifies only the general Strind area; it does not place a marker on a private home.</p>
+      <h3>AIRCRAFT</h3>
+      <p>The logo-free B737 model comes from <a href="https://github.com/amvlab/aircraft-models">AMV Lab aircraft-models</a> at pinned commit <code>91d835e</code>, licensed under <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>. TURN UP scales, orients and outlines it at runtime.</p>
+    </article>
+  </dialog>
+
+  <noscript><p class="noscript">TURN UP needs JavaScript to run its flight engine.</p></noscript>
+  <script type="module" src="./app.mjs?build=20260822-r1"></script>
+</body>
+</html>

--- a/turnup/scene.mjs
+++ b/turnup/scene.mjs
@@ -1,0 +1,566 @@
+import * as maplibregl from 'maplibre-gl';
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+
+const INK = 0x08090a;
+const PAPER = 0xfff8e8;
+const CYAN = 0x38d9ff;
+const PINK = 0xff4fa3;
+const YELLOW = 0xffd43b;
+const AMVLAB_COMMIT = '91d835e8e851b2317fe79af291c9fed6153fd525';
+const AIRCRAFT_URL = `https://raw.githubusercontent.com/amvlab/aircraft-models/${AMVLAB_COMMIT}/models/B737_nologo.glb`;
+const B737_LENGTH_TO_SPAN = 39.5 / 35.8;
+
+export const MAP_STYLE_URL = 'https://tiles.openfreemap.org/styles/liberty';
+export const TERRAIN_TILE_URL = 'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png';
+export const AIRPORT_ORIGIN = Object.freeze({
+  lng: 17.443,
+  lat: 62.5285,
+  elevation: 5
+});
+
+const originMercator = maplibregl.MercatorCoordinate.fromLngLat(AIRPORT_ORIGIN, 0);
+const metresToMercator = originMercator.meterInMercatorCoordinateUnits();
+
+const COURSE_GEO = Object.freeze([
+  Object.freeze({ lng: 17.4498, lat: 62.5198, altitude: 92, label: 'RUNWAY 16' }),
+  Object.freeze({ lng: 17.483, lat: 62.509, altitude: 145, label: 'SÖRÅKER APPROACH' }),
+  Object.freeze({ lng: 17.526, lat: 62.506, altitude: 205, label: 'SÖRÅKER' }),
+  Object.freeze({ lng: 17.592, lat: 62.522, altitude: 265, label: 'STRIND AREA' }),
+  Object.freeze({ lng: 17.66, lat: 62.542, altitude: 325, label: 'EASTERN TURN' }),
+  Object.freeze({ lng: 17.61, lat: 62.576, altitude: 275, label: 'COASTAL RETURN' }),
+  Object.freeze({ lng: 17.52, lat: 62.57, altitude: 190, label: 'INDALSÄLVEN' }),
+  Object.freeze({ lng: 17.447, lat: 62.541, altitude: 112, label: 'MIDLANDA RETURN' })
+]);
+
+export const COURSE_POINTS = Object.freeze(COURSE_GEO.map((waypoint) => Object.freeze({
+  ...geographicToLocal(waypoint),
+  label: waypoint.label,
+  lng: waypoint.lng,
+  lat: waypoint.lat
+})));
+
+const startLocation = geographicToLocal({ lng: 17.4362, lat: 62.5362, altitude: 78 });
+const firstGate = COURSE_POINTS[0];
+const START_HEADING = Math.atan2(
+  firstGate.x - startLocation.x,
+  startLocation.z - firstGate.z
+);
+
+export const MAP_START_POSE = Object.freeze({
+  ...startLocation,
+  heading: START_HEADING,
+  pitch: degreesToRadians(2.5),
+  bank: 0,
+  speed: 91,
+  throttle: 0.7
+});
+
+export async function createFlightScene(container, {
+  reducedMotion = false,
+  onModelStatus = () => {}
+} = {}) {
+  if (!container) throw new Error('TURN UP needs a map container.');
+  if (!maplibregl.supported()) throw new Error('This browser does not support the WebGL map TURN UP needs.');
+
+  const map = new maplibregl.Map({
+    container,
+    style: MAP_STYLE_URL,
+    center: [AIRPORT_ORIGIN.lng, AIRPORT_ORIGIN.lat],
+    zoom: 14.3,
+    pitch: 72,
+    bearing: radiansToDegrees(MAP_START_POSE.heading),
+    maxPitch: 85,
+    minZoom: 10.5,
+    maxZoom: 17.5,
+    maxBounds: [[17.22, 62.39], [17.84, 62.67]],
+    interactive: false,
+    renderWorldCopies: false,
+    attributionControl: false,
+    fadeDuration: reducedMotion ? 0 : 180,
+    canvasContextAttributes: { antialias: true }
+  });
+
+  map.addControl(new maplibregl.AttributionControl({
+    compact: true,
+    customAttribution: 'TURN UP · AMV Lab aircraft'
+  }), 'bottom-left');
+
+  map.on('error', (event) => {
+    const message = String(event?.error?.message || '');
+    if (/terrain|elevation|raster-dem/i.test(message)) {
+      console.info('TURN UP: terrain tile unavailable; continuing with the vector map.', event.error);
+      return;
+    }
+    console.info('TURN UP map resource warning.', event.error || event);
+  });
+
+  const threeScene = new THREE.Scene();
+  const threeCamera = new THREE.Camera();
+  addLighting(threeScene);
+  const aircraftRig = createAircraftRig();
+  threeScene.add(aircraftRig.root);
+  const gateObjects = buildCourse(threeScene);
+  let terrainAtOrigin = AIRPORT_ORIGIN.elevation;
+  let renderer = null;
+  let aircraftSource = 'TURN UP local fallback aircraft';
+  let activeGateIndex = 0;
+
+  onModelStatus('Loading the B737 and the Midlanda map…');
+  const aircraftPromise = loadAircraft().then((model) => {
+    aircraftRig.modelContainer.clear();
+    aircraftRig.modelContainer.add(model);
+    aircraftSource = 'AMV Lab B737_nologo.glb, CC BY 4.0';
+    onModelStatus('Midlanda map and B737 ready.');
+  }).catch((error) => {
+    console.info('TURN UP: B737 unavailable; using the lightweight fallback aircraft.', error);
+    onModelStatus('Map ready. The lightweight backup aircraft is in use.');
+  });
+
+  await new Promise((resolve) => map.once('load', resolve));
+  installTerrain(map, reducedMotion);
+  installThreeDimensionalBuildings(map);
+  installRouteLine(map);
+  setSkyAndFog(map, reducedMotion);
+
+  const customLayer = {
+    id: 'turn-up-flight-objects',
+    type: 'custom',
+    renderingMode: '3d',
+    onAdd(_map, gl) {
+      renderer = new THREE.WebGLRenderer({
+        canvas: map.getCanvas(),
+        context: gl,
+        antialias: true
+      });
+      renderer.autoClear = false;
+      renderer.outputColorSpace = THREE.SRGBColorSpace;
+    },
+    render(_gl, args) {
+      terrainAtOrigin = map.queryTerrainElevation([
+        AIRPORT_ORIGIN.lng,
+        AIRPORT_ORIGIN.lat
+      ]) ?? terrainAtOrigin;
+      const mapOrigin = maplibregl.MercatorCoordinate.fromLngLat(
+        AIRPORT_ORIGIN,
+        terrainAtOrigin
+      );
+      const projection = new THREE.Matrix4().fromArray(args.defaultProjectionData.mainMatrix);
+      const localTransform = new THREE.Matrix4()
+        .makeTranslation(mapOrigin.x, mapOrigin.y, mapOrigin.z)
+        .scale(new THREE.Vector3(metresToMercator, -metresToMercator, metresToMercator));
+      threeCamera.projectionMatrix = projection.multiply(localTransform);
+      renderer.resetState();
+      renderer.render(threeScene, threeCamera);
+    }
+  };
+
+  map.addLayer(customLayer);
+  await aircraftPromise;
+  setGateState(gateObjects, activeGateIndex);
+
+  function resize() {
+    map.resize();
+  }
+
+  function render(flightState, elapsedSeconds = 0) {
+    const mapPosition = flightToMapPosition(flightState.position);
+    aircraftRig.root.position.copy(mapPosition);
+    aircraftRig.root.rotation.z = -flightState.heading;
+    aircraftRig.pitch.rotation.x = flightState.pitch;
+    aircraftRig.bank.rotation.y = -flightState.bank;
+
+    if (!reducedMotion) {
+      const activeGate = gateObjects[activeGateIndex];
+      if (activeGate) {
+        const pulse = 1 + Math.sin(elapsedSeconds * 4.2) * 0.035;
+        activeGate.scale.setScalar(pulse);
+        activeGate.userData.marker.rotation.z += 0.008;
+      }
+    }
+
+    const ahead = localToLngLat(
+      flightState.position.x + Math.sin(flightState.heading) * 310,
+      flightState.position.z - Math.cos(flightState.heading) * 310
+    );
+    const altitudeZoom = clamp((flightState.position.y - 80) / 720, 0, 1);
+    map.jumpTo({
+      center: ahead,
+      bearing: radiansToDegrees(flightState.heading),
+      pitch: reducedMotion ? 68 : 73,
+      roll: reducedMotion ? 0 : radiansToDegrees(flightState.bank) * 0.12,
+      zoom: 15.45 - altitudeZoom * 1.55
+    });
+    map.triggerRepaint();
+  }
+
+  function setActiveGate(index) {
+    activeGateIndex = Math.max(0, Math.min(index, gateObjects.length));
+    setGateState(gateObjects, activeGateIndex);
+  }
+
+  function getGate(index) {
+    return COURSE_POINTS[index] || null;
+  }
+
+  function getRespawnPose(index) {
+    const previous = index > 0 ? COURSE_POINTS[index - 1] : MAP_START_POSE;
+    const target = COURSE_POINTS[index] || COURSE_POINTS[0];
+    const dx = target.x - previous.x;
+    const dz = target.z - previous.z;
+    const horizontalDistance = Math.max(1, Math.hypot(dx, dz));
+    return {
+      x: previous.x - dx / horizontalDistance * 90,
+      y: Math.max(65, previous.y + 14),
+      z: previous.z - dz / horizontalDistance * 90,
+      heading: Math.atan2(dx, -dz),
+      pitch: Math.atan2(target.y - previous.y, horizontalDistance)
+    };
+  }
+
+  function groundElevationAt(position) {
+    const location = localToLngLat(position.x, position.z);
+    const elevation = map.queryTerrainElevation(location);
+    if (!Number.isFinite(elevation)) return 0;
+    return elevation - terrainAtOrigin;
+  }
+
+  function dispose() {
+    renderer?.dispose();
+    threeScene.traverse((node) => {
+      node.geometry?.dispose?.();
+      if (Array.isArray(node.material)) node.material.forEach((entry) => entry.dispose?.());
+      else node.material?.dispose?.();
+    });
+    map.remove();
+  }
+
+  return Object.freeze({
+    map,
+    startPose: MAP_START_POSE,
+    gates: COURSE_POINTS,
+    gateRadius: 88,
+    get aircraftSource() {
+      return aircraftSource;
+    },
+    resize,
+    render,
+    setActiveGate,
+    getGate,
+    getRespawnPose,
+    groundElevationAt,
+    dispose
+  });
+}
+
+function installTerrain(map, reducedMotion) {
+  if (!map.getSource('turn-up-terrain')) {
+    map.addSource('turn-up-terrain', {
+      type: 'raster-dem',
+      tiles: [TERRAIN_TILE_URL],
+      tileSize: 256,
+      maxzoom: 15,
+      encoding: 'terrarium',
+      attribution: 'Terrain © Mapzen/AWS Open Data'
+    });
+  }
+
+  const firstLabelId = map.getStyle().layers?.find((layer) => layer.type === 'symbol')?.id;
+  if (!map.getLayer('turn-up-hillshade')) {
+    map.addLayer({
+      id: 'turn-up-hillshade',
+      type: 'hillshade',
+      source: 'turn-up-terrain',
+      paint: {
+        'hillshade-shadow-color': '#143642',
+        'hillshade-highlight-color': '#fff0a8',
+        'hillshade-accent-color': '#2389b8',
+        'hillshade-exaggeration': reducedMotion ? 0.24 : 0.36
+      }
+    }, firstLabelId);
+  }
+  map.setTerrain({ source: 'turn-up-terrain', exaggeration: 1.18 });
+}
+
+function installThreeDimensionalBuildings(map) {
+  const styleLayers = map.getStyle().layers || [];
+  const sourceLayer = styleLayers.find((layer) => layer['source-layer'] === 'building');
+  if (!sourceLayer || map.getLayer('turn-up-buildings')) return;
+
+  const firstLabelId = styleLayers.find((layer) => layer.type === 'symbol')?.id;
+  map.addLayer({
+    id: 'turn-up-buildings',
+    source: sourceLayer.source,
+    'source-layer': 'building',
+    type: 'fill-extrusion',
+    minzoom: 13,
+    paint: {
+      'fill-extrusion-color': [
+        'interpolate', ['linear'], ['coalesce', ['get', 'render_height'], ['get', 'height'], 6],
+        0, '#fff8e8',
+        30, '#ffe087',
+        90, '#ff8caf'
+      ],
+      'fill-extrusion-height': ['coalesce', ['get', 'render_height'], ['get', 'height'], 6],
+      'fill-extrusion-base': ['coalesce', ['get', 'render_min_height'], ['get', 'min_height'], 0],
+      'fill-extrusion-opacity': 0.84
+    }
+  }, firstLabelId);
+}
+
+function installRouteLine(map) {
+  const coordinates = [
+    [17.4362, 62.5362],
+    ...COURSE_GEO.map((point) => [point.lng, point.lat])
+  ];
+  map.addSource('turn-up-route', {
+    type: 'geojson',
+    data: {
+      type: 'Feature',
+      properties: {},
+      geometry: { type: 'LineString', coordinates }
+    }
+  });
+
+  const firstLabelId = map.getStyle().layers?.find((layer) => layer.type === 'symbol')?.id;
+  map.addLayer({
+    id: 'turn-up-route-outline',
+    type: 'line',
+    source: 'turn-up-route',
+    paint: {
+      'line-color': '#08090a',
+      'line-width': 7,
+      'line-opacity': 0.5
+    }
+  }, firstLabelId);
+  map.addLayer({
+    id: 'turn-up-route-line',
+    type: 'line',
+    source: 'turn-up-route',
+    paint: {
+      'line-color': '#ffd43b',
+      'line-width': 3,
+      'line-dasharray': [2, 2],
+      'line-opacity': 0.85
+    }
+  }, firstLabelId);
+}
+
+function setSkyAndFog(map, reducedMotion) {
+  try {
+    map.setSky?.({
+      'sky-color': '#68c8f2',
+      'horizon-color': '#fff8e8',
+      'fog-color': '#bdeeff',
+      'sky-horizon-blend': reducedMotion ? 0.25 : 0.42,
+      'horizon-fog-blend': 0.72,
+      'fog-ground-blend': 0.35
+    });
+  } catch (error) {
+    console.info('TURN UP: this MapLibre build does not expose sky styling.', error);
+  }
+}
+
+function createAircraftRig() {
+  const root = new THREE.Group();
+  const pitch = new THREE.Group();
+  const bank = new THREE.Group();
+  const modelContainer = new THREE.Group();
+  root.add(pitch);
+  pitch.add(bank);
+  bank.add(modelContainer);
+  // Aircraft assets use Three.js' Y-up / -Z-forward convention. The geospatial
+  // custom layer is X-east / Y-north / Z-up, so rotate the visual once at its root.
+  modelContainer.rotation.x = Math.PI / 2;
+  modelContainer.add(createFallbackAircraft());
+  return { root, pitch, bank, modelContainer };
+}
+
+async function loadAircraft() {
+  const gltf = await new GLTFLoader().loadAsync(AIRCRAFT_URL);
+  return prepareAircraftAsset(gltf.scene, {
+    targetLength: 34,
+    lengthToSpanRatio: B737_LENGTH_TO_SPAN
+  });
+}
+
+function addLighting(scene) {
+  scene.add(new THREE.HemisphereLight(0xbdeeff, 0x3b6b49, 2.1));
+  const sun = new THREE.DirectionalLight(PAPER, 3.2);
+  sun.position.set(-500, 300, 900);
+  scene.add(sun);
+}
+
+function buildCourse(scene) {
+  const gates = [];
+  let previous = MAP_START_POSE;
+  for (let index = 0; index < COURSE_POINTS.length; index += 1) {
+    const point = COURSE_POINTS[index];
+    const gate = createGate(index);
+    gate.position.copy(flightToMapPosition(point));
+    const direction = new THREE.Vector3(
+      point.x - previous.x,
+      previous.z - point.z,
+      point.y - previous.y
+    ).normalize();
+    gate.quaternion.setFromUnitVectors(new THREE.Vector3(0, 0, 1), direction);
+    scene.add(gate);
+    gates.push(gate);
+    previous = point;
+  }
+  return gates;
+}
+
+function createGate(index) {
+  const group = new THREE.Group();
+  group.name = `Flight gate ${index + 1}`;
+  const outline = new THREE.Mesh(
+    new THREE.TorusGeometry(88, 11, 8, 48),
+    new THREE.MeshBasicMaterial({ color: INK, side: THREE.DoubleSide })
+  );
+  const color = new THREE.Mesh(
+    new THREE.TorusGeometry(88, 6.8, 8, 48),
+    new THREE.MeshBasicMaterial({
+      color: YELLOW,
+      side: THREE.DoubleSide,
+      transparent: true,
+      opacity: 0.9
+    })
+  );
+  group.add(outline, color);
+
+  const marker = new THREE.Group();
+  for (let side = 0; side < 4; side += 1) {
+    const tab = new THREE.Mesh(
+      new THREE.BoxGeometry(25, 10, 3),
+      new THREE.MeshBasicMaterial({ color: side % 2 ? PINK : CYAN })
+    );
+    tab.position.y = 110;
+    tab.rotation.z = side * Math.PI / 2;
+    marker.add(tab);
+  }
+  group.add(marker);
+  group.userData = { color, marker };
+  return group;
+}
+
+function setGateState(gates, activeIndex) {
+  for (let index = 0; index < gates.length; index += 1) {
+    const gate = gates[index];
+    const active = index === activeIndex;
+    gate.visible = index >= activeIndex;
+    gate.scale.setScalar(1);
+    gate.userData.color.material.color.setHex(active ? PINK : YELLOW);
+    gate.userData.color.material.opacity = active ? 1 : 0.38;
+    gate.userData.marker.visible = active;
+  }
+}
+
+function prepareAircraftAsset(source, { targetLength, lengthToSpanRatio }) {
+  const model = source.clone(true);
+  const meshes = [];
+  model.traverse((node) => {
+    if (!node.isMesh || !node.material) return;
+    meshes.push(node);
+    const materials = Array.isArray(node.material) ? node.material : [node.material];
+    const clones = materials.map((entry) => {
+      const clone = entry.clone();
+      if ('roughness' in clone) clone.roughness = Math.max(clone.roughness ?? 0.72, 0.62);
+      return clone;
+    });
+    node.material = Array.isArray(node.material) ? clones : clones[0];
+  });
+
+  alignAndScaleAircraft(model, targetLength, lengthToSpanRatio);
+  for (const mesh of meshes) {
+    const outline = new THREE.Mesh(
+      mesh.geometry,
+      new THREE.MeshBasicMaterial({
+        color: INK,
+        side: THREE.BackSide,
+        depthWrite: false,
+        polygonOffset: true,
+        polygonOffsetFactor: 1,
+        polygonOffsetUnits: 1
+      })
+    );
+    outline.scale.setScalar(1.012);
+    mesh.add(outline);
+  }
+  return model;
+}
+
+function alignAndScaleAircraft(model, targetLength, lengthToSpanRatio) {
+  model.updateMatrixWorld(true);
+  let bounds = new THREE.Box3().setFromObject(model);
+  let size = bounds.getSize(new THREE.Vector3());
+  const zAsLengthError = Math.abs((size.z / Math.max(size.x, 0.001)) - lengthToSpanRatio);
+  const xAsLengthError = Math.abs((size.x / Math.max(size.z, 0.001)) - lengthToSpanRatio);
+  if (xAsLengthError < zAsLengthError) {
+    model.rotation.y += Math.PI / 2;
+    model.updateMatrixWorld(true);
+    bounds = new THREE.Box3().setFromObject(model);
+    size = bounds.getSize(new THREE.Vector3());
+  }
+  model.scale.multiplyScalar(targetLength / Math.max(size.z, 0.001));
+  model.updateMatrixWorld(true);
+  bounds = new THREE.Box3().setFromObject(model);
+  const center = bounds.getCenter(new THREE.Vector3());
+  model.position.sub(center);
+}
+
+function createFallbackAircraft() {
+  const group = new THREE.Group();
+  const bodyMaterial = new THREE.MeshStandardMaterial({ color: PAPER, roughness: 0.7 });
+  const accentMaterial = new THREE.MeshStandardMaterial({ color: PINK, roughness: 0.76 });
+  const body = new THREE.Mesh(new THREE.CylinderGeometry(2.4, 3, 21, 10), bodyMaterial);
+  body.rotation.x = Math.PI / 2;
+  group.add(body);
+  const nose = new THREE.Mesh(new THREE.ConeGeometry(2.42, 6.4, 10), accentMaterial);
+  nose.rotation.x = -Math.PI / 2;
+  nose.position.z = -13.7;
+  group.add(nose);
+  const wings = new THREE.Mesh(new THREE.BoxGeometry(27, 0.8, 5.4), bodyMaterial);
+  wings.position.z = 1.5;
+  group.add(wings);
+  const tailWing = new THREE.Mesh(new THREE.BoxGeometry(11, 0.62, 2.8), accentMaterial);
+  tailWing.position.z = 9;
+  group.add(tailWing);
+  const tail = new THREE.Mesh(new THREE.BoxGeometry(0.8, 6.4, 4.5), accentMaterial);
+  tail.position.set(0, 3, 8.8);
+  group.add(tail);
+  return group;
+}
+
+function geographicToLocal({ lng, lat, altitude = 0 }) {
+  const coordinate = maplibregl.MercatorCoordinate.fromLngLat({ lng, lat }, 0);
+  return {
+    x: (coordinate.x - originMercator.x) / metresToMercator,
+    y: altitude,
+    z: (coordinate.y - originMercator.y) / metresToMercator
+  };
+}
+
+function localToLngLat(x, z) {
+  return new maplibregl.MercatorCoordinate(
+    originMercator.x + x * metresToMercator,
+    originMercator.y + z * metresToMercator,
+    0
+  ).toLngLat();
+}
+
+function flightToMapPosition(position) {
+  return new THREE.Vector3(position.x, -position.z, position.y);
+}
+
+function clamp(value, minimum, maximum) {
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+function degreesToRadians(value) {
+  return value * Math.PI / 180;
+}
+
+function radiansToDegrees(value) {
+  return value * 180 / Math.PI;
+}

--- a/turnup/styles.css
+++ b/turnup/styles.css
@@ -1,0 +1,1094 @@
+@import url('/turn/design-tokens.css?revision=r162-social-sharing');
+
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-rounded, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --ink: var(--turn-ink, #08090a);
+  --paper: var(--turn-paper, #fff8e8);
+  --white: var(--turn-white, #fffdf6);
+  --cyan: var(--turn-blue-500, #38d9ff);
+  --cyan-soft: var(--turn-blue-100, #bdeeff);
+  --pink: var(--turn-pink-500, #ff4fa3);
+  --yellow: var(--turn-yellow-400, #ffd43b);
+  --yellow-dark: var(--turn-yellow-600, #ffbd12);
+  --green: var(--turn-green-500, #8ce99a);
+  --orange: var(--turn-orange-500, #ff7b54);
+  --red: var(--turn-red-500, #ff6b6b);
+  --app-width: 100vw;
+  --app-height: 100vh;
+}
+
+@supports (height: 100dvh) {
+  :root {
+    --app-width: 100dvw;
+    --app-height: 100dvh;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+  overscroll-behavior: none;
+  background: var(--cyan);
+}
+
+body {
+  position: fixed;
+  inset: 0;
+  width: var(--app-width);
+  min-width: 100vw;
+  height: var(--app-height);
+  min-height: 100vh;
+  color: var(--ink);
+  font-weight: 800;
+  -webkit-tap-highlight-color: transparent;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  min-height: 44px;
+  appearance: none;
+  border: 3px solid var(--ink);
+  border-radius: var(--turn-radius-compact, 12px);
+  background: var(--paper);
+  color: var(--ink);
+  box-shadow: var(--turn-shadow-compact, 3px 3px 0 var(--ink));
+  font-weight: 950;
+  letter-spacing: 0.025em;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+button:hover:not(:disabled) {
+  filter: brightness(1.05) saturate(1.05);
+}
+
+button:active:not(:disabled),
+button.is-down {
+  transform: translate(3px, 3px);
+  box-shadow: none;
+}
+
+button:disabled {
+  cursor: wait;
+  opacity: 0.54;
+  filter: grayscale(0.4);
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+[tabindex]:focus-visible {
+  outline: 5px solid var(--cyan);
+  outline-offset: 4px;
+}
+
+a {
+  color: #005a78;
+  text-decoration-thickness: 0.13em;
+  text-underline-offset: 0.13em;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+.skip-link {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  z-index: 1000;
+  padding: 10px 14px;
+  border: 3px solid var(--ink);
+  border-radius: 10px;
+  background: var(--paper);
+  color: var(--ink);
+  transform: translateY(-160%);
+}
+
+.skip-link:focus {
+  transform: none;
+}
+
+#game {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--cyan);
+}
+
+#game canvas {
+  width: 100% !important;
+  height: 100% !important;
+  display: block;
+}
+
+.maplibregl-ctrl-bottom-left {
+  bottom: max(2px, env(safe-area-inset-bottom));
+  left: max(2px, env(safe-area-inset-left));
+  z-index: 12;
+}
+
+.maplibregl-ctrl-attrib {
+  border: 1px solid rgb(8 9 10 / 0.45);
+  background: rgb(255 248 232 / 0.88) !important;
+  color: var(--ink);
+  font-size: 10px;
+  font-weight: 650;
+}
+
+.maplibregl-ctrl-attrib a {
+  color: #004c68;
+}
+
+.launch-panel {
+  position: absolute;
+  inset: 0;
+  z-index: 50;
+  display: grid;
+  place-items: center;
+  overflow: auto;
+  padding:
+    max(18px, env(safe-area-inset-top))
+    max(18px, env(safe-area-inset-right))
+    max(18px, env(safe-area-inset-bottom))
+    max(18px, env(safe-area-inset-left));
+  background:
+    radial-gradient(circle at 13% 18%, rgb(255 79 163 / 0.83) 0 8%, transparent 8.5%),
+    radial-gradient(circle at 83% 20%, rgb(255 212 59 / 0.78) 0 11%, transparent 11.5%),
+    linear-gradient(135deg, rgb(56 217 255 / 0.87), rgb(142 216 255 / 0.76));
+}
+
+.launch-card {
+  display: grid;
+  grid-template-columns: minmax(160px, 0.55fr) minmax(370px, 1.45fr);
+  gap: clamp(20px, 4vw, 48px);
+  align-items: center;
+  width: min(1050px, 94vw);
+  min-height: min(82vh, 600px);
+  padding: clamp(22px, 4.2vw, 52px);
+  border: 6px solid var(--ink);
+  border-radius: var(--turn-radius-hero, 28px);
+  background: rgb(255 248 232 / 0.96);
+  box-shadow: var(--turn-shadow-hero, 12px 12px 0 var(--ink));
+  transform: rotate(-0.45deg);
+}
+
+.launch-mark {
+  display: grid;
+  place-items: center;
+}
+
+.launch-mark img {
+  width: min(27vw, 250px);
+  max-height: 52vh;
+  border: 5px solid var(--ink);
+  border-radius: 24%;
+  background: var(--cyan);
+  box-shadow: 9px 9px 0 var(--ink);
+  transform: rotate(3deg);
+}
+
+.kicker,
+.dialog-kicker {
+  display: inline-block;
+  padding: 6px 10px;
+  border: 3px solid var(--ink);
+  border-radius: var(--turn-radius-pill, 999px);
+  background: var(--yellow);
+  font-size: 0.72rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin: 14px 0 0;
+  font-size: clamp(4rem, 10vw, 8rem);
+  line-height: 0.72;
+  letter-spacing: -0.095em;
+  font-weight: 1000;
+}
+
+h1 span {
+  display: block;
+}
+
+.tagline {
+  margin: 17px 0 11px;
+  color: #006d8d;
+  font-size: clamp(1.1rem, 2.5vw, 1.65rem);
+  letter-spacing: 0.075em;
+}
+
+.intro-copy {
+  max-width: 58ch;
+  margin-bottom: 14px;
+  font-size: clamp(0.92rem, 1.55vw, 1.13rem);
+  line-height: 1.35;
+}
+
+.route-chip {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 5px 8px;
+  align-items: center;
+  margin: 0 0 20px;
+  padding: 8px 11px;
+  border: 3px solid var(--ink);
+  border-radius: 12px;
+  background: var(--cyan-soft);
+  font-size: 0.72rem;
+  letter-spacing: 0.035em;
+}
+
+.route-chip strong {
+  padding-right: 3px;
+  color: #00627e;
+}
+
+.launch-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 11px;
+}
+
+.launch-actions button,
+.dialog-actions button {
+  padding: 11px 16px;
+}
+
+.primary {
+  border-radius: var(--turn-radius-pill, 999px);
+  background: var(--pink);
+}
+
+.game-action {
+  background: var(--cyan);
+}
+
+.utility-action {
+  background: var(--paper);
+}
+
+.warning-action {
+  background: var(--yellow);
+}
+
+.navigation-action,
+.close-button {
+  background: var(--orange);
+}
+
+.loading-status {
+  min-height: 1.4em;
+  margin: 17px 0 2px;
+  font-size: 0.82rem;
+  line-height: 1.3;
+}
+
+.model-status {
+  min-height: 1.2em;
+  margin: 0;
+  color: rgb(8 9 10 / 0.68);
+  font-size: 0.7rem;
+}
+
+.launch-meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 8px 16px;
+  align-items: center;
+  margin-top: 17px;
+  font-size: 0.64rem;
+  letter-spacing: 0.055em;
+}
+
+.launch-meta button {
+  min-height: auto;
+  padding: 2px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  color: #005d7b;
+  text-decoration: underline;
+  text-underline-offset: 0.16em;
+}
+
+.hud {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  padding:
+    max(10px, env(safe-area-inset-top))
+    max(12px, env(safe-area-inset-right))
+    max(10px, env(safe-area-inset-bottom))
+    max(12px, env(safe-area-inset-left));
+  pointer-events: none;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  max-width: calc(100% - 100px);
+}
+
+.chip,
+.objective,
+.attitude {
+  border: 3px solid var(--ink);
+  background: rgb(255 248 232 / 0.91);
+  color: var(--ink);
+  box-shadow: 4px 4px 0 var(--ink);
+}
+
+.chip {
+  min-width: 84px;
+  padding: 6px 9px 7px;
+  border-radius: 12px;
+  text-transform: uppercase;
+}
+
+.chip span {
+  display: block;
+  font-size: 0.55rem;
+  letter-spacing: 0.07em;
+}
+
+.chip strong {
+  display: block;
+  margin-top: 2px;
+  font-size: clamp(0.82rem, 1.7vw, 1.12rem);
+  letter-spacing: -0.025em;
+  white-space: nowrap;
+}
+
+.pause-button {
+  position: relative;
+  z-index: 3;
+  padding: 7px 11px;
+  background: var(--paper);
+  font-size: 0.68rem;
+  pointer-events: auto;
+}
+
+.objective {
+  position: absolute;
+  top: 50%;
+  left: max(13px, env(safe-area-inset-left));
+  display: flex;
+  gap: 9px;
+  align-items: center;
+  padding: 7px 10px;
+  border-radius: 14px;
+  transform: translateY(-50%);
+}
+
+.objective span {
+  display: block;
+  font-size: 0.52rem;
+  letter-spacing: 0.07em;
+}
+
+.objective b {
+  display: block;
+  max-width: 22ch;
+  margin: 1px 0;
+  color: #00637f;
+  font-size: 0.64rem;
+  letter-spacing: 0.025em;
+  line-height: 1.05;
+}
+
+.objective strong {
+  display: block;
+  font-size: 0.95rem;
+}
+
+.course-dial {
+  position: relative;
+  width: 42px;
+  height: 42px;
+  border: 3px solid var(--ink);
+  border-radius: 50%;
+  background: var(--cyan-soft);
+}
+
+.course-dial::after {
+  content: "N";
+  position: absolute;
+  top: 2px;
+  left: 50%;
+  font-size: 0.42rem;
+  transform: translateX(-50%);
+}
+
+.course-dial i {
+  --course-angle: 0deg;
+  position: absolute;
+  inset: 6px 17px;
+  border: 2px solid var(--ink);
+  border-radius: 999px 999px 4px 4px;
+  background: var(--pink);
+  transform: rotate(var(--course-angle));
+  transform-origin: 50% 50%;
+}
+
+.course-dial i::before {
+  content: "";
+  position: absolute;
+  top: -5px;
+  left: 50%;
+  border-right: 5px solid transparent;
+  border-bottom: 8px solid var(--ink);
+  border-left: 5px solid transparent;
+  transform: translateX(-50%);
+}
+
+.attitude {
+  --bank-angle: 0deg;
+  --pitch-offset: 0px;
+  position: absolute;
+  top: 51%;
+  left: 50%;
+  width: clamp(88px, 12vw, 132px);
+  aspect-ratio: 1;
+  overflow: hidden;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.attitude-world {
+  position: absolute;
+  inset: -45%;
+  transform: translateY(var(--pitch-offset)) rotate(var(--bank-angle));
+  transform-origin: center;
+}
+
+.attitude-sky,
+.attitude-ground {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 50%;
+}
+
+.attitude-sky {
+  top: 0;
+  background: var(--cyan);
+}
+
+.attitude-ground {
+  bottom: 0;
+  background: #72b77b;
+}
+
+.attitude-horizon {
+  position: absolute;
+  top: calc(50% - 2px);
+  left: 0;
+  width: 100%;
+  height: 4px;
+  background: var(--ink);
+}
+
+.attitude-plane {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: flex;
+  align-items: center;
+  transform: translate(-50%, -50%);
+}
+
+.attitude-plane i {
+  width: 26px;
+  height: 4px;
+  border: 1px solid var(--ink);
+  background: var(--yellow);
+}
+
+.attitude-plane b {
+  width: 10px;
+  height: 10px;
+  border: 3px solid var(--ink);
+  border-radius: 50%;
+  background: var(--paper);
+}
+
+.flight-message {
+  position: absolute;
+  top: 23%;
+  left: 50%;
+  max-width: min(74vw, 680px);
+  margin: 0;
+  padding: 8px 13px;
+  border: 3px solid var(--ink);
+  border-radius: var(--turn-radius-pill, 999px);
+  background: var(--yellow);
+  box-shadow: 4px 4px 0 var(--ink);
+  font-size: clamp(0.72rem, 1.6vw, 0.94rem);
+  text-align: center;
+  opacity: 0;
+  transform: translateX(-50%) rotate(-1deg);
+  transition: opacity 130ms ease;
+}
+
+.flight-message.show {
+  opacity: 1;
+}
+
+.is-stalling .chip:nth-child(3),
+.is-stalling .attitude {
+  background: var(--red);
+}
+
+.is-stalling .chip:nth-child(3)::after {
+  content: " · STALL";
+  font-size: 0.64rem;
+}
+
+.flight-controls {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  pointer-events: none;
+}
+
+.flight-controls button {
+  pointer-events: auto;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.manual-controls {
+  position: absolute;
+  bottom: max(22px, env(safe-area-inset-bottom));
+  left: max(18px, env(safe-area-inset-left));
+  display: grid;
+  grid-template-columns: repeat(3, clamp(56px, 8vw, 76px));
+  grid-template-rows: repeat(2, clamp(48px, 7vw, 66px));
+  gap: 8px;
+  grid-template-areas:
+    ". up ."
+    "left down right";
+}
+
+.direction {
+  padding: 6px;
+  background: var(--cyan);
+  font-size: clamp(0.55rem, 1.3vw, 0.72rem);
+}
+
+.direction.up { grid-area: up; }
+.direction.left { grid-area: left; }
+.direction.right { grid-area: right; }
+.direction.down { grid-area: down; }
+
+.recalibrate {
+  position: absolute;
+  bottom: max(18px, env(safe-area-inset-bottom));
+  left: max(18px, env(safe-area-inset-left));
+  padding: 8px 10px;
+  background: var(--paper);
+  font-size: 0.62rem;
+}
+
+.throttle-controls {
+  position: absolute;
+  right: max(18px, env(safe-area-inset-right));
+  bottom: max(18px, env(safe-area-inset-bottom));
+  display: grid;
+  grid-template-columns: 17px clamp(70px, 10vw, 105px) clamp(78px, 12vw, 118px);
+  gap: 10px;
+  align-items: end;
+}
+
+.throttle-controls button {
+  height: clamp(68px, 11vw, 104px);
+  padding: 7px;
+  border-radius: 50%;
+  font-size: clamp(0.57rem, 1.3vw, 0.78rem);
+}
+
+.throttle-controls .thrust {
+  height: clamp(80px, 13vw, 120px);
+  background: var(--green);
+}
+
+.air-brake {
+  background: var(--orange);
+}
+
+.throttle-meter {
+  position: relative;
+  width: 17px;
+  height: clamp(82px, 13vw, 120px);
+  overflow: hidden;
+  border: 3px solid var(--ink);
+  border-radius: 999px;
+  background: var(--paper);
+  box-shadow: 3px 3px 0 var(--ink);
+}
+
+.throttle-meter i {
+  --throttle: 70%;
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: var(--throttle);
+  background: linear-gradient(to top, var(--green), var(--yellow));
+}
+
+.rotate-gate {
+  display: none;
+  position: absolute;
+  inset: 0;
+  z-index: 90;
+  place-items: center;
+  padding: 22px;
+  background: linear-gradient(145deg, var(--cyan), #9775fa);
+  text-align: center;
+}
+
+.rotate-card {
+  max-width: 420px;
+  padding: 30px;
+  border: 5px solid var(--ink);
+  border-radius: 24px;
+  background: var(--yellow);
+  box-shadow: 10px 10px 0 var(--ink);
+}
+
+.rotate-card h2 {
+  margin: 0;
+  font-size: clamp(1.8rem, 8vw, 3.2rem);
+  line-height: 0.9;
+}
+
+.rotate-card p {
+  margin: 16px 0 0;
+  line-height: 1.3;
+}
+
+.rotate-phone {
+  width: 98px;
+  height: 56px;
+  margin: 0 auto 18px;
+  border: 5px solid var(--ink);
+  border-radius: 14px;
+  background: var(--paper);
+  transform: rotate(-11deg);
+}
+
+.turn-dialog {
+  width: min(760px, calc(100vw - 32px));
+  max-height: calc(100vh - 32px);
+  overflow: auto;
+  padding: 0;
+  border: 5px solid var(--ink);
+  border-radius: 24px;
+  background: var(--paper);
+  color: var(--ink);
+  box-shadow: 10px 10px 0 var(--ink);
+}
+
+.turn-dialog::backdrop {
+  background: rgb(8 9 10 / 0.72);
+  backdrop-filter: blur(4px);
+}
+
+.turn-dialog article {
+  padding: clamp(20px, 4vw, 36px);
+}
+
+.turn-dialog header {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: flex-start;
+  margin-bottom: 20px;
+}
+
+.turn-dialog h2 {
+  margin: 9px 0 0;
+  font-size: clamp(2.2rem, 7vw, 4.8rem);
+  line-height: 0.82;
+  letter-spacing: -0.065em;
+}
+
+.turn-dialog h3 {
+  margin: 22px 0 7px;
+  font-size: 1rem;
+  letter-spacing: 0.05em;
+}
+
+.turn-dialog p {
+  line-height: 1.44;
+}
+
+.close-button {
+  flex: 0 0 auto;
+  padding: 8px 11px;
+  font-size: 0.64rem;
+}
+
+.instruction-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.instruction-grid section {
+  padding: 14px;
+  border: 3px solid var(--ink);
+  border-radius: 14px;
+  background: var(--white);
+}
+
+.instruction-grid section:nth-child(1) { background: var(--cyan-soft); }
+.instruction-grid section:nth-child(2) { background: #ffd1e6; }
+.instruction-grid section:nth-child(3) { background: #d9f5c2; }
+.instruction-grid section:nth-child(4) { background: #fff0a8; }
+
+.instruction-grid strong {
+  font-size: 0.78rem;
+  letter-spacing: 0.05em;
+}
+
+.instruction-grid p {
+  margin: 7px 0 0;
+  font-size: 0.88rem;
+}
+
+.keyboard-help {
+  margin: 16px 0 0;
+  padding: 11px;
+  border-left: 5px solid var(--cyan);
+  background: rgb(56 217 255 / 0.14);
+  font-size: 0.82rem;
+}
+
+.mode-pill {
+  padding: 7px 10px;
+  border: 3px solid var(--ink);
+  border-radius: 999px;
+  background: var(--cyan);
+  font-size: 0.7rem;
+  white-space: nowrap;
+}
+
+.pause-dialog fieldset {
+  margin: 0 0 18px;
+  padding: 14px;
+  border: 3px solid var(--ink);
+  border-radius: 14px;
+}
+
+.pause-dialog legend {
+  padding: 0 7px;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+}
+
+.pause-dialog label {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  padding: 10px;
+  border-radius: 10px;
+}
+
+.pause-dialog label + label {
+  border-top: 2px solid rgb(8 9 10 / 0.14);
+}
+
+.pause-dialog input {
+  width: 27px;
+  height: 27px;
+  accent-color: var(--pink);
+}
+
+.pause-dialog label span,
+.pause-dialog label strong,
+.pause-dialog label small {
+  display: block;
+}
+
+.pause-dialog label strong {
+  font-size: 0.82rem;
+}
+
+.pause-dialog label small {
+  margin-top: 2px;
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.dialog-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 11px;
+}
+
+.result-dialog {
+  text-align: center;
+}
+
+.result-dialog h2 {
+  margin-top: 16px;
+}
+
+.result-time {
+  margin: 24px 0 4px;
+  font-size: clamp(3rem, 10vw, 6.5rem);
+  line-height: 1;
+  letter-spacing: -0.06em;
+}
+
+.result-best {
+  color: #00637f;
+  font-size: 1.1rem;
+}
+
+.result-dialog .dialog-actions {
+  justify-content: center;
+}
+
+.about-dialog code {
+  padding: 2px 5px;
+  border-radius: 5px;
+  background: rgb(8 9 10 / 0.1);
+  font-size: 0.85em;
+}
+
+.noscript {
+  position: fixed;
+  inset: 20px;
+  z-index: 1000;
+  display: grid;
+  place-items: center;
+  padding: 30px;
+  border: 5px solid var(--ink);
+  background: var(--red);
+  color: var(--ink);
+  text-align: center;
+}
+
+@media (orientation: portrait) {
+  body.is-flying .rotate-gate {
+    display: grid;
+  }
+
+  .launch-card {
+    grid-template-columns: 1fr;
+    min-height: auto;
+  }
+
+  .launch-mark {
+    display: none;
+  }
+
+  h1 {
+    font-size: clamp(4rem, 22vw, 7rem);
+  }
+}
+
+@media (max-height: 510px) and (orientation: landscape) {
+  .launch-panel {
+    place-items: start center;
+    padding-top: max(11px, env(safe-area-inset-top));
+  }
+
+  .launch-card {
+    grid-template-columns: minmax(120px, 0.35fr) minmax(420px, 1.65fr);
+    min-height: 0;
+    padding: 18px 25px;
+    gap: 24px;
+  }
+
+  .launch-mark img {
+    width: min(22vw, 154px);
+  }
+
+  h1 {
+    margin-top: 10px;
+    font-size: clamp(3.4rem, 14vh, 5rem);
+  }
+
+  .tagline {
+    margin: 10px 0 5px;
+    font-size: 1rem;
+  }
+
+  .intro-copy {
+    margin-bottom: 8px;
+    font-size: 0.78rem;
+  }
+
+  .route-chip {
+    margin-bottom: 10px;
+    padding: 5px 8px;
+    font-size: 0.58rem;
+  }
+
+  .launch-actions button {
+    min-height: 38px;
+    padding: 6px 11px;
+    font-size: 0.68rem;
+  }
+
+  .loading-status {
+    margin-top: 9px;
+    font-size: 0.66rem;
+  }
+
+  .model-status,
+  .launch-meta {
+    font-size: 0.56rem;
+  }
+
+  .chip {
+    min-width: 68px;
+    padding: 4px 7px 5px;
+  }
+
+  .chip span {
+    font-size: 0.46rem;
+  }
+
+  .chip strong {
+    font-size: 0.78rem;
+  }
+
+  .optional-chip {
+    display: none;
+  }
+
+  .objective {
+    padding: 4px 7px;
+  }
+
+  .course-dial {
+    width: 34px;
+    height: 34px;
+  }
+
+  .course-dial i {
+    inset: 5px 13px;
+  }
+
+  .flight-message {
+    top: 17%;
+  }
+
+  .manual-controls {
+    grid-template-columns: repeat(3, 52px);
+    grid-template-rows: repeat(2, 44px);
+    bottom: 10px;
+  }
+
+  .recalibrate,
+  .throttle-controls {
+    bottom: 10px;
+  }
+
+  .throttle-controls {
+    grid-template-columns: 14px 66px 76px;
+    gap: 7px;
+  }
+
+  .throttle-controls button {
+    height: 64px;
+  }
+
+  .throttle-controls .thrust,
+  .throttle-meter {
+    height: 76px;
+  }
+}
+
+@media (max-width: 760px) {
+  .instruction-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+
+  .launch-card,
+  .launch-mark img,
+  .flight-message,
+  .rotate-phone {
+    transform: none;
+  }
+
+  .flight-message {
+    transform: translateX(-50%);
+  }
+}
+
+@media (prefers-contrast: more) {
+  .chip,
+  .objective,
+  .attitude,
+  .maplibregl-ctrl-attrib {
+    background: var(--paper) !important;
+  }
+}
+
+@media (forced-colors: active) {
+  button,
+  .launch-card,
+  .chip,
+  .objective,
+  .attitude,
+  .turn-dialog,
+  .instruction-grid section,
+  .route-chip {
+    forced-color-adjust: auto;
+  }
+
+  .attitude-sky,
+  .attitude-ground,
+  .throttle-meter i {
+    forced-color-adjust: none;
+  }
+}


### PR DESCRIPTION
## What changed

- adds **TURN UP**, a mobile-first arcade flight simulator at `/turnup/`
- reuses TURN's production platform adapter and canonical motion steering, with a calibrated second tilt axis for climb/dive
- builds a real Midlanda → Söråker → general Strind-area course with MapLibre, OpenFreeMap/OSM, open terrain elevation, 3D buildings and a Three.js flight layer
- loads AMV Lab's logo-free B737 from a pinned upstream commit, with visible CC BY 4.0 attribution and a local fallback aircraft
- includes touch/button, keyboard and switch-accessible controls, reduced motion, high contrast, pitch inversion and privacy-safe location copy
- adds a focused GitHub Actions production contract test

## Validation

- `node --check` passes for all four JavaScript modules
- `node turn-tests/turnup-production.mjs` — 11 tests pass

## Data and privacy

The route uses public map/elevation data and identifies only the general Strind area. It does not place a marker on a private home.