### PR TITLE
Keep speed-responsive camera locked to the car

### DIFF
--- a/turn-tests/drift-camera-production.mjs
+++ b/turn-tests/drift-camera-production.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import {
+  resolveCameraMotionLeadTime,
   resolveDriftCameraBlend,
   resolveDriftCameraYawOffset,
   updateRaceCameraState
@@ -66,6 +67,11 @@ approximately(resolveDriftCameraBlend(0), 0);
 approximately(resolveDriftCameraBlend(8 / 3.6), 0);
 approximately(resolveDriftCameraBlend(28 / 3.6), 1);
 approximately(resolveDriftCameraBlend(100 / 3.6), 1);
+approximately(resolveCameraMotionLeadTime(6.2, 0), 1 / 6.2);
+approximately(
+  resolveCameraMotionLeadTime(6.2, 1 / 60),
+  (1 / 60) / Math.expm1(6.2 / 60)
+);
 
 const forward = { x: 0, z: 1 };
 const right = { x: 1, z: 0 };
@@ -169,7 +175,6 @@ assert.ok(
   'Enabled Drift Camera should look along actual travel instead of only the car nose'
 );
 approximately(drift.state.driftCameraYawOffset, combined.state.driftCameraYawOffset, 1e-9);
-approximately(drift.cameraTarget.x, combined.cameraTarget.x, 1e-9);
 approximately(drift.camera.fov, classic.camera.fov, 1e-9);
 approximately(combined.camera.fov, speedResponsive.camera.fov, 1e-9);
 assert.equal(
@@ -216,6 +221,72 @@ approximately(legacyFast.camera.fov, 82);
 approximately(responsiveFast.camera.fov, 82);
 approximately(legacyFast.cameraTarget.z, responsiveFast.cameraTarget.z);
 
+function movingCameraRun(speedResponsiveEnabled, dt = 1 / 60) {
+  globalThis.__turnDriftCameraEnabled = false;
+  globalThis.__turnSpeedResponsiveCameraEnabled = speedResponsiveEnabled;
+  const speed = 88;
+  const cameraPosition = { x: 0, y: 7.7, z: speedResponsiveEnabled ? -14 : -21 };
+  const cameraTarget = { x: 0, y: 2, z: 27 };
+  const camera = {
+    position: { copy(value) { this.x = value.x; this.y = value.y; this.z = value.z; } },
+    up: { set() {} },
+    lookAt() {},
+    rotateZ() {},
+    fov: 68,
+    updateProjectionMatrix() {}
+  };
+  const state = {
+    speed,
+    velocity: makeVelocity(0, speed),
+    position: { x: 0, y: 0, z: 0 },
+    nearestTrackIndex: 0,
+    sensorMode: false,
+    driftCameraYawOffset: 0
+  };
+
+  const frameCount = Math.ceil(10 / dt);
+  for (let frame = 0; frame < frameCount; frame += 1) {
+    state.position.z += speed * dt;
+    updateRaceCameraState({
+      state,
+      camera,
+      cameraPosition,
+      cameraTarget,
+      getForward: () => forward,
+      getRight: () => right,
+      samples: [],
+      maxSpeed: 88,
+      dt
+    });
+  }
+
+  return {
+    followDistance: state.position.z - cameraPosition.z,
+    targetDistance: cameraTarget.z - state.position.z,
+    fov: camera.fov
+  };
+}
+
+const movingLegacy = movingCameraRun(false);
+const movingResponsive = movingCameraRun(true);
+assert.ok(
+  movingLegacy.followDistance > 30,
+  'The regression harness must reproduce the established high-speed world-space camera lag'
+);
+assert.ok(
+  movingLegacy.targetDistance < 20,
+  'The regression harness must reproduce the established high-speed look-target lag'
+);
+approximately(movingResponsive.followDistance, 14, 1e-6);
+approximately(movingResponsive.targetDistance, 27, 1e-6);
+approximately(movingResponsive.fov, 82, 1e-6);
+for (const dt of [1 / 30, 1 / 120, 0.12]) {
+  const frameRateVariant = movingCameraRun(true, dt);
+  approximately(frameRateVariant.followDistance, 14, 1e-6);
+  approximately(frameRateVariant.targetDistance, 27, 1e-6);
+  approximately(frameRateVariant.fov, 82, 1e-6);
+}
+
 const settingSource = await fs.readFile(new URL('../turn/ui/drift-camera-setting.js', import.meta.url), 'utf8');
 const cameraSource = await fs.readFile(new URL('../turn/render/camera.js', import.meta.url), 'utf8');
 assert.match(settingSource, /getItem\(DRIFT_CAMERA_STORAGE_KEY\) === 'on'/,
@@ -235,7 +306,11 @@ assert.match(cameraSource, /\? 15 - speedRatio/,
   'The responsive camera must move from distance 15 toward 14 as speed builds');
 assert.match(cameraSource, /: 14 \+ speedRatio \* 7/,
   'Speed-responsive Camera OFF must preserve the established pull-back exactly');
+assert.match(cameraSource, /resolveCameraMotionLeadTime\(CAMERA_POSITION_RESPONSE_RATE, dt\)/,
+  'The responsive camera must cancel speed-dependent world-space follow lag');
+assert.match(cameraSource, /resolveCameraMotionLeadTime\(CAMERA_TARGET_RESPONSE_RATE, dt\)/,
+  'The responsive look target must cancel speed-dependent world-space follow lag');
 assert.match(cameraSource, /camera\.fov = lerp\(camera\.fov, 68 \+ speedRatio \* 14/,
   'FOV must remain the primary speed cue in either camera profile');
 
-console.log('TURN independent Drift and Speed-responsive Camera preferences, profiles and parity passed.');
+console.log('TURN independent camera preferences, motion-compensated speed profile and legacy parity passed.');

--- a/turn/render/camera.js
+++ b/turn/render/camera.js
@@ -10,6 +10,8 @@ const DRIFT_CAMERA_BLEND_START_SPEED = 8 / 3.6;
 const DRIFT_CAMERA_FULL_BLEND_SPEED = 28 / 3.6;
 const DRIFT_CAMERA_TRAVEL_WEIGHT = 0.85;
 const DRIFT_CAMERA_RESPONSE_RATE = 7.5;
+const CAMERA_POSITION_RESPONSE_RATE = 6.2;
+const CAMERA_TARGET_RESPONSE_RATE = 8.5;
 
 installDriftCameraSetting();
 
@@ -117,6 +119,18 @@ export function resolveDriftCameraYawOffset({
   return normalizeAngle(previous + targetDelta * response);
 }
 
+export function resolveCameraMotionLeadTime(responseRate, dt) {
+  const rate = Math.max(0, Number(responseRate) || 0);
+  if (!rate) return 0;
+
+  const elapsed = Math.max(0, Number(dt) || 0);
+  if (!elapsed) return 1 / rate;
+
+  const denominator = Math.expm1(elapsed * rate);
+  if (!Number.isFinite(denominator)) return 0;
+  return denominator > 0 ? elapsed / denominator : 1 / rate;
+}
+
 export function updateRaceCameraState({
   state,
   camera,
@@ -151,6 +165,8 @@ export function updateRaceCameraState({
   };
   const speedRatio = clamp(state.speed / maxSpeed, 0, 1);
   const speedResponsiveCamera = globalThis.__turnSpeedResponsiveCameraEnabled === true;
+  const velocityX = finiteNumber(state.velocity?.x, 0);
+  const velocityZ = finiteNumber(state.velocity?.z, 0);
   // Keep the established lateral-drift offset driven by the car's own axis.
   // Drift Camera changes only camera orientation, not handling or the amount of
   // existing lateral camera movement.
@@ -174,32 +190,45 @@ export function updateRaceCameraState({
     ? 8.2 - speedRatio * 0.5
     : 7.7 + speedRatio * 2.5;
   const lateralOffset = lateralVelocity * 0.11;
-  const cameraResponse = 1 - Math.exp(-dt * 6.2);
+  const cameraResponse = 1 - Math.exp(-dt * CAMERA_POSITION_RESPONSE_RATE);
+  // Exponential world-space following otherwise adds a second, much larger
+  // speed-dependent pull-back: at racing speed the camera trails the moving car
+  // by roughly velocity / responseRate. Lead the moving target by the exact
+  // discrete-time amount so smoothing remains available for turns without
+  // allowing straight-line translation to move the car away on screen.
+  const cameraMotionLead = speedResponsiveCamera
+    ? resolveCameraMotionLeadTime(CAMERA_POSITION_RESPONSE_RATE, dt)
+    : 0;
   cameraPosition.x = lerp(
     cameraPosition.x,
-    state.position.x - forward.x * followDistance - right.x * lateralOffset,
+    state.position.x + velocityX * cameraMotionLead
+      - forward.x * followDistance - right.x * lateralOffset,
     cameraResponse
   );
   cameraPosition.y = lerp(cameraPosition.y, roadY + cameraHeight, cameraResponse);
   cameraPosition.z = lerp(
     cameraPosition.z,
-    state.position.z - forward.z * followDistance - right.z * lateralOffset,
+    state.position.z + velocityZ * cameraMotionLead
+      - forward.z * followDistance - right.z * lateralOffset,
     cameraResponse
   );
   camera.position.copy(cameraPosition);
 
   const targetDistance = 15 + speedRatio * 12;
-  const targetResponse = 1 - Math.exp(-dt * 8.5);
+  const targetResponse = 1 - Math.exp(-dt * CAMERA_TARGET_RESPONSE_RATE);
+  const targetMotionLead = speedResponsiveCamera
+    ? resolveCameraMotionLeadTime(CAMERA_TARGET_RESPONSE_RATE, dt)
+    : 0;
   cameraTarget.x = lerp(
     cameraTarget.x,
-    state.position.x + forward.x * targetDistance,
+    state.position.x + velocityX * targetMotionLead + forward.x * targetDistance,
     targetResponse
   );
   const anticipatedRoadY = roadY + (lookAheadRoadY - roadY) * 0.35;
   cameraTarget.y = lerp(cameraTarget.y, anticipatedRoadY + 2, targetResponse);
   cameraTarget.z = lerp(
     cameraTarget.z,
-    state.position.z + forward.z * targetDistance,
+    state.position.z + velocityZ * targetMotionLead + forward.z * targetDistance,
     targetResponse
   );
   camera.up.set(0, 1, 0);


### PR DESCRIPTION
## Cause

The intended Speed-responsive Camera distance curve was correctly reversed from 15 to 14, but both the camera position and look target still used exponential smoothing against the car's absolute world position. That introduces a separate translation lag proportional to speed. At racing speed it added roughly 10–14 world units of unintended separation, overwhelming the one-unit move toward the car.

## Fix

- compensate the moving camera target by the exact frame-rate-aware lead required by its existing exponential response
- compensate the moving look target independently using its own response rate
- retain smoothing for turns and camera-direction changes
- preserve the 15 → 14 distance curve, 8.2 → 7.7 height curve and 68° → 82° FOV curve
- apply compensation only when Speed-responsive Camera is enabled
- leave legacy camera behavior byte-for-byte equivalent when disabled

## Validation

- reproduce the former high-speed lag with a ten-second moving-camera simulation
- verify responsive follow distance remains exactly 14 at maximum speed
- verify look target remains exactly 27 units ahead
- verify the result at 30, 60 and 120 fps and with a 120 ms frame hitch
- `node turn-tests/drift-camera-production.mjs`
- `node --check turn/render/camera.js`