### PR TITLE
Add portrait play experiment to TURN LAB

### DIFF
--- a/turn-lab/README.md
+++ b/turn-lab/README.md
@@ -1,29 +1,39 @@
-# TURN LAB — viewport flight recorder
+# TURN LAB — isolated gameplay experiments
 
-`/turn-lab/` is a temporary real-device diagnostic shell for issue #394.
+`/turn-lab/` runs the current production TURN module graph through `<base href="/turn/">`, while keeping a separate PWA identity and separate `turn-lab:` storage namespace. Production `/turn/` files and save data are not modified by LAB testing.
 
-It intentionally runs the **current production TURN 1.7.0 / 2026.08.09-r163 module graph** through `<base href="/turn/">`, while keeping a separate PWA identity and a separate storage namespace. Production `/turn/` files and save data are not modified by LAB testing.
+## Active experiments
 
-## Why this exists
+### Portrait play R1
 
-The intermittent bottom strip only reproduces reliably in the installed iOS Home Screen app. Desktop/browser DevTools are therefore not a sufficient observation point. The LAB flight recorder starts before the production PWA viewport boundary and persists several launches so a random good launch can be compared with a random bad launch later.
+Portrait is now a real race layout rather than a rotate-device blocker:
 
-## Real-device procedure
+- the rendered game occupies the upper portrait stage;
+- the existing four-zone drive pad occupies a dedicated lower control deck;
+- the HUD is condensed into a five-chip row with the map, boost and a LAB-only live steering meter above it;
+- the camera uses `zoom = 0.78` to recover useful horizontal road context without changing race physics;
+- production's forced landscape lock is suppressed only while LAB is already in portrait.
+
+The first steering hypothesis deliberately preserves the proven production transfer function. Phone steering still engages at 2.2°, releases at 0.9°, and reaches full lock at ±24°. The existing damped iPad profile still engages at 3.2° and releases at 1.4°. Only visible camera roll is reduced to ±16° in portrait; landscape LAB remains at ±24°.
+
+This makes the first real-device comparison interpretable: any difference in steering feel comes from the portrait grip and viewport, not a hidden sensitivity change.
+
+### Connected roadtrip R1
+
+The six-track connected-world experiment remains active in both orientations. Each track retains its two experimental exits and isolated LAB state.
+
+## Try it
 
 1. Open `https://enkel.design/turn-lab/` in Safari.
-2. Add **TURN LAB** to the Home Screen.
-3. Cold-launch it in the orientations that have produced the strip.
-4. Open the fixed **LAB** control.
-5. While the symptom is visible, choose **MARK BAD**. For a normal launch choose **MARK GOOD**.
-6. Optionally choose **COLOR LAYERS** while the strip is visible. This changes diagnostic backgrounds only after launch: HTML = red/pink, BODY = green, `#game` = blue, with outlined full-screen TURN surfaces.
-7. After at least one good and one bad session, choose **COPY LOG** and paste the JSON into the debugging thread.
-
-The recorder captures screen, window, document, Visual Viewport, orientation, body/game/Home/rotate/loading rectangles, TURN's own `__turnPwaViewportDiagnostics`, CSS app dimensions, and event timing around startup/rotation/visibility changes.
+2. Add **TURN LAB** to the Home Screen, or choose **Play in browser anyway**.
+3. Keep the device in portrait, choose a car and track, and start a motion-steering race.
+4. Recalibrate in your natural two-handed portrait grip.
+5. Use the live steering meter to compare physical angle with delivered steering. Full lock is ±24°.
+6. Rotate back to landscape before starting another race if you want a direct control comparison.
 
 ## Safety
 
-- No production TURN code is changed to make the diagnostic build work.
+- No production TURN file is changed for these experiments.
 - LAB uses `turn-lab:` / `turn-lab-session:` storage prefixes and does not seed data from production.
-- The diagnostic UI is fixed/overlayed and does not consume layout space.
-- The production PWA viewport boundary remains unchanged, so the lab should preserve the failure mode instead of "fixing" it before measurement.
-- Old historical `turn-lab` implementation files may still exist in the repository, but the current LAB entry point does not load them; current gameplay assets resolve from `/turn/`.
+- Portrait layout and orientation-lock behavior are scoped to `data-turn-deployment="lab"`.
+- The production physics, vehicle handling, drift, boost, Drive By Ear and accessibility systems remain the runtime source of truth.

--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -1,12 +1,12 @@
 <!doctype html>
-<!-- TURN LAB connected-world experiment. Runtime source: production TURN 2026.08.18-r175. -->
+<!-- TURN LAB connected-world + portrait-play experiments. Runtime source: production TURN 2026.08.23-r183. -->
 <html lang="en" data-turn-deployment="lab"><head>
   <base href="/turn/">
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no, shrink-to-fit=no">
   <meta name="theme-color" content="#08090a">
   <meta name="application-name" content="TURN LAB">
