### PR TITLE
Smooth MOUNTAIN start/finish seam

### DIFF
--- a/turn-lab/tests/mountain-long-lab.mjs
+++ b/turn-lab/tests/mountain-long-lab.mjs
@@ -92,13 +92,25 @@ assert.ok(ratio >= 2.0 && ratio <= 2.25,
   `Promoted MOUNTAIN should remain ~2.1x the retired short course, got ${ratio.toFixed(3)}x`);
 
 const productionMountain = PRODUCTION_TRACK_DEFINITIONS.find((track) => track.id === 'mountain');
-assert.equal(productionMountain?.storageRevision, 'mountain-r2-long');
+assert.equal(productionMountain?.storageRevision, 'mountain-r3-start-seam');
 assert.equal(productionMountain?.sampleCount, 2160);
 assert.equal(productionMountain?.freeRoamDistance, 18.2);
 assert.equal(productionMountain?.collisionProfile?.colliders?.length, 0);
 assert.equal(productionMountain?.collisionProfile?.bridgeGuide?.sampleCount, 2160);
-assert.match(labDefinitions, /storageRevision: 'mountain-lab-long-r1'/,
-  'LAB may keep its isolated rival namespace even though geometry is now production');
+assert.deepEqual(
+  productionMountain?.collisionProfile?.bridgeGuide?.positiveNormalRange,
+  { startIndex: 1005, endIndex: 1095, featherSamples: 4 }
+);
+assert.deepEqual(
+  productionMountain?.collisionProfile?.bridgeGuide?.negativeNormalRange,
+  { startIndex: 994, endIndex: 1095, featherSamples: 4 }
+);
+assert.match(labDefinitions, /storageRevision: 'mountain-lab-long-r2'/,
+  'LAB keeps an isolated fresh rival namespace for the smoothed shared geometry');
+assert.match(labDefinitions, /startIndex: 1005[\s\S]*endIndex: 1095/,
+  'LAB positive-side guide must follow the same re-sampled physical rail span');
+assert.match(labDefinitions, /startIndex: 994[\s\S]*endIndex: 1095/,
+  'LAB negative-side guide must follow the same re-sampled physical rail span');
 
 // The tested MOUNTAIN content promoted to production must remain byte-identical to
 // the LAB source where possible, preventing accidental divergence during promotion.

--- a/turn-lab/tests/multi-track-production.mjs
+++ b/turn-lab/tests/multi-track-production.mjs
@@ -41,14 +41,14 @@ assert.deepEqual(
     { id: 'cliffside', difficulty: 'MEDIUM', storageRevision: 'cliffside-r68', freeRoamDistance: 22.2 },
     { id: 'harbor', difficulty: 'HARD', storageRevision: 'harbor-r80', freeRoamDistance: 170 },
     { id: 'midnight-city', difficulty: 'HARD', storageRevision: 'midnight-city-r2', freeRoamDistance: 34 },
-    { id: 'mountain', difficulty: 'HARD', storageRevision: 'mountain-r2-long', freeRoamDistance: 18.2 }
+    { id: 'mountain', difficulty: 'HARD', storageRevision: 'mountain-r3-start-seam', freeRoamDistance: 18.2 }
   ],
   'Every playable track must own identity, difficulty, record namespace and containment in one source of truth'
 );
 assert.deepEqual(TRACK_PLACEHOLDERS, [], 'Track 6 must be a real playable MOUNTAIN track rather than the old TBA teaser');
 assert.equal(getTrackStorageRevision('midnight-city'), 'midnight-city-r2');
 assert.equal(getTrackFreeRoamDistance('midnight-city'), 34);
-assert.equal(getTrackStorageRevision('mountain'), 'mountain-r2-long');
+assert.equal(getTrackStorageRevision('mountain'), 'mountain-r3-start-seam');
 assert.equal(getTrackFreeRoamDistance('mountain'), 18.2);
 assert.equal(getTrackStorageRevision('future-track'), 'future-track');
 assert.equal(getTrackFreeRoamDistance('future-track'), 170);
