### PR TITLE
Reduce first-lap rival and MAYDAY finish spikes

### DIFF
--- a/turn-tests/rival-visual-sync-production.mjs
+++ b/turn-tests/rival-visual-sync-production.mjs
@@ -1,13 +1,32 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [releaseSource, index, main, trackManager, leaderMarker, carModels] = await Promise.all([
+const [
+  releaseSource,
+  index,
+  main,
+  trackManager,
+  leaderMarker,
+  carModels,
+  trackRegistry,
+  rivalPrewarm,
+  airportWorld,
+  maydayPolish,
+  maydayHud,
+  maydayFinal
+] = await Promise.all([
   fs.readFile(new URL('../turn/release.json', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/main.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/tracks/track-manager.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/ui/leader-marker-r500.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/vehicle/car-models.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/vehicle/car-models.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/tracks/registry.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/race/rival-visual-prewarm.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/tracks/airport-world-r56.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/tracks/airport-emergency-r494.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/tracks/airport-emergency-r496.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/tracks/airport-emergency-r497.js', import.meta.url), 'utf8')
 ]);
 
 const release = JSON.parse(releaseSource);
@@ -95,6 +114,32 @@ assert.equal(
 assert.doesNotMatch(normalizationSection, /model\.updateMatrixWorld\(true\)[\s\S]*model\.updateMatrixWorld\(true\)/,
   'Normalization must not force two complete matrix/bounds passes per visual');
 
+assert.match(trackRegistry, /import '\.\.\/race\/rival-visual-prewarm\.js';/,
+  'The track runtime must install the selected-car rival prewarm before the first completed lap');
+assert.match(rivalPrewarm, /state\.running === true/,
+  'Prewarming must never deliberately start while a race is already running');
+assert.match(rivalPrewarm, /requestIdleCallback\(runPrewarm, \{ timeout: IDLE_TIMEOUT_MS \}\)/,
+  'Browsers with idle scheduling should move selected-rival preparation away from active interaction');
+assert.match(rivalPrewarm, /ghost: true[\s\S]*targetLength: RIVAL_TARGET_LENGTH[\s\S]*outline: true/,
+  'Prewarming must populate the exact 5.5-unit ghost template used by finish-line rival sync');
+assert.doesNotMatch(rivalPrewarm, /localStorage|sessionStorage|syncCompetitorVisuals/,
+  'Visual prewarming must not touch replay persistence or race ordering');
+
+assert.match(airportWorld, /deferWreckCalibration: true/,
+  'Production Airport must consolidate historical MAYDAY depth calibration into one pass');
+assert.match(maydayPolish, /if \(options\.deferWreckCalibration !== true\) installWreckPenetration\(world, runtime\)/,
+  'r494 must skip its legacy first-lap polling loop in production');
+assert.match(maydayHud, /if \(options\.deferWreckCalibration !== true\) installWreckCalibration\(options\.world, runtime\)/,
+  'r496 must skip its second legacy first-lap polling loop in production');
+assert.match(maydayFinal, /deferredParentCalibration = options\.deferWreckCalibration === true/,
+  'The final MAYDAY layer must know when it owns the complete tested wreck depth');
+assert.match(maydayFinal, /mount\.position\.y -= TARGET_WRECK_PENETRATION_Y/,
+  'The consolidated production path must apply the tested 16-unit penetration directly');
+assert.match(maydayFinal, /turnMaydayR494DepthApplied = true[\s\S]*turnMaydayR496DepthApplied = true/,
+  'Consolidated calibration must preserve historical depth-stage diagnostics');
+assert.doesNotMatch(maydayFinal, /world\.updateMatrixWorld\(true\)/,
+  'The final MAYDAY calibration must not synchronously traverse the whole Airport world');
+
 const leaderRoofSection = section(leaderMarker, 'function carRoofHeight', '\nfunction installRuntime');
 assert.match(leaderRoofSection, /child\.userData\?\.turnAssetVisual/, 'The leader marker must measure the installed rival model');
 assert.match(leaderRoofSection, /child\.visible !== false/, 'The procedural car must remain a fallback while its asset loads');
@@ -109,7 +154,7 @@ const infrastructureSection = section(trackManager, 'function ensureTrackInfrast
 assert.match(infrastructureSection, /currentRuntime\.ensureCompetitorCars\?\.\(\)/, 'Dynamic-world setup must still create the full fixed rival pool before reparenting');
 assert.doesNotMatch(infrastructureSection, /syncCompetitorVisuals/, 'World-layer setup must not perform unrelated model identity work');
 
-console.log(`TURN ${release.id} event-driven rival model synchronisation and reusable finish-line visual fast path passed.`);
+console.log(`TURN ${release.id} event-driven rival synchronisation, first-lap visual prewarm and MAYDAY finish-line fast paths passed.`);
 
 function section(source, startMarker, endMarker) {
   const start = source.indexOf(startMarker);

--- a/turn/race/rival-visual-prewarm.js
+++ b/turn/race/rival-visual-prewarm.js
@@ -1,0 +1,62 @@
+import { createCarVisual } from '../vehicle/car-models.js';
+
+const RIVAL_TARGET_LENGTH = 5.5;
+const FALLBACK_SECONDARY = '#f8f9fa';
+const IDLE_TIMEOUT_MS = 900;
+
+let scheduled = null;
+let warmedKey = '';
+let pendingKey = '';
+
+function currentIdentity() {
+  const state = globalThis.__turnRuntime?.state;
+  if (!state || state.running === true) return null;
+  const carId = String(state.vehicleId || 'sedan');
+  const color = String(state.vehicleColor || '#ffd43b');
+  const secondaryColor = String(state.vehicleSecondaryColor || FALLBACK_SECONDARY);
+  return {
+    key: `${carId}|${color}|${secondaryColor}`,
+    carId,
+    color,
+    secondaryColor
+  };
+}
+
+function runPrewarm() {
+  scheduled = null;
+  const identity = currentIdentity();
+  if (!identity || identity.key === warmedKey || identity.key === pendingKey) return;
+
+  pendingKey = identity.key;
+  void createCarVisual({
+    carId: identity.carId,
+    color: identity.color,
+    secondaryColor: identity.secondaryColor,
+    ghost: true,
+    targetLength: RIVAL_TARGET_LENGTH,
+    outline: true
+  }).then(() => {
+    warmedKey = identity.key;
+  }).catch(() => {
+    // A failed optional prewarm must never block Home, The Lot or race startup.
+  }).finally(() => {
+    if (pendingKey === identity.key) pendingKey = '';
+  });
+}
+
+function schedulePrewarm() {
+  if (scheduled || !currentIdentity()) return;
+
+  if (typeof globalThis.requestIdleCallback === 'function') {
+    const id = globalThis.requestIdleCallback(runPrewarm, { timeout: IDLE_TIMEOUT_MS });
+    scheduled = { type: 'idle', id };
+    return;
+  }
+
+  const id = globalThis.setTimeout(runPrewarm, 80);
+  scheduled = { type: 'timeout', id };
+}
+
+globalThis.addEventListener?.('turn:ui-state-change', schedulePrewarm);
+globalThis.addEventListener?.('turn:track-changed', schedulePrewarm);
+globalThis.setTimeout?.(schedulePrewarm, 0);

--- a/turn/tracks/airport-emergency-r494.js
+++ b/turn/tracks/airport-emergency-r494.js
@@ -40,7 +40,10 @@ export function installAirportEmergency(options = {}) {
 
   if (world) {
     installMedicalEntrance(world);
-    installWreckPenetration(world, runtime);
+    // Production r56 delegates the three historical depth corrections to the final r497
+    // layer so only one wreck lookup/poll runs during the first lap. Keep this local path
+    // for older standalone wrappers that still install r494 directly.
+    if (options.deferWreckCalibration !== true) installWreckPenetration(world, runtime);
   }
 
   return installation;

--- a/turn/tracks/airport-emergency-r496.js
+++ b/turn/tracks/airport-emergency-r496.js
@@ -26,7 +26,9 @@ export function installAirportEmergency(options = {}) {
   const installation = installAirportEmergencyR494(options);
   installHudStyle();
   installAchievementToastHook();
-  installWreckCalibration(options.world, runtime);
+  // Production r56 lets r497 apply the complete tested depth once. This avoids a second
+  // 120 ms wreck poll plus a full Airport matrix traversal during the first lap.
+  if (options.deferWreckCalibration !== true) installWreckCalibration(options.world, runtime);
   return installation;
 }
 

--- a/turn/tracks/airport-emergency-r497.js
+++ b/turn/tracks/airport-emergency-r497.js
@@ -13,18 +13,21 @@ const R496_TARGET_PENETRATION_Y = 10.5;
 // Lower it another 4 world units from the tested 12-unit result.
 const TARGET_WRECK_PENETRATION_Y = 16.0;
 const EXTRA_WRECK_PENETRATION_Y = TARGET_WRECK_PENETRATION_Y - R496_TARGET_PENETRATION_Y;
+// Production defers the two parent calibration layers, so r497 owns one single lookup
+// and applies the already-tested final 16-unit penetration in one cheap position change.
+const WRECK_FIND_INTERVAL_MS = 250;
+const WRECK_FIND_ATTEMPTS = 80;
 // The original layered flame works well up close but is too small relative to the
 // full-scale 62-unit B787. Scaling the existing fire group keeps the same animation,
 // materials and cost while making the emergency legible from the racing line.
 const FIRE_SCALE = 1.7;
-const WRECK_FIND_INTERVAL_MS = 120;
-const WRECK_FIND_ATTEMPTS = 160;
 
 export function installAirportEmergency(options = {}) {
   const runtime = options.runtime || globalThis.__turnRuntime;
+  const deferredParentCalibration = options.deferWreckCalibration === true;
   const installation = installAirportEmergencyR496(options);
   enlargeCrashFire(options.world);
-  installFinalWreckDepth(options.world, runtime);
+  installFinalWreckDepth(options.world, runtime, { deferredParentCalibration });
   return installation;
 }
 
@@ -34,31 +37,36 @@ function enlargeCrashFire(world) {
   if (!fire) return;
   fire.scale.setScalar(FIRE_SCALE);
   world.userData.turnMaydayR497FireScaleApplied = Object.freeze({ scale: FIRE_SCALE });
-  world.updateMatrixWorld(true);
 }
 
-function installFinalWreckDepth(world, runtime) {
+function installFinalWreckDepth(world, runtime, { deferredParentCalibration = false } = {}) {
   if (!world || world.userData.turnMaydayR497WreckCalibration) return;
 
   let timer = 0;
   let attempts = 0;
   let applied = false;
+  let preparedWreck = null;
 
   const tryApply = () => {
     timer = 0;
     if (applied) return;
 
-    const wreck = world.getObjectByName(PREPARED_WRECK_NAME);
+    preparedWreck ||= world.getObjectByName(PREPARED_WRECK_NAME);
+    const wreck = preparedWreck;
     const mount = wreck?.parent;
-    if (
-      wreck
-      && mount
-      && mount.userData.turnMaydayR496DepthApplied
-      && !mount.userData.turnMaydayR497DepthApplied
-    ) {
-      mount.position.y -= EXTRA_WRECK_PENETRATION_Y;
+    if (wreck && mount && !mount.userData.turnMaydayR497DepthApplied) {
+      if (deferredParentCalibration) {
+        mount.position.y -= TARGET_WRECK_PENETRATION_Y;
+        // Preserve the historical layer flags for diagnostics and any code that only
+        // cares whether those approved depth stages have effectively been applied.
+        mount.userData.turnMaydayR494DepthApplied = true;
+        mount.userData.turnMaydayR496DepthApplied = true;
+      } else {
+        mount.position.y -= EXTRA_WRECK_PENETRATION_Y;
+      }
       mount.userData.turnMaydayR497DepthApplied = true;
-      world.updateMatrixWorld(true);
+      // No forced world.updateMatrixWorld(true): the renderer updates this small transform
+      // naturally on the next frame, avoiding a synchronous traversal of the full Airport.
       applied = true;
       return;
     }
@@ -84,9 +92,10 @@ function installFinalWreckDepth(world, runtime) {
   arm();
 
   world.userData.turnMaydayR497WreckCalibration = Object.freeze({
-    basePenetration: R496_TARGET_PENETRATION_Y,
+    basePenetration: deferredParentCalibration ? 0 : R496_TARGET_PENETRATION_Y,
     targetPenetration: TARGET_WRECK_PENETRATION_Y,
-    additionalPenetration: EXTRA_WRECK_PENETRATION_Y,
-    basis: 'r498 playtest correction; lowers the tested r497 wreck another 4 world units'
+    additionalPenetration: deferredParentCalibration ? TARGET_WRECK_PENETRATION_Y : EXTRA_WRECK_PENETRATION_Y,
+    deferredParentCalibration,
+    basis: 'r498 playtest correction; production applies the same final depth in one calibration pass'
   });
 }

--- a/turn/tracks/airport-emergency-r497.js
+++ b/turn/tracks/airport-emergency-r497.js
@@ -65,8 +65,8 @@ function installFinalWreckDepth(world, runtime, { deferredParentCalibration = fa
         mount.position.y -= EXTRA_WRECK_PENETRATION_Y;
       }
       mount.userData.turnMaydayR497DepthApplied = true;
-      // No forced world.updateMatrixWorld(true): the renderer updates this small transform
-      // naturally on the next frame, avoiding a synchronous traversal of the full Airport.
+      // No forced full-world matrix refresh: normal rendering updates this small transform
+      // on the next frame instead of synchronously traversing the entire Airport scene.
       applied = true;
       return;
     }

--- a/turn/tracks/airport-world-r56.js
+++ b/turn/tracks/airport-world-r56.js
@@ -11,7 +11,11 @@ export function installAirportWorld(options = {}) {
   installAirportEmergency({
     world,
     samples: options.samples,
-    runtime: options.runtime || globalThis.__turnRuntime
+    runtime: options.runtime || globalThis.__turnRuntime,
+    // r494, r496 and r497 used to run three independent first-lap polling loops and
+    // full-world matrix refreshes for the same final wreck depth. Production delegates
+    // those historical increments to r497 so the tested 16-unit result is applied once.
+    deferWreckCalibration: true
   });
 
   world.name = 'TURN Airport r56';
@@ -37,7 +41,8 @@ export function installAirportWorld(options = {}) {
     maydayStandardAchievementToast: true,
     maydayLongerGuidanceHold: true,
     maydayFinalWreckDepth: true,
-    maydayLargerCrashFire: true
+    maydayLargerCrashFire: true,
+    maydaySingleWreckCalibration: true
   });
   return world;
 }

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -13,6 +13,7 @@ import { installMidnightCityWorld } from './midnight-city-world-r11.js?build=202
 // Historical MOUNTAIN regression markers: mountain-world-r3.js?revision=r3-continuous-terrain-v1, mountain-world-r3.js?revision=r6-night-treatment, mountain-world-r3.js?revision=r8-shadowless-spotlight, mountain-world-r3.js?revision=r560-shared-night-spotlight, mountain-world-r3.js?revision=r561-200m-headlight, mountain-world-r3.js?revision=r563-lower-headlight-target, mountain-world-r3.js?revision=r174-night-headlight-tune, mountain-world-r3.js?revision=r175-reconcile-night-headlight
 import { installMountainWorld } from './mountain-world-r3.js?revision=r177-ipad-sky-aspect';
 import { isForgivingTrackSurface } from './airport-runoff.js?build=20260722-r52';
+import '../race/rival-visual-prewarm.js';
 import './contextual-road-edges.js?revision=r518-signature-yellow';
 import './road-contour-color-r512.js?revision=r513-countryside';
 import './start-area-polish-r519.js?revision=r519-start-area-consistency-v2';


### PR DESCRIPTION
## Why

Playtesting after #675 removed start-line freezes, but exposed two remaining first-lap hotspots:

- a small hitch on some tracks when the player's newly completed lap becomes a rival for the first time
- a severe ~2 second AIRPORT/AMBULANCE freeze when MAYDAY starts after the first lap

The rival hitch comes from the player's own ghost identity still being cold until the first finish. The MAYDAY chain also had three historical wreck-depth wrappers polling independently during lap one; when the prepared B787 appeared, each layer could force another full `world.updateMatrixWorld(true)` traversal of the Airport scene.

## Changes

- prewarm the selected car's exact 5.5-unit ghost/rival visual while TURN is idle and not racing
- keep the prewarm visual-only: no replay persistence, ranking or race-state changes
- production Airport now tells r494/r496 to defer their historical wreck calibration loops
- r497 applies the already-tested final 16-unit wreck penetration once
- remove the final production full-world matrix refresh; normal rendering updates the small changed transform on the next frame
- reduce the remaining final wreck lookup to one 250 ms polling path instead of three overlapping 120 ms paths
- retain the old wrapper calibration paths for older standalone consumers
- extend the existing production regression so both the selected-rival prewarm and consolidated MAYDAY path are locked in

No gameplay, MAYDAY sequence, wreck depth, responder placement, accessibility behavior, lap ranking or car appearance changes are intended. No new revision strings are introduced.