### PR TITLE
Refresh TURN UP production module cache

### DIFF
--- a/turn-tests/turnup-production.mjs
+++ b/turn-tests/turnup-production.mjs
@@ -66,6 +66,7 @@ test('TURN UP imports the canonical TURN platform and steering engine', () => {
   assert.match(app, /resolveMotionSteeringProfile/);
   assert.match(app, /updateMotionInputState/);
   assert.match(app, /controlFromAngle\(motionState\.pitch - motionState\.neutralPitch/);
+  assert.match(app, /scene\.mjs\?build=20260822-r3/);
   assert.doesNotMatch(app, /DeviceMotionEvent\.requestPermission/);
 });
 

--- a/turnup/app.mjs
+++ b/turnup/app.mjs
@@ -19,9 +19,9 @@ import {
   shortestAngle,
   updateFlightState
 } from './flight-model.mjs';
-import { COURSE_POINTS, createFlightScene } from './scene.mjs?build=20260822-r2';
+import { COURSE_POINTS, createFlightScene } from './scene.mjs?build=20260822-r3';
 
-const BUILD = '2026.08.22-r2';
+const BUILD = '2026.08.22-r3';
 const BEST_TIME_KEY = 'turnup.bestCourseSeconds.v1';
 const SETTINGS_KEY = 'turnup.settings.v1';
 const reducedMotion = globalThis.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;

--- a/turnup/index.html
+++ b/turnup/index.html
@@ -213,6 +213,6 @@
   </dialog>
 
   <noscript><p class="noscript">TURN UP needs JavaScript to run its flight engine.</p></noscript>
-  <script type="module" src="./app.mjs?build=20260822-r2"></script>
+  <script type="module" src="./app.mjs?build=20260822-r3"></script>
 </body>
 </html>


### PR DESCRIPTION
Bumps the TURN UP app and scene module keys to build `2026.08.22-r3` so browsers that cached the brief failed Pages deployment fetch the corrected MapLibre startup graph immediately. The production contract now locks the fresh scene key. All 11 TURN UP tests pass.