### PR TITLE
Make achievement tags composable

### DIFF
--- a/turn/achievements/unread-markers.js
+++ b/turn/achievements/unread-markers.js
@@ -1,6 +1,35 @@
 const STYLE_ID = 'turn-achievement-unread-marker-styles';
-const HIDDEN_FILTER = 'hidden';
+const ALL_FILTER = 'all';
 const NEW_FILTER = 'new';
+const ONBOARDING_FILTER = 'onboarding';
+const WAYS_TO_PLAY_FILTER = 'ways-to-play';
+const EXPLORATION_FILTER = 'exploration';
+const RACING_FILTER = 'racing';
+const TIME_TRIALS_FILTER = 'time-trials';
+const HIDDEN_FILTER = 'hidden';
+const UNLOCKED_FILTER = 'unlocked';
+
+const TAG_LABELS = Object.freeze({
+  [ONBOARDING_FILTER]: 'GETTING STARTED',
+  [WAYS_TO_PLAY_FILTER]: 'WAYS TO PLAY',
+  [EXPLORATION_FILTER]: 'EXPLORATION',
+  [RACING_FILTER]: 'RACING',
+  [TIME_TRIALS_FILTER]: 'TIME TRIALS',
+  [HIDDEN_FILTER]: 'HIDDEN',
+  [NEW_FILTER]: 'NEW'
+});
+
+const FILTERS = Object.freeze([
+  [ALL_FILTER, 'ALL'],
+  [NEW_FILTER, 'NEW'],
+  [ONBOARDING_FILTER, 'GETTING STARTED'],
+  [WAYS_TO_PLAY_FILTER, 'WAYS TO PLAY'],
+  [EXPLORATION_FILTER, 'EXPLORATION'],
+  [RACING_FILTER, 'RACING'],
+  [TIME_TRIALS_FILTER, 'TIME TRIALS'],
+  [HIDDEN_FILTER, 'HIDDEN'],
+  [UNLOCKED_FILTER, 'UNLOCKED']
+]);
 
 function installStyles() {
   if (document.querySelector(`#${STYLE_ID}`)) return;
@@ -34,6 +63,42 @@ function installStyles() {
       white-space: nowrap;
       border: 0;
     }
+    .turn-achievement-meta {
+      display: flex !important;
+      flex-wrap: wrap;
+      gap: 5px 7px;
+      align-items: center;
+      margin-bottom: 3px;
+    }
+    .turn-achievement-tag {
+      display: inline-flex;
+      align-items: center;
+      min-height: 22px;
+      padding: 2px 7px;
+      border: 2px solid var(--turn-ink, #08090a);
+      border-radius: var(--turn-radius-pill, 999px);
+      background: var(--turn-surface-page, #fff8e8);
+      color: var(--turn-ink, #08090a);
+      font-size: .58rem;
+      font-weight: 950;
+      line-height: 1;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+    .turn-achievement-tag[data-achievement-tag="hidden"] {
+      background: var(--turn-muted, #d6d0c2);
+    }
+    .turn-achievement-tag[data-achievement-tag="new"] {
+      background: var(--turn-action-warning, #ffd43b);
+    }
+    .turn-achievement-trophies {
+      font-size: .68rem;
+      font-weight: 950;
+      letter-spacing: .11em;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
     .turn-achievement-card:focus {
       outline: 5px solid var(--turn-action-information, #38d9ff);
       outline-offset: 4px;
@@ -63,9 +128,75 @@ function createFilterButton(filter, label) {
   const button = document.createElement('button');
   button.type = 'button';
   button.dataset.achievementFilter = filter;
-  button.setAttribute('aria-pressed', 'false');
+  button.setAttribute('aria-pressed', String(filter === ALL_FILTER));
   button.textContent = label;
   return button;
+}
+
+function installFilterButtons(filters) {
+  if (!filters) return new Map();
+  const buttons = new Map();
+  const nodes = FILTERS.map(([filter, label]) => {
+    const button = createFilterButton(filter, label);
+    buttons.set(filter, button);
+    return button;
+  });
+  filters.replaceChildren(...nodes);
+  return buttons;
+}
+
+function staticAchievementTags(achievement) {
+  const declared = Array.isArray(achievement?.tags)
+    ? achievement.tags
+    : [achievement?.category];
+  const tags = declared.filter(Boolean);
+
+  // Time trials are races too. Keeping both tags makes car choice and race craft
+  // part of the challenge without collapsing TIME TRIALS into a separate silo.
+  if (achievement?.category === TIME_TRIALS_FILTER && !tags.includes(RACING_FILTER)) {
+    tags.unshift(RACING_FILTER);
+  }
+  if (achievement?.hidden === true && !tags.includes(HIDDEN_FILTER)) tags.push(HIDDEN_FILTER);
+  return [...new Set(tags)];
+}
+
+function visibleAchievementTags(achievement, isNew) {
+  const tags = staticAchievementTags(achievement);
+  if (isNew && !tags.includes(NEW_FILTER)) tags.push(NEW_FILTER);
+  return tags;
+}
+
+function decorateMeta(copy, achievement, isNew) {
+  if (!copy || !achievement) return;
+  let meta = copy.querySelector(':scope > .turn-achievement-meta');
+  if (!meta) {
+    meta = copy.querySelector(':scope > span:not(.turn-achievement-unread-text)');
+    if (!meta) {
+      meta = document.createElement('span');
+      copy.prepend(meta);
+    }
+    meta.className = 'turn-achievement-meta';
+  }
+
+  const tags = visibleAchievementTags(achievement, isNew);
+  const nodes = tags.map((tag) => {
+    const label = document.createElement('span');
+    label.className = 'turn-achievement-tag';
+    label.dataset.achievementTag = tag;
+    label.textContent = TAG_LABELS[tag] || String(tag).toUpperCase();
+    return label;
+  });
+  const trophies = document.createElement('span');
+  trophies.className = 'turn-achievement-trophies';
+  trophies.textContent = `${achievement.trophies} trophies`;
+  meta.replaceChildren(...nodes, trophies);
+}
+
+function removeTimeTrialRecommendation(copy, achievement) {
+  if (!copy || achievement?.category !== TIME_TRIALS_FILTER) return;
+  for (const small of copy.querySelectorAll(':scope > small')) {
+    if (/^Recommended:/i.test(small.textContent?.trim() || '')) small.remove();
+  }
 }
 
 export function installAchievementUnreadMarkers(
@@ -82,29 +213,18 @@ export function installAchievementUnreadMarkers(
   const dialog = achievements.dialog;
   const list = dialog.querySelector('.turn-achievements-list');
   const filters = dialog.querySelector('.turn-achievements-filters');
-  const allFilter = filters?.querySelector('[data-achievement-filter="all"]');
-  const unlockedFilter = filters?.querySelector('[data-achievement-filter="unlocked"]');
+  const filterButtons = installFilterButtons(filters);
+  const allFilter = filterButtons.get(ALL_FILTER) || null;
+  const newFilter = filterButtons.get(NEW_FILTER) || null;
   const triggers = [achievements.homeTrigger, achievements.raceTrigger].filter(Boolean);
   const achievementById = new Map(
     achievements.catalog.map((achievement) => [achievement.id, achievement])
   );
-  let hiddenFilter = filters?.querySelector(`[data-achievement-filter="${HIDDEN_FILTER}"]`) || null;
-  let newFilter = filters?.querySelector(`[data-achievement-filter="${NEW_FILTER}"]`) || null;
   let pendingIds = new Set();
   let decorationQueued = false;
-  let activeSpecialFilter = '';
+  let activeFilter = ALL_FILTER;
 
-  if (filters && !hiddenFilter) {
-    hiddenFilter = createFilterButton(HIDDEN_FILTER, 'HIDDEN');
-    if (unlockedFilter) unlockedFilter.before(hiddenFilter);
-    else filters.appendChild(hiddenFilter);
-  }
-  if (filters && !newFilter) {
-    newFilter = createFilterButton(NEW_FILTER, 'NEW');
-    newFilter.hidden = true;
-    if (unlockedFilter) unlockedFilter.before(newFilter);
-    else filters.appendChild(newFilter);
-  }
+  if (newFilter) newFilter.hidden = true;
 
   function cardsWithAchievements() {
     return [...list.querySelectorAll('.turn-achievement-card')].map((card, index) => ({
@@ -115,52 +235,42 @@ export function installAchievementUnreadMarkers(
     }));
   }
 
-  function applySpecialFilter() {
-    if (!activeSpecialFilter) return;
+  function matchesFilter(card, achievement) {
+    if (activeFilter === ALL_FILTER) return true;
+    if (activeFilter === UNLOCKED_FILTER) return card.dataset.achievementStatus === 'unlocked';
+    if (activeFilter === NEW_FILTER) return Boolean(achievement && pendingIds.has(achievement.id));
+    return staticAchievementTags(achievement).includes(activeFilter);
+  }
+
+  function applyFilter() {
     for (const { card, achievement } of cardsWithAchievements()) {
-      const visible = activeSpecialFilter === HIDDEN_FILTER
-        ? achievement?.hidden === true
-        : activeSpecialFilter === NEW_FILTER
-          ? Boolean(achievement && pendingIds.has(achievement.id))
-          : true;
-      card.hidden = !visible;
+      card.hidden = !matchesFilter(card, achievement);
     }
+  }
+
+  function setActiveFilter(filter) {
+    if (!filterButtons.has(filter)) filter = ALL_FILTER;
+    if (filter === NEW_FILTER && pendingIds.size === 0) filter = ALL_FILTER;
+    activeFilter = filter;
+    for (const [candidate, button] of filterButtons) {
+      button.setAttribute('aria-pressed', String(candidate === activeFilter));
+    }
+    applyFilter();
   }
 
   function syncNewFilter() {
     if (!newFilter) return;
     const hasNewAchievements = pendingIds.size > 0;
     newFilter.hidden = !hasNewAchievements;
-    if (!hasNewAchievements && activeSpecialFilter === NEW_FILTER) {
-      allFilter?.click();
-      activeSpecialFilter = '';
-    }
-  }
-
-  function activateSpecialFilter(filter) {
-    if (filter !== HIDDEN_FILTER && filter !== NEW_FILTER) return;
-    if (filter === NEW_FILTER && pendingIds.size === 0) return;
-    allFilter?.click();
-    activeSpecialFilter = filter;
-    for (const button of filters?.querySelectorAll('[data-achievement-filter]') || []) {
-      button.setAttribute('aria-pressed', String(button.dataset.achievementFilter === filter));
-    }
-    applySpecialFilter();
+    if (!hasNewAchievements && activeFilter === NEW_FILTER) setActiveFilter(ALL_FILTER);
   }
 
   function handleFilterClick(event) {
     const button = event.target.closest?.('[data-achievement-filter]');
     if (!button || !filters?.contains(button)) return;
-    const filter = button.dataset.achievementFilter;
-    if (filter === HIDDEN_FILTER || filter === NEW_FILTER) {
-      activateSpecialFilter(filter);
-      return;
-    }
-    activeSpecialFilter = '';
-    hiddenFilter?.setAttribute('aria-pressed', 'false');
-    newFilter?.setAttribute('aria-pressed', 'false');
+    setActiveFilter(button.dataset.achievementFilter || ALL_FILTER);
   }
-  filters?.addEventListener('click', handleFilterClick, { capture: true });
+  filters?.addEventListener('click', handleFilterClick);
 
   function snapshotUnseen() {
     pendingIds = new Set(achievements.store.unseenIds());
@@ -173,12 +283,16 @@ export function installAchievementUnreadMarkers(
       if (!achievement) continue;
       card.dataset.achievementId = achievement.id;
       card.dataset.achievementHidden = String(achievement.hidden === true);
+      card.dataset.achievementTags = staticAchievementTags(achievement).join(' ');
       card.tabIndex = -1;
       const isNew = pendingIds.has(achievement.id);
       const icon = card.querySelector('.turn-achievement-icon');
       const copy = card.querySelector('.turn-achievement-copy');
       let dot = icon?.querySelector('.turn-achievement-unread-dot');
       let text = copy?.querySelector('.turn-achievement-unread-text');
+
+      decorateMeta(copy, achievement, isNew);
+      removeTimeTrialRecommendation(copy, achievement);
 
       if (isNew) {
         if (!dot && icon) {
@@ -201,7 +315,7 @@ export function installAchievementUnreadMarkers(
       }
     }
     syncNewFilter();
-    applySpecialFilter();
+    applyFilter();
   }
 
   function queueDecoration() {
@@ -239,8 +353,7 @@ export function installAchievementUnreadMarkers(
   function focusAchievement(achievementId) {
     const target = list.querySelector(`[data-achievement-id="${achievementId}"]`);
     if (!target) return false;
-    allFilter?.click();
-    activeSpecialFilter = '';
+    setActiveFilter(ALL_FILTER);
     target.hidden = false;
     target.focus({ preventScroll: true });
     target.scrollIntoView({ block: 'center', behavior: 'auto' });
@@ -274,11 +387,15 @@ export function installAchievementUnreadMarkers(
   toastOpen?.addEventListener('click', openToastAchievement);
 
   dialog.addEventListener('close', () => {
-    if (activeSpecialFilter) allFilter?.click();
-    activeSpecialFilter = '';
     pendingIds.clear();
     syncNewFilter();
+    setActiveFilter(ALL_FILTER);
   });
+
+  // The first achievement list already exists before this enhancer installs.
+  // Decorate it immediately so tags and the complete filter set are available
+  // even before the player has unlocked anything new.
+  decorate();
 
   dialog.dataset.turnUnreadMarkers = 'installed';
   const api = Object.freeze({
@@ -288,14 +405,12 @@ export function installAchievementUnreadMarkers(
     disconnect() {
       listObserver.disconnect();
       window.removeEventListener('turn:achievements-updated', handleAchievementUpdate);
-      filters?.removeEventListener('click', handleFilterClick, { capture: true });
+      filters?.removeEventListener('click', handleFilterClick);
       toastOpen?.removeEventListener('click', openToastAchievement);
       toastOpen?.remove();
       for (const trigger of triggers) {
         trigger.removeEventListener('click', captureBeforeOpen, { capture: true });
       }
-      hiddenFilter?.remove();
-      newFilter?.remove();
       pendingIds.clear();
       delete dialog.dataset.turnUnreadMarkers;
     }

--- a/turn/achievements/unread-markers.js
+++ b/turn/achievements/unread-markers.js
@@ -19,18 +19,6 @@ const TAG_LABELS = Object.freeze({
   [NEW_FILTER]: 'NEW'
 });
 
-const FILTERS = Object.freeze([
-  [ALL_FILTER, 'ALL'],
-  [NEW_FILTER, 'NEW'],
-  [ONBOARDING_FILTER, 'GETTING STARTED'],
-  [WAYS_TO_PLAY_FILTER, 'WAYS TO PLAY'],
-  [EXPLORATION_FILTER, 'EXPLORATION'],
-  [RACING_FILTER, 'RACING'],
-  [TIME_TRIALS_FILTER, 'TIME TRIALS'],
-  [HIDDEN_FILTER, 'HIDDEN'],
-  [UNLOCKED_FILTER, 'UNLOCKED']
-]);
-
 function installStyles() {
   if (document.querySelector(`#${STYLE_ID}`)) return;
   const style = document.createElement('style');
@@ -135,14 +123,19 @@ function createFilterButton(filter, label) {
 
 function installFilterButtons(filters) {
   if (!filters) return new Map();
-  const buttons = new Map();
-  const nodes = FILTERS.map(([filter, label]) => {
-    const button = createFilterButton(filter, label);
-    buttons.set(filter, button);
-    return button;
-  });
+  const nodes = [
+    createFilterButton(ALL_FILTER, 'ALL'),
+    createFilterButton(NEW_FILTER, 'NEW'),
+    createFilterButton(ONBOARDING_FILTER, 'GETTING STARTED'),
+    createFilterButton(WAYS_TO_PLAY_FILTER, 'WAYS TO PLAY'),
+    createFilterButton(EXPLORATION_FILTER, 'EXPLORATION'),
+    createFilterButton(RACING_FILTER, 'RACING'),
+    createFilterButton(TIME_TRIALS_FILTER, 'TIME TRIALS'),
+    createFilterButton(HIDDEN_FILTER, 'HIDDEN'),
+    createFilterButton(UNLOCKED_FILTER, 'UNLOCKED')
+  ];
   filters.replaceChildren(...nodes);
-  return buttons;
+  return new Map(nodes.map((button) => [button.dataset.achievementFilter, button]));
 }
 
 function staticAchievementTags(achievement) {
@@ -214,7 +207,6 @@ export function installAchievementUnreadMarkers(
   const list = dialog.querySelector('.turn-achievements-list');
   const filters = dialog.querySelector('.turn-achievements-filters');
   const filterButtons = installFilterButtons(filters);
-  const allFilter = filterButtons.get(ALL_FILTER) || null;
   const newFilter = filterButtons.get(NEW_FILTER) || null;
   const triggers = [achievements.homeTrigger, achievements.raceTrigger].filter(Boolean);
   const achievementById = new Map(


### PR DESCRIPTION
## What changed

- render achievement categories as visible reusable tags instead of a single mutually exclusive label
- hidden achievements now show HIDDEN alongside their normal tag, e.g. EXPLORATION + HIDDEN
- time trials now show RACING + TIME TRIALS so they participate in both filters
- newly unlocked achievements temporarily show a NEW tag while their notification is still unseen
- expose the full filter set: NEW, GETTING STARTED, WAYS TO PLAY, EXPLORATION, RACING, TIME TRIALS, HIDDEN and UNLOCKED
- remove the visible Future Racer recommendation from time-trial cards; choosing the car is part of solving the target now
- keep achievement-toast navigation and unread markers intact

No achievement thresholds, trophy values or unlock logic change.