### PR TITLE
Handle TURN UP WebGL2 startup failures

### DIFF
--- a/turn-tests/turnup-production.mjs
+++ b/turn-tests/turnup-production.mjs
@@ -66,7 +66,7 @@ test('TURN UP imports the canonical TURN platform and steering engine', () => {
   assert.match(app, /resolveMotionSteeringProfile/);
   assert.match(app, /updateMotionInputState/);
   assert.match(app, /controlFromAngle\(motionState\.pitch - motionState\.neutralPitch/);
-  assert.match(app, /scene\.mjs\?build=20260822-r3/);
+  assert.match(app, /scene\.mjs\?build=20260822-r4/);
   assert.doesNotMatch(app, /DeviceMotionEvent\.requestPermission/);
 });
 
@@ -78,6 +78,8 @@ test('the real Midlanda–Söråker course uses open 3D map infrastructure', () 
   assert.match(scene, /renderingMode: '3d'/);
   assert.match(scene, /defaultProjectionData\.mainMatrix/);
   assert.doesNotMatch(scene, /maplibregl\.supported/);
+  assert.match(scene, /getContext\('webgl2'\)/);
+  assert.match(app, /TURN UP needs WebGL2 for its 3D map/);
   assert.match(scene, /RUNWAY 16/);
   assert.match(scene, /SÖRÅKER/);
   assert.match(scene, /STRIND AREA/);

--- a/turnup/app.mjs
+++ b/turnup/app.mjs
@@ -19,9 +19,9 @@ import {
   shortestAngle,
   updateFlightState
 } from './flight-model.mjs';
-import { COURSE_POINTS, createFlightScene } from './scene.mjs?build=20260822-r3';
+import { COURSE_POINTS, createFlightScene } from './scene.mjs?build=20260822-r4';
 
-const BUILD = '2026.08.22-r3';
+const BUILD = '2026.08.22-r4';
 const BEST_TIME_KEY = 'turnup.bestCourseSeconds.v1';
 const SETTINGS_KEY = 'turnup.settings.v1';
 const reducedMotion = globalThis.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
@@ -147,9 +147,13 @@ const scenePromise = createFlightScene(elements.game, {
 }).catch((error) => {
   console.error('TURN UP could not start.', error);
   globalThis.clearTimeout(slowLoadingTimer);
-  elements.loadingStatus.textContent = 'TURN UP could not load. Check your connection and try again.';
+  elements.loadingStatus.textContent = /WebGL2/i.test(String(error?.message))
+    ? 'TURN UP needs WebGL2 for its 3D map. Try a current Safari, Chrome or Firefox browser.'
+    : 'TURN UP could not load. Check your connection and try again.';
+  elements.modelStatus.textContent = 'The map and aircraft could not start on this device.';
+  document.documentElement.dataset.turnUpReady = 'unsupported';
   setLaunchEnabled(false);
-  throw error;
+  return null;
 });
 
 elements.takeOff.addEventListener('click', () => startFlight('tilt'));
@@ -215,7 +219,8 @@ portraitQuery?.addEventListener?.('change', (event) => {
 async function startFlight(requestedMode) {
   setLaunchEnabled(false);
   elements.loadingStatus.textContent = 'Preparing your flight…';
-  await scenePromise;
+  const readyScene = await scenePromise;
+  if (!readyScene) return;
 
   let resolvedMode = requestedMode;
   if (requestedMode === 'tilt') {

--- a/turnup/index.html
+++ b/turnup/index.html
@@ -213,6 +213,6 @@
   </dialog>
 
   <noscript><p class="noscript">TURN UP needs JavaScript to run its flight engine.</p></noscript>
-  <script type="module" src="./app.mjs?build=20260822-r3"></script>
+  <script type="module" src="./app.mjs?build=20260822-r4"></script>
 </body>
 </html>

--- a/turnup/scene.mjs
+++ b/turnup/scene.mjs
@@ -61,6 +61,9 @@ export async function createFlightScene(container, {
   onModelStatus = () => {}
 } = {}) {
   if (!container) throw new Error('TURN UP needs a map container.');
+  if (!supportsWebGl2()) {
+    throw new Error('TURN UP needs WebGL2 for its 3D terrain and aircraft.');
+  }
 
   const map = new maplibregl.Map({
     container,
@@ -562,4 +565,12 @@ function degreesToRadians(value) {
 
 function radiansToDegrees(value) {
   return value * 180 / Math.PI;
+}
+
+function supportsWebGl2() {
+  const canvas = document.createElement('canvas');
+  const context = canvas.getContext('webgl2');
+  if (!context) return false;
+  context.getExtension('WEBGL_lose_context')?.loseContext();
+  return true;
 }


### PR DESCRIPTION
## Fix

- detects WebGL2 before starting the MapLibre 6 terrain renderer
- replaces the indefinite loading state with a specific browser/device message when 3D rendering is unavailable
- resolves the scene startup promise cleanly instead of creating an unhandled rejection
- advances the production graph to build `2026.08.22-r4`

This was found during live verification in a cloud browser without a WebGL2 GPU. WebGL2-capable devices continue into the full map/aircraft scene. All 11 TURN UP production tests pass.