-  <meta name="description" content="TURN LAB runs isolated experiments on the current production TURN runtime. This build prototypes a connected six-track roadtrip world.">
+  <meta name="description" content="TURN LAB runs isolated experiments on the current production TURN runtime. This build supports portrait racing and a connected six-track roadtrip world.">
   <meta name="robots" content="noindex,nofollow">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="mobile-web-app-capable" content="yes">
@@ -20,13 +20,13 @@
       cacheKey: '20260823-r183'
     });
     globalThis.__TURN_LAB_SOURCE__ = Object.freeze({
-      runtime: 'production TURN 2026.08.18-r175',
-      purpose: 'roadtrip-world-r1'
+      runtime: 'production TURN 2026.08.23-r183',
+      purpose: 'roadtrip-world-r1+portrait-play-r1'
     });
   </script>
   <link rel="icon" href="/turn/TURNicon.PNG?icon=20260803-profile-512" type="image/png" sizes="512x512">
   <link rel="apple-touch-icon" href="/turn/TURNicon.PNG?icon=20260803-profile-512" sizes="512x512">
-  <link rel="manifest" href="/turn-lab/site.webmanifest?revision=roadtrip-world-r1">
+  <link rel="manifest" href="/turn-lab/site.webmanifest?revision=portrait-play-r1">
   <link rel="stylesheet" href="./styles.css?build=20260823-r183-native-html">
   <link rel="stylesheet" href="./vertical-drive.css?build=20260823-r183">
   <link rel="stylesheet" href="./hud-tuning.css?build=20260823-r183">
@@ -57,9 +57,11 @@
   <link rel="stylesheet" href="./home-header-r425.css?revision=r425-header-boundary">
   <link rel="stylesheet" href="./home-track-row-gap-r200.css?revision=r200-match-horizontal-gap">
   <link rel="stylesheet" href="/turn-lab/roadtrip-world-r1.css?revision=r1">
+  <link rel="stylesheet" href="/turn-lab/portrait-play-r1.css?revision=r1">
   <script src="/turn-lab/lab-bootstrap.js?revision=roadtrip-world-r1"></script>
   <script src="./pwa-usable-viewport-r181.js?revision=r181-usable-web-layer"></script>
   <script src="./motion-safe-zone.js?build=20260823-r183"></script>
+  <script src="/turn-lab/portrait-play-r1.js?revision=r1"></script>
   <script src="./orientation-compat.js?build=20260823-r183&revision=r163-voiceover-native-picker-events"></script>
   <script src="./live-steering-setting.js?build=20260823-r183-live-steering"></script>
   <script type="importmap">
@@ -133,12 +135,12 @@
     <div class="install-shell">
       <div class="install-art" aria-hidden="true"><img class="install-icon" src="./TURNicon.PNG?icon=20260803-profile-512" alt=""></div>
       <div class="install-card">
-        <span class="install-kicker">TURN LAB · ROADTRIP WORLD R1 · production engine r175</span>
+        <span class="install-kicker">TURN LAB · PORTRAIT PLAY R1 · ROADTRIP WORLD R1</span>
         <h1 id="installTitle">TURN LAB</h1>
-        <p class="install-copy">Six tracks. Two roads out of each. Drive the current TURN engine through the connected-world experiment without touching production TURN.</p>
+        <p class="install-copy">Race the current TURN engine in portrait or landscape, with the connected six-track roadtrip experiment still active. Production TURN stays untouched.</p>
         <div class="install-actions">
           <button id="installTurnButton" class="install-primary" type="button">Install TURN LAB</button>
-          <p class="install-note" id="installNote">TURN LAB has separate saves. Install it as a separate Home Screen app, or test the roadtrip in this browser.</p>
+          <p class="install-note" id="installNote">TURN LAB has separate saves. Install it as a separate Home Screen app, or test portrait play and the roadtrip in this browser.</p>
           <button class="install-secondary" id="playBrowserButton" type="button">Play in browser anyway</button>
         </div>
       </div>

