### PR TITLE
Rebalance SAFETY achievement targets

### DIFF
--- a/turn-lab/tests/achievements-production.mjs
+++ b/turn-lab/tests/achievements-production.mjs
@@ -136,16 +136,25 @@ for (const trackId of TRACK_IDS) {
   assert.match(safety?.title || '', /SAFETY$/);
 }
 
+assert.equal(byId('countryside-safety')?.description, 'Finish Countryside without going off-road in under 15 seconds.');
+assert.equal(byId('airport-safety')?.description, 'Finish Airport without going off-road in under 20 seconds.');
+assert.equal(byId('cliffside-safety')?.description, 'Finish Cliffside without going off-road in under 20 seconds.');
+assert.equal(byId('harbor-safety')?.description, 'Finish Harbor without going off-road in under 30 seconds.');
+assert.equal(byId('midnight-city-safety')?.description, 'Finish Midnight City without going off-road in under 70 seconds.');
+assert.equal(byId('mountain-safety')?.description, 'Finish Mountain without going off-road in under 40 seconds.');
+
 assert.equal(byId('an-army-of-me')?.title, 'AN ARMY OF ME');
 assert.equal(byId('an-army-of-me')?.trophies, 200);
 assert.match(byId('an-army-of-me')?.description || '', /four saved rivals on every track/i);
 assert.equal(byId('on-course-of-course')?.title, 'ON COURSE, OF COURSE');
 assert.equal(byId('on-course-of-course')?.trophies, 100);
 assert.match(byId('on-course-of-course')?.description || '', /without going off-road/i);
