### PR TITLE
Prewarm CHASE YOUR BEST ghost preview

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -83,6 +83,7 @@
         "/turn/achievements/trophy-road-showcase.js?revision=r160-reward-detail-sync": "/turn/achievements/trophy-road-showcase.js?revision=r179-native-car-surfaces",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-post-soak",
         "/turn/render/covered-rendering.js?build=20260823-r183": "/turn/render/covered-rendering.js?build=20260823-r183&revision=r164-long-session-robustness",
+        "/turn/ui/rival-onboarding.js?build=20260823-r183": "/turn/ui/rival-onboarding.js?build=20260823-r183&revision=r209-prewarmed-ghost",
         "/turn/progression/lot-paint-reward.js?revision=r206-pwa-color": "/turn/progression/lot-paint-reward.js?revision=r208-secondary-color-import",
         "/turn/garage/lot-showroom-experiment.js?revision=r206-race-before-locks": "/turn/garage/lot-showroom-experiment.js?revision=r179-native-car-surfaces",
         "/turn/vehicle/catalog.js?build=20260804-r157-factory-colors": "/turn/vehicle/catalog.js?revision=r179-native-car-surfaces",

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -211,6 +211,11 @@ const imports = JSON.parse(importMapText).imports;
 assert.match(index, new RegExp(`TURN v${release.version.replaceAll('.', '\\.')} · Build ${release.id.replaceAll('.', '\\.')}`));
 assert.match(index, new RegExp(`lap-result-toast\\.css\\?build=${release.cacheKey}`));
 assert.match(index, new RegExp(`rival-onboarding\\.css\\?build=${release.cacheKey}`));
