### PR TITLE
Auto-recalibrate YOUR TURN after landscape handoff

### DIFF
--- a/turn-tests/yourturn-engine-parity-production.mjs
+++ b/turn-tests/yourturn-engine-parity-production.mjs
@@ -139,8 +139,8 @@ assert.match(
 );
 assert.match(
   yourTurnImportMap.imports?.['/yourturn/session.js?revision=r3'] || '',
-  /r593-canonical-motion/,
-  'YOUR TURN must cache-bust the canonical-motion session handoff'
+  /r595-landscape-recalibrate/,
+  'YOUR TURN must cache-bust the canonical-motion session handoff while preserving canonical TURN steering ownership'
 );
 
 console.log('YOUR TURN production steering, controls and vehicle parity contract passed.');

--- a/turn-tests/yourturn-motion-start-guard-production.mjs
+++ b/turn-tests/yourturn-motion-start-guard-production.mjs
@@ -12,8 +12,8 @@ assert.doesNotMatch(index, /start-axis-guard\.js/,
   'YOUR TURN must not load a challenge-specific motion-axis guard');
 assert.match(index, /\/yourturn\/app\.js\?revision=r593-canonical-motion/,
   'YOUR TURN must cache-bust the canonical-motion app handoff');
-assert.match(index, /\/yourturn\/session\.js\?revision=r593-canonical-motion-r594-preview-orientation/,
-  'YOUR TURN must load the preview-safe session under a fresh cache identity');
+assert.match(index, /\/yourturn\/session\.js\?revision=r595-landscape-recalibrate/,
+  'YOUR TURN must load the post-landscape recalibration session under a fresh cache identity');
 
 assert.match(app, /installMotionLifecycleBridge/,
   'YOUR TURN must install TURN’s production motion lifecycle bridge');
@@ -48,5 +48,19 @@ assert.match(session, /await nextPaint\(\);[\s\S]*return startAcceptedRace\(\);/
   'YOUR TURN may wait for the landscape UI to paint before handing off to TURN');
 assert.match(session, /await raceSession\.startGame\(access\.fullscreenPromise\)/,
   'YOUR TURN must hand race start directly to TURN’s canonical race session');
+assert.match(session, /const POST_LANDSCAPE_RECALIBRATE_DELAY_MS = 360/,
+  'YOUR TURN must allow fresh landscape sensor readings after TURN finishes fullscreen/orientation locking');
 
