### PR TITLE
TURN: teach SHIFT, DRIFT POINTS and FLOW POINTS

### DIFF
--- a/turn-tests/form-disclosure-system.mjs
+++ b/turn-tests/form-disclosure-system.mjs
@@ -56,7 +56,7 @@ assert.match(components, /\.m8-dbe-guide\[open\] \.m8-disclosure-symbol::before[
 assert.match(components, /\.m8-dbe-guide-panel,[\s\S]*background: var\(--turn-disclosure-panel\)/);
 assert.doesNotMatch(components, /#eaf9ef/);
 
-assert.match(guide, /GUIDE_VERSION = 'r220-overcharge-disclosure'/);
+assert.match(guide, /GUIDE_VERSION = 'r221-scoring-links'/);
 assert.match(
   guide,
   /<summary><span class="m8-disclosure-symbol" aria-hidden="true"><\/span><span>Explore the Drive By Ear sounds<\/span><\/summary>/

--- a/turn-tests/how-to-play-guide-production.mjs
+++ b/turn-tests/how-to-play-guide-production.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [app, guide, css, components, homeReset, resetCss, rivalStorage, trackManager] = await Promise.all([
+const [app, guide, css, components, homeReset, resetCss, rivalStorage, trackManager, scorekeeper] = await Promise.all([
   fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/ui/how-to-play-guide.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/m8-how-to-play-r126.css', import.meta.url), 'utf8'),
@@ -9,7 +9,8 @@ const [app, guide, css, components, homeReset, resetCss, rivalStorage, trackMana
   fs.readFile(new URL('../turn/ui/home-rival-reset.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/rival-reset-context-r127.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/race/rival-storage.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/tracks/track-manager.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/tracks/track-manager.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/scoring/scorekeeper-records.js', import.meta.url), 'utf8')
 ]);
 
 assert.match(app, /m8-how-to-play-r126\.css\?revision=r220-overcharge-disclosure/);
@@ -30,7 +31,7 @@ assert.ok(
   'The contextual reset enhancer must run only after the shared Settings dialog exists'
 );
 
-assert.match(guide, /GUIDE_VERSION = 'r220-overcharge-disclosure'/);
+assert.match(guide, /GUIDE_VERSION = 'r221-scoring-links'/);
 assert.match(guide, /slide between <strong>GAS<\/strong>, <strong>DRIFT<\/strong>, <strong>BOOST<\/strong> and <strong>BRAKE · REVERSE<\/strong>/);
 assert.match(guide, /slide outward past it into <strong>LOCK<\/strong>/);
 assert.match(guide, /<strong>DRIFT<\/strong> charges <strong>BOOST<\/strong> as you slide/);
@@ -42,6 +43,44 @@ assert.match(guide, /<strong>CATCH<\/strong><span>Slide to GAS before OVERCHARGE
 assert.match(guide, /<strong>HOLD<\/strong><span>Stay on GAS to hold the OVERCHARGE you caught\.<\/span>/);
 assert.match(guide, /<strong>SPEND<\/strong><span>Slide to BOOST\. OVERCHARGE is spent before normal BOOST\.<\/span>/);
 assert.match(guide, /Uncaught OVERCHARGE leaks\. At its peak, it starts leaking even while you keep using DRIFT/);
+
+assert.match(guide, /title: 'SHIFT'/);
+assert.match(guide, /normal attributes and the alternate setup you configured in <strong>THE LOT<\/strong>/);
+assert.match(guide, /redistributes attribute points — it does not add free power/);
+assert.match(guide, /slide from GAS into SHIFT to swap setup, then SHIFT again to return/);
+assert.match(guide, /title: 'DRIFT POINTS'/);
+assert.match(guide, /DRIFT POINTS<\/strong> reward strong, fast, controlled slides — not pressing DRIFT/);
+assert.match(guide, /large live number is the current drift value at risk/);
+assert.match(guide, /Link drifts to raise <strong>COMBO<\/strong>/);
+assert.match(guide, /clean exit <strong>BANKS<\/strong>/);
+assert.match(guide, /<strong>LAP<\/strong> is this lap, <strong>LAST<\/strong> is your previous completed lap and <strong>BEST<\/strong> is the saved record for this track/);
+assert.match(guide, /title: 'FLOW POINTS'/);
+assert.match(guide, /FLOW POINTS<\/strong> reward useful choreography between systems such as SHIFT, BOOST, DRIFT, LOCK, OVERCHARGE catches and clean exits/);
+assert.match(guide, /Button presses alone score nothing/);
+assert.match(guide, /Variety and useful timing build <strong>COMBO<\/strong>/);
+assert.match(guide, /gauge shows your current FLOW momentum/);
+assert.match(guide, /HOW_TO_PLAY_OPEN_EVENT = 'turn:open-how-to-play'/);
+assert.match(guide, /TARGET_SECTION_ID/);
+assert.match(guide, /m8HowDriftPoints/);
+assert.match(guide, /m8HowFlowPoints/);
+assert.match(guide, /dialog\.__turnReturnFocus = trigger/);
+assert.match(guide, /heading\.focus\?\.\(\{ preventScroll: true \}\)/);
+assert.match(guide, /section\.scrollIntoView\?\.\(\{ behavior: 'auto', block: 'center', inline: 'nearest' \}\)/);
+assert.match(guide, /globalThis\.__turnOpenHowToPlaySection = openTarget/);
+
+assert.match(scorekeeper, /className = 'score-feedback-info'/);
+assert.match(scorekeeper, /button\.textContent = 'i'/);
+assert.match(scorekeeper, /About \$\{channel\.toUpperCase\(\)\} scoring/);
+assert.match(scorekeeper, /data-score-feedback-help/);
+assert.match(scorekeeper, /HOW_TO_PLAY_OPEN_EVENT = 'turn:open-how-to-play'/);
+assert.match(scorekeeper, /detail: \{ section: channel, trigger: button \}/);
+assert.match(scorekeeper, /pointer-events: auto/,
+  'The info button must remain tappable even though the scorekeeper HUD itself ignores pointer input');
+assert.match(scorekeeper, /touch-action: manipulation/);
+assert.match(scorekeeper, /\.score-feedback-info:focus-visible/);
+assert.doesNotMatch(scorekeeper, /setInterval|setTimeout|requestAnimationFrame/,
+  'Scorekeeper help links must remain event-driven and add no racing-loop work');
+
 assert.match(guide, /<details class="m8-dbe-guide">/);
 assert.match(
   guide,
@@ -139,4 +178,4 @@ assert.match(rivalStorage, /syncPrimaryRivalState\(state\)/);
 assert.match(trackManager, /clearRivalsState\(currentRuntime\.state, \{ trackId: activeTrackId \}\)/, 'The race reset implementation must clear only the current track storage key');
 assert.match(trackManager, /globalThis\.__turnResetRivals = resetCurrentTrackRivals/);
 
-console.log('TURN native disclosure help, scroll stability and contextual rival reset passed.');
+console.log('TURN native disclosure help, SHIFT/scoring guidance, scorekeeper deep links and contextual rival reset passed.');

--- a/turn/scoring/scorekeeper-records.js
+++ b/turn/scoring/scorekeeper-records.js
@@ -2,6 +2,7 @@ import { getBestDriftRecord } from './drift-records.js';
 import { getBestFlowRecord } from './flow-records.js';
 
 const SCOREKEEPER_STYLE_ID = 'turn-scorekeeper-history-style';
+const HOW_TO_PLAY_OPEN_EVENT = 'turn:open-how-to-play';
 const numberFormatter = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 0
 });
@@ -58,6 +59,47 @@ function ensureScorekeeperStyle(documentRef) {
   font-size: clamp(1.22rem, 3vw, 1.78rem);
 }
 
+.score-feedback-heading {
+  align-items: center;
+}
+
+.score-feedback-title {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 4px;
+}
+
+.score-feedback-info {
+  display: inline-grid;
+  place-items: center;
+  flex: 0 0 24px;
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  min-height: 24px;
+  margin: -5px 0;
+  padding: 0;
+  border: 2px solid var(--turn-ink);
+  border-radius: 50%;
+  color: var(--turn-ink);
+  background: var(--turn-action-information, #38d9ff);
+  box-shadow: none;
+  font: inherit;
+  font-size: .58rem;
+  font-weight: 950;
+  line-height: 1;
+  text-transform: none;
+  cursor: pointer;
+  pointer-events: auto;
+  touch-action: manipulation;
+}
+
+.score-feedback-info:focus-visible {
+  outline: 3px solid var(--turn-yellow-400, #ffd43b);
+  outline-offset: 2px;
+}
+
 .score-feedback-footer {
   justify-content: flex-start;
 }
@@ -100,6 +142,15 @@ function ensureScorekeeperStyle(documentRef) {
     font-size: 1.18rem;
   }
 
+  .score-feedback-info {
+    flex-basis: 22px;
+    width: 22px;
+    height: 22px;
+    min-width: 22px;
+    min-height: 22px;
+    font-size: .54rem;
+  }
+
   .score-feedback-footer .score-feedback-lap {
     font-size: .56rem;
   }
@@ -132,12 +183,54 @@ function makeReadout(documentRef, channel, kind, label) {
   return { readout, value };
 }
 
-function ensureHistoryReadouts(documentRef, root, channel) {
-  const row = root.querySelector(
+function scoreState(root, channel) {
+  return root.querySelector(
     channel === 'flow'
       ? '[data-score-feedback-flow-state]'
       : '[data-score-feedback-state]'
   );
+}
+
+function ensureInfoButton(documentRef, root, channel, eventTarget) {
+  const row = scoreState(root, channel);
+  const heading = row?.querySelector?.('.score-feedback-heading');
+  const label = channel === 'flow'
+    ? heading?.querySelector?.('span')
+    : heading?.querySelector?.('[data-score-feedback-label]');
+  if (!heading || !label) return null;
+
+  let title = heading.querySelector?.('.score-feedback-title');
+  if (!title) {
+    title = documentRef.createElement('span');
+    title.className = 'score-feedback-title';
+    label.insertAdjacentElement?.('beforebegin', title);
+    title.append?.(label);
+  }
+
+  const selector = `[data-score-feedback-help="${channel}"]`;
+  let button = title.querySelector?.(selector);
+  if (button) return button;
+
+  button = documentRef.createElement('button');
+  button.type = 'button';
+  button.className = 'score-feedback-info';
+  button.textContent = 'i';
+  button.setAttribute('data-score-feedback-help', channel);
+  button.setAttribute('aria-label', `About ${channel.toUpperCase()} scoring`);
+  button.setAttribute('title', `About ${channel.toUpperCase()} scoring`);
+  button.addEventListener?.('click', (event) => {
+    event.stopPropagation?.();
+    if (typeof globalThis.CustomEvent !== 'function') return;
+    eventTarget?.dispatchEvent?.(new globalThis.CustomEvent(HOW_TO_PLAY_OPEN_EVENT, {
+      detail: { section: channel, trigger: button }
+    }));
+  });
+  title.append?.(button);
+  return button;
+}
+
+function ensureHistoryReadouts(documentRef, root, channel) {
+  const row = scoreState(root, channel);
   if (!row) return { last: null, best: null };
 
   const selector = `[data-score-feedback-${channel}-history]`;
@@ -199,6 +292,8 @@ export function installScorekeeperRecords({
   root.querySelector?.('[data-score-feedback-flow-techniques]')?.remove?.();
 
   ensureScorekeeperStyle(documentRef);
+  ensureInfoButton(documentRef, root, 'drift', eventTarget);
+  ensureInfoButton(documentRef, root, 'flow', eventTarget);
   const drift = ensureHistoryReadouts(documentRef, root, 'drift');
   const flow = ensureHistoryReadouts(documentRef, root, 'flow');
   const targetStorage = storageOrDefault(storage);

--- a/turn/ui/how-to-play-guide.js
+++ b/turn/ui/how-to-play-guide.js
@@ -1,5 +1,12 @@
-const GUIDE_VERSION = 'r220-overcharge-disclosure';
+const GUIDE_VERSION = 'r221-scoring-links';
+const HOW_TO_PLAY_OPEN_EVENT = 'turn:open-how-to-play';
 const PACE_NOTE_EXPLANATION = 'Before major corners, one to three beeps play in the ear on the turn side. One beep means a gentler corner, two means medium and three means tight. A long corner keeps the same number of beeps but holds the final beep longer: bip-beeeep for a long medium corner and bip-bip-beeeep for a long tight corner. Separate groups describe linked corners in the order you will meet them.';
+
+const TARGET_SECTION_ID = Object.freeze({
+  shift: 'm8HowShift',
+  drift: 'm8HowDriftPoints',
+  flow: 'm8HowFlowPoints'
+});
 
 export function installHowToPlayGuide(root = document) {
   const dialog = root.querySelector('.m8-how-dialog');
@@ -8,7 +15,9 @@ export function installHowToPlayGuide(root = document) {
 
   updateDriveControlCopy(dialog);
   updateDriftAndBoostCopy(dialog);
+  installShiftAndScoringSections(dialog);
   installDriveByEarDisclosure(dialog);
+  installTargetedOpening(dialog);
   updateAudioPanelCopy(root);
 
   dialog.dataset.guideVersion = GUIDE_VERSION;
@@ -45,6 +54,81 @@ function updateDriftAndBoostCopy(dialog) {
         <p class="m8-overcharge-leak"><strong>WATCH THE PEAK</strong> Uncaught OVERCHARGE leaks. At its peak, it starts leaking even while you keep using DRIFT.</p>
       </div>
     </details>`;
+}
+
+function makeGuideSection(dialog, { number, id, target, title, copy }) {
+  const section = dialog.ownerDocument.createElement('section');
+  section.className = 'm8-guide-system';
+  section.dataset.howToPlayTarget = target;
+  section.innerHTML = `
+    <strong>${number}</strong>
+    <div>
+      <h3 id="${id}" tabindex="-1">${title}</h3>
+      <p>${copy}</p>
+    </div>`;
+  return section;
+}
+
+function installShiftAndScoringSections(dialog) {
+  const grid = dialog.querySelector('.m8-guide-grid');
+  const before = grid?.querySelector('.m8-guide-wide');
+  if (!grid || !before) return;
+
+  for (const existing of grid.querySelectorAll('.m8-guide-system')) existing.remove();
+
+  const shift = makeGuideSection(dialog, {
+    number: '5',
+    id: TARGET_SECTION_ID.shift,
+    target: 'shift',
+    title: 'SHIFT',
+    copy: '<strong>SHIFT</strong> swaps between your car’s normal attributes and the alternate setup you configured in <strong>THE LOT</strong>. It redistributes attribute points — it does not add free power. During a race, slide from GAS into SHIFT to swap setup, then SHIFT again to return. Trade for what you need next: for example more DRIFT or CONTROL into a slide, or more acceleration and BOOST performance on the exit.'
+  });
+  const drift = makeGuideSection(dialog, {
+    number: '6',
+    id: TARGET_SECTION_ID.drift,
+    target: 'drift',
+    title: 'DRIFT POINTS',
+    copy: '<strong>DRIFT POINTS</strong> reward strong, fast, controlled slides — not pressing DRIFT. The large live number is the current drift value at risk and the gauge shows how strongly it is scoring right now. Link drifts to raise <strong>COMBO</strong>. A clean exit <strong>BANKS</strong> the current drift; a failed drift can lose the unbanked points without erasing points already banked this lap. <strong>LAP</strong> is this lap, <strong>LAST</strong> is your previous completed lap and <strong>BEST</strong> is the saved record for this track.'
+  });
+  const flow = makeGuideSection(dialog, {
+    number: '7',
+    id: TARGET_SECTION_ID.flow,
+    target: 'flow',
+    title: 'FLOW POINTS',
+    copy: '<strong>FLOW POINTS</strong> reward useful choreography between systems such as SHIFT, BOOST, DRIFT, LOCK, OVERCHARGE catches and clean exits. Button presses alone score nothing. Variety and useful timing build <strong>COMBO</strong>; repeating the same idea adds less and mistakes can break the chain. The gauge shows your current FLOW momentum. <strong>LAP</strong> is this lap, <strong>LAST</strong> is your previous completed lap and <strong>BEST</strong> is the saved record for this track.'
+  });
+
+  grid.insertBefore(shift, before);
+  grid.insertBefore(drift, before);
+  grid.insertBefore(flow, before);
+}
+
+function installTargetedOpening(dialog, eventTarget = globalThis) {
+  if (dialog.dataset.targetedHelp === 'scoring-v1') return;
+  dialog.dataset.targetedHelp = 'scoring-v1';
+
+  const openTarget = (target, trigger = null) => {
+    const id = TARGET_SECTION_ID[String(target || '').toLowerCase()];
+    const heading = id ? dialog.querySelector(`#${id}`) : null;
+    const section = heading?.closest?.('[data-how-to-play-target]');
+    if (!heading || !section) return false;
+
+    dialog.__turnReturnFocus = trigger || eventTarget.document?.activeElement || null;
+    if (!dialog.open) {
+      if (typeof dialog.showModal === 'function') dialog.showModal();
+      else dialog.setAttribute('open', '');
+    }
+
+    heading.focus?.({ preventScroll: true });
+    section.scrollIntoView?.({ behavior: 'auto', block: 'center', inline: 'nearest' });
+    return true;
+  };
+
+  eventTarget.addEventListener?.(HOW_TO_PLAY_OPEN_EVENT, (event) => {
+    openTarget(event?.detail?.section, event?.detail?.trigger || null);
+  });
+
+  globalThis.__turnOpenHowToPlaySection = openTarget;
 }
 
 function installDriveByEarDisclosure(dialog) {


### PR DESCRIPTION
## Summary

Implements #752 without taking on the broader #748 visual-onboarding pass.

- adds **SHIFT**, **DRIFT POINTS** and **FLOW POINTS** to the existing HOW TO PLAY grid
- keeps the copy player-facing and avoids exposing tuning constants or trophy thresholds
- explains LAP / LAST / BEST in the scoring sections
- adds compact accessible `i` buttons beside DRIFT and FLOW in the live scorekeeper
- DRIFT `i` opens HOW TO PLAY directly at DRIFT POINTS
- FLOW `i` opens HOW TO PLAY directly at FLOW POINTS
- reuses the existing HOW TO PLAY dialog as the single source of help copy
- targeted opening focuses and scrolls to the requested section, then existing dialog close behavior returns focus to the invoking `i` button

## Performance

- help links are entirely event-driven
- no new scoring polling, requestAnimationFrame loop, interval, timeout or per-frame work
- scorekeeper buttons only dispatch a semantic HOW TO PLAY event on activation

## Accessibility

- `About DRIFT scoring` / `About FLOW scoring` accessible names
- 24px information controls with visible keyboard focus
- explanation does not depend on the DRIFT/FLOW colors
- targeted section headings receive programmatic focus

## Verification

Extends the existing HOW TO PLAY regression with the new copy, targeted navigation, scorekeeper controls and no-new-loop contract.

Closes #752
Refs #722
Refs #738
Refs #739
Refs #748