### PR TITLE
TURN: keep DRIFT ScoreFeedback stable between drifts

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -191,10 +191,10 @@
     <div class="topbar"><div class="stats"><div class="chip">speed<strong><span id="speed">0</span> km/h</strong></div><div class="chip">lap<strong id="lap">1</strong></div><div class="chip">time<strong id="lapTime">0:00.000</strong></div><div class="chip">best<strong id="bestTime">--:--.---</strong></div></div><div class="map-wrap"><canvas id="map" width="300" height="210" aria-label="Track map"></canvas></div></div>
     <div class="message" id="message" role="status"></div>
     <aside class="score-feedback" id="scoreFeedback" aria-label="Driving score" hidden>
+      <div class="score-feedback-meter" aria-hidden="true"><i data-score-feedback-meter-fill></i></div>
       <section class="score-feedback-state" data-score-feedback-state>
         <div class="score-feedback-heading"><span data-score-feedback-label>DRIFT</span><span>COMBO</span></div>
         <div class="score-feedback-values"><strong data-score-feedback-current>0</strong><b data-score-feedback-multiplier>×1</b></div>
-        <div class="score-feedback-meter" aria-hidden="true"><i data-score-feedback-meter-fill></i></div>
         <div class="score-feedback-lap"><span>LAP</span><b data-score-feedback-total>0</b></div>
       </section>
       <section class="score-feedback-callout" data-score-feedback-callout aria-hidden="true" hidden>

--- a/turn-next/index.html
+++ b/turn-next/index.html
@@ -159,10 +159,10 @@
     <div class="topbar"><div class="stats"><div class="chip">speed<strong><span id="speed">0</span> km/h</strong></div><div class="chip">lap<strong id="lap">1</strong></div><div class="chip">time<strong id="lapTime">0:00.000</strong></div><div class="chip">best<strong id="bestTime">--:--.---</strong></div></div><div class="map-wrap"><canvas id="map" width="300" height="210" aria-label="Track map"></canvas></div></div>
     <div class="message" id="message" role="status"></div>
     <aside class="score-feedback" id="scoreFeedback" aria-label="Driving score" hidden>
+      <div class="score-feedback-meter" aria-hidden="true"><i data-score-feedback-meter-fill></i></div>
       <section class="score-feedback-state" data-score-feedback-state>
         <div class="score-feedback-heading"><span data-score-feedback-label>DRIFT</span><span>COMBO</span></div>
         <div class="score-feedback-values"><strong data-score-feedback-current>0</strong><b data-score-feedback-multiplier>×1</b></div>
-        <div class="score-feedback-meter" aria-hidden="true"><i data-score-feedback-meter-fill></i></div>
         <div class="score-feedback-lap"><span>LAP</span><b data-score-feedback-total>0</b></div>
       </section>
       <section class="score-feedback-callout" data-score-feedback-callout aria-hidden="true" hidden>

