### PR TITLE
Add small achievement, spectate and perk cues

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -194,7 +194,7 @@
   <script type="module" src="./tracks/cliffside-house-inset-r203.js?revision=r203-inset-edge-houses"></script>
   <script type="module" src="./tracks/kenney-track-landmarks-r517.js?revision=r532-countryside-nature-polish"></script>
   <script type="module" src="./input/qe-drive-controls-bootstrap.js?revision=r418-qe"></script>
-  <script type="module" src="./ui/r411-race-controls.js?revision=r227-night-marker-outline"></script>
+  <script type="module" src="./ui/r411-race-controls.js?revision=r229-minor-ux-polish"></script>
   <script type="module" src="./accessibility/color-accessibility-r163.js?build=20260826-r184-paint-basics"></script>
   <script type="module" src="./achievements/chromatic-camouflage-r183.js?revision=r183-production"></script>
   <script type="module" src="./social/your-turn-share-bootstrap.js?revision=r2"></script>

--- a/turn-tests/yourturn-r411-production.mjs
+++ b/turn-tests/yourturn-r411-production.mjs
@@ -8,21 +8,23 @@ const [
   yourTurnMap,
   yourTurnCss,
   turnIndex,
-  turnControls
+  turnControls,
+  minorUx
 ] = await Promise.all([
   fs.readFile(new URL('../yourturn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../yourturn/race-controls-r411.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../yourturn/track-map-r417.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../yourturn/r411.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/ui/r411-race-controls.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/ui/r411-race-controls.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/ui/minor-ux-polish-r229.js', import.meta.url), 'utf8')
 ]);
 
 assert.match(yourTurnIndex, /race-controls-r417\.js\?revision=r417/);
 assert.match(yourTurnIndex, /track-map-r417\.js\?revision=r417/);
 assert.match(yourTurnIndex, /r411\.css\?revision=r411/);
