### PR TITLE
Tighten Lot attribute meter density

### DIFF
--- a/turn-lab/tests/lot-layout-production.mjs
+++ b/turn-lab/tests/lot-layout-production.mjs
@@ -10,6 +10,7 @@ const [
   perkDisclosure,
   layout,
   layoutCss,
+  infoPanel,
   infoTypography,
   lot,
   legend,
@@ -24,6 +25,7 @@ const [
   fs.readFile(new URL('../../turn/garage/lot-perk-disclosure.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-layout-r60.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-layout-r60.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-info-panel-r212.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-info-typography-r213.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-r10.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-stat-legend.js', import.meta.url), 'utf8'),
@@ -68,6 +70,12 @@ assert.match(wrapper, /lot-r10\.js\?build=20260809-r163-native-html&revision=r59
   'The wrapper must load the canonical-lock Lot implementation under a fresh URL');
 assert.match(wrapper, /lot-enhancement-runtime\.js\?revision=r588-canonical-attributes/,
   'The wrapper must load the canonical-attribute accessibility bundle');
+assert.match(wrapper, /lot-enhancement-runtime\.js\?revision=r216-meter-density&build=20260804-r157/,
+  'The wrapper must bypass cached Lot layout enhancements');
+assert.match(wrapper, /lot-info-panel-r212\.css\?revision=r216-meter-density/,
+  'The tightened race-action spacing must load under a fresh stylesheet URL');
+assert.match(wrapper, /lot-info-typography-r213\.css\?revision=r216-meter-density/,
+  'The refined attribute meters must load under a fresh stylesheet URL');
 assert.match(wrapper, /const removeEnhancements = enhanceLotNow\(\)/);
 assert.match(wrapper, /await chooseTrackBeforeLot\(\)/);
 assert.doesNotMatch(wrapper, /installLotLayout|installLotStatLegend|installLotAccessibility/);
@@ -247,12 +255,14 @@ assert.match(
   /\.lot-showroom \.lot-car-description\.lot-a11y-only\s*\{[\s\S]*display: block !important;/,
   'Short landscape layouts must keep the visually hidden description in the accessibility tree'
 );
-assert.match(infoTypography, /grid-template-rows: repeat\(6, minmax\(17px, 34px\)\)/,
-  'All six attribute rows must retain a readable responsive height');
+assert.match(infoTypography, /flex: 1 1 88px;[\s\S]*grid-template-rows: repeat\(6, minmax\(13px, 34px\)\);[\s\S]*align-content: space-between;[\s\S]*min-height: 88px;/,
+  'All six attribute rows must stay readable while yielding enough height to avoid inner scrolling');
 assert.match(infoTypography, /height: clamp\(13px, 2\.7vh, 18px\)/,
   'Meter segments must remain substantially larger than the old 7px bars');
-assert.match(infoTypography, /border: 3px solid var\(--lot-stat-accent\)/,
-  'Attribute category color must live on every segment outline');
+assert.match(infoTypography, /border: 2px solid var\(--lot-stat-accent\)/,
+  'Attribute category outlines must stay thin enough to preserve the dark meter fill');
+assert.match(infoPanel, /\.lot-showroom \.lot-card-actions\s*\{[\s\S]*padding: 2px 0 0;/,
+  'The race action must sit close to the last attribute row');
 assert.match(infoTypography, /--lot-stat-accent: var\(--turn-control-gas, #8ce99a\)/);
 assert.match(infoTypography, /--lot-stat-accent: var\(--turn-control-drift, #38d9ff\)/);
 assert.match(infoTypography, /--lot-stat-accent: var\(--turn-control-boost, #ffd43b\)/);

--- a/turn-lab/tests/lot-pwa-color-scroll-boundary.mjs
+++ b/turn-lab/tests/lot-pwa-color-scroll-boundary.mjs
@@ -30,10 +30,10 @@ assert.match(boundary, /-webkit-overflow-scrolling:\s*touch/,
   'The inner information scroller must retain native iOS momentum scrolling');
 
 // With description and perk copy removed from visual flow, keep title, ATTRIBUTES and
-// the responsive stat grid packed in a predictable order. The stat grid itself owns
-// spare height; negative space still becomes ordinary inner scrolling.
-assert.match(boundary, /\.lot-showroom \.lot-card-info-scroll\s*\{[\s\S]*display:\s*flex;[\s\S]*flex-direction:\s*column;[\s\S]*justify-content:\s*flex-start;[\s\S]*gap:\s*clamp\(4px, 0\.8vh, 8px\);/,
-  'Car-information sections must stay packed while the larger attribute grid owns responsive height');
+// the responsive stat grid packed in a predictable order. Keep the inter-section
+// spacing small enough that all six rows fit before the fixed race action.
+assert.match(boundary, /\.lot-showroom \.lot-card-info-scroll\s*\{[\s\S]*display:\s*flex;[\s\S]*flex-direction:\s*column;[\s\S]*justify-content:\s*flex-start;[\s\S]*gap:\s*clamp\(2px, 0\.5vh, 5px\);/,
+  'Car-information sections must stay packed without creating avoidable inner scrolling');
 
 // The wrapper must contain every car-information node, including the hidden popover
 // source and visible ATTRIBUTES row, while COLOR and RACE stay as card siblings outside it.
@@ -60,7 +60,7 @@ assert.match(layout, /attributesRow\.appendChild\(infoButton\)/);
 
 // The production enhancement lifecycle must install the boundary after perk/stat/layout
 // construction, before the later screen-reader pass moves COLOR into the card.
-assert.match(runtime, /lot-card-scroll-boundary\.js\?revision=r215-info-space/);
+assert.match(runtime, /lot-card-scroll-boundary\.js\?revision=r216-meter-density/);
 assert.match(runtime, /installLotCardScrollBoundary: scrollBoundary\.installLotCardScrollBoundary/);
 const installOrder = runtime.match(/const removePerkDisclosure[\s\S]*?const removeAccessibility = installLotAccessibility\(scope\);/)?.[0] || '';
 assert.ok(installOrder, 'Lot enhancement installation order must remain inspectable');

--- a/turn/garage/lot-card-scroll-boundary.js
+++ b/turn/garage/lot-card-scroll-boundary.js
@@ -1,4 +1,4 @@
-const STYLE_ID = 'turn-lot-card-scroll-boundary-r215-style';
+const STYLE_ID = 'turn-lot-card-scroll-boundary-r216-style';
 const activeBoundaries = new WeakMap();
 
 function findLotScreen(root) {
@@ -26,7 +26,7 @@ function installStyle() {
       display: flex;
       flex-direction: column;
       justify-content: flex-start;
-      gap: clamp(4px, 0.8vh, 8px);
+      gap: clamp(2px, 0.5vh, 5px);
       overflow-x: hidden;
       overflow-y: auto;
       overscroll-behavior: contain;

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -25,7 +25,7 @@ export function prepareLotEnhancements() {
     import('./lot-layout-r60.js?build=20260729-r116&revision=r213-attributes-typography'),
     import('./lot-accessibility-r118.js?build=20260729-r118&revision=r588-canonical-attributes'),
     import('./lot-perk-disclosure.js?revision=r203-idempotent'),
-    import('./lot-card-scroll-boundary.js?revision=r215-info-space'),
+    import('./lot-card-scroll-boundary.js?revision=r216-meter-density'),
     import('./lot-vehicle-copy.js?revision=r181-hatchback-rally'),
     import('../progression/lot-trophy-gate.js?revision=r585-visible-locks'),
     import('../progression/lot-paint-reward.js?revision=r206-pwa-color')

--- a/turn/garage/lot-info-panel-r212.css
+++ b/turn/garage/lot-info-panel-r212.css
@@ -74,7 +74,7 @@
   flex: 0 0 auto;
   width: auto;
   margin: auto 0 0;
-  padding: 5px 0 0;
+  padding: 2px 0 0;
   background: transparent;
 }
 

--- a/turn/garage/lot-info-typography-r213.css
+++ b/turn/garage/lot-info-typography-r213.css
@@ -61,12 +61,14 @@
   font-size: .78rem;
 }
 
+/* Six 13px meters plus five 2px row gaps need exactly 88px. Let the grid shrink
+   to that honest minimum and place spare height between rows, never below BOOST TANK. */
 .lot-showroom .lot-stats {
-  flex: 1 0 112px;
-  grid-template-rows: repeat(6, minmax(17px, 34px));
-  align-content: space-evenly;
+  flex: 1 1 88px;
+  grid-template-rows: repeat(6, minmax(13px, 34px));
+  align-content: space-between;
   gap: 2px;
-  min-height: 112px;
+  min-height: 88px;
   margin: 0;
 }
 
@@ -88,7 +90,7 @@
 }
 
 .lot-showroom .lot-stat b {
-  border: 3px solid var(--lot-stat-accent);
+  border: 2px solid var(--lot-stat-accent);
   border-radius: 999px;
   background: var(--paper, #fff8e8);
 }

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -1,7 +1,7 @@
 import {
   enhanceLotNow,
   prepareLotEnhancements
-} from './lot-enhancement-runtime.js?revision=r215-info-space&build=20260804-r157';
+} from './lot-enhancement-runtime.js?revision=r216-meter-density&build=20260804-r157';
 import { installLotPwaColorSwatches } from './lot-pwa-color-swatch.js?revision=r206-pwa-color';
 import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r52';
 import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
@@ -76,11 +76,11 @@ function prepareShowroomStyles() {
     ),
     prepareStylesheet(
       SHOWROOM_INFO_STYLE_ID,
-      './lot-info-panel-r212.css?revision=r212-future-racer-fit'
+      './lot-info-panel-r212.css?revision=r216-meter-density'
     ),
     prepareStylesheet(
       SHOWROOM_TYPOGRAPHY_STYLE_ID,
-      './lot-info-typography-r213.css?revision=r214-future-racer-no-scroll'
+      './lot-info-typography-r213.css?revision=r216-meter-density'
     )
   ]);
   return showroomStylePromise;


### PR DESCRIPTION
## Summary
- reduce attribute meter outlines from 3px to 2px so filled segments retain more of the requested `#313131` area
- let the six-row grid shrink to its true 88px minimum and distribute spare height between rows instead of below BOOST TANK
- tighten information-section and race-action spacing to avoid unnecessary inner scrolling
- refresh asset revisions and regression coverage

## Verification
- full TURN regression workflow passed locally
- ESLint: 0 errors (4 pre-existing warnings)
- release and TURN NEXT parity checks passed