### PR TITLE
Fix Lot secondary factory-color ReferenceError

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -83,7 +83,7 @@
         "/turn/achievements/trophy-road-showcase.js?revision=r160-reward-detail-sync": "/turn/achievements/trophy-road-showcase.js?revision=r179-native-car-surfaces",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-post-soak",
         "/turn/render/covered-rendering.js?build=20260823-r183": "/turn/render/covered-rendering.js?build=20260823-r183&revision=r164-long-session-robustness",
-        "/turn/progression/lot-paint-reward.js?revision=r206-pwa-color": "/turn/progression/lot-paint-reward.js?revision=r207-reward-color-catalog",
+        "/turn/progression/lot-paint-reward.js?revision=r206-pwa-color": "/turn/progression/lot-paint-reward.js?revision=r208-secondary-color-import",
         "/turn/garage/lot-showroom-experiment.js?revision=r206-race-before-locks": "/turn/garage/lot-showroom-experiment.js?revision=r179-native-car-surfaces",
         "/turn/vehicle/catalog.js?build=20260804-r157-factory-colors": "/turn/vehicle/catalog.js?revision=r179-native-car-surfaces",
         "/turn/vehicle/catalog.js?build=20260720-r20&revision=r588-canonical-attributes": "/turn/vehicle/catalog.js?revision=r179-native-car-surfaces",

--- a/turn-lab/tests/paint-lock-observer-production.mjs
+++ b/turn-lab/tests/paint-lock-observer-production.mjs
@@ -34,6 +34,11 @@ const importMapText = index.match(/<script type="importmap">\s*([\s\S]*?)\s*<\/s
 assert.ok(importMapText, 'TURN production entry must expose an import map');
 const importMap = JSON.parse(importMapText);
 const imports = importMap.imports || {};
+const catalogImport = paintGate.match(/import\s*\{([\s\S]*?)\}\s*from '\.\.\/vehicle\/catalog\.js[^']*';/)?.[1] || '';
+assert.ok(catalogImport, 'The paint gate must import its vehicle-catalog helpers explicitly');
+assert.match(catalogImport, /\bgetVehicleDefaultColor\b/);
+assert.match(catalogImport, /\bgetVehicleDefaultSecondaryColor\b/,
+  'The paint gate must import the secondary factory-color helper it calls');
 const syncBody = paintGate.match(/function sync\(\) \{([\s\S]*?)\n  \}\n\n  const observer/)?.[1] || '';
 assert.ok(syncBody, 'The paint gate must expose a bounded synchronization function');
 
@@ -172,8 +177,8 @@ assert.match(
 const canonicalLotCatalog = '/turn/vehicle/catalog.js?revision=r179-native-car-surfaces';
 assert.equal(
   imports['/turn/progression/lot-paint-reward.js?revision=r206-pwa-color'],
-  '/turn/progression/lot-paint-reward.js?revision=r207-reward-color-catalog',
-  'Installed PWAs must refetch the COLOR state module'
+  '/turn/progression/lot-paint-reward.js?revision=r208-secondary-color-import',
+  'Installed PWAs must refetch the corrected COLOR state module'
 );
 assert.equal(
   imports['/turn/garage/lot-showroom-experiment.js?revision=r206-race-before-locks'],
@@ -201,4 +206,4 @@ assert.match(perkPresentation, /getCarDefinition\(vehicleId\)\?\.perk/);
 assert.doesNotMatch(perkPresentation, /observer\.observe\(screen,/);
 assert.match(app, /trophy-road-r157\.css\?revision=r163-native-picker-parent-click/);
 
-console.log('TURN Lot PWA swatch compositing, reward-car catalog coherence, state matrix, cue geometry, cache bridge, car order and observer safety regressions passed.');
+console.log('TURN Lot PWA swatch compositing, factory-color imports, reward-car catalog coherence, state matrix, cue geometry, cache bridge, car order and observer safety regressions passed.');

--- a/turn/index.html
+++ b/turn/index.html
@@ -94,7 +94,7 @@
         "/turn/achievements/trophy-road-showcase.js?revision=r160-reward-detail-sync": "/turn/achievements/trophy-road-showcase.js?revision=r179-native-car-surfaces",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-post-soak",
         "/turn/render/covered-rendering.js?build=20260823-r183": "/turn/render/covered-rendering.js?build=20260823-r183&revision=r164-long-session-robustness",
-        "/turn/progression/lot-paint-reward.js?revision=r206-pwa-color": "/turn/progression/lot-paint-reward.js?revision=r207-reward-color-catalog",
+        "/turn/progression/lot-paint-reward.js?revision=r206-pwa-color": "/turn/progression/lot-paint-reward.js?revision=r208-secondary-color-import",
         "/turn/garage/lot-showroom-experiment.js?revision=r206-race-before-locks": "/turn/garage/lot-showroom-experiment.js?revision=r179-native-car-surfaces",
         "/turn/vehicle/catalog.js?build=20260804-r157-factory-colors": "/turn/vehicle/catalog.js?revision=r179-native-car-surfaces",
         "/turn/vehicle/catalog.js?build=20260720-r20&revision=r588-canonical-attributes": "/turn/vehicle/catalog.js?revision=r179-native-car-surfaces",

--- a/turn/progression/lot-paint-reward.js
+++ b/turn/progression/lot-paint-reward.js
@@ -1,6 +1,7 @@
 import {
   CAR_CATALOG,
-  getVehicleDefaultColor
+  getVehicleDefaultColor,
+  getVehicleDefaultSecondaryColor
 } from '../vehicle/catalog.js?build=20260804-r157-factory-colors';
 import { describeColorCue } from '../accessibility/color-cues.js?revision=r163';
 import {


### PR DESCRIPTION
## Bug

TURN 1.10.4 r183 could show `Can't find variable: getVehicleDefaultSecondaryColor` beside the Home RACE button. The Lot paint gate calls `getVehicleDefaultSecondaryColor()` for factory paint and fixed emergency liveries, but only imported `getVehicleDefaultColor`.

## Fix

- explicitly import `getVehicleDefaultSecondaryColor` in `lot-paint-reward.js`
- strengthen the Lot regression so it verifies every factory-color helper used by the paint gate is actually imported, not merely referenced in source
- move the installed-PWA import-map bridge from `r207-reward-color-catalog` to fresh `r208-secondary-color-import` in TURN and TURN LAB, so Safari/iOS cannot keep executing the broken nested module from HTTP/module cache

No gameplay, progression, paint semantics or vehicle defaults are changed.