### PR TITLE
Add thumb-friendly portrait arc to TURN LAB

### DIFF
--- a/turn-lab/README.md
+++ b/turn-lab/README.md
@@ -4,19 +4,22 @@
 
 ## Active experiments
 
-### Portrait play R1
+### Portrait play R2
 
 Portrait is now a real race layout rather than a rotate-device blocker:
 
 - the rendered game occupies the upper portrait stage;
-- the existing four-zone drive pad occupies a dedicated lower control deck;
+- the existing four-zone Drive Pad keeps its production behavior but follows a large right-thumb arc in the lower control deck;
+- Brake/Reverse, Gas, Drift and Boost rise around the natural inward-to-outward thumb sweep, with every visible segment remaining substantially larger than a 44 px touch target on supported phone sizes;
 - the HUD is condensed into a five-chip row with the map, boost and a LAB-only live steering meter above it;
 - the camera uses `zoom = 0.78` to recover useful horizontal road context without changing race physics;
 - production's forced landscape lock is suppressed only while LAB is already in portrait.
 
 The first steering hypothesis deliberately preserves the proven production transfer function. Phone steering still engages at 2.2°, releases at 0.9°, and reaches full lock at ±24°. The existing damped iPad profile still engages at 3.2° and releases at 1.4°. Only visible camera roll is reduced to ±16° in portrait; landscape LAB remains at ±24°.
 
-This makes the first real-device comparison interpretable: any difference in steering feel comes from the portrait grip and viewport, not a hidden sensitivity change.
+The R2 arc reuses the same four production buttons and the same 32% / 44% / 24% vertical zone contract. A small LAB-only geometry adapter moves the top Drift/Boost split to 72% of the physical arc width so those visible targets follow the right thumb instead of the old rectangular midpoint. Sliding between zones, boost charge, drift recharge, braking, reverse, pointer capture and VoiceOver labels remain owned by the production control module. Landscape still uses the untouched production Drive Pad and hit geometry.
+
+Steering remains directly comparable between orientations: any difference in steering feel comes from the portrait grip and viewport, not a hidden sensitivity change.
 
 ### Connected roadtrip R1
 
@@ -28,12 +31,13 @@ The six-track connected-world experiment remains active in both orientations. Ea
 2. Add **TURN LAB** to the Home Screen, or choose **Play in browser anyway**.
 3. Keep the device in portrait, choose a car and track, and start a motion-steering race.
 4. Recalibrate in your natural two-handed portrait grip.
-5. Use the live steering meter to compare physical angle with delivered steering. Full lock is ±24°.
-6. Rotate back to landscape before starting another race if you want a direct control comparison.
+5. Rest the right thumb on the arc and slide through Brake/Reverse → Gas → Drift → Boost without changing grip.
+6. Use the live steering meter to compare physical angle with delivered steering. Full lock is ±24°.
+7. Rotate back to landscape before starting another race if you want a direct control comparison.
 
 ## Safety
 
 - No production TURN file is changed for these experiments.
 - LAB uses `turn-lab:` / `turn-lab-session:` storage prefixes and does not seed data from production.
-- Portrait layout and orientation-lock behavior are scoped to `data-turn-deployment="lab"`.
+- Portrait layout, thumb arc and orientation-lock behavior are scoped to `data-turn-deployment="lab"`.
 - The production physics, vehicle handling, drift, boost, Drive By Ear and accessibility systems remain the runtime source of truth.

--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -21,7 +21,7 @@
     });
     globalThis.__TURN_LAB_SOURCE__ = Object.freeze({
       runtime: 'production TURN 2026.08.23-r183',
-      purpose: 'roadtrip-world-r1+portrait-play-r1'
+      purpose: 'roadtrip-world-r1+portrait-play-r2-thumb-arc'
     });
   </script>
   <link rel="icon" href="/turn/TURNicon.PNG?icon=20260803-profile-512" type="image/png" sizes="512x512">
@@ -58,10 +58,12 @@
   <link rel="stylesheet" href="./home-track-row-gap-r200.css?revision=r200-match-horizontal-gap">
   <link rel="stylesheet" href="/turn-lab/roadtrip-world-r1.css?revision=r1">
   <link rel="stylesheet" href="/turn-lab/portrait-play-r1.css?revision=r1">
+  <link rel="stylesheet" href="/turn-lab/portrait-thumb-arc-r2.css?revision=r2">
   <script src="/turn-lab/lab-bootstrap.js?revision=roadtrip-world-r1"></script>
   <script src="./pwa-usable-viewport-r181.js?revision=r181-usable-web-layer"></script>
   <script src="./motion-safe-zone.js?build=20260823-r183"></script>
   <script src="/turn-lab/portrait-play-r1.js?revision=r1"></script>
