### PR TITLE
Use paper background for TURN shell

### DIFF
--- a/turn/styles.css
+++ b/turn/styles.css
@@ -29,7 +29,7 @@ body {
   margin: 0;
   overflow: hidden;
   overscroll-behavior: none;
-  background: var(--cyan);
+  background: var(--paper);
 }
 
 body {


### PR DESCRIPTION
## Summary
- switch the TURN shell background from cyan to the existing `--paper` token (`#fff8e8`)
- leave track cards, car paint/semantic color logic, and release wiring untouched

## Conflict isolation
- branched from current `main` at `8cfa948`
- this PR changes only `turn/styles.css`
- ongoing car-colour PR #687 does not change `turn/styles.css`, so there is no file-level overlap with that work