### PR TITLE
Fix TURN startup after handedness feature

### DIFF
--- a/turn/ui/control-handedness.js
+++ b/turn/ui/control-handedness.js
@@ -20,13 +20,17 @@ export function loadControlHandedness(storage = globalThis.localStorage) {
 
 export function applyControlHandedness(value) {
   const handedness = normalizeControlHandedness(value);
-  const root = document.documentElement;
-  root.dataset.turnControlHandedness = handedness;
-  root.classList.toggle('turn-left-handed-controls', handedness === CONTROL_HANDEDNESS.LEFT);
-  root.classList.toggle('turn-right-handed-controls', handedness === CONTROL_HANDEDNESS.RIGHT);
-  window.dispatchEvent(new CustomEvent('turn:control-handedness-change', {
-    detail: { handedness }
-  }));
+  const root = globalThis.document?.documentElement;
+  if (root) {
+    root.dataset.turnControlHandedness = handedness;
+    root.classList.toggle('turn-left-handed-controls', handedness === CONTROL_HANDEDNESS.LEFT);
+    root.classList.toggle('turn-right-handed-controls', handedness === CONTROL_HANDEDNESS.RIGHT);
+  }
+  try {
+    globalThis.dispatchEvent?.(new CustomEvent('turn:control-handedness-change', {
+      detail: { handedness }
+    }));
+  } catch (_) {}
   return handedness;
 }
 


### PR DESCRIPTION
Hotfix for the LOADING hang introduced by #699. The handedness module now tolerates startup contexts where document/window event APIs are not yet available, while keeping the same stored preference and runtime behavior.