-assert.match(byId('on-course-of-course')?.recommendation || '', /Countryside, Airport and Cliffside < 0:30/);
-assert.match(byId('on-course-of-course')?.recommendation || '', /Harbor < 1:00/);
-assert.match(byId('on-course-of-course')?.recommendation || '', /Mountain < 1:50/);
-assert.match(byId('on-course-of-course')?.recommendation || '', /Midnight City < 2:00/);
+assert.match(byId('on-course-of-course')?.recommendation || '', /Countryside < 15 seconds/);
+assert.match(byId('on-course-of-course')?.recommendation || '', /Airport < 20 seconds/);
+assert.match(byId('on-course-of-course')?.recommendation || '', /Cliffside < 20 seconds/);
+assert.match(byId('on-course-of-course')?.recommendation || '', /Harbor < 30 seconds/);
+assert.match(byId('on-course-of-course')?.recommendation || '', /Midnight City < 70 seconds/);
+assert.match(byId('on-course-of-course')?.recommendation || '', /Mountain < 40 seconds/);
 
 for (const id of ['find-lilya', 'find-darvid', 'save-bella', 'satans-sedan']) {
   const achievement = byId(id);
@@ -200,12 +209,12 @@ assert.equal(completedAllTimeTrials((id) => id !== 'mountain-sprint'), false,
 assert.equal(completedAllTimeTrials((id) => id !== 'harbor-sprint', 'harbor-sprint'), true);
 
 assert.deepEqual(CLEAN_LAP_TARGETS, {
-  countryside: 30,
-  airport: 30,
-  cliffside: 30,
-  harbor: 60,
-  'midnight-city': 120,
-  mountain: 110
+  countryside: 15,
+  airport: 20,
+  cliffside: 20,
+  harbor: 30,
+  'midnight-city': 70,
+  mountain: 40
 });
 assert.equal(qualifiesForArmyLap({ rivalCountAtStart: 4 }, { position: 1, total: 5 }), true);
 assert.equal(qualifiesForArmyLap({ rivalCountAtStart: 3 }, { position: 1, total: 4 }), false);
@@ -216,16 +225,16 @@ assert.equal(qualifiesForCatchGas({ running: true, caught: true, overcharge: 0, 
 assert.equal(qualifiesForCatchGas({ running: true, caught: false, overcharge: 0.5, visible: true }), false);
 assert.equal(qualifiesForCleanLap(
   { trackId: 'countryside', onCourseThroughout: true },
-  { time: 29.999 }
+  { time: 14.999 }
 ), true);
 assert.equal(qualifiesForCleanLap(
   { trackId: 'countryside', onCourseThroughout: true },
-  { time: 30 }
+  { time: 15 }
 ), false, 'Matching a clean-lap target exactly must not count');
 assert.equal(qualifiesForCleanLap(
   { trackId: 'mountain', onCourseThroughout: true },
-  { time: 109.999 }
-), true, 'A clean Mountain lap below its 1:50 target should count');
+  { time: 39.999 }
+), true, 'A clean Mountain lap below its 40-second target should count');
 assert.equal(qualifiesForCleanLap(
   { trackId: 'harbor', onCourseThroughout: false },
   { time: 20 }
@@ -375,6 +384,8 @@ assert.match(productionCatalogSource, /title: 'GOT STARTED'/);
 assert.match(productionCatalogSource, /title: 'CATCH THE CHARGE'/);
 assert.match(productionCatalogSource, /TRACK_WINNER_ACHIEVEMENTS/);
 assert.match(productionCatalogSource, /TRACK_SAFETY_ACHIEVEMENTS/);
+assert.match(productionCatalogSource, /countryside: '15 seconds'/);
+assert.match(productionCatalogSource, /'midnight-city': '70 seconds'/);
 assert.match(legacyCatalogSource, /catalog-production\.js\?revision=r222-awd-label/,
   'The old Chromatic catalog URL must converge on the same production source of truth');
 
@@ -411,7 +422,7 @@ assert.match(challengeSource, /CATCH_GAS_MIN_OVERCHARGE = 0\.001/);
 assert.doesNotMatch(challengeSource, /CATCH_GAS_REQUIRED_MS|catchGasMs|3000/,
   'CATCH THE CHARGE must not retain a hidden timed-hold requirement');
 assert.match(challengeSource, /GOT_STARTED_ID = 'got-started'/);
-assert.match(challengeSource, /mountain: 110/);
+assert.match(challengeSource, /mountain: 40/);
 assert.match(challengeSource, /rivalCountAtStart/);
 assert.match(challengeSource, /runtime\.state\.offRoad === true/);
 assert.match(challengeSource, /achievements\.unlock\(\s*CATCH_THE_CHARGE_ID/,

--- a/turn-lab/tests/chromatic-camouflage-production.mjs
+++ b/turn-lab/tests/chromatic-camouflage-production.mjs
@@ -147,7 +147,7 @@ assert.ok(challengeUnlocks.some(({ id }) => id === 'got-started'),
   'Existing players with every Getting Started achievement should receive GOT STARTED automatically');
 challengeUnlocks.length = 0;
 challengeApi.beginLap();
-challengeApi.completeLap({ position: 1, total: 5, time: 20 });
+challengeApi.completeLap({ position: 1, total: 5, time: 14 });
 assert.deepEqual(
   challengeUnlocks.map(({ id }) => id),
   ['countryside-winner', 'countryside-safety'],

--- a/turn/achievements/catalog-production.js
+++ b/turn/achievements/catalog-production.js
@@ -45,12 +45,12 @@ export const ONBOARDING_ACHIEVEMENT_IDS = Object.freeze([
 ]);
 
 const SAFETY_TARGET_LABELS = Object.freeze({
-  countryside: '0:30',
-  airport: '0:30',
-  cliffside: '0:30',
-  harbor: '1:00',
-  'midnight-city': '2:00',
-  mountain: '1:50'
+  countryside: '15 seconds',
+  airport: '20 seconds',
+  cliffside: '20 seconds',
+  harbor: '30 seconds',
+  'midnight-city': '70 seconds',
+  mountain: '40 seconds'
 });
 
 export const TRACK_WINNER_ACHIEVEMENTS = Object.freeze(
@@ -76,6 +76,12 @@ export const TRACK_SAFETY_ACHIEVEMENTS = Object.freeze(
 );
 
 const rebalancedBaseAchievements = base.ACHIEVEMENTS.map((achievement) => {
+  if (achievement.id === 'on-course-of-course') {
+    return Object.freeze({
+      ...achievement,
+      recommendation: 'Targets: Countryside < 15 seconds · Airport < 20 seconds · Cliffside < 20 seconds · Harbor < 30 seconds · Midnight City < 70 seconds · Mountain < 40 seconds'
+    });
+  }
   if (achievement.category !== base.CATEGORY.TIME_TRIALS) return achievement;
   return Object.freeze({
     ...achievement,

--- a/turn/achievements/challenge-expansion-r166.js
+++ b/turn/achievements/challenge-expansion-r166.js
@@ -5,12 +5,12 @@ import {
 
 export const CHALLENGE_PROGRESS_STORAGE_KEY = 'turn-achievement-challenges-v1';
 export const CLEAN_LAP_TARGETS = Object.freeze({
-  countryside: 30,
-  airport: 30,
-  cliffside: 30,
-  harbor: 60,
-  'midnight-city': 120,
-  mountain: 110
+  countryside: 15,
+  airport: 20,
+  cliffside: 20,
+  harbor: 30,
+  'midnight-city': 70,
+  mountain: 40
 });
 export const CATCH_GAS_MIN_OVERCHARGE = 0.001;
 


### PR DESCRIPTION
Tightens the per-track SAFETY clean-lap requirements after DRIFT LOCK made staying on course easier.

New strict targets:
- Countryside < 15 seconds
- Airport < 20 seconds
- Cliffside < 20 seconds
- Harbor < 30 seconds
- Midnight City < 70 seconds
- Mountain < 40 seconds

Also changes SAFETY requirement copy to seconds-only wording and updates the ON COURSE, OF COURSE target summary plus regression coverage. Actual clean-lap trigger thresholds are updated to match the copy.