--- a/turn-lab/portrait-play-r1.css
+++ b/turn-lab/portrait-play-r1.css
@@ -1,0 +1,301 @@
+html.turn-lab-portrait {
+  --turn-portrait-deck-height: clamp(310px, 43dvh, 400px);
+  --turn-portrait-stage-height: calc(100dvh - var(--turn-portrait-deck-height));
+}
+
+@media (orientation: portrait) {
+  html.turn-lab-portrait,
+  html.turn-lab-portrait body {
+    min-width: 0 !important;
+    min-height: 0 !important;
+    background: #242628 !important;
+  }
+
+  html.turn-lab-portrait .rotate-panel {
+    display: none !important;
+  }
+
+  html.turn-lab-portrait #game {
+    position: fixed !important;
+    inset: 0 0 auto !important;
+    width: 100% !important;
+    height: var(--turn-portrait-stage-height) !important;
+    min-width: 0 !important;
+    min-height: 0 !important;
+    border-bottom: 4px solid var(--ink) !important;
+    background: var(--cyan) !important;
+  }
+
+  html.turn-lab-portrait #game canvas {
+    width: 100% !important;
+    height: 100% !important;
+  }
+
+  html.turn-lab-portrait .hud {
+    position: fixed !important;
+    inset: 0 0 auto !important;
+    width: 100% !important;
+    height: var(--turn-portrait-stage-height) !important;
+    padding: max(8px, env(safe-area-inset-top)) 8px 8px !important;
+  }
+
+  html.turn-lab-portrait .hud .topbar {
+    position: absolute !important;
+    inset: auto 8px 8px !important;
+    display: grid !important;
+    grid-template-columns: 86px minmax(0, 1fr) !important;
+    grid-template-rows: auto auto !important;
+    gap: 6px !important;
+    align-items: end !important;
+  }
+
+  html.turn-lab-portrait .hud .map-wrap {
+    grid-column: 1 !important;
+    grid-row: 1 !important;
+    width: 86px !important;
+    min-width: 0 !important;
+    padding: 3px !important;
+    border-width: 2px !important;
+    border-radius: 11px !important;
+    box-shadow: 3px 3px 0 var(--ink) !important;
+  }
+
+  html.turn-lab-portrait .hud .stats {
+    grid-column: 1 / -1 !important;
+    grid-row: 2 !important;
+    display: grid !important;
+    grid-template-columns: 1.14fr 0.64fr 0.84fr 1.18fr 1.2fr !important;
+    gap: 4px !important;
+    min-width: 0 !important;
+  }
+
+  html.turn-lab-portrait .hud .stats > .chip,
+  html.turn-lab-portrait .hud .stats > .race-position-hud {
+    width: auto !important;
+    min-width: 0 !important;
+    padding: 5px 4px 6px !important;
+    overflow: hidden !important;
+    border-width: 2px !important;
+    border-radius: 10px !important;
+    box-shadow: 3px 3px 0 var(--ink) !important;
+    font-size: clamp(0.43rem, 1.65vw, 0.57rem) !important;
+    letter-spacing: 0.025em !important;
+  }
+
+  html.turn-lab-portrait .hud .stats > .chip strong,
+  html.turn-lab-portrait .hud .stats > .race-position-hud strong {
+    margin-top: 2px !important;
+    overflow: hidden !important;
+    font-size: clamp(0.72rem, 3.25vw, 1rem) !important;
+    letter-spacing: -0.055em !important;
+    text-overflow: clip !important;
+    white-space: nowrap !important;
+  }
+
+  html.turn-lab-portrait .hud .message {
+    top: 14% !important;
+    max-width: calc(100vw - 28px) !important;
+    text-align: center !important;
+  }
+
+  html.turn-lab-portrait .boost-hud {
+    bottom: 118px !important;
+    width: min(46vw, 184px) !important;
+  }
+
+  html.turn-lab-portrait .turn-lab-portrait-meter {
+    --turn-portrait-steer: 0;
+    position: absolute;
+    z-index: 4;
+    left: 50%;
+    bottom: 66px;
+    width: min(50vw, 200px);
+    padding: 5px 8px 6px;
+    border: 2px solid var(--ink);
+    border-radius: 12px;
+    background: rgb(255 248 232 / 0.9);
+    color: var(--ink);
+    box-shadow: 3px 3px 0 var(--ink);
+    transform: translateX(-50%);
+    text-align: center;
+  }
+
+  html.turn-lab-portrait .turn-lab-portrait-meter-head {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 3px;
+    font-size: 0.46rem;
+    letter-spacing: 0.07em;
+  }
+
+  html.turn-lab-portrait .turn-lab-portrait-meter-track {
+    position: relative;
+    height: 10px;
+    overflow: hidden;
+    border: 2px solid var(--ink);
+    border-radius: 999px;
+    background: linear-gradient(90deg, #54c2ef 0 48%, #fff8e8 48% 52%, #ffd43b 52% 100%);
+  }
+
+  html.turn-lab-portrait .turn-lab-portrait-meter-track::after {
+    content: "";
+    position: absolute;
+    inset: -2px auto -2px 50%;
+    width: 2px;
+    background: var(--ink);
+    transform: translateX(-50%);
+  }
+
+  html.turn-lab-portrait .turn-lab-portrait-meter-dead {
+    position: absolute;
+    inset: 0 auto 0 45.4%;
+    width: 9.2%;
+    background: rgb(255 248 232 / 0.72);
+  }
+
+  html.turn-lab-portrait .turn-lab-portrait-meter-needle {
+    position: absolute;
+    z-index: 2;
+    top: 50%;
+    left: calc(50% + var(--turn-portrait-steer) * 48%);
+    width: 7px;
+    height: 16px;
+    border: 2px solid var(--ink);
+    border-radius: 5px;
+    background: #ff5a5f;
+    transform: translate(-50%, -50%);
+  }
+
+  html.turn-lab-portrait .turn-lab-portrait-meter-value {
+    display: block;
+    margin-top: 3px;
+    color: var(--ink);
+    font: 900 0.48rem/1 system-ui, sans-serif;
+    letter-spacing: 0.045em;
+  }
+
+  html.turn-lab-portrait .controls {
+    position: fixed !important;
+    z-index: 20 !important;
+    inset: var(--turn-portrait-stage-height) 0 0 !important;
+    width: 100% !important;
+    height: var(--turn-portrait-deck-height) !important;
+    display: grid !important;
+    grid-template-rows: auto minmax(0, 1fr) !important;
+    justify-items: center !important;
+    align-items: start !important;
+    gap: 8px !important;
+    padding: 10px max(12px, env(safe-area-inset-right)) max(10px, env(safe-area-inset-bottom)) max(12px, env(safe-area-inset-left)) !important;
+    border-top: 4px solid var(--cyan) !important;
+    background: #242628 !important;
+  }
+
+  html.turn-lab-portrait .controls .utility-group {
+    width: min(100%, 520px) !important;
+    min-width: 0 !important;
+    display: flex !important;
+    flex: none !important;
+    justify-content: flex-start !important;
+    align-items: stretch !important;
+    gap: 6px !important;
+    overflow-x: auto !important;
+    overflow-y: hidden !important;
+    padding: 1px 4px 5px !important;
+    pointer-events: auto !important;
+    scrollbar-width: none;
+  }
+
+  html.turn-lab-portrait .controls .utility-group::-webkit-scrollbar {
+    display: none;
+  }
+
+  html.turn-lab-portrait .controls .utility-group[data-menu-state="racing"] {
+    justify-content: center !important;
+  }
+
+  html.turn-lab-portrait .controls .utility-group .utility {
+    flex: 0 0 auto !important;
+    min-height: 40px !important;
+    padding: 6px 9px !important;
+    border-radius: 11px !important;
+    font-size: clamp(0.52rem, 2.2vw, 0.66rem) !important;
+  }
+
+  html.turn-lab-portrait .controls .pedals {
+    width: min(100%, 390px) !important;
+    min-height: 0 !important;
+    display: grid !important;
+    place-items: start center !important;
+    align-self: stretch !important;
+    padding: 0 !important;
+  }
+
+  html.turn-lab-portrait .controls .drive-stack {
+    width: min(100%, 370px) !important;
+    min-height: 0 !important;
+    align-self: stretch !important;
+  }
+
+  html.turn-lab-portrait .controls .drive-pad {
+    width: 100% !important;
+    height: min(292px, calc(var(--turn-portrait-deck-height) - 64px - max(10px, env(safe-area-inset-bottom)))) !important;
+    grid-template-rows: 29% 47% 24% !important;
+    border-radius: 23px !important;
+    box-shadow: 6px 7px 0 var(--ink) !important;
+  }
+
+  html.turn-lab-portrait .controls .drive-zone,
+  html.turn-lab-portrait .controls .drive-pad .drive-gas-zone,
+  html.turn-lab-portrait .controls .drive-pad .drive-brake-zone {
+    font-size: clamp(0.78rem, 4vw, 1.05rem) !important;
+  }
+
+  html.turn-lab-portrait .controls .drive-pad .drive-brake-zone {
+    font-size: clamp(0.66rem, 3.5vw, 0.9rem) !important;
+  }
+
+  html.turn-lab-portrait .manual-steer {
+    position: fixed !important;
+    z-index: 24 !important;
+    left: 14px !important;
+    right: 14px !important;
+    top: auto !important;
+    bottom: calc(var(--turn-portrait-deck-height) + 74px) !important;
+    width: auto !important;
+    height: 86px !important;
+  }
+
+  html.turn-lab-portrait .turn-steering-limit-edge {
+    top: 0 !important;
+    bottom: auto !important;
+    height: var(--turn-portrait-stage-height) !important;
+  }
+
+  html.turn-lab-portrait[data-turn-deployment="lab"]::after {
+    content: "TURN LAB · PORTRAIT R1";
+    right: auto;
+    bottom: auto;
+    left: max(7px, env(safe-area-inset-left));
+    top: max(6px, env(safe-area-inset-top));
+  }
+}
+
+@media (orientation: portrait) and (max-height: 720px) {
+  html.turn-lab-portrait {
+    --turn-portrait-deck-height: 310px;
+  }
+
+  html.turn-lab-portrait .boost-hud {
+    bottom: 108px !important;
+  }
+
+  html.turn-lab-portrait .turn-lab-portrait-meter {
+    bottom: 60px;
+  }
+}
+
+@media (orientation: landscape) {
+  html.turn-lab-portrait .turn-lab-portrait-meter {
+    display: none !important;
+  }
+}

