### PR TITLE
Fix TURN UP MapLibre 6 startup

### DIFF
--- a/turn-tests/turnup-production.mjs
+++ b/turn-tests/turnup-production.mjs
@@ -76,6 +76,7 @@ test('the real Midlanda–Söråker course uses open 3D map infrastructure', () 
   assert.match(scene, /type: 'fill-extrusion'/);
   assert.match(scene, /renderingMode: '3d'/);
   assert.match(scene, /defaultProjectionData\.mainMatrix/);
+  assert.doesNotMatch(scene, /maplibregl\.supported/);
   assert.match(scene, /RUNWAY 16/);
   assert.match(scene, /SÖRÅKER/);
   assert.match(scene, /STRIND AREA/);

--- a/turnup/app.mjs
+++ b/turnup/app.mjs
@@ -19,9 +19,9 @@ import {
   shortestAngle,
   updateFlightState
 } from './flight-model.mjs';
-import { COURSE_POINTS, createFlightScene } from './scene.mjs';
+import { COURSE_POINTS, createFlightScene } from './scene.mjs?build=20260822-r2';
 
-const BUILD = '2026.08.22-r1';
+const BUILD = '2026.08.22-r2';
 const BEST_TIME_KEY = 'turnup.bestCourseSeconds.v1';
 const SETTINGS_KEY = 'turnup.settings.v1';
 const reducedMotion = globalThis.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;

--- a/turnup/index.html
+++ b/turnup/index.html
@@ -213,6 +213,6 @@
   </dialog>
 
   <noscript><p class="noscript">TURN UP needs JavaScript to run its flight engine.</p></noscript>
-  <script type="module" src="./app.mjs?build=20260822-r1"></script>
+  <script type="module" src="./app.mjs?build=20260822-r2"></script>
 </body>
 </html>

--- a/turnup/scene.mjs
+++ b/turnup/scene.mjs
@@ -61,7 +61,6 @@ export async function createFlightScene(container, {
   onModelStatus = () => {}
 } = {}) {
   if (!container) throw new Error('TURN UP needs a map container.');
-  if (!maplibregl.supported()) throw new Error('This browser does not support the WebGL map TURN UP needs.');
 
   const map = new maplibregl.Map({
     container,


### PR DESCRIPTION
## Fix

- removes the legacy `maplibregl.supported()` guard, which is not exported by MapLibre GL JS 6.5
- bumps the app and scene cache keys to build `2026.08.22-r2`
- adds a regression assertion preventing the removed API from returning

## Verification

- reproduced on the deployed `/turnup/` URL through a clean cloud browser
- all 11 TURN UP production tests pass locally
- module syntax checks pass