### PR TITLE
Improve night-track race markers and tighten Midnight City target

### DIFF
--- a/turn-lab/tests/achievements-production.mjs
+++ b/turn-lab/tests/achievements-production.mjs
@@ -181,7 +181,7 @@ assert.deepEqual(
     ['airport', 16],
     ['cliffside', 15],
     ['harbor', 22],
-    ['midnight-city', 53],
+    ['midnight-city', 52],
     ['mountain', 25]
   ]
 );
@@ -402,7 +402,7 @@ assert.match(timeTrialSource, /targetSeconds: 11/);
 assert.match(timeTrialSource, /targetSeconds: 16/);
 assert.match(timeTrialSource, /targetSeconds: 15/);
 assert.match(timeTrialSource, /targetSeconds: 22/);
-assert.match(timeTrialSource, /targetSeconds: 53/);
+assert.match(timeTrialSource, /targetSeconds: 52/);
 assert.match(timeTrialSource, /targetSeconds: 25/);
 assert.match(timeTrialSource, /seconds >= trial\.targetSeconds/);
 

--- a/turn-tests/yourturn-r411-production.mjs
+++ b/turn-tests/yourturn-r411-production.mjs
@@ -21,7 +21,8 @@ const [
 assert.match(yourTurnIndex, /race-controls-r417\.js\?revision=r417/);
 assert.match(yourTurnIndex, /track-map-r417\.js\?revision=r417/);
 assert.match(yourTurnIndex, /r411\.css\?revision=r411/);
-assert.match(turnIndex, /ui\/r411-race-controls\.js\?revision=r411/);
+assert.match(turnIndex, /ui\/r411-race-controls\.js\?revision=[^"']+/,
+  'TURN must load its r411 race-control behavior regardless of the current cache revision');
 
 assert.match(yourTurnMap, /getTrackPreviewPoints/,
   'YOUR TURN maps must derive from TURN canonical track geometry');

--- a/turn/achievements/time-trials.js
+++ b/turn/achievements/time-trials.js
@@ -30,9 +30,9 @@ export const TIME_TRIALS = Object.freeze([
   Object.freeze({
     id: 'midnight-sprint',
     trackId: 'midnight-city',
-    targetSeconds: 53,
+    targetSeconds: 52,
     title: 'MIDNIGHT SPRINT',
-    description: 'Finish Midnight City in under 53 seconds.'
+    description: 'Finish Midnight City in under 52 seconds.'
   }),
   Object.freeze({
     id: 'mountain-sprint',

--- a/turn/index.html
+++ b/turn/index.html
@@ -192,7 +192,7 @@
   <script type="module" src="./tracks/cliffside-house-inset-r203.js?revision=r203-inset-edge-houses"></script>
   <script type="module" src="./tracks/kenney-track-landmarks-r517.js?revision=r532-countryside-nature-polish"></script>
   <script type="module" src="./input/qe-drive-controls-bootstrap.js?revision=r418-qe"></script>
-  <script type="module" src="./ui/r411-race-controls.js?revision=r411"></script>
+  <script type="module" src="./ui/r411-race-controls.js?revision=r227-night-marker-outline"></script>
   <script type="module" src="./accessibility/color-accessibility-r163.js?build=20260826-r184-paint-basics"></script>
   <script type="module" src="./achievements/chromatic-camouflage-r183.js?revision=r183-production"></script>
   <script type="module" src="./social/your-turn-share-bootstrap.js?revision=r2"></script>

--- a/turn/ui/leader-marker-r500.js
+++ b/turn/ui/leader-marker-r500.js
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import './player-marker-r428.js?revision=r432';
+import './player-marker-r428.js?revision=r227-night-marker-outline';
 
 const LEADER_MARKER_SIZE_VIEWPORT_RATIO = 0.032;
 const LEADER_MARKER_SIZE_MIN_PX = 12;
@@ -11,6 +11,9 @@ const LEADER_PROGRESS_EPSILON = 0.002;
 const LEADER_CHECK_INTERVAL_MS = 50;
 const FALLBACK_ROOF_HEIGHT = 1.8;
 const FALLBACK_MARKER_COLOR = '#38d9ff';
+const DARK_MARKER_OUTLINE = '#08090a';
+const LIGHT_MARKER_OUTLINE = '#ffffff';
+const LIGHT_OUTLINE_TRACKS = new Set(['midnight-city', 'mountain']);
 const FIXED_LIVERY_MARKER_COLORS = Object.freeze({
   firetruck: '#d92d20',
   police: '#0b0d10',
@@ -28,6 +31,12 @@ function markerSizePixels(viewportHeight) {
     LEADER_MARKER_SIZE_MIN_PX,
     LEADER_MARKER_SIZE_MAX_PX
   );
+}
+
+export function leaderMarkerOutlineColor(trackId) {
+  return LIGHT_OUTLINE_TRACKS.has(String(trackId || '').toLowerCase())
+    ? LIGHT_MARKER_OUTLINE
+    : DARK_MARKER_OUTLINE;
 }
 
 export function leaderMarkerNeedsHelp(apparentRoofPixels, wasVisible = false) {
@@ -115,7 +124,7 @@ function installStyles() {
 
     .turn-leader-marker path {
       fill: var(--turn-leader-marker-color, ${FALLBACK_MARKER_COLOR});
-      stroke: #08090a;
+      stroke: var(--turn-leader-marker-outline, ${DARK_MARKER_OUTLINE});
       stroke-width: 2.5px;
       stroke-linejoin: round;
       vector-effect: non-scaling-stroke;
@@ -216,6 +225,7 @@ function installRuntime(runtime) {
   let visualHelpActive = false;
   let lastLeaderIndex = -1;
   let lastColor = '';
+  let lastOutlineColor = '';
 
   function measure() {
     rect = runtime.renderer?.domElement?.getBoundingClientRect?.() || null;
@@ -281,6 +291,12 @@ function installRuntime(runtime) {
     if (color !== lastColor) {
       marker.style.setProperty('--turn-leader-marker-color', color);
       lastColor = color;
+    }
+
+    const outlineColor = leaderMarkerOutlineColor(runtime.state?.trackId);
+    if (outlineColor !== lastOutlineColor) {
+      marker.style.setProperty('--turn-leader-marker-outline', outlineColor);
+      lastOutlineColor = outlineColor;
     }
 
     marker.style.left = `${pose.x.toFixed(1)}px`;

--- a/turn/ui/player-marker-r428.js
+++ b/turn/ui/player-marker-r428.js
@@ -13,6 +13,9 @@ const MARKER_SIZE_MIN_PX = 17;
 const MARKER_SIZE_MAX_PX = 23;
 const FALLBACK_ROOF_HEIGHT = 1.8;
 const FALLBACK_MARKER_COLOR = '#38d9ff';
+const DARK_MARKER_OUTLINE = '#08090a';
+const LIGHT_MARKER_OUTLINE = '#ffffff';
+const LIGHT_OUTLINE_TRACKS = new Set(['midnight-city', 'mountain']);
 const FIXED_LIVERY_MARKER_COLORS = Object.freeze({
   firetruck: '#d92d20',
   police: '#0b0d10',
@@ -31,6 +34,12 @@ function markerSizePixels(viewportHeight) {
   );
 }
 
+export function playerMarkerOutlineColor(trackId) {
+  return LIGHT_OUTLINE_TRACKS.has(String(trackId || '').toLowerCase())
+    ? LIGHT_MARKER_OUTLINE
+    : DARK_MARKER_OUTLINE;
+}
+
 function installStyles() {
   if (document.querySelector('#turn-player-marker-r428-styles')) return;
   const style = document.createElement('style');
@@ -43,6 +52,7 @@ function installStyles() {
 
     .turn-player-marker path {
       fill: var(--turn-player-marker-color, ${FALLBACK_MARKER_COLOR});
+      stroke: var(--turn-player-marker-outline, ${DARK_MARKER_OUTLINE});
       stroke-width: 2.5px;
       vector-effect: non-scaling-stroke;
     }
@@ -172,6 +182,7 @@ function installRuntime(runtime) {
   let nextAutoCheckAt = 0;
   let autoNearby = false;
   let lastColor = '';
+  let lastOutlineColor = '';
   let lastCarId = null;
   let roofHeight = FALLBACK_ROOF_HEIGHT;
 
@@ -246,6 +257,12 @@ function installRuntime(runtime) {
     if (color !== lastColor) {
       marker.style.setProperty('--turn-player-marker-color', color);
       lastColor = color;
+    }
+
+    const outlineColor = playerMarkerOutlineColor(runtime.state?.trackId);
+    if (outlineColor !== lastOutlineColor) {
+      marker.style.setProperty('--turn-player-marker-outline', outlineColor);
+      lastOutlineColor = outlineColor;
     }
 
     marker.style.left = `${pose.x.toFixed(1)}px`;

--- a/turn/ui/r411-race-controls.js
+++ b/turn/ui/r411-race-controls.js
@@ -1,4 +1,4 @@
-import './leader-marker-r500.js?revision=r511';
+import './leader-marker-r500.js?revision=r227-night-marker-outline';
 
 function installStyles() {
   if (document.querySelector('#turn-r411-race-control-styles')) return;


### PR DESCRIPTION
Updates TURN production with two small visibility/balance changes:

- Player and leader triangle markers use white outlines on MIDNIGHT CITY and MOUNTAIN, while other tracks keep the existing black outline.
- MIDNIGHT SPRINT target is now strictly under 52 seconds.
- Cache-bust the marker module chain so installed/browser sessions receive the new treatment.
- Update the achievement regression for the 52-second target.

No marker size/activation behavior, car colors, physics, or other time-trial targets are changed.