### PR TITLE
Tune speed camera and lower Boost bar

### DIFF
--- a/turn-tests/drift-camera-production.mjs
+++ b/turn-tests/drift-camera-production.mjs
@@ -207,9 +207,9 @@ approximately(-legacyStopped.cameraPosition.z, 14);
 approximately(-legacyFast.cameraPosition.z, 21);
 approximately(legacyStopped.cameraPosition.y, 7.7);
 approximately(legacyFast.cameraPosition.y, 10.2);
-approximately(-responsiveStopped.cameraPosition.z, 15);
+approximately(-responsiveStopped.cameraPosition.z, 16);
 approximately(-responsiveFast.cameraPosition.z, 14);
-approximately(responsiveStopped.cameraPosition.y, 8.2);
+approximately(responsiveStopped.cameraPosition.y, 8.7);
 approximately(responsiveFast.cameraPosition.y, 7.7);
 assert.ok(
   -responsiveFast.cameraPosition.z < -responsiveStopped.cameraPosition.z,
@@ -218,7 +218,7 @@ assert.ok(
 approximately(legacyStopped.camera.fov, 68);
 approximately(responsiveStopped.camera.fov, 68);
 approximately(legacyFast.camera.fov, 82);
-approximately(responsiveFast.camera.fov, 82);
+approximately(responsiveFast.camera.fov, 88);
 approximately(legacyFast.cameraTarget.z, responsiveFast.cameraTarget.z);
 
 function movingCameraRun(speedResponsiveEnabled, dt = 1 / 60) {
@@ -279,16 +279,17 @@ assert.ok(
 );
 approximately(movingResponsive.followDistance, 14, 1e-6);
 approximately(movingResponsive.targetDistance, 27, 1e-6);
-approximately(movingResponsive.fov, 82, 1e-6);
+approximately(movingResponsive.fov, 88, 1e-6);
 for (const dt of [1 / 30, 1 / 120, 0.12]) {
   const frameRateVariant = movingCameraRun(true, dt);
   approximately(frameRateVariant.followDistance, 14, 1e-6);
   approximately(frameRateVariant.targetDistance, 27, 1e-6);
-  approximately(frameRateVariant.fov, 82, 1e-6);
+  approximately(frameRateVariant.fov, 88, 1e-6);
 }
 
 const settingSource = await fs.readFile(new URL('../turn/ui/drift-camera-setting.js', import.meta.url), 'utf8');
 const cameraSource = await fs.readFile(new URL('../turn/render/camera.js', import.meta.url), 'utf8');
+const gameplayCss = await fs.readFile(new URL('../turn/gameplay-v2.css', import.meta.url), 'utf8');
 assert.match(settingSource, /getItem\(DRIFT_CAMERA_STORAGE_KEY\) === 'on'/,
   'Missing storage must continue to mean classic drift direction');
 assert.match(settingSource, /SPEED_RESPONSIVE_CAMERA_DEFAULT = false/);
@@ -302,15 +303,31 @@ assert.match(cameraSource, /DRIFT_CAMERA_BLEND_START_SPEED = 8 \/ 3\.6/);
 assert.match(cameraSource, /DRIFT_CAMERA_FULL_BLEND_SPEED = 28 \/ 3\.6/);
 assert.match(cameraSource, /\?revision=r213-speed-responsive-camera/,
   'The combined Camera settings module must be cache-busted');
-assert.match(cameraSource, /\? 15 - speedRatio/,
-  'The responsive camera must move from distance 15 toward 14 as speed builds');
+assert.match(cameraSource, /\? 16 - speedRatio \* 2/,
+  'The responsive camera must move from distance 16 toward 14 as speed builds');
+assert.match(cameraSource, /\? 8\.7 - speedRatio/,
+  'Responsive camera height must preserve the tuned vertical composition');
 assert.match(cameraSource, /: 14 \+ speedRatio \* 7/,
   'Speed-responsive Camera OFF must preserve the established pull-back exactly');
 assert.match(cameraSource, /resolveCameraMotionLeadTime\(CAMERA_POSITION_RESPONSE_RATE, dt\)/,
   'The responsive camera must cancel speed-dependent world-space follow lag');
 assert.match(cameraSource, /resolveCameraMotionLeadTime\(CAMERA_TARGET_RESPONSE_RATE, dt\)/,
   'The responsive look target must cancel speed-dependent world-space follow lag');
-assert.match(cameraSource, /camera\.fov = lerp\(camera\.fov, 68 \+ speedRatio \* 14/,
+assert.match(cameraSource, /const fovSpeedGain = speedResponsiveCamera \? 20 : 14/,
+  'The responsive profile must increase FOV more strongly without changing legacy FOV');
+assert.match(cameraSource, /camera\.fov = lerp\(camera\.fov, 68 \+ speedRatio \* fovSpeedGain/,
   'FOV must remain the primary speed cue in either camera profile');
+assert.match(gameplayCss, /--boost-hud-downshift: 20px/,
+  'Boost bar must move down by approximately its own racing height');
+assert.match(
+  gameplayCss,
+  /bottom: calc\(clamp\(92px, 20vh, 150px\) - var\(--boost-hud-downshift\)\)/,
+  'Standard-height HUD must apply the independent Boost bar downshift'
+);
+assert.match(
+  gameplayCss,
+  /bottom: calc\(74px - var\(--boost-hud-downshift\)\)/,
+  'Short landscape HUD must preserve the same Boost bar downshift'
+);
 
-console.log('TURN independent camera preferences, motion-compensated speed profile and legacy parity passed.');
+console.log('TURN tuned speed camera, independent Boost HUD shift and legacy parity passed.');

--- a/turn/gameplay-v2.css
+++ b/turn/gameplay-v2.css
@@ -34,9 +34,10 @@
 
 .boost-hud {
   --boost-charge: 100%;
+  --boost-hud-downshift: 20px;
   position: absolute;
   left: 50%;
-  bottom: clamp(92px, 20vh, 150px);
+  bottom: calc(clamp(92px, 20vh, 150px) - var(--boost-hud-downshift));
   width: clamp(116px, 18vw, 178px);
   transform: translateX(-50%) rotate(-1deg);
   color: var(--ink);
@@ -212,7 +213,7 @@
   }
 
   .boost-hud {
-    bottom: 74px;
+    bottom: calc(74px - var(--boost-hud-downshift));
     width: 112px;
   }
 

--- a/turn/render/camera.js
+++ b/turn/render/camera.js
@@ -184,10 +184,10 @@ export function updateRaceCameraState({
   // it moves slightly closer and lower as speed builds while FOV supplies the
   // primary sense of acceleration. OFF remains exact legacy camera behavior.
   const followDistance = speedResponsiveCamera
-    ? 15 - speedRatio
+    ? 16 - speedRatio * 2
     : 14 + speedRatio * 7;
   const cameraHeight = speedResponsiveCamera
-    ? 8.2 - speedRatio * 0.5
+    ? 8.7 - speedRatio
     : 7.7 + speedRatio * 2.5;
   const lateralOffset = lateralVelocity * 0.11;
   const cameraResponse = 1 - Math.exp(-dt * CAMERA_POSITION_RESPONSE_RATE);
@@ -255,7 +255,8 @@ export function updateRaceCameraState({
     state.horizonCameraRoll = 0;
   }
 
-  camera.fov = lerp(camera.fov, 68 + speedRatio * 14, Math.min(1, dt * 4.5));
+  const fovSpeedGain = speedResponsiveCamera ? 20 : 14;
+  camera.fov = lerp(camera.fov, 68 + speedRatio * fovSpeedGain, Math.min(1, dt * 4.5));
   camera.updateProjectionMatrix();
 }
 


### PR DESCRIPTION
## What changed

### Speed-responsive camera

- widen its follow-distance range from 15 → 14 to 16 → 14
- adjust camera height proportionally from 8.7 → 7.7 to preserve vertical composition
- strengthen its FOV expansion from 68° → 82° to 68° → 88°
- keep motion-lag compensation, road look-ahead and Drift Camera independence unchanged
- keep Speed-responsive Camera OFF at the exact legacy 14 → 21 distance and 68° → 82° FOV behavior

### Boost HUD

- move the Boost bar down 20 px, approximately its rendered racing height
- apply the same independent shift in standard and short-landscape layouts
- do not couple the HUD position to either camera setting

## Validation

- static and moving camera tests verify 16 → 14 distance, 8.7 → 7.7 height and 68° → 88° FOV
- legacy camera parity remains covered
- moving-camera behavior remains stable at 30, 60 and 120 fps and through a 120 ms hitch
- production CSS regression verifies the 20 px Boost HUD shift in both height layouts
- `node turn-tests/drift-camera-production.mjs`
- `node --check turn/render/camera.js`