### PR TITLE
Keep BUILD-A-CAR visible when The Lot mounts late

### DIFF
--- a/turn-lab/build-a-car/entry.js
+++ b/turn-lab/build-a-car/entry.js
@@ -17,8 +17,7 @@ export function installBuildACarExperiment(root = document.body) {
   const sync = () => {
     const screen = root.querySelector?.('.lot-screen');
     if (!screen || installedScreens.has(screen)) return;
-    installedScreens.add(screen);
-    decorateLot(screen);
+    if (decorateLot(screen)) installedScreens.add(screen);
   };
   const observer = new MutationObserver((mutations) => {
     if (!mutations.some((mutation) => mutation.addedNodes.length || mutation.removedNodes.length)) return;
@@ -39,9 +38,10 @@ export function installBuildACarExperiment(root = document.body) {
 }
 
 function decorateLot(screen) {
+  if (screen.querySelector('.build-a-car-lot-entry')) return true;
   const actions = screen.querySelector('.lot-card-actions') || screen.querySelector('.lot-card');
   const raceButton = screen.querySelector('.lot-race');
-  if (!actions || !raceButton) return;
+  if (!actions || !raceButton) return false;
 
   const wrapper = document.createElement('section');
   wrapper.className = 'build-a-car-lot-entry';
@@ -69,6 +69,8 @@ function decorateLot(screen) {
     const cabin = getPart('cabin', saved.parts.cabin)?.label || 'CAR';
     summary.textContent = `${saved.name} · ${body} + ${cabin} · saved in TURN LAB`;
   }
+
+  return true;
 }
 
 function openBuilder(trigger, afterSave) {

--- a/turn-lab/tests/build-a-car-schema.mjs
+++ b/turn-lab/tests/build-a-car-schema.mjs
@@ -83,6 +83,17 @@ assert.match(index, /buildACarEntry\.searchParams\.set\('build', globalThis\.__T
 assert.doesNotMatch(index, /build-a-car\/entry\.js\?revision=/,
   'BUILD-A-CAR must not create a private revision-string namespace');
 assert.match(entry, /root\.querySelector\?\.\('\.lot-screen'\)/);
+assert.match(
+  entry,
+  /if \(decorateLot\(screen\)\) installedScreens\.add\(screen\);/,
+  'A Lot screen must only be marked installed after its action area is ready'
+);
+assert.match(entry, /if \(screen\.querySelector\('\.build-a-car-lot-entry'\)\) return true;/,
+  'Repeated observer passes must remain idempotent');
+assert.match(entry, /if \(!actions \|\| !raceButton\) return false;/,
+  'An incomplete Lot must stay eligible for the next mutation pass');
+assert.doesNotMatch(entry, /installedScreens\.add\(screen\);\s+decorateLot\(screen\)/,
+  'The installer must not permanently skip a partially mounted Lot');
 assert.match(entry, /actions\.insertBefore\(wrapper, raceButton\)/,
   'The LAB installer must enter through The Lot without forking it');
 assert.match(entry, /turn-lab:custom-car-saved/);


### PR DESCRIPTION
## Summary

Fix the merged BUILD-A-CAR prototype sometimes being absent from TURN LAB's The Lot.

The installer previously added a newly found `.lot-screen` to its `WeakSet` before the screen's actions and race button necessarily existed. If The Lot mounted in stages, the first decoration attempt returned early and every later mutation was ignored for that screen.

- only mark a Lot screen installed after decoration succeeds
- keep incomplete screens eligible for the next mutation pass
- make repeated passes idempotent when the LAB entry already exists
- add regression coverage for the late-mount contract

## Scope

TURN LAB only. Production TURN, gameplay, release metadata, assets, and saved builds are unchanged.

## Verification

- branch differs from main in exactly the LAB entry module and its BUILD-A-CAR regression test
- syntax, lint, BUILD-A-CAR tests, and the full TURN regression workflow remain the merge gate