+  <script src="/turn-lab/portrait-thumb-arc-r2.js?revision=r2"></script>
   <script src="./orientation-compat.js?build=20260823-r183&revision=r163-voiceover-native-picker-events"></script>
   <script src="./live-steering-setting.js?build=20260823-r183-live-steering"></script>
   <script type="importmap">
@@ -135,7 +137,7 @@
     <div class="install-shell">
       <div class="install-art" aria-hidden="true"><img class="install-icon" src="./TURNicon.PNG?icon=20260803-profile-512" alt=""></div>
       <div class="install-card">
-        <span class="install-kicker">TURN LAB · PORTRAIT PLAY R1 · ROADTRIP WORLD R1</span>
+        <span class="install-kicker">TURN LAB · PORTRAIT PLAY R2 · ROADTRIP WORLD R1</span>
         <h1 id="installTitle">TURN LAB</h1>
         <p class="install-copy">Race the current TURN engine in portrait or landscape, with the connected six-track roadtrip experiment still active. Production TURN stays untouched.</p>
         <div class="install-actions">

--- a/turn-lab/portrait-thumb-arc-r2.css
+++ b/turn-lab/portrait-thumb-arc-r2.css
@@ -1,0 +1,237 @@
+/*
+ * TURN LAB portrait R2: reshape the production four-zone Drive Pad into a
+ * right-thumb arc. The 32 / 44 / 24 row contract deliberately matches
+ * gameplay-controls.js (Drift+Boost / Gas / Brake+Reverse), so the production
+ * pointer-capture, slide, boost-charge and reverse behavior remains untouched.
+ */
+@media (orientation: portrait) {
+  html.turn-lab-portrait .controls {
+    grid-template-columns: minmax(0, 1fr) !important;
+    justify-items: stretch !important;
+  }
+
+  html.turn-lab-portrait .controls .utility-group {
+    width: 100% !important;
+    justify-self: stretch !important;
+  }
+
+  html.turn-lab-portrait .controls .pedals {
+    width: 100% !important;
+    height: 100% !important;
+    min-width: 0 !important;
+    display: grid !important;
+    grid-template-columns: minmax(0, 1fr) !important;
+    place-items: stretch !important;
+    justify-self: stretch !important;
+    align-self: stretch !important;
+  }
+
+  html.turn-lab-portrait .controls .drive-stack {
+    width: min(100%, 420px) !important;
+    height: 100% !important;
+    min-width: 0 !important;
+    min-height: 0 !important;
+    margin: 0 0 0 auto !important;
+    display: grid !important;
+    justify-self: end !important;
+    align-self: stretch !important;
+  }
+
+  html.turn-lab-portrait .controls .drive-pad {
+    --turn-portrait-arc-gap: 5px;
+    width: 100% !important;
+    height: 100% !important;
+    min-width: 0 !important;
+    min-height: 0 !important;
+    display: grid !important;
+    grid-template-columns: minmax(0, 1fr) !important;
+    grid-template-rows: minmax(0, 32fr) minmax(0, 44fr) minmax(0, 24fr) !important;
+    gap: var(--turn-portrait-arc-gap) !important;
+    padding: var(--turn-portrait-arc-gap) !important;
+    overflow: hidden !important;
+    border: 0 !important;
+    border-radius: 0 !important;
+    background: var(--ink) !important;
+    box-shadow: none !important;
+    filter:
+      drop-shadow(-3px 0 0 var(--ink))
+      drop-shadow(3px 0 0 var(--ink))
+      drop-shadow(0 -3px 0 var(--ink))
+      drop-shadow(0 3px 0 var(--ink))
+      drop-shadow(5px 6px 0 var(--ink));
+    clip-path: polygon(
+      45% 100%,
+      43% 91%,
+      41% 82%,
+      39.5% 73%,
+      38% 64%,
+      37% 55%,
+      37% 46%,
+      40% 39%,
+      48% 32%,
+      52% 25%,
+      56% 18%,
+      63% 12%,
+      70% 6%,
+      82% 3%,
+      100% 0,
+      100% 34%,
+      95% 35%,
+      90% 38%,
+      86% 42%,
+      82% 48%,
+      78% 54%,
+      74% 62%,
+      72% 71%,
+      70% 80%,
+      70% 90%,
+      72% 100%
+    );
+    -webkit-clip-path: polygon(
+      45% 100%,
+      43% 91%,
+      41% 82%,
+      39.5% 73%,
+      38% 64%,
+      37% 55%,
+      37% 46%,
+      40% 39%,
+      48% 32%,
+      52% 25%,
+      56% 18%,
+      63% 12%,
+      70% 6%,
+      82% 3%,
+      100% 0,
+      100% 34%,
+      95% 35%,
+      90% 38%,
+      86% 42%,
+      82% 48%,
+      78% 54%,
+      74% 62%,
+      72% 71%,
+      70% 80%,
+      70% 90%,
+      72% 100%
+    );
+  }
+
+  html.turn-lab-portrait .controls .drive-pad.is-boosting {
+    box-shadow: none !important;
+    filter:
+      drop-shadow(-3px 0 0 var(--ink))
+      drop-shadow(3px 0 0 var(--ink))
+      drop-shadow(0 -3px 0 var(--ink))
+      drop-shadow(0 3px 0 var(--ink))
+      drop-shadow(5px 6px 0 var(--ink))
+      drop-shadow(0 0 8px rgb(255 212 59 / 0.5));
+  }
+
+  html.turn-lab-portrait .controls .drive-pad-top {
+    min-width: 0 !important;
+    min-height: 0 !important;
+    display: grid !important;
+    grid-template-columns: minmax(0, 72fr) minmax(0, 28fr) !important;
+    gap: var(--turn-portrait-arc-gap) !important;
+    background: var(--ink) !important;
+  }
+
+  html.turn-lab-portrait .controls .drive-zone,
+  html.turn-lab-portrait .controls .drive-pad .drive-gas-zone,
+  html.turn-lab-portrait .controls .drive-pad .drive-brake-zone {
+    min-width: 0 !important;
+    min-height: 0 !important;
+    width: 100% !important;
+    height: 100% !important;
+    margin: 0 !important;
+    border: 0 !important;
+    border-radius: 0 !important;
+    box-shadow: none !important;
+    display: flex !important;
+    align-items: center !important;
+    color: var(--ink) !important;
+    font-size: clamp(0.68rem, 3.8vw, 0.96rem) !important;
+    font-weight: 900 !important;
+    letter-spacing: 0.035em !important;
+    line-height: 1 !important;
+    text-align: center !important;
+    text-transform: uppercase !important;
+    white-space: nowrap !important;
+  }
+
+  html.turn-lab-portrait .controls .drive-drift-zone {
+    justify-content: flex-end !important;
+    padding: 0 5% 0 0 !important;
+    background: #38d9ff !important;
+  }
+
+  html.turn-lab-portrait .controls .drive-boost-zone {
+    justify-content: center !important;
+    padding: 0 !important;
+    background: linear-gradient(
+      to top,
+      #ffd43b 0 var(--boost-charge),
+      #b8a768 var(--boost-charge) 100%
+    ) !important;
+  }
+
+  html.turn-lab-portrait .controls .drive-pad .drive-gas-zone {
+    justify-content: flex-start !important;
+    padding: 0 0 0 55% !important;
+    background: #8ce99a !important;
+  }
+
+  html.turn-lab-portrait .controls .drive-pad .drive-brake-zone {
+    justify-content: flex-start !important;
+    padding: 0 0 0 52% !important;
+    background: #ff7b54 !important;
+    font-size: 0 !important;
+  }
+
+  html.turn-lab-portrait .controls .drive-pad .drive-brake-zone::before {
+    content: "BRAKE\A REVERSE";
+    white-space: pre-line;
+    font-size: clamp(0.5rem, 2.7vw, 0.7rem);
+    line-height: 1.05;
+  }
+
+  html.turn-lab-portrait .controls .drive-pad[data-drive-zone="gas"] .drive-gas-zone,
+  html.turn-lab-portrait .controls .drive-drift-zone.is-active,
+  html.turn-lab-portrait .controls .drive-boost-zone.is-active,
+  html.turn-lab-portrait .controls .drive-brake-zone.is-active {
+    box-shadow: inset 0 0 0 5px rgb(255 248 232 / 0.9) !important;
+    filter: brightness(1.08);
+  }
+
+  html.turn-lab-portrait .controls .drive-pad.is-boosting .drive-boost-zone {
+    background: linear-gradient(
+      to top,
+      #ffd43b 0 var(--boost-charge),
+      #ff8f3f var(--boost-charge) 100%
+    ) !important;
+  }
+
+  html.turn-lab-portrait .controls .drive-boost-zone.is-locked::after {
+    right: 7% !important;
+    bottom: 7px !important;
+  }
+
+  html.turn-lab-portrait[data-turn-deployment="lab"]::after {
+    content: "TURN LAB · PORTRAIT R2";
+  }
+}
+
+@media (orientation: portrait) and (max-width: 360px) {
+  html.turn-lab-portrait .controls .drive-pad .drive-gas-zone {
+    padding-left: 53% !important;
+  }
+
+  html.turn-lab-portrait .controls .drive-pad .drive-brake-zone {
+    padding-left: 50% !important;
+  }
+
+  html.turn-lab-portrait .controls .drive-pad .drive-brake-zone::before {
+    font-size: 0.48rem !important;
+  }
+}

