### PR TITLE
Reduce classic camera pull-back

### DIFF
--- a/turn-tests/drift-camera-production.mjs
+++ b/turn-tests/drift-camera-production.mjs
@@ -204,7 +204,7 @@ const responsiveFast = cameraSnapshot({
 });
 
 approximately(-legacyStopped.cameraPosition.z, 14);
-approximately(-legacyFast.cameraPosition.z, 21);
+approximately(-legacyFast.cameraPosition.z, 18);
 approximately(legacyStopped.cameraPosition.y, 7.7);
 approximately(legacyFast.cameraPosition.y, 10.2);
 approximately(-responsiveStopped.cameraPosition.z, 16);
@@ -225,7 +225,7 @@ function movingCameraRun(speedResponsiveEnabled, dt = 1 / 60) {
   globalThis.__turnDriftCameraEnabled = false;
   globalThis.__turnSpeedResponsiveCameraEnabled = speedResponsiveEnabled;
   const speed = 88;
-  const cameraPosition = { x: 0, y: 7.7, z: speedResponsiveEnabled ? -14 : -21 };
+  const cameraPosition = { x: 0, y: 7.7, z: speedResponsiveEnabled ? -14 : -18 };
   const cameraTarget = { x: 0, y: 2, z: 27 };
   const camera = {
     position: { copy(value) { this.x = value.x; this.y = value.y; this.z = value.z; } },
@@ -309,8 +309,8 @@ assert.match(cameraSource, /\? 16 - speedRatio \* 2/,
   'The responsive camera must move from distance 16 toward 14 as speed builds');
 assert.match(cameraSource, /\? 8\.7 - speedRatio/,
   'Responsive camera height must preserve the tuned vertical composition');
-assert.match(cameraSource, /: 14 \+ speedRatio \* 7/,
-  'Speed-responsive Camera OFF must preserve the established pull-back exactly');
+assert.match(cameraSource, /: 14 \+ speedRatio \* 4/,
+  'Zoom OFF must use the tuned 14-to-18 classic pull-back');
 assert.match(cameraSource, /resolveCameraMotionLeadTime\(CAMERA_POSITION_RESPONSE_RATE, dt\)/,
   'The responsive camera must cancel speed-dependent world-space follow lag');
 assert.match(cameraSource, /resolveCameraMotionLeadTime\(CAMERA_TARGET_RESPONSE_RATE, dt\)/,
@@ -332,4 +332,4 @@ assert.match(
   'Short landscape HUD must preserve the same Boost bar downshift'
 );
 
-console.log('TURN shared speed FOV, Zoom preference, classic pull-back and Boost HUD shift passed.');
+console.log('TURN shared speed FOV, tuned classic pull-back, Zoom preference and Boost HUD shift passed.');

--- a/turn/render/camera.js
+++ b/turn/render/camera.js
@@ -185,7 +185,7 @@ export function updateRaceCameraState({
   // OFF preserves the classic distance and height curves.
   const followDistance = speedResponsiveCamera
     ? 16 - speedRatio * 2
-    : 14 + speedRatio * 7;
+    : 14 + speedRatio * 4;
   const cameraHeight = speedResponsiveCamera
     ? 8.7 - speedRatio
     : 7.7 + speedRatio * 2.5;


### PR DESCRIPTION
## Summary
- tune **Zoom off** from a 14→21 to a 14→18 follow-distance curve
- keep the shared 68°→88° speed FOV unchanged
- leave **Zoom on** at 16→14 and preserve its motion-lag compensation
- leave camera height, Drift camera and Boost HUD behavior unchanged

## Why 18
The stronger shared FOV now supplies most of the speed sensation. A maximum distance of 18 keeps a visible classic pull-back without combining it with the old, oversized 21-unit retreat.

## Validation
- `node turn-tests/drift-camera-production.mjs`
- `node --check turn/render/camera.js`