### PR TITLE
TURN stats: publish DRIFT/FLOW calibration dashboard

### DIFF
--- a/turn-tests/telemetry-production.mjs
+++ b/turn-tests/telemetry-production.mjs
@@ -60,6 +60,8 @@ assert.match(statsHtml, /data-audience="players" aria-pressed="true">PLAYERS/);
 assert.match(statsHtml, /data-audience="developer">DEVELOPER/);
 assert.match(statsHtml, /MARK AS DEVELOPER/);
 assert.match(statsHtml, /older activity cannot be separated/i);
+assert.match(statsHtml, /stats\.js\?revision=r4-score-calibration/,
+  'The private dashboard must bust the pre-calibration stats script cache');
 assert.doesNotMatch(productionIndex, /href=["'][^"']*\/turn\/stats|href=["'][^"']*stats\//i,
   'The private dashboard must not be linked into public TURN navigation');
 assert.match(statsJs, /location\.hash\.slice\(1\)/,

--- a/turn/stats/index.html
+++ b/turn/stats/index.html
@@ -123,6 +123,6 @@
       </footer>
     </section>
   </main>
-  <script type="module" src="./stats.js?revision=r3-awd-label"></script>
+  <script type="module" src="./stats.js?revision=r4-score-calibration"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- publishes the already-merged DRIFT/FLOW calibration dashboard under a fresh stats-script cache identity
- ensures browsers fetch the current `stats.js` that includes DRIFT and FLOW score distributions
- makes MOUNTAIN appear in track rankings, lap averages and DRIFT/FLOW calibration rows through the already-merged track definition
- adds a regression so future stats feature updates cannot accidentally keep the pre-calibration script cache identity

## Why
#751 already added the calibration panels, MOUNTAIN and the Worker/API support on `main`, but `/turn/stats/` still referenced `stats.js?revision=r3-awd-label`. Browsers that had cached that URL could continue running the old dashboard JavaScript and therefore miss the new scoring data/track.

## Cloudflare
No Worker schema/API change is required here. Worker v3 already accepts `drift_score` / `flow_score` and returns `scoreDistributions`; this PR only makes the private dashboard reliably load the matching client renderer.

## Verification
- existing telemetry regression still checks score distribution rendering, developer/player separation and MOUNTAIN coverage
- new assertion guards `stats.js?revision=r4-score-calibration`

Refs #739