### PR TITLE
Refine achievement discovery and navigation

### DIFF
--- a/turn-lab/tests/achievements-production.mjs
+++ b/turn-lab/tests/achievements-production.mjs
@@ -15,6 +15,7 @@ import {
   normalizeAchievementState,
   normalizeChallengeProgress,
   qualifiesForArmyLap,
+  qualifiesForCatchGas,
   qualifiesForCleanLap,
   qualifyingTimeTrial,
   totalAvailableTrophies
@@ -105,12 +106,19 @@ assert.equal(byId('got-started')?.category, 'onboarding');
 assert.equal(byId('catch-the-charge')?.title, 'CATCH THE CHARGE');
 assert.equal(byId('catch-the-charge')?.trophies, 25);
 assert.equal(byId('catch-the-charge')?.category, 'onboarding');
-assert.equal(byId('catch-the-charge')?.progressMax, 3);
-assert.match(byId('catch-the-charge')?.description || '', /Switch to GAS to catch it/);
-assert.match(byId('catch-the-charge')?.description || '', /keep GAS held for three seconds/);
+assert.equal(Object.hasOwn(byId('catch-the-charge') || {}, 'progressMax'), false,
+  'CATCH THE CHARGE must not imply a timed GAS hold');
+assert.equal(
+  byId('catch-the-charge')?.description,
+  'Overcharge the BOOST bar using DRIFT. Retain the overcharge using GAS.'
+);
 assert.equal(byId('golden-hour')?.title, 'MAYDAY!');
 assert.equal(byId('golden-hour')?.trophies, 100);
 assert.equal(byId('golden-hour')?.hidden, true);
+assert.equal(
+  byId('golden-hour')?.lockedDescription,
+  'Hidden achievement. You’ll know what to do when the moment comes.'
+);
 assert.match(byId('golden-hour')?.description || '', /Ambulance/);
 assert.match(byId('golden-hour')?.description || '', /30 seconds/);
 assert.equal(byId('chromatic-camouflage')?.title, 'CHROMATIC CAMOUFLAGE');
@@ -150,11 +158,14 @@ assert.equal(byId('find-darvid')?.title, 'FIND DARVID!');
 assert.equal(byId('save-bella')?.title, 'SAVE BELLA!');
 assert.equal(byId('save-bella')?.icon, 'cat');
 assert.match(byId('save-bella')?.description || '', /Fire Truck/);
-assert.equal(byId('find-lilya')?.lockedDescription, '');
-assert.equal(byId('find-darvid')?.lockedDescription, '');
-assert.equal(byId('save-bella')?.lockedDescription, '');
+assert.equal(byId('find-lilya')?.lockedDescription, 'Hidden achievement.');
+assert.equal(byId('find-darvid')?.lockedDescription, 'Hidden achievement.');
+assert.equal(
+  byId('save-bella')?.lockedDescription,
+  'Hidden achievement. You’ll know what to do when the moment comes.'
+);
 assert.equal(byId('satans-sedan')?.lockedDescription, undefined,
-  'Satan’s Hatchback may retain the generic hidden clue treatment');
+  'Satan’s Hatchback may retain the generic hidden title-clue treatment');
 
 assert.equal(TIME_TRIALS.length, 6);
 assert.equal(TIME_TRIAL_ACHIEVEMENT_IDS.length, 6);
