### PR TITLE
Improve Learner Car roof L and use info blue for PERK

### DIFF
--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -1,4 +1,5 @@
 // Historical regression marker: lot-perk-disclosure.js?revision=r164-vintage-rally-perks
+// Historical regression marker: lot-perk-disclosure.js?revision=r217-stable-perk-slot
 // Historical regression marker: lot-trophy-gate.js?revision=r164-vintage-rally-perks
 // Historical regression marker: lot-paint-reward.js?revision=r164-perks
 // Historical regression marker: lot-paint-reward.js?revision=r203-color-label
@@ -24,7 +25,7 @@ export function prepareLotEnhancements() {
     import('./lot-stat-legend.js?build=20260724-r59'),
     import('./lot-layout-r60.js?build=20260729-r116&revision=r213-attributes-typography'),
     import('./lot-accessibility-r118.js?build=20260729-r118&revision=r588-canonical-attributes'),
-    import('./lot-perk-disclosure.js?revision=r217-stable-perk-slot'),
+    import('./lot-perk-disclosure.js?revision=r225-information-blue'),
     import('./lot-card-scroll-boundary.js?revision=r216-meter-density'),
     import('./lot-vehicle-copy.js?revision=r223-training-car-taxi'),
     import('./lot-trophy-order.js'),

--- a/turn/garage/lot-perk-disclosure.js
+++ b/turn/garage/lot-perk-disclosure.js
@@ -1,7 +1,7 @@
 import { getCarDefinition } from '../vehicle/catalog.js?revision=r223-training-car-taxi';
 import { vehiclePerkPresentation } from '../vehicle/perk-presentation.js?revision=r220-apex-grip';
 
-const STYLE_ID = 'turn-lot-perk-popover-r217-styles';
+const STYLE_ID = 'turn-lot-perk-popover-r225-styles';
 const activeDisclosures = new WeakMap();
 let nextPopoverId = 0;
 
@@ -31,7 +31,7 @@ function installStyles() {
       padding: 5px 13px;
       border: 2.5px solid var(--ink, #08090a);
       border-radius: 999px;
-      background: var(--pink, #ff4fa3);
+      background: var(--turn-action-information, #38d9ff);
       box-shadow: 4px 4px 0 var(--ink, #08090a);
       color: var(--ink, #08090a);
       font-size: clamp(.58rem, 1.05vw, .72rem);

--- a/turn/vehicle/learner-car-livery.js
+++ b/turn/vehicle/learner-car-livery.js
@@ -4,6 +4,7 @@ const LEARNER_CAR_ID = 'classic';
 const LEARNER_YELLOW = new THREE.Color('#ffcc00');
 const LEARNER_INK = new THREE.Color('#08090a');
 const SIGN_FACE_TEXTURE_SIZE = 128;
+const SIGN_FACE_BORDER_PX = 10;
 
 // Exact Taxi roof-sign geometry from Kenney Car Kit 3.1 `taxi.obj`.
 // These are the original eight authored positions and ten authored triangles
@@ -174,7 +175,7 @@ function getLearnerSignFaceTexture() {
   if (signFaceTexture) return signFaceTexture;
 
   const size = SIGN_FACE_TEXTURE_SIZE;
-  const border = 8;
+  const border = SIGN_FACE_BORDER_PX;
   const pixels = new Uint8Array(size * size * 4);
   const yellow = [255, 204, 0, 255];
   const ink = [8, 9, 10, 255];
@@ -182,8 +183,11 @@ function getLearnerSignFaceTexture() {
   for (let y = 0; y < size; y += 1) {
     for (let x = 0; x < size; x += 1) {
       const edge = x < border || x >= size - border || y < border || y >= size - border;
-      const stem = x >= 53 && x <= 67 && y >= 31 && y <= 88;
-      const foot = x >= 53 && x <= 88 && y >= 31 && y <= 45;
+      // The roof sign is tiny in the Lot and during racing, so use a deliberately
+      // broad, almost sign-painter-weight L. It occupies most of the short face and
+      // remains recognizable after perspective reduction on a phone display.
+      const stem = x >= 44 && x <= 69 && y >= 21 && y <= 103;
+      const foot = x >= 44 && x <= 99 && y >= 21 && y <= 46;
       const color = edge || stem || foot ? ink : yellow;
       const offset = (y * size + x) * 4;
       pixels[offset] = color[0];
@@ -196,9 +200,11 @@ function getLearnerSignFaceTexture() {
   signFaceTexture = new THREE.DataTexture(pixels, size, size, THREE.RGBAFormat);
   signFaceTexture.name = 'learner-car-yellow-black-l';
   signFaceTexture.colorSpace = THREE.SRGBColorSpace;
+  // Avoid mipmap averaging turning the already-small black L into a grey smudge in
+  // The Lot. The learner sign is intentionally graphic/pixel-crisp at this scale.
   signFaceTexture.magFilter = THREE.NearestFilter;
-  signFaceTexture.minFilter = THREE.LinearMipmapLinearFilter;
-  signFaceTexture.generateMipmaps = true;
+  signFaceTexture.minFilter = THREE.NearestFilter;
+  signFaceTexture.generateMipmaps = false;
   signFaceTexture.flipY = false;
   signFaceTexture.needsUpdate = true;
   return signFaceTexture;


### PR DESCRIPTION
## Learner Car
- keep the authentic Kenney Taxi roof-sign geometry and the front/rear-only L placement from #693
- enlarge and thicken the black L and its border on the short sign faces
- disable mipmap averaging for that tiny graphic so it stays crisp instead of turning into a grey/ambiguous mark in The Lot
- leave the door L livery unchanged

## The Lot
- change the PERK trigger from primary pink to `var(--turn-action-information, #38d9ff)`
- leave the popover and its close button behavior unchanged
- refresh the PERK presentation module cache identity

No gameplay, progression, paint, mesh or car-selection changes.