### PR TITLE
Add speed FOV to classic camera

### DIFF
--- a/turn-tests/drift-camera-production.mjs
+++ b/turn-tests/drift-camera-production.mjs
@@ -217,7 +217,7 @@ assert.ok(
 );
 approximately(legacyStopped.camera.fov, 68);
 approximately(responsiveStopped.camera.fov, 68);
-approximately(legacyFast.camera.fov, 82);
+approximately(legacyFast.camera.fov, 88);
 approximately(responsiveFast.camera.fov, 88);
 approximately(legacyFast.cameraTarget.z, responsiveFast.cameraTarget.z);
 
@@ -277,6 +277,7 @@ assert.ok(
   movingLegacy.targetDistance < 20,
   'The regression harness must reproduce the established high-speed look-target lag'
 );
+approximately(movingLegacy.fov, 88, 1e-6);
 approximately(movingResponsive.followDistance, 14, 1e-6);
 approximately(movingResponsive.targetDistance, 27, 1e-6);
 approximately(movingResponsive.fov, 88, 1e-6);
@@ -293,7 +294,8 @@ const gameplayCss = await fs.readFile(new URL('../turn/gameplay-v2.css', import.
 assert.match(settingSource, /getItem\(DRIFT_CAMERA_STORAGE_KEY\) === 'on'/,
   'Missing storage must continue to mean classic drift direction');
 assert.match(settingSource, /SPEED_RESPONSIVE_CAMERA_DEFAULT = false/);
-assert.match(settingSource, /Speed-responsive camera/);
+assert.match(settingSource, /<strong>Zoom<\/strong>/);
+assert.match(settingSource, /Off uses the classic pull-back; both modes widen the view with speed\./);
 assert.match(settingSource, /globalThis\.__turnDriftCameraEnabled = next/,
   'The Drift Camera toggle must update camera behavior live without a reload');
 assert.match(settingSource, /globalThis\.__turnSpeedResponsiveCameraEnabled = next/,
@@ -301,7 +303,7 @@ assert.match(settingSource, /globalThis\.__turnSpeedResponsiveCameraEnabled = ne
 assert.match(cameraSource, /DRIFT_CAMERA_TRAVEL_WEIGHT = 0\.85/);
 assert.match(cameraSource, /DRIFT_CAMERA_BLEND_START_SPEED = 8 \/ 3\.6/);
 assert.match(cameraSource, /DRIFT_CAMERA_FULL_BLEND_SPEED = 28 \/ 3\.6/);
-assert.match(cameraSource, /\?revision=r213-speed-responsive-camera/,
+assert.match(cameraSource, /\?revision=r214-shared-speed-fov/,
   'The combined Camera settings module must be cache-busted');
 assert.match(cameraSource, /\? 16 - speedRatio \* 2/,
   'The responsive camera must move from distance 16 toward 14 as speed builds');
@@ -313,10 +315,10 @@ assert.match(cameraSource, /resolveCameraMotionLeadTime\(CAMERA_POSITION_RESPONS
   'The responsive camera must cancel speed-dependent world-space follow lag');
 assert.match(cameraSource, /resolveCameraMotionLeadTime\(CAMERA_TARGET_RESPONSE_RATE, dt\)/,
   'The responsive look target must cancel speed-dependent world-space follow lag');
-assert.match(cameraSource, /const fovSpeedGain = speedResponsiveCamera \? 20 : 14/,
-  'The responsive profile must increase FOV more strongly without changing legacy FOV');
-assert.match(cameraSource, /camera\.fov = lerp\(camera\.fov, 68 \+ speedRatio \* fovSpeedGain/,
-  'FOV must remain the primary speed cue in either camera profile');
+assert.match(cameraSource, /camera\.fov = lerp\(camera\.fov, 68 \+ speedRatio \* 20/,
+  'Both distance profiles must share the same 68-to-88-degree speed FOV');
+assert.doesNotMatch(cameraSource, /fovSpeedGain/,
+  'The FOV curve must not depend on the Zoom preference');
 assert.match(gameplayCss, /--boost-hud-downshift: 20px/,
   'Boost bar must move down by approximately its own racing height');
 assert.match(
@@ -330,4 +332,4 @@ assert.match(
   'Short landscape HUD must preserve the same Boost bar downshift'
 );
 
-console.log('TURN tuned speed camera, independent Boost HUD shift and legacy parity passed.');
+console.log('TURN shared speed FOV, Zoom preference, classic pull-back and Boost HUD shift passed.');

--- a/turn/render/camera.js
+++ b/turn/render/camera.js
@@ -180,9 +180,9 @@ export function updateRaceCameraState({
     ? finiteNumber(samples[lookAheadIndex]?.point?.y, roadY)
     : roadY;
 
-  // The experimental speed-responsive profile reverses the established pull-back:
-  // it moves slightly closer and lower as speed builds while FOV supplies the
-  // primary sense of acceleration. OFF remains exact legacy camera behavior.
+  // Zoom reverses the established physical pull-back: it moves slightly closer
+  // and lower as speed builds. Both profiles share the same widening FOV, while
+  // OFF preserves the classic distance and height curves.
   const followDistance = speedResponsiveCamera
     ? 16 - speedRatio * 2
     : 14 + speedRatio * 7;

--- a/turn/render/camera.js
+++ b/turn/render/camera.js
@@ -1,4 +1,4 @@
-import { installDriftCameraSetting } from '../ui/drift-camera-setting.js?revision=r213-speed-responsive-camera';
+import { installDriftCameraSetting } from '../ui/drift-camera-setting.js?revision=r214-shared-speed-fov';
 
 const DEFAULT_MAX_SENSOR_CAMERA_ROLL = 18 * Math.PI / 180;
 const MAX_CONFIGURED_SAFE_ZONE_DEGREES = 45;
@@ -255,8 +255,7 @@ export function updateRaceCameraState({
     state.horizonCameraRoll = 0;
   }
 
-  const fovSpeedGain = speedResponsiveCamera ? 20 : 14;
-  camera.fov = lerp(camera.fov, 68 + speedRatio * fovSpeedGain, Math.min(1, dt * 4.5));
+  camera.fov = lerp(camera.fov, 68 + speedRatio * 20, Math.min(1, dt * 4.5));
   camera.updateProjectionMatrix();
 }
 

--- a/turn/ui/drift-camera-setting.js
+++ b/turn/ui/drift-camera-setting.js
@@ -97,8 +97,8 @@ function attachSettingsControl() {
       <label class="m8-toggle-row">
         <input id="m8SpeedResponsiveCameraEnabled" type="checkbox">
         <span>
-          <strong>Speed-responsive camera</strong>
-          <small>Keeps the car close while the view widens as speed builds. Experimental; the current camera remains the default.</small>
+          <strong>Zoom</strong>
+          <small>Keeps the car close as speed builds. Off uses the classic pull-back; both modes widen the view with speed.</small>
         </span>
       </label>`;
     const steering = list.querySelector('.m8-steering-setting');
@@ -124,11 +124,11 @@ function attachSettingsControl() {
       const next = speedCheckbox.checked;
       if (!saveSpeedResponsiveCameraEnabled(next)) {
         speedCheckbox.checked = previous;
-        announce(dialog, 'Speed-responsive camera could not be changed because local storage is unavailable.');
+        announce(dialog, 'Zoom could not be changed because local storage is unavailable.');
         return;
       }
       globalThis.__turnSpeedResponsiveCameraEnabled = next;
-      announce(dialog, `Speed-responsive camera ${next ? 'on' : 'off'}.`);
+      announce(dialog, `Zoom ${next ? 'on' : 'off'}.`);
     });
   }
 


### PR DESCRIPTION
## Summary
- apply the tuned 68°→88° speed FOV to both camera distance profiles
- rename the setting to **Zoom** while preserving its existing storage key and saved user preference
- keep **Zoom off** on the classic 14→21 pull-back and **Zoom on** on the 16→14 close-in curve
- keep Drift camera behavior and the independent Boost bar offset unchanged

## Validation
- `node turn-tests/drift-camera-production.mjs`
- `node --check turn/render/camera.js`
- `node --check turn/ui/drift-camera-setting.js`