### PR TITLE
Tighten time trials and simplify attribute summary

### DIFF
--- a/turn-lab/tests/achievements-production.mjs
+++ b/turn-lab/tests/achievements-production.mjs
@@ -177,10 +177,10 @@ assert.equal(byId('faster-than-the-dev')?.trophies, 300,
 assert.deepEqual(
   TIME_TRIALS.map(({ trackId, targetSeconds }) => [trackId, targetSeconds]),
   [
-    ['countryside', 12],
-    ['airport', 17],
+    ['countryside', 11],
+    ['airport', 16],
     ['cliffside', 15],
-    ['harbor', 23],
+    ['harbor', 22],
     ['midnight-city', 53],
     ['mountain', 25]
   ]
@@ -398,10 +398,10 @@ assert.match(lilyaSource, /signalSecretAchievement\('find-lilya'/);
 assert.match(darvidSource, /signalSecretAchievement\('find-darvid'/);
 assert.match(sedanSource, /signalSecretAchievement\('satans-sedan'/);
 
-assert.match(timeTrialSource, /targetSeconds: 12/);
-assert.match(timeTrialSource, /targetSeconds: 17/);
+assert.match(timeTrialSource, /targetSeconds: 11/);
+assert.match(timeTrialSource, /targetSeconds: 16/);
 assert.match(timeTrialSource, /targetSeconds: 15/);
-assert.match(timeTrialSource, /targetSeconds: 23/);
+assert.match(timeTrialSource, /targetSeconds: 22/);
 assert.match(timeTrialSource, /targetSeconds: 53/);
 assert.match(timeTrialSource, /targetSeconds: 25/);
 assert.match(timeTrialSource, /seconds >= trial\.targetSeconds/);

--- a/turn-lab/tests/stat-legend-production.mjs
+++ b/turn-lab/tests/stat-legend-production.mjs
@@ -80,6 +80,11 @@ assert.match(legendModule, /Every car always has 18 attribute points in total\./
   'The attribute modal must explain the fixed 18-point budget shared by every car');
 assert.match(legendModule, /What changes is how those 18 points are distributed\./,
   'The attribute modal must explain that car identity comes from point distribution');
+assert.doesNotMatch(
+  legendModule,
+  /GAS is fastest|DRIFT turns harder|BOOST is a limited burst/,
+  'The yellow attribute summary must stay focused on the shared 18-point budget rather than repeat control behavior'
+);
 assert.doesNotMatch(legendModule, /mountObserver|subtree: true/, 'The legend module must not observe the whole game DOM');
 assert.match(legendModule, /statsObserver\.observe\(stats, \{ childList: true \}\)/, 'Only actual car-stat replacement must trigger relabelling');
 assert.match(legendModule, /label\.textContent !== definition\.label/, 'Relabelling must not rewrite unchanged labels');

--- a/turn/achievements/time-trials.js
+++ b/turn/achievements/time-trials.js
@@ -2,16 +2,16 @@ export const TIME_TRIALS = Object.freeze([
   Object.freeze({
     id: 'countryside-sprint',
     trackId: 'countryside',
-    targetSeconds: 12,
+    targetSeconds: 11,
     title: 'COUNTRYSIDE SPRINT',
-    description: 'Finish Countryside in under 12 seconds.'
+    description: 'Finish Countryside in under 11 seconds.'
   }),
   Object.freeze({
     id: 'airport-sprint',
     trackId: 'airport',
-    targetSeconds: 17,
+    targetSeconds: 16,
     title: 'AIRPORT SPRINT',
-    description: 'Finish Airport in under 17 seconds.'
+    description: 'Finish Airport in under 16 seconds.'
   }),
   Object.freeze({
     id: 'cliffside-sprint',
@@ -23,9 +23,9 @@ export const TIME_TRIALS = Object.freeze([
   Object.freeze({
     id: 'harbor-sprint',
     trackId: 'harbor',
-    targetSeconds: 23,
+    targetSeconds: 22,
     title: 'HARBOR SPRINT',
-    description: 'Finish Harbor in under 23 seconds.'
+    description: 'Finish Harbor in under 22 seconds.'
   }),
   Object.freeze({
     id: 'midnight-sprint',

--- a/turn/garage/lot-stat-legend.js
+++ b/turn/garage/lot-stat-legend.js
@@ -90,7 +90,7 @@ export function installLotStatLegend(root = document.body) {
 
     const rule = document.createElement('p');
     rule.className = 'lot-stats-dialog-rule';
-    rule.textContent = 'Every car always has 18 attribute points in total. What changes is how those 18 points are distributed. GAS is fastest. DRIFT turns harder but always costs speed. BOOST is a limited burst.';
+    rule.textContent = 'Every car always has 18 attribute points in total. What changes is how those 18 points are distributed.';
 
     panel.append(header, list, rule);
     overlay.appendChild(panel);


### PR DESCRIPTION
Updates TURN production balancing and Lot copy:

- Countryside Sprint: under 11s
- Airport Sprint: under 16s
- Harbor Sprint: under 22s
- Keep the yellow attribute summary focused on the shared 18-point budget; remove the repeated GAS/DRIFT/BOOST explanation
- Update regression coverage for both changes

No gameplay physics or other track targets are changed.