### PR TITLE
Tighten Sprint targets and repair modal headings

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -87,7 +87,8 @@
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=mountain-long-prod-r1",
         "/turn/achievements/catalog.js?revision=r222-awd-label": "/turn/achievements/catalog.js?revision=mountain-long-prod-r1",
         "/turn/achievements/catalog-production.js?revision=r222-awd-label": "/turn/achievements/catalog-production.js?revision=mountain-long-prod-r1",
-        "/turn/achievements/time-trials.js?revision=r166-bella-records": "/turn/achievements/time-trials.js?revision=mountain-long-prod-r1",
+        "/turn/achievements/time-trials.js?revision=r166-bella-records": "/turn/achievements/time-trials.js?revision=r224-sprint-targets",
+        "/turn/achievements/view.js?revision=r166-bella-records": "/turn/achievements/view.js?revision=r224-modal-headings",
         "/turn/achievements/challenge-expansion-r166.js?revision=r166-bella-records": "/turn/achievements/challenge-expansion-r166.js?revision=mountain-long-prod-r1",
         "./achievements/runtime.js?revision=r164-long-session-robustness": "./achievements/runtime.js?revision=r195-unranked-super-sedan&build=20260901-r190",
         "/turn/achievements/trophy-road-showcase.js?revision=r160-reward-detail-sync": "/turn/achievements/trophy-road-showcase.js?revision=r220-race-reward",
@@ -192,10 +193,10 @@
   </div>
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button" aria-label="Restart the current lap from the start line">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
-  <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260901-r190-r534-heading-first-about"></script>
+  <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260901-r190-r534-heading-first-about-r224-modal-headings"></script>
   <script src="./ui/startup-screen-reader-handoff-r529.js?build=20260901-r190&revision=r531-screen-reader-followup"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
-  <script type="module" src="./app.js?build=20260901-r190-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r420-music-warm-r426-loading-copy-r164-long-session-robustness-post-soak-r199-card-gap-rim-r518-landmark-framing-ground-layering-showroom-r200-pwa-color-r206-r532-countryside-nature-r221-trajectory-wheel-steering-30-r220-race-apex-guide"></script>
+  <script type="module" src="./app.js?build=20260901-r190-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r420-music-warm-r426-loading-copy-r164-long-session-robustness-post-soak-r199-card-gap-rim-r518-landmark-framing-ground-layering-showroom-r200-pwa-color-r206-r532-countryside-nature-r221-trajectory-wheel-steering-30-r220-race-apex-guide-r224-modal-headings"></script>
   <script type="module" src="./render/skid-continuity-r198.js?revision=r198-skid-continuity"></script>
   <script type="module" src="./tracks/cliffside-inner-buildings-r202.js?revision=r202-kenney-suburban-village"></script>
   <script type="module" src="./tracks/cliffside-house-inset-r203.js?revision=r203-inset-edge-houses"></script>

