### PR TITLE
Polish achievement filters and time-trial guidance

### DIFF
--- a/turn-tests/startup-and-unread-production.mjs
+++ b/turn-tests/startup-and-unread-production.mjs
@@ -81,9 +81,15 @@ assert.match(unreadMarkers, /listObserver\.observe\(list, \{ childList: true \}\
 assert.match(unreadMarkers, /createFilterButton\(HIDDEN_FILTER, 'HIDDEN'\)/,
   'Achievements must expose a dedicated Hidden filter');
 assert.match(unreadMarkers, /createFilterButton\(NEW_FILTER, 'NEW'\)/,
-  'Achievements must expose a New filter for unseen achievement notifications');
-assert.match(unreadMarkers, /newFilter\.hidden = !hasNewAchievements/,
-  'The New filter must only appear while there are unseen achievements to inspect');
+  'Achievements must always expose a New filter');
+assert.match(unreadMarkers, /createFilterButton\(LOCKED_FILTER, 'LOCKED'\)/,
+  'The existing Locked filter must remain available alongside the composable tags');
+assert.doesNotMatch(unreadMarkers, /newFilter\.hidden\s*=/,
+  'NEW must stay visible in the filter row even when there is nothing new');
+assert.match(unreadMarkers, /newFilter\.disabled = !hasNewAchievements/,
+  'NEW should remain visible but inert when there are no unseen achievements');
+assert.match(unreadMarkers, /min-height: 34px/,
+  'Achievement filter pills should use the more compact requested height');
 assert.match(unreadMarkers, /achievement\?\.hidden === true/,
   'The Hidden filter must derive from the achievement hidden contract rather than title matching');
 assert.match(unreadMarkers, /turn-achievement-toast-open/,

--- a/turn/achievements/catalog-production.js
+++ b/turn/achievements/catalog-production.js
@@ -77,9 +77,8 @@ export const TRACK_SAFETY_ACHIEVEMENTS = Object.freeze(
 
 const rebalancedBaseAchievements = base.ACHIEVEMENTS.map((achievement) => {
   if (achievement.category !== base.CATEGORY.TIME_TRIALS) return achievement;
-  const { recommendation: _oldRecommendation, ...withoutRecommendation } = achievement;
   return Object.freeze({
-    ...withoutRecommendation,
+    ...achievement,
     trophies: achievement.id === 'faster-than-the-dev' ? 300 : 75,
     ...(achievement.id === 'faster-than-the-dev'
       ? { recommendation: 'A variety of cars were used to set the target times. Choosing the right car for each track matters.' }

--- a/turn/achievements/catalog-production.js
+++ b/turn/achievements/catalog-production.js
@@ -77,9 +77,13 @@ export const TRACK_SAFETY_ACHIEVEMENTS = Object.freeze(
 
 const rebalancedBaseAchievements = base.ACHIEVEMENTS.map((achievement) => {
   if (achievement.category !== base.CATEGORY.TIME_TRIALS) return achievement;
+  const { recommendation: _oldRecommendation, ...withoutRecommendation } = achievement;
   return Object.freeze({
-    ...achievement,
-    trophies: achievement.id === 'faster-than-the-dev' ? 300 : 75
+    ...withoutRecommendation,
+    trophies: achievement.id === 'faster-than-the-dev' ? 300 : 75,
+    ...(achievement.id === 'faster-than-the-dev'
+      ? { recommendation: 'A variety of cars were used to set the target times. Choosing the right car for each track matters.' }
+      : {})
   });
 });
 

--- a/turn/achievements/unread-markers.js
+++ b/turn/achievements/unread-markers.js
@@ -8,6 +8,7 @@ const RACING_FILTER = 'racing';
 const TIME_TRIALS_FILTER = 'time-trials';
 const HIDDEN_FILTER = 'hidden';
 const UNLOCKED_FILTER = 'unlocked';
+const LOCKED_FILTER = 'locked';
 
 const TAG_LABELS = Object.freeze({
   [ONBOARDING_FILTER]: 'GETTING STARTED',
@@ -87,6 +88,15 @@ function installStyles() {
       text-transform: uppercase;
       white-space: nowrap;
     }
+    .turn-achievements-filters button {
+      min-height: 34px;
+      padding: 3px 10px;
+      line-height: 1;
+    }
+    .turn-achievements-filters button:disabled {
+      opacity: .5;
+      cursor: default;
+    }
     .turn-achievement-card:focus {
       outline: 5px solid var(--turn-action-information, #38d9ff);
       outline-offset: 4px;
@@ -132,7 +142,8 @@ function installFilterButtons(filters) {
     createFilterButton(RACING_FILTER, 'RACING'),
     createFilterButton(TIME_TRIALS_FILTER, 'TIME TRIALS'),
     createFilterButton(HIDDEN_FILTER, 'HIDDEN'),
-    createFilterButton(UNLOCKED_FILTER, 'UNLOCKED')
+    createFilterButton(UNLOCKED_FILTER, 'UNLOCKED'),
+    createFilterButton(LOCKED_FILTER, 'LOCKED')
   ];
   filters.replaceChildren(...nodes);
   return new Map(nodes.map((button) => [button.dataset.achievementFilter, button]));
@@ -216,8 +227,6 @@ export function installAchievementUnreadMarkers(
   let decorationQueued = false;
   let activeFilter = ALL_FILTER;
 
-  if (newFilter) newFilter.hidden = true;
-
   function cardsWithAchievements() {
     return [...list.querySelectorAll('.turn-achievement-card')].map((card, index) => ({
       card,
@@ -230,6 +239,7 @@ export function installAchievementUnreadMarkers(
   function matchesFilter(card, achievement) {
     if (activeFilter === ALL_FILTER) return true;
     if (activeFilter === UNLOCKED_FILTER) return card.dataset.achievementStatus === 'unlocked';
+    if (activeFilter === LOCKED_FILTER) return card.dataset.achievementStatus !== 'unlocked';
     if (activeFilter === NEW_FILTER) return Boolean(achievement && pendingIds.has(achievement.id));
     return staticAchievementTags(achievement).includes(activeFilter);
   }
@@ -253,7 +263,9 @@ export function installAchievementUnreadMarkers(
   function syncNewFilter() {
     if (!newFilter) return;
     const hasNewAchievements = pendingIds.size > 0;
-    newFilter.hidden = !hasNewAchievements;
+    newFilter.disabled = !hasNewAchievements;
+    newFilter.setAttribute('aria-disabled', String(!hasNewAchievements));
+    newFilter.title = hasNewAchievements ? 'Show newly unlocked achievements' : 'No new achievements';
     if (!hasNewAchievements && activeFilter === NEW_FILTER) setActiveFilter(ALL_FILTER);
   }
 


### PR DESCRIPTION
Keep NEW and HIDDEN visible in achievement filters, retain LOCKED, make the filter pills shorter, and revise FASTER THAN THE DEV car-choice guidance without changing unlock logic or trophy values.