### PR TITLE
Tighten Cliffside Sprint to 14 seconds

### DIFF
--- a/turn-lab/tests/achievements-production.mjs
+++ b/turn-lab/tests/achievements-production.mjs
@@ -179,7 +179,7 @@ assert.deepEqual(
   [
     ['countryside', 11],
     ['airport', 15],
-    ['cliffside', 15],
+    ['cliffside', 14],
     ['harbor', 22],
     ['midnight-city', 52],
     ['mountain', 25]
@@ -400,7 +400,7 @@ assert.match(sedanSource, /signalSecretAchievement\('satans-sedan'/);
 
 assert.match(timeTrialSource, /targetSeconds: 11/);
 assert.match(timeTrialSource, /targetSeconds: 15/);
-assert.match(timeTrialSource, /targetSeconds: 15/);
+assert.match(timeTrialSource, /targetSeconds: 14/);
 assert.match(timeTrialSource, /targetSeconds: 22/);
 assert.match(timeTrialSource, /targetSeconds: 52/);
 assert.match(timeTrialSource, /targetSeconds: 25/);

--- a/turn/achievements/time-trials.js
+++ b/turn/achievements/time-trials.js
@@ -16,9 +16,9 @@ export const TIME_TRIALS = Object.freeze([
   Object.freeze({
     id: 'cliffside-sprint',
     trackId: 'cliffside',
-    targetSeconds: 15,
+    targetSeconds: 14,
     title: 'CLIFFSIDE SPRINT',
-    description: 'Finish Cliffside in under 15 seconds.'
+    description: 'Finish Cliffside in under 14 seconds.'
   }),
   Object.freeze({
     id: 'harbor-sprint',


### PR DESCRIPTION
Updates CLIFFSIDE SPRINT from strictly under 15 seconds to strictly under 14 seconds, including the displayed achievement copy and production regression expectations. Other time-trial targets are unchanged.