@@ -169,9 +180,9 @@ assert.deepEqual(
     ['countryside', 12],
     ['airport', 17],
     ['cliffside', 15],
-    ['harbor', 24],
+    ['harbor', 23],
     ['midnight-city', 53],
-    ['mountain', 27]
+    ['mountain', 25]
   ]
 );
 for (const trial of TIME_TRIALS) {
@@ -199,6 +210,10 @@ assert.deepEqual(CLEAN_LAP_TARGETS, {
 assert.equal(qualifiesForArmyLap({ rivalCountAtStart: 4 }, { position: 1, total: 5 }), true);
 assert.equal(qualifiesForArmyLap({ rivalCountAtStart: 3 }, { position: 1, total: 4 }), false);
 assert.equal(qualifiesForArmyLap({ rivalCountAtStart: 4 }, { position: 2, total: 5 }), false);
+assert.equal(qualifiesForCatchGas({ running: true, caught: true, overcharge: 0.001, visible: true }), true,
+  'Any real caught overcharge should satisfy CATCH THE CHARGE immediately');
+assert.equal(qualifiesForCatchGas({ running: true, caught: true, overcharge: 0, visible: true }), false);
+assert.equal(qualifiesForCatchGas({ running: true, caught: false, overcharge: 0.5, visible: true }), false);
 assert.equal(qualifiesForCleanLap(
   { trackId: 'countryside', onCourseThroughout: true },
   { time: 29.999 }
@@ -364,13 +379,15 @@ assert.match(legacyCatalogSource, /catalog-production\.js\?revision=r184-achieve
 assert.match(secretCatalog, /title: 'FIND LILYA!'/);
 assert.match(secretCatalog, /title: 'FIND DARVID!'/);
 assert.match(secretCatalog, /title: 'SAVE BELLA!'/);
+assert.match(secretCatalog, /lockedDescription: 'Hidden achievement\.'/,
+  'LILYA and DARVID must identify themselves as hidden without giving a clue');
+assert.match(secretCatalog, /You’ll know what to do when the moment comes/,
+  'SAVE BELLA should promise contextual discovery rather than expose its solution');
 assert.equal((secretCatalog.match(/hidden: true/g) || []).length, 4);
 assert.equal((secretCatalog.match(/trophies: 25/g) || []).length, 4);
 assert.match(secretRuntime, /Object\.hasOwn\(achievement, 'lockedDescription'\)/);
-assert.match(secretRuntime, /else description\.remove\(\)/,
-  'Clue-only hidden cards must remove rather than replace their description');
 assert.match(secretRuntime, /Hidden achievement\. The title is your clue\./,
-  'The generic clue remains available for hidden achievements that use it');
+  'The generic clue remains available for hidden achievements that use their title as the clue');
 assert.match(secretRuntime, /pendingSecretAchievements/);
 assert.match(secretRuntime, /acknowledgeSecretAchievement/);
 assert.match(secretEvents, /SECRET_ACHIEVEMENT_EVIDENCE_STORAGE_KEY/);
@@ -382,16 +399,21 @@ assert.match(sedanSource, /signalSecretAchievement\('satans-sedan'/);
 assert.match(timeTrialSource, /targetSeconds: 12/);
 assert.match(timeTrialSource, /targetSeconds: 17/);
 assert.match(timeTrialSource, /targetSeconds: 15/);
-assert.match(timeTrialSource, /targetSeconds: 24/);
+assert.match(timeTrialSource, /targetSeconds: 23/);
 assert.match(timeTrialSource, /targetSeconds: 53/);
-assert.match(timeTrialSource, /targetSeconds: 27/);
+assert.match(timeTrialSource, /targetSeconds: 25/);
 assert.match(timeTrialSource, /seconds >= trial\.targetSeconds/);
 
 assert.match(challengeSource, /SAMPLE_INTERVAL_MS = 50/);
+assert.match(challengeSource, /CATCH_GAS_MIN_OVERCHARGE = 0\.001/);
+assert.doesNotMatch(challengeSource, /CATCH_GAS_REQUIRED_MS|catchGasMs|3000/,
+  'CATCH THE CHARGE must not retain a hidden timed-hold requirement');
 assert.match(challengeSource, /GOT_STARTED_ID = 'got-started'/);
 assert.match(challengeSource, /mountain: 110/);
 assert.match(challengeSource, /rivalCountAtStart/);
 assert.match(challengeSource, /runtime\.state\.offRoad === true/);
+assert.match(challengeSource, /achievements\.unlock\(\s*CATCH_THE_CHARGE_ID/,
+  'A qualifying GAS catch must unlock CATCH THE CHARGE directly');
 assert.match(challengeSource, /achievements\.unlock\('an-army-of-me'/);
 assert.match(challengeSource, /achievements\.unlock\('on-course-of-course'/);
 assert.match(challengeSource, /turn:lap-result/);

--- a/turn-lab/tests/chromatic-camouflage-production.mjs
+++ b/turn-lab/tests/chromatic-camouflage-production.mjs
@@ -46,11 +46,12 @@ assert.equal(gotStarted?.description, 'Finish all Getting Started achievements.'
 assert.equal(catchTheCharge?.title, 'CATCH THE CHARGE');
 assert.equal(catchTheCharge?.category, 'onboarding');
 assert.equal(catchTheCharge?.trophies, 25);
-assert.equal(catchTheCharge?.progressMax, 3);
-assert.match(catchTheCharge?.description || '', /DRIFT/);
-assert.match(catchTheCharge?.description || '', /purple OVERCHARGE/);
-assert.match(catchTheCharge?.description || '', /Switch to GAS to catch it/);
-assert.match(catchTheCharge?.description || '', /keep GAS held for three seconds/);
+assert.equal(Object.hasOwn(catchTheCharge || {}, 'progressMax'), false,
+  'CATCH THE CHARGE should unlock on the catch itself, without a timed hold');
+assert.equal(
+  catchTheCharge?.description,
+  'Overcharge the BOOST bar using DRIFT. Retain the overcharge using GAS.'
+);
 assert.equal(ONBOARDING_ACHIEVEMENT_IDS.length, 11,
   'GOT STARTED must require every Getting Started lesson, including CATCH THE CHARGE, without requiring itself');
 assert.equal(ONBOARDING_ACHIEVEMENT_IDS.includes('catch-the-charge'), true);
@@ -68,7 +69,10 @@ assert.equal(mayday?.title, 'MAYDAY!');
 assert.equal(mayday?.hidden, true);
 assert.equal(mayday?.category, 'racing');
 assert.equal(mayday?.trophies, 100);
-assert.equal(mayday?.lockedDescription, '');
+assert.equal(
+  mayday?.lockedDescription,
+  'Hidden achievement. You’ll know what to do when the moment comes.'
+);
 assert.match(mayday?.description || '', /Ambulance/);
 assert.match(mayday?.description || '', /Airport MAYDAY/);
 assert.match(mayday?.description || '', /30 seconds/);

--- a/turn-tests/startup-and-unread-production.mjs
+++ b/turn-tests/startup-and-unread-production.mjs
@@ -78,8 +78,22 @@ assert.match(unreadMarkers, /turn-achievement-unread-dot/);
 assert.match(unreadMarkers, /Newly unlocked achievement\./);
 assert.match(unreadMarkers, /new MutationObserver\(queueDecoration\)/);
 assert.match(unreadMarkers, /listObserver\.observe\(list, \{ childList: true \}\)/);
+assert.match(unreadMarkers, /createFilterButton\(HIDDEN_FILTER, 'HIDDEN'\)/,
+  'Achievements must expose a dedicated Hidden filter');
+assert.match(unreadMarkers, /createFilterButton\(NEW_FILTER, 'NEW'\)/,
+  'Achievements must expose a New filter for unseen achievement notifications');
+assert.match(unreadMarkers, /newFilter\.hidden = !hasNewAchievements/,
+  'The New filter must only appear while there are unseen achievements to inspect');
+assert.match(unreadMarkers, /achievement\?\.hidden === true/,
+  'The Hidden filter must derive from the achievement hidden contract rather than title matching');
+assert.match(unreadMarkers, /turn-achievement-toast-open/,
+  'Achievement toasts must expose a full-toast activation target');
+assert.match(unreadMarkers, /function achievementFromToast\(\)/);
+assert.match(unreadMarkers, /function focusAchievement\(achievementId\)/);
+assert.match(unreadMarkers, /scrollIntoView\(\{ block: 'center', behavior: 'auto' \}\)/,
+  'Opening a toast must take the player directly to the unlocked achievement without extra motion');
 
-console.log(`TURN ${release.version} startup cover, landscape-gated screen-reader onboarding, refreshed Bella graph, fixed Home viewport, spoken training labels and unread achievement markers passed.`);
+console.log(`TURN ${release.version} startup cover, landscape-gated screen-reader onboarding, refreshed Bella graph, fixed Home viewport, spoken training labels and unread achievement navigation passed.`);
 
 function escapeRegex(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/turn/achievements.js
+++ b/turn/achievements.js
@@ -17,7 +17,6 @@ export {
 } from './achievements/time-trials.js?revision=r166-bella-records';
 export {
   CATCH_GAS_MIN_OVERCHARGE,
-  CATCH_GAS_REQUIRED_MS,
   CLEAN_LAP_TARGETS,
   CHALLENGE_PROGRESS_STORAGE_KEY,
   normalizeChallengeProgress,

--- a/turn/achievements/catalog-production.js
+++ b/turn/achievements/catalog-production.js
@@ -15,7 +15,7 @@ const MAYDAY = Object.freeze({
   category: base.CATEGORY.RACING,
   trophies: 100,
   hidden: true,
-  lockedDescription: '',
+  lockedDescription: 'Hidden achievement. You’ll know what to do when the moment comes.',
   title: 'MAYDAY!',
   description: 'In the Ambulance, answer the Airport MAYDAY with sirens and deliver the patient to the terminal medical bay within 30 seconds.',
   icon: 'siren'
@@ -26,9 +26,8 @@ export const CATCH_THE_CHARGE_ACHIEVEMENT = Object.freeze({
   category: base.CATEGORY.ONBOARDING,
   trophies: 25,
   title: 'CATCH THE CHARGE',
-  description: 'Keep holding DRIFT after BOOST is full to build purple OVERCHARGE. Switch to GAS to catch it, then keep GAS held for three seconds.',
-  icon: 'charge',
-  progressMax: 3
+  description: 'Overcharge the BOOST bar using DRIFT. Retain the overcharge using GAS.',
+  icon: 'charge'
 });
 
 export const GOT_STARTED_ACHIEVEMENT = Object.freeze({

--- a/turn/achievements/challenge-expansion-r166.js
+++ b/turn/achievements/challenge-expansion-r166.js
@@ -12,11 +12,9 @@ export const CLEAN_LAP_TARGETS = Object.freeze({
   'midnight-city': 120,
   mountain: 110
 });
-export const CATCH_GAS_REQUIRED_MS = 3000;
-export const CATCH_GAS_MIN_OVERCHARGE = 0.05;
+export const CATCH_GAS_MIN_OVERCHARGE = 0.001;
 
 const SAMPLE_INTERVAL_MS = 50;
-const MAX_SAMPLE_DELTA_MS = 250;
 const GOT_STARTED_ID = 'got-started';
 const CATCH_THE_CHARGE_ID = 'catch-the-charge';
 
@@ -116,11 +114,9 @@ export function installAchievementChallengeExpansion({
 
   const progress = loadProgress(storage);
   let currentLap = null;
-  let catchGasMs = 0;
   let catchGasUnlocked = Boolean(
     achievements.getState?.().unlocked?.[CATCH_THE_CHARGE_ID]
   );
-  let lastSampleAt = performance.now();
 
   function syncGotStarted() {
     const state = achievements.getState?.();
@@ -164,21 +160,15 @@ export function installAchievementChallengeExpansion({
     };
   }
 
-  function sampleCatchGas(elapsedMs) {
-    if (catchGasUnlocked) return;
+  function sampleCatchGas() {
+    if (catchGasUnlocked) return null;
     const qualifies = qualifiesForCatchGas({
       running: runtime.state.running === true,
       caught: globalThis.__turnBoostOverchargeCaught === true,
       overcharge: globalThis.__turnBoostOvercharge,
       visible: document.visibilityState !== 'hidden'
     });
-    if (!qualifies) {
-      catchGasMs = 0;
-      return;
-    }
-
-    catchGasMs += elapsedMs;
-    if (catchGasMs < CATCH_GAS_REQUIRED_MS) return;
+    if (!qualifies) return null;
 
     const unlocked = achievements.unlock(
       CATCH_THE_CHARGE_ID,
@@ -188,24 +178,16 @@ export function installAchievementChallengeExpansion({
       )
     );
     if (unlocked?.length) catchGasUnlocked = true;
-    catchGasMs = 0;
+    return unlocked;
   }
 
   function sampleCourseState() {
-    const now = performance.now();
-    const elapsedMs = Math.min(MAX_SAMPLE_DELTA_MS, Math.max(0, now - lastSampleAt));
-    lastSampleAt = now;
     if (currentLap && runtime.state.offRoad === true) currentLap.onCourseThroughout = false;
-    sampleCatchGas(elapsedMs);
+    sampleCatchGas();
   }
 
   function resetLap() {
     currentLap = null;
-  }
-
-  function resetCatchGas() {
-    catchGasMs = 0;
-    lastSampleAt = performance.now();
   }
 
   function completeLap(detail) {
@@ -237,14 +219,10 @@ export function installAchievementChallengeExpansion({
   const handleUiState = (event) => {
     const reason = event.detail?.reason;
     if (reason === 'lap-started') beginLap();
-    if (reason === 'race-reset') {
-      resetLap();
-      resetCatchGas();
-    }
+    if (reason === 'race-reset') resetLap();
     if (Object.prototype.hasOwnProperty.call(event.detail || {}, 'running')
         && event.detail.running === false) {
       resetLap();
-      resetCatchGas();
     }
   };
   const handleLapResult = (event) => completeLap(event.detail || {});

--- a/turn/achievements/secret-catalog.js
+++ b/turn/achievements/secret-catalog.js
@@ -4,7 +4,7 @@ export const SECRET_ACHIEVEMENTS = Object.freeze([
     category: 'exploration',
     trophies: 25,
     hidden: true,
-    lockedDescription: '',
+    lockedDescription: 'Hidden achievement.',
     title: 'FIND LILYA!',
     description: 'Find the hidden Lilya portrait in Midnight City.',
     icon: 'spectate'
@@ -14,7 +14,7 @@ export const SECRET_ACHIEVEMENTS = Object.freeze([
     category: 'exploration',
     trophies: 25,
     hidden: true,
-    lockedDescription: '',
+    lockedDescription: 'Hidden achievement.',
     title: 'FIND DARVID!',
     description: 'Find Darvid’s hidden face in Harbor.',
     icon: 'spectate'
@@ -24,7 +24,7 @@ export const SECRET_ACHIEVEMENTS = Object.freeze([
     category: 'exploration',
     trophies: 25,
     hidden: true,
-    lockedDescription: '',
+    lockedDescription: 'Hidden achievement. You’ll know what to do when the moment comes.',
     title: 'SAVE BELLA!',
     description: 'Find Bella in Countryside using the Fire Truck.',
     icon: 'cat'

--- a/turn/achievements/time-trials.js
+++ b/turn/achievements/time-trials.js
@@ -23,9 +23,9 @@ export const TIME_TRIALS = Object.freeze([
   Object.freeze({
     id: 'harbor-sprint',
     trackId: 'harbor',
-    targetSeconds: 24,
+    targetSeconds: 23,
     title: 'HARBOR SPRINT',
-    description: 'Finish Harbor in under 24 seconds.'
+    description: 'Finish Harbor in under 23 seconds.'
   }),
   Object.freeze({
     id: 'midnight-sprint',
@@ -37,9 +37,9 @@ export const TIME_TRIALS = Object.freeze([
   Object.freeze({
     id: 'mountain-sprint',
     trackId: 'mountain',
-    targetSeconds: 27,
+    targetSeconds: 25,
     title: 'MOUNTAIN SPRINT',
-    description: 'Finish Mountain in under 27 seconds.'
+    description: 'Finish Mountain in under 25 seconds.'
   })
 ]);
 

--- a/turn/achievements/unread-markers.js
+++ b/turn/achievements/unread-markers.js
@@ -1,4 +1,6 @@
 const STYLE_ID = 'turn-achievement-unread-marker-styles';
+const HIDDEN_FILTER = 'hidden';
+const NEW_FILTER = 'new';
 
 function installStyles() {
   if (document.querySelector(`#${STYLE_ID}`)) return;
@@ -32,8 +34,38 @@ function installStyles() {
       white-space: nowrap;
       border: 0;
     }
+    .turn-achievement-card:focus {
+      outline: 5px solid var(--turn-action-information, #38d9ff);
+      outline-offset: 4px;
+    }
+    .turn-achievement-toast:not(.turn-trophy-reward-toast) {
+      pointer-events: auto;
+    }
+    .turn-achievement-toast-open {
+      position: absolute;
+      z-index: 3;
+      inset: 0;
+      padding: 0;
+      border: 0;
+      border-radius: inherit;
+      background: transparent;
+      cursor: pointer;
+    }
+    .turn-achievement-toast-open:focus-visible {
+      outline: 5px solid var(--turn-action-information, #38d9ff);
+      outline-offset: 4px;
+    }
   `;
   document.head.appendChild(style);
+}
+
+function createFilterButton(filter, label) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.dataset.achievementFilter = filter;
+  button.setAttribute('aria-pressed', 'false');
+  button.textContent = label;
+  return button;
 }
 
 export function installAchievementUnreadMarkers(
@@ -49,20 +81,100 @@ export function installAchievementUnreadMarkers(
   installStyles();
   const dialog = achievements.dialog;
   const list = dialog.querySelector('.turn-achievements-list');
+  const filters = dialog.querySelector('.turn-achievements-filters');
+  const allFilter = filters?.querySelector('[data-achievement-filter="all"]');
+  const unlockedFilter = filters?.querySelector('[data-achievement-filter="unlocked"]');
   const triggers = [achievements.homeTrigger, achievements.raceTrigger].filter(Boolean);
+  const achievementById = new Map(
+    achievements.catalog.map((achievement) => [achievement.id, achievement])
+  );
+  let hiddenFilter = filters?.querySelector(`[data-achievement-filter="${HIDDEN_FILTER}"]`) || null;
+  let newFilter = filters?.querySelector(`[data-achievement-filter="${NEW_FILTER}"]`) || null;
   let pendingIds = new Set();
   let decorationQueued = false;
+  let activeSpecialFilter = '';
+
+  if (filters && !hiddenFilter) {
+    hiddenFilter = createFilterButton(HIDDEN_FILTER, 'HIDDEN');
+    if (unlockedFilter) unlockedFilter.before(hiddenFilter);
+    else filters.appendChild(hiddenFilter);
+  }
+  if (filters && !newFilter) {
+    newFilter = createFilterButton(NEW_FILTER, 'NEW');
+    newFilter.hidden = true;
+    if (unlockedFilter) unlockedFilter.before(newFilter);
+    else filters.appendChild(newFilter);
+  }
+
+  function cardsWithAchievements() {
+    return [...list.querySelectorAll('.turn-achievement-card')].map((card, index) => ({
+      card,
+      achievement: achievementById.get(card.dataset.achievementId)
+        || achievements.catalog[index]
+        || null
+    }));
+  }
+
+  function applySpecialFilter() {
+    if (!activeSpecialFilter) return;
+    for (const { card, achievement } of cardsWithAchievements()) {
+      const visible = activeSpecialFilter === HIDDEN_FILTER
+        ? achievement?.hidden === true
+        : activeSpecialFilter === NEW_FILTER
+          ? Boolean(achievement && pendingIds.has(achievement.id))
+          : true;
+      card.hidden = !visible;
+    }
+  }
+
+  function syncNewFilter() {
+    if (!newFilter) return;
+    const hasNewAchievements = pendingIds.size > 0;
+    newFilter.hidden = !hasNewAchievements;
+    if (!hasNewAchievements && activeSpecialFilter === NEW_FILTER) {
+      allFilter?.click();
+      activeSpecialFilter = '';
+    }
+  }
+
+  function activateSpecialFilter(filter) {
+    if (filter !== HIDDEN_FILTER && filter !== NEW_FILTER) return;
+    if (filter === NEW_FILTER && pendingIds.size === 0) return;
+    allFilter?.click();
+    activeSpecialFilter = filter;
+    for (const button of filters?.querySelectorAll('[data-achievement-filter]') || []) {
+      button.setAttribute('aria-pressed', String(button.dataset.achievementFilter === filter));
+    }
+    applySpecialFilter();
+  }
+
+  function handleFilterClick(event) {
+    const button = event.target.closest?.('[data-achievement-filter]');
+    if (!button || !filters?.contains(button)) return;
+    const filter = button.dataset.achievementFilter;
+    if (filter === HIDDEN_FILTER || filter === NEW_FILTER) {
+      activateSpecialFilter(filter);
+      return;
+    }
+    activeSpecialFilter = '';
+    hiddenFilter?.setAttribute('aria-pressed', 'false');
+    newFilter?.setAttribute('aria-pressed', 'false');
+  }
+  filters?.addEventListener('click', handleFilterClick, { capture: true });
 
   function snapshotUnseen() {
     pendingIds = new Set(achievements.store.unseenIds());
+    syncNewFilter();
   }
 
   function decorate() {
     decorationQueued = false;
-    const cards = [...list.querySelectorAll('.turn-achievement-card')];
-    cards.forEach((card, index) => {
-      const achievement = achievements.catalog[index];
-      const isNew = Boolean(achievement && pendingIds.has(achievement.id));
+    for (const { card, achievement } of cardsWithAchievements()) {
+      if (!achievement) continue;
+      card.dataset.achievementId = achievement.id;
+      card.dataset.achievementHidden = String(achievement.hidden === true);
+      card.tabIndex = -1;
+      const isNew = pendingIds.has(achievement.id);
       const icon = card.querySelector('.turn-achievement-icon');
       const copy = card.querySelector('.turn-achievement-copy');
       let dot = icon?.querySelector('.turn-achievement-unread-dot');
@@ -87,7 +199,9 @@ export function installAchievementUnreadMarkers(
         text?.remove();
         delete card.dataset.achievementUnseen;
       }
-    });
+    }
+    syncNewFilter();
+    applySpecialFilter();
   }
 
   function queueDecoration() {
@@ -110,23 +224,78 @@ export function installAchievementUnreadMarkers(
 
   const handleAchievementUpdate = (event) => {
     for (const id of event.detail?.unlocked || []) pendingIds.add(id);
+    syncNewFilter();
     queueDecoration();
   };
   window.addEventListener('turn:achievements-updated', handleAchievementUpdate);
+
+  function achievementFromToast() {
+    const heading = achievements.toast?.querySelector('strong')?.textContent?.trim() || '';
+    return achievements.catalog.find((achievement) => (
+      heading === achievement.title || heading.startsWith(`${achievement.title} + `)
+    )) || null;
+  }
+
+  function focusAchievement(achievementId) {
+    const target = list.querySelector(`[data-achievement-id="${achievementId}"]`);
+    if (!target) return false;
+    allFilter?.click();
+    activeSpecialFilter = '';
+    target.hidden = false;
+    target.focus({ preventScroll: true });
+    target.scrollIntoView({ block: 'center', behavior: 'auto' });
+    return true;
+  }
+
+  const toastOpen = achievements.toast && !achievements.toast.querySelector('.turn-achievement-toast-open')
+    ? document.createElement('button')
+    : null;
+  if (toastOpen) {
+    toastOpen.type = 'button';
+    toastOpen.className = 'turn-achievement-toast-open';
+    toastOpen.setAttribute('aria-label', 'Open unlocked achievement');
+    toastOpen.title = 'Open achievement';
+    achievements.toast.appendChild(toastOpen);
+  }
+
+  function openToastAchievement() {
+    const achievement = achievementFromToast();
+    if (!achievement) return;
+    snapshotUnseen();
+    const returnTrigger = achievements.raceTrigger?.hidden === false
+      ? achievements.raceTrigger
+      : achievements.homeTrigger;
+    achievements.open(returnTrigger || null);
+    queueMicrotask(() => {
+      decorate();
+      focusAchievement(achievement.id);
+    });
+  }
+  toastOpen?.addEventListener('click', openToastAchievement);
+
   dialog.addEventListener('close', () => {
+    if (activeSpecialFilter) allFilter?.click();
+    activeSpecialFilter = '';
     pendingIds.clear();
+    syncNewFilter();
   });
 
   dialog.dataset.turnUnreadMarkers = 'installed';
   const api = Object.freeze({
     snapshotUnseen,
     decorate,
+    focusAchievement,
     disconnect() {
       listObserver.disconnect();
       window.removeEventListener('turn:achievements-updated', handleAchievementUpdate);
+      filters?.removeEventListener('click', handleFilterClick, { capture: true });
+      toastOpen?.removeEventListener('click', openToastAchievement);
+      toastOpen?.remove();
       for (const trigger of triggers) {
         trigger.removeEventListener('click', captureBeforeOpen, { capture: true });
       }
+      hiddenFilter?.remove();
+      newFilter?.remove();
       pendingIds.clear();
       delete dialog.dataset.turnUnreadMarkers;
     }


### PR DESCRIPTION
## What changed

- update **CATCH THE CHARGE** copy to: “Overcharge the BOOST bar using DRIFT. Retain the overcharge using GAS.”
- remove the three-second hold requirement: a real caught overcharge now unlocks the achievement immediately
- tighten **HARBOR SPRINT** to < 23 s and **MOUNTAIN SPRINT** to < 25 s
- give FIND LILYA! and FIND DARVID! the neutral locked copy “Hidden achievement.”
- give MAYDAY! and SAVE BELLA! contextual locked copy: “Hidden achievement. You’ll know what to do when the moment comes.”
- add **HIDDEN** and conditional **NEW** achievement filters; NEW appears only while there are unseen achievement notifications
- make achievement toasts tappable so they open Achievements, reveal the matching card and move focus to it

No trophy values or Trophy Road thresholds change.