### PR TITLE
Align The Lot with Trophy Road car order

### DIFF
--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -27,6 +27,7 @@ export function prepareLotEnhancements() {
     import('./lot-perk-disclosure.js?revision=r217-stable-perk-slot'),
     import('./lot-card-scroll-boundary.js?revision=r216-meter-density'),
     import('./lot-vehicle-copy.js?revision=r181-hatchback-rally'),
+    import('./lot-trophy-order.js'),
     import('../progression/lot-trophy-gate.js?revision=r585-visible-locks'),
     import('../progression/lot-paint-reward.js?revision=r206-pwa-color')
   ]).then(([
@@ -36,6 +37,7 @@ export function prepareLotEnhancements() {
     perkDisclosure,
     scrollBoundary,
     vehicleCopy,
+    trophyOrder,
     trophyGate,
     paintGate
   ]) => {
@@ -46,6 +48,7 @@ export function prepareLotEnhancements() {
       installLotPerkDisclosure: perkDisclosure.installLotPerkDisclosure,
       installLotCardScrollBoundary: scrollBoundary.installLotCardScrollBoundary,
       installLotVehicleCopy: vehicleCopy.installLotVehicleCopy,
+      installLotTrophyOrder: trophyOrder.installLotTrophyOrder,
       gateLotNow: trophyGate.gateLotNow,
       gateLotPaintNow: paintGate.gateLotPaintNow
     });
@@ -126,10 +129,12 @@ export function enhanceLotNow(root = document.body) {
     installLotLayout,
     installLotAccessibility,
     installLotCardScrollBoundary,
-    installLotVehicleCopy
+    installLotVehicleCopy,
+    installLotTrophyOrder
   } = enhancementBundle;
   const scope = screen.parentElement || document.body;
   const removeEntryClickGuard = installLotEntryClickGuard(screen);
+  const removeTrophyOrder = installLotTrophyOrder(scope);
   const removeTrophyGate = gateLotNow(scope);
   const removePaintGate = gateLotPaintNow(scope);
   const removePerkDisclosure = installLotPerkDisclosure(scope);
@@ -151,6 +156,7 @@ export function enhanceLotNow(root = document.body) {
     removePerkDisclosure();
     removePaintGate();
     removeTrophyGate();
+    removeTrophyOrder();
     removeEntryClickGuard();
     activeEnhancements.delete(screen);
     delete screen.dataset.lotEnhancements;

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -1,7 +1,7 @@
 import {
   enhanceLotNow,
   prepareLotEnhancements
-} from './lot-enhancement-runtime.js?revision=r217-stable-perk-slot&build=20260804-r157';
+} from './lot-enhancement-runtime.js?revision=r221-trophy-order';
 import { installLotPwaColorSwatches } from './lot-pwa-color-swatch.js?revision=r206-pwa-color';
 import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r52';
 import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
@@ -12,6 +12,7 @@ import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
 // lot-enhancement-runtime.js?revision=r205-color-baseline
 // lot-enhancement-runtime.js?revision=r206-pwa-color
 // lot-enhancement-runtime.js?revision=r214-future-racer-fit
+// lot-enhancement-runtime.js?revision=r217-stable-perk-slot&build=20260804-r157
 // lot-showroom-experiment.js?revision=r200-production-candidate
 // export async function showEnhancedLot
 // SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r203-polish'

--- a/turn/garage/lot-trophy-order.js
+++ b/turn/garage/lot-trophy-order.js
@@ -1,0 +1,102 @@
+export const LOT_TROPHY_ORDER = Object.freeze([
+  'classic',
+  'truck',
+  'sedan',
+  'van',
+  'suv',
+  'convertible',
+  'sedan-sports',
+  'vintage-racer',
+  'race',
+  'firetruck',
+  'ambulance',
+  'police',
+  'monster-truck',
+  'race-future',
+  'toy-racer'
+]);
+
+function findLotScreen(root) {
+  if (root?.matches?.('.lot-screen')) return root;
+  return root?.querySelector?.('.lot-screen') || null;
+}
+
+function orderedButtons(picker) {
+  const byId = new Map(
+    [...picker.querySelectorAll('.lot-car-option')]
+      .map((button) => [button.dataset.carId, button])
+      .filter(([id]) => Boolean(id))
+  );
+  return LOT_TROPHY_ORDER.map((id) => byId.get(id)).filter(Boolean);
+}
+
+function selectedIndex(buttons) {
+  const index = buttons.findIndex((button) => button.getAttribute('aria-checked') === 'true');
+  return index >= 0 ? index : 0;
+}
+
+export function installLotTrophyOrder(root = document.body) {
+  const screen = findLotScreen(root);
+  const picker = screen?.querySelector('.lot-car-picker');
+  if (!screen || !picker) return () => {};
+
+  const originalOrder = [...picker.children];
+  const buttons = orderedButtons(picker);
+  if (!buttons.length) return () => {};
+
+  for (const button of buttons) picker.appendChild(button);
+
+  const previousButton = screen.querySelector('.lot-cycle-prev');
+  const nextButton = screen.querySelector('.lot-cycle-next');
+
+  const activateAt = (index, { focus = false } = {}) => {
+    const button = buttons[(index + buttons.length) % buttons.length];
+    if (!button) return;
+    button.click();
+    if (focus) button.focus();
+  };
+
+  const cycle = (direction, options) => {
+    activateAt(selectedIndex(buttons) + direction, options);
+  };
+
+  const handlePrevious = (event) => {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    cycle(-1);
+  };
+  const handleNext = (event) => {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    cycle(1);
+  };
+  const handleKeydown = (event) => {
+    let targetIndex = null;
+    if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+      targetIndex = selectedIndex(buttons) + 1;
+    } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+      targetIndex = selectedIndex(buttons) - 1;
+    } else if (event.key === 'Home') {
+      targetIndex = 0;
+    } else if (event.key === 'End') {
+      targetIndex = buttons.length - 1;
+    }
+    if (targetIndex == null) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    activateAt(targetIndex, { focus: true });
+  };
+
+  previousButton?.addEventListener('click', handlePrevious, true);
+  nextButton?.addEventListener('click', handleNext, true);
+  picker.addEventListener('keydown', handleKeydown, true);
+  screen.dataset.lotTrophyOrder = 'vehicle-unlocks';
+
+  return () => {
+    previousButton?.removeEventListener('click', handlePrevious, true);
+    nextButton?.removeEventListener('click', handleNext, true);
+    picker.removeEventListener('keydown', handleKeydown, true);
+    for (const node of originalOrder) picker.appendChild(node);
+    delete screen.dataset.lotTrophyOrder;
+  };
+}

