### PR TITLE
Explain the 18-point car budget and replay new rewards on Home

### DIFF
--- a/turn-lab/tests/stat-legend-production.mjs
+++ b/turn-lab/tests/stat-legend-production.mjs
@@ -14,7 +14,19 @@ assert.match(
   'The DRIFT legend must state the permanent speed tradeoff'
 );
 
-const [index, releaseSource, wrapper, enhancementRuntime, legendModule, legendCss, lotCss, lotSource, physicsSource] = await Promise.all([
+const [
+  index,
+  releaseSource,
+  wrapper,
+  enhancementRuntime,
+  legendModule,
+  legendCss,
+  lotCss,
+  lotSource,
+  physicsSource,
+  achievementsEntry,
+  homeRewardReplay
+] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/release.json', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-track-select.js', import.meta.url), 'utf8'),
@@ -23,7 +35,9 @@ const [index, releaseSource, wrapper, enhancementRuntime, legendModule, legendCs
   fs.readFile(new URL('../../turn/garage/lot-stat-legend.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-r10.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/garage/lot-r10.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/vehicle/physics.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../../turn/vehicle/physics.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/achievements.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/achievements/home-reward-replay-r225.js', import.meta.url), 'utf8')
 ]);
 
 const release = JSON.parse(releaseSource);
