### PR TITLE
Add black inset edge to Lot attribute meters

### DIFF
--- a/turn-lab/tests/lot-layout-production.mjs
+++ b/turn-lab/tests/lot-layout-production.mjs
@@ -74,8 +74,8 @@ assert.match(wrapper, /lot-enhancement-runtime\.js\?revision=r217-stable-perk-sl
   'The wrapper must bypass cached Lot layout enhancements');
 assert.match(wrapper, /lot-info-panel-r212\.css\?revision=r216-meter-density/,
   'The tightened race-action spacing must load under a fresh stylesheet URL');
-assert.match(wrapper, /lot-info-typography-r213\.css\?revision=r216-meter-density/,
-  'The refined attribute meters must load under a fresh stylesheet URL');
+assert.match(wrapper, /lot-info-typography-r213\.css\?revision=r218-meter-black-outline/,
+  'The black-edged attribute meters must load under a fresh stylesheet URL');
 assert.match(wrapper, /const removeEnhancements = enhanceLotNow\(\)/);
 assert.match(wrapper, /await chooseTrackBeforeLot\(\)/);
 assert.doesNotMatch(wrapper, /installLotLayout|installLotStatLegend|installLotAccessibility/);
@@ -275,6 +275,10 @@ assert.match(infoTypography, /height: clamp\(13px, 2\.7vh, 18px\)/,
   'Meter segments must remain substantially larger than the old 7px bars');
 assert.match(infoTypography, /border: 2px solid var\(--lot-stat-accent\)/,
   'Attribute category outlines must stay thin enough to preserve the dark meter fill');
+assert.match(infoTypography, /outline: 0\.5px solid #000/,
+  'Attribute meters must gain a 0.5px black outer edge');
+assert.match(infoTypography, /outline-offset: -0\.5px/,
+  'The black edge must sit inside the existing meter footprint rather than increase its size');
 assert.match(infoPanel, /\.lot-showroom \.lot-card-actions\s*\{[\s\S]*padding: 2px 0 0;/,
   'The race action must sit close to the last attribute row');
 assert.match(infoTypography, /--lot-stat-accent: var\(--turn-control-gas, #8ce99a\)/);

--- a/turn/garage/lot-info-typography-r213.css
+++ b/turn/garage/lot-info-typography-r213.css
@@ -91,6 +91,8 @@
 
 .lot-showroom .lot-stat b {
   border: 2px solid var(--lot-stat-accent);
+  outline: 0.5px solid #000;
+  outline-offset: -0.5px;
   border-radius: 999px;
   background: var(--paper, #fff8e8);
 }

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -80,7 +80,7 @@ function prepareShowroomStyles() {
     ),
     prepareStylesheet(
       SHOWROOM_TYPOGRAPHY_STYLE_ID,
-      './lot-info-typography-r213.css?revision=r216-meter-density'
+      './lot-info-typography-r213.css?revision=r218-meter-black-outline'
     )
   ]);
   return showroomStylePromise;


### PR DESCRIPTION
## Summary
- keep the existing 2px semantic-color meter border
- overlay its outer 0.5px with a black outline using a negative outline offset
- preserve the exact meter footprint: no added width, height, gap, or layout pressure
- refresh only the changed typography stylesheet URL and pin the no-growth contract in the Lot regression

## Visual intent
The colored frame still communicates GAS / DRIFT / BOOST categories, while the new black hairline gives each pill the requested stronger edge. Filled segments remain `#313131`.

## Scope
Presentation only. No car stats, layout dimensions, PERK behavior, accessibility semantics, physics, or controls change.