+assert.equal(
+  imports[`/turn/ui/rival-onboarding.js?build=${release.cacheKey}`],
+  `/turn/ui/rival-onboarding.js?build=${release.cacheKey}&revision=r209-prewarmed-ghost`,
+  'Installed PWAs must refetch the prewarmed CHASE YOUR BEST runtime'
+);
 assert.ok(
   imports['./race/lap-system.js?build=20260720-r19']?.startsWith(`./race/lap-system-r86.js?build=${release.cacheKey}`),
   'The current release must publish the current unranked easter egg policy around the verified lap engine'
@@ -265,9 +270,9 @@ assert.doesNotMatch(gameState, /READY FOR THE LINE/, 'Restart Lap must not show 
 assert.match(onboarding, /CHASE YOUR BEST/, 'The first rival must introduce the core chase-your-best loop');
 assert.match(onboarding, /reason === 'lap-completed'/, 'Onboarding must be tied to the first newly saved rival after a completed lap');
 assert.match(onboarding, /!hadRival && hasRival\) schedule\(rivals\[0\]\)/, 'The onboarding must use the newly saved rival rather than the current selection');
-assert.match(onboarding, /rival\?\.carId/, 'The first-rival preview must use the saved ghost model');
-assert.match(onboarding, /rival\?\.carColor/, 'The first-rival preview must use the saved ghost body paint');
-assert.match(onboarding, /rival\?\.carSecondaryColor/, 'The first-rival preview must preserve saved secondary paint');
+assert.match(onboarding, /source\.carId \|\| source\.vehicleId/, 'The prepared preview must use the selected model and confirm it against the saved ghost model');
+assert.match(onboarding, /source\.carColor \|\| source\.vehicleColor/, 'The prepared preview must use the selected body paint and confirm it against saved ghost paint');
+assert.match(onboarding, /source\.carSecondaryColor \|\| source\.vehicleSecondaryColor/, 'The prepared preview must preserve selected and saved secondary paint');
 assert.match(onboarding, /ghost: true/, 'The onboarding model must use the same lighter solid ghost treatment as race rivals');
 assert.match(onboarding, /targetLength: 6\.4/, 'The onboarding model must use the Lot 3D viewer presentation scale');
 assert.match(onboarding, /PerspectiveCamera\(34, 1, 0\.1, 60\)/, 'The onboarding model must reuse the Lot viewer camera language');

--- a/turn-lab/tests/runtime-hotpath-performance-production.mjs
+++ b/turn-lab/tests/runtime-hotpath-performance-production.mjs
@@ -10,7 +10,8 @@ const [
   homeLayout,
   worldRender,
   rivalStorage,
-  mainSource
+  mainSource,
+  rivalOnboarding
 ] = await Promise.all([
   fs.readFile(new URL('../../turn/progression/lot-paint-reward.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements/view.js', import.meta.url), 'utf8'),
@@ -20,7 +21,8 @@ const [
   fs.readFile(new URL('../../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/render/world.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/race/rival-storage.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/ui/rival-onboarding.js', import.meta.url), 'utf8')
 ]);
 
 // CHROMATIC CAMOUFLAGE matches the primary/body paint only. The visible Color Cue must
@@ -47,6 +49,30 @@ assert.doesNotMatch(achievementView, /\.offsetWidth|\.offsetHeight|getBoundingCl
   'Achievement hot paths must not force synchronous layout');
 assert.match(achievementView, /requestAnimationFrame/,
   'Achievement entrance animations should cross a frame boundary without a forced reflow');
+
+// CHASE YOUR BEST has its own WebGL context. The newer semantic car shaders make a first
+// render there materially more expensive than the original r40 implementation, so the context,
+// model and shader programs must be prepared before the first rival is saved/revealed.
+const revealFunction = rivalOnboarding.match(/  function reveal\(\) \{[\s\S]*?\n  \}/)?.[0] || '';
+assert.ok(revealFunction, 'Rival onboarding must keep a bounded reveal function');
+assert.doesNotMatch(revealFunction, /offsetWidth|offsetHeight|getBoundingClientRect|renderer\.render|renderFrame/,
+  'CHASE YOUR BEST reveal must not force layout or perform a first WebGL render');
+assert.match(revealFunction, /requestAnimationFrame/,
+  'CHASE YOUR BEST should cross a frame boundary without a forced reflow');
+assert.match(rivalOnboarding, /reason === 'race-started'[\s\S]*!hasRival && state[\s\S]*preparePreview\(state\)/,
+  'The first-rival 3D preview must begin preparing during the first race, not at lap completion');
+assert.match(rivalOnboarding, /requestIdleCallback\(prepare\)/,
+  'Optional rival-preview context creation must wait for browser idle time when supported');
+assert.match(rivalOnboarding, /renderer\.compileAsync\(scene, camera\)/,
+  'The separate onboarding WebGL context must asynchronously precompile semantic car shaders');
+assert.match(rivalOnboarding, /renderer\.render\(scene, camera\);\s*warmed = true;/,
+  'The preview must warm one hidden frame before becoming eligible for visible rendering');
+const previewStart = rivalOnboarding.match(/    start\(\) \{[\s\S]*?\n    \},/)?.[0] || '';
+assert.ok(previewStart, 'Rival onboarding preview must expose a bounded start method');
+assert.doesNotMatch(previewStart, /renderer\.render|renderFrame|compile/,
+  'Starting the visible rival preview must never discover GPU programs synchronously');
+assert.match(previewStart, /requestAnimationFrame\(tick\)/,
+  'Visible rival rendering should begin on a later animation frame');
 
 // One logical unlock batch may award multiple achievements and Trophy Road rewards. Persist it once.
 assert.match(achievementStore, /function batch\(callback\)/);
@@ -84,4 +110,4 @@ const worldHomeGate = worldRender.indexOf('await waitForHomeBeforeCosmetics();')
 assert.ok(worldPrewarm >= 0 && worldHomeGate >= 0 && worldPrewarm < worldHomeGate,
   'World cosmetic module graph must prewarm before Home while installation still waits for Home');
 
-console.log('TURN runtime hot-path, observer and deferred-loading performance contracts passed.');
+console.log('TURN runtime hot-path, observer, rival-preview and deferred-loading performance contracts passed.');

--- a/turn/index.html
+++ b/turn/index.html
@@ -94,6 +94,7 @@
         "/turn/achievements/trophy-road-showcase.js?revision=r160-reward-detail-sync": "/turn/achievements/trophy-road-showcase.js?revision=r179-native-car-surfaces",
         "/turn/progression/trophy-road.js?revision=r166-bella-records": "/turn/progression/trophy-road-chromatic-r183.js?revision=r183-post-soak",
         "/turn/render/covered-rendering.js?build=20260823-r183": "/turn/render/covered-rendering.js?build=20260823-r183&revision=r164-long-session-robustness",
+        "/turn/ui/rival-onboarding.js?build=20260823-r183": "/turn/ui/rival-onboarding.js?build=20260823-r183&revision=r209-prewarmed-ghost",
         "/turn/progression/lot-paint-reward.js?revision=r206-pwa-color": "/turn/progression/lot-paint-reward.js?revision=r208-secondary-color-import",
         "/turn/garage/lot-showroom-experiment.js?revision=r206-race-before-locks": "/turn/garage/lot-showroom-experiment.js?revision=r179-native-car-surfaces",
         "/turn/vehicle/catalog.js?build=20260804-r157-factory-colors": "/turn/vehicle/catalog.js?revision=r179-native-car-surfaces",

--- a/turn/ui/rival-onboarding.js
+++ b/turn/ui/rival-onboarding.js
@@ -250,7 +250,7 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
   renderer.setSize(PREVIEW_WARM_WIDTH, PREVIEW_WARM_HEIGHT, false);
   modelHost.appendChild(renderer.domElement);
 
-  const camera = new THREE.PerspectiveCamera(34, PREVIEW_WARM_WIDTH / PREVIEW_WARM_HEIGHT, 0.1, 60);
+  const camera = new THREE.PerspectiveCamera(34, 1, 0.1, 60);
   camera.position.set(7.8, 4.8, 8.8);
   camera.lookAt(0, 1.1, 0);
 

--- a/turn/ui/rival-onboarding.js
+++ b/turn/ui/rival-onboarding.js
@@ -119,8 +119,8 @@ export function installRivalOnboarding() {
     plate.hidden = false;
     plate.classList.remove('is-visible', 'is-leaving');
 
-    // Cross a frame boundary instead of forcing layout with offsetWidth. The 3D preview
-    // is prepared independently; revealing CHASE YOUR BEST must never wait for WebGL.
+    // Cross a frame boundary instead of forcing a synchronous layout read. The 3D
+    // preview is prepared independently; revealing CHASE YOUR BEST must never wait for WebGL.
     revealFrame = requestAnimationFrame(() => {
       revealFrame = 0;
       if (plate.hidden) return;

--- a/turn/ui/rival-onboarding.js
+++ b/turn/ui/rival-onboarding.js
@@ -11,7 +11,9 @@ import { createCarVisual } from '../vehicle/car-models.js?build=20260720-r22';
 const RESULT_TOAST_HANDOFF_MS = 4300;
 const ONBOARDING_VISIBLE_MS = 3200;
 const ONBOARDING_EXIT_MS = 180;
-const PREVIEW_PREP_IDLE_TIMEOUT_MS = 2400;
+const PREVIEW_FALLBACK_PREP_DELAY_MS = 500;
+const PREVIEW_WARM_WIDTH = 126;
+const PREVIEW_WARM_HEIGHT = 92;
 const VIEWER_INITIAL_YAW = Math.PI - 0.55;
 const VIEWER_ROTATION_RADIANS_PER_SECOND = 0.144;
 const VIEWER_FRAME_INTERVAL_MS = 1000 / 30;
@@ -49,6 +51,8 @@ export function installRivalOnboarding() {
   let preparationIdleHandle = 0;
   let preparationTimer = 0;
   let previewGeneration = 0;
+  let pendingPreviewIdentity = '';
+  let previewIdentity = '';
   let preview = null;
 
   function clearTimers() {
@@ -70,13 +74,19 @@ export function installRivalOnboarding() {
     window.clearTimeout(preparationTimer);
     preparationIdleHandle = 0;
     preparationTimer = 0;
+    pendingPreviewIdentity = '';
+  }
+
+  function disposePreviewVisual() {
+    preview?.dispose();
+    preview = null;
+    previewIdentity = '';
+    modelHost.replaceChildren();
   }
 
   function destroyPreview() {
     cancelPreparation();
-    preview?.dispose();
-    preview = null;
-    modelHost.replaceChildren();
+    disposePreviewVisual();
     plate.classList.remove('is-model-unavailable');
   }
 
@@ -110,7 +120,7 @@ export function installRivalOnboarding() {
     plate.classList.remove('is-visible', 'is-leaving');
 
     // Cross a frame boundary instead of forcing layout with offsetWidth. The 3D preview
-    // has already been prepared independently; revealing the copy must never wait for it.
+    // is prepared independently; revealing CHASE YOUR BEST must never wait for WebGL.
     revealFrame = requestAnimationFrame(() => {
       revealFrame = 0;
       if (plate.hidden) return;
@@ -120,49 +130,76 @@ export function installRivalOnboarding() {
     hideTimer = window.setTimeout(() => hide(), ONBOARDING_VISIBLE_MS);
   }
 
-  function preparePreview({ carId, color, secondaryColor }) {
-    const generation = ++previewGeneration;
+  function normalizedPreviewData(source = {}) {
+    return {
+      carId: source.carId || source.vehicleId || 'sedan',
+      color: normalizeVehicleColor(
+        source.carColor || source.vehicleColor || DEFAULT_VEHICLE_COLOR
+      ),
+      secondaryColor: normalizeVehicleSecondaryColor(
+        source.carSecondaryColor || source.vehicleSecondaryColor || DEFAULT_VEHICLE_SECONDARY_COLOR
+      )
+    };
+  }
+
+  function previewKey({ carId, color, secondaryColor }) {
+    return `${carId}|${color}|${secondaryColor}`;
+  }
+
+  function preparePreview(data) {
+    const normalized = normalizedPreviewData(data);
+    const identity = previewKey(normalized);
+    if ((preview && previewIdentity === identity) || pendingPreviewIdentity === identity) return;
+
+    cancelPreparation();
+    disposePreviewVisual();
+    plate.classList.remove('is-model-unavailable');
+    pendingPreviewIdentity = identity;
+    const generation = previewGeneration;
+
     const prepare = () => {
       preparationIdleHandle = 0;
       preparationTimer = 0;
-      if (generation !== previewGeneration) return;
+      if (generation !== previewGeneration || pendingPreviewIdentity !== identity) return;
 
-      const nextPreview = createGhostPreview({ modelHost, carId, color, secondaryColor, onError() {
-        plate.classList.add('is-model-unavailable');
-      } });
-      if (generation !== previewGeneration) {
+      const nextPreview = createGhostPreview({
+        modelHost,
+        ...normalized,
+        onError() {
+          plate.classList.add('is-model-unavailable');
+        }
+      });
+      if (generation !== previewGeneration || pendingPreviewIdentity !== identity) {
         nextPreview.dispose();
         return;
       }
       preview = nextPreview;
+      previewIdentity = identity;
+      pendingPreviewIdentity = '';
       if (!plate.hidden) preview.start();
     };
 
-    // Creating a second WebGL context and cloning the ghost scene is optional onboarding
-    // work. Give it the quiet result-toast handoff window instead of the lap-completion frame.
+    // With no rival yet, race-started gives us an entire first lap to prepare the
+    // optional second WebGL context. Do it only when the browser reports idle time.
+    // Older engines get a delayed fallback, still well before the first rival reveal.
     if (typeof globalThis.requestIdleCallback === 'function') {
-      preparationIdleHandle = globalThis.requestIdleCallback(prepare, {
-        timeout: PREVIEW_PREP_IDLE_TIMEOUT_MS
-      });
+      preparationIdleHandle = globalThis.requestIdleCallback(prepare);
     } else {
-      preparationTimer = window.setTimeout(prepare, 120);
+      preparationTimer = window.setTimeout(prepare, PREVIEW_FALLBACK_PREP_DELAY_MS);
     }
   }
 
   function schedule(rival) {
     clearTimers();
-    destroyPreview();
     plate.hidden = true;
     plate.classList.remove('is-visible', 'is-leaving');
 
-    const carId = rival?.carId || 'sedan';
-    const color = normalizeVehicleColor(rival?.carColor || DEFAULT_VEHICLE_COLOR);
-    const secondaryColor = normalizeVehicleSecondaryColor(
-      rival?.carSecondaryColor || DEFAULT_VEHICLE_SECONDARY_COLOR
-    );
-
-    plate.style.setProperty('--rival-onboarding-color', makeGhostColor(color));
-    preparePreview({ carId, color, secondaryColor });
+    const normalized = normalizedPreviewData(rival);
+    plate.style.setProperty('--rival-onboarding-color', makeGhostColor(normalized.color));
+    // Normally this is already the exact preview prepared at race-started. If the
+    // saved rival differs for any reason, prepare the corrected model without making
+    // the reveal wait for it.
+    preparePreview(normalized);
 
     showTimer = window.setTimeout(() => {
       showTimer = 0;
@@ -177,11 +214,16 @@ export function installRivalOnboarding() {
 
   window.addEventListener('turn:ui-state-change', (event) => {
     const reason = event.detail?.reason;
-    const rivals = globalThis.__turnRuntime?.state?.competitorLaps || [];
+    const state = globalThis.__turnRuntime?.state;
+    const rivals = state?.competitorLaps || [];
     const hasRival = rivals.length > 0;
 
-    if (reason === 'rivals-loaded' || reason === 'race-started') {
+    if (reason === 'rivals-loaded') {
       hadRival = hasRival;
+    } else if (reason === 'race-started') {
+      hadRival = hasRival;
+      if (!hasRival && state) preparePreview(state);
+      else if (hasRival) destroyPreview();
     } else if (reason === 'lap-completed') {
       if (!hadRival && hasRival) schedule(rivals[0]);
       hadRival = hasRival;
@@ -203,12 +245,12 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
   renderer.outputColorSpace = THREE.SRGBColorSpace;
   renderer.setPixelRatio(Math.min(devicePixelRatio, 1.35));
   renderer.setClearColor(0x000000, 0);
-  // Keep the hidden warm-up surface tiny. ResizeObserver supplies the real size only
-  // after the onboarding becomes visible, avoiding a reveal-time layout read.
-  renderer.setSize(1, 1, false);
+  // Warm at the maximum CSS preview size so the visible reveal does not discover a
+  // larger drawing buffer. This surface is still tiny compared with the race canvas.
+  renderer.setSize(PREVIEW_WARM_WIDTH, PREVIEW_WARM_HEIGHT, false);
   modelHost.appendChild(renderer.domElement);
 
-  const camera = new THREE.PerspectiveCamera(34, 1, 0.1, 60);
+  const camera = new THREE.PerspectiveCamera(34, PREVIEW_WARM_WIDTH / PREVIEW_WARM_HEIGHT, 0.1, 60);
   camera.position.set(7.8, 4.8, 8.8);
   camera.lookAt(0, 1.1, 0);
 
@@ -286,7 +328,7 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
       warmIdleHandle = globalThis.requestIdleCallback(() => {
         warmIdleHandle = 0;
         if (!disposed) callback();
-      }, { timeout: PREVIEW_PREP_IDLE_TIMEOUT_MS });
+      });
     } else {
       warmTimer = window.setTimeout(() => {
         warmTimer = 0;
@@ -297,8 +339,8 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
 
   const finishWarmup = () => {
     if (disposed || !visual) return;
-    // One 1×1 hidden render uploads geometry/textures after compilation. The visible
-    // first frame then has no new program or texture work to discover.
+    // One hidden render uploads geometry and textures after shader compilation. The
+    // first visible frame then has no new GPU program or texture work to discover.
     renderer.render(scene, camera);
     warmed = true;
     if (active && !animationFrame) {
@@ -311,8 +353,9 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
     if (disposed || !visual) return;
     try {
       if (typeof renderer.compileAsync === 'function') {
-        // KHR_parallel_shader_compile lets the separate onboarding context prepare the
-        // newer semantic paint shaders without stalling the racing frame.
+        // The native semantic paint system made these shaders more substantial than
+        // the original r40 onboarding. Compile them asynchronously in this separate
+        // WebGL context rather than on the CHASE YOUR BEST reveal frame.
         await renderer.compileAsync(scene, camera);
         if (disposed) return;
         runWarmupWhenIdle(finishWarmup);
@@ -326,9 +369,18 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
     } catch (error) {
       if (disposed) return;
       console.warn('TURN: first rival preview shader warm-up failed.', error);
-      // A failed optimization must not suppress onboarding; let the ordinary render path recover.
-      warmed = true;
-      if (active && !animationFrame) animationFrame = requestAnimationFrame(tick);
+      // Even the recovery compile stays off the reveal path. If it fails too, keep the
+      // onboarding copy and hide only the optional model.
+      runWarmupWhenIdle(() => {
+        if (disposed) return;
+        try {
+          renderer.compile(scene, camera);
+          finishWarmup();
+        } catch (fallbackError) {
+          console.warn('TURN: first rival preview fallback warm-up failed.', fallbackError);
+          onError?.(fallbackError);
+        }
+      });
     }
   };
 
@@ -358,8 +410,8 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
       active = true;
       lastTickAt = performance.now();
       if (!observer) resize();
-      // Never synchronously render on reveal. If warm-up is still finishing, the copy
-      // appears on time and the 3D model joins on a later animation frame.
+      // Never synchronously render on reveal. If warm-up is still finishing, CHASE
+      // YOUR BEST appears on time and the 3D ghost joins on a later animation frame.
       animationFrame = requestAnimationFrame(tick);
     },
     dispose() {

--- a/turn/ui/rival-onboarding.js
+++ b/turn/ui/rival-onboarding.js
@@ -11,6 +11,7 @@ import { createCarVisual } from '../vehicle/car-models.js?build=20260720-r22';
 const RESULT_TOAST_HANDOFF_MS = 4300;
 const ONBOARDING_VISIBLE_MS = 3200;
 const ONBOARDING_EXIT_MS = 180;
+const PREVIEW_PREP_IDLE_TIMEOUT_MS = 2400;
 const VIEWER_INITIAL_YAW = Math.PI - 0.55;
 const VIEWER_ROTATION_RADIANS_PER_SECOND = 0.144;
 const VIEWER_FRAME_INTERVAL_MS = 1000 / 30;
@@ -44,18 +45,35 @@ export function installRivalOnboarding() {
   let showTimer = 0;
   let hideTimer = 0;
   let exitTimer = 0;
+  let revealFrame = 0;
+  let preparationIdleHandle = 0;
+  let preparationTimer = 0;
+  let previewGeneration = 0;
   let preview = null;
 
   function clearTimers() {
     window.clearTimeout(showTimer);
     window.clearTimeout(hideTimer);
     window.clearTimeout(exitTimer);
+    cancelAnimationFrame(revealFrame);
     showTimer = 0;
     hideTimer = 0;
     exitTimer = 0;
+    revealFrame = 0;
+  }
+
+  function cancelPreparation() {
+    previewGeneration += 1;
+    if (preparationIdleHandle && typeof globalThis.cancelIdleCallback === 'function') {
+      globalThis.cancelIdleCallback(preparationIdleHandle);
+    }
+    window.clearTimeout(preparationTimer);
+    preparationIdleHandle = 0;
+    preparationTimer = 0;
   }
 
   function destroyPreview() {
+    cancelPreparation();
     preview?.dispose();
     preview = null;
     modelHost.replaceChildren();
@@ -90,11 +108,45 @@ export function installRivalOnboarding() {
     clearTimers();
     plate.hidden = false;
     plate.classList.remove('is-visible', 'is-leaving');
-    preview?.resize();
-    preview?.start();
-    void plate.offsetWidth;
-    plate.classList.add('is-visible');
+
+    // Cross a frame boundary instead of forcing layout with offsetWidth. The 3D preview
+    // has already been prepared independently; revealing the copy must never wait for it.
+    revealFrame = requestAnimationFrame(() => {
+      revealFrame = 0;
+      if (plate.hidden) return;
+      preview?.start();
+      plate.classList.add('is-visible');
+    });
     hideTimer = window.setTimeout(() => hide(), ONBOARDING_VISIBLE_MS);
+  }
+
+  function preparePreview({ carId, color, secondaryColor }) {
+    const generation = ++previewGeneration;
+    const prepare = () => {
+      preparationIdleHandle = 0;
+      preparationTimer = 0;
+      if (generation !== previewGeneration) return;
+
+      const nextPreview = createGhostPreview({ modelHost, carId, color, secondaryColor, onError() {
+        plate.classList.add('is-model-unavailable');
+      } });
+      if (generation !== previewGeneration) {
+        nextPreview.dispose();
+        return;
+      }
+      preview = nextPreview;
+      if (!plate.hidden) preview.start();
+    };
+
+    // Creating a second WebGL context and cloning the ghost scene is optional onboarding
+    // work. Give it the quiet result-toast handoff window instead of the lap-completion frame.
+    if (typeof globalThis.requestIdleCallback === 'function') {
+      preparationIdleHandle = globalThis.requestIdleCallback(prepare, {
+        timeout: PREVIEW_PREP_IDLE_TIMEOUT_MS
+      });
+    } else {
+      preparationTimer = window.setTimeout(prepare, 120);
+    }
   }
 
   function schedule(rival) {
@@ -110,9 +162,7 @@ export function installRivalOnboarding() {
     );
 
     plate.style.setProperty('--rival-onboarding-color', makeGhostColor(color));
-    preview = createGhostPreview({ modelHost, carId, color, secondaryColor, onError() {
-      plate.classList.add('is-model-unavailable');
-    } });
+    preparePreview({ carId, color, secondaryColor });
 
     showTimer = window.setTimeout(() => {
       showTimer = 0;
@@ -153,6 +203,9 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
   renderer.outputColorSpace = THREE.SRGBColorSpace;
   renderer.setPixelRatio(Math.min(devicePixelRatio, 1.35));
   renderer.setClearColor(0x000000, 0);
+  // Keep the hidden warm-up surface tiny. ResizeObserver supplies the real size only
+  // after the onboarding becomes visible, avoiding a reveal-time layout read.
+  renderer.setSize(1, 1, false);
   modelHost.appendChild(renderer.domElement);
 
   const camera = new THREE.PerspectiveCamera(34, 1, 0.1, 60);
@@ -172,23 +225,31 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
   let visual = null;
   let disposed = false;
   let active = false;
+  let warmed = false;
   let animationFrame = 0;
+  let warmIdleHandle = 0;
+  let warmTimer = 0;
   let lastTickAt = 0;
   let lastRenderAt = 0;
   let yaw = VIEWER_INITIAL_YAW;
   const reducedMotion = globalThis.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches === true;
 
+  const resizeTo = (width, height) => {
+    if (disposed || !width || !height) return;
+    camera.aspect = width / height;
+    camera.updateProjectionMatrix();
+    renderer.setSize(Math.round(width), Math.round(height), false);
+    if (active && warmed && reducedMotion) renderer.render(scene, camera);
+  };
+
   const resize = () => {
     if (disposed) return;
     const rect = modelHost.getBoundingClientRect();
-    if (!rect.width || !rect.height) return;
-    camera.aspect = rect.width / rect.height;
-    camera.updateProjectionMatrix();
-    renderer.setSize(Math.round(rect.width), Math.round(rect.height), false);
+    resizeTo(rect.width, rect.height);
   };
 
   const renderFrame = (now) => {
-    if (disposed) return;
+    if (disposed || !warmed) return;
     stage.rotation.y = yaw;
     stage.rotation.x = 0.08;
     if (visual) visual.position.y = reducedMotion ? 0 : Math.sin((now / 1000) * 2.1) * 0.04;
@@ -197,6 +258,10 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
 
   const tick = (now) => {
     if (!active || disposed) return;
+    if (!warmed) {
+      animationFrame = requestAnimationFrame(tick);
+      return;
+    }
     const dt = Math.min(0.1, Math.max(0, (now - lastTickAt) / 1000));
     lastTickAt = now;
     if (!reducedMotion) yaw += dt * VIEWER_ROTATION_RADIANS_PER_SECOND;
@@ -204,11 +269,68 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
       lastRenderAt = now;
       renderFrame(now);
     }
-    animationFrame = requestAnimationFrame(tick);
+    animationFrame = reducedMotion ? 0 : requestAnimationFrame(tick);
   };
 
-  const observer = typeof ResizeObserver === 'function' ? new ResizeObserver(resize) : null;
+  const observer = typeof ResizeObserver === 'function'
+    ? new ResizeObserver((entries) => {
+      const rect = entries[0]?.contentRect;
+      if (rect) resizeTo(rect.width, rect.height);
+    })
+    : null;
   observer?.observe(modelHost);
+
+  const runWarmupWhenIdle = (callback) => {
+    if (disposed) return;
+    if (typeof globalThis.requestIdleCallback === 'function') {
+      warmIdleHandle = globalThis.requestIdleCallback(() => {
+        warmIdleHandle = 0;
+        if (!disposed) callback();
+      }, { timeout: PREVIEW_PREP_IDLE_TIMEOUT_MS });
+    } else {
+      warmTimer = window.setTimeout(() => {
+        warmTimer = 0;
+        if (!disposed) callback();
+      }, 120);
+    }
+  };
+
+  const finishWarmup = () => {
+    if (disposed || !visual) return;
+    // One 1×1 hidden render uploads geometry/textures after compilation. The visible
+    // first frame then has no new program or texture work to discover.
+    renderer.render(scene, camera);
+    warmed = true;
+    if (active && !animationFrame) {
+      lastTickAt = performance.now();
+      animationFrame = requestAnimationFrame(tick);
+    }
+  };
+
+  const warmRenderer = async () => {
+    if (disposed || !visual) return;
+    try {
+      if (typeof renderer.compileAsync === 'function') {
+        // KHR_parallel_shader_compile lets the separate onboarding context prepare the
+        // newer semantic paint shaders without stalling the racing frame.
+        await renderer.compileAsync(scene, camera);
+        if (disposed) return;
+        runWarmupWhenIdle(finishWarmup);
+      } else {
+        runWarmupWhenIdle(() => {
+          if (disposed) return;
+          renderer.compile(scene, camera);
+          finishWarmup();
+        });
+      }
+    } catch (error) {
+      if (disposed) return;
+      console.warn('TURN: first rival preview shader warm-up failed.', error);
+      // A failed optimization must not suppress onboarding; let the ordinary render path recover.
+      warmed = true;
+      if (active && !animationFrame) animationFrame = requestAnimationFrame(tick);
+    }
+  };
 
   void createCarVisual({
     carId,
@@ -221,15 +343,12 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
     if (disposed) return;
     visual = next;
     stage.add(visual);
-    resize();
-    if (active) renderFrame(performance.now());
+    void warmRenderer();
   }).catch((error) => {
     if (disposed) return;
     console.warn('TURN: first rival could not load in the onboarding viewer.', error);
     onError?.(error);
   });
-
-  resize();
 
   return {
     renderer,
@@ -237,18 +356,21 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
     start() {
       if (disposed || active) return;
       active = true;
-      resize();
-      const now = performance.now();
-      lastTickAt = now;
-      lastRenderAt = 0;
-      renderFrame(now);
-      if (!reducedMotion) animationFrame = requestAnimationFrame(tick);
+      lastTickAt = performance.now();
+      if (!observer) resize();
+      // Never synchronously render on reveal. If warm-up is still finishing, the copy
+      // appears on time and the 3D model joins on a later animation frame.
+      animationFrame = requestAnimationFrame(tick);
     },
     dispose() {
       if (disposed) return;
       disposed = true;
       active = false;
       cancelAnimationFrame(animationFrame);
+      if (warmIdleHandle && typeof globalThis.cancelIdleCallback === 'function') {
+        globalThis.cancelIdleCallback(warmIdleHandle);
+      }
+      window.clearTimeout(warmTimer);
       observer?.disconnect();
       renderer.dispose();
       renderer.domElement.remove();


### PR DESCRIPTION
## Problem

The first-rival **CHASE YOUR BEST** onboarding still created a separate Three.js WebGL context and performed its first visible render at reveal time. That was cheap when the feature shipped in r40, but TURN's newer semantic vehicle shaders make first-program compilation in a second WebGL context noticeably more expensive. The component also retained an old forced-layout animation restart.

## Fix

- when a race starts with zero rivals, begin preparing the exact current car/paint preview before the first rival exists, instead of waiting for lap completion
- use `WebGLRenderer.compileAsync()` for the separate preview context when available
- warm one hidden small preview frame so shader programs, geometry and textures are ready before the onboarding can become visible
- keep the rotating 3D ghost and its saved car/body/secondary paint identity
- if preparation is still incomplete, reveal **CHASE YOUR BEST** on time and let the optional 3D ghost join on a later animation frame rather than blocking the UI
- remove the reveal-time forced layout; entrance now crosses `requestAnimationFrame`
- bridge the existing r183 onboarding module URL to fresh `r209-prewarmed-ghost` in TURN and TURN LAB so installed PWAs fetch the fix
- add hot-path regression coverage forbidding reveal-time layout/GPU compilation and guarding the cache bridge

No race physics, rival storage, onboarding timing or presentation copy is changed.

## Verification

- first-rival onboarding regression passes with the exact saved ghost model and paints
- runtime hot-path regression verifies CHASE YOUR BEST does no forced layout or first-time WebGL work on reveal
- full TURN regression suite passes end-to-end
- challenge, admin unlock, Chromatic Camouflage and color-accessibility workflows all pass