@@ -81,4 +95,25 @@ assert.match(physicsSource, /baseSpeedLimit \* effectiveDriftSpeedMultiplier/, '
 assert.match(physicsSource, /3\.2 \* driftStabilityMultiplier/, 'The DRIFT stat must improve recovery from a slide');
 assert.match(physicsSource, /0\.42 \* driftStabilityMultiplier/, 'The DRIFT stat must improve lateral stability while the control is held');
 
-console.log(`TURN ${release.id} route-independent shared vehicle stat legend passed.`);
+assert.match(achievementsEntry, /home-reward-replay-r225\.js\?revision=r225-home-reward-replay/,
+  'The achievements entry must install the Home reward reminder persistently');
+assert.match(homeRewardReplay, /PENDING_STORAGE_KEY = 'turn-home-reward-replay-v1'/,
+  'A reward reminder must survive closing the installed app or browser');
+assert.match(homeRewardReplay, /window\.addEventListener\('turn:trophy-road-updated', handleRewardUpdate\)/,
+  'New Trophy Road rewards must be captured synchronously when they unlock');
+assert.match(homeRewardReplay, /document\.documentElement\.classList\.contains\('turn-home-ready'\)/);
+assert.match(homeRewardReplay, /document\.body\.classList\.contains\('turn-home-open'\)/,
+  'Reward reminders must be gated to the CHOOSE TRACK\/Home screen');
+assert.match(homeRewardReplay, /document\.addEventListener\('turn:home-ready', handleHomeReady\)/,
+  'A pending reward from a closed previous session must replay when the next Home becomes ready');
+assert.match(homeRewardReplay, /const addedThisSession = new Set\(\)/);
+assert.match(homeRewardReplay, /const shownAwayFromHome = new Set\(\)/,
+  'The runtime must distinguish a reward already shown during the race from one first shown on Home');
+assert.match(homeRewardReplay, /if \(!addedThisSession\.has\(id\)\) return true;/,
+  'Rewards carried across sessions must be ready for immediate Home replay');
+assert.match(homeRewardReplay, /if \(shownAwayFromHome\.has\(id\)\) return true;/,
+  'A reward already shown in-race must be deliberately shown again after returning Home');
+assert.match(homeRewardReplay, /consume\(currentIds\)/,
+  'If the ordinary reward toast first appears after Home is already open, it must count as the Home reminder instead of duplicating immediately');
+
+console.log(`TURN ${release.id} route-independent vehicle stat legend and persistent Home reward reminder passed.`);

--- a/turn-lab/tests/stat-legend-production.mjs
+++ b/turn-lab/tests/stat-legend-production.mjs
@@ -53,6 +53,8 @@ assert.ok(
   'Enhancement must connect to the already-created synchronous Lot DOM'
 );
 assert.match(enhancementRuntime, /installLotStatLegend\(scope\)/, 'Every Lot route must mount the shared stat legend');
+assert.match(enhancementRuntime, /lot-stat-legend\.js\?revision=r225-18-point-budget/,
+  'The revised attribute explanation must load under a fresh module identity');
 assert.ok(
   enhancementRuntime.indexOf('installLotStatLegend(scope)') < enhancementRuntime.indexOf('installLotLayout(scope)'),
   'The legend trigger must exist before the compact layout turns it into an info icon'
@@ -60,6 +62,10 @@ assert.ok(
 assert.match(legendModule, /VEHICLE_STAT_LEGEND/, 'The in-game legend must use the shared source of truth');
 assert.match(legendModule, /aria-modal/, 'The legend must open as an accessible modal');
 assert.match(legendModule, /WHAT DO THE STATS MEAN\?/, 'The legend trigger must be discoverable before the compact layout turns it into an info icon');
+assert.match(legendModule, /Every car always has 18 attribute points in total\./,
+  'The attribute modal must explain the fixed 18-point budget shared by every car');
+assert.match(legendModule, /What changes is how those 18 points are distributed\./,
+  'The attribute modal must explain that car identity comes from point distribution');
 assert.doesNotMatch(legendModule, /mountObserver|subtree: true/, 'The legend module must not observe the whole game DOM');
 assert.match(legendModule, /statsObserver\.observe\(stats, \{ childList: true \}\)/, 'Only actual car-stat replacement must trigger relabelling');
 assert.match(legendModule, /label\.textContent !== definition\.label/, 'Relabelling must not rewrite unchanged labels');

--- a/turn/achievements.js
+++ b/turn/achievements.js
@@ -1,3 +1,5 @@
+import './achievements/home-reward-replay-r225.js?revision=r225-home-reward-replay';
+
 export {
   ACHIEVEMENTS,
   ONBOARDING_ACHIEVEMENT_IDS

--- a/turn/achievements/home-reward-replay-r225.js
+++ b/turn/achievements/home-reward-replay-r225.js
@@ -17,13 +17,17 @@ function normalizedIds(value) {
   return [...new Set(value.filter((id) => typeof id === 'string' && getTrophyRoadReward(id)))];
 }
 
-function loadPending(storage = globalThis.localStorage) {
+function loadReplayState(storage = globalThis.localStorage) {
   try {
     const raw = storage?.getItem?.(PENDING_STORAGE_KEY);
-    if (!raw) return [];
-    return normalizedIds(JSON.parse(raw)?.pending);
+    if (!raw) return { pending: [], presented: [] };
+    const parsed = JSON.parse(raw);
+    return {
+      pending: normalizedIds(parsed?.pending),
+      presented: normalizedIds(parsed?.presented)
+    };
   } catch (_) {
-    return [];
+    return { pending: [], presented: [] };
   }
 }
 
@@ -40,11 +44,12 @@ function unseenStoredRewards(storage = globalThis.localStorage) {
   }
 }
 
-function savePending(pending, storage = globalThis.localStorage) {
+function saveReplayState(pending, presented, storage = globalThis.localStorage) {
   try {
     storage?.setItem?.(PENDING_STORAGE_KEY, JSON.stringify({
       version: 1,
-      pending: [...pending]
+      pending: [...pending],
+      presented: [...presented]
     }));
     return true;
   } catch (_) {
@@ -53,9 +58,11 @@ function savePending(pending, storage = globalThis.localStorage) {
 }
 
 function homeIsReady() {
-  return document.documentElement.classList.contains('turn-home-ready')
+  return Boolean(
+    document.documentElement.classList.contains('turn-home-ready')
     && document.body.classList.contains('turn-home-open')
-    && document.querySelector('.m8-home:not([hidden])');
+    && document.querySelector('.m8-home:not([hidden])')
+  );
 }
 
 function rewardToastElement() {
@@ -104,11 +111,13 @@ export function installHomeRewardReplay({ storage = globalThis.localStorage } = 
   if (installed) return installed;
   if (typeof document === 'undefined' || typeof window === 'undefined') return null;
 
-  const pending = new Set([
-    ...loadPending(storage),
-    ...unseenStoredRewards(storage)
-  ]);
-  savePending(pending, storage);
+  const stored = loadReplayState(storage);
+  const presented = new Set(stored.presented);
+  const pending = new Set(stored.pending.filter((id) => !presented.has(id)));
+  for (const id of unseenStoredRewards(storage)) {
+    if (!presented.has(id)) pending.add(id);
+  }
+  saveReplayState(pending, presented, storage);
 
   // These distinguish rewards earned during this document from rewards carried
   // across a closed/reopened app. A carried reward has no live race-toast timer,
@@ -122,16 +131,19 @@ export function installHomeRewardReplay({ storage = globalThis.localStorage } = 
   let toastWasVisible = false;
   let toastObserver = null;
 
-  const persist = () => savePending(pending, storage);
+  const persist = () => saveReplayState(pending, presented, storage);
 
   function consume(ids) {
     let changed = false;
     for (const id of ids) {
-      if (!pending.delete(id)) continue;
+      if (pending.delete(id)) changed = true;
+      if (!presented.has(id)) {
+        presented.add(id);
+        changed = true;
+      }
       addedThisSession.delete(id);
       shownAwayFromHome.delete(id);
       addedAt.delete(id);
-      changed = true;
     }
     if (changed) persist();
   }
@@ -193,10 +205,11 @@ export function installHomeRewardReplay({ storage = globalThis.localStorage } = 
 
     const ids = idsReadyForHomeReplay();
     if (!ids.length) {
-      const nextWait = Math.max(250, Math.min(...[...pending]
+      const waits = [...pending]
         .filter((id) => addedThisSession.has(id))
-        .map((id) => CURRENT_SESSION_FALLBACK_MS - (Date.now() - (addedAt.get(id) || Date.now())))));
-      replayTimer = globalThis.setTimeout(flushHomeReplay, Number.isFinite(nextWait) ? nextWait : 500);
+        .map((id) => CURRENT_SESSION_FALLBACK_MS - (Date.now() - (addedAt.get(id) || Date.now())));
+      const nextWait = waits.length ? Math.max(250, Math.min(...waits)) : 500;
+      replayTimer = globalThis.setTimeout(flushHomeReplay, nextWait);
       return;
     }
 
@@ -227,6 +240,7 @@ export function installHomeRewardReplay({ storage = globalThis.localStorage } = 
     if (!ids.length) return;
     const now = Date.now();
     for (const id of ids) {
+      presented.delete(id);
       pending.add(id);
       addedThisSession.add(id);
       shownAwayFromHome.delete(id);
@@ -258,6 +272,7 @@ export function installHomeRewardReplay({ storage = globalThis.localStorage } = 
   installed = Object.freeze({
     storageKey: PENDING_STORAGE_KEY,
     pendingIds: () => [...pending],
+    presentedIds: () => [...presented],
     flush: flushHomeReplay,
     disconnect() {
       globalThis.clearTimeout(replayTimer);

--- a/turn/achievements/home-reward-replay-r225.js
+++ b/turn/achievements/home-reward-replay-r225.js
@@ -1,0 +1,277 @@
+import {
+  TROPHY_ROAD_REWARD_ICONS,
+  getTrophyRoadReward
+} from '../progression/trophy-road-perks-r164.js?revision=r220-race-reward';
+
+const PENDING_STORAGE_KEY = 'turn-home-reward-replay-v1';
+const ACHIEVEMENT_STORAGE_KEY = 'turn-achievements-v1';
+const HOME_REPLAY_DELAY_MS = 350;
+const CURRENT_SESSION_FALLBACK_MS = 9000;
+const TOAST_VISIBLE_MS = 3600;
+const TOAST_CONCEAL_MS = 220;
+
+let installed = null;
+
+function normalizedIds(value) {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value.filter((id) => typeof id === 'string' && getTrophyRoadReward(id)))];
+}
+
+function loadPending(storage = globalThis.localStorage) {
+  try {
+    const raw = storage?.getItem?.(PENDING_STORAGE_KEY);
+    if (!raw) return [];
+    return normalizedIds(JSON.parse(raw)?.pending);
+  } catch (_) {
+    return [];
+  }
+}
+
+function unseenStoredRewards(storage = globalThis.localStorage) {
+  try {
+    const raw = storage?.getItem?.(ACHIEVEMENT_STORAGE_KEY);
+    if (!raw) return [];
+    const state = JSON.parse(raw);
+    const unlocked = normalizedIds(state?.rewards?.unlocked);
+    const seen = new Set(normalizedIds(state?.rewards?.seen));
+    return unlocked.filter((id) => !seen.has(id));
+  } catch (_) {
+    return [];
+  }
+}
+
+function savePending(pending, storage = globalThis.localStorage) {
+  try {
+    storage?.setItem?.(PENDING_STORAGE_KEY, JSON.stringify({
+      version: 1,
+      pending: [...pending]
+    }));
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+function homeIsReady() {
+  return document.documentElement.classList.contains('turn-home-ready')
+    && document.body.classList.contains('turn-home-open')
+    && document.querySelector('.m8-home:not([hidden])');
+}
+
+function rewardToastElement() {
+  return document.querySelector('.turn-trophy-reward-toast');
+}
+
+function toastIsVisible(toast) {
+  return Boolean(toast && !toast.hidden && toast.classList.contains('is-visible'));
+}
+
+function writeRewardToast(toast, rewards) {
+  const first = rewards[0];
+  toast.querySelector('.turn-achievement-toast-icon').innerHTML = TROPHY_ROAD_REWARD_ICONS[first.icon] || '';
+  toast.querySelector('span').textContent = rewards.length === 1
+    ? 'TROPHY ROAD REWARD'
+    : `${rewards.length} TROPHY ROAD REWARDS`;
+  toast.querySelector('strong').textContent = rewards.length === 1
+    ? first.title
+    : `${first.title} + ${rewards.length - 1} MORE`;
+  toast.querySelector('b').textContent = 'UNLOCKED';
+  toast.setAttribute(
+    'aria-label',
+    `${rewards.length === 1 ? 'Trophy Road reward unlocked' : `${rewards.length} Trophy Road rewards unlocked`}. ${rewards.map((reward) => reward.shortTitle).join(', ')}.`
+  );
+}
+
+function presentRewardToast(toast, rewards, onShown) {
+  if (!toast || !rewards.length) return false;
+  writeRewardToast(toast, rewards);
+  toast.hidden = false;
+  toast.classList.remove('is-visible');
+  requestAnimationFrame(() => {
+    toast.classList.add('is-visible');
+    onShown?.();
+  });
+  globalThis.setTimeout(() => {
+    toast.classList.remove('is-visible');
+    globalThis.setTimeout(() => {
+      toast.hidden = true;
+    }, TOAST_CONCEAL_MS);
+  }, TOAST_VISIBLE_MS);
+  return true;
+}
+
+export function installHomeRewardReplay({ storage = globalThis.localStorage } = {}) {
+  if (installed) return installed;
+  if (typeof document === 'undefined' || typeof window === 'undefined') return null;
+
+  const pending = new Set([
+    ...loadPending(storage),
+    ...unseenStoredRewards(storage)
+  ]);
+  savePending(pending, storage);
+
+  // These distinguish rewards earned during this document from rewards carried
+  // across a closed/reopened app. A carried reward has no live race-toast timer,
+  // so it can be replayed as soon as Home is ready next session.
+  const addedThisSession = new Set();
+  const shownAwayFromHome = new Set();
+  const addedAt = new Map();
+  let replayTimer = 0;
+  let replayInProgress = false;
+  let observedToast = null;
+  let toastWasVisible = false;
+  let toastObserver = null;
+
+  const persist = () => savePending(pending, storage);
+
+  function consume(ids) {
+    let changed = false;
+    for (const id of ids) {
+      if (!pending.delete(id)) continue;
+      addedThisSession.delete(id);
+      shownAwayFromHome.delete(id);
+      addedAt.delete(id);
+      changed = true;
+    }
+    if (changed) persist();
+  }
+
+  function rewardObjects(ids) {
+    return ids.map((id) => getTrophyRoadReward(id)).filter(Boolean);
+  }
+
+  function ensureToastObserver() {
+    const toast = rewardToastElement();
+    if (!toast || toast === observedToast) return toast;
+    toastObserver?.disconnect();
+    observedToast = toast;
+    toastWasVisible = toastIsVisible(toast);
+    toastObserver = new MutationObserver(() => {
+      const visible = toastIsVisible(toast);
+      if (visible && !toastWasVisible && !replayInProgress) {
+        const currentIds = [...pending].filter((id) => addedThisSession.has(id));
+        if (homeIsReady()) {
+          // The ordinary race reward toast reached the player only after they had
+          // already returned Home. That already satisfies the Home reminder, so do
+          // not immediately show a duplicate copy of the same message.
+          consume(currentIds);
+        } else {
+          for (const id of currentIds) shownAwayFromHome.add(id);
+        }
+      }
+      toastWasVisible = visible;
+    });
+    toastObserver.observe(toast, {
+      attributes: true,
+      attributeFilter: ['class', 'hidden']
+    });
+    return toast;
+  }
+
+  function idsReadyForHomeReplay() {
+    const now = Date.now();
+    return [...pending].filter((id) => {
+      if (!addedThisSession.has(id)) return true;
+      if (shownAwayFromHome.has(id)) return true;
+      const started = Number(addedAt.get(id)) || now;
+      return now - started >= CURRENT_SESSION_FALLBACK_MS;
+    });
+  }
+
+  function flushHomeReplay() {
+    replayTimer = 0;
+    if (!homeIsReady() || !pending.size) return;
+    const toast = ensureToastObserver();
+    if (!toast) {
+      replayTimer = globalThis.setTimeout(flushHomeReplay, 120);
+      return;
+    }
+    if (toastIsVisible(toast)) {
+      replayTimer = globalThis.setTimeout(flushHomeReplay, 300);
+      return;
+    }
+
+    const ids = idsReadyForHomeReplay();
+    if (!ids.length) {
+      const nextWait = Math.max(250, Math.min(...[...pending]
+        .filter((id) => addedThisSession.has(id))
+        .map((id) => CURRENT_SESSION_FALLBACK_MS - (Date.now() - (addedAt.get(id) || Date.now())))));
+      replayTimer = globalThis.setTimeout(flushHomeReplay, Number.isFinite(nextWait) ? nextWait : 500);
+      return;
+    }
+
+    const rewards = rewardObjects(ids);
+    if (!rewards.length) {
+      consume(ids);
+      return;
+    }
+
+    replayInProgress = true;
+    presentRewardToast(toast, rewards, () => {
+      consume(ids);
+      // Keep the observer from treating our deliberately replayed toast as the
+      // original in-race presentation.
+      toastWasVisible = true;
+      replayInProgress = false;
+    });
+  }
+
+  function scheduleHomeReplay(delay = HOME_REPLAY_DELAY_MS) {
+    if (!homeIsReady() || !pending.size) return;
+    globalThis.clearTimeout(replayTimer);
+    replayTimer = globalThis.setTimeout(flushHomeReplay, delay);
+  }
+
+  function handleRewardUpdate(event) {
+    const ids = normalizedIds(event.detail?.unlocked);
+    if (!ids.length) return;
+    const now = Date.now();
+    for (const id of ids) {
+      pending.add(id);
+      addedThisSession.add(id);
+      shownAwayFromHome.delete(id);
+      addedAt.set(id, now);
+    }
+    persist();
+    ensureToastObserver();
+    scheduleHomeReplay();
+  }
+
+  let homeWasOpen = document.body.classList.contains('turn-home-open');
+  const homeObserver = new MutationObserver(() => {
+    ensureToastObserver();
+    const open = document.body.classList.contains('turn-home-open');
+    if (open && !homeWasOpen) scheduleHomeReplay();
+    homeWasOpen = open;
+  });
+  homeObserver.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+
+  const toastMountObserver = new MutationObserver(() => ensureToastObserver());
+  toastMountObserver.observe(document.body, { childList: true });
+
+  const handleHomeReady = () => scheduleHomeReplay();
+  window.addEventListener('turn:trophy-road-updated', handleRewardUpdate);
+  document.addEventListener('turn:home-ready', handleHomeReady);
+  ensureToastObserver();
+  scheduleHomeReplay();
+
+  installed = Object.freeze({
+    storageKey: PENDING_STORAGE_KEY,
+    pendingIds: () => [...pending],
+    flush: flushHomeReplay,
+    disconnect() {
+      globalThis.clearTimeout(replayTimer);
+      homeObserver.disconnect();
+      toastMountObserver.disconnect();
+      toastObserver?.disconnect();
+      window.removeEventListener('turn:trophy-road-updated', handleRewardUpdate);
+      document.removeEventListener('turn:home-ready', handleHomeReady);
+      installed = null;
+    }
+  });
+  return installed;
+}
+
+if (typeof document !== 'undefined' && typeof window !== 'undefined') {
+  installHomeRewardReplay();
+}

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -22,7 +22,7 @@ export function prepareLotEnhancements() {
   if (enhancementPreparation) return enhancementPreparation;
 
   enhancementPreparation = Promise.all([
-    import('./lot-stat-legend.js?build=20260724-r59'),
+    import('./lot-stat-legend.js?revision=r225-18-point-budget'),
     import('./lot-layout-r60.js?build=20260729-r116&revision=r213-attributes-typography'),
     import('./lot-accessibility-r118.js?build=20260729-r118&revision=r588-canonical-attributes'),
     import('./lot-perk-disclosure.js?revision=r225-information-blue'),

--- a/turn/garage/lot-stat-legend.js
+++ b/turn/garage/lot-stat-legend.js
@@ -88,15 +88,11 @@ export function installLotStatLegend(root = document.body) {
       list.appendChild(item);
     }
 
-    const budget = document.createElement('p');
-    budget.className = 'lot-stats-dialog-rule';
-    budget.textContent = 'Every car always has 18 attribute points in total. What changes is how those 18 points are distributed.';
-
     const rule = document.createElement('p');
     rule.className = 'lot-stats-dialog-rule';
-    rule.textContent = 'GAS is fastest. DRIFT turns harder but always costs speed. BOOST is a limited burst.';
+    rule.textContent = 'Every car always has 18 attribute points in total. What changes is how those 18 points are distributed. GAS is fastest. DRIFT turns harder but always costs speed. BOOST is a limited burst.';
 
-    panel.append(header, list, budget, rule);
+    panel.append(header, list, rule);
     overlay.appendChild(panel);
 
     overlay.addEventListener('click', (event) => {

--- a/turn/garage/lot-stat-legend.js
+++ b/turn/garage/lot-stat-legend.js
@@ -88,11 +88,15 @@ export function installLotStatLegend(root = document.body) {
       list.appendChild(item);
     }
 
+    const budget = document.createElement('p');
+    budget.className = 'lot-stats-dialog-rule';
+    budget.textContent = 'Every car always has 18 attribute points in total. What changes is how those 18 points are distributed.';
+
     const rule = document.createElement('p');
     rule.className = 'lot-stats-dialog-rule';
     rule.textContent = 'GAS is fastest. DRIFT turns harder but always costs speed. BOOST is a limited burst.';
 
-    panel.append(header, list, rule);
+    panel.append(header, list, budget, rule);
     overlay.appendChild(panel);
 
     overlay.addEventListener('click', (event) => {


### PR DESCRIPTION
## Attributes information
- add a clear rule to the Lot attributes modal: every car always has 18 attribute points in total
- explain that the difference between cars is how those 18 points are distributed
- refresh the stat-legend module identity and regression coverage

## Reward UX
- persist newly unlocked Trophy Road rewards until they have been surfaced on CHOOSE TRACK / Home
- if the normal reward toast was already shown during the race, show that reward toast again after the player returns Home
- if the app is closed before returning Home, retain the pending reward and show it when Home becomes ready next session
- if the ordinary delayed race toast first appears only after the player already returned Home, count that as the Home reminder rather than immediately duplicating it
- keep this reminder state separate from the existing Achievements unread/seen state, so opening Achievements during a race cannot accidentally suppress the requested Home reminder

The replay layer reuses the existing Trophy Road reward toast and its accessibility semantics; it does not change reward thresholds, achievement scoring, car locks, or progression data.