### PR TITLE
Add opt-in speed-responsive camera

### DIFF
--- a/turn-tests/drift-camera-production.mjs
+++ b/turn-tests/drift-camera-production.mjs
@@ -7,8 +7,11 @@ import {
 } from '../turn/render/camera.js';
 import {
   DRIFT_CAMERA_STORAGE_KEY,
+  SPEED_RESPONSIVE_CAMERA_STORAGE_KEY,
   driftCameraEnabled,
-  saveDriftCameraEnabled
+  saveDriftCameraEnabled,
+  saveSpeedResponsiveCameraEnabled,
+  speedResponsiveCameraEnabled
 } from '../turn/ui/drift-camera-setting.js';
 
 const toRadians = (degrees) => degrees * Math.PI / 180;
@@ -24,6 +27,16 @@ const emptyStorage = {
   setItem() {}
 };
 assert.equal(driftCameraEnabled(emptyStorage), false, 'Drift Camera must remain opt-in during playtesting');
+assert.equal(
+  speedResponsiveCameraEnabled(emptyStorage),
+  false,
+  'Speed-responsive Camera must remain opt-in during playtesting'
+);
+assert.equal(
+  speedResponsiveCameraEnabled(emptyStorage, true),
+  true,
+  'A future default change should apply when no explicit preference exists'
+);
 
 const values = new Map();
 const storage = {
@@ -36,6 +49,18 @@ assert.equal(driftCameraEnabled(storage), true);
 assert.equal(saveDriftCameraEnabled(false, storage), true);
 assert.equal(values.get(DRIFT_CAMERA_STORAGE_KEY), 'off');
 assert.equal(driftCameraEnabled(storage), false);
+
+assert.equal(saveSpeedResponsiveCameraEnabled(true, storage), true);
+assert.equal(values.get(SPEED_RESPONSIVE_CAMERA_STORAGE_KEY), 'on');
+assert.equal(speedResponsiveCameraEnabled(storage), true);
+assert.equal(saveSpeedResponsiveCameraEnabled(false, storage), true);
+assert.equal(values.get(SPEED_RESPONSIVE_CAMERA_STORAGE_KEY), 'off');
+assert.equal(speedResponsiveCameraEnabled(storage), false);
+assert.equal(
+  speedResponsiveCameraEnabled(storage, true),
+  false,
+  'An explicit off preference must survive a future default-on change'
+);
 
 approximately(resolveDriftCameraBlend(0), 0);
 approximately(resolveDriftCameraBlend(8 / 3.6), 0);
@@ -86,8 +111,15 @@ function makeVelocity(x, z) {
   };
 }
 
