### PR TITLE
Add catchable BOOST overcharge

### DIFF
--- a/turn-lab/tests/achievements-production.mjs
+++ b/turn-lab/tests/achievements-production.mjs
@@ -83,17 +83,17 @@ assert.equal(
   1725,
   'The base catalog must stay separate from production progression balancing'
 );
-assert.equal(ACHIEVEMENTS.length, 44,
-  'Production TURN must expose all 44 intended achievements');
-assert.equal(new Set(ACHIEVEMENTS.map((achievement) => achievement.id)).size, 44,
+assert.equal(ACHIEVEMENTS.length, 45,
+  'Production TURN must expose all 45 intended achievements');
+assert.equal(new Set(ACHIEVEMENTS.map((achievement) => achievement.id)).size, 45,
   'Production achievement ids must remain unique');
-assert.equal(ONBOARDING_ACHIEVEMENT_IDS.length, 10,
-  'GOT STARTED must remain the master of the ten prerequisite Getting Started achievements, not recursively require itself');
-assert.equal(totalAvailableTrophies(), 3050);
-assert.equal(TROPHY_ROAD_MAX_THRESHOLD, 3050);
+assert.equal(ONBOARDING_ACHIEVEMENT_IDS.length, 11,
+  'GOT STARTED must remain the master of the eleven prerequisite Getting Started achievements, not recursively require itself');
+assert.equal(totalAvailableTrophies(), 3075);
+assert.equal(TROPHY_ROAD_MAX_THRESHOLD, 3075);
 assert.equal(
   ACHIEVEMENTS.reduce((total, achievement) => total + achievement.trophies, 0),
-  3050
+  3075
 );
 assert.ok(ACHIEVEMENTS.every((achievement) => Number.isFinite(achievement.trophies)));
 assert.ok(ACHIEVEMENTS.every((achievement) => !Object.hasOwn(achievement, 'points')));
@@ -102,6 +102,12 @@ const byId = (id) => ACHIEVEMENTS.find((achievement) => achievement.id === id);
 assert.equal(byId('got-started')?.title, 'GOT STARTED');
 assert.equal(byId('got-started')?.trophies, 75);
 assert.equal(byId('got-started')?.category, 'onboarding');
+assert.equal(byId('catch-the-charge')?.title, 'CATCH THE CHARGE');
+assert.equal(byId('catch-the-charge')?.trophies, 25);
+assert.equal(byId('catch-the-charge')?.category, 'onboarding');
+assert.equal(byId('catch-the-charge')?.progressMax, 3);
+assert.match(byId('catch-the-charge')?.description || '', /Switch to GAS to catch it/);
+assert.match(byId('catch-the-charge')?.description || '', /keep GAS held for three seconds/);
 assert.equal(byId('golden-hour')?.title, 'MAYDAY!');
 assert.equal(byId('golden-hour')?.trophies, 100);
 assert.equal(byId('golden-hour')?.hidden, true);
@@ -349,6 +355,7 @@ assert.doesNotMatch(productionCatalogSource, /from '.\/catalog\.js/,
   'The production catalog must extend the explicit base module, never depend on the public facade');
 assert.match(productionCatalogSource, /title: 'MAYDAY!'/);
 assert.match(productionCatalogSource, /title: 'GOT STARTED'/);
+assert.match(productionCatalogSource, /title: 'CATCH THE CHARGE'/);
 assert.match(productionCatalogSource, /TRACK_WINNER_ACHIEVEMENTS/);
 assert.match(productionCatalogSource, /TRACK_SAFETY_ACHIEVEMENTS/);
 assert.match(legacyCatalogSource, /catalog-production\.js\?revision=r184-achievement-integrity/,
@@ -435,4 +442,4 @@ assert.match(app, /achievements=r166-bella-records/);
 assert.match(workflow, /Run achievement system regression/);
 assert.match(workflow, /node turn-lab\/tests\/achievements-production\.mjs/);
 
-console.log('TURN 44-achievement, 3050-trophy production catalog integrity regression passed.');
+console.log('TURN 45-achievement, 3075-trophy production catalog integrity regression passed.');

--- a/turn-lab/tests/chromatic-camouflage-production.mjs
+++ b/turn-lab/tests/chromatic-camouflage-production.mjs
@@ -33,17 +33,26 @@ const release = JSON.parse(releaseSource);
 
 const achievement = getAchievement(CHROMATIC_CAMOUFLAGE_ID);
 const mayday = getAchievement('golden-hour');
+const catchTheCharge = getAchievement('catch-the-charge');
 const gotStarted = getAchievement('got-started');
 
-assert.equal(ACHIEVEMENTS.length, 44,
-  'Production TURN should expose 43 existing achievements plus GOT STARTED');
+assert.equal(ACHIEVEMENTS.length, 45,
+  'Production TURN should expose the existing achievement set, CATCH THE CHARGE and GOT STARTED');
 assert.equal(GOT_STARTED_ACHIEVEMENT, gotStarted);
 assert.equal(gotStarted?.title, 'GOT STARTED');
 assert.equal(gotStarted?.category, 'onboarding');
 assert.equal(gotStarted?.trophies, 75);
 assert.equal(gotStarted?.description, 'Finish all Getting Started achievements.');
-assert.equal(ONBOARDING_ACHIEVEMENT_IDS.length, 10,
-  'GOT STARTED is the master reward and must not recursively require itself');
+assert.equal(catchTheCharge?.title, 'CATCH THE CHARGE');
+assert.equal(catchTheCharge?.category, 'onboarding');
+assert.equal(catchTheCharge?.trophies, 25);
+assert.equal(catchTheCharge?.progressMax, 3);
+assert.match(catchTheCharge?.description || '', /DRIFT/);
+assert.match(catchTheCharge?.description || '', /purple OVERCHARGE/);
+assert.match(catchTheCharge?.description || '', /GAS for three seconds/);
+assert.equal(ONBOARDING_ACHIEVEMENT_IDS.length, 11,
+  'GOT STARTED must require every Getting Started lesson, including CATCH THE CHARGE, without requiring itself');
+assert.equal(ONBOARDING_ACHIEVEMENT_IDS.includes('catch-the-charge'), true);
 assert.equal(ONBOARDING_ACHIEVEMENT_IDS.includes('got-started'), false);
 
 assert.equal(achievement?.title, 'CHROMATIC CAMOUFLAGE');
@@ -130,7 +139,7 @@ assert.ok(challengeUnlocks.some(({ id }) => id === 'airport-winner'),
 assert.ok(challengeUnlocks.some(({ id }) => id === 'harbor-safety'),
   'Stored all-track progress should backfill the corresponding SAFETY achievement');
 assert.ok(challengeUnlocks.some(({ id }) => id === 'got-started'),
-  'Existing players with all Getting Started achievements should receive GOT STARTED automatically');
+  'Existing players with every Getting Started achievement should receive GOT STARTED automatically');
 challengeUnlocks.length = 0;
 challengeApi.beginLap();
 challengeApi.completeLap({ position: 1, total: 5, time: 20 });
@@ -143,9 +152,9 @@ challengeApi.disconnect();
 
 assert.equal(
   ACHIEVEMENTS.reduce((total, item) => total + item.trophies, 0),
-  3050
+  3075
 );
-assert.equal(TROPHY_ROAD_MAX_THRESHOLD, 3050);
+assert.equal(TROPHY_ROAD_MAX_THRESHOLD, 3075);
 assert.deepEqual(
   TROPHY_ROAD_REWARDS.map(({ id, threshold }) => [id, threshold]),
   [

--- a/turn-lab/tests/chromatic-camouflage-production.mjs
+++ b/turn-lab/tests/chromatic-camouflage-production.mjs
@@ -49,7 +49,8 @@ assert.equal(catchTheCharge?.trophies, 25);
 assert.equal(catchTheCharge?.progressMax, 3);
 assert.match(catchTheCharge?.description || '', /DRIFT/);
 assert.match(catchTheCharge?.description || '', /purple OVERCHARGE/);
-assert.match(catchTheCharge?.description || '', /GAS for three seconds/);
+assert.match(catchTheCharge?.description || '', /Switch to GAS to catch it/);
+assert.match(catchTheCharge?.description || '', /keep GAS held for three seconds/);
 assert.equal(ONBOARDING_ACHIEVEMENT_IDS.length, 11,
   'GOT STARTED must require every Getting Started lesson, including CATCH THE CHARGE, without requiring itself');
 assert.equal(ONBOARDING_ACHIEVEMENT_IDS.includes('catch-the-charge'), true);

--- a/turn-lab/tests/trophy-road-production.mjs
+++ b/turn-lab/tests/trophy-road-production.mjs
@@ -77,7 +77,7 @@ assert.equal(TROPHY_ROAD_STORAGE_VERSION, 5,
   'Adding locks to previously unrestricted cars requires a one-time ownership grandfather migration');
 assert.equal(TROPHY_ROAD_MAX_THRESHOLD, 1700,
   'The legacy base module keeps its historical scale for compatibility');
-assert.equal(PRODUCTION_TROPHY_ROAD_MAX_THRESHOLD, 3050,
+assert.equal(PRODUCTION_TROPHY_ROAD_MAX_THRESHOLD, 3075,
   'Production must expose the complete current achievement-trophy scale');
 assert.equal(TROPHY_ROAD_VIEWPORT_THRESHOLD, 600);
 
@@ -105,7 +105,7 @@ assert.deepEqual(productionRewardIdsForTrophies(800), through800);
 assert.deepEqual(productionRewardIdsForTrophies(900), through900);
 assert.deepEqual(productionRewardIdsForTrophies(999), through900);
 assert.deepEqual(productionRewardIdsForTrophies(1000), through1000);
-assert.deepEqual(productionRewardIdsForTrophies(3050), productionRewardIds);
+assert.deepEqual(productionRewardIdsForTrophies(3075), productionRewardIds);
 
 assert.equal(getProductionTrophyRoadReward('mountain')?.threshold, 700);
 assert.equal(getProductionTrophyRoadReward('paintjob')?.threshold, 900);
@@ -294,7 +294,7 @@ assert.match(app, /trophy-road\.js\?revision=r166-bella-records/);
 assert.match(fixedLayout, /r166-bella-records/);
 assert.match(workflow, /Run Trophy Road progression regression/);
 assert.match(workflow, /node turn-lab\/tests\/trophy-road-production\.mjs/);
-assert.match(perkWrapper, /TROPHY_ROAD_MAX_THRESHOLD = 3050/);
+assert.match(perkWrapper, /TROPHY_ROAD_MAX_THRESHOLD = 3075/);
 assert.match(perkWrapper, /\['vintage-racer', 300\]/);
 assert.match(perkWrapper, /\['midnight-city', 400\]/);
 assert.match(perkWrapper, /\['mountain', 700\]/);

--- a/turn-tests/how-to-play-guide-production.mjs
+++ b/turn-tests/how-to-play-guide-production.mjs
@@ -31,7 +31,9 @@ assert.ok(
 );
 
 assert.match(guide, /GUIDE_VERSION = 'r141-form-disclosure-system'/);
-assert.match(guide, /Holding <strong>DRIFT<\/strong> also charges <strong>BOOST<\/strong> faster/);
+assert.match(guide, /<strong>DRIFT<\/strong> charges <strong>BOOST<\/strong> as you slide/);
+assert.match(guide, /Keep drifting after the bar is full to build purple <strong>OVERCHARGE<\/strong>/);
+assert.match(guide, /slide to <strong>GAS<\/strong> to catch and hold it, or <strong>BOOST<\/strong> to spend it/);
 assert.match(guide, /<details class="m8-dbe-guide">/);
 assert.match(
   guide,

--- a/turn/achievements.js
+++ b/turn/achievements.js
@@ -16,10 +16,13 @@ export {
   qualifyingTimeTrial
 } from './achievements/time-trials.js?revision=r166-bella-records';
 export {
+  CATCH_GAS_MIN_OVERCHARGE,
+  CATCH_GAS_REQUIRED_MS,
   CLEAN_LAP_TARGETS,
   CHALLENGE_PROGRESS_STORAGE_KEY,
   normalizeChallengeProgress,
   qualifiesForArmyLap,
+  qualifiesForCatchGas,
   qualifiesForCleanLap,
   installAchievementChallengeExpansion
 } from './achievements/challenge-expansion-r166.js?revision=r166-bella-records';

--- a/turn/achievements/catalog-production.js
+++ b/turn/achievements/catalog-production.js
@@ -21,6 +21,16 @@ const MAYDAY = Object.freeze({
   icon: 'siren'
 });
 
+export const CATCH_THE_CHARGE_ACHIEVEMENT = Object.freeze({
+  id: 'catch-the-charge',
+  category: base.CATEGORY.ONBOARDING,
+  trophies: 25,
+  title: 'CATCH THE CHARGE',
+  description: 'Keep holding DRIFT after BOOST is full to build purple OVERCHARGE. Hold GAS for three seconds to catch it.',
+  icon: 'charge',
+  progressMax: 3
+});
+
 export const GOT_STARTED_ACHIEVEMENT = Object.freeze({
   id: 'got-started',
   category: base.CATEGORY.ONBOARDING,
@@ -29,6 +39,11 @@ export const GOT_STARTED_ACHIEVEMENT = Object.freeze({
   description: 'Finish all Getting Started achievements.',
   icon: 'trophy'
 });
+
+export const ONBOARDING_ACHIEVEMENT_IDS = Object.freeze([
+  ...base.ONBOARDING_ACHIEVEMENT_IDS,
+  CATCH_THE_CHARGE_ACHIEVEMENT.id
+]);
 
 const SAFETY_TARGET_LABELS = Object.freeze({
   countryside: '0:30',
@@ -72,13 +87,14 @@ const rebalancedBaseAchievements = base.ACHIEVEMENTS.map((achievement) => {
 const firstNonOnboardingIndex = rebalancedBaseAchievements.findIndex(
   (achievement) => achievement.category !== base.CATEGORY.ONBOARDING
 );
-const gotStartedInsertionIndex = firstNonOnboardingIndex >= 0
+const onboardingInsertionIndex = firstNonOnboardingIndex >= 0
   ? firstNonOnboardingIndex
   : rebalancedBaseAchievements.length;
 const withGotStarted = [
-  ...rebalancedBaseAchievements.slice(0, gotStartedInsertionIndex),
+  ...rebalancedBaseAchievements.slice(0, onboardingInsertionIndex),
+  CATCH_THE_CHARGE_ACHIEVEMENT,
   GOT_STARTED_ACHIEVEMENT,
-  ...rebalancedBaseAchievements.slice(gotStartedInsertionIndex)
+  ...rebalancedBaseAchievements.slice(onboardingInsertionIndex)
 ];
 
 const expandedBaseAchievements = withGotStarted.flatMap((achievement) => {

--- a/turn/achievements/catalog-production.js
+++ b/turn/achievements/catalog-production.js
@@ -26,7 +26,7 @@ export const CATCH_THE_CHARGE_ACHIEVEMENT = Object.freeze({
   category: base.CATEGORY.ONBOARDING,
   trophies: 25,
   title: 'CATCH THE CHARGE',
-  description: 'Keep holding DRIFT after BOOST is full to build purple OVERCHARGE. Hold GAS for three seconds to catch it.',
+  description: 'Keep holding DRIFT after BOOST is full to build purple OVERCHARGE. Switch to GAS to catch it, then keep GAS held for three seconds.',
   icon: 'charge',
   progressMax: 3
 });

--- a/turn/achievements/challenge-expansion-r166.js
+++ b/turn/achievements/challenge-expansion-r166.js
@@ -12,9 +12,13 @@ export const CLEAN_LAP_TARGETS = Object.freeze({
   'midnight-city': 120,
   mountain: 110
 });
+export const CATCH_GAS_REQUIRED_MS = 3000;
+export const CATCH_GAS_MIN_OVERCHARGE = 0.05;
 
 const SAMPLE_INTERVAL_MS = 50;
+const MAX_SAMPLE_DELTA_MS = 250;
 const GOT_STARTED_ID = 'got-started';
+const CATCH_THE_CHARGE_ID = 'catch-the-charge';
 
 function normalizedTracks(value) {
   if (!Array.isArray(value)) return [];
@@ -42,6 +46,18 @@ export function qualifiesForCleanLap(attempt, detail) {
     && Number.isFinite(seconds)
     && seconds > 5
     && seconds < target;
+}
+
+export function qualifiesForCatchGas({
+  running = false,
+  caught = false,
+  overcharge = 0,
+  visible = true
+} = {}) {
+  return running === true
+    && caught === true
+    && Number(overcharge) >= CATCH_GAS_MIN_OVERCHARGE
+    && visible === true;
 }
 
 function winnerAchievementId(trackId) {
@@ -100,6 +116,11 @@ export function installAchievementChallengeExpansion({
 
   const progress = loadProgress(storage);
   let currentLap = null;
+  let catchGasMs = 0;
+  let catchGasUnlocked = Boolean(
+    achievements.getState?.().unlocked?.[CATCH_THE_CHARGE_ID]
+  );
+  let lastSampleAt = performance.now();
 
   function syncGotStarted() {
     const state = achievements.getState?.();
@@ -143,12 +164,48 @@ export function installAchievementChallengeExpansion({
     };
   }
 
+  function sampleCatchGas(elapsedMs) {
+    if (catchGasUnlocked) return;
+    const qualifies = qualifiesForCatchGas({
+      running: runtime.state.running === true,
+      caught: globalThis.__turnBoostOverchargeCaught === true,
+      overcharge: globalThis.__turnBoostOvercharge,
+      visible: document.visibilityState !== 'hidden'
+    });
+    if (!qualifies) {
+      catchGasMs = 0;
+      return;
+    }
+
+    catchGasMs += elapsedMs;
+    if (catchGasMs < CATCH_GAS_REQUIRED_MS) return;
+
+    const unlocked = achievements.unlock(
+      CATCH_THE_CHARGE_ID,
+      achievementContext(
+        runtime.state.trackId || globalThis.__turnGetTrackId?.() || '',
+        runtime.state.vehicleId || ''
+      )
+    );
+    if (unlocked?.length) catchGasUnlocked = true;
+    catchGasMs = 0;
+  }
+
   function sampleCourseState() {
+    const now = performance.now();
+    const elapsedMs = Math.min(MAX_SAMPLE_DELTA_MS, Math.max(0, now - lastSampleAt));
+    lastSampleAt = now;
     if (currentLap && runtime.state.offRoad === true) currentLap.onCourseThroughout = false;
+    sampleCatchGas(elapsedMs);
   }
 
   function resetLap() {
     currentLap = null;
+  }
+
+  function resetCatchGas() {
+    catchGasMs = 0;
+    lastSampleAt = performance.now();
   }
 
   function completeLap(detail) {
@@ -180,15 +237,22 @@ export function installAchievementChallengeExpansion({
   const handleUiState = (event) => {
     const reason = event.detail?.reason;
     if (reason === 'lap-started') beginLap();
-    if (reason === 'race-reset') resetLap();
+    if (reason === 'race-reset') {
+      resetLap();
+      resetCatchGas();
+    }
     if (Object.prototype.hasOwnProperty.call(event.detail || {}, 'running')
         && event.detail.running === false) {
       resetLap();
+      resetCatchGas();
     }
   };
   const handleLapResult = (event) => completeLap(event.detail || {});
   const handleLapInvalid = () => resetLap();
-  const handleAchievementsUpdated = () => queueMicrotask(syncGotStarted);
+  const handleAchievementsUpdated = (event) => {
+    if (event.detail?.unlocked?.includes(CATCH_THE_CHARGE_ID)) catchGasUnlocked = true;
+    queueMicrotask(syncGotStarted);
+  };
 
   unlockStoredTrackAchievements();
   syncGotStarted();
@@ -202,6 +266,7 @@ export function installAchievementChallengeExpansion({
     progress,
     beginLap,
     sampleCourseState,
+    sampleCatchGas,
     completeLap,
     syncGotStarted,
     disconnect() {

--- a/turn/gameplay-v2.css
+++ b/turn/gameplay-v2.css
@@ -34,6 +34,8 @@
 
 .boost-hud {
   --boost-charge: 100%;
+  --boost-overcharge-width: 0%;
+  --boost-base-width: 100%;
   --boost-hud-downshift: 20px;
   position: absolute;
   left: 50%;
@@ -59,12 +61,20 @@
 
 .boost-hud > div {
   position: relative;
+  left: 50%;
+  width: calc(100% + var(--boost-overcharge-width));
   height: 15px;
   overflow: hidden;
   border: 3px solid var(--ink);
   border-radius: 999px;
   background: rgb(255 248 232 / 0.82);
   box-shadow: 3px 3px 0 var(--ink);
+  transform: translateX(-50%);
+  transform-origin: center;
+  transition:
+    width 80ms linear,
+    background 120ms ease,
+    box-shadow 120ms ease;
 }
 
 .boost-hud i {
@@ -74,6 +84,17 @@
   background: linear-gradient(90deg, #ff922b, #ff5a5f);
   box-shadow: 3px 0 0 var(--ink);
   transition: width 70ms linear;
+}
+
+.boost-hud.has-overcharge > div {
+  background: #8b5cf6;
+}
+
+.boost-hud.has-overcharge i {
+  left: 50%;
+  width: var(--boost-base-width);
+  transform: translateX(-50%);
+  box-shadow: none;
 }
 
 .boost-hud.is-boosting {
@@ -108,6 +129,14 @@
 
 .boost-hud.is-boost-empty-flash > div {
   animation: turn-boost-empty-bar-flash 620ms ease-out;
+}
+
+.boost-hud.is-overcharge-volatile:not(.is-boost-full-flash):not(.is-boost-empty-flash) > div {
+  animation: turn-overcharge-wiggle 620ms ease-in-out infinite;
+}
+
+.boost-hud.is-overcharge-peak > div {
+  animation: turn-overcharge-peak 400ms cubic-bezier(.18,.88,.24,1);
 }
 
 @keyframes turn-boost-full-flash {
@@ -159,9 +188,25 @@
   }
 }
 
+@keyframes turn-overcharge-wiggle {
+  0%, 100% { transform: translateX(-50%) rotate(0deg) scaleY(1); }
+  26% { transform: translateX(-50%) rotate(-0.45deg) scaleY(1.025); }
+  54% { transform: translateX(-50%) rotate(0.55deg) scaleY(0.985); }
+  78% { transform: translateX(-50%) rotate(-0.25deg) scaleY(1.018); }
+}
+
+@keyframes turn-overcharge-peak {
+  0%, 100% { transform: translateX(-50%) rotate(0deg) scaleY(1); }
+  22% { transform: translateX(-50%) rotate(-1.1deg) scaleY(1.1); }
+  48% { transform: translateX(-50%) rotate(0.9deg) scaleY(0.94); }
+  72% { transform: translateX(-50%) rotate(-0.45deg) scaleY(1.05); }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .boost-hud.is-boost-full-flash,
-  .boost-hud.is-boost-empty-flash {
+  .boost-hud.is-boost-empty-flash,
+  .boost-hud.is-overcharge-volatile > div,
+  .boost-hud.is-overcharge-peak > div {
     animation: none;
   }
 }

--- a/turn/input/boost-overcharge.js
+++ b/turn/input/boost-overcharge.js
@@ -1,0 +1,113 @@
+export const BOOST_OVERCHARGE_MAX_SECONDS = 0.6;
+export const BOOST_OVERCHARGE_BUILD_SECONDS = 1.8;
+export const BOOST_OVERCHARGE_DECAY_SECONDS = 8;
+export const BOOST_OVERCHARGE_MAX_WIDTH = 0.2;
+export const BOOST_OVERCHARGE_MIN_SPEED = 14;
+export const BOOST_OVERCHARGE_MIN_SLIP_RADIANS = 10 * Math.PI / 180;
+export const BOOST_OVERCHARGE_REGULAR_RECHARGE_MULTIPLIER = 2.4;
+
+export const BOOST_OVERCHARGE_PHASE = Object.freeze({
+  READY: 'ready',
+  BUILDING: 'building',
+  DECAYING: 'decaying'
+});
+
+export function resolveBoostSlipAngle({ heading = 0, velocity = null } = {}) {
+  const angle = finiteNumber(heading);
+  const velocityX = finiteNumber(velocity?.x);
+  const velocityZ = finiteNumber(velocity?.z);
+  const speed = Math.hypot(velocityX, velocityZ);
+  if (speed <= 0.0001) return 0;
+
+  const forwardX = Math.sin(angle);
+  const forwardZ = Math.cos(angle);
+  const rightX = Math.cos(angle);
+  const rightZ = -Math.sin(angle);
+  const longitudinal = velocityX * forwardX + velocityZ * forwardZ;
+  const lateral = velocityX * rightX + velocityZ * rightZ;
+  return Math.abs(Math.atan2(lateral, longitudinal));
+}
+
+export function qualifiesForBoostOvercharge({
+  driftHeld = false,
+  speed = 0,
+  slipAngle = 0
+} = {}) {
+  return driftHeld === true
+    && finiteNumber(speed) >= BOOST_OVERCHARGE_MIN_SPEED
+    && Math.abs(finiteNumber(slipAngle)) >= BOOST_OVERCHARGE_MIN_SLIP_RADIANS;
+}
+
+export function boostOverchargeBuildRate(rechargeMultiplier = BOOST_OVERCHARGE_REGULAR_RECHARGE_MULTIPLIER) {
+  const multiplier = Math.max(0, finiteNumber(rechargeMultiplier));
+  return multiplier
+    / BOOST_OVERCHARGE_REGULAR_RECHARGE_MULTIPLIER
+    / BOOST_OVERCHARGE_BUILD_SECONDS;
+}
+
+export function advanceBoostOvercharge({
+  amount = 0,
+  phase = BOOST_OVERCHARGE_PHASE.READY,
+  dt = 0,
+  zone = '',
+  qualifyingDrift = false,
+  rechargeMultiplier = BOOST_OVERCHARGE_REGULAR_RECHARGE_MULTIPLIER,
+  consuming = false
+} = {}) {
+  let nextAmount = clamp(finiteNumber(amount), 0, 1);
+  let nextPhase = validPhase(phase);
+  const elapsed = Math.max(0, finiteNumber(dt));
+  let peaked = false;
+
+  if (consuming && nextAmount > 0) {
+    nextPhase = BOOST_OVERCHARGE_PHASE.DECAYING;
+    nextAmount = Math.max(0, nextAmount - elapsed / BOOST_OVERCHARGE_MAX_SECONDS);
+  } else if (zone === 'gas' && nextAmount > 0) {
+    // GAS catches the current pressure exactly where it is. The phase is kept so
+    // a pre-peak catch may resume building, while a post-peak catch resumes decay.
+  } else if (nextPhase === BOOST_OVERCHARGE_PHASE.DECAYING && nextAmount > 0) {
+    nextAmount = Math.max(0, nextAmount - elapsed / BOOST_OVERCHARGE_DECAY_SECONDS);
+  } else if (zone === 'drift' && qualifyingDrift) {
+    nextPhase = BOOST_OVERCHARGE_PHASE.BUILDING;
+    nextAmount = Math.min(1, nextAmount + elapsed * boostOverchargeBuildRate(rechargeMultiplier));
+    if (nextAmount >= 1) {
+      nextAmount = 1;
+      nextPhase = BOOST_OVERCHARGE_PHASE.DECAYING;
+      peaked = true;
+    }
+  } else if (zone === 'drift' && nextPhase === BOOST_OVERCHARGE_PHASE.BUILDING && nextAmount > 0) {
+    // Briefly losing the slip angle while still holding DRIFT should not destroy
+    // the mini-game. Pressure leaks, but the player may resume building before peak.
+    nextAmount = Math.max(0, nextAmount - elapsed / BOOST_OVERCHARGE_DECAY_SECONDS);
+  } else if (nextAmount > 0) {
+    // Releasing DRIFT without catching on GAS commits the bonus to its decay phase.
+    nextPhase = BOOST_OVERCHARGE_PHASE.DECAYING;
+    nextAmount = Math.max(0, nextAmount - elapsed / BOOST_OVERCHARGE_DECAY_SECONDS);
+  }
+
+  if (nextAmount <= 0.000001) {
+    nextAmount = 0;
+    nextPhase = BOOST_OVERCHARGE_PHASE.READY;
+  }
+
+  return Object.freeze({ amount: nextAmount, phase: nextPhase, peaked });
+}
+
+export function boostOverchargeVisualWidth(amount = 0) {
+  return clamp(finiteNumber(amount), 0, 1) * BOOST_OVERCHARGE_MAX_WIDTH;
+}
+
+function validPhase(value) {
+  return Object.values(BOOST_OVERCHARGE_PHASE).includes(value)
+    ? value
+    : BOOST_OVERCHARGE_PHASE.READY;
+}
+
+function finiteNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}

--- a/turn/progression/trophy-road-chromatic-r183.js
+++ b/turn/progression/trophy-road-chromatic-r183.js
@@ -8,7 +8,7 @@ import {
 
 export * from './trophy-road-perks-r164.js?revision=r164-trophy-road-order';
 
-export const TROPHY_ROAD_MAX_THRESHOLD = 3050;
+export const TROPHY_ROAD_MAX_THRESHOLD = 3075;
 
 export const TROPHY_ROAD_REWARD_ICONS = Object.freeze({
   ...BASE_TROPHY_ROAD_REWARD_ICONS,

--- a/turn/progression/trophy-road-perks-r164.js
+++ b/turn/progression/trophy-road-perks-r164.js
@@ -4,7 +4,7 @@ import {
 
 export * from './trophy-road.js?revision=r164-vintage-rally-perks';
 
-export const TROPHY_ROAD_MAX_THRESHOLD = 3050;
+export const TROPHY_ROAD_MAX_THRESHOLD = 3075;
 
 const BASE_REWARD_BY_ID = new Map(
   BASE_TROPHY_ROAD_REWARDS.map((reward) => [reward.id, reward])

--- a/turn/ui/gameplay-controls.js
+++ b/turn/ui/gameplay-controls.js
@@ -208,7 +208,6 @@ function installGameplayUi() {
     boostHud.classList.remove('is-overcharge-peak');
     boostHud.classList.add('is-overcharge-peak');
     safeVibrate([14, 18, 24]);
-    globalThis.__turnAudio?.cue('boost-overcharge-peak');
     overchargePeakTimer = window.setTimeout(() => {
       boostHud.classList.remove('is-overcharge-peak');
       overchargePeakTimer = 0;
@@ -235,10 +234,10 @@ function installGameplayUi() {
     boostFlashTimer = 0;
     overchargePeakTimer = 0;
     boostCharge = 1;
-    boostOvercharge = 0;
-    boostOverchargePhase = BOOST_OVERCHARGE_PHASE.READY;
     previousBoostCharge = 1;
     boostExhausted = false;
+    boostOvercharge = 0;
+    boostOverchargePhase = BOOST_OVERCHARGE_PHASE.READY;
     globalThis.__turnBoostCharge = 1;
     globalThis.__turnBoostOvercharge = 0;
     globalThis.__turnBoostOverchargeCaught = false;

--- a/turn/ui/gameplay-controls.js
+++ b/turn/ui/gameplay-controls.js
@@ -5,9 +5,18 @@ import {
   pointerUsesDriftLock,
   resolveDriftBoostRechargeMultiplier
 } from '../input/drift-lock.js?revision=r218-boost-balance';
+import {
+  BOOST_OVERCHARGE_PHASE,
+  advanceBoostOvercharge,
+  boostOverchargeVisualWidth,
+  qualifiesForBoostOvercharge,
+  resolveBoostSlipAngle
+} from '../input/boost-overcharge.js';
 
 globalThis.__turnBoostActive = false;
 globalThis.__turnBoostCharge = 1;
+globalThis.__turnBoostOvercharge = 0;
+globalThis.__turnBoostOverchargeCaught = false;
 globalThis.__turnDriftHeld = false;
 globalThis.__turnDriftLockAmount = 0;
 
@@ -107,7 +116,7 @@ function installGameplayUi() {
   drivePad.setAttribute('role', 'group');
   drivePad.setAttribute(
     'aria-label',
-    'Drive control. Double tap and hold, then slide between Drift, Boost, Gas, and Brake or Reverse. While holding Drift, slide left into Lock for rear-wheel lock.'
+    'Drive control. Double tap and hold, then slide between Drift, Boost, Gas, and Brake or Reverse. Drift charges Boost and can build Overcharge past full. Gas catches Overcharge. While holding Drift, slide left into Lock for rear-wheel lock.'
   );
   drivePad.style.setProperty('--boost-charge', '100%');
 
@@ -123,7 +132,7 @@ function installGameplayUi() {
   driftZone.type = 'button';
   driftZone.className = 'drive-zone drive-drift-zone';
   driftZone.textContent = 'Drift';
-  driftZone.setAttribute('aria-label', 'Gas and drift. Slide left into Lock for rear-wheel lock.');
+  driftZone.setAttribute('aria-label', 'Gas and drift. Drift charges Boost and can build Overcharge past full. Slide left into Lock for rear-wheel lock.');
 
   const boostZone = document.createElement('button');
   boostZone.type = 'button';
@@ -133,7 +142,7 @@ function installGameplayUi() {
 
   gasButton.classList.add('drive-gas-zone');
   gasButton.textContent = 'Gas';
-  gasButton.setAttribute('aria-label', 'Gas');
+  gasButton.setAttribute('aria-label', 'Gas. Holds any purple Boost Overcharge.');
 
   brakeButton.classList.add('drive-brake-zone', 'brake-reverse');
   brakeButton.textContent = 'Brake · Reverse';
@@ -151,8 +160,11 @@ function installGameplayUi() {
   let driftLockRequested = false;
   let driftLockAmount = 0;
   let boostCharge = 1;
+  let boostOvercharge = 0;
+  let boostOverchargePhase = BOOST_OVERCHARGE_PHASE.READY;
   let previousBoostCharge = boostCharge;
   let boostFlashTimer = 0;
+  let overchargePeakTimer = 0;
   let previousTime = performance.now();
   const TOP_ZONE_SHARE = 0.32;
   const BRAKE_ZONE_START = 0.76;
@@ -168,6 +180,9 @@ function installGameplayUi() {
   let publishedLocked = null;
   let publishedDriftCharging = null;
   let publishedDriftLocking = null;
+  let publishedOvercharge = null;
+  let publishedOverchargeCaught = null;
+  let publishedOverchargeVolatile = null;
   let publishedChargePercent = null;
   let publishedAriaLabel = null;
 
@@ -188,6 +203,18 @@ function installGameplayUi() {
     }, 700);
   }
 
+  function flashOverchargePeak() {
+    window.clearTimeout(overchargePeakTimer);
+    boostHud.classList.remove('is-overcharge-peak');
+    boostHud.classList.add('is-overcharge-peak');
+    safeVibrate([14, 18, 24]);
+    globalThis.__turnAudio?.cue('boost-overcharge-peak');
+    overchargePeakTimer = window.setTimeout(() => {
+      boostHud.classList.remove('is-overcharge-peak');
+      overchargePeakTimer = 0;
+    }, 420);
+  }
+
   function getBoostDrainSeconds() {
     const duration = Number(globalThis.__turnVehicleTuning?.boostDurationSeconds);
     const baseDuration = Number.isFinite(duration)
@@ -204,23 +231,34 @@ function installGameplayUi() {
 
   function refillBoost() {
     window.clearTimeout(boostFlashTimer);
+    window.clearTimeout(overchargePeakTimer);
     boostFlashTimer = 0;
+    overchargePeakTimer = 0;
     boostCharge = 1;
+    boostOvercharge = 0;
+    boostOverchargePhase = BOOST_OVERCHARGE_PHASE.READY;
     previousBoostCharge = 1;
     boostExhausted = false;
     globalThis.__turnBoostCharge = 1;
+    globalThis.__turnBoostOvercharge = 0;
+    globalThis.__turnBoostOverchargeCaught = false;
     boostVisualDirty = true;
     lastBoostVisualAt = -Infinity;
     publishedChargePercent = null;
     publishedAriaLabel = null;
     publishedLocked = null;
     publishedDriftLocking = null;
+    publishedOvercharge = null;
+    publishedOverchargeCaught = null;
+    publishedOverchargeVolatile = null;
     driftLockRequested = false;
     driftLockAmount = 0;
     globalThis.__turnDriftLockAmount = 0;
     boostFill?.style.removeProperty('background');
     drivePad.style.setProperty('--boost-charge', '100%');
     boostHud.style.setProperty('--boost-charge', '100%');
+    boostHud.style.setProperty('--boost-overcharge-width', '0%');
+    boostHud.style.setProperty('--boost-base-width', '100%');
     boostHud.setAttribute('aria-label', 'Boost 100 percent charged');
     driveStack.classList.toggle('is-drift-ready', driveZone === 'drift');
     driveStack.classList.remove('is-drift-locking');
@@ -229,7 +267,11 @@ function installGameplayUi() {
     boostHud.classList.remove(
       'is-boost-full-flash',
       'is-boost-empty-flash',
-      'is-drift-locking'
+      'is-drift-locking',
+      'has-overcharge',
+      'is-overcharge-caught',
+      'is-overcharge-volatile',
+      'is-overcharge-peak'
     );
   }
 
@@ -294,7 +336,7 @@ function installGameplayUi() {
     globalThis.__turnDriftHeld = nextZone === 'drift';
     boostRequested = nextZone === 'boost';
     setBrakeInput(nextZone === 'brake');
-    boostVisualDirty = boostVisualDirty || lockRequestChanged;
+    boostVisualDirty = boostVisualDirty || lockRequestChanged || zoneChanged;
 
     drivePad.dataset.driveZone = nextZone || '';
     driveStack.classList.toggle('is-drift-ready', nextZone === 'drift');
@@ -478,47 +520,110 @@ function installGameplayUi() {
     if (lockCanRun) {
       globalThis.__turnAnalogGas = driftThrottleForLock(driftLockAmount);
     }
-    const active = boostRequested && !boostExhausted && boostCharge > 0.001;
+
+    const rechargeMultiplier = resolveDriftBoostRechargeMultiplier({
+      driftHeld: globalThis.__turnDriftHeld === true,
+      driftLockAmount,
+      lockedMultiplier: getDriftRechargeMultiplier(),
+      lockCeilingMultiplier: DRIFT_LOCK_RECHARGE_MULTIPLIER
+    });
+    const active = boostRequested && !boostExhausted && (boostOvercharge > 0.001 || boostCharge > 0.001);
 
     if (active) {
-      boostCharge = Math.max(0, boostCharge - dt / getBoostDrainSeconds());
-      if (boostCharge <= 0) {
-        boostExhausted = true;
-        safeVibrate([28, 36, 62]);
+      if (boostOvercharge > 0.001) {
+        const overchargeState = advanceBoostOvercharge({
+          amount: boostOvercharge,
+          phase: boostOverchargePhase,
+          dt,
+          zone: driveZone,
+          consuming: true
+        });
+        boostOvercharge = overchargeState.amount;
+        boostOverchargePhase = overchargeState.phase;
+      } else {
+        boostCharge = Math.max(0, boostCharge - dt / getBoostDrainSeconds());
+        if (boostCharge <= 0) {
+          boostExhausted = true;
+          safeVibrate([28, 36, 62]);
+        }
       }
     } else {
-      const rechargeMultiplier = resolveDriftBoostRechargeMultiplier({
-        driftHeld: globalThis.__turnDriftHeld === true,
-        driftLockAmount,
-        lockedMultiplier: getDriftRechargeMultiplier(),
-        lockCeilingMultiplier: DRIFT_LOCK_RECHARGE_MULTIPLIER
-      });
-      boostCharge = Math.min(1, boostCharge + dt * rechargeMultiplier / BOOST_RECHARGE_SECONDS);
+      if (boostCharge < 0.999999) {
+        boostCharge = Math.min(1, boostCharge + dt * rechargeMultiplier / BOOST_RECHARGE_SECONDS);
+      }
+
+      if (boostCharge >= 0.999999 || boostOvercharge > 0) {
+        const runtimeState = globalThis.__turnRuntime?.state;
+        const slipAngle = resolveBoostSlipAngle({
+          heading: runtimeState?.heading,
+          velocity: runtimeState?.velocity
+        });
+        const qualifyingDrift = qualifiesForBoostOvercharge({
+          driftHeld: globalThis.__turnDriftHeld === true,
+          speed: runtimeState?.speed,
+          slipAngle
+        });
+        const overchargeState = advanceBoostOvercharge({
+          amount: boostOvercharge,
+          phase: boostOverchargePhase,
+          dt,
+          zone: driveZone,
+          qualifyingDrift,
+          rechargeMultiplier
+        });
+        boostOvercharge = overchargeState.amount;
+        boostOverchargePhase = overchargeState.phase;
+        if (overchargeState.peaked) flashOverchargePeak();
+      }
     }
 
     const becameEmpty = previousBoostCharge > 0.001 && boostCharge <= 0.001;
     const becameFull = previousBoostCharge < 0.999 && boostCharge >= 0.999;
     previousBoostCharge = boostCharge;
 
-    const boosting = boostRequested && !boostExhausted && boostCharge > 0.001;
+    const boosting = boostRequested && !boostExhausted && (boostOvercharge > 0.001 || boostCharge > 0.001);
+    const overchargeCaught = boostOvercharge > 0.001 && driveZone === 'gas' && !boosting;
+    const overchargeVolatile = boostOvercharge > 0.001 && !overchargeCaught && !boosting;
     globalThis.__turnBoostActive = boosting;
     globalThis.__turnBoostCharge = boostCharge;
+    globalThis.__turnBoostOvercharge = boostOvercharge;
+    globalThis.__turnBoostOverchargeCaught = overchargeCaught;
     updateAudio(now, boosting);
 
     const locked = boostRequested && boostExhausted;
     const driftCharging = globalThis.__turnDriftHeld && !boosting;
     const driftLocking = driftCharging && (driftLockRequested || driftLockAmount > 0.001);
+    const hasOvercharge = boostOvercharge > 0.001;
     const chargePercent = (boostCharge * 100).toFixed(1) + '%';
+    const overchargePercent = Math.round(boostOvercharge * 100);
+    const overchargeWidth = boostOverchargeVisualWidth(boostOvercharge);
+    const overchargeWidthPercent = (overchargeWidth * 100).toFixed(1) + '%';
+    const baseWidthPercent = (100 / (1 + overchargeWidth)).toFixed(2) + '%';
     const ariaPercent = Math.round(boostCharge * 100);
-    const ariaLabel = driftLocking
-      ? `Drift lock active. Boost ${ariaPercent} percent charged`
-      : `Boost ${ariaPercent} percent charged`;
+    let ariaLabel;
+    if (hasOvercharge) {
+      const overchargeStateLabel = overchargeCaught
+        ? 'caught with Gas'
+        : boosting
+          ? 'being used'
+          : boostOverchargePhase === BOOST_OVERCHARGE_PHASE.DECAYING
+            ? 'leaking'
+            : 'building';
+      ariaLabel = `Boost full. Overcharge ${overchargePercent} percent ${overchargeStateLabel}.`;
+    } else {
+      ariaLabel = driftLocking
+        ? `Drift lock active. Boost ${ariaPercent} percent charged`
+        : `Boost ${ariaPercent} percent charged`;
+    }
     const controlsVisible = !controlsRoot?.hidden && !document.hidden;
     const stateChanged =
       boosting !== publishedBoosting ||
       locked !== publishedLocked ||
       driftCharging !== publishedDriftCharging ||
-      driftLocking !== publishedDriftLocking;
+      driftLocking !== publishedDriftLocking ||
+      hasOvercharge !== publishedOvercharge ||
+      overchargeCaught !== publishedOverchargeCaught ||
+      overchargeVolatile !== publishedOverchargeVolatile;
     const visualDue = now - lastBoostVisualAt >= BOOST_VISUAL_INTERVAL_MS;
 
     if (!controlsVisible) {
@@ -562,9 +667,23 @@ function installGameplayUi() {
       }
       publishedDriftLocking = driftLocking;
     }
-    if (boostVisualDirty || chargePercent !== publishedChargePercent) {
+    if (boostVisualDirty || hasOvercharge !== publishedOvercharge) {
+      boostHud.classList.toggle('has-overcharge', hasOvercharge);
+      publishedOvercharge = hasOvercharge;
+    }
+    if (boostVisualDirty || overchargeCaught !== publishedOverchargeCaught) {
+      boostHud.classList.toggle('is-overcharge-caught', overchargeCaught);
+      publishedOverchargeCaught = overchargeCaught;
+    }
+    if (boostVisualDirty || overchargeVolatile !== publishedOverchargeVolatile) {
+      boostHud.classList.toggle('is-overcharge-volatile', overchargeVolatile);
+      publishedOverchargeVolatile = overchargeVolatile;
+    }
+    if (boostVisualDirty || chargePercent !== publishedChargePercent || hasOvercharge) {
       drivePad.style.setProperty('--boost-charge', chargePercent);
       boostHud.style.setProperty('--boost-charge', chargePercent);
+      boostHud.style.setProperty('--boost-overcharge-width', overchargeWidthPercent);
+      boostHud.style.setProperty('--boost-base-width', baseWidthPercent);
       publishedChargePercent = chargePercent;
     }
     if (boostVisualDirty || ariaLabel !== publishedAriaLabel) {

--- a/turn/ui/how-to-play-guide.js
+++ b/turn/ui/how-to-play-guide.js
@@ -20,7 +20,7 @@ function updateDriftAndBoostCopy(dialog) {
   const paragraph = section?.querySelector('p');
   if (!paragraph) return;
 
-  paragraph.innerHTML = 'DRIFT helps the car rotate but costs grip. Holding <strong>DRIFT</strong> also charges <strong>BOOST</strong> faster, so a controlled slide can prepare the next burst. BOOST gives speed but can make the next corner harder. Fast laps come from balancing both.';
+  paragraph.innerHTML = '<strong>DRIFT</strong> charges <strong>BOOST</strong> as you slide. Keep drifting after the bar is full to build purple <strong>OVERCHARGE</strong>. At its peak, OVERCHARGE starts leaking: slide to <strong>GAS</strong> to catch and hold it, or <strong>BOOST</strong> to spend it.';
 }
 
 function installDriveByEarDisclosure(dialog) {


### PR DESCRIPTION
## Why

The DRIFT → earned BOOST loop feels better after #677, but a full tank currently ends the charging interaction. Overcharge adds a small timing game above full and gives GAS a clear tactical role without bringing passive recharge back.

## Balance

- normal BOOST remains unchanged below 100%
- continued real DRIFT at 14+ speed and at least ~10° slip builds purple OVERCHARGE
- ordinary DRIFT reaches maximum overcharge in about 1.8 seconds; existing higher DRIFT/LOCK recharge multipliers build it faster
- maximum overcharge stores 0.6 seconds of extra BOOST independent of TANK rating
- overcharge is consumed before the ordinary tank
- at maximum, overcharge immediately begins an ~8 second peak-to-zero decay even if DRIFT remains held
- after peak, DRIFT cannot prop the bonus back up during that cycle
- GAS catches/freezes the current overcharge immediately; it adds no charge
- leaving DRIFT for anything other than GAS lets the bonus leak

## HUD

- the BOOST bar expands symmetrically from its centre up to 120% width
- purple appears only at the two expanding outer edges
- volatile overcharge has a subtle pressure wiggle
- GAS catch stops the wiggle immediately
- peak gets one stronger elastic wiggle plus haptic feedback
- reduced-motion users keep the width/colour state without wiggle animations
- accessibility labels expose build, leak, caught and spending states

## Getting Started

Adds **CATCH THE CHARGE** (25 trophies):

> Keep holding DRIFT after BOOST is full to build purple OVERCHARGE. Switch to GAS to catch it, then keep GAS held for three seconds.

Catching happens immediately on GAS. The three-second hold is only the measurable achievement condition: a real caught overcharge (at least 5%) must remain held with GAS continuously for three seconds. It becomes an additional prerequisite for GOT STARTED. HOW TO PLAY is also updated with the same DRIFT → OVERCHARGE → GAS/BOOST interaction.

No new manual revision strings are introduced.