### PR TITLE
TURN: add LAST score and tighten scorekeeper hierarchy

### DIFF
--- a/turn-tests/drift-attack-runtime-production.mjs
+++ b/turn-tests/drift-attack-runtime-production.mjs
@@ -278,11 +278,23 @@ assert.match(scorekeeperRecordsSource, /getBestDriftRecord/);
 assert.match(scorekeeperRecordsSource, /getBestFlowRecord/);
 assert.match(scorekeeperRecordsSource, /data-score-feedback-drift-best/);
 assert.match(scorekeeperRecordsSource, /data-score-feedback-flow-best/);
+assert.match(scorekeeperRecordsSource, /data-score-feedback-drift-last/);
+assert.match(scorekeeperRecordsSource, /data-score-feedback-flow-last/);
+assert.match(scorekeeperRecordsSource, /score-feedback-history/,
+  'LAST and BEST must share a stable secondary scorekeeper row beneath the active LAP score');
+assert.match(scorekeeperRecordsSource, /setLast\(drift\.last, event\?\.detail\?\.score\)/);
+assert.match(scorekeeperRecordsSource, /setLast\(flow\.last, event\?\.detail\?\.score\)/);
+assert.match(scorekeeperRecordsSource, /clearLastLap\(\)[\s\S]*race-started/,
+  'LAST is session context and must clear when a race session is restarted');
+assert.match(scorekeeperRecordsSource, /--score-feedback-paper-width: clamp\(148px, 18\.5vw, 198px\)/,
+  'The scorekeeper paper should be narrower than the original 226px maximum');
+assert.match(scorekeeperRecordsSource, /font-size: clamp\(1\.22rem, 3vw, 1\.78rem\)/,
+  'The live score should be reduced so LAP, LAST and BEST gain hierarchy');
 assert.match(scorekeeperRecordsSource, /turn:drift-lap-result/);
 assert.match(scorekeeperRecordsSource, /turn:flow-lap-result/);
 assert.doesNotMatch(scorekeeperRecordsSource, /requestAnimationFrame|setInterval|setTimeout/,
-  'BEST is lifecycle/event-driven and must not introduce another racing-loop or polling path');
+  'LAST/BEST are lifecycle/event-driven and must not introduce another racing-loop or polling path');
 assert.match(flowScorerSource, /feedbackState\.tokens\.includes/,
   'FLOW must retain its tiny internal token history because repetition/variety is scoring logic, not HUD decoration');
 
-console.log('TURN DRIFT ATTACK runtime, hidden-HUD and stable scorekeeper BEST regressions passed.');
+console.log('TURN DRIFT ATTACK runtime, hidden-HUD and LAP/LAST/BEST scorekeeper regressions passed.');

--- a/turn-tests/drift-attack-runtime-production.mjs
+++ b/turn-tests/drift-attack-runtime-production.mjs
@@ -276,10 +276,10 @@ assert.match(scorekeeperRecordsSource, /data-score-feedback-flow-techniques[\s\S
   'The unreadable rolling FLOW token strip must be removed before ScoreFeedback can retain its DOM nodes');
 assert.match(scorekeeperRecordsSource, /getBestDriftRecord/);
 assert.match(scorekeeperRecordsSource, /getBestFlowRecord/);
-assert.match(scorekeeperRecordsSource, /data-score-feedback-drift-best/);
-assert.match(scorekeeperRecordsSource, /data-score-feedback-flow-best/);
-assert.match(scorekeeperRecordsSource, /data-score-feedback-drift-last/);
-assert.match(scorekeeperRecordsSource, /data-score-feedback-flow-last/);
+assert.match(scorekeeperRecordsSource, /data-score-feedback-\$\{channel\}-\$\{kind\}/,
+  'DRIFT and FLOW LAST/BEST hooks must use the shared channel/kind builder');
+assert.match(scorekeeperRecordsSource, /makeReadout\(documentRef, channel, 'last', 'LAST'\)/);
+assert.match(scorekeeperRecordsSource, /makeReadout\(documentRef, channel, 'best', 'BEST'\)/);
 assert.match(scorekeeperRecordsSource, /score-feedback-history/,
   'LAST and BEST must share a stable secondary scorekeeper row beneath the active LAP score');
 assert.match(scorekeeperRecordsSource, /setLast\(drift\.last, event\?\.detail\?\.score\)/);

--- a/turn/scoring/scorekeeper-records.js
+++ b/turn/scoring/scorekeeper-records.js
@@ -1,6 +1,7 @@
 import { getBestDriftRecord } from './drift-records.js';
 import { getBestFlowRecord } from './flow-records.js';
 
+const SCOREKEEPER_STYLE_ID = 'turn-scorekeeper-history-style';
 const numberFormatter = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 0
 });
@@ -26,43 +27,159 @@ function defaultTrackId() {
   }
 }
 
