### PR TITLE
Align front wheels with extreme drift trajectory

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -70,6 +70,7 @@
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
+        "/turn/main.js?build=20260826-r184": "/turn/main.js?build=20260826-r184&revision=r219-trajectory-wheel-steering",
         "/turn/input/motion.js": "/turn/input/motion.js?revision=r164-ipad-motion-profile",
         "/turn/race/session-orchestrator.js?source=20260729-r118-m8": "/turn/race/session-orchestrator.js?source=20260817-r172-screen-reader-followup",
         "/turn/training/drive-by-ear-training.js?build=20260817-r172-r151-dbe-training-device-fixes": "/turn/training/drive-by-ear-training.js?build=20260817-r172&revision=r172-screen-reader-followup",

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -3,6 +3,13 @@ import fs from 'node:fs/promises';
 
 const catalogSource = await fs.readFile(new URL('../../turn/vehicle/catalog.js', import.meta.url), 'utf8');
 const catalog = await import(`data:text/javascript;base64,${Buffer.from(catalogSource).toString('base64')}`);
+const frontWheelSteeringSource = await fs.readFile(
+  new URL('../../turn/vehicle/front-wheel-steering.js', import.meta.url),
+  'utf8'
+);
+const frontWheelSteering = await import(
+  `data:text/javascript;base64,${Buffer.from(frontWheelSteeringSource).toString('base64')}`
+);
 
 const expectedQuarterTurns = new Map([
   ['convertible', 1],
@@ -203,7 +210,90 @@ assert.match(lot, /VIEWER_INITIAL_YAW = Math\.PI - 0\.55/, 'The viewer must star
 assert.match(main, /playerCar\.rotation\.y = state\.heading \+ Math\.PI/);
 assert.match(main, /car\.rotation\.y = frame\.h \+ Math\.PI/);
 
-console.log(`TURN ${release.id} car orientation, visible steering integration and surface-specific visual sizing passed for all 15 models.`);
+const degrees = (value) => value * Math.PI / 180;
+const trajectoryVelocity = (angle, speed = 30) => ({
+  velocityX: Math.sin(angle) * speed,
+  velocityZ: Math.cos(angle) * speed
+});
+const halfInputAngle = frontWheelSteering.FRONT_WHEEL_STEER_ANGLE * 0.5;
+
+assertClose(
+  frontWheelSteering.EXTREME_DRIFT_SLIP_THRESHOLD,
+  degrees(45),
+  'Extreme DRIFT trajectory threshold'
+);
+assertClose(
+  frontWheelSteering.resolveFrontWheelSteeringAngle({
+    steering: 0.5,
+    heading: 0,
+    ...trajectoryVelocity(degrees(70)),
+    driftHeld: false
+  }),
+  halfInputAngle,
+  'Normal steering must remain tilt-driven outside DRIFT'
+);
+assertClose(
+  frontWheelSteering.resolveFrontWheelSteeringAngle({
+    steering: 0.5,
+    heading: 0,
+    ...trajectoryVelocity(degrees(44)),
+    driftHeld: true
+  }),
+  halfInputAngle,
+  'DRIFT below 45 degrees must remain tilt-driven'
+);
+assertClose(
+  frontWheelSteering.resolveFrontWheelSteeringAngle({
+    steering: -1,
+    heading: 0,
+    ...trajectoryVelocity(degrees(45)),
+    driftHeld: true
+  }),
+  degrees(45),
+  'DRIFT at 45 degrees must align the wheels with trajectory'
+);
+assertClose(
+  frontWheelSteering.resolveFrontWheelSteeringAngle({
+    steering: 1,
+    heading: 0,
+    ...trajectoryVelocity(degrees(-70)),
+    driftLockAmount: 1
+  }),
+  degrees(-70),
+  'DRIFT LOCK must align the wheels with a negative trajectory angle'
+);
+assertClose(
+  frontWheelSteering.resolveFrontWheelSteeringAngle({
+    steering: 0,
+    heading: degrees(150),
+    ...trajectoryVelocity(degrees(-150)),
+    driftLockAmount: 1
+  }),
+  degrees(60),
+  'Trajectory alignment must take the shortest angle across the wrap boundary'
+);
+assertClose(
+  frontWheelSteering.resolveFrontWheelSteeringAngle({
+    steering: 0.5,
+    heading: 0,
+    ...trajectoryVelocity(degrees(70), 0.5),
+    driftHeld: true
+  }),
+  halfInputAngle,
+  'Near-zero velocity must retain stable tilt-driven steering'
+);
+assert.match(
+  main,
+  /resolveFrontWheelSteeringAngle\(\{[\s\S]*driftHeld: Boolean\(globalThis\.__turnDriftHeld\)[\s\S]*driftLockAmount: state\.driftLockAmount/,
+  'The player wheel animator must use both DRIFT and LOCK state'
+);
+assert.match(
+  main,
+  /pivot\.rotation\.y = lerpAngle\(pivot\.rotation\.y, steerAngle, Math\.min\(1, dt \* 16\)\)/,
+  'Trajectory takeover must retain the quick smooth wheel transition'
+);
+
+console.log(`TURN ${release.id} car orientation, trajectory steering, visible wheel integration and surface-specific visual sizing passed for all 15 models.`);
 
 function assertClose(actual, expected, label) {
   assert.ok(

--- a/turn-next/index.html
+++ b/turn-next/index.html
@@ -77,6 +77,7 @@
     {
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
+        "/turn/main.js?build=20260826-r184": "/turn/main.js?build=20260826-r184&revision=r219-trajectory-wheel-steering",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/turn/race/game-state.js?build=20260805-r160": "/turn/race/game-state.js?build=20260826-r184",
         "/turn/race/rival-storage.js?build=20260805-r160": "/turn/race/rival-storage.js?build=20260826-r184",
@@ -149,6 +150,6 @@
   <div class="hud" id="hud" hidden><div class="topbar"><div class="stats"><div class="chip">speed<strong><span id="speed">0</span> km/h</strong></div><div class="chip">lap<strong id="lap">1</strong></div><div class="chip">time<strong id="lapTime">0:00.000</strong></div><div class="chip">best<strong id="bestTime">--:--.---</strong></div></div><div class="map-wrap"><canvas id="map" width="300" height="210" aria-label="Track map"></canvas></div></div><div class="message" id="message" role="status"></div><div class="tilt-drive" aria-hidden="true"><span><b>brake</b><b>gas</b></span><div class="tilt-track"><i class="tilt-needle" id="tiltNeedle"></i></div><small class="tilt-value" id="tiltValue">neutral</small></div></div>
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
-  <script type="module" src="/turn-next/app.js?source=20260826-r184-browser-consent-r166-bella-records"></script>
+  <script type="module" src="/turn-next/app.js?source=20260826-r184-browser-consent-r166-bella-records-r219-trajectory-wheel-steering"></script>
   <script type="module" src="./ui/about-history-bootstrap.js?revision=r164-design-navigation"></script>
 </body></html>

--- a/turn-next/main.js
+++ b/turn-next/main.js
@@ -22,6 +22,10 @@ import {
   saveVehicleSelection
 } from '/turn/vehicle/catalog.js?build=20260720-r19';
 import { createCarVisual } from '/turn/vehicle/car-models.js?build=20260720-r19';
+import {
+  FRONT_WHEEL_STEER_ANGLE,
+  resolveFrontWheelSteeringAngle
+} from '/turn/vehicle/front-wheel-steering.js?revision=r219-trajectory-wheel-steering';
 import { installPerformanceMonitor, recordPerformanceFrame } from '/turn/performance-monitor.js?build=20260720-r19';
 
 const intro = document.querySelector('#intro');
@@ -1021,10 +1025,15 @@ function ghostFrameAt(time) {
   return bestLap ? lapFrameAt(bestLap, time) : null;
 }
 
-function animateWheels(car, steering, speed, dt) {
-  const steerAngle = steering * 0.58;
+function animateWheels(
+  car,
+  steering,
+  speed,
+  dt,
+  steerAngle = steering * FRONT_WHEEL_STEER_ANGLE
+) {
   for (const pivot of car.userData.frontWheelPivots || []) {
-    pivot.rotation.y = THREE.MathUtils.lerp(pivot.rotation.y, steerAngle, Math.min(1, dt * 16));
+    pivot.rotation.y = lerpAngle(pivot.rotation.y, steerAngle, Math.min(1, dt * 16));
   }
   for (const spinner of car.userData.wheelSpinners || []) {
     spinner.rotation.y -= speed * dt * 1.35;
@@ -1033,11 +1042,19 @@ function animateWheels(car, steering, speed, dt) {
 
 function placePlayerCar(dt) {
   const surfaceSample = samples[state.nearestTrackIndex] || findNearestTrack(state.position).sample;
+  const frontWheelSteeringAngle = resolveFrontWheelSteeringAngle({
+    steering: state.steering,
+    heading: state.heading,
+    velocityX: state.velocity.x,
+    velocityZ: state.velocity.z,
+    driftHeld: Boolean(globalThis.__turnDriftHeld),
+    driftLockAmount: state.driftLockAmount
+  });
   playerCar.position.copy(state.position);
   playerCar.rotation.x = trackPitch(surfaceSample);
   playerCar.rotation.y = state.heading + Math.PI;
   playerCar.rotation.z = -state.steering * 0.035 - state.velocity.dot(getRight()) * 0.0025;
-  animateWheels(playerCar, state.steering, state.speed, dt);
+  animateWheels(playerCar, state.steering, state.speed, dt, frontWheelSteeringAngle);
 }
 
 function placeCompetitorCars(dt) {

--- a/turn/index.html
+++ b/turn/index.html
@@ -78,6 +78,7 @@
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
+        "/turn/main.js?build=20260826-r184": "/turn/main.js?build=20260826-r184&revision=r219-trajectory-wheel-steering",
         "/turn/input/motion.js": "/turn/input/motion.js?revision=r164-ipad-motion-profile",
         "/turn/race/session-orchestrator.js?source=20260729-r118-m8": "/turn/race/session-orchestrator.js?source=20260817-r172-screen-reader-followup",
         "/turn/training/drive-by-ear-training.js?build=20260817-r172-r151-dbe-training-device-fixes": "/turn/training/drive-by-ear-training.js?build=20260817-r172&revision=r172-screen-reader-followup",
@@ -181,7 +182,7 @@
   <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260826-r184-r534-heading-first-about"></script>
   <script src="./ui/startup-screen-reader-handoff-r529.js?build=20260826-r184&revision=r531-screen-reader-followup"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
-  <script type="module" src="./app.js?build=20260826-r184-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r420-music-warm-r426-loading-copy-r164-long-session-robustness-post-soak-r199-card-gap-rim-r518-landmark-framing-ground-layering-showroom-r200-pwa-color-r206-r532-countryside-nature"></script>
+  <script type="module" src="./app.js?build=20260826-r184-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r420-music-warm-r426-loading-copy-r164-long-session-robustness-post-soak-r199-card-gap-rim-r518-landmark-framing-ground-layering-showroom-r200-pwa-color-r206-r532-countryside-nature-r219-trajectory-wheel-steering"></script>
   <script type="module" src="./render/skid-continuity-r198.js?revision=r198-skid-continuity"></script>
   <script type="module" src="./tracks/cliffside-inner-buildings-r202.js?revision=r202-kenney-suburban-village"></script>
   <script type="module" src="./tracks/cliffside-house-inset-r203.js?revision=r203-inset-edge-houses"></script>

--- a/turn/main.js
+++ b/turn/main.js
@@ -22,6 +22,10 @@ import {
   saveVehicleSelection
 } from '/turn/vehicle/catalog.js?build=20260720-r19';
 import { createCarVisual } from '/turn/vehicle/car-models.js?build=20260720-r19';
+import {
+  FRONT_WHEEL_STEER_ANGLE,
+  resolveFrontWheelSteeringAngle
+} from '/turn/vehicle/front-wheel-steering.js?revision=r219-trajectory-wheel-steering';
 import { installPerformanceMonitor, recordPerformanceFrame } from '/turn/performance-monitor.js?build=20260720-r19';
 
 const intro = document.querySelector('#intro');
@@ -1021,10 +1025,15 @@ function ghostFrameAt(time) {
   return bestLap ? lapFrameAt(bestLap, time) : null;
 }
 
-function animateWheels(car, steering, speed, dt) {
-  const steerAngle = steering * 0.58;
+function animateWheels(
+  car,
+  steering,
+  speed,
+  dt,
+  steerAngle = steering * FRONT_WHEEL_STEER_ANGLE
+) {
   for (const pivot of car.userData.frontWheelPivots || []) {
-    pivot.rotation.y = THREE.MathUtils.lerp(pivot.rotation.y, steerAngle, Math.min(1, dt * 16));
+    pivot.rotation.y = lerpAngle(pivot.rotation.y, steerAngle, Math.min(1, dt * 16));
   }
   for (const spinner of car.userData.wheelSpinners || []) {
     spinner.rotation.y -= speed * dt * 1.35;
@@ -1033,11 +1042,19 @@ function animateWheels(car, steering, speed, dt) {
 
 function placePlayerCar(dt) {
   const surfaceSample = samples[state.nearestTrackIndex] || findNearestTrack(state.position).sample;
+  const frontWheelSteeringAngle = resolveFrontWheelSteeringAngle({
+    steering: state.steering,
+    heading: state.heading,
+    velocityX: state.velocity.x,
+    velocityZ: state.velocity.z,
+    driftHeld: Boolean(globalThis.__turnDriftHeld),
+    driftLockAmount: state.driftLockAmount
+  });
   playerCar.position.copy(state.position);
   playerCar.rotation.x = trackPitch(surfaceSample);
   playerCar.rotation.y = state.heading + Math.PI;
   playerCar.rotation.z = -state.steering * 0.035 - state.velocity.dot(getRight()) * 0.0025;
-  animateWheels(playerCar, state.steering, state.speed, dt);
+  animateWheels(playerCar, state.steering, state.speed, dt, frontWheelSteeringAngle);
 }
 
 function placeCompetitorCars(dt) {

--- a/turn/vehicle/front-wheel-steering.js
+++ b/turn/vehicle/front-wheel-steering.js
@@ -1,0 +1,45 @@
+export const FRONT_WHEEL_STEER_ANGLE = 0.58;
+export const EXTREME_DRIFT_SLIP_THRESHOLD = Math.PI / 4;
+export const MIN_TRAJECTORY_ALIGNMENT_SPEED = 1;
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function finiteNumber(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+export function normalizeWheelAngle(angle) {
+  const finiteAngle = finiteNumber(angle);
+  return Math.atan2(Math.sin(finiteAngle), Math.cos(finiteAngle));
+}
+
+export function resolveFrontWheelSteeringAngle({
+  steering = 0,
+  heading = 0,
+  velocityX = 0,
+  velocityZ = 0,
+  driftHeld = false,
+  driftLockAmount = 0
+} = {}) {
+  const inputAngle = clamp(finiteNumber(steering), -1, 1) * FRONT_WHEEL_STEER_ANGLE;
+  const x = finiteNumber(velocityX);
+  const z = finiteNumber(velocityZ);
+  const speedSquared = x * x + z * z;
+  const driftActive = Boolean(driftHeld) || finiteNumber(driftLockAmount) > 0;
+
+  if (!driftActive || speedSquared < MIN_TRAJECTORY_ALIGNMENT_SPEED ** 2) {
+    return inputAngle;
+  }
+
+  const trajectoryHeading = Math.atan2(x, z);
+  const slipAngle = normalizeWheelAngle(trajectoryHeading - finiteNumber(heading));
+
+  if (Math.abs(slipAngle) < EXTREME_DRIFT_SLIP_THRESHOLD - Number.EPSILON * 4) {
+    return inputAngle;
+  }
+
+  return slipAngle;
+}


### PR DESCRIPTION
## Summary

- keep the visible front wheels driven by tilt steering during normal driving and DRIFT below 45° of slip
- during DRIFT or DRIFT LOCK at 45°+ slip, point the front wheels along the car's horizontal velocity trajectory regardless of steering input
- preserve the existing quick wheel interpolation, now with shortest-angle smoothing
- leave vehicle physics unchanged and cache-bust the canonical TURN / TURN NEXT runtime

## Verification

- added numerical coverage for normal steering, the 45° takeover, DRIFT LOCK, negative slip, angle wrapping, and low-speed stability
- kept `turn-next/main.js` byte-for-byte aligned with canonical `turn/main.js`
- locally exercised the pure trajectory resolver before opening the PR