### PR TITLE
Refine TURN UP aircraft framing

### DIFF
--- a/turn-tests/turnup-production.mjs
+++ b/turn-tests/turnup-production.mjs
@@ -67,7 +67,7 @@ test('TURN UP imports the canonical TURN platform and steering engine', () => {
   assert.match(app, /resolveMotionSteeringProfile/);
   assert.match(app, /updateMotionInputState/);
   assert.match(app, /controlFromAngle\(motionState\.pitch - motionState\.neutralPitch/);
-  assert.match(app, /scene\.mjs\?build=20260823-r3/);
+  assert.match(app, /scene\.mjs\?build=20260823-r4/);
   assert.doesNotMatch(app, /DeviceMotionEvent\.requestPermission/);
 });
 
@@ -93,7 +93,8 @@ test('the map declutters labels and the chase camera follows aircraft elevation'
   assert.match(scene, /visible \? 'visible' : 'none'/);
   assert.doesNotMatch(scene, /turn-up-buildings/);
   assert.match(scene, /centerClampedToGround: false/);
-  assert.match(scene, /CAMERA_LOOK_AHEAD_METRES = 220/);
+  assert.match(scene, /CAMERA_LOOK_AHEAD_METRES = 185/);
+  assert.match(scene, /CAMERA_TARGET_DROP_METRES = 78/);
   assert.match(scene, /terrainAtOrigin \+ flightState\.position\.y - CAMERA_TARGET_DROP_METRES/);
   assert.match(scene, /elevation: targetElevation/);
   assert.match(scene, /map\.getCanvas\(\)\.clientHeight/);
@@ -105,6 +106,7 @@ test('the chase camera keeps a TURN-like aircraft scale across viewports', () =>
   const phoneZoom = resolveChaseCameraZoom(390, 80);
   const tabletZoom = resolveChaseCameraZoom(780, 80);
   assert.equal(phoneZoom, CHASE_CAMERA.baseZoom);
+  assert.equal(phoneZoom, 16.05);
   assert.equal(tabletZoom, phoneZoom + 1);
 
   const phoneWorldHeight = 390 / (2 ** phoneZoom);
@@ -113,7 +115,9 @@ test('the chase camera keeps a TURN-like aircraft scale across viewports', () =>
 
   const highAltitudeZoom = resolveChaseCameraZoom(390, 800);
   assert.ok(highAltitudeZoom < phoneZoom);
-  assert.ok(phoneZoom - highAltitudeZoom <= CHASE_CAMERA.maximumAltitudePullback);
+  assert.ok(
+    phoneZoom - highAltitudeZoom <= CHASE_CAMERA.maximumAltitudePullback + Number.EPSILON * 16
+  );
   assert.equal(resolveChaseCameraZoom(200, 80), CHASE_CAMERA.minimumZoom);
   assert.equal(resolveChaseCameraZoom(2000, 80), CHASE_CAMERA.maximumZoom);
 });
@@ -155,7 +159,7 @@ test('TURN styling includes focus, contrast and reduced-motion treatment', () =>
 
 test('the attitude indicator occupies the control lane above thrust', () => {
   assert.match(html, /styles\.css\?build=20260823-r2/);
-  assert.match(html, /app\.mjs\?build=20260823-r3/);
+  assert.match(html, /app\.mjs\?build=20260823-r4/);
   assert.match(css, /bottom: calc\(max\(18px, env\(safe-area-inset-bottom\)\) \+ clamp\(80px, 13vw, 120px\) \+ 12px\)/);
   assert.match(css, /width: clamp\(78px, 12vw, 118px\)/);
   assert.match(css, /\.attitude \{\n    right: max\(18px, env\(safe-area-inset-right\)\);\n    bottom: 94px;\n    width: 76px;/);

--- a/turnup/README.md
+++ b/turnup/README.md
@@ -7,7 +7,7 @@ The first route starts over Sundsvall–Timrå Airport (Midlanda), crosses Sör�
 ## Runtime
 
 - MapLibre GL JS 6.5 renders the vector map, 3D terrain, buildings and Three.js custom flight layer.
-- The chase camera compensates for viewport height so the B737 keeps a TURN-like player-vehicle scale on phones and tablets, with a small altitude pullback.
+- The chase camera compensates for viewport height so the B737 keeps a TURN-like player-vehicle scale on phones and tablets, with a small altitude pullback and forward-biased framing that keeps the complete aircraft visible.
 - OpenFreeMap's Liberty style supplies OpenStreetMap/OpenMapTiles map data. TURN UP applies a natural semantic palette for water, forest, fields, built-up land and airport surfaces, then hides road, route and POI labels while preserving place and airport names.
 - Mapterhorn supplies the Terrarium-encoded elevation tiles.
 - Three.js 0.184 renders gates and the aircraft.

--- a/turnup/app.mjs
+++ b/turnup/app.mjs
@@ -19,9 +19,9 @@ import {
   shortestAngle,
   updateFlightState
 } from './flight-model.mjs';
-import { COURSE_POINTS, createFlightScene } from './scene.mjs?build=20260823-r3';
+import { COURSE_POINTS, createFlightScene } from './scene.mjs?build=20260823-r4';
 
-const BUILD = '2026.08.23-r3';
+const BUILD = '2026.08.23-r4';
 const BEST_TIME_KEY = 'turnup.bestCourseSeconds.v1';
 const SETTINGS_KEY = 'turnup.settings.v1';
 const reducedMotion = globalThis.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;

--- a/turnup/camera-model.mjs
+++ b/turnup/camera-model.mjs
@@ -1,6 +1,6 @@
 export const CHASE_CAMERA = Object.freeze({
   referenceViewportHeight: 390,
-  baseZoom: 16.2,
+  baseZoom: 16.05,
   minimumZoom: 15.9,
   maximumZoom: 17.45,
   altitudePullbackStart: 80,

--- a/turnup/index.html
+++ b/turnup/index.html
@@ -213,6 +213,6 @@
   </dialog>
 
   <noscript><p class="noscript">TURN UP needs JavaScript to run its flight engine.</p></noscript>
-  <script type="module" src="./app.mjs?build=20260823-r3"></script>
+  <script type="module" src="./app.mjs?build=20260823-r4"></script>
 </body>
 </html>

--- a/turnup/scene.mjs
+++ b/turnup/scene.mjs
@@ -1,7 +1,7 @@
 import * as maplibregl from 'maplibre-gl';
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
-import { resolveChaseCameraZoom } from './camera-model.mjs?build=20260823-r3';
+import { resolveChaseCameraZoom } from './camera-model.mjs?build=20260823-r4';
 
 const INK = 0x08090a;
 const PAPER = 0xfff8e8;
@@ -21,8 +21,8 @@ export const AIRPORT_ORIGIN = Object.freeze({
 });
 
 const PLACE_LABEL_SOURCE_LAYERS = new Set(['place', 'aerodrome_label']);
-const CAMERA_LOOK_AHEAD_METRES = 220;
-const CAMERA_TARGET_DROP_METRES = 64;
+const CAMERA_LOOK_AHEAD_METRES = 185;
+const CAMERA_TARGET_DROP_METRES = 78;
 const CAMERA_TERRAIN_CLEARANCE_METRES = 8;
 
 const originMercator = maplibregl.MercatorCoordinate.fromLngLat(AIRPORT_ORIGIN, 0);


### PR DESCRIPTION
## Summary
- reduce the TURN UP B737's apparent size by about 10%
- shift the chase target closer and lower so the complete aircraft sits slightly farther forward in the frame
- bump the runtime cache revision and document the forward-biased framing

## Validation
- `node --check turnup/camera-model.mjs`
- `node --check turnup/scene.mjs`
- `node --check turnup/app.mjs`
- `node turn-tests/turnup-production.mjs` — 15 tests passed