### PR TITLE
Bring the TURN UP aircraft closer

### DIFF
--- a/turn-tests/turnup-production.mjs
+++ b/turn-tests/turnup-production.mjs
@@ -15,6 +15,7 @@ import {
   shortestAngle,
   updateFlightState
 } from '../turnup/flight-model.mjs';
+import { CHASE_CAMERA, resolveChaseCameraZoom } from '../turnup/camera-model.mjs';
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const read = (path) => readFile(resolve(repositoryRoot, path), 'utf8');
@@ -66,7 +67,7 @@ test('TURN UP imports the canonical TURN platform and steering engine', () => {
   assert.match(app, /resolveMotionSteeringProfile/);
   assert.match(app, /updateMotionInputState/);
   assert.match(app, /controlFromAngle\(motionState\.pitch - motionState\.neutralPitch/);
-  assert.match(app, /scene\.mjs\?build=20260823-r1/);
+  assert.match(app, /scene\.mjs\?build=20260823-r3/);
   assert.doesNotMatch(app, /DeviceMotionEvent\.requestPermission/);
 });
 
@@ -95,7 +96,26 @@ test('the map declutters labels and the chase camera follows aircraft elevation'
   assert.match(scene, /CAMERA_LOOK_AHEAD_METRES = 220/);
   assert.match(scene, /terrainAtOrigin \+ flightState\.position\.y - CAMERA_TARGET_DROP_METRES/);
   assert.match(scene, /elevation: targetElevation/);
+  assert.match(scene, /map\.getCanvas\(\)\.clientHeight/);
+  assert.match(scene, /zoom: chaseZoom/);
   assert.match(scene, /targetLength: 40/);
+});
+
+test('the chase camera keeps a TURN-like aircraft scale across viewports', () => {
+  const phoneZoom = resolveChaseCameraZoom(390, 80);
+  const tabletZoom = resolveChaseCameraZoom(780, 80);
+  assert.equal(phoneZoom, CHASE_CAMERA.baseZoom);
+  assert.equal(tabletZoom, phoneZoom + 1);
+
+  const phoneWorldHeight = 390 / (2 ** phoneZoom);
+  const tabletWorldHeight = 780 / (2 ** tabletZoom);
+  assert.ok(Math.abs(phoneWorldHeight - tabletWorldHeight) < 1e-12);
+
+  const highAltitudeZoom = resolveChaseCameraZoom(390, 800);
+  assert.ok(highAltitudeZoom < phoneZoom);
+  assert.ok(phoneZoom - highAltitudeZoom <= CHASE_CAMERA.maximumAltitudePullback);
+  assert.equal(resolveChaseCameraZoom(200, 80), CHASE_CAMERA.minimumZoom);
+  assert.equal(resolveChaseCameraZoom(2000, 80), CHASE_CAMERA.maximumZoom);
 });
 
 test('the real-world map uses a natural semantic palette', () => {
@@ -135,7 +155,7 @@ test('TURN styling includes focus, contrast and reduced-motion treatment', () =>
 
 test('the attitude indicator occupies the control lane above thrust', () => {
   assert.match(html, /styles\.css\?build=20260823-r2/);
-  assert.match(html, /app\.mjs\?build=20260823-r2/);
+  assert.match(html, /app\.mjs\?build=20260823-r3/);
   assert.match(css, /bottom: calc\(max\(18px, env\(safe-area-inset-bottom\)\) \+ clamp\(80px, 13vw, 120px\) \+ 12px\)/);
   assert.match(css, /width: clamp\(78px, 12vw, 118px\)/);
   assert.match(css, /\.attitude \{\n    right: max\(18px, env\(safe-area-inset-right\)\);\n    bottom: 94px;\n    width: 76px;/);

--- a/turnup/README.md
+++ b/turnup/README.md
@@ -7,6 +7,7 @@ The first route starts over Sundsvall–Timrå Airport (Midlanda), crosses Sör�
 ## Runtime
 
 - MapLibre GL JS 6.5 renders the vector map, 3D terrain, buildings and Three.js custom flight layer.
+- The chase camera compensates for viewport height so the B737 keeps a TURN-like player-vehicle scale on phones and tablets, with a small altitude pullback.
 - OpenFreeMap's Liberty style supplies OpenStreetMap/OpenMapTiles map data. TURN UP applies a natural semantic palette for water, forest, fields, built-up land and airport surfaces, then hides road, route and POI labels while preserving place and airport names.
 - Mapterhorn supplies the Terrarium-encoded elevation tiles.
 - Three.js 0.184 renders gates and the aircraft.

--- a/turnup/app.mjs
+++ b/turnup/app.mjs
@@ -19,9 +19,9 @@ import {
   shortestAngle,
   updateFlightState
 } from './flight-model.mjs';
-import { COURSE_POINTS, createFlightScene } from './scene.mjs?build=20260823-r1';
+import { COURSE_POINTS, createFlightScene } from './scene.mjs?build=20260823-r3';
 
-const BUILD = '2026.08.23-r2';
+const BUILD = '2026.08.23-r3';
 const BEST_TIME_KEY = 'turnup.bestCourseSeconds.v1';
 const SETTINGS_KEY = 'turnup.settings.v1';
 const reducedMotion = globalThis.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;

--- a/turnup/camera-model.mjs
+++ b/turnup/camera-model.mjs
@@ -1,0 +1,37 @@
+export const CHASE_CAMERA = Object.freeze({
+  referenceViewportHeight: 390,
+  baseZoom: 16.2,
+  minimumZoom: 15.9,
+  maximumZoom: 17.45,
+  altitudePullbackStart: 80,
+  altitudePullbackRange: 720,
+  maximumAltitudePullback: 0.15
+});
+
+export function resolveChaseCameraZoom(viewportHeight, altitude) {
+  const height = Math.max(
+    1,
+    Number(viewportHeight) || CHASE_CAMERA.referenceViewportHeight
+  );
+  const viewportCompensation = Math.log2(
+    height / CHASE_CAMERA.referenceViewportHeight
+  );
+  const altitudeRatio = clamp(
+    (Number(altitude) - CHASE_CAMERA.altitudePullbackStart)
+      / CHASE_CAMERA.altitudePullbackRange,
+    0,
+    1
+  );
+
+  return clamp(
+    CHASE_CAMERA.baseZoom
+      + viewportCompensation
+      - altitudeRatio * CHASE_CAMERA.maximumAltitudePullback,
+    CHASE_CAMERA.minimumZoom,
+    CHASE_CAMERA.maximumZoom
+  );
+}
+
+function clamp(value, minimum, maximum) {
+  return Math.min(maximum, Math.max(minimum, value));
+}

--- a/turnup/index.html
+++ b/turnup/index.html
@@ -213,6 +213,6 @@
   </dialog>
 
   <noscript><p class="noscript">TURN UP needs JavaScript to run its flight engine.</p></noscript>
-  <script type="module" src="./app.mjs?build=20260823-r2"></script>
+  <script type="module" src="./app.mjs?build=20260823-r3"></script>
 </body>
 </html>

--- a/turnup/scene.mjs
+++ b/turnup/scene.mjs
@@ -1,6 +1,7 @@
 import * as maplibregl from 'maplibre-gl';
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { resolveChaseCameraZoom } from './camera-model.mjs?build=20260823-r3';
 
 const INK = 0x08090a;
 const PAPER = 0xfff8e8;
@@ -198,14 +199,17 @@ export async function createFlightScene(container, {
       minimumTargetElevation,
       terrainAtOrigin + flightState.position.y - CAMERA_TARGET_DROP_METRES
     );
-    const altitudeZoom = clamp((flightState.position.y - 80) / 720, 0, 1);
+    const chaseZoom = resolveChaseCameraZoom(
+      map.getCanvas().clientHeight,
+      flightState.position.y
+    );
     map.jumpTo({
       center: ahead,
       elevation: targetElevation,
       bearing: radiansToDegrees(flightState.heading),
       pitch: reducedMotion ? 65 : 68,
       roll: reducedMotion ? 0 : radiansToDegrees(flightState.bank) * 0.08,
-      zoom: 15.2 - altitudeZoom * 1.25
+      zoom: chaseZoom
     });
     map.triggerRepaint();
   }


### PR DESCRIPTION
## What changed

- bring the camera substantially closer so the B737 reads as the controlled vehicle, like the car in TURN
- compensate zoom for viewport height so phones and iPads retain the same world-space chase distance
- keep a small 0.15-zoom pullback from low to high altitude instead of the previous 1.25-zoom retreat
- preserve the real 40 m aircraft scale rather than artificially enlarging the model
- isolate and test the chase-camera calculation in a pure camera module
- refresh the production scene/app cache key

## Validation

- `node --check` for camera, scene, and app modules
- `node turn-tests/turnup-production.mjs` — 15/15 pass
- phone/iPad world-space framing parity check
- zoom-bound checks at 320, 390, 430, 768, and 900 px viewport heights
- source hygiene checks