### PR TITLE
Move Learner Car roof L to sign ends and fix fresh reward unlocks

### DIFF
--- a/turn-lab/tests/admin-unlock-production.mjs
+++ b/turn-lab/tests/admin-unlock-production.mjs
@@ -6,14 +6,30 @@ import {
   completeAdminUnlockFromLot,
   createAdminRewardState
 } from '../../turn/testing/admin-unlock-sequence.js';
-import { TROPHY_ROAD_REWARDS } from '../../turn/progression/trophy-road.js';
+import {
+  TROPHY_ROAD_REWARDS,
+  prepareTrophyRoadProfile,
+  readTrophyRoadSnapshot
+} from '../../turn/progression/trophy-road.js';
 
-const [source, indexSource, releaseSource] = await Promise.all([
+const [source, roadSource, indexSource, releaseSource] = await Promise.all([
   fs.readFile(new URL('../../turn/testing/admin-unlock-sequence.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/progression/trophy-road.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/release.json', import.meta.url), 'utf8')
 ]);
 const release = JSON.parse(releaseSource);
+
+function createMemoryStorage(initial = {}) {
+  const memory = new Map(Object.entries(initial));
+  return {
+    get length() { return memory.size; },
+    key(index) { return [...memory.keys()][index] ?? null; },
+    getItem(key) { return memory.get(key) ?? null; },
+    setItem(key, value) { memory.set(key, String(value)); },
+    removeItem(key) { memory.delete(key); }
+  };
+}
 
 assert.deepEqual(ADMIN_UNLOCK_SEQUENCE, [
   'track:countryside',
@@ -132,6 +148,54 @@ assert.deepEqual(repaired.snapshot.rewards.unlocked, rewardIds);
 assert.equal(repaired.snapshot.unlocked['save-bella'], undefined,
   'SAVE BELLA! must remain available for real rescue testing');
 
+// A clean domain can legitimately acquire default preference/selection keys before
+// Trophy Road finishes startup. Those keys must never be mistaken for an old player.
+const freshStartupStorage = createMemoryStorage({
+  'turn-vehicle-selection-v1': JSON.stringify({ carId: 'classic' }),
+  'turn-selected-track-v1': 'countryside',
+  'turn-steering-mode-v1': 'motion',
+  'turn-drive-by-ear-v1': 'true'
+});
+assert.equal(prepareTrophyRoadProfile(freshStartupStorage), null,
+  'Default startup keys on a cleared domain must not create a grandfathered profile');
+assert.deepEqual(readTrophyRoadSnapshot(freshStartupStorage).unlockedRewardIds, [],
+  'A clean installation must begin with Trophy Road rewards locked');
+
+// Repair the exact bad state produced by the former settings-only legacy heuristic:
+// no achievements, current storage version, every reward silently grandfathered.
+const falseGrandfatherStorage = createMemoryStorage({
+  'turn-vehicle-selection-v1': JSON.stringify({ carId: 'classic' }),
+  'turn-achievements-v1': JSON.stringify({
+    version: 6,
+    unlocked: {},
+    seen: [],
+    progress: { tracks: [], blankTracks: [] },
+    rewards: { unlocked: rewardIds, seen: rewardIds }
+  })
+});
+const repairedFreshProfile = prepareTrophyRoadProfile(falseGrandfatherStorage);
+assert.equal(repairedFreshProfile?.version, 6);
+assert.deepEqual(repairedFreshProfile?.rewards?.unlocked, [],
+  'The accidental all-rewards fresh profile must self-repair without another data clear');
+assert.deepEqual(readTrophyRoadSnapshot(falseGrandfatherStorage).unlockedRewardIds, []);
+
+// The explicit hidden admin path remains intentional and must survive the repair guard.
+const intentionalAdminStorage = createMemoryStorage({
+  'turn-admin-unlock-v1': JSON.stringify({ version: 2, rewardsOnly: true }),
+  'turn-achievements-v1': JSON.stringify({
+    version: 6,
+    unlocked: {},
+    seen: [],
+    progress: { tracks: [], blankTracks: [] },
+    rewards: { unlocked: rewardIds, seen: rewardIds }
+  })
+});
+assert.deepEqual(
+  prepareTrophyRoadProfile(intentionalAdminStorage)?.rewards?.unlocked,
+  rewardIds,
+  'The hidden developer rewards profile must not be mistaken for the fresh-install bug'
+);
+
 assert.match(source, /target\.closest\('\.m8-track-continue'\)/,
   'The Home RACE action must be the separator that opens The Lot');
 assert.match(source, /aria-checked="true"/,
@@ -152,6 +216,10 @@ assert.match(source, /globalThis\.setTimeout\?\.\(reload, 0\)/,
   'The final action must reload so all pre-rendered reward gates rebuild unlocked');
 assert.match(source, /installAdminUnlockSequence\(\);\s*$/,
   'The isolated production module must install itself');
+assert.match(roadSource, /hasLegacyProfileEvidence\(storage\)/,
+  'Trophy Road legacy migration must require meaningful player evidence rather than any TURN setting key');
+assert.match(roadSource, /repairFalseFreshProfile\(existing, storage\)/,
+  'Known accidentally-grandfathered clean profiles must repair during startup');
 assert.match(indexSource,
   /<script type="module" src="\.\/testing\/admin-unlock-sequence\.js\?revision=r176-admin-rewards"><\/script>/,
   'The production entry must publish the rewards-only recognizer with a fresh cache identity');
@@ -159,7 +227,7 @@ assert.match(indexSource,
   new RegExp(`src="\\.\\/live-steering-setting\\.js\\?build=${escapeRegex(release.cacheKey)}-live-steering"`),
   'The hidden recognizer must not disturb the canonical steering entry');
 
-console.log('TURN rewards-only admin unlock regression passed.');
+console.log('TURN rewards-only admin unlock and fresh-profile reward locking regression passed.');
 
 function escapeRegex(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/turn-lab/tests/emergency-livery-layering-production.mjs
+++ b/turn-lab/tests/emergency-livery-layering-production.mjs
@@ -96,6 +96,12 @@ assert.match(learnerLivery, /sourceVertexIds: Object\.freeze\(\[367, 368, 369, 3
   'Learner roof signage must retain the documented original Kenney Taxi source vertices');
 assert.match(learnerLivery, /sourceTriangleCount: 10/,
   'Learner roof signage must retain all ten original Kenney Taxi sign triangles');
+assert.match(learnerLivery, /const SIGN_GRAPHIC_TRIANGLES = new Set\(\[0, 1, 4, 5\]\)/,
+  'Only the two short front/back end faces of the Taxi sign may carry the roof L graphic');
+assert.match(learnerLivery, /graphicTriangleIds: Object\.freeze\(\[0, 1, 4, 5\]\)/,
+  'The Learner Car sign contract must record its exact decorated source faces');
+assert.doesNotMatch(learnerLivery, /SIGN_GRAPHIC_TRIANGLES = new Set\(\[2, 3, 8, 9\]\)/,
+  'The long side faces must stay plain yellow');
 assert.match(learnerLivery, /Object\.freeze\(\[-0\.1, 1\.3, -0\.45\]\)/);
 assert.match(learnerLivery, /Object\.freeze\(\[0\.05, 1\.5, 0\.05\]\)/);
 assert.doesNotMatch(learnerLivery, /BoxGeometry|PlaneGeometry|CylinderGeometry|SphereGeometry/,
@@ -173,4 +179,4 @@ for (const specifier of [
     `YOUR TURN must share the canonical factory color catalog for ${specifier}`);
 }
 
-console.log('TURN semantic emergency liveries, authentic Learner Car livery, factory colors and shared catalog routing passed.');
+console.log('TURN semantic emergency liveries, end-faced Learner Car sign, factory colors and shared catalog routing passed.');

--- a/turn/progression/trophy-road.js
+++ b/turn/progression/trophy-road.js
@@ -134,6 +134,9 @@ const REWARD_BY_FEATURE = new Map(
   TROPHY_ROAD_REWARDS.filter((reward) => reward.featureId).map((reward) => [reward.featureId, reward])
 );
 const PREPARED_STORAGE = new WeakSet();
+const ADMIN_UNLOCK_MARKER = 'turn-admin-unlock-v1';
+const RIVAL_STORAGE_PREFIX = 'turn-personal-rivals-v1';
+const LEGACY_GHOST_STORAGE_PREFIX = 'turn-three-ghost-v4';
 const VERSION_THREE_GRANDFATHERED_REWARDS = Object.freeze([
   'paintjob',
   'monster',
@@ -245,41 +248,109 @@ function markPreparationChecked(storage) {
   if (canRememberStorage(storage)) PREPARED_STORAGE.add(storage);
 }
 
-function hasLegacyTurnProfile(storage) {
-  const exactKeys = [
-    'turn-vehicle-selection-v1',
-    'turn-selected-track-v1',
-    'turn-steering-mode-v1',
-    'turn-drive-by-ear-v1',
-    'turn-personal-rivals-v1',
-    'turn-three-ghost-v4'
-  ];
-  for (const key of exactKeys) {
+function storageKeys(storage) {
+  const keys = [];
+  try {
+    const length = Number(storage?.length) || 0;
+    for (let index = 0; index < length; index += 1) {
+      const key = storage?.key?.(index);
+      if (typeof key === 'string' && key) keys.push(key);
+    }
+  } catch (_) {}
+  return keys;
+}
+
+function hasPlayedRivalPayload(payload) {
+  return Array.isArray(payload?.laps)
+    && payload.laps.some((lap) => Number.isFinite(Number(lap?.time)) && Number(lap.time) > 5);
+}
+
+function hasPlayedLegacyGhost(payload) {
+  return Number.isFinite(Number(payload?.bestTime)) && Number(payload.bestTime) > 5;
+}
+
+function hasLegacyRaceProgress(storage) {
+  const keys = new Set([
+    RIVAL_STORAGE_PREFIX,
+    LEGACY_GHOST_STORAGE_PREFIX,
+    ...storageKeys(storage).filter((key) =>
+      key.startsWith(`${RIVAL_STORAGE_PREFIX}:`) || key.startsWith(`${LEGACY_GHOST_STORAGE_PREFIX}:`)
+    )
+  ]);
+
+  for (const key of keys) {
     try {
-      if (storage?.getItem?.(key) != null) return true;
+      const payload = safeParse(storage?.getItem?.(key));
+      if (key.startsWith(RIVAL_STORAGE_PREFIX) && hasPlayedRivalPayload(payload)) return true;
+      if (key.startsWith(LEGACY_GHOST_STORAGE_PREFIX) && hasPlayedLegacyGhost(payload)) return true;
     } catch (_) {
       return false;
     }
   }
-
-  try {
-    const length = Number(storage?.length) || 0;
-    for (let index = 0; index < length; index += 1) {
-      const key = storage?.key?.(index) || '';
-      if (key.startsWith('turn-personal-rivals-v1:') || key.startsWith('turn-three-ghost-v4:')) return true;
-    }
-  } catch (_) {}
   return false;
+}
+
+function hasAdminRewardMarker(storage) {
+  try {
+    return storage?.getItem?.(ADMIN_UNLOCK_MARKER) != null;
+  } catch (_) {
+    return false;
+  }
+}
+
+function hasAchievementProgress(state) {
+  return Object.keys(state?.unlocked || {}).length > 0
+    || (Array.isArray(state?.progress?.tracks) && state.progress.tracks.length > 0)
+    || (Array.isArray(state?.progress?.blankTracks) && state.progress.blankTracks.length > 0);
+}
+
+function hasEveryRewardStored(state) {
+  const stored = new Set(Array.isArray(state?.rewards?.unlocked) ? state.rewards.unlocked : []);
+  return TROPHY_ROAD_REWARDS.every((reward) => stored.has(reward.id));
+}
+
+function cleanTrophyRoadState() {
+  return {
+    version: TROPHY_ROAD_STORAGE_VERSION,
+    unlocked: {},
+    seen: [],
+    progress: { tracks: [], blankTracks: [] },
+    rewards: { unlocked: [], seen: [] }
+  };
+}
+
+function repairFalseFreshProfile(state, storage) {
+  if (!state || hasAchievementProgress(state) || hasAdminRewardMarker(storage) || hasLegacyRaceProgress(storage)) {
+    return state;
+  }
+
+  const sourceVersion = Number(state.version || 0);
+  const looksLikeSettingsOnlyLegacyShell = sourceVersion < 3;
+  const looksLikeFalseGrandfather = sourceVersion >= 5 && hasEveryRewardStored(state);
+  if (!looksLikeSettingsOnlyLegacyShell && !looksLikeFalseGrandfather) return state;
+
+  const clean = cleanTrophyRoadState();
+  try {
+    storage?.setItem?.(TROPHY_ROAD_STORAGE_KEY, JSON.stringify(clean));
+  } catch (_) {
+    return state;
+  }
+  return clean;
 }
 
 export function prepareTrophyRoadProfile(storage = globalThis.localStorage) {
   try {
     const raw = storage?.getItem?.(TROPHY_ROAD_STORAGE_KEY);
     const existing = safeParse(raw);
-    if (existing) return existing;
+    if (existing) return repairFalseFreshProfile(existing, storage);
     if (preparationAlreadyChecked(storage)) return null;
     markPreparationChecked(storage);
-    if (!hasLegacyTurnProfile(storage)) return null;
+
+    // Settings such as the selected car, track, steering mode and audio preference can
+    // be written during a brand-new startup. They are not proof of an older TURN
+    // profile. Grandfather rewards only when there is actual pre-Trophy-Road race
+    // progress: a saved rival lap or a legacy best ghost.
+    if (!hasLegacyRaceProgress(storage)) return null;
 
     const legacyShell = {
       version: 2,

--- a/turn/progression/trophy-road.js
+++ b/turn/progression/trophy-road.js
@@ -135,6 +135,7 @@ const REWARD_BY_FEATURE = new Map(
 );
 const PREPARED_STORAGE = new WeakSet();
 const ADMIN_UNLOCK_MARKER = 'turn-admin-unlock-v1';
+const LEGACY_VEHICLE_SELECTION_KEY = 'turn-vehicle-selection-v1';
 const RIVAL_STORAGE_PREFIX = 'turn-personal-rivals-v1';
 const LEGACY_GHOST_STORAGE_PREFIX = 'turn-three-ghost-v4';
 const VERSION_THREE_GRANDFATHERED_REWARDS = Object.freeze([
@@ -290,6 +291,20 @@ function hasLegacyRaceProgress(storage) {
   return false;
 }
 
+function hasLegacyVehicleChoice(storage) {
+  try {
+    const selection = safeParse(storage?.getItem?.(LEGACY_VEHICLE_SELECTION_KEY));
+    const carId = typeof selection?.carId === 'string' ? selection.carId : '';
+    return Boolean(carId && carId !== 'classic');
+  } catch (_) {
+    return false;
+  }
+}
+
+function hasLegacyProfileEvidence(storage) {
+  return hasLegacyRaceProgress(storage) || hasLegacyVehicleChoice(storage);
+}
+
 function hasAdminRewardMarker(storage) {
   try {
     return storage?.getItem?.(ADMIN_UNLOCK_MARKER) != null;
@@ -320,7 +335,7 @@ function cleanTrophyRoadState() {
 }
 
 function repairFalseFreshProfile(state, storage) {
-  if (!state || hasAchievementProgress(state) || hasAdminRewardMarker(storage) || hasLegacyRaceProgress(storage)) {
+  if (!state || hasAchievementProgress(state) || hasAdminRewardMarker(storage) || hasLegacyProfileEvidence(storage)) {
     return state;
   }
 
@@ -346,11 +361,11 @@ export function prepareTrophyRoadProfile(storage = globalThis.localStorage) {
     if (preparationAlreadyChecked(storage)) return null;
     markPreparationChecked(storage);
 
-    // Settings such as the selected car, track, steering mode and audio preference can
-    // be written during a brand-new startup. They are not proof of an older TURN
-    // profile. Grandfather rewards only when there is actual pre-Trophy-Road race
-    // progress: a saved rival lap or a legacy best ghost.
-    if (!hasLegacyRaceProgress(storage)) return null;
+    // Default settings can be written during a brand-new startup, so their mere
+    // presence is not proof of an older TURN profile. Grandfather only when there
+    // is meaningful pre-Trophy-Road evidence: a completed saved lap/ghost or a
+    // genuinely non-default historical vehicle choice.
+    if (!hasLegacyProfileEvidence(storage)) return null;
 
     const legacyShell = {
       version: 2,

--- a/turn/vehicle/learner-car-livery.js
+++ b/turn/vehicle/learner-car-livery.js
@@ -35,8 +35,9 @@ const KENNEY_TAXI_SIGN_TRIANGLES = Object.freeze([
   Object.freeze([7, 2, 5])
 ]);
 
-// Broad sign faces in the source triangle list: +X (2,3) and -X (8,9).
-const SIGN_GRAPHIC_TRIANGLES = new Set([2, 3, 8, 9]);
+// The learner L belongs on the two short end faces of the original Taxi sign:
+// +Z (triangles 0,1) and -Z (4,5). The long side faces stay plain yellow.
+const SIGN_GRAPHIC_TRIANGLES = new Set([0, 1, 4, 5]);
 let signFaceTexture = null;
 
 export function installLearnerCarLivery(model, car, { ghost = false } = {}) {
@@ -126,12 +127,12 @@ function createAuthenticKenneyTaxiSign({ ghost }) {
     const start = positions.length / 3;
     for (const vertexIndex of triangle) positions.push(...KENNEY_TAXI_SIGN_POSITIONS[vertexIndex]);
 
-    // Map the two broad faces independently so the L reads normally from either
-    // side of the car. The opposite side intentionally mirrors U in model space.
-    if (triangleIndex === 2) uvs.push(0, 1, 1, 0, 1, 1);
-    else if (triangleIndex === 3) uvs.push(1, 0, 0, 1, 0, 0);
-    else if (triangleIndex === 8) uvs.push(1, 0, 0, 1, 0, 0);
-    else if (triangleIndex === 9) uvs.push(0, 1, 1, 0, 1, 1);
+    // The front and back short faces use opposite horizontal UV directions so the
+    // same texture reads as a normal upright L from either end of the car.
+    if (triangleIndex === 0) uvs.push(1, 1, 0, 0, 1, 0);
+    else if (triangleIndex === 1) uvs.push(0, 0, 1, 1, 0, 1);
+    else if (triangleIndex === 4) uvs.push(1, 1, 0, 0, 1, 0);
+    else if (triangleIndex === 5) uvs.push(0, 0, 1, 1, 0, 1);
     else uvs.push(0, 0, 0, 0, 0, 0);
 
     groups.push({ start, count: 3, materialIndex: SIGN_GRAPHIC_TRIANGLES.has(triangleIndex) ? 1 : 0 });
@@ -158,7 +159,7 @@ function createAuthenticKenneyTaxiSign({ ghost }) {
     roughness: 0.78,
     metalness: 0
   });
-  faceMaterial.name = 'learner-sign-l-face';
+  faceMaterial.name = 'learner-sign-l-end-face';
 
   const sign = new THREE.Mesh(geometry, [yellowMaterial, faceMaterial]);
   sign.name = 'kenney-taxi-roof-sign-learner-livery';
@@ -207,5 +208,6 @@ export const LEARNER_CAR_KENNEY_SIGN_CONTRACT = Object.freeze({
   positions: KENNEY_TAXI_SIGN_POSITIONS,
   triangles: KENNEY_TAXI_SIGN_TRIANGLES,
   sourceVertexIds: Object.freeze([367, 368, 369, 370, 375, 376, 377, 378]),
-  sourceTriangleCount: 10
+  sourceTriangleCount: 10,
+  graphicTriangleIds: Object.freeze([0, 1, 4, 5])
 });


### PR DESCRIPTION
## Learner Car roof sign
- keep the exact original Kenney Taxi roof-sign geometry
- remove the L treatment from both long side faces
- put the outlined black `L` on the two short end faces instead, with mirrored UV orientation so it reads correctly from both front and rear
- leave the door L livery unchanged
- lock the decorated source-triangle IDs in regression coverage

## Trophy Road fresh-profile fix
A cleared/new domain could be misclassified as a pre-Trophy-Road player because ordinary default TURN settings were treated as legacy-profile evidence. That created a v2 shell, which intentionally grandfathered every reward.

This PR:
- stops treating default car/track/steering/audio keys as sufficient legacy evidence
- preserves grandfathering for meaningful old-player evidence (saved race progress or a genuinely non-default old vehicle selection)
- repairs the known accidental current-version state: zero achievement progress + every reward grandfathered + no admin marker/legacy evidence
- preserves the intentional hidden admin rewards-only profile
- adds regression coverage reproducing the clean-domain/default-settings failure and the self-repair path

No gameplay tuning or door-livery geometry changes.