### PR TITLE
Move TURN UP attitude indicator above thrust

### DIFF
--- a/turn-tests/turnup-production.mjs
+++ b/turn-tests/turnup-production.mjs
@@ -133,6 +133,14 @@ test('TURN styling includes focus, contrast and reduced-motion treatment', () =>
   assert.match(icon, /#ff4fa3/);
 });
 
+test('the attitude indicator occupies the control lane above thrust', () => {
+  assert.match(html, /styles\.css\?build=20260823-r2/);
+  assert.match(html, /app\.mjs\?build=20260823-r2/);
+  assert.match(css, /bottom: calc\(max\(18px, env\(safe-area-inset-bottom\)\) \+ clamp\(80px, 13vw, 120px\) \+ 12px\)/);
+  assert.match(css, /width: clamp\(78px, 12vw, 118px\)/);
+  assert.match(css, /\.attitude \{\n    right: max\(18px, env\(safe-area-inset-right\)\);\n    bottom: 94px;\n    width: 76px;/);
+});
+
 test('pitch control has a calm dead zone and a reversible response', () => {
   assert.equal(controlFromAngle(degreesToRadians(1)), 0);
   const standard = controlFromAngle(degreesToRadians(10));

--- a/turnup/app.mjs
+++ b/turnup/app.mjs
@@ -21,7 +21,7 @@ import {
 } from './flight-model.mjs';
 import { COURSE_POINTS, createFlightScene } from './scene.mjs?build=20260823-r1';
 
-const BUILD = '2026.08.23-r1';
+const BUILD = '2026.08.23-r2';
 const BEST_TIME_KEY = 'turnup.bestCourseSeconds.v1';
 const SETTINGS_KEY = 'turnup.settings.v1';
 const reducedMotion = globalThis.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;

--- a/turnup/index.html
+++ b/turnup/index.html
@@ -25,7 +25,7 @@
   <link rel="preconnect" href="https://tiles.mapterhorn.com">
   <link rel="preload" as="fetch" crossorigin href="https://raw.githubusercontent.com/amvlab/aircraft-models/91d835e8e851b2317fe79af291c9fed6153fd525/models/B737_nologo.glb">
   <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@6.5.0/dist/maplibre-gl.css">
-  <link rel="stylesheet" href="./styles.css?build=20260823-r1">
+  <link rel="stylesheet" href="./styles.css?build=20260823-r2">
   <script type="importmap">
     {
       "imports": {
@@ -213,6 +213,6 @@
   </dialog>
 
   <noscript><p class="noscript">TURN UP needs JavaScript to run its flight engine.</p></noscript>
-  <script type="module" src="./app.mjs?build=20260823-r1"></script>
+  <script type="module" src="./app.mjs?build=20260823-r2"></script>
 </body>
 </html>

--- a/turnup/styles.css
+++ b/turnup/styles.css
@@ -489,13 +489,12 @@ h1 span {
   --bank-angle: 0deg;
   --pitch-offset: 0px;
   position: absolute;
-  top: 51%;
-  left: 50%;
-  width: clamp(88px, 12vw, 132px);
+  right: max(18px, env(safe-area-inset-right));
+  bottom: calc(max(18px, env(safe-area-inset-bottom)) + clamp(80px, 13vw, 120px) + 12px);
+  width: clamp(78px, 12vw, 118px);
   aspect-ratio: 1;
   overflow: hidden;
   border-radius: 50%;
-  transform: translate(-50%, -50%);
 }
 
 .attitude-world {
@@ -1032,6 +1031,12 @@ h1 span {
   .recalibrate,
   .throttle-controls {
     bottom: 10px;
+  }
+
+  .attitude {
+    right: max(18px, env(safe-area-inset-right));
+    bottom: 94px;
+    width: 76px;
   }
 
   .throttle-controls {


### PR DESCRIPTION
## What changed

- move the round attitude/horizon indicator out of the center flight view
- align it directly above THRUST, sharing the button's right edge and responsive diameter
- use a compact 76 px indicator with an 8 px gap on short landscape screens
- refresh the production CSS/app cache key
- add regression coverage for the right-hand control-lane placement

## Validation

- `node --check turnup/app.mjs`
- `node turn-tests/turnup-production.mjs` — 14/14 pass
- non-overlap arithmetic checks at short, mid-size, and regular landscape heights
- source hygiene checks