--- a/turn-lab/portrait-play-r1.js
+++ b/turn-lab/portrait-play-r1.js
@@ -1,0 +1,262 @@
+(() => {
+  const root = document.documentElement;
+  if (root.dataset.turnDeployment !== 'lab') return;
+
+  const PORTRAIT_STEERING_DEGREES = 24;
+  const PORTRAIT_HORIZON_DEGREES = 16;
+  const PORTRAIT_CAMERA_ZOOM = 0.78;
+  const SETTLE_DELAYS_MS = Object.freeze([0, 120, 420, 900]);
+  const orientationMedia = window.matchMedia('(orientation: portrait)');
+
+  root.classList.add('turn-lab-portrait');
+  root.dataset.turnLabPortrait = 'r1';
+
+  function portraitActive() {
+    return orientationMedia.matches;
+  }
+
+  function publishMotionProfile() {
+    const current = globalThis.__TURN_MOTION_SAFE_ZONE__ || {};
+    globalThis.__TURN_MOTION_SAFE_ZONE__ = Object.freeze({
+      ...current,
+      degrees: PORTRAIT_STEERING_DEGREES,
+      steeringDegrees: PORTRAIT_STEERING_DEGREES,
+      horizonDegrees: portraitActive()
+        ? PORTRAIT_HORIZON_DEGREES
+        : PORTRAIT_STEERING_DEGREES,
+      feedbackNearDegrees: 19,
+      feedbackHardDegrees: PORTRAIT_STEERING_DEGREES,
+      feedbackHardRearmDegrees: 22,
+      feedbackClearDegrees: 17.5,
+      directionalFeedback: true
+    });
+    root.dataset.turnMotionSafeZone = String(PORTRAIT_STEERING_DEGREES);
+    root.dataset.turnLabHorizon = String(
+      portraitActive() ? PORTRAIT_HORIZON_DEGREES : PORTRAIT_STEERING_DEGREES
+    );
+  }
+
+  function keepPortraitWhenTheRaceRequestsLandscape() {
+    const orientation = screen.orientation;
+    if (!orientation) return;
+
+    const nativeLock = typeof orientation.lock === 'function'
+      ? orientation.lock.bind(orientation)
+      : null;
+    const labLock = (requested = 'landscape') => {
+      const type = String(requested || '').toLowerCase();
+      if (portraitActive() && type.startsWith('landscape')) {
+        console.info('TURN LAB: kept portrait play active instead of applying the production landscape lock.');
+        return Promise.resolve();
+      }
+      return nativeLock ? nativeLock(requested) : Promise.resolve();
+    };
+
+    try {
+      Object.defineProperty(orientation, 'lock', {
+        configurable: true,
+        enumerable: false,
+        writable: true,
+        value: labLock
+      });
+    } catch (_) {
+      try {
+        orientation.lock = labLock;
+      } catch (_) {}
+    }
+  }
+
+  function installPortraitLanguagePatches() {
+    if (typeof MutationObserver !== 'function') return;
+    const readyReplacement = 'TURN LAB is ready. Portrait play is available. Choose a track, then choose a car.';
+    let readyPatched = false;
+    let guidePatched = false;
+    let observer = null;
+    let stopTimer = 0;
+
+    function patch() {
+      if (!portraitActive()) return;
+
+      const status = document.querySelector('#turn-screen-reader-status');
+      if (
+        status
+        && /^TURN is ready\. Rotate your device to landscape\.?$/i.test(String(status.textContent || '').trim())
+      ) {
+        status.textContent = readyReplacement;
+        readyPatched = true;
+      }
+
+      for (const paragraph of document.querySelectorAll('.m8-how-dialog .m8-guide-grid p')) {
+        const text = String(paragraph.textContent || '').trim();
+        if (!text.startsWith('Hold the phone or tablet in landscape')) continue;
+        paragraph.textContent = 'Hold the phone or tablet in portrait or landscape and rotate it like a steering wheel. Recalibrate at the start line whenever your resting angle changes.';
+        guidePatched = true;
+      }
+
+      if (readyPatched && guidePatched) {
+        observer?.disconnect();
+        window.clearTimeout(stopTimer);
+      }
+    }
+
+    function start() {
+      if (!document.body || observer) return;
+      observer = new MutationObserver(patch);
+      observer.observe(document.body, { childList: true, characterData: true, subtree: true });
+      patch();
+      stopTimer = window.setTimeout(() => observer?.disconnect(), 8000);
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', start, { once: true });
+    } else {
+      start();
+    }
+  }
+
+  function normalizedAngle(value) {
+    let angle = Number(value) || 0;
+    while (angle > Math.PI) angle -= Math.PI * 2;
+    while (angle < -Math.PI) angle += Math.PI * 2;
+    return angle;
+  }
+
+  function createSteeringMeter() {
+    const existing = document.querySelector('.turn-lab-portrait-meter');
+    if (existing) return existing;
+    const hud = document.querySelector('#hud');
+    if (!hud) return null;
+
+    const meter = document.createElement('div');
+    meter.className = 'turn-lab-portrait-meter';
+    meter.hidden = true;
+    meter.setAttribute('aria-hidden', 'true');
+    meter.innerHTML = `
+      <div class="turn-lab-portrait-meter-head">
+        <span>STEERING</span><strong>±${PORTRAIT_STEERING_DEGREES}°</strong>
+      </div>
+      <div class="turn-lab-portrait-meter-track">
+        <i class="turn-lab-portrait-meter-dead"></i>
+        <b class="turn-lab-portrait-meter-needle"></b>
+      </div>
+      <output class="turn-lab-portrait-meter-value">CENTER · 0.0° · 0%</output>`;
+    hud.appendChild(meter);
+    return meter;
+  }
+
+  function installRuntime(runtime) {
+    if (!runtime?.renderer || !runtime?.camera || runtime.__turnLabPortraitPlayInstalled) return;
+    runtime.__turnLabPortraitPlayInstalled = true;
+
+    const game = document.querySelector('#game');
+    const renderer = runtime.renderer;
+    const camera = runtime.camera;
+    const canvas = renderer.domElement;
+    const previousSetSize = renderer.setSize.bind(renderer);
+    const meter = createSteeringMeter();
+    const meterValue = meter?.querySelector('.turn-lab-portrait-meter-value');
+    let meterFrame = 0;
+    let settleTimers = [];
+
+    function portraitGameSize() {
+      const rect = game?.getBoundingClientRect();
+      return {
+        width: Math.max(1, Math.round(Number(rect?.width) || window.innerWidth || 1)),
+        height: Math.max(1, Math.round(Number(rect?.height) || window.innerHeight || 1))
+      };
+    }
+
+    function applyProjection(width, height, portrait) {
+      camera.aspect = Math.max(1, width) / Math.max(1, height);
+      camera.zoom = portrait ? PORTRAIT_CAMERA_ZOOM : 1;
+      camera.updateProjectionMatrix();
+    }
+
+    function applyGameViewport() {
+      const size = portraitGameSize();
+      applyProjection(size.width, size.height, portraitActive());
+      const result = previousSetSize(size.width, size.height, false);
+      canvas.style.setProperty('width', '100%', 'important');
+      canvas.style.setProperty('height', '100%', 'important');
+      return result;
+    }
+
+    renderer.setSize = function usePortraitGameViewport(width, height, updateStyle = true) {
+      // Production temporarily resizes the shared renderer for garage and
+      // achievement thumbnails. Only redirect normal viewport resizes; keep
+      // explicit off-screen sizes (updateStyle === false) intact.
+      if (!portraitActive() || updateStyle === false) {
+        return previousSetSize(width, height, updateStyle);
+      }
+      return applyGameViewport();
+    };
+
+    function syncViewport() {
+      applyGameViewport();
+      root.classList.toggle('turn-lab-portrait-active', portraitActive());
+    }
+
+    function settleViewport() {
+      for (const timer of settleTimers) window.clearTimeout(timer);
+      settleTimers = SETTLE_DELAYS_MS.map((delay) => window.setTimeout(syncViewport, delay));
+    }
+
+    function updateMeter() {
+      const active = portraitActive()
+        && runtime.state?.running === true
+        && runtime.state?.sensorMode === true
+        && !document.hidden;
+
+      if (meter) meter.hidden = !active;
+      if (active && meter && meterValue) {
+        const relativeRoll = normalizedAngle(
+          (Number(runtime.state.roll) || 0) - (Number(runtime.state.neutralRoll) || 0)
+        );
+        // TURN's vehicle yaw uses the opposite sign; roll itself is already in
+        // normalized screen space (positive is a right steering gesture).
+        const screenDegrees = relativeRoll * 180 / Math.PI;
+        const normalized = Math.max(-1, Math.min(1, screenDegrees / PORTRAIT_STEERING_DEGREES));
+        const steeringPercent = Math.round(Math.max(-1, Math.min(1, -runtime.state.steering)) * 100);
+        const direction = screenDegrees < -0.35
+          ? 'LEFT'
+          : screenDegrees > 0.35
+            ? 'RIGHT'
+            : 'CENTER';
+        meter.style.setProperty('--turn-portrait-steer', String(normalized));
+        meterValue.textContent = `${direction} · ${Math.abs(screenDegrees).toFixed(1)}° · ${Math.abs(steeringPercent)}%`;
+      }
+
+      meterFrame = requestAnimationFrame(updateMeter);
+    }
+
+    for (const eventName of ['resize', 'orientationchange', 'pageshow']) {
+      window.addEventListener(eventName, settleViewport, { passive: true });
+    }
+    orientationMedia.addEventListener?.('change', settleViewport);
+    window.visualViewport?.addEventListener('resize', settleViewport, { passive: true });
+    screen.orientation?.addEventListener?.('change', settleViewport, { passive: true });
+    document.addEventListener('visibilitychange', () => {
+      if (!document.hidden) settleViewport();
+    }, { passive: true });
+    window.addEventListener('pagehide', () => cancelAnimationFrame(meterFrame), { once: true });
+
+    settleViewport();
+    updateMeter();
+  }
+
+  publishMotionProfile();
+  keepPortraitWhenTheRaceRequestsLandscape();
+  installPortraitLanguagePatches();
+
+  const refreshProfile = () => {
+    publishMotionProfile();
+    root.classList.toggle('turn-lab-portrait-active', portraitActive());
+  };
+  orientationMedia.addEventListener?.('change', refreshProfile);
+  window.addEventListener('orientationchange', refreshProfile, { passive: true });
+
+  if (globalThis.__turnRuntime) installRuntime(globalThis.__turnRuntime);
+  window.addEventListener('turn:runtime-ready', (event) => {
+    installRuntime(event.detail || globalThis.__turnRuntime);
+  }, { once: true });
+})();