--- a/turn-lab/tests/achievements-production.mjs
+++ b/turn-lab/tests/achievements-production.mjs
@@ -50,7 +50,9 @@ const [
   sedanSource,
   fixedLayout,
   app,
-  workflow
+  workflow,
+  productionEntry,
+  labEntry
 ] = await Promise.all([
   fs.readFile(new URL('../../turn/achievements/catalog.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/achievements/catalog-base.js', import.meta.url), 'utf8'),
@@ -72,7 +74,9 @@ const [
   fs.readFile(new URL('../../turn/vehicle/sports-sedan-easter-egg.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/m8-home-fixed-layout.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/app.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../.github/workflows/turn-lab-tests.yml', import.meta.url), 'utf8')
+  fs.readFile(new URL('../../.github/workflows/turn-lab-tests.yml', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../index.html', import.meta.url), 'utf8')
 ]);
 
 assert.equal(ACHIEVEMENT_STORAGE_KEY, 'turn-achievements-v1');
@@ -190,10 +194,12 @@ assert.deepEqual(
     ['airport', 15],
     ['cliffside', 14],
     ['harbor', 22],
-    ['midnight-city', 52],
-    ['mountain', 48]
+    ['midnight-city', 50],
+    ['mountain', 47]
   ]
 );
+assert.equal(byId('midnight-sprint')?.description, 'Finish Midnight City in under 50 seconds.');
+assert.equal(byId('mountain-sprint')?.description, 'Finish Mountain in under 47 seconds.');
 for (const trial of TIME_TRIALS) {
   assert.equal(qualifyingTimeTrial(trial.trackId, trial.targetSeconds - 0.001)?.id, trial.id);
   assert.equal(qualifyingTimeTrial(trial.trackId, trial.targetSeconds), null,
@@ -418,9 +424,15 @@ assert.match(timeTrialSource, /targetSeconds: 11/);
 assert.match(timeTrialSource, /targetSeconds: 15/);
 assert.match(timeTrialSource, /targetSeconds: 14/);
 assert.match(timeTrialSource, /targetSeconds: 22/);
-assert.match(timeTrialSource, /targetSeconds: 52/);
-assert.match(timeTrialSource, /targetSeconds: 48/);
+assert.match(timeTrialSource, /targetSeconds: 50/);
+assert.match(timeTrialSource, /targetSeconds: 47/);
 assert.match(timeTrialSource, /seconds >= trial\.targetSeconds/);
+for (const entry of [productionEntry, labEntry]) {
+  assert.match(entry, /"\/turn\/achievements\/time-trials\.js\?revision=r166-bella-records": "\/turn\/achievements\/time-trials\.js\?revision=r224-sprint-targets"/,
+    'Production and Lab must route cached achievement imports to the new Sprint targets');
+  assert.match(entry, /"\/turn\/achievements\/view\.js\?revision=r166-bella-records": "\/turn\/achievements\/view\.js\?revision=r224-modal-headings"/,
+    'Production and Lab must route cached achievement views to the corrected modal header');
+}
 
 assert.match(challengeSource, /SAMPLE_INTERVAL_MS = 50/);
 assert.match(challengeSource, /CATCH_GAS_MIN_OVERCHARGE = 0\.001/);

--- a/turn-tests/about-history-production.mjs
+++ b/turn-tests/about-history-production.mjs
@@ -31,7 +31,7 @@ const [
 
 const release = JSON.parse(releaseSource);
 
-assert.match(productionEntry, new RegExp(`about-history-bootstrap-r165\\.js\\?build=${escapeRegex(release.cacheKey)}-r534-heading-first-about`),
+assert.match(productionEntry, new RegExp(`about-history-bootstrap-r165\\.js\\?build=${escapeRegex(release.cacheKey)}-r534-heading-first-about-r224-modal-headings`),
   'The public website must load the heading-first browser-aware About implementation directly with the current release cache identity');
 assert.ok(
   productionEntry.indexOf('about-history-bootstrap-r165.js') < productionEntry.indexOf('./app.js?build='),

--- a/turn-tests/home-feedback-production.mjs
+++ b/turn-tests/home-feedback-production.mjs
@@ -1,13 +1,18 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [app, feedback, css] = await Promise.all([
+const [app, feedback, css, homeCss, achievementsCss, achievementsView, aboutHistory] = await Promise.all([
   fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/ui/home-feedback.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/home-feedback-r135.css', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/home-feedback-r135.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/m8-home.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/achievements.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/achievements/view.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/ui/about-history-bootstrap-r165.js', import.meta.url), 'utf8')
 ]);
 
-assert.match(app, /home-feedback-r135\.css\?revision=r137-feedback-above-fold/);
+assert.match(app, /m8-home\.css\?revision=r224-modal-headings/);
+assert.match(app, /home-feedback-r135\.css\?revision=r224-modal-headings/);
 assert.match(app, /data-turn-home-feedback/);
 assert.match(app, /home-feedback\.js\?revision=r137-feedback-above-fold/);
 assert.match(app, /installHomeFeedback\(\)/);
@@ -101,6 +106,19 @@ assert.match(css, /\.m8-feedback-status:not\(:empty\)[\s\S]*min-height: 1\.5em/,
 assert.doesNotMatch(css, /\.m8-feedback-attribution/, 'Removed feedback attribution must leave no stale layout rules');
 assert.match(css, /\.m8-feedback-email[\s\S]*background: var\(--m8-pink\)/);
 assert.match(css, /\.m8-feedback-copy[\s\S]*background: var\(--m8-yellow\)/);
+assert.doesNotMatch(css, /\.m8-dialog-head > div > span/,
+  'The shared modal heading fix belongs in the base Home dialog stylesheet');
+assert.match(homeCss, /\.m8-dialog-head > div\s*\{[\s\S]*display: grid[\s\S]*row-gap: 4px/,
+  'Modal eyebrow, title and optional metadata need independent grid rows');
+assert.match(homeCss, /\.m8-dialog-head > div > span\s*\{[\s\S]*min-height: 1\.7em[\s\S]*padding-block: 0\.24em 0\.34em[\s\S]*line-height: 1\.4/,
+  'Modal eyebrows need enough paint-box space for iOS Safari font metrics');
+assert.match(homeCss, /\.m8-dialog-head h2\s*\{[\s\S]*margin: 0[\s\S]*line-height: 1/,
+  'Modal titles must not overlap the eyebrow row');
+assert.match(achievementsCss, /\.turn-achievements-head\s*\{[\s\S]*border-bottom: var\(--turn-border-default, 4px\) solid var\(--turn-action-success, #8ce99a\)[\s\S]*background: transparent/,
+  'Achievements should use a restrained success accent instead of a solid green title block');
+assert.match(achievementsView, /achievements\.css\?build=\$\{buildKey\}-r224-modal-headings/);
+assert.match(aboutHistory, /m8-home\.css\?revision=r224-modal-headings/,
+  'Install-gate About and History must load the corrected shared heading geometry');
 assert.match(css, /@media \(max-width: 760px\) and \(orientation: portrait\)[\s\S]*grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/, 'Four Home menu actions should remain a readable two-by-two grid in portrait');
 assert.match(css, /@media \(max-width: 760px\) and \(orientation: portrait\)[\s\S]*\.m8-home-fixed-layout \.m8-home-meta[\s\S]*display: none/, 'Header metadata must stay out of the compact portrait layout');
 assert.doesNotMatch(`${feedback}\n${css}`, /setInterval|@keyframes|animation:/, 'Feedback and About must add no loop or decorative animation');

--- a/turn-tests/home-navigation-production.mjs
+++ b/turn-tests/home-navigation-production.mjs
@@ -36,7 +36,10 @@ const [
 assert.match(productionApp, /installM8HomeNavigation/);
 assert.match(productionApp, /m8-home\.js\?revision=r131-motion-permission-retry/);
 assert.match(productionApp, /installM8HomeFixedLayout/);
-assert.match(productionApp, /installStylesheet\('\.\/m8-home\.css'/);
+assert.match(
+  productionApp,
+  /installStylesheet\(\s*'\.\/m8-home\.css\?revision=r224-modal-headings',\s*'data-turn-m8-home-styles'\s*\)/
+);
 assert.match(productionApp, /m8-home-fixed-layout\.js\?revision=m8\.9-track-title-alignment/);
 assert.ok(productionApp.indexOf('installM8HomeNavigation()') < productionApp.indexOf('installM8HomeFixedLayout()'));
 assert.match(productionApp, /turnHomeLifecycle = 'home-m8'/);

--- a/turn/achievements.css
+++ b/turn/achievements.css
@@ -88,7 +88,9 @@
 }
 
 .turn-achievements-head {
-  background: var(--turn-action-success, #8ce99a);
+  padding-bottom: clamp(12px, 2vh, 18px);
+  border-bottom: var(--turn-border-default, 4px) solid var(--turn-action-success, #8ce99a);
+  background: transparent;
 }
 
 .turn-achievements-content {

--- a/turn/achievements/time-trials.js
+++ b/turn/achievements/time-trials.js
@@ -30,16 +30,16 @@ export const TIME_TRIALS = Object.freeze([
   Object.freeze({
     id: 'midnight-sprint',
     trackId: 'midnight-city',
-    targetSeconds: 52,
+    targetSeconds: 50,
     title: 'MIDNIGHT SPRINT',
-    description: 'Finish Midnight City in under 52 seconds.'
+    description: 'Finish Midnight City in under 50 seconds.'
   }),
   Object.freeze({
     id: 'mountain-sprint',
     trackId: 'mountain',
-    targetSeconds: 48,
+    targetSeconds: 47,
     title: 'MOUNTAIN SPRINT',
-    description: 'Finish Mountain in under 48 seconds.'
+    description: 'Finish Mountain in under 47 seconds.'
   })
 ]);
 

--- a/turn/achievements/view.js
+++ b/turn/achievements/view.js
@@ -112,7 +112,7 @@ function installStylesheet() {
   const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
   const stylesheet = document.createElement('link');
   stylesheet.rel = 'stylesheet';
-  stylesheet.href = `/turn/achievements.css?build=${buildKey}-r166-bella-records`;
+  stylesheet.href = `/turn/achievements.css?build=${buildKey}-r224-modal-headings`;
   stylesheet.setAttribute('data-turn-achievements', '');
   document.head.appendChild(stylesheet);
 }

--- a/turn/app.js
+++ b/turn/app.js
@@ -340,7 +340,10 @@ const { installScreenBlanking } = await import(
   withBuild('./ui/screen-blanking.js?revision=r143-temporary-dbe-position')
 );
 installScreenBlanking(globalThis.__turnRuntime);
-installStylesheet('./m8-home.css', 'data-turn-m8-home-styles');
+installStylesheet(
+  './m8-home.css?revision=r224-modal-headings',
+  'data-turn-m8-home-styles'
+);
 installStylesheet(
   './m8-midnight-city-postcard-r130.css?revision=r130-neon-skyline',
   'data-turn-midnight-city-postcard'
@@ -380,7 +383,7 @@ const { installM8HomeFixedLayout } = await import(
 );
 await installM8HomeFixedLayout();
 installStylesheet(
-  './home-feedback-r135.css?revision=r137-feedback-above-fold',
+  './home-feedback-r135.css?revision=r224-modal-headings',
   'data-turn-home-feedback'
 );
 const { installHomeFeedback } = await import(

--- a/turn/design-dialogs.html
+++ b/turn/design-dialogs.html
@@ -8,7 +8,7 @@
   <title>TURN Design System — Dialogs</title>
   <link rel="stylesheet" href="./design-tokens.css?revision=r141-form-disclosure">
   <link rel="stylesheet" href="./design-semantic.css?revision=r141-form-disclosure">
-  <link rel="stylesheet" href="./m8-home.css?revision=r163-dialog-reference">
+  <link rel="stylesheet" href="./m8-home.css?revision=r224-modal-headings">
   <link rel="stylesheet" href="./dialog-system-r163.css?revision=r163-modal-pattern">
   <link rel="stylesheet" href="./design-navigation.css?revision=r164-design-navigation">
   <style>

--- a/turn/home-feedback-r135.css
+++ b/turn/home-feedback-r135.css
@@ -1,15 +1,5 @@
 @import url('./design-semantic.css?revision=r140-difficulty-system');
 
-/* Keep the small modal kicker fully inside its own line box. iOS Safari can
-   clip the lower half of these heavy, letter-spaced labels at the compact
-   UI baseline unless the inline span gets explicit block geometry. */
-.m8-dialog-head > div > span {
-  display: block;
-  line-height: 1.35;
-  padding-block: 0.14em;
-  overflow: visible;
-}
-
 .m8-home-fixed-layout .m8-feedback-button {
   align-self: auto;
   display: block;

--- a/turn/index.html
+++ b/turn/index.html
@@ -98,7 +98,8 @@
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=mountain-long-prod-r1",
         "/turn/achievements/catalog.js?revision=r222-awd-label": "/turn/achievements/catalog.js?revision=mountain-long-prod-r1",
         "/turn/achievements/catalog-production.js?revision=r222-awd-label": "/turn/achievements/catalog-production.js?revision=mountain-long-prod-r1",
-        "/turn/achievements/time-trials.js?revision=r166-bella-records": "/turn/achievements/time-trials.js?revision=mountain-long-prod-r1",
+        "/turn/achievements/time-trials.js?revision=r166-bella-records": "/turn/achievements/time-trials.js?revision=r224-sprint-targets",
+        "/turn/achievements/view.js?revision=r166-bella-records": "/turn/achievements/view.js?revision=r224-modal-headings",
         "/turn/achievements/challenge-expansion-r166.js?revision=r166-bella-records": "/turn/achievements/challenge-expansion-r166.js?revision=mountain-long-prod-r1",
         "./achievements/runtime.js?revision=r164-long-session-robustness": "./achievements/runtime.js?revision=r195-unranked-super-sedan&build=20260901-r190",
         "/turn/achievements/trophy-road-showcase.js?revision=r160-reward-detail-sync": "/turn/achievements/trophy-road-showcase.js?revision=r220-race-reward",
@@ -189,10 +190,10 @@
   </div>
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button" aria-label="Restart the current lap from the start line">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
-  <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260901-r190-r534-heading-first-about"></script>
+  <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260901-r190-r534-heading-first-about-r224-modal-headings"></script>
   <script src="./ui/startup-screen-reader-handoff-r529.js?build=20260901-r190&revision=r531-screen-reader-followup"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r176-admin-rewards"></script>
-  <script type="module" src="./app.js?build=20260901-r190-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r420-music-warm-r426-loading-copy-r164-long-session-robustness-post-soak-r199-card-gap-rim-r518-landmark-framing-ground-layering-showroom-r200-pwa-color-r206-r532-countryside-nature-r221-trajectory-wheel-steering-30-r220-race-apex-guide"></script>
+  <script type="module" src="./app.js?build=20260901-r190-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r420-music-warm-r426-loading-copy-r164-long-session-robustness-post-soak-r199-card-gap-rim-r518-landmark-framing-ground-layering-showroom-r200-pwa-color-r206-r532-countryside-nature-r221-trajectory-wheel-steering-30-r220-race-apex-guide-r224-modal-headings"></script>
   <script type="module" src="./render/skid-continuity-r198.js?revision=r198-skid-continuity"></script>
   <script type="module" src="./tracks/cliffside-inner-buildings-r202.js?revision=r202-kenney-suburban-village"></script>
   <script type="module" src="./tracks/cliffside-house-inset-r203.js?revision=r203-inset-edge-houses"></script>

--- a/turn/m8-home.css
+++ b/turn/m8-home.css
@@ -315,16 +315,31 @@
   margin-bottom: 22px;
 }
 
-.m8-dialog-head span {
+.m8-dialog-head > div {
+  display: grid;
+  align-content: start;
+  min-width: 0;
+  row-gap: 4px;
+}
+
+/* Give iOS Safari a generous, independent paint box for the small kicker.
+   Keeping it in its own grid row also prevents the title from painting over
+   the lower half of the glyphs. */
+.m8-dialog-head > div > span {
+  display: block;
+  min-height: 1.7em;
+  padding-block: 0.24em 0.34em;
+  overflow: visible;
   font-size: 0.78rem;
   font-weight: 900;
+  line-height: 1.4;
   letter-spacing: 0.16em;
 }
 
 .m8-dialog-head h2 {
-  margin: 2px 0 0;
+  margin: 0;
   font-size: clamp(2rem, 5vw, 4rem);
-  line-height: 0.9;
+  line-height: 1;
   letter-spacing: -0.05em;
 }
 

--- a/turn/ui/about-history-bootstrap-r165.js
+++ b/turn/ui/about-history-bootstrap-r165.js
@@ -365,7 +365,7 @@ function waitForAbout() {
 }
 
 export async function installAboutHistory() {
-  installStylesheet('../m8-home.css?revision=r165-browser-about', 'data-turn-home-dialog-foundation');
+  installStylesheet('../m8-home.css?revision=r224-modal-headings', 'data-turn-home-dialog-foundation');
   installStylesheet('../dialog-system-r163.css?revision=r165-browser-about', 'data-turn-dialog-system');
   installStylesheet('../about-history-r163.css?revision=r165-browser-about', 'data-turn-about-history');
   installStylesheet('../browser-install-r165.css?revision=r165-browser-about', 'data-turn-browser-install');


### PR DESCRIPTION
## Summary

- set MIDNIGHT SPRINT to a strict `< 50 seconds` requirement
- set MOUNTAIN SPRINT to a strict `< 47 seconds` requirement
- give modal eyebrow text its own generously sized grid row so iOS Safari no longer clips the lower half
- keep titles and optional History build metadata in separate rows
- replace the solid green ACHIEVEMENTS header block with a restrained green divider
- refresh Production and TURN LAB cache routes for the changed achievement data, view, CSS and dialog bootstrap

## Validation

- achievement catalog and strict-boundary regression
- Home / Feedback / About modal regression
- About History and dialog-system regression
- startup and unread-achievement regression
- design-system regression
- How to Play and Drive By Ear 101 regressions
- TURN NEXT entry/parity checks
- syntax and release source-of-truth checks
- headless 1024×768 dialog render confirmed a 4px gap between the complete eyebrow paint box and title