--- a/turn-tests/drift-attack-runtime-production.mjs
+++ b/turn-tests/drift-attack-runtime-production.mjs
@@ -45,6 +45,7 @@ function makeFeedback() {
     states: [],
     events: [],
     cleared: [],
+    dismissed: [],
     activeEvent: { active: false },
     updateState(channel, state, now) {
       this.states.push({ channel, score: state.score, unbanked: state.unbanked, now });
@@ -58,6 +59,10 @@ function makeFeedback() {
     },
     clearChannel(channel) {
       this.cleared.push(channel);
+      if (this.activeEvent.channel === channel) this.activeEvent = { active: false };
+    },
+    dismissEvent(channel) {
+      this.dismissed.push(channel);
       if (this.activeEvent.channel === channel) this.activeEvent = { active: false };
     },
     inspect() {
@@ -234,13 +239,13 @@ for (let index = 0; index < 8; index += 1) {
 }
 visibleState.collided = false;
 assert.ok(visibleFeedback.events.some((event) => event.type === 'loss'));
-const clearsAfterLoss = visibleFeedback.cleared.length;
+const dismissalsAfterLoss = visibleFeedback.dismissed.length;
 for (let index = 0; index < 8; index += 1) {
   recoveryNow += 1000 / 60;
   visibleRuntime.advance(1 / 60, recoveryNow);
 }
-assert.ok(visibleFeedback.cleared.length > clearsAfterLoss,
-  'Starting a fresh drift must dismiss stale LOSS presentation instead of blocking the new buildup');
+assert.ok(visibleFeedback.dismissed.length > dismissalsAfterLoss,
+  'Starting a fresh drift must dismiss stale LOSS feedback without clearing the persistent score row');
 
 const failingStorage = {
   getItem() {

--- a/turn-tests/score-feedback-production.mjs
+++ b/turn-tests/score-feedback-production.mjs
@@ -83,6 +83,11 @@ const feedback = createScoreFeedback({
 });
 
 assert.equal(fixture.root.hidden, true, 'An idle ScoreFeedback root stays out of the HUD');
+feedback.setChannelVisible(SCORE_FEEDBACK_CHANNEL.DRIFT, true, 0);
+assert.equal(fixture.root.hidden, false, 'An available scoring row remains visible at zero');
+assert.equal(element(fixture, '[data-score-feedback-state]').hidden, false);
+assert.equal(element(fixture, '[data-score-feedback-current]').textContent, '0');
+assert.equal(fixture.root.dataset.driftGaugeVisible, 'true');
 
 const driftState = {
   active: true,
@@ -160,7 +165,8 @@ const flowState = {
   phase: 'intensify',
   label: 'FLOW'
 };
-feedback.updateState(SCORE_FEEDBACK_CHANNEL.FLOW, flowState, 500);
+feedback.setChannelVisible(SCORE_FEEDBACK_CHANNEL.FLOW, true, 500);
+feedback.updateState(SCORE_FEEDBACK_CHANNEL.FLOW, flowState, 600);
 assert.equal(fixture.root.dataset.channel, 'flow', 'FLOW becomes persistent context when both channels are active');
 assert.equal(element(fixture, '[data-score-feedback-current]').textContent, '18,420');
 assert.equal(
@@ -212,6 +218,36 @@ assert.equal(
   element(fixture, '[data-score-feedback-meter-fill]').style.getPropertyValue('--score-feedback-progress'),
   '0'
 );
+
+feedback.setChannelVisible(SCORE_FEEDBACK_CHANNEL.DRIFT, true, 4100);
+feedback.updateState(SCORE_FEEDBACK_CHANNEL.DRIFT, {
+  active: false,
+  score: 4820,
+  unbanked: 0,
+  multiplier: 1,
+  intensity: 0,
+  phase: 'quiet',
+  label: 'DRIFT'
+}, 4200);
+assert.equal(fixture.root.hidden, false, 'The DRIFT instrument does not flicker out between drifts');
+assert.equal(element(fixture, '[data-score-feedback-current]').textContent, '0');
+assert.equal(element(fixture, '[data-score-feedback-total]').textContent, '4,820');
+assert.equal(
+  element(fixture, '[data-score-feedback-meter-fill]').style.getPropertyValue('--score-feedback-progress'),
+  '0'
+);
+feedback.publishEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, SCORE_FEEDBACK_EVENT.LOSS, {
+  score: 120
+}, 4300);
+feedback.dismissEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, 4350);
+assert.equal(element(fixture, '[data-score-feedback-callout]').hidden, true);
+assert.equal(element(fixture, '[data-score-feedback-total]').textContent, '4,820',
+  'Dismissing stale feedback must not clear the persistent lap total');
+feedback.clearChannel(SCORE_FEEDBACK_CHANNEL.DRIFT, 4400);
+assert.equal(fixture.root.hidden, false, 'Clearing a visible channel leaves its zero-state instrument mounted');
+assert.equal(element(fixture, '[data-score-feedback-total]').textContent, '0');
+feedback.setChannelVisible(SCORE_FEEDBACK_CHANNEL.DRIFT, false, 4500);
+assert.equal(fixture.root.hidden, true, 'The HUD setting still removes the scoring instrument');
 assert.equal(
   element(fixture, '[data-score-feedback-flow-meter-fill]').style.getPropertyValue('--score-feedback-progress'),
   '0'
@@ -253,7 +289,19 @@ for (const [mountName, markup] of [
     /data-score-feedback-label>DRIFT<\/span><span>COMBO<\/span>/,
     `${mountName} exposes COMBO vocabulary in accessible markup`
   );
+  assert.ok(
+    markup.indexOf('class="score-feedback-meter"') < markup.indexOf('class="score-feedback-state"'),
+    `${mountName} keeps the gauge behind the paper as a sibling stacking layer`
+  );
 }
+assert.match(css, /\.score-feedback-state \{[\s\S]*?z-index: 1;/,
+  'The paper owns the foreground stacking layer');
+assert.match(css, /\.score-feedback-meter,[\s\S]*?z-index: 0;/,
+  'The attached gauge sits behind the paper instead of intruding into it');
+assert.match(css, /--score-feedback-gauge-track: var\(--turn-ink\);/,
+  'The gauge body uses the canonical TURN ink token');
+assert.doesNotMatch(css, /#(?:000(?:000)?|08090a)\b/i,
+  'ScoreFeedback never substitutes a local black for --turn-ink');
 assert.match(css, /data-score-channel="flow"/,
   'The reusable horizontal gauge primitive has a FLOW channel treatment ready for #739');
 assert.match(

--- a/turn/index.html
+++ b/turn/index.html
@@ -188,10 +188,10 @@
     <div class="topbar"><div class="stats"><div class="chip">speed<strong><span id="speed">0</span> km/h</strong></div><div class="chip">lap<strong id="lap">1</strong></div><div class="chip">time<strong id="lapTime">0:00.000</strong></div><div class="chip">best<strong id="bestTime">--:--.---</strong></div></div><div class="map-wrap"><canvas id="map" width="300" height="210" aria-label="Track map"></canvas></div></div>
     <div class="message" id="message" role="status"></div>
     <aside class="score-feedback" id="scoreFeedback" aria-label="Driving score" hidden>
+      <div class="score-feedback-meter" aria-hidden="true"><i data-score-feedback-meter-fill></i></div>
       <section class="score-feedback-state" data-score-feedback-state>
         <div class="score-feedback-heading"><span data-score-feedback-label>DRIFT</span><span>COMBO</span></div>
         <div class="score-feedback-values"><strong data-score-feedback-current>0</strong><b data-score-feedback-multiplier>×1</b></div>
-        <div class="score-feedback-meter" aria-hidden="true"><i data-score-feedback-meter-fill></i></div>
         <div class="score-feedback-lap"><span>LAP</span><b data-score-feedback-total>0</b></div>
       </section>
       <section class="score-feedback-callout" data-score-feedback-callout aria-hidden="true" hidden>

--- a/turn/scoring/drift-attack-runtime.js
+++ b/turn/scoring/drift-attack-runtime.js
@@ -89,7 +89,7 @@ export function createDriftAttackRuntime({
         if (activeEvent?.active
           && activeEvent.channel === SCORE_FEEDBACK_CHANNEL.DRIFT
           && activeEvent.type === SCORE_FEEDBACK_EVENT.LOSS) {
-          scoreFeedback.clearChannel(SCORE_FEEDBACK_CHANNEL.DRIFT, now);
+          scoreFeedback.dismissEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, now);
         }
       } else {
         scoreFeedback.publishEvent(

--- a/turn/scoring/score-feedback.css
+++ b/turn/scoring/score-feedback.css
@@ -10,7 +10,7 @@
   top: clamp(92px, 24vh, 160px);
   left: max(14px, env(safe-area-inset-left));
   width: var(--score-feedback-paper-width);
-  color: var(--turn-ink, #08090a);
+  color: var(--turn-ink);
   pointer-events: none;
 }
 
@@ -24,9 +24,9 @@
 .score-feedback-state,
 .score-feedback-callout {
   box-sizing: border-box;
-  border: 3px solid var(--turn-ink, #08090a);
+  border: 3px solid var(--turn-ink);
   background: rgb(255 248 232 / .94);
-  box-shadow: 4px 4px 0 var(--turn-ink, #08090a);
+  box-shadow: 4px 4px 0 var(--turn-ink);
 }
 
 /*
@@ -37,6 +37,7 @@
  */
 .score-feedback-state {
   position: relative;
+  z-index: 1;
   display: grid;
   grid-template-rows: auto 1fr auto;
   width: 100%;
@@ -133,9 +134,9 @@
 .score-feedback-gauge {
   --score-feedback-gauge-fill-a: #0bbcf4;
   --score-feedback-gauge-fill-b: #67e2ff;
-  --score-feedback-gauge-track: var(--turn-ink, #08090a);
+  --score-feedback-gauge-track: var(--turn-ink);
   position: absolute;
-  z-index: -1;
+  z-index: 0;
   top: var(--score-feedback-gauge-inset-y);
   left: calc(100% - var(--score-feedback-gauge-overlap));
   box-sizing: border-box;
@@ -143,7 +144,7 @@
   height: var(--score-feedback-gauge-height);
   margin: 0;
   overflow: hidden;
-  border: 3px solid var(--turn-ink, #08090a);
+  border: 3px solid var(--turn-ink);
   border-radius: 0 10px 10px 0;
   background: var(--score-feedback-gauge-track);
   opacity: 1;
@@ -161,7 +162,7 @@
 .score-feedback-gauge[data-score-channel="flow"] {
   --score-feedback-gauge-fill-a: #ff4f8d;
   --score-feedback-gauge-fill-b: #ff91bd;
-  --score-feedback-gauge-track: var(--turn-ink, #08090a);
+  --score-feedback-gauge-track: var(--turn-ink);
 }
 
 /* Future FLOW row aligns its gauge with the second fixed scoring row. */
@@ -169,7 +170,7 @@
   top: calc(var(--score-feedback-paper-height) + var(--score-feedback-gauge-inset-y));
 }
 
-.score-feedback[data-drift-active="false"] .score-feedback-gauge[data-score-channel="flow"] {
+.score-feedback[data-drift-visible="false"] .score-feedback-gauge[data-score-channel="flow"] {
   top: var(--score-feedback-gauge-inset-y);
 }
 
@@ -305,6 +306,7 @@
 
 .score-feedback-callout {
   position: absolute;
+  z-index: 2;
   top: calc(var(--score-feedback-paper-height) + 9px);
   left: 8px;
   width: max-content;
@@ -363,7 +365,7 @@
 }
 
 .score-feedback-callout.is-release {
-  box-shadow: 5px 5px 0 var(--turn-ink, #08090a);
+  box-shadow: 5px 5px 0 var(--turn-ink);
 }
 
 @keyframes turn-score-gauge-hot {
@@ -412,7 +414,7 @@
   .score-feedback-state {
     padding: 7px 9px 8px;
     border-width: 2px;
-    box-shadow: 3px 3px 0 var(--turn-ink, #08090a);
+    box-shadow: 3px 3px 0 var(--turn-ink);
   }
 
   .score-feedback-meter,

--- a/turn/scoring/score-feedback.js
+++ b/turn/scoring/score-feedback.js
@@ -50,7 +50,7 @@ const numberFormatter = new Intl.NumberFormat('en-US', {
 function makeChannel(label) {
   return {
     active: false,
-    visible: true,
+    visible: false,
     score: 0,
     unbanked: 0,
     multiplier: 1,
@@ -318,9 +318,18 @@ export function createScoreFeedback({
     return commit(now, true);
   }
 
+  function dismissEvent(channel, now = 0) {
+    const normalizedChannel = normalizeChannel(channel);
+    if (!activeEvent.active || activeEvent.channel !== normalizedChannel) return false;
+    clearEvent();
+    dirty = true;
+    return commit(now, true);
+  }
+
   function reset(now = 0) {
     for (const channel of Object.values(channels)) {
       resetChannelState(channel);
+      channel.visible = false;
     }
     clearEvent();
     announcementRevision += 1;
@@ -347,11 +356,16 @@ export function createScoreFeedback({
       ? flow
       : driftActive
         ? drift
-        : null;
+        : drift.visible
+          ? drift
+          : flow.visible
+            ? flow
+            : null;
     const eventVisible = activeEvent.active && channels[activeEvent.channel].visible;
     const flowHasOwnGauge = Boolean(flowGaugeFill);
     const fallbackGaugeToFlow = !flowHasOwnGauge && flowActive && primary === flow;
     const driftGaugeActive = driftActive || fallbackGaugeToFlow;
+    const driftGaugeVisible = drift.visible || fallbackGaugeToFlow;
     const driftGaugeIntensity = fallbackGaugeToFlow ? flow.intensity : drift.intensity;
 
     driftGaugeFill.style.setProperty(
@@ -366,8 +380,10 @@ export function createScoreFeedback({
     }
     setData(root, 'driftActive', driftActive);
     setData(root, 'flowActive', flowActive);
-    setData(root, 'driftGaugeVisible', driftGaugeActive);
-    setData(root, 'flowGaugeVisible', Boolean(flowHasOwnGauge && flowActive));
+    setData(root, 'driftVisible', drift.visible);
+    setData(root, 'flowVisible', flow.visible);
+    setData(root, 'driftGaugeVisible', driftGaugeVisible);
+    setData(root, 'flowGaugeVisible', Boolean(flowHasOwnGauge && flow.visible));
     setData(root, 'driftHeat', heatTier(drift.intensity, driftActive));
     setData(root, 'flowHeat', heatTier(flow.intensity, flowActive));
     setData(root, 'gaugeHeat', heatTier(driftGaugeIntensity, driftGaugeActive));
@@ -375,13 +391,15 @@ export function createScoreFeedback({
     setData(
       statePanel,
       'scoreLayout',
-      flowReadout && flowActive && driftActive ? 'dual' : 'single'
+      flowReadout && flow.visible && drift.visible ? 'dual' : 'single'
     );
-    if (flowReadout) setHidden(flowReadout, !flowActive);
+    if (flowReadout) setHidden(flowReadout, !flow.visible);
 
     setHidden(statePanel, !primary);
     if (primary) {
-      const liveScore = primary.unbanked > 0 ? primary.unbanked : primary.score;
+      const liveScore = primary.active
+        ? primary.unbanked > 0 ? primary.unbanked : primary.score
+        : 0;
       setData(root, 'channel', primary === flow ? SCORE_FEEDBACK_CHANNEL.FLOW : SCORE_FEEDBACK_CHANNEL.DRIFT);
       setData(root, 'phase', primary.phase);
       setText(stateLabel, primary.label);
@@ -430,6 +448,7 @@ export function createScoreFeedback({
     setChannelVisible,
     commit,
     clearChannel,
+    dismissEvent,
     reset,
     inspect
   });


### PR DESCRIPTION
## Summary

Playtest follow-up for #738 after the horizontal attached-gauge work.

- move the gauge out of the paper and give the two siblings explicit stacking layers, so the paper covers the attachment seam
- use the canonical `--turn-ink` token directly for every black ScoreFeedback surface, border and shadow
- keep an unlocked, enabled DRIFT row mounted throughout the race HUD instead of hiding it between drifts
- show `0` as the idle current score while preserving the lap total
- keep the zero-state gauge visible with its cyan remnant
- continue to hide the entire row when DRIFT is locked or the live HUD setting is off
- dismiss stale LOSS callouts without clearing the persistent lap display

This deliberately chooses stable persistence over a disappearance timeout. It removes flicker today and preserves independent presentation visibility for future scoring layers without implementing FLOW.

## Performance

- no new timer, `requestAnimationFrame`, observer or monitoring loop
- no scoring, sampling, physics or calibration change
- idle persistence produces no continuous DOM updates; ScoreFeedback still commits only through the existing throttled path when dirty
- buildup animations remain transform/opacity only

## Verification

- `node --check turn/scoring/score-feedback.js`
- `node --check turn/scoring/drift-attack-runtime.js`
- `node turn-tests/score-feedback-production.mjs`
- `node turn-tests/drift-attack-core-production.mjs`
- `node turn-tests/drift-attack-runtime-production.mjs`
- `node turn-tests/drift-attack-integration-production.mjs`
- `node turn-tests/turn-next-entry-production.mjs`
- `node turn-tests/release-production.mjs`

Refs #737
Refs #738.