### PR TITLE
Make Lot attributes readable and move perks to a popover

### DIFF
--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -223,9 +223,14 @@ assert.match(lotEnhancementRuntime, /screen\.dataset\.lotEnhancements = ENHANCEM
 assert.match(lotPerkDisclosure, /getCarDefinition\(vehicleId\)\?\.perk/);
 assert.doesNotMatch(lotPerkDisclosure, /rewardForVehicle|trophy-road/,
   'Perk identity and display must come directly from the car definition');
-assert.match(lotPerkDisclosure, /<strong>\$\{perkTitle\}:<\/strong>/);
-assert.match(lotPerkDisclosure, /color: #2f6f38/);
-assert.doesNotMatch(lotPerkDisclosure, /lot-perk-button|aria-expanded|<strong>PERK:<\/strong>/);
+assert.match(lotPerkDisclosure, /className = 'lot-perk-button'/);
+assert.match(lotPerkDisclosure, /trigger\.textContent = 'PERK'/);
+assert.match(lotPerkDisclosure, /aria-haspopup', 'dialog'/);
+assert.match(lotPerkDisclosure, /aria-expanded', 'false'/);
+assert.match(lotPerkDisclosure, /setAttribute\('popover', 'auto'\)/);
+assert.match(lotPerkDisclosure, /trigger\.hidden = !perkText/);
+assert.match(lotPerkDisclosure, /copy\.textContent = perkDescription/);
+assert.doesNotMatch(lotPerkDisclosure, /innerHTML\s*=/);
 assert.match(lotTrophyGate, /trophy-road\.js\?revision=r164-vintage-rally-perks/);
 assert.match(lotTrophyGate, /FALLBACK_VEHICLE_ID = 'classic'/);
 assert.match(lotTrophyGate, /raceButton\.disabled = locked/);

--- a/turn-lab/tests/lot-layout-production.mjs
+++ b/turn-lab/tests/lot-layout-production.mjs
@@ -10,6 +10,7 @@ const [
   perkDisclosure,
   layout,
   layoutCss,
+  infoTypography,
   lot,
   legend,
   accessibility,
@@ -23,6 +24,7 @@ const [
   fs.readFile(new URL('../../turn/garage/lot-perk-disclosure.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-layout-r60.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-layout-r60.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-info-typography-r213.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-r10.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-stat-legend.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-accessibility-r118.js', import.meta.url), 'utf8'),
@@ -93,10 +95,23 @@ assert.match(perkDisclosure, /className = 'lot-perk-copy'/);
 assert.match(perkDisclosure, /getCarDefinition\(vehicleId\)\?\.perk/);
 assert.doesNotMatch(perkDisclosure, /rewardForVehicle|trophy-road/,
   'Perk display must be driven by the selected car definition rather than Trophy Road ownership');
-assert.match(perkDisclosure, /<strong>\$\{perkTitle\}:<\/strong>/);
-assert.match(perkDisclosure, /color: #2f6f38/);
-assert.doesNotMatch(perkDisclosure, /lot-perk-button|aria-expanded/,
-  'Perk content must be inline instead of hidden behind a disclosure button');
+assert.match(perkDisclosure, /className = 'lot-perk-button'/);
+assert.match(perkDisclosure, /trigger\.textContent = 'PERK'/);
+assert.match(perkDisclosure, /trigger\.setAttribute\('aria-haspopup', 'dialog'\)/);
+assert.match(perkDisclosure, /trigger\.setAttribute\('aria-controls', popoverId\)/);
+assert.match(perkDisclosure, /trigger\.setAttribute\('aria-expanded', 'false'\)/);
+assert.match(perkDisclosure, /popover\.setAttribute\('popover', 'auto'\)/);
+assert.match(perkDisclosure, /popover\.setAttribute\('role', 'dialog'\)/);
+assert.match(perkDisclosure, /popover\.setAttribute\('aria-labelledby', titleId\)/);
+assert.match(perkDisclosure, /popover\.setAttribute\('aria-describedby', descriptionId\)/);
+assert.match(perkDisclosure, /trigger\.hidden = !perkText/,
+  'The PERK action must exist only for cars with named perk content');
+assert.match(perkDisclosure, /closePopover\(\);[\s\S]*trigger\.hidden = !perkText/,
+  'Changing cars must close any open perk before updating the trigger');
+assert.match(perkDisclosure, /event\.key !== 'Escape'/);
+assert.match(perkDisclosure, /closePopover\(\{ restoreFocus: true \}\)/);
+assert.doesNotMatch(perkDisclosure, /innerHTML\s*=/,
+  'Perk names and descriptions must be written as text rather than parsed markup');
 assert.match(perkDisclosure, /const picker = screen\?\.querySelector\?\.\('\.lot-car-picker'\)/);
 assert.match(
   perkDisclosure,
@@ -180,6 +195,10 @@ assert.match(trainingGuide, /markTrainingCarTried\(\)/);
 
 assert.doesNotMatch(layout, /appendChild\(colors\)|lot-view-close|lot-view-open/);
 assert.match(layout, /document\.createTextNode\('ATTRIBUTES'\)/);
+assert.match(layout, /carDescription\?\.classList\.add\('lot-a11y-only'\)/,
+  'The visual description must become screen-reader-only without leaving CAR INFORMATION');
+assert.match(layout, /carDescription\?\.classList\.remove\('lot-a11y-only'\)/,
+  'The layout cleanup must restore the original description class state');
 assert.match(layout, /infoButton\.textContent = 'i'/);
 assert.match(layout, /aria-label', 'What do the attributes mean\?'/);
 assert.doesNotMatch(layout, /MutationObserver|setAnimationLoop|requestAnimationFrame/);
@@ -222,6 +241,23 @@ assert.doesNotMatch(layoutCss, /\.lot-color-input|\.lot-color-preset/);
 assert.match(layoutCss, /\.lot-race \{[\s\S]*background: var\(--pink\)/);
 assert.match(layoutCss, /@media \(max-height: 520px\)/);
 assert.match(layoutCss, /@media \(max-height: 430px\)/);
+
+assert.match(
+  infoTypography,
+  /\.lot-showroom \.lot-car-description\.lot-a11y-only\s*\{[\s\S]*display: block !important;/,
+  'Short landscape layouts must keep the visually hidden description in the accessibility tree'
+);
+assert.match(infoTypography, /grid-template-rows: repeat\(6, minmax\(17px, 34px\)\)/,
+  'All six attribute rows must retain a readable responsive height');
+assert.match(infoTypography, /height: clamp\(13px, 2\.7vh, 18px\)/,
+  'Meter segments must remain substantially larger than the old 7px bars');
+assert.match(infoTypography, /border: 3px solid var\(--lot-stat-accent\)/,
+  'Attribute category color must live on every segment outline');
+assert.match(infoTypography, /--lot-stat-accent: var\(--turn-control-gas, #8ce99a\)/);
+assert.match(infoTypography, /--lot-stat-accent: var\(--turn-control-drift, #38d9ff\)/);
+assert.match(infoTypography, /--lot-stat-accent: var\(--turn-control-boost, #ffd43b\)/);
+assert.match(infoTypography, /b\.is-full\s*\{[\s\S]*background: #313131;/,
+  'Filled attribute segments must use the requested neutral #313131 fill');
 
 assert.match(accessibility, /makeHiddenHeading\('lot-choose-car-heading', 'Choose car'\)/);
 assert.match(accessibility, /makeHiddenHeading\('lot-paint-heading', 'Choose car colour'\)/);

--- a/turn-lab/tests/lot-pwa-color-scroll-boundary.mjs
+++ b/turn-lab/tests/lot-pwa-color-scroll-boundary.mjs
@@ -14,9 +14,10 @@ const [boundary, runtime, screenReader, perk, showroomCss, layout] = await Promi
 assert.match(screenReader, /card\.insertBefore\(colors, raceHeading\)/,
   'The screen-reader pass must keep COLOR between Car information and Race in DOM order');
 
-// Reward cars have perk copy, which can make the information panel genuinely scroll.
-assert.match(perk, /description\.after\(perk\)/,
-  'Perk copy must remain part of car information rather than the floating COLOR control');
+// The perk popover remains adjacent to the description in source order, while its
+// fixed/top-layer presentation keeps it from consuming information-panel height.
+assert.match(perk, /description\.after\(popover\)/,
+  'Perk content must remain associated with car information rather than the floating COLOR control');
 assert.match(showroomCss, /\.lot-showroom \.lot-card\s*\{[\s\S]*overflow-y:\s*auto/,
   'The base showroom still documents the historical card-level scroll behavior this compatibility layer overrides');
 
@@ -28,15 +29,14 @@ assert.match(boundary, /\.lot-showroom \.lot-card-info-scroll\s*\{[\s\S]*overflo
 assert.match(boundary, /-webkit-overflow-scrolling:\s*touch/,
   'The inner information scroller must retain native iOS momentum scrolling');
 
-// When the information is shorter than its viewport, do not dump all spare height
-// below the stat table. Keep the Race action anchored while sharing that room between
-// the visible information sections. With negative free space, space-between naturally
-// collapses back to normal packed flow and the same container can scroll.
-assert.match(boundary, /\.lot-showroom \.lot-card-info-scroll\s*\{[\s\S]*display:\s*flex;[\s\S]*flex-direction:\s*column;[\s\S]*justify-content:\s*space-between;[\s\S]*gap:\s*2px;/,
-  'Spare car-information height must be distributed between sections instead of accumulating below the stats');
+// With description and perk copy removed from visual flow, keep title, ATTRIBUTES and
+// the responsive stat grid packed in a predictable order. The stat grid itself owns
+// spare height; negative space still becomes ordinary inner scrolling.
+assert.match(boundary, /\.lot-showroom \.lot-card-info-scroll\s*\{[\s\S]*display:\s*flex;[\s\S]*flex-direction:\s*column;[\s\S]*justify-content:\s*flex-start;[\s\S]*gap:\s*clamp\(4px, 0\.8vh, 8px\);/,
+  'Car-information sections must stay packed while the larger attribute grid owns responsive height');
 
-// The wrapper must contain every variable-height information node, especially perk copy
-// and the visible ATTRIBUTES row, while COLOR and RACE stay as card siblings outside it.
+// The wrapper must contain every car-information node, including the hidden popover
+// source and visible ATTRIBUTES row, while COLOR and RACE stay as card siblings outside it.
 for (const selector of [
   "'.lot-car-title'",
   "'.lot-car-description'",

--- a/turn-lab/tests/trophy-road-production.mjs
+++ b/turn-lab/tests/trophy-road-production.mjs
@@ -311,11 +311,15 @@ assert.match(perkDisclosure, /getCarDefinition\(vehicleId\)\?\.perk/,
 assert.doesNotMatch(perkDisclosure, /rewardForVehicle|trophy-road/,
   'Vehicle perks must not be free-floating Trophy Road entitlements');
 assert.match(perkDisclosure, /className = 'lot-perk-copy'/);
-assert.match(perkDisclosure, /color: #2f6f38/,
-  'Named vehicle perk copy must use the dark achievement-green treatment');
-assert.doesNotMatch(perkDisclosure, /lot-perk-button|aria-expanded/,
-  'Named perk information must be inline and must not spend vertical space on a disclosure button');
-assert.match(perkDisclosure, /<strong>\$\{perkTitle\}:<\/strong>/);
+assert.match(perkDisclosure, /className = 'lot-perk-button'/);
+assert.match(perkDisclosure, /trigger\.hidden = !perkText/,
+  'Only cars that own a perk may expose the PERK action');
+assert.match(perkDisclosure, /trigger\.setAttribute\('aria-expanded', String\(nextOpen\)\)/,
+  'The PERK action must expose its popover state');
+assert.match(perkDisclosure, /popover\.setAttribute\('role', 'dialog'\)/,
+  'Named perk information must open as a labelled popover dialog');
+assert.match(perkDisclosure, /title\.textContent = perkTitle/);
+assert.match(perkDisclosure, /copy\.textContent = perkDescription/);
 assert.match(enhancementRuntime, /installLotPerkDisclosure/);
 assert.match(enhancementRuntime, /lot-perk-disclosure\.js\?revision=r164-vintage-rally-perks/);
 assert.match(enhancementRuntime, /lot-trophy-gate\.js\?revision=r164-vintage-rally-perks/);

--- a/turn/garage/lot-card-scroll-boundary.js
+++ b/turn/garage/lot-card-scroll-boundary.js
@@ -25,8 +25,8 @@ function installStyle() {
       flex: 1 1 auto;
       display: flex;
       flex-direction: column;
-      justify-content: space-between;
-      gap: 2px;
+      justify-content: flex-start;
+      gap: clamp(4px, 0.8vh, 8px);
       overflow-x: hidden;
       overflow-y: auto;
       overscroll-behavior: contain;

--- a/turn/garage/lot-info-typography-r213.css
+++ b/turn/garage/lot-info-typography-r213.css
@@ -1,6 +1,6 @@
-/* Readability pass for THE LOT after the compact r212 information-panel fit.
-   Future Racer's two-line perk is the height-budget acceptance case: every six-stat
-   row must remain visible at rest without needing to scroll the information panel. */
+/* Readable car attributes for THE LOT. Descriptive copy remains available in CAR
+   INFORMATION for assistive technology, while the visual panel gives its space to
+   the six canonical attributes and opens optional perk copy in a popover. */
 
 /* The old SELECTED CAR eyebrow stays in source for legacy compatibility, but the
    showroom no longer spends visible space on it. */
@@ -11,7 +11,7 @@
 .lot-showroom .lot-car-title {
   grid-template-columns: minmax(0, 1fr);
   gap: 0;
-  padding-bottom: 3px;
+  padding-bottom: 5px;
 }
 
 .lot-showroom .lot-car-title > span {
@@ -27,20 +27,11 @@
   line-height: .92;
 }
 
-.lot-showroom .lot-car-description {
-  margin: 4px 0 1px;
-  font-size: clamp(.52rem, .94vw, .63rem);
-  line-height: 1.16;
-}
-
-.lot-showroom .lot-perk-disclosure {
-  margin-top: 2px !important;
-}
-
-.lot-showroom .lot-perk-copy {
-  margin-bottom: 3px;
-  font-size: clamp(.48rem, .86vw, .58rem);
-  line-height: 1.14;
+/* The selected-car description is useful alt-style information, but no longer
+   competes with the visual meters. Keep it in the accessibility tree at every
+   viewport height, including the old <=430px landscape breakpoint. */
+.lot-showroom .lot-car-description.lot-a11y-only {
+  display: block !important;
 }
 
 /* Visual section label only: screen-reader heading navigation intentionally stays
@@ -48,46 +39,84 @@
 .lot-showroom .lot-attributes-row {
   display: flex;
   min-width: 0;
-  min-height: 18px;
-  margin: 2px 0 0;
+  min-height: 28px;
+  margin: 5px 0 1px;
   align-items: center;
-  gap: 5px;
+  gap: 7px;
 }
 
 .lot-showroom .lot-attributes-label {
   color: var(--ink, #08090a);
-  font-size: clamp(.46rem, .76vw, .53rem);
+  font-size: clamp(.68rem, 1.35vw, .92rem);
   font-weight: 950;
   line-height: 1;
-  letter-spacing: .08em;
+  letter-spacing: .055em;
 }
 
 .lot-showroom .lot-stats-help {
-  flex: 0 0 21px;
-  width: 21px;
-  height: 21px;
+  flex: 0 0 27px;
+  width: 27px;
+  height: 27px;
   margin: 0;
-  font-size: .7rem;
+  font-size: .78rem;
 }
 
 .lot-showroom .lot-stats {
-  gap: 1px;
-  margin: 0 0 1px;
+  flex: 1 0 112px;
+  grid-template-rows: repeat(6, minmax(17px, 34px));
+  align-content: space-evenly;
+  gap: 2px;
+  min-height: 112px;
+  margin: 0;
 }
 
 .lot-showroom .lot-stat {
-  grid-template-columns: 88px minmax(0, 1fr);
-  gap: 6px;
+  grid-template-columns: clamp(82px, 11vw, 104px) minmax(0, 1fr);
+  gap: clamp(6px, .85vw, 10px);
 }
 
 .lot-showroom .lot-stat > span {
-  font-size: clamp(.44rem, .73vw, .5rem);
+  font-size: clamp(.56rem, 1.05vw, .72rem);
   line-height: 1;
-  letter-spacing: .04em;
+  letter-spacing: .025em;
 }
 
 .lot-showroom .lot-stat i {
-  height: 7px;
+  grid-template-columns: repeat(5, minmax(12px, 1fr));
+  gap: clamp(3px, .48vw, 6px);
+  height: clamp(13px, 2.7vh, 18px);
+}
+
+.lot-showroom .lot-stat b {
+  border: 3px solid var(--lot-stat-accent);
+  border-radius: 999px;
+  background: var(--paper, #fff8e8);
+}
+
+.lot-showroom .lot-stat:nth-child(1),
+.lot-showroom .lot-stat:nth-child(2) {
+  --lot-stat-accent: var(--turn-control-gas, #8ce99a);
+}
+
+.lot-showroom .lot-stat:nth-child(3),
+.lot-showroom .lot-stat:nth-child(4) {
+  --lot-stat-accent: var(--turn-control-drift, #38d9ff);
+}
+
+.lot-showroom .lot-stat:nth-child(5),
+.lot-showroom .lot-stat:nth-child(6) {
+  --lot-stat-accent: var(--turn-control-boost, #ffd43b);
+}
+
+.lot-showroom .lot-stat:is(
+  :nth-child(1),
+  :nth-child(2),
+  :nth-child(3),
+  :nth-child(4),
+  :nth-child(5),
+  :nth-child(6)
+) b.is-full {
+  background: #313131;
 }
 
 /* This button intentionally uses the compact CHOOSE TRACK-style footprint. */
@@ -137,41 +166,29 @@
     font-size: clamp(1.12rem, 2.35vw, 1.72rem);
   }
 
-  .lot-showroom .lot-car-description {
-    margin-top: 3px;
-    font-size: clamp(.5rem, .9vw, .6rem);
-    line-height: 1.13;
-  }
-
-  .lot-showroom .lot-perk-disclosure {
-    margin-top: 1px !important;
-  }
-
-  .lot-showroom .lot-perk-copy {
-    margin-bottom: 2px;
-    font-size: clamp(.46rem, .82vw, .55rem);
-    line-height: 1.12;
-  }
-
   .lot-showroom .lot-attributes-row {
-    min-height: 17px;
-    margin-top: 1px;
-    gap: 4px;
+    min-height: 25px;
+    margin-top: 3px;
+    gap: 6px;
   }
 
   .lot-showroom .lot-attributes-label {
-    font-size: clamp(.44rem, .72vw, .5rem);
+    font-size: clamp(.64rem, 1.22vw, .82rem);
   }
 
   .lot-showroom .lot-stats-help {
-    flex-basis: 20px;
-    width: 20px;
-    height: 20px;
-    font-size: .66rem;
+    flex-basis: 24px;
+    width: 24px;
+    height: 24px;
+    font-size: .72rem;
   }
 
   .lot-showroom .lot-stat > span {
-    font-size: clamp(.42rem, .7vw, .48rem);
+    font-size: clamp(.54rem, 1vw, .66rem);
+  }
+
+  .lot-showroom .lot-stat i {
+    height: 13px;
   }
 
   .lot-showroom .lot-race {

--- a/turn/garage/lot-layout-r60.js
+++ b/turn/garage/lot-layout-r60.js
@@ -75,6 +75,7 @@ function installBottomActionStyles() {
 export function installLotLayout(root = document.body) {
   const screen = root.querySelector('.lot-screen');
   const attributesHeading = screen?.querySelector('.lot-car-title > span');
+  const carDescription = screen?.querySelector('.lot-car-description');
   const infoButton = screen?.querySelector('.lot-stats-help');
   const headingCopy = screen?.querySelector('.lot-heading > p');
   const backButton = screen?.querySelector('.lot-back');
@@ -89,6 +90,7 @@ export function installLotLayout(root = document.body) {
   // without introducing another semantic heading between CAR INFORMATION and RACE.
   if (screen.classList.contains('lot-showroom')) {
     attributesHeading.replaceChildren(document.createTextNode('SELECTED CAR'));
+    carDescription?.classList.add('lot-a11y-only');
 
     const stats = screen.querySelector('.lot-stats');
     let attributesRow = screen.querySelector('.lot-attributes-row');
@@ -115,6 +117,7 @@ export function installLotLayout(root = document.body) {
       if (infoButton?.isConnected && attributesHeading.isConnected) {
         attributesHeading.appendChild(infoButton);
       }
+      carDescription?.classList.remove('lot-a11y-only');
       attributesRow?.remove();
     };
   }

--- a/turn/garage/lot-perk-disclosure.js
+++ b/turn/garage/lot-perk-disclosure.js
@@ -1,35 +1,151 @@
 import { getCarDefinition } from '../vehicle/catalog.js?revision=r164-vintage-rally-polish';
 import { vehiclePerkPresentation } from '../vehicle/perk-presentation.js?revision=r164-post-soak';
 
-const STYLE_ID = 'turn-lot-perk-inline-styles';
+const STYLE_ID = 'turn-lot-perk-popover-styles';
 const activeDisclosures = new WeakMap();
+let nextPopoverId = 0;
 
 function installStyles() {
   if (document.getElementById(STYLE_ID)) return;
   const style = document.createElement('style');
   style.id = STYLE_ID;
   style.textContent = `
-    .lot-perk-disclosure {
-      margin: 6px 0 0;
+    .lot-showroom .lot-car-title {
+      grid-template-columns: minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 8px;
     }
+
+    .lot-showroom .lot-car-title strong {
+      grid-column: 1;
+      grid-row: 1;
+      min-width: 0;
+    }
+
+    .lot-showroom .lot-perk-button {
+      grid-column: 2;
+      grid-row: 1;
+      min-width: 0;
+      min-height: 38px;
+      margin: 0 3px 3px 0;
+      padding: 5px 13px;
+      border: 2.5px solid var(--ink, #08090a);
+      border-radius: 999px;
+      background: var(--pink, #ff4fa3);
+      box-shadow: 4px 4px 0 var(--ink, #08090a);
+      color: var(--ink, #08090a);
+      font-size: clamp(.58rem, 1.05vw, .72rem);
+      font-weight: 950;
+      letter-spacing: .07em;
+      line-height: 1;
+    }
+
+    .lot-showroom .lot-perk-button[hidden],
     .lot-perk-disclosure[hidden] {
       display: none !important;
     }
-    .lot-perk-copy {
-      max-width: 100%;
-      margin: 0;
-      color: #2f6f38;
-      font-size: 0.52rem;
-      font-weight: 800;
-      line-height: 1.25;
+
+    .lot-showroom .lot-perk-button:focus-visible,
+    .lot-perk-disclosure:focus-visible,
+    .lot-perk-disclosure .lot-perk-close:focus-visible {
+      outline: 3px solid var(--cyan, #38d9ff);
+      outline-offset: 3px;
     }
-    .lot-perk-copy strong {
-      color: inherit;
+
+    .lot-perk-disclosure {
+      position: fixed;
+      z-index: 40;
+      inset: auto;
+      top: var(--lot-perk-popover-top, 12px);
+      left: var(--lot-perk-popover-left, 12px);
+      box-sizing: border-box;
+      width: min(300px, calc(100vw - 24px));
+      max-height: min(230px, calc(100vh - 24px));
+      max-height: min(230px, calc(100dvh - 24px));
+      margin: 0 !important;
+      padding: 11px 12px 12px;
+      overflow: auto;
+      overscroll-behavior: contain;
+      border: 3px solid var(--ink, #08090a);
+      border-radius: 15px;
+      background: var(--paper, #fff8e8);
+      box-shadow: 7px 7px 0 var(--ink, #08090a);
+      color: var(--ink, #08090a);
+    }
+
+    .lot-perk-disclosure .lot-perk-head {
+      display: flex;
+      min-width: 0;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 10px;
+    }
+
+    .lot-perk-disclosure .lot-perk-heading {
+      min-width: 0;
+    }
+
+    .lot-perk-disclosure .lot-perk-eyebrow {
+      display: block;
+      margin-bottom: 4px;
+      color: #a20f5d;
+      font-size: .48rem;
       font-weight: 950;
+      letter-spacing: .1em;
     }
-    @media (max-height: 430px) {
-      .lot-perk-disclosure { margin-top: 4px; }
-      .lot-perk-copy { font-size: 0.48rem; }
+
+    .lot-perk-disclosure .lot-perk-title {
+      display: block;
+      font-size: clamp(.78rem, 1.7vw, 1.05rem);
+      font-weight: 950;
+      line-height: 1.05;
+      overflow-wrap: anywhere;
+    }
+
+    .lot-perk-disclosure .lot-perk-close {
+      flex: 0 0 34px;
+      width: 34px;
+      height: 34px;
+      min-height: 0;
+      padding: 0 0 3px;
+      border: 2px solid var(--ink, #08090a);
+      border-radius: 50%;
+      background: var(--pink, #ff4fa3);
+      box-shadow: 3px 3px 0 var(--ink, #08090a);
+      color: var(--ink, #08090a);
+      font: 950 1.2rem/1 system-ui, sans-serif;
+    }
+
+    .lot-showroom .lot-perk-disclosure .lot-perk-copy {
+      margin: 9px 0 0;
+      color: var(--ink, #08090a);
+      font-family: system-ui, sans-serif;
+      font-size: clamp(.7rem, 1.35vw, .86rem);
+      font-weight: 750;
+      line-height: 1.3;
+    }
+
+    @media (max-height: 520px) {
+      .lot-showroom .lot-perk-button {
+        min-height: 34px;
+        margin-right: 2px;
+        padding: 4px 11px;
+        font-size: clamp(.54rem, 1vw, .64rem);
+      }
+
+      .lot-perk-disclosure {
+        width: min(280px, calc(100vw - 20px));
+        max-height: calc(100vh - 20px);
+        max-height: calc(100dvh - 20px);
+        padding: 9px 10px 10px;
+        border-radius: 13px;
+        box-shadow: 5px 5px 0 var(--ink, #08090a);
+      }
+
+      .lot-showroom .lot-perk-disclosure .lot-perk-copy {
+        margin-top: 7px;
+        font-size: clamp(.66rem, 1.28vw, .8rem);
+      }
     }
   `;
   document.head.appendChild(style);
@@ -39,33 +155,201 @@ function selectedVehicleId(screen) {
   return screen.querySelector('.lot-car-option[aria-checked="true"]')?.dataset.carId || '';
 }
 
+function focusWithoutScroll(element) {
+  if (!element) return;
+  try {
+    element.focus({ preventScroll: true });
+  } catch (_) {
+    element.focus();
+  }
+}
+
 export function installLotPerkDisclosure(root = document.body) {
   const screen = root?.matches?.('.lot-screen') ? root : root?.querySelector?.('.lot-screen');
   const card = screen?.querySelector?.('.lot-card');
+  const carTitle = card?.querySelector?.('.lot-car-title');
+  const carName = carTitle?.querySelector?.(':scope > strong');
   const description = card?.querySelector?.('.lot-car-description');
   const picker = screen?.querySelector?.('.lot-car-picker');
-  if (!screen || !card || !description || !picker) return () => {};
+  if (!screen || !card || !carTitle || !carName || !description || !picker) return () => {};
 
   const active = activeDisclosures.get(screen);
   if (active) return active.release;
 
   // A Lot can be enhanced through both the prepared route and the long-lived
   // enhancement runtime. Keep the perk presentation idempotent even if those
-  // paths overlap, and clean up any stale duplicate left by an older install.
-  for (const stale of card.querySelectorAll('.lot-perk-disclosure')) stale.remove();
+  // paths overlap, and clean up stale controls left by an older install.
+  for (const stale of screen.querySelectorAll('.lot-perk-disclosure')) stale.remove();
+  for (const stale of screen.querySelectorAll('.lot-perk-button')) stale.remove();
 
   installStyles();
 
-  const perk = document.createElement('div');
-  perk.className = 'lot-perk-disclosure';
-  perk.hidden = true;
+  nextPopoverId += 1;
+  const popoverId = `turn-lot-perk-popover-${nextPopoverId}`;
+  const titleId = `${popoverId}-title`;
+  const descriptionId = `${popoverId}-description`;
+
+  const trigger = document.createElement('button');
+  trigger.type = 'button';
+  trigger.className = 'lot-perk-button';
+  trigger.textContent = 'PERK';
+  trigger.hidden = true;
+  trigger.setAttribute('aria-haspopup', 'dialog');
+  trigger.setAttribute('aria-controls', popoverId);
+  trigger.setAttribute('aria-expanded', 'false');
+  carName.after(trigger);
+
+  const popover = document.createElement('div');
+  popover.className = 'lot-perk-disclosure';
+  popover.id = popoverId;
+  popover.hidden = true;
+  popover.tabIndex = -1;
+  popover.setAttribute('popover', 'auto');
+  popover.setAttribute('role', 'dialog');
+  popover.setAttribute('aria-modal', 'false');
+  popover.setAttribute('aria-labelledby', titleId);
+  popover.setAttribute('aria-describedby', descriptionId);
+
+  const header = document.createElement('div');
+  header.className = 'lot-perk-head';
+
+  const heading = document.createElement('div');
+  heading.className = 'lot-perk-heading';
+
+  const eyebrow = document.createElement('span');
+  eyebrow.className = 'lot-perk-eyebrow';
+  eyebrow.textContent = 'PERK';
+  eyebrow.setAttribute('aria-hidden', 'true');
+
+  const title = document.createElement('strong');
+  title.className = 'lot-perk-title';
+  title.id = titleId;
+  heading.append(eyebrow, title);
+
+  const close = document.createElement('button');
+  close.type = 'button';
+  close.className = 'lot-perk-close';
+  close.textContent = '×';
+  close.setAttribute('aria-label', 'Close perk information');
+  header.append(heading, close);
 
   const copy = document.createElement('p');
   copy.className = 'lot-perk-copy';
-  perk.appendChild(copy);
-  description.after(perk);
+  copy.id = descriptionId;
+  popover.append(header, copy);
+  description.after(popover);
 
+  const supportsNativePopover = typeof popover.showPopover === 'function'
+    && typeof popover.hidePopover === 'function';
+  let isOpen = false;
   let currentPerkText = '';
+  let focusFrame = 0;
+
+  function positionPopover() {
+    if (!isOpen || !trigger.isConnected || !popover.isConnected) return;
+
+    const visualViewport = globalThis.visualViewport;
+    const viewportLeft = visualViewport?.offsetLeft || 0;
+    const viewportTop = visualViewport?.offsetTop || 0;
+    const viewportWidth = visualViewport?.width || globalThis.innerWidth || document.documentElement.clientWidth;
+    const viewportHeight = visualViewport?.height || globalThis.innerHeight || document.documentElement.clientHeight;
+    const margin = viewportHeight <= 520 ? 10 : 12;
+    const gap = 8;
+    const triggerBox = trigger.getBoundingClientRect();
+    const popoverBox = popover.getBoundingClientRect();
+    const minLeft = viewportLeft + margin;
+    const maxLeft = viewportLeft + viewportWidth - popoverBox.width - margin;
+    const left = Math.min(Math.max(minLeft, triggerBox.right - popoverBox.width), Math.max(minLeft, maxLeft));
+    const below = triggerBox.bottom + gap;
+    const above = triggerBox.top - popoverBox.height - gap;
+    const maxTop = viewportTop + viewportHeight - popoverBox.height - margin;
+    const top = below <= maxTop ? below : Math.max(viewportTop + margin, above);
+
+    popover.style.setProperty('--lot-perk-popover-left', `${Math.round(left)}px`);
+    popover.style.setProperty('--lot-perk-popover-top', `${Math.round(top)}px`);
+  }
+
+  function addOpenListeners() {
+    document.addEventListener('keydown', handleDocumentKeydown, true);
+    if (!supportsNativePopover) document.addEventListener('pointerdown', handleDocumentPointerDown, true);
+    globalThis.addEventListener?.('resize', positionPopover);
+    globalThis.addEventListener?.('scroll', positionPopover, true);
+    globalThis.visualViewport?.addEventListener?.('resize', positionPopover);
+    globalThis.visualViewport?.addEventListener?.('scroll', positionPopover);
+  }
+
+  function removeOpenListeners() {
+    document.removeEventListener('keydown', handleDocumentKeydown, true);
+    document.removeEventListener('pointerdown', handleDocumentPointerDown, true);
+    globalThis.removeEventListener?.('resize', positionPopover);
+    globalThis.removeEventListener?.('scroll', positionPopover, true);
+    globalThis.visualViewport?.removeEventListener?.('resize', positionPopover);
+    globalThis.visualViewport?.removeEventListener?.('scroll', positionPopover);
+  }
+
+  function setOpenState(nextOpen) {
+    if (isOpen === nextOpen) return;
+    isOpen = nextOpen;
+    trigger.setAttribute('aria-expanded', String(nextOpen));
+    if (nextOpen) addOpenListeners();
+    else removeOpenListeners();
+  }
+
+  function openPopover() {
+    if (isOpen || !currentPerkText || trigger.hidden) return;
+    popover.hidden = false;
+    if (supportsNativePopover) popover.showPopover();
+    setOpenState(true);
+    positionPopover();
+    if (focusFrame) cancelAnimationFrame(focusFrame);
+    focusFrame = requestAnimationFrame(() => {
+      focusFrame = 0;
+      positionPopover();
+      focusWithoutScroll(popover);
+    });
+  }
+
+  function closePopover({ restoreFocus = false } = {}) {
+    if (focusFrame) {
+      cancelAnimationFrame(focusFrame);
+      focusFrame = 0;
+    }
+    if (supportsNativePopover && popover.matches(':popover-open')) popover.hidePopover();
+    popover.hidden = true;
+    setOpenState(false);
+    if (restoreFocus && trigger.isConnected && !trigger.hidden) focusWithoutScroll(trigger);
+  }
+
+  function handleTriggerClick() {
+    if (isOpen) closePopover({ restoreFocus: true });
+    else openPopover();
+  }
+
+  function handleCloseClick() {
+    closePopover({ restoreFocus: true });
+  }
+
+  function handleDocumentKeydown(event) {
+    if (event.key !== 'Escape' || !isOpen) return;
+    event.preventDefault();
+    event.stopPropagation();
+    closePopover({ restoreFocus: true });
+  }
+
+  function handleDocumentPointerDown(event) {
+    if (!isOpen || popover.contains(event.target) || trigger.contains(event.target)) return;
+    closePopover();
+  }
+
+  function handleNativeToggle(event) {
+    const nextOpen = event.newState === 'open';
+    if (!nextOpen) popover.hidden = true;
+    setOpenState(nextOpen);
+  }
+
+  trigger.addEventListener('click', handleTriggerClick);
+  close.addEventListener('click', handleCloseClick);
+  if (supportsNativePopover) popover.addEventListener('toggle', handleNativeToggle);
 
   function sync() {
     const vehicleId = selectedVehicleId(screen);
@@ -76,21 +360,27 @@ export function installLotPerkDisclosure(root = document.body) {
       ? `${perkTitle}: ${perkDescription}`
       : '';
 
-    perk.hidden = !perkText;
+    closePopover();
+    trigger.hidden = !perkText;
     if (!perkText) {
-      if (currentPerkText) copy.replaceChildren();
+      trigger.removeAttribute('aria-label');
+      title.textContent = '';
+      copy.textContent = '';
       currentPerkText = '';
       return;
     }
 
+    trigger.setAttribute('aria-label', `Perk: ${perkTitle}`);
     if (perkText !== currentPerkText) {
-      copy.innerHTML = `<strong>${perkTitle}:</strong> ${perkDescription}`;
+      title.textContent = perkTitle;
+      copy.textContent = perkDescription;
       currentPerkText = perkText;
     }
   }
 
-  // Observe only the radio-selection state. Perk copy lives outside the picker,
-  // so updating it cannot trigger this observer or recreate the r164 freeze loop.
+  // Observe only the radio-selection state. The button and popover live outside
+  // the picker, so opening, closing or rewriting them cannot recreate the r164
+  // mutation loop that previously froze The Lot.
   const observer = new MutationObserver(sync);
   observer.observe(picker, {
     subtree: true,
@@ -104,7 +394,12 @@ export function installLotPerkDisclosure(root = document.body) {
     if (released) return;
     released = true;
     observer.disconnect();
-    perk.remove();
+    closePopover();
+    trigger.removeEventListener('click', handleTriggerClick);
+    close.removeEventListener('click', handleCloseClick);
+    if (supportsNativePopover) popover.removeEventListener('toggle', handleNativeToggle);
+    trigger.remove();
+    popover.remove();
     activeDisclosures.delete(screen);
   };
 


### PR DESCRIPTION
## Summary

- keep each selected-car description in **CAR INFORMATION** for screen readers while removing it from the visual layout
- enlarge all six attribute meters, use `#313131` for filled segments, and move the established green/blue/yellow language to segment outlines
- replace inline perk copy with a conditional **PERK** button beside the car name
- open perk details in a labelled, focusable popover with Escape, light-dismiss, close-button and focus-return behavior
- close the popover when the selected car changes and keep the freeze guard scoped strictly to car `aria-checked` mutations
- preserve the standalone-iOS boundary that keeps **COLOR** and **RACE THIS CAR** outside the inner information scroller

## Responsive behavior

Meter segments remain 13–18 px high instead of shrinking toward 7 px. The stat grid expands on taller screens and becomes the only internally scrollable content when a very short landscape viewport cannot fit the full readable layout.

## Verification

- all 75 Node checks from the TURN regression workflow
- syntax checks for TURN, TURN NEXT and test modules
- release identity and all TURN NEXT parity checks
- ESLint: 0 errors (4 pre-existing warnings in unrelated files)
- targeted Lot, Trophy Road, M8/VoiceOver, paint-observer and standalone-PWA scroll-boundary regressions