### PR TITLE
Add opt-in Advanced DRIFT

### DIFF
--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -1,5 +1,10 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
+import {
+  ADVANCED_DRIFT_LOCK_ZONE_SHARE,
+  resolveAdvancedDriftLock,
+  resolveAdvancedDriftThrottle
+} from '../../turn/input/advanced-drift.js';
 import { updateVehiclePhysicsState } from '../../turn/vehicle/physics.js';
 import { spokenRivalCount } from '../../turn/ui/race-announcements.js';
 import { lapAnnouncementPriorityMs } from '../../turn/ui/race-speech.js';
@@ -14,6 +19,19 @@ assert.ok(
   lapAnnouncementPriorityMs('Lap void. Stay on the track.') >= 3200,
   'A void-lap summary also needs priority over live race updates'
 );
+
+assert.equal(ADVANCED_DRIFT_LOCK_ZONE_SHARE, 0.24);
+const driftLockGeometry = { enabled: true, driftActive: true, padLeft: 100, padWidth: 200 };
+assert.equal(resolveAdvancedDriftLock({ ...driftLockGeometry, pointerX: 124 }), 0);
+assert.ok(Math.abs(resolveAdvancedDriftLock({ ...driftLockGeometry, pointerX: 112 }) - 1 / 3) < 1e-12);
+assert.ok(Math.abs(resolveAdvancedDriftLock({ ...driftLockGeometry, pointerX: 100 }) - 2 / 3) < 1e-12);
+assert.equal(resolveAdvancedDriftLock({ ...driftLockGeometry, pointerX: 88 }), 1);
+assert.equal(resolveAdvancedDriftLock({ ...driftLockGeometry, pointerX: 60 }), 1);
+assert.equal(resolveAdvancedDriftLock({ ...driftLockGeometry, pointerX: 100, enabled: false }), 0);
+assert.equal(resolveAdvancedDriftLock({ ...driftLockGeometry, pointerX: 100, driftActive: false }), 0);
+assert.equal(resolveAdvancedDriftThrottle(0), 1);
+assert.ok(Math.abs(resolveAdvancedDriftThrottle(2 / 3) - 1 / 3) < 1e-12);
+assert.equal(resolveAdvancedDriftThrottle(1), 0);
 
 class Vec3 {
   constructor(x = 0, y = 0, z = 0) { this.x = x; this.y = y; this.z = z; }
@@ -35,7 +53,9 @@ const [
   gameplayCss,
   positionCss,
   analogGas,
-  spectate
+  spectate,
+  settingsSource,
+  mainSource
 ] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/release.json', import.meta.url), 'utf8'),
@@ -47,7 +67,9 @@ const [
   fs.readFile(new URL('../../turn/gameplay-v2.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/position-hud-r83.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/input/analog-gas.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/ui/drift-camera-setting.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
 const release = JSON.parse(releaseSource);
@@ -96,8 +118,15 @@ assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad mu
 assert.match(controls, /y >= BRAKE_ZONE_START\) return 'brake'/, 'Bottom drive pad must map to Brake and Reverse');
 assert.match(controls, /return 'gas'/, 'Middle drive pad must map to Gas');
 assert.match(controls, /const forwardDrive = nextZone === 'gas' \|\| nextZone === 'drift' \|\| nextZone === 'boost'/, 'Only forward-driving zones may keep gas engaged');
-assert.match(controls, /globalThis\.__turnAnalogGas = forwardDrive \? 1 : 0/, 'Brake must immediately release gas');
+assert.match(controls, /globalThis\.__turnAnalogGas = forwardDrive \? forwardThrottle : 0/,
+  'Brake must release gas while Advanced DRIFT may progressively reduce it');
 assert.match(controls, /globalThis\.__turnDriftHeld = nextZone === 'drift'/, 'Drift zone must add drift to gas');
+assert.match(controls, /globalThis\.__turnDriftLockAmount = lockAmount/,
+  'The drive pad must publish one normalized LOCK value for vehicle physics');
+assert.match(controls, /resolveAdvancedDriftThrottle\(lockAmount\)/,
+  'LOCK must progressively release gas instead of acting as a binary brake button');
+assert.match(controls, /turn:advanced-drift-change/,
+  'Changing the setting must update the live drive pad without a reload');
 assert.match(controls, /boostRequested = nextZone === 'boost'/, 'Boost zone must add boost to gas');
 assert.match(controls, /runtimeState\.touchBrake = Boolean\(active\)/, 'The unified Brake zone must drive the existing brake and reverse physics');
 assert.match(controls, /brakeButton\.classList\.toggle\('is-active', nextZone === 'brake'\)/, 'Brake must receive the same active-state treatment as every other zone');
@@ -119,7 +148,17 @@ assert.match(css, /place-items: center/, 'Drive-zone labels must be vertically a
 assert.match(css, /content: "LEAVE"/, 'Boost lock hint must explain that leaving the Boost zone re-arms it');
 assert.match(css, /\.drive-pad \.drive-brake-zone \{/, 'Brake and Reverse must be styled as an internal drive-pad zone');
 assert.match(css, /\.drive-brake-zone\.is-active/, 'Brake must have visible active feedback');
+assert.match(css, /\.drive-pad\.has-advanced-drift \.drive-drift-zone \{[\s\S]*#8b5cf6[\s\S]*#54c2ef/,
+  'Advanced DRIFT must integrate a purple-to-cyan LOCK affordance into the Drift surface');
 assert.match(gameplayCss, /\.boost-hud i \{[\s\S]*box-shadow: 3px 0 0 var\(--ink\);/, 'Boost charge must have a high-contrast ink edge at the live fill level');
+assert.match(gameplayCss, /\.boost-hud\.is-drift-locking i \{[\s\S]*width: var\(--drift-lock\);[\s\S]*#9b5de5/,
+  'The unobscured Boost HUD must visualize actual LOCK intensity in purple');
+assert.match(controls, /boostLabel\.textContent = driftLocking \? 'DRIFT LOCK' : 'BOOST'/,
+  'The shared HUD must name the temporary LOCK meter while it is active');
+assert.match(settingsSource, /<strong>Advanced DRIFT<\/strong>/);
+assert.match(settingsSource, /Experimental; off by default\./);
+assert.match(mainSource, /driftLock: globalThis\.__turnDriftLockAmount \|\| 0/,
+  'The production runtime must pass the progressive LOCK value into vehicle physics');
 assert.match(gameplayCss, /\.boost-hud\.is-boost-full-flash/, 'Boost HUD must visibly react when recharge reaches full capacity');
 assert.match(gameplayCss, /\.boost-hud\.is-boost-empty-flash/, 'Boost HUD must react distinctly when the tank becomes empty');
 assert.match(gameplayCss, /@keyframes turn-boost-full-flash/, 'Full boost feedback must have its own animation');
@@ -151,4 +190,38 @@ assert.ok(state.velocity.z < -0.1, 'Holding Brake after stopping must engage rev
 for (let i = 0; i < 100; i += 1) updateVehiclePhysicsState(physicsArgs);
 assert.ok(state.velocity.z >= -(80 * 0.32 + 0.5), 'Reverse must stay capped well below forward top speed');
 
-console.log(`TURN ${release.id} four-zone drive pad, lap-priority race speech, topbar position HUD, restart boost refill and reverse passed.`);
+function runDriftLock(lockAmount) {
+  const driftState = {
+    position: new Vec3(), velocity: new Vec3(0, 0, 30), touchGas: false, touchBrake: false,
+    throttle: 0, brake: 0, steering: 1, driftAmount: 0.7, heading: 0, progress: 0,
+    lastProgress: 0, nearestTrackIndex: 0, trackDistance: 0, offRoad: false, speed: 30
+  };
+  updateVehiclePhysicsState({
+    ...physicsArgs,
+    state: driftState,
+    analogGas: resolveAdvancedDriftThrottle(lockAmount),
+    boostActive: false,
+    driftHeld: true,
+    driftLock: lockAmount
+  });
+  return driftState;
+}
+
+const ordinaryDrift = runDriftLock(0);
+const fullLockDrift = runDriftLock(1);
+assert.equal(ordinaryDrift.driftLockAmount, 0);
+assert.equal(fullLockDrift.driftLockAmount, 1);
+assert.ok(
+  Math.abs(fullLockDrift.heading) > Math.abs(ordinaryDrift.heading),
+  'Progressive LOCK must increase yaw authority for a larger slip angle'
+);
+assert.ok(
+  Math.abs(fullLockDrift.velocity.x) > Math.abs(ordinaryDrift.velocity.x),
+  'Progressive LOCK must preserve and strengthen the lateral slide'
+);
+assert.ok(
+  fullLockDrift.speed < ordinaryDrift.speed,
+  'Full LOCK must release gas and add modest handbrake drag'
+);
+
+console.log(`TURN ${release.id} Advanced DRIFT, four-zone drive pad, LOCK HUD, restart boost refill and reverse passed.`);

--- a/turn-lab/tests/vehicle-drift-production.mjs
+++ b/turn-lab/tests/vehicle-drift-production.mjs
@@ -110,6 +110,14 @@ assert.match(physicsSource, /3\.2 \* driftStabilityMultiplier/,
   'DRIFT must affect slide recovery');
 assert.match(physicsSource, /0\.42 \* driftStabilityMultiplier/,
   'DRIFT must affect lateral stability');
+assert.match(mainSource, /driftLock: globalThis\.__turnDriftLockAmount \|\| 0/,
+  'The runtime must pass progressive Advanced DRIFT LOCK into vehicle physics');
+assert.match(physicsSource, /lockYawMultiplier = lerp\(1, 1\.55, driftLockAmount\)/,
+  'LOCK must progressively increase rotation without adding wheel simulations');
+assert.match(physicsSource, /lockGripMultiplier = lerp\(1, 0\.22, driftLockAmount\)/,
+  'LOCK must progressively release rear lateral grip');
+assert.match(physicsSource, /driftLockAmount \* 0\.18/,
+  'LOCK must add a modest handbrake-like speed cost');
 assert.match(physicsSource, /\* tuningBoostPowerMultiplier/,
   'BOOST POWER must scale actual boost acceleration');
 assert.match(physicsSource, /boostSpeedMultiplier: tuningBoostSpeedMultiplier/,
@@ -170,8 +178,9 @@ assert.match(physicsSource, /steeringStatMultiplier \*[\s\S]*driftYawMultiplier/
   'Vehicle physics must apply the car-owned DRIFT yaw multiplier');
 assert.match(physicsSource, /0\.42 \* driftStabilityMultiplier \* driftGripTuningMultiplier/,
   'Vehicle physics must apply the car-owned slip/grip multiplier');
-assert.match(physicsSource, /slideStrength = \(driftHeld \? 0\.235 : 0\.12\) \* driftSlideMultiplier/,
-  'Vehicle physics must apply the car-owned sustained-slide multiplier');
+assert.match(physicsSource,
+  /slideStrength = \(driftHeld \? 0\.235 : 0\.12\) \*[\s\S]*driftSlideMultiplier \* lockSlideMultiplier/,
+  'Vehicle physics must apply both the car-owned and progressive LOCK slide multipliers');
 
 const rallyRacer = CAR_CATALOG.find((car) => car.id === 'toy-racer');
 assert.ok(rallyRacer, 'The former Toy Racer asset/id must remain available for saved selections and ghosts');

--- a/turn-next/main.js
+++ b/turn-next/main.js
@@ -84,6 +84,7 @@ const state = {
   velocity: new THREE.Vector3(),
   heading: 0,
   driftAmount: 0,
+  driftLockAmount: 0,
   offRoad: false,
   trackDistance: 0,
   progress: 0,
@@ -942,6 +943,7 @@ function updatePhysics(dt, now) {
     analogGas: globalThis.__turnAnalogGas || 0,
     boostActive: Boolean(globalThis.__turnBoostActive),
     driftHeld: Boolean(globalThis.__turnDriftHeld),
+    driftLock: globalThis.__turnDriftLockAmount || 0,
     vehicleTuning: state.vehicleTuning
   });
 

--- a/turn-tests/drift-camera-production.mjs
+++ b/turn-tests/drift-camera-production.mjs
@@ -14,6 +14,12 @@ import {
   saveSpeedResponsiveCameraEnabled,
   speedResponsiveCameraEnabled
 } from '../turn/ui/drift-camera-setting.js';
+import {
+  ADVANCED_DRIFT_DEFAULT,
+  ADVANCED_DRIFT_STORAGE_KEY,
+  advancedDriftEnabled,
+  saveAdvancedDriftEnabled
+} from '../turn/input/advanced-drift.js';
 
 const toRadians = (degrees) => degrees * Math.PI / 180;
 const approximately = (actual, expected, tolerance = 1e-6) => {
@@ -28,6 +34,8 @@ const emptyStorage = {
   setItem() {}
 };
 assert.equal(driftCameraEnabled(emptyStorage), false, 'Drift Camera must remain opt-in during playtesting');
+assert.equal(ADVANCED_DRIFT_DEFAULT, false, 'Advanced DRIFT must remain opt-in during playtesting');
+assert.equal(advancedDriftEnabled(emptyStorage), false);
 assert.equal(
   speedResponsiveCameraEnabled(emptyStorage),
   false,
@@ -50,6 +58,18 @@ assert.equal(driftCameraEnabled(storage), true);
 assert.equal(saveDriftCameraEnabled(false, storage), true);
 assert.equal(values.get(DRIFT_CAMERA_STORAGE_KEY), 'off');
 assert.equal(driftCameraEnabled(storage), false);
+
+assert.equal(saveAdvancedDriftEnabled(true, storage), true);
+assert.equal(values.get(ADVANCED_DRIFT_STORAGE_KEY), 'on');
+assert.equal(advancedDriftEnabled(storage), true);
+assert.equal(saveAdvancedDriftEnabled(false, storage), true);
+assert.equal(values.get(ADVANCED_DRIFT_STORAGE_KEY), 'off');
+assert.equal(advancedDriftEnabled(storage), false);
+assert.equal(
+  advancedDriftEnabled(storage, true),
+  false,
+  'An explicit Advanced DRIFT off preference must survive a future default-on change'
+);
 
 assert.equal(saveSpeedResponsiveCameraEnabled(true, storage), true);
 assert.equal(values.get(SPEED_RESPONSIVE_CAMERA_STORAGE_KEY), 'on');
@@ -294,6 +314,10 @@ const gameplayCss = await fs.readFile(new URL('../turn/gameplay-v2.css', import.
 assert.match(settingSource, /getItem\(DRIFT_CAMERA_STORAGE_KEY\) === 'on'/,
   'Missing storage must continue to mean classic drift direction');
 assert.match(settingSource, /SPEED_RESPONSIVE_CAMERA_DEFAULT = false/);
+assert.match(settingSource, /<strong>Advanced DRIFT<\/strong>/);
+assert.match(settingSource, /progressively release the gas and lock the rear wheels/);
+assert.match(settingSource, /turn:advanced-drift-change/,
+  'Advanced DRIFT must update the live drive pad without a reload');
 assert.match(settingSource, /<strong>Zoom<\/strong>/);
 assert.match(settingSource, /Off uses the classic pull-back; both modes widen the view with speed\./);
 assert.match(settingSource, /globalThis\.__turnDriftCameraEnabled = next/,
@@ -303,7 +327,7 @@ assert.match(settingSource, /globalThis\.__turnSpeedResponsiveCameraEnabled = ne
 assert.match(cameraSource, /DRIFT_CAMERA_TRAVEL_WEIGHT = 0\.85/);
 assert.match(cameraSource, /DRIFT_CAMERA_BLEND_START_SPEED = 8 \/ 3\.6/);
 assert.match(cameraSource, /DRIFT_CAMERA_FULL_BLEND_SPEED = 28 \/ 3\.6/);
-assert.match(cameraSource, /\?revision=r214-shared-speed-fov/,
+assert.match(cameraSource, /\?revision=r215-advanced-drift/,
   'The combined Camera settings module must be cache-busted');
 assert.match(cameraSource, /\? 16 - speedRatio \* 2/,
   'The responsive camera must move from distance 16 toward 14 as speed builds');

--- a/turn-tests/session-orchestrator-production.mjs
+++ b/turn-tests/session-orchestrator-production.mjs
@@ -65,7 +65,8 @@ function createHarness({ selection = { carId: 'sedan', color: '#fff', secondaryC
     },
     __turnAnalogGas: 0.7,
     __turnBoostActive: true,
-    __turnDriftHeld: true
+    __turnDriftHeld: true,
+    __turnDriftLockAmount: 0.8
   };
   environment.window = environment;
 
@@ -208,6 +209,7 @@ assert.equal(lotCancelled.state.touchGas, false);
 assert.equal(lotCancelled.environment.__turnAnalogGas, 0);
 assert.equal(lotCancelled.environment.__turnBoostActive, false);
 assert.equal(lotCancelled.environment.__turnDriftHeld, false);
+assert.equal(lotCancelled.environment.__turnDriftLockAmount, 0);
 assert.deepEqual(lotCancelled.published, ['lot-open', 'lot-cancelled']);
 assert.equal(lotCancelled.orchestrator.getPhase(), 'racing');
 

--- a/turn/drive-pad.css
+++ b/turn/drive-pad.css
@@ -102,6 +102,16 @@ body .m8-feedback-content * {
   background: #54c2ef;
 }
 
+.drive-pad.has-advanced-drift .drive-drift-zone {
+  background: linear-gradient(
+    90deg,
+    #8b5cf6 0%,
+    #7668e4 10%,
+    #54c2ef 24%,
+    #54c2ef 100%
+  );
+}
+
 .drive-boost-zone {
   position: relative;
   overflow: hidden;
@@ -161,6 +171,22 @@ body .m8-feedback-content * {
 
 .drive-drift-zone.is-active {
   background: #38d9ff;
+}
+
+.drive-pad.has-advanced-drift .drive-drift-zone.is-active {
+  background: linear-gradient(
+    90deg,
+    #9b5de5 0%,
+    #806ee8 10%,
+    #38d9ff 24%,
+    #38d9ff 100%
+  );
+}
+
+.drive-pad.is-drift-locking .drive-drift-zone {
+  box-shadow:
+    inset 0 0 0 6px rgb(255 248 232 / 0.78),
+    inset 14px 0 0 rgb(155 93 229 / 0.3);
 }
 
 .drive-brake-zone.is-active {

--- a/turn/gameplay-v2.css
+++ b/turn/gameplay-v2.css
@@ -34,6 +34,7 @@
 
 .boost-hud {
   --boost-charge: 100%;
+  --drift-lock: 0%;
   --boost-hud-downshift: 20px;
   position: absolute;
   left: 50%;
@@ -88,6 +89,30 @@
 
 .boost-hud.is-drift-charging i {
   background: linear-gradient(90deg, #38d9ff, #8ce99a);
+}
+
+.boost-hud.is-drift-locking {
+  transform: translateX(-50%) scale(1.06) rotate(1deg);
+}
+
+.boost-hud.is-drift-locking > span {
+  background: #e9d5ff;
+}
+
+.boost-hud.is-drift-locking > div {
+  background: rgb(155 93 229 / 0.16);
+  box-shadow:
+    3px 3px 0 var(--ink),
+    0 0 0 4px rgb(155 93 229 / 0.22);
+}
+
+.boost-hud.is-drift-locking i {
+  width: var(--drift-lock);
+  background: linear-gradient(90deg, #38d9ff, #9b5de5);
+}
+
+.boost-hud.is-drift-lock-max {
+  animation: turn-drift-lock-max 420ms ease-in-out infinite alternate;
 }
 
 .boost-hud.is-boost-full-flash {
@@ -155,9 +180,15 @@
   }
 }
 
+@keyframes turn-drift-lock-max {
+  from { transform: translateX(-50%) scale(1.06) rotate(-1deg); }
+  to { transform: translateX(-50%) scale(1.11) rotate(1deg); }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .boost-hud.is-boost-full-flash,
-  .boost-hud.is-boost-empty-flash {
+  .boost-hud.is-boost-empty-flash,
+  .boost-hud.is-drift-lock-max {
     animation: none;
   }
 }

--- a/turn/input/advanced-drift.js
+++ b/turn/input/advanced-drift.js
@@ -1,0 +1,67 @@
+export const ADVANCED_DRIFT_STORAGE_KEY = 'turn-advanced-drift-v1';
+export const ADVANCED_DRIFT_DEFAULT = false;
+export const ADVANCED_DRIFT_LOCK_ZONE_SHARE = 0.24;
+
+export function advancedDriftEnabled(
+  storage = getStorage(),
+  defaultEnabled = ADVANCED_DRIFT_DEFAULT
+) {
+  try {
+    const preference = storage?.getItem(ADVANCED_DRIFT_STORAGE_KEY);
+    if (preference === 'on') return true;
+    if (preference === 'off') return false;
+    return defaultEnabled === true;
+  } catch (_) {
+    return defaultEnabled === true;
+  }
+}
+
+export function saveAdvancedDriftEnabled(enabled, storage = getStorage()) {
+  if (!storage || typeof storage.setItem !== 'function') return false;
+  try {
+    storage.setItem(ADVANCED_DRIFT_STORAGE_KEY, enabled ? 'on' : 'off');
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+export function resolveAdvancedDriftLock({
+  enabled = false,
+  driftActive = false,
+  pointerX = 0,
+  padLeft = 0,
+  padWidth = 0
+} = {}) {
+  if (!enabled || !driftActive) return 0;
+
+  const width = Math.max(1, finiteNumber(padWidth));
+  const left = finiteNumber(padLeft);
+  const lockZoneWidth = width * 0.5 * ADVANCED_DRIFT_LOCK_ZONE_SHARE;
+  const overdragWidth = Math.min(24, Math.max(10, width * 0.06));
+  const lockZoneStart = left + lockZoneWidth;
+  const lockTravel = lockZoneWidth + overdragWidth;
+
+  return clamp((lockZoneStart - finiteNumber(pointerX)) / lockTravel, 0, 1);
+}
+
+export function resolveAdvancedDriftThrottle(lockAmount) {
+  return 1 - clamp(finiteNumber(lockAmount), 0, 1);
+}
+
+function getStorage() {
+  try {
+    return globalThis.localStorage;
+  } catch (_) {
+    return null;
+  }
+}
+
+function finiteNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}

--- a/turn/main.js
+++ b/turn/main.js
@@ -84,6 +84,7 @@ const state = {
   velocity: new THREE.Vector3(),
   heading: 0,
   driftAmount: 0,
+  driftLockAmount: 0,
   offRoad: false,
   trackDistance: 0,
   progress: 0,
@@ -942,6 +943,7 @@ function updatePhysics(dt, now) {
     analogGas: globalThis.__turnAnalogGas || 0,
     boostActive: Boolean(globalThis.__turnBoostActive),
     driftHeld: Boolean(globalThis.__turnDriftHeld),
+    driftLock: globalThis.__turnDriftLockAmount || 0,
     vehicleTuning: state.vehicleTuning
   });
 

--- a/turn/race/session-orchestrator.js
+++ b/turn/race/session-orchestrator.js
@@ -93,6 +93,7 @@ export function createRaceSessionOrchestrator({
     environment.__turnAnalogGas = 0;
     environment.__turnBoostActive = false;
     environment.__turnDriftHeld = false;
+    environment.__turnDriftLockAmount = 0;
   }
 
   function stopSpectating() {

--- a/turn/render/camera.js
+++ b/turn/render/camera.js
@@ -1,4 +1,4 @@
-import { installDriftCameraSetting } from '../ui/drift-camera-setting.js?revision=r214-shared-speed-fov';
+import { installDriftCameraSetting } from '../ui/drift-camera-setting.js?revision=r215-advanced-drift';
 
 const DEFAULT_MAX_SENSOR_CAMERA_ROLL = 18 * Math.PI / 180;
 const MAX_CONFIGURED_SAFE_ZONE_DEGREES = 45;

--- a/turn/ui/drift-camera-setting.js
+++ b/turn/ui/drift-camera-setting.js
@@ -1,3 +1,8 @@
+import {
+  advancedDriftEnabled,
+  saveAdvancedDriftEnabled
+} from '../input/advanced-drift.js?revision=r215-advanced-drift';
+
 export const DRIFT_CAMERA_STORAGE_KEY = 'turn-drift-camera-v1';
 export const SPEED_RESPONSIVE_CAMERA_STORAGE_KEY = 'turn-speed-responsive-camera-v1';
 export const SPEED_RESPONSIVE_CAMERA_DEFAULT = false;
@@ -50,8 +55,10 @@ export function saveSpeedResponsiveCameraEnabled(enabled, storage = getStorage()
 export function installDriftCameraSetting() {
   const driftEnabled = driftCameraEnabled();
   const speedResponsiveEnabled = speedResponsiveCameraEnabled();
+  const advancedDrift = advancedDriftEnabled();
   globalThis.__turnDriftCameraEnabled = driftEnabled;
   globalThis.__turnSpeedResponsiveCameraEnabled = speedResponsiveEnabled;
+  globalThis.__turnAdvancedDriftEnabled = advancedDrift;
   if (typeof document === 'undefined') return driftEnabled;
   if (installed) {
     attachSettingsControl();
@@ -79,6 +86,42 @@ function attachSettingsControl() {
   const list = dialog?.querySelector('.m8-settings-list');
   if (!dialog || !list) return false;
 
+  let drivingSection = list.querySelector('[data-turn-advanced-drift-setting]');
+  if (!drivingSection) {
+    drivingSection = document.createElement('section');
+    drivingSection.className = 'm8-setting-card';
+    drivingSection.dataset.turnAdvancedDriftSetting = '';
+    drivingSection.setAttribute('aria-labelledby', 'm8DrivingTitle');
+    drivingSection.innerHTML = `
+      <h3 id="m8DrivingTitle">Driving</h3>
+      <label class="m8-toggle-row">
+        <input id="m8AdvancedDriftEnabled" type="checkbox">
+        <span>
+          <strong>Advanced DRIFT</strong>
+          <small>Pull farther left in DRIFT to progressively release the gas and lock the rear wheels. Experimental; off by default.</small>
+        </span>
+      </label>`;
+    const steering = list.querySelector('.m8-steering-setting');
+    if (steering) steering.after(drivingSection);
+    else list.prepend(drivingSection);
+
+    const advancedDriftCheckbox = drivingSection.querySelector('#m8AdvancedDriftEnabled');
+    advancedDriftCheckbox.addEventListener('change', () => {
+      const previous = globalThis.__turnAdvancedDriftEnabled === true;
+      const next = advancedDriftCheckbox.checked;
+      if (!saveAdvancedDriftEnabled(next)) {
+        advancedDriftCheckbox.checked = previous;
+        announce(dialog, 'Advanced DRIFT could not be changed because local storage is unavailable.');
+        return;
+      }
+      globalThis.__turnAdvancedDriftEnabled = next;
+      globalThis.dispatchEvent(new CustomEvent('turn:advanced-drift-change', {
+        detail: { enabled: next }
+      }));
+      announce(dialog, `Advanced DRIFT ${next ? 'on' : 'off'}.`);
+    });
+  }
+
   let section = list.querySelector('[data-turn-drift-camera-setting]');
   if (!section) {
     section = document.createElement('section');
@@ -101,9 +144,7 @@ function attachSettingsControl() {
           <small>Keeps the car close as speed builds. Off uses the classic pull-back; both modes widen the view with speed.</small>
         </span>
       </label>`;
-    const steering = list.querySelector('.m8-steering-setting');
-    if (steering) steering.after(section);
-    else list.prepend(section);
+    drivingSection.after(section);
 
     const driftCheckbox = section.querySelector('#m8DriftCameraEnabled');
     driftCheckbox.addEventListener('change', () => {
@@ -133,6 +174,10 @@ function attachSettingsControl() {
   }
 
   const sync = () => {
+    const advancedDriftCheckbox = drivingSection.querySelector('#m8AdvancedDriftEnabled');
+    if (advancedDriftCheckbox) {
+      advancedDriftCheckbox.checked = globalThis.__turnAdvancedDriftEnabled === true;
+    }
     const driftCheckbox = section.querySelector('#m8DriftCameraEnabled');
     if (driftCheckbox) driftCheckbox.checked = globalThis.__turnDriftCameraEnabled === true;
     const speedCheckbox = section.querySelector('#m8SpeedResponsiveCameraEnabled');
@@ -141,8 +186,8 @@ function attachSettingsControl() {
     }
   };
   sync();
-  if (!dialog.dataset.turnDriftCameraSync) {
-    dialog.dataset.turnDriftCameraSync = 'true';
+  if (!dialog.dataset.turnDrivingCameraSync) {
+    dialog.dataset.turnDrivingCameraSync = 'true';
     dialog.addEventListener('toggle', sync);
   }
   return true;

--- a/turn/ui/gameplay-controls.js
+++ b/turn/ui/gameplay-controls.js
@@ -1,6 +1,14 @@
+import {
+  advancedDriftEnabled,
+  resolveAdvancedDriftLock,
+  resolveAdvancedDriftThrottle
+} from '../input/advanced-drift.js?revision=r215-advanced-drift';
+
 globalThis.__turnBoostActive = false;
 globalThis.__turnBoostCharge = 1;
 globalThis.__turnDriftHeld = false;
+globalThis.__turnDriftLockAmount = 0;
+globalThis.__turnAdvancedDriftEnabled = advancedDriftEnabled();
 
 if (!globalThis.__turnGameplayControlsInstalled) {
   globalThis.__turnGameplayControlsInstalled = true;
@@ -88,6 +96,7 @@ function installGameplayUi() {
   boostHud.className = 'boost-hud';
   boostHud.innerHTML = '<span>BOOST</span><div><i></i></div>';
   hud.appendChild(boostHud);
+  const boostLabel = boostHud.querySelector('span');
 
   const driveStack = document.createElement('div');
   driveStack.className = 'drive-stack';
@@ -100,6 +109,8 @@ function installGameplayUi() {
     'Drive control. Double tap and hold, then slide between Drift, Boost, Gas, and Brake or Reverse.'
   );
   drivePad.style.setProperty('--boost-charge', '100%');
+  drivePad.style.setProperty('--drift-lock', '0%');
+  boostHud.style.setProperty('--drift-lock', '0%');
 
   const driveTop = document.createElement('div');
   driveTop.className = 'drive-pad-top';
@@ -148,8 +159,11 @@ function installGameplayUi() {
   let publishedBoosting = null;
   let publishedLocked = null;
   let publishedDriftCharging = null;
+  let publishedDriftLocking = null;
+  let publishedDriftLockPercent = null;
+  let publishedDriftLockMax = null;
   let publishedChargePercent = null;
-  let publishedAriaPercent = null;
+  let publishedAriaLabel = null;
 
   function safeVibrate(pattern) {
     try {
@@ -190,20 +204,26 @@ function installGameplayUi() {
     boostVisualDirty = true;
     lastBoostVisualAt = -Infinity;
     publishedChargePercent = null;
-    publishedAriaPercent = null;
+    publishedAriaLabel = null;
     publishedLocked = null;
     drivePad.style.setProperty('--boost-charge', '100%');
     boostHud.style.setProperty('--boost-charge', '100%');
+    boostHud.style.setProperty('--drift-lock', '0%');
     boostHud.setAttribute('aria-label', 'Boost 100 percent charged');
+    if (boostLabel) boostLabel.textContent = 'BOOST';
     drivePad.classList.remove('is-boost-locked');
     boostZone.classList.remove('is-locked');
-    boostHud.classList.remove('is-boost-full-flash', 'is-boost-empty-flash');
+    boostHud.classList.remove(
+      'is-boost-full-flash',
+      'is-boost-empty-flash',
+      'is-drift-locking',
+      'is-drift-lock-max'
+    );
   }
 
   globalThis.__turnRefillBoost = refillBoost;
 
-  function zoneFromPointer(event) {
-    const rect = drivePad.getBoundingClientRect();
+  function zoneFromPointer(event, rect = drivePad.getBoundingClientRect()) {
     const margin = 24;
     if (
       event.clientX < rect.left - margin ||
@@ -219,23 +239,49 @@ function installGameplayUi() {
     return 'gas';
   }
 
+  function driveInputFromPointer(event) {
+    const rect = drivePad.getBoundingClientRect();
+    const zone = zoneFromPointer(event, rect);
+    const driftLock = resolveAdvancedDriftLock({
+      enabled: globalThis.__turnAdvancedDriftEnabled === true,
+      driftActive: zone === 'drift',
+      pointerX: event.clientX,
+      padLeft: rect.left,
+      padWidth: rect.width
+    });
+    return { zone, driftLock };
+  }
+
   function setBrakeInput(active) {
     const runtimeState = globalThis.__turnRuntime?.state;
     if (runtimeState) runtimeState.touchBrake = Boolean(active);
   }
 
-  function setDriveZone(nextZone, { announce = true } = {}) {
-    if (nextZone === driveZone) return;
+  function setDriveZone(nextZone, driftLock = 0, { announce = true } = {}) {
+    const lockAmount = nextZone === 'drift' && globalThis.__turnAdvancedDriftEnabled === true
+      ? Math.max(0, Math.min(1, Number(driftLock) || 0))
+      : 0;
+    const previousLockAmount = Math.max(0, Number(globalThis.__turnDriftLockAmount) || 0);
+    const zoneChanged = nextZone !== driveZone;
+    const lockChanged = Math.abs(lockAmount - previousLockAmount) > 0.001;
+    if (!zoneChanged && !lockChanged) return;
     const previousZone = driveZone;
     if (previousZone === 'boost' && nextZone !== 'boost') boostExhausted = false;
     driveZone = nextZone;
     const forwardDrive = nextZone === 'gas' || nextZone === 'drift' || nextZone === 'boost';
-    globalThis.__turnAnalogGas = forwardDrive ? 1 : 0;
+    const forwardThrottle = nextZone === 'drift'
+      ? resolveAdvancedDriftThrottle(lockAmount)
+      : 1;
+    globalThis.__turnAnalogGas = forwardDrive ? forwardThrottle : 0;
     globalThis.__turnDriftHeld = nextZone === 'drift';
+    globalThis.__turnDriftLockAmount = lockAmount;
     boostRequested = nextZone === 'boost';
     setBrakeInput(nextZone === 'brake');
+    boostVisualDirty = boostVisualDirty || lockChanged;
 
     drivePad.dataset.driveZone = nextZone || '';
+    drivePad.style.setProperty('--drift-lock', `${(lockAmount * 100).toFixed(1)}%`);
+    drivePad.classList.toggle('is-drift-locking', lockAmount > 0.001);
     gasButton.classList.toggle('is-active', nextZone === 'gas');
     driftZone.classList.toggle('is-active', nextZone === 'drift');
     boostZone.classList.toggle('is-active', nextZone === 'boost');
@@ -254,7 +300,8 @@ function installGameplayUi() {
   function updateDrivePointer(event) {
     consumeDrivePointer(event);
     if (drivePointerId === null || event.pointerId !== drivePointerId) return;
-    setDriveZone(zoneFromPointer(event));
+    const input = driveInputFromPointer(event);
+    setDriveZone(input.zone, input.driftLock);
   }
 
   function releaseDrive(event) {
@@ -263,7 +310,7 @@ function installGameplayUi() {
     const releasedPointerId = drivePointerId;
     drivePointerId = null;
     drivePad.releasePointerCapture?.(releasedPointerId);
-    setDriveZone(null, { announce: false });
+    setDriveZone(null, 0, { announce: false });
     boostRequested = false;
     boostExhausted = false;
     globalThis.__turnBoostActive = false;
@@ -276,13 +323,35 @@ function installGameplayUi() {
     drivePointerId = event.pointerId;
     boostExhausted = false;
     drivePad.setPointerCapture?.(event.pointerId);
-    setDriveZone(zoneFromPointer(event), { announce: false });
+    const input = driveInputFromPointer(event);
+    setDriveZone(input.zone, input.driftLock, { announce: false });
   }, { capture: true });
   drivePad.addEventListener('pointermove', updateDrivePointer, { capture: true });
   drivePad.addEventListener('pointerup', releaseDrive, { capture: true });
   drivePad.addEventListener('pointercancel', releaseDrive, { capture: true });
   drivePad.addEventListener('lostpointercapture', (event) => {
     if (drivePointerId === event.pointerId) releaseDrive(event);
+  });
+
+  function syncAdvancedDriftUi(enabled = globalThis.__turnAdvancedDriftEnabled === true) {
+    const active = enabled === true;
+    globalThis.__turnAdvancedDriftEnabled = active;
+    drivePad.classList.toggle('has-advanced-drift', active);
+    drivePad.setAttribute(
+      'aria-label',
+      active
+        ? 'Drive control. Double tap and hold, then slide between Drift, Boost, Gas, and Brake or Reverse. In Drift, slide farther left for progressive rear-wheel lock.'
+        : 'Drive control. Double tap and hold, then slide between Drift, Boost, Gas, and Brake or Reverse.'
+    );
+    driftZone.setAttribute(
+      'aria-label',
+      active ? 'Gas and drift. Slide left for progressive lock.' : 'Gas and drift'
+    );
+    if (!active) setDriveZone(driveZone, 0, { announce: false });
+  }
+
+  window.addEventListener('turn:advanced-drift-change', (event) => {
+    syncAdvancedDriftUi(event.detail?.enabled === true);
   });
 
   const resetRivalsButton = document.createElement('button');
@@ -389,6 +458,7 @@ function installGameplayUi() {
       throttle: runtimeState?.throttle || 0,
       driftAmount: runtimeState?.driftAmount || 0,
       driftHeld: Boolean(globalThis.__turnDriftHeld),
+      driftLockAmount: Math.max(0, Number(globalThis.__turnDriftLockAmount) || 0),
       boostActive: boosting,
       vehicleId: runtimeState?.vehicleId || '',
       enginePitch: runtimeState?.vehicleTuning?.enginePitch || 1,
@@ -423,13 +493,25 @@ function installGameplayUi() {
 
     const locked = boostRequested && boostExhausted;
     const driftCharging = globalThis.__turnDriftHeld && !boosting;
+    const driftLockAmount = globalThis.__turnAdvancedDriftEnabled === true && driftCharging
+      ? Math.max(0, Math.min(1, Number(globalThis.__turnDriftLockAmount) || 0))
+      : 0;
+    const driftLocking = driftLockAmount > 0.001;
+    const driftLockMax = driftLockAmount >= 0.98;
+    const driftLockPercent = (driftLockAmount * 100).toFixed(1) + '%';
+    const driftLockAriaPercent = Math.round(driftLockAmount * 100);
     const chargePercent = (boostCharge * 100).toFixed(1) + '%';
     const ariaPercent = Math.round(boostCharge * 100);
+    const ariaLabel = driftLocking
+      ? `Drift lock ${driftLockAriaPercent} percent. Boost ${ariaPercent} percent charged`
+      : `Boost ${ariaPercent} percent charged`;
     const controlsVisible = !controlsRoot?.hidden && !document.hidden;
     const stateChanged =
       boosting !== publishedBoosting ||
       locked !== publishedLocked ||
-      driftCharging !== publishedDriftCharging;
+      driftCharging !== publishedDriftCharging ||
+      driftLocking !== publishedDriftLocking ||
+      driftLockMax !== publishedDriftLockMax;
     const visualDue = now - lastBoostVisualAt >= BOOST_VISUAL_INTERVAL_MS;
 
     if (!controlsVisible) {
@@ -459,19 +541,33 @@ function installGameplayUi() {
       boostHud.classList.toggle('is-drift-charging', driftCharging);
       publishedDriftCharging = driftCharging;
     }
+    if (boostVisualDirty || driftLocking !== publishedDriftLocking) {
+      boostHud.classList.toggle('is-drift-locking', driftLocking);
+      if (boostLabel) boostLabel.textContent = driftLocking ? 'DRIFT LOCK' : 'BOOST';
+      publishedDriftLocking = driftLocking;
+    }
+    if (boostVisualDirty || driftLockMax !== publishedDriftLockMax) {
+      boostHud.classList.toggle('is-drift-lock-max', driftLockMax);
+      publishedDriftLockMax = driftLockMax;
+    }
+    if (boostVisualDirty || driftLockPercent !== publishedDriftLockPercent) {
+      boostHud.style.setProperty('--drift-lock', driftLockPercent);
+      publishedDriftLockPercent = driftLockPercent;
+    }
     if (boostVisualDirty || chargePercent !== publishedChargePercent) {
       drivePad.style.setProperty('--boost-charge', chargePercent);
       boostHud.style.setProperty('--boost-charge', chargePercent);
       publishedChargePercent = chargePercent;
     }
-    if (boostVisualDirty || ariaPercent !== publishedAriaPercent) {
-      boostHud.setAttribute('aria-label', 'Boost ' + ariaPercent + ' percent charged');
-      publishedAriaPercent = ariaPercent;
+    if (boostVisualDirty || ariaLabel !== publishedAriaLabel) {
+      boostHud.setAttribute('aria-label', ariaLabel);
+      publishedAriaLabel = ariaLabel;
     }
     boostVisualDirty = false;
     lastBoostVisualAt = now;
   }
 
-  setDriveZone(null, { announce: false });
+  syncAdvancedDriftUi();
+  setDriveZone(null, 0, { announce: false });
   globalThis.__turnUpdateGameplayControls = updateBoost;
 }

--- a/turn/vehicle/physics.js
+++ b/turn/vehicle/physics.js
@@ -86,6 +86,7 @@ export function updateVehiclePhysicsState({
   analogGas = 0,
   boostActive = false,
   driftHeld = false,
+  driftLock = 0,
   vehicleTuning = null
 }) {
   updateMotionInput(dt);
@@ -106,6 +107,13 @@ export function updateVehiclePhysicsState({
   const driftSlideMultiplier = driftHeld
     ? clamp(positiveNumber(tuning?.driftSlideMultiplier, 1), 0.75, 1.5)
     : 1;
+  const driftLockAmount = driftHeld
+    ? clamp(nonNegativeNumber(driftLock, 0), 0, 1)
+    : 0;
+  const lockYawMultiplier = lerp(1, 1.55, driftLockAmount);
+  const lockGripMultiplier = lerp(1, 0.22, driftLockAmount);
+  const lockSlideMultiplier = lerp(1, 1.25, driftLockAmount);
+  state.driftLockAmount = driftLockAmount;
   const tuningBoostPowerMultiplier = positiveNumber(tuning?.boostPowerMultiplier, 1);
   const tuningBoostSpeedMultiplier = positiveNumber(tuning?.boostSpeedMultiplier, 1.32);
   const effectiveMaxSpeed = maxSpeed;
@@ -175,7 +183,8 @@ export function updateVehiclePhysicsState({
     Math.abs(state.steering) * speedRatio * 0.9 +
       brakeDriftInput * Math.abs(state.steering) * 1.35 +
       Math.abs(lateralSpeed) / 22 +
-      (driftHeld ? 0.48 + Math.abs(state.steering) * 0.5 : 0),
+      (driftHeld ? 0.48 + Math.abs(state.steering) * 0.5 : 0) +
+      driftLockAmount * (0.25 + Math.abs(state.steering) * 0.35),
     0,
     1
   );
@@ -200,6 +209,7 @@ export function updateVehiclePhysicsState({
     steeringAuthority *
     steeringStatMultiplier *
     driftYawMultiplier *
+    lockYawMultiplier *
     (1 + state.driftAmount * 0.65 + (driftHeld ? 0.58 : 0));
 
   state.heading = normalizeAngle(state.heading + yawRate * dt);
@@ -211,7 +221,7 @@ export function updateVehiclePhysicsState({
     ? 1
     : 0.92 + controlMultiplier * 0.08;
   const driftGripMultiplier = driftHeld
-    ? 0.42 * driftStabilityMultiplier * driftGripTuningMultiplier
+    ? 0.42 * driftStabilityMultiplier * driftGripTuningMultiplier * lockGripMultiplier
     : 1;
   const grip = (
     physicsOffRoad
@@ -223,7 +233,8 @@ export function updateVehiclePhysicsState({
   state.velocity.addScaledVector(newRight, -lateralSpeed * lateralCorrection);
 
   if ((state.driftAmount > 0.18 || driftHeld) && speed > 14) {
-    const slideStrength = (driftHeld ? 0.235 : 0.12) * driftSlideMultiplier;
+    const slideStrength = (driftHeld ? 0.235 : 0.12) *
+      driftSlideMultiplier * lockSlideMultiplier;
     state.velocity.addScaledVector(
       newRight,
       state.steering * speed * Math.max(state.driftAmount, 0.48) * slideStrength * dt
@@ -232,7 +243,7 @@ export function updateVehiclePhysicsState({
 
   const drag = physicsOffRoad
     ? 0.34
-    : 0.11 + speed * 0.0009 + (driftHeld ? driftDragAdd : 0);
+    : 0.11 + speed * 0.0009 + (driftHeld ? driftDragAdd : 0) + driftLockAmount * 0.18;
   state.velocity.multiplyScalar(Math.exp(-drag * dt));
 
   speed = state.velocity.length();


### PR DESCRIPTION
## Summary
- add a persisted **Advanced DRIFT** toggle under Driving, defaulting to OFF
- progressively trade throttle for rear-wheel LOCK across the far-left DRIFT range and a small overdrag
- add lightweight arcade lock handling through stronger yaw/slide, reduced rear grip, and modest drag
- show the available range directly in the DRIFT pad with an integrated cyan-to-purple gradient
- temporarily turn the Boost HUD into a cyan-to-purple **DRIFT LOCK** meter, with a reduced-motion-safe max pulse
- preserve ordinary DRIFT behavior exactly when the setting is disabled and reset lock state across releases/restarts
- keep TURN and TURN NEXT entry points in parity

## Validation
- `node turn-tests/drift-camera-production.mjs`
- `node turn-tests/session-orchestrator-production.mjs`
- `node turn-lab/tests/drive-pad-production.mjs`
- `node turn-lab/tests/vehicle-drift-production.mjs`
- `node --check` on all modified JavaScript modules/tests
- verified `turn/main.js` and `turn-next/main.js` are identical
