### PR TITLE
TURN: add ScoreFeedback and begin DRIFT ATTACK (#737–#738)

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -193,6 +193,9 @@ jobs:
       - name: Run lap result toast regression
         run: node turn-lab/tests/lap-result-toast-production.mjs
 
+      - name: Run shared ScoreFeedback regression
+        run: node turn-tests/score-feedback-production.mjs
+
       - name: Run achievement system regression
         run: node turn-lab/tests/achievements-production.mjs
 

--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -196,6 +196,15 @@ jobs:
       - name: Run shared ScoreFeedback regression
         run: node turn-tests/score-feedback-production.mjs
 
+      - name: Run DRIFT ATTACK core regression
+        run: node turn-tests/drift-attack-core-production.mjs
+
+      - name: Run DRIFT ATTACK runtime regression
+        run: node turn-tests/drift-attack-runtime-production.mjs
+
+      - name: Run DRIFT ATTACK integration regression
+        run: node turn-tests/drift-attack-integration-production.mjs
+
       - name: Run achievement system regression
         run: node turn-lab/tests/achievements-production.mjs
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,6 +35,7 @@ export default [
       'turn/render/covered-rendering.js',
       'turn/scoring/*.js',
       'turn/training/*.js',
+      'turn/ui/drift-attack-setting.js',
       'turn/ui/steering-limit-warning.js',
       'turn/ui/track-select.js',
       'turn/vehicle/catalog.js',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,6 +33,7 @@ export default [
       'turn/race/track-spatial-index.js',
       'turn/render/camera.js',
       'turn/render/covered-rendering.js',
+      'turn/scoring/*.js',
       'turn/training/*.js',
       'turn/ui/steering-limit-warning.js',
       'turn/ui/track-select.js',

--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -41,6 +41,7 @@
   <link rel="stylesheet" href="./manual-steering.css?build=20260903-r198">
   <link rel="stylesheet" href="./orientation-guard.css?build=20260903-r198-home-portrait">
   <link rel="stylesheet" href="./lap-result-toast.css?build=20260903-r198">
+  <link rel="stylesheet" href="./scoring/score-feedback.css?build=20260903-r198">
   <link rel="stylesheet" href="./rival-onboarding.css?build=20260903-r198">
   <link rel="stylesheet" href="./track-select.css?build=20260903-r198">
   <link rel="stylesheet" href="./track-select-r54.css?build=20260903-r198">
@@ -189,6 +190,19 @@
   <div class="hud" id="hud" hidden>
     <div class="topbar"><div class="stats"><div class="chip">speed<strong><span id="speed">0</span> km/h</strong></div><div class="chip">lap<strong id="lap">1</strong></div><div class="chip">time<strong id="lapTime">0:00.000</strong></div><div class="chip">best<strong id="bestTime">--:--.---</strong></div></div><div class="map-wrap"><canvas id="map" width="300" height="210" aria-label="Track map"></canvas></div></div>
     <div class="message" id="message" role="status"></div>
+    <aside class="score-feedback" id="scoreFeedback" aria-label="Driving score" hidden>
+      <section class="score-feedback-state" data-score-feedback-state>
+        <div class="score-feedback-heading"><span data-score-feedback-label>DRIFT</span><span>CURRENT</span></div>
+        <div class="score-feedback-values"><strong data-score-feedback-current>0</strong><b data-score-feedback-multiplier>×1</b></div>
+        <div class="score-feedback-meter" aria-hidden="true"><i data-score-feedback-meter-fill></i></div>
+        <div class="score-feedback-lap"><span>LAP</span><b data-score-feedback-total>0</b></div>
+      </section>
+      <section class="score-feedback-callout" data-score-feedback-callout aria-hidden="true" hidden>
+        <strong data-score-feedback-callout-label></strong>
+        <b data-score-feedback-callout-score hidden></b>
+      </section>
+      <p class="turn-sr-only" data-score-feedback-announcer role="status" aria-live="polite" aria-atomic="true"></p>
+    </aside>
     <div class="tilt-drive" aria-hidden="true"><span><b>brake</b><b>gas</b></span><div class="tilt-track"><i class="tilt-needle" id="tiltNeedle"></i></div><small class="tilt-value" id="tiltValue">neutral</small></div>
   </div>
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -19,6 +19,14 @@ assert.equal(
   lapResultAnnouncement({ position: 1, time: 75.346 }),
   'Lap. Position: first. Time: one minute, fifteen point three four six seconds.'
 );
+assert.equal(
+  lapResultAnnouncement({
+    position: 1,
+    time: 75.346,
+    drift: { available: true, score: 8420, bestScore: 8420, newBest: true }
+  }),
+  'Lap. Position: first. Time: one minute, fifteen point three four six seconds. Drift score: 8420 points. New best.'
+);
 
 function makeFrames(count = 25) {
   return Array.from({ length: count }, (_, index) => ({
@@ -183,6 +191,32 @@ try {
     ranked: false,
     onCourseThroughout: true
   }, 'The player may still see the completed lap result while consumers know it is unranked');
+
+  const scoredState = makeState();
+  let scoreContext = null;
+  const scoredResult = completeLapState({
+    state: scoredState,
+    samples,
+    now: 13500,
+    competitorLimit: 4,
+    saveGhost() {},
+    finalizeScores(context) {
+      scoreContext = context;
+      return {
+        drift: { available: true, score: 8420, bestScore: 8420, newBest: true }
+      };
+    }
+  });
+  assert.deepEqual(scoreContext, {
+    finishedTime: 13.5,
+    completedLap: true,
+    validLap: true,
+    rankedLap: true,
+    onCourseThroughout: true
+  }, 'Scoring engines receive the frozen lap validity and ranking context once');
+  assert.equal(scoredResult.drift.score, 8420);
+  assert.equal(publishedResults.at(-1)?.detail.drift.newBest, true,
+    'The composed lap-result event carries DRIFT without creating a competing finish event');
 } finally {
   if (originalCustomEvent === undefined) delete globalThis.CustomEvent;
   else globalThis.CustomEvent = originalCustomEvent;
@@ -226,6 +260,7 @@ assert.ok(
 assert.equal(imports['./race/game-state.js'], `./race/game-state.js?build=${release.cacheKey}`, 'The current release must publish reset-safe invalid-lap state');
 assert.equal(imports['./ui/race-announcements.js'], `./ui/race-announcements.js?build=${release.cacheKey}`, 'Shared spoken race formatting must follow the release cache key');
 assert.match(app, /installLapResultToast\(\)/, 'The lap result toast must install before the game runtime starts');
+assert.match(app, /installDriftAttackSetting\(\)/, 'The live DRIFT HUD setting must install after Home exists');
 assert.match(app, /installRivalOnboarding\(\)/, 'The rival onboarding plate must install before the game runtime starts');
 assert.match(lapSystem, /turn:lap-result/, 'Completed lap finish must publish one frozen result event');
 assert.match(lapSystem, /turn:lap-invalid/, 'Incomplete checkpoint chains must publish explicit invalid-lap feedback');
@@ -262,6 +297,8 @@ assert.doesNotMatch(toast, /MISSED CHECKPOINT/, 'Technical checkpoint language m
 assert.match(toast, /turn:lap-invalid/, 'The unified toast must listen for invalid-lap events');
 assert.match(toast, /lap-result-position/, 'The toast must show frozen finishing position');
 assert.match(toast, /lap-result-time/, 'The toast must show the completed lap time');
+assert.match(toast, /lap-result-drift-score/, 'The single finish toast must include the DRIFT result');
+assert.match(toast, /NEW BEST/, 'A new per-track DRIFT best must be explicit in the finish toast');
 assert.match(toast, /toast\.setAttribute\('aria-label', 'Lap result'\)/, 'The visible result must remain inspectable without becoming another live region');
 assert.doesNotMatch(toast, /toast\.setAttribute\('role', 'status'\)/, 'The visible toast must not duplicate the dedicated announcer');
 assert.doesNotMatch(toast, /toast\.setAttribute\('aria-live'/, 'The visible toast must not announce each child mutation');
@@ -289,6 +326,7 @@ assert.match(toastCss, /background: var\(--yellow\)/, 'Valid lap results must ke
 assert.match(toastCss, /\.lap-result-toast\.is-invalid \{\s*background: #ff6b6b;/s, 'STAY ON THE TRACK must use the same red void-lap colour as the TIME card');
 assert.match(toastCss, /left: 50%/, 'The lap toast must occupy the central finish-message position');
 assert.match(toastCss, /top: 22%/, 'The lap toast must sit where the old TOP X LAP message appeared');
+assert.match(toastCss, /\.lap-result-drift/, 'The DRIFT result must reuse the existing finish surface');
 assert.doesNotMatch(toastCss, /left: max\(112px/, 'The retired lower-left toast placement must stay removed');
 assert.match(toastCss, /prefers-reduced-motion: reduce/, 'Toast animation must respect reduced-motion preferences');
 assert.match(onboardingCss, /\.rival-onboarding-model/, 'The onboarding must reserve an adjacent host for the ghost model');

--- a/turn-lab/tests/vehicle-drift-production.mjs
+++ b/turn-lab/tests/vehicle-drift-production.mjs
@@ -119,9 +119,13 @@ assert.match(physicsSource, /driftHeld \? driftDragAdd : 0/,
   'DRIFT must affect drag while drifting');
 assert.match(physicsSource, /baseSpeedLimit \* effectiveDriftSpeedMultiplier/,
   'DRIFT must affect the active speed ceiling');
-assert.match(physicsSource, /driftSlipAngle = Math\.abs\(Math\.atan2\(/,
+assert.match(physicsSource, /signedDriftSlipAngle = Math\.atan2\(/,
   'The DRIFT ceiling must respond to real velocity slip instead of only button state');
-assert.doesNotMatch(physicsSource, /driftSlipAngle = Math\.atan2\([\s\S]{0,140}Math\.abs\(state\.velocity\.dot\(currentForward\)\)/,
+assert.match(physicsSource, /state\.driftSlipAngle = signedDriftSlipAngle/,
+  'Automatic drift scoring must receive the signed physical slip direction');
+assert.match(physicsSource, /driftSlipAngle = Math\.abs\(signedDriftSlipAngle\)/,
+  'The existing speed ceiling must continue using slip magnitude');
+assert.doesNotMatch(physicsSource, /signedDriftSlipAngle = Math\.atan2\([\s\S]{0,140}Math\.abs\(state\.velocity\.dot\(currentForward\)\)/,
   'The DRIFT ceiling must not fold reverse-heading spins back into a mild forward slip');
 assert.match(physicsSource, /driftSlipAngle,[\s\S]*driftLockAmount/,
   'The live speed-limit call must pass both slip angle and LOCK state');

--- a/turn-next/index.html
+++ b/turn-next/index.html
@@ -54,6 +54,7 @@
   <link rel="stylesheet" href="./manual-steering.css?build=20260903-r198">
   <link rel="stylesheet" href="./orientation-guard.css?build=20260903-r198-home-portrait">
   <link rel="stylesheet" href="./lap-result-toast.css?build=20260903-r198">
+  <link rel="stylesheet" href="./scoring/score-feedback.css?build=20260903-r198">
   <link rel="stylesheet" href="./rival-onboarding.css?build=20260903-r198">
   <link rel="stylesheet" href="./track-select.css?build=20260903-r198">
   <link rel="stylesheet" href="./track-select-r54.css?build=20260903-r198">
@@ -154,7 +155,24 @@
   <div id="game" aria-label="Third-person motion-controlled arcade racing game"></div>
   <section class="panel" id="intro" hidden aria-hidden="true"><button id="motionButton" type="button" hidden></button><button id="manualButton" type="button" hidden></button><p id="status" role="status" hidden></p></section>
   <section class="rotate-panel" aria-label="Rotate your device to landscape"><div class="rotate-card"><div class="rotate-phone" aria-hidden="true"></div><strong>ROTATE YOUR DEVICE TO LANDSCAPE</strong></div></section>
-  <div class="hud" id="hud" hidden><div class="topbar"><div class="stats"><div class="chip">speed<strong><span id="speed">0</span> km/h</strong></div><div class="chip">lap<strong id="lap">1</strong></div><div class="chip">time<strong id="lapTime">0:00.000</strong></div><div class="chip">best<strong id="bestTime">--:--.---</strong></div></div><div class="map-wrap"><canvas id="map" width="300" height="210" aria-label="Track map"></canvas></div></div><div class="message" id="message" role="status"></div><div class="tilt-drive" aria-hidden="true"><span><b>brake</b><b>gas</b></span><div class="tilt-track"><i class="tilt-needle" id="tiltNeedle"></i></div><small class="tilt-value" id="tiltValue">neutral</small></div></div>
+  <div class="hud" id="hud" hidden>
+    <div class="topbar"><div class="stats"><div class="chip">speed<strong><span id="speed">0</span> km/h</strong></div><div class="chip">lap<strong id="lap">1</strong></div><div class="chip">time<strong id="lapTime">0:00.000</strong></div><div class="chip">best<strong id="bestTime">--:--.---</strong></div></div><div class="map-wrap"><canvas id="map" width="300" height="210" aria-label="Track map"></canvas></div></div>
+    <div class="message" id="message" role="status"></div>
+    <aside class="score-feedback" id="scoreFeedback" aria-label="Driving score" hidden>
+      <section class="score-feedback-state" data-score-feedback-state>
+        <div class="score-feedback-heading"><span data-score-feedback-label>DRIFT</span><span>CURRENT</span></div>
+        <div class="score-feedback-values"><strong data-score-feedback-current>0</strong><b data-score-feedback-multiplier>×1</b></div>
+        <div class="score-feedback-meter" aria-hidden="true"><i data-score-feedback-meter-fill></i></div>
+        <div class="score-feedback-lap"><span>LAP</span><b data-score-feedback-total>0</b></div>
+      </section>
+      <section class="score-feedback-callout" data-score-feedback-callout aria-hidden="true" hidden>
+        <strong data-score-feedback-callout-label></strong>
+        <b data-score-feedback-callout-score hidden></b>
+      </section>
+      <p class="turn-sr-only" data-score-feedback-announcer role="status" aria-live="polite" aria-atomic="true"></p>
+    </aside>
+    <div class="tilt-drive" aria-hidden="true"><span><b>brake</b><b>gas</b></span><div class="tilt-track"><i class="tilt-needle" id="tiltNeedle"></i></div><small class="tilt-value" id="tiltValue">neutral</small></div>
+  </div>
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>
   <div class="controls" id="controls" hidden><div class="utility-group"><button class="utility" id="calibrateButton" type="button">Recalibrate</button><button class="utility" id="resetButton" type="button">Restart Lap</button></div><div class="pedals"><button class="pedal brake" id="brakeButton" type="button">Brake</button><button class="pedal gas" id="gasButton" type="button">Gas</button></div></div>
   <script type="module" src="/turn-next/app.js?source=20260903-r198-browser-consent-r166-bella-records-r221-trajectory-wheel-steering-30-r220-race-apex-guide"></script>

--- a/turn-next/main.js
+++ b/turn-next/main.js
@@ -27,12 +27,19 @@ import {
   resolveFrontWheelSteeringAngle
 } from '/turn/vehicle/front-wheel-steering.js?revision=r221-trajectory-wheel-steering-30';
 import { installPerformanceMonitor, recordPerformanceFrame } from '/turn/performance-monitor.js?build=20260720-r19';
-import { isVehiclePerkUnlocked } from '/turn/progression/trophy-road.js?revision=r230-vehicle-perks';
+import {
+  isFeatureUnlocked,
+  isVehiclePerkUnlocked
+} from '/turn/progression/trophy-road.js?revision=r230-vehicle-perks';
 import {
   resetVehiclePerkRuntimeState,
   resolveGraduatedStageFeedback
 } from '/turn/vehicle/perk-runtime.js?revision=r233-graduated';
 import { createScoreFeedback } from '/turn/scoring/score-feedback.js';
+import {
+  DRIFT_ATTACK_FEATURE_ID,
+  createDriftAttackRuntime
+} from '/turn/scoring/drift-attack-runtime.js';
 
 const intro = document.querySelector('#intro');
 const hud = document.querySelector('#hud');
@@ -95,7 +102,9 @@ const state = {
   velocity: new THREE.Vector3(),
   heading: 0,
   driftAmount: 0,
+  driftSlipAngle: 0,
   driftLockAmount: 0,
+  collided: false,
   offRoad: false,
   courseSafetyOffRoad: false,
   lapCourseViolation: false,
@@ -137,6 +146,13 @@ const scoreFeedback = createScoreFeedback({
     }));
   }
 });
+const driftAttack = createDriftAttackRuntime({
+  state,
+  scoreFeedback,
+  eventTarget: window,
+  isUnlocked: () => isFeatureUnlocked(DRIFT_ATTACK_FEATURE_ID)
+});
+globalThis.__turnDriftAttack = driftAttack;
 
 function publishUiState(reason) {
   window.dispatchEvent(new CustomEvent('turn:ui-state-change', {
@@ -974,6 +990,7 @@ function updateMotionInput(dt) {
 
 function beginTimedLap(now) {
   beginTimedLapState({ state, samples, now, showMessage });
+  driftAttack.beginLap(now);
   publishUiState('lap-started');
 }
 
@@ -1002,6 +1019,8 @@ function updatePhysics(dt, now) {
   );
   if (graduatedFeedback) showMessage(graduatedFeedback, 1800);
 
+  driftAttack.advance(dt, now);
+
   updateLapProgressState({
     state,
     nearestAfter,
@@ -1026,6 +1045,22 @@ function completeLap(now) {
     competitorLimit: RIVAL_LIMIT,
     saveGhost,
     showMessage,
+    finalizeScores({ finishedTime, validLap, rankedLap }) {
+      return {
+        drift: driftAttack.completeLap({
+          now,
+          time: finishedTime,
+          valid: validLap,
+          ranked: rankedLap,
+          trackId: state.trackId,
+          carId: state.vehicleId
+        })
+      };
+    },
+    onScoreError(error) {
+      console.error('TURN: DRIFT ATTACK could not finalize this lap.', error);
+      globalThis.__turnLastDriftScoreError = error;
+    },
     onError(error) {
       console.error('TURN: completed lap could not be added to rivals, continuing race.', error);
       globalThis.__turnLastLapError = error;
@@ -1433,7 +1468,8 @@ const turnRuntime = {
   runSceneOverride(dt) {
     return turnSceneOverride ? turnSceneOverride(dt) === true : false;
   },
-  scoreFeedback
+  scoreFeedback,
+  driftAttack
 };
 globalThis.__turnRuntime = turnRuntime;
 function syncSelectedVehiclePerkEntitlement() {

--- a/turn-next/main.js
+++ b/turn-next/main.js
@@ -32,6 +32,7 @@ import {
   resetVehiclePerkRuntimeState,
   resolveGraduatedStageFeedback
 } from '/turn/vehicle/perk-runtime.js?revision=r233-graduated';
+import { createScoreFeedback } from '/turn/scoring/score-feedback.js';
 
 const intro = document.querySelector('#intro');
 const hud = document.querySelector('#hud');
@@ -54,6 +55,7 @@ const mapCtx = mapCanvas.getContext('2d');
 const tiltNeedle = document.querySelector('#tiltNeedle');
 const tiltValue = document.querySelector('#tiltValue');
 const installGate = document.querySelector('#installGate');
+const scoreFeedbackRoot = document.querySelector('#scoreFeedback');
 
 const TAU = Math.PI * 2;
 const TRACK_WIDTH = 27;
@@ -126,6 +128,15 @@ globalThis.__turnVehicleTuning = state.vehicleTuning;
 resetVehiclePerkRuntimeState(state);
 
 installGameModeState(state);
+
+const scoreFeedback = createScoreFeedback({
+  root: scoreFeedbackRoot,
+  onSound(type, channel, detail) {
+    window.dispatchEvent(new CustomEvent('turn:score-feedback-sound', {
+      detail: { type, channel, cue: detail?.sound || type }
+    }));
+  }
+});
 
 function publishUiState(reason) {
   window.dispatchEvent(new CustomEvent('turn:ui-state-change', {
@@ -1328,7 +1339,7 @@ function updateRacePosition() {
   globalThis.__turnSetRacePosition?.(rivalsAhead + 1, total);
 }
 
-function updateHud() {
+function updateHud(now = performance.now()) {
   updateHudState({
     state,
     speedEl,
@@ -1345,6 +1356,7 @@ function updateHud() {
     findNearestTrack,
     setRacePosition: globalThis.__turnSetRacePosition
   });
+  scoreFeedback.commit(now);
 }
 
 function showMessage(text, duration = 1600) {
@@ -1420,7 +1432,8 @@ const turnRuntime = {
   },
   runSceneOverride(dt) {
     return turnSceneOverride ? turnSceneOverride(dt) === true : false;
-  }
+  },
+  scoreFeedback
 };
 globalThis.__turnRuntime = turnRuntime;
 function syncSelectedVehiclePerkEntitlement() {
@@ -1477,7 +1490,7 @@ renderer.setAnimationLoop((now) => {
 
     updateScene(frameDt);
     if (now >= nextHudUpdateAt) {
-      updateHud();
+      updateHud(now);
       nextHudUpdateAt = now + HUD_UPDATE_INTERVAL_MS;
     }
   } else {

--- a/turn-tests/drift-attack-core-production.mjs
+++ b/turn-tests/drift-attack-core-production.mjs
@@ -1,0 +1,178 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+import {
+  DRIFT_ATTACK_MAX_SLIP,
+  DRIFT_ATTACK_MIN_SLIP,
+  DRIFT_ATTACK_SAMPLE_HZ,
+  createDriftAttackScorer,
+  driftAngleQuality
+} from '../turn/scoring/drift-attack.js';
+import {
+  DRIFT_RECORDS_STORAGE_KEY,
+  getBestDriftRecord,
+  saveBestDriftRecord
+} from '../turn/scoring/drift-records.js';
+import { SCORE_FEEDBACK_EVENT } from '../turn/scoring/score-feedback.js';
+
+class MemoryStorage {
+  constructor() {
+    this.values = new Map();
+  }
+
+  getItem(key) {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key, value) {
+    this.values.set(key, String(value));
+  }
+}
+
+function radians(degrees) {
+  return degrees * Math.PI / 180;
+}
+
+function runFor(scorer, seconds, dt, {
+  speed = 24,
+  slip = radians(58),
+  offRoad = false,
+  collided = false,
+  startAt = 0
+} = {}) {
+  let now = startAt;
+  const steps = Math.ceil(seconds / dt);
+  for (let index = 0; index < steps; index += 1) {
+    now += dt * 1000;
+    scorer.advance(dt, now, speed, slip, offRoad, collided && index === 0, true);
+  }
+  return now;
+}
+
+assert.equal(DRIFT_ATTACK_SAMPLE_HZ, 12);
+assert.equal(driftAngleQuality(DRIFT_ATTACK_MIN_SLIP - 0.001), 0);
+assert.equal(driftAngleQuality(radians(55)), 1);
+assert.ok(driftAngleQuality(radians(90)) > 0.8);
+assert.equal(driftAngleQuality(DRIFT_ATTACK_MAX_SLIP), 0);
+
+const events = [];
+const scorer = createDriftAttackScorer({
+  onEvent: (type, detail) => events.push({ type, detail })
+});
+scorer.beginLap(0);
+let now = runFor(scorer, 2, 1 / 60);
+assert.ok(scorer.inspect().unbanked > 0, 'Qualifying speed and slip build unbanked score');
+assert.ok(scorer.inspect().sampleCount >= 23 && scorer.inspect().sampleCount <= 25,
+  'The scorer samples near 12 Hz even when the physics loop runs at 60 Hz');
+assert.equal(events[0].type, SCORE_FEEDBACK_EVENT.BUILD);
+
+now = runFor(scorer, 0.45, 1 / 60, { speed: 24, slip: radians(4), startAt: now });
+const firstBank = events.find((event) => event.type === SCORE_FEEDBACK_EVENT.BANK);
+assert.ok(firstBank?.detail.score > 0);
+assert.equal(scorer.inspect().lapScore, firstBank.detail.score);
+assert.equal(scorer.inspect().unbanked, 0);
+
+now = runFor(scorer, 0.55, 1 / 60, { speed: 24, slip: radians(-62), startAt: now });
+assert.equal(scorer.inspect().multiplier, 2, 'An opposite linked drift increases the multiplier');
+assert.ok(events.some((event) =>
+  event.type === SCORE_FEEDBACK_EVENT.MILESTONE && event.detail.multiplier === 2
+));
+const bankedBeforeLoss = scorer.inspect().lapScore;
+now = runFor(scorer, 0.1, 1 / 60, {
+  speed: 24,
+  slip: radians(-62),
+  collided: true,
+  startAt: now
+});
+assert.ok(events.some((event) => event.type === SCORE_FEEDBACK_EVENT.LOSS));
+assert.equal(scorer.inspect().lapScore, bankedBeforeLoss,
+  'A failed drift loses only unbanked score');
+
+const lapResult = scorer.completeLap(now);
+assert.equal(lapResult.score, bankedBeforeLoss);
+assert.equal(lapResult.bankCount, 1);
+assert.equal(scorer.inspect().lapScore, 0, 'Completing a lap starts a fresh DRIFT tally');
+
+const hysteresisScorer = createDriftAttackScorer();
+hysteresisScorer.beginLap(0);
+let hysteresisNow = runFor(hysteresisScorer, 1, 1 / 60);
+const scoreBeforeGreyBand = hysteresisScorer.inspect().unbanked;
+hysteresisNow = runFor(hysteresisScorer, 0.5, 1 / 60, {
+  slip: radians(14),
+  startAt: hysteresisNow
+});
+assert.equal(hysteresisScorer.inspect().drifting, true,
+  'The 10–18 degree hysteresis band must not flicker a live drift into a bank');
+assert.equal(hysteresisScorer.inspect().unbanked, scoreBeforeGreyBand,
+  'The hysteresis band preserves, but does not add to, unbanked score');
+runFor(hysteresisScorer, 0.4, 1 / 60, {
+  slip: radians(4),
+  startAt: hysteresisNow
+});
+assert.equal(hysteresisScorer.inspect().drifting, false,
+  'A genuinely settled car banks after the release delay');
+assert.ok(hysteresisScorer.inspect().lapScore > 0);
+
+function simulatedScore(dt) {
+  const candidate = createDriftAttackScorer();
+  candidate.beginLap(0);
+  let timestamp = runFor(candidate, 4, dt);
+  timestamp = runFor(candidate, 0.5, dt, { slip: radians(2), startAt: timestamp });
+  return candidate.completeLap(timestamp).score;
+}
+
+const scoreAt60Fps = simulatedScore(1 / 60);
+const scoreAt23Fps = simulatedScore(1 / 23);
+assert.ok(Math.abs(scoreAt60Fps - scoreAt23Fps) / scoreAt60Fps < 0.035,
+  `Elapsed-time scoring should remain stable as rendering slows (${scoreAt60Fps} vs ${scoreAt23Fps})`);
+
+const idleScorer = createDriftAttackScorer();
+idleScorer.beginLap(0);
+runFor(idleScorer, 30, 1 / 60, { speed: 5, slip: radians(60) });
+assert.equal(idleScorer.inspect().sampleCount, 0, 'Below qualification speed the scorer sleeps');
+
+const offRoadScorer = createDriftAttackScorer();
+offRoadScorer.beginLap(0);
+runFor(offRoadScorer, 1, 1 / 60, { speed: 26, slip: radians(60), offRoad: true });
+assert.equal(offRoadScorer.inspect().unbanked, 0,
+  'A qualifying-looking slide cannot begin scoring while off road');
+
+const storage = new MemoryStorage();
+const firstSave = saveBestDriftRecord({
+  trackId: 'mountain',
+  score: 8420,
+  carId: 'sedan-sports',
+  lapTime: 47.2,
+  hitAt: 1000
+}, storage);
+assert.equal(firstSave.isNewBest, true);
+assert.deepEqual(getBestDriftRecord('mountain', storage), {
+  score: 8420,
+  carId: 'sedan-sports',
+  hitAt: 1000,
+  lapTime: 47.2
+});
+const slowerSave = saveBestDriftRecord({
+  trackId: 'mountain',
+  score: 7910,
+  carId: 'classic',
+  lapTime: 45,
+  hitAt: 2000
+}, storage);
+assert.equal(slowerSave.saved, false);
+assert.equal(getBestDriftRecord('mountain', storage).score, 8420);
+assert.equal(JSON.parse(storage.getItem(DRIFT_RECORDS_STORAGE_KEY)).tracks.mountain.score, 8420);
+assert.deepEqual(saveBestDriftRecord({ trackId: 'harbor', score: 1200 }, null), {
+  record: null,
+  isNewBest: false,
+  saved: false
+}, 'Unavailable storage must not report a phantom persisted best');
+
+const source = await fs.readFile(new URL('../turn/scoring/drift-attack.js', import.meta.url), 'utf8');
+assert.doesNotMatch(source, /requestAnimationFrame|querySelector|createElement|localStorage/);
+assert.doesNotMatch(source, /syncFeedback\(\s*\{/,
+  'The 10–15 Hz sample path must reuse its presentation snapshot without object churn');
+assert.doesNotMatch(source, /driftHeld|boostActive|shiftActive|overcharge/i,
+  'Inputs and helper systems must not score directly');
+
+console.log('TURN DRIFT ATTACK core and per-track record regressions passed.');

--- a/turn-tests/drift-attack-integration-production.mjs
+++ b/turn-tests/drift-attack-integration-production.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const [main, app, physics, gameState, lapSystem, setting, toast, announcements] = await Promise.all([
+  fs.readFile(new URL('../turn/main.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/vehicle/physics.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/race/game-state.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/race/lap-system.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/ui/drift-attack-setting.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/ui/lap-result-toast.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/ui/race-announcements.js', import.meta.url), 'utf8')
+]);
+
+assert.match(main, /createDriftAttackRuntime\(\{[\s\S]*state,[\s\S]*scoreFeedback,[\s\S]*isFeatureUnlocked/,
+  'DRIFT ATTACK must consume central race state and Trophy Road availability');
+assert.match(main, /import \{[\s\S]*isFeatureUnlocked,[\s\S]*isVehiclePerkUnlocked[\s\S]*\} from '\/turn\/progression\/trophy-road\.js/,
+  'The runtime must import its feature gate from Trophy Road');
+assert.match(main, /driftAttack\.advance\(dt, now\)/,
+  'The scorer must sample from the existing physics loop');
+assert.match(main, /finalizeScores\([\s\S]*driftAttack\.completeLap/,
+  'Lap completion must compose the DRIFT result into the established result event');
+assert.doesNotMatch(main, /requestAnimationFrame\([^)]*drift|drift[^\n]*requestAnimationFrame/i,
+  'DRIFT ATTACK must not add a render loop');
+
+assert.match(physics, /state\.driftSlipAngle = signedDriftSlipAngle/,
+  'Vehicle physics must expose signed physical slip');
+assert.match(physics, /state\.collided = collision\.collided === true/,
+  'Vehicle physics must expose collision failure state');
+assert.match(gameState, /state\.driftSlipAngle = 0/);
+assert.match(gameState, /state\.collided = false/);
+assert.match(lapSystem, /finalizeScores/);
+assert.match(lapSystem, /\.\.\.\(scoreResults \|\| \{\}\)/,
+  'Scoring data must be merged into one lap-result contract');
+
+assert.match(app, /installDriftAttackSetting\(\)/);
+assert.match(setting, /Show DRIFT scoring/);
+assert.match(setting, /Scores, records and achievements continue when hidden\./);
+assert.doesNotMatch(setting, /scorer\.reset|runtime\.reset/,
+  'The presentation preference must never turn scoring off');
+assert.match(toast, /lap-result-drift/);
+assert.match(announcements, /Drift score:/,
+  'Lap and DRIFT results must form one assistive-technology announcement');
+
+console.log('TURN DRIFT ATTACK physics, settings and lap-result integration regressions passed.');

--- a/turn-tests/drift-attack-runtime-production.mjs
+++ b/turn-tests/drift-attack-runtime-production.mjs
@@ -1,0 +1,163 @@
+import assert from 'node:assert/strict';
+
+import {
+  DRIFT_HUD_STORAGE_KEY,
+  createDriftAttackRuntime,
+  driftHudVisible
+} from '../turn/scoring/drift-attack-runtime.js';
+
+class MemoryStorage {
+  constructor() {
+    this.values = new Map();
+  }
+
+  getItem(key) {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key, value) {
+    this.values.set(key, String(value));
+  }
+}
+
+class EventTargetStub {
+  constructor() {
+    this.listeners = new Map();
+    this.events = [];
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) || [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatchEvent(event) {
+    this.events.push(event);
+    for (const listener of this.listeners.get(event.type) || []) listener(event);
+    return true;
+  }
+}
+
+function makeFeedback() {
+  return {
+    visible: true,
+    states: [],
+    events: [],
+    cleared: [],
+    updateState(channel, state, now) {
+      this.states.push({ channel, score: state.score, unbanked: state.unbanked, now });
+    },
+    publishEvent(channel, type, detail, now) {
+      this.events.push({ channel, type, detail: { ...detail }, now });
+    },
+    setChannelVisible(_channel, visible) {
+      this.visible = visible;
+    },
+    clearChannel(channel) {
+      this.cleared.push(channel);
+    }
+  };
+}
+
+function radians(degrees) {
+  return degrees * Math.PI / 180;
+}
+
+function scoreLap(runtime, state, startAt = 0) {
+  runtime.beginLap(startAt);
+  let now = startAt;
+  state.lapActive = true;
+  state.speed = 25;
+  state.driftSlipAngle = radians(60);
+  for (let index = 0; index < 180; index += 1) {
+    now += 1000 / 60;
+    runtime.advance(1 / 60, now);
+  }
+  state.driftSlipAngle = radians(3);
+  for (let index = 0; index < 24; index += 1) {
+    now += 1000 / 60;
+    runtime.advance(1 / 60, now);
+  }
+  return { now, time: (now - startAt) / 1000 };
+}
+
+const storage = new MemoryStorage();
+const eventTarget = new EventTargetStub();
+const feedback = makeFeedback();
+const state = {
+  speed: 0,
+  driftSlipAngle: 0,
+  offRoad: false,
+  collided: false,
+  lapActive: false,
+  trackId: 'mountain',
+  vehicleId: 'sedan-sports'
+};
+
+const runtime = createDriftAttackRuntime({
+  state,
+  scoreFeedback: feedback,
+  storage,
+  eventTarget,
+  isUnlocked: () => true,
+  wallClock: () => 123456
+});
+
+assert.equal(runtime.isEnabled(), true);
+assert.equal(runtime.isHudVisible(), true);
+assert.equal(driftHudVisible(storage), true);
+assert.equal(runtime.setHudVisible(false, { now: 10 }), true);
+assert.equal(storage.getItem(DRIFT_HUD_STORAGE_KEY), 'off');
+assert.equal(feedback.visible, false);
+const hiddenStateCommits = feedback.states.length;
+const hiddenPresentationEvents = feedback.events.length;
+
+const firstLap = scoreLap(runtime, state);
+const firstResult = runtime.completeLap({
+  now: firstLap.now,
+  time: firstLap.time,
+  valid: true,
+  ranked: true
+});
+assert.ok(firstResult.score > 0, 'Scoring continues while the live HUD is hidden');
+assert.equal(firstResult.newBest, true);
+assert.equal(firstResult.bestScore, firstResult.score);
+assert.equal(runtime.getBestRecord('mountain').carId, 'sedan-sports');
+assert.equal(runtime.getBestRecord('mountain').hitAt, 123456);
+assert.equal(feedback.states.length, hiddenStateCommits,
+  'Hidden-HUD scoring must not perform numeric presentation commits');
+assert.equal(feedback.events.length, hiddenPresentationEvents,
+  'Hidden-HUD scoring must not send transient presentation events');
+assert.ok(eventTarget.events.some((event) => event.type === 'turn:drift-score-event'));
+assert.ok(eventTarget.events.some((event) => event.type === 'turn:drift-lap-result'));
+
+const secondLap = scoreLap(runtime, state, firstLap.now + 1000);
+const unrankedResult = runtime.completeLap({
+  now: secondLap.now,
+  time: secondLap.time,
+  valid: true,
+  ranked: false
+});
+assert.equal(unrankedResult.eligible, false);
+assert.equal(unrankedResult.saved, false);
+assert.equal(runtime.getBestRecord('mountain').score, firstResult.score,
+  'An unranked car cannot replace the persisted DRIFT best');
+
+let unlocked = false;
+const dormantFeedback = makeFeedback();
+const dormant = createDriftAttackRuntime({
+  state: { ...state, lapActive: true },
+  scoreFeedback: dormantFeedback,
+  storage: new MemoryStorage(),
+  eventTarget: new EventTargetStub(),
+  isUnlocked: () => unlocked
+});
+assert.equal(dormant.isEnabled(), false);
+assert.equal(dormant.advance(1, 1000), false);
+assert.equal(dormant.scorer.inspect().sampleCount, 0, 'Locked DRIFT processing remains dormant');
+unlocked = true;
+assert.equal(dormant.refreshEntitlement(2000), true);
+assert.equal(dormantFeedback.visible, true);
+
+console.log('TURN DRIFT ATTACK runtime, hidden-HUD and dormant-lock regressions passed.');

--- a/turn-tests/score-feedback-production.mjs
+++ b/turn-tests/score-feedback-production.mjs
@@ -165,18 +165,32 @@ assert.equal(element(fixture, '[data-score-feedback-callout-label]').textContent
 feedback.setChannelVisible(SCORE_FEEDBACK_CHANNEL.DRIFT, false, 3100);
 assert.equal(element(fixture, '[data-score-feedback-callout]').hidden, true);
 assert.equal(fixture.root.hidden, false, 'Hiding DRIFT presentation leaves active FLOW context visible');
+assert.equal(feedback.publishEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, SCORE_FEEDBACK_EVENT.BANK, {
+  score: 9999
+}, 3150), false, 'A hidden channel cannot take presentation priority from a visible channel');
+assert.equal(feedback.publishEvent(SCORE_FEEDBACK_CHANNEL.FLOW, SCORE_FEEDBACK_EVENT.TECHNIQUE, {
+  label: 'CLEAN LINE'
+}, 3160), true);
+assert.equal(element(fixture, '[data-score-feedback-callout-label]').textContent, 'CLEAN LINE');
 feedback.setChannelVisible(SCORE_FEEDBACK_CHANNEL.FLOW, false, 3200);
 assert.equal(fixture.root.hidden, true, 'Presentation visibility is independent per scoring channel');
+
+feedback.setChannelVisible(SCORE_FEEDBACK_CHANNEL.FLOW, true, 3300);
+feedback.updateState(SCORE_FEEDBACK_CHANNEL.FLOW, flowState, 3400);
+feedback.clearChannel(SCORE_FEEDBACK_CHANNEL.DRIFT, 3500);
+assert.equal(fixture.root.dataset.channel, 'flow', 'Clearing DRIFT must not reset FLOW');
+assert.equal(feedback.inspect().flow.score, 18420);
 
 feedback.reset(4000);
 assert.equal(fixture.root.hidden, true);
 assert.equal(feedback.inspect().drift.score, 0);
 
-const [source, css, index, nextIndex, main] = await Promise.all([
+const [source, css, index, nextIndex, labIndex, main] = await Promise.all([
   fs.readFile(new URL('../turn/scoring/score-feedback.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/scoring/score-feedback.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-next/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn-lab/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/main.js', import.meta.url), 'utf8')
 ]);
 
@@ -189,6 +203,8 @@ assert.match(css, /@media \(prefers-reduced-motion: reduce\)/);
 assert.match(index, /id="scoreFeedback"/);
 assert.match(nextIndex, /id="scoreFeedback"/,
   'TURN NEXT must provide the fixed ScoreFeedback DOM expected by the canonical runtime');
+assert.match(labIndex, /id="scoreFeedback"/,
+  'TURN LAB must provide the fixed ScoreFeedback DOM expected by the canonical runtime');
 assert.match(index, /data-score-feedback-announcer role="status" aria-live="polite"/);
 assert.doesNotMatch(index, /data-score-feedback-current[^>]*aria-live/);
 assert.match(main, /scoreFeedback\.commit\(now\)/,

--- a/turn-tests/score-feedback-production.mjs
+++ b/turn-tests/score-feedback-production.mjs
@@ -1,0 +1,197 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+import {
+  SCORE_FEEDBACK_CHANNEL,
+  SCORE_FEEDBACK_COMMIT_INTERVAL_MS,
+  SCORE_FEEDBACK_EVENT,
+  createScoreFeedback
+} from '../turn/scoring/score-feedback.js';
+
+class FakeClassList {
+  constructor() {
+    this.values = new Set();
+  }
+
+  toggle(name, force) {
+    if (force) this.values.add(name);
+    else this.values.delete(name);
+  }
+
+  remove(...names) {
+    for (const name of names) this.values.delete(name);
+  }
+
+  contains(name) {
+    return this.values.has(name);
+  }
+}
+
+class FakeStyle {
+  constructor() {
+    this.values = new Map();
+  }
+
+  setProperty(name, value) {
+    this.values.set(name, String(value));
+  }
+
+  getPropertyValue(name) {
+    return this.values.get(name) || '';
+  }
+}
+
+class FakeElement {
+  constructor() {
+    this.hidden = false;
+    this.textContent = '';
+    this.dataset = {};
+    this.style = new FakeStyle();
+    this.classList = new FakeClassList();
+  }
+}
+
+function makeFixture() {
+  const selectors = [
+    '[data-score-feedback-state]',
+    '[data-score-feedback-label]',
+    '[data-score-feedback-current]',
+    '[data-score-feedback-multiplier]',
+    '[data-score-feedback-total]',
+    '[data-score-feedback-meter-fill]',
+    '[data-score-feedback-callout]',
+    '[data-score-feedback-callout-label]',
+    '[data-score-feedback-callout-score]',
+    '[data-score-feedback-announcer]'
+  ];
+  const elements = new Map(selectors.map((selector) => [selector, new FakeElement()]));
+  const root = new FakeElement();
+  root.querySelector = (selector) => elements.get(selector) || null;
+  return { root, elements };
+}
+
+function element(fixture, selector) {
+  return fixture.elements.get(selector);
+}
+
+const fixture = makeFixture();
+const sounds = [];
+const feedback = createScoreFeedback({
+  root: fixture.root,
+  onSound: (type, channel) => sounds.push(`${channel}:${type}`)
+});
+
+assert.equal(fixture.root.hidden, true, 'An idle ScoreFeedback root stays out of the HUD');
+
+const driftState = {
+  active: true,
+  score: 4820,
+  unbanked: 1740,
+  multiplier: 3,
+  intensity: 0.72,
+  phase: 'intensify',
+  label: 'DRIFT'
+};
+feedback.updateState(SCORE_FEEDBACK_CHANNEL.DRIFT, driftState, 100);
+assert.equal(fixture.root.hidden, false);
+assert.equal(element(fixture, '[data-score-feedback-current]').textContent, '1,740');
+assert.equal(element(fixture, '[data-score-feedback-total]').textContent, '4,820');
+assert.equal(element(fixture, '[data-score-feedback-multiplier]').textContent, '×3');
+assert.equal(
+  element(fixture, '[data-score-feedback-meter-fill]').style.getPropertyValue('--score-feedback-progress'),
+  '0.72'
+);
+
+driftState.unbanked = 1820;
+feedback.updateState(SCORE_FEEDBACK_CHANNEL.DRIFT, driftState, 100 + SCORE_FEEDBACK_COMMIT_INTERVAL_MS / 2);
+assert.equal(
+  element(fixture, '[data-score-feedback-current]').textContent,
+  '1,740',
+  'Rapid score ticks are not committed at physics frequency'
+);
+feedback.commit(100 + SCORE_FEEDBACK_COMMIT_INTERVAL_MS);
+assert.equal(element(fixture, '[data-score-feedback-current]').textContent, '1,820');
+
+feedback.publishEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, SCORE_FEEDBACK_EVENT.BANK, {
+  score: 1820,
+  multiplier: 3
+}, 300);
+assert.equal(element(fixture, '[data-score-feedback-callout-label]').textContent, '✓ BANKED ×3');
+assert.equal(element(fixture, '[data-score-feedback-callout-score]').textContent, '+1,820');
+assert.equal(element(fixture, '[data-score-feedback-callout]').dataset.event, 'bank');
+assert.deepEqual(sounds, ['drift:bank']);
+
+const lowerPriorityAccepted = feedback.publishEvent(
+  SCORE_FEEDBACK_CHANNEL.FLOW,
+  SCORE_FEEDBACK_EVENT.TECHNIQUE,
+  { label: 'BOOST › DRIFT' },
+  350
+);
+assert.equal(lowerPriorityAccepted, false, 'A technique event cannot replace an active release');
+assert.equal(element(fixture, '[data-score-feedback-callout]').dataset.event, 'bank');
+
+feedback.publishEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, SCORE_FEEDBACK_EVENT.PERSONAL_BEST, {
+  score: 8420
+}, 400);
+assert.equal(element(fixture, '[data-score-feedback-callout-label]').textContent, 'NEW BEST');
+await Promise.resolve();
+assert.equal(
+  element(fixture, '[data-score-feedback-announcer]').textContent,
+  'New drift best.',
+  'Higher-priority semantic events may replace an announcement inside the rate limit'
+);
+
+const flowState = {
+  active: true,
+  score: 18420,
+  unbanked: 0,
+  multiplier: 5.1,
+  intensity: 0.84,
+  phase: 'intensify',
+  label: 'FLOW'
+};
+feedback.updateState(SCORE_FEEDBACK_CHANNEL.FLOW, flowState, 500);
+assert.equal(fixture.root.dataset.channel, 'flow', 'FLOW becomes persistent context when both channels are active');
+assert.equal(element(fixture, '[data-score-feedback-current]').textContent, '18,420');
+
+feedback.publishEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, SCORE_FEEDBACK_EVENT.BANK, {
+  label: 'DRIFT +2,840 ×4',
+  score: 2840,
+  multiplier: 4
+}, 3000);
+assert.equal(fixture.root.dataset.channel, 'flow');
+assert.equal(element(fixture, '[data-score-feedback-callout-label]').textContent, 'DRIFT +2,840 ×4');
+
+feedback.setChannelVisible(SCORE_FEEDBACK_CHANNEL.DRIFT, false, 3100);
+assert.equal(element(fixture, '[data-score-feedback-callout]').hidden, true);
+assert.equal(fixture.root.hidden, false, 'Hiding DRIFT presentation leaves active FLOW context visible');
+feedback.setChannelVisible(SCORE_FEEDBACK_CHANNEL.FLOW, false, 3200);
+assert.equal(fixture.root.hidden, true, 'Presentation visibility is independent per scoring channel');
+
+feedback.reset(4000);
+assert.equal(fixture.root.hidden, true);
+assert.equal(feedback.inspect().drift.score, 0);
+
+const [source, css, index, nextIndex, main] = await Promise.all([
+  fs.readFile(new URL('../turn/scoring/score-feedback.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/scoring/score-feedback.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn-next/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/main.js', import.meta.url), 'utf8')
+]);
+
+assert.doesNotMatch(source, /requestAnimationFrame/);
+assert.doesNotMatch(source, /createElement|appendChild|replaceChildren/,
+  'ScoreFeedback must reuse the fixed document nodes');
+assert.match(css, /transform: scaleX\(var\(--score-feedback-progress, 0\)\)/);
+assert.doesNotMatch(css, /transition:[^;]*(?:width|height|top|left)/);
+assert.match(css, /@media \(prefers-reduced-motion: reduce\)/);
+assert.match(index, /id="scoreFeedback"/);
+assert.match(nextIndex, /id="scoreFeedback"/,
+  'TURN NEXT must provide the fixed ScoreFeedback DOM expected by the canonical runtime');
+assert.match(index, /data-score-feedback-announcer role="status" aria-live="polite"/);
+assert.doesNotMatch(index, /data-score-feedback-current[^>]*aria-live/);
+assert.match(main, /scoreFeedback\.commit\(now\)/,
+  'ScoreFeedback commits through TURN\'s existing throttled HUD path');
+
+console.log('TURN shared ScoreFeedback engine regression passed.');

--- a/turn/app.js
+++ b/turn/app.js
@@ -362,6 +362,8 @@ const { installM8HomeNavigation } = await import(
 );
 const home = await installM8HomeNavigation();
 globalThis.__turnHome = home;
+const { installDriftAttackSetting } = await import(withBuild('./ui/drift-attack-setting.js'));
+installDriftAttackSetting();
 motionPermissionCancelRecovery.resume(home, globalThis.__turnRuntime);
 const { installHowToPlayGuide } = await import(
   withBuild('./ui/how-to-play-guide.js?revision=r220-overcharge-disclosure')

--- a/turn/index.html
+++ b/turn/index.html
@@ -52,6 +52,7 @@
   <link rel="stylesheet" href="./manual-steering.css?build=20260903-r198">
   <link rel="stylesheet" href="./orientation-guard.css?build=20260903-r198-home-portrait">
   <link rel="stylesheet" href="./lap-result-toast.css?build=20260903-r198">
+  <link rel="stylesheet" href="./scoring/score-feedback.css?build=20260903-r198">
   <link rel="stylesheet" href="./rival-onboarding.css?build=20260903-r198">
   <link rel="stylesheet" href="./track-select.css?build=20260903-r198">
   <link rel="stylesheet" href="./track-select-r54.css?build=20260903-r198">
@@ -186,6 +187,19 @@
   <div class="hud" id="hud" hidden>
     <div class="topbar"><div class="stats"><div class="chip">speed<strong><span id="speed">0</span> km/h</strong></div><div class="chip">lap<strong id="lap">1</strong></div><div class="chip">time<strong id="lapTime">0:00.000</strong></div><div class="chip">best<strong id="bestTime">--:--.---</strong></div></div><div class="map-wrap"><canvas id="map" width="300" height="210" aria-label="Track map"></canvas></div></div>
     <div class="message" id="message" role="status"></div>
+    <aside class="score-feedback" id="scoreFeedback" aria-label="Driving score" hidden>
+      <section class="score-feedback-state" data-score-feedback-state>
+        <div class="score-feedback-heading"><span data-score-feedback-label>DRIFT</span><span>CURRENT</span></div>
+        <div class="score-feedback-values"><strong data-score-feedback-current>0</strong><b data-score-feedback-multiplier>×1</b></div>
+        <div class="score-feedback-meter" aria-hidden="true"><i data-score-feedback-meter-fill></i></div>
+        <div class="score-feedback-lap"><span>LAP</span><b data-score-feedback-total>0</b></div>
+      </section>
+      <section class="score-feedback-callout" data-score-feedback-callout aria-hidden="true" hidden>
+        <strong data-score-feedback-callout-label></strong>
+        <b data-score-feedback-callout-score hidden></b>
+      </section>
+      <p class="turn-sr-only" data-score-feedback-announcer role="status" aria-live="polite" aria-atomic="true"></p>
+    </aside>
     <div class="tilt-drive" aria-hidden="true"><span><b>brake</b><b>gas</b></span><div class="tilt-track"><i class="tilt-needle" id="tiltNeedle"></i></div><small class="tilt-value" id="tiltValue">neutral</small></div>
   </div>
   <div class="manual-steer" id="manualSteer" role="slider" aria-label="Steering. Drag left or right." aria-valuemin="-100" aria-valuemax="100" aria-valuenow="0" hidden><span class="manual-steer-knob" aria-hidden="true"></span></div>

--- a/turn/lap-result-toast.css
+++ b/turn/lap-result-toast.css
@@ -62,6 +62,32 @@
   font-size: 0.72em;
 }
 
+.lap-result-drift {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 7px;
+  margin-top: 8px;
+  padding-top: 7px;
+  border-top: 2px solid rgb(8 9 10 / .38);
+  font-size: clamp(0.56rem, 1.3vw, 0.72rem);
+  line-height: 1;
+  letter-spacing: 0.045em;
+  white-space: nowrap;
+}
+
+.lap-result-drift[hidden] {
+  display: none;
+}
+
+.lap-result-drift b {
+  font-size: 1.3em;
+}
+
+.lap-result-drift em {
+  font-style: normal;
+}
+
 @media (max-height: 430px) {
   .lap-result-toast {
     top: 17%;

--- a/turn/main.js
+++ b/turn/main.js
@@ -27,12 +27,19 @@ import {
   resolveFrontWheelSteeringAngle
 } from '/turn/vehicle/front-wheel-steering.js?revision=r221-trajectory-wheel-steering-30';
 import { installPerformanceMonitor, recordPerformanceFrame } from '/turn/performance-monitor.js?build=20260720-r19';
-import { isVehiclePerkUnlocked } from '/turn/progression/trophy-road.js?revision=r230-vehicle-perks';
+import {
+  isFeatureUnlocked,
+  isVehiclePerkUnlocked
+} from '/turn/progression/trophy-road.js?revision=r230-vehicle-perks';
 import {
   resetVehiclePerkRuntimeState,
   resolveGraduatedStageFeedback
 } from '/turn/vehicle/perk-runtime.js?revision=r233-graduated';
 import { createScoreFeedback } from '/turn/scoring/score-feedback.js';
+import {
+  DRIFT_ATTACK_FEATURE_ID,
+  createDriftAttackRuntime
+} from '/turn/scoring/drift-attack-runtime.js';
 
 const intro = document.querySelector('#intro');
 const hud = document.querySelector('#hud');
@@ -95,7 +102,9 @@ const state = {
   velocity: new THREE.Vector3(),
   heading: 0,
   driftAmount: 0,
+  driftSlipAngle: 0,
   driftLockAmount: 0,
+  collided: false,
   offRoad: false,
   courseSafetyOffRoad: false,
   lapCourseViolation: false,
@@ -137,6 +146,13 @@ const scoreFeedback = createScoreFeedback({
     }));
   }
 });
+const driftAttack = createDriftAttackRuntime({
+  state,
+  scoreFeedback,
+  eventTarget: window,
+  isUnlocked: () => isFeatureUnlocked(DRIFT_ATTACK_FEATURE_ID)
+});
+globalThis.__turnDriftAttack = driftAttack;
 
 function publishUiState(reason) {
   window.dispatchEvent(new CustomEvent('turn:ui-state-change', {
@@ -974,6 +990,7 @@ function updateMotionInput(dt) {
 
 function beginTimedLap(now) {
   beginTimedLapState({ state, samples, now, showMessage });
+  driftAttack.beginLap(now);
   publishUiState('lap-started');
 }
 
@@ -1002,6 +1019,8 @@ function updatePhysics(dt, now) {
   );
   if (graduatedFeedback) showMessage(graduatedFeedback, 1800);
 
+  driftAttack.advance(dt, now);
+
   updateLapProgressState({
     state,
     nearestAfter,
@@ -1026,6 +1045,22 @@ function completeLap(now) {
     competitorLimit: RIVAL_LIMIT,
     saveGhost,
     showMessage,
+    finalizeScores({ finishedTime, validLap, rankedLap }) {
+      return {
+        drift: driftAttack.completeLap({
+          now,
+          time: finishedTime,
+          valid: validLap,
+          ranked: rankedLap,
+          trackId: state.trackId,
+          carId: state.vehicleId
+        })
+      };
+    },
+    onScoreError(error) {
+      console.error('TURN: DRIFT ATTACK could not finalize this lap.', error);
+      globalThis.__turnLastDriftScoreError = error;
+    },
     onError(error) {
       console.error('TURN: completed lap could not be added to rivals, continuing race.', error);
       globalThis.__turnLastLapError = error;
@@ -1433,7 +1468,8 @@ const turnRuntime = {
   runSceneOverride(dt) {
     return turnSceneOverride ? turnSceneOverride(dt) === true : false;
   },
-  scoreFeedback
+  scoreFeedback,
+  driftAttack
 };
 globalThis.__turnRuntime = turnRuntime;
 function syncSelectedVehiclePerkEntitlement() {

--- a/turn/main.js
+++ b/turn/main.js
@@ -32,6 +32,7 @@ import {
   resetVehiclePerkRuntimeState,
   resolveGraduatedStageFeedback
 } from '/turn/vehicle/perk-runtime.js?revision=r233-graduated';
+import { createScoreFeedback } from '/turn/scoring/score-feedback.js';
 
 const intro = document.querySelector('#intro');
 const hud = document.querySelector('#hud');
@@ -54,6 +55,7 @@ const mapCtx = mapCanvas.getContext('2d');
 const tiltNeedle = document.querySelector('#tiltNeedle');
 const tiltValue = document.querySelector('#tiltValue');
 const installGate = document.querySelector('#installGate');
+const scoreFeedbackRoot = document.querySelector('#scoreFeedback');
 
 const TAU = Math.PI * 2;
 const TRACK_WIDTH = 27;
@@ -126,6 +128,15 @@ globalThis.__turnVehicleTuning = state.vehicleTuning;
 resetVehiclePerkRuntimeState(state);
 
 installGameModeState(state);
+
+const scoreFeedback = createScoreFeedback({
+  root: scoreFeedbackRoot,
+  onSound(type, channel, detail) {
+    window.dispatchEvent(new CustomEvent('turn:score-feedback-sound', {
+      detail: { type, channel, cue: detail?.sound || type }
+    }));
+  }
+});
 
 function publishUiState(reason) {
   window.dispatchEvent(new CustomEvent('turn:ui-state-change', {
@@ -1328,7 +1339,7 @@ function updateRacePosition() {
   globalThis.__turnSetRacePosition?.(rivalsAhead + 1, total);
 }
 
-function updateHud() {
+function updateHud(now = performance.now()) {
   updateHudState({
     state,
     speedEl,
@@ -1345,6 +1356,7 @@ function updateHud() {
     findNearestTrack,
     setRacePosition: globalThis.__turnSetRacePosition
   });
+  scoreFeedback.commit(now);
 }
 
 function showMessage(text, duration = 1600) {
@@ -1420,7 +1432,8 @@ const turnRuntime = {
   },
   runSceneOverride(dt) {
     return turnSceneOverride ? turnSceneOverride(dt) === true : false;
-  }
+  },
+  scoreFeedback
 };
 globalThis.__turnRuntime = turnRuntime;
 function syncSelectedVehiclePerkEntitlement() {
@@ -1477,7 +1490,7 @@ renderer.setAnimationLoop((now) => {
 
     updateScene(frameDt);
     if (now >= nextHudUpdateAt) {
-      updateHud();
+      updateHud(now);
       nextHudUpdateAt = now + HUD_UPDATE_INTERVAL_MS;
     }
   } else {

--- a/turn/race/game-state.js
+++ b/turn/race/game-state.js
@@ -64,6 +64,8 @@ export function resetRaceToStage({
   state.heading = Math.atan2(start.tangent.x, start.tangent.z);
   state.speed = 0;
   state.driftAmount = 0;
+  state.driftSlipAngle = 0;
+  state.collided = false;
   state.vehiclePerkProgress = 0;
   state.vehiclePerkStage = 0;
   state.vehicleEffectiveTuning = state.vehicleTuning || null;

--- a/turn/race/lap-system.js
+++ b/turn/race/lap-system.js
@@ -141,6 +141,8 @@ export function completeLapState({
   competitorLimit,
   saveGhost,
   onError,
+  finalizeScores,
+  onScoreError,
   ranked = true
 }) {
   const finishedTime = (now - state.lapStartedAt) / 1000;
@@ -151,6 +153,7 @@ export function completeLapState({
   let finishingPosition = null;
   let finishingTotal = null;
   let savedLap = false;
+  let scoreResults = null;
 
   if (completedLap) {
     const raceRivals = state.competitorLaps
@@ -206,6 +209,20 @@ export function completeLapState({
     }
   }
 
+  if (typeof finalizeScores === 'function') {
+    try {
+      scoreResults = finalizeScores({
+        finishedTime,
+        completedLap,
+        validLap,
+        rankedLap,
+        onCourseThroughout
+      }) || null;
+    } catch (error) {
+      onScoreError?.(error);
+    }
+  }
+
   if (completedLap) {
     publishLapResult({
       position: finishingPosition,
@@ -214,7 +231,8 @@ export function completeLapState({
       valid: validLap,
       saved: savedLap,
       ranked: rankedLap,
-      onCourseThroughout
+      onCourseThroughout,
+      ...(scoreResults || {})
     });
   }
 
@@ -236,7 +254,8 @@ export function completeLapState({
     ranked: rankedLap,
     onCourseThroughout,
     position: finishingPosition,
-    total: finishingTotal
+    total: finishingTotal,
+    ...(scoreResults || {})
   };
 }
 

--- a/turn/scoring/drift-attack-runtime.js
+++ b/turn/scoring/drift-attack-runtime.js
@@ -1,0 +1,222 @@
+import {
+  SCORE_FEEDBACK_CHANNEL,
+  SCORE_FEEDBACK_EVENT
+} from './score-feedback.js';
+import { createDriftAttackScorer } from './drift-attack.js';
+import {
+  getBestDriftRecord,
+  saveBestDriftRecord
+} from './drift-records.js';
+
+export const DRIFT_ATTACK_FEATURE_ID = 'drift-attack';
+export const DRIFT_HUD_STORAGE_KEY = 'turn-drift-hud-v1';
+
+function getStorage(storage) {
+  if (storage !== undefined) return storage;
+  try {
+    return globalThis.localStorage;
+  } catch (_) {
+    return null;
+  }
+}
+
+export function driftHudVisible(storage) {
+  try {
+    return getStorage(storage)?.getItem?.(DRIFT_HUD_STORAGE_KEY) !== 'off';
+  } catch (_) {
+    return true;
+  }
+}
+
+export function saveDriftHudVisible(visible, storage) {
+  const target = getStorage(storage);
+  if (!target || typeof target.setItem !== 'function') return false;
+  try {
+    target.setItem(DRIFT_HUD_STORAGE_KEY, visible === false ? 'off' : 'on');
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+function dispatchSemanticEvent(eventTarget, type, detail) {
+  if (typeof eventTarget?.dispatchEvent !== 'function' || typeof globalThis.CustomEvent !== 'function') return;
+  eventTarget.dispatchEvent(new globalThis.CustomEvent(type, { detail }));
+}
+
+export function createDriftAttackRuntime({
+  state,
+  scoreFeedback,
+  storage,
+  eventTarget = globalThis,
+  isUnlocked = () => true,
+  wallClock = () => Date.now()
+} = {}) {
+  if (!state || typeof state !== 'object') throw new TypeError('TURN DRIFT ATTACK requires race state.');
+  if (!scoreFeedback || typeof scoreFeedback.updateState !== 'function') {
+    throw new TypeError('TURN DRIFT ATTACK requires ScoreFeedback.');
+  }
+
+  const targetStorage = getStorage(storage);
+  let enabled = isUnlocked() === true;
+  let hudVisible = driftHudVisible(targetStorage);
+
+  function publishState(snapshot, now) {
+    if (!enabled || !hudVisible) return;
+    scoreFeedback.updateState(SCORE_FEEDBACK_CHANNEL.DRIFT, snapshot, now);
+  }
+
+  function publishEvent(type, detail, now) {
+    if (enabled && hudVisible) {
+      scoreFeedback.publishEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, type, detail, now);
+    }
+    dispatchSemanticEvent(eventTarget, 'turn:drift-score-event', {
+      channel: SCORE_FEEDBACK_CHANNEL.DRIFT,
+      type,
+      ...detail
+    });
+  }
+
+  const scorer = createDriftAttackScorer({
+    onState: publishState,
+    onEvent: publishEvent
+  });
+
+  function syncPresentation(now = 0) {
+    if (enabled && hudVisible) {
+      scoreFeedback.updateState(SCORE_FEEDBACK_CHANNEL.DRIFT, scorer.feedbackState, now);
+    }
+    scoreFeedback.setChannelVisible(
+      SCORE_FEEDBACK_CHANNEL.DRIFT,
+      enabled && hudVisible,
+      now
+    );
+  }
+
+  function reset(now = 0) {
+    scorer.reset(now);
+    scoreFeedback.clearChannel(SCORE_FEEDBACK_CHANNEL.DRIFT, now);
+  }
+
+  function beginLap(now = 0) {
+    if (!enabled) return false;
+    scorer.beginLap(now);
+    return true;
+  }
+
+  function advance(dt, now) {
+    if (!enabled) return false;
+    return scorer.advance(
+      dt,
+      now,
+      state.speed,
+      state.driftSlipAngle,
+      state.offRoad,
+      state.collided,
+      state.lapActive
+    );
+  }
+
+  function completeLap({
+    now = 0,
+    time,
+    valid = false,
+    ranked = true,
+    trackId = state.trackId,
+    carId = state.vehicleId
+  } = {}) {
+    if (!enabled) return Object.freeze({ available: false });
+
+    const scoreResult = scorer.completeLap(now);
+    const eligible = valid === true && ranked !== false;
+    const previousBest = getBestDriftRecord(trackId, targetStorage);
+    const saved = eligible
+      ? saveBestDriftRecord({
+        trackId,
+        score: scoreResult.score,
+        carId,
+        lapTime: time,
+        hitAt: wallClock()
+      }, targetStorage)
+      : { record: previousBest, isNewBest: false, saved: false };
+    const bestScore = saved.record?.score || previousBest?.score || 0;
+    const result = Object.freeze({
+      available: true,
+      score: scoreResult.score,
+      bestScore,
+      newBest: saved.isNewBest === true,
+      saved: saved.saved === true,
+      eligible,
+      bankCount: scoreResult.bankCount,
+      bestBank: scoreResult.bestBank,
+      maxMultiplier: scoreResult.maxMultiplier,
+      carId: String(carId || ''),
+      lapTime: Number(time) || 0
+    });
+
+    if (hudVisible && scoreResult.score > 0) {
+      const type = result.newBest
+        ? SCORE_FEEDBACK_EVENT.PERSONAL_BEST
+        : SCORE_FEEDBACK_EVENT.LAP_RESULT;
+      scoreFeedback.publishEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, type, {
+        score: result.score,
+        multiplier: result.maxMultiplier,
+        label: result.newBest ? 'NEW DRIFT BEST' : 'DRIFT LAP',
+        announce: false
+      }, now);
+    }
+    dispatchSemanticEvent(eventTarget, 'turn:drift-lap-result', result);
+    return result;
+  }
+
+  function setHudVisible(visible, { persist = true, now = 0 } = {}) {
+    const next = visible !== false;
+    if (persist && !saveDriftHudVisible(next, targetStorage)) return false;
+    hudVisible = next;
+    syncPresentation(now);
+    dispatchSemanticEvent(eventTarget, 'turn:drift-hud-visibility-change', {
+      visible: hudVisible,
+      enabled
+    });
+    return true;
+  }
+
+  function refreshEntitlement(now = 0) {
+    const nextEnabled = isUnlocked() === true;
+    if (nextEnabled === enabled) {
+      syncPresentation(now);
+      return enabled;
+    }
+    enabled = nextEnabled;
+    reset(now);
+    syncPresentation(now);
+    dispatchSemanticEvent(eventTarget, 'turn:drift-availability-change', { enabled });
+    return enabled;
+  }
+
+  function handleUiState(event) {
+    const reason = event?.detail?.reason;
+    if (reason === 'race-started' || reason === 'race-reset' || reason === 'track-changed' || reason === 'home-open') {
+      reset(globalThis.performance?.now?.() || 0);
+    }
+  }
+
+  eventTarget?.addEventListener?.('turn:trophy-road-updated', () => refreshEntitlement(
+    globalThis.performance?.now?.() || 0
+  ));
+  eventTarget?.addEventListener?.('turn:ui-state-change', handleUiState);
+  syncPresentation(0);
+
+  return Object.freeze({
+    scorer,
+    beginLap,
+    advance,
+    completeLap,
+    reset,
+    refreshEntitlement,
+    setHudVisible,
+    isEnabled: () => enabled,
+    isHudVisible: () => hudVisible,
+    getBestRecord: (trackId = state.trackId) => getBestDriftRecord(trackId, targetStorage)
+  });
+}

--- a/turn/scoring/drift-attack.js
+++ b/turn/scoring/drift-attack.js
@@ -1,0 +1,376 @@
+import { SCORE_FEEDBACK_EVENT } from './score-feedback.js';
+
+export const DRIFT_ATTACK_SAMPLE_HZ = 12;
+export const DRIFT_ATTACK_SAMPLE_INTERVAL_SECONDS = 1 / DRIFT_ATTACK_SAMPLE_HZ;
+export const DRIFT_ATTACK_MIN_SPEED = 11;
+export const DRIFT_ATTACK_FAIL_SPEED = 4;
+export const DRIFT_ATTACK_MIN_SLIP = Math.PI * 18 / 180;
+export const DRIFT_ATTACK_EXIT_SLIP = Math.PI * 10 / 180;
+export const DRIFT_ATTACK_IDEAL_SLIP_START = Math.PI * 45 / 180;
+export const DRIFT_ATTACK_IDEAL_SLIP_END = Math.PI * 80 / 180;
+export const DRIFT_ATTACK_STRONG_SLIP_END = Math.PI * 95 / 180;
+export const DRIFT_ATTACK_MAX_SLIP = Math.PI * 125 / 180;
+export const DRIFT_ATTACK_BANK_DELAY_SECONDS = 0.3;
+export const DRIFT_ATTACK_CHAIN_WINDOW_MS = 1400;
+export const DRIFT_ATTACK_MAX_MULTIPLIER = 8;
+
+const POINTS_PER_METER = 5;
+const MIN_BANK_SCORE = 10;
+const DIRECTION_DEADZONE = Math.PI / 180;
+
+function finiteNumber(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function lerp(start, end, amount) {
+  return start + (end - start) * amount;
+}
+
+function smoothstep(start, end, value) {
+  const amount = clamp((value - start) / Math.max(0.000001, end - start), 0, 1);
+  return amount * amount * (3 - 2 * amount);
+}
+
+function directionForSlip(slipAngle, fallback = 1) {
+  if (slipAngle > DIRECTION_DEADZONE) return 1;
+  if (slipAngle < -DIRECTION_DEADZONE) return -1;
+  return fallback || 1;
+}
+
+export function driftAngleQuality(slipAngle) {
+  const slip = Math.abs(finiteNumber(slipAngle));
+  if (slip < DRIFT_ATTACK_MIN_SLIP || slip >= DRIFT_ATTACK_MAX_SLIP) return 0;
+  if (slip < DRIFT_ATTACK_IDEAL_SLIP_START) {
+    return lerp(0.22, 1, smoothstep(DRIFT_ATTACK_MIN_SLIP, DRIFT_ATTACK_IDEAL_SLIP_START, slip));
+  }
+  if (slip <= DRIFT_ATTACK_IDEAL_SLIP_END) return 1;
+  if (slip <= DRIFT_ATTACK_STRONG_SLIP_END) {
+    return lerp(1, 0.82, smoothstep(DRIFT_ATTACK_IDEAL_SLIP_END, DRIFT_ATTACK_STRONG_SLIP_END, slip));
+  }
+  return lerp(0.82, 0, smoothstep(DRIFT_ATTACK_STRONG_SLIP_END, DRIFT_ATTACK_MAX_SLIP, slip));
+}
+
+export function driftSpeedQuality(speed) {
+  const metresPerSecond = Math.max(0, finiteNumber(speed));
+  if (metresPerSecond < DRIFT_ATTACK_MIN_SPEED) return 0;
+  const roadSpeed = smoothstep(DRIFT_ATTACK_MIN_SPEED, 28, metresPerSecond);
+  const highSpeed = smoothstep(28, 42, metresPerSecond);
+  return 0.45 + roadSpeed * 0.55 + highSpeed * 0.28;
+}
+
+export function createDriftAttackScorer({ onState = null, onEvent = null } = {}) {
+  const feedbackState = {
+    active: false,
+    score: 0,
+    unbanked: 0,
+    multiplier: 1,
+    intensity: 0,
+    phase: 'quiet',
+    label: 'DRIFT'
+  };
+
+  let attemptActive = false;
+  let drifting = false;
+  let accumulator = 0;
+  let collisionPending = false;
+  let currentExact = 0;
+  let lapExact = 0;
+  let driftSeconds = 0;
+  let exitSeconds = 0;
+  let direction = 0;
+  let lastBankDirection = 0;
+  let chainExpiresAt = 0;
+  let multiplier = 1;
+  let bankCount = 0;
+  let bestBank = 0;
+  let maxMultiplier = 1;
+  let sampleCount = 0;
+
+  function emitState(now) {
+    if (typeof onState === 'function') onState(feedbackState, now);
+  }
+
+  function emitEvent(type, detail, now) {
+    if (typeof onEvent === 'function') onEvent(type, detail, now);
+  }
+
+  function syncFeedback(
+    now,
+    active = drifting,
+    phase = active ? 'build' : 'quiet',
+    intensity = 0
+  ) {
+    feedbackState.active = active;
+    feedbackState.score = Math.max(0, Math.round(lapExact));
+    feedbackState.unbanked = Math.max(0, Math.round(currentExact));
+    feedbackState.multiplier = multiplier;
+    feedbackState.intensity = clamp(intensity, 0, 1);
+    feedbackState.phase = phase;
+    emitState(now);
+  }
+
+  function resetLapValues() {
+    drifting = false;
+    accumulator = 0;
+    collisionPending = false;
+    currentExact = 0;
+    lapExact = 0;
+    driftSeconds = 0;
+    exitSeconds = 0;
+    direction = 0;
+    lastBankDirection = 0;
+    chainExpiresAt = 0;
+    multiplier = 1;
+    bankCount = 0;
+    bestBank = 0;
+    maxMultiplier = 1;
+  }
+
+  function beginLap(now = 0) {
+    attemptActive = true;
+    resetLapValues();
+    syncFeedback(now);
+  }
+
+  function reset(now = 0) {
+    attemptActive = false;
+    resetLapValues();
+    syncFeedback(now);
+  }
+
+  function startDrift(now, nextDirection) {
+    const linked = chainExpiresAt > 0 && now <= chainExpiresAt;
+    const oppositeDirection = linked && lastBankDirection !== 0 && nextDirection !== lastBankDirection;
+    if (!linked) multiplier = 1;
+    else if (oppositeDirection) {
+      multiplier = Math.min(DRIFT_ATTACK_MAX_MULTIPLIER, multiplier + 1);
+      maxMultiplier = Math.max(maxMultiplier, multiplier);
+      emitEvent(SCORE_FEEDBACK_EVENT.MILESTONE, {
+        multiplier,
+        label: `DRIFT ×${multiplier}`,
+        direction: nextDirection
+      }, now);
+    }
+
+    drifting = true;
+    currentExact = 0;
+    driftSeconds = 0;
+    exitSeconds = 0;
+    direction = nextDirection;
+    chainExpiresAt = 0;
+    emitEvent(SCORE_FEEDBACK_EVENT.BUILD, {
+      multiplier,
+      direction,
+      announce: false
+    }, now);
+  }
+
+  function bank(now, reason = 'exit') {
+    const bankedExact = currentExact;
+    const bankedScore = Math.max(0, Math.round(bankedExact));
+    const bankedDirection = direction;
+    const duration = driftSeconds;
+
+    drifting = false;
+    currentExact = 0;
+    driftSeconds = 0;
+    exitSeconds = 0;
+    direction = 0;
+
+    if (bankedScore < MIN_BANK_SCORE) {
+      if (!bankCount) multiplier = 1;
+      syncFeedback(now);
+      return 0;
+    }
+
+    lapExact += bankedExact;
+    bankCount += 1;
+    bestBank = Math.max(bestBank, bankedScore);
+    lastBankDirection = bankedDirection;
+    chainExpiresAt = now + DRIFT_ATTACK_CHAIN_WINDOW_MS;
+    maxMultiplier = Math.max(maxMultiplier, multiplier);
+    syncFeedback(now);
+    emitEvent(SCORE_FEEDBACK_EVENT.BANK, {
+      score: bankedScore,
+      lapScore: Math.max(0, Math.round(lapExact)),
+      multiplier,
+      direction: bankedDirection,
+      duration,
+      reason,
+      announce: reason !== 'lap'
+    }, now);
+    return bankedScore;
+  }
+
+  function lose(now, reason) {
+    const lostScore = Math.max(0, Math.round(currentExact));
+    const lostDirection = direction;
+    const duration = driftSeconds;
+    drifting = false;
+    currentExact = 0;
+    driftSeconds = 0;
+    exitSeconds = 0;
+    direction = 0;
+    lastBankDirection = 0;
+    chainExpiresAt = 0;
+    multiplier = 1;
+    syncFeedback(now);
+    if (lostScore > 0) {
+      emitEvent(SCORE_FEEDBACK_EVENT.LOSS, {
+        score: lostScore,
+        lapScore: Math.max(0, Math.round(lapExact)),
+        multiplier: 1,
+        direction: lostDirection,
+        duration,
+        reason
+      }, now);
+    }
+    return lostScore;
+  }
+
+  function expireChain(now) {
+    if (drifting || !chainExpiresAt || now <= chainExpiresAt) return;
+    chainExpiresAt = 0;
+    lastBankDirection = 0;
+    multiplier = 1;
+  }
+
+  function sample(sampleDt, now, speed, slipAngle, offRoad, collided) {
+    sampleCount += 1;
+    expireChain(now);
+    const slip = finiteNumber(slipAngle);
+    const absoluteSlip = Math.abs(slip);
+    const angleQuality = driftAngleQuality(slip);
+    const speedQuality = driftSpeedQuality(speed);
+    const qualifying = angleQuality > 0 && speedQuality > 0;
+    const failed = collisionPending || collided || offRoad || absoluteSlip >= DRIFT_ATTACK_MAX_SLIP;
+
+    if (drifting && failed) {
+      lose(now, collisionPending || collided ? 'collision' : offRoad ? 'off-road' : 'spin');
+      return;
+    }
+    if (!drifting && failed) return;
+
+    const sampleDirection = directionForSlip(slip, direction || lastBankDirection || 1);
+    if (!drifting) {
+      if (!qualifying) return;
+      startDrift(now, sampleDirection);
+    } else if (qualifying && sampleDirection !== direction) {
+      bank(now, 'linked-transition');
+      startDrift(now, sampleDirection);
+    }
+
+    if (!drifting) return;
+
+    if (!qualifying) {
+      const exiting = absoluteSlip <= DRIFT_ATTACK_EXIT_SLIP
+        || speed < DRIFT_ATTACK_MIN_SPEED;
+      exitSeconds = exiting ? exitSeconds + sampleDt : 0;
+      const settledIntensity = Math.max(0, feedbackState.intensity - sampleDt / DRIFT_ATTACK_BANK_DELAY_SECONDS);
+      syncFeedback(now, true, 'settle', settledIntensity);
+      if (speed < DRIFT_ATTACK_FAIL_SPEED) lose(now, 'stopped');
+      else if (exiting && exitSeconds >= DRIFT_ATTACK_BANK_DELAY_SECONDS) bank(now);
+      return;
+    }
+
+    exitSeconds = 0;
+    driftSeconds += sampleDt;
+    const durationQuality = 0.72 + smoothstep(0, 2.6, driftSeconds) * 0.28;
+    const distance = Math.max(0, speed) * sampleDt;
+    currentExact += distance * POINTS_PER_METER * angleQuality * speedQuality * durationQuality * multiplier;
+    const intensity = clamp(
+      angleQuality * 0.58 + Math.min(1, speedQuality) * 0.2 + Math.min(1, driftSeconds / 2.6) * 0.22,
+      0,
+      1
+    );
+    syncFeedback(now, true, intensity >= 0.82 ? 'intensify' : 'build', intensity);
+  }
+
+  function advance(
+    dt,
+    now,
+    speed,
+    slipAngle,
+    offRoad = false,
+    collided = false,
+    lapActive = true
+  ) {
+    const elapsed = clamp(finiteNumber(dt), 0, 0.25);
+    const timestamp = finiteNumber(now);
+    if (!lapActive) {
+      accumulator = 0;
+      collisionPending = false;
+      return false;
+    }
+    if (!attemptActive) beginLap(timestamp);
+
+    collisionPending = collisionPending || collided === true;
+    if (!drifting && finiteNumber(speed) < DRIFT_ATTACK_MIN_SPEED) {
+      expireChain(timestamp);
+      collisionPending = false;
+      accumulator = 0;
+      return false;
+    }
+
+    accumulator += elapsed;
+    if (accumulator + Number.EPSILON < DRIFT_ATTACK_SAMPLE_INTERVAL_SECONDS) return false;
+    const sampleDt = accumulator;
+    accumulator = 0;
+    sample(
+      sampleDt,
+      timestamp,
+      Math.max(0, finiteNumber(speed)),
+      finiteNumber(slipAngle),
+      offRoad === true,
+      collided === true
+    );
+    collisionPending = false;
+    return true;
+  }
+
+  function completeLap(now = 0) {
+    const timestamp = finiteNumber(now);
+    if (drifting) bank(timestamp, 'lap');
+    const result = Object.freeze({
+      score: Math.max(0, Math.round(lapExact)),
+      bankCount,
+      bestBank,
+      maxMultiplier
+    });
+    attemptActive = true;
+    resetLapValues();
+    syncFeedback(timestamp);
+    return result;
+  }
+
+  function inspect() {
+    return {
+      attemptActive,
+      drifting,
+      lapScore: Math.max(0, Math.round(lapExact)),
+      unbanked: Math.max(0, Math.round(currentExact)),
+      driftSeconds,
+      multiplier,
+      bankCount,
+      bestBank,
+      maxMultiplier,
+      sampleCount,
+      chainExpiresAt,
+      feedback: { ...feedbackState }
+    };
+  }
+
+  return Object.freeze({
+    feedbackState,
+    beginLap,
+    advance,
+    completeLap,
+    reset,
+    inspect
+  });
+}

--- a/turn/scoring/drift-records.js
+++ b/turn/scoring/drift-records.js
@@ -1,0 +1,84 @@
+export const DRIFT_RECORDS_STORAGE_KEY = 'turn-drift-records-v1';
+export const DRIFT_RECORDS_STORAGE_VERSION = 1;
+
+const DEFAULT_TRACK_ID = 'countryside';
+
+function storageOrDefault(storage) {
+  if (storage !== undefined) return storage;
+  try {
+    return globalThis.localStorage;
+  } catch (_) {
+    return null;
+  }
+}
+
+function normalizeTrackId(trackId) {
+  const value = String(trackId || '').trim();
+  return value && /^[a-z0-9-]+$/i.test(value) ? value : DEFAULT_TRACK_ID;
+}
+
+function finitePositive(value, fallback = null) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : fallback;
+}
+
+function normalizeRecord(record) {
+  const score = Math.round(finitePositive(record?.score, 0));
+  if (score <= 0) return null;
+  const normalized = {
+    score,
+    carId: String(record?.carId || 'classic'),
+    hitAt: finitePositive(record?.hitAt)
+  };
+  const lapTime = finitePositive(record?.lapTime);
+  if (lapTime != null) normalized.lapTime = lapTime;
+  return Object.freeze(normalized);
+}
+
+function readPayload(storage) {
+  try {
+    const parsed = JSON.parse(storage?.getItem?.(DRIFT_RECORDS_STORAGE_KEY));
+    return parsed && typeof parsed === 'object' && parsed.tracks && typeof parsed.tracks === 'object'
+      ? parsed
+      : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+export function getBestDriftRecord(trackId, storage) {
+  const payload = readPayload(storageOrDefault(storage));
+  return normalizeRecord(payload?.tracks?.[normalizeTrackId(trackId)]);
+}
+
+export function saveBestDriftRecord({
+  trackId,
+  score,
+  carId,
+  lapTime,
+  hitAt = Date.now()
+} = {}, storage) {
+  const targetStorage = storageOrDefault(storage);
+  const normalizedTrackId = normalizeTrackId(trackId);
+  const candidate = normalizeRecord({ score, carId, lapTime, hitAt });
+  const current = getBestDriftRecord(normalizedTrackId, targetStorage);
+  if (!candidate || (current && candidate.score <= current.score)) {
+    return Object.freeze({ record: current, isNewBest: false, saved: false });
+  }
+  if (!targetStorage || typeof targetStorage.setItem !== 'function') {
+    return Object.freeze({ record: current, isNewBest: false, saved: false });
+  }
+
+  const existing = readPayload(targetStorage);
+  const tracks = { ...(existing?.tracks || {}), [normalizedTrackId]: candidate };
+  const payload = {
+    version: DRIFT_RECORDS_STORAGE_VERSION,
+    tracks
+  };
+  try {
+    targetStorage.setItem(DRIFT_RECORDS_STORAGE_KEY, JSON.stringify(payload));
+    return Object.freeze({ record: candidate, isNewBest: true, saved: true });
+  } catch (_) {
+    return Object.freeze({ record: current, isNewBest: false, saved: false });
+  }
+}

--- a/turn/scoring/score-feedback.css
+++ b/turn/scoring/score-feedback.css
@@ -1,0 +1,202 @@
+.score-feedback {
+  position: absolute;
+  z-index: 14;
+  top: clamp(92px, 24vh, 160px);
+  left: max(14px, env(safe-area-inset-left));
+  width: clamp(148px, 20vw, 214px);
+  color: var(--turn-ink, #08090a);
+  pointer-events: none;
+}
+
+.score-feedback[hidden],
+.score-feedback-state[hidden],
+.score-feedback-callout[hidden] {
+  display: none;
+}
+
+.score-feedback-state,
+.score-feedback-callout {
+  box-sizing: border-box;
+  border: 3px solid var(--turn-ink, #08090a);
+  background: rgb(255 248 232 / .92);
+  box-shadow: 4px 4px 0 var(--turn-ink, #08090a);
+}
+
+.score-feedback-state {
+  padding: 9px 11px 10px;
+  border-radius: 15px;
+  transform: translateZ(0);
+  transition: opacity 140ms linear, transform 180ms ease-out;
+}
+
+.score-feedback-heading,
+.score-feedback-values,
+.score-feedback-lap {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.score-feedback-heading,
+.score-feedback-lap {
+  font-size: clamp(.48rem, 1.1vw, .63rem);
+  font-weight: 950;
+  letter-spacing: .075em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.score-feedback-values {
+  margin-top: 4px;
+  line-height: 1;
+}
+
+.score-feedback-values strong {
+  overflow: hidden;
+  font-size: clamp(1.32rem, 3.4vw, 2rem);
+  letter-spacing: -.055em;
+  text-overflow: ellipsis;
+}
+
+.score-feedback-values b {
+  flex: 0 0 auto;
+  padding: 3px 6px 4px;
+  border: 2px solid currentColor;
+  border-radius: 999px;
+  background: var(--turn-blue-200, #8ed8ff);
+  font-size: clamp(.68rem, 1.55vw, .9rem);
+  line-height: 1;
+}
+
+.score-feedback-meter {
+  height: 8px;
+  margin: 8px 0 7px;
+  overflow: hidden;
+  border: 2px solid var(--turn-ink, #08090a);
+  border-radius: 999px;
+  background: rgb(8 9 10 / .12);
+}
+
+.score-feedback-meter > i {
+  display: block;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, var(--turn-blue-500, #38d9ff), var(--turn-pink-500, #ff4fa3));
+  transform: scaleX(var(--score-feedback-progress, 0));
+  transform-origin: left center;
+  transition: transform 100ms linear;
+  will-change: transform;
+}
+
+.score-feedback-lap b {
+  font: inherit;
+  font-size: 1.08em;
+}
+
+.score-feedback[data-channel="flow"] .score-feedback-values b,
+.score-feedback[data-channel="flow"] .score-feedback-meter > i {
+  background-color: var(--turn-pink-500, #ff4fa3);
+}
+
+.score-feedback-callout {
+  position: absolute;
+  top: calc(100% + 9px);
+  left: 8px;
+  width: max-content;
+  max-width: calc(100vw - 44px);
+  padding: 7px 10px 8px;
+  border-radius: 12px;
+  opacity: 1;
+  transform-origin: left top;
+}
+
+.score-feedback-callout strong,
+.score-feedback-callout b {
+  display: block;
+  white-space: nowrap;
+}
+
+.score-feedback-callout strong {
+  font-size: clamp(.66rem, 1.55vw, .9rem);
+  letter-spacing: .055em;
+  line-height: 1;
+}
+
+.score-feedback-callout b {
+  margin-top: 3px;
+  font-size: clamp(.92rem, 2.2vw, 1.26rem);
+  line-height: 1;
+}
+
+.score-feedback-callout[data-event="bank"] {
+  background: var(--turn-green-500, #8ce99a);
+}
+
+.score-feedback-callout[data-event="loss"] {
+  background: var(--turn-red-500, #ff6b6b);
+}
+
+.score-feedback-callout[data-event="milestone"] {
+  background: var(--turn-yellow-400, #ffd43b);
+}
+
+.score-feedback-callout[data-event="personal-best"],
+.score-feedback-callout[data-event="lap-result"] {
+  background: var(--turn-pink-500, #ff4fa3);
+}
+
+.score-feedback-callout.is-event-a {
+  animation: turn-score-callout-a 420ms cubic-bezier(.16, .82, .24, 1);
+}
+
+.score-feedback-callout.is-event-b {
+  animation: turn-score-callout-b 420ms cubic-bezier(.16, .82, .24, 1);
+}
+
+.score-feedback-callout.is-release {
+  box-shadow: 5px 5px 0 var(--turn-ink, #08090a);
+}
+
+@keyframes turn-score-callout-a {
+  0% { opacity: 0; transform: translateY(7px) scale(.94); }
+  58% { opacity: 1; transform: translateY(-2px) scale(1.04); }
+  100% { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+@keyframes turn-score-callout-b {
+  0% { opacity: 0; transform: translateY(7px) scale(.94); }
+  58% { opacity: 1; transform: translateY(-2px) scale(1.04); }
+  100% { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+@media (max-height: 430px) {
+  .score-feedback {
+    top: 80px;
+    width: 142px;
+  }
+
+  .score-feedback-state {
+    padding: 7px 9px 8px;
+    border-width: 2px;
+    box-shadow: 3px 3px 0 var(--turn-ink, #08090a);
+  }
+
+  .score-feedback-meter {
+    height: 6px;
+    margin: 6px 0 5px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .score-feedback-state,
+  .score-feedback-meter > i {
+    transition: none;
+  }
+
+  .score-feedback-callout.is-event-a,
+  .score-feedback-callout.is-event-b {
+    animation: none;
+    transform: none;
+  }
+}

--- a/turn/scoring/score-feedback.js
+++ b/turn/scoring/score-feedback.js
@@ -199,7 +199,13 @@ export function createScoreFeedback({
   }
 
   function setChannelVisible(channel, visible, now = 0) {
-    channels[normalizeChannel(channel)].visible = visible !== false;
+    const normalizedChannel = normalizeChannel(channel);
+    channels[normalizedChannel].visible = visible !== false;
+    if (!channels[normalizedChannel].visible
+      && activeEvent.active
+      && activeEvent.channel === normalizedChannel) {
+      clearEvent();
+    }
     dirty = true;
     return commit(now, true);
   }
@@ -209,10 +215,9 @@ export function createScoreFeedback({
     const normalizedType = normalizeEventType(type);
     const timestamp = finiteNumber(now);
     if (normalizedType === SCORE_FEEDBACK_EVENT.RESET) {
-      clearEvent();
-      dirty = true;
-      return commit(timestamp, true);
+      return clearChannel(normalizedChannel, timestamp);
     }
+    if (!channels[normalizedChannel].visible) return false;
 
     const priority = Math.max(
       SCORE_FEEDBACK_PRIORITY[normalizedType] || 0,
@@ -281,14 +286,26 @@ export function createScoreFeedback({
     activeEvent.announcement = '';
   }
 
+  function resetChannelState(channel) {
+    channel.active = false;
+    channel.score = 0;
+    channel.unbanked = 0;
+    channel.multiplier = 1;
+    channel.intensity = 0;
+    channel.phase = 'quiet';
+  }
+
+  function clearChannel(channel, now = 0) {
+    const normalizedChannel = normalizeChannel(channel);
+    resetChannelState(channels[normalizedChannel]);
+    if (activeEvent.active && activeEvent.channel === normalizedChannel) clearEvent();
+    dirty = true;
+    return commit(now, true);
+  }
+
   function reset(now = 0) {
     for (const channel of Object.values(channels)) {
-      channel.active = false;
-      channel.score = 0;
-      channel.unbanked = 0;
-      channel.multiplier = 1;
-      channel.intensity = 0;
-      channel.phase = 'quiet';
+      resetChannelState(channel);
     }
     clearEvent();
     announcementRevision += 1;
@@ -367,6 +384,7 @@ export function createScoreFeedback({
     publishEvent,
     setChannelVisible,
     commit,
+    clearChannel,
     reset,
     inspect
   });

--- a/turn/scoring/score-feedback.js
+++ b/turn/scoring/score-feedback.js
@@ -1,0 +1,373 @@
+export const SCORE_FEEDBACK_CHANNEL = Object.freeze({
+  DRIFT: 'drift',
+  FLOW: 'flow'
+});
+
+export const SCORE_FEEDBACK_EVENT = Object.freeze({
+  BUILD: 'build',
+  TECHNIQUE: 'technique',
+  MILESTONE: 'milestone',
+  BANK: 'bank',
+  LOSS: 'loss',
+  PERSONAL_BEST: 'personal-best',
+  LAP_RESULT: 'lap-result',
+  RESET: 'reset'
+});
+
+export const SCORE_FEEDBACK_PRIORITY = Object.freeze({
+  [SCORE_FEEDBACK_EVENT.BUILD]: 10,
+  [SCORE_FEEDBACK_EVENT.TECHNIQUE]: 20,
+  [SCORE_FEEDBACK_EVENT.MILESTONE]: 30,
+  [SCORE_FEEDBACK_EVENT.BANK]: 40,
+  [SCORE_FEEDBACK_EVENT.LOSS]: 40,
+  [SCORE_FEEDBACK_EVENT.PERSONAL_BEST]: 50,
+  [SCORE_FEEDBACK_EVENT.LAP_RESULT]: 50,
+  [SCORE_FEEDBACK_EVENT.RESET]: 100
+});
+
+export const SCORE_FEEDBACK_COMMIT_INTERVAL_MS = 100;
+export const SCORE_FEEDBACK_ANNOUNCEMENT_INTERVAL_MS = 1200;
+
+const EVENT_DURATION_MS = Object.freeze({
+  [SCORE_FEEDBACK_EVENT.BUILD]: 500,
+  [SCORE_FEEDBACK_EVENT.TECHNIQUE]: 850,
+  [SCORE_FEEDBACK_EVENT.MILESTONE]: 1100,
+  [SCORE_FEEDBACK_EVENT.BANK]: 1500,
+  [SCORE_FEEDBACK_EVENT.LOSS]: 1600,
+  [SCORE_FEEDBACK_EVENT.PERSONAL_BEST]: 2400,
+  [SCORE_FEEDBACK_EVENT.LAP_RESULT]: 2400
+});
+
+const CHANNEL_LABEL = Object.freeze({
+  [SCORE_FEEDBACK_CHANNEL.DRIFT]: 'DRIFT',
+  [SCORE_FEEDBACK_CHANNEL.FLOW]: 'FLOW'
+});
+
+const numberFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 0
+});
+
+function makeChannel(label) {
+  return {
+    active: false,
+    visible: true,
+    score: 0,
+    unbanked: 0,
+    multiplier: 1,
+    intensity: 0,
+    phase: 'quiet',
+    label
+  };
+}
+
+function finiteNumber(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function setText(element, value) {
+  const text = String(value);
+  if (element.textContent !== text) element.textContent = text;
+}
+
+function setHidden(element, hidden) {
+  if (element.hidden !== hidden) element.hidden = hidden;
+}
+
+function setData(element, key, value) {
+  const text = String(value);
+  if (element.dataset[key] !== text) element.dataset[key] = text;
+}
+
+function requiredElement(root, selector) {
+  const element = root?.querySelector?.(selector);
+  if (!element) throw new Error(`TURN ScoreFeedback could not find ${selector}.`);
+  return element;
+}
+
+function normalizeChannel(channel) {
+  return channel === SCORE_FEEDBACK_CHANNEL.FLOW
+    ? SCORE_FEEDBACK_CHANNEL.FLOW
+    : SCORE_FEEDBACK_CHANNEL.DRIFT;
+}
+
+function normalizeEventType(type) {
+  return Object.values(SCORE_FEEDBACK_EVENT).includes(type)
+    ? type
+    : SCORE_FEEDBACK_EVENT.BUILD;
+}
+
+function defaultEventLabel(type, channel, score, multiplier) {
+  const channelLabel = CHANNEL_LABEL[channel];
+  if (type === SCORE_FEEDBACK_EVENT.BANK) return `✓ BANKED ×${formatMultiplier(multiplier)}`;
+  if (type === SCORE_FEEDBACK_EVENT.LOSS) return `${channelLabel} LOST`;
+  if (type === SCORE_FEEDBACK_EVENT.PERSONAL_BEST) return 'NEW BEST';
+  if (type === SCORE_FEEDBACK_EVENT.LAP_RESULT) return `${channelLabel} ${numberFormatter.format(score)}`;
+  if (type === SCORE_FEEDBACK_EVENT.MILESTONE) return `${channelLabel} ×${formatMultiplier(multiplier)}`;
+  return channelLabel;
+}
+
+function defaultAnnouncement(type, channel, score, multiplier) {
+  const channelLabel = CHANNEL_LABEL[channel].toLocaleLowerCase('en');
+  if (type === SCORE_FEEDBACK_EVENT.BANK) {
+    return `${channelLabel} banked. ${numberFormatter.format(score)} points.`;
+  }
+  if (type === SCORE_FEEDBACK_EVENT.LOSS) {
+    return `${channelLabel} lost. ${numberFormatter.format(score)} unbanked points lost.`;
+  }
+  if (type === SCORE_FEEDBACK_EVENT.PERSONAL_BEST) return `New ${channelLabel} best.`;
+  if (type === SCORE_FEEDBACK_EVENT.LAP_RESULT) {
+    return `${channelLabel} result. ${numberFormatter.format(score)} points.`;
+  }
+  if (type === SCORE_FEEDBACK_EVENT.MILESTONE) {
+    return `${channelLabel} multiplier times ${formatMultiplier(multiplier)}.`;
+  }
+  return '';
+}
+
+function formatMultiplier(value) {
+  const multiplier = Math.max(1, finiteNumber(value, 1));
+  return Number.isInteger(multiplier) ? String(multiplier) : multiplier.toFixed(1);
+}
+
+function formatScore(value) {
+  return numberFormatter.format(Math.max(0, Math.round(finiteNumber(value))));
+}
+
+export function createScoreFeedback({
+  root,
+  commitIntervalMs = SCORE_FEEDBACK_COMMIT_INTERVAL_MS,
+  announcementIntervalMs = SCORE_FEEDBACK_ANNOUNCEMENT_INTERVAL_MS,
+  onSound = null
+} = {}) {
+  if (!root) throw new Error('TURN ScoreFeedback requires a fixed root element.');
+
+  const statePanel = requiredElement(root, '[data-score-feedback-state]');
+  const stateLabel = requiredElement(root, '[data-score-feedback-label]');
+  const currentScore = requiredElement(root, '[data-score-feedback-current]');
+  const multiplier = requiredElement(root, '[data-score-feedback-multiplier]');
+  const lapScore = requiredElement(root, '[data-score-feedback-total]');
+  const meterFill = requiredElement(root, '[data-score-feedback-meter-fill]');
+  const callout = requiredElement(root, '[data-score-feedback-callout]');
+  const calloutLabel = requiredElement(root, '[data-score-feedback-callout-label]');
+  const calloutScore = requiredElement(root, '[data-score-feedback-callout-score]');
+  const announcer = requiredElement(root, '[data-score-feedback-announcer]');
+
+  const channels = {
+    [SCORE_FEEDBACK_CHANNEL.DRIFT]: makeChannel(CHANNEL_LABEL.drift),
+    [SCORE_FEEDBACK_CHANNEL.FLOW]: makeChannel(CHANNEL_LABEL.flow)
+  };
+  const activeEvent = {
+    active: false,
+    channel: SCORE_FEEDBACK_CHANNEL.DRIFT,
+    type: SCORE_FEEDBACK_EVENT.BUILD,
+    priority: 0,
+    score: 0,
+    multiplier: 1,
+    label: '',
+    announcement: '',
+    expiresAt: 0,
+    revision: 0
+  };
+  const minCommitInterval = Math.max(80, finiteNumber(commitIntervalMs, SCORE_FEEDBACK_COMMIT_INTERVAL_MS));
+  const minAnnouncementInterval = Math.max(
+    500,
+    finiteNumber(announcementIntervalMs, SCORE_FEEDBACK_ANNOUNCEMENT_INTERVAL_MS)
+  );
+  let dirty = true;
+  let lastCommitAt = -Infinity;
+  let lastAnnouncementAt = -Infinity;
+  let lastAnnouncementPriority = 0;
+  let announcementRevision = 0;
+
+  function updateState(channel, snapshot = {}, now = 0) {
+    const normalizedChannel = normalizeChannel(channel);
+    const target = channels[normalizedChannel];
+    target.active = snapshot.active === true;
+    target.score = Math.max(0, finiteNumber(snapshot.score));
+    target.unbanked = Math.max(0, finiteNumber(snapshot.unbanked));
+    target.multiplier = Math.max(1, finiteNumber(snapshot.multiplier, 1));
+    target.intensity = clamp(finiteNumber(snapshot.intensity), 0, 1);
+    target.phase = String(snapshot.phase || (target.active ? 'build' : 'quiet'));
+    target.label = String(snapshot.label || CHANNEL_LABEL[normalizedChannel]);
+    dirty = true;
+    return commit(now);
+  }
+
+  function setChannelVisible(channel, visible, now = 0) {
+    channels[normalizeChannel(channel)].visible = visible !== false;
+    dirty = true;
+    return commit(now, true);
+  }
+
+  function publishEvent(channel, type, detail = {}, now = 0) {
+    const normalizedChannel = normalizeChannel(channel);
+    const normalizedType = normalizeEventType(type);
+    const timestamp = finiteNumber(now);
+    if (normalizedType === SCORE_FEEDBACK_EVENT.RESET) {
+      clearEvent();
+      dirty = true;
+      return commit(timestamp, true);
+    }
+
+    const priority = Math.max(
+      SCORE_FEEDBACK_PRIORITY[normalizedType] || 0,
+      finiteNumber(detail.priority)
+    );
+    if (activeEvent.active && timestamp < activeEvent.expiresAt && priority < activeEvent.priority) {
+      return false;
+    }
+
+    const score = Math.max(0, finiteNumber(detail.score));
+    const eventMultiplier = Math.max(1, finiteNumber(detail.multiplier, 1));
+    activeEvent.active = true;
+    activeEvent.channel = normalizedChannel;
+    activeEvent.type = normalizedType;
+    activeEvent.priority = priority;
+    activeEvent.score = score;
+    activeEvent.multiplier = eventMultiplier;
+    activeEvent.label = String(
+      detail.label || defaultEventLabel(normalizedType, normalizedChannel, score, eventMultiplier)
+    );
+    activeEvent.announcement = detail.announce === false
+      ? ''
+      : String(
+        detail.announcement || defaultAnnouncement(
+          normalizedType,
+          normalizedChannel,
+          score,
+          eventMultiplier
+        )
+      );
+    activeEvent.expiresAt = timestamp + Math.max(
+      250,
+      finiteNumber(detail.durationMs, EVENT_DURATION_MS[normalizedType] || 800)
+    );
+    activeEvent.revision += 1;
+    dirty = true;
+
+    if (channels[normalizedChannel].visible) {
+      announceActiveEvent(timestamp);
+      if (typeof onSound === 'function') onSound(normalizedType, normalizedChannel, detail);
+    }
+    return commit(timestamp, true);
+  }
+
+  function announceActiveEvent(now) {
+    const message = activeEvent.announcement.trim();
+    if (!message) return false;
+    const higherPriority = activeEvent.priority > lastAnnouncementPriority;
+    if (!higherPriority && now - lastAnnouncementAt < minAnnouncementInterval) return false;
+
+    lastAnnouncementAt = now;
+    lastAnnouncementPriority = activeEvent.priority;
+    const revision = ++announcementRevision;
+    announcer.textContent = '';
+    globalThis.queueMicrotask?.(() => {
+      if (revision === announcementRevision) announcer.textContent = message;
+    });
+    return true;
+  }
+
+  function clearEvent() {
+    activeEvent.active = false;
+    activeEvent.priority = 0;
+    activeEvent.expiresAt = 0;
+    activeEvent.label = '';
+    activeEvent.announcement = '';
+  }
+
+  function reset(now = 0) {
+    for (const channel of Object.values(channels)) {
+      channel.active = false;
+      channel.score = 0;
+      channel.unbanked = 0;
+      channel.multiplier = 1;
+      channel.intensity = 0;
+      channel.phase = 'quiet';
+    }
+    clearEvent();
+    announcementRevision += 1;
+    announcer.textContent = '';
+    lastAnnouncementPriority = 0;
+    dirty = true;
+    return commit(now, true);
+  }
+
+  function commit(now = 0, force = false) {
+    const timestamp = finiteNumber(now);
+    if (activeEvent.active && timestamp >= activeEvent.expiresAt) {
+      clearEvent();
+      dirty = true;
+      lastAnnouncementPriority = 0;
+    }
+    if (!dirty || (!force && timestamp - lastCommitAt < minCommitInterval)) return false;
+
+    const flow = channels[SCORE_FEEDBACK_CHANNEL.FLOW];
+    const drift = channels[SCORE_FEEDBACK_CHANNEL.DRIFT];
+    const primary = flow.visible && flow.active
+      ? flow
+      : drift.visible && drift.active
+        ? drift
+        : null;
+    const eventVisible = activeEvent.active && channels[activeEvent.channel].visible;
+
+    setHidden(statePanel, !primary);
+    if (primary) {
+      const liveScore = primary.unbanked > 0 ? primary.unbanked : primary.score;
+      setData(root, 'channel', primary === flow ? SCORE_FEEDBACK_CHANNEL.FLOW : SCORE_FEEDBACK_CHANNEL.DRIFT);
+      setData(root, 'phase', primary.phase);
+      setText(stateLabel, primary.label);
+      setText(currentScore, formatScore(liveScore));
+      setText(multiplier, `×${formatMultiplier(primary.multiplier)}`);
+      setText(lapScore, formatScore(primary.score));
+      meterFill.style.setProperty('--score-feedback-progress', String(primary.intensity));
+    }
+
+    setHidden(callout, !eventVisible);
+    if (eventVisible) {
+      setData(callout, 'event', activeEvent.type);
+      setData(callout, 'channel', activeEvent.channel);
+      setText(calloutLabel, activeEvent.label);
+      const eventScore = activeEvent.type === SCORE_FEEDBACK_EVENT.BANK
+        ? `+${formatScore(activeEvent.score)}`
+        : formatScore(activeEvent.score);
+      setText(calloutScore, activeEvent.score > 0 ? eventScore : '');
+      calloutScore.hidden = !(activeEvent.score > 0);
+      callout.classList.toggle('is-release', activeEvent.priority >= SCORE_FEEDBACK_PRIORITY.bank);
+      const evenRevision = activeEvent.revision % 2 === 0;
+      callout.classList.toggle('is-event-a', !evenRevision);
+      callout.classList.toggle('is-event-b', evenRevision);
+    } else {
+      callout.classList.remove('is-release', 'is-event-a', 'is-event-b');
+    }
+
+    setHidden(root, !primary && !eventVisible);
+    dirty = false;
+    lastCommitAt = timestamp;
+    return true;
+  }
+
+  function inspect() {
+    return {
+      activeEvent: { ...activeEvent },
+      drift: { ...channels[SCORE_FEEDBACK_CHANNEL.DRIFT] },
+      flow: { ...channels[SCORE_FEEDBACK_CHANNEL.FLOW] },
+      lastCommitAt
+    };
+  }
+
+  reset(0);
+  return Object.freeze({
+    updateState,
+    publishEvent,
+    setChannelVisible,
+    commit,
+    reset,
+    inspect
+  });
+}

--- a/turn/ui/drift-attack-setting.js
+++ b/turn/ui/drift-attack-setting.js
@@ -1,0 +1,62 @@
+let installed = false;
+
+export function installDriftAttackSetting(runtime = globalThis.__turnDriftAttack) {
+  if (!runtime || typeof document === 'undefined') return false;
+  const dialog = document.querySelector('.m8-settings-dialog');
+  const list = dialog?.querySelector('.m8-settings-list');
+  if (!dialog || !list) return false;
+
+  let section = list.querySelector('[data-turn-scoring-settings]');
+  if (!section) {
+    section = document.createElement('section');
+    section.className = 'm8-setting-card';
+    section.dataset.turnScoringSettings = '';
+    section.setAttribute('aria-labelledby', 'm8ScoringTitle');
+    section.innerHTML = `
+      <h3 id="m8ScoringTitle">Scoring</h3>
+      <label class="m8-toggle-row" data-turn-drift-hud-setting>
+        <input id="m8DriftHudVisible" type="checkbox">
+        <span>
+          <strong>Show DRIFT scoring</strong>
+          <small>Show the live DRIFT HUD. Scores, records and achievements continue when hidden.</small>
+        </span>
+      </label>`;
+    const records = list.querySelector('.m8-record-setting');
+    if (records) records.before(section);
+    else list.appendChild(section);
+  }
+
+  const row = section.querySelector('[data-turn-drift-hud-setting]');
+  const checkbox = section.querySelector('#m8DriftHudVisible');
+  const status = dialog.querySelector('.m8-settings-status');
+
+  function sync() {
+    const available = runtime.isEnabled() === true;
+    row.hidden = !available;
+    section.hidden = !available;
+    checkbox.checked = runtime.isHudVisible() === true;
+  }
+
+  if (!installed) {
+    installed = true;
+    checkbox.addEventListener('change', () => {
+      const next = checkbox.checked;
+      if (!runtime.setHudVisible(next, { now: globalThis.performance?.now?.() || 0 })) {
+        checkbox.checked = runtime.isHudVisible() === true;
+        if (status) status.textContent = 'DRIFT scoring visibility could not be saved.';
+        return;
+      }
+      if (status) {
+        status.textContent = next
+          ? 'Live DRIFT scoring shown.'
+          : 'Live DRIFT scoring hidden. Scoring and records remain active.';
+      }
+    });
+    dialog.addEventListener('toggle', sync);
+    globalThis.addEventListener?.('turn:drift-availability-change', sync);
+    globalThis.addEventListener?.('turn:drift-hud-visibility-change', sync);
+  }
+
+  sync();
+  return true;
+}

--- a/turn/ui/lap-result-toast.js
+++ b/turn/ui/lap-result-toast.js
@@ -8,6 +8,7 @@ import {
 
 const TOAST_VISIBLE_MS = 4000;
 const TOAST_EXIT_MS = 220;
+const scoreFormatter = new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 });
 
 export function installLapResultToast() {
   if (globalThis.__turnLapResultToastInstalled) return;
@@ -27,6 +28,11 @@ export function installLapResultToast() {
       <i aria-hidden="true">•</i>
       <b class="lap-result-time">0:00.000</b>
     </strong>
+    <div class="lap-result-drift" hidden>
+      <span>DRIFT</span>
+      <b class="lap-result-drift-score">0</b>
+      <em class="lap-result-drift-status"></em>
+    </div>
   `;
 
   const announcer = document.createElement('div');
@@ -39,6 +45,9 @@ export function installLapResultToast() {
   const position = toast.querySelector('.lap-result-position');
   const separator = toast.querySelector('i');
   const time = toast.querySelector('.lap-result-time');
+  const drift = toast.querySelector('.lap-result-drift');
+  const driftScore = toast.querySelector('.lap-result-drift-score');
+  const driftStatus = toast.querySelector('.lap-result-drift-status');
   let hideTimer = 0;
   let exitTimer = 0;
 
@@ -92,9 +101,31 @@ export function installLapResultToast() {
     time.hidden = false;
     time.textContent = formatLapTime(seconds);
     time.setAttribute('aria-label', `Lap time, ${spokenLapTime(seconds)}`);
+    showDriftResult(result?.drift);
     toast.classList.remove('is-invalid');
     reveal();
-    setLiveAnnouncement(announcer, lapResultAnnouncement({ position: normalizedPlace, time: seconds }));
+    setLiveAnnouncement(announcer, lapResultAnnouncement({
+      position: normalizedPlace,
+      time: seconds,
+      drift: result?.drift
+    }));
+  }
+
+  function showDriftResult(result) {
+    if (result?.available !== true || !Number.isFinite(Number(result.score))) {
+      drift.hidden = true;
+      return;
+    }
+
+    const score = Math.max(0, Math.round(Number(result.score)));
+    const best = Math.max(0, Math.round(Number(result.bestScore) || 0));
+    driftScore.textContent = scoreFormatter.format(score);
+    driftStatus.textContent = result.newBest === true
+      ? 'NEW BEST'
+      : best > 0
+        ? `BEST ${scoreFormatter.format(best)}`
+        : '';
+    drift.hidden = false;
   }
 
   function showInvalid(result) {
@@ -107,6 +138,7 @@ export function installLapResultToast() {
     separator.hidden = true;
     time.hidden = true;
     time.removeAttribute('aria-label');
+    drift.hidden = true;
     toast.classList.add('is-invalid');
     reveal();
     setLiveAnnouncement(announcer, lapVoidAnnouncement(result?.reason));

--- a/turn/ui/race-announcements.js
+++ b/turn/ui/race-announcements.js
@@ -120,8 +120,16 @@ export function spokenLapTime(seconds) {
   return parts.join(', ');
 }
 
-export function lapResultAnnouncement({ position, time } = {}) {
-  return `Lap. Position: ${ordinalWord(position)}. Time: ${spokenLapTime(time)}.`;
+export function lapResultAnnouncement({ position, time, drift } = {}) {
+  const lap = `Lap. Position: ${ordinalWord(position)}. Time: ${spokenLapTime(time)}.`;
+  if (drift?.available !== true || !Number.isFinite(Number(drift.score))) return lap;
+
+  const score = Math.max(0, Math.round(Number(drift.score)));
+  if (drift.newBest === true) return `${lap} Drift score: ${score} points. New best.`;
+
+  const best = Math.max(0, Math.round(Number(drift.bestScore) || 0));
+  const bestResult = best > 0 ? ` Best: ${best} points.` : '';
+  return `${lap} Drift score: ${score} points.${bestResult}`;
 }
 
 export function lapVoidAnnouncement(reason) {

--- a/turn/vehicle/physics.js
+++ b/turn/vehicle/physics.js
@@ -342,10 +342,12 @@ export function updateVehiclePhysicsState({
   // Keep the full 0..PI relationship between the car and its velocity. Folding
   // the longitudinal component with Math.abs made a car spinning past 90 degrees
   // look like a mild forward slide and incorrectly restored most of its momentum.
-  const driftSlipAngle = Math.abs(Math.atan2(
+  const signedDriftSlipAngle = Math.atan2(
     state.velocity.dot(currentRight),
     state.velocity.dot(currentForward)
-  ));
+  );
+  state.driftSlipAngle = signedDriftSlipAngle;
+  const driftSlipAngle = Math.abs(signedDriftSlipAngle);
   const speedLimit = getVehicleSpeedLimit({
     offRoad: physicsOffRoad,
     offRoadPenalty,
@@ -377,6 +379,7 @@ export function updateVehiclePhysicsState({
     collisionProfile: currentCollisionProfile(),
     dt
   });
+  state.collided = collision.collided === true;
   if (collision.collided) updateVehicleOverdriveState({ state, collided: true });
   if (collision.collided) nearestAfter = findNearestTrack(state.position);
 


### PR DESCRIPTION
## Summary

- complete the narrow shared ScoreFeedback engine for DRIFT and FLOW
  - fixed production, TURN NEXT and TURN LAB DOM
  - deterministic event priority and channel visibility
  - throttled 10 Hz numeric commits on TURN's existing HUD path
  - transform/opacity feedback, reduced-motion behavior, sparse sound hooks and rate-limited semantic announcements
- begin DRIFT ATTACK as an automatic scoring layer
  - 12 Hz elapsed-time scorer using physical speed, signed slip, off-road and collision state
  - distance/duration, angle, speed and linked opposite-drift multiplier scoring
  - unbanked bank/loss behavior that preserves already banked lap score
  - no input-button scoring, new rAF loop, scene scans, DOM queries or per-sample object churn
  - semantic `turn:drift-score-event` and `turn:drift-lap-result` events for FLOW/achievement consumers
- persist one best DRIFT score per track with car, time and date metadata
- add `Show DRIFT scoring` as a presentation-only preference; hidden mode continues scoring and persistence without HUD commits
- compose DRIFT score/PB into the existing lap result and single live-region announcement
- retain generated TURN NEXT parity and repair TURN LAB's production-runtime surface

Closes #737.
Progresses #738.

## Verification

- full command set from `.github/workflows/turn-lab-tests.yml`
- repository-wide syntax check
- ESLint (no errors; existing warnings only)
- release source-of-truth check
- TURN NEXT app/main/entry parity checks
- focused ScoreFeedback, DRIFT core/runtime/integration, lap-result, vehicle-drift and MOUNTAIN LAB regressions
- score consistency regression at 60 fps vs 23 fps

## Deliberately deferred from #738

- tune score constants from real playtest distributions
- validate baseline vs hidden/visible HUD on physical iPad 9 + MOUNTAIN
- add achievements only after calibration, as required by the issue

#739 FLOW and #740 Trophy Road 2 remain downstream work.