### PR TITLE
TURN: match attached DRIFT gauge proportions

### DIFF
--- a/turn-tests/score-feedback-production.mjs
+++ b/turn-tests/score-feedback-production.mjs
@@ -233,8 +233,10 @@ assert.match(source, /data-score-feedback-flow-meter-fill/,
   'The shared engine must already understand the optional future FLOW gauge mount');
 assert.match(css, /--score-feedback-paper-height: 104px/,
   'Each scoring paper row has a stable gameplay height');
-assert.match(css, /--score-feedback-gauge-height:/,
-  'The horizontal instrument has an explicit stable height');
+assert.match(css, /--score-feedback-gauge-height: calc\(var\(--score-feedback-paper-height\) - 14px\)/,
+  'The attached gauge fills nearly the full stable scoring-row height');
+assert.match(css, /top: var\(--score-feedback-gauge-inset-y\)/,
+  'The attached gauge keeps equal optical insets inside its scoring row');
 assert.match(css, /transform: scaleX\(var\(--score-feedback-progress, 0\)\)/,
   'Score gauges fill horizontally without layout work');
 assert.doesNotMatch(css, /transform: scaleY\(var\(--score-feedback-progress, 0\)\)/,
@@ -254,7 +256,9 @@ for (const [mountName, markup] of [
 }
 assert.match(css, /data-score-channel="flow"/,
   'The reusable horizontal gauge primitive has a FLOW channel treatment ready for #739');
-assert.match(css, /top: calc\(var\(--score-feedback-paper-height\) \+ 30px\)/,
+assert.match(
+  css,
+  /top: calc\(var\(--score-feedback-paper-height\) \+ var\(--score-feedback-gauge-inset-y\)\)/,
   'The future FLOW gauge is aligned to its own fixed paper row');
 assert.match(css, /@keyframes turn-score-gauge-rush/,
   'High-intensity scoring keeps a transform-driven peripheral-noise layer');

--- a/turn/scoring/score-feedback.css
+++ b/turn/scoring/score-feedback.css
@@ -1,8 +1,9 @@
 .score-feedback {
   --score-feedback-paper-width: clamp(164px, 21vw, 226px);
   --score-feedback-paper-height: 104px;
-  --score-feedback-gauge-width: clamp(52px, 7vw, 76px);
-  --score-feedback-gauge-height: clamp(34px, 5vw, 48px);
+  --score-feedback-gauge-width: clamp(48px, 6vw, 64px);
+  --score-feedback-gauge-height: calc(var(--score-feedback-paper-height) - 14px);
+  --score-feedback-gauge-inset-y: 7px;
   --score-feedback-gauge-overlap: 3px;
   position: absolute;
   z-index: 14;
@@ -135,7 +136,7 @@
   --score-feedback-gauge-track: var(--turn-ink, #08090a);
   position: absolute;
   z-index: -1;
-  top: 30px;
+  top: var(--score-feedback-gauge-inset-y);
   left: calc(100% - var(--score-feedback-gauge-overlap));
   box-sizing: border-box;
   width: var(--score-feedback-gauge-width);
@@ -165,11 +166,11 @@
 
 /* Future FLOW row aligns its gauge with the second fixed scoring row. */
 .score-feedback-gauge[data-score-channel="flow"] {
-  top: calc(var(--score-feedback-paper-height) + 30px);
+  top: calc(var(--score-feedback-paper-height) + var(--score-feedback-gauge-inset-y));
 }
 
 .score-feedback[data-drift-active="false"] .score-feedback-gauge[data-score-channel="flow"] {
-  top: 30px;
+  top: var(--score-feedback-gauge-inset-y);
 }
 
 .score-feedback[data-flow-gauge-visible="false"] .score-feedback-gauge[data-score-channel="flow"] {
@@ -402,7 +403,8 @@
     --score-feedback-paper-width: 150px;
     --score-feedback-paper-height: 88px;
     --score-feedback-gauge-width: 46px;
-    --score-feedback-gauge-height: 32px;
+    --score-feedback-gauge-height: calc(var(--score-feedback-paper-height) - 12px);
+    --score-feedback-gauge-inset-y: 6px;
     --score-feedback-gauge-overlap: 2px;
     top: 80px;
   }
@@ -415,17 +417,8 @@
 
   .score-feedback-meter,
   .score-feedback-gauge {
-    top: 26px;
     border-width: 2px;
     border-radius: 0 8px 8px 0;
-  }
-
-  .score-feedback-gauge[data-score-channel="flow"] {
-    top: calc(var(--score-feedback-paper-height) + 26px);
-  }
-
-  .score-feedback[data-drift-active="false"] .score-feedback-gauge[data-score-channel="flow"] {
-    top: 26px;
   }
 
   .score-feedback-meter::before,


### PR DESCRIPTION
## Summary

Follow-up to #745 based on the production playtest screenshot.

- make the attached DRIFT gauge nearly fill the fixed paper-row height
- center it with equal optical top/bottom insets
- narrow the gauge slightly to match the intended chunky proportions
- keep the paper in front at the attachment seam; the existing negative stacking is intentional
- apply the same proportional geometry to compact-height layouts
- preserve the dormant reusable FLOW geometry without mounting or implementing FLOW

## Performance

CSS geometry only. Progress and heat continue to use the existing transform/opacity path; there is no scoring, sampling, physics, records, DOM, or animation-loop change.

## Verification

- `node turn-tests/score-feedback-production.mjs`
- `node turn-tests/drift-attack-runtime-production.mjs`
- `node turn-tests/drift-attack-integration-production.mjs`
- `node turn-tests/turn-next-entry-production.mjs`
- `node turn-tests/release-production.mjs`

Refs #738.