### PR TITLE
TURN: calibrate DRIFT and FLOW achievements

### DIFF
--- a/turn-lab/tests/achievements-production.mjs
+++ b/turn-lab/tests/achievements-production.mjs
@@ -90,14 +90,14 @@ assert.equal(
   'The base catalog must stay separate from production progression balancing'
 );
 assert.equal(ACHIEVEMENTS.length, 58,
-  'Production TURN must expose the existing 45 achievements plus 13 scoring placeholders');
+  'Production TURN must expose the existing 45 achievements plus 13 scoring achievements');
 assert.equal(new Set(ACHIEVEMENTS.map((achievement) => achievement.id)).size, 58,
   'Production achievement ids must remain unique');
 assert.equal(ONBOARDING_ACHIEVEMENT_IDS.length, 11,
   'GOT STARTED must remain the master of the eleven prerequisite Getting Started achievements, not recursively require itself');
-assert.equal(totalAvailableTrophies(), 3075,
-  'Pending calibration trophies must not inflate the currently available total');
-assert.equal(TROPHY_ROAD_MAX_THRESHOLD, 3075);
+assert.equal(totalAvailableTrophies(), 3975,
+  'Calibrated DRIFT and FLOW achievements must contribute their 900-trophy scoring reservoir');
+assert.equal(TROPHY_ROAD_MAX_THRESHOLD, 3975);
 assert.equal(
   ACHIEVEMENTS.reduce((total, achievement) => total + achievement.trophies, 0),
   3975
@@ -131,6 +131,15 @@ assert.equal(byId('chromatic-camouflage')?.title, 'CHROMATIC CAMOUFLAGE');
 assert.equal(byId('chromatic-camouflage')?.trophies, 50);
 assert.equal(byId('chromatic-camouflage')?.hidden, true);
 
+const scoringTargets = Object.freeze({
+  countryside: Object.freeze({ drift: 8000, flow: 7000 }),
+  airport: Object.freeze({ drift: 11000, flow: 12000 }),
+  cliffside: Object.freeze({ drift: 20000, flow: 13000 }),
+  harbor: Object.freeze({ drift: 18000, flow: 23000 }),
+  'midnight-city': Object.freeze({ drift: 20000, flow: 25000 }),
+  mountain: Object.freeze({ drift: 20000, flow: 20000 })
+});
+
 for (const trackId of TRACK_IDS) {
   const winner = byId(`${trackId}-winner`);
   const safety = byId(`${trackId}-safety`);
@@ -142,32 +151,34 @@ for (const trackId of TRACK_IDS) {
   assert.match(safety?.title || '', /SAFETY$/);
   for (const channel of ['drift', 'flow']) {
     const scoring = byId(`${trackId}-${channel}-score`);
+    const target = scoringTargets[trackId][channel];
     assert.equal(scoring?.trophies, 50);
     assert.equal(scoring?.category, 'scoring');
-    assert.equal(scoring?.target, null);
-    assert.equal(scoring?.calibrationPending, true);
-    assert.match(scoring?.description || '', /target pending playtest calibration/i);
+    assert.equal(scoring?.target, target);
+    assert.equal(scoring?.calibrationPending, false);
+    assert.match(scoring?.description || '', new RegExp(target.toLocaleString('en-US')));
   }
 }
 
 assert.equal(byId('drift-flow-master')?.trophies, 300);
 assert.equal(byId('drift-flow-master')?.progressMax, 12);
-assert.equal(byId('drift-flow-master')?.calibrationPending, true);
+assert.equal(byId('drift-flow-master')?.calibrationPending, false);
+assert.equal(byId('drift-flow-master')?.recommendation, 'Clear both scoring targets on all six tracks.');
 
-const pendingUnlockMemory = new Map([[ACHIEVEMENT_STORAGE_KEY, JSON.stringify({
+const scoringUnlockMemory = new Map([[ACHIEVEMENT_STORAGE_KEY, JSON.stringify({
     version: TROPHY_ROAD_STORAGE_VERSION,
     unlocked: {
       'countryside-drift-score': { unlockedAt: Date.now() }
     }
   })]]);
-const pendingUnlockStorage = {
-  getItem: (key) => pendingUnlockMemory.get(key) ?? null,
-  setItem: (key, value) => pendingUnlockMemory.set(key, String(value))
+const scoringUnlockStorage = {
+  getItem: (key) => scoringUnlockMemory.get(key) ?? null,
+  setItem: (key, value) => scoringUnlockMemory.set(key, String(value))
 };
-const pendingUnlockStore = createAchievementStore(pendingUnlockStorage);
-assert.equal(pendingUnlockStore.isUnlocked('countryside-drift-score'), false);
-assert.equal(pendingUnlockStore.trophyTotal(), 0,
-  'A calibration-pending id in storage must not grant trophies before its target exists');
+const scoringUnlockStore = createAchievementStore(scoringUnlockStorage);
+assert.equal(scoringUnlockStore.isUnlocked('countryside-drift-score'), true);
+assert.equal(scoringUnlockStore.trophyTotal(), 50,
+  'A calibrated scoring achievement in storage must grant its trophies');
 
 assert.equal(byId('countryside-safety')?.description, 'Finish Countryside without going off-road in under 15 seconds.');
 assert.equal(byId('airport-safety')?.description, 'Finish Airport without going off-road in under 20 seconds.');
@@ -523,4 +534,4 @@ assert.match(app, /achievements=r166-bella-records/);
 assert.match(workflow, /Run achievement system regression/);
 assert.match(workflow, /node turn-lab\/tests\/achievements-production\.mjs/);
 
-console.log('TURN achievement catalog and pending scoring calibration integrity regression passed.');
+console.log('TURN achievement catalog and calibrated scoring integrity regression passed.');

--- a/turn-lab/tests/chromatic-camouflage-production.mjs
+++ b/turn-lab/tests/chromatic-camouflage-production.mjs
@@ -158,9 +158,9 @@ challengeApi.disconnect();
 assert.equal(
   ACHIEVEMENTS.reduce((total, item) => total + item.trophies, 0),
   3975,
-  'The raw catalog includes 900 trophies held behind pending score calibration'
+  'The calibrated catalog includes the 900-trophy DRIFT and FLOW reservoir'
 );
-assert.equal(TROPHY_ROAD_MAX_THRESHOLD, 3075);
+assert.equal(TROPHY_ROAD_MAX_THRESHOLD, 3975);
 assert.deepEqual(
   TROPHY_ROAD_REWARDS.map(({ id, threshold }) => [id, threshold]),
   [

--- a/turn-lab/tests/trophy-road-production.mjs
+++ b/turn-lab/tests/trophy-road-production.mjs
@@ -94,7 +94,7 @@ assert.equal(TROPHY_ROAD_STORAGE_VERSION, 7,
   'Independent vehicle-perk entitlements require a versioned Trophy Road migration');
 assert.equal(TROPHY_ROAD_MAX_THRESHOLD, 2000,
   'The base module must cover the final defined perk threshold');
-assert.equal(PRODUCTION_TROPHY_ROAD_MAX_THRESHOLD, 3075,
+assert.equal(PRODUCTION_TROPHY_ROAD_MAX_THRESHOLD, 3975,
   'Production must expose the complete current achievement-trophy scale');
 assert.equal(TROPHY_ROAD_VIEWPORT_THRESHOLD, 600);
 
@@ -483,7 +483,7 @@ assert.match(app, /trophy-road\.js\?revision=r166-bella-records/);
 assert.match(fixedLayout, /r166-bella-records/);
 assert.match(workflow, /Run Trophy Road progression regression/);
 assert.match(workflow, /node turn-lab\/tests\/trophy-road-production\.mjs/);
-assert.match(perkWrapper, /TROPHY_ROAD_MAX_THRESHOLD = 3075/);
+assert.match(perkWrapper, /TROPHY_ROAD_MAX_THRESHOLD = 3975/);
 assert.match(perkWrapper, /\['vintage-racer', 300\]/);
 assert.match(perkWrapper, /\['midnight-city', 400\]/);
 assert.match(perkWrapper, /\['race-car', 500\]/);

--- a/turn-tests/flow-integration-production.mjs
+++ b/turn-tests/flow-integration-production.mjs
@@ -3,16 +3,18 @@ import fs from 'node:fs/promises';
 import {
   TRACK_SCORING_ACHIEVEMENTS,
   SCORING_MASTER_ACHIEVEMENT,
-  qualifyingScoringAchievement
+  qualifyingScoringAchievement,
+  storedScoringAchievementUnlockEntries
 } from '../turn/achievements/scoring-achievements.js';
 
-const [main, setting, toast, announcements, achievements, scoringCatalog] = await Promise.all([
+const [main, setting, toast, announcements, achievements, scoringCatalog, achievementRuntime] = await Promise.all([
   fs.readFile(new URL('../turn/main.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/ui/drift-attack-setting.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/ui/lap-result-toast.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/ui/race-announcements.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/achievements/catalog-production.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/achievements/scoring-achievements.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/achievements/scoring-achievements.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/achievements/runtime.js', import.meta.url), 'utf8')
 ]);
 
 const toastCss = await fs.readFile(new URL('../turn/lap-result-toast.css', import.meta.url), 'utf8');
@@ -53,5 +55,31 @@ for (const achievement of TRACK_SCORING_ACHIEVEMENTS) {
 }
 assert.match(scoringCatalog, /value < target/,
   'A score equal to the calibrated target must qualify');
+
+const storedRecords = new Map([
+  ['turn-drift-records-v1', JSON.stringify({
+    version: 1,
+    tracks: {
+      countryside: { score: 8000, carId: 'classic', lapTime: 18, hitAt: 1 },
+      airport: { score: 10999, carId: 'race', lapTime: 20, hitAt: 2 }
+    }
+  })],
+  ['turn-flow-records-v1', JSON.stringify({
+    version: 1,
+    tracks: {
+      countryside: { score: 7000, carId: 'classic', lapTime: 18, hitAt: 1 }
+    }
+  })]
+]);
+const recordStorage = {
+  getItem: (key) => storedRecords.get(key) ?? null
+};
+assert.deepEqual(
+  storedScoringAchievementUnlockEntries(recordStorage).map(({ id }) => id),
+  ['countryside-drift-score', 'countryside-flow-score'],
+  'Existing qualifying personal-best records must backfill calibrated achievements without replaying the lap'
+);
+assert.match(achievementRuntime, /importStoredScoringAchievements\(\)/);
+assert.match(achievementRuntime, /storedScoringAchievementUnlockEntries\(undefined, store\.isUnlocked\)/);
 
 console.log('TURN FLOW integration and calibrated scoring-achievement regressions passed.');

--- a/turn-tests/flow-integration-production.mjs
+++ b/turn-tests/flow-integration-production.mjs
@@ -28,11 +28,16 @@ assert.match(announcements, /spokenScoreResult\('Flow', flow\)/);
 
 assert.match(achievements, /TRACK_SCORING_ACHIEVEMENTS/);
 assert.equal((scoringCatalog.match(/trophies: 50/g) || []).length, 1,
-  'One generated contract supplies 50 trophies to every track/channel placeholder');
+  'One generated contract supplies 50 trophies to every track/channel achievement');
 assert.match(scoringCatalog, /trophies: 300/);
-assert.match(scoringCatalog, /target pending playtest calibration/i);
-assert.match(scoringCatalog, /drift:[\s\S]*TRACK_IDS\.map[\s\S]*flow:/);
-assert.doesNotMatch(scoringCatalog, /countryside:\s*\d|airport:\s*\d|mountain:\s*\d/,
-  'No achievement target is guessed before playtest calibration');
+for (const target of [8000, 11000, 20000, 18000, 7000, 12000, 13000, 23000, 25000]) {
+  assert.match(scoringCatalog, new RegExp(`\\b${target}\\b`), `Missing calibrated scoring target ${target}`);
+}
+assert.match(scoringCatalog, /'midnight-city': 20000/);
+assert.match(scoringCatalog, /mountain: 20000/);
+assert.doesNotMatch(scoringCatalog, /target pending playtest calibration/i,
+  'Production scoring achievements must no longer expose placeholder targets');
+assert.match(scoringCatalog, /value < target/,
+  'A score equal to the calibrated target must qualify');
 
-console.log('TURN FLOW integration and placeholder scoring-achievement regressions passed.');
+console.log('TURN FLOW integration and calibrated scoring-achievement regressions passed.');

--- a/turn-tests/flow-integration-production.mjs
+++ b/turn-tests/flow-integration-production.mjs
@@ -1,5 +1,10 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
+import {
+  TRACK_SCORING_ACHIEVEMENTS,
+  SCORING_MASTER_ACHIEVEMENT,
+  qualifyingScoringAchievement
+} from '../turn/achievements/scoring-achievements.js';
 
 const [main, setting, toast, announcements, achievements, scoringCatalog] = await Promise.all([
   fs.readFile(new URL('../turn/main.js', import.meta.url), 'utf8'),
@@ -35,8 +40,17 @@ for (const target of [8000, 11000, 20000, 18000, 7000, 12000, 13000, 23000, 2500
 }
 assert.match(scoringCatalog, /'midnight-city': 20000/);
 assert.match(scoringCatalog, /mountain: 20000/);
-assert.doesNotMatch(scoringCatalog, /target pending playtest calibration/i,
-  'Production scoring achievements must no longer expose placeholder targets');
+assert.equal(TRACK_SCORING_ACHIEVEMENTS.length, 12);
+assert.ok(TRACK_SCORING_ACHIEVEMENTS.every((achievement) => achievement.calibrationPending === false));
+assert.ok(TRACK_SCORING_ACHIEVEMENTS.every((achievement) => Number.isFinite(achievement.target) && achievement.target > 0));
+assert.equal(SCORING_MASTER_ACHIEVEMENT.calibrationPending, false);
+for (const achievement of TRACK_SCORING_ACHIEVEMENTS) {
+  assert.equal(
+    qualifyingScoringAchievement(achievement.scoreChannel, achievement.trackId, achievement.target)?.id,
+    achievement.id,
+    `${achievement.id} must qualify at its exact calibrated target`
+  );
+}
 assert.match(scoringCatalog, /value < target/,
   'A score equal to the calibrated target must qualify');
 

--- a/turn/achievements/runtime.js
+++ b/turn/achievements/runtime.js
@@ -25,7 +25,8 @@ import {
 import {
   SCORING_MASTER_ACHIEVEMENT_ID,
   completedAllScoringAchievements,
-  qualifyingScoringAchievement
+  qualifyingScoringAchievement,
+  storedScoringAchievementUnlockEntries
 } from './scoring-achievements.js?revision=r1-placeholder-targets';
 import { replayFrameAt } from '../race/replay-system.js?revision=r146-achievement-expansion';
 import { getStoredBestLap } from '../race/rival-storage.js';
@@ -237,6 +238,10 @@ export function installAchievements(runtime = globalThis.__turnRuntime) {
     }
 
     unlockSilently(entries);
+  }
+
+  function importStoredScoringAchievements() {
+    unlockSilently(storedScoringAchievementUnlockEntries(undefined, store.isUnlocked));
   }
 
   function sampleListenClosely(state, elapsedMs) {
@@ -490,6 +495,7 @@ export function installAchievements(runtime = globalThis.__turnRuntime) {
   menuObserver?.observe(utilityGroup, { attributes: true, attributeFilter: ['data-menu-state'] });
 
   importStoredTimeTrials();
+  importStoredScoringAchievements();
   syncDrivingSampler();
   syncRaceTriggerVisibility();
 

--- a/turn/achievements/scoring-achievements.js
+++ b/turn/achievements/scoring-achievements.js
@@ -3,6 +3,8 @@ import {
   TRACK_IDS,
   TRACK_NAMES
 } from './catalog-base.js?revision=r222-awd-label';
+import { getBestDriftRecord } from '../scoring/drift-records.js';
+import { getBestFlowRecord } from '../scoring/flow-records.js';
 
 export const SCORING_MASTER_ACHIEVEMENT_ID = 'drift-flow-master';
 
@@ -82,6 +84,41 @@ export function qualifyingScoringAchievement(channel, trackId, score) {
   return TRACK_SCORING_ACHIEVEMENTS.find((achievement) =>
     achievement.scoreChannel === normalizedChannel && achievement.trackId === trackId
   ) || null;
+}
+
+export function storedScoringAchievementUnlockEntries(storage, isUnlocked = () => false) {
+  const channels = [
+    ['drift', getBestDriftRecord],
+    ['flow', getBestFlowRecord]
+  ];
+  const entries = [];
+  const pendingIds = new Set();
+
+  for (const [channel, getRecord] of channels) {
+    for (const trackId of TRACK_IDS) {
+      const record = getRecord(trackId, storage);
+      const achievement = qualifyingScoringAchievement(channel, trackId, record?.score);
+      if (!achievement) continue;
+      pendingIds.add(achievement.id);
+      entries.push({
+        id: achievement.id,
+        context: {
+          trackId,
+          vehicleId: record?.carId || '',
+          time: Number(record?.lapTime) || null
+        }
+      });
+    }
+  }
+
+  if (completedAllScoringAchievements(isUnlocked, [...pendingIds])) {
+    entries.push({
+      id: SCORING_MASTER_ACHIEVEMENT_ID,
+      context: { trackId: '', vehicleId: '', time: null }
+    });
+  }
+
+  return entries;
 }
 
 export function completedAllScoringAchievements(isUnlocked, additionalIds = []) {

--- a/turn/achievements/scoring-achievements.js
+++ b/turn/achievements/scoring-achievements.js
@@ -6,12 +6,25 @@ import {
 
 export const SCORING_MASTER_ACHIEVEMENT_ID = 'drift-flow-master';
 
-// Score targets deliberately stay unset until real DRIFT and FLOW lap
-// distributions have been collected. Keeping calibration in one data object
-// makes the eventual tuning change explicit and reviewable.
+// Calibrated from production playtesting. Keep all track/channel targets in one
+// reviewable data object so future balance changes remain explicit.
 export const SCORING_ACHIEVEMENT_TARGETS = Object.freeze({
-  drift: Object.freeze(Object.fromEntries(TRACK_IDS.map((trackId) => [trackId, null]))),
-  flow: Object.freeze(Object.fromEntries(TRACK_IDS.map((trackId) => [trackId, null])))
+  drift: Object.freeze({
+    countryside: 8000,
+    airport: 11000,
+    cliffside: 20000,
+    harbor: 18000,
+    'midnight-city': 20000,
+    mountain: 20000
+  }),
+  flow: Object.freeze({
+    countryside: 7000,
+    airport: 12000,
+    cliffside: 13000,
+    harbor: 23000,
+    'midnight-city': 25000,
+    mountain: 20000
+  })
 });
 
 function targetFor(channel, trackId) {
@@ -55,7 +68,7 @@ export const SCORING_MASTER_ACHIEVEMENT = Object.freeze({
   trophies: 300,
   title: 'DRIFT & FLOW MASTER',
   description: 'Clear every track’s calibrated DRIFT and FLOW achievement.',
-  recommendation: 'The twelve track targets are pending playtest calibration.',
+  recommendation: 'Clear both scoring targets on all six tracks.',
   icon: 'trophy',
   progressMax: TRACK_SCORING_ACHIEVEMENT_IDS.length,
   calibrationPending: TRACK_SCORING_ACHIEVEMENTS.some((achievement) => achievement.calibrationPending)

--- a/turn/progression/trophy-road-chromatic-r183.js
+++ b/turn/progression/trophy-road-chromatic-r183.js
@@ -8,7 +8,7 @@ import {
 
 export * from './trophy-road-perks-r164.js?revision=r230-vehicle-perks';
 
-export const TROPHY_ROAD_MAX_THRESHOLD = 3075;
+export const TROPHY_ROAD_MAX_THRESHOLD = 3975;
 
 export const TROPHY_ROAD_REWARD_ICONS = Object.freeze({
   ...BASE_TROPHY_ROAD_REWARD_ICONS,

--- a/turn/progression/trophy-road-perks-r164.js
+++ b/turn/progression/trophy-road-perks-r164.js
@@ -4,7 +4,7 @@ import {
 
 export * from './trophy-road.js?revision=r230-vehicle-perks';
 
-export const TROPHY_ROAD_MAX_THRESHOLD = 3075;
+export const TROPHY_ROAD_MAX_THRESHOLD = 3975;
 
 const BASE_REWARD_BY_ID = new Map(
   BASE_TROPHY_ROAD_REWARDS.map((reward) => [reward.id, reward])


### PR DESCRIPTION
## Summary

Activates the twelve per-track DRIFT/FLOW score achievements using the playtested production targets.

- keeps every per-track scoring achievement at **50 trophies**
- activates **DRIFT & FLOW MASTER** at **300 trophies** once all twelve are cleared
- removes the target-pending state/copy
- raises the currently available trophy ceiling from **3,075 → 3,975** now that the 900-trophy scoring reservoir is real
- updates achievement + FLOW integration regressions
- does **not** change the current Trophy Road reward order; #740 owns the redesigned road, unlock order and migration

## Calibrated targets

| Track | DRIFT | FLOW |
|---|---:|---:|
| COUNTRYSIDE | 8,000 | 7,000 |
| AIRPORT | 11,000 | 12,000 |
| CLIFFSIDE | 20,000 | 13,000 |
| HARBOR | 18,000 | 23,000 |
| MIDNIGHT CITY | 20,000 | 25,000 |
| MOUNTAIN | 20,000 | 20,000 |

A score **equal to or above** its target qualifies.

## Trophy supply audit

- DRIFT track achievements: 6 × 50 = **300**
- FLOW track achievements: 6 × 50 = **300**
- DRIFT & FLOW MASTER: **300**
- new scoring supply: **900 trophies**
- production total available trophies after calibration: **3,975**

This gives #740 enough supply for the planned 2,200-trophy near-term road without making secrets/alternative-play achievements mandatory progression currency. The late 300-trophy master can produce a multi-reward unlock burst, so #740 should retain its batch-friendly reveal requirement.

## Runtime / performance

No new loop, polling, timer, scoring sampler or DOM work is introduced. The existing lap-result achievement path evaluates the calibrated score once per completed eligible lap.

## Follow-up

The old `r1-placeholder-targets` query string remains as an internal cache identity in existing importers. #740’s progression release/cache pass should replace that stale naming/build identity when the combined progression update ships.

Refs #738
Refs #739
Refs #740