### PR TITLE
Stabilize TURN UP terrain and chase camera

### DIFF
--- a/turn-tests/turnup-production.mjs
+++ b/turn-tests/turnup-production.mjs
@@ -66,15 +66,14 @@ test('TURN UP imports the canonical TURN platform and steering engine', () => {
   assert.match(app, /resolveMotionSteeringProfile/);
   assert.match(app, /updateMotionInputState/);
   assert.match(app, /controlFromAngle\(motionState\.pitch - motionState\.neutralPitch/);
-  assert.match(app, /scene\.mjs\?build=20260822-r4/);
+  assert.match(app, /scene\.mjs\?build=20260823-r1/);
   assert.doesNotMatch(app, /DeviceMotionEvent\.requestPermission/);
 });
 
 test('the real Midlanda–Söråker course uses open 3D map infrastructure', () => {
   assert.match(scene, /tiles\.openfreemap\.org\/styles\/liberty/);
-  assert.match(scene, /elevation-tiles-prod\/terrarium/);
+  assert.match(scene, /tiles\.mapterhorn\.com\/tilejson\.json/);
   assert.match(scene, /type: 'raster-dem'/);
-  assert.match(scene, /type: 'fill-extrusion'/);
   assert.match(scene, /renderingMode: '3d'/);
   assert.match(scene, /defaultProjectionData\.mainMatrix/);
   assert.doesNotMatch(scene, /maplibregl\.supported/);
@@ -85,6 +84,28 @@ test('the real Midlanda–Söråker course uses open 3D map infrastructure', () 
   assert.match(scene, /STRIND AREA/);
   assert.match(scene, /17\.66/);
   assert.match(scene, /maxBounds: \[\[17\.22, 62\.39\], \[17\.84, 62\.67\]\]/);
+});
+
+test('the map declutters labels and the chase camera follows aircraft elevation', () => {
+  assert.match(scene, /new Set\(\['place', 'aerodrome_label'\]\)/);
+  assert.match(scene, /layer\.type !== 'symbol'/);
+  assert.match(scene, /visible \? 'visible' : 'none'/);
+  assert.doesNotMatch(scene, /turn-up-buildings/);
+  assert.match(scene, /centerClampedToGround: false/);
+  assert.match(scene, /CAMERA_LOOK_AHEAD_METRES = 220/);
+  assert.match(scene, /terrainAtOrigin \+ flightState\.position\.y - CAMERA_TARGET_DROP_METRES/);
+  assert.match(scene, /elevation: targetElevation/);
+  assert.match(scene, /targetLength: 40/);
+});
+
+test('the real-world map uses a natural semantic palette', () => {
+  assert.match(scene, /function applyNaturalMapPalette/);
+  assert.match(scene, /\['water', '#4e9fc6'\]/);
+  assert.match(scene, /\['landcover_wood', '#6f9362'\]/);
+  assert.match(scene, /background-color', '#9eb47a'/);
+  assert.match(scene, /turn-up-semantic-landuse/);
+  assert.match(scene, /\['farmland', 'farmyard'\], '#b6b77c'/);
+  assert.match(scene, /layer\['source-layer'\] === 'aeroway'/);
 });
 
 test('aircraft asset is immutable, attributed and has an offline visual fallback', () => {
@@ -99,7 +120,7 @@ test('privacy and map credits are visible in the product', () => {
   assert.match(html, /general Strind area/);
   assert.match(html, /does not place a marker on a private home/);
   assert.match(html, /OpenStreetMap contributors/);
-  assert.match(html, /AWS Registry of Open Data/);
+  assert.match(html, /Mapterhorn/);
 });
 
 test('TURN styling includes focus, contrast and reduced-motion treatment', () => {

--- a/turnup/README.md
+++ b/turnup/README.md
@@ -7,8 +7,8 @@ The first route starts over Sundsvall–Timrå Airport (Midlanda), crosses Sör�
 ## Runtime
 
 - MapLibre GL JS 6.5 renders the vector map, 3D terrain, buildings and Three.js custom flight layer.
-- OpenFreeMap's Liberty style supplies OpenStreetMap/OpenMapTiles map data.
-- AWS Terrain Tiles supply Terrarium elevation data.
+- OpenFreeMap's Liberty style supplies OpenStreetMap/OpenMapTiles map data. TURN UP applies a natural semantic palette for water, forest, fields, built-up land and airport surfaces, then hides road, route and POI labels while preserving place and airport names.
+- Mapterhorn supplies the Terrarium-encoded elevation tiles.
 - Three.js 0.184 renders gates and the aircraft.
 - `B737_nologo.glb` loads at runtime from AMV Lab's `aircraft-models` commit `91d835e8e851b2317fe79af291c9fed6153fd525` under CC BY 4.0. A lightweight local aircraft is used if the remote asset is unavailable.
 - TURN design tokens, platform adapters and canonical motion steering remain shared from `/turn/`.
@@ -34,4 +34,4 @@ The production test checks the flight model, TURN integration contract, map/terr
 
 ## Credits
 
-Map data © OpenStreetMap contributors, served through OpenFreeMap/OpenMapTiles. Terrain data is hosted through the AWS Registry of Open Data. Aircraft © AMV Lab contributors, CC BY 4.0.
+Map data © OpenStreetMap contributors, served through OpenFreeMap/OpenMapTiles. Terrain data is served by Mapterhorn from open elevation datasets. Aircraft © AMV Lab contributors, CC BY 4.0.

--- a/turnup/app.mjs
+++ b/turnup/app.mjs
@@ -19,9 +19,9 @@ import {
   shortestAngle,
   updateFlightState
 } from './flight-model.mjs';
-import { COURSE_POINTS, createFlightScene } from './scene.mjs?build=20260822-r4';
+import { COURSE_POINTS, createFlightScene } from './scene.mjs?build=20260823-r1';
 
-const BUILD = '2026.08.22-r4';
+const BUILD = '2026.08.23-r1';
 const BEST_TIME_KEY = 'turnup.bestCourseSeconds.v1';
 const SETTINGS_KEY = 'turnup.settings.v1';
 const reducedMotion = globalThis.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;

--- a/turnup/index.html
+++ b/turnup/index.html
@@ -22,10 +22,10 @@
   <title>TURN UP</title>
   <link rel="icon" href="./icon.svg" type="image/svg+xml">
   <link rel="preconnect" href="https://tiles.openfreemap.org">
-  <link rel="preconnect" href="https://s3.amazonaws.com">
+  <link rel="preconnect" href="https://tiles.mapterhorn.com">
   <link rel="preload" as="fetch" crossorigin href="https://raw.githubusercontent.com/amvlab/aircraft-models/91d835e8e851b2317fe79af291c9fed6153fd525/models/B737_nologo.glb">
   <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@6.5.0/dist/maplibre-gl.css">
-  <link rel="stylesheet" href="./styles.css?build=20260822-r1">
+  <link rel="stylesheet" href="./styles.css?build=20260823-r1">
   <script type="importmap">
     {
       "imports": {
@@ -205,7 +205,7 @@
       </header>
       <p>TURN UP is a small arcade flight simulator built from TURN’s production motion and platform engine. It uses the same iPad steering profile and adds a second tilt axis for pitch.</p>
       <h3>REAL-WORLD MAP</h3>
-      <p>The Midlanda, Söråker and Strind-area landscape is rendered with <a href="https://maplibre.org/">MapLibre GL JS</a>, <a href="https://openfreemap.org/">OpenFreeMap</a>, <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>, OpenMapTiles and open terrain elevation tiles hosted through the <a href="https://registry.opendata.aws/terrain-tiles/">AWS Registry of Open Data</a>.</p>
+      <p>The Midlanda, Söråker and Strind-area landscape is rendered with <a href="https://maplibre.org/">MapLibre GL JS</a>, <a href="https://openfreemap.org/">OpenFreeMap</a>, <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>, OpenMapTiles and open elevation data served by <a href="https://mapterhorn.com/">Mapterhorn</a>. Water, woodland, fields and built-up land use a natural palette, and the flight view keeps only place and airport names visible.</p>
       <p>The route identifies only the general Strind area; it does not place a marker on a private home.</p>
       <h3>AIRCRAFT</h3>
       <p>The logo-free B737 model comes from <a href="https://github.com/amvlab/aircraft-models">AMV Lab aircraft-models</a> at pinned commit <code>91d835e</code>, licensed under <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>. TURN UP scales, orients and outlines it at runtime.</p>
@@ -213,6 +213,6 @@
   </dialog>
 
   <noscript><p class="noscript">TURN UP needs JavaScript to run its flight engine.</p></noscript>
-  <script type="module" src="./app.mjs?build=20260822-r4"></script>
+  <script type="module" src="./app.mjs?build=20260823-r1"></script>
 </body>
 </html>

--- a/turnup/scene.mjs
+++ b/turnup/scene.mjs
@@ -12,12 +12,17 @@ const AIRCRAFT_URL = `https://raw.githubusercontent.com/amvlab/aircraft-models/$
 const B737_LENGTH_TO_SPAN = 39.5 / 35.8;
 
 export const MAP_STYLE_URL = 'https://tiles.openfreemap.org/styles/liberty';
-export const TERRAIN_TILE_URL = 'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png';
+export const TERRAIN_TILEJSON_URL = 'https://tiles.mapterhorn.com/tilejson.json';
 export const AIRPORT_ORIGIN = Object.freeze({
   lng: 17.443,
   lat: 62.5285,
   elevation: 5
 });
+
+const PLACE_LABEL_SOURCE_LAYERS = new Set(['place', 'aerodrome_label']);
+const CAMERA_LOOK_AHEAD_METRES = 220;
+const CAMERA_TARGET_DROP_METRES = 64;
+const CAMERA_TERRAIN_CLEARANCE_METRES = 8;
 
 const originMercator = maplibregl.MercatorCoordinate.fromLngLat(AIRPORT_ORIGIN, 0);
 const metresToMercator = originMercator.meterInMercatorCoordinateUnits();
@@ -69,6 +74,8 @@ export async function createFlightScene(container, {
     container,
     style: MAP_STYLE_URL,
     center: [AIRPORT_ORIGIN.lng, AIRPORT_ORIGIN.lat],
+    centerClampedToGround: false,
+    elevation: AIRPORT_ORIGIN.elevation + MAP_START_POSE.y - CAMERA_TARGET_DROP_METRES,
     zoom: 14.3,
     pitch: 72,
     bearing: radiansToDegrees(MAP_START_POSE.heading),
@@ -83,10 +90,7 @@ export async function createFlightScene(container, {
     canvasContextAttributes: { antialias: true }
   });
 
-  map.addControl(new maplibregl.AttributionControl({
-    compact: true,
-    customAttribution: 'TURN UP · AMV Lab aircraft'
-  }), 'bottom-left');
+  map.addControl(new maplibregl.AttributionControl({ compact: true }), 'bottom-left');
 
   map.on('error', (event) => {
     const message = String(event?.error?.message || '');
@@ -120,8 +124,9 @@ export async function createFlightScene(container, {
   });
 
   await new Promise((resolve) => map.once('load', resolve));
+  applyNaturalMapPalette(map);
+  simplifyMapLabels(map);
   installTerrain(map, reducedMotion);
-  installThreeDimensionalBuildings(map);
   installRouteLine(map);
   setSkyAndFog(map, reducedMotion);
 
@@ -182,16 +187,25 @@ export async function createFlightScene(container, {
     }
 
     const ahead = localToLngLat(
-      flightState.position.x + Math.sin(flightState.heading) * 310,
-      flightState.position.z - Math.cos(flightState.heading) * 310
+      flightState.position.x + Math.sin(flightState.heading) * CAMERA_LOOK_AHEAD_METRES,
+      flightState.position.z - Math.cos(flightState.heading) * CAMERA_LOOK_AHEAD_METRES
+    );
+    const terrainAtTarget = map.queryTerrainElevation(ahead);
+    const minimumTargetElevation = Number.isFinite(terrainAtTarget)
+      ? terrainAtTarget + CAMERA_TERRAIN_CLEARANCE_METRES
+      : AIRPORT_ORIGIN.elevation;
+    const targetElevation = Math.max(
+      minimumTargetElevation,
+      terrainAtOrigin + flightState.position.y - CAMERA_TARGET_DROP_METRES
     );
     const altitudeZoom = clamp((flightState.position.y - 80) / 720, 0, 1);
     map.jumpTo({
       center: ahead,
+      elevation: targetElevation,
       bearing: radiansToDegrees(flightState.heading),
-      pitch: reducedMotion ? 68 : 73,
-      roll: reducedMotion ? 0 : radiansToDegrees(flightState.bank) * 0.12,
-      zoom: 15.45 - altitudeZoom * 1.55
+      pitch: reducedMotion ? 65 : 68,
+      roll: reducedMotion ? 0 : radiansToDegrees(flightState.bank) * 0.08,
+      zoom: 15.2 - altitudeZoom * 1.25
     });
     map.triggerRepaint();
   }
@@ -259,11 +273,7 @@ function installTerrain(map, reducedMotion) {
   if (!map.getSource('turn-up-terrain')) {
     map.addSource('turn-up-terrain', {
       type: 'raster-dem',
-      tiles: [TERRAIN_TILE_URL],
-      tileSize: 256,
-      maxzoom: 15,
-      encoding: 'terrarium',
-      attribution: 'Terrain © Mapzen/AWS Open Data'
+      url: TERRAIN_TILEJSON_URL
     });
   }
 
@@ -274,40 +284,108 @@ function installTerrain(map, reducedMotion) {
       type: 'hillshade',
       source: 'turn-up-terrain',
       paint: {
-        'hillshade-shadow-color': '#143642',
-        'hillshade-highlight-color': '#fff0a8',
-        'hillshade-accent-color': '#2389b8',
+        'hillshade-shadow-color': '#28493c',
+        'hillshade-highlight-color': '#e3e4b6',
+        'hillshade-accent-color': '#5d806d',
         'hillshade-exaggeration': reducedMotion ? 0.24 : 0.36
       }
     }, firstLabelId);
   }
-  map.setTerrain({ source: 'turn-up-terrain', exaggeration: 1.18 });
+  map.setTerrain({ source: 'turn-up-terrain', exaggeration: 1 });
 }
 
-function installThreeDimensionalBuildings(map) {
-  const styleLayers = map.getStyle().layers || [];
-  const sourceLayer = styleLayers.find((layer) => layer['source-layer'] === 'building');
-  if (!sourceLayer || map.getLayer('turn-up-buildings')) return;
+function applyNaturalMapPalette(map) {
+  const fillColors = new Map([
+    ['park', '#83a66f'],
+    ['landcover_wood', '#6f9362'],
+    ['landcover_grass', '#a6ba7b'],
+    ['landcover_ice', '#dbe8e7'],
+    ['landcover_wetland', '#80a79c'],
+    ['landcover_sand', '#d9c99b'],
+    ['landuse_pitch', '#91ad70'],
+    ['landuse_track', '#aaa982'],
+    ['landuse_cemetery', '#8fa57b'],
+    ['landuse_hospital', '#c9c0ad'],
+    ['landuse_school', '#c8c2a8'],
+    ['water', '#4e9fc6'],
+    ['aeroway_fill', '#858b89'],
+    ['building', '#b5aa96']
+  ]);
 
-  const firstLabelId = styleLayers.find((layer) => layer.type === 'symbol')?.id;
-  map.addLayer({
-    id: 'turn-up-buildings',
-    source: sourceLayer.source,
-    'source-layer': 'building',
-    type: 'fill-extrusion',
-    minzoom: 13,
-    paint: {
-      'fill-extrusion-color': [
-        'interpolate', ['linear'], ['coalesce', ['get', 'render_height'], ['get', 'height'], 6],
-        0, '#fff8e8',
-        30, '#ffe087',
-        90, '#ff8caf'
-      ],
-      'fill-extrusion-height': ['coalesce', ['get', 'render_height'], ['get', 'height'], 6],
-      'fill-extrusion-base': ['coalesce', ['get', 'render_min_height'], ['get', 'min_height'], 0],
-      'fill-extrusion-opacity': 0.84
+  for (const layer of map.getStyle().layers || []) {
+    if (layer.type === 'background') {
+      map.setPaintProperty(layer.id, 'background-color', '#9eb47a');
+      continue;
     }
-  }, firstLabelId);
+
+    if (layer.type === 'fill' && fillColors.has(layer.id)) {
+      if (layer.id === 'landcover_wetland') {
+        map.setPaintProperty(layer.id, 'fill-pattern', null);
+      }
+      map.setPaintProperty(layer.id, 'fill-color', fillColors.get(layer.id));
+      if (layer.id === 'landcover_wood') map.setPaintProperty(layer.id, 'fill-opacity', 0.9);
+      if (layer.id === 'landcover_grass') map.setPaintProperty(layer.id, 'fill-opacity', 0.76);
+      continue;
+    }
+
+    if (layer.type === 'fill-extrusion' && layer['source-layer'] === 'building') {
+      map.setPaintProperty(layer.id, 'fill-extrusion-color', '#a99f8e');
+      map.setPaintProperty(layer.id, 'fill-extrusion-opacity', 0.86);
+      continue;
+    }
+
+    if (layer.type !== 'line') continue;
+    if (layer['source-layer'] === 'waterway') {
+      map.setPaintProperty(layer.id, 'line-color', '#4e9fc6');
+    } else if (layer['source-layer'] === 'aeroway') {
+      map.setPaintProperty(layer.id, 'line-color', layer.id.includes('runway') ? '#5e6463' : '#777d7b');
+    } else if (layer['source-layer'] === 'transportation') {
+      const color = layer.id.includes('casing')
+        ? '#74736b'
+        : layer.id.includes('rail')
+          ? '#626966'
+          : layer.id.includes('motorway')
+            ? '#c09a70'
+            : '#d4cbb5';
+      map.setPaintProperty(layer.id, 'line-color', color);
+    }
+  }
+
+  const styleLayers = map.getStyle().layers || [];
+  const landuseLayer = styleLayers.find((layer) => layer['source-layer'] === 'landuse');
+  const beforeLandcover = styleLayers.find((layer) => layer['source-layer'] === 'landcover')?.id;
+  if (landuseLayer && !map.getLayer('turn-up-semantic-landuse')) {
+    map.addLayer({
+      id: 'turn-up-semantic-landuse',
+      type: 'fill',
+      source: landuseLayer.source,
+      'source-layer': 'landuse',
+      filter: [
+        'match', ['get', 'class'],
+        ['residential', 'commercial', 'industrial', 'retail', 'farmland', 'farmyard', 'orchard'],
+        true,
+        false
+      ],
+      paint: {
+        'fill-color': [
+          'match', ['get', 'class'],
+          ['commercial', 'industrial', 'retail'], '#b9af9c',
+          ['farmland', 'farmyard'], '#b6b77c',
+          'orchard', '#91a66d',
+          '#d0c8b3'
+        ],
+        'fill-opacity': 0.64
+      }
+    }, beforeLandcover);
+  }
+}
+
+function simplifyMapLabels(map) {
+  for (const layer of map.getStyle().layers || []) {
+    if (layer.type !== 'symbol') continue;
+    const visible = PLACE_LABEL_SOURCE_LAYERS.has(layer['source-layer']);
+    map.setLayoutProperty(layer.id, 'visibility', visible ? 'visible' : 'none');
+  }
 }
 
 function installRouteLine(map) {
@@ -381,7 +459,7 @@ function createAircraftRig() {
 async function loadAircraft() {
   const gltf = await new GLTFLoader().loadAsync(AIRCRAFT_URL);
   return prepareAircraftAsset(gltf.scene, {
-    targetLength: 34,
+    targetLength: 40,
     lengthToSpanRatio: B737_LENGTH_TO_SPAN
   });
 }

--- a/turnup/styles.css
+++ b/turnup/styles.css
@@ -136,9 +136,10 @@ a {
 }
 
 .maplibregl-ctrl-bottom-left {
-  bottom: max(2px, env(safe-area-inset-bottom));
-  left: max(2px, env(safe-area-inset-left));
+  bottom: max(4px, env(safe-area-inset-bottom));
+  left: 50%;
   z-index: 12;
+  transform: translateX(-50%);
 }
 
 .maplibregl-ctrl-attrib {
@@ -147,6 +148,17 @@ a {
   color: var(--ink);
   font-size: 10px;
   font-weight: 650;
+  line-height: 1.2;
+}
+
+.maplibregl-ctrl-attrib.maplibregl-compact {
+  max-width: min(64vw, 540px);
+  margin: 0 !important;
+}
+
+.maplibregl-ctrl-attrib.maplibregl-compact-show {
+  max-height: 40px;
+  overflow: auto;
 }
 
 .maplibregl-ctrl-attrib a {


### PR DESCRIPTION
## What changed

- replace the discontinuous AWS Terrarium tiles with seamless Mapterhorn terrain tiles
- keep the MapLibre camera target at aircraft elevation and above local ground, with less look-ahead, roll, and pitch
- enlarge the B737 slightly so it remains readable on compact screens
- keep only place and airport labels; hide road names, shields, POIs, and other map text
- apply natural colors for water, woodland, grass, farmland, developed land, airport surfaces, buildings, roads, and hillshade
- remove the duplicate building extrusion layer and constrain the compact attribution panel
- refresh runtime credits and cache keys

## Why

The supplied screen recording showed terrain seams rendered as tall vertical walls, the aircraft repeatedly approaching or crossing the top edge, and map labels competing with the flight UI. Sampling adjacent terrain tiles around Midlanda confirmed large elevation discontinuities at tile boundaries.

## Validation

- `node --check turnup/scene.mjs`
- `node --check turnup/app.mjs`
- `node turn-tests/turnup-production.mjs` — 13/13 pass
- semantic style smoke test against the current OpenFreeMap Liberty layer structure — 83 paint updates and 25 label decisions
- source hygiene checks