-assert.match(turnIndex, /ui\/r411-race-controls\.js\?revision=[^"']+/,
-  'TURN must load its r411 race-control behavior regardless of the current cache revision');
+assert.match(turnIndex, /ui\/r411-race-controls\.js\?revision=r229-minor-ux-polish/,
+  'TURN must cache-bust the race-control entry when the UX polish bundle changes');
 
 assert.match(yourTurnMap, /getTrackPreviewPoints/,
   'YOUR TURN maps must derive from TURN canonical track geometry');
@@ -63,7 +65,38 @@ assert.match(turnControls, /back-to-start-button[\s\S]*#ff7b54/,
   'TURN Restart Lap must be orange during a valid active lap');
 assert.match(turnControls, /back-to-start-button\.is-lap-invalid[\s\S]*#ff6b6b/,
   'TURN Restart Lap must turn red for LAP VOID');
+assert.match(turnControls, /minor-ux-polish-r229\.js\?revision=r229-discoverability-cues/,
+  'TURN must load the isolated minor UX polish bundle from the existing race-control entry');
 assert.doesNotMatch(turnControls, /gap:|align-items:|top:|bottom:|translate|margin:/,
   'The TURN r411 control patch must not copy incidental mockup layout changes');
 
-console.log('TURN/YOUR TURN r411 maps and race-control alignment regression passed.');
+assert.match(
+  minorUx,
+  /button\[data-achievement-filter="new"\]\[aria-pressed="true"\]:not\(:disabled\)::after/,
+  'The NEW filter must show its notification dot only while the filter is active'
+);
+assert.match(minorUx, /background: var\(--turn-action-warning, #ffd43b\)/,
+  'The active NEW filter dot must use TURN warning yellow');
+assert.match(minorUx, /PERK_ATTENTION_STORAGE_KEY = 'turn-perk-first-encounter-seen-v1'/,
+  'The PERK attention cue must be a persisted first-encounter behavior');
+assert.match(
+  minorUx,
+  /\.lot-showroom \.lot-perk-button:not\(\.is-layout-placeholder\):not\(:disabled\)/,
+  'PERK attention must wait until the player actually encounters an available perk'
+);
+assert.match(minorUx, /turn-first-perk-attention/,
+  'The first available PERK button must receive the attention animation class');
+assert.match(minorUx, /prefers-reduced-motion: reduce/,
+  'PERK attention must have a reduced-motion treatment');
+assert.match(minorUx, /className = 'turn-player-marker turn-spectate-player-marker'/,
+  'Spectate must reuse the established player-marker visual language');
+assert.match(minorUx, /globalThis\.__turnGetSpectateV3State\?\.\(\)/,
+  'The spectate marker must follow the currently selected spectate record');
+assert.match(minorUx, /runtime\.competitorCars\?\.\[current\.index\]/,
+  'The marker must attach to the selected spectated car rather than the ordinary player car');
+assert.match(minorUx, /playerMarkerOutlineColor\(runtime\.state\?\.trackId\)/,
+  'The spectate marker must retain the night-track white outline behavior');
+assert.match(minorUx, /typeof document !== 'undefined' && typeof window !== 'undefined'/,
+  'The polish bundle must guard browser-only startup work');
+
+console.log('TURN/YOUR TURN r411 maps, race-control alignment and minor UX polish regression passed.');

--- a/turn/index.html
+++ b/turn/index.html
@@ -192,7 +192,7 @@
   <script type="module" src="./tracks/cliffside-house-inset-r203.js?revision=r203-inset-edge-houses"></script>
   <script type="module" src="./tracks/kenney-track-landmarks-r517.js?revision=r532-countryside-nature-polish"></script>
   <script type="module" src="./input/qe-drive-controls-bootstrap.js?revision=r418-qe"></script>
-  <script type="module" src="./ui/r411-race-controls.js?revision=r227-night-marker-outline"></script>
+  <script type="module" src="./ui/r411-race-controls.js?revision=r229-minor-ux-polish"></script>
   <script type="module" src="./accessibility/color-accessibility-r163.js?build=20260826-r184-paint-basics"></script>
   <script type="module" src="./achievements/chromatic-camouflage-r183.js?revision=r183-production"></script>
   <script type="module" src="./social/your-turn-share-bootstrap.js?revision=r2"></script>

--- a/turn/ui/minor-ux-polish-r229.js
+++ b/turn/ui/minor-ux-polish-r229.js
@@ -1,0 +1,317 @@
+import * as THREE from 'three';
+import { playerMarkerOutlineColor } from './player-marker-r428.js?revision=r227-night-marker-outline';
+
+const STYLE_ID = 'turn-minor-ux-polish-r229-styles';
+const PERK_ATTENTION_STORAGE_KEY = 'turn-perk-first-encounter-seen-v1';
+const FALLBACK_MARKER_COLOR = '#38d9ff';
+const FALLBACK_ROOF_HEIGHT = 1.8;
+const MARKER_GAP_PX = 20;
+const FIXED_LIVERY_MARKER_COLORS = Object.freeze({
+  firetruck: '#d92d20',
+  police: '#0b0d10',
+  ambulance: '#f8f9fa'
+});
+
+let perkAttentionSeenThisSession = false;
+
+function installStyles() {
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = `
+    .turn-achievements-filters button[data-achievement-filter="new"] {
+      position: relative;
+      overflow: visible;
+    }
+
+    .turn-achievements-filters button[data-achievement-filter="new"][aria-pressed="true"]:not(:disabled)::after {
+      content: "";
+      position: absolute;
+      z-index: 3;
+      top: -9px;
+      right: -9px;
+      width: 16px;
+      height: 16px;
+      box-sizing: border-box;
+      border: 3px solid var(--turn-ink, #08090a);
+      border-radius: 50%;
+      background: var(--turn-action-warning, #ffd43b);
+      box-shadow: 2px 2px 0 var(--turn-ink, #08090a);
+      pointer-events: none;
+    }
+
+    .lot-showroom .lot-perk-button.turn-first-perk-attention {
+      animation: turn-first-perk-attention 620ms cubic-bezier(.2,.85,.25,1.15) 2;
+      transform-origin: 50% 50%;
+    }
+
+    @keyframes turn-first-perk-attention {
+      0%, 100% { transform: rotate(0deg) scale(1); }
+      25% { transform: rotate(-4deg) scale(1.08); }
+      50% { transform: rotate(4deg) scale(1.08); }
+      75% { transform: rotate(-2deg) scale(1.04); }
+    }
+
+    .turn-spectate-player-marker {
+      z-index: 22;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .lot-showroom .lot-perk-button.turn-first-perk-attention {
+        animation: none;
+        outline: 5px solid var(--turn-action-warning, #ffd43b);
+        outline-offset: 4px;
+      }
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+function perkAttentionWasSeen() {
+  if (perkAttentionSeenThisSession) return true;
+  try {
+    return globalThis.localStorage?.getItem(PERK_ATTENTION_STORAGE_KEY) === '1';
+  } catch (_) {
+    return false;
+  }
+}
+
+function markPerkAttentionSeen() {
+  perkAttentionSeenThisSession = true;
+  try {
+    globalThis.localStorage?.setItem(PERK_ATTENTION_STORAGE_KEY, '1');
+  } catch (_) {}
+}
+
+function installFirstPerkAttention() {
+  if (perkAttentionWasSeen() || typeof MutationObserver !== 'function') return null;
+
+  let queued = false;
+  let observer = null;
+
+  function findAvailablePerkButton() {
+    return document.querySelector(
+      '.lot-showroom .lot-perk-button:not(.is-layout-placeholder):not(:disabled)'
+    );
+  }
+
+  function showAttention(trigger) {
+    if (!trigger || perkAttentionWasSeen()) return false;
+    markPerkAttentionSeen();
+    observer?.disconnect();
+    requestAnimationFrame(() => {
+      if (!trigger.isConnected) return;
+      trigger.classList.add('turn-first-perk-attention');
+      const clear = () => trigger.classList.remove('turn-first-perk-attention');
+      trigger.addEventListener('animationend', clear, { once: true });
+      globalThis.setTimeout?.(clear, 1700);
+    });
+    return true;
+  }
+
+  function check() {
+    queued = false;
+    const trigger = findAvailablePerkButton();
+    if (trigger) showAttention(trigger);
+  }
+
+  function queueCheck() {
+    if (queued || perkAttentionWasSeen()) return;
+    queued = true;
+    queueMicrotask(check);
+  }
+
+  observer = new MutationObserver(queueCheck);
+  observer.observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['class', 'disabled']
+  });
+  check();
+  return observer;
+}
+
+function createSpectateMarker() {
+  const marker = document.createElement('div');
+  marker.className = 'turn-player-marker turn-spectate-player-marker';
+  marker.hidden = true;
+  marker.setAttribute('aria-hidden', 'true');
+  marker.innerHTML = `
+    <svg viewBox="0 0 48 48" focusable="false" aria-hidden="true">
+      <path d="M24 42 L5 7 L43 7 Z"></path>
+    </svg>`;
+  document.body.appendChild(marker);
+  return marker;
+}
+
+function screenPoint(position, camera, rect, { allowOutside = false } = {}) {
+  if (!position?.clone || !camera || !rect?.width || !rect?.height) return null;
+  const projected = position.clone().project(camera);
+  if (!Number.isFinite(projected.x) || !Number.isFinite(projected.y) || !Number.isFinite(projected.z)) {
+    return null;
+  }
+  if (projected.z < -1 || projected.z > 1) return null;
+  if (!allowOutside && (Math.abs(projected.x) > 1.15 || Math.abs(projected.y) > 1.15)) return null;
+  return {
+    x: rect.left + (projected.x + 1) * rect.width * 0.5,
+    y: rect.top + (1 - projected.y) * rect.height * 0.5
+  };
+}
+
+function markerSizePixels(rect) {
+  return Math.min(23, Math.max(17, (Number(rect?.height) || 0) * 0.045));
+}
+
+function carRoofHeight(car) {
+  if (!car?.position) return FALLBACK_ROOF_HEIGHT;
+  try {
+    const bounds = new THREE.Box3().setFromObject(car);
+    const height = bounds.max.y - car.position.y;
+    if (Number.isFinite(height) && height > 0.4 && height < 6) return height;
+  } catch (_) {}
+  return FALLBACK_ROOF_HEIGHT;
+}
+
+function spectateMarkerPose(car, camera, rect, roofHeight) {
+  if (!car?.position || !camera) return null;
+  const carPoint = screenPoint(car.position, camera, rect);
+  if (!carPoint) return null;
+
+  const roof = car.position.clone();
+  roof.y += roofHeight;
+  const roofPoint = screenPoint(roof, camera, rect, { allowOutside: true });
+  if (!roofPoint) return null;
+
+  let upX = roofPoint.x - carPoint.x;
+  let upY = roofPoint.y - carPoint.y;
+  const length = Math.hypot(upX, upY);
+  if (length < 0.001) {
+    upX = 0;
+    upY = -1;
+  } else {
+    upX /= length;
+    upY /= length;
+  }
+
+  const centerGap = MARKER_GAP_PX + markerSizePixels(rect) * 0.5;
+  return {
+    x: roofPoint.x + upX * centerGap,
+    y: roofPoint.y + upY * centerGap,
+    rotation: Math.atan2(upX, -upY) * 180 / Math.PI
+  };
+}
+
+function spectatedMarkerColor(runtime, index) {
+  const lap = runtime?.state?.competitorLaps?.[index];
+  const carId = lap?.carId || '';
+  const fixed = FIXED_LIVERY_MARKER_COLORS[carId];
+  if (fixed) return fixed;
+  return typeof lap?.carColor === 'string' && lap.carColor.trim()
+    ? lap.carColor.trim()
+    : FALLBACK_MARKER_COLOR;
+}
+
+function installSpectatePlayerMarker(runtime) {
+  if (!runtime || runtime.__minorUxSpectateMarkerR229) {
+    return runtime?.__minorUxSpectateMarkerR229 || null;
+  }
+
+  const marker = createSpectateMarker();
+  let frame = 0;
+  let rect = null;
+  let metricCar = null;
+  let metricVisualKey = '';
+  let roofHeight = FALLBACK_ROOF_HEIGHT;
+
+  function measure() {
+    rect = runtime.renderer?.domElement?.getBoundingClientRect?.() || null;
+  }
+
+  function render() {
+    frame = requestAnimationFrame(render);
+    const current = globalThis.__turnGetSpectateV3State?.();
+    if (!current?.active) {
+      marker.hidden = true;
+      return;
+    }
+
+    const car = runtime.competitorCars?.[current.index];
+    if (!car?.visible) {
+      marker.hidden = true;
+      return;
+    }
+
+    if (!rect?.width || !rect?.height) measure();
+    if (!rect?.width || !rect?.height) {
+      marker.hidden = true;
+      return;
+    }
+
+    const visualKey = car.userData?.turnVisualKey || '';
+    if (car !== metricCar || visualKey !== metricVisualKey) {
+      metricCar = car;
+      metricVisualKey = visualKey;
+      roofHeight = carRoofHeight(car);
+    }
+
+    const pose = spectateMarkerPose(car, runtime.camera, rect, roofHeight);
+    if (!pose) {
+      marker.hidden = true;
+      return;
+    }
+
+    marker.style.setProperty('--turn-player-marker-color', spectatedMarkerColor(runtime, current.index));
+    marker.style.setProperty(
+      '--turn-player-marker-outline',
+      playerMarkerOutlineColor(runtime.state?.trackId)
+    );
+    marker.style.left = `${pose.x.toFixed(1)}px`;
+    marker.style.top = `${pose.y.toFixed(1)}px`;
+    marker.style.transform = `translate(-50%, -50%) rotate(${pose.rotation.toFixed(2)}deg)`;
+    marker.hidden = false;
+  }
+
+  const invalidateMeasurement = () => {
+    rect = null;
+  };
+  globalThis.addEventListener?.('resize', invalidateMeasurement, { passive: true });
+  globalThis.addEventListener?.('orientationchange', invalidateMeasurement, { passive: true });
+  globalThis.visualViewport?.addEventListener?.('resize', invalidateMeasurement, { passive: true });
+
+  measure();
+  frame = requestAnimationFrame(render);
+  const api = Object.freeze({
+    marker,
+    stop() {
+      cancelAnimationFrame(frame);
+      marker.remove();
+      globalThis.removeEventListener?.('resize', invalidateMeasurement);
+      globalThis.removeEventListener?.('orientationchange', invalidateMeasurement);
+      globalThis.visualViewport?.removeEventListener?.('resize', invalidateMeasurement);
+    }
+  });
+  runtime.__minorUxSpectateMarkerR229 = api;
+  return api;
+}
+
+function installSpectateMarkerWhenReady() {
+  if (globalThis.__turnRuntime) return installSpectatePlayerMarker(globalThis.__turnRuntime);
+  globalThis.addEventListener?.('turn:runtime-ready', (event) => {
+    installSpectatePlayerMarker(event.detail || globalThis.__turnRuntime);
+  }, { once: true });
+  return null;
+}
+
+function bootstrap() {
+  installStyles();
+  installFirstPerkAttention();
+  installSpectateMarkerWhenReady();
+}
+
+if (typeof document !== 'undefined' && typeof window !== 'undefined') bootstrap();
+
+export {
+  PERK_ATTENTION_STORAGE_KEY,
+  spectatedMarkerColor
+};

--- a/turn/ui/r411-race-controls.js
+++ b/turn/ui/r411-race-controls.js
@@ -1,4 +1,5 @@
 import './leader-marker-r500.js?revision=r227-night-marker-outline';
+import './minor-ux-polish-r229.js?revision=r229-discoverability-cues';
 
 function installStyles() {
   if (document.querySelector('#turn-r411-race-control-styles')) return;


### PR DESCRIPTION
Three isolated UX improvements from the latest playtest:

- NEW achievement filter gets the yellow notification dot while NEW is actively selected.
- SPECTATE gives the currently followed recorded car the established player triangle marker, using that car's color and the existing white-outline treatment on MIDNIGHT CITY/MOUNTAIN.
- The first available PERK a player encounters gets a short two-beat attention wiggle. The encounter is persisted so it happens only once; reduced-motion users get a static highlight instead.

The behavior lives in one guarded enhancement module loaded through the existing r411 entry point. Production cache revision is bumped, and the existing TURN/YOUR TURN regression now pins all three contracts. No physics, race state, achievement state, perk behavior, or SPECTATE camera behavior is changed.