-function cameraSnapshot(enabled) {
-  globalThis.__turnDriftCameraEnabled = enabled;
+function cameraSnapshot({
+  driftEnabled = false,
+  speedResponsiveEnabled = false,
+  speed = 20,
+  velocity = makeVelocity(20, 0),
+  dt = 1
+} = {}) {
+  globalThis.__turnDriftCameraEnabled = driftEnabled;
+  globalThis.__turnSpeedResponsiveCameraEnabled = speedResponsiveEnabled;
   const cameraPosition = { x: 0, y: 0, z: 0 };
   const cameraTarget = { x: 0, y: 0, z: 0 };
   const camera = {
@@ -99,8 +131,8 @@ function cameraSnapshot(enabled) {
     updateProjectionMatrix() {}
   };
   const state = {
-    speed: 20,
-    velocity: makeVelocity(20, 0),
+    speed,
+    velocity,
     position: { x: 0, y: 0, z: 0 },
     nearestTrackIndex: 0,
     sensorMode: false,
@@ -116,14 +148,17 @@ function cameraSnapshot(enabled) {
     getRight: () => right,
     samples: [],
     maxSpeed: 88,
-    dt: 1
+    dt
   });
   return { cameraPosition, cameraTarget, camera, state };
 }
 
-const classic = cameraSnapshot(false);
-const drift = cameraSnapshot(true);
+const classic = cameraSnapshot();
+const drift = cameraSnapshot({ driftEnabled: true });
+const speedResponsive = cameraSnapshot({ speedResponsiveEnabled: true });
+const combined = cameraSnapshot({ driftEnabled: true, speedResponsiveEnabled: true });
 approximately(classic.state.driftCameraYawOffset, 0, 1e-9);
+approximately(speedResponsive.state.driftCameraYawOffset, 0, 1e-9);
 approximately(classic.cameraTarget.x, 0, 1e-9);
 assert.ok(
   drift.state.driftCameraYawOffset > toRadians(70),
@@ -133,30 +168,74 @@ assert.ok(
   drift.cameraTarget.x > 10,
   'Enabled Drift Camera should look along actual travel instead of only the car nose'
 );
-approximately(
-  drift.camera.fov,
-  classic.camera.fov,
-  1e-9
-);
+approximately(drift.state.driftCameraYawOffset, combined.state.driftCameraYawOffset, 1e-9);
+approximately(drift.cameraTarget.x, combined.cameraTarget.x, 1e-9);
+approximately(drift.camera.fov, classic.camera.fov, 1e-9);
+approximately(combined.camera.fov, speedResponsive.camera.fov, 1e-9);
 assert.equal(
   drift.cameraPosition.y,
   classic.cameraPosition.y,
-  'Drift Camera must not alter the established camera height/speed response'
+  'Drift Camera must not alter the selected camera height/speed response'
 );
+assert.equal(
+  combined.cameraPosition.y,
+  speedResponsive.cameraPosition.y,
+  'Drift Camera and Speed-responsive Camera must remain independent'
+);
+
+const legacyStopped = cameraSnapshot({ speed: 0, velocity: makeVelocity(0, 0), dt: 10 });
+const legacyFast = cameraSnapshot({ speed: 88, velocity: makeVelocity(0, 88), dt: 10 });
+const responsiveStopped = cameraSnapshot({
+  speedResponsiveEnabled: true,
+  speed: 0,
+  velocity: makeVelocity(0, 0),
+  dt: 10
+});
+const responsiveFast = cameraSnapshot({
+  speedResponsiveEnabled: true,
+  speed: 88,
+  velocity: makeVelocity(0, 88),
+  dt: 10
+});
+
+approximately(-legacyStopped.cameraPosition.z, 14);
+approximately(-legacyFast.cameraPosition.z, 21);
+approximately(legacyStopped.cameraPosition.y, 7.7);
+approximately(legacyFast.cameraPosition.y, 10.2);
+approximately(-responsiveStopped.cameraPosition.z, 15);
+approximately(-responsiveFast.cameraPosition.z, 14);
+approximately(responsiveStopped.cameraPosition.y, 8.2);
+approximately(responsiveFast.cameraPosition.y, 7.7);
+assert.ok(
+  -responsiveFast.cameraPosition.z < -responsiveStopped.cameraPosition.z,
+  'Speed-responsive Camera must move closer as speed builds'
+);
+approximately(legacyStopped.camera.fov, 68);
+approximately(responsiveStopped.camera.fov, 68);
+approximately(legacyFast.camera.fov, 82);
+approximately(responsiveFast.camera.fov, 82);
+approximately(legacyFast.cameraTarget.z, responsiveFast.cameraTarget.z);
 
 const settingSource = await fs.readFile(new URL('../turn/ui/drift-camera-setting.js', import.meta.url), 'utf8');
 const cameraSource = await fs.readFile(new URL('../turn/render/camera.js', import.meta.url), 'utf8');
 assert.match(settingSource, /getItem\(DRIFT_CAMERA_STORAGE_KEY\) === 'on'/,
-  'Missing storage must continue to mean classic camera');
-assert.match(settingSource, /Experimental; the classic camera remains the default\./);
+  'Missing storage must continue to mean classic drift direction');
+assert.match(settingSource, /SPEED_RESPONSIVE_CAMERA_DEFAULT = false/);
+assert.match(settingSource, /Speed-responsive camera/);
 assert.match(settingSource, /globalThis\.__turnDriftCameraEnabled = next/,
-  'The Settings toggle must update camera behavior live without a reload');
+  'The Drift Camera toggle must update camera behavior live without a reload');
+assert.match(settingSource, /globalThis\.__turnSpeedResponsiveCameraEnabled = next/,
+  'The Speed-responsive Camera toggle must update camera behavior live without a reload');
 assert.match(cameraSource, /DRIFT_CAMERA_TRAVEL_WEIGHT = 0\.85/);
 assert.match(cameraSource, /DRIFT_CAMERA_BLEND_START_SPEED = 8 \/ 3\.6/);
 assert.match(cameraSource, /DRIFT_CAMERA_FULL_BLEND_SPEED = 28 \/ 3\.6/);
-assert.match(cameraSource, /const followDistance = 14 \+ speedRatio \* 7/,
-  'Existing camera distance must remain untouched in this feature');
+assert.match(cameraSource, /\?revision=r213-speed-responsive-camera/,
+  'The combined Camera settings module must be cache-busted');
+assert.match(cameraSource, /\? 15 - speedRatio/,
+  'The responsive camera must move from distance 15 toward 14 as speed builds');
+assert.match(cameraSource, /: 14 \+ speedRatio \* 7/,
+  'Speed-responsive Camera OFF must preserve the established pull-back exactly');
 assert.match(cameraSource, /camera\.fov = lerp\(camera\.fov, 68 \+ speedRatio \* 14/,
-  'Existing speed/FOV behavior must remain untouched in this feature');
+  'FOV must remain the primary speed cue in either camera profile');
 
-console.log('TURN opt-in Drift Camera preference, velocity-led blend, low-speed fallback and classic-camera parity passed.');
+console.log('TURN independent Drift and Speed-responsive Camera preferences, profiles and parity passed.');

--- a/turn/render/camera.js
+++ b/turn/render/camera.js
@@ -1,4 +1,4 @@
-import { installDriftCameraSetting } from '../ui/drift-camera-setting.js?revision=r212-drift-camera';
+import { installDriftCameraSetting } from '../ui/drift-camera-setting.js?revision=r213-speed-responsive-camera';
 
 const DEFAULT_MAX_SENSOR_CAMERA_ROLL = 18 * Math.PI / 180;
 const MAX_CONFIGURED_SAFE_ZONE_DEGREES = 45;
@@ -150,6 +150,7 @@ export function updateRaceCameraState({
     z: carRight.z * driftCosine - carForward.z * driftSine
   };
   const speedRatio = clamp(state.speed / maxSpeed, 0, 1);
+  const speedResponsiveCamera = globalThis.__turnSpeedResponsiveCameraEnabled === true;
   // Keep the established lateral-drift offset driven by the car's own axis.
   // Drift Camera changes only camera orientation, not handling or the amount of
   // existing lateral camera movement.
@@ -163,7 +164,15 @@ export function updateRaceCameraState({
     ? finiteNumber(samples[lookAheadIndex]?.point?.y, roadY)
     : roadY;
 
-  const followDistance = 14 + speedRatio * 7;
+  // The experimental speed-responsive profile reverses the established pull-back:
+  // it moves slightly closer and lower as speed builds while FOV supplies the
+  // primary sense of acceleration. OFF remains exact legacy camera behavior.
+  const followDistance = speedResponsiveCamera
+    ? 15 - speedRatio
+    : 14 + speedRatio * 7;
+  const cameraHeight = speedResponsiveCamera
+    ? 8.2 - speedRatio * 0.5
+    : 7.7 + speedRatio * 2.5;
   const lateralOffset = lateralVelocity * 0.11;
   const cameraResponse = 1 - Math.exp(-dt * 6.2);
   cameraPosition.x = lerp(
@@ -171,7 +180,7 @@ export function updateRaceCameraState({
     state.position.x - forward.x * followDistance - right.x * lateralOffset,
     cameraResponse
   );
-  cameraPosition.y = lerp(cameraPosition.y, roadY + 7.7 + speedRatio * 2.5, cameraResponse);
+  cameraPosition.y = lerp(cameraPosition.y, roadY + cameraHeight, cameraResponse);
   cameraPosition.z = lerp(
     cameraPosition.z,
     state.position.z - forward.z * followDistance - right.z * lateralOffset,

--- a/turn/ui/drift-camera-setting.js
+++ b/turn/ui/drift-camera-setting.js
@@ -1,4 +1,6 @@
 export const DRIFT_CAMERA_STORAGE_KEY = 'turn-drift-camera-v1';
+export const SPEED_RESPONSIVE_CAMERA_STORAGE_KEY = 'turn-speed-responsive-camera-v1';
+export const SPEED_RESPONSIVE_CAMERA_DEFAULT = false;
 
 let installed = false;
 let settingsObserver = null;
@@ -21,13 +23,39 @@ export function saveDriftCameraEnabled(enabled, storage = getStorage()) {
   }
 }
 
+export function speedResponsiveCameraEnabled(
+  storage = getStorage(),
+  defaultEnabled = SPEED_RESPONSIVE_CAMERA_DEFAULT
+) {
+  try {
+    const preference = storage?.getItem(SPEED_RESPONSIVE_CAMERA_STORAGE_KEY);
+    if (preference === 'on') return true;
+    if (preference === 'off') return false;
+    return defaultEnabled === true;
+  } catch (_) {
+    return defaultEnabled === true;
+  }
+}
+
+export function saveSpeedResponsiveCameraEnabled(enabled, storage = getStorage()) {
+  if (!storage || typeof storage.setItem !== 'function') return false;
+  try {
+    storage.setItem(SPEED_RESPONSIVE_CAMERA_STORAGE_KEY, enabled ? 'on' : 'off');
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
 export function installDriftCameraSetting() {
-  const enabled = driftCameraEnabled();
-  globalThis.__turnDriftCameraEnabled = enabled;
-  if (typeof document === 'undefined') return enabled;
+  const driftEnabled = driftCameraEnabled();
+  const speedResponsiveEnabled = speedResponsiveCameraEnabled();
+  globalThis.__turnDriftCameraEnabled = driftEnabled;
+  globalThis.__turnSpeedResponsiveCameraEnabled = speedResponsiveEnabled;
+  if (typeof document === 'undefined') return driftEnabled;
   if (installed) {
     attachSettingsControl();
-    return enabled;
+    return driftEnabled;
   }
   installed = true;
 
@@ -43,7 +71,7 @@ export function installDriftCameraSetting() {
     settingsObserver.observe(document.body, { childList: true, subtree: true });
   }
   document.addEventListener('turn:home-ready', attach, { once: true });
-  return enabled;
+  return driftEnabled;
 }
 
 function attachSettingsControl() {
@@ -65,28 +93,52 @@ function attachSettingsControl() {
           <strong>Drift camera</strong>
           <small>Follows the car’s actual direction of travel during slides. Experimental; the classic camera remains the default.</small>
         </span>
+      </label>
+      <label class="m8-toggle-row">
+        <input id="m8SpeedResponsiveCameraEnabled" type="checkbox">
+        <span>
+          <strong>Speed-responsive camera</strong>
+          <small>Keeps the car close while the view widens as speed builds. Experimental; the current camera remains the default.</small>
+        </span>
       </label>`;
     const steering = list.querySelector('.m8-steering-setting');
     if (steering) steering.after(section);
     else list.prepend(section);
 
-    const checkbox = section.querySelector('#m8DriftCameraEnabled');
-    checkbox.addEventListener('change', () => {
+    const driftCheckbox = section.querySelector('#m8DriftCameraEnabled');
+    driftCheckbox.addEventListener('change', () => {
       const previous = globalThis.__turnDriftCameraEnabled === true;
-      const next = checkbox.checked;
+      const next = driftCheckbox.checked;
       if (!saveDriftCameraEnabled(next)) {
-        checkbox.checked = previous;
+        driftCheckbox.checked = previous;
         announce(dialog, 'Drift camera could not be changed because local storage is unavailable.');
         return;
       }
       globalThis.__turnDriftCameraEnabled = next;
       announce(dialog, `Drift camera ${next ? 'on' : 'off'}.`);
     });
+
+    const speedCheckbox = section.querySelector('#m8SpeedResponsiveCameraEnabled');
+    speedCheckbox.addEventListener('change', () => {
+      const previous = globalThis.__turnSpeedResponsiveCameraEnabled === true;
+      const next = speedCheckbox.checked;
+      if (!saveSpeedResponsiveCameraEnabled(next)) {
+        speedCheckbox.checked = previous;
+        announce(dialog, 'Speed-responsive camera could not be changed because local storage is unavailable.');
+        return;
+      }
+      globalThis.__turnSpeedResponsiveCameraEnabled = next;
+      announce(dialog, `Speed-responsive camera ${next ? 'on' : 'off'}.`);
+    });
   }
 
   const sync = () => {
-    const checkbox = section.querySelector('#m8DriftCameraEnabled');
-    if (checkbox) checkbox.checked = globalThis.__turnDriftCameraEnabled === true;
+    const driftCheckbox = section.querySelector('#m8DriftCameraEnabled');
+    if (driftCheckbox) driftCheckbox.checked = globalThis.__turnDriftCameraEnabled === true;
+    const speedCheckbox = section.querySelector('#m8SpeedResponsiveCameraEnabled');
+    if (speedCheckbox) {
+      speedCheckbox.checked = globalThis.__turnSpeedResponsiveCameraEnabled === true;
+    }
   };
   sync();
   if (!dialog.dataset.turnDriftCameraSync) {


### PR DESCRIPTION
## What changed

- add a second, persisted `Speed-responsive camera` toggle beside Drift camera in Settings
- keep the two camera features fully independent and live-switchable
- reverse the current speed pull-back when enabled: follow distance moves from 15 to 14 and height from 8.2 to 7.7 as speed builds
- preserve the existing 68° to 82° FOV expansion and speed-based road look-ahead
- keep the current camera profile byte-for-byte equivalent when the setting is off
- preserve an explicit user choice if the product default changes later

## Product behavior

The new profile is opt-in during playtesting. Its widening FOV remains the main speed cue while the camera moves slightly closer to the car instead of pulling far away. Drift camera continues to affect direction only.

## Validation

- `node turn-tests/drift-camera-production.mjs`
- `node --check turn/render/camera.js`
- `node --check turn/ui/drift-camera-setting.js`

Regression coverage includes storage/default semantics, live-toggle wiring, the 15 → 14 curve, legacy 14 → 21 parity, unchanged FOV/look-ahead, and all four combinations of Drift and Speed-responsive camera.