--- a/turn-lab/site.webmanifest
+++ b/turn-lab/site.webmanifest
@@ -2,7 +2,7 @@
   "id": "/turn-lab/",
   "name": "TURN LAB",
   "short_name": "TURN LAB",
-  "description": "TURN LAB runs isolated experiments on the current TURN engine. This build prototypes a connected six-track roadtrip world.",
+  "description": "TURN LAB runs isolated experiments on the current TURN engine, including portrait racing and a connected six-track roadtrip world.",
   "start_url": "/turn-lab/",
   "scope": "/turn-lab/",
   "display": "standalone",

--- a/turn-lab/tests/portrait-play-lab.mjs
+++ b/turn-lab/tests/portrait-play-lab.mjs
@@ -1,0 +1,207 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import vm from 'node:vm';
+
+const [index, script, styles, manifest, productionMotion] = await Promise.all([
+  fs.readFile(new URL('../index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../portrait-play-r1.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../portrait-play-r1.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../site.webmanifest', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/input/motion.js', import.meta.url), 'utf8')
+]);
+
+assert.match(index, /\/turn-lab\/portrait-play-r1\.css\?revision=r1/);
+assert.match(index, /\/turn-lab\/portrait-play-r1\.js\?revision=r1/);
+assert.match(index, /site\.webmanifest\?revision=portrait-play-r1/);
+assert.ok(
+  index.indexOf('/turn-lab/portrait-play-r1.js') < index.indexOf('./orientation-compat.js'),
+  'The LAB profile and orientation-lock shim must run before production orientation compatibility'
+);
+assert.equal(JSON.parse(manifest).orientation, 'any', 'TURN LAB must remain installable in portrait');
+
+assert.match(script, /PORTRAIT_STEERING_DEGREES = 24/);
+assert.match(script, /PORTRAIT_HORIZON_DEGREES = 16/);
+assert.match(script, /PORTRAIT_CAMERA_ZOOM = 0\.78/);
+assert.match(script, /type\.startsWith\('landscape'\)/);
+assert.match(script, /TURN LAB is ready\. Portrait play is available/);
+assert.match(script, /Hold the phone or tablet in portrait or landscape/);
+assert.match(script, /runtime\.state\?\.sensorMode === true/);
+assert.match(script, /renderer\.setSize = function usePortraitGameViewport/);
+assert.match(script, /screenDegrees = relativeRoll/);
+
+assert.match(styles, /@media \(orientation: portrait\)/);
+assert.match(styles, /--turn-portrait-stage-height/);
+assert.match(styles, /#game[\s\S]*height: var\(--turn-portrait-stage-height\) !important/);
+assert.match(styles, /\.controls[\s\S]*inset: var\(--turn-portrait-stage-height\) 0 0 !important/);
+assert.match(styles, /grid-template-rows: 29% 47% 24%/);
+assert.match(styles, /\.rotate-panel[\s\S]*display: none !important/);
+assert.match(styles, /\.turn-lab-portrait-meter/);
+
+assert.match(productionMotion, /steeringEnterThreshold: degToRad\(2\.2\)/);
+assert.match(productionMotion, /steeringExitThreshold: degToRad\(0\.9\)/);
+assert.match(productionMotion, /id: 'ipad-damped'/);
+
+const rootClasses = new Set();
+const eventHandlers = new Map();
+const nativeLocks = [];
+const rendererSizes = [];
+const styleValues = new Map();
+const meterOutput = { textContent: '' };
+let meter = null;
+
+function listen(target, type, callback) {
+  const key = `${target}:${type}`;
+  const handlers = eventHandlers.get(key) || [];
+  handlers.push(callback);
+  eventHandlers.set(key, handlers);
+}
+
+const orientationMedia = {
+  matches: true,
+  addEventListener(type, callback) { listen('media', type, callback); }
+};
+const orientation = {
+  async lock(type) { nativeLocks.push(type); },
+  addEventListener(type, callback) { listen('orientation', type, callback); }
+};
+const root = {
+  dataset: { turnDeployment: 'lab' },
+  classList: {
+    add(...names) { for (const name of names) rootClasses.add(name); },
+    toggle(name, active) {
+      if (active) rootClasses.add(name);
+      else rootClasses.delete(name);
+    }
+  }
+};
+const game = {
+  getBoundingClientRect() {
+    return orientationMedia.matches
+      ? { width: 402, height: 498 }
+      : { width: 874, height: 402 };
+  }
+};
+const hud = {
+  appendChild(node) { meter = node; }
+};
+const documentRef = {
+  documentElement: root,
+  hidden: false,
+  querySelector(selector) {
+    if (selector === '.turn-lab-portrait-meter') return meter;
+    if (selector === '#hud') return hud;
+    if (selector === '#game') return game;
+    return null;
+  },
+  createElement() {
+    return {
+      hidden: false,
+      className: '',
+      innerHTML: '',
+      setAttribute() {},
+      querySelector(selector) {
+        return selector === '.turn-lab-portrait-meter-value' ? meterOutput : null;
+      },
+      style: {
+        setProperty(name, value) { styleValues.set(name, value); }
+      }
+    };
+  },
+  addEventListener(type, callback) { listen('document', type, callback); }
+};
+const camera = {
+  aspect: 0,
+  zoom: 1,
+  updates: 0,
+  updateProjectionMatrix() { this.updates += 1; }
+};
+const renderer = {
+  domElement: {
+    style: {
+      setProperty(name, value) { styleValues.set(`canvas:${name}`, value); }
+    }
+  },
+  setSize(width, height, updateStyle) {
+    rendererSizes.push([width, height, updateStyle]);
+    return this;
+  }
+};
+const runtime = {
+  camera,
+  renderer,
+  state: {
+    running: true,
+    sensorMode: true,
+    roll: 12 * Math.PI / 180,
+    neutralRoll: 0,
+    steering: -0.5
+  }
+};
+const context = {
+  console: { info() {} },
+  document: documentRef,
+  screen: { orientation },
+  innerWidth: 402,
+  innerHeight: 874,
+  matchMedia() { return orientationMedia; },
+  addEventListener(type, callback) { listen('window', type, callback); },
+  visualViewport: {
+    addEventListener(type, callback) { listen('visualViewport', type, callback); }
+  },
+  requestAnimationFrame() { return 1; },
+  cancelAnimationFrame() {},
+  setTimeout(callback) { callback(); return 1; },
+  clearTimeout() {},
+  __TURN_MOTION_SAFE_ZONE__: Object.freeze({ steeringDegrees: 14, horizonDegrees: 14 })
+};
+context.window = context;
+context.globalThis = context;
+
+vm.runInNewContext(script, context, { filename: 'portrait-play-r1.js' });
+
+assert.ok(rootClasses.has('turn-lab-portrait'));
+assert.equal(context.__TURN_MOTION_SAFE_ZONE__.steeringDegrees, 24);
+assert.equal(context.__TURN_MOTION_SAFE_ZONE__.horizonDegrees, 16);
+assert.equal(Object.isFrozen(context.__TURN_MOTION_SAFE_ZONE__), true);
+
+await orientation.lock('landscape');
+assert.deepEqual(nativeLocks, [], 'Portrait LAB must absorb the production landscape lock');
+await orientation.lock('portrait-primary');
+assert.deepEqual(nativeLocks, ['portrait-primary'], 'Non-landscape lock requests must retain native behavior');
+
+for (const callback of eventHandlers.get('window:turn:runtime-ready') || []) {
+  callback({ detail: runtime });
+}
+
+assert.ok(runtime.__turnLabPortraitPlayInstalled);
+assert.ok(rendererSizes.length >= 1);
+assert.deepEqual(rendererSizes.at(-1), [402, 498, false]);
+assert.equal(camera.aspect, 402 / 498);
+assert.equal(camera.zoom, 0.78);
+assert.ok(camera.updates >= 1);
+assert.equal(meter.hidden, false);
+assert.equal(meterOutput.textContent, 'RIGHT · 12.0° · 50%');
+assert.equal(styleValues.get('--turn-portrait-steer'), '0.5');
+assert.equal(styleValues.get('canvas:width'), '100%');
+assert.equal(styleValues.get('canvas:height'), '100%');
+
+runtime.renderer.setSize(96, 64, false);
+assert.deepEqual(
+  rendererSizes.at(-1),
+  [96, 64, false],
+  'Explicit thumbnail renders must bypass the portrait viewport override'
+);
+
+runtime.renderer.setSize(402, 874);
+assert.deepEqual(
+  rendererSizes.at(-1),
+  [402, 498, false],
+  'Normal renderer resizes must remain pinned to the portrait game stage'
+);
+
+orientationMedia.matches = false;
+for (const callback of eventHandlers.get('media:change') || []) callback();
+assert.equal(camera.zoom, 1, 'Returning to landscape must restore production camera zoom');
+assert.deepEqual(rendererSizes.at(-1), [874, 402, false]);
+
+console.log('TURN LAB portrait viewport, steering parity, camera and orientation contract passed.');


### PR DESCRIPTION
## Summary

- enable real portrait racing in isolated `/turn-lab/` while leaving production `/turn/` unchanged
- preserve the production motion steering transfer (±24° full lock and existing phone/iPad hysteresis)
- add a portrait-only upper game stage, lower four-zone Drive Pad deck, condensed HUD, wider camera framing, and live steering meter
- suppress production's landscape lock only while TURN LAB is already portrait
- keep the connected roadtrip experiment active in both orientations

## Tuning hypothesis

Portrait R1 deliberately keeps steering parity with landscape so the real-device comparison isolates grip and viewport effects. Visible horizon roll is capped at ±16° and camera zoom is 0.78 only in portrait.

## Verification

- `node turn-lab/tests/portrait-play-lab.mjs`
- existing Drive Pad, manual steering, performance, startup accessibility, regression, and multi-track suites
- `git diff --check`
- confirmed no diff under `turn/`