### PR TITLE
Retune drift trajectory wheel takeover

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -70,7 +70,7 @@
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
-        "/turn/main.js?build=20260826-r184": "/turn/main.js?build=20260826-r184&revision=r220-trajectory-wheel-steering-35",
+        "/turn/main.js?build=20260826-r184": "/turn/main.js?build=20260826-r184&revision=r221-trajectory-wheel-steering-30",
         "/turn/input/motion.js": "/turn/input/motion.js?revision=r164-ipad-motion-profile",
         "/turn/race/session-orchestrator.js?source=20260729-r118-m8": "/turn/race/session-orchestrator.js?source=20260817-r172-screen-reader-followup",
         "/turn/training/drive-by-ear-training.js?build=20260817-r172-r151-dbe-training-device-fixes": "/turn/training/drive-by-ear-training.js?build=20260817-r172&revision=r172-screen-reader-followup",

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -219,7 +219,7 @@ const halfInputAngle = frontWheelSteering.FRONT_WHEEL_STEER_ANGLE * 0.5;
 
 assertClose(
   frontWheelSteering.EXTREME_DRIFT_SLIP_THRESHOLD,
-  degrees(35),
+  degrees(30),
   'Extreme DRIFT trajectory threshold'
 );
 assertClose(
@@ -236,21 +236,21 @@ assertClose(
   frontWheelSteering.resolveFrontWheelSteeringAngle({
     steering: 0.5,
     heading: 0,
-    ...trajectoryVelocity(degrees(34)),
+    ...trajectoryVelocity(degrees(29)),
     driftHeld: true
   }),
   halfInputAngle,
-  'DRIFT below 35 degrees must remain tilt-driven'
+  'DRIFT below 30 degrees must remain tilt-driven'
 );
 assertClose(
   frontWheelSteering.resolveFrontWheelSteeringAngle({
     steering: -1,
     heading: 0,
-    ...trajectoryVelocity(degrees(35)),
+    ...trajectoryVelocity(degrees(30)),
     driftHeld: true
   }),
-  degrees(35),
-  'DRIFT at 35 degrees must align the wheels with trajectory'
+  degrees(30),
+  'DRIFT at 30 degrees must align the wheels with trajectory'
 );
 assertClose(
   frontWheelSteering.resolveFrontWheelSteeringAngle({
@@ -289,7 +289,7 @@ assert.match(
 );
 assert.match(
   main,
-  /pivot\.rotation\.y = lerpAngle\(pivot\.rotation\.y, steerAngle, Math\.min\(1, dt \* 12\)\)/,
+  /pivot\.rotation\.y = lerpAngle\(pivot\.rotation\.y, steerAngle, Math\.min\(1, dt \* 8\)\)/,
   'Trajectory takeover must retain the quick smooth wheel transition'
 );
 

--- a/turn-next/index.html
+++ b/turn-next/index.html
@@ -77,7 +77,7 @@
     {
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
-        "/turn/main.js?build=20260826-r184": "/turn/main.js?build=20260826-r184&revision=r220-trajectory-wheel-steering-35",
+        "/turn/main.js?build=20260826-r184": "/turn/main.js?build=20260826-r184&revision=r221-trajectory-wheel-steering-30",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
         "/turn/race/game-state.js?build=20260805-r160": "/turn/race/game-state.js?build=20260826-r184",
         "/turn/race/rival-storage.js?build=20260805-r160": "/turn/race/rival-storage.js?build=20260826-r184",
@@ -150,6 +150,6 @@
   <div class="hud" id="hud" hidden><div class="topbar"><div class="stats"><div class="chip">speed<strong><span id="speed">0</span> km/h</strong></div><div class="chip">lap<strong id="lap">1</strong></div><div class="chip">time<strong id="lapTime">0:00.000</strong></div><div class="chip">best<strong id="bestTime">--:--.---</strong></div></div><div class="map-wrap"><canvas id="map" width="300" height="210" aria-label="Track map"></canvas></div></div><div class="message" id="message" role="status"></div><div class="tilt-drive" aria-hidden="true"><span><b>brake</b><b>gas</b></span><div class="tilt-track"><i class="tilt-needle" id="tiltNeedle"></i></div><small class="tilt-value" id="tiltValue">neutral</small></div></div>
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
-  <script type="module" src="/turn-next/app.js?source=20260826-r184-browser-consent-r166-bella-records-r220-trajectory-wheel-steering-35"></script>
+  <script type="module" src="/turn-next/app.js?source=20260826-r184-browser-consent-r166-bella-records-r221-trajectory-wheel-steering-30"></script>
   <script type="module" src="./ui/about-history-bootstrap.js?revision=r164-design-navigation"></script>
 </body></html>

--- a/turn-next/main.js
+++ b/turn-next/main.js
@@ -25,7 +25,7 @@ import { createCarVisual } from '/turn/vehicle/car-models.js?build=20260720-r19'
 import {
   FRONT_WHEEL_STEER_ANGLE,
   resolveFrontWheelSteeringAngle
-} from '/turn/vehicle/front-wheel-steering.js?revision=r220-trajectory-wheel-steering-35';
+} from '/turn/vehicle/front-wheel-steering.js?revision=r221-trajectory-wheel-steering-30';
 import { installPerformanceMonitor, recordPerformanceFrame } from '/turn/performance-monitor.js?build=20260720-r19';
 
 const intro = document.querySelector('#intro');
@@ -1033,7 +1033,7 @@ function animateWheels(
   steerAngle = steering * FRONT_WHEEL_STEER_ANGLE
 ) {
   for (const pivot of car.userData.frontWheelPivots || []) {
-    pivot.rotation.y = lerpAngle(pivot.rotation.y, steerAngle, Math.min(1, dt * 12));
+    pivot.rotation.y = lerpAngle(pivot.rotation.y, steerAngle, Math.min(1, dt * 8));
   }
   for (const spinner of car.userData.wheelSpinners || []) {
     spinner.rotation.y -= speed * dt * 1.35;

--- a/turn/index.html
+++ b/turn/index.html
@@ -78,7 +78,7 @@
       "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
         "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
-        "/turn/main.js?build=20260826-r184": "/turn/main.js?build=20260826-r184&revision=r220-trajectory-wheel-steering-35",
+        "/turn/main.js?build=20260826-r184": "/turn/main.js?build=20260826-r184&revision=r221-trajectory-wheel-steering-30",
         "/turn/input/motion.js": "/turn/input/motion.js?revision=r164-ipad-motion-profile",
         "/turn/race/session-orchestrator.js?source=20260729-r118-m8": "/turn/race/session-orchestrator.js?source=20260817-r172-screen-reader-followup",
         "/turn/training/drive-by-ear-training.js?build=20260817-r172-r151-dbe-training-device-fixes": "/turn/training/drive-by-ear-training.js?build=20260817-r172&revision=r172-screen-reader-followup",
@@ -182,7 +182,7 @@
   <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260826-r184-r534-heading-first-about"></script>
   <script src="./ui/startup-screen-reader-handoff-r529.js?build=20260826-r184&revision=r531-screen-reader-followup"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
-  <script type="module" src="./app.js?build=20260826-r184-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r420-music-warm-r426-loading-copy-r164-long-session-robustness-post-soak-r199-card-gap-rim-r518-landmark-framing-ground-layering-showroom-r200-pwa-color-r206-r532-countryside-nature-r220-trajectory-wheel-steering-35"></script>
+  <script type="module" src="./app.js?build=20260826-r184-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r420-music-warm-r426-loading-copy-r164-long-session-robustness-post-soak-r199-card-gap-rim-r518-landmark-framing-ground-layering-showroom-r200-pwa-color-r206-r532-countryside-nature-r221-trajectory-wheel-steering-30"></script>
   <script type="module" src="./render/skid-continuity-r198.js?revision=r198-skid-continuity"></script>
   <script type="module" src="./tracks/cliffside-inner-buildings-r202.js?revision=r202-kenney-suburban-village"></script>
   <script type="module" src="./tracks/cliffside-house-inset-r203.js?revision=r203-inset-edge-houses"></script>

--- a/turn/main.js
+++ b/turn/main.js
@@ -25,7 +25,7 @@ import { createCarVisual } from '/turn/vehicle/car-models.js?build=20260720-r19'
 import {
   FRONT_WHEEL_STEER_ANGLE,
   resolveFrontWheelSteeringAngle
-} from '/turn/vehicle/front-wheel-steering.js?revision=r220-trajectory-wheel-steering-35';
+} from '/turn/vehicle/front-wheel-steering.js?revision=r221-trajectory-wheel-steering-30';
 import { installPerformanceMonitor, recordPerformanceFrame } from '/turn/performance-monitor.js?build=20260720-r19';
 
 const intro = document.querySelector('#intro');
@@ -1033,7 +1033,7 @@ function animateWheels(
   steerAngle = steering * FRONT_WHEEL_STEER_ANGLE
 ) {
   for (const pivot of car.userData.frontWheelPivots || []) {
-    pivot.rotation.y = lerpAngle(pivot.rotation.y, steerAngle, Math.min(1, dt * 12));
+    pivot.rotation.y = lerpAngle(pivot.rotation.y, steerAngle, Math.min(1, dt * 8));
   }
   for (const spinner of car.userData.wheelSpinners || []) {
     spinner.rotation.y -= speed * dt * 1.35;

--- a/turn/vehicle/front-wheel-steering.js
+++ b/turn/vehicle/front-wheel-steering.js
@@ -1,5 +1,5 @@
 export const FRONT_WHEEL_STEER_ANGLE = 0.58;
-export const EXTREME_DRIFT_SLIP_THRESHOLD = 35 * Math.PI / 180;
+export const EXTREME_DRIFT_SLIP_THRESHOLD = 30 * Math.PI / 180;
 export const MIN_TRAJECTORY_ALIGNMENT_SPEED = 1;
 
 function clamp(value, min, max) {


### PR DESCRIPTION
## Summary

- lower the DRIFT / DRIFT LOCK trajectory takeover threshold from 35° to 30°
- slow visible front-wheel interpolation from 12 to 8
- refresh TURN, TURN LAB and TURN NEXT runtime cache routes

## Verification

- move boundary coverage from 34°/35° to 29°/30°
- verify the pure trajectory resolver on both sides of the new threshold
- preserve canonical TURN / TURN NEXT main parity