### PR TITLE
Use paper background on TURN home

### DIFF
--- a/turn/home-header-r425.css
+++ b/turn/home-header-r425.css
@@ -1,8 +1,8 @@
 /* TURN Home header boundary + metadata alignment.
-   The fixed Home canvas is blue; the header itself owns the yellow fill so
+   The fixed Home canvas uses TURN paper; the header itself owns the yellow fill so
    yellow can never extend below the header's real grid-row height. */
 html .m8-home.m8-home-fixed-layout {
-  background: var(--m8-blue);
+  background: var(--m8-cream);
 }
 
 html .m8-home.m8-home-fixed-layout .m8-home-head {


### PR DESCRIPTION
## Summary
- change the actual fixed TURN Home canvas from blue to the existing paper/cream token
- keep the yellow header fill unchanged
- update the nearby comment so it reflects the current design

## Why the earlier change had no visible effect
`turn/styles.css` only changed the document/body background. The Home screen is a fixed `.m8-home.m8-home-fixed-layout` layer, and `home-header-r425.css` explicitly set that layer back to `var(--m8-blue)`, so it covered the body background completely.

## Conflict isolation
- changes only `turn/home-header-r425.css`
- ongoing car-colour PR #687 does not touch this file or Home background CSS