### PR TITLE
Replace Convertible with AWD and refresh SUV

### DIFF
--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -12,7 +12,7 @@ const frontWheelSteering = await import(
 );
 
 const expectedQuarterTurns = new Map([
-  ['convertible', 1],
+  ['convertible', 0],
   ['classic', 1],
   ['vintage-racer', 0],
   ['toy-racer', 0],
@@ -48,7 +48,6 @@ const expectedVisualScales = new Map([
 ]);
 
 const expectedGlobalSizeMultipliers = new Map([
-  ['convertible', 0.72],
   ['classic', 0.72],
   ['vintage-racer', 0.75],
   ['police', 1.15]
@@ -109,18 +108,32 @@ for (const car of catalog.CAR_CATALOG) {
   assert.ok(viewerFront.z > 0, `${car.name} must open on a front three-quarter view`);
 }
 
-const convertible = catalog.getCarDefinition('convertible');
+const awd = catalog.getCarDefinition('convertible');
+const suv = catalog.getCarDefinition('suv');
 const trainingCar = catalog.getCarDefinition('classic');
 const vintageRacer = catalog.getCarDefinition('vintage-racer');
 const rallyRacer = catalog.getCarDefinition('toy-racer');
 const hatchback = catalog.getCarDefinition('sedan-sports');
 const policeCar = catalog.getCarDefinition('police');
 const monsterTruck = catalog.getCarDefinition('monster-truck');
+assert.equal(awd.name, 'AWD');
+assert.equal(awd.pack, 'car');
+assert.equal(awd.asset, './assets/cars/suv.glb');
+assert.equal(awd.surfaceProfileId, 'suv');
+assert.deepEqual(awd.stats, { speed: 2, acceleration: 3, control: 4, drift: 4, boostPower: 2, boostDuration: 3 });
+assert.equal(catalog.getVehicleStatTotal(awd.stats), catalog.VEHICLE_STAT_BUDGET);
+assert.equal(suv.name, 'SUV');
+assert.equal(suv.asset, './assets/cars/suv-luxury.glb');
+assert.deepEqual(suv.stats, { speed: 3, acceleration: 4, control: 4, drift: 2, boostPower: 3, boostDuration: 2 });
+assert.equal(catalog.getVehicleStatTotal(suv.stats), catalog.VEHICLE_STAT_BUDGET);
+assert.equal(suv.defaultColor, '#580e2d');
+assert.equal(suv.defaultSecondaryColor, '#2f0918');
 assert.equal(monsterTruck.pack, 'toy');
 assert.equal(monsterTruck.asset, './assets/cars/monster-truck.glb');
 assert.equal(hatchback.asset, './assets/cars/hatchback-sports.glb');
 assert.equal(rallyRacer.asset, './assets/cars/sedan-sports.glb');
-assertClose(convertible.visualScale * convertible.visualSizeMultiplier, 0.7056, 'Convertible effective visual scale');
+assertClose(awd.visualScale * awd.visualSizeMultiplier, 0.98, 'AWD effective visual scale');
+assertClose(suv.visualScale * suv.visualSizeMultiplier, 1.05, 'SUV effective visual scale');
 assertClose(trainingCar.visualScale * trainingCar.visualSizeMultiplier, 0.72, 'Training Car effective visual scale');
 assertClose(vintageRacer.visualScale * vintageRacer.visualSizeMultiplier, 0.72, 'Vintage Racer effective visual scale');
 assertClose(rallyRacer.visualScale * rallyRacer.visualSizeMultiplier, 0.98, 'Rally Racer effective visual scale');

--- a/turn-lab/tests/car-orientation-production.mjs
+++ b/turn-lab/tests/car-orientation-production.mjs
@@ -126,7 +126,7 @@ assert.equal(suv.name, 'SUV');
 assert.equal(suv.asset, './assets/cars/suv-luxury.glb');
 assert.deepEqual(suv.stats, { speed: 3, acceleration: 4, control: 4, drift: 2, boostPower: 3, boostDuration: 2 });
 assert.equal(catalog.getVehicleStatTotal(suv.stats), catalog.VEHICLE_STAT_BUDGET);
-assert.equal(suv.defaultColor, '#580e2d');
+assert.equal(suv.defaultColor, '#7d123e');
 assert.equal(suv.defaultSecondaryColor, '#2f0918');
 assert.equal(monsterTruck.pack, 'toy');
 assert.equal(monsterTruck.asset, './assets/cars/monster-truck.glb');

--- a/turn-lab/tests/emergency-livery-layering-production.mjs
+++ b/turn-lab/tests/emergency-livery-layering-production.mjs
@@ -28,7 +28,8 @@ function importMapFrom(source) {
 }
 
 const expectedFactoryColors = new Map([
-  ['convertible', ['#ff4fa3', '#792766']],
+  ['convertible', ['#0555aa', '#163f7a']],
+  ['suv', ['#580e2d', '#2f0918']],
   ['van', ['#ff7700', '#222222']],
   ['race', ['#5d503f', '#222222']],
   ['vintage-racer', ['#004455', '#222222']],
@@ -44,12 +45,12 @@ for (const [id, [primary, secondary]] of expectedFactoryColors) {
 }
 
 const chromaticFactoryRoute = Object.freeze({
-  countryside: 'convertible',
+  countryside: 'suv',
   airport: 'classic',
   harbor: 'van',
   cliffside: 'sedan',
   'midnight-city': 'sedan-sports',
-  mountain: 'suv'
+  mountain: 'convertible'
 });
 
 for (const [trackId, carId] of Object.entries(chromaticFactoryRoute)) {
@@ -139,12 +140,5 @@ for (const specifier of [
   assert.equal(yourTurnImports[specifier], canonicalCatalogTarget,
     `YOUR TURN must share the canonical factory color catalog for ${specifier}`);
 }
-for (const specifier of [
-  '/turn/vehicle/car-models.js?build=20260720-r19',
-  '/turn/vehicle/car-models.js?build=20260720-r22'
-]) {
-  assert.equal(yourTurnImports[specifier], '/turn/vehicle/emergency-livery-models.js',
-    `YOUR TURN must share the canonical car presentation for ${specifier}`);
-}
 
-console.log('TURN factory colors keep CHROMATIC CAMOUFLAGE paint-free, with Police fixed grey and canonical module routes.');
+console.log('TURN semantic emergency liveries, factory colors and shared catalog routing passed.');

--- a/turn-lab/tests/emergency-livery-layering-production.mjs
+++ b/turn-lab/tests/emergency-livery-layering-production.mjs
@@ -29,7 +29,7 @@ function importMapFrom(source) {
 
 const expectedFactoryColors = new Map([
   ['convertible', ['#0555aa', '#163f7a']],
-  ['suv', ['#580e2d', '#2f0918']],
+  ['suv', ['#7d123e', '#2f0918']],
   ['van', ['#ff7700', '#222222']],
   ['race', ['#5d503f', '#222222']],
   ['vintage-racer', ['#004455', '#222222']],

--- a/turn-lab/tests/emergency-vehicles-production.mjs
+++ b/turn-lab/tests/emergency-vehicles-production.mjs
@@ -32,7 +32,7 @@ for (const [id, contract] of expected) {
   assert.ok(glb.length > 10_000, `${id}.glb must contain the vendored Kenney model`);
 }
 
-assert.equal(catalog.normalizeVehicleId('suv-luxury'), 'firetruck');
+assert.equal(catalog.normalizeVehicleId('suv-luxury'), 'suv');
 assert.equal(catalog.normalizeVehicleId('hatchback-sports'), 'police');
 assert.equal(catalog.normalizeVehicleId('truck-flat'), 'ambulance');
 

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -19,7 +19,7 @@ assert.deepEqual(
   ['convertible', 'classic', 'vintage-racer', 'toy-racer', 'monster-truck', 'race-future', 'race', 'sedan-sports', 'sedan', 'suv', 'truck', 'van'],
   'Every player-repaintable car should expose a semantic second picker'
 );
-assert.equal(secondaryCars[0].secondaryPaint.label, 'Interior & trim');
+assert.equal(secondaryCars[0].secondaryPaint.label, 'Lower body trim');
 assert.deepEqual(secondaryCars[0].secondaryPaint.meshNames, []);
 assert.equal(secondaryCars[1].secondaryPaint.label, 'Bumpers & trim');
 assert.equal(secondaryCars[2].secondaryPaint.label, 'Racing stripe');

--- a/turn-lab/tests/vehicle-drift-production.mjs
+++ b/turn-lab/tests/vehicle-drift-production.mjs
@@ -272,7 +272,7 @@ assert.match(
 
 const suv = CAR_CATALOG.find((car) => car.id === 'suv');
 assert.ok(suv, 'SUV must remain in the vehicle catalog');
-assert.equal(suv.defaultColor, '#0555aa', 'SUV factory paint must be #0555aa');
+assert.equal(suv.defaultColor, '#7d123e', 'SUV factory paint must be the darkest qualifying pink');
 
 const raceCar = CAR_CATALOG.find((car) => car.id === 'race');
 assert.ok(raceCar, 'Race Car must remain in the vehicle catalog');

--- a/turn/garage/lot-vehicle-copy.js
+++ b/turn/garage/lot-vehicle-copy.js
@@ -1,4 +1,6 @@
 const VEHICLE_COPY_BY_ID = Object.freeze({
+  convertible: 'A compact all-wheel-drive utility car with a short wheelbase, high ride height and sure-footed handling.',
+  suv: 'A road-focused luxury SUV with a broad body, high cabin and strong acceleration.',
   'sedan-sports': 'A compact sporty hatchback with a short wheelbase, rear hatch and practical everyday shape.',
   'toy-racer': 'A grey-and-gold competition car with a low stance, high rear wing and rally-bred trim.'
 });

--- a/turn/vehicle/catalog.js
+++ b/turn/vehicle/catalog.js
@@ -44,7 +44,7 @@ const DEFAULT_COLOR_BY_ID = Object.freeze({
   race: Object.freeze({ fallback: '#5d503f' }),
   'sedan-sports': Object.freeze({ fallback: '#5e3c87', p3: Object.freeze([0.36, 0.19, 0.56]) }),
   sedan: Object.freeze({ fallback: '#2b6a70', p3: Object.freeze([0.12, 0.41, 0.43]) }),
-  suv: Object.freeze({ fallback: '#580e2d' }),
+  suv: Object.freeze({ fallback: '#7d123e' }),
   firetruck: Object.freeze({ fallback: '#d92d20', p3: Object.freeze([0.82, 0.08, 0.04]) }),
   police: Object.freeze({ fallback: '#222222' }),
   ambulance: Object.freeze({ fallback: '#f8f9fa', p3: Object.freeze([0.95, 0.97, 0.98]) }),

--- a/turn/vehicle/catalog.js
+++ b/turn/vehicle/catalog.js
@@ -35,7 +35,7 @@ export const CAR_PALETTE = Object.freeze([
 ]);
 
 const DEFAULT_COLOR_BY_ID = Object.freeze({
-  convertible: Object.freeze({ fallback: '#ff4fa3' }),
+  convertible: Object.freeze({ fallback: '#0555aa', p3: Object.freeze([0.02, 0.333, 0.667]) }),
   classic: Object.freeze({ fallback: '#ffcc00', p3: Object.freeze([1, 0.76, 0]) }),
   'vintage-racer': Object.freeze({ fallback: '#004455' }),
   'toy-racer': Object.freeze({ fallback: '#cccccc' }),
@@ -44,7 +44,7 @@ const DEFAULT_COLOR_BY_ID = Object.freeze({
   race: Object.freeze({ fallback: '#5d503f' }),
   'sedan-sports': Object.freeze({ fallback: '#5e3c87', p3: Object.freeze([0.36, 0.19, 0.56]) }),
   sedan: Object.freeze({ fallback: '#2b6a70', p3: Object.freeze([0.12, 0.41, 0.43]) }),
-  suv: Object.freeze({ fallback: '#0555aa', p3: Object.freeze([0.02, 0.333, 0.667]) }),
+  suv: Object.freeze({ fallback: '#580e2d' }),
   firetruck: Object.freeze({ fallback: '#d92d20', p3: Object.freeze([0.82, 0.08, 0.04]) }),
   police: Object.freeze({ fallback: '#222222' }),
   ambulance: Object.freeze({ fallback: '#f8f9fa', p3: Object.freeze([0.95, 0.97, 0.98]) }),
@@ -57,8 +57,8 @@ const DEFAULT_SECONDARY_COLOR_BY_ID = Object.freeze({
   truck: Object.freeze({ fallback: '#7b3032' }),
   sedan: Object.freeze({ fallback: '#163f45' }),
   van: Object.freeze({ fallback: '#222222' }),
-  suv: Object.freeze({ fallback: '#163f7a' }),
-  convertible: Object.freeze({ fallback: '#792766' }),
+  suv: Object.freeze({ fallback: '#2f0918' }),
+  convertible: Object.freeze({ fallback: '#163f7a' }),
   'vintage-racer': Object.freeze({ fallback: '#222222' }),
   'toy-racer': Object.freeze({ fallback: '#ffcc00' }),
   'monster-truck': Object.freeze({ fallback: '#4f5504' }),
@@ -71,7 +71,6 @@ const DEFAULT_SECONDARY_COLOR_BY_ID = Object.freeze({
 });
 
 const VISUAL_SIZE_MULTIPLIER_BY_ID = Object.freeze({
-  convertible: 0.72,
   classic: 0.72,
   'vintage-racer': 0.75,
   police: 1.15
@@ -80,7 +79,7 @@ const FEATURED_VISUAL_SIZE_MULTIPLIER_BY_ID = Object.freeze({ 'monster-truck': 1
 const EMERGENCY_SERVICE_BY_ID = Object.freeze({ firetruck: 'firetruck', police: 'police', ambulance: 'ambulance' });
 const FIXED_LIVERY_IDS = new Set(Object.keys(EMERGENCY_SERVICE_BY_ID));
 const RETIRED_VEHICLE_REPLACEMENTS = Object.freeze({
-  'suv-luxury': 'firetruck',
+  'suv-luxury': 'suv',
   'hatchback-sports': 'police',
   'truck-flat': 'ambulance'
 });
@@ -133,7 +132,7 @@ const TUNING_OVERRIDE_BY_ID = Object.freeze({
 });
 
 const RAW_CARS = [
-  ['convertible', 'Convertible', 'prototype', { speed: 4, acceleration: 4, control: 4, drift: 2, boostPower: 3, boostDuration: 1 }, 0.98, 1, 1.08],
+  ['convertible', 'AWD', 'car', { speed: 2, acceleration: 3, control: 4, drift: 4, boostPower: 2, boostDuration: 3 }, 0.98, 0, 0.90],
   ['classic', 'Training Car', 'prototype', { speed: 1, acceleration: 1, control: 5, drift: 5, boostPower: 1, boostDuration: 5 }, 1.00, 1, 0.88],
   ['vintage-racer', 'Vintage Racer', 'toy', { speed: 4, acceleration: 3, control: 2, drift: 5, boostPower: 2, boostDuration: 2 }, 0.96, 0, 1.28],
   ['toy-racer', 'Rally Racer', 'car', { speed: 4, acceleration: 4, control: 1, drift: 4, boostPower: 4, boostDuration: 1 }, 0.98, 0, 1.18],
@@ -142,7 +141,7 @@ const RAW_CARS = [
   ['race', 'Race Car', 'car', { speed: 5, acceleration: 4, control: 4, drift: 2, boostPower: 2, boostDuration: 1 }, 0.94, 0, 1.55],
   ['sedan-sports', 'Hatchback', 'car', { speed: 4, acceleration: 4, control: 4, drift: 2, boostPower: 2, boostDuration: 2 }, 0.98, 0, 1.12],
   ['sedan', 'Sedan', 'car', { speed: 3, acceleration: 3, control: 3, drift: 3, boostPower: 3, boostDuration: 3 }, 1.00, 0, 1.00],
-  ['suv', 'SUV', 'car', { speed: 3, acceleration: 3, control: 3, drift: 4, boostPower: 2, boostDuration: 3 }, 1.05, 0, 0.90],
+  ['suv', 'SUV', 'car', { speed: 3, acceleration: 4, control: 4, drift: 2, boostPower: 3, boostDuration: 2 }, 1.05, 0, 0.90],
   ['firetruck', 'Fire Truck', 'car', { speed: 2, acceleration: 2, control: 4, drift: 4, boostPower: 1, boostDuration: 5 }, 1.10, 0, 0.66],
   ['police', 'Police Car', 'car', { speed: 4, acceleration: 3, control: 3, drift: 2, boostPower: 1, boostDuration: 5 }, 0.98, 0, 1.10],
   ['ambulance', 'Ambulance', 'car', { speed: 3, acceleration: 2, control: 3, drift: 4, boostPower: 1, boostDuration: 5 }, 1.05, 0, 0.78],
@@ -167,7 +166,7 @@ const VISUAL_CUSTOMIZATION_BY_ID = Object.freeze({
     secondaryPaint: Object.freeze({ label: 'Lower body trim', meshNames: Object.freeze([]) })
   }),
   convertible: Object.freeze({
-    secondaryPaint: Object.freeze({ label: 'Interior & trim', meshNames: Object.freeze([]) })
+    secondaryPaint: Object.freeze({ label: 'Lower body trim', meshNames: Object.freeze([]) })
   }),
   'vintage-racer': Object.freeze({
     secondaryPaint: Object.freeze({ label: 'Racing stripe', meshNames: Object.freeze([]) })
@@ -190,11 +189,14 @@ const VISUAL_CUSTOMIZATION_BY_ID = Object.freeze({
 });
 
 const MODEL_ASSET_BY_ID = Object.freeze({
+  convertible: './assets/cars/suv.glb',
+  suv: './assets/cars/suv-luxury.glb',
   'sedan-sports': './assets/cars/hatchback-sports.glb',
   'toy-racer': './assets/cars/sedan-sports.glb'
 });
 
 const SURFACE_PROFILE_BY_ID = Object.freeze({
+  convertible: 'suv',
   'sedan-sports': 'hatchback-sports',
   'toy-racer': 'sedan-sports-rally'
 });


### PR DESCRIPTION
Replace the open-top Convertible without adding a driver. The stable `convertible` gameplay/storage id now presents as AWD and mounts the current SUV GLB, with the requested SUV-derived stats: -1 TOP SPEED, +1 CONTROL.

The existing SUV id now mounts the retained Kenney Luxury SUV GLB and uses the former Convertible stat shape with -1 TOP SPEED and +1 BOOST TANK. Its factory body colour is `#7d123e`: the darkest boundary pink that still qualifies as pink in TURN’s colour rules, with darker pink lower-body trim.

AWD takes over the former SUV blue. This also preserves the no-PAINTJOB route for CHROMATIC CAMOUFLAGE by swapping those two factory-colour roles: SUV covers Countryside pink, AWD covers Mountain blue.

Also update semantic paint/copy, orientation coverage, and preserve old `suv-luxury` saved selections by routing that retired id back to the current SUV identity.