### PR TITLE
Add opt-in Drift Camera for production playtesting

### DIFF
--- a/turn-tests/drift-camera-production.mjs
+++ b/turn-tests/drift-camera-production.mjs
@@ -1,0 +1,162 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import {
+  resolveDriftCameraBlend,
+  resolveDriftCameraYawOffset,
+  updateRaceCameraState
+} from '../turn/render/camera.js';
+import {
+  DRIFT_CAMERA_STORAGE_KEY,
+  driftCameraEnabled,
+  saveDriftCameraEnabled
+} from '../turn/ui/drift-camera-setting.js';
+
+const toRadians = (degrees) => degrees * Math.PI / 180;
+const approximately = (actual, expected, tolerance = 1e-6) => {
+  assert.ok(
+    Math.abs(actual - expected) <= tolerance,
+    `Expected ${actual} to be within ${tolerance} of ${expected}`
+  );
+};
+
+const emptyStorage = {
+  getItem() { return null; },
+  setItem() {}
+};
+assert.equal(driftCameraEnabled(emptyStorage), false, 'Drift Camera must remain opt-in during playtesting');
+
+const values = new Map();
+const storage = {
+  getItem(key) { return values.get(key) ?? null; },
+  setItem(key, value) { values.set(key, value); }
+};
+assert.equal(saveDriftCameraEnabled(true, storage), true);
+assert.equal(values.get(DRIFT_CAMERA_STORAGE_KEY), 'on');
+assert.equal(driftCameraEnabled(storage), true);
+assert.equal(saveDriftCameraEnabled(false, storage), true);
+assert.equal(values.get(DRIFT_CAMERA_STORAGE_KEY), 'off');
+assert.equal(driftCameraEnabled(storage), false);
+
+approximately(resolveDriftCameraBlend(0), 0);
+approximately(resolveDriftCameraBlend(8 / 3.6), 0);
+approximately(resolveDriftCameraBlend(28 / 3.6), 1);
+approximately(resolveDriftCameraBlend(100 / 3.6), 1);
+
+const forward = { x: 0, z: 1 };
+const right = { x: 1, z: 0 };
+const highSpeedSideways = { x: 20, z: 0 };
+const settledSidewaysOffset = resolveDriftCameraYawOffset({
+  velocity: highSpeedSideways,
+  forward,
+  right,
+  previousOffset: 0,
+  dt: 10,
+  enabled: true
+});
+approximately(settledSidewaysOffset, toRadians(90) * 0.85, 1e-6);
+
+const crawlingSidewaysOffset = resolveDriftCameraYawOffset({
+  velocity: { x: 1, z: 0 },
+  forward,
+  right,
+  previousOffset: 0,
+  dt: 10,
+  enabled: true
+});
+approximately(crawlingSidewaysOffset, 0, 1e-9);
+approximately(resolveDriftCameraYawOffset({
+  velocity: highSpeedSideways,
+  forward,
+  right,
+  previousOffset: toRadians(25),
+  dt: 1 / 60,
+  enabled: false
+}), 0, 1e-9);
+
+function makeVelocity(x, z) {
+  return {
+    x,
+    y: 0,
+    z,
+    dot(vector) {
+      return this.x * (Number(vector?.x) || 0)
+        + this.y * (Number(vector?.y) || 0)
+        + this.z * (Number(vector?.z) || 0);
+    }
+  };
+}
+
+function cameraSnapshot(enabled) {
+  globalThis.__turnDriftCameraEnabled = enabled;
+  const cameraPosition = { x: 0, y: 0, z: 0 };
+  const cameraTarget = { x: 0, y: 0, z: 0 };
+  const camera = {
+    position: { copy(value) { this.x = value.x; this.y = value.y; this.z = value.z; } },
+    up: { set() {} },
+    lookAt() {},
+    rotateZ() {},
+    fov: 68,
+    updateProjectionMatrix() {}
+  };
+  const state = {
+    speed: 20,
+    velocity: makeVelocity(20, 0),
+    position: { x: 0, y: 0, z: 0 },
+    nearestTrackIndex: 0,
+    sensorMode: false,
+    driftCameraYawOffset: 0
+  };
+
+  updateRaceCameraState({
+    state,
+    camera,
+    cameraPosition,
+    cameraTarget,
+    getForward: () => forward,
+    getRight: () => right,
+    samples: [],
+    maxSpeed: 88,
+    dt: 1
+  });
+  return { cameraPosition, cameraTarget, camera, state };
+}
+
+const classic = cameraSnapshot(false);
+const drift = cameraSnapshot(true);
+approximately(classic.state.driftCameraYawOffset, 0, 1e-9);
+approximately(classic.cameraTarget.x, 0, 1e-9);
+assert.ok(
+  drift.state.driftCameraYawOffset > toRadians(70),
+  'Enabled Drift Camera should rotate strongly toward a high-speed sideways travel vector'
+);
+assert.ok(
+  drift.cameraTarget.x > 10,
+  'Enabled Drift Camera should look along actual travel instead of only the car nose'
+);
+approximately(
+  drift.camera.fov,
+  classic.camera.fov,
+  1e-9
+);
+assert.equal(
+  drift.cameraPosition.y,
+  classic.cameraPosition.y,
+  'Drift Camera must not alter the established camera height/speed response'
+);
+
+const settingSource = await fs.readFile(new URL('../turn/ui/drift-camera-setting.js', import.meta.url), 'utf8');
+const cameraSource = await fs.readFile(new URL('../turn/render/camera.js', import.meta.url), 'utf8');
+assert.match(settingSource, /getItem\(DRIFT_CAMERA_STORAGE_KEY\) === 'on'/,
+  'Missing storage must continue to mean classic camera');
+assert.match(settingSource, /Experimental; the classic camera remains the default\./);
+assert.match(settingSource, /globalThis\.__turnDriftCameraEnabled = next/,
+  'The Settings toggle must update camera behavior live without a reload');
+assert.match(cameraSource, /DRIFT_CAMERA_TRAVEL_WEIGHT = 0\.85/);
+assert.match(cameraSource, /DRIFT_CAMERA_BLEND_START_SPEED = 8 \/ 3\.6/);
+assert.match(cameraSource, /DRIFT_CAMERA_FULL_BLEND_SPEED = 28 \/ 3\.6/);
+assert.match(cameraSource, /const followDistance = 14 \+ speedRatio \* 7/,
+  'Existing camera distance must remain untouched in this feature');
+assert.match(cameraSource, /camera\.fov = lerp\(camera\.fov, 68 \+ speedRatio \* 14/,
+  'Existing speed/FOV behavior must remain untouched in this feature');
+
+console.log('TURN opt-in Drift Camera preference, velocity-led blend, low-speed fallback and classic-camera parity passed.');

--- a/turn-tests/short-viewport-repair-production.mjs
+++ b/turn-tests/short-viewport-repair-production.mjs
@@ -55,4 +55,8 @@ assert.doesNotMatch(repair, /TURN viewport repair bench|COPY REPAIR RESULT|COLOR
 assert.doesNotMatch(repair, /document\.addEventListener\('click'|window\.addEventListener\('click'/,
   'The first-interaction fallback must stay scoped to Home rather than becoming a global click delegate');
 
+// Drift Camera adds its opt-in control to the same Home Settings surface. Keep its
+// preference and camera-direction contract in the production Home regression path.
+await import('./drift-camera-production.mjs');
+
 console.log('TURN short iOS viewport production repair and vertical-only Home menu passed.');

--- a/turn/render/camera.js
+++ b/turn/render/camera.js
@@ -1,9 +1,17 @@
+import { installDriftCameraSetting } from '../ui/drift-camera-setting.js?revision=r212-drift-camera';
+
 const DEFAULT_MAX_SENSOR_CAMERA_ROLL = 18 * Math.PI / 180;
 const MAX_CONFIGURED_SAFE_ZONE_DEGREES = 45;
 const LOW_SPEED_HORIZON_DEAD_ZONE = 1.25 * Math.PI / 180;
 const LOW_SPEED_HORIZON_FULL_STABILIZATION_SPEED = 5 / 3.6;
 const LOW_SPEED_HORIZON_RELEASE_SPEED = 25 / 3.6;
 const LOW_SPEED_HORIZON_SMOOTHING_RATE = 10;
+const DRIFT_CAMERA_BLEND_START_SPEED = 8 / 3.6;
+const DRIFT_CAMERA_FULL_BLEND_SPEED = 28 / 3.6;
+const DRIFT_CAMERA_TRAVEL_WEIGHT = 0.85;
+const DRIFT_CAMERA_RESPONSE_RATE = 7.5;
+
+installDriftCameraSetting();
 
 export function resolveSensorCameraRollLimit(
   configuration = globalThis.__TURN_MOTION_SAFE_ZONE__
@@ -71,6 +79,44 @@ export function smoothLowSpeedHorizonRoll(previousRoll, targetRoll, speed, dt) {
   return lerp(target, smoothedRoll, stabilizationAmount);
 }
 
+export function resolveDriftCameraBlend(speed) {
+  const magnitude = Math.abs(Number(speed) || 0);
+  if (magnitude <= DRIFT_CAMERA_BLEND_START_SPEED) return 0;
+  if (magnitude >= DRIFT_CAMERA_FULL_BLEND_SPEED) return 1;
+  const progress = (
+    magnitude - DRIFT_CAMERA_BLEND_START_SPEED
+  ) / (
+    DRIFT_CAMERA_FULL_BLEND_SPEED - DRIFT_CAMERA_BLEND_START_SPEED
+  );
+  return progress * progress * (3 - 2 * progress);
+}
+
+export function resolveDriftCameraYawOffset({
+  velocity,
+  forward,
+  right,
+  previousOffset = 0,
+  dt = 0,
+  enabled = globalThis.__turnDriftCameraEnabled === true
+}) {
+  if (!enabled) return 0;
+
+  const velocityX = finiteNumber(velocity?.x, 0);
+  const velocityZ = finiteNumber(velocity?.z, 0);
+  const travelSpeed = Math.hypot(velocityX, velocityZ);
+  const blend = resolveDriftCameraBlend(travelSpeed);
+  const previous = normalizeAngle(previousOffset);
+  const longitudinal = velocityX * finiteNumber(forward?.x, 0)
+    + velocityZ * finiteNumber(forward?.z, 0);
+  const lateral = velocityX * finiteNumber(right?.x, 0)
+    + velocityZ * finiteNumber(right?.z, 0);
+  const travelOffset = travelSpeed > 0.0001 ? Math.atan2(lateral, longitudinal) : 0;
+  const targetOffset = travelOffset * DRIFT_CAMERA_TRAVEL_WEIGHT * blend;
+  const targetDelta = normalizeAngle(targetOffset - previous);
+  const response = 1 - Math.exp(-Math.max(0, Number(dt) || 0) * DRIFT_CAMERA_RESPONSE_RATE);
+  return normalizeAngle(previous + targetDelta * response);
+}
+
 export function updateRaceCameraState({
   state,
   camera,
@@ -82,10 +128,32 @@ export function updateRaceCameraState({
   maxSpeed,
   dt
 }) {
-  const forward = getForward();
-  const right = getRight();
+  const carForward = getForward();
+  const carRight = getRight();
+  state.driftCameraYawOffset = resolveDriftCameraYawOffset({
+    velocity: state.velocity,
+    forward: carForward,
+    right: carRight,
+    previousOffset: state.driftCameraYawOffset,
+    dt
+  });
+  const driftCosine = Math.cos(state.driftCameraYawOffset);
+  const driftSine = Math.sin(state.driftCameraYawOffset);
+  const forward = {
+    x: carForward.x * driftCosine + carRight.x * driftSine,
+    y: 0,
+    z: carForward.z * driftCosine + carRight.z * driftSine
+  };
+  const right = {
+    x: carRight.x * driftCosine - carForward.x * driftSine,
+    y: 0,
+    z: carRight.z * driftCosine - carForward.z * driftSine
+  };
   const speedRatio = clamp(state.speed / maxSpeed, 0, 1);
-  const lateralVelocity = state.velocity.dot(right);
+  // Keep the established lateral-drift offset driven by the car's own axis.
+  // Drift Camera changes only camera orientation, not handling or the amount of
+  // existing lateral camera movement.
+  const lateralVelocity = state.velocity.dot(carRight);
   const roadY = finiteNumber(state.position?.y, 0);
   const lookAheadCount = 18 + Math.round(speedRatio * 12);
   const lookAheadIndex = Array.isArray(samples) && samples.length && Number.isFinite(state.nearestTrackIndex)

--- a/turn/ui/drift-camera-setting.js
+++ b/turn/ui/drift-camera-setting.js
@@ -1,0 +1,110 @@
+export const DRIFT_CAMERA_STORAGE_KEY = 'turn-drift-camera-v1';
+
+let installed = false;
+let settingsObserver = null;
+
+export function driftCameraEnabled(storage = getStorage()) {
+  try {
+    return storage?.getItem(DRIFT_CAMERA_STORAGE_KEY) === 'on';
+  } catch (_) {
+    return false;
+  }
+}
+
+export function saveDriftCameraEnabled(enabled, storage = getStorage()) {
+  if (!storage || typeof storage.setItem !== 'function') return false;
+  try {
+    storage.setItem(DRIFT_CAMERA_STORAGE_KEY, enabled ? 'on' : 'off');
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+export function installDriftCameraSetting() {
+  const enabled = driftCameraEnabled();
+  globalThis.__turnDriftCameraEnabled = enabled;
+  if (typeof document === 'undefined') return enabled;
+  if (installed) {
+    attachSettingsControl();
+    return enabled;
+  }
+  installed = true;
+
+  const attach = () => {
+    if (!attachSettingsControl()) return false;
+    settingsObserver?.disconnect();
+    settingsObserver = null;
+    return true;
+  };
+
+  if (!attach() && document.body && typeof MutationObserver !== 'undefined') {
+    settingsObserver = new MutationObserver(attach);
+    settingsObserver.observe(document.body, { childList: true, subtree: true });
+  }
+  document.addEventListener('turn:home-ready', attach, { once: true });
+  return enabled;
+}
+
+function attachSettingsControl() {
+  const dialog = document.querySelector('.m8-settings-dialog');
+  const list = dialog?.querySelector('.m8-settings-list');
+  if (!dialog || !list) return false;
+
+  let section = list.querySelector('[data-turn-drift-camera-setting]');
+  if (!section) {
+    section = document.createElement('section');
+    section.className = 'm8-setting-card';
+    section.dataset.turnDriftCameraSetting = '';
+    section.setAttribute('aria-labelledby', 'm8CameraTitle');
+    section.innerHTML = `
+      <h3 id="m8CameraTitle">Camera</h3>
+      <label class="m8-toggle-row">
+        <input id="m8DriftCameraEnabled" type="checkbox">
+        <span>
+          <strong>Drift camera</strong>
+          <small>Follows the car’s actual direction of travel during slides. Experimental; the classic camera remains the default.</small>
+        </span>
+      </label>`;
+    const steering = list.querySelector('.m8-steering-setting');
+    if (steering) steering.after(section);
+    else list.prepend(section);
+
+    const checkbox = section.querySelector('#m8DriftCameraEnabled');
+    checkbox.addEventListener('change', () => {
+      const previous = globalThis.__turnDriftCameraEnabled === true;
+      const next = checkbox.checked;
+      if (!saveDriftCameraEnabled(next)) {
+        checkbox.checked = previous;
+        announce(dialog, 'Drift camera could not be changed because local storage is unavailable.');
+        return;
+      }
+      globalThis.__turnDriftCameraEnabled = next;
+      announce(dialog, `Drift camera ${next ? 'on' : 'off'}.`);
+    });
+  }
+
+  const sync = () => {
+    const checkbox = section.querySelector('#m8DriftCameraEnabled');
+    if (checkbox) checkbox.checked = globalThis.__turnDriftCameraEnabled === true;
+  };
+  sync();
+  if (!dialog.dataset.turnDriftCameraSync) {
+    dialog.dataset.turnDriftCameraSync = 'true';
+    dialog.addEventListener('toggle', sync);
+  }
+  return true;
+}
+
+function announce(dialog, message) {
+  const status = dialog.querySelector('.m8-settings-status');
+  if (status) status.textContent = message;
+}
+
+function getStorage() {
+  try {
+    return globalThis.localStorage;
+  } catch (_) {
+    return null;
+  }
+}


### PR DESCRIPTION
## Feature
Add the first production Drift Camera implementation as an explicit opt-in while preserving the classic TURN camera as the default during playtesting.

## Behavior
- new **Settings → Camera → Drift camera** checkbox
- default OFF unless the player explicitly enables it
- preference persists in local storage and applies live without reload
- at crawling speed the camera stays aligned with vehicle heading
- from 8–28 km/h it progressively blends toward actual travel direction
- at normal racing speed travel direction contributes 85% and vehicle heading 15%
- shortest-angle smoothing avoids wraparound snaps

## Deliberately unchanged
- vehicle physics and handling
- current follow distance
- current camera height
- current speed/FOV response
- lap timing, rivals, achievements and recordings

## Regression
Adds a production regression covering default OFF, preference persistence, low-speed fallback, strong velocity-led drift behavior, live classic-camera parity, and unchanged FOV/height behavior.