### PR TITLE
Keep Lot information layout stable across cars

### DIFF
--- a/turn-lab/tests/garage-production.mjs
+++ b/turn-lab/tests/garage-production.mjs
@@ -223,12 +223,14 @@ assert.match(lotEnhancementRuntime, /screen\.dataset\.lotEnhancements = ENHANCEM
 assert.match(lotPerkDisclosure, /getCarDefinition\(vehicleId\)\?\.perk/);
 assert.doesNotMatch(lotPerkDisclosure, /rewardForVehicle|trophy-road/,
   'Perk identity and display must come directly from the car definition');
-assert.match(lotPerkDisclosure, /className = 'lot-perk-button'/);
+assert.match(lotPerkDisclosure, /className = 'lot-perk-button is-layout-placeholder'/);
 assert.match(lotPerkDisclosure, /trigger\.textContent = 'PERK'/);
 assert.match(lotPerkDisclosure, /aria-haspopup', 'dialog'/);
 assert.match(lotPerkDisclosure, /aria-expanded', 'false'/);
 assert.match(lotPerkDisclosure, /setAttribute\('popover', 'auto'\)/);
-assert.match(lotPerkDisclosure, /trigger\.hidden = !perkText/);
+assert.match(lotPerkDisclosure, /trigger\.classList\.toggle\('is-layout-placeholder', !available\)/);
+assert.match(lotPerkDisclosure, /trigger\.disabled = !available/);
+assert.doesNotMatch(lotPerkDisclosure, /trigger\.hidden = !perkText/);
 assert.match(lotPerkDisclosure, /copy\.textContent = perkDescription/);
 assert.doesNotMatch(lotPerkDisclosure, /innerHTML\s*=/);
 assert.match(lotTrophyGate, /trophy-road\.js\?revision=r164-vintage-rally-perks/);

--- a/turn-lab/tests/lot-layout-production.mjs
+++ b/turn-lab/tests/lot-layout-production.mjs
@@ -70,7 +70,7 @@ assert.match(wrapper, /lot-r10\.js\?build=20260809-r163-native-html&revision=r59
   'The wrapper must load the canonical-lock Lot implementation under a fresh URL');
 assert.match(wrapper, /lot-enhancement-runtime\.js\?revision=r588-canonical-attributes/,
   'The wrapper must load the canonical-attribute accessibility bundle');
-assert.match(wrapper, /lot-enhancement-runtime\.js\?revision=r216-meter-density&build=20260804-r157/,
+assert.match(wrapper, /lot-enhancement-runtime\.js\?revision=r217-stable-perk-slot&build=20260804-r157/,
   'The wrapper must bypass cached Lot layout enhancements');
 assert.match(wrapper, /lot-info-panel-r212\.css\?revision=r216-meter-density/,
   'The tightened race-action spacing must load under a fresh stylesheet URL');
@@ -103,7 +103,7 @@ assert.match(perkDisclosure, /className = 'lot-perk-copy'/);
 assert.match(perkDisclosure, /getCarDefinition\(vehicleId\)\?\.perk/);
 assert.doesNotMatch(perkDisclosure, /rewardForVehicle|trophy-road/,
   'Perk display must be driven by the selected car definition rather than Trophy Road ownership');
-assert.match(perkDisclosure, /className = 'lot-perk-button'/);
+assert.match(perkDisclosure, /className = 'lot-perk-button is-layout-placeholder'/);
 assert.match(perkDisclosure, /trigger\.textContent = 'PERK'/);
 assert.match(perkDisclosure, /trigger\.setAttribute\('aria-haspopup', 'dialog'\)/);
 assert.match(perkDisclosure, /trigger\.setAttribute\('aria-controls', popoverId\)/);
@@ -112,10 +112,22 @@ assert.match(perkDisclosure, /popover\.setAttribute\('popover', 'auto'\)/);
 assert.match(perkDisclosure, /popover\.setAttribute\('role', 'dialog'\)/);
 assert.match(perkDisclosure, /popover\.setAttribute\('aria-labelledby', titleId\)/);
 assert.match(perkDisclosure, /popover\.setAttribute\('aria-describedby', descriptionId\)/);
-assert.match(perkDisclosure, /trigger\.hidden = !perkText/,
-  'The PERK action must exist only for cars with named perk content');
-assert.match(perkDisclosure, /closePopover\(\);[\s\S]*trigger\.hidden = !perkText/,
-  'Changing cars must close any open perk before updating the trigger');
+assert.match(perkDisclosure, /\.lot-perk-button\.is-layout-placeholder\s*\{[\s\S]*visibility: hidden;[\s\S]*pointer-events: none;/,
+  'Cars without perks must reserve the same title-row footprint without drawing a false action');
+assert.match(perkDisclosure, /trigger\.disabled = !available;[\s\S]*trigger\.classList\.toggle\('is-layout-placeholder', !available\)/,
+  'Only cars with named perk content may expose an interactive PERK action');
+assert.match(perkDisclosure, /trigger\.setAttribute\('aria-hidden', 'true'\)[\s\S]*trigger\.tabIndex = -1/,
+  'The layout placeholder must stay out of the accessibility tree and tab order');
+assert.match(perkDisclosure, /trigger\.removeAttribute\('aria-hidden'\);[\s\S]*trigger\.removeAttribute\('tabindex'\)/,
+  'A real PERK action must return to the accessibility tree and normal tab order');
+assert.match(perkDisclosure, /if \(isOpen \|\| !currentPerkText \|\| trigger\.disabled\) return;/,
+  'The invisible layout placeholder must never open the perk popover');
+assert.match(perkDisclosure, /restoreFocus && trigger\.isConnected && !trigger\.disabled/,
+  'Popover cleanup must never move focus to an unavailable placeholder');
+assert.match(perkDisclosure, /closePopover\(\);[\s\S]*setTriggerAvailable\(Boolean\(perkText\)\)/,
+  'Changing cars must close any open perk before updating action availability');
+assert.doesNotMatch(perkDisclosure, /trigger\.hidden = !perkText/,
+  'Hiding the PERK action must not collapse the shared information layout');
 assert.match(perkDisclosure, /event\.key !== 'Escape'/);
 assert.match(perkDisclosure, /closePopover\(\{ restoreFocus: true \}\)/);
 assert.doesNotMatch(perkDisclosure, /innerHTML\s*=/,
@@ -130,6 +142,8 @@ assert.doesNotMatch(perkDisclosure, /observer\.observe\(screen,/,
   'The perk presentation must never observe the subtree that contains its own generated copy');
 assert.doesNotMatch(perkDisclosure, /childList:\s*true|characterData:\s*true/,
   'The perk presentation must not react to DOM/text mutations that its own sync function can create');
+assert.match(enhancementRuntime, /lot-perk-disclosure\.js\?revision=r217-stable-perk-slot/,
+  'The stable PERK slot must load under a fresh module URL');
 
 assert.match(
   lot,

--- a/turn-lab/tests/paint-lock-observer-production.mjs
+++ b/turn-lab/tests/paint-lock-observer-production.mjs
@@ -208,7 +208,7 @@ for (const staleCatalogSpecifier of [
 assert.match(paintCss, /\.lot-colors\.is-paint-locked[\s\S]*min-height: 54px/);
 assert.match(lotGate, /function dismissVisibleUnlockNotice\(\)/);
 assert.match(lotRuntime, /lot-trophy-gate\.js\?revision=r164-vintage-rally-perks/);
-assert.match(lotRuntime, /lot-perk-disclosure\.js\?revision=r203-idempotent/);
+assert.match(lotRuntime, /lot-perk-disclosure\.js\?revision=r217-stable-perk-slot/);
 assert.match(perkPresentation, /getCarDefinition\(vehicleId\)\?\.perk/);
 assert.doesNotMatch(perkPresentation, /observer\.observe\(screen,/);
 assert.match(app, /trophy-road-r157\.css\?revision=r163-native-picker-parent-click/);

--- a/turn-lab/tests/trophy-road-production.mjs
+++ b/turn-lab/tests/trophy-road-production.mjs
@@ -311,9 +311,11 @@ assert.match(perkDisclosure, /getCarDefinition\(vehicleId\)\?\.perk/,
 assert.doesNotMatch(perkDisclosure, /rewardForVehicle|trophy-road/,
   'Vehicle perks must not be free-floating Trophy Road entitlements');
 assert.match(perkDisclosure, /className = 'lot-perk-copy'/);
-assert.match(perkDisclosure, /className = 'lot-perk-button'/);
-assert.match(perkDisclosure, /trigger\.hidden = !perkText/,
-  'Only cars that own a perk may expose the PERK action');
+assert.match(perkDisclosure, /className = 'lot-perk-button is-layout-placeholder'/);
+assert.match(perkDisclosure, /trigger\.classList\.toggle\('is-layout-placeholder', !available\)/,
+  'Only cars that own a perk may expose an interactive PERK action');
+assert.match(perkDisclosure, /trigger\.disabled = !available/,
+  'The reserved PERK footprint must remain inert for cars without perks');
 assert.match(perkDisclosure, /trigger\.setAttribute\('aria-expanded', String\(nextOpen\)\)/,
   'The PERK action must expose its popover state');
 assert.match(perkDisclosure, /popover\.setAttribute\('role', 'dialog'\)/,

--- a/turn-tests/m8-lot-selection-production.mjs
+++ b/turn-tests/m8-lot-selection-production.mjs
@@ -173,7 +173,7 @@ assert.match(paintReward, /`<strong>\$\{threshold\} 🏆<\/strong><small>TO UNLO
   'Locked paint must display its Trophy Road unlock requirement next to the swatch');
 assert.match(paintReward, /`Color locked\. Car color controls unlock at \$\{threshold\} trophies on Trophy Road\.`/,
   'The locked color button must explain specifically that color, not the whole car, is locked');
-assert.match(enhancementRuntime, /lot-perk-disclosure\.js\?revision=r203-idempotent/,
+assert.match(enhancementRuntime, /lot-perk-disclosure\.js\?revision=r217-stable-perk-slot/,
   'The fixed perk installer must receive a fresh module cache identity');
 assert.match(enhancementRuntime, /lot-paint-reward\.js\?revision=r203-color-label/,
   'The clarified color gate must receive a fresh module cache identity');

--- a/turn-tests/post-soak-production.mjs
+++ b/turn-tests/post-soak-production.mjs
@@ -159,7 +159,7 @@ assert.equal(
   'Other vehicle perk copy must remain untouched'
 );
 assert.match(lotPerk, /vehiclePerkPresentation\(vehicleId, getCarDefinition\(vehicleId\)\?\.perk\)/);
-assert.match(lotRuntime, /lot-perk-disclosure\.js\?revision=r203-idempotent/);
+assert.match(lotRuntime, /lot-perk-disclosure\.js\?revision=r217-stable-perk-slot/);
 assert.match(trophyWrapper, /FUTURE_RACER_REWARD_PERK_DESCRIPTION/);
 assert.match(trophyWrapper, /reward\.id !== 'future-racer'/);
 

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -24,7 +24,7 @@ export function prepareLotEnhancements() {
     import('./lot-stat-legend.js?build=20260724-r59'),
     import('./lot-layout-r60.js?build=20260729-r116&revision=r213-attributes-typography'),
     import('./lot-accessibility-r118.js?build=20260729-r118&revision=r588-canonical-attributes'),
-    import('./lot-perk-disclosure.js?revision=r203-idempotent'),
+    import('./lot-perk-disclosure.js?revision=r217-stable-perk-slot'),
     import('./lot-card-scroll-boundary.js?revision=r216-meter-density'),
     import('./lot-vehicle-copy.js?revision=r181-hatchback-rally'),
     import('../progression/lot-trophy-gate.js?revision=r585-visible-locks'),

--- a/turn/garage/lot-perk-disclosure.js
+++ b/turn/garage/lot-perk-disclosure.js
@@ -1,7 +1,7 @@
 import { getCarDefinition } from '../vehicle/catalog.js?revision=r164-vintage-rally-polish';
 import { vehiclePerkPresentation } from '../vehicle/perk-presentation.js?revision=r164-post-soak';
 
-const STYLE_ID = 'turn-lot-perk-popover-styles';
+const STYLE_ID = 'turn-lot-perk-popover-r217-styles';
 const activeDisclosures = new WeakMap();
 let nextPopoverId = 0;
 
@@ -40,7 +40,13 @@ function installStyles() {
       line-height: 1;
     }
 
-    .lot-showroom .lot-perk-button[hidden],
+    /* Keep the PERK footprint in every title row. Cars without a perk use an
+       inert, invisible placeholder so their attributes start at the same height. */
+    .lot-showroom .lot-perk-button.is-layout-placeholder {
+      visibility: hidden;
+      pointer-events: none;
+    }
+
     .lot-perk-disclosure[hidden] {
       display: none !important;
     }
@@ -191,9 +197,11 @@ export function installLotPerkDisclosure(root = document.body) {
 
   const trigger = document.createElement('button');
   trigger.type = 'button';
-  trigger.className = 'lot-perk-button';
+  trigger.className = 'lot-perk-button is-layout-placeholder';
   trigger.textContent = 'PERK';
-  trigger.hidden = true;
+  trigger.disabled = true;
+  trigger.tabIndex = -1;
+  trigger.setAttribute('aria-hidden', 'true');
   trigger.setAttribute('aria-haspopup', 'dialog');
   trigger.setAttribute('aria-controls', popoverId);
   trigger.setAttribute('aria-expanded', 'false');
@@ -296,7 +304,7 @@ export function installLotPerkDisclosure(root = document.body) {
   }
 
   function openPopover() {
-    if (isOpen || !currentPerkText || trigger.hidden) return;
+    if (isOpen || !currentPerkText || trigger.disabled) return;
     popover.hidden = false;
     if (supportsNativePopover) popover.showPopover();
     setOpenState(true);
@@ -317,7 +325,7 @@ export function installLotPerkDisclosure(root = document.body) {
     if (supportsNativePopover && popover.matches(':popover-open')) popover.hidePopover();
     popover.hidden = true;
     setOpenState(false);
-    if (restoreFocus && trigger.isConnected && !trigger.hidden) focusWithoutScroll(trigger);
+    if (restoreFocus && trigger.isConnected && !trigger.disabled) focusWithoutScroll(trigger);
   }
 
   function handleTriggerClick() {
@@ -351,6 +359,19 @@ export function installLotPerkDisclosure(root = document.body) {
   close.addEventListener('click', handleCloseClick);
   if (supportsNativePopover) popover.addEventListener('toggle', handleNativeToggle);
 
+  function setTriggerAvailable(available) {
+    if (!available && document.activeElement === trigger) trigger.blur();
+    trigger.disabled = !available;
+    trigger.classList.toggle('is-layout-placeholder', !available);
+    if (available) {
+      trigger.removeAttribute('aria-hidden');
+      trigger.removeAttribute('tabindex');
+    } else {
+      trigger.setAttribute('aria-hidden', 'true');
+      trigger.tabIndex = -1;
+    }
+  }
+
   function sync() {
     const vehicleId = selectedVehicleId(screen);
     const vehiclePerk = vehiclePerkPresentation(vehicleId, getCarDefinition(vehicleId)?.perk);
@@ -361,7 +382,7 @@ export function installLotPerkDisclosure(root = document.body) {
       : '';
 
     closePopover();
-    trigger.hidden = !perkText;
+    setTriggerAvailable(Boolean(perkText));
     if (!perkText) {
       trigger.removeAttribute('aria-label');
       title.textContent = '';

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -1,7 +1,7 @@
 import {
   enhanceLotNow,
   prepareLotEnhancements
-} from './lot-enhancement-runtime.js?revision=r216-meter-density&build=20260804-r157';
+} from './lot-enhancement-runtime.js?revision=r217-stable-perk-slot&build=20260804-r157';
 import { installLotPwaColorSwatches } from './lot-pwa-color-swatch.js?revision=r206-pwa-color';
 import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r52';
 import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';


### PR DESCRIPTION
## Summary
- preserve the PERK button footprint for every selected car so title, divider, ATTRIBUTES and meters no longer jump vertically
- keep the placeholder invisible, disabled, non-interactive, outside the tab order and hidden from assistive technology
- retain the normal accessible button and popover behavior for cars that actually have a perk
- refresh module routing and regression contracts

## Verification
- full TURN regression workflow passed locally
- release and TURN NEXT parity checks passed
- ESLint: 0 errors (4 pre-existing warnings)