### PR TITLE
Add standard binary DRIFT LOCK

### DIFF
--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -1,5 +1,12 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
+import {
+  DRIFT_LOCK_ENGAGE_SECONDS,
+  DRIFT_LOCK_RELEASE_SECONDS,
+  advanceDriftLockAmount,
+  driftThrottleForLock,
+  pointerUsesDriftLock
+} from '../../turn/input/drift-lock.js';
 import { updateVehiclePhysicsState } from '../../turn/vehicle/physics.js';
 import { spokenRivalCount } from '../../turn/ui/race-announcements.js';
 import { lapAnnouncementPriorityMs } from '../../turn/ui/race-speech.js';
@@ -14,6 +21,28 @@ assert.ok(
   lapAnnouncementPriorityMs('Lap void. Stay on the track.') >= 3200,
   'A void-lap summary also needs priority over live race updates'
 );
+
+const driftLockGeometry = {
+  driftActive: true,
+  padLeft: 100,
+  padTop: 50,
+  padHeight: 200,
+  bubbleWidth: 60
+};
+assert.equal(pointerUsesDriftLock({ ...driftLockGeometry, pointerX: 50, pointerY: 80 }), true);
+assert.equal(pointerUsesDriftLock({ ...driftLockGeometry, pointerX: 104, pointerY: 80 }), true);
+assert.equal(pointerUsesDriftLock({ ...driftLockGeometry, pointerX: 105, pointerY: 80 }), false);
+assert.equal(pointerUsesDriftLock({ ...driftLockGeometry, pointerX: 21, pointerY: 80 }), false);
+assert.equal(pointerUsesDriftLock({ ...driftLockGeometry, pointerX: 50, pointerY: 37 }), false);
+assert.equal(pointerUsesDriftLock({ ...driftLockGeometry, pointerX: 50, pointerY: 127 }), false);
+assert.equal(pointerUsesDriftLock({ ...driftLockGeometry, pointerX: 50, pointerY: 80, driftActive: false }), false);
+assert.equal(advanceDriftLockAmount(0, true, DRIFT_LOCK_ENGAGE_SECONDS / 2), 0.5);
+assert.equal(advanceDriftLockAmount(0.5, true, DRIFT_LOCK_ENGAGE_SECONDS / 2), 1);
+assert.equal(advanceDriftLockAmount(1, false, DRIFT_LOCK_RELEASE_SECONDS / 2), 0.5);
+assert.equal(advanceDriftLockAmount(0.5, false, DRIFT_LOCK_RELEASE_SECONDS / 2), 0);
+assert.equal(driftThrottleForLock(0), 1);
+assert.equal(driftThrottleForLock(0.5), 0.5);
+assert.equal(driftThrottleForLock(1), 0);
 
 class Vec3 {
   constructor(x = 0, y = 0, z = 0) { this.x = x; this.y = y; this.z = z; }
@@ -35,7 +64,8 @@ const [
   gameplayCss,
   positionCss,
   analogGas,
-  spectate
+  spectate,
+  mainSource
 ] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/release.json', import.meta.url), 'utf8'),
@@ -47,7 +77,8 @@ const [
   fs.readFile(new URL('../../turn/gameplay-v2.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/position-hud-r83.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/input/analog-gas.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8')
 ]);
 
 const release = JSON.parse(releaseSource);
@@ -96,8 +127,23 @@ assert.match(controls, /return x < 0\.5 \? 'drift' : 'boost'/, 'Top drive pad mu
 assert.match(controls, /y >= BRAKE_ZONE_START\) return 'brake'/, 'Bottom drive pad must map to Brake and Reverse');
 assert.match(controls, /return 'gas'/, 'Middle drive pad must map to Gas');
 assert.match(controls, /const forwardDrive = nextZone === 'gas' \|\| nextZone === 'drift' \|\| nextZone === 'boost'/, 'Only forward-driving zones may keep gas engaged');
-assert.match(controls, /globalThis\.__turnAnalogGas = forwardDrive \? 1 : 0/, 'Brake must immediately release gas');
+assert.match(controls, /globalThis\.__turnAnalogGas = forwardDrive \? forwardThrottle : 0/,
+  'Brake must release gas while the smooth binary LOCK transition may reduce it');
 assert.match(controls, /globalThis\.__turnDriftHeld = nextZone === 'drift'/, 'Drift zone must add drift to gas');
+assert.match(controls, /pointerUsesDriftLock\(\{/,
+  'The external bubble must own a dedicated forgiving hit target');
+assert.match(controls, /driftActive: driveZone === 'drift'/,
+  'LOCK must only become available after the player has engaged DRIFT');
+assert.match(controls, /if \(lockRequested\) return \{ zone: 'drift', lockRequested: true \}/,
+  'Entering the bubble must keep DRIFT held while switching binary LOCK on');
+assert.match(controls, /advanceDriftLockAmount\(/,
+  'The binary target must use a short mechanical transition instead of snapping');
+assert.match(controls, /globalThis\.__turnDriftLockAmount = lockCanRun \? driftLockAmount : 0/,
+  'The smoothed LOCK amount must be published for vehicle physics');
+assert.match(controls, /driftThrottleForLock\(driftLockAmount\)/,
+  'Gas must fade out over the same short LOCK transition');
+assert.doesNotMatch(controls, /Advanced DRIFT|turn:advanced-drift-change/,
+  'Binary LOCK must be standard behavior without an experimental setting');
 assert.match(controls, /boostRequested = nextZone === 'boost'/, 'Boost zone must add boost to gas');
 assert.match(controls, /runtimeState\.touchBrake = Boolean\(active\)/, 'The unified Brake zone must drive the existing brake and reverse physics');
 assert.match(controls, /brakeButton\.classList\.toggle\('is-active', nextZone === 'brake'\)/, 'Brake must receive the same active-state treatment as every other zone');
@@ -119,7 +165,23 @@ assert.match(css, /place-items: center/, 'Drive-zone labels must be vertically a
 assert.match(css, /content: "LEAVE"/, 'Boost lock hint must explain that leaving the Boost zone re-arms it');
 assert.match(css, /\.drive-pad \.drive-brake-zone \{/, 'Brake and Reverse must be styled as an internal drive-pad zone');
 assert.match(css, /\.drive-brake-zone\.is-active/, 'Brake must have visible active feedback');
+assert.match(css, /\.drive-lock-bubble \{[\s\S]*right: calc\(100% - 4px\);[\s\S]*background: #748ffc/,
+  'LOCK must be a separate bubble attached outside the left edge of the pad');
+assert.match(css, /\.drive-stack\.is-drift-ready \.drive-lock-bubble \{[\s\S]*opacity: 1;[\s\S]*scaleX\(1\)/,
+  'The LOCK bubble must animate quickly into view while DRIFT is held');
+assert.match(css, /\.drive-stack\.is-drift-locking \.drive-lock-bubble \{[\s\S]*#8b5cf6/,
+  'The bubble must visibly confirm the binary LOCK state in purple');
+assert.match(css, /prefers-reduced-motion: reduce[\s\S]*\.drive-lock-bubble/,
+  'The bubble reveal must respect reduced-motion preferences');
 assert.match(gameplayCss, /\.boost-hud i \{[\s\S]*box-shadow: 3px 0 0 var\(--ink\);/, 'Boost charge must have a high-contrast ink edge at the live fill level');
+assert.match(gameplayCss, /\.boost-hud\.is-drift-charging i \{[\s\S]*background-color: #38d9ff/,
+  'Ordinary DRIFT recharge must show the Boost charge in light blue');
+assert.match(gameplayCss, /\.boost-hud\.is-drift-locking i \{[\s\S]*background-color: #8b5cf6/,
+  'Using LOCK must simply turn the existing Boost charge fill purple');
+assert.match(controls, /boostHud\.innerHTML = '<span>BOOST<\/span>/,
+  'The Boost HUD label must stay BOOST instead of becoming a second LOCK meter');
+assert.match(mainSource, /driftLock: globalThis\.__turnDriftLockAmount \|\| 0/,
+  'The production runtime must pass the smoothed binary LOCK value into vehicle physics');
 assert.match(gameplayCss, /\.boost-hud\.is-boost-full-flash/, 'Boost HUD must visibly react when recharge reaches full capacity');
 assert.match(gameplayCss, /\.boost-hud\.is-boost-empty-flash/, 'Boost HUD must react distinctly when the tank becomes empty');
 assert.match(gameplayCss, /@keyframes turn-boost-full-flash/, 'Full boost feedback must have its own animation');
@@ -151,4 +213,38 @@ assert.ok(state.velocity.z < -0.1, 'Holding Brake after stopping must engage rev
 for (let i = 0; i < 100; i += 1) updateVehiclePhysicsState(physicsArgs);
 assert.ok(state.velocity.z >= -(80 * 0.32 + 0.5), 'Reverse must stay capped well below forward top speed');
 
-console.log(`TURN ${release.id} four-zone drive pad, lap-priority race speech, topbar position HUD, restart boost refill and reverse passed.`);
+function runDriftLock(lockAmount) {
+  const driftState = {
+    position: new Vec3(), velocity: new Vec3(0, 0, 30), touchGas: false, touchBrake: false,
+    throttle: 0, brake: 0, steering: 1, driftAmount: 0.7, heading: 0, progress: 0,
+    lastProgress: 0, nearestTrackIndex: 0, trackDistance: 0, offRoad: false, speed: 30
+  };
+  updateVehiclePhysicsState({
+    ...physicsArgs,
+    state: driftState,
+    analogGas: driftThrottleForLock(lockAmount),
+    boostActive: false,
+    driftHeld: true,
+    driftLock: lockAmount
+  });
+  return driftState;
+}
+
+const ordinaryDrift = runDriftLock(0);
+const fullLockDrift = runDriftLock(1);
+assert.equal(ordinaryDrift.driftLockAmount, 0);
+assert.equal(fullLockDrift.driftLockAmount, 1);
+assert.ok(
+  Math.abs(fullLockDrift.heading) > Math.abs(ordinaryDrift.heading),
+  'LOCK must increase yaw authority for a larger slip angle'
+);
+assert.ok(
+  Math.abs(fullLockDrift.velocity.x) > Math.abs(ordinaryDrift.velocity.x),
+  'LOCK must preserve and strengthen the lateral slide'
+);
+assert.ok(
+  fullLockDrift.speed < ordinaryDrift.speed,
+  'Full LOCK must release gas and add modest handbrake drag'
+);
+
+console.log(`TURN ${release.id} binary DRIFT LOCK bubble, smooth lock physics, Boost color, restart refill and reverse passed.`);

--- a/turn-lab/tests/vehicle-drift-production.mjs
+++ b/turn-lab/tests/vehicle-drift-production.mjs
@@ -110,6 +110,14 @@ assert.match(physicsSource, /3\.2 \* driftStabilityMultiplier/,
   'DRIFT must affect slide recovery');
 assert.match(physicsSource, /0\.42 \* driftStabilityMultiplier/,
   'DRIFT must affect lateral stability');
+assert.match(mainSource, /driftLock: globalThis\.__turnDriftLockAmount \|\| 0/,
+  'The runtime must pass the smoothed binary DRIFT LOCK amount into vehicle physics');
+assert.match(physicsSource, /lockYawMultiplier = lerp\(1, 1\.55, driftLockAmount\)/,
+  'The short LOCK transition must scale rotation without adding wheel simulations');
+assert.match(physicsSource, /lockGripMultiplier = lerp\(1, 0\.22, driftLockAmount\)/,
+  'The short LOCK transition must release rear lateral grip');
+assert.match(physicsSource, /driftLockAmount \* 0\.18/,
+  'LOCK must add a modest handbrake-like speed cost');
 assert.match(physicsSource, /\* tuningBoostPowerMultiplier/,
   'BOOST POWER must scale actual boost acceleration');
 assert.match(physicsSource, /boostSpeedMultiplier: tuningBoostSpeedMultiplier/,
@@ -170,8 +178,9 @@ assert.match(physicsSource, /steeringStatMultiplier \*[\s\S]*driftYawMultiplier/
   'Vehicle physics must apply the car-owned DRIFT yaw multiplier');
 assert.match(physicsSource, /0\.42 \* driftStabilityMultiplier \* driftGripTuningMultiplier/,
   'Vehicle physics must apply the car-owned slip/grip multiplier');
-assert.match(physicsSource, /slideStrength = \(driftHeld \? 0\.235 : 0\.12\) \* driftSlideMultiplier/,
-  'Vehicle physics must apply the car-owned sustained-slide multiplier');
+assert.match(physicsSource,
+  /slideStrength = \(driftHeld \? 0\.235 : 0\.12\) \*[\s\S]*driftSlideMultiplier \* lockSlideMultiplier/,
+  'Vehicle physics must apply both the car-owned and smoothed binary LOCK slide multipliers');
 
 const rallyRacer = CAR_CATALOG.find((car) => car.id === 'toy-racer');
 assert.ok(rallyRacer, 'The former Toy Racer asset/id must remain available for saved selections and ghosts');

--- a/turn-next/main.js
+++ b/turn-next/main.js
@@ -84,6 +84,7 @@ const state = {
   velocity: new THREE.Vector3(),
   heading: 0,
   driftAmount: 0,
+  driftLockAmount: 0,
   offRoad: false,
   trackDistance: 0,
   progress: 0,
@@ -942,6 +943,7 @@ function updatePhysics(dt, now) {
     analogGas: globalThis.__turnAnalogGas || 0,
     boostActive: Boolean(globalThis.__turnBoostActive),
     driftHeld: Boolean(globalThis.__turnDriftHeld),
+    driftLock: globalThis.__turnDriftLockAmount || 0,
     vehicleTuning: state.vehicleTuning
   });
 

--- a/turn-tests/session-orchestrator-production.mjs
+++ b/turn-tests/session-orchestrator-production.mjs
@@ -65,7 +65,8 @@ function createHarness({ selection = { carId: 'sedan', color: '#fff', secondaryC
     },
     __turnAnalogGas: 0.7,
     __turnBoostActive: true,
-    __turnDriftHeld: true
+    __turnDriftHeld: true,
+    __turnDriftLockAmount: 0.8
   };
   environment.window = environment;
 
@@ -208,6 +209,7 @@ assert.equal(lotCancelled.state.touchGas, false);
 assert.equal(lotCancelled.environment.__turnAnalogGas, 0);
 assert.equal(lotCancelled.environment.__turnBoostActive, false);
 assert.equal(lotCancelled.environment.__turnDriftHeld, false);
+assert.equal(lotCancelled.environment.__turnDriftLockAmount, 0);
 assert.deepEqual(lotCancelled.published, ['lot-open', 'lot-cancelled']);
 assert.equal(lotCancelled.orchestrator.getPhase(), 'racing');
 

--- a/turn/drive-pad.css
+++ b/turn/drive-pad.css
@@ -43,7 +43,12 @@ body .m8-feedback-content * {
 }
 
 .drive-stack {
+  --drive-pad-height: clamp(190px, 26vw, 268px);
+  --drift-lock-bubble-width: clamp(52px, 7.2vw, 74px);
+  position: relative;
+  isolation: isolate;
   width: clamp(190px, 24vw, 260px);
+  height: var(--drive-pad-height);
   display: grid;
   pointer-events: auto;
 }
@@ -51,7 +56,8 @@ body .m8-feedback-content * {
 .drive-pad {
   --boost-charge: 100%;
   position: relative;
-  height: clamp(190px, 26vw, 268px);
+  z-index: 2;
+  height: var(--drive-pad-height);
   overflow: hidden;
   display: grid;
   grid-template-rows: 32% 44% 24%;
@@ -62,6 +68,50 @@ body .m8-feedback-content * {
   touch-action: none;
   user-select: none;
   -webkit-user-select: none;
+}
+
+.drive-lock-bubble {
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  right: calc(100% - 4px);
+  width: var(--drift-lock-bubble-width);
+  height: 32%;
+  box-sizing: border-box;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  border: 4px solid var(--ink);
+  border-radius: 999px 0 0 999px;
+  background: #748ffc;
+  color: var(--ink);
+  opacity: 0;
+  transform: translateX(62%) scaleX(0.38);
+  transform-origin: right center;
+  transition:
+    opacity 80ms ease-out,
+    transform 140ms cubic-bezier(.2,.88,.25,1),
+    background-color 100ms ease;
+  pointer-events: none;
+}
+
+.drive-lock-bubble span {
+  display: block;
+  transform: rotate(-90deg);
+  font-size: clamp(0.58rem, 1.55vw, 0.82rem);
+  font-weight: 900;
+  letter-spacing: 0.035em;
+  line-height: 1;
+}
+
+.drive-stack.is-drift-ready .drive-lock-bubble {
+  opacity: 1;
+  transform: translateX(0) scaleX(1);
+}
+
+.drive-stack.is-drift-locking .drive-lock-bubble {
+  background: #8b5cf6;
+  box-shadow: inset 0 0 0 5px rgb(255 248 232 / 0.62);
 }
 
 .drive-pad-top {
@@ -197,11 +247,12 @@ body .m8-feedback-content * {
 
 @media (max-height: 430px) {
   .drive-stack {
+    --drive-pad-height: clamp(174px, 23.5vw, 205px);
+    --drift-lock-bubble-width: clamp(48px, 6.8vw, 64px);
     width: clamp(174px, 23vw, 224px);
   }
 
   .drive-pad {
-    height: clamp(174px, 23.5vw, 205px);
     border-width: 3px;
     border-radius: 24px;
     box-shadow: 5px 6px 0 var(--ink);
@@ -218,5 +269,16 @@ body .m8-feedback-content * {
 
   .drive-boost-zone {
     border-left-width: 1.5px;
+  }
+
+  .drive-lock-bubble {
+    right: calc(100% - 3px);
+    border-width: 3px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .drive-lock-bubble {
+    transition: none;
   }
 }

--- a/turn/gameplay-v2.css
+++ b/turn/gameplay-v2.css
@@ -73,7 +73,9 @@
   width: var(--boost-charge);
   background: linear-gradient(90deg, #ff922b, #ff5a5f);
   box-shadow: 3px 0 0 var(--ink);
-  transition: width 70ms linear;
+  transition:
+    width 70ms linear,
+    background-color 120ms ease;
 }
 
 .boost-hud.is-boosting {
@@ -87,7 +89,12 @@
 }
 
 .boost-hud.is-drift-charging i {
-  background: linear-gradient(90deg, #38d9ff, #8ce99a);
+  background-color: #38d9ff;
+  background-image: none;
+}
+
+.boost-hud.is-drift-locking i {
+  background-color: #8b5cf6;
 }
 
 .boost-hud.is-boost-full-flash {

--- a/turn/input/drift-lock.js
+++ b/turn/input/drift-lock.js
@@ -1,0 +1,58 @@
+export const DRIFT_LOCK_ENGAGE_SECONDS = 0.14;
+export const DRIFT_LOCK_RELEASE_SECONDS = 0.1;
+export const DRIFT_LOCK_TOP_ZONE_SHARE = 0.32;
+export const DRIFT_LOCK_OUTER_SLOP_PX = 18;
+export const DRIFT_LOCK_VERTICAL_SLOP_PX = 12;
+export const DRIFT_LOCK_SEAM_OVERLAP_PX = 4;
+
+export function pointerUsesDriftLock({
+  driftActive = false,
+  pointerX = 0,
+  pointerY = 0,
+  padLeft = 0,
+  padTop = 0,
+  padHeight = 0,
+  bubbleWidth = 0
+} = {}) {
+  if (!driftActive) return false;
+
+  const left = finiteNumber(padLeft);
+  const top = finiteNumber(padTop);
+  const height = Math.max(1, finiteNumber(padHeight));
+  const width = Math.max(1, finiteNumber(bubbleWidth));
+  const x = finiteNumber(pointerX);
+  const y = finiteNumber(pointerY);
+  const lockTop = top - DRIFT_LOCK_VERTICAL_SLOP_PX;
+  const lockBottom = top + height * DRIFT_LOCK_TOP_ZONE_SHARE + DRIFT_LOCK_VERTICAL_SLOP_PX;
+  const lockLeft = left - width - DRIFT_LOCK_OUTER_SLOP_PX;
+  const lockRight = left + DRIFT_LOCK_SEAM_OVERLAP_PX;
+
+  return x >= lockLeft && x <= lockRight && y >= lockTop && y <= lockBottom;
+}
+
+export function advanceDriftLockAmount(currentAmount, lockRequested, dt) {
+  const current = clamp(finiteNumber(currentAmount), 0, 1);
+  const target = lockRequested === true ? 1 : 0;
+  if (current === target) return target;
+
+  const seconds = target > current
+    ? DRIFT_LOCK_ENGAGE_SECONDS
+    : DRIFT_LOCK_RELEASE_SECONDS;
+  const step = Math.max(0, finiteNumber(dt)) / seconds;
+  return target > current
+    ? Math.min(target, current + step)
+    : Math.max(target, current - step);
+}
+
+export function driftThrottleForLock(lockAmount) {
+  return 1 - clamp(finiteNumber(lockAmount), 0, 1);
+}
+
+function finiteNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}

--- a/turn/main.js
+++ b/turn/main.js
@@ -84,6 +84,7 @@ const state = {
   velocity: new THREE.Vector3(),
   heading: 0,
   driftAmount: 0,
+  driftLockAmount: 0,
   offRoad: false,
   trackDistance: 0,
   progress: 0,
@@ -942,6 +943,7 @@ function updatePhysics(dt, now) {
     analogGas: globalThis.__turnAnalogGas || 0,
     boostActive: Boolean(globalThis.__turnBoostActive),
     driftHeld: Boolean(globalThis.__turnDriftHeld),
+    driftLock: globalThis.__turnDriftLockAmount || 0,
     vehicleTuning: state.vehicleTuning
   });
 

--- a/turn/race/session-orchestrator.js
+++ b/turn/race/session-orchestrator.js
@@ -93,6 +93,7 @@ export function createRaceSessionOrchestrator({
     environment.__turnAnalogGas = 0;
     environment.__turnBoostActive = false;
     environment.__turnDriftHeld = false;
+    environment.__turnDriftLockAmount = 0;
   }
 
   function stopSpectating() {

--- a/turn/ui/gameplay-controls.js
+++ b/turn/ui/gameplay-controls.js
@@ -1,6 +1,13 @@
+import {
+  advanceDriftLockAmount,
+  driftThrottleForLock,
+  pointerUsesDriftLock
+} from '../input/drift-lock.js?revision=r216-binary-lock';
+
 globalThis.__turnBoostActive = false;
 globalThis.__turnBoostCharge = 1;
 globalThis.__turnDriftHeld = false;
+globalThis.__turnDriftLockAmount = 0;
 
 if (!globalThis.__turnGameplayControlsInstalled) {
   globalThis.__turnGameplayControlsInstalled = true;
@@ -97,9 +104,14 @@ function installGameplayUi() {
   drivePad.setAttribute('role', 'group');
   drivePad.setAttribute(
     'aria-label',
-    'Drive control. Double tap and hold, then slide between Drift, Boost, Gas, and Brake or Reverse.'
+    'Drive control. Double tap and hold, then slide between Drift, Boost, Gas, and Brake or Reverse. While holding Drift, slide left into Lock for rear-wheel lock.'
   );
   drivePad.style.setProperty('--boost-charge', '100%');
+
+  const driftLockBubble = document.createElement('div');
+  driftLockBubble.className = 'drive-lock-bubble';
+  driftLockBubble.setAttribute('aria-hidden', 'true');
+  driftLockBubble.innerHTML = '<span>LOCK</span>';
 
   const driveTop = document.createElement('div');
   driveTop.className = 'drive-pad-top';
@@ -108,7 +120,7 @@ function installGameplayUi() {
   driftZone.type = 'button';
   driftZone.className = 'drive-zone drive-drift-zone';
   driftZone.textContent = 'Drift';
-  driftZone.setAttribute('aria-label', 'Gas and drift');
+  driftZone.setAttribute('aria-label', 'Gas and drift. Slide left into Lock for rear-wheel lock.');
 
   const boostZone = document.createElement('button');
   boostZone.type = 'button';
@@ -126,13 +138,15 @@ function installGameplayUi() {
 
   driveTop.append(driftZone, boostZone);
   drivePad.append(driveTop, gasButton, brakeButton);
-  driveStack.append(drivePad);
+  driveStack.append(driftLockBubble, drivePad);
   pedals.replaceChildren(driveStack);
 
   let drivePointerId = null;
   let driveZone = null;
   let boostRequested = false;
   let boostExhausted = false;
+  let driftLockRequested = false;
+  let driftLockAmount = 0;
   let boostCharge = 1;
   let previousBoostCharge = boostCharge;
   let boostFlashTimer = 0;
@@ -148,8 +162,9 @@ function installGameplayUi() {
   let publishedBoosting = null;
   let publishedLocked = null;
   let publishedDriftCharging = null;
+  let publishedDriftLocking = null;
   let publishedChargePercent = null;
-  let publishedAriaPercent = null;
+  let publishedAriaLabel = null;
 
   function safeVibrate(pattern) {
     try {
@@ -190,20 +205,29 @@ function installGameplayUi() {
     boostVisualDirty = true;
     lastBoostVisualAt = -Infinity;
     publishedChargePercent = null;
-    publishedAriaPercent = null;
+    publishedAriaLabel = null;
     publishedLocked = null;
+    publishedDriftLocking = null;
+    driftLockRequested = false;
+    driftLockAmount = 0;
+    globalThis.__turnDriftLockAmount = 0;
     drivePad.style.setProperty('--boost-charge', '100%');
     boostHud.style.setProperty('--boost-charge', '100%');
     boostHud.setAttribute('aria-label', 'Boost 100 percent charged');
+    driveStack.classList.toggle('is-drift-ready', driveZone === 'drift');
+    driveStack.classList.remove('is-drift-locking');
     drivePad.classList.remove('is-boost-locked');
     boostZone.classList.remove('is-locked');
-    boostHud.classList.remove('is-boost-full-flash', 'is-boost-empty-flash');
+    boostHud.classList.remove(
+      'is-boost-full-flash',
+      'is-boost-empty-flash',
+      'is-drift-locking'
+    );
   }
 
   globalThis.__turnRefillBoost = refillBoost;
 
-  function zoneFromPointer(event) {
-    const rect = drivePad.getBoundingClientRect();
+  function zoneFromPointer(event, rect = drivePad.getBoundingClientRect()) {
     const margin = 24;
     if (
       event.clientX < rect.left - margin ||
@@ -219,23 +243,54 @@ function installGameplayUi() {
     return 'gas';
   }
 
+  function driveInputFromPointer(event) {
+    const rect = drivePad.getBoundingClientRect();
+    const lockRequested = pointerUsesDriftLock({
+      driftActive: driveZone === 'drift',
+      pointerX: event.clientX,
+      pointerY: event.clientY,
+      padLeft: rect.left,
+      padTop: rect.top,
+      padHeight: rect.height,
+      bubbleWidth: driftLockBubble.offsetWidth
+    });
+    if (lockRequested) return { zone: 'drift', lockRequested: true };
+
+    const zone = zoneFromPointer(event, rect);
+    return { zone, lockRequested: false };
+  }
+
   function setBrakeInput(active) {
     const runtimeState = globalThis.__turnRuntime?.state;
     if (runtimeState) runtimeState.touchBrake = Boolean(active);
   }
 
-  function setDriveZone(nextZone, { announce = true } = {}) {
-    if (nextZone === driveZone) return;
+  function setDriveZone(nextZone, lockRequested = false, { announce = true } = {}) {
+    const nextLockRequested = nextZone === 'drift' && lockRequested === true;
+    const zoneChanged = nextZone !== driveZone;
+    const lockRequestChanged = nextLockRequested !== driftLockRequested;
+    if (!zoneChanged && !lockRequestChanged) return;
     const previousZone = driveZone;
     if (previousZone === 'boost' && nextZone !== 'boost') boostExhausted = false;
     driveZone = nextZone;
+    driftLockRequested = nextLockRequested;
+    if (nextZone !== 'drift') {
+      driftLockAmount = 0;
+      globalThis.__turnDriftLockAmount = 0;
+    }
     const forwardDrive = nextZone === 'gas' || nextZone === 'drift' || nextZone === 'boost';
-    globalThis.__turnAnalogGas = forwardDrive ? 1 : 0;
+    const forwardThrottle = nextZone === 'drift'
+      ? driftThrottleForLock(driftLockAmount)
+      : 1;
+    globalThis.__turnAnalogGas = forwardDrive ? forwardThrottle : 0;
     globalThis.__turnDriftHeld = nextZone === 'drift';
     boostRequested = nextZone === 'boost';
     setBrakeInput(nextZone === 'brake');
+    boostVisualDirty = boostVisualDirty || lockRequestChanged;
 
     drivePad.dataset.driveZone = nextZone || '';
+    driveStack.classList.toggle('is-drift-ready', nextZone === 'drift');
+    driveStack.classList.toggle('is-drift-locking', nextLockRequested);
     gasButton.classList.toggle('is-active', nextZone === 'gas');
     driftZone.classList.toggle('is-active', nextZone === 'drift');
     boostZone.classList.toggle('is-active', nextZone === 'boost');
@@ -243,6 +298,9 @@ function installGameplayUi() {
 
     if (announce && nextZone && nextZone !== previousZone && (nextZone === 'drift' || nextZone === 'boost')) {
       safeVibrate(14);
+    }
+    if (announce && lockRequestChanged && nextZone === 'drift') {
+      safeVibrate(nextLockRequested ? 18 : 8);
     }
   }
 
@@ -254,7 +312,8 @@ function installGameplayUi() {
   function updateDrivePointer(event) {
     consumeDrivePointer(event);
     if (drivePointerId === null || event.pointerId !== drivePointerId) return;
-    setDriveZone(zoneFromPointer(event));
+    const input = driveInputFromPointer(event);
+    setDriveZone(input.zone, input.lockRequested);
   }
 
   function releaseDrive(event) {
@@ -263,7 +322,7 @@ function installGameplayUi() {
     const releasedPointerId = drivePointerId;
     drivePointerId = null;
     drivePad.releasePointerCapture?.(releasedPointerId);
-    setDriveZone(null, { announce: false });
+    setDriveZone(null, false, { announce: false });
     boostRequested = false;
     boostExhausted = false;
     globalThis.__turnBoostActive = false;
@@ -276,7 +335,8 @@ function installGameplayUi() {
     drivePointerId = event.pointerId;
     boostExhausted = false;
     drivePad.setPointerCapture?.(event.pointerId);
-    setDriveZone(zoneFromPointer(event), { announce: false });
+    const input = driveInputFromPointer(event);
+    setDriveZone(input.zone, input.lockRequested, { announce: false });
   }, { capture: true });
   drivePad.addEventListener('pointermove', updateDrivePointer, { capture: true });
   drivePad.addEventListener('pointerup', releaseDrive, { capture: true });
@@ -389,6 +449,7 @@ function installGameplayUi() {
       throttle: runtimeState?.throttle || 0,
       driftAmount: runtimeState?.driftAmount || 0,
       driftHeld: Boolean(globalThis.__turnDriftHeld),
+      driftLockAmount: Math.max(0, Number(globalThis.__turnDriftLockAmount) || 0),
       boostActive: boosting,
       vehicleId: runtimeState?.vehicleId || '',
       enginePitch: runtimeState?.vehicleTuning?.enginePitch || 1,
@@ -399,6 +460,16 @@ function installGameplayUi() {
   function updateBoost(now) {
     const dt = Math.min(0.05, Math.max(0, (now - previousTime) / 1000));
     previousTime = now;
+    const lockCanRun = driveZone === 'drift' && globalThis.__turnDriftHeld === true;
+    driftLockAmount = advanceDriftLockAmount(
+      driftLockAmount,
+      lockCanRun && driftLockRequested,
+      dt
+    );
+    globalThis.__turnDriftLockAmount = lockCanRun ? driftLockAmount : 0;
+    if (lockCanRun) {
+      globalThis.__turnAnalogGas = driftThrottleForLock(driftLockAmount);
+    }
     const active = boostRequested && !boostExhausted && boostCharge > 0.001;
 
     if (active) {
@@ -423,13 +494,18 @@ function installGameplayUi() {
 
     const locked = boostRequested && boostExhausted;
     const driftCharging = globalThis.__turnDriftHeld && !boosting;
+    const driftLocking = driftCharging && (driftLockRequested || driftLockAmount > 0.001);
     const chargePercent = (boostCharge * 100).toFixed(1) + '%';
     const ariaPercent = Math.round(boostCharge * 100);
+    const ariaLabel = driftLocking
+      ? `Drift lock active. Boost ${ariaPercent} percent charged`
+      : `Boost ${ariaPercent} percent charged`;
     const controlsVisible = !controlsRoot?.hidden && !document.hidden;
     const stateChanged =
       boosting !== publishedBoosting ||
       locked !== publishedLocked ||
-      driftCharging !== publishedDriftCharging;
+      driftCharging !== publishedDriftCharging ||
+      driftLocking !== publishedDriftLocking;
     const visualDue = now - lastBoostVisualAt >= BOOST_VISUAL_INTERVAL_MS;
 
     if (!controlsVisible) {
@@ -459,19 +535,23 @@ function installGameplayUi() {
       boostHud.classList.toggle('is-drift-charging', driftCharging);
       publishedDriftCharging = driftCharging;
     }
+    if (boostVisualDirty || driftLocking !== publishedDriftLocking) {
+      boostHud.classList.toggle('is-drift-locking', driftLocking);
+      publishedDriftLocking = driftLocking;
+    }
     if (boostVisualDirty || chargePercent !== publishedChargePercent) {
       drivePad.style.setProperty('--boost-charge', chargePercent);
       boostHud.style.setProperty('--boost-charge', chargePercent);
       publishedChargePercent = chargePercent;
     }
-    if (boostVisualDirty || ariaPercent !== publishedAriaPercent) {
-      boostHud.setAttribute('aria-label', 'Boost ' + ariaPercent + ' percent charged');
-      publishedAriaPercent = ariaPercent;
+    if (boostVisualDirty || ariaLabel !== publishedAriaLabel) {
+      boostHud.setAttribute('aria-label', ariaLabel);
+      publishedAriaLabel = ariaLabel;
     }
     boostVisualDirty = false;
     lastBoostVisualAt = now;
   }
 
-  setDriveZone(null, { announce: false });
+  setDriveZone(null, false, { announce: false });
   globalThis.__turnUpdateGameplayControls = updateBoost;
 }

--- a/turn/vehicle/physics.js
+++ b/turn/vehicle/physics.js
@@ -86,6 +86,7 @@ export function updateVehiclePhysicsState({
   analogGas = 0,
   boostActive = false,
   driftHeld = false,
+  driftLock = 0,
   vehicleTuning = null
 }) {
   updateMotionInput(dt);
@@ -106,6 +107,13 @@ export function updateVehiclePhysicsState({
   const driftSlideMultiplier = driftHeld
     ? clamp(positiveNumber(tuning?.driftSlideMultiplier, 1), 0.75, 1.5)
     : 1;
+  const driftLockAmount = driftHeld
+    ? clamp(nonNegativeNumber(driftLock, 0), 0, 1)
+    : 0;
+  const lockYawMultiplier = lerp(1, 1.55, driftLockAmount);
+  const lockGripMultiplier = lerp(1, 0.22, driftLockAmount);
+  const lockSlideMultiplier = lerp(1, 1.25, driftLockAmount);
+  state.driftLockAmount = driftLockAmount;
   const tuningBoostPowerMultiplier = positiveNumber(tuning?.boostPowerMultiplier, 1);
   const tuningBoostSpeedMultiplier = positiveNumber(tuning?.boostSpeedMultiplier, 1.32);
   const effectiveMaxSpeed = maxSpeed;
@@ -175,7 +183,8 @@ export function updateVehiclePhysicsState({
     Math.abs(state.steering) * speedRatio * 0.9 +
       brakeDriftInput * Math.abs(state.steering) * 1.35 +
       Math.abs(lateralSpeed) / 22 +
-      (driftHeld ? 0.48 + Math.abs(state.steering) * 0.5 : 0),
+      (driftHeld ? 0.48 + Math.abs(state.steering) * 0.5 : 0) +
+      driftLockAmount * (0.25 + Math.abs(state.steering) * 0.35),
     0,
     1
   );
@@ -200,6 +209,7 @@ export function updateVehiclePhysicsState({
     steeringAuthority *
     steeringStatMultiplier *
     driftYawMultiplier *
+    lockYawMultiplier *
     (1 + state.driftAmount * 0.65 + (driftHeld ? 0.58 : 0));
 
   state.heading = normalizeAngle(state.heading + yawRate * dt);
@@ -211,7 +221,7 @@ export function updateVehiclePhysicsState({
     ? 1
     : 0.92 + controlMultiplier * 0.08;
   const driftGripMultiplier = driftHeld
-    ? 0.42 * driftStabilityMultiplier * driftGripTuningMultiplier
+    ? 0.42 * driftStabilityMultiplier * driftGripTuningMultiplier * lockGripMultiplier
     : 1;
   const grip = (
     physicsOffRoad
@@ -223,7 +233,8 @@ export function updateVehiclePhysicsState({
   state.velocity.addScaledVector(newRight, -lateralSpeed * lateralCorrection);
 
   if ((state.driftAmount > 0.18 || driftHeld) && speed > 14) {
-    const slideStrength = (driftHeld ? 0.235 : 0.12) * driftSlideMultiplier;
+    const slideStrength = (driftHeld ? 0.235 : 0.12) *
+      driftSlideMultiplier * lockSlideMultiplier;
     state.velocity.addScaledVector(
       newRight,
       state.steering * speed * Math.max(state.driftAmount, 0.48) * slideStrength * dt
@@ -232,7 +243,7 @@ export function updateVehiclePhysicsState({
 
   const drag = physicsOffRoad
     ? 0.34
-    : 0.11 + speed * 0.0009 + (driftHeld ? driftDragAdd : 0);
+    : 0.11 + speed * 0.0009 + (driftHeld ? driftDragAdd : 0) + driftLockAmount * 0.18;
   state.velocity.multiplyScalar(Math.exp(-drag * dt));
 
   speed = state.velocity.length();


### PR DESCRIPTION
## Summary
- make rear-wheel LOCK a standard part of DRIFT with no mode or setting
- reveal a separate periwinkle LOCK bubble just outside the pad when DRIFT is held
- treat entering/leaving the bubble as a binary target while smoothing throttle and lock physics over 140 ms in and 100 ms out
- retain the #657 arcade handling at full lock: stronger yaw and slide, reduced lateral grip, and modest drag
- keep the Boost HUD label and charge amount unchanged; only change its DRIFT fill from light blue to purple while LOCK is used
- add haptic state confirmation, VoiceOver gesture guidance, reduced-motion handling, lifecycle reset, and TURN NEXT parity

## Interaction
1. Press or slide into DRIFT; the LOCK bubble quickly reveals to the left.
2. Slide into the bubble to engage LOCK.
3. Slide back into DRIFT to release LOCK.
4. Leaving DRIFT removes the bubble and resets LOCK immediately.

## Validation
- `node turn-tests/drift-camera-production.mjs`
- `node turn-tests/session-orchestrator-production.mjs`
- `node turn-lab/tests/drive-pad-production.mjs`
- `node turn-lab/tests/vehicle-drift-production.mjs`
- `node --check` on all modified JavaScript modules/tests
- verified `turn/main.js` and `turn-next/main.js` are identical

Built from the clean rollback in #658.
