### PR TITLE
Create portrait motion-balancing game NO TILT

### DIFF
--- a/.github/workflows/notilt-tests.yml
+++ b/.github/workflows/notilt-tests.yml
@@ -1,0 +1,33 @@
+name: NO TILT tests
+
+on:
+  push:
+    paths:
+      - 'notilt/**'
+      - '.github/workflows/notilt-tests.yml'
+  pull_request:
+    paths:
+      - 'notilt/**'
+      - '.github/workflows/notilt-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Syntax check modules
+        run: |
+          node --check notilt/app.mjs
+          node --check notilt/audio.mjs
+          node --check notilt/game-core.mjs
+          node --check notilt/game-view.mjs
+          node --check notilt/input.mjs
+      - name: Run NO TILT regression suite
+        run: node --test notilt/*.test.mjs

--- a/notilt/README.md
+++ b/notilt/README.md
@@ -1,0 +1,39 @@
+# NO TILT
+
+Portrait-first motion balancing game at `https://enkel.design/notilt/`.
+
+## First playable scope
+
+- **EASY — THE BROOM:** a forgiving two-axis inverted balance on a broad concave dish.
+- **MEDIUM — MARKER ON MARKER:** a smaller pivot, faster instability and stronger drift.
+- **HARD — THE SIGNAL:** the same balance problem with side projectiles. A quick upward phone movement jumps; the visible JUMP control and Space key are equivalent fallbacks.
+- Five flow/combo stages progressively raise score multiplication, procedural music density, lighting, color and attack pressure.
+- Motion permission is requested from the explicit start action. Calibration uses the current portrait grip and reruns automatically after returning from landscape.
+- TOUCH MODE and arrow/WASD controls run through the same physics as motion input.
+
+## Sensor mapping
+
+Gravity is transformed into screen space before roll and pitch are calculated. The calibrated pose becomes neutral. Roughly 17° side tilt or 13° fore/aft tilt reaches full control. HARD detects a short vertical acceleration impulse from `DeviceMotionEvent.acceleration`, with a high-pass gravity fallback for devices that do not expose linear acceleration.
+
+The control is intentionally counter-steering: move the yellow input dot opposite the pink falling-object dot.
+
+## YOUR TURN groundwork
+
+Only the actual game ships in this first version. The best run for each difficulty is stored under `notilt.best-runs.v1` with:
+
+- mode, seed, survival time, score and maximum combo;
+- a 15 Hz compact frame stream containing `[milliseconds, inputX, inputY, angleX, angleY, jumpHeight]`;
+- a schema version and recording timestamp.
+
+That is enough to add deterministic ghost playback and self-contained challenge-link encoding without changing the game physics.
+
+## Verification
+
+```sh
+node --test notilt/*.test.mjs
+node --check notilt/app.mjs
+node --check notilt/audio.mjs
+node --check notilt/game-core.mjs
+node --check notilt/game-view.mjs
+node --check notilt/input.mjs
+```

--- a/notilt/app.mjs
+++ b/notilt/app.mjs
@@ -1,0 +1,685 @@
+import {
+  FLOW_STAGES,
+  createRunSnapshot,
+  createRunState,
+  formatRunTime,
+  getModeConfig,
+  stepBalance
+} from './game-core.mjs';
+import { NoTiltInput } from './input.mjs';
+import { NoTiltAudio } from './audio.mjs';
+import { NoTiltView } from './game-view.mjs';
+
+const BEST_RUNS_KEY = 'notilt.best-runs.v1';
+const RECORD_INTERVAL_SECONDS = 1 / 15;
+const $ = (selector) => document.querySelector(selector);
+
+const elements = {
+  scene: $('#scene'),
+  home: $('#home'),
+  hud: $('#hud'),
+  time: $('#timeValue'),
+  score: $('#scoreValue'),
+  best: $('#bestValue'),
+  flowCard: $('#flowCard'),
+  flowName: $('#flowName'),
+  combo: $('#comboValue'),
+  flowProgress: $('#flowProgress'),
+  flowFill: $('#flowFill'),
+  callout: $('#callout'),
+  startStatus: $('#startStatus'),
+  startTilt: $('#startTilt'),
+  startTouch: $('#startTouch'),
+  countdown: $('#countdown'),
+  countdownTitle: $('#countdownTitle'),
+  countdownHint: $('#countdownHint'),
+  countdownMode: $('#countdownMode'),
+  balanceControl: $('#balanceControl'),
+  balanceOrb: $('#balanceOrb'),
+  leanDot: $('#leanDot'),
+  inputDot: $('#inputDot'),
+  controlHint: $('#controlHint'),
+  controls: $('#gameControls'),
+  calibrate: $('#calibrateButton'),
+  pause: $('#pauseButton'),
+  sound: $('#soundButton'),
+  jump: $('#jumpButton'),
+  pauseDialog: $('#pauseDialog'),
+  resume: $('#resumeButton'),
+  pauseRecenter: $('#pauseRecenterButton'),
+  leave: $('#leaveButton'),
+  resultDialog: $('#resultDialog'),
+  resultKicker: $('#resultKicker'),
+  resultTitle: $('#resultTitle'),
+  resultTime: $('#resultTime'),
+  resultScore: $('#resultScore'),
+  resultCombo: $('#resultCombo'),
+  resultCopy: $('#resultCopy'),
+  again: $('#againButton'),
+  changeMode: $('#changeModeButton'),
+  srStatus: $('#screenReaderStatus')
+};
+
+const reducedMotion = globalThis.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
+const audio = new NoTiltAudio();
+const input = new NoTiltInput({
+  onModeChange: syncControlMode,
+  onJumpSignal: (source) => {
+    if (phase === 'playing' && selectedMode === 'hard' && source === 'lift') {
+      showCallout('LIFT!');
+    }
+  }
+});
+let view = null;
+
+try {
+  view = new NoTiltView(elements.scene, { reducedMotion });
+} catch (error) {
+  elements.startStatus.textContent = 'This browser could not start the 3D arena. Try current Safari, Chrome, Edge or Firefox.';
+  elements.startStatus.classList.add('is-warning');
+  elements.startTilt.disabled = true;
+  elements.startTouch.disabled = true;
+  console.error(error);
+}
+
+let phase = 'home';
+let selectedMode = 'easy';
+let controlMode = 'motion';
+let runState = null;
+let runFrames = [];
+let lastFrameAt = performance.now();
+let lastRecordAt = -Infinity;
+let lastHudAt = -Infinity;
+let lastScreenReaderAt = -Infinity;
+let calloutTimer = 0;
+let countdownToken = 0;
+let pausedByOrientation = false;
+let pointerActive = false;
+let bestRuns = readBestRuns();
+const heldKeys = new Set();
+
+bindEvents();
+syncModeCards();
+syncControlMode('motion');
+syncMotionAvailability();
+view?.setMode(selectedMode);
+document.documentElement.dataset.notiltReady = 'true';
+requestAnimationFrame(frame);
+
+function bindEvents() {
+  document.querySelectorAll('input[name="mode"]').forEach((radio) => {
+    radio.addEventListener('change', () => {
+      if (!radio.checked) return;
+      selectedMode = radio.value;
+      syncModeCards();
+      view?.setMode(selectedMode);
+      syncMotionAvailability();
+    });
+  });
+
+  elements.startTilt.addEventListener('click', () => startRun('motion'));
+  elements.startTouch.addEventListener('click', () => startRun('manual'));
+  elements.calibrate.addEventListener('click', recenter);
+  elements.pause.addEventListener('click', () => pauseRun(false));
+  elements.resume.addEventListener('click', resumeRun);
+  elements.pauseRecenter.addEventListener('click', recenter);
+  elements.leave.addEventListener('click', goHome);
+  elements.again.addEventListener('click', () => {
+    closeDialog(elements.resultDialog);
+    startRun(controlMode);
+  });
+  elements.changeMode.addEventListener('click', goHome);
+  elements.sound.addEventListener('click', () => {
+    const muted = audio.toggleMuted();
+    elements.sound.textContent = muted ? 'SOUND OFF' : 'SOUND ON';
+    elements.sound.setAttribute('aria-pressed', String(!muted));
+  });
+  elements.jump.addEventListener('pointerdown', (event) => {
+    event.preventDefault();
+    input.queueJump('button');
+  });
+
+  elements.balanceOrb.addEventListener('pointerdown', handlePadPointer);
+  elements.balanceOrb.addEventListener('pointermove', handlePadPointer);
+  elements.balanceOrb.addEventListener('pointerup', releasePadPointer);
+  elements.balanceOrb.addEventListener('pointercancel', releasePadPointer);
+
+  globalThis.addEventListener('keydown', handleKeyDown);
+  globalThis.addEventListener('keyup', handleKeyUp);
+  globalThis.addEventListener('blur', clearHeldControls);
+  globalThis.addEventListener('orientationchange', scheduleOrientationCheck, { passive: true });
+  globalThis.screen?.orientation?.addEventListener?.('change', scheduleOrientationCheck);
+  globalThis.matchMedia?.('(orientation: portrait)')?.addEventListener?.('change', scheduleOrientationCheck);
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden && phase === 'playing') pauseRun(false);
+  });
+
+  elements.pauseDialog.addEventListener('cancel', (event) => {
+    event.preventDefault();
+    resumeRun();
+  });
+  elements.resultDialog.addEventListener('cancel', (event) => event.preventDefault());
+}
+
+async function startRun(preferredControl) {
+  if (!view || phase === 'countdown') return;
+  const token = ++countdownToken;
+  closeDialog(elements.pauseDialog);
+  closeDialog(elements.resultDialog);
+  phase = 'countdown';
+  document.body.dataset.phase = phase;
+  document.body.dataset.stage = '0';
+  document.body.classList.remove('is-danger', 'is-hit');
+  elements.startTilt.disabled = true;
+  elements.startTouch.disabled = true;
+
+  // Both calls happen from the initiating button gesture. iOS requires that for
+  // motion permission, and browsers require it before Web Audio may start.
+  const audioPromise = audio.start();
+  let motionResult = { granted: false, reason: 'manual' };
+  if (preferredControl === 'motion') {
+    if (input.getMode() === 'motion' && input.motionPermission === 'granted') {
+      motionResult = { granted: true, reason: 'existing' };
+    } else {
+      motionResult = await input.enableMotion();
+    }
+  } else {
+    input.enableManual();
+  }
+  await audioPromise;
+  if (token !== countdownToken) return;
+
+  controlMode = motionResult.granted ? 'motion' : 'manual';
+  if (!motionResult.granted && preferredControl === 'motion') {
+    input.enableManual();
+    elements.startStatus.textContent = motionResult.reason === 'denied'
+      ? 'Motion access was not allowed, so TOUCH MODE is active instead.'
+      : 'No motion signal was available, so TOUCH MODE is active instead.';
+    elements.startStatus.classList.add('is-warning');
+  }
+
+  view.setMode(selectedMode);
+  elements.home.hidden = true;
+  elements.countdown.hidden = false;
+  elements.countdownMode.textContent = controlMode === 'motion' ? 'CALIBRATING TILT' : 'TOUCH MODE';
+  elements.countdownHint.textContent = controlMode === 'motion'
+    ? 'HOLD YOUR PHONE COMFORTABLY'
+    : 'DRAG THE BALANCE TARGET';
+
+  await delay(260);
+  if (controlMode === 'motion') input.calibrate();
+  for (const count of ['3', '2', '1']) {
+    if (token !== countdownToken) return;
+    elements.countdownTitle.textContent = count;
+    announce(`${count}.`);
+    await delay(530);
+  }
+  if (token !== countdownToken) return;
+
+  if (controlMode === 'motion') {
+    if (!input.hasFreshPose(1500)) {
+      input.enableManual();
+      controlMode = 'manual';
+      elements.countdownMode.textContent = 'TOUCH MODE';
+      elements.countdownHint.textContent = 'NO SENSOR SIGNAL — DRAG THE TARGET';
+      announce('No current sensor signal. Touch mode is active.');
+      await delay(520);
+    } else {
+      input.calibrate();
+    }
+  }
+
+  elements.countdownTitle.textContent = 'GO!';
+  await delay(360);
+  if (token !== countdownToken) return;
+  beginPlaying();
+}
+
+function beginPlaying() {
+  runState = createRunState(selectedMode);
+  runFrames = [];
+  lastRecordAt = -Infinity;
+  lastHudAt = -Infinity;
+  lastScreenReaderAt = -Infinity;
+  phase = 'playing';
+  pausedByOrientation = false;
+  document.body.dataset.phase = phase;
+  elements.countdown.hidden = true;
+  elements.hud.hidden = false;
+  elements.controls.hidden = false;
+  elements.balanceControl.hidden = false;
+  elements.jump.hidden = selectedMode !== 'hard';
+  syncControlMode(input.getMode());
+  updateHud({ x: 0, y: 0 }, true);
+  audio.resume();
+  announce(`${getModeConfig(selectedMode).name} run started. Tilt against the fall${selectedMode === 'hard' ? ' and lift the phone to jump over incoming projectiles' : ''}.`);
+  showCallout('KEEP IT UP!');
+}
+
+function frame(timestamp) {
+  const dt = Math.min(0.05, Math.max(0, (timestamp - lastFrameAt) / 1000));
+  lastFrameAt = timestamp;
+  let vector = { x: 0, y: 0 };
+
+  if (phase === 'playing' && isPortrait()) {
+    updateKeyboardVector();
+    vector = input.getVector(dt);
+    const events = stepBalance(runState, {
+      x: vector.x,
+      y: vector.y,
+      jump: input.consumeJump()
+    }, dt);
+    recordFrame(vector);
+    handleRunEvents(events);
+    if (runState && timestamp - lastHudAt >= 45) {
+      lastHudAt = timestamp;
+      updateHud(vector);
+    }
+    if (runState && timestamp - lastScreenReaderAt >= 5000) {
+      lastScreenReaderAt = timestamp;
+      announceRunStatus();
+    }
+    audio.update({
+      stage: runState?.stage || 0,
+      stability: runState?.stability || 0,
+      danger: runState?.danger || 0
+    });
+  } else if (phase === 'paused' && runState) {
+    vector = input.getVector(dt);
+  }
+
+  view?.render({
+    state: phase === 'home' || phase === 'countdown' ? null : runState,
+    input: vector,
+    deltaSeconds: dt,
+    phase
+  });
+  requestAnimationFrame(frame);
+}
+
+function handleRunEvents(events) {
+  for (const event of events) {
+    if (event.type === 'stage') {
+      const stage = FLOW_STAGES[event.stage];
+      audio.stageUp(event.stage);
+      view?.pulse('flow');
+      showCallout(`${stage.name}  ×${stage.multiplier}`);
+      retriggerClass(elements.flowCard, 'stage-up');
+      vibrate([18, 32, 24]);
+    } else if (event.type === 'projectile') {
+      audio.warning(event.side);
+      showCallout(`INCOMING ${event.side < 0 ? 'LEFT' : 'RIGHT'} — LIFT!`);
+    } else if (event.type === 'jump') {
+      audio.jump();
+      elements.jump.classList.add('is-airborne');
+      elements.jump.querySelector('small').textContent = 'AIRBORNE';
+      vibrate(12);
+    } else if (event.type === 'land') {
+      audio.land();
+      elements.jump.classList.remove('is-airborne');
+      elements.jump.querySelector('small').textContent = 'LIFT PHONE OR TAP';
+    } else if (event.type === 'dodge') {
+      audio.dodge(event.side);
+      view?.pulse('flow');
+      showCallout('CLEAN JUMP + FLOW');
+      vibrate([10, 24, 10]);
+    } else if (event.type === 'hit') {
+      audio.hit(event.side);
+      view?.pulse('hit');
+      showCallout('HIT! SAVE THE BALANCE');
+      retriggerClass(document.body, 'is-hit');
+      vibrate(45);
+    } else if (event.type === 'save') {
+      audio.save();
+      showCallout('CLUTCH SAVE + FLOW');
+    } else if (event.type === 'fall') {
+      endRun();
+      break;
+    }
+  }
+}
+
+function endRun() {
+  if (!runState || phase !== 'playing') return;
+  phase = 'result';
+  document.body.dataset.phase = phase;
+  elements.controls.hidden = true;
+  elements.balanceControl.hidden = true;
+  document.body.classList.remove('is-danger');
+  audio.fall();
+  vibrate([45, 45, 75]);
+
+  const snapshot = createRunSnapshot(runState, runFrames);
+  const previousBest = bestRuns[selectedMode];
+  const isBest = !previousBest
+    || snapshot.score > previousBest.score
+    || (snapshot.score === previousBest.score && snapshot.time > previousBest.time);
+  if (isBest) {
+    bestRuns = { ...bestRuns, [selectedMode]: snapshot };
+    writeBestRuns(bestRuns);
+  }
+
+  elements.resultKicker.textContent = isBest ? 'NEW BEST · GHOST SAVED' : 'RUN COMPLETE';
+  elements.resultTitle.textContent = runState.maxStageReached >= 4 ? 'NO TILT!' : 'THAT TILTED.';
+  elements.resultTime.textContent = formatRunTime(snapshot.time);
+  elements.resultScore.textContent = formatScore(snapshot.score);
+  elements.resultCombo.textContent = `×${snapshot.maxCombo}`;
+  elements.resultCopy.textContent = isBest
+    ? 'Your best try is saved on this device and already recorded for the future YOUR TURN challenge mode.'
+    : `Your best remains ${formatScore(previousBest.score)} points. This run did not replace your saved ghost.`;
+  updateHud({ x: 0, y: 0 }, true);
+  announce(`${isBest ? 'New best. ' : ''}Run complete. ${formatRunTime(snapshot.time)}, ${snapshot.score} points, best combo times ${snapshot.maxCombo}.`);
+
+  setTimeout(() => {
+    audio.pause();
+    showDialog(elements.resultDialog);
+  }, reducedMotion ? 0 : 420);
+}
+
+function pauseRun(fromOrientation) {
+  if (phase !== 'playing') return;
+  phase = 'paused';
+  document.body.dataset.phase = phase;
+  pausedByOrientation = Boolean(fromOrientation);
+  audio.pause();
+  clearHeldControls();
+  if (!fromOrientation) {
+    showDialog(elements.pauseDialog);
+    announce('Paused.');
+  }
+}
+
+function resumeRun() {
+  if (phase !== 'paused' || !isPortrait()) return;
+  closeDialog(elements.pauseDialog);
+  input.calibrate();
+  phase = 'playing';
+  pausedByOrientation = false;
+  document.body.dataset.phase = phase;
+  audio.resume();
+  showCallout(input.getMode() === 'motion' ? 'RECENTERED' : 'GO!');
+  announce('Run resumed.');
+}
+
+function goHome() {
+  countdownToken += 1;
+  phase = 'home';
+  document.body.dataset.phase = phase;
+  document.body.dataset.stage = '0';
+  document.body.classList.remove('is-danger', 'is-hit');
+  runState = null;
+  runFrames = [];
+  audio.pause();
+  clearHeldControls();
+  closeDialog(elements.pauseDialog);
+  closeDialog(elements.resultDialog);
+  elements.home.hidden = false;
+  elements.hud.hidden = true;
+  elements.controls.hidden = true;
+  elements.balanceControl.hidden = true;
+  elements.countdown.hidden = true;
+  elements.startTilt.disabled = false;
+  elements.startTouch.disabled = false;
+  view?.setMode(selectedMode);
+  syncMotionAvailability();
+  elements.startTilt.focus({ preventScroll: true });
+}
+
+function recenter() {
+  if (input.getMode() === 'motion') {
+    if (input.calibrate()) {
+      showCallout('CENTER RESET');
+      announce('Tilt center reset.');
+    } else {
+      showCallout('HOLD PHONE UPRIGHT');
+      announce('No motion sample yet. Hold the phone upright and try again.');
+    }
+  } else {
+    input.setManualVector(0, 0);
+    showCallout('TOUCH CENTER RESET');
+  }
+}
+
+function updateHud(vector, force = false) {
+  if (!runState) return;
+  const config = getModeConfig(runState.modeId);
+  const stage = FLOW_STAGES[runState.stage];
+  const best = bestRuns[runState.modeId];
+  elements.time.textContent = formatRunTime(runState.time);
+  elements.score.textContent = formatScore(runState.score);
+  elements.best.textContent = best ? formatScore(best.score) : '—';
+  elements.flowName.textContent = stage.name;
+  elements.combo.textContent = `×${stage.multiplier}`;
+  document.body.dataset.stage = String(runState.stage);
+  document.body.classList.toggle('is-danger', runState.danger > 0.48);
+
+  const currentThreshold = stage.threshold;
+  const nextThreshold = FLOW_STAGES[runState.stage + 1]?.threshold ?? 64;
+  const progress = runState.stage >= FLOW_STAGES.length - 1
+    ? 100
+    : clamp((runState.flow - currentThreshold) / (nextThreshold - currentThreshold) * 100, 0, 100);
+  elements.flowFill.style.width = `${progress.toFixed(1)}%`;
+  elements.flowProgress.setAttribute('aria-valuenow', String(Math.round(progress)));
+
+  const leanScale = 32 / config.failAngle;
+  setDot(elements.leanDot, runState.angleX * leanScale, runState.angleY * leanScale);
+  setDot(elements.inputDot, vector.x * 32, vector.y * 32);
+  if (runState.modeId === 'hard') {
+    elements.jump.classList.toggle('is-airborne', runState.jumpY > 0.02);
+  }
+
+  if (force) elements.hud.offsetWidth;
+}
+
+function recordFrame(vector) {
+  if (!runState || runState.time - lastRecordAt < RECORD_INTERVAL_SECONDS) return;
+  lastRecordAt = runState.time;
+  runFrames.push([
+    Math.round(runState.time * 1000),
+    Math.round(vector.x * 1000),
+    Math.round(vector.y * 1000),
+    Math.round(runState.angleX * 10000),
+    Math.round(runState.angleY * 10000),
+    Math.round(runState.jumpY * 100)
+  ]);
+  if (runFrames.length > 4800) runFrames.shift();
+}
+
+function announceRunStatus() {
+  if (!runState) return;
+  const stage = FLOW_STAGES[runState.stage];
+  const warning = runState.danger > 0.72 ? ' Danger. Counter the fall.' : '';
+  announce(`${formatRunTime(runState.time)}, ${stage.name}, combo times ${stage.multiplier}, score ${Math.round(runState.score)}.${warning}`);
+}
+
+function handlePadPointer(event) {
+  if (phase !== 'playing' || input.getMode() !== 'manual') return;
+  if (event.type === 'pointerdown') {
+    pointerActive = true;
+    elements.balanceOrb.setPointerCapture?.(event.pointerId);
+  }
+  if (!pointerActive) return;
+  event.preventDefault();
+  const rect = elements.balanceOrb.getBoundingClientRect();
+  const radius = Math.min(rect.width, rect.height) * 0.38;
+  const x = (event.clientX - rect.left - rect.width / 2) / radius;
+  const y = (event.clientY - rect.top - rect.height / 2) / radius;
+  const length = Math.max(1, Math.hypot(x, y));
+  input.setManualVector(x / length, y / length);
+}
+
+function releasePadPointer(event) {
+  if (!pointerActive) return;
+  pointerActive = false;
+  elements.balanceOrb.releasePointerCapture?.(event.pointerId);
+  input.setManualVector(0, 0);
+}
+
+function handleKeyDown(event) {
+  if (phase !== 'playing' && event.key.toLowerCase() !== 'p') return;
+  const key = event.key.toLowerCase();
+  if (['arrowleft', 'arrowright', 'arrowup', 'arrowdown', 'a', 'd', 'w', 's'].includes(key)) {
+    if (input.getMode() !== 'manual') return;
+    heldKeys.add(key);
+    event.preventDefault();
+  } else if (key === ' ' && selectedMode === 'hard') {
+    event.preventDefault();
+    input.queueJump('keyboard');
+  } else if (key === 'p' && phase === 'playing') {
+    pauseRun(false);
+  } else if (key === 'r') {
+    recenter();
+  }
+}
+
+function handleKeyUp(event) {
+  heldKeys.delete(event.key.toLowerCase());
+  if (input.getMode() === 'manual' && !pointerActive && heldKeys.size === 0) {
+    input.setManualVector(0, 0);
+  }
+}
+
+function updateKeyboardVector() {
+  if (input.getMode() !== 'manual' || pointerActive || heldKeys.size === 0) return;
+  const left = heldKeys.has('arrowleft') || heldKeys.has('a');
+  const right = heldKeys.has('arrowright') || heldKeys.has('d');
+  const up = heldKeys.has('arrowup') || heldKeys.has('w');
+  const down = heldKeys.has('arrowdown') || heldKeys.has('s');
+  input.setManualVector(Number(right) - Number(left), Number(down) - Number(up));
+}
+
+function clearHeldControls() {
+  heldKeys.clear();
+  pointerActive = false;
+  input.setManualVector(0, 0);
+}
+
+function syncControlMode(mode) {
+  const manual = mode === 'manual';
+  elements.balanceControl.classList.toggle('is-manual', manual);
+  elements.controlHint.textContent = manual ? 'DRAG AGAINST THE FALL' : 'TILT AGAINST THE FALL';
+  elements.calibrate.textContent = manual ? 'RESET PAD' : 'RECENTER';
+}
+
+function syncModeCards() {
+  document.querySelectorAll('.mode-card').forEach((card) => {
+    const radio = card.querySelector('input');
+    card.classList.toggle('is-selected', radio.checked);
+  });
+}
+
+function syncMotionAvailability() {
+  if (!NoTiltInput.supportsMotion()) {
+    elements.startStatus.textContent = 'Motion sensors were not detected here. TOUCH MODE gives you the same balance physics.';
+    elements.startStatus.classList.add('is-warning');
+    return;
+  }
+  elements.startStatus.classList.remove('is-warning');
+  elements.startStatus.textContent = selectedMode === 'hard'
+    ? 'Allow motion access, then hold portrait. A quick upward lift jumps; the JUMP button is always available too.'
+    : 'For tilt play, allow motion access when your phone asks.';
+}
+
+function scheduleOrientationCheck() {
+  setTimeout(handleOrientationChange, 100);
+}
+
+function handleOrientationChange() {
+  if (!isPortrait()) {
+    if (phase === 'playing') pauseRun(true);
+    return;
+  }
+  if (phase === 'paused' && pausedByOrientation) {
+    input.calibrate();
+    phase = 'playing';
+    pausedByOrientation = false;
+    document.body.dataset.phase = phase;
+    audio.resume();
+    showCallout('PORTRAIT · RECENTERED');
+    announce('Portrait restored. Tilt center reset and run resumed.');
+  } else if (phase === 'countdown') {
+    input.calibrate();
+  }
+}
+
+function isPortrait() {
+  return globalThis.matchMedia?.('(orientation: portrait)').matches
+    ?? globalThis.innerHeight >= globalThis.innerWidth;
+}
+
+function showCallout(message, duration = 1050) {
+  clearTimeout(calloutTimer);
+  elements.callout.textContent = message;
+  elements.callout.classList.add('show');
+  calloutTimer = setTimeout(() => elements.callout.classList.remove('show'), duration);
+}
+
+function setDot(element, xPixels, yPixels) {
+  element.style.left = `calc(50% + ${clamp(xPixels, -32, 32).toFixed(1)}px)`;
+  element.style.top = `calc(50% + ${clamp(yPixels, -32, 32).toFixed(1)}px)`;
+}
+
+function announce(message) {
+  elements.srStatus.textContent = '';
+  requestAnimationFrame(() => { elements.srStatus.textContent = message; });
+}
+
+function showDialog(dialog) {
+  if (dialog.open) return;
+  if (typeof dialog.showModal === 'function') dialog.showModal();
+  else dialog.setAttribute('open', '');
+}
+
+function closeDialog(dialog) {
+  if (!dialog?.open) return;
+  if (typeof dialog.close === 'function') dialog.close();
+  else dialog.removeAttribute('open');
+}
+
+function readBestRuns() {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(BEST_RUNS_KEY) || '{}');
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    return Object.fromEntries(
+      Object.entries(parsed).filter(([mode, run]) => (
+        ['easy', 'medium', 'hard'].includes(mode)
+        && run
+        && Number.isFinite(Number(run.score))
+        && Array.isArray(run.frames)
+      ))
+    );
+  } catch (_) {
+    return {};
+  }
+}
+
+function writeBestRuns(runs) {
+  try {
+    localStorage.setItem(BEST_RUNS_KEY, JSON.stringify(runs));
+  } catch (_) {
+    // A completed run must still be playable when private storage is unavailable.
+  }
+}
+
+function retriggerClass(element, className) {
+  element.classList.remove(className);
+  element.offsetWidth;
+  element.classList.add(className);
+  setTimeout(() => element.classList.remove(className), 520);
+}
+
+function vibrate(pattern) {
+  try { globalThis.navigator?.vibrate?.(pattern); } catch (_) {}
+}
+
+function formatScore(value) {
+  return Math.max(0, Math.round(Number(value) || 0)).toLocaleString('en-US');
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}

--- a/notilt/audio.mjs
+++ b/notilt/audio.mjs
@@ -1,0 +1,249 @@
+const SCALE = Object.freeze([0, 3, 5, 7, 10, 12, 15, 17]);
+
+export class NoTiltAudio {
+  constructor() {
+    this.context = null;
+    this.master = null;
+    this.droneGain = null;
+    this.tensionGain = null;
+    this.filter = null;
+    this.started = false;
+    this.muted = false;
+    this.paused = true;
+    this.stage = 0;
+    this.beat = 0;
+    this.nextBeatAt = 0;
+  }
+
+  async start() {
+    if (this.started) {
+      await this.resume();
+      return true;
+    }
+    const AudioContext = globalThis.AudioContext || globalThis.webkitAudioContext;
+    if (!AudioContext) return false;
+
+    this.context = new AudioContext({ latencyHint: 'interactive' });
+    this.master = this.context.createGain();
+    this.master.gain.value = 0.0001;
+    this.master.connect(this.context.destination);
+
+    this.filter = this.context.createBiquadFilter();
+    this.filter.type = 'lowpass';
+    this.filter.frequency.value = 420;
+    this.filter.Q.value = 0.8;
+    this.filter.connect(this.master);
+
+    this.droneGain = this.context.createGain();
+    this.droneGain.gain.value = 0.018;
+    this.droneGain.connect(this.filter);
+    this.createDrone(55, 'sine', -5);
+    this.createDrone(82.5, 'triangle', 5);
+
+    this.tensionGain = this.context.createGain();
+    this.tensionGain.gain.value = 0.0001;
+    this.tensionGain.connect(this.filter);
+    const tension = this.context.createOscillator();
+    tension.type = 'sawtooth';
+    tension.frequency.value = 110;
+    tension.connect(this.tensionGain);
+    tension.start();
+
+    this.started = true;
+    this.paused = false;
+    this.nextBeatAt = this.context.currentTime + 0.15;
+    this.setMasterTarget();
+    return true;
+  }
+
+  async resume() {
+    if (!this.context) return false;
+    if (this.context.state === 'suspended') await this.context.resume();
+    this.paused = false;
+    this.nextBeatAt = Math.max(this.context.currentTime + 0.08, this.nextBeatAt);
+    this.setMasterTarget();
+    return true;
+  }
+
+  pause() {
+    this.paused = true;
+    this.setMasterTarget();
+  }
+
+  setMuted(muted) {
+    this.muted = Boolean(muted);
+    this.setMasterTarget();
+    return this.muted;
+  }
+
+  toggleMuted() {
+    return this.setMuted(!this.muted);
+  }
+
+  update({ stage = 0, stability = 1, danger = 0 } = {}) {
+    if (!this.context || !this.started) return;
+    this.stage = clamp(Math.round(stage), 0, 4);
+    const now = this.context.currentTime;
+    const timeConstant = 0.08;
+    this.filter.frequency.setTargetAtTime(360 + this.stage * 190 + stability * 170, now, 0.12);
+    this.droneGain.gain.setTargetAtTime(0.016 + this.stage * 0.0045, now, 0.15);
+    this.tensionGain.gain.setTargetAtTime(
+      this.paused || this.muted ? 0.0001 : 0.003 + danger * 0.026,
+      now,
+      timeConstant
+    );
+
+    if (this.paused || this.muted) return;
+    const bpm = 90 + this.stage * 11;
+    const beatDuration = 60 / bpm / 2;
+    let guard = 0;
+    while (now >= this.nextBeatAt && guard < 4) {
+      this.scheduleBeat(this.nextBeatAt, this.beat, this.stage);
+      this.nextBeatAt += beatDuration;
+      this.beat += 1;
+      guard += 1;
+    }
+  }
+
+  stageUp(stage) {
+    const level = clamp(Number(stage) || 0, 1, 4);
+    const root = 220 * 2 ** (level / 12);
+    this.playTone(root, 0.16, 0.06, 0, 'square', root * 1.5);
+    this.playTone(root * 1.5, 0.22, 0.045, 0, 'triangle', root * 2);
+  }
+
+  warning(side = 1) {
+    this.playTone(196, 0.11, 0.045, side * 0.72, 'square', 146);
+  }
+
+  jump() {
+    this.playTone(220, 0.18, 0.055, 0, 'triangle', 520);
+  }
+
+  land() {
+    this.noise(0.07, 0.035, 0);
+  }
+
+  dodge(side = 1) {
+    this.playTone(523.25, 0.13, 0.06, -side * 0.35, 'square', 783.99);
+    this.playTone(783.99, 0.2, 0.04, side * 0.35, 'triangle', 1046.5);
+  }
+
+  save() {
+    this.playTone(392, 0.12, 0.04, 0, 'triangle', 587.33);
+  }
+
+  hit(side = 1) {
+    this.noise(0.13, 0.085, -side * 0.5);
+    this.playTone(92, 0.22, 0.07, -side * 0.35, 'sawtooth', 58);
+  }
+
+  fall() {
+    this.playTone(174.61, 0.5, 0.075, 0, 'sawtooth', 48);
+  }
+
+  setMasterTarget() {
+    if (!this.context || !this.master) return;
+    const target = this.muted || this.paused ? 0.0001 : 0.38;
+    this.master.gain.setTargetAtTime(target, this.context.currentTime, 0.06);
+  }
+
+  createDrone(frequency, type, detune) {
+    const oscillator = this.context.createOscillator();
+    oscillator.type = type;
+    oscillator.frequency.value = frequency;
+    oscillator.detune.value = detune;
+    oscillator.connect(this.droneGain);
+    oscillator.start();
+  }
+
+  scheduleBeat(at, beat, stage) {
+    if (!this.context || at < this.context.currentTime - 0.05) at = this.context.currentTime;
+    const root = 55;
+    if (beat % 4 === 0) this.kick(at, 0.038 + stage * 0.004);
+
+    if (stage >= 1 && beat % 2 === 0) {
+      const bassSteps = [0, 0, 5, 3, 0, 7, 5, 3];
+      const frequency = root * 2 ** (bassSteps[Math.floor(beat / 2) % bassSteps.length] / 12);
+      this.scheduleTone(frequency, at, 0.12, 0.026, 0, 'square');
+    }
+
+    if (stage >= 2) {
+      const note = SCALE[beat % (stage >= 4 ? SCALE.length : 5)];
+      const frequency = 220 * 2 ** (note / 12);
+      this.scheduleTone(frequency, at, stage >= 4 ? 0.08 : 0.12, 0.018 + stage * 0.003, 0, 'triangle');
+    }
+
+    if (stage >= 4 && beat % 2 === 1) {
+      this.scheduleTone(880 * 2 ** (SCALE[(beat + 3) % SCALE.length] / 12), at, 0.045, 0.012, 0, 'sine');
+    }
+  }
+
+  kick(at, gain) {
+    if (!this.context || !this.master) return;
+    const oscillator = this.context.createOscillator();
+    const envelope = this.context.createGain();
+    oscillator.type = 'sine';
+    oscillator.frequency.setValueAtTime(120, at);
+    oscillator.frequency.exponentialRampToValueAtTime(46, at + 0.095);
+    envelope.gain.setValueAtTime(Math.max(0.0001, gain), at);
+    envelope.gain.exponentialRampToValueAtTime(0.0001, at + 0.11);
+    oscillator.connect(envelope).connect(this.master);
+    oscillator.start(at);
+    oscillator.stop(at + 0.12);
+  }
+
+  playTone(frequency, duration, gain, pan, type, glideTo = frequency) {
+    if (!this.context || this.muted) return;
+    const at = this.context.currentTime;
+    this.scheduleTone(frequency, at, duration, gain, pan, type, glideTo);
+  }
+
+  scheduleTone(frequency, at, duration, gain, pan = 0, type = 'sine', glideTo = frequency) {
+    if (!this.context || !this.master) return;
+    const oscillator = this.context.createOscillator();
+    const envelope = this.context.createGain();
+    oscillator.type = type;
+    oscillator.frequency.setValueAtTime(Math.max(24, frequency), at);
+    oscillator.frequency.exponentialRampToValueAtTime(Math.max(24, glideTo), at + duration);
+    envelope.gain.setValueAtTime(0.0001, at);
+    envelope.gain.exponentialRampToValueAtTime(Math.max(0.0001, gain), at + 0.012);
+    envelope.gain.exponentialRampToValueAtTime(0.0001, at + duration);
+
+    if (typeof this.context.createStereoPanner === 'function') {
+      const panner = this.context.createStereoPanner();
+      panner.pan.value = clamp(pan, -1, 1);
+      oscillator.connect(envelope).connect(panner).connect(this.master);
+    } else {
+      oscillator.connect(envelope).connect(this.master);
+    }
+    oscillator.start(at);
+    oscillator.stop(at + duration + 0.02);
+  }
+
+  noise(duration, gain, pan) {
+    if (!this.context || !this.master || this.muted) return;
+    const sampleCount = Math.max(1, Math.floor(this.context.sampleRate * duration));
+    const buffer = this.context.createBuffer(1, sampleCount, this.context.sampleRate);
+    const data = buffer.getChannelData(0);
+    for (let index = 0; index < data.length; index += 1) {
+      data[index] = (Math.random() * 2 - 1) * (1 - index / data.length);
+    }
+    const source = this.context.createBufferSource();
+    const envelope = this.context.createGain();
+    envelope.gain.value = gain;
+    source.buffer = buffer;
+    if (typeof this.context.createStereoPanner === 'function') {
+      const panner = this.context.createStereoPanner();
+      panner.pan.value = clamp(pan, -1, 1);
+      source.connect(envelope).connect(panner).connect(this.master);
+    } else {
+      source.connect(envelope).connect(this.master);
+    }
+    source.start();
+  }
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}

--- a/notilt/game-core.mjs
+++ b/notilt/game-core.mjs
@@ -1,0 +1,359 @@
+const HALF_PI = Math.PI / 2;
+
+export const FLOW_STAGES = Object.freeze([
+  Object.freeze({ level: 1, name: 'STEADY', threshold: 0, multiplier: 1 }),
+  Object.freeze({ level: 2, name: 'LOCKED IN', threshold: 7, multiplier: 2 }),
+  Object.freeze({ level: 3, name: 'FLOW STATE', threshold: 17, multiplier: 3 }),
+  Object.freeze({ level: 4, name: 'ELECTRIC', threshold: 30, multiplier: 4 }),
+  Object.freeze({ level: 5, name: 'NO TILT', threshold: 46, multiplier: 5 })
+]);
+
+export const MODE_CONFIGS = Object.freeze({
+  easy: Object.freeze({
+    id: 'easy',
+    name: 'EASY',
+    objectName: 'THE BROOM',
+    failAngle: 0.94,
+    gravity: 2.35,
+    control: 6.8,
+    damping: 1.32,
+    maxAngularSpeed: 2.8,
+    windStrength: 0.17,
+    windMinSeconds: 2.4,
+    windMaxSeconds: 4.4,
+    initialLean: 0.025,
+    scoreRate: 92,
+    projectiles: false
+  }),
+  medium: Object.freeze({
+    id: 'medium',
+    name: 'MEDIUM',
+    objectName: 'MARKER ON MARKER',
+    failAngle: 0.76,
+    gravity: 3.05,
+    control: 7.25,
+    damping: 1.16,
+    maxAngularSpeed: 3.25,
+    windStrength: 0.3,
+    windMinSeconds: 1.8,
+    windMaxSeconds: 3.5,
+    initialLean: 0.034,
+    scoreRate: 112,
+    projectiles: false
+  }),
+  hard: Object.freeze({
+    id: 'hard',
+    name: 'HARD',
+    objectName: 'THE SIGNAL',
+    failAngle: 0.8,
+    gravity: 3.45,
+    control: 7.65,
+    damping: 1.08,
+    maxAngularSpeed: 3.6,
+    windStrength: 0.38,
+    windMinSeconds: 1.55,
+    windMaxSeconds: 3.1,
+    initialLean: 0.036,
+    scoreRate: 132,
+    projectiles: true
+  })
+});
+
+export function createRunState(modeId = 'easy', seed = randomSeed()) {
+  const config = getModeConfig(modeId);
+  const normalizedSeed = normalizeSeed(seed);
+  const state = {
+    modeId: config.id,
+    seed: normalizedSeed,
+    rngState: normalizedSeed,
+    time: 0,
+    score: 0,
+    flow: 0,
+    stage: 0,
+    stability: 1,
+    danger: 0,
+    angleX: 0,
+    angleY: 0,
+    angularVelocityX: 0,
+    angularVelocityY: 0,
+    windX: 0,
+    windY: 0,
+    windTargetX: 0,
+    windTargetY: 0,
+    windTimer: 0.9,
+    nearSaveArmed: false,
+    lastNearSaveAt: -99,
+    jumpY: 0,
+    jumpVelocity: 0,
+    jumpCooldown: 0,
+    projectileTimer: config.projectiles ? 4.2 : Infinity,
+    projectiles: [],
+    projectileSequence: 0,
+    failed: false,
+    failureReason: '',
+    lastInputX: 0,
+    lastInputY: 0
+  };
+
+  const direction = nextRandom(state) < 0.5 ? -1 : 1;
+  state.angleX = direction * config.initialLean * (0.72 + nextRandom(state) * 0.56);
+  state.angleY = (nextRandom(state) - 0.5) * config.initialLean * 0.7;
+  state.angularVelocityX = direction * 0.015;
+  return state;
+}
+
+export function stepBalance(state, input = {}, deltaSeconds = 1 / 60) {
+  if (!state || state.failed) return [];
+  const config = getModeConfig(state.modeId);
+  const dt = clamp(Number(deltaSeconds) || 0, 0, 1 / 20);
+  if (dt <= 0) return [];
+  const events = [];
+
+  state.time += dt;
+  state.jumpCooldown = Math.max(0, state.jumpCooldown - dt);
+  state.lastInputX = clamp(Number(input.x) || 0, -1, 1);
+  state.lastInputY = clamp(Number(input.y) || 0, -1, 1);
+
+  updateWind(state, config, dt);
+  updateJump(state, config, Boolean(input.jump), dt, events);
+
+  const intensity = 1 + Math.min(0.48, state.time * 0.0035 + state.stage * 0.035);
+  const accelerationX = config.gravity * Math.sin(state.angleX) * intensity
+    + state.lastInputX * config.control
+    + state.windX;
+  const accelerationY = config.gravity * Math.sin(state.angleY) * intensity
+    + state.lastInputY * config.control
+    + state.windY;
+
+  state.angularVelocityX += accelerationX * dt;
+  state.angularVelocityY += accelerationY * dt;
+  const damping = Math.exp(-config.damping * dt);
+  state.angularVelocityX *= damping;
+  state.angularVelocityY *= damping;
+  state.angularVelocityX = clamp(
+    state.angularVelocityX,
+    -config.maxAngularSpeed,
+    config.maxAngularSpeed
+  );
+  state.angularVelocityY = clamp(
+    state.angularVelocityY,
+    -config.maxAngularSpeed,
+    config.maxAngularSpeed
+  );
+  state.angleX = clamp(state.angleX + state.angularVelocityX * dt, -HALF_PI, HALF_PI);
+  state.angleY = clamp(state.angleY + state.angularVelocityY * dt, -HALF_PI, HALF_PI);
+
+  if (config.projectiles) updateProjectiles(state, config, dt, events);
+  updateFlow(state, config, dt, events);
+
+  const lean = Math.hypot(state.angleX, state.angleY);
+  if (lean >= config.failAngle) {
+    state.failed = true;
+    state.failureReason = 'tilt';
+    events.push({ type: 'fall', reason: 'tilt' });
+  }
+  return events;
+}
+
+export function applyImpact(state, direction = 1, strength = 1) {
+  if (!state || state.failed) return;
+  const side = Math.sign(Number(direction) || 1);
+  const amount = clamp(Number(strength) || 1, 0.2, 2.5);
+  state.angularVelocityX += side * 1.06 * amount;
+  state.angularVelocityY += (nextRandom(state) - 0.5) * 0.72 * amount;
+  state.flow = Math.max(0, state.flow - 10 * amount);
+  state.nearSaveArmed = true;
+}
+
+export function awardDodge(state) {
+  if (!state || state.failed) return;
+  const stage = FLOW_STAGES[state.stage] || FLOW_STAGES[0];
+  state.flow = Math.min(64, state.flow + 5.5);
+  state.score += 180 * stage.multiplier;
+}
+
+export function stageForFlow(flow) {
+  const value = Math.max(0, Number(flow) || 0);
+  let stage = 0;
+  for (let index = 1; index < FLOW_STAGES.length; index += 1) {
+    if (value >= FLOW_STAGES[index].threshold) stage = index;
+  }
+  return stage;
+}
+
+export function getModeConfig(modeId) {
+  return MODE_CONFIGS[modeId] || MODE_CONFIGS.easy;
+}
+
+export function formatRunTime(seconds) {
+  const safe = Math.max(0, Number(seconds) || 0);
+  const minutes = Math.floor(safe / 60);
+  const remainder = safe - minutes * 60;
+  return minutes > 0
+    ? `${minutes}:${remainder.toFixed(1).padStart(4, '0')}`
+    : `${remainder.toFixed(1)}s`;
+}
+
+export function createRunSnapshot(state, frames = []) {
+  const config = getModeConfig(state?.modeId);
+  return Object.freeze({
+    version: 1,
+    mode: config.id,
+    seed: normalizeSeed(state?.seed),
+    time: round(Number(state?.time) || 0, 3),
+    score: Math.max(0, Math.round(Number(state?.score) || 0)),
+    maxCombo: Math.max(1, Number(state?.maxStageReached || state?.stage || 0) + 1),
+    recordedAt: new Date().toISOString(),
+    frames: Array.isArray(frames) ? frames.slice(0, 4800) : []
+  });
+}
+
+function updateWind(state, config, dt) {
+  state.windTimer -= dt;
+  if (state.windTimer <= 0) {
+    const stageIntensity = 1 + state.stage * 0.13 + Math.min(0.5, state.time / 120);
+    const angle = nextRandom(state) * Math.PI * 2;
+    const magnitude = config.windStrength * stageIntensity * (0.45 + nextRandom(state) * 0.55);
+    state.windTargetX = Math.cos(angle) * magnitude;
+    state.windTargetY = Math.sin(angle) * magnitude;
+    state.windTimer = mix(config.windMinSeconds, config.windMaxSeconds, nextRandom(state));
+  }
+  const follow = 1 - Math.exp(-dt * 1.45);
+  state.windX += (state.windTargetX - state.windX) * follow;
+  state.windY += (state.windTargetY - state.windY) * follow;
+}
+
+function updateJump(state, config, requested, dt, events) {
+  if (config.projectiles && requested && state.jumpY <= 0.001 && state.jumpCooldown <= 0) {
+    state.jumpVelocity = 5.35;
+    state.jumpCooldown = 0.56;
+    state.angularVelocityX += state.lastInputX * 0.08;
+    state.angularVelocityY += state.lastInputY * 0.08;
+    events.push({ type: 'jump' });
+  }
+
+  if (state.jumpY > 0 || state.jumpVelocity > 0) {
+    state.jumpVelocity -= 13.8 * dt;
+    state.jumpY += state.jumpVelocity * dt;
+    if (state.jumpY <= 0) {
+      const landedHard = state.jumpVelocity < -4.4;
+      state.jumpY = 0;
+      state.jumpVelocity = 0;
+      if (landedHard) events.push({ type: 'land' });
+    }
+  }
+}
+
+function updateProjectiles(state, config, dt, events) {
+  state.projectileTimer -= dt;
+  if (state.projectileTimer <= 0) {
+    const side = nextRandom(state) < 0.5 ? -1 : 1;
+    const speed = 3.45 + Math.min(2.35, state.time * 0.018 + state.stage * 0.18);
+    const projectile = {
+      id: ++state.projectileSequence,
+      x: side * 6.8,
+      velocity: -side * speed,
+      side,
+      resolved: false,
+      hit: false
+    };
+    state.projectiles.push(projectile);
+    state.projectileTimer = Math.max(1.35, 3.5 - state.time * 0.015 - state.stage * 0.12)
+      + nextRandom(state) * 0.72;
+    events.push({ type: 'projectile', side });
+  }
+
+  for (const projectile of state.projectiles) {
+    const previousX = projectile.x;
+    projectile.x += projectile.velocity * dt;
+    const crossedCenter = previousX === 0 || Math.sign(previousX) !== Math.sign(projectile.x);
+    if (!projectile.resolved && (Math.abs(projectile.x) < 0.34 || crossedCenter)) {
+      projectile.resolved = true;
+      if (state.jumpY >= 0.7) {
+        awardDodge(state);
+        events.push({ type: 'dodge', side: projectile.side });
+      } else {
+        projectile.hit = true;
+        applyImpact(state, -projectile.side, 1);
+        events.push({ type: 'hit', side: projectile.side });
+      }
+    }
+  }
+  state.projectiles = state.projectiles.filter((projectile) => Math.abs(projectile.x) < 7.7);
+}
+
+function updateFlow(state, config, dt, events) {
+  const previousStage = state.stage;
+  const leanRatio = Math.hypot(state.angleX, state.angleY) / config.failAngle;
+  state.stability = 1 - clamp(leanRatio, 0, 1);
+  state.danger = smoothstep(0.56, 1, leanRatio);
+
+  if (leanRatio < 0.58) {
+    state.flow += dt * (0.72 + state.stability * 0.86);
+  } else {
+    state.flow -= dt * (leanRatio > 0.82 ? 5.2 : 1.25);
+  }
+  state.flow = clamp(state.flow, 0, 64);
+
+  if (leanRatio > 0.78) state.nearSaveArmed = true;
+  if (
+    state.nearSaveArmed
+    && leanRatio < 0.42
+    && state.time - state.lastNearSaveAt > 1.2
+  ) {
+    state.nearSaveArmed = false;
+    state.lastNearSaveAt = state.time;
+    state.flow = Math.min(64, state.flow + 3.2);
+    state.score += 120 * FLOW_STAGES[state.stage].multiplier;
+    events.push({ type: 'save' });
+  }
+
+  state.stage = stageForFlow(state.flow);
+  state.maxStageReached = Math.max(state.maxStageReached || 0, state.stage);
+  if (state.stage > previousStage) {
+    events.push({ type: 'stage', stage: state.stage });
+  }
+
+  const multiplier = FLOW_STAGES[state.stage].multiplier;
+  const controlQuality = 0.42 + state.stability * 0.58;
+  state.score += dt * config.scoreRate * multiplier * controlQuality;
+}
+
+function nextRandom(state) {
+  let value = normalizeSeed(state.rngState);
+  value ^= value << 13;
+  value ^= value >>> 17;
+  value ^= value << 5;
+  state.rngState = value >>> 0 || 0x6d2b79f5;
+  return state.rngState / 0x100000000;
+}
+
+function normalizeSeed(seed) {
+  const number = Number(seed);
+  if (!Number.isFinite(number)) return 0x6d2b79f5;
+  return (Math.floor(number) >>> 0) || 0x6d2b79f5;
+}
+
+function randomSeed() {
+  const array = new Uint32Array(1);
+  globalThis.crypto?.getRandomValues?.(array);
+  return array[0] || ((Date.now() * 2654435761) >>> 0);
+}
+
+function smoothstep(edge0, edge1, value) {
+  const t = clamp((value - edge0) / (edge1 - edge0), 0, 1);
+  return t * t * (3 - 2 * t);
+}
+
+function mix(a, b, amount) {
+  return a + (b - a) * amount;
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function round(value, precision) {
+  const scale = 10 ** precision;
+  return Math.round(value * scale) / scale;
+}

--- a/notilt/game-core.test.mjs
+++ b/notilt/game-core.test.mjs
@@ -1,0 +1,132 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  FLOW_STAGES,
+  MODE_CONFIGS,
+  applyImpact,
+  createRunSnapshot,
+  createRunState,
+  stageForFlow,
+  stepBalance
+} from './game-core.mjs';
+
+test('all three modes expose distinct balance rules', () => {
+  assert.deepEqual(Object.keys(MODE_CONFIGS), ['easy', 'medium', 'hard']);
+  assert.equal(MODE_CONFIGS.easy.projectiles, false);
+  assert.equal(MODE_CONFIGS.medium.projectiles, false);
+  assert.equal(MODE_CONFIGS.hard.projectiles, true);
+  assert.ok(MODE_CONFIGS.easy.failAngle > MODE_CONFIGS.medium.failAngle);
+  assert.ok(MODE_CONFIGS.hard.scoreRate > MODE_CONFIGS.easy.scoreRate);
+});
+
+test('an unattended inverted object eventually falls', () => {
+  const state = createRunState('easy', 42);
+  for (let frame = 0; frame < 1200 && !state.failed; frame += 1) {
+    stepBalance(state, { x: 0, y: 0 }, 1 / 60);
+  }
+  assert.equal(state.failed, true);
+  assert.equal(state.failureReason, 'tilt');
+  assert.ok(state.time > 0.5);
+});
+
+test('counter-control keeps EASY stable long enough to build an epic combo', () => {
+  const state = createRunState('easy', 103);
+  for (let frame = 0; frame < 60 * 42 && !state.failed; frame += 1) {
+    const x = clamp(-state.angleX * 1.55 - state.angularVelocityX * 0.52, -1, 1);
+    const y = clamp(-state.angleY * 1.55 - state.angularVelocityY * 0.52, -1, 1);
+    stepBalance(state, { x, y }, 1 / 60);
+  }
+  assert.equal(state.failed, false);
+  assert.ok(state.stage >= 3, `expected stage 4 or higher, got ${state.stage + 1}`);
+  assert.ok(state.score > 10000);
+});
+
+test('flow stages follow the declared thresholds', () => {
+  for (let index = 0; index < FLOW_STAGES.length; index += 1) {
+    assert.equal(stageForFlow(FLOW_STAGES[index].threshold), index);
+  }
+  assert.equal(stageForFlow(-10), 0);
+  assert.equal(stageForFlow(999), FLOW_STAGES.length - 1);
+});
+
+test('HARD supports a physical jump arc and side projectiles', () => {
+  const state = createRunState('hard', 88);
+  state.angleX = 0;
+  state.angleY = 0;
+  state.angularVelocityX = 0;
+  state.angularVelocityY = 0;
+  state.projectileTimer = 0;
+  let maximumJump = 0;
+  let sawJump = false;
+  let sawProjectile = false;
+
+  for (let frame = 0; frame < 120; frame += 1) {
+    const events = stepBalance(state, { x: 0, y: 0, jump: frame === 0 }, 1 / 60);
+    maximumJump = Math.max(maximumJump, state.jumpY);
+    sawJump ||= events.some((event) => event.type === 'jump');
+    sawProjectile ||= events.some((event) => event.type === 'projectile');
+  }
+
+  assert.equal(sawJump, true);
+  assert.equal(sawProjectile, true);
+  assert.ok(maximumJump >= 0.7);
+  assert.equal(state.jumpY, 0);
+});
+
+test('impacts disturb the balance and drain flow', () => {
+  const state = createRunState('hard', 19);
+  state.angularVelocityX = 0;
+  state.flow = 24;
+  applyImpact(state, -1, 1);
+  assert.ok(state.angularVelocityX < -0.9);
+  assert.equal(state.flow, 14);
+  assert.equal(state.nearSaveArmed, true);
+});
+
+test('runs with the same seed and input remain deterministic', () => {
+  const first = createRunState('medium', 20260824);
+  const second = createRunState('medium', 20260824);
+  for (let frame = 0; frame < 360; frame += 1) {
+    const input = { x: Math.sin(frame / 33) * 0.08, y: Math.cos(frame / 41) * 0.06 };
+    stepBalance(first, input, 1 / 60);
+    stepBalance(second, input, 1 / 60);
+  }
+  assert.deepEqual(serializableState(first), serializableState(second));
+});
+
+test('best-run snapshots keep a compact ghost-ready frame stream', () => {
+  const state = createRunState('easy', 7);
+  state.time = 12.34567;
+  state.score = 1234.7;
+  state.maxStageReached = 2;
+  const frames = Array.from({ length: 5000 }, (_, index) => [index, 0, 0, 0, 0, 0]);
+  const snapshot = createRunSnapshot(state, frames);
+  assert.equal(snapshot.version, 1);
+  assert.equal(snapshot.mode, 'easy');
+  assert.equal(snapshot.time, 12.346);
+  assert.equal(snapshot.score, 1235);
+  assert.equal(snapshot.maxCombo, 3);
+  assert.equal(snapshot.frames.length, 4800);
+});
+
+function serializableState(state) {
+  return {
+    time: state.time,
+    score: state.score,
+    flow: state.flow,
+    stage: state.stage,
+    angleX: state.angleX,
+    angleY: state.angleY,
+    angularVelocityX: state.angularVelocityX,
+    angularVelocityY: state.angularVelocityY,
+    windX: state.windX,
+    windY: state.windY,
+    rngState: state.rngState,
+    failed: state.failed
+  };
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}

--- a/notilt/game-view.mjs
+++ b/notilt/game-view.mjs
@@ -1,0 +1,450 @@
+import * as THREE from 'three';
+
+const BASE_Y = -1.82;
+const STAGE_COLORS = [0x38d9ff, 0x8ce99a, 0xffd43b, 0xff8caf, 0xff4fa3];
+
+export class NoTiltView {
+  constructor(container, { reducedMotion = false } = {}) {
+    if (!container) throw new Error('NO TILT needs a scene container.');
+    this.container = container;
+    this.reducedMotion = reducedMotion;
+    this.elapsed = 0;
+    this.modeId = '';
+    this.stage = 0;
+    this.flash = 0;
+    this.projectileMeshes = new Map();
+    this.stageMaterials = [];
+
+    this.scene = new THREE.Scene();
+    this.scene.fog = new THREE.FogExp2(0x38d9ff, 0.052);
+    this.camera = new THREE.PerspectiveCamera(48, 1, 0.1, 60);
+    this.camera.position.set(0, 1.35, 10.2);
+    this.camera.lookAt(0, 0.55, 0);
+
+    this.renderer = new THREE.WebGLRenderer({
+      antialias: true,
+      alpha: true,
+      powerPreference: 'high-performance'
+    });
+    this.renderer.setPixelRatio(Math.min(globalThis.devicePixelRatio || 1, 1.7));
+    this.renderer.setSize(
+      container.clientWidth || globalThis.innerWidth || 1,
+      container.clientHeight || globalThis.innerHeight || 1,
+      false
+    );
+    this.renderer.outputColorSpace = THREE.SRGBColorSpace;
+    this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    this.renderer.toneMappingExposure = 1.08;
+    this.renderer.shadowMap.enabled = true;
+    this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+    this.renderer.domElement.setAttribute('aria-hidden', 'true');
+    container.append(this.renderer.domElement);
+
+    this.buildLighting();
+    this.buildWorld();
+    this.setMode('easy');
+
+    this.resizeObserver = typeof ResizeObserver === 'function'
+      ? new ResizeObserver(() => this.resize())
+      : null;
+    this.resizeObserver?.observe(container);
+    this.boundResize = () => this.resize();
+    globalThis.addEventListener?.('resize', this.boundResize, { passive: true });
+    this.resize();
+  }
+
+  setMode(modeId) {
+    if (this.modeId === modeId && this.objectPivot) return;
+    this.modeId = modeId;
+    this.stageMaterials.length = 0;
+    if (this.modeRoot) {
+      this.balanceRoot.remove(this.modeRoot);
+      disposeGroup(this.modeRoot);
+    }
+    this.modeRoot = new THREE.Group();
+    this.baseTilt = new THREE.Group();
+    this.objectPivot = new THREE.Group();
+    this.modeRoot.add(this.baseTilt, this.objectPivot);
+    this.balanceRoot.add(this.modeRoot);
+
+    if (modeId === 'medium') this.buildMarkerMode();
+    else if (modeId === 'hard') this.buildHardMode();
+    else this.buildBroomMode();
+  }
+
+  render({ state, input = { x: 0, y: 0 }, deltaSeconds = 1 / 60, phase = 'home' } = {}) {
+    const dt = Math.min(0.05, Math.max(0, Number(deltaSeconds) || 0));
+    this.elapsed += dt;
+    const idle = !state;
+    const angleX = idle ? Math.sin(this.elapsed * 0.72) * 0.045 : state.angleX;
+    const angleY = idle ? Math.cos(this.elapsed * 0.53) * 0.025 : state.angleY;
+    const jumpY = state?.jumpY || 0;
+    const stage = state?.stage || 0;
+    const danger = state?.danger || 0;
+
+    if (stage !== this.stage) this.applyStage(stage);
+    this.balanceRoot.position.y = BASE_Y + jumpY;
+    this.objectPivot.rotation.z = -angleX;
+    this.objectPivot.rotation.x = angleY;
+    this.baseTilt.rotation.z += (-input.x * 0.065 - this.baseTilt.rotation.z) * Math.min(1, dt * 9);
+    this.baseTilt.rotation.x += (input.y * 0.055 - this.baseTilt.rotation.x) * Math.min(1, dt * 9);
+
+    const shadowScale = 1 + jumpY * 0.28;
+    this.balanceShadow.scale.setScalar(shadowScale);
+    this.balanceShadow.material.opacity = Math.max(0.08, 0.32 - jumpY * 0.12);
+    this.syncProjectiles(state?.projectiles || []);
+
+    const decorativeSpeed = this.reducedMotion ? 0 : 0.12 + stage * 0.055;
+    this.flowRings.rotation.z += dt * decorativeSpeed;
+    this.flowRings.rotation.y = Math.sin(this.elapsed * 0.17) * 0.12;
+    this.starField.rotation.z += dt * decorativeSpeed * 0.07;
+    if (!this.reducedMotion) {
+      const targetCameraX = input.x * 0.24 + Math.sin(this.elapsed * 0.22) * 0.035 * stage;
+      const targetCameraY = 1.35 - input.y * 0.12 + Math.cos(this.elapsed * 0.19) * 0.025 * stage;
+      this.camera.position.x += (targetCameraX - this.camera.position.x) * Math.min(1, dt * 3.8);
+      this.camera.position.y += (targetCameraY - this.camera.position.y) * Math.min(1, dt * 3.8);
+      this.camera.lookAt(0, 0.48 + jumpY * 0.12, 0);
+    }
+
+    const dangerPulse = 1 + danger * (0.13 + Math.sin(this.elapsed * 18) * 0.06);
+    this.objectPivot.scale.setScalar(dangerPulse);
+    this.flash = Math.max(0, this.flash - dt * 2.8);
+    this.keyLight.intensity = 3.2 + stage * 0.34 + this.flash * 3.2;
+    this.rimLight.intensity = 6 + stage * 0.85 + danger * 2.6;
+    this.renderer.toneMappingExposure = 1.05 + stage * 0.045 + this.flash * 0.12;
+
+    if (phase === 'paused') this.renderer.toneMappingExposure *= 0.72;
+    this.renderer.render(this.scene, this.camera);
+  }
+
+  pulse(kind = 'flow') {
+    this.flash = kind === 'hit' ? 1.25 : 0.78;
+  }
+
+  resize() {
+    const width = Math.max(1, this.container.clientWidth || globalThis.innerWidth || 1);
+    const height = Math.max(1, this.container.clientHeight || globalThis.innerHeight || 1);
+    this.camera.aspect = width / height;
+    this.camera.fov = width / height < 0.62 ? 50 : 45;
+    this.camera.updateProjectionMatrix();
+    this.renderer.setSize(width, height, false);
+  }
+
+  destroy() {
+    this.resizeObserver?.disconnect();
+    globalThis.removeEventListener?.('resize', this.boundResize);
+    this.renderer.dispose();
+    this.renderer.domElement.remove();
+  }
+
+  buildLighting() {
+    const hemisphere = new THREE.HemisphereLight(0xdff8ff, 0x2b1557, 2.2);
+    this.scene.add(hemisphere);
+
+    this.keyLight = new THREE.DirectionalLight(0xfff3c4, 3.2);
+    this.keyLight.position.set(-4.5, 8, 6);
+    this.keyLight.castShadow = true;
+    this.keyLight.shadow.mapSize.set(1024, 1024);
+    this.keyLight.shadow.camera.left = -7;
+    this.keyLight.shadow.camera.right = 7;
+    this.keyLight.shadow.camera.top = 9;
+    this.keyLight.shadow.camera.bottom = -4;
+    this.scene.add(this.keyLight);
+
+    this.rimLight = new THREE.PointLight(0xff4fa3, 6, 18, 1.8);
+    this.rimLight.position.set(4.5, 3.8, 3.2);
+    this.scene.add(this.rimLight);
+  }
+
+  buildWorld() {
+    this.balanceRoot = new THREE.Group();
+    this.scene.add(this.balanceRoot);
+
+    const floorMaterial = new THREE.MeshStandardMaterial({
+      color: 0x20252b,
+      roughness: 0.78,
+      metalness: 0.14
+    });
+    const floor = new THREE.Mesh(new THREE.CircleGeometry(8.5, 64), floorMaterial);
+    floor.rotation.x = -Math.PI / 2;
+    floor.position.y = BASE_Y - 0.12;
+    floor.receiveShadow = true;
+    this.scene.add(floor);
+
+    const floorRingMaterial = new THREE.MeshBasicMaterial({
+      color: 0xffd43b,
+      transparent: true,
+      opacity: 0.56,
+      side: THREE.DoubleSide
+    });
+    for (const radius of [2.4, 4.1, 6.2]) {
+      const ring = new THREE.Mesh(new THREE.RingGeometry(radius, radius + 0.055, 80), floorRingMaterial.clone());
+      ring.rotation.x = -Math.PI / 2;
+      ring.position.y = BASE_Y - 0.105;
+      this.scene.add(ring);
+    }
+
+    this.balanceShadow = new THREE.Mesh(
+      new THREE.CircleGeometry(1.36, 48),
+      new THREE.MeshBasicMaterial({ color: 0x08090a, transparent: true, opacity: 0.32, depthWrite: false })
+    );
+    this.balanceShadow.rotation.x = -Math.PI / 2;
+    this.balanceShadow.position.set(0, BASE_Y - 0.09, 0.08);
+    this.scene.add(this.balanceShadow);
+
+    this.flowRings = new THREE.Group();
+    const ringColors = [0xff4fa3, 0xffd43b, 0x8ce99a];
+    ringColors.forEach((color, index) => {
+      const material = new THREE.MeshBasicMaterial({
+        color,
+        transparent: true,
+        opacity: 0.14,
+        depthWrite: false
+      });
+      const ring = new THREE.Mesh(new THREE.TorusGeometry(3.7 + index * 0.8, 0.025 + index * 0.008, 8, 96), material);
+      ring.position.set(0, 1.05 + index * 0.1, -3.5 - index * 0.22);
+      ring.rotation.x = 0.12 + index * 0.09;
+      ring.rotation.z = index * 0.8;
+      this.flowRings.add(ring);
+    });
+    this.scene.add(this.flowRings);
+
+    const starPositions = new Float32Array(180 * 3);
+    for (let index = 0; index < starPositions.length; index += 3) {
+      starPositions[index] = (Math.random() - 0.5) * 15;
+      starPositions[index + 1] = Math.random() * 11 - 3;
+      starPositions[index + 2] = -3 - Math.random() * 7;
+    }
+    const starGeometry = new THREE.BufferGeometry();
+    starGeometry.setAttribute('position', new THREE.BufferAttribute(starPositions, 3));
+    this.starField = new THREE.Points(
+      starGeometry,
+      new THREE.PointsMaterial({ color: 0xfff8e8, size: 0.055, transparent: true, opacity: 0.68 })
+    );
+    this.scene.add(this.starField);
+  }
+
+  buildBroomMode() {
+    const dishMaterial = stageMaterial(0x35b8e7, 0x0b5f7e, 0.18, 0.72);
+    this.stageMaterials.push(dishMaterial);
+    const profile = [
+      new THREE.Vector2(0.02, 0.03),
+      new THREE.Vector2(0.38, 0.055),
+      new THREE.Vector2(0.82, 0.16),
+      new THREE.Vector2(1.26, 0.4),
+      new THREE.Vector2(1.52, 0.68)
+    ];
+    const dish = new THREE.Mesh(new THREE.LatheGeometry(profile, 64), dishMaterial);
+    dish.receiveShadow = true;
+    this.baseTilt.add(dish);
+    const rim = new THREE.Mesh(
+      new THREE.TorusGeometry(1.51, 0.105, 12, 64),
+      outlinedMaterial(0xfff8e8, 0x08090a)
+    );
+    rim.rotation.x = Math.PI / 2;
+    rim.position.y = 0.68;
+    rim.castShadow = true;
+    this.baseTilt.add(rim);
+
+    this.objectPivot.position.y = 0.075;
+    const handle = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.105, 0.14, 3.42, 14),
+      outlinedMaterial(0xffd43b, 0x5a3000)
+    );
+    handle.position.y = 1.71;
+    handle.castShadow = true;
+    this.objectPivot.add(handle);
+
+    const brushMaterial = stageMaterial(0xff4fa3, 0x741444, 0.2, 0.58);
+    this.stageMaterials.push(brushMaterial);
+    const brush = new THREE.Mesh(new THREE.BoxGeometry(1.38, 0.52, 0.52), brushMaterial);
+    brush.position.y = 3.55;
+    brush.castShadow = true;
+    this.objectPivot.add(brush);
+    for (let index = -3; index <= 3; index += 1) {
+      const bristle = new THREE.Mesh(
+        new THREE.BoxGeometry(0.14, 0.48, 0.12),
+        new THREE.MeshStandardMaterial({ color: index % 2 ? 0xffd43b : 0xfff8e8, roughness: 0.72 })
+      );
+      bristle.position.set(index * 0.18, 3.98, 0);
+      bristle.rotation.z = index * 0.025;
+      bristle.castShadow = true;
+      this.objectPivot.add(bristle);
+    }
+  }
+
+  buildMarkerMode() {
+    const cradle = new THREE.Mesh(
+      new THREE.CylinderGeometry(1.24, 1.44, 0.28, 48),
+      stageMaterial(0x8ce99a, 0x1b6b46, 0.14, 0.7)
+    );
+    cradle.position.y = 0.06;
+    cradle.receiveShadow = true;
+    this.baseTilt.add(cradle);
+
+    const lower = marker(2.72, 0.31, 0x35b8e7, 0x08090a);
+    lower.rotation.z = Math.PI / 2;
+    lower.position.y = 0.54;
+    lower.castShadow = true;
+    this.baseTilt.add(lower);
+
+    this.objectPivot.position.y = 0.88;
+    const upper = marker(3.35, 0.27, 0xff4fa3, 0xffd43b);
+    upper.position.y = 1.7;
+    this.objectPivot.add(upper);
+    upper.traverse((child) => {
+      if (child.isMesh) child.castShadow = true;
+      if (child.material?.emissive) this.stageMaterials.push(child.material);
+    });
+  }
+
+  buildHardMode() {
+    const platformMaterial = stageMaterial(0x292b59, 0x171735, 0.5, 0.36);
+    this.stageMaterials.push(platformMaterial);
+    const platform = new THREE.Mesh(new THREE.CylinderGeometry(1.15, 1.42, 0.32, 8), platformMaterial);
+    platform.position.y = 0.12;
+    platform.receiveShadow = true;
+    this.baseTilt.add(platform);
+    const padRing = new THREE.Mesh(
+      new THREE.TorusGeometry(0.82, 0.09, 10, 48),
+      new THREE.MeshStandardMaterial({ color: 0xffd43b, emissive: 0xff8c00, emissiveIntensity: 0.52 })
+    );
+    padRing.rotation.x = Math.PI / 2;
+    padRing.position.y = 0.36;
+    this.baseTilt.add(padRing);
+
+    this.objectPivot.position.y = 0.36;
+    const stemMaterial = stageMaterial(0xfff8e8, 0x35b8e7, 0.38, 0.4);
+    this.stageMaterials.push(stemMaterial);
+    const stem = new THREE.Mesh(new THREE.CylinderGeometry(0.16, 0.23, 3.1, 10), stemMaterial);
+    stem.position.y = 1.55;
+    stem.castShadow = true;
+    this.objectPivot.add(stem);
+
+    const coreMaterial = stageMaterial(0xff4fa3, 0xff195f, 0.58, 0.24);
+    this.stageMaterials.push(coreMaterial);
+    const core = new THREE.Mesh(new THREE.OctahedronGeometry(0.78, 0), coreMaterial);
+    core.position.y = 3.32;
+    core.rotation.y = Math.PI / 4;
+    core.castShadow = true;
+    this.objectPivot.add(core);
+    [2.25, 3.32, 4.02].forEach((height, index) => {
+      const ring = new THREE.Mesh(
+        new THREE.TorusGeometry(0.54 - index * 0.08, 0.055, 8, 40),
+        new THREE.MeshStandardMaterial({
+          color: index === 1 ? 0x8ce99a : 0xffd43b,
+          emissive: index === 1 ? 0x22aa66 : 0xd88900,
+          emissiveIntensity: 0.72
+        })
+      );
+      ring.position.y = height;
+      ring.rotation.x = Math.PI / 2;
+      this.objectPivot.add(ring);
+    });
+  }
+
+  syncProjectiles(projectiles) {
+    const activeIds = new Set();
+    for (const projectile of projectiles) {
+      activeIds.add(projectile.id);
+      let mesh = this.projectileMeshes.get(projectile.id);
+      if (!mesh) {
+        mesh = createProjectile(projectile.side);
+        this.projectileMeshes.set(projectile.id, mesh);
+        this.scene.add(mesh);
+      }
+      mesh.position.set(projectile.x, BASE_Y + 0.74, 0.12);
+      mesh.rotation.z += 0.18 * Math.sign(projectile.velocity);
+      if (projectile.hit) mesh.scale.setScalar(1.18);
+    }
+
+    for (const [id, mesh] of this.projectileMeshes) {
+      if (activeIds.has(id)) continue;
+      this.scene.remove(mesh);
+      disposeGroup(mesh);
+      this.projectileMeshes.delete(id);
+    }
+  }
+
+  applyStage(stage) {
+    this.stage = Math.max(0, Math.min(4, Number(stage) || 0));
+    const color = new THREE.Color(STAGE_COLORS[this.stage]);
+    this.scene.fog.color.copy(color).multiplyScalar(0.72);
+    this.rimLight.color.copy(color);
+    this.flowRings.children.forEach((ring, index) => {
+      ring.material.opacity = 0.12 + this.stage * 0.035 + index * 0.012;
+    });
+    for (const material of this.stageMaterials) {
+      if (!material?.emissive) continue;
+      material.emissive.copy(color).multiplyScalar(0.46);
+      material.emissiveIntensity = 0.2 + this.stage * 0.15;
+    }
+  }
+}
+
+function marker(length, radius, bodyColor, capColor) {
+  const group = new THREE.Group();
+  const bodyMaterial = stageMaterial(bodyColor, bodyColor, 0.18, 0.48);
+  const capMaterial = new THREE.MeshStandardMaterial({ color: capColor, roughness: 0.52, metalness: 0.08 });
+  const body = new THREE.Mesh(new THREE.CylinderGeometry(radius, radius, length, 20), bodyMaterial);
+  const capTop = new THREE.Mesh(new THREE.SphereGeometry(radius, 20, 10), capMaterial);
+  const capBottom = capTop.clone();
+  capTop.position.y = length / 2;
+  capBottom.position.y = -length / 2;
+  group.add(body, capTop, capBottom);
+  return group;
+}
+
+function createProjectile(side) {
+  const group = new THREE.Group();
+  const material = new THREE.MeshStandardMaterial({
+    color: side < 0 ? 0xffd43b : 0xff4fa3,
+    emissive: side < 0 ? 0xd88700 : 0xd41462,
+    emissiveIntensity: 0.72,
+    roughness: 0.3,
+    metalness: 0.22
+  });
+  const core = new THREE.Mesh(new THREE.IcosahedronGeometry(0.34, 1), material);
+  core.castShadow = true;
+  const ring = new THREE.Mesh(
+    new THREE.TorusGeometry(0.47, 0.055, 8, 32),
+    new THREE.MeshBasicMaterial({ color: 0xfff8e8 })
+  );
+  ring.rotation.y = Math.PI / 2;
+  const tail = new THREE.Mesh(
+    new THREE.ConeGeometry(0.22, 0.9, 8),
+    new THREE.MeshBasicMaterial({ color: material.color, transparent: true, opacity: 0.42 })
+  );
+  tail.rotation.z = side < 0 ? -Math.PI / 2 : Math.PI / 2;
+  tail.position.x = side * 0.65;
+  group.add(core, ring, tail);
+  return group;
+}
+
+function stageMaterial(color, emissive, emissiveIntensity, roughness) {
+  return new THREE.MeshStandardMaterial({
+    color,
+    emissive,
+    emissiveIntensity,
+    roughness,
+    metalness: 0.12
+  });
+}
+
+function outlinedMaterial(color, emissive) {
+  return new THREE.MeshStandardMaterial({
+    color,
+    emissive,
+    emissiveIntensity: 0.12,
+    roughness: 0.56,
+    metalness: 0.08
+  });
+}
+
+function disposeGroup(group) {
+  group.traverse?.((child) => {
+    child.geometry?.dispose?.();
+    if (Array.isArray(child.material)) child.material.forEach((material) => material.dispose?.());
+    else child.material?.dispose?.();
+  });
+}

--- a/notilt/index.html
+++ b/notilt/index.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<html lang="en" data-game="notilt">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no">
+  <meta name="theme-color" content="#38d9ff">
+  <meta name="application-name" content="NO TILT">
+  <meta name="apple-mobile-web-app-title" content="NO TILT">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="description" content="NO TILT is a portrait motion-controlled balancing game. Counter every wobble, build your flow and keep it up.">
+  <link rel="canonical" href="https://enkel.design/notilt/">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="NO TILT">
+  <meta property="og:title" content="NO TILT — Keep it up">
+  <meta property="og:description" content="A portrait motion-controlled balance game in the world of TURN.">
+  <meta property="og:url" content="https://enkel.design/notilt/">
+  <title>NO TILT</title>
+  <link rel="stylesheet" href="/turn/design-tokens.css?revision=notilt-r1">
+  <link rel="stylesheet" href="./styles.css?revision=r1">
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js"
+      }
+    }
+  </script>
+</head>
+<body data-phase="home" data-stage="0">
+  <div class="scene" id="scene" aria-hidden="true"></div>
+  <div class="scene-wash" aria-hidden="true"></div>
+
+  <header class="game-hud" id="hud" hidden aria-label="Current run">
+    <div class="hud-stats">
+      <div class="hud-chip"><span>TIME</span><strong id="timeValue">0.0s</strong></div>
+      <div class="hud-chip hud-chip-score"><span>SCORE</span><strong id="scoreValue">0</strong></div>
+      <div class="hud-chip"><span>BEST</span><strong id="bestValue">—</strong></div>
+    </div>
+    <div class="flow-card" id="flowCard">
+      <div class="flow-copy">
+        <span id="flowName">STEADY</span>
+        <strong id="comboValue">×1</strong>
+      </div>
+      <div class="flow-track" role="progressbar" aria-label="Flow combo progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" id="flowProgress">
+        <i id="flowFill"></i>
+      </div>
+    </div>
+  </header>
+
+  <div class="callout" id="callout" role="status" aria-live="polite"></div>
+
+  <main>
+    <section class="screen home-screen" id="home" aria-labelledby="gameTitle">
+      <article class="start-card">
+        <span class="kicker">A TURN EXPERIMENT</span>
+        <h1 class="logo" id="gameTitle"><span>NO</span><span>TILT</span></h1>
+        <p class="tagline">KEEP IT UP.</p>
+        <p class="intro-copy">Hold your phone in portrait. Tilt against every wobble. Stay centered long enough and the whole game builds into something bigger.</p>
+
+        <fieldset class="mode-picker">
+          <legend>CHOOSE YOUR BALANCE</legend>
+          <label class="mode-card easy-card">
+            <input type="radio" name="mode" value="easy" checked>
+            <span class="mode-art broom-art" aria-hidden="true"><i></i><b></b></span>
+            <span><strong>EASY</strong><small>Broom on a broad concave dish.</small></span>
+          </label>
+          <label class="mode-card medium-card">
+            <input type="radio" name="mode" value="medium">
+            <span class="mode-art marker-art" aria-hidden="true"><i></i><b></b></span>
+            <span><strong>MEDIUM</strong><small>Marker on marker. Smaller pivot, quicker fall.</small></span>
+          </label>
+          <label class="mode-card hard-card">
+            <input type="radio" name="mode" value="hard">
+            <span class="mode-art signal-art" aria-hidden="true"><i></i><b></b></span>
+            <span><strong>HARD</strong><small>Balance, dodge side attacks, lift your phone to jump.</small></span>
+          </label>
+        </fieldset>
+
+        <p class="start-status" id="startStatus">For tilt play, allow motion access when your phone asks.</p>
+        <div class="start-actions">
+          <button class="button primary-button" id="startTilt" type="button">PLAY WITH TILT</button>
+          <button class="button secondary-button" id="startTouch" type="button">TOUCH MODE</button>
+        </div>
+        <p class="storage-note">Your best try stays on this device, ready for the future YOUR TURN challenge mode.</p>
+      </article>
+    </section>
+
+    <section class="countdown-screen" id="countdown" hidden aria-labelledby="countdownTitle">
+      <div class="countdown-card">
+        <span id="countdownHint">HOLD YOUR PHONE COMFORTABLY</span>
+        <strong id="countdownTitle">3</strong>
+        <small id="countdownMode">CALIBRATING</small>
+      </div>
+    </section>
+
+    <section class="balance-control" id="balanceControl" hidden aria-label="Balance direction">
+      <div class="balance-orb" id="balanceOrb">
+        <span class="orb-cross" aria-hidden="true"></span>
+        <i class="lean-dot" id="leanDot" aria-hidden="true"></i>
+        <b class="input-dot" id="inputDot" aria-hidden="true"></b>
+      </div>
+      <p id="controlHint">TILT AGAINST THE FALL</p>
+    </section>
+
+    <nav class="game-controls" id="gameControls" hidden aria-label="Run controls">
+      <button class="utility-button" id="calibrateButton" type="button">RECENTER</button>
+      <button class="jump-button" id="jumpButton" type="button" hidden><span>JUMP</span><small>LIFT PHONE OR TAP</small></button>
+      <button class="utility-button" id="soundButton" type="button" aria-pressed="true">SOUND ON</button>
+      <button class="utility-button" id="pauseButton" type="button">PAUSE</button>
+    </nav>
+
+    <dialog class="game-dialog" id="pauseDialog" aria-labelledby="pauseTitle">
+      <article class="dialog-card">
+        <span class="dialog-kicker">NO TILT</span>
+        <h2 id="pauseTitle">PAUSED</h2>
+        <p>Take your time. Recenter before you continue if your grip changed.</p>
+        <div class="dialog-actions">
+          <button class="button primary-button" id="resumeButton" type="button">KEEP BALANCING</button>
+          <button class="button secondary-button" id="pauseRecenterButton" type="button">RECENTER</button>
+          <button class="button navigation-button" id="leaveButton" type="button">BACK TO START</button>
+        </div>
+      </article>
+    </dialog>
+
+    <dialog class="game-dialog" id="resultDialog" aria-labelledby="resultTitle">
+      <article class="dialog-card result-card">
+        <span class="dialog-kicker" id="resultKicker">RUN COMPLETE</span>
+        <h2 id="resultTitle">THAT TILTED.</h2>
+        <div class="result-stats">
+          <div><span>TIME</span><strong id="resultTime">0.0s</strong></div>
+          <div><span>SCORE</span><strong id="resultScore">0</strong></div>
+          <div><span>BEST COMBO</span><strong id="resultCombo">×1</strong></div>
+        </div>
+        <p id="resultCopy">Your best try is saved on this device.</p>
+        <div class="dialog-actions">
+          <button class="button primary-button" id="againButton" type="button">TRY AGAIN</button>
+          <button class="button navigation-button" id="changeModeButton" type="button">CHANGE MODE</button>
+        </div>
+      </article>
+    </dialog>
+
+    <section class="orientation-guard" id="orientationGuard" role="dialog" aria-modal="true" aria-labelledby="orientationTitle">
+      <div class="orientation-card">
+        <div class="portrait-phone" aria-hidden="true"><i></i></div>
+        <strong id="orientationTitle">ROTATE BACK TO PORTRAIT</strong>
+        <p>NO TILT is built upright.</p>
+      </div>
+    </section>
+
+    <p class="sr-status" id="screenReaderStatus" role="status" aria-live="polite"></p>
+  </main>
+
+  <script type="module" src="./app.mjs?revision=r1"></script>
+</body>
+</html>

--- a/notilt/input.mjs
+++ b/notilt/input.mjs
@@ -1,0 +1,248 @@
+const DEG = Math.PI / 180;
+const MOTION_SAMPLE_STALE_MS = 320;
+
+export class NoTiltInput {
+  constructor({ onModeChange, onJumpSignal } = {}) {
+    this.onModeChange = onModeChange;
+    this.onJumpSignal = onJumpSignal;
+    this.mode = 'idle';
+    this.pose = null;
+    this.neutral = null;
+    this.manual = { x: 0, y: 0 };
+    this.smoothed = { x: 0, y: 0 };
+    this.jumpQueued = false;
+    this.lastJumpAt = -Infinity;
+    this.lastMotionAt = 0;
+    this.lastLinearY = 0;
+    this.gravityBaselineY = null;
+    this.motionPermission = 'unknown';
+    this.boundMotion = (event) => this.handleMotion(event);
+    this.boundOrientation = (event) => this.handleOrientation(event);
+  }
+
+  static supportsMotion(environment = globalThis) {
+    return Boolean(environment?.DeviceMotionEvent || environment?.DeviceOrientationEvent);
+  }
+
+  async enableMotion() {
+    const environment = globalThis;
+    if (!NoTiltInput.supportsMotion(environment)) {
+      this.enableManual();
+      return { granted: false, reason: 'unsupported' };
+    }
+
+    try {
+      const MotionEvent = environment.DeviceMotionEvent;
+      const OrientationEvent = environment.DeviceOrientationEvent;
+      let result = 'granted';
+
+      if (typeof MotionEvent?.requestPermission === 'function') {
+        result = await MotionEvent.requestPermission();
+      } else if (typeof OrientationEvent?.requestPermission === 'function') {
+        result = await OrientationEvent.requestPermission();
+      }
+
+      if (result !== 'granted') {
+        this.motionPermission = 'denied';
+        this.enableManual();
+        return { granted: false, reason: 'denied' };
+      }
+    } catch (error) {
+      this.motionPermission = 'denied';
+      this.enableManual();
+      return { granted: false, reason: 'error', error };
+    }
+
+    this.detachListeners();
+    environment.addEventListener?.('devicemotion', this.boundMotion, { passive: true });
+    environment.addEventListener?.('deviceorientation', this.boundOrientation, { passive: true });
+    this.motionPermission = 'granted';
+    this.setMode('motion');
+    return { granted: true, reason: 'granted' };
+  }
+
+  enableManual() {
+    this.setMode('manual');
+    this.neutral = null;
+    this.smoothed.x = 0;
+    this.smoothed.y = 0;
+    return { granted: true, reason: 'manual' };
+  }
+
+  calibrate() {
+    if (this.mode !== 'motion' || !this.pose) return false;
+    this.neutral = { roll: this.pose.roll, pitch: this.pose.pitch };
+    this.smoothed.x = 0;
+    this.smoothed.y = 0;
+    return true;
+  }
+
+  getVector(deltaSeconds = 1 / 60) {
+    const dt = Math.min(0.05, Math.max(0, Number(deltaSeconds) || 0));
+    let targetX = 0;
+    let targetY = 0;
+
+    if (this.mode === 'manual') {
+      targetX = this.manual.x;
+      targetY = this.manual.y;
+    } else if (this.mode === 'motion' && this.pose && this.neutral) {
+      targetX = shapeAxis(shortestAngle(this.neutral.roll, this.pose.roll) / (17 * DEG));
+      targetY = shapeAxis(shortestAngle(this.neutral.pitch, this.pose.pitch) / (13 * DEG));
+    }
+
+    const response = 1 - Math.exp(-dt * (this.mode === 'manual' ? 14 : 10));
+    this.smoothed.x += (targetX - this.smoothed.x) * response;
+    this.smoothed.y += (targetY - this.smoothed.y) * response;
+    return { x: this.smoothed.x, y: this.smoothed.y };
+  }
+
+  setManualVector(x, y) {
+    this.manual.x = clamp(Number(x) || 0, -1, 1);
+    this.manual.y = clamp(Number(y) || 0, -1, 1);
+  }
+
+  queueJump(source = 'button') {
+    const now = performance.now();
+    if (now - this.lastJumpAt < 360) return false;
+    this.lastJumpAt = now;
+    this.jumpQueued = true;
+    this.onJumpSignal?.(source);
+    return true;
+  }
+
+  consumeJump() {
+    const queued = this.jumpQueued;
+    this.jumpQueued = false;
+    return queued;
+  }
+
+  hasFreshPose(maxAgeMs = 1000) {
+    return Boolean(this.pose && performance.now() - this.pose.at <= maxAgeMs);
+  }
+
+  getMode() {
+    return this.mode;
+  }
+
+  destroy() {
+    this.detachListeners();
+    this.mode = 'idle';
+  }
+
+  handleMotion(event) {
+    const pose = poseFromGravity(event?.accelerationIncludingGravity);
+    if (pose) {
+      this.pose = { ...pose, at: performance.now(), source: 'gravity' };
+      this.lastMotionAt = this.pose.at;
+      if (!this.neutral && this.mode === 'motion') this.calibrate();
+    }
+
+    const screenAcceleration = screenSpaceVector(event?.acceleration);
+    const gravityAcceleration = screenSpaceVector(event?.accelerationIncludingGravity);
+    const linearY = Number(screenAcceleration?.y);
+    let verticalImpulse = Number.isFinite(linearY) ? Math.abs(linearY) : 0;
+
+    if (gravityAcceleration && Number.isFinite(gravityAcceleration.y)) {
+      if (!Number.isFinite(this.gravityBaselineY)) this.gravityBaselineY = gravityAcceleration.y;
+      this.gravityBaselineY += (gravityAcceleration.y - this.gravityBaselineY) * 0.08;
+      verticalImpulse = Math.max(verticalImpulse, Math.abs(gravityAcceleration.y - this.gravityBaselineY));
+    }
+
+    const jerk = Math.abs((Number.isFinite(linearY) ? linearY : 0) - this.lastLinearY);
+    this.lastLinearY = Number.isFinite(linearY) ? linearY : this.lastLinearY * 0.8;
+    if (verticalImpulse >= 2.85 && (jerk >= 0.65 || verticalImpulse >= 4.4)) {
+      this.queueJump('lift');
+    }
+  }
+
+  handleOrientation(event) {
+    if (performance.now() - this.lastMotionAt < MOTION_SAMPLE_STALE_MS) return;
+    const gamma = Number(event?.gamma);
+    const beta = Number(event?.beta);
+    if (!Number.isFinite(gamma) || !Number.isFinite(beta)) return;
+
+    const screenAngle = getScreenOrientationAngle();
+    const portraitSign = Math.cos(screenAngle) < 0 ? -1 : 1;
+    this.pose = {
+      roll: gamma * DEG * portraitSign,
+      pitch: beta * DEG * portraitSign,
+      at: performance.now(),
+      source: 'orientation'
+    };
+    if (!this.neutral && this.mode === 'motion') this.calibrate();
+  }
+
+  setMode(nextMode) {
+    if (this.mode === nextMode) return;
+    this.mode = nextMode;
+    this.onModeChange?.(nextMode);
+  }
+
+  detachListeners() {
+    globalThis.removeEventListener?.('devicemotion', this.boundMotion);
+    globalThis.removeEventListener?.('deviceorientation', this.boundOrientation);
+  }
+}
+
+function poseFromGravity(gravity) {
+  const vector = screenSpaceVector(gravity);
+  if (!vector) return null;
+  const planarGravity = Math.hypot(vector.x, vector.y);
+  const totalGravity = Math.hypot(planarGravity, vector.z);
+  if (totalGravity < 1.4 || planarGravity < 0.8) return null;
+
+  let roll = normalizeAngle(Math.atan2(vector.x, -vector.y));
+  if (roll > Math.PI / 2) roll -= Math.PI;
+  if (roll < -Math.PI / 2) roll += Math.PI;
+  return {
+    roll,
+    pitch: Math.atan2(vector.z, planarGravity)
+  };
+}
+
+function screenSpaceVector(vector) {
+  if (!vector) return null;
+  const x = Number(vector.x);
+  const y = Number(vector.y);
+  const z = Number(vector.z);
+  if (![x, y, z].every(Number.isFinite)) return null;
+  const angle = getScreenOrientationAngle();
+  const cos = Math.cos(angle);
+  const sin = Math.sin(angle);
+  return {
+    x: x * cos + y * sin,
+    y: -x * sin + y * cos,
+    z
+  };
+}
+
+function getScreenOrientationAngle() {
+  const degrees = Number.isFinite(globalThis.screen?.orientation?.angle)
+    ? globalThis.screen.orientation.angle
+    : Number(globalThis.orientation || 0);
+  return (Number.isFinite(degrees) ? degrees : 0) * DEG;
+}
+
+function shapeAxis(value) {
+  const clamped = clamp(Number(value) || 0, -1, 1);
+  const magnitude = Math.abs(clamped);
+  if (magnitude < 0.035) return 0;
+  const normalized = (magnitude - 0.035) / 0.965;
+  const eased = normalized * normalized * (3 - 2 * normalized);
+  return Math.sign(clamped) * eased;
+}
+
+function shortestAngle(from, to) {
+  return normalizeAngle(to - from);
+}
+
+function normalizeAngle(angle) {
+  let value = angle;
+  while (value > Math.PI) value -= Math.PI * 2;
+  while (value < -Math.PI) value += Math.PI * 2;
+  return value;
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}

--- a/notilt/notilt-contract.test.mjs
+++ b/notilt/notilt-contract.test.mjs
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const [html, css, app, input] = await Promise.all([
+  readFile(new URL('./index.html', import.meta.url), 'utf8'),
+  readFile(new URL('./styles.css', import.meta.url), 'utf8'),
+  readFile(new URL('./app.mjs', import.meta.url), 'utf8'),
+  readFile(new URL('./input.mjs', import.meta.url), 'utf8')
+]);
+
+test('NO TILT is explicitly portrait-first', () => {
+  assert.match(html, /ROTATE BACK TO PORTRAIT/);
+  assert.match(css, /@media \(orientation: landscape\)/);
+  assert.match(css, /\.orientation-guard \{ display: grid; \}/);
+  assert.match(app, /pauseRun\(true\)/);
+  assert.match(app, /PORTRAIT · RECENTERED/);
+});
+
+test('all modes and both input paths are present in the start experience', () => {
+  assert.match(html, /value="easy"/);
+  assert.match(html, /value="medium"/);
+  assert.match(html, /value="hard"/);
+  assert.match(html, /PLAY WITH TILT/);
+  assert.match(html, /TOUCH MODE/);
+  assert.match(html, /LIFT PHONE OR TAP/);
+});
+
+test('motion permission, gravity pose and physical lift detection are implemented', () => {
+  assert.match(input, /requestPermission/);
+  assert.match(input, /accelerationIncludingGravity/);
+  assert.match(input, /verticalImpulse/);
+  assert.match(input, /queueJump\('lift'\)/);
+  assert.match(input, /screenSpaceVector/);
+});
+
+test('the visual runtime uses the same Three.js version as TURN', () => {
+  assert.match(html, /three@0\.184\.0\/build\/three\.module\.js/);
+  assert.match(html, /type="importmap"/);
+  assert.match(app, /from '\.\/game-view\.mjs'/);
+});
+
+test('screen-reader, reduced-motion and high-contrast affordances are included', () => {
+  assert.match(html, /aria-live="polite"/);
+  assert.match(html, /role="progressbar"/);
+  assert.match(css, /prefers-reduced-motion: reduce/);
+  assert.match(css, /prefers-contrast: more/);
+});
+
+test('best attempts are recorded for a later YOUR TURN layer', () => {
+  assert.match(app, /notilt\.best-runs\.v1/);
+  assert.match(app, /RECORD_INTERVAL_SECONDS = 1 \/ 15/);
+  assert.match(app, /createRunSnapshot/);
+  assert.match(html, /future YOUR TURN challenge mode/);
+});

--- a/notilt/styles.css
+++ b/notilt/styles.css
@@ -1,0 +1,814 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-rounded, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --ink: var(--turn-ink, #08090a);
+  --paper: var(--turn-paper, #fff8e8);
+  --white: var(--turn-white, #fffdf6);
+  --cyan: var(--turn-blue-500, #38d9ff);
+  --pink: var(--turn-pink-500, #ff4fa3);
+  --yellow: var(--turn-yellow-400, #ffd43b);
+  --lime: var(--turn-green-500, #8ce99a);
+  --orange: var(--turn-orange-500, #ff7b54);
+  --red: var(--turn-red-500, #ff6b6b);
+  --app-height: 100vh;
+  --stage-color: var(--cyan);
+  --stage-soft: #8ed8ff;
+}
+
+@supports (height: 100dvh) {
+  :root { --app-height: 100dvh; }
+}
+
+* { box-sizing: border-box; }
+
+html,
+body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+  overscroll-behavior: none;
+  background: var(--cyan);
+}
+
+body {
+  position: fixed;
+  inset: 0;
+  min-width: 100vw;
+  min-height: 100vh;
+  height: var(--app-height);
+  color: var(--ink);
+  font-weight: 850;
+  -webkit-font-smoothing: antialiased;
+  -webkit-tap-highlight-color: transparent;
+  transition: background-color 500ms ease;
+}
+
+body[data-stage="1"] { --stage-color: var(--lime); --stage-soft: #d9f5c2; }
+body[data-stage="2"] { --stage-color: var(--yellow); --stage-soft: #fff0a8; }
+body[data-stage="3"] { --stage-color: #ff8caf; --stage-soft: #ffd1e6; }
+body[data-stage="4"] { --stage-color: var(--pink); --stage-soft: #ff8caf; }
+
+button,
+input { font: inherit; }
+
+button {
+  appearance: none;
+  min-height: 48px;
+  border: 3px solid var(--ink);
+  border-radius: var(--turn-radius-compact, 12px);
+  color: var(--ink);
+  box-shadow: 4px 4px 0 var(--ink);
+  cursor: pointer;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+button:active {
+  transform: translate(2px, 2px);
+  box-shadow: 2px 2px 0 var(--ink);
+}
+
+button:focus-visible,
+input:focus-visible + .mode-art {
+  outline: 4px solid var(--white);
+  outline-offset: 3px;
+}
+
+[hidden] { display: none !important; }
+
+.scene,
+.scene-wash {
+  position: absolute;
+  inset: 0;
+}
+
+.scene {
+  z-index: 0;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 50% 24%, rgb(255 255 255 / 0.48), transparent 26%),
+    linear-gradient(175deg, var(--stage-soft) 0%, var(--cyan) 44%, #6857d9 100%);
+  transition: background 600ms ease;
+}
+
+.scene canvas {
+  display: block;
+  width: 100% !important;
+  height: 100% !important;
+}
+
+.scene-wash {
+  z-index: 1;
+  pointer-events: none;
+  background:
+    radial-gradient(circle at 50% 46%, transparent 30%, rgb(8 9 10 / 0.17) 100%),
+    linear-gradient(180deg, rgb(255 255 255 / 0.08), transparent 34%, rgb(8 9 10 / 0.18));
+  transition: box-shadow 140ms ease, background 400ms ease;
+}
+
+body.is-danger .scene-wash {
+  box-shadow: inset 0 0 70px 10px rgb(255 55 82 / 0.55);
+}
+
+body.is-hit .scene-wash { animation: impact-flash 180ms linear; }
+
+main { position: relative; z-index: 5; }
+
+.screen,
+.countdown-screen,
+.orientation-guard {
+  position: fixed;
+  inset: 0;
+}
+
+.home-screen {
+  z-index: 20;
+  overflow: auto;
+  padding:
+    max(18px, env(safe-area-inset-top))
+    max(16px, env(safe-area-inset-right))
+    max(22px, env(safe-area-inset-bottom))
+    max(16px, env(safe-area-inset-left));
+  scrollbar-width: none;
+}
+
+.home-screen::-webkit-scrollbar { display: none; }
+
+.start-card {
+  width: min(100%, 520px);
+  margin: 0 auto;
+  padding: 19px 18px 17px;
+  border: 5px solid var(--ink);
+  border-radius: var(--turn-radius-hero, 28px);
+  background: rgb(255 248 232 / 0.95);
+  box-shadow: 9px 9px 0 var(--ink);
+  backdrop-filter: blur(14px);
+}
+
+.kicker,
+.dialog-kicker {
+  display: inline-block;
+  padding: 5px 9px;
+  border: 3px solid var(--ink);
+  border-radius: 999px;
+  background: var(--yellow);
+  font-size: 0.66rem;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  text-transform: uppercase;
+  transform: rotate(-1deg);
+}
+
+.logo {
+  display: grid;
+  width: fit-content;
+  margin: 10px 0 0;
+  font-size: clamp(4rem, 19vw, 7.4rem);
+  font-weight: 1000;
+  letter-spacing: -0.095em;
+  line-height: 0.67;
+}
+
+.logo span:last-child {
+  color: var(--pink);
+  -webkit-text-stroke: 3px var(--ink);
+  paint-order: stroke fill;
+  transform: rotate(-3deg) translateX(0.08em);
+}
+
+.tagline {
+  margin: 15px 0 2px;
+  font-size: 1.05rem;
+  letter-spacing: 0.08em;
+}
+
+.intro-copy {
+  margin: 5px 0 15px;
+  font-size: 0.82rem;
+  font-weight: 730;
+  line-height: 1.35;
+}
+
+.mode-picker {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.mode-picker legend {
+  margin-bottom: 7px;
+  padding: 0;
+  font-size: 0.69rem;
+  letter-spacing: 0.08em;
+}
+
+.mode-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: 54px 1fr;
+  align-items: center;
+  min-height: 66px;
+  padding: 8px 10px;
+  border: 3px solid var(--ink);
+  border-radius: 14px;
+  background: var(--white);
+  box-shadow: 3px 3px 0 var(--ink);
+  cursor: pointer;
+}
+
+.mode-card input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+}
+
+.mode-card.is-selected,
+.mode-card:has(input:checked) {
+  transform: translate(-2px, -2px);
+  box-shadow: 6px 6px 0 var(--ink);
+}
+
+.easy-card.is-selected,
+.easy-card:has(input:checked) { background: var(--turn-difficulty-easy, #d9f5c2); }
+.medium-card.is-selected,
+.medium-card:has(input:checked) { background: var(--turn-difficulty-medium, #ffe087); }
+.hard-card.is-selected,
+.hard-card:has(input:checked) { background: var(--turn-difficulty-hard, #ff9b91); }
+
+.mode-card strong,
+.mode-card small { display: block; }
+
+.mode-card strong {
+  font-size: 0.9rem;
+  letter-spacing: 0.04em;
+}
+
+.mode-card small {
+  margin-top: 2px;
+  font-size: 0.67rem;
+  font-weight: 710;
+  line-height: 1.18;
+}
+
+.mode-art {
+  position: relative;
+  display: block;
+  width: 44px;
+  height: 44px;
+  border: 3px solid var(--ink);
+  border-radius: 50%;
+  background: var(--cyan);
+  overflow: hidden;
+}
+
+.mode-art i,
+.mode-art b {
+  position: absolute;
+  display: block;
+  border: 2px solid var(--ink);
+}
+
+.broom-art i {
+  left: 19px;
+  top: 7px;
+  width: 5px;
+  height: 25px;
+  border-radius: 4px;
+  background: var(--yellow);
+  transform: rotate(-6deg);
+}
+
+.broom-art b {
+  left: 12px;
+  top: 5px;
+  width: 20px;
+  height: 9px;
+  border-radius: 4px;
+  background: var(--pink);
+  transform: rotate(-6deg);
+}
+
+.marker-art { background: var(--yellow); }
+.marker-art i,
+.marker-art b {
+  width: 8px;
+  height: 30px;
+  border-radius: 6px;
+}
+.marker-art i { left: 18px; top: 2px; background: var(--pink); transform: rotate(8deg); }
+.marker-art b { left: 18px; top: 20px; background: var(--cyan); transform: rotate(88deg); }
+
+.signal-art { background: #292b59; }
+.signal-art i {
+  left: 18px;
+  top: 9px;
+  width: 8px;
+  height: 28px;
+  border-radius: 6px;
+  background: var(--white);
+}
+.signal-art b {
+  left: 12px;
+  top: 4px;
+  width: 20px;
+  height: 20px;
+  background: var(--pink);
+  transform: rotate(45deg);
+}
+
+.start-status {
+  min-height: 2.4em;
+  margin: 13px 2px 8px;
+  font-size: 0.69rem;
+  font-weight: 720;
+  line-height: 1.25;
+}
+
+.start-status.is-warning {
+  padding: 7px 9px;
+  border: 2px solid var(--ink);
+  border-radius: 9px;
+  background: var(--yellow);
+}
+
+.start-actions {
+  display: grid;
+  grid-template-columns: 1fr 0.72fr;
+  gap: 9px;
+}
+
+.button {
+  padding: 10px 12px;
+  font-size: 0.75rem;
+  letter-spacing: 0.025em;
+}
+
+.primary-button { background: var(--pink); }
+.secondary-button { background: var(--cyan); }
+.navigation-button { background: var(--orange); }
+
+.storage-note {
+  margin: 11px 2px 0;
+  color: rgb(8 9 10 / 0.67);
+  font-size: 0.61rem;
+  font-weight: 680;
+  line-height: 1.25;
+}
+
+.game-hud {
+  position: fixed;
+  z-index: 10;
+  top: 0;
+  left: 0;
+  right: 0;
+  padding:
+    max(10px, env(safe-area-inset-top))
+    max(10px, env(safe-area-inset-right))
+    0
+    max(10px, env(safe-area-inset-left));
+  pointer-events: none;
+}
+
+.hud-stats {
+  display: grid;
+  grid-template-columns: 1fr 1.15fr 1fr;
+  gap: 7px;
+}
+
+.hud-chip,
+.flow-card {
+  border: 3px solid var(--ink);
+  color: var(--ink);
+  box-shadow: 3px 3px 0 var(--ink);
+}
+
+.hud-chip {
+  min-width: 0;
+  padding: 5px 7px 6px;
+  border-radius: 11px;
+  background: rgb(255 248 232 / 0.91);
+}
+
+.hud-chip-score { background: var(--stage-soft); }
+
+.hud-chip span,
+.hud-chip strong { display: block; }
+
+.hud-chip span {
+  font-size: 0.5rem;
+  letter-spacing: 0.08em;
+}
+
+.hud-chip strong {
+  overflow: hidden;
+  margin-top: 1px;
+  font-size: clamp(0.8rem, 3.6vw, 1.1rem);
+  line-height: 1;
+  text-overflow: ellipsis;
+}
+
+.flow-card {
+  width: min(78vw, 330px);
+  margin: 7px auto 0;
+  padding: 5px 7px 6px;
+  border-radius: 12px;
+  background: rgb(255 248 232 / 0.92);
+  transition: transform 180ms ease, background 300ms ease;
+}
+
+.flow-card.stage-up { animation: combo-pop 480ms cubic-bezier(.2, .85, .25, 1.25); }
+
+.flow-copy {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 0.64rem;
+  letter-spacing: 0.07em;
+}
+
+.flow-copy strong { font-size: 0.95rem; }
+
+.flow-track {
+  height: 9px;
+  margin-top: 3px;
+  overflow: hidden;
+  border: 2px solid var(--ink);
+  border-radius: 999px;
+  background: var(--white);
+}
+
+.flow-track i {
+  display: block;
+  width: 0;
+  height: 100%;
+  background: var(--stage-color);
+  transition: width 100ms linear, background-color 300ms ease;
+}
+
+.callout {
+  position: fixed;
+  z-index: 16;
+  left: 50%;
+  top: 25%;
+  max-width: 88vw;
+  padding: 7px 12px;
+  border: 3px solid var(--ink);
+  border-radius: 999px;
+  background: var(--stage-color);
+  color: var(--ink);
+  box-shadow: 4px 4px 0 var(--ink);
+  font-size: 0.72rem;
+  letter-spacing: 0.055em;
+  text-align: center;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, 12px) rotate(-2deg) scale(0.86);
+  transition: opacity 120ms ease, transform 180ms ease;
+}
+
+.callout.show {
+  opacity: 1;
+  transform: translate(-50%, 0) rotate(-2deg) scale(1);
+}
+
+.countdown-screen {
+  z-index: 30;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+  background: rgb(8 9 10 / 0.28);
+  backdrop-filter: blur(4px);
+}
+
+.countdown-card {
+  width: min(88vw, 370px);
+  padding: 22px;
+  border: 5px solid var(--ink);
+  border-radius: 26px;
+  background: var(--yellow);
+  box-shadow: 9px 9px 0 var(--ink);
+  text-align: center;
+  transform: rotate(-1deg);
+}
+
+.countdown-card span,
+.countdown-card small { display: block; }
+
+.countdown-card span {
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+}
+
+.countdown-card strong {
+  display: block;
+  margin: 8px 0;
+  font-size: clamp(5rem, 28vw, 9rem);
+  line-height: 0.9;
+}
+
+.countdown-card small { font-size: 0.66rem; letter-spacing: 0.1em; }
+
+.balance-control {
+  position: fixed;
+  z-index: 12;
+  left: max(10px, env(safe-area-inset-left));
+  bottom: max(76px, calc(env(safe-area-inset-bottom) + 70px));
+  width: 92px;
+  text-align: center;
+  pointer-events: none;
+}
+
+.balance-orb {
+  position: relative;
+  width: 84px;
+  height: 84px;
+  margin: 0 auto;
+  border: 3px solid var(--ink);
+  border-radius: 50%;
+  background: rgb(255 248 232 / 0.82);
+  box-shadow: 3px 3px 0 var(--ink);
+  touch-action: none;
+}
+
+.balance-control.is-manual { pointer-events: auto; }
+.balance-control.is-manual .balance-orb {
+  background: rgb(255 248 232 / 0.94);
+  cursor: grab;
+}
+.balance-control.is-manual .balance-orb:active { cursor: grabbing; }
+
+.orb-cross::before,
+.orb-cross::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  background: rgb(8 9 10 / 0.22);
+  transform: translate(-50%, -50%);
+}
+
+.orb-cross::before { width: 2px; height: 72%; }
+.orb-cross::after { width: 72%; height: 2px; }
+
+.lean-dot,
+.input-dot {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  border: 2px solid var(--ink);
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  will-change: left, top;
+}
+
+.lean-dot {
+  width: 18px;
+  height: 18px;
+  background: var(--pink);
+  box-shadow: 1px 1px 0 var(--ink);
+}
+
+.input-dot {
+  width: 10px;
+  height: 10px;
+  background: var(--yellow);
+}
+
+.balance-control p {
+  margin: 5px -7px 0;
+  padding: 3px 4px;
+  border: 2px solid var(--ink);
+  border-radius: 7px;
+  background: rgb(255 248 232 / 0.9);
+  box-shadow: 2px 2px 0 var(--ink);
+  font-size: 0.49rem;
+  line-height: 1.05;
+  letter-spacing: 0.04em;
+}
+
+.game-controls {
+  position: fixed;
+  z-index: 14;
+  left: max(9px, env(safe-area-inset-left));
+  right: max(9px, env(safe-area-inset-right));
+  bottom: max(9px, env(safe-area-inset-bottom));
+  display: flex;
+  align-items: end;
+  justify-content: flex-end;
+  gap: 7px;
+}
+
+.utility-button {
+  min-height: 47px;
+  padding: 6px 9px;
+  background: rgb(255 248 232 / 0.94);
+  font-size: 0.55rem;
+  letter-spacing: 0.025em;
+}
+
+.jump-button {
+  min-width: 112px;
+  min-height: 62px;
+  margin-right: auto;
+  margin-left: 0;
+  padding: 6px 10px;
+  border-radius: 18px;
+  background: var(--yellow);
+}
+
+.jump-button span,
+.jump-button small { display: block; }
+.jump-button span { font-size: 1rem; line-height: 1; }
+.jump-button small { margin-top: 3px; font-size: 0.45rem; letter-spacing: 0.04em; }
+.jump-button.is-airborne { background: var(--cyan); }
+
+.game-dialog {
+  width: 100%;
+  max-width: none;
+  height: 100%;
+  max-height: none;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--ink);
+}
+
+.game-dialog::backdrop { background: rgb(8 9 10 / 0.48); backdrop-filter: blur(5px); }
+
+.game-dialog[open] {
+  display: grid;
+  place-items: center;
+  padding:
+    max(20px, env(safe-area-inset-top))
+    max(16px, env(safe-area-inset-right))
+    max(20px, env(safe-area-inset-bottom))
+    max(16px, env(safe-area-inset-left));
+}
+
+.dialog-card {
+  width: min(100%, 430px);
+  padding: 22px;
+  border: 5px solid var(--ink);
+  border-radius: 26px;
+  background: var(--paper);
+  box-shadow: 9px 9px 0 var(--ink);
+}
+
+.dialog-card h2 {
+  margin: 10px 0 5px;
+  font-size: clamp(2.5rem, 14vw, 4.5rem);
+  line-height: 0.82;
+  letter-spacing: -0.075em;
+}
+
+.dialog-card p { margin: 13px 0; font-size: 0.83rem; line-height: 1.35; }
+
+.dialog-actions { display: grid; gap: 9px; }
+
+.result-card { background: var(--stage-soft); }
+
+.result-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
+  margin: 17px 0 12px;
+}
+
+.result-stats div {
+  min-width: 0;
+  padding: 8px 5px;
+  border: 3px solid var(--ink);
+  border-radius: 11px;
+  background: var(--white);
+  text-align: center;
+  box-shadow: 3px 3px 0 var(--ink);
+}
+
+.result-stats span,
+.result-stats strong { display: block; }
+.result-stats span { font-size: 0.47rem; letter-spacing: 0.06em; }
+.result-stats strong { margin-top: 3px; font-size: clamp(0.82rem, 4vw, 1.2rem); }
+
+.orientation-guard {
+  z-index: 100;
+  display: none;
+  place-items: center;
+  padding: 20px;
+  background:
+    radial-gradient(circle at 20% 18%, var(--pink) 0 10%, transparent 10.5%),
+    radial-gradient(circle at 80% 78%, var(--yellow) 0 12%, transparent 12.5%),
+    var(--cyan);
+}
+
+.orientation-card {
+  padding: 22px;
+  border: 5px solid var(--ink);
+  border-radius: 24px;
+  background: var(--yellow);
+  box-shadow: 8px 8px 0 var(--ink);
+  text-align: center;
+  transform: rotate(-1deg);
+}
+
+.orientation-card strong { display: block; font-size: 1.1rem; }
+.orientation-card p { margin: 7px 0 0; font-size: 0.76rem; }
+
+.portrait-phone {
+  position: relative;
+  width: 52px;
+  height: 88px;
+  margin: 0 auto 13px;
+  border: 5px solid var(--ink);
+  border-radius: 13px;
+  background: var(--paper);
+}
+
+.portrait-phone i {
+  position: absolute;
+  left: 50%;
+  bottom: 5px;
+  width: 8px;
+  height: 8px;
+  border: 2px solid var(--ink);
+  border-radius: 50%;
+  transform: translateX(-50%);
+}
+
+.sr-status {
+  position: fixed;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+@media (orientation: landscape) {
+  .orientation-guard { display: grid; }
+}
+
+@media (min-width: 700px) and (orientation: portrait) {
+  .start-card { width: min(72vw, 600px); padding: 25px 26px 23px; }
+  .mode-card { min-height: 78px; }
+  .mode-card small { font-size: 0.76rem; }
+  .game-hud { width: min(680px, 100%); left: 50%; right: auto; transform: translateX(-50%); }
+  .balance-control { left: max(24px, env(safe-area-inset-left)); bottom: 100px; transform: scale(1.15); transform-origin: bottom left; }
+  .game-controls { left: max(24px, env(safe-area-inset-left)); right: max(24px, env(safe-area-inset-right)); bottom: max(20px, env(safe-area-inset-bottom)); }
+}
+
+@media (max-height: 700px) and (orientation: portrait) {
+  .home-screen { padding-top: max(10px, env(safe-area-inset-top)); }
+  .start-card { padding: 14px 15px 13px; }
+  .logo { font-size: clamp(3.4rem, 17vw, 5rem); }
+  .tagline { margin-top: 11px; }
+  .intro-copy { margin-bottom: 10px; }
+  .mode-card { min-height: 58px; padding-block: 5px; }
+  .mode-art { width: 40px; height: 40px; }
+  .start-status { margin-top: 9px; }
+  .storage-note { display: none; }
+}
+
+@media (max-width: 360px) {
+  .start-actions { grid-template-columns: 1fr; }
+  .mode-card { grid-template-columns: 49px 1fr; }
+  .utility-button { padding-inline: 6px; font-size: 0.5rem; }
+  .jump-button { min-width: 96px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+}
+
+@media (prefers-contrast: more) {
+  .start-card,
+  .hud-chip,
+  .flow-card,
+  .balance-orb,
+  .balance-control p,
+  .utility-button { background-color: var(--paper); }
+  .scene-wash { background: rgb(8 9 10 / 0.12); }
+}
+
+@keyframes combo-pop {
+  0% { transform: scale(1); }
+  40% { transform: scale(1.09) rotate(-1deg); }
+  100% { transform: scale(1); }
+}
+
+@keyframes impact-flash {
+  0%, 100% { background-color: transparent; }
+  45% { background-color: rgb(255 255 255 / 0.72); }
+}


### PR DESCRIPTION
## What changed

- add a new portrait-only game at `/notilt/` in TURN’s high-contrast, low-poly visual language
- add three genuinely different balance modes:
  - **EASY:** broom balanced handle-down on a broad concave dish
  - **MEDIUM:** marker balanced on another marker with a tighter pivot
  - **HARD:** an abstract signal balanced while side projectiles attack; a quick upward phone movement jumps, with visible button and Space-key fallbacks
- use two-axis calibrated device motion, screen-space orientation correction, iOS permission handling, automatic portrait-return recalibration, and a full touch/keyboard fallback through the same physics
- add a five-stage flow combo that increases score multiplier, procedural music density, lighting, color, tension, and HARD attack pace over time
- save each difficulty’s best attempt locally as a compact 15 Hz, seeded, ghost-ready run without exposing sharing UI yet
- include pause/recenter, sound controls, reduced-motion treatment, high-contrast treatment, screen-reader status updates, and a hard landscape guard
- add focused NO TILT CI and implementation notes

## Product boundary

This is the actual game-first release. The future YOUR TURN layer can encode and replay the already-recorded best-run frames, but challenge links and sharing are deliberately not included yet.

The change is isolated to `/notilt` plus its own workflow. No TURN, YOUR TURN, track, or gameplay files are changed.

## Validation

- `node --check` passes for every NO TILT module
- `node --test notilt/*.test.mjs` — 14/14 passing
- deterministic physics coverage for unattended falls, counter-control survival, combo progression, HARD jumps/projectiles, impacts, run seeding, and ghost snapshot bounds
- markup contract coverage for portrait enforcement, all modes/input paths, motion permission/lift detection, current TURN Three.js parity, reduced motion, high contrast, ARIA status, and ghost-ready storage
- HTML IDs and `aria-labelledby` references validated as unique and complete