### PR TITLE
Keep Chromatic Camouflage achievable without Paintjob

### DIFF
--- a/turn-lab/tests/emergency-livery-layering-production.mjs
+++ b/turn-lab/tests/emergency-livery-layering-production.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
+import { matchesTrackColor } from '../../turn/achievements/chromatic-camouflage-r183.js';
 
 const [
   bridge,
@@ -27,6 +28,7 @@ function importMapFrom(source) {
 }
 
 const expectedFactoryColors = new Map([
+  ['convertible', ['#ff4fa3', '#792766']],
   ['van', ['#ff7700', '#222222']],
   ['race', ['#5d503f', '#222222']],
   ['vintage-racer', ['#004455', '#222222']],
@@ -39,6 +41,24 @@ for (const [id, [primary, secondary]] of expectedFactoryColors) {
   const car = catalog.getCarDefinition(id);
   assert.equal(car.defaultColor, primary, `${car.name} factory primary color`);
   assert.equal(car.defaultSecondaryColor, secondary, `${car.name} factory secondary color`);
+}
+
+const chromaticFactoryRoute = Object.freeze({
+  countryside: 'convertible',
+  airport: 'classic',
+  harbor: 'van',
+  cliffside: 'sedan',
+  'midnight-city': 'sedan-sports',
+  mountain: 'suv'
+});
+
+for (const [trackId, carId] of Object.entries(chromaticFactoryRoute)) {
+  const car = catalog.getCarDefinition(carId);
+  assert.equal(
+    matchesTrackColor(trackId, car.defaultColor),
+    true,
+    `CHROMATIC CAMOUFLAGE must remain achievable without PAINTJOB: ${car.name} factory ${car.defaultColor} should match ${trackId}`
+  );
 }
 
 for (const id of ['police', 'ambulance', 'firetruck']) {
@@ -126,4 +146,4 @@ for (const specifier of [
     `YOUR TURN must share the canonical car presentation for ${specifier}`);
 }
 
-console.log('TURN and YOUR TURN factory vehicle colors, Police fixed grey and canonical module routes passed.');
+console.log('TURN factory colors keep CHROMATIC CAMOUFLAGE paint-free, with Police fixed grey and canonical module routes.');

--- a/turn/vehicle/catalog.js
+++ b/turn/vehicle/catalog.js
@@ -35,7 +35,7 @@ export const CAR_PALETTE = Object.freeze([
 ]);
 
 const DEFAULT_COLOR_BY_ID = Object.freeze({
-  convertible: Object.freeze({ fallback: '#a8327a', p3: Object.freeze([0.66, 0.14, 0.43]) }),
+  convertible: Object.freeze({ fallback: '#ff4fa3' }),
   classic: Object.freeze({ fallback: '#ffcc00', p3: Object.freeze([1, 0.76, 0]) }),
   'vintage-racer': Object.freeze({ fallback: '#004455' }),
   'toy-racer': Object.freeze({ fallback: '#cccccc' }),


### PR DESCRIPTION
## Summary

Make the factory CONVERTIBLE unmistakably Countryside-compatible and lock the no-PAINTJOB achievement route into regression coverage.

- CONVERTIBLE factory primary: `#ff4fa3` (Bubblegum pink)
- secondary remains `#792766`
- CHROMATIC CAMOUFLAGE color rules are unchanged: Countryside still accepts the existing pink/magenta family
- regression now derives the six-track route from the actual vehicle catalog defaults rather than hard-coded historical colors

## Guaranteed factory route

- COUNTRYSIDE → CONVERTIBLE (`#ff4fa3`)
- AIRPORT → TRAINING CAR (`#ffcc00`)
- HARBOR → VAN (`#ff7700`)
- CLIFFSIDE → SEDAN (`#2b6a70`)
- MIDNIGHT CITY → HATCHBACK (`#5e3c87`)
- MOUNTAIN → SUV (`#0555aa`)

Every one of those current factory colors must satisfy the production CHROMATIC CAMOUFLAGE classifier. This makes the hidden achievement explicitly achievable without unlocking PAINTJOB, and future factory-color changes will fail the already-run emergency/native-surface regression if they break that route.

No achievement thresholds, trophy values, gameplay or user paint selections are changed.