-console.log('YOUR TURN canonical motion ownership and preview orientation-lock contract passed.');
+const startBlock = session.match(/async function startAcceptedRace\(\) \{([\s\S]*?)\n  function handleLapResult/)?.[1] || '';
+const canonicalStart = startBlock.indexOf('await raceSession.startGame(access.fullscreenPromise)');
+const settleDelay = startBlock.indexOf('POST_LANDSCAPE_RECALIBRATE_DELAY_MS');
+const canonicalRecalibrate = startBlock.indexOf("document.querySelector('#calibrateButton')?.click()");
+const controlsVisible = startBlock.indexOf('ui.showRaceChrome()');
+assert.ok(canonicalStart >= 0 && settleDelay >= 0 && canonicalRecalibrate >= 0 && controlsVisible >= 0,
+  'YOUR TURN motion start must include canonical start, landscape settling, canonical recalibration and control reveal');
+assert.ok(canonicalStart < settleDelay && settleDelay < canonicalRecalibrate && canonicalRecalibrate < controlsVisible,
+  'YOUR TURN must recalibrate only after landscape start settles and before controls become interactive');
+assert.match(startBlock, /if \(access\.mode === 'motion' && runtime\.state\.sensorMode\)/,
+  'Automatic post-landscape recalibration must run only for motion steering');
+
+console.log('YOUR TURN canonical motion ownership, preview orientation-lock and landscape recalibration contract passed.');

--- a/turn-tests/yourturn-production.mjs
+++ b/turn-tests/yourturn-production.mjs
@@ -48,7 +48,7 @@ assert.match(indexSource, /\/yourturn\/storage-bootstrap\.js/);
 assert.match(indexSource, /\/yourturn\/app\.js\?revision=r593-canonical-motion/);
 assert.match(indexSource, /growing-challenge\.css/);
 assert.match(indexSource, /racer-labels-bootstrap\.js/);
-assert.match(indexSource, /session\.js\?revision=r3[^\n]*session\.js\?revision=r593-canonical-motion/,
+assert.match(indexSource, /session\.js\?revision=r3[^\n]*session\.js\?revision=r595-landscape-recalibrate/,
   'The page must cache-bust the current YOUR TURN session while app.js stays on canonical TURN runtime modules');
 assert.match(indexSource, /Your name in the challenge/);
 assert.match(indexSource, /id="yourTurnChallengeButton"[\s\S]*>THE CHALLENGE<\/button>/);
@@ -101,7 +101,7 @@ assert.match(sessionSource, /navigator\.clipboard/);
 assert.doesNotMatch(sessionSource, /ghost/i,
   'Recipient-facing YOUR TURN challenge code describes people and cars, not ghosts');
 assert.doesNotMatch(sessionSource, /devicemotion|neutralRoll\s*=|horizonRollReference\s*=/,
-  'YOUR TURN session orchestration must leave sensor sampling and calibration to TURN');
+  'YOUR TURN session orchestration must leave sensor sampling and calibration state writes to TURN');
 
 assert.match(uiSource, /action\.share/);
 assert.match(uiSource, /action\.game/);

--- a/turn-tests/yourturn-short-links-production.mjs
+++ b/turn-tests/yourturn-short-links-production.mjs
@@ -108,7 +108,7 @@ assert.match(turnShareSource, /Preparing challenge link…/,
   'The composer should announce the short-link preparation delay');
 assert.match(turnIndex, /your-turn-share-bootstrap\.js\?revision=r2/,
   'TURN must cache-bust the short-link sharing bootstrap');
-assert.match(yourTurnIndex, /session\.js\?revision=r3[^\n]*session\.js\?revision=r593-canonical-motion/,
+assert.match(yourTurnIndex, /session\.js\?revision=r3[^\n]*session\.js\?revision=r595-landscape-recalibrate/,
   'YOUR TURN must cache-bust the current session that understands short IDs');
 
 console.log('TURN and YOUR TURN short snapshot links, readback and self-contained fallback regression passed.');

--- a/yourturn/index.html
+++ b/yourturn/index.html
@@ -67,7 +67,7 @@
         "/turn/vehicle/catalog.js?revision=r164-vintage-rally-polish": "/turn/vehicle/catalog.js?revision=r179-native-car-surfaces",
         "/turn/vehicle/car-models.js?build=20260720-r19": "/turn/vehicle/emergency-livery-models.js?build=20260823-r183",
         "/turn/vehicle/car-models.js?build=20260720-r22": "/turn/vehicle/emergency-livery-models.js?build=20260823-r183",
-        "/yourturn/session.js?revision=r3": "/yourturn/session.js?revision=r593-canonical-motion-r594-preview-orientation",
+        "/yourturn/session.js?revision=r3": "/yourturn/session.js?revision=r595-landscape-recalibrate",
         "/yourturn/ui.js?revision=r3": "/yourturn/ui.js?revision=r10",
         "/yourturn/protocol.js?revision=r3": "/yourturn/protocol-social.js?revision=r1",
         "/yourturn/scene.js?revision=r1": "/yourturn/scene.js?revision=r7"

--- a/yourturn/session.js
+++ b/yourturn/session.js
@@ -28,6 +28,7 @@ import { createChallengeScene } from '/yourturn/scene.js?revision=r1';
 import { aboutTurnHtml, escapeHtml, newcomerAssistiveText } from '/yourturn/ui.js?revision=r3';
 
 const RACER_ID_KEY = 'yourturn-racer-id-v1';
+const POST_LANDSCAPE_RECALIBRATE_DELAY_MS = 360;
 
 export function readYourTurnRequest(locationRef = globalThis.location) {
   const query = new URLSearchParams(locationRef?.search || '');
@@ -306,6 +307,16 @@ export function createYourTurnSession({ runtime, raceSession, ui, animation, req
     useChallengeField();
     const access = state.pendingAccess || raceSession.prepareManualAccess();
     await raceSession.startGame(access.fullscreenPromise);
+
+    // TURN's built-in 220 ms start centering can run while YOUR TURN is still
+    // completing its portrait -> landscape fullscreen/orientation handoff. Keep the
+    // staged scene paused, let fresh landscape motion readings arrive, then invoke
+    // TURN's existing RECALIBRATE control once before the player can start driving.
+    if (access.mode === 'motion' && runtime.state.sensorMode) {
+      await new Promise((resolve) => setTimeout(resolve, POST_LANDSCAPE_RECALIBRATE_DELAY_MS));
+      document.querySelector('#calibrateButton')?.click();
+    }
+
     runtime.setGameMode(GAME_MODE.STAGED);
     runtime.state.velocity.set(0, 0, 0);
     stopDrivingInputs();


### PR DESCRIPTION
## Problem
After #640, YOUR TURN steering itself works, but accepting a challenge in portrait and rotating to landscape can leave steering pinned at maximum until the player presses RECALIBRATE manually.

## Cause
TURN's canonical `startGame()` schedules its automatic neutral centering 220 ms after start begins, before `startGame()` has necessarily finished fullscreen/orientation locking. That is fine for TURN's normal landscape-first race flow, but YOUR TURN explicitly starts motion permission in portrait and then rotates into landscape. The 220 ms center can therefore sample a transitional orientation.

The fact that the existing RECALIBRATE button immediately fixes the state confirms that the canonical steering engine and orientation mapping are now correct; only the neutral timing is wrong.

## Fix
- keep YOUR TURN's staged scene paused after canonical `raceSession.startGame()` returns;
- for motion steering only, wait 360 ms for fresh landscape sensor readings;
- invoke TURN's existing `#calibrateButton` once;
- only then reveal/resume interactive race controls;
- cache-bust the YOUR TURN session;
- extend the motion ownership regression to require this ordering.

## Scope
No production `turn/*` changes. No new device-motion listener. No direct writes to TURN's neutral/roll state. The fix deliberately reuses the same canonical RECALIBRATE path that already works when pressed manually.