### PR TITLE
Reduce finish-line rival visual spikes

### DIFF
--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -167,8 +167,8 @@ assert.match(
 );
 assert.match(
   carModels,
-  /normalizeModelToGround\(model, targetLength \* effectiveVisualScale\)/,
-  'Every model surface must receive its resolved scale through the shared factory'
+  /normalizeModelToGround\(\s*model,\s*targetLength \* effectiveVisualScale,\s*`\$\{car\.id\}\|\$\{outline \? 1 : 0\}`\s*\)/,
+  'Every model surface must receive its resolved scale and stable geometry cache identity through the shared factory'
 );
 assert.match(carModels, /turnVisualSizeMultiplier = car\.visualSizeMultiplier/);
 assert.match(carModels, /turnFeaturedVisualSizeMultiplier = featuredVisualSizeMultiplier/);

--- a/turn-tests/rival-visual-sync-production.mjs
+++ b/turn-tests/rival-visual-sync-production.mjs
@@ -1,12 +1,13 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [releaseSource, index, main, trackManager, leaderMarker] = await Promise.all([
+const [releaseSource, index, main, trackManager, leaderMarker, carModels] = await Promise.all([
   fs.readFile(new URL('../turn/release.json', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/main.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/tracks/track-manager.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/ui/leader-marker-r500.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/ui/leader-marker-r500.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/vehicle/car-models.js', import.meta.url), 'utf8')
 ]);
 
 const release = JSON.parse(releaseSource);
@@ -50,6 +51,50 @@ assert.ok(
 assert.match(main, /competitorCars,\s*ensureCompetitorCars,\s*syncCompetitorVisuals,/, 'The runtime must expose separate pool and identity operations');
 assert.match(main, /if \(root\.userData\.turnVisualKey === key \|\| root\.userData\.turnVisualPendingKey === key\) return;/, 'Model installation must retain its duplicate-key fast path');
 
+const createVisualSection = section(carModels, 'export async function createCarVisual({', '\nfunction reusableCompetitorGhostKey');
+assert.match(createVisualSection, /competitorGhostTemplateCache\.get\(competitorTemplateKey\)/,
+  'Repeated 5.5-unit rival identities must consult the in-memory visual template cache');
+assert.ok(
+  createVisualSection.indexOf('competitorGhostTemplateCache.get(competitorTemplateKey)')
+    < createVisualSection.indexOf('const source = await loadCarSource(car.id)'),
+  'A cached rival identity must avoid GLTF cloning, material classification and normalization entirely'
+);
+assert.match(createVisualSection, /return cloneCompetitorGhostVisual\(cachedCompetitorTemplate\)/,
+  'Cached rival identities must use the lightweight clone path');
+assert.match(createVisualSection, /rememberCompetitorGhostTemplate\(competitorTemplateKey, root\)/,
+  'The first fully prepared rival identity must become the reusable template');
+
+const cloneSection = section(carModels, 'function cloneCompetitorGhostVisual(template)', '\nfunction installWheelAnimationHostBridge');
+assert.match(cloneSection, /for \(const child of template\.children\) clone\.add\(child\.clone\(true\)\)/,
+  'Fast rival clones must reuse the already-prepared geometry/material graph');
+assert.match(cloneSection, /frontWheelPivots\.push\(node\)/,
+  'Fast rival clones must rebuild their own steering-pivot references');
+assert.match(cloneSection, /turnFastGhostClone = true/,
+  'The optimized path must remain inspectable in diagnostics');
+assert.doesNotMatch(cloneSection, /loadCarSource|installSemanticCarFinish|normalizeModelToGround|addOutlines/,
+  'Fast rival cloning must not repeat the expensive first-build pipeline');
+
+const outlineSection = section(carModels, 'function addOutlines(model)', '\nfunction installFrontWheelSteeringRig');
+assert.match(carModels, /const CAR_OUTLINE_MATERIAL = new THREE\.MeshBasicMaterial\(/,
+  'All car outlines must share one immutable material instead of allocating one material per mesh');
+assert.match(outlineSection, /new THREE\.Mesh\(node\.geometry, CAR_OUTLINE_MATERIAL\)/,
+  'Outline meshes must reuse the shared material');
+assert.doesNotMatch(outlineSection, /new THREE\.MeshBasicMaterial/,
+  'Repeated rival creation must not allocate outline materials per mesh');
+
+const normalizationSection = section(carModels, 'function normalizeModelToGround', '\nfunction isProtectedPart');
+assert.match(carModels, /const normalizationMetricsCache = new Map\(\)/,
+  'Geometry normalization metrics must be cached by stable car geometry identity');
+assert.match(normalizationSection, /normalizationMetricsCache\.get\(cacheKey\)/,
+  'Repeated visuals must reuse the already-measured footprint');
+assert.equal(
+  (normalizationSection.match(/new THREE\.Box3\(\)\.setFromObject\(model\)/g) || []).length,
+  1,
+  'A cold normalization may measure bounds once; the old second full scene traversal must not return'
+);
+assert.doesNotMatch(normalizationSection, /model\.updateMatrixWorld\(true\)[\s\S]*model\.updateMatrixWorld\(true\)/,
+  'Normalization must not force two complete matrix/bounds passes per visual');
+
 const leaderRoofSection = section(leaderMarker, 'function carRoofHeight', '\nfunction installRuntime');
 assert.match(leaderRoofSection, /child\.userData\?\.turnAssetVisual/, 'The leader marker must measure the installed rival model');
 assert.match(leaderRoofSection, /child\.visible !== false/, 'The procedural car must remain a fallback while its asset loads');
@@ -64,7 +109,7 @@ const infrastructureSection = section(trackManager, 'function ensureTrackInfrast
 assert.match(infrastructureSection, /currentRuntime\.ensureCompetitorCars\?\.\(\)/, 'Dynamic-world setup must still create the full fixed rival pool before reparenting');
 assert.doesNotMatch(infrastructureSection, /syncCompetitorVisuals/, 'World-layer setup must not perform unrelated model identity work');
 
-console.log(`TURN ${release.id} event-driven rival model synchronisation passed.`);
+console.log(`TURN ${release.id} event-driven rival model synchronisation and reusable finish-line visual fast path passed.`);
 
 function section(source, startMarker, endMarker) {
   const start = source.indexOf(startMarker);

--- a/turn/vehicle/car-models.js
+++ b/turn/vehicle/car-models.js
@@ -21,10 +21,25 @@ import {
 
 const loadersByPack = new Map();
 const sourceCache = new Map();
+const normalizationMetricsCache = new Map();
+const competitorGhostTemplateCache = new Map();
 const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
 const TIRE_COLOR = 0x17191c;
 const FEATURED_SURFACE_TARGET_LENGTHS = new Set([5.15, 5.5]);
 const REVERSED_FRONT_WHEEL_LABEL_IDS = new Set(['vintage-racer']);
+const COMPETITOR_GHOST_TARGET_LENGTH = 5.5;
+const COMPETITOR_GHOST_TEMPLATE_LIMIT = 16;
+const CAR_OUTLINE_MATERIAL = new THREE.MeshBasicMaterial({
+  color: 0x08090a,
+  side: THREE.BackSide,
+  transparent: false,
+  opacity: 1,
+  depthTest: true,
+  depthWrite: false,
+  polygonOffset: true,
+  polygonOffsetFactor: 1,
+  polygonOffsetUnits: 1
+});
 
 export async function preloadCarModels(carIds) {
   await Promise.all(carIds.map((carId) => loadCarSource(carId).catch(() => null)));
@@ -51,17 +66,30 @@ export async function createCarVisual({
   outline = true
 }) {
   const car = getCarDefinition(carId);
+  const requestedColor = normalizeVehicleColor(color, car.defaultColor);
+  const requestedSecondaryColor = normalizeVehicleSecondaryColor(
+    secondaryColor,
+    car.defaultSecondaryColor
+  );
+  const competitorTemplateKey = reusableCompetitorGhostKey({
+    car,
+    color: requestedColor,
+    secondaryColor: requestedSecondaryColor,
+    ghost,
+    targetLength,
+    outline
+  });
+  const cachedCompetitorTemplate = competitorTemplateKey
+    ? competitorGhostTemplateCache.get(competitorTemplateKey)
+    : null;
+  if (cachedCompetitorTemplate) return cloneCompetitorGhostVisual(cachedCompetitorTemplate);
+
   const source = await loadCarSource(car.id);
   const root = new THREE.Group();
   const model = source.clone(true);
   model.rotation.y = Math.PI + car.modelYawQuarterTurns * Math.PI / 2;
   root.add(model);
 
-  const requestedColor = normalizeVehicleColor(color, car.defaultColor);
-  const requestedSecondaryColor = normalizeVehicleSecondaryColor(
-    secondaryColor,
-    car.defaultSecondaryColor
-  );
   const requestedColorSpec = primaryColorSpec(car, requestedColor);
   const requestedSecondaryColorSpec = secondaryColorSpec(car, requestedSecondaryColor);
   const ghostColor = makeGhostColor(requestedColor);
@@ -147,7 +175,11 @@ export async function createCarVisual({
   const effectiveVisualScale = car.visualScale
     * car.visualSizeMultiplier
     * featuredVisualSizeMultiplier;
-  normalizeModelToGround(model, targetLength * effectiveVisualScale);
+  normalizeModelToGround(
+    model,
+    targetLength * effectiveVisualScale,
+    `${car.id}|${outline ? 1 : 0}`
+  );
   if (car.emergencyService && !ghost) installEmergencyLightRig(root, model, car.emergencyService);
 
   root.userData.turnCarId = car.id;
@@ -166,7 +198,61 @@ export async function createCarVisual({
   root.userData.frontWheelPivots = frontWheelPivots;
   root.userData.wheelSpinners = [];
   installWheelAnimationHostBridge(root);
+  if (competitorTemplateKey) rememberCompetitorGhostTemplate(competitorTemplateKey, root);
   return root;
+}
+
+function reusableCompetitorGhostKey({ car, color, secondaryColor, ghost, targetLength, outline }) {
+  if (
+    ghost !== true
+    || outline !== true
+    || Math.abs(Number(targetLength) - COMPETITOR_GHOST_TARGET_LENGTH) > 0.000001
+  ) return '';
+  return `${car.id}|${color}|${secondaryColor}|${COMPETITOR_GHOST_TARGET_LENGTH}`;
+}
+
+function rememberCompetitorGhostTemplate(key, visual) {
+  if (competitorGhostTemplateCache.has(key)) competitorGhostTemplateCache.delete(key);
+  competitorGhostTemplateCache.set(key, visual);
+  while (competitorGhostTemplateCache.size > COMPETITOR_GHOST_TEMPLATE_LIMIT) {
+    competitorGhostTemplateCache.delete(competitorGhostTemplateCache.keys().next().value);
+  }
+}
+
+function cloneCompetitorGhostVisual(template) {
+  const clone = new THREE.Group();
+  clone.name = template.name;
+  clone.position.copy(template.position);
+  clone.quaternion.copy(template.quaternion);
+  clone.scale.copy(template.scale);
+  clone.visible = template.visible;
+  for (const child of template.children) clone.add(child.clone(true));
+
+  const frontWheelPivots = [];
+  clone.traverse((node) => {
+    if (!String(node?.name || '').endsWith('-steer-pivot')) return;
+    node.rotation.y = 0;
+    frontWheelPivots.push(node);
+  });
+
+  clone.userData.turnCarId = template.userData.turnCarId;
+  clone.userData.turnCarColor = template.userData.turnCarColor;
+  clone.userData.turnCarSecondaryColor = template.userData.turnCarSecondaryColor;
+  clone.userData.turnGhost = true;
+  clone.userData.turnModelYawQuarterTurns = template.userData.turnModelYawQuarterTurns;
+  clone.userData.turnVisualSizeMultiplier = template.userData.turnVisualSizeMultiplier;
+  clone.userData.turnFeaturedVisualSizeMultiplier = template.userData.turnFeaturedVisualSizeMultiplier;
+  clone.userData.turnFeaturedVisualSurface = template.userData.turnFeaturedVisualSurface;
+  clone.userData.turnEffectiveVisualScale = template.userData.turnEffectiveVisualScale;
+  clone.userData.turnPrimaryPaintMaterials = [];
+  clone.userData.turnSecondaryPaintMaterials = [];
+  clone.userData.turnPaintMaterials = [];
+  clone.userData.turnSemanticPaintRecords = [];
+  clone.userData.frontWheelPivots = frontWheelPivots;
+  clone.userData.wheelSpinners = [];
+  clone.userData.turnFastGhostClone = true;
+  installWheelAnimationHostBridge(clone);
+  return clone;
 }
 
 function installWheelAnimationHostBridge(visual) {
@@ -329,20 +415,7 @@ function addOutlines(model) {
   });
 
   for (const node of originals) {
-    const outline = new THREE.Mesh(
-      node.geometry,
-      new THREE.MeshBasicMaterial({
-        color: 0x08090a,
-        side: THREE.BackSide,
-        transparent: false,
-        opacity: 1,
-        depthTest: true,
-        depthWrite: false,
-        polygonOffset: true,
-        polygonOffsetFactor: 1,
-        polygonOffsetUnits: 1
-      })
-    );
+    const outline = new THREE.Mesh(node.geometry, CAR_OUTLINE_MATERIAL);
     outline.scale.setScalar(1.035);
     outline.castShadow = false;
     outline.receiveShadow = false;
@@ -384,19 +457,27 @@ function wheelRole(name = '') {
   return null;
 }
 
-function normalizeModelToGround(model, targetLength) {
-  model.updateMatrixWorld(true);
-  const initialBounds = new THREE.Box3().setFromObject(model);
-  const size = initialBounds.getSize(new THREE.Vector3());
-  const footprintLength = Math.max(0.001, size.x, size.z);
-  model.scale.multiplyScalar(targetLength / footprintLength);
-  model.updateMatrixWorld(true);
+function normalizeModelToGround(model, targetLength, cacheKey = '') {
+  let metrics = cacheKey ? normalizationMetricsCache.get(cacheKey) : null;
+  if (!metrics) {
+    model.updateMatrixWorld(true);
+    const initialBounds = new THREE.Box3().setFromObject(model);
+    const size = initialBounds.getSize(new THREE.Vector3());
+    const center = initialBounds.getCenter(new THREE.Vector3());
+    metrics = Object.freeze({
+      footprintLength: Math.max(0.001, size.x, size.z),
+      centerOffsetX: center.x - model.position.x,
+      centerOffsetZ: center.z - model.position.z,
+      minYOffset: initialBounds.min.y - model.position.y
+    });
+    if (cacheKey) normalizationMetricsCache.set(cacheKey, metrics);
+  }
 
-  const bounds = new THREE.Box3().setFromObject(model);
-  const center = bounds.getCenter(new THREE.Vector3());
-  model.position.x -= center.x;
-  model.position.z -= center.z;
-  model.position.y -= bounds.min.y;
+  const scaleFactor = targetLength / metrics.footprintLength;
+  model.scale.multiplyScalar(scaleFactor);
+  model.position.x -= model.position.x + metrics.centerOffsetX * scaleFactor;
+  model.position.z -= model.position.z + metrics.centerOffsetZ * scaleFactor;
+  model.position.y -= model.position.y + metrics.minYOffset * scaleFactor;
 }
 
 function isProtectedPart(node, material) {


### PR DESCRIPTION
## Why

Repeated short freezes at the start/finish line line up with rival identity refreshes. `completeLap()` refreshes the top-four rival visuals immediately after the saved lap set changes. The old car factory rebuilt each requested rival from the parsed GLTF every time: deep scene clone, per-material cloning/classification, per-mesh outline-material allocation, front-wheel rig setup and two complete `Box3.setFromObject()` traversals. When ranks shift, several visually identical rival identities can be rebuilt in the same finish transition.

This also compounds the first AIRPORT/AMBULANCE finish where MAYDAY is triggered. MAYDAY already prewarms its wreck/responders; reducing the simultaneous rival-car work attacks the remaining shared finish-line hotspot rather than adding another delayed crash workaround.

## Changes

- cache fully prepared **5.5-unit ghost-rival templates** by car + primary/secondary color
- repeated rival identities now use a lightweight object-tree clone that reuses the already-prepared geometry/material graph instead of repeating GLTF/material/semantic/normalization work
- keep each clone's front-wheel steering pivots instance-local
- cap the session template cache at 16 identities
- use one immutable shared black outline material for all car outline meshes instead of allocating a new material per mesh
- cache stable geometry-normalization metrics by car/outline identity
- reduce cold normalization from two full `Box3.setFromObject()` passes to one; repeated visuals of the same car need no bounds traversal
- extend the existing rival visual regression to lock the finish-line fast path and ensure the expensive build pipeline cannot leak back into cached rival clones

## Scope

No replay data, rival ranking, timing, physics, car appearance, MAYDAY behavior, progression or accessibility semantics change. The first completely new rival identity still needs one full build; subsequent occurrences and rank reshuffles reuse prepared work.

No new revision strings are introduced.