@@ -127,7 +127,7 @@ try {
     { trackId: 'airport', time: 22.42, key: 'turn-personal-rivals-v1:airport-r50' },
     { trackId: 'harbor', time: 38.61, key: 'turn-personal-rivals-v1:harbor-r80' },
     { trackId: 'midnight-city', time: 104.82, key: 'turn-personal-rivals-v1:midnight-city-r2' },
-    { trackId: 'mountain', time: 98.14, key: 'turn-personal-rivals-v1:mountain-r2-long' }
+    { trackId: 'mountain', time: 98.14, key: 'turn-personal-rivals-v1:mountain-r3-start-seam' }
   ];
   for (const entry of states) {
     const state = { trackId: entry.trackId, competitorLaps: [{ time: entry.time, carId: 'hatchback-sports', frames: Array.from({ length: 25 }, (_, index) => ({ t: index / 10, p: index / 24 })) }] };
@@ -138,7 +138,9 @@ try {
   clearRivalsState({ trackId: 'midnight-city', competitorLaps: [] });
   assert.equal(storage.has('turn-personal-rivals-v1:midnight-city-r2'), false);
   assert.equal(storage.has('turn-personal-rivals-v1:harbor-r80'), true);
-  assert.equal(storage.has('turn-personal-rivals-v1:mountain-r2-long'), true);
+  assert.equal(storage.has('turn-personal-rivals-v1:mountain-r3-start-seam'), true);
+  assert.equal(storage.has('turn-personal-rivals-v1:mountain-r2-long'), false,
+    'The smoothed MOUNTAIN must never reinterpret or overwrite pre-seam long-course rivals');
   assert.equal(storage.has('turn-personal-rivals-v1:mountain-r1'), false,
     'The promoted MOUNTAIN must never migrate or overwrite the old short-course namespace');
   assert.equal(storage.has('turn-personal-rivals-v1'), true);
@@ -190,7 +192,7 @@ const [
 assert.match(definitionsBase, /id: 'midnight-city'[\s\S]*difficulty: 'HARD'/);
 assert.match(definitionsBase, /storageRevision: 'midnight-city-r2'/);
 assert.match(definitionsBase, /id: 'mountain'[\s\S]*difficulty: 'HARD'/);
-assert.match(definitions, /storageRevision: 'mountain-r2-long'/);
+assert.match(definitions, /storageRevision: 'mountain-r3-start-seam'/);
 assert.match(definitions, /sampleCount: 2160/);
 assert.doesNotMatch(definitionsBase, /id: 'track-6-tba'/);
 assert.match(catalog, /MIDNIGHT_CITY_CONTROL_POINTS\.map/);

--- a/turn-lab/tracks/definitions.js
+++ b/turn-lab/tracks/definitions.js
@@ -24,17 +24,16 @@ const bridgeGuide = Object.freeze({
   minimumInwardSpeed: 2.4,
   offRoadDrag: 0.34,
   sampleCount: 2160,
-  // These indices are the tested nearest samples for the actual instanced rail
-  // endpoints on the 2,160-sample long route. +normal is the omitted left/north
-  // entry rail, hence its later start. Feathering stays inside each visible span.
+  // The start/finish smoothing shortens the full closed route slightly. These
+  // are the re-sampled indices of the same physical instanced rail endpoints.
   positiveNormalRange: Object.freeze({
-    startIndex: 1003,
-    endIndex: 1093,
+    startIndex: 1005,
+    endIndex: 1095,
     featherSamples: 4
   }),
   negativeNormalRange: Object.freeze({
-    startIndex: 992,
-    endIndex: 1093,
+    startIndex: 994,
+    endIndex: 1095,
     featherSamples: 4
   })
 });
@@ -44,7 +43,7 @@ export const TRACK_DEFINITIONS = Object.freeze(production.TRACK_DEFINITIONS.map(
   return Object.freeze({
     ...track,
     description: 'Summit climb. Waterfall descent. Lake bridge. Valley lights.',
-    storageRevision: 'mountain-lab-long-r1',
+    storageRevision: 'mountain-lab-long-r2',
     sampleCount: 2160,
     // TURN's sampled envelope remains the general no-drop/anti-shortcut guard.
     // The bridge adds one O(1), route-normal slippery guide aligned with the

--- a/turn-lab/tracks/mountain-layout.js
+++ b/turn-lab/tracks/mountain-layout.js
@@ -81,7 +81,9 @@ export const MOUNTAIN_CONTROL_POINTS = Object.freeze([
 
   // Forest return and final climb. This parallel leg stays roughly 80 metres
   // from the southern run, then makes one deliberate climbing hairpin before
-  // reconnecting with the original village start.
+  // reconnecting with the original village start. The final landing is kept
+  // shallow and tangent-aligned so the start/finish seam does not introduce a
+  // small S-wiggle or abrupt pitch change under the player car.
   Object.freeze([-240, 3.0, -255]),
   Object.freeze([-190, 2.7, -282]),
   Object.freeze([-120, 2.4, -286]),
@@ -90,9 +92,9 @@ export const MOUNTAIN_CONTROL_POINTS = Object.freeze([
   Object.freeze([95, 1.6, -282]),
   Object.freeze([125, 2.4, -262]),
   Object.freeze([125, 4.0, -240]),
-  Object.freeze([100, 6.0, -218]),
-  Object.freeze([65, 4.2, -207]),
-  Object.freeze([30, 1.7, -214])
+  Object.freeze([105, 3.2, -226]),
+  Object.freeze([72, 1.8, -225]),
+  Object.freeze([38, 0.6, -227])
 ]);
 
 export const MOUNTAIN_BRIDGE_CENTERS = Object.freeze([

--- a/turn-tests/mountain-track-production.mjs
+++ b/turn-tests/mountain-track-production.mjs
@@ -93,6 +93,20 @@ assert.ok(closedLength(MOUNTAIN_CONTROL_POINTS) > 3000,
   'Promoted MOUNTAIN must retain the substantially longer route');
 assert.equal(findProperIntersections(MOUNTAIN_CONTROL_POINTS).length, 0);
 assert.ok(maximumTurn(MOUNTAIN_CONTROL_POINTS) < 100);
+
+const startSeam = [
+  ...MOUNTAIN_CONTROL_POINTS.slice(-3),
+  ...MOUNTAIN_CONTROL_POINTS.slice(0, 2)
+];
+assert.ok(maximumOpenTurn(startSeam) < 16,
+  `MOUNTAIN start/finish must not reintroduce a steering S-kink: ${maximumOpenTurn(startSeam).toFixed(2)}°`);
+const startLanding = [
+  ...MOUNTAIN_CONTROL_POINTS.slice(-4),
+  ...MOUNTAIN_CONTROL_POINTS.slice(0, 2)
+];
+assert.ok(maximumGrade(startLanding) < 0.05,
+  `MOUNTAIN final landing must stay below a 5% control-point grade: ${(maximumGrade(startLanding) * 100).toFixed(2)}%`);
+
 assert.equal(MOUNTAIN_BRIDGE_CENTERS.length, 6);
 assert.equal(MOUNTAIN_TUNNEL_SPECS.length, 1);
 
@@ -178,11 +192,34 @@ function maximumTurn(points) {
     const previous = points[(index - 1 + points.length) % points.length];
     const current = points[index];
     const next = points[(index + 1) % points.length];
-    const incoming = [current[0] - previous[0], current[2] - previous[2]];
-    const outgoing = [next[0] - current[0], next[2] - current[2]];
-    const denominator = Math.max(1e-9, Math.hypot(...incoming) * Math.hypot(...outgoing));
-    const cosine = (incoming[0] * outgoing[0] + incoming[1] * outgoing[1]) / denominator;
-    maximum = Math.max(maximum, Math.acos(Math.max(-1, Math.min(1, cosine))) * 180 / Math.PI);
+    maximum = Math.max(maximum, turnDegrees(previous, current, next));
+  }
+  return maximum;
+}
+
+function maximumOpenTurn(points) {
+  let maximum = 0;
+  for (let index = 1; index < points.length - 1; index += 1) {
+    maximum = Math.max(maximum, turnDegrees(points[index - 1], points[index], points[index + 1]));
+  }
+  return maximum;
+}
+
+function turnDegrees(previous, current, next) {
+  const incoming = [current[0] - previous[0], current[2] - previous[2]];
+  const outgoing = [next[0] - current[0], next[2] - current[2]];
+  const denominator = Math.max(1e-9, Math.hypot(...incoming) * Math.hypot(...outgoing));
+  const cosine = (incoming[0] * outgoing[0] + incoming[1] * outgoing[1]) / denominator;
+  return Math.acos(Math.max(-1, Math.min(1, cosine))) * 180 / Math.PI;
+}
+
+function maximumGrade(points) {
+  let maximum = 0;
+  for (let index = 1; index < points.length; index += 1) {
+    const previous = points[index - 1];
+    const current = points[index];
+    const horizontal = Math.max(1e-9, Math.hypot(current[0] - previous[0], current[2] - previous[2]));
+    maximum = Math.max(maximum, Math.abs(current[1] - previous[1]) / horizontal);
   }
   return maximum;
 }

--- a/turn-tests/mountain-track-production.mjs
+++ b/turn-tests/mountain-track-production.mjs
@@ -60,7 +60,7 @@ assert.ok(mountain, 'MOUNTAIN must remain a production track');
 assert.equal(mountain.name, 'Mountain');
 assert.equal(mountain.eyebrow, 'TRACK 6');
 assert.equal(mountain.difficulty, 'HARD');
-assert.equal(mountain.storageRevision, 'mountain-r2-long');
+assert.equal(mountain.storageRevision, 'mountain-r3-start-seam');
 assert.equal(mountain.sampleCount, 2160);
 assert.equal(mountain.freeRoamDistance, 18.2);
 assert.equal(mountain.collisionProfile.shoulderStartDistance, 15.0);
@@ -69,6 +69,16 @@ assert.equal(mountain.collisionProfile.colliders.length, 0,
   'The promoted bridge must not reintroduce padded box colliders');
 assert.ok(Object.isFrozen(mountain.collisionProfile.bridgeGuide));
 assert.equal(mountain.collisionProfile.bridgeGuide.offRoadDrag, 0.34);
+assert.deepEqual(
+  mountain.collisionProfile.bridgeGuide.positiveNormalRange,
+  { startIndex: 1005, endIndex: 1095, featherSamples: 4 },
+  'Smoothed route must keep the positive-side bridge guide aligned to the same visible rails'
+);
+assert.deepEqual(
+  mountain.collisionProfile.bridgeGuide.negativeNormalRange,
+  { startIndex: 994, endIndex: 1095, featherSamples: 4 },
+  'Smoothed route must keep the negative-side bridge guide aligned to the same visible rails'
+);
 assert.deepEqual(TRACK_PLACEHOLDERS, []);
 
 for (const baseTrack of BASE_TRACK_DEFINITIONS) {
@@ -124,7 +134,7 @@ assert.ok(MOUNTAIN_LONG_CHECKPOINTS.every((value, index, values) => (
 )), 'Long MOUNTAIN checkpoints must be ordered around the full lap');
 
 assert.match(definitions, /definitions-base\.js/);
-assert.match(definitions, /storageRevision: 'mountain-r2-long'/);
+assert.match(definitions, /storageRevision: 'mountain-r3-start-seam'/);
 assert.match(definitions, /sampleCount: 2160/);
 assert.match(definitionsBase, /storageRevision: 'mountain-r1'/,
   'The retired short-course definition remains intact only as the rollback/base contract');

--- a/turn/tracks/definitions.js
+++ b/turn/tracks/definitions.js
@@ -21,14 +21,17 @@ const bridgeGuide = Object.freeze({
   minimumInwardSpeed: 2.4,
   offRoadDrag: 0.34,
   sampleCount: 2160,
+  // The smoothed start/finish approach shortens the closed curve slightly, so
+  // the same physical rail endpoints land two samples later after arc-length
+  // resampling. Keep the slippery guide aligned with the visible bridge rails.
   positiveNormalRange: Object.freeze({
-    startIndex: 1003,
-    endIndex: 1093,
+    startIndex: 1005,
+    endIndex: 1095,
     featherSamples: 4
   }),
   negativeNormalRange: Object.freeze({
-    startIndex: 992,
-    endIndex: 1093,
+    startIndex: 994,
+    endIndex: 1095,
     featherSamples: 4
   })
 });
@@ -38,9 +41,9 @@ export const TRACK_DEFINITIONS = Object.freeze(base.TRACK_DEFINITIONS.map((track
   return Object.freeze({
     ...track,
     description: 'Summit climb. Waterfall descent. Lake bridge. Valley lights.',
-    // Deliberately start a fresh MOUNTAIN rival/PB namespace. The old short-course
-    // records remain stored but are never interpreted against the new geometry.
-    storageRevision: 'mountain-r2-long',
+    // The smoothed start/finish approach changes absolute replay coordinates.
+    // Deliberately start fresh rather than reinterpret r2 ghosts/PBs on r3 geometry.
+    storageRevision: 'mountain-r3-start-seam',
     sampleCount: 2160,
     freeRoamDistance: 18.2,
     collisionProfile: Object.freeze({

--- a/turn/tracks/mountain-layout.js
+++ b/turn/tracks/mountain-layout.js
@@ -81,7 +81,9 @@ export const MOUNTAIN_CONTROL_POINTS = Object.freeze([
 
   // Forest return and final climb. This parallel leg stays roughly 80 metres
   // from the southern run, then makes one deliberate climbing hairpin before
-  // reconnecting with the original village start.
+  // reconnecting with the original village start. The final landing is kept
+  // shallow and tangent-aligned so the start/finish seam does not introduce a
+  // small S-wiggle or abrupt pitch change under the player car.
   Object.freeze([-240, 3.0, -255]),
   Object.freeze([-190, 2.7, -282]),
   Object.freeze([-120, 2.4, -286]),
@@ -90,9 +92,9 @@ export const MOUNTAIN_CONTROL_POINTS = Object.freeze([
   Object.freeze([95, 1.6, -282]),
   Object.freeze([125, 2.4, -262]),
   Object.freeze([125, 4.0, -240]),
-  Object.freeze([100, 6.0, -218]),
-  Object.freeze([65, 4.2, -207]),
-  Object.freeze([30, 1.7, -214])
+  Object.freeze([105, 3.2, -226]),
+  Object.freeze([72, 1.8, -225]),
+  Object.freeze([38, 0.6, -227])
 ]);
 
 export const MOUNTAIN_BRIDGE_CENTERS = Object.freeze([


### PR DESCRIPTION
## Bug
Video playtest after the long-MOUNTAIN rebuild showed the player car visually settling/tilting and the start area feeling wobbly, as if the road surface were jagged.

## Root cause
The rebuilt final return landed into the unchanged village start with a small plan-view S change and a sharper-than-necessary elevation descent. Because TURN samples elevation/track pitch from the nearest route sample, that short transition is especially visible under the car at the start/finish line.

## Fix
- keep the MOUNTAIN start/finish point itself unchanged
- smooth only the final three approach control points
- align the last approach closely with the outgoing start tangent
- ease the final descent into the village start
- mirror the same route in TURN LAB to preserve production/LAB parity
- add a regression requiring the start seam to stay below 16° local turn and the final landing below 5% control-point grade
- use a fresh `mountain-r3-start-seam` rival/PB namespace rather than reinterpret existing long-course ghosts on the adjusted geometry
- re-align the slippery bridge guide to the same physical rail endpoints after the closed route is re-sampled (`+normal 1005..1095`, `-normal 994..1095`)

No changes to tunnel, checkpoints, pace notes, achievement targets, general collision behavior, or other tracks. MOUNTAIN-specific rivals/PBs intentionally start fresh again for safety.