### PR TITLE
TURN: optimise scoring and physics hot paths

### DIFF
--- a/.github/workflows/turn-lab-tests.yml
+++ b/.github/workflows/turn-lab-tests.yml
@@ -202,6 +202,9 @@ jobs:
       - name: Run DRIFT ATTACK runtime regression
         run: node turn-tests/drift-attack-runtime-production.mjs
 
+      - name: Run scoring performance architecture regression
+        run: node turn-tests/scoring-performance-architecture-production.mjs
+
       - name: Run DRIFT ATTACK integration regression
         run: node turn-tests/drift-attack-integration-production.mjs
 

--- a/turn-tests/scoring-performance-architecture-production.mjs
+++ b/turn-tests/scoring-performance-architecture-production.mjs
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+import {
+  createTrackSpatialIndex,
+  findNearestTrackBruteForce
+} from '../turn/race/track-spatial-index.js';
+import {
+  DRIFT_ATTACK_SAMPLE_INTERVAL_SECONDS,
+  createDriftAttackScorer
+} from '../turn/scoring/drift-attack.js';
+import { summarizePerformancePhases } from '../turn/performance-monitor.js';
+
+const samplesA = [
+  { point: { x: -20, z: 0 } },
+  { point: { x: 0, z: 0 } },
+  { point: { x: 20, z: 0 } },
+  { point: { x: 40, z: 0 } }
+];
+const samplesB = [
+  { point: { x: -20, z: 100 } },
+  { point: { x: 0, z: 100 } },
+  { point: { x: 20, z: 100 } },
+  { point: { x: 40, z: 100 } }
+];
+const spatialIndex = createTrackSpatialIndex(samplesA, { cellSize: 16 });
+const position = { x: 18, z: 3 };
+const first = spatialIndex.find(position);
+const afterFirst = spatialIndex.getStats();
+const second = spatialIndex.find({ ...position });
+const afterSecond = spatialIndex.getStats();
+const brute = findNearestTrackBruteForce(samplesA, position);
+
+assert.equal(first.index, brute.index);
+assert.equal(second.index, brute.index,
+  'An exact repeated physics position must retain the same nearest track sample');
+assert.equal(second.distance, first.distance,
+  'The zero-check reuse path must preserve the exact nearest-track distance');
+assert.equal(second.checks, 0,
+  'The second half of one physics step can seed the first half of the next step without another spatial scan');
+assert.equal(afterSecond.queryCount, afterFirst.queryCount + 1,
+  'Cached lookups remain visible to diagnostics as real queries');
+assert.equal(afterSecond.totalChecks, afterFirst.totalChecks,
+  'An exact repeated position performs no additional track-sample checks');
+assert.equal(afterSecond.lastChecks, 0);
+
+spatialIndex.replaceSamples(samplesB);
+const afterReplace = spatialIndex.find(position);
+const bruteAfterReplace = findNearestTrackBruteForce(samplesB, position);
+assert.equal(afterReplace.index, bruteAfterReplace.index,
+  'Replacing the active track must invalidate the repeated-position cache');
+assert.equal(afterReplace.distance, bruteAfterReplace.distance);
+assert.ok(afterReplace.checks > 0,
+  'The first lookup after a track replacement must query the new index rather than reuse stale geometry');
+
+const irregularScorer = createDriftAttackScorer();
+irregularScorer.beginLap(0);
+let elapsed = 0;
+let now = 0;
+const dts = [0.049, 0.031, 0.044, 0.027, 0.052, 0.036];
+for (let index = 0; index < 120; index += 1) {
+  const dt = dts[index % dts.length];
+  elapsed += dt;
+  now += dt * 1000;
+  irregularScorer.advance(dt, now, 25, Math.PI / 3, false, false, true);
+}
+const expectedSamples = Math.floor((elapsed + Number.EPSILON) / DRIFT_ATTACK_SAMPLE_INTERVAL_SECONDS);
+assert.equal(irregularScorer.inspect().sampleCount, expectedSamples,
+  'DRIFT must retain fractional sample time instead of discarding it at irregular frame cadences');
+
+assert.deepEqual(
+  summarizePerformancePhases({ physics: 9, scoring: 3, hud: 1.5, render: 15 }, 3),
+  { physicsMs: 3, scoringMs: 1, hudMs: 0.5, renderMs: 5 },
+  'Perf diagnostics report CPU phase cost per delivered frame'
+);
+
+const [
+  driftRuntimeSource,
+  flowRuntimeSource,
+  scoreFeedbackSource,
+  scorekeeperSource,
+  performanceSource,
+  physicsSource,
+  trackIndexSource
+] = await Promise.all([
+  fs.readFile(new URL('../turn/scoring/drift-attack-runtime.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/scoring/flow-runtime.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/scoring/score-feedback.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/scoring/scorekeeper-records.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/performance-monitor.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/vehicle/physics.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/race/track-spatial-index.js', import.meta.url), 'utf8')
+]);
+
+assert.doesNotMatch(driftRuntimeSource, /import ['"]\.\/scorekeeper-records\.js['"]/,
+  'The DRIFT domain runtime must not bootstrap Scorekeeper presentation as an import side effect');
+assert.match(scoreFeedbackSource, /import \{ installScorekeeperRecords \} from '\.\/scorekeeper-records\.js'/);
+assert.match(scoreFeedbackSource, /installScorekeeperRecords\(\{ documentRef:/,
+  'Scorekeeper is explicitly composed by the ScoreFeedback presentation layer');
+assert.doesNotMatch(scorekeeperSource, /\ninstallScorekeeperRecords\(\);?\s*$/,
+  'Importing Scorekeeper records alone must not mutate the document or attach listeners');
+assert.equal((flowRuntimeSource.match(/scorer\.inspect\(\)/g) || []).length, 1,
+  'One FLOW technique expiry should take one scorer snapshot instead of repeatedly allocating inspection objects');
+assert.match(performanceSource, /globalThis\.__turnPerfRecordPhase/);
+assert.match(performanceSource, /score HUD D:\$\{scoreHud\.drift\} · F:\$\{scoreHud\.flow\}/,
+  'Perf mode must make the DRIFT/FLOW HUD A/B state explicit in its panel');
+assert.match(performanceSource, /cpu\/frame phy/,
+  'Perf mode must expose CPU phase timings next to the existing GPU/render diagnostics');
+assert.match(physicsSource, /recordPhase\('physics'/,
+  'Physics timing instrumentation must remain dormant behind the perf-mode hook');
+assert.match(driftRuntimeSource, /recordPhase\('scoring'/);
+assert.match(flowRuntimeSource, /recordPhase\('scoring'/);
+assert.match(scoreFeedbackSource, /recordPhase\('hud'/);
+assert.match(trackIndexSource, /function reuseLastResult\(x, z\)/);
+
+console.log('TURN scoring performance and architecture regressions passed.');

--- a/turn/performance-monitor.js
+++ b/turn/performance-monitor.js
@@ -1,5 +1,7 @@
 const SAMPLE_LIMIT = 240;
 const DISPLAY_INTERVAL_MS = 500;
+const PERFORMANCE_PHASES = Object.freeze(['physics', 'scoring', 'hud', 'render']);
+const RENDER_TIMING_FLAG = Symbol.for('turn.performance-render-timing');
 
 let activeMonitor = null;
 
@@ -31,6 +33,15 @@ export function summarizeFrameSamples(samples) {
   });
 }
 
+export function summarizePerformancePhases(totals = {}, frameCount = 0) {
+  const frames = Math.max(1, Number(frameCount) || 0);
+  const summary = {};
+  for (const phase of PERFORMANCE_PHASES) {
+    summary[`${phase}Ms`] = Math.max(0, Number(totals?.[phase]) || 0) / frames;
+  }
+  return Object.freeze(summary);
+}
+
 export function installPerformanceMonitor({ getMode, getTrackStats } = {}) {
   if (!performanceModeRequested() || typeof document === 'undefined') return null;
   if (activeMonitor) return activeMonitor;
@@ -56,6 +67,8 @@ export function installPerformanceMonitor({ getMode, getTrackStats } = {}) {
   document.body.appendChild(panel);
 
   const timelines = new Map();
+  const phaseTotals = Object.fromEntries(PERFORMANCE_PHASES.map((phase) => [phase, 0]));
+  let phaseFrames = 0;
   let activeLabel = 'starting';
   let latestRenderers = [];
   let lastDisplayAt = 0;
@@ -64,9 +77,19 @@ export function installPerformanceMonitor({ getMode, getTrackStats } = {}) {
 
   activeMonitor = Object.freeze({
     enabled: true,
+    recordPhase(phase, durationMs) {
+      if (!PERFORMANCE_PHASES.includes(phase)) return false;
+      const duration = Number(durationMs);
+      if (!Number.isFinite(duration) || duration < 0 || duration > 1000) return false;
+      phaseTotals[phase] += duration;
+      return true;
+    },
     record(label, renderers, now = performance.now(), { rendered = true } = {}) {
       activeLabel = label || getMode?.() || 'unknown';
       latestRenderers = normalizeRenderers(renderers);
+      for (const renderer of latestRenderers) installRendererTiming(renderer);
+      if (rendered) phaseFrames += 1;
+
       let timeline = timelines.get(activeLabel);
       if (!timeline) {
         timeline = { samples: new Float32Array(SAMPLE_LIMIT), cursor: 0, count: 0, lastAt: null };
@@ -91,6 +114,8 @@ export function installPerformanceMonitor({ getMode, getTrackStats } = {}) {
       const summary = summarizeFrameSamples(frames);
       const render = summarizeRenderers(latestRenderers);
       const track = summarizeTrackChecks(getTrackStats?.(), lastTrackStats);
+      const phases = summarizePerformancePhases(phaseTotals, phaseFrames);
+      const scoringHud = currentScoringHudState();
       if (track.current) lastTrackStats = track.current;
 
       snapshot = Object.freeze({
@@ -100,10 +125,14 @@ export function installPerformanceMonitor({ getMode, getTrackStats } = {}) {
         samples: timeline.count,
         profile: currentPerformanceProfile(),
         shadowPolicy: currentTrackShadowPolicy(),
+        scoringHud,
         ...summary,
         ...render,
+        ...phases,
         trackChecksPerQuery: track.average
       });
+      resetPhaseWindow(phaseTotals);
+      phaseFrames = 0;
       globalThis.__turnPerfSnapshot = snapshot;
       panel.textContent = formatSnapshot(snapshot);
       window.dispatchEvent(new CustomEvent('turn:perf-snapshot', { detail: snapshot }));
@@ -115,12 +144,57 @@ export function installPerformanceMonitor({ getMode, getTrackStats } = {}) {
 
   globalThis.__turnPerfMonitor = activeMonitor;
   globalThis.__turnGetPerfSnapshot = () => activeMonitor?.getSnapshot() || null;
+  globalThis.__turnPerfRecordPhase = (phase, durationMs) => activeMonitor?.recordPhase(phase, durationMs) || false;
   panel.textContent = `TURN PERF · collecting…\n${currentPerformanceProfile().label}`;
   return activeMonitor;
 }
 
 export function recordPerformanceFrame(label, renderers, now, options) {
   activeMonitor?.record(label, renderers, now, options);
+}
+
+export function recordPerformancePhase(phase, durationMs) {
+  return activeMonitor?.recordPhase(phase, durationMs) || false;
+}
+
+function installRendererTiming(renderer) {
+  if (!renderer || renderer[RENDER_TIMING_FLAG] || typeof renderer.render !== 'function') return false;
+  const originalRender = renderer.render;
+  try {
+    renderer.render = function renderWithTurnPerformanceTiming(...args) {
+      const startedAt = performance.now();
+      try {
+        return originalRender.apply(this, args);
+      } finally {
+        recordPerformancePhase('render', Math.max(0, performance.now() - startedAt));
+      }
+    };
+    Object.defineProperty(renderer, RENDER_TIMING_FLAG, {
+      configurable: false,
+      enumerable: false,
+      writable: false,
+      value: true
+    });
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+function resetPhaseWindow(totals) {
+  for (const phase of PERFORMANCE_PHASES) totals[phase] = 0;
+}
+
+function currentScoringHudState() {
+  return Object.freeze({
+    drift: channelHudState(globalThis.__turnDriftAttack),
+    flow: channelHudState(globalThis.__turnFlow)
+  });
+}
+
+function channelHudState(runtime) {
+  if (!runtime || runtime.isEnabled?.() !== true) return 'locked';
+  return runtime.isHudVisible?.() === false ? 'off' : 'on';
 }
 
 function currentPerformanceProfile() {
@@ -181,11 +255,14 @@ function summarizeTrackChecks(current, previous) {
 }
 
 function formatSnapshot(snapshot) {
+  const scoreHud = snapshot.scoringHud || { drift: 'unknown', flow: 'unknown' };
   return [
     `TURN PERF · ${snapshot.label}`,
     snapshot.profile?.label || 'DPR≤2.00 · shadows 1024',
     snapshot.shadowPolicy?.label || null,
+    `score HUD D:${scoreHud.drift} · F:${scoreHud.flow}`,
     `${snapshot.fps.toFixed(1)} fps · p50 ${snapshot.p50Ms.toFixed(1)} · p95 ${snapshot.p95Ms.toFixed(1)} ms`,
+    `cpu/frame phy ${snapshot.physicsMs.toFixed(2)} · score ${snapshot.scoringMs.toFixed(2)} · HUD ${snapshot.hudMs.toFixed(2)} · render ${snapshot.renderMs.toFixed(2)} ms`,
     `${snapshot.drawCalls} calls · ${compactNumber(snapshot.triangles)} tris · ${snapshot.renderers} renderer${snapshot.renderers === 1 ? '' : 's'}`,
     `${snapshot.geometries} geo · ${snapshot.textures} tex · actual DPR ${snapshot.pixelRatio.toFixed(2)}`,
     `track ${snapshot.trackChecksPerQuery.toFixed(1)} checks/query · >33ms ${snapshot.slowPercent.toFixed(1)}%`

--- a/turn/race/track-spatial-index.js
+++ b/turn/race/track-spatial-index.js
@@ -15,6 +15,9 @@ export function createTrackSpatialIndex(initialSamples, { cellSize = DEFAULT_CEL
   let totalChecks = 0;
   let maxChecks = 0;
   let lastChecks = 0;
+  let lastQueryX = NaN;
+  let lastQueryZ = NaN;
+  let lastQueryResult = null;
 
   rebuild(initialSamples);
 
@@ -26,6 +29,9 @@ export function createTrackSpatialIndex(initialSamples, { cellSize = DEFAULT_CEL
     maxCellX = -Infinity;
     minCellZ = Infinity;
     maxCellZ = -Infinity;
+    lastQueryX = NaN;
+    lastQueryZ = NaN;
+    lastQueryResult = null;
 
     for (let index = 0; index < samples.length; index += 1) {
       const point = samples[index].point;
@@ -63,6 +69,9 @@ export function createTrackSpatialIndex(initialSamples, { cellSize = DEFAULT_CEL
       return recordResult(findNearestTrackBruteForce(samples, position));
     }
 
+    const cached = reuseLastResult(x, z);
+    if (cached) return cached;
+
     const centerCellX = Math.floor(x / size);
     const centerCellZ = Math.floor(z / size);
 
@@ -75,7 +84,7 @@ export function createTrackSpatialIndex(initialSamples, { cellSize = DEFAULT_CEL
       centerCellZ < minCellZ ||
       centerCellZ > maxCellZ
     ) {
-      return recordResult(findNearestTrackHierarchy(samples, hierarchy, position));
+      return recordResult(findNearestTrackHierarchy(samples, hierarchy, position), x, z);
     }
 
     let bestIndex = -1;
@@ -142,24 +151,47 @@ export function createTrackSpatialIndex(initialSamples, { cellSize = DEFAULT_CEL
       if (radius >= MAX_GRID_RADIUS_BEFORE_HIERARCHY) {
         const hierarchyResult = findNearestTrackHierarchy(samples, hierarchy, position);
         hierarchyResult.checks += checks;
-        return recordResult(hierarchyResult);
+        return recordResult(hierarchyResult, x, z);
       }
     }
 
-    if (bestIndex < 0) return recordResult(findNearestTrackHierarchy(samples, hierarchy, position));
+    if (bestIndex < 0) {
+      return recordResult(findNearestTrackHierarchy(samples, hierarchy, position), x, z);
+    }
     return recordResult({
       index: bestIndex,
       sample: samples[bestIndex],
       distance: Math.sqrt(bestDistanceSq),
       checks
-    });
+    }, x, z);
   }
 
-  function recordResult(result) {
+  function reuseLastResult(x, z) {
+    if (!lastQueryResult || x !== lastQueryX || z !== lastQueryZ) return null;
+    queryCount += 1;
+    lastChecks = 0;
+    return {
+      index: lastQueryResult.index,
+      sample: lastQueryResult.sample,
+      distance: lastQueryResult.distance,
+      checks: 0
+    };
+  }
+
+  function recordResult(result, x = NaN, z = NaN) {
     lastChecks = result.checks;
     queryCount += 1;
     totalChecks += result.checks;
     maxChecks = Math.max(maxChecks, result.checks);
+    if (Number.isFinite(x) && Number.isFinite(z)) {
+      lastQueryX = x;
+      lastQueryZ = z;
+      lastQueryResult = {
+        index: result.index,
+        sample: result.sample,
+        distance: result.distance
+      };
+    }
     return result;
   }
 

--- a/turn/scoring/drift-attack-runtime.js
+++ b/turn/scoring/drift-attack-runtime.js
@@ -2,7 +2,6 @@ import {
   SCORE_FEEDBACK_CHANNEL,
   SCORE_FEEDBACK_EVENT
 } from './score-feedback.js';
-import './scorekeeper-records.js';
 import { createDriftAttackScorer } from './drift-attack.js';
 import {
   getBestDriftRecord,
@@ -19,6 +18,10 @@ function getStorage(storage) {
   } catch (_) {
     return null;
   }
+}
+
+function performanceNow() {
+  return globalThis.performance?.now?.() ?? Date.now();
 }
 
 export function driftHudVisible(storage) {
@@ -138,15 +141,33 @@ export function createDriftAttackRuntime({
 
   function advance(dt, now) {
     if (!enabled) return false;
-    return scorer.advance(
-      dt,
-      now,
-      state.speed,
-      state.driftSlipAngle,
-      state.offRoad,
-      state.collided,
-      state.lapActive
-    );
+    const recordPhase = globalThis.__turnPerfRecordPhase;
+    if (typeof recordPhase !== 'function') {
+      return scorer.advance(
+        dt,
+        now,
+        state.speed,
+        state.driftSlipAngle,
+        state.offRoad,
+        state.collided,
+        state.lapActive
+      );
+    }
+
+    const startedAt = performanceNow();
+    try {
+      return scorer.advance(
+        dt,
+        now,
+        state.speed,
+        state.driftSlipAngle,
+        state.offRoad,
+        state.collided,
+        state.lapActive
+      );
+    } finally {
+      recordPhase('scoring', Math.max(0, performanceNow() - startedAt));
+    }
   }
 
   function completeLap({

--- a/turn/scoring/drift-attack.js
+++ b/turn/scoring/drift-attack.js
@@ -319,10 +319,9 @@ export function createDriftAttackScorer({ onState = null, onEvent = null } = {})
 
     accumulator += elapsed;
     if (accumulator + Number.EPSILON < DRIFT_ATTACK_SAMPLE_INTERVAL_SECONDS) return false;
-    const sampleDt = accumulator;
-    accumulator = 0;
+    accumulator = Math.max(0, accumulator - DRIFT_ATTACK_SAMPLE_INTERVAL_SECONDS);
     sample(
-      sampleDt,
+      DRIFT_ATTACK_SAMPLE_INTERVAL_SECONDS,
       timestamp,
       Math.max(0, finiteNumber(speed)),
       finiteNumber(slipAngle),

--- a/turn/scoring/flow-runtime.js
+++ b/turn/scoring/flow-runtime.js
@@ -39,6 +39,10 @@ function getStorage(storage) {
   }
 }
 
+function performanceNow() {
+  return globalThis.performance?.now?.() ?? Date.now();
+}
+
 function nowFrom(event) {
   return finiteNumber(event?.detail?.at, globalThis.performance?.now?.() || 0);
 }
@@ -144,24 +148,38 @@ export function createFlowRuntime({
 
   function scheduleChainExpiry(now) {
     clearChainTimer();
+    const chainSnapshot = scorer.inspect();
+    const expiresAt = chainSnapshot.lastTechniqueAt + FLOW_CHAIN_WINDOW_MS;
+    const lapScoreAtSchedule = chainSnapshot.lapScore;
     chainTimer = setTimer(() => {
       chainTimer = 0;
-      const expiresAt = scorer.inspect().lastTechniqueAt + FLOW_CHAIN_WINDOW_MS;
       if (scorer.expireChain(expiresAt)) {
         lastMilestoneTier = 1;
         dispatchSemanticEvent(eventTarget, 'turn:flow-score-event', {
           channel: SCORE_FEEDBACK_CHANNEL.FLOW,
           type: 'chain-expired',
-          score: scorer.inspect().lapScore
+          score: lapScoreAtSchedule
         });
       }
-    }, Math.max(0, scorer.inspect().lastTechniqueAt + FLOW_CHAIN_WINDOW_MS - now));
+    }, Math.max(0, expiresAt - now));
   }
 
   function accept(technique, token, basePoints, now, detail = {}) {
-    const result = scorer.acceptTechnique({ technique, token, basePoints, now, detail });
-    if (result) scheduleChainExpiry(now);
-    return result;
+    const recordPhase = globalThis.__turnPerfRecordPhase;
+    if (typeof recordPhase !== 'function') {
+      const result = scorer.acceptTechnique({ technique, token, basePoints, now, detail });
+      if (result) scheduleChainExpiry(now);
+      return result;
+    }
+
+    const startedAt = performanceNow();
+    try {
+      const result = scorer.acceptTechnique({ technique, token, basePoints, now, detail });
+      if (result) scheduleChainExpiry(now);
+      return result;
+    } finally {
+      recordPhase('scoring', Math.max(0, performanceNow() - startedAt));
+    }
   }
 
   function validPendingShift(now) {

--- a/turn/scoring/score-feedback.js
+++ b/turn/scoring/score-feedback.js
@@ -1,3 +1,5 @@
+import { installScorekeeperRecords } from './scorekeeper-records.js';
+
 export const SCORE_FEEDBACK_CHANNEL = Object.freeze({
   DRIFT: 'drift',
   FLOW: 'flow'
@@ -152,6 +154,10 @@ function formatScore(value) {
   return numberFormatter.format(Math.max(0, Math.round(finiteNumber(value))));
 }
 
+function performanceNow() {
+  return globalThis.performance?.now?.() ?? Date.now();
+}
+
 export function createScoreFeedback({
   root,
   commitIntervalMs = SCORE_FEEDBACK_COMMIT_INTERVAL_MS,
@@ -159,6 +165,11 @@ export function createScoreFeedback({
   onSound = null
 } = {}) {
   if (!root) throw new Error('TURN ScoreFeedback requires a fixed root element.');
+
+  // Scorekeeper history is presentation composition, not a DRIFT runtime side effect.
+  // Install it before retaining any optional DOM references so it can remove the
+  // intentionally hidden FLOW token strip in the production document.
+  installScorekeeperRecords({ documentRef: root.ownerDocument || globalThis.document });
 
   const statePanel = requiredElement(root, '[data-score-feedback-state]');
   const driftReadout = optionalElement(root, '[data-score-feedback-drift-readout]') || statePanel;
@@ -362,6 +373,8 @@ export function createScoreFeedback({
     }
     if (!dirty || (!force && timestamp - lastCommitAt < minCommitInterval)) return false;
 
+    const recordPhase = globalThis.__turnPerfRecordPhase;
+    const phaseStartedAt = typeof recordPhase === 'function' ? performanceNow() : null;
     const flow = channels[SCORE_FEEDBACK_CHANNEL.FLOW];
     const drift = channels[SCORE_FEEDBACK_CHANNEL.DRIFT];
     const driftActive = drift.visible && drift.active;
@@ -454,6 +467,7 @@ export function createScoreFeedback({
     setHidden(root, !drift.visible && !flow.visible && !eventVisible);
     dirty = false;
     lastCommitAt = timestamp;
+    if (phaseStartedAt != null) recordPhase('hud', Math.max(0, performanceNow() - phaseStartedAt));
     return true;
   }
 

--- a/turn/scoring/scorekeeper-records.js
+++ b/turn/scoring/scorekeeper-records.js
@@ -264,5 +264,3 @@ export function installScorekeeperRecords({
     }
   });
 }
-
-installScorekeeperRecords();

--- a/turn/vehicle/physics.js
+++ b/turn/vehicle/physics.js
@@ -135,7 +135,7 @@ export function getVehicleSpeedLimit({
     : baseSpeedLimit;
 }
 
-export function updateVehiclePhysicsState({
+function updateVehiclePhysicsStateCore({
   state,
   dt,
   updateMotionInput,
@@ -406,6 +406,18 @@ export function updateVehiclePhysicsState({
   return nearestAfter;
 }
 
+export function updateVehiclePhysicsState(options) {
+  const recordPhase = globalThis.__turnPerfRecordPhase;
+  if (typeof recordPhase !== 'function') return updateVehiclePhysicsStateCore(options);
+
+  const startedAt = performanceNow();
+  try {
+    return updateVehiclePhysicsStateCore(options);
+  } finally {
+    recordPhase('physics', Math.max(0, performanceNow() - startedAt));
+  }
+}
+
 function isForgivingSurface(position) {
   try {
     return globalThis.__turnIsForgivingSurface?.(position) === true;
@@ -420,6 +432,10 @@ function currentCollisionProfile() {
   } catch (_) {
     return null;
   }
+}
+
+function performanceNow() {
+  return globalThis.performance?.now?.() ?? Date.now();
 }
 
 function positiveNumber(value, fallback) {


### PR DESCRIPTION
## Summary

Focused performance/architecture follow-up after the DRIFT/FLOW review.

- reuses an exact consecutive nearest-track query result, eliminating the redundant first spatial scan of the next physics step while preserving query diagnostics and invalidating on track rebuilds
- keeps the DRIFT 12 Hz sampler on a fixed interval while retaining fractional accumulator time instead of discarding it
- removes Scorekeeper's DRIFT-runtime import side effect and explicitly composes Scorekeeper from the ScoreFeedback presentation layer
- reduces FLOW chain-expiry inspection/object churn to one scorer snapshot per scheduled expiry
- extends `?perf=1` with per-frame CPU phase diagnostics for physics, scoring runtime, HUD commits and renderer time, plus visible DRIFT/FLOW HUD on/off state for A/B testing
- adds a dedicated regression covering exact track-cache results, cache invalidation, irregular-cadence DRIFT sampling, diagnostic phase summaries and the new dependency direction

No scoring targets, reward thresholds, physics rates, visual scoring effects, or gameplay rules are intentionally changed.