### PR TITLE
Tune camera, Boost balance and steering tyres

### DIFF
--- a/turn-lab/tests/drive-pad-production.mjs
+++ b/turn-lab/tests/drive-pad-production.mjs
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises';
 import {
   DRIFT_LOCK_ENGAGE_SECONDS,
   DRIFT_LOCK_RELEASE_SECONDS,
+  DRIFT_LOCK_RECHARGE_MULTIPLIER,
   REGULAR_DRIFT_RECHARGE_BLEND,
   advanceDriftLockAmount,
   driftThrottleForLock,
@@ -46,10 +47,43 @@ assert.equal(driftThrottleForLock(0), 1);
 assert.equal(driftThrottleForLock(0.5), 0.5);
 assert.equal(driftThrottleForLock(1), 0);
 assert.equal(REGULAR_DRIFT_RECHARGE_BLEND, 0.5);
+assert.equal(DRIFT_LOCK_RECHARGE_MULTIPLIER, 3.6);
 assert.equal(resolveDriftBoostRechargeMultiplier({ driftHeld: false, driftLockAmount: 1, lockedMultiplier: 2.4 }), 0);
+// Legacy helper calls remain deterministic for older callers.
 assert.ok(Math.abs(resolveDriftBoostRechargeMultiplier({ driftHeld: true, driftLockAmount: 0, lockedMultiplier: 2.4 }) - 1.7) < 1e-12);
 assert.ok(Math.abs(resolveDriftBoostRechargeMultiplier({ driftHeld: true, driftLockAmount: 0.5, lockedMultiplier: 2.4 }) - 2.05) < 1e-12);
 assert.ok(Math.abs(resolveDriftBoostRechargeMultiplier({ driftHeld: true, driftLockAmount: 1, lockedMultiplier: 2.4 }) - 2.4) < 1e-12);
+// Production balance restores the old ordinary DRIFT rate and makes LOCK use the former Rally perk rate.
+assert.ok(Math.abs(resolveDriftBoostRechargeMultiplier({
+  driftHeld: true,
+  driftLockAmount: 0,
+  lockedMultiplier: 2.4,
+  lockCeilingMultiplier: 3.6
+}) - 2.4) < 1e-12);
+assert.ok(Math.abs(resolveDriftBoostRechargeMultiplier({
+  driftHeld: true,
+  driftLockAmount: 0.5,
+  lockedMultiplier: 2.4,
+  lockCeilingMultiplier: 3.6
+}) - 3.0) < 1e-12);
+assert.ok(Math.abs(resolveDriftBoostRechargeMultiplier({
+  driftHeld: true,
+  driftLockAmount: 1,
+  lockedMultiplier: 2.4,
+  lockCeilingMultiplier: 3.6
+}) - 3.6) < 1e-12);
+assert.ok(Math.abs(resolveDriftBoostRechargeMultiplier({
+  driftHeld: true,
+  driftLockAmount: 0,
+  lockedMultiplier: 3.6,
+  lockCeilingMultiplier: 3.6
+}) - 3.6) < 1e-12);
+assert.ok(Math.abs(resolveDriftBoostRechargeMultiplier({
+  driftHeld: true,
+  driftLockAmount: 1,
+  lockedMultiplier: 3.6,
+  lockCeilingMultiplier: 3.6
+}) - 3.6) < 1e-12);
 
 class Vec3 {
   constructor(x = 0, y = 0, z = 0) { this.x = x; this.y = y; this.z = z; }
@@ -70,6 +104,7 @@ const [
   raceSpeech,
   css,
   gameplayCss,
+  semanticCss,
   positionCss,
   analogGas,
   spectate,
@@ -84,6 +119,7 @@ const [
   fs.readFile(new URL('../../turn/ui/race-speech.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/drive-pad.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/gameplay-v2.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/design-semantic.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/position-hud-r83.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/input/analog-gas.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/ui/spectate.js', import.meta.url), 'utf8'),
@@ -106,8 +142,8 @@ assert.ok(
   'The topbar position override must load after the legacy gameplay HUD rules'
 );
 assert.match(app, /race-position-layout\.js/, 'The production module graph must install the position layout after gameplay controls');
-assert.match(app, /gameplay-controls\.js\?revision=r217-drift-lock-balance/,
-  'The new recharge balance must bypass stale production module caches');
+assert.match(app, /gameplay-controls\.js\?revision=r218-boost-balance-lock-color/,
+  'The current Boost balance and LOCK-color controls must bypass stale production module caches');
 assert.match(app, /installRaceSpeech\(\)/, 'The production graph must install concise race speech before the runtime starts');
 assert.ok(
   app.indexOf('./ui/gameplay-controls.js') < app.indexOf('./ui/race-speech.js')
@@ -161,6 +197,12 @@ assert.match(controls, /driftThrottleForLock\(driftLockAmount\)/,
   'Gas must fade out over the same short LOCK transition');
 assert.match(controls, /resolveDriftBoostRechargeMultiplier\(\{/,
   'Boost recharge must be owned by the standard-versus-LOCK DRIFT balance rule');
+assert.match(controls, /BOOST_TANK_DURATION_MULTIPLIER = 1\.5/,
+  'Every Boost tank must last 50 percent longer after passive recharge removal');
+assert.match(controls, /DRIFT_RECHARGE_MULTIPLIER = 2\.4/,
+  'Ordinary DRIFT must restore the former default recharge rate');
+assert.match(controls, /lockCeilingMultiplier: DRIFT_LOCK_RECHARGE_MULTIPLIER/,
+  'LOCK recharge must use the shared 3.6x ceiling');
 assert.doesNotMatch(controls, /__turnDriftHeld \? getDriftRechargeMultiplier\(\) : 1/,
   'Boost must no longer refill passively outside DRIFT');
 assert.doesNotMatch(controls, /Advanced DRIFT|turn:advanced-drift-change/,
@@ -204,6 +246,10 @@ assert.match(gameplayCss, /\.boost-hud\.is-drift-charging i \{[\s\S]*linear-grad
   'Ordinary DRIFT recharge must show the Boost gradient from blue to green');
 assert.match(gameplayCss, /\.boost-hud\.is-drift-locking i \{[\s\S]*linear-gradient\(90deg, #8b5cf6, #8ce99a\)/,
   'LOCK must change the existing Boost gradient from purple to green');
+assert.match(semanticCss, /\.boost-hud\.is-drift-locking i \{[\s\S]*#8b5cf6[\s\S]*!important/,
+  'The semantic !important layer must define LOCK after ordinary DRIFT so it cannot mask the purple state');
+assert.match(controls, /setProperty\('background', DRIFT_LOCK_BOOST_GRADIENT, 'important'\)/,
+  'Runtime LOCK feedback must also survive stale semantic CSS precedence');
 assert.match(controls, /boostHud\.innerHTML = '<span>BOOST<\/span>/,
   'The Boost HUD label must stay BOOST instead of becoming a second LOCK meter');
 assert.match(mainSource, /driftLock: globalThis\.__turnDriftLockAmount \|\| 0/,
@@ -273,4 +319,4 @@ assert.ok(
   'Full LOCK must release gas and add modest handbrake drag'
 );
 
-console.log(`TURN ${release.id} connected DRIFT LOCK bubble, DRIFT-only Boost recharge, gradients, restart refill and reverse passed.`);
+console.log(`TURN ${release.id} connected DRIFT LOCK, 50% larger Boost tanks, 2.4x→3.6x recharge balance, reliable LOCK gradient, restart refill and reverse passed.`);

--- a/turn-tests/drift-camera-production.mjs
+++ b/turn-tests/drift-camera-production.mjs
@@ -4,6 +4,7 @@ import {
   resolveCameraMotionLeadTime,
   resolveDriftCameraBlend,
   resolveDriftCameraYawOffset,
+  resolveRaceCameraFov,
   updateRaceCameraState
 } from '../turn/render/camera.js';
 import {
@@ -72,6 +73,10 @@ approximately(
   resolveCameraMotionLeadTime(6.2, 1 / 60),
   (1 / 60) / Math.expm1(6.2 / 60)
 );
+approximately(resolveRaceCameraFov({ speedRatio: 1, speedResponsiveCamera: false, reducedMotion: false }), 78);
+approximately(resolveRaceCameraFov({ speedRatio: 1, speedResponsiveCamera: true, reducedMotion: false }), 88);
+approximately(resolveRaceCameraFov({ speedRatio: 1, speedResponsiveCamera: false, reducedMotion: true }), 68);
+approximately(resolveRaceCameraFov({ speedRatio: 1, speedResponsiveCamera: true, reducedMotion: true }), 68);
 
 const forward = { x: 0, z: 1 };
 const right = { x: 1, z: 0 };
@@ -217,7 +222,7 @@ assert.ok(
 );
 approximately(legacyStopped.camera.fov, 68);
 approximately(responsiveStopped.camera.fov, 68);
-approximately(legacyFast.camera.fov, 88);
+approximately(legacyFast.camera.fov, 78);
 approximately(responsiveFast.camera.fov, 88);
 approximately(legacyFast.cameraTarget.z, responsiveFast.cameraTarget.z);
 
@@ -277,7 +282,7 @@ assert.ok(
   movingLegacy.targetDistance < 20,
   'The regression harness must reproduce the established high-speed look-target lag'
 );
-approximately(movingLegacy.fov, 88, 1e-6);
+approximately(movingLegacy.fov, 78, 1e-6);
 approximately(movingResponsive.followDistance, 14, 1e-6);
 approximately(movingResponsive.targetDistance, 27, 1e-6);
 approximately(movingResponsive.fov, 88, 1e-6);
@@ -305,6 +310,14 @@ assert.match(cameraSource, /DRIFT_CAMERA_BLEND_START_SPEED = 8 \/ 3\.6/);
 assert.match(cameraSource, /DRIFT_CAMERA_FULL_BLEND_SPEED = 28 \/ 3\.6/);
 assert.match(cameraSource, /\?revision=r214-shared-speed-fov/,
   'The combined Camera settings module must be cache-busted');
+assert.match(cameraSource, /CLASSIC_MAX_CAMERA_FOV = 78/,
+  'Zoom OFF must top out at the calmer 78-degree FOV');
+assert.match(cameraSource, /ZOOM_MAX_CAMERA_FOV = 88/,
+  'Zoom ON must retain the stronger 88-degree FOV');
+assert.match(cameraSource, /prefers-reduced-motion: reduce/,
+  'Speed-based FOV changes must respect the platform reduced-motion preference');
+assert.match(cameraSource, /if \(reducedMotion\) return BASE_CAMERA_FOV/,
+  'Reduced motion must pin FOV to the 68-degree baseline');
 assert.match(cameraSource, /\? 16 - speedRatio \* 2/,
   'The responsive camera must move from distance 16 toward 14 as speed builds');
 assert.match(cameraSource, /\? 8\.7 - speedRatio/,
@@ -315,10 +328,8 @@ assert.match(cameraSource, /resolveCameraMotionLeadTime\(CAMERA_POSITION_RESPONS
   'The responsive camera must cancel speed-dependent world-space follow lag');
 assert.match(cameraSource, /resolveCameraMotionLeadTime\(CAMERA_TARGET_RESPONSE_RATE, dt\)/,
   'The responsive look target must cancel speed-dependent world-space follow lag');
-assert.match(cameraSource, /camera\.fov = lerp\(camera\.fov, 68 \+ speedRatio \* 20/,
-  'Both distance profiles must share the same 68-to-88-degree speed FOV');
-assert.doesNotMatch(cameraSource, /fovSpeedGain/,
-  'The FOV curve must not depend on the Zoom preference');
+assert.match(cameraSource, /const targetFov = resolveRaceCameraFov\(\{ speedRatio, speedResponsiveCamera \}\)/,
+  'Race camera updates must use the reduced-motion-aware FOV resolver');
 assert.match(gameplayCss, /--boost-hud-downshift: 20px/,
   'Boost bar must move down by approximately its own racing height');
 assert.match(
@@ -332,4 +343,4 @@ assert.match(
   'Short landscape HUD must preserve the same Boost bar downshift'
 );
 
-console.log('TURN shared speed FOV, tuned classic pull-back, Zoom preference and Boost HUD shift passed.');
+console.log('TURN classic 78-degree FOV, Zoom 88-degree FOV, reduced-motion guard and tuned pull-back passed.');

--- a/turn/app.js
+++ b/turn/app.js
@@ -307,7 +307,7 @@ const { installLotEnhancementRuntime } = await import(
 installLotEnhancementRuntime();
 
 await import(withBuild('./input/analog-gas.js'));
-await import(withBuild('./ui/gameplay-controls.js?revision=r217-drift-lock-balance'));
+await import(withBuild('./ui/gameplay-controls.js?revision=r218-boost-balance-lock-color'));
 const { installRaceSpeech } = await import(withBuild('./ui/race-speech.js'));
 installRaceSpeech();
 const { installRacePositionLayout } = await import(withBuild('./ui/race-position-layout.js'));

--- a/turn/design-semantic.css
+++ b/turn/design-semantic.css
@@ -142,3 +142,7 @@
 .boost-hud.is-drift-charging i {
   background: linear-gradient(90deg, var(--turn-control-drift), var(--turn-control-gas)) !important;
 }
+
+.boost-hud.is-drift-locking i {
+  background: linear-gradient(90deg, #8b5cf6, var(--turn-control-gas)) !important;
+}

--- a/turn/input/drift-lock.js
+++ b/turn/input/drift-lock.js
@@ -5,6 +5,7 @@ export const DRIFT_LOCK_OUTER_SLOP_PX = 18;
 export const DRIFT_LOCK_VERTICAL_SLOP_PX = 12;
 export const DRIFT_LOCK_SEAM_OVERLAP_PX = 4;
 export const REGULAR_DRIFT_RECHARGE_BLEND = 0.5;
+export const DRIFT_LOCK_RECHARGE_MULTIPLIER = 3.6;
 
 export function pointerUsesDriftLock({
   driftActive = false,
@@ -52,14 +53,26 @@ export function driftThrottleForLock(lockAmount) {
 export function resolveDriftBoostRechargeMultiplier({
   driftHeld = false,
   driftLockAmount = 0,
-  lockedMultiplier = 1
+  lockedMultiplier = 1,
+  lockCeilingMultiplier = null
 } = {}) {
   if (!driftHeld) return 0;
 
-  const locked = Math.max(1, finiteNumber(lockedMultiplier));
-  const regular = 1 + (locked - 1) * REGULAR_DRIFT_RECHARGE_BLEND;
+  const tunedMultiplier = Math.max(1, finiteNumber(lockedMultiplier));
   const lockMix = clamp(finiteNumber(driftLockAmount), 0, 1);
-  return regular + (locked - regular) * lockMix;
+
+  // Current production balance: the selected car's historical DRIFT recharge
+  // rate is the regular-DRIFT rate, while LOCK ramps to the shared 3.6x ceiling.
+  // Rally Racer already owns a 3.6x tuning value, so its regular DRIFT and LOCK
+  // naturally recharge at the same rate. Keep the legacy midpoint behavior when
+  // no explicit ceiling is supplied so older callers/tests remain deterministic.
+  if (lockCeilingMultiplier != null) {
+    const locked = Math.max(tunedMultiplier, finiteNumber(lockCeilingMultiplier));
+    return tunedMultiplier + (locked - tunedMultiplier) * lockMix;
+  }
+
+  const regular = 1 + (tunedMultiplier - 1) * REGULAR_DRIFT_RECHARGE_BLEND;
+  return regular + (tunedMultiplier - regular) * lockMix;
 }
 
 function finiteNumber(value) {

--- a/turn/render/camera.js
+++ b/turn/render/camera.js
@@ -12,6 +12,10 @@ const DRIFT_CAMERA_TRAVEL_WEIGHT = 0.85;
 const DRIFT_CAMERA_RESPONSE_RATE = 7.5;
 const CAMERA_POSITION_RESPONSE_RATE = 6.2;
 const CAMERA_TARGET_RESPONSE_RATE = 8.5;
+const BASE_CAMERA_FOV = 68;
+const CLASSIC_MAX_CAMERA_FOV = 78;
+const ZOOM_MAX_CAMERA_FOV = 88;
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
 
 installDriftCameraSetting();
 
@@ -131,6 +135,17 @@ export function resolveCameraMotionLeadTime(responseRate, dt) {
   return denominator > 0 ? elapsed / denominator : 1 / rate;
 }
 
+export function resolveRaceCameraFov({
+  speedRatio = 0,
+  speedResponsiveCamera = globalThis.__turnSpeedResponsiveCameraEnabled === true,
+  reducedMotion = globalThis.matchMedia?.(REDUCED_MOTION_QUERY)?.matches === true
+} = {}) {
+  if (reducedMotion) return BASE_CAMERA_FOV;
+  const ratio = clamp(Number(speedRatio) || 0, 0, 1);
+  const maxFov = speedResponsiveCamera ? ZOOM_MAX_CAMERA_FOV : CLASSIC_MAX_CAMERA_FOV;
+  return BASE_CAMERA_FOV + ratio * (maxFov - BASE_CAMERA_FOV);
+}
+
 export function updateRaceCameraState({
   state,
   camera,
@@ -181,8 +196,8 @@ export function updateRaceCameraState({
     : roadY;
 
   // Zoom reverses the established physical pull-back: it moves slightly closer
-  // and lower as speed builds. Both profiles share the same widening FOV, while
-  // OFF preserves the classic distance and height curves.
+  // and lower as speed builds. Classic keeps its pull-back but now widens more
+  // modestly (68–78°), while Zoom keeps the stronger 68–88° speed cue.
   const followDistance = speedResponsiveCamera
     ? 16 - speedRatio * 2
     : 14 + speedRatio * 4;
@@ -255,7 +270,8 @@ export function updateRaceCameraState({
     state.horizonCameraRoll = 0;
   }
 
-  camera.fov = lerp(camera.fov, 68 + speedRatio * 20, Math.min(1, dt * 4.5));
+  const targetFov = resolveRaceCameraFov({ speedRatio, speedResponsiveCamera });
+  camera.fov = lerp(camera.fov, targetFov, Math.min(1, dt * 4.5));
   camera.updateProjectionMatrix();
 }
 

--- a/turn/ui/gameplay-controls.js
+++ b/turn/ui/gameplay-controls.js
@@ -1,9 +1,10 @@
 import {
+  DRIFT_LOCK_RECHARGE_MULTIPLIER,
   advanceDriftLockAmount,
   driftThrottleForLock,
   pointerUsesDriftLock,
   resolveDriftBoostRechargeMultiplier
-} from '../input/drift-lock.js?revision=r217-drift-lock-balance';
+} from '../input/drift-lock.js?revision=r218-boost-balance';
 
 globalThis.__turnBoostActive = false;
 globalThis.__turnBoostCharge = 1;
@@ -96,6 +97,7 @@ function installGameplayUi() {
   boostHud.className = 'boost-hud';
   boostHud.innerHTML = '<span>BOOST</span><div><i></i></div>';
   hud.appendChild(boostHud);
+  const boostFill = boostHud.querySelector('i');
 
   const driveStack = document.createElement('div');
   driveStack.className = 'drive-stack';
@@ -155,8 +157,10 @@ function installGameplayUi() {
   const TOP_ZONE_SHARE = 0.32;
   const BRAKE_ZONE_START = 0.76;
   const DEFAULT_BOOST_DRAIN_SECONDS = 2.0;
+  const BOOST_TANK_DURATION_MULTIPLIER = 1.5;
   const BOOST_RECHARGE_SECONDS = 4.2;
   const DRIFT_RECHARGE_MULTIPLIER = 2.4;
+  const DRIFT_LOCK_BOOST_GRADIENT = 'linear-gradient(90deg, #8b5cf6, #8ce99a)';
   const BOOST_VISUAL_INTERVAL_MS = 1000 / 30;
   let lastBoostVisualAt = -Infinity;
   let boostVisualDirty = true;
@@ -186,8 +190,10 @@ function installGameplayUi() {
 
   function getBoostDrainSeconds() {
     const duration = Number(globalThis.__turnVehicleTuning?.boostDurationSeconds);
-    if (!Number.isFinite(duration)) return DEFAULT_BOOST_DRAIN_SECONDS;
-    return Math.max(0.8, Math.min(5, duration));
+    const baseDuration = Number.isFinite(duration)
+      ? Math.max(0.8, Math.min(5, duration))
+      : DEFAULT_BOOST_DRAIN_SECONDS;
+    return baseDuration * BOOST_TANK_DURATION_MULTIPLIER;
   }
 
   function getDriftRechargeMultiplier() {
@@ -212,6 +218,7 @@ function installGameplayUi() {
     driftLockRequested = false;
     driftLockAmount = 0;
     globalThis.__turnDriftLockAmount = 0;
+    boostFill?.style.removeProperty('background');
     drivePad.style.setProperty('--boost-charge', '100%');
     boostHud.style.setProperty('--boost-charge', '100%');
     boostHud.setAttribute('aria-label', 'Boost 100 percent charged');
@@ -483,7 +490,8 @@ function installGameplayUi() {
       const rechargeMultiplier = resolveDriftBoostRechargeMultiplier({
         driftHeld: globalThis.__turnDriftHeld === true,
         driftLockAmount,
-        lockedMultiplier: getDriftRechargeMultiplier()
+        lockedMultiplier: getDriftRechargeMultiplier(),
+        lockCeilingMultiplier: DRIFT_LOCK_RECHARGE_MULTIPLIER
       });
       boostCharge = Math.min(1, boostCharge + dt * rechargeMultiplier / BOOST_RECHARGE_SECONDS);
     }
@@ -542,6 +550,16 @@ function installGameplayUi() {
     }
     if (boostVisualDirty || driftLocking !== publishedDriftLocking) {
       boostHud.classList.toggle('is-drift-locking', driftLocking);
+      if (boostFill) {
+        if (driftLocking) {
+          // design-semantic.css intentionally owns the normal DRIFT gradient with
+          // !important. LOCK is a stronger transient state, so publish its fill
+          // directly at the element level with the same cascade priority.
+          boostFill.style.setProperty('background', DRIFT_LOCK_BOOST_GRADIENT, 'important');
+        } else {
+          boostFill.style.removeProperty('background');
+        }
+      }
       publishedDriftLocking = driftLocking;
     }
     if (boostVisualDirty || chargePercent !== publishedChargePercent) {

--- a/turn/vehicle/emergency-livery-models.js
+++ b/turn/vehicle/emergency-livery-models.js
@@ -5,6 +5,7 @@ import {
 } from './car-models.js?build=20260823-r183-native-car-surfaces&revision=r211-steering-wheels';
 
 const EMERGENCY_IDS = new Set(['police', 'ambulance', 'firetruck']);
+const DARK_TIRE_COLOR = 0x060708;
 
 export { preloadCarModels, recolorCarVisual };
 
@@ -17,8 +18,28 @@ export { preloadCarModels, recolorCarVisual };
  */
 export async function createCarVisual(options = {}) {
   const root = await createBaseCarVisual(options);
+  darkenVisibleWheels(root);
   if (EMERGENCY_IDS.has(root?.userData?.turnCarId)) {
     root.userData.turnEmergencyLivery = 'native-kenney-palette';
   }
   return root;
+}
+
+function darkenVisibleWheels(root) {
+  root?.traverse?.((node) => {
+    if (!node?.isMesh || !node.material) return;
+    const materials = Array.isArray(node.material) ? node.material : [node.material];
+    for (const material of materials) {
+      const label = `${node.name || ''} ${material?.name || ''}`.toLowerCase();
+      if (!/wheel|tire|tyre|rubber/.test(label) || !material?.color) continue;
+
+      // Kenney wheel meshes use palette textures. Their semantic rim shader runs
+      // after the material tint, so this makes the tyre/rubber nearly black while
+      // keeping paintable rim cells legible in their authored/selected colour.
+      material.color.setHex(DARK_TIRE_COLOR);
+      if ('roughness' in material) {
+        material.roughness = Math.max(Number(material.roughness) || 0, 0.9);
+      }
+    }
+  });
 }


### PR DESCRIPTION
## Summary
- calm Zoom-off/classic speed FOV from 68→88° to 68→78°, while keeping Zoom at 68→88°
- pin race FOV to 68° when `prefers-reduced-motion: reduce` is active
- increase every Boost tank duration by 50% now that passive recharge is gone
- restore ordinary DRIFT recharge to the former rate (2.4× by default) and raise DRIFT LOCK to 3.6×
- preserve Rally Racer’s existing perk copy while making its ordinary DRIFT recharge equal LOCK at 3.6×
- fix the LOCK Boost-bar gradient at its actual cascade conflict (`design-semantic.css` was overriding the purple state with `!important`) and add a runtime fallback so LOCK reliably displays purple→green
- darken authored wheel/tyre materials so the new visible steering angle reads more clearly without adding per-frame geometry or physics work

## Balance
- passive Boost recharge remains disabled
- Boost still starts full
- default ordinary DRIFT: 2.4× recharge
- default DRIFT LOCK: 3.6× recharge
- Rally Racer ordinary DRIFT: 3.6× recharge
- Rally Racer LOCK: 3.6× recharge
- all Boost tanks: 1.5× previous duration

## Accessibility
- speed-responsive FOV is disabled under `prefers-reduced-motion`; distance/height camera behavior is otherwise unchanged

## Regression
- updated the camera regression for classic 78°, Zoom 88° and reduced-motion 68° behavior
- changes remain on the canonical TURN runtime shared by TURN NEXT