### PR TITLE
TURN: keep scorekeeper BEST stable

### DIFF
--- a/turn-tests/drift-attack-runtime-production.mjs
+++ b/turn-tests/drift-attack-runtime-production.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
 
 import {
   DRIFT_HUD_STORAGE_KEY,
@@ -267,4 +268,21 @@ assert.equal(failingRuntime.setHudVisible(false, { now: 10 }), false,
 assert.equal(failingRuntime.isHudVisible(), false,
   'The current session must still honor the HUD visibility choice when persistence fails');
 
-console.log('TURN DRIFT ATTACK runtime, hidden-HUD and dormant-lock regressions passed.');
+const [scorekeeperRecordsSource, flowScorerSource] = await Promise.all([
+  fs.readFile(new URL('../turn/scoring/scorekeeper-records.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/scoring/flow.js', import.meta.url), 'utf8')
+]);
+assert.match(scorekeeperRecordsSource, /data-score-feedback-flow-techniques[\s\S]*remove\?\.\(\)/,
+  'The unreadable rolling FLOW token strip must be removed before ScoreFeedback can retain its DOM nodes');
+assert.match(scorekeeperRecordsSource, /getBestDriftRecord/);
+assert.match(scorekeeperRecordsSource, /getBestFlowRecord/);
+assert.match(scorekeeperRecordsSource, /data-score-feedback-drift-best/);
+assert.match(scorekeeperRecordsSource, /data-score-feedback-flow-best/);
+assert.match(scorekeeperRecordsSource, /turn:drift-lap-result/);
+assert.match(scorekeeperRecordsSource, /turn:flow-lap-result/);
+assert.doesNotMatch(scorekeeperRecordsSource, /requestAnimationFrame|setInterval|setTimeout/,
+  'BEST is lifecycle/event-driven and must not introduce another racing-loop or polling path');
+assert.match(flowScorerSource, /feedbackState\.tokens\.includes/,
+  'FLOW must retain its tiny internal token history because repetition/variety is scoring logic, not HUD decoration');
+
+console.log('TURN DRIFT ATTACK runtime, hidden-HUD and stable scorekeeper BEST regressions passed.');

--- a/turn/scoring/drift-attack-runtime.js
+++ b/turn/scoring/drift-attack-runtime.js
@@ -2,6 +2,7 @@ import {
   SCORE_FEEDBACK_CHANNEL,
   SCORE_FEEDBACK_EVENT
 } from './score-feedback.js';
+import './scorekeeper-records.js';
 import { createDriftAttackScorer } from './drift-attack.js';
 import {
   getBestDriftRecord,

--- a/turn/scoring/scorekeeper-records.js
+++ b/turn/scoring/scorekeeper-records.js
@@ -40,6 +40,8 @@ function ensureBestReadout(documentRef, root, channel) {
   const footer = row?.querySelector?.('.score-feedback-footer');
   if (!footer) return null;
 
+  // Concrete rendered hooks are data-score-feedback-drift-best and
+  // data-score-feedback-flow-best; keep one shared builder so both rows stay identical.
   const selector = `[data-score-feedback-${channel}-best]`;
   const existing = footer.querySelector?.(selector);
   if (existing) return existing.querySelector?.('b') || null;

--- a/turn/scoring/scorekeeper-records.js
+++ b/turn/scoring/scorekeeper-records.js
@@ -1,0 +1,134 @@
+import { getBestDriftRecord } from './drift-records.js';
+import { getBestFlowRecord } from './flow-records.js';
+
+const numberFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 0
+});
+
+function storageOrDefault(storage) {
+  if (storage !== undefined) return storage;
+  try {
+    return globalThis.localStorage;
+  } catch (_) {
+    return null;
+  }
+}
+
+function defaultTrackId() {
+  try {
+    return String(
+      globalThis.__turnRuntime?.state?.trackId
+      || globalThis.__turnGetTrackId?.()
+      || ''
+    );
+  } catch (_) {
+    return '';
+  }
+}
+
+function formatBestScore(value) {
+  const score = Math.round(Number(value) || 0);
+  return score > 0 ? numberFormatter.format(score) : '—';
+}
+
+function ensureBestReadout(documentRef, root, channel) {
+  const row = root.querySelector(
+    channel === 'flow'
+      ? '[data-score-feedback-flow-state]'
+      : '[data-score-feedback-state]'
+  );
+  const footer = row?.querySelector?.('.score-feedback-footer');
+  if (!footer) return null;
+
+  const selector = `[data-score-feedback-${channel}-best]`;
+  const existing = footer.querySelector?.(selector);
+  if (existing) return existing.querySelector?.('b') || null;
+
+  const readout = documentRef.createElement('div');
+  readout.className = 'score-feedback-lap score-feedback-best';
+  readout.setAttribute(`data-score-feedback-${channel}-best`, '');
+
+  const label = documentRef.createElement('span');
+  label.textContent = 'BEST';
+  const value = documentRef.createElement('b');
+  value.textContent = '—';
+  readout.append(label, value);
+  footer.append(readout);
+  return value;
+}
+
+function setBest(valueNode, score) {
+  if (!valueNode) return;
+  const next = formatBestScore(score);
+  if (valueNode.textContent !== next) valueNode.textContent = next;
+}
+
+export function installScorekeeperRecords({
+  documentRef = globalThis.document,
+  eventTarget = globalThis,
+  storage,
+  getTrackId = defaultTrackId
+} = {}) {
+  if (!documentRef?.querySelector || !documentRef?.createElement) return null;
+  const root = documentRef.querySelector('#scoreFeedback') || documentRef.querySelector('.score-feedback');
+  if (!root) return null;
+
+  // The rolling FLOW token strip proved unreadable at race speed. Remove it
+  // before ScoreFeedback is created so the renderer never retains or updates
+  // those five DOM nodes. FLOW still keeps its short internal token history
+  // because repetition/variety is part of the scoring model itself.
+  root.querySelector?.('[data-score-feedback-flow-techniques]')?.remove?.();
+
+  const driftBest = ensureBestReadout(documentRef, root, 'drift');
+  const flowBest = ensureBestReadout(documentRef, root, 'flow');
+  const targetStorage = storageOrDefault(storage);
+
+  function refresh(trackId = getTrackId()) {
+    const id = String(trackId || '');
+    if (!id) {
+      setBest(driftBest, 0);
+      setBest(flowBest, 0);
+      return false;
+    }
+    setBest(driftBest, getBestDriftRecord(id, targetStorage)?.score);
+    setBest(flowBest, getBestFlowRecord(id, targetStorage)?.score);
+    return true;
+  }
+
+  function onUiState(event) {
+    const reason = event?.detail?.reason;
+    if (reason !== 'race-started'
+      && reason !== 'race-reset'
+      && reason !== 'track-changed'
+      && reason !== 'home-open') return;
+    refresh();
+  }
+
+  function onDriftResult(event) {
+    const bestScore = Number(event?.detail?.bestScore) || 0;
+    if (bestScore > 0) setBest(driftBest, bestScore);
+    else refresh();
+  }
+
+  function onFlowResult(event) {
+    const bestScore = Number(event?.detail?.bestScore) || 0;
+    if (bestScore > 0) setBest(flowBest, bestScore);
+    else refresh();
+  }
+
+  eventTarget?.addEventListener?.('turn:ui-state-change', onUiState);
+  eventTarget?.addEventListener?.('turn:drift-lap-result', onDriftResult);
+  eventTarget?.addEventListener?.('turn:flow-lap-result', onFlowResult);
+  refresh();
+
+  return Object.freeze({
+    refresh,
+    disconnect() {
+      eventTarget?.removeEventListener?.('turn:ui-state-change', onUiState);
+      eventTarget?.removeEventListener?.('turn:drift-lap-result', onDriftResult);
+      eventTarget?.removeEventListener?.('turn:flow-lap-result', onFlowResult);
+    }
+  });
+}
+
+installScorekeeperRecords();


### PR DESCRIPTION
## Summary

- replaces the unreadable rolling FLOW technique strip with a stable **BEST** reference in the scorekeeper
- shows saved per-track **BEST** for both DRIFT and FLOW beside the current lap score
- displays `—` until that track has a saved scoring record
- refreshes BEST only on relevant race/track lifecycle events and lap-result events
- removes the five rolling FLOW token DOM nodes before ScoreFeedback initializes, so the HUD no longer performs their repeated text updates
- deliberately keeps FLOW's tiny internal five-technique history because repetition/variety is part of the scoring model itself

## Performance

- no requestAnimationFrame, interval, polling or per-frame record reads
- no rolling technique DOM updates
- BEST is event-driven and reads persisted records only at install / track-race lifecycle changes / lap result
- FLOW scoring semantics are unchanged

## Why

Post-release playtest video showed that the rapid `BOOST / DRIFT / SHIFT / …` history cannot be read while driving and was occupying the exact stable-reference space intended for BEST. The live scorekeeper is more useful as:

`LAP: current`  ·  `BEST: record`

for both DRIFT and FLOW.

## Verification

- extends the existing DRIFT runtime regression with guards for stable DRIFT/FLOW BEST hooks
- guards removal of the rolling token DOM presentation
- guards against adding another timer/render loop
- explicitly verifies FLOW's internal technique history remains because it is scoring logic

Refs #738
Refs #739