### PR TITLE
Connect DRIFT LOCK and rebalance Boost

### DIFF
--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -3,9 +3,11 @@ import fs from 'node:fs/promises';
 import {
   DRIFT_LOCK_ENGAGE_SECONDS,
   DRIFT_LOCK_RELEASE_SECONDS,
+  REGULAR_DRIFT_RECHARGE_BLEND,
   advanceDriftLockAmount,
   driftThrottleForLock,
-  pointerUsesDriftLock
+  pointerUsesDriftLock,
+  resolveDriftBoostRechargeMultiplier
 } from '../../turn/input/drift-lock.js';
 import { updateVehiclePhysicsState } from '../../turn/vehicle/physics.js';
 import { spokenRivalCount } from '../../turn/ui/race-announcements.js';
@@ -43,6 +45,11 @@ assert.equal(advanceDriftLockAmount(0.5, false, DRIFT_LOCK_RELEASE_SECONDS / 2),
 assert.equal(driftThrottleForLock(0), 1);
 assert.equal(driftThrottleForLock(0.5), 0.5);
 assert.equal(driftThrottleForLock(1), 0);
+assert.equal(REGULAR_DRIFT_RECHARGE_BLEND, 0.5);
+assert.equal(resolveDriftBoostRechargeMultiplier({ driftHeld: false, driftLockAmount: 1, lockedMultiplier: 2.4 }), 0);
+assert.ok(Math.abs(resolveDriftBoostRechargeMultiplier({ driftHeld: true, driftLockAmount: 0, lockedMultiplier: 2.4 }) - 1.7) < 1e-12);
+assert.ok(Math.abs(resolveDriftBoostRechargeMultiplier({ driftHeld: true, driftLockAmount: 0.5, lockedMultiplier: 2.4 }) - 2.05) < 1e-12);
+assert.ok(Math.abs(resolveDriftBoostRechargeMultiplier({ driftHeld: true, driftLockAmount: 1, lockedMultiplier: 2.4 }) - 2.4) < 1e-12);
 
 class Vec3 {
   constructor(x = 0, y = 0, z = 0) { this.x = x; this.y = y; this.z = z; }
@@ -55,6 +62,7 @@ class Vec3 {
 
 const [
   index,
+  nextIndex,
   releaseSource,
   app,
   controls,
@@ -68,6 +76,7 @@ const [
   mainSource
 ] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn-next/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/release.json', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/ui/gameplay-controls.js', import.meta.url), 'utf8'),
@@ -85,12 +94,20 @@ const release = JSON.parse(releaseSource);
 assert.match(index, new RegExp(`TURN v${release.version.replaceAll('.', '\\.')} · Build ${release.id.replaceAll('.', '\\.')}`));
 assert.match(index, new RegExp(`drive-pad\\.css\\?build=${release.cacheKey}`));
 assert.match(index, new RegExp(`gameplay-v2\\.css\\?build=${release.cacheKey}`));
+assert.match(index, /gameplay-v2\.css\?build=20260823-r183&revision=r217-drift-lock-design/,
+  'The Boost gradient fix must bypass stale production CSS caches');
+assert.match(index, /drive-pad\.css\?build=20260823-r183&revision=r217-drift-lock-design/,
+  'The connected LOCK geometry must bypass stale production CSS caches');
+assert.match(nextIndex, /gameplay-v2\.css\?build=20260823-r183&revision=r217-drift-lock-design/);
+assert.match(nextIndex, /drive-pad\.css\?build=20260823-r183&revision=r217-drift-lock-design/);
 assert.match(index, new RegExp(`position-hud-r83\\.css\\?build=${release.cacheKey}`));
 assert.ok(
   index.indexOf('gameplay-v2.css') < index.indexOf('position-hud-r83.css'),
   'The topbar position override must load after the legacy gameplay HUD rules'
 );
 assert.match(app, /race-position-layout\.js/, 'The production module graph must install the position layout after gameplay controls');
+assert.match(app, /gameplay-controls\.js\?revision=r217-drift-lock-balance/,
+  'The new recharge balance must bypass stale production module caches');
 assert.match(app, /installRaceSpeech\(\)/, 'The production graph must install concise race speech before the runtime starts');
 assert.ok(
   app.indexOf('./ui/gameplay-controls.js') < app.indexOf('./ui/race-speech.js')
@@ -142,6 +159,10 @@ assert.match(controls, /globalThis\.__turnDriftLockAmount = lockCanRun \? driftL
   'The smoothed LOCK amount must be published for vehicle physics');
 assert.match(controls, /driftThrottleForLock\(driftLockAmount\)/,
   'Gas must fade out over the same short LOCK transition');
+assert.match(controls, /resolveDriftBoostRechargeMultiplier\(\{/,
+  'Boost recharge must be owned by the standard-versus-LOCK DRIFT balance rule');
+assert.doesNotMatch(controls, /__turnDriftHeld \? getDriftRechargeMultiplier\(\) : 1/,
+  'Boost must no longer refill passively outside DRIFT');
 assert.doesNotMatch(controls, /Advanced DRIFT|turn:advanced-drift-change/,
   'Binary LOCK must be standard behavior without an experimental setting');
 assert.match(controls, /boostRequested = nextZone === 'boost'/, 'Boost zone must add boost to gas');
@@ -153,6 +174,7 @@ assert.match(controls, /boostRequested && !boostExhausted/, 'Boost must stay loc
 assert.match(controls, /previousZone === 'boost' && nextZone !== 'boost'\) boostExhausted = false/, 'Leaving Boost for any other drive zone must re-arm Boost without requiring pointer release');
 assert.match(controls, /Brake · Reverse/, 'The integrated brake control must advertise reverse');
 assert.match(controls, /function refillBoost\(\)/, 'Gameplay controls must expose one reset-safe boost refill path');
+assert.match(controls, /let boostCharge = 1;/, 'Boost must still begin full even though passive recharge is removed');
 assert.match(controls, /boostCharge = 1;\s*previousBoostCharge = 1;\s*boostExhausted = false;/s, 'Restarting must fully refill and unlock boost without creating a recharge transition');
 assert.match(controls, /event\.detail\?\.reason === 'race-reset'\) refillBoost\(\)/, 'The race reset event must refill boost');
 assert.match(controls, /globalThis\.__turnRefillBoost = refillBoost/, 'Boost refill must remain reusable by the runtime');
@@ -169,15 +191,19 @@ assert.match(css, /\.drive-lock-bubble \{[\s\S]*right: calc\(100% - 4px\);[\s\S]
   'LOCK must be a separate bubble attached outside the left edge of the pad');
 assert.match(css, /\.drive-stack\.is-drift-ready \.drive-lock-bubble \{[\s\S]*opacity: 1;[\s\S]*scaleX\(1\)/,
   'The LOCK bubble must animate quickly into view while DRIFT is held');
+assert.match(css, /--drift-lock-row-offset: 8px;[\s\S]*height: calc\(32% \+ var\(--drift-lock-row-offset\)\)/,
+  'The bubble bottom must align with the lower edge of the DRIFT row divider');
+assert.match(css, /\.drive-stack\.is-drift-ready \.drive-pad \{[\s\S]*border-top-left-radius: 0;/,
+  'The pad must drop its upper-left radius while LOCK is attached');
 assert.match(css, /\.drive-stack\.is-drift-locking \.drive-lock-bubble \{[\s\S]*#8b5cf6/,
   'The bubble must visibly confirm the binary LOCK state in purple');
 assert.match(css, /prefers-reduced-motion: reduce[\s\S]*\.drive-lock-bubble/,
   'The bubble reveal must respect reduced-motion preferences');
 assert.match(gameplayCss, /\.boost-hud i \{[\s\S]*box-shadow: 3px 0 0 var\(--ink\);/, 'Boost charge must have a high-contrast ink edge at the live fill level');
-assert.match(gameplayCss, /\.boost-hud\.is-drift-charging i \{[\s\S]*background-color: #38d9ff/,
-  'Ordinary DRIFT recharge must show the Boost charge in light blue');
-assert.match(gameplayCss, /\.boost-hud\.is-drift-locking i \{[\s\S]*background-color: #8b5cf6/,
-  'Using LOCK must simply turn the existing Boost charge fill purple');
+assert.match(gameplayCss, /\.boost-hud\.is-drift-charging i \{[\s\S]*linear-gradient\(90deg, #38d9ff, #8ce99a\)/,
+  'Ordinary DRIFT recharge must show the Boost gradient from blue to green');
+assert.match(gameplayCss, /\.boost-hud\.is-drift-locking i \{[\s\S]*linear-gradient\(90deg, #8b5cf6, #8ce99a\)/,
+  'LOCK must change the existing Boost gradient from purple to green');
 assert.match(controls, /boostHud\.innerHTML = '<span>BOOST<\/span>/,
   'The Boost HUD label must stay BOOST instead of becoming a second LOCK meter');
 assert.match(mainSource, /driftLock: globalThis\.__turnDriftLockAmount \|\| 0/,
@@ -247,4 +273,4 @@ assert.ok(
   'Full LOCK must release gas and add modest handbrake drag'
 );
 
-console.log(`TURN ${release.id} binary DRIFT LOCK bubble, smooth lock physics, Boost color, restart refill and reverse passed.`);
+console.log(`TURN ${release.id} connected DRIFT LOCK bubble, DRIFT-only Boost recharge, gradients, restart refill and reverse passed.`);

--- a/turn-lab/tests/vehicle-drift-production.mjs
+++ b/turn-lab/tests/vehicle-drift-production.mjs
@@ -218,8 +218,8 @@ assert.match(controlsSource, /function getDriftRechargeMultiplier\(\)/);
 assert.match(controlsSource, /driftBoostRechargeMultiplier/);
 assert.match(
   controlsSource,
-  /globalThis\.__turnDriftHeld \? getDriftRechargeMultiplier\(\) : 1/,
-  'Boost recharge must read the selected car tuning only while DRIFT is held'
+  /resolveDriftBoostRechargeMultiplier\(\{[\s\S]*lockedMultiplier: getDriftRechargeMultiplier\(\)/,
+  'The selected car tuning must remain the LOCK recharge ceiling while regular DRIFT uses the midpoint'
 );
 
 const suv = CAR_CATALOG.find((car) => car.id === 'suv');

--- a/turn-next/index.html
+++ b/turn-next/index.html
@@ -152,4 +152,3 @@
   <script type="module" src="/turn-next/app.js?source=20260823-r183-browser-consent-r166-bella-records"></script>
   <script type="module" src="./ui/about-history-bootstrap.js?revision=r164-design-navigation"></script>
 </body></html>
-

--- a/turn-next/index.html
+++ b/turn-next/index.html
@@ -46,9 +46,9 @@
   <link rel="stylesheet" href="./hud-tuning.css?build=20260823-r183">
   <link rel="stylesheet" href="./install-gate.css?build=20260823-r183-social-browser">
   <link rel="stylesheet" href="./gameplay-features.css?build=20260823-r183">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260823-r183">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260823-r183&revision=r217-drift-lock-design">
   <link rel="stylesheet" href="./position-hud-r83.css?build=20260823-r183">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260823-r183">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260823-r183&revision=r217-drift-lock-design">
   <link rel="stylesheet" href="./in-game-menu.css?build=20260823-r183">
   <link rel="stylesheet" href="./spectate-v3.css?build=20260823-r183">
   <link rel="stylesheet" href="./manual-steering.css?build=20260823-r183">
@@ -152,3 +152,4 @@
   <script type="module" src="/turn-next/app.js?source=20260823-r183-browser-consent-r166-bella-records"></script>
   <script type="module" src="./ui/about-history-bootstrap.js?revision=r164-design-navigation"></script>
 </body></html>
+

--- a/turn/app.js
+++ b/turn/app.js
@@ -307,7 +307,7 @@ const { installLotEnhancementRuntime } = await import(
 installLotEnhancementRuntime();
 
 await import(withBuild('./input/analog-gas.js'));
-await import(withBuild('./ui/gameplay-controls.js'));
+await import(withBuild('./ui/gameplay-controls.js?revision=r217-drift-lock-balance'));
 const { installRaceSpeech } = await import(withBuild('./ui/race-speech.js'));
 installRaceSpeech();
 const { installRacePositionLayout } = await import(withBuild('./ui/race-position-layout.js'));

--- a/turn/drive-pad.css
+++ b/turn/drive-pad.css
@@ -45,6 +45,7 @@ body .m8-feedback-content * {
 .drive-stack {
   --drive-pad-height: clamp(190px, 26vw, 268px);
   --drift-lock-bubble-width: clamp(52px, 7.2vw, 74px);
+  --drift-lock-row-offset: 8px;
   position: relative;
   isolation: isolate;
   width: clamp(190px, 24vw, 260px);
@@ -76,7 +77,7 @@ body .m8-feedback-content * {
   top: 0;
   right: calc(100% - 4px);
   width: var(--drift-lock-bubble-width);
-  height: 32%;
+  height: calc(32% + var(--drift-lock-row-offset));
   box-sizing: border-box;
   display: grid;
   place-items: center;
@@ -107,6 +108,10 @@ body .m8-feedback-content * {
 .drive-stack.is-drift-ready .drive-lock-bubble {
   opacity: 1;
   transform: translateX(0) scaleX(1);
+}
+
+.drive-stack.is-drift-ready .drive-pad {
+  border-top-left-radius: 0;
 }
 
 .drive-stack.is-drift-locking .drive-lock-bubble {
@@ -249,6 +254,7 @@ body .m8-feedback-content * {
   .drive-stack {
     --drive-pad-height: clamp(174px, 23.5vw, 205px);
     --drift-lock-bubble-width: clamp(48px, 6.8vw, 64px);
+    --drift-lock-row-offset: 6px;
     width: clamp(174px, 23vw, 224px);
   }
 

--- a/turn/gameplay-v2.css
+++ b/turn/gameplay-v2.css
@@ -73,9 +73,7 @@
   width: var(--boost-charge);
   background: linear-gradient(90deg, #ff922b, #ff5a5f);
   box-shadow: 3px 0 0 var(--ink);
-  transition:
-    width 70ms linear,
-    background-color 120ms ease;
+  transition: width 70ms linear;
 }
 
 .boost-hud.is-boosting {
@@ -89,12 +87,11 @@
 }
 
 .boost-hud.is-drift-charging i {
-  background-color: #38d9ff;
-  background-image: none;
+  background: linear-gradient(90deg, #38d9ff, #8ce99a);
 }
 
 .boost-hud.is-drift-locking i {
-  background-color: #8b5cf6;
+  background: linear-gradient(90deg, #8b5cf6, #8ce99a);
 }
 
 .boost-hud.is-boost-full-flash {

--- a/turn/index.html
+++ b/turn/index.html
@@ -44,9 +44,9 @@
   <link rel="stylesheet" href="./install-gate.css?build=20260823-r183-social-browser">
   <link rel="stylesheet" href="./browser-install-r165.css?revision=r165-browser-about">
   <link rel="stylesheet" href="./gameplay-features.css?build=20260823-r183">
-  <link rel="stylesheet" href="./gameplay-v2.css?build=20260823-r183">
+  <link rel="stylesheet" href="./gameplay-v2.css?build=20260823-r183&revision=r217-drift-lock-design">
   <link rel="stylesheet" href="./position-hud-r83.css?build=20260823-r183">
-  <link rel="stylesheet" href="./drive-pad.css?build=20260823-r183">
+  <link rel="stylesheet" href="./drive-pad.css?build=20260823-r183&revision=r217-drift-lock-design">
   <link rel="stylesheet" href="./in-game-menu.css?build=20260823-r183">
   <link rel="stylesheet" href="./spectate-v3.css?build=20260823-r183">
   <link rel="stylesheet" href="./manual-steering.css?build=20260823-r183">

--- a/turn/input/drift-lock.js
+++ b/turn/input/drift-lock.js
@@ -4,6 +4,7 @@ export const DRIFT_LOCK_TOP_ZONE_SHARE = 0.32;
 export const DRIFT_LOCK_OUTER_SLOP_PX = 18;
 export const DRIFT_LOCK_VERTICAL_SLOP_PX = 12;
 export const DRIFT_LOCK_SEAM_OVERLAP_PX = 4;
+export const REGULAR_DRIFT_RECHARGE_BLEND = 0.5;
 
 export function pointerUsesDriftLock({
   driftActive = false,
@@ -46,6 +47,19 @@ export function advanceDriftLockAmount(currentAmount, lockRequested, dt) {
 
 export function driftThrottleForLock(lockAmount) {
   return 1 - clamp(finiteNumber(lockAmount), 0, 1);
+}
+
+export function resolveDriftBoostRechargeMultiplier({
+  driftHeld = false,
+  driftLockAmount = 0,
+  lockedMultiplier = 1
+} = {}) {
+  if (!driftHeld) return 0;
+
+  const locked = Math.max(1, finiteNumber(lockedMultiplier));
+  const regular = 1 + (locked - 1) * REGULAR_DRIFT_RECHARGE_BLEND;
+  const lockMix = clamp(finiteNumber(driftLockAmount), 0, 1);
+  return regular + (locked - regular) * lockMix;
 }
 
 function finiteNumber(value) {

--- a/turn/ui/gameplay-controls.js
+++ b/turn/ui/gameplay-controls.js
@@ -1,8 +1,9 @@
 import {
   advanceDriftLockAmount,
   driftThrottleForLock,
-  pointerUsesDriftLock
-} from '../input/drift-lock.js?revision=r216-binary-lock';
+  pointerUsesDriftLock,
+  resolveDriftBoostRechargeMultiplier
+} from '../input/drift-lock.js?revision=r217-drift-lock-balance';
 
 globalThis.__turnBoostActive = false;
 globalThis.__turnBoostCharge = 1;
@@ -479,7 +480,11 @@ function installGameplayUi() {
         safeVibrate([28, 36, 62]);
       }
     } else {
-      const rechargeMultiplier = globalThis.__turnDriftHeld ? getDriftRechargeMultiplier() : 1;
+      const rechargeMultiplier = resolveDriftBoostRechargeMultiplier({
+        driftHeld: globalThis.__turnDriftHeld === true,
+        driftLockAmount,
+        lockedMultiplier: getDriftRechargeMultiplier()
+      });
       boostCharge = Math.min(1, boostCharge + dt * rechargeMultiplier / BOOST_RECHARGE_SECONDS);
     }
 


### PR DESCRIPTION
## Summary
- connect the LOCK bubble flush to the DRIFT button, align it with the full top row, and remove DRIFT's top-left rounding while LOCK is visible
- restore the Boost gradients with cyan → green for regular drift and purple → green while LOCK is active
- keep Boost full at race start, remove passive recharge, recharge regular drift at the midpoint between the former passive and drift rates, and keep LOCK at the former drift rate
- preserve each vehicle's existing drift-recharge tuning as the LOCK ceiling and cache-bust the updated controls/CSS in production and TURN NEXT

## Balance
- default regular DRIFT recharge: 1.7×
- default locked DRIFT recharge: 2.4× (unchanged old drift rate)
- no recharge without DRIFT
- existing records are intentionally left as-is

## Validation
- `node --check` on modified JavaScript/test files
- `node turn-tests/drift-camera-production.mjs`
- `node turn-tests/session-orchestrator-production.mjs`
- `node turn-lab/tests/drive-pad-production.mjs`
- `node turn-lab/tests/vehicle-drift-production.mjs`
- verified `turn/main.js` and `turn-next/main.js` remain identical