### PR TITLE
TURN: collapse How to Play cards and clean scorekeeper HUD

### DIFF
--- a/turn-tests/form-disclosure-system.mjs
+++ b/turn-tests/form-disclosure-system.mjs
@@ -56,7 +56,10 @@ assert.match(components, /\.m8-dbe-guide\[open\] \.m8-disclosure-symbol::before[
 assert.match(components, /\.m8-dbe-guide-panel,[\s\S]*background: var\(--turn-disclosure-panel\)/);
 assert.doesNotMatch(components, /#eaf9ef/);
 
-assert.match(guide, /GUIDE_VERSION = 'r221-scoring-links'/);
+assert.match(guide, /GUIDE_VERSION = 'r222-collapsible-cards'/);
+assert.match(guide, /details\.className = 'm8-guide-card-disclosure'/);
+assert.match(guide, /section\.classList\.contains\('m8-guide-wide'\)/,
+  'Drive By Ear must remain the non-collapsible outer card');
 assert.match(
   guide,
   /<summary><span class="m8-disclosure-symbol" aria-hidden="true"><\/span><span>Explore the Drive By Ear sounds<\/span><\/summary>/

--- a/turn-tests/how-to-play-guide-production.mjs
+++ b/turn-tests/how-to-play-guide-production.mjs
@@ -31,7 +31,7 @@ assert.ok(
   'The contextual reset enhancer must run only after the shared Settings dialog exists'
 );
 
-assert.match(guide, /GUIDE_VERSION = 'r221-scoring-links'/);
+assert.match(guide, /GUIDE_VERSION = 'r222-collapsible-cards'/);
 assert.match(guide, /slide between <strong>GAS<\/strong>, <strong>DRIFT<\/strong>, <strong>BOOST<\/strong> and <strong>BRAKE · REVERSE<\/strong>/);
 assert.match(guide, /slide outward past it into <strong>LOCK<\/strong>/);
 assert.match(guide, /<strong>DRIFT<\/strong> charges <strong>BOOST<\/strong> as you slide/);
@@ -59,27 +59,21 @@ assert.match(guide, /FLOW POINTS<\/strong> reward useful choreography between sy
 assert.match(guide, /Button presses alone score nothing/);
 assert.match(guide, /Variety and useful timing build <strong>COMBO<\/strong>/);
 assert.match(guide, /gauge shows your current FLOW momentum/);
-assert.match(guide, /HOW_TO_PLAY_OPEN_EVENT = 'turn:open-how-to-play'/);
-assert.match(guide, /TARGET_SECTION_ID/);
-assert.match(guide, /m8HowDriftPoints/);
-assert.match(guide, /m8HowFlowPoints/);
-assert.match(guide, /dialog\.__turnReturnFocus = trigger/);
-assert.match(guide, /heading\.focus\?\.\(\{ preventScroll: true \}\)/);
-assert.match(guide, /section\.scrollIntoView\?\.\(\{ behavior: 'auto', block: 'center', inline: 'nearest' \}\)/);
-assert.match(guide, /globalThis\.__turnOpenHowToPlaySection = openTarget/);
 
-assert.match(scorekeeper, /className = 'score-feedback-info'/);
-assert.match(scorekeeper, /button\.textContent = 'i'/);
-assert.match(scorekeeper, /About \$\{channel\.toUpperCase\(\)\} scoring/);
-assert.match(scorekeeper, /data-score-feedback-help/);
-assert.match(scorekeeper, /HOW_TO_PLAY_OPEN_EVENT = 'turn:open-how-to-play'/);
-assert.match(scorekeeper, /detail: \{ section: channel, trigger: button \}/);
-assert.match(scorekeeper, /pointer-events: auto/,
-  'The info button must remain tappable even though the scorekeeper HUD itself ignores pointer input');
-assert.match(scorekeeper, /touch-action: manipulation/);
-assert.match(scorekeeper, /\.score-feedback-info:focus-visible/);
+assert.match(guide, /installGuideCardDisclosures\(dialog\)/);
+assert.match(guide, /section\.classList\.contains\('m8-guide-wide'\)/,
+  'Drive By Ear must remain the one ordinary card with its disclosure inside');
+assert.match(guide, /details\.className = 'm8-guide-card-disclosure'/);
+assert.match(guide, /summary\.append\(badge, title\)/);
+assert.match(guide, /title\.setAttribute\('role', 'heading'\)/);
+assert.match(guide, /title\.setAttribute\('aria-level', '3'\)/);
+assert.doesNotMatch(guide, /turn:open-how-to-play|installTargetedOpening|__turnOpenHowToPlaySection|TARGET_SECTION_ID/,
+  'Removing the scorekeeper info buttons must also remove their deep-link event wiring');
+
+assert.doesNotMatch(scorekeeper, /score-feedback-info|data-score-feedback-help|turn:open-how-to-play|About .* scoring/,
+  'The live scorekeeper must stay visually clean and contain no scoring help controls');
 assert.doesNotMatch(scorekeeper, /setInterval|setTimeout|requestAnimationFrame/,
-  'Scorekeeper help links must remain event-driven and add no racing-loop work');
+  'The scorekeeper record helper must remain event-driven and add no racing-loop work');
 
 assert.match(guide, /<details class="m8-dbe-guide">/);
 assert.match(
@@ -89,7 +83,7 @@ assert.match(
 assert.match(
   guide,
   /<summary><span class="m8-disclosure-symbol" aria-hidden="true"><\/span><span>Explore the Drive By Ear sounds<\/span><\/summary>[\s\S]*<div class="m8-dbe-guide-panel">[\s\S]*<div class="m8-dbe-guide-content">/,
-  'Every expanded help section must remain inside one visual disclosure panel'
+  'Every expanded Drive By Ear help section must remain inside one visual disclosure panel'
 );
 assert.ok(
   guide.indexOf('m8-disclosure-symbol') < guide.indexOf('Explore the Drive By Ear sounds'),
@@ -120,9 +114,17 @@ assert.match(css, /\.m8-how-dialog[\s\S]*-webkit-text-size-adjust: 100%[\s\S]*te
 assert.match(css, /\.m8-how-dialog \.m8-dialog-card[\s\S]*overscroll-behavior-y: contain/);
 assert.match(css, /scroll-padding-block-end: max\(32px, env\(safe-area-inset-bottom\)\)/);
 assert.match(css, /scrollbar-gutter: stable/, 'The dialog width must remain stable when expanded content creates a scrollbar');
-assert.match(css, /\.m8-dbe-guide[\s\S]*border: 3px solid[\s\S]*border-radius: 16px[\s\S]*overflow: clip/, 'The summary and expanded content must share one containing card');
+assert.match(css, /\.m8-guide-grid section\.m8-guide-card-shell[\s\S]*background: transparent[\s\S]*box-shadow: none/,
+  'Ordinary guide sections become neutral grid shells around the disclosure card');
+assert.match(css, /\.m8-guide-card-disclosure[\s\S]*border: 4px solid var\(--m8-ink\)[\s\S]*border-radius: 20px[\s\S]*box-shadow: 5px 5px 0 var\(--m8-ink\)/);
+assert.match(css, /\.m8-guide-card-disclosure > summary[\s\S]*display: grid[\s\S]*cursor: pointer/);
+assert.match(css, /\.m8-guide-card-disclosure\[open\] > summary[\s\S]*border-bottom: 3px solid/);
+assert.match(css, /\.m8-guide-card-disclosure > summary::after[\s\S]*content: "\+"/);
+assert.match(css, /\.m8-guide-card-disclosure\[open\] > summary::after[\s\S]*content: "−"/);
+assert.match(css, /\.m8-guide-card-panel[\s\S]*overflow-anchor: none/);
+assert.match(css, /\.m8-dbe-guide[\s\S]*border: 3px solid[\s\S]*border-radius: 16px[\s\S]*overflow: clip/, 'The Drive By Ear summary and expanded content must share one containing card');
 assert.match(css, /\.m8-guide-disclosure/,
-  'The Overcharge lesson must share the native disclosure component without masquerading as Drive By Ear');
+  'The Overcharge lesson must share the native nested disclosure component without masquerading as Drive By Ear');
 assert.match(css, /\.m8-overcharge-steps[\s\S]*display: grid/);
 assert.match(css, /\.m8-overcharge-leak[\s\S]*border-top: 2px solid/);
 assert.match(css, /\.m8-dbe-guide > summary/);
@@ -178,4 +180,4 @@ assert.match(rivalStorage, /syncPrimaryRivalState\(state\)/);
 assert.match(trackManager, /clearRivalsState\(currentRuntime\.state, \{ trackId: activeTrackId \}\)/, 'The race reset implementation must clear only the current track storage key');
 assert.match(trackManager, /globalThis\.__turnResetRivals = resetCurrentTrackRivals/);
 
-console.log('TURN native disclosure help, SHIFT/scoring guidance, scorekeeper deep links and contextual rival reset passed.');
+console.log('TURN collapsible How to Play cards, SHIFT/scoring guidance, clean scorekeeper and contextual rival reset passed.');

--- a/turn/m8-how-to-play-r126.css
+++ b/turn/m8-how-to-play-r126.css
@@ -15,6 +15,100 @@
   font-size: 1rem;
 }
 
+.m8-guide-grid section.m8-guide-card-shell {
+  display: block;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.m8-guide-card-disclosure {
+  width: 100%;
+  border: 4px solid var(--m8-ink);
+  border-radius: 20px;
+  background: white;
+  box-shadow: 5px 5px 0 var(--m8-ink);
+  box-sizing: border-box;
+  overflow: hidden;
+  overflow: clip;
+}
+
+.m8-guide-card-disclosure > summary {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 13px;
+  min-height: 70px;
+  padding: 13px 16px;
+  color: var(--m8-ink);
+  background: white;
+  cursor: pointer;
+  list-style: none;
+  box-sizing: border-box;
+}
+
+.m8-guide-card-disclosure > summary::-webkit-details-marker {
+  display: none;
+}
+
+.m8-guide-card-disclosure[open] > summary {
+  border-bottom: 3px solid var(--m8-ink);
+}
+
+.m8-guide-card-disclosure > summary::after {
+  content: "+";
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border: 2px solid var(--m8-ink);
+  border-radius: 50%;
+  background: var(--m8-cream);
+  font-size: 1.3rem;
+  font-weight: 950;
+  line-height: 1;
+}
+
+.m8-guide-card-disclosure[open] > summary::after {
+  content: "−";
+}
+
+.m8-guide-card-disclosure > summary:focus-visible {
+  outline: 5px solid var(--m8-pink);
+  outline-offset: 4px;
+}
+
+.m8-guide-card-number {
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: var(--m8-yellow);
+  font-size: 1.3rem;
+}
+
+.m8-guide-card-title {
+  min-width: 0;
+  font-size: 1.12rem;
+  font-weight: 950;
+  line-height: 1.15;
+}
+
+.m8-guide-card-panel {
+  padding: 14px 16px 16px;
+  background: rgb(255 255 255 / 0.5);
+  overflow-anchor: none;
+}
+
+.m8-guide-card-panel > p {
+  margin: 0;
+  line-height: 1.42;
+}
+
 .m8-dbe-guide,
 .m8-guide-disclosure {
   width: 100%;
@@ -201,6 +295,15 @@
 }
 
 @media (max-height: 560px) and (orientation: landscape) {
+  .m8-guide-card-disclosure > summary {
+    min-height: 60px;
+    padding: 9px 12px;
+  }
+
+  .m8-guide-card-panel {
+    padding: 10px 12px 12px;
+  }
+
   .m8-dbe-guide-panel,
   .m8-guide-disclosure-panel {
     padding: 10px 10px max(30px, env(safe-area-inset-bottom));

--- a/turn/scoring/scorekeeper-records.js
+++ b/turn/scoring/scorekeeper-records.js
@@ -2,7 +2,6 @@ import { getBestDriftRecord } from './drift-records.js';
 import { getBestFlowRecord } from './flow-records.js';
 
 const SCOREKEEPER_STYLE_ID = 'turn-scorekeeper-history-style';
-const HOW_TO_PLAY_OPEN_EVENT = 'turn:open-how-to-play';
 const numberFormatter = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 0
 });
@@ -59,47 +58,6 @@ function ensureScorekeeperStyle(documentRef) {
   font-size: clamp(1.22rem, 3vw, 1.78rem);
 }
 
-.score-feedback-heading {
-  align-items: center;
-}
-
-.score-feedback-title {
-  display: inline-flex;
-  min-width: 0;
-  align-items: center;
-  gap: 4px;
-}
-
-.score-feedback-info {
-  display: inline-grid;
-  place-items: center;
-  flex: 0 0 24px;
-  width: 24px;
-  height: 24px;
-  min-width: 24px;
-  min-height: 24px;
-  margin: -5px 0;
-  padding: 0;
-  border: 2px solid var(--turn-ink);
-  border-radius: 50%;
-  color: var(--turn-ink);
-  background: var(--turn-action-information, #38d9ff);
-  box-shadow: none;
-  font: inherit;
-  font-size: .58rem;
-  font-weight: 950;
-  line-height: 1;
-  text-transform: none;
-  cursor: pointer;
-  pointer-events: auto;
-  touch-action: manipulation;
-}
-
-.score-feedback-info:focus-visible {
-  outline: 3px solid var(--turn-yellow-400, #ffd43b);
-  outline-offset: 2px;
-}
-
 .score-feedback-footer {
   justify-content: flex-start;
 }
@@ -142,15 +100,6 @@ function ensureScorekeeperStyle(documentRef) {
     font-size: 1.18rem;
   }
 
-  .score-feedback-info {
-    flex-basis: 22px;
-    width: 22px;
-    height: 22px;
-    min-width: 22px;
-    min-height: 22px;
-    font-size: .54rem;
-  }
-
   .score-feedback-footer .score-feedback-lap {
     font-size: .56rem;
   }
@@ -189,44 +138,6 @@ function scoreState(root, channel) {
       ? '[data-score-feedback-flow-state]'
       : '[data-score-feedback-state]'
   );
-}
-
-function ensureInfoButton(documentRef, root, channel, eventTarget) {
-  const row = scoreState(root, channel);
-  const heading = row?.querySelector?.('.score-feedback-heading');
-  const label = channel === 'flow'
-    ? heading?.querySelector?.('span')
-    : heading?.querySelector?.('[data-score-feedback-label]');
-  if (!heading || !label) return null;
-
-  let title = heading.querySelector?.('.score-feedback-title');
-  if (!title) {
-    title = documentRef.createElement('span');
-    title.className = 'score-feedback-title';
-    label.insertAdjacentElement?.('beforebegin', title);
-    title.append?.(label);
-  }
-
-  const selector = `[data-score-feedback-help="${channel}"]`;
-  let button = title.querySelector?.(selector);
-  if (button) return button;
-
-  button = documentRef.createElement('button');
-  button.type = 'button';
-  button.className = 'score-feedback-info';
-  button.textContent = 'i';
-  button.setAttribute('data-score-feedback-help', channel);
-  button.setAttribute('aria-label', `About ${channel.toUpperCase()} scoring`);
-  button.setAttribute('title', `About ${channel.toUpperCase()} scoring`);
-  button.addEventListener?.('click', (event) => {
-    event.stopPropagation?.();
-    if (typeof globalThis.CustomEvent !== 'function') return;
-    eventTarget?.dispatchEvent?.(new globalThis.CustomEvent(HOW_TO_PLAY_OPEN_EVENT, {
-      detail: { section: channel, trigger: button }
-    }));
-  });
-  title.append?.(button);
-  return button;
 }
 
 function ensureHistoryReadouts(documentRef, root, channel) {
@@ -292,8 +203,6 @@ export function installScorekeeperRecords({
   root.querySelector?.('[data-score-feedback-flow-techniques]')?.remove?.();
 
   ensureScorekeeperStyle(documentRef);
-  ensureInfoButton(documentRef, root, 'drift', eventTarget);
-  ensureInfoButton(documentRef, root, 'flow', eventTarget);
   const drift = ensureHistoryReadouts(documentRef, root, 'drift');
   const flow = ensureHistoryReadouts(documentRef, root, 'flow');
   const targetStorage = storageOrDefault(storage);

--- a/turn/ui/how-to-play-guide.js
+++ b/turn/ui/how-to-play-guide.js
@@ -1,12 +1,5 @@
-const GUIDE_VERSION = 'r221-scoring-links';
-const HOW_TO_PLAY_OPEN_EVENT = 'turn:open-how-to-play';
+const GUIDE_VERSION = 'r222-collapsible-cards';
 const PACE_NOTE_EXPLANATION = 'Before major corners, one to three beeps play in the ear on the turn side. One beep means a gentler corner, two means medium and three means tight. A long corner keeps the same number of beeps but holds the final beep longer: bip-beeeep for a long medium corner and bip-bip-beeeep for a long tight corner. Separate groups describe linked corners in the order you will meet them.';
-
-const TARGET_SECTION_ID = Object.freeze({
-  shift: 'm8HowShift',
-  drift: 'm8HowDriftPoints',
-  flow: 'm8HowFlowPoints'
-});
 
 export function installHowToPlayGuide(root = document) {
   const dialog = root.querySelector('.m8-how-dialog');
@@ -17,7 +10,7 @@ export function installHowToPlayGuide(root = document) {
   updateDriftAndBoostCopy(dialog);
   installShiftAndScoringSections(dialog);
   installDriveByEarDisclosure(dialog);
-  installTargetedOpening(dialog);
+  installGuideCardDisclosures(dialog);
   updateAudioPanelCopy(root);
 
   dialog.dataset.guideVersion = GUIDE_VERSION;
@@ -56,14 +49,13 @@ function updateDriftAndBoostCopy(dialog) {
     </details>`;
 }
 
-function makeGuideSection(dialog, { number, id, target, title, copy }) {
+function makeGuideSection(dialog, { number, title, copy }) {
   const section = dialog.ownerDocument.createElement('section');
   section.className = 'm8-guide-system';
-  section.dataset.howToPlayTarget = target;
   section.innerHTML = `
     <strong>${number}</strong>
     <div>
-      <h3 id="${id}" tabindex="-1">${title}</h3>
+      <h3>${title}</h3>
       <p>${copy}</p>
     </div>`;
   return section;
@@ -78,22 +70,16 @@ function installShiftAndScoringSections(dialog) {
 
   const shift = makeGuideSection(dialog, {
     number: '5',
-    id: TARGET_SECTION_ID.shift,
-    target: 'shift',
     title: 'SHIFT',
     copy: '<strong>SHIFT</strong> swaps between your car’s normal attributes and the alternate setup you configured in <strong>THE LOT</strong>. It redistributes attribute points — it does not add free power. During a race, slide from GAS into SHIFT to swap setup, then SHIFT again to return. Trade for what you need next: for example more DRIFT or CONTROL into a slide, or more acceleration and BOOST performance on the exit.'
   });
   const drift = makeGuideSection(dialog, {
     number: '6',
-    id: TARGET_SECTION_ID.drift,
-    target: 'drift',
     title: 'DRIFT POINTS',
     copy: '<strong>DRIFT POINTS</strong> reward strong, fast, controlled slides — not pressing DRIFT. The large live number is the current drift value at risk and the gauge shows how strongly it is scoring right now. Link drifts to raise <strong>COMBO</strong>. A clean exit <strong>BANKS</strong> the current drift; a failed drift can lose the unbanked points without erasing points already banked this lap. <strong>LAP</strong> is this lap, <strong>LAST</strong> is your previous completed lap and <strong>BEST</strong> is the saved record for this track.'
   });
   const flow = makeGuideSection(dialog, {
     number: '7',
-    id: TARGET_SECTION_ID.flow,
-    target: 'flow',
     title: 'FLOW POINTS',
     copy: '<strong>FLOW POINTS</strong> reward useful choreography between systems such as SHIFT, BOOST, DRIFT, LOCK, OVERCHARGE catches and clean exits. Button presses alone score nothing. Variety and useful timing build <strong>COMBO</strong>; repeating the same idea adds less and mistakes can break the chain. The gauge shows your current FLOW momentum. <strong>LAP</strong> is this lap, <strong>LAST</strong> is your previous completed lap and <strong>BEST</strong> is the saved record for this track.'
   });
@@ -103,32 +89,42 @@ function installShiftAndScoringSections(dialog) {
   grid.insertBefore(flow, before);
 }
 
-function installTargetedOpening(dialog, eventTarget = globalThis) {
-  if (dialog.dataset.targetedHelp === 'scoring-v1') return;
-  dialog.dataset.targetedHelp = 'scoring-v1';
+function installGuideCardDisclosures(dialog) {
+  const sections = [...dialog.querySelectorAll('.m8-guide-grid > section')];
+  for (const section of sections) {
+    if (section.classList.contains('m8-guide-wide')
+      || section.classList.contains('m8-guide-card-shell')) continue;
 
-  const openTarget = (target, trigger = null) => {
-    const id = TARGET_SECTION_ID[String(target || '').toLowerCase()];
-    const heading = id ? dialog.querySelector(`#${id}`) : null;
-    const section = heading?.closest?.('[data-how-to-play-target]');
-    if (!heading || !section) return false;
+    const number = section.querySelector(':scope > strong');
+    const content = section.querySelector(':scope > div');
+    const heading = content?.querySelector(':scope > h3');
+    if (!number || !content || !heading) continue;
 
-    dialog.__turnReturnFocus = trigger || eventTarget.document?.activeElement || null;
-    if (!dialog.open) {
-      if (typeof dialog.showModal === 'function') dialog.showModal();
-      else dialog.setAttribute('open', '');
+    const details = dialog.ownerDocument.createElement('details');
+    details.className = 'm8-guide-card-disclosure';
+
+    const summary = dialog.ownerDocument.createElement('summary');
+    const badge = dialog.ownerDocument.createElement('strong');
+    badge.className = 'm8-guide-card-number';
+    badge.textContent = number.textContent;
+
+    const title = dialog.ownerDocument.createElement('span');
+    title.className = 'm8-guide-card-title';
+    title.setAttribute('role', 'heading');
+    title.setAttribute('aria-level', '3');
+    title.textContent = heading.textContent;
+    summary.append(badge, title);
+
+    const panel = dialog.ownerDocument.createElement('div');
+    panel.className = 'm8-guide-card-panel';
+    for (const child of [...content.children]) {
+      if (child !== heading) panel.append(child);
     }
 
-    heading.focus?.({ preventScroll: true });
-    section.scrollIntoView?.({ behavior: 'auto', block: 'center', inline: 'nearest' });
-    return true;
-  };
-
-  eventTarget.addEventListener?.(HOW_TO_PLAY_OPEN_EVENT, (event) => {
-    openTarget(event?.detail?.section, event?.detail?.trigger || null);
-  });
-
-  globalThis.__turnOpenHowToPlaySection = openTarget;
+    details.append(summary, panel);
+    section.classList.add('m8-guide-card-shell');
+    section.replaceChildren(details);
+  }
 }
 
 function installDriveByEarDisclosure(dialog) {


### PR DESCRIPTION
Follow-up to #752 based on playtest feedback.

- makes every ordinary HOW TO PLAY card a native disclosure so the guide is much less visually dense
- keeps Drive By Ear as the exception: one normal outer card with its existing disclosure inside
- preserves the nested OVERCHARGE disclosure inside its now-collapsible card
- removes the DRIFT/FLOW scorekeeper `i` buttons entirely
- removes the scoring deep-link event/focus wiring that only existed for those buttons
- keeps SHIFT, DRIFT POINTS and FLOW POINTS help copy in HOW TO PLAY
- adds/updates regression coverage for the disclosure structure and clean scorekeeper

No scoring, physics, telemetry or hot-path behavior is changed.