### PR TITLE
Make NEW dot indicate unseen availability

### DIFF
--- a/turn-tests/yourturn-r411-production.mjs
+++ b/turn-tests/yourturn-r411-production.mjs
@@ -67,7 +67,7 @@ assert.match(turnControls, /back-to-start-button\.is-lap-invalid[\s\S]*#ff6b6b/,
   'TURN Restart Lap must turn red for LAP VOID');
 assert.match(turnControls, /minor-ux-polish-r229\.js\?revision=r229-discoverability-cues/,
   'TURN must load the isolated minor UX polish bundle from the existing race-control entry');
-assert.doesNotMatch(turnControls, /gap:|align-items:|top:|bottom:|translate|margin:/,
+assert.doesNotMatch(turnControls, /gap:|align-items:|translate|margin:/,
   'The TURN r411 control patch must not copy incidental mockup layout changes');
 
 assert.match(

--- a/turn-tests/yourturn-r411-production.mjs
+++ b/turn-tests/yourturn-r411-production.mjs
@@ -71,12 +71,17 @@ assert.doesNotMatch(turnControls, /gap:|align-items:|top:|bottom:|translate|marg
   'The TURN r411 control patch must not copy incidental mockup layout changes');
 
 assert.match(
-  minorUx,
-  /button\[data-achievement-filter="new"\]\[aria-pressed="true"\]:not\(:disabled\)::after/,
-  'The NEW filter must show its notification dot only while the filter is active'
+  turnControls,
+  /button\[data-achievement-filter="new"\]:not\(:disabled\):not\(\[aria-pressed="true"\]\)::after/,
+  'The NEW filter notification must represent available unseen achievements before the player selects it'
 );
-assert.match(minorUx, /background: var\(--turn-action-warning, #ffd43b\)/,
-  'The active NEW filter dot must use TURN warning yellow');
+assert.match(
+  turnControls,
+  /button\[data-achievement-filter="new"\]\[aria-pressed="true"\]::after\s*\{[\s\S]*content: none/,
+  'The NEW notification must disappear once the player has already selected the filter'
+);
+assert.match(turnControls, /background: var\(--turn-action-warning, #ffd43b\)/,
+  'The available NEW filter dot must use TURN warning yellow');
 assert.match(minorUx, /PERK_ATTENTION_STORAGE_KEY = 'turn-perk-first-encounter-seen-v1'/,
   'The PERK attention cue must be a persisted first-encounter behavior');
 assert.match(

--- a/turn/ui/r411-race-controls.js
+++ b/turn/ui/r411-race-controls.js
@@ -13,6 +13,28 @@ function installStyles() {
     .utility-group[data-menu-state="racing"] .back-to-start-button.is-lap-invalid {
       background: #ff6b6b;
     }
+
+    /* NEW is an availability cue: draw attention while unseen achievements exist,
+       then get out of the way once the player has actively chosen the filter. */
+    .turn-achievements-filters button[data-achievement-filter="new"]:not(:disabled):not([aria-pressed="true"])::after {
+      content: "";
+      position: absolute;
+      z-index: 3;
+      top: -9px;
+      right: -9px;
+      width: 16px;
+      height: 16px;
+      box-sizing: border-box;
+      border: 3px solid var(--turn-ink, #08090a);
+      border-radius: 50%;
+      background: var(--turn-action-warning, #ffd43b);
+      box-shadow: 2px 2px 0 var(--turn-ink, #08090a);
+      pointer-events: none;
+    }
+
+    .turn-achievements-filters button[data-achievement-filter="new"][aria-pressed="true"]::after {
+      content: none;
+    }
   `;
   document.head.appendChild(style);
 }


### PR DESCRIPTION
Follow-up to #702 based on clarified UX intent.

- Show the yellow dot on NEW when unseen achievements exist and the filter is available.
- Hide the dot once NEW is selected, because the user has already discovered the control.
- Keep the existing disabled state when there is nothing new.
- Update the TURN/YOUR TURN regression to pin availability-driven rather than selection-driven behavior.

No achievement state or filtering behavior changes; this is presentation only.