### PR TITLE
Tighten Airport Sprint to 15 seconds

### DIFF
--- a/turn-lab/tests/achievements-production.mjs
+++ b/turn-lab/tests/achievements-production.mjs
@@ -178,7 +178,7 @@ assert.deepEqual(
   TIME_TRIALS.map(({ trackId, targetSeconds }) => [trackId, targetSeconds]),
   [
     ['countryside', 11],
-    ['airport', 16],
+    ['airport', 15],
     ['cliffside', 15],
     ['harbor', 22],
     ['midnight-city', 52],
@@ -399,7 +399,7 @@ assert.match(darvidSource, /signalSecretAchievement\('find-darvid'/);
 assert.match(sedanSource, /signalSecretAchievement\('satans-sedan'/);
 
 assert.match(timeTrialSource, /targetSeconds: 11/);
-assert.match(timeTrialSource, /targetSeconds: 16/);
+assert.match(timeTrialSource, /targetSeconds: 15/);
 assert.match(timeTrialSource, /targetSeconds: 15/);
 assert.match(timeTrialSource, /targetSeconds: 22/);
 assert.match(timeTrialSource, /targetSeconds: 52/);

--- a/turn/achievements/time-trials.js
+++ b/turn/achievements/time-trials.js
@@ -9,9 +9,9 @@ export const TIME_TRIALS = Object.freeze([
   Object.freeze({
     id: 'airport-sprint',
     trackId: 'airport',
-    targetSeconds: 16,
+    targetSeconds: 15,
     title: 'AIRPORT SPRINT',
-    description: 'Finish Airport in under 16 seconds.'
+    description: 'Finish Airport in under 15 seconds.'
   }),
   Object.freeze({
     id: 'cliffside-sprint',


### PR DESCRIPTION
Updates AIRPORT SPRINT from strictly under 16 seconds to strictly under 15 seconds, including the displayed achievement copy and production regression expectations. Other time-trial targets are unchanged.