-function formatBestScore(value) {
-  const score = Math.round(Number(value) || 0);
-  return score > 0 ? numberFormatter.format(score) : '—';
+function formatScore(value, { emptyWhenMissing = false, emptyWhenZero = false } = {}) {
+  if (value === undefined || value === null || !Number.isFinite(Number(value))) {
+    return emptyWhenMissing ? '—' : '0';
+  }
+  const score = Math.max(0, Math.round(Number(value)));
+  if (emptyWhenZero && score <= 0) return '—';
+  return numberFormatter.format(score);
 }
 
-function ensureBestReadout(documentRef, root, channel) {
+function ensureScorekeeperStyle(documentRef) {
+  if (!documentRef?.createElement) return false;
+  if (documentRef.getElementById?.(SCOREKEEPER_STYLE_ID)) return true;
+
+  const style = documentRef.createElement('style');
+  style.id = SCOREKEEPER_STYLE_ID;
+  style.textContent = `
+.score-feedback {
+  --score-feedback-paper-width: clamp(148px, 18.5vw, 198px);
+  --score-feedback-paper-height: 112px;
+  --score-feedback-gauge-width: clamp(44px, 5.5vw, 58px);
+}
+
+.score-feedback-state {
+  grid-template-rows: auto 1fr auto auto;
+  padding: 8px 10px 9px;
+}
+
+.score-feedback-values strong {
+  font-size: clamp(1.22rem, 3vw, 1.78rem);
+}
+
+.score-feedback-footer {
+  justify-content: flex-start;
+}
+
+.score-feedback-footer .score-feedback-lap {
+  font-size: clamp(.60rem, 1.35vw, .76rem);
+  letter-spacing: .04em;
+}
+
+.score-feedback-history {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 6px;
+  margin-top: 3px;
+}
+
+.score-feedback-history .score-feedback-lap {
+  font-size: clamp(.48rem, 1.05vw, .61rem);
+  letter-spacing: .055em;
+}
+
+.score-feedback-history .score-feedback-best {
+  margin-left: auto;
+}
+
+@media (max-height: 430px) {
+  .score-feedback {
+    --score-feedback-paper-width: 138px;
+    --score-feedback-paper-height: 96px;
+    --score-feedback-gauge-width: 42px;
+  }
+
+  .score-feedback-state {
+    padding: 6px 8px 7px;
+  }
+
+  .score-feedback-values strong {
+    font-size: 1.18rem;
+  }
+
+  .score-feedback-footer .score-feedback-lap {
+    font-size: .56rem;
+  }
+
+  .score-feedback-history {
+    margin-top: 2px;
+  }
+
+  .score-feedback-history .score-feedback-lap {
+    font-size: .46rem;
+  }
+}
+`;
+
+  const target = documentRef.head || documentRef.documentElement;
+  target?.append?.(style);
+  return true;
+}
+
+function makeReadout(documentRef, channel, kind, label) {
+  const readout = documentRef.createElement('div');
+  readout.className = `score-feedback-lap score-feedback-${kind}`;
+  readout.setAttribute(`data-score-feedback-${channel}-${kind}`, '');
+
+  const labelNode = documentRef.createElement('span');
+  labelNode.textContent = label;
+  const value = documentRef.createElement('b');
+  value.textContent = '—';
+  readout.append(labelNode, value);
+  return { readout, value };
+}
+
+function ensureHistoryReadouts(documentRef, root, channel) {
   const row = root.querySelector(
     channel === 'flow'
       ? '[data-score-feedback-flow-state]'
       : '[data-score-feedback-state]'
   );
-  const footer = row?.querySelector?.('.score-feedback-footer');
-  if (!footer) return null;
+  if (!row) return { last: null, best: null };
 
-  // Concrete rendered hooks are data-score-feedback-drift-best and
-  // data-score-feedback-flow-best; keep one shared builder so both rows stay identical.
-  const selector = `[data-score-feedback-${channel}-best]`;
-  const existing = footer.querySelector?.(selector);
-  if (existing) return existing.querySelector?.('b') || null;
+  const selector = `[data-score-feedback-${channel}-history]`;
+  let history = row.querySelector?.(selector);
+  if (!history) {
+    history = documentRef.createElement('div');
+    history.className = 'score-feedback-history';
+    history.setAttribute(`data-score-feedback-${channel}-history`, '');
+    row.append?.(history);
+  }
 
-  const readout = documentRef.createElement('div');
-  readout.className = 'score-feedback-lap score-feedback-best';
-  readout.setAttribute(`data-score-feedback-${channel}-best`, '');
+  let last = history.querySelector?.(`[data-score-feedback-${channel}-last] b`);
+  if (!last) {
+    const created = makeReadout(documentRef, channel, 'last', 'LAST');
+    history.append?.(created.readout);
+    last = created.value;
+  }
 
-  const label = documentRef.createElement('span');
-  label.textContent = 'BEST';
-  const value = documentRef.createElement('b');
-  value.textContent = '—';
-  readout.append(label, value);
-  footer.append(readout);
-  return value;
+  let best = history.querySelector?.(`[data-score-feedback-${channel}-best] b`);
+  if (!best) {
+    const created = makeReadout(documentRef, channel, 'best', 'BEST');
+    history.append?.(created.readout);
+    best = created.value;
+  }
+
+  return { last, best };
 }
 
 function setBest(valueNode, score) {
   if (!valueNode) return;
-  const next = formatBestScore(score);
+  const next = formatScore(score, { emptyWhenMissing: true, emptyWhenZero: true });
   if (valueNode.textContent !== next) valueNode.textContent = next;
+}
+
+function setLast(valueNode, score) {
+  if (!valueNode) return;
+  const next = formatScore(score, { emptyWhenMissing: true });
+  if (valueNode.textContent !== next) valueNode.textContent = next;
+}
+
+function clearLast(valueNode) {
+  if (valueNode && valueNode.textContent !== '—') valueNode.textContent = '—';
 }
 
 export function installScorekeeperRecords({
@@ -81,20 +198,26 @@ export function installScorekeeperRecords({
   // because repetition/variety is part of the scoring model itself.
   root.querySelector?.('[data-score-feedback-flow-techniques]')?.remove?.();
 
-  const driftBest = ensureBestReadout(documentRef, root, 'drift');
-  const flowBest = ensureBestReadout(documentRef, root, 'flow');
+  ensureScorekeeperStyle(documentRef);
+  const drift = ensureHistoryReadouts(documentRef, root, 'drift');
+  const flow = ensureHistoryReadouts(documentRef, root, 'flow');
   const targetStorage = storageOrDefault(storage);
 
-  function refresh(trackId = getTrackId()) {
+  function refreshBest(trackId = getTrackId()) {
     const id = String(trackId || '');
     if (!id) {
-      setBest(driftBest, 0);
-      setBest(flowBest, 0);
+      setBest(drift.best, 0);
+      setBest(flow.best, 0);
       return false;
     }
-    setBest(driftBest, getBestDriftRecord(id, targetStorage)?.score);
-    setBest(flowBest, getBestFlowRecord(id, targetStorage)?.score);
+    setBest(drift.best, getBestDriftRecord(id, targetStorage)?.score);
+    setBest(flow.best, getBestFlowRecord(id, targetStorage)?.score);
     return true;
+  }
+
+  function clearLastLap() {
+    clearLast(drift.last);
+    clearLast(flow.last);
   }
 
   function onUiState(event) {
@@ -103,28 +226,33 @@ export function installScorekeeperRecords({
       && reason !== 'race-reset'
       && reason !== 'track-changed'
       && reason !== 'home-open') return;
-    refresh();
+    clearLastLap();
+    refreshBest();
   }
 
   function onDriftResult(event) {
+    setLast(drift.last, event?.detail?.score);
     const bestScore = Number(event?.detail?.bestScore) || 0;
-    if (bestScore > 0) setBest(driftBest, bestScore);
-    else refresh();
+    if (bestScore > 0) setBest(drift.best, bestScore);
+    else refreshBest();
   }
 
   function onFlowResult(event) {
+    setLast(flow.last, event?.detail?.score);
     const bestScore = Number(event?.detail?.bestScore) || 0;
-    if (bestScore > 0) setBest(flowBest, bestScore);
-    else refresh();
+    if (bestScore > 0) setBest(flow.best, bestScore);
+    else refreshBest();
   }
 
   eventTarget?.addEventListener?.('turn:ui-state-change', onUiState);
   eventTarget?.addEventListener?.('turn:drift-lap-result', onDriftResult);
   eventTarget?.addEventListener?.('turn:flow-lap-result', onFlowResult);
-  refresh();
+  refreshBest();
+  clearLastLap();
 
   return Object.freeze({
-    refresh,
+    refresh: refreshBest,
+    clearLastLap,
     disconnect() {
       eventTarget?.removeEventListener?.('turn:ui-state-change', onUiState);
       eventTarget?.removeEventListener?.('turn:drift-lap-result', onDriftResult);


### PR DESCRIPTION
## Summary

- adds persistent per-channel **LAST** lap score beneath the current LAP score
- keeps **BEST** as the saved per-track record
- LAST updates from DRIFT/FLOW lap-result events and clears on race restart/reset, track change, or home
- makes LAP the strongest persistent reference, with LAST/BEST as a secondary line
- reduces the large live score size and narrows the paper box to match the playtest mockup
- slightly increases row height so the new history line fits without crowding
- keeps the existing FLOW internal technique history/scoring semantics unchanged

## Performance

- no new requestAnimationFrame, interval, timeout, polling, or per-frame record reads
- LAST/BEST update only on existing lap-result/lifecycle events
- visual changes are fixed DOM + CSS only

## Verification

- extends the existing DRIFT runtime regression with LAST/BEST hooks, lifecycle clearing, hierarchy sizing, and no-new-loop guards

Refs #738
Refs #739