--- a/turn-lab/portrait-thumb-arc-r2.js
+++ b/turn-lab/portrait-thumb-arc-r2.js
@@ -1,0 +1,64 @@
+(() => {
+  const root = document.documentElement;
+  if (root.dataset.turnDeployment !== 'lab') return;
+
+  const portraitMedia = window.matchMedia('(orientation: portrait)');
+  const PHYSICAL_TOP_SPLIT = 0.72;
+  const VIRTUAL_WIDTH_SCALE = PHYSICAL_TOP_SPLIT / 0.5;
+
+  root.dataset.turnLabThumbArc = 'r2';
+  root.dataset.turnLabThumbArcSplit = String(Math.round(PHYSICAL_TOP_SPLIT * 100));
+
+  function virtualHitRect(rect) {
+    if (!portraitMedia.matches) return rect;
+
+    const width = Math.max(0, Number(rect.width) || 0) * VIRTUAL_WIDTH_SCALE;
+    const height = Math.max(0, Number(rect.height) || 0);
+    const left = Number(rect.left) || 0;
+    const top = Number(rect.top) || 0;
+    const result = {
+      x: left,
+      y: top,
+      left,
+      top,
+      width,
+      height,
+      right: left + width,
+      bottom: top + height
+    };
+    result.toJSON = () => ({ ...result, toJSON: undefined });
+    return result;
+  }
+
+  function installArcHitGeometry(drivePad) {
+    if (!drivePad || drivePad.dataset.turnPortraitArcHitGeometry === 'r2') return false;
+
+    const nativeGetBoundingClientRect = drivePad.getBoundingClientRect.bind(drivePad);
+    Object.defineProperty(drivePad, 'getBoundingClientRect', {
+      configurable: true,
+      value() {
+        return virtualHitRect(nativeGetBoundingClientRect());
+      }
+    });
+    drivePad.dataset.turnPortraitArcHitGeometry = 'r2';
+    return true;
+  }
+
+  function start() {
+    if (!document.body) return;
+    if (installArcHitGeometry(document.querySelector('.drive-pad'))) return;
+    if (typeof MutationObserver !== 'function') return;
+
+    const observer = new MutationObserver(() => {
+      if (!installArcHitGeometry(document.querySelector('.drive-pad'))) return;
+      observer.disconnect();
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start, { once: true });
+  } else {
+    start();
+  }
+})();

--- a/turn-lab/tests/portrait-thumb-arc-lab.mjs
+++ b/turn-lab/tests/portrait-thumb-arc-lab.mjs
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+import vm from 'node:vm';
+
+const [index, arc, arcRuntime, portraitR1, productionControls] = await Promise.all([
+  fs.readFile(new URL('../index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../portrait-thumb-arc-r2.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../portrait-thumb-arc-r2.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../portrait-play-r1.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/ui/gameplay-controls.js', import.meta.url), 'utf8')
+]);
+
+const r1Href = '/turn-lab/portrait-play-r1.css?revision=r1';
+const r2Href = '/turn-lab/portrait-thumb-arc-r2.css?revision=r2';
+const r2Runtime = '/turn-lab/portrait-thumb-arc-r2.js?revision=r2';
+
+assert.ok(index.includes(r2Href), 'TURN LAB must load the portrait R2 thumb arc');
+assert.ok(index.includes(r2Runtime), 'TURN LAB must load the portrait R2 hit-geometry adapter');
+assert.ok(
+  index.indexOf(r2Href) > index.indexOf(r1Href),
+  'The rollback-friendly R2 control layer must load after the portrait R1 foundation'
+);
+assert.match(index, /purpose: 'roadtrip-world-r1\+portrait-play-r2-thumb-arc'/);
+assert.match(index, /TURN LAB · PORTRAIT PLAY R2/);
+
+assert.match(arc, /@media \(orientation: portrait\)/);
+assert.doesNotMatch(arc, /@media \(orientation: landscape\)/);
+assert.match(arc, /html\.turn-lab-portrait \.controls/);
+assert.match(arc, /grid-template-columns: minmax\(0, 1fr\) !important/);
+assert.match(arc, /grid-template-columns: minmax\(0, 72fr\) minmax\(0, 28fr\) !important/);
+assert.match(arc, /justify-self: end !important/);
+assert.match(arc, /clip-path: polygon\(/);
+assert.match(arc, /-webkit-clip-path: polygon\(/);
+assert.match(
+  arc,
+  /grid-template-rows: minmax\(0, 32fr\) minmax\(0, 44fr\) minmax\(0, 24fr\) !important/,
+  'The visible arc segments must retain the production Drive Pad row contract'
+);
+
+assert.match(productionControls, /const TOP_ZONE_SHARE = 0\.32/);
+assert.match(productionControls, /const BRAKE_ZONE_START = 0\.76/);
+assert.match(productionControls, /drivePad\.setPointerCapture/);
+assert.match(productionControls, /drivePad\.dataset\.driveZone/);
+assert.match(productionControls, /brakeButton\.textContent = 'Brake · Reverse'/);
+assert.match(productionControls, /driftZone\.setAttribute\('aria-label', 'Gas and drift'\)/);
+assert.match(productionControls, /boostZone\.setAttribute\('aria-label', 'Gas and boost'\)/);
+
+assert.doesNotMatch(portraitR1, /thumb-arc-r2/);
+
+let portrait = true;
+const drivePad = {
+  dataset: {},
+  getBoundingClientRect() {
+    return { x: 12, y: 500, left: 12, top: 500, width: 369, height: 268, right: 381, bottom: 768 };
+  }
+};
+const root = { dataset: { turnDeployment: 'lab' } };
+const context = {
+  document: {
+    documentElement: root,
+    body: {},
+    readyState: 'complete',
+    querySelector(selector) { return selector === '.drive-pad' ? drivePad : null; }
+  },
+  matchMedia() { return { get matches() { return portrait; } }; }
+};
+context.window = context;
+vm.runInNewContext(arcRuntime, context, { filename: 'portrait-thumb-arc-r2.js' });
+
+assert.equal(root.dataset.turnLabThumbArc, 'r2');
+assert.equal(root.dataset.turnLabThumbArcSplit, '72');
+assert.equal(drivePad.dataset.turnPortraitArcHitGeometry, 'r2');
+
+const portraitRect = drivePad.getBoundingClientRect();
+assert.equal(portraitRect.left, 12);
+assert.equal(portraitRect.top, 500);
+assert.equal(portraitRect.width, 369 * 1.44);
+assert.equal(portraitRect.right, 12 + 369 * 1.44);
+assert.equal(portraitRect.height, 268);
+
+// Short portrait viewport, 34 px home-indicator inset and the production
+// utility-row sizing: even the 24% Brake row remains above TURN's comfortable
+// 44 CSS px design baseline. The narrowest visible arc band is wider still.
+const shortDeckHeight = 310;
+const shortPadHeight = shortDeckHeight - 4 - 10 - 34 - 46 - 8;
+const shortPadInnerHeight = shortPadHeight - 10 - 10;
+const rowHeights = [0.32, 0.44, 0.24].map((share) => shortPadInnerHeight * share);
+assert.ok(Math.min(...rowHeights) >= 44);
+assert.ok((320 - 24) * 0.24 >= 44);
+
+portrait = false;
+assert.deepEqual(
+  { ...drivePad.getBoundingClientRect() },
+  { x: 12, y: 500, left: 12, top: 500, width: 369, height: 268, right: 381, bottom: 768 },
+  'Landscape must receive the untouched production hit rectangle'
+);
+
+console.log('TURN LAB portrait R2 thumb arc, race-state sizing and production control contract passed.');


### PR DESCRIPTION
## Summary
- replace the portrait TURN LAB rectangle with a large right-edge thumb arc
- keep the four production Drive Pad buttons and their existing pointer/slide/charge behavior
- fix the race-state shrink/left regression with an explicit full-width grid
- add a Lab-only hit-geometry adapter so the visible Drift/Boost split matches production input mapping
- leave landscape and `/turn/` production code untouched

## Validation
- `node --check turn-lab/portrait-thumb-arc-r2.js`
- `node turn-lab/tests/portrait-thumb-arc-lab.mjs`
- all TURN LAB production/regression suites pass
- `git diff --check`
- verified no diff under `turn/`