### PR TITLE
Align THE LOT with Trophy Road car unlock order

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -85,7 +85,7 @@
         "/turn/render/covered-rendering.js?build=20260823-r183": "/turn/render/covered-rendering.js?build=20260823-r183&revision=r164-long-session-robustness",
         "/turn/ui/rival-onboarding.js?build=20260823-r183": "/turn/ui/rival-onboarding.js?build=20260823-r183&revision=r209-prewarmed-ghost",
         "/turn/progression/lot-paint-reward.js?revision=r206-pwa-color": "/turn/progression/lot-paint-reward.js?revision=r208-secondary-color-import",
-        "/turn/garage/lot-showroom-experiment.js?revision=r206-race-before-locks": "/turn/garage/lot-showroom-experiment.js?revision=r179-native-car-surfaces",
+        "/turn/garage/lot-showroom-experiment.js?revision=r206-race-before-locks": "/turn/garage/lot-showroom-experiment.js?revision=r210-trophy-unlock-order",
         "/turn/vehicle/catalog.js?build=20260804-r157-factory-colors": "/turn/vehicle/catalog.js?revision=r179-native-car-surfaces",
         "/turn/vehicle/catalog.js?build=20260720-r20&revision=r588-canonical-attributes": "/turn/vehicle/catalog.js?revision=r179-native-car-surfaces",
         "/turn/vehicle/catalog.js?revision=r164-vintage-rally-polish": "/turn/vehicle/catalog.js?revision=r179-native-car-surfaces",

--- a/turn-lab/tests/paint-lock-observer-production.mjs
+++ b/turn-lab/tests/paint-lock-observer-production.mjs
@@ -146,10 +146,17 @@ assert.doesNotMatch(paintGate, /colors\.setAttribute\('role', 'button'\)|colors\
 const orderMatch = showroom.match(/export const LOT_CAR_ORDER = Object\.freeze\(\[([\s\S]*?)\]\);/);
 assert.ok(orderMatch, 'The showroom must expose one canonical car order');
 const order = [...orderMatch[1].matchAll(/'([^']+)'/g)].map((match) => match[1]);
-assert.ok(order.indexOf('race') < order.indexOf('firetruck'),
-  'Race Car must be the final base car before Trophy Road/emergency locked cars');
-assert.equal(order[order.indexOf('race') + 1], 'firetruck',
-  'Race Car and Fire Truck must form the visible/keyboard entitlement boundary');
+const lockedTail = [
+  'vintage-racer',
+  'race-future',
+  'firetruck',
+  'ambulance',
+  'police',
+  'monster-truck',
+  'toy-racer'
+];
+assert.deepEqual(order.slice(order.indexOf('race') + 1), lockedTail,
+  'The horizontal Lot and its keyboard/VoiceOver order must follow the Trophy Road vehicle unlock sequence');
 
 // --- Fresh module identities for already-installed PWAs -----------------------
 assert.match(lotRuntime, /lot-paint-reward\.js\?revision=r206-pwa-color/,

--- a/turn-lab/tests/paint-lock-observer-production.mjs
+++ b/turn-lab/tests/paint-lock-observer-production.mjs
@@ -189,8 +189,8 @@ assert.equal(
 );
 assert.equal(
   imports['/turn/garage/lot-showroom-experiment.js?revision=r206-race-before-locks'],
-  '/turn/garage/lot-showroom-experiment.js?revision=r179-native-car-surfaces',
-  'Installed PWAs must refetch the showroom module that creates paint controls'
+  '/turn/garage/lot-showroom-experiment.js?revision=r210-trophy-unlock-order',
+  'Installed PWAs must refetch the showroom module when the visible Trophy Road order changes'
 );
 for (const staleCatalogSpecifier of [
   '/turn/vehicle/catalog.js?build=20260804-r157-factory-colors',

--- a/turn/garage/lot-showroom-experiment.js
+++ b/turn/garage/lot-showroom-experiment.js
@@ -35,11 +35,11 @@ export const LOT_CAR_ORDER = Object.freeze([
   'convertible',
   'sedan-sports',
   'race',
+  'vintage-racer',
+  'race-future',
   'firetruck',
   'ambulance',
   'police',
-  'vintage-racer',
-  'race-future',
   'monster-truck',
   'toy-racer'
 ]);

--- a/turn/index.html
+++ b/turn/index.html
@@ -96,7 +96,7 @@
         "/turn/render/covered-rendering.js?build=20260823-r183": "/turn/render/covered-rendering.js?build=20260823-r183&revision=r164-long-session-robustness",
         "/turn/ui/rival-onboarding.js?build=20260823-r183": "/turn/ui/rival-onboarding.js?build=20260823-r183&revision=r209-prewarmed-ghost",
         "/turn/progression/lot-paint-reward.js?revision=r206-pwa-color": "/turn/progression/lot-paint-reward.js?revision=r208-secondary-color-import",
-        "/turn/garage/lot-showroom-experiment.js?revision=r206-race-before-locks": "/turn/garage/lot-showroom-experiment.js?revision=r179-native-car-surfaces",
+        "/turn/garage/lot-showroom-experiment.js?revision=r206-race-before-locks": "/turn/garage/lot-showroom-experiment.js?revision=r210-trophy-unlock-order",
         "/turn/vehicle/catalog.js?build=20260804-r157-factory-colors": "/turn/vehicle/catalog.js?revision=r179-native-car-surfaces",
         "/turn/vehicle/catalog.js?build=20260720-r20&revision=r588-canonical-attributes": "/turn/vehicle/catalog.js?revision=r179-native-car-surfaces",
         "/turn/vehicle/catalog.js?revision=r164-vintage-rally-polish": "/turn/vehicle/catalog.js?revision=r179-native-car-surfaces",


### PR DESCRIPTION
## What changed

- reorder the locked-car tail in the horizontal THE LOT carousel to match the current Trophy Road sequence
- keep the base cars through Race Car unchanged
- locked sequence is now: Vintage Racer → Future Racer → Fire Truck → Ambulance → Police Car → Monster Truck → Rally Racer
- because keyboard/VoiceOver traversal follows the same canonical `LOT_CAR_ORDER`, non-visual and arrow-key browsing now matches the visible order too
- cache-bust the showroom module in TURN and TURN LAB so installed PWAs do not retain the previous ordering
- strengthen the Lot regression to assert the exact locked-car sequence and fresh cache identity

No car IDs, unlock thresholds, saves, stats, paint state, or reward ownership are changed.