### PR TITLE
Stop YOUR TURN preview from locking portrait steering orientation

### DIFF
--- a/turn-tests/yourturn-motion-start-guard-production.mjs
+++ b/turn-tests/yourturn-motion-start-guard-production.mjs
@@ -1,18 +1,19 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [index, app, session] = await Promise.all([
+const [index, app, session, orientationCompat] = await Promise.all([
   fs.readFile(new URL('../yourturn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../yourturn/app.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../yourturn/session.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../yourturn/session.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/orientation-compat.js', import.meta.url), 'utf8')
 ]);
 
 assert.doesNotMatch(index, /start-axis-guard\.js/,
   'YOUR TURN must not load a challenge-specific motion-axis guard');
 assert.match(index, /\/yourturn\/app\.js\?revision=r593-canonical-motion/,
   'YOUR TURN must cache-bust the canonical-motion app handoff');
-assert.match(index, /\/yourturn\/session\.js\?revision=r593-canonical-motion/,
-  'YOUR TURN must cache-bust the session that no longer samples motion itself');
+assert.match(index, /\/yourturn\/session\.js\?revision=r593-canonical-motion-r594-preview-orientation/,
+  'YOUR TURN must load the preview-safe session under a fresh cache identity');
 
 assert.match(app, /installMotionLifecycleBridge/,
   'YOUR TURN must install TURN’s production motion lifecycle bridge');
@@ -29,9 +30,23 @@ assert.doesNotMatch(session, /neutralRoll\s*=|horizonRollReference\s*=/,
 assert.doesNotMatch(app, /deferResumeUntil/,
   'YOUR TURN hard pause must not carry a steering-specific resume barrier');
 
+assert.match(
+  orientationCompat,
+  /setGameplayActive\(Boolean\(event\.detail\?\.running\)\)/,
+  'The production TURN orientation guard must continue to derive gameplay lock state from running UI events'
+);
+
+const launchBlock = session.match(/async function launch\(\) \{([\s\S]*?)\n  function setChallenge/)?.[1] || '';
+const previewModePublish = launchBlock.indexOf('runtime.setGameMode(GAME_MODE.STAGED)');
+const previewRunningEnable = launchBlock.indexOf('runtime.state.running = true');
+assert.ok(previewModePublish >= 0 && previewRunningEnable >= 0,
+  'YOUR TURN invitation preview must explicitly stage the runtime and enable its render loop');
+assert.ok(previewModePublish < previewRunningEnable,
+  'YOUR TURN must publish its preview mode while running is still false so TURN does not lock portrait orientation as gameplay');
+
 assert.match(session, /await nextPaint\(\);[\s\S]*return startAcceptedRace\(\);/,
   'YOUR TURN may wait for the landscape UI to paint before handing off to TURN');
 assert.match(session, /await raceSession\.startGame\(access\.fullscreenPromise\)/,
   'YOUR TURN must hand race start directly to TURN’s canonical race session');
 
-console.log('YOUR TURN canonical motion ownership contract passed.');
+console.log('YOUR TURN canonical motion ownership and preview orientation-lock contract passed.');

--- a/yourturn/index.html
+++ b/yourturn/index.html
@@ -67,7 +67,7 @@
         "/turn/vehicle/catalog.js?revision=r164-vintage-rally-polish": "/turn/vehicle/catalog.js?revision=r179-native-car-surfaces",
         "/turn/vehicle/car-models.js?build=20260720-r19": "/turn/vehicle/emergency-livery-models.js?build=20260823-r183",
         "/turn/vehicle/car-models.js?build=20260720-r22": "/turn/vehicle/emergency-livery-models.js?build=20260823-r183",
-        "/yourturn/session.js?revision=r3": "/yourturn/session.js?revision=r594-preview-orientation",
+        "/yourturn/session.js?revision=r3": "/yourturn/session.js?revision=r593-canonical-motion-r594-preview-orientation",
         "/yourturn/ui.js?revision=r3": "/yourturn/ui.js?revision=r10",
         "/yourturn/protocol.js?revision=r3": "/yourturn/protocol-social.js?revision=r1",
         "/yourturn/scene.js?revision=r1": "/yourturn/scene.js?revision=r7"

--- a/yourturn/index.html
+++ b/yourturn/index.html
@@ -67,7 +67,7 @@
         "/turn/vehicle/catalog.js?revision=r164-vintage-rally-polish": "/turn/vehicle/catalog.js?revision=r179-native-car-surfaces",
         "/turn/vehicle/car-models.js?build=20260720-r19": "/turn/vehicle/emergency-livery-models.js?build=20260823-r183",
         "/turn/vehicle/car-models.js?build=20260720-r22": "/turn/vehicle/emergency-livery-models.js?build=20260823-r183",
-        "/yourturn/session.js?revision=r3": "/yourturn/session.js?revision=r593-canonical-motion",
+        "/yourturn/session.js?revision=r3": "/yourturn/session.js?revision=r594-preview-orientation",
         "/yourturn/ui.js?revision=r3": "/yourturn/ui.js?revision=r10",
         "/yourturn/protocol.js?revision=r3": "/yourturn/protocol-social.js?revision=r1",
         "/yourturn/scene.js?revision=r1": "/yourturn/scene.js?revision=r7"

--- a/yourturn/session.js
+++ b/yourturn/session.js
@@ -88,12 +88,17 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
     useChallengeField();
     document.body.classList.add('yourturn-active', 'yourturn-preview');
 
+    // The invitation preview needs TURN's render loop, but it is not gameplay.
+    // Publish STAGED while running is still false so TURN's orientation guard stays
+    // unlocked through the portrait invitation and portrait -> landscape rotation.
+    // The canonical race-started event is the first running:true state event and is
+    // therefore the only point where TURN locks the gameplay steering orientation.
+    runtime.setGameMode(GAME_MODE.STAGED);
     runtime.state.running = true;
     runtime.state.lastFrame = performance.now();
     runtime.state.touchGas = false;
     runtime.state.touchBrake = false;
     runtime.state.velocity.set(0, 0, 0);
-    runtime.setGameMode(GAME_MODE.STAGED);
     runtime.playerCar.visible = false;
 
     state.scene = createChallengeScene({


### PR DESCRIPTION
## Problem
After #639, YOUR TURN still shows the same severe steering failure on multiple physical devices, while the corrected yellow BOOST confirms the current bundle is deployed.

## Root cause
This is deterministic YOUR TURN state orchestration, not a device-specific sensor bug.

`yourturn/session.js` starts the animated invitation preview by doing:

1. `runtime.state.running = true`
2. `runtime.setGameMode(GAME_MODE.STAGED)`

`runtime.setGameMode()` publishes TURN's canonical `turn:ui-state-change` event including `running: state.running`.

TURN's production `orientation-compat.js` intentionally treats any such event with `running: true` as gameplay activation and freezes the resolved steering orientation for the race. In YOUR TURN this event happens while the invitation is still portrait, before the user accepts and rotates to landscape. Because gameplay is already considered active, the later orientation change follows TURN's active-race path rather than resetting pre-race axis calibration.

So #639 correctly removed parallel motion engines, but exposed the actual lifecycle bug: **YOUR TURN was asking TURN to lock gameplay orientation during its non-gameplay preview.**

## Fix
- publish `GAME_MODE.STAGED` while `runtime.state.running` is still false;
- only then set `running = true` silently so the canonical TURN render loop can animate the invitation;
- leave the actual `raceSession.startGame()` as the first `running: true` UI-state publication, after YOUR TURN has rotated to landscape;
- cache-bust only the YOUR TURN session;
- add a regression contract that ties this ordering explicitly to TURN's production `setGameplayActive(Boolean(event.detail?.running))` behavior.

## Scope
No production `turn/*` file changes. No new motion listener, calibration, axis shim, or steering math. This only corrects YOUR TURN's preview/race lifecycle ordering.

## Expected behavior
The invitation can still animate in portrait. TURN's orientation guard remains in pre-game state until the accepted race starts in landscape, so the same canonical steering engine used by TURN locks against the landscape orientation rather than the invitation's portrait orientation.