--- a/turn/progression/trophy-road-r157.css
+++ b/turn/progression/trophy-road-r157.css
@@ -22,6 +22,7 @@
 
 .turn-trophy-road-marker:is(
   [data-trophy-reward="vintage-racer"],
+  [data-trophy-reward="race-car"],
   [data-trophy-reward="future-racer"],
   [data-trophy-reward="emergency-pack"],
   [data-trophy-reward="monster"],
@@ -32,6 +33,7 @@
 
 .turn-trophy-road-marker:is(
   [data-trophy-reward="vintage-racer"],
+  [data-trophy-reward="race-car"],
   [data-trophy-reward="future-racer"],
   [data-trophy-reward="emergency-pack"],
   [data-trophy-reward="monster"],
@@ -67,6 +69,7 @@
    :has() is progressive enhancement; older engines retain the standard green detail card. */
 .turn-achievements-dialog:has(.turn-trophy-road-marker:is(
   [data-trophy-reward="vintage-racer"],
+  [data-trophy-reward="race-car"],
   [data-trophy-reward="future-racer"],
   [data-trophy-reward="emergency-pack"],
   [data-trophy-reward="monster"],
@@ -77,6 +80,7 @@
 
 .turn-achievements-dialog:has(.turn-trophy-road-marker:is(
   [data-trophy-reward="vintage-racer"],
+  [data-trophy-reward="race-car"],
   [data-trophy-reward="future-racer"],
   [data-trophy-reward="emergency-pack"],
   [data-trophy-reward="monster"],


### PR DESCRIPTION
Reorder The Lot’s visible/selectable car sequence to follow vehicle unlock progression: Vintage Racer → Race Car → Emergency vehicles → Monster Truck → Future Racer → Rally Racer. Keep arrow-key and previous/next navigation in the same order. Also add Race Car to the existing blue vehicle-reward color family on Trophy Road.