### PR TITLE
TURN: polish DRIFT buildup and finish feedback

### DIFF
--- a/turn-tests/drift-attack-runtime-production.mjs
+++ b/turn-tests/drift-attack-runtime-production.mjs
@@ -45,17 +45,23 @@ function makeFeedback() {
     states: [],
     events: [],
     cleared: [],
+    activeEvent: { active: false },
     updateState(channel, state, now) {
       this.states.push({ channel, score: state.score, unbanked: state.unbanked, now });
     },
     publishEvent(channel, type, detail, now) {
       this.events.push({ channel, type, detail: { ...detail }, now });
+      this.activeEvent = { active: true, channel, type };
     },
     setChannelVisible(_channel, visible) {
       this.visible = visible;
     },
     clearChannel(channel) {
       this.cleared.push(channel);
+      if (this.activeEvent.channel === channel) this.activeEvent = { active: false };
+    },
+    inspect() {
+      return { activeEvent: { ...this.activeEvent } };
     }
   };
 }
@@ -70,6 +76,8 @@ function scoreLap(runtime, state, startAt = 0) {
   state.lapActive = true;
   state.speed = 25;
   state.driftSlipAngle = radians(60);
+  state.offRoad = false;
+  state.collided = false;
   for (let index = 0; index < 180; index += 1) {
     now += 1000 / 60;
     runtime.advance(1 / 60, now);
@@ -159,5 +167,99 @@ assert.equal(dormant.scorer.inspect().sampleCount, 0, 'Locked DRIFT processing r
 unlocked = true;
 assert.equal(dormant.refreshEntitlement(2000), true);
 assert.equal(dormantFeedback.visible, true);
+
+const visibleStorage = new MemoryStorage();
+const visibleFeedback = makeFeedback();
+const visibleState = {
+  speed: 0,
+  driftSlipAngle: 0,
+  offRoad: false,
+  collided: false,
+  lapActive: false,
+  trackId: 'harbor',
+  vehicleId: 'vintage-racer'
+};
+const visibleRuntime = createDriftAttackRuntime({
+  state: visibleState,
+  scoreFeedback: visibleFeedback,
+  storage: visibleStorage,
+  eventTarget: new EventTargetStub(),
+  isUnlocked: () => true,
+  wallClock: () => 654321
+});
+
+const visibleFirstLap = scoreLap(visibleRuntime, visibleState);
+const visibleFirstResult = visibleRuntime.completeLap({
+  now: visibleFirstLap.now,
+  time: visibleFirstLap.time,
+  valid: true,
+  ranked: true
+});
+assert.equal(visibleFirstResult.newBest, true);
+assert.ok(visibleFeedback.events.some((event) => event.type === 'personal-best'),
+  'A new DRIFT PB keeps its separate pink celebration');
+const neutralBank = visibleFeedback.events.find((event) => event.type === 'bank');
+assert.equal(neutralBank?.detail.label, '✓ BANKED',
+  'Neutral ×1 must not spend release emphasis on the default multiplier');
+
+const finishCelebrationsBefore = visibleFeedback.events.filter((event) =>
+  event.type === 'personal-best' || event.type === 'lap-result'
+).length;
+const visibleSecondLap = scoreLap(visibleRuntime, visibleState, visibleFirstLap.now + 1000);
+const visibleSecondResult = visibleRuntime.completeLap({
+  now: visibleSecondLap.now,
+  time: visibleSecondLap.time,
+  valid: true,
+  ranked: true
+});
+assert.equal(visibleSecondResult.newBest, false);
+assert.equal(visibleFeedback.events.filter((event) =>
+  event.type === 'personal-best' || event.type === 'lap-result'
+).length, finishCelebrationsBefore,
+'An ordinary lap must use the yellow lap card without a duplicate pink DRIFT LAP card');
+
+let recoveryNow = visibleSecondLap.now + 2000;
+visibleRuntime.beginLap(recoveryNow);
+visibleState.speed = 25;
+visibleState.driftSlipAngle = radians(60);
+visibleState.collided = false;
+for (let index = 0; index < 30; index += 1) {
+  recoveryNow += 1000 / 60;
+  visibleRuntime.advance(1 / 60, recoveryNow);
+}
+visibleState.collided = true;
+for (let index = 0; index < 8; index += 1) {
+  recoveryNow += 1000 / 60;
+  visibleRuntime.advance(1 / 60, recoveryNow);
+}
+visibleState.collided = false;
+assert.ok(visibleFeedback.events.some((event) => event.type === 'loss'));
+const clearsAfterLoss = visibleFeedback.cleared.length;
+for (let index = 0; index < 8; index += 1) {
+  recoveryNow += 1000 / 60;
+  visibleRuntime.advance(1 / 60, recoveryNow);
+}
+assert.ok(visibleFeedback.cleared.length > clearsAfterLoss,
+  'Starting a fresh drift must dismiss stale LOSS presentation instead of blocking the new buildup');
+
+const failingStorage = {
+  getItem() {
+    return null;
+  },
+  setItem() {
+    throw new Error('storage unavailable');
+  }
+};
+const failingRuntime = createDriftAttackRuntime({
+  state: { ...visibleState },
+  scoreFeedback: makeFeedback(),
+  storage: failingStorage,
+  eventTarget: new EventTargetStub(),
+  isUnlocked: () => true
+});
+assert.equal(failingRuntime.setHudVisible(false, { now: 10 }), false,
+  'A failed persistence write is still reported to Settings');
+assert.equal(failingRuntime.isHudVisible(), false,
+  'The current session must still honor the HUD visibility choice when persistence fails');
 
 console.log('TURN DRIFT ATTACK runtime, hidden-HUD and dormant-lock regressions passed.');

--- a/turn/scoring/drift-attack-runtime.js
+++ b/turn/scoring/drift-attack-runtime.js
@@ -44,6 +44,22 @@ function dispatchSemanticEvent(eventTarget, type, detail) {
   eventTarget.dispatchEvent(new globalThis.CustomEvent(type, { detail }));
 }
 
+function presentationDetail(type, detail) {
+  if (type === SCORE_FEEDBACK_EVENT.LOSS) {
+    return {
+      ...detail,
+      durationMs: detail?.durationMs ?? 1050
+    };
+  }
+  if (type === SCORE_FEEDBACK_EVENT.BANK && Number(detail?.multiplier) <= 1 && !detail?.label) {
+    return {
+      ...detail,
+      label: '✓ BANKED'
+    };
+  }
+  return detail;
+}
+
 export function createDriftAttackRuntime({
   state,
   scoreFeedback,
@@ -68,7 +84,12 @@ export function createDriftAttackRuntime({
 
   function publishEvent(type, detail, now) {
     if (enabled && hudVisible) {
-      scoreFeedback.publishEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, type, detail, now);
+      scoreFeedback.publishEvent(
+        SCORE_FEEDBACK_CHANNEL.DRIFT,
+        type,
+        presentationDetail(type, detail),
+        now
+      );
     }
     dispatchSemanticEvent(eventTarget, 'turn:drift-score-event', {
       channel: SCORE_FEEDBACK_CHANNEL.DRIFT,
@@ -154,14 +175,13 @@ export function createDriftAttackRuntime({
       lapTime: Number(time) || 0
     });
 
-    if (hudVisible && scoreResult.score > 0) {
-      const type = result.newBest
-        ? SCORE_FEEDBACK_EVENT.PERSONAL_BEST
-        : SCORE_FEEDBACK_EVENT.LAP_RESULT;
-      scoreFeedback.publishEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, type, {
+    // The yellow lap-result card is the authoritative finish summary. Keep a
+    // separate pink ScoreFeedback release only when the result is exceptional.
+    if (hudVisible && result.newBest && scoreResult.score > 0) {
+      scoreFeedback.publishEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, SCORE_FEEDBACK_EVENT.PERSONAL_BEST, {
         score: result.score,
         multiplier: result.maxMultiplier,
-        label: result.newBest ? 'NEW DRIFT BEST' : 'DRIFT LAP',
+        label: 'NEW DRIFT BEST',
         announce: false
       }, now);
     }
@@ -171,14 +191,15 @@ export function createDriftAttackRuntime({
 
   function setHudVisible(visible, { persist = true, now = 0 } = {}) {
     const next = visible !== false;
-    if (persist && !saveDriftHudVisible(next, targetStorage)) return false;
+    const persisted = !persist || saveDriftHudVisible(next, targetStorage);
     hudVisible = next;
     syncPresentation(now);
     dispatchSemanticEvent(eventTarget, 'turn:drift-hud-visibility-change', {
       visible: hudVisible,
-      enabled
+      enabled,
+      persisted
     });
-    return true;
+    return persisted;
   }
 
   function refreshEntitlement(now = 0) {

--- a/turn/scoring/drift-attack-runtime.js
+++ b/turn/scoring/drift-attack-runtime.js
@@ -84,12 +84,21 @@ export function createDriftAttackRuntime({
 
   function publishEvent(type, detail, now) {
     if (enabled && hudVisible) {
-      scoreFeedback.publishEvent(
-        SCORE_FEEDBACK_CHANNEL.DRIFT,
-        type,
-        presentationDetail(type, detail),
-        now
-      );
+      if (type === SCORE_FEEDBACK_EVENT.BUILD) {
+        const activeEvent = scoreFeedback.inspect?.().activeEvent;
+        if (activeEvent?.active
+          && activeEvent.channel === SCORE_FEEDBACK_CHANNEL.DRIFT
+          && activeEvent.type === SCORE_FEEDBACK_EVENT.LOSS) {
+          scoreFeedback.clearChannel(SCORE_FEEDBACK_CHANNEL.DRIFT, now);
+        }
+      } else {
+        scoreFeedback.publishEvent(
+          SCORE_FEEDBACK_CHANNEL.DRIFT,
+          type,
+          presentationDetail(type, detail),
+          now
+        );
+      }
     }
     dispatchSemanticEvent(eventTarget, 'turn:drift-score-event', {
       channel: SCORE_FEEDBACK_CHANNEL.DRIFT,

--- a/turn/scoring/score-feedback.css
+++ b/turn/scoring/score-feedback.css
@@ -26,6 +26,7 @@
   padding: 9px 11px 10px;
   border-radius: 15px;
   transform: translateZ(0);
+  transform-origin: left center;
   transition: opacity 140ms linear, transform 180ms ease-out;
 }
 
@@ -53,10 +54,13 @@
 }
 
 .score-feedback-values strong {
+  display: inline-block;
   overflow: hidden;
   font-size: clamp(1.32rem, 3.4vw, 2rem);
   letter-spacing: -.055em;
   text-overflow: ellipsis;
+  transform-origin: left center;
+  transition: transform 160ms ease-out;
 }
 
 .score-feedback-values b {
@@ -94,9 +98,23 @@
   font-size: 1.08em;
 }
 
+/* Buildup uses only composited transforms: no new animation loop or layout work. */
+.score-feedback[data-phase="intensify"] .score-feedback-state {
+  transform: translateZ(0) scale(1.018);
+}
+
+.score-feedback[data-phase="intensify"] .score-feedback-values strong {
+  transform: scale(1.055);
+}
+
+.score-feedback[data-phase="settle"] .score-feedback-state {
+  opacity: .96;
+  transform: translateZ(0) scale(.992);
+}
+
 .score-feedback[data-channel="flow"] .score-feedback-values b,
 .score-feedback[data-channel="flow"] .score-feedback-meter > i {
-  background-color: var(--turn-pink-500, #ff4fa3);
+  background: var(--turn-pink-500, #ff4fa3);
 }
 
 .score-feedback-callout {
@@ -190,8 +208,16 @@
 
 @media (prefers-reduced-motion: reduce) {
   .score-feedback-state,
+  .score-feedback-values strong,
   .score-feedback-meter > i {
     transition: none;
+  }
+
+  .score-feedback[data-phase="intensify"] .score-feedback-state,
+  .score-feedback[data-phase="settle"] .score-feedback-state,
+  .score-feedback[data-phase="intensify"] .score-feedback-values strong {
+    opacity: 1;
+    transform: none;
   }
 
   .score-feedback-callout.is-event-a,


### PR DESCRIPTION
## Summary

Small #738 polish pass based on the first merged DRIFT ATTACK playtest/video.

### Changes
- add cheap transform-only buildup emphasis when DRIFT enters `intensify`
- soften the HUD during `settle` without adding any new loop or layout animation
- shorten LOSS presentation and let a fresh drift dismiss stale LOSS feedback instead of blocking the new buildup
- keep neutral ×1 out of BANKED release copy (`✓ BANKED` rather than `✓ BANKED ×1`)
- make the yellow lap-result card authoritative for ordinary DRIFT finishes
- reserve the separate pink ScoreFeedback finish celebration for `NEW DRIFT BEST`
- honor a HUD hide/show choice for the current session even if localStorage persistence fails, while still reporting the persistence failure to Settings
- fix the future FLOW meter override so it replaces the DRIFT gradient rather than leaving a background-image behind

### Deliberately unchanged
- DRIFT score constants/calibration
- physics / slip detection
- 12 Hz scoring cadence
- record rules
- achievements
- Trophy Road gating

## Validation
- extends `turn-tests/drift-attack-runtime-production.mjs` for:
  - no duplicate pink ordinary-lap result
  - PB-only finish celebration
  - neutral ×1 BANKED copy
  - stale LOSS replacement by a new drift
  - session visibility behavior when persistence fails
- existing CI should exercise the full TURN regression suite

Refs #738.