### PR TITLE
TURN: refresh the design system for the current product

### DIFF
--- a/turn-tests/about-history-production.mjs
+++ b/turn-tests/about-history-production.mjs
@@ -13,7 +13,7 @@ const [
   historyCss,
   designMain,
   designReference,
-  designNavigation
+  designReferenceCss
 ] = await Promise.all([
   fs.readFile(new URL('../turn/release.json', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
@@ -26,7 +26,7 @@ const [
   fs.readFile(new URL('../turn/about-history-r163.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/design.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/design-dialogs.html', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/design-navigation.css', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/design-reference.css', import.meta.url), 'utf8')
 ]);
 
 const release = JSON.parse(releaseSource);
@@ -145,7 +145,6 @@ assert.match(content, /≈4\.7 km/);
 assert.match(content, /≈3\.8 km/);
 assert.doesNotMatch(content, /MOUNTAIN at 1,000 trophies/);
 
-
 for (const size of ['compact', 'standard', 'wide', 'reader']) {
   assert.match(dialogCss, new RegExp(`\\.turn-dialog--${size}`),
     `Dialog system must define the ${size} size`);
@@ -166,7 +165,7 @@ assert.match(historyCss, /\.m8-about-summary[\s\S]*font-size: 0\.8rem !important
 assert.match(historyCss, /\.m8-about-actions[\s\S]*grid-template-columns: 1fr/,
   'The sole About action must span the full available width');
 
-assert.match(designReference, /TURN DIALOGS/);
+assert.match(designReference, /TURN dialogs/i);
 assert.match(designReference, /Standardize the shell, not the content/);
 assert.match(designReference, /Production dialog inventory/);
 assert.match(designReference, /About TURN/);
@@ -180,27 +179,29 @@ assert.match(designReference, /href="\.\/design\.html"/,
   'The dialog reference must remain connected to the main design system');
 
 for (const designPage of [designMain, designReference]) {
-  assert.match(designPage, /href="\.\/design-navigation\.css\?revision=r164-design-navigation"/,
-    'Every design-system page must use the shared navigation pattern');
-  assert.match(designPage, /class="design-page-nav" aria-label="Design system pages"/);
+  assert.match(designPage, /href="\.\/design-reference\.css\?revision=r204-current-product-language"/,
+    'Every design-system page must use the shared current-product reference shell');
+  assert.match(designPage, /class="system-toolbar" aria-label="Design reference pages"/);
   assert.match(designPage, />Design system<\/a>[\s\S]*>Dialogs<\/a>[\s\S]*>Open TURN<\/a>/,
     'Design-system pages must expose the same page navigation in the same order');
-  assert.match(designPage, /href="\/turn\/" target="_blank" rel="noopener noreferrer">Open TURN<\/a>/,
-    'Open TURN must use a fresh browsing context so mobile Safari cannot carry the documentation viewport scale into the game');
-  assert.match(designPage, /class="design-page-scroll" href="#[^"]+"/,
-    'Every design-system hero must visibly indicate that content continues below');
-  assert.match(designPage, /class="section-nav design-section-nav"/,
-    'Every design-system page must use the shared section-navigation treatment');
+  assert.match(designPage, /href="\.\/" target="_blank" rel="noopener">Open TURN<\/a>/,
+    'Open TURN must use a fresh browsing context so mobile Safari cannot carry documentation viewport state into the game');
+  assert.match(designPage, /class="section-nav" aria-label="[^"]+ sections"/,
+    'Every design-system page must expose compact sticky section navigation');
+  assert.match(designPage, new RegExp(`TURN ${escapeRegex(release.version)}`),
+    'Design references must identify the current production version');
+  assert.match(designPage, new RegExp(`Build ${escapeRegex(release.id)}`, 'i'),
+    'Design references must identify the current production build');
 }
 
 assert.match(designMain, /href="\.\/design\.html" aria-current="page">Design system<\/a>/);
 assert.match(designReference, /href="\.\/design-dialogs\.html" aria-current="page">Dialogs<\/a>/);
-assert.match(designNavigation, /min-height: 100svh/);
-assert.match(designNavigation, /\.design-page-nav a\[aria-current='page'\]/);
-assert.match(designNavigation, /\.section-nav\.design-section-nav/);
-assert.match(designNavigation, /prefers-reduced-motion: reduce/);
+assert.match(designReferenceCss, /\.system-header[\s\S]*background: var\(--turn-yellow-600\)/);
+assert.match(designReferenceCss, /\.system-toolbar[\s\S]*background: var\(--turn-blue-300\)/);
+assert.match(designReferenceCss, /\.section-nav[\s\S]*position: sticky/);
+assert.match(designReferenceCss, /prefers-reduced-motion: reduce/);
 
-console.log('TURN website About, history, dialog system and design-system navigation regression passed.');
+console.log('TURN website About, history, dialog system and current design-reference navigation regression passed.');
 
 function escapeRegex(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/turn-tests/design-system-production.mjs
+++ b/turn-tests/design-system-production.mjs
@@ -1,23 +1,47 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [design, tokens, semantic, homeFeedback, release, index] = await Promise.all([
+const [design, dialogs, referenceCss, tokens, semantic, releaseSource, index] = await Promise.all([
   fs.readFile(new URL('../turn/design.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/design-dialogs.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/design-reference.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/design-tokens.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/design-semantic.css', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/home-feedback-r135.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/release.json', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8')
 ]);
 
-assert.match(design, /^<!doctype html>/i);
-assert.match(design, /<html lang="en">/);
-assert.match(design, /<meta name="viewport" content="width=device-width, initial-scale=1">/);
-assert.doesNotMatch(design, /user-scalable=no/);
-assert.doesNotMatch(design, /<script\b/i, 'The reference page must remain static');
-assert.doesNotMatch(design, /https?:\/\//i, 'The reference page must remain dependency-free');
-assert.match(design, /href="\.\/design-tokens\.css\?revision=r162-social-sharing"/);
-assert.match(design, /href="\.\/design-semantic\.css\?revision=r162-social-sharing"/);
+const release = JSON.parse(releaseSource);
+
+for (const page of [design, dialogs]) {
+  assert.match(page, /^<!doctype html>/i);
+  assert.match(page, /<html lang="en">/);
+  assert.match(page, /<meta name="viewport" content="width=device-width, initial-scale=1">/);
+  assert.doesNotMatch(page, /user-scalable=no/);
+  assert.doesNotMatch(page, /<script\b/i, 'Design references must remain static');
+  assert.doesNotMatch(page, /https?:\/\//i, 'Design references must remain dependency-free');
+  assert.match(page, /href="\.\/design-tokens\.css\?revision=r162-social-sharing"/);
+  assert.match(page, /href="\.\/design-semantic\.css\?revision=r162-social-sharing"/);
+  assert.match(page, /href="\.\/design-reference\.css\?revision=r204-current-product-language"/);
+  assert.match(page, /class="system-toolbar" aria-label="Design reference pages"/);
+  assert.match(page, />Design system<\/a>[\s\S]*>Dialogs<\/a>[\s\S]*>Open TURN<\/a>/);
+  assert.match(page, /href="\.\/" target="_blank" rel="noopener">Open TURN<\/a>/,
+    'Open TURN must use a fresh browsing context');
+  assert.match(page, new RegExp(`TURN ${escapeRegex(release.version)}`),
+    'Current design references must identify the canonical production release');
+  assert.match(page, new RegExp(`Build ${escapeRegex(release.id)}`, 'i'),
+    'Current design references must identify the canonical production build');
+}
+
+assert.match(design, /href="\.\/design\.html" aria-current="page">Design system<\/a>/);
+assert.match(dialogs, /href="\.\/design-dialogs\.html" aria-current="page">Dialogs<\/a>/);
+assert.match(design, /Current product language · September 2026/);
+assert.match(design, /Built from the game, not beside it\./);
+assert.match(design, /what the shipped game actually does today instead of presenting an aspirational concept board/);
+assert.doesNotMatch(design, /Normative production system · TURN 1\.7/);
+assert.doesNotMatch(design, /TURN V1\.7\.0 · BUILD 2026\.08\.09-R163/);
+assert.doesNotMatch(design, /TRACK PREVIEW|3D CAR VIEW|Actual components, not substitute illustrations/,
+  'The current reference must use real structural specimens instead of the old placeholder-board vocabulary');
 
 const primitivePalette = new Map([
   ['--turn-ink', '#08090a'],
@@ -52,11 +76,10 @@ assert.equal(
   primitivePalette.size,
   'The reference must show every primitive colour exactly once'
 );
-
 for (const [token, value] of primitivePalette) {
   assert.ok(tokens.includes(`${token}: ${value}`), `Missing primitive definition ${token}: ${value}`);
   assert.ok(design.includes(`data-token="${token}"`), `Missing primitive swatch ${token}`);
-  assert.ok(design.includes(`<code>${token}</code>`), `Missing visible primitive variable name ${token}`);
+  assert.ok(design.includes(`<code>${token}</code>`), `Missing visible primitive variable ${token}`);
   assert.ok(design.includes(`<span>${value}</span>`), `Missing visible primitive value ${value}`);
 }
 
@@ -99,13 +122,12 @@ assert.equal(
   semanticMappings.size,
   'The reference must show every semantic colour role exactly once'
 );
-
 for (const [semanticToken, primitiveToken] of semanticMappings) {
   const definition = `${semanticToken}: var(${primitiveToken})`;
   assert.ok(tokens.includes(definition), `Missing semantic mapping ${definition}`);
   assert.ok(design.includes(`data-semantic="${semanticToken}"`), `Missing semantic reference row ${semanticToken}`);
   assert.ok(design.includes(`<code>${semanticToken}</code>`), `Missing visible semantic variable ${semanticToken}`);
-  assert.ok(design.includes(`<code>var(${primitiveToken})</code>`), `Missing visible semantic mapping ${semanticToken} to ${primitiveToken}`);
+  assert.ok(design.includes(`<code>var(${primitiveToken})</code>`), `Missing visible semantic mapping ${semanticToken}`);
 }
 
 const compatibilityAliases = new Map([
@@ -121,7 +143,6 @@ const compatibilityAliases = new Map([
   ['--m8-yellow', '--turn-yellow-600'],
   ['--m8-blue', '--turn-blue-300']
 ]);
-
 for (const [alias, target] of compatibilityAliases) {
   assert.ok(tokens.includes(`${alias}: var(${target})`), `Missing compatibility alias ${alias}`);
   assert.ok(design.includes(`<code>${alias}</code>`), `Missing visible compatibility alias ${alias}`);
@@ -129,134 +150,85 @@ for (const [alias, target] of compatibilityAliases) {
 }
 
 for (const token of [
-  '--turn-border-micro',
-  '--turn-border-compact',
-  '--turn-border-default',
-  '--turn-border-heavy',
-  '--turn-radius-micro',
-  '--turn-radius-compact',
-  '--turn-radius-default',
-  '--turn-radius-hero',
-  '--turn-radius-pill',
-  '--turn-radius-circle',
-  '--turn-shadow-compact',
-  '--turn-shadow-default',
-  '--turn-shadow-hero'
+  '--turn-border-micro', '--turn-border-compact', '--turn-border-default', '--turn-border-heavy',
+  '--turn-radius-micro', '--turn-radius-compact', '--turn-radius-default', '--turn-radius-hero',
+  '--turn-radius-pill', '--turn-radius-circle', '--turn-shadow-compact', '--turn-shadow-default', '--turn-shadow-hero'
 ]) {
   assert.ok(tokens.includes(token), `Missing geometry or elevation token ${token}`);
 }
 
 assert.match(semantic, /@import url\('\.\/design-tokens\.css\?revision=r162-social-sharing'\)/);
 assert.match(semantic, /\.install-primary,[\s\S]*\.m8-home-fixed-layout \.m8-track-continue,[\s\S]*\.track-select-continue,[\s\S]*\.lot-race/);
-assert.match(semantic, /border-radius: var\(--turn-radius-pill\) !important;/);
-assert.match(semantic, /background: var\(--turn-action-primary\) !important;/);
-assert.match(semantic, /\.turn-yourturn-share-submit,[\s\S]*\.yourturn-actions button\.is-share[\s\S]*var\(--turn-action-share\)/,
-  'TURN and YOUR TURN share actions must consume the same semantic role');
-assert.match(semantic, /\.yourturn-actions button\.is-game[\s\S]*var\(--turn-action-game\)/,
-  'The YOUR TURN → TURN handoff must consume the game-handoff role');
-assert.match(semantic, /\.yourturn-order-1[\s\S]*var\(--turn-social-racer-1\)/);
-assert.match(semantic, /\.yourturn-order-5[\s\S]*var\(--turn-social-racer-5\)/);
-assert.match(semantic, /background: var\(--turn-action-utility\) !important;/);
-assert.match(semantic, /background: var\(--turn-action-navigation\) !important;/);
+assert.match(semantic, /\.drive-drift-zone,[\s\S]*var\(--turn-control-drift\)/);
+assert.match(semantic, /\.drive-pad \.drive-gas-zone,[\s\S]*var\(--turn-control-gas\)/);
+assert.match(semantic, /\.drive-pad \.drive-brake-zone,[\s\S]*var\(--turn-control-brake\)/);
+assert.match(semantic, /\.drive-boost-zone[\s\S]*var\(--turn-control-boost\)[\s\S]*var\(--turn-control-boost-empty\)/);
 
-for (const difficultyContract of [
-  '.track-card-countryside .track-card-difficulty',
-  '.track-card-airport .track-card-difficulty',
-  '.track-card-cliffside .track-card-difficulty',
-  '.track-card-harbor .track-card-difficulty',
-  '.track-card-midnight-city .track-card-difficulty',
-  '.track-card-mountain .track-card-difficulty',
-  '.track-card-locked .track-card-difficulty'
-]) {
-  assert.ok(semantic.includes(difficultyContract), `Missing difficulty contract ${difficultyContract}`);
-}
-
-assert.match(homeFeedback, /Visually a text link; semantically a button because it opens a dialog/);
-assert.match(homeFeedback, /\.m8-home-fixed-layout \.m8-about-trigger[\s\S]*appearance: none/);
-assert.match(homeFeedback, /text-decoration: underline/);
-
-for (const section of ['audit', 'colour', 'patterns', 'screens', 'migration']) {
+for (const section of ['principles', 'foundations', 'components', 'gameplay', 'progression', 'layouts', 'accessibility', 'legacy']) {
   assert.match(design, new RegExp(`id="${section}"`));
   assert.match(design, new RegExp(`href="#${section}"`));
 }
-
 for (const colourLayer of ['primitive-palette', 'semantic-mappings', 'compatibility-aliases']) {
   assert.match(design, new RegExp(`id="${colourLayer}"`));
 }
 
 for (const decision of [
-  'Primitive palette',
-  'Semantic variables and mappings',
-  'Compatibility aliases',
-  'Primary action',
-  'Social share',
-  'Game handoff',
-  'Racer identity',
-  'Utility',
-  'Navigation',
-  'Easy green 200, Medium yellow 200, Advanced orange 200, Expert red 200',
-  'Form controls',
-  'Disclosure',
-  'ABOUT TURN is visually a link but semantically a button',
-  'Install TURN',
-  'Race this track',
-  'Race this car',
-  'Share Your Turn',
-  'Get the Game',
-  'Settings',
-  'How to Play',
-  'Give Feedback',
-  'Race Again',
-  'Leave race',
-  'Close',
-  'Gas',
-  'Drift',
-  'Boost',
-  'Brake · Reverse'
+  'Race this track', 'Settings', 'How to play', 'Achievements', 'Leave race',
+  'Easy', 'Medium', 'Advanced', 'Expert', 'Locked',
+  'Device steering', 'On-screen steering', 'Left-handed layout', 'Drive By Ear',
+  'Drift Points', 'Drift', 'Boost', 'Gas', 'Brake · Reverse', 'Lock', 'Shift',
+  'Scorekeeper paper', 'Trophy Road is a literal road now', 'START', 'FINISH',
+  'Vehicle', 'Feature / perk', 'Scoring', 'The Lot', 'SPORTS CAR',
+  'Screen reader', 'Blank screen', 'Reduced motion'
 ]) {
-  assert.ok(design.toLocaleLowerCase('en').includes(decision.toLocaleLowerCase('en')), `Missing design decision ${decision}`);
+  assert.ok(design.toLocaleLowerCase('en').includes(decision.toLocaleLowerCase('en')), `Missing current design decision ${decision}`);
 }
 
 assert.match(design, /Colour reinforces progression but never replaces the label/);
-assert.match(design, /Colour follows stable join order\. A faster lap may change race rank, but never the racer’s social colour\./);
-assert.match(design, /Name is required before sharing/);
-assert.match(design, /stable racer ID carries identity through a challenge chain/);
-assert.match(design, /selected track record and inside a new-personal-best result/);
+assert.match(design, /Social racer colour follows stable join order\. A faster lap may change race rank, but never the racer’s social colour\./);
+assert.match(design, /Vehicle[\s\S]*blue-100 → blue-500/);
+assert.match(design, /Track[\s\S]*green-200 → green-500/);
+assert.match(design, /Feature \/ perk[\s\S]*yellow-100 → yellow-400/);
+assert.match(design, /Scoring[\s\S]*pink-100 → pink-200/);
+assert.match(design, /Locked perks stay still/);
+assert.match(design, /selecting a car with an active perk gives the short confirmation wiggle/);
+assert.match(design, /reward detail can close on outside click/i);
+assert.match(design, /orange close control/i);
 
-for (const page of [
-  'TURN install page design specimen',
-  'TURN Home and track-selection design specimen',
-  'TURN The Lot design specimen',
-  'TURN race HUD and control design specimen',
-  'YOUR TURN social challenge design specimen',
-  'TURN How to Play dialog design specimen'
-]) {
-  assert.match(design, new RegExp(page));
-}
-for (const placeholder of ['TRACK PREVIEW', '3D CAR VIEW', 'GAME VIEW']) {
-  assert.ok(design.includes(placeholder), `Missing labelled content area ${placeholder}`);
-}
-assert.doesNotMatch(design, /car-shape|track-preview-sample|race-road/);
-assert.match(design, /Actual components, not substitute illustrations\./);
-assert.match(design, /Core game and social challenge patterns are represented\./);
-assert.match(design, /Social challenge semantics: active\./);
-assert.match(design, /class="skip-link" href="#main"/);
-assert.match(design, /aria-label="Design system sections"/);
-assert.match(design, /@media \(prefers-reduced-motion: reduce\)/);
+assert.match(referenceCss, /\.system-header[\s\S]*background: var\(--turn-yellow-600\)/,
+  'The reference itself must use the current solid yellow Home-header language');
+assert.match(referenceCss, /\.system-toolbar[\s\S]*background: var\(--turn-blue-300\)/);
+assert.match(referenceCss, /\.button-sample\.primary[\s\S]*background: var\(--turn-action-primary\)/);
+assert.match(referenceCss, /\.dialog-demo__close[\s\S]*background: var\(--turn-orange-500\)/);
+assert.match(referenceCss, /\.drive-demo__drift[\s\S]*var\(--turn-control-drift\)/);
+assert.match(referenceCss, /\.drive-demo__boost[\s\S]*var\(--turn-control-boost\)/);
+assert.match(referenceCss, /\.drive-demo__gas[\s\S]*var\(--turn-control-gas\)/);
+assert.match(referenceCss, /\.drive-demo__brake[\s\S]*var\(--turn-control-brake\)/);
+assert.match(referenceCss, /\.score-row\.flow \.score-gauge i[\s\S]*var\(--turn-pink-500\)/);
+assert.match(referenceCss, /\.reward-tile\.vehicle\.locked[\s\S]*var\(--turn-blue-100\)/);
+assert.match(referenceCss, /\.reward-tile\.scoring\.unlocked[\s\S]*var\(--turn-pink-200\)/);
+assert.match(referenceCss, /@media \(prefers-reduced-motion: reduce\)/);
 
-const releaseDefinition = JSON.parse(release);
-assert.match(index, new RegExp(`TURN v${escapeRegex(releaseDefinition.version)} · Build ${escapeRegex(releaseDefinition.id)}`));
-assert.match(index, new RegExp(`version: '${escapeRegex(releaseDefinition.version)}'`));
-assert.match(index, new RegExp(`id: '${escapeRegex(releaseDefinition.id)}'`));
-assert.match(index, new RegExp(`cacheKey: '${escapeRegex(releaseDefinition.cacheKey)}'`));
-assert.match(design, /Normative production system · TURN 1\.7/,
-  'The design reference has its own documented design-system revision and need not mirror every game release bump');
-assert.match(design, /TURN V1\.7\.0 · BUILD 2026\.08\.09-R163/,
-  'Static screen specimens remain labelled with the release they document until the design reference itself is revised');
-assert.doesNotMatch(design, /TURN V1\.4\.0|2026\.08\.03-R126/,
-  'The living design reference must not regress to obsolete pre-1.7 metadata');
+assert.match(dialogs, /TURN dialogs/i);
+assert.match(dialogs, /Standardize the shell, not the content\./);
+assert.match(dialogs, /Production dialog inventory/);
+assert.match(dialogs, /About TURN/);
+assert.match(dialogs, /Development history &amp; changelog/);
+assert.match(dialogs, /Drive By Ear 101 introduction/);
+assert.match(dialogs, /Motion access denied/);
+assert.match(dialogs, /In-race audio settings/);
+assert.match(dialogs, /Compact[\s\S]*Standard[\s\S]*Wide[\s\S]*Reader/);
+assert.match(dialogs, /Do not stack modal dialogs/);
+assert.match(dialogs, /Focus the heading first/);
+assert.match(dialogs, /Return focus/);
+assert.match(dialogs, /Contain scrolling/);
 
-console.log('TURN 1.6 primitive palette, social challenge semantics, mappings and component reference passed.');
+assert.match(index, new RegExp(`TURN v${escapeRegex(release.version)} · Build ${escapeRegex(release.id)}`));
+assert.match(index, new RegExp(`version: '${escapeRegex(release.version)}'`));
+assert.match(index, new RegExp(`id: '${escapeRegex(release.id)}'`));
+assert.match(index, new RegExp(`cacheKey: '${escapeRegex(release.cacheKey)}'`));
+
+console.log('TURN current product-language design system, palette, gameplay, progression and dialog reference passed.');
 
 function escapeRegex(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/turn-tests/design-system-production.mjs
+++ b/turn-tests/design-system-production.mjs
@@ -176,7 +176,7 @@ for (const decision of [
   'Race this track', 'Settings', 'How to play', 'Achievements', 'Leave race',
   'Easy', 'Medium', 'Advanced', 'Expert', 'Locked',
   'Device steering', 'On-screen steering', 'Left-handed layout', 'Drive By Ear',
-  'Drift Points', 'Drift', 'Boost', 'Gas', 'Brake · Reverse', 'Lock', 'Shift',
+  'DRIFT and FLOW scorekeeper', 'Drift', 'Boost', 'Gas', 'Brake · Reverse', 'Lock', 'Shift',
   'Scorekeeper paper', 'Trophy Road is a literal road now', 'START', 'FINISH',
   'Vehicle', 'Feature / perk', 'Scoring', 'The Lot', 'SPORTS CAR',
   'Screen reader', 'Blank screen', 'Reduced motion'
@@ -192,8 +192,8 @@ assert.match(design, /Feature \/ perk[\s\S]*yellow-100 → yellow-400/);
 assert.match(design, /Scoring[\s\S]*pink-100 → pink-200/);
 assert.match(design, /Locked perks stay still/);
 assert.match(design, /selecting a car with an active perk gives the short confirmation wiggle/);
-assert.match(design, /reward detail can close on outside click/i);
-assert.match(design, /orange close control/i);
+assert.match(design, /clicking outside also closes it/i);
+assert.match(design, /detail close button uses[\s\S]*--turn-orange-500/i);
 
 assert.match(referenceCss, /\.system-header[\s\S]*background: var\(--turn-yellow-600\)/,
   'The reference itself must use the current solid yellow Home-header language');

--- a/turn-tests/form-disclosure-system.mjs
+++ b/turn-tests/form-disclosure-system.mjs
@@ -99,21 +99,24 @@ assert.doesNotMatch(
 );
 
 for (const specimen of [
-  'Native form controls',
-  'Legend and heading elements share one floating card-title treatment',
-  'Radio buttons',
-  'Checkboxes',
-  'Disclosure',
-  'Blue trigger, Paper panel',
-  'The decorative state symbol sits directly before the summary text'
+  'Native disclosure',
+  'Steering',
+  'Device steering',
+  'On-screen steering',
+  'Left-handed layout',
+  'Drive By Ear',
+  'Use native',
+  'The visible trigger is blue; expanded information returns to Paper.'
 ]) {
-  assert.ok(design.includes(specimen), `Missing design-system specimen or rule: ${specimen}`);
+  assert.ok(design.includes(specimen), `Missing current design-system specimen or rule: ${specimen}`);
 }
 assert.match(design, /<fieldset class="form-card">[\s\S]*<legend>Steering<\/legend>/);
-assert.match(design, /<section class="form-card" aria-labelledby="designAudioTitle">[\s\S]*<h3 id="designAudioTitle">Audio<\/h3>/);
-assert.match(design, /<input type="radio" name="designSteering" checked>/);
-assert.match(design, /<input type="checkbox" checked>/);
-assert.match(design, /<details class="disclosure-sample"[^>]*>[\s\S]*<summary><span class="disclosure-symbol" aria-hidden="true"><\/span><span>Explore the Drive By Ear sounds<\/span><\/summary>/);
+assert.match(design, /<input type="radio" name="steering" checked>/);
+assert.match(design, /<input type="radio" name="steering">/);
+assert.match(design, /<input type="checkbox">[\s\S]*<strong>Left-handed layout<\/strong>/);
+assert.match(design, /<details class="disclosure-sample">[\s\S]*<summary>Drive By Ear<\/summary>/);
+assert.match(design, /<code>details<\/code>[\s\S]*<code>summary<\/code>/,
+  'The current reference must explicitly prefer native details/summary semantics');
 
 assert.match(
   settingsHome,

--- a/turn/design-dialogs.html
+++ b/turn/design-dialogs.html
@@ -6,331 +6,142 @@
   <meta name="color-scheme" content="light">
   <meta name="robots" content="noindex">
   <title>TURN Design System — Dialogs</title>
-  <link rel="stylesheet" href="./design-tokens.css?revision=r141-form-disclosure">
-  <link rel="stylesheet" href="./design-semantic.css?revision=r141-form-disclosure">
-  <link rel="stylesheet" href="./m8-home.css?revision=r224-modal-headings">
+  <link rel="stylesheet" href="./design-tokens.css?revision=r162-social-sharing">
+  <link rel="stylesheet" href="./design-semantic.css?revision=r162-social-sharing">
   <link rel="stylesheet" href="./dialog-system-r163.css?revision=r163-modal-pattern">
-  <link rel="stylesheet" href="./design-navigation.css?revision=r164-design-navigation">
-  <style>
-    :root {
-      font-family: Inter, ui-rounded, system-ui, sans-serif;
-      color-scheme: light;
-      --design-page-width: 1120px;
-      --m8-ink: var(--turn-ink);
-      --m8-cream: var(--turn-paper);
-      --m8-pink: var(--turn-pink-500);
-      --m8-blue: var(--turn-blue-500);
-      --m8-yellow: var(--turn-yellow-400);
-    }
-
-    * { box-sizing: border-box; }
-    html { scroll-behavior: smooth; background: var(--turn-ink); }
-    body { margin: 0; background: var(--turn-ink); color: var(--turn-paper); font-weight: 780; line-height: 1.48; }
-    a, button { color: inherit; font: inherit; }
-    code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
-    a:focus-visible, button:focus-visible { outline: 5px solid var(--turn-form-control-focus); outline-offset: 4px; }
-
-    .skip-link {
-      position: fixed;
-      z-index: 100;
-      top: 12px;
-      left: 12px;
-      padding: 10px 14px;
-      border: 4px solid var(--turn-ink);
-      border-radius: var(--turn-radius-compact);
-      background: var(--turn-yellow-400);
-      color: var(--turn-ink);
-      box-shadow: var(--turn-shadow-default);
-      transform: translateY(-180%);
-    }
-
-    .skip-link:focus { transform: none; }
-
-    .hero {
-      padding: clamp(40px, 8vw, 96px) max(22px, calc((100vw - 1120px) / 2));
-      background: linear-gradient(145deg, var(--turn-blue-500), var(--turn-green-500));
-      color: var(--turn-ink);
-    }
-
-    .eyebrow {
-      display: inline-block;
-      padding: 7px 11px;
-      border: 3px solid var(--turn-ink);
-      border-radius: var(--turn-radius-pill);
-      background: var(--turn-yellow-400);
-      box-shadow: var(--turn-shadow-compact);
-      font-size: .72rem;
-      font-weight: 950;
-      letter-spacing: .15em;
-      text-transform: uppercase;
-    }
-
-    h1 { max-width: 9ch; margin: 20px 0 14px; font-size: clamp(3.7rem, 11vw, 7rem); line-height: .78; letter-spacing: -.075em; }
-    .hero p { max-width: 68rem; margin: 0; font-size: clamp(1rem, 2vw, 1.3rem); }
-
-    .section-nav {
-      position: sticky;
-      z-index: 20;
-      top: 0;
-      display: flex;
-      gap: 8px;
-      overflow-x: auto;
-      padding: 10px max(18px, calc((100vw - 1120px) / 2));
-      border-block: 4px solid var(--turn-ink);
-      background: rgb(255 248 232 / .97);
-      color: var(--turn-ink);
-    }
-
-    .section-nav a { flex: 0 0 auto; padding: 8px 12px; border-radius: var(--turn-radius-pill); text-decoration: none; }
-    .section-nav a:hover { background: var(--turn-yellow-400); }
-    main { width: min(1120px, 100%); margin: auto; padding: 70px 22px 110px; }
-    section { scroll-margin-top: 78px; margin-top: 90px; }
-    section:first-child { margin-top: 0; }
-    .kicker { font-size: .72rem; font-weight: 950; letter-spacing: .15em; text-transform: uppercase; }
-    .section-head { display: grid; grid-template-columns: minmax(0, 1fr) minmax(260px, .55fr); gap: 28px; align-items: end; margin-bottom: 26px; }
-    .section-head h2 { margin: 7px 0 0; font-size: clamp(2.2rem, 5vw, 4rem); line-height: .9; letter-spacing: -.055em; }
-    .section-head p { margin: 0; color: rgb(255 248 232 / .78); }
-
-    .card,
-    .table-wrap,
-    .specimen {
-      border: 4px solid var(--turn-ink);
-      border-radius: var(--turn-radius-default);
-      background: var(--turn-paper);
-      color: var(--turn-ink);
-      box-shadow: var(--turn-shadow-default);
-    }
-
-    .grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 16px; }
-    .card { padding: 20px; }
-    .card h3 { margin: 7px 0 8px; }
-    .card p { margin: 0; }
-    .table-wrap { overflow-x: auto; }
-    table { width: 100%; min-width: 760px; border-collapse: collapse; text-align: left; }
-    th, td { padding: 13px 15px; border-bottom: 2px solid var(--turn-ink); vertical-align: top; }
-    th { background: var(--turn-yellow-400); font-size: .7rem; letter-spacing: .12em; text-transform: uppercase; }
-    tr:last-child td { border-bottom: 0; }
-    .status { display: inline-block; padding: 3px 8px; border: 2px solid var(--turn-ink); border-radius: var(--turn-radius-pill); font-size: .68rem; font-weight: 950; white-space: nowrap; }
-    .status.current { background: var(--turn-green-200); }
-    .status.special { background: var(--turn-blue-200); }
-    .status.migrate { background: var(--turn-yellow-200); }
-
-    .anatomy { display: grid; gap: 12px; margin: 0; padding: 0; list-style: none; counter-reset: anatomy; }
-    .anatomy li { counter-increment: anatomy; display: grid; grid-template-columns: 42px minmax(0, 1fr); gap: 13px; align-items: start; padding: 16px; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-default); background: var(--turn-paper); color: var(--turn-ink); box-shadow: var(--turn-shadow-compact); }
-    .anatomy li::before { content: counter(anatomy); display: grid; place-items: center; width: 38px; height: 38px; border: 3px solid var(--turn-ink); border-radius: 50%; background: var(--turn-pink-200); font-weight: 950; }
-    .anatomy strong, .anatomy span { display: block; }
-    .anatomy span { margin-top: 3px; font-size: .9rem; }
-
-    .sizes { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 14px; }
-    .size-card { min-width: 0; padding: 18px; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-default); background: var(--turn-paper); color: var(--turn-ink); box-shadow: var(--turn-shadow-compact); }
-    .size-card span { display: block; font-size: .7rem; font-weight: 950; letter-spacing: .12em; text-transform: uppercase; }
-    .size-card h3 { margin: 5px 0 8px; }
-    .size-card p { margin: 0; font-size: .88rem; }
-
-    .rules { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
-    .rules article { padding: 19px; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-default); background: var(--turn-paper); color: var(--turn-ink); box-shadow: var(--turn-shadow-compact); }
-    .rules h3 { margin: 0 0 8px; }
-    .rules ul { margin: 0; padding-left: 20px; }
-    .rules li + li { margin-top: 7px; }
-
-    .specimen { padding: 24px; }
-    .demo-stage { display: grid; place-items: center; min-height: 240px; padding: 24px; border: 4px dashed var(--turn-ink); border-radius: var(--turn-radius-default); background: var(--turn-blue-200); }
-    .demo-open { min-height: 52px; padding: 10px 18px; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-pill); background: var(--turn-pink-500); color: var(--turn-ink); box-shadow: var(--turn-shadow-default); font-weight: 950; }
-    .demo-open:active, .m8-dialog button:active { transform: translate(5px, 5px); box-shadow: 1px 1px 0 var(--turn-ink); }
-    .demo-body p { max-width: 58ch; margin: 0; line-height: 1.5; }
-    .demo-actions { margin-top: 18px; }
-    .demo-actions button { min-height: 46px; padding: 9px 16px; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-pill); background: var(--turn-yellow-400); color: var(--turn-ink); box-shadow: var(--turn-shadow-compact); font-weight: 950; }
-
-    .code-block { overflow-x: auto; padding: 18px; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-default); background: #151719; color: var(--turn-paper); box-shadow: var(--turn-shadow-default); }
-    .code-block pre { margin: 0; font-size: .82rem; line-height: 1.55; }
-    footer { padding: 38px 22px; border-top: 4px solid var(--turn-ink); background: var(--turn-yellow-600); color: var(--turn-ink); text-align: center; }
-
-    @media (max-width: 900px) {
-      .grid, .sizes { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-      .section-head { grid-template-columns: 1fr; }
-    }
-
-    @media (max-width: 620px) {
-      .grid, .sizes, .rules { grid-template-columns: 1fr; }
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-      html { scroll-behavior: auto; }
-      *, *::before, *::after { transition: none !important; }
-    }
-  </style>
+  <link rel="stylesheet" href="./design-reference.css?revision=r204-current-product-language">
 </head>
 <body>
-  <a class="skip-link" href="#main">Skip to dialog guidance</a>
+  <a class="skip-link" href="#main">Skip to dialog system</a>
 
-  <header class="hero design-page-hero">
-    <div class="design-page-shell">
-      <nav class="design-page-nav" aria-label="Design system pages">
-        <a href="./design.html">Design system</a>
-        <a href="./design-dialogs.html" aria-current="page">Dialogs</a>
-        <a href="/turn/" target="_blank" rel="noopener noreferrer">Open TURN</a>
-      </nav>
-      <div class="design-page-hero-content">
-        <span class="eyebrow">Normative component pattern</span>
-        <h1>TURN DIALOGS</h1>
-        <p>One interaction model and one visual anatomy, with deliberate size variants for short decisions, settings, rich tools and long-form reading.</p>
+  <header class="system-header">
+    <div class="system-header__inner">
+      <div class="turn-mark" aria-hidden="true"><span>TURN</span></div>
+      <div class="system-title">
+        <p>Design system · dialog architecture</p>
+        <h1>DIALOG SYSTEM</h1>
       </div>
-      <a class="design-page-scroll" href="#dialog-sections"><span aria-hidden="true">↓</span> Explore dialog guidance</a>
+      <div class="system-meta" aria-label="Reference baseline">
+        <strong>Production reference</strong>
+        <span>TURN 1.17.3</span>
+        <span>Build 2026.09.05-r203</span>
+      </div>
     </div>
   </header>
 
-  <nav id="dialog-sections" class="section-nav design-section-nav" aria-label="Dialog design sections">
-    <a href="#principles">Principles</a>
-    <a href="#inventory">Inventory</a>
+  <div class="system-toolbar" aria-label="Design reference pages">
+    <div class="system-toolbar__inner">
+      <a href="./design.html">Design system</a>
+      <a href="./design-dialogs.html" aria-current="page">Dialogs</a>
+      <a href="./" target="_blank" rel="noopener">Open TURN</a>
+    </div>
+  </div>
+
+  <nav class="section-nav" aria-label="Dialog system sections">
     <a href="#anatomy">Anatomy</a>
     <a href="#sizes">Sizes</a>
-    <a href="#behaviour">Behaviour</a>
-    <a href="#specimen">Specimen</a>
+    <a href="#inventory">Inventory</a>
+    <a href="#behavior">Behavior</a>
   </nav>
 
   <main id="main">
-    <section id="principles">
-      <div class="section-head">
-        <div><span class="kicker">01 · Decision</span><h2>Standardize the shell, not the content.</h2></div>
-        <p>TURN dialogs should feel related and behave predictably. A Trophy Road tool, a denial alert and a long history reader do not need the same dimensions or internal layout.</p>
+    <section id="anatomy" aria-labelledby="dialogs-title">
+      <div class="lead-board">
+        <div class="lead-copy">
+          <span class="kicker">TURN dialogs</span>
+          <h2 id="dialogs-title">Standardize the shell, not the content.</h2>
+          <p>TURN has many kinds of dialog content, but they share one production structure: a strong Paper surface, a compact heading region, one scrolling body when needed, optional actions, and an orange close control. Size is chosen from the system scale rather than invented per feature.</p>
+        </div>
+        <aside class="status-board">
+          <span class="kicker">Dialog contract</span>
+          <strong>One modal at a time.</strong>
+          <div class="status-row"><span class="status-dot" aria-hidden="true"></span><span>Heading receives initial focus where appropriate.</span></div>
+          <div class="status-row"><span class="status-dot" aria-hidden="true"></span><span>Body owns scrolling, not the whole viewport.</span></div>
+          <div class="status-row"><span class="status-dot" aria-hidden="true"></span><span>Close returns focus to the trigger.</span></div>
+        </aside>
       </div>
-      <div class="grid">
-        <article class="card"><span class="kicker">Structure</span><h3>Native dialog</h3><p>Use <code>&lt;dialog&gt;</code>, an accessible name, one visible heading and a real close control.</p></article>
-        <article class="card"><span class="kicker">Ownership</span><h3>One scroll surface</h3><p>The shell remains stable. Long content scrolls inside the body rather than moving the close control away.</p></article>
-        <article class="card"><span class="kicker">Variation</span><h3>Named sizes</h3><p>Choose compact, standard, wide or reader. Avoid one-off pixel widths tied to a single feature.</p></article>
+
+      <div class="specimen" style="margin-top:24px">
+        <div class="specimen-head"><strong>Normative anatomy</strong><span class="specimen-label">Header · body · actions</span></div>
+        <div class="specimen-body">
+          <div class="dialog-demo">
+            <div class="dialog-demo__head">
+              <div><span class="dialog-demo__eyebrow">How to play</span><h3>DRIFT POINTS</h3></div>
+              <button class="dialog-demo__close" type="button" aria-label="Close">×</button>
+            </div>
+            <div class="dialog-demo__body">
+              <div class="dialog-demo__panel"><strong>BODY</strong><p>The content region owns overflow when the dialog is taller than the available viewport.</p></div>
+              <div class="dialog-demo__panel"><strong>ACTIONS</strong><p>Use actions only when the task needs an explicit next step. Close remains a navigation action.</p></div>
+            </div>
+          </div>
+          <div class="table-wrap" style="margin-top:24px">
+            <table>
+              <thead><tr><th>Part</th><th>Production class</th><th>Responsibility</th></tr></thead>
+              <tbody>
+                <tr><td>Dialog</td><td><code>.turn-dialog</code></td><td>Modal root and size variables.</td></tr>
+                <tr><td>Surface</td><td><code>.turn-dialog__surface</code></td><td>Paper card, border, radius, shadow and vertical composition.</td></tr>
+                <tr><td>Header</td><td><code>.turn-dialog__header</code></td><td>Label, title and close control.</td></tr>
+                <tr><td>Body</td><td><code>.turn-dialog__body</code></td><td>Owns scrolling and overscroll containment.</td></tr>
+                <tr><td>Actions</td><td><code>.turn-dialog__actions</code></td><td>Optional task completion or navigation actions.</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
       </div>
     </section>
 
-    <section id="inventory">
+    <section id="sizes" aria-labelledby="sizes-title">
       <div class="section-head">
-        <div><span class="kicker">02 · Production audit</span><h2>Current modal landscape.</h2></div>
-        <p>The audit covers production Home, race, progression, training and platform dialogs. Installation guidance remains an onboarding overlay outside this in-game pattern.</p>
+        <div><span class="kicker">Size scale</span><h2 id="sizes-title">Compact. Standard. Wide. Reader.</h2></div>
+        <p>Size describes content complexity. It should not be used to make a dialog feel important.</p>
       </div>
-      <div class="table-wrap" tabindex="0" role="region" aria-label="Production dialog inventory">
+      <div class="grid">
+        <article class="card"><span class="token-label">Compact</span><h3>≤ 660px</h3><p>Short decisions, simple notices and small About-style content.</p></article>
+        <article class="card"><span class="token-label">Standard</span><h3>≤ 760px</h3><p>Feedback forms, audio settings and medium-complexity tasks.</p></article>
+        <article class="card"><span class="token-label">Wide</span><h3>≤ 1040px</h3><p>Settings, How to Play, Achievements and multi-column configuration.</p></article>
+        <article class="card"><span class="token-label">Reader</span><h3>Near full screen</h3><p>History and changelog. The shell is fixed; the reading pane scrolls.</p></article>
+      </div>
+    </section>
+
+    <section id="inventory" aria-labelledby="inventory-title">
+      <div class="section-head">
+        <div><span class="kicker">Production dialog inventory</span><h2 id="inventory-title">Map shipped content to the system.</h2></div>
+        <p>Specialized content is expected. Specialized modal mechanics are not.</p>
+      </div>
+      <div class="table-wrap">
         <table>
-          <thead><tr><th>Dialog</th><th>Recommended size</th><th>Status</th><th>Notes</th></tr></thead>
+          <thead><tr><th>Dialog</th><th>Size</th><th>Notes</th></tr></thead>
           <tbody>
-            <tr><td>About TURN</td><td>Compact</td><td><span class="status current">Normative</span></td><td>Short overview, credits, history and design-system actions.</td></tr>
-            <tr><td>Development history &amp; changelog</td><td>Reader</td><td><span class="status current">Normative</span></td><td>Nearly full screen; stable header, tabs and one internal reading surface.</td></tr>
-            <tr><td>Give Feedback</td><td>Standard</td><td><span class="status current">Normative shell</span></td><td>Compact body and action row.</td></tr>
-            <tr><td>How to Play</td><td>Wide</td><td><span class="status current">Normative shell</span></td><td>Card grid needs horizontal room.</td></tr>
-            <tr><td>Home Settings</td><td>Wide</td><td><span class="status current">Normative shell</span></td><td>Two-column form becomes one column in portrait.</td></tr>
-            <tr><td>Achievements / Trophy Road</td><td>Wide or Reader</td><td><span class="status special">Specialized body</span></td><td>Uses the common shell; owns filtering, preview and list layout.</td></tr>
-            <tr><td>Drive By Ear 101 introduction</td><td>Wide</td><td><span class="status special">Specialized focus</span></td><td>Top-preserving focus and delayed WebKit scroll correction are intentional.</td></tr>
-            <tr><td>Drive By Ear 101 part complete</td><td>Wide</td><td><span class="status current">Normative shell</span></td><td>Short instructional content plus navigation actions.</td></tr>
-            <tr><td>Motion access denied</td><td>Compact alert</td><td><span class="status migrate">Migration candidate</span></td><td>Keep the direct acknowledgement flow; align visual anatomy when next touched.</td></tr>
-            <tr><td>In-race audio settings</td><td>Standard</td><td><span class="status migrate">Migration candidate</span></td><td>Legacy visual shell; content semantics remain valid.</td></tr>
-            <tr><td>Reset-rivals confirmation</td><td>Inline confirmation</td><td><span class="status special">Not a modal</span></td><td>Keep the confirmation inside Settings; avoid a dialog on top of a dialog.</td></tr>
+            <tr><td>About TURN</td><td>Compact</td><td>Short product summary and History / Changelog entry.</td></tr>
+            <tr><td>Development history &amp; changelog</td><td>Reader</td><td>Tabbed reader; one internal body owns scroll.</td></tr>
+            <tr><td>Give Feedback</td><td>Standard</td><td>Native form controls and compact heading spacing.</td></tr>
+            <tr><td>Settings</td><td>Wide</td><td>Use available width for grouped controls; avoid a long single column.</td></tr>
+            <tr><td>How to Play</td><td>Wide</td><td>Native disclosures, selectable text and large readable sections.</td></tr>
+            <tr><td>Achievements</td><td>Wide</td><td>Collection and Trophy Road content; reward details may use a contextual modal layer.</td></tr>
+            <tr><td>Drive By Ear 101 introduction</td><td>Wide</td><td>Training setup with clear primary action.</td></tr>
+            <tr><td>Motion access denied</td><td>Compact</td><td>Explains fallback without trapping the player.</td></tr>
+            <tr><td>In-race audio settings</td><td>Standard</td><td>Readable without pausing or obscuring more race state than necessary.</td></tr>
           </tbody>
         </table>
       </div>
     </section>
 
-    <section id="anatomy">
+    <section id="behavior" aria-labelledby="behavior-title">
       <div class="section-head">
-        <div><span class="kicker">03 · Anatomy</span><h2>A stable frame around changing content.</h2></div>
-        <p>Class names describe responsibility. Feature classes may extend the body but should not redefine the complete shell.</p>
+        <div><span class="kicker">Behavior</span><h2 id="behavior-title">The interaction model is as normative as the border.</h2></div>
+        <p>Modal consistency depends on focus, scrolling and dismissal behavior as much as visual styling.</p>
       </div>
-      <ol class="anatomy">
-        <li><div><strong><code>.turn-dialog</code></strong><span>The native dialog element. Owns viewport bounds, backdrop and size variant.</span></div></li>
-        <li><div><strong><code>.turn-dialog__surface</code></strong><span>The bordered TURN card. Owns padding, radius, hard shadow and overflow boundary.</span></div></li>
-        <li><div><strong><code>.turn-dialog__header</code></strong><span>Eyebrow, h2 and close button. Remains visible in reader dialogs.</span></div></li>
-        <li><div><strong><code>.turn-dialog__body</code></strong><span>The sole scroll owner when content exceeds the available block size.</span></div></li>
-        <li><div><strong><code>.turn-dialog__actions</code></strong><span>Optional grouped actions. Use buttons for commands and links for navigation.</span></div></li>
-      </ol>
-    </section>
-
-    <section id="sizes">
-      <div class="section-head">
-        <div><span class="kicker">04 · Size scale</span><h2>Four named choices.</h2></div>
-        <p>Choose the smallest size that supports the content without cramped controls, excessive wrapping or unnecessary empty space.</p>
-      </div>
-      <div class="sizes">
-        <article class="size-card"><span>Compact</span><h3>≈ 660 px</h3><p>About, alerts and short explanations.</p></article>
-        <article class="size-card"><span>Standard</span><h3>≈ 760 px</h3><p>Feedback, simple settings and focused tasks.</p></article>
-        <article class="size-card"><span>Wide</span><h3>≈ 1040 px</h3><p>Card grids, complex settings, training and progression.</p></article>
-        <article class="size-card"><span>Reader</span><h3>Near full screen</h3><p>Long documents, tabs and dense lists where stable navigation matters.</p></article>
-      </div>
-    </section>
-
-    <section id="behaviour">
-      <div class="section-head">
-        <div><span class="kicker">05 · Behaviour</span><h2>Predictable focus and dismissal.</h2></div>
-        <p>Visual consistency without consistent keyboard, screen-reader and scroll behaviour is not a component system.</p>
-      </div>
-      <div class="rules">
-        <article><h3>Opening</h3><ul><li>Record the invoking control.</li><li>Reset the intended scroll surface to the top.</li><li>Focus the close control unless feature testing proves another target is better.</li><li>Use <code>preventScroll</code> when available.</li></ul></article>
-        <article><h3>Closing</h3><ul><li>Close button and backdrop dismiss ordinary dialogs.</li><li>Escape uses native dialog behaviour.</li><li>Return focus to the invoking control.</li><li>Do not return focus to an element inside a dialog that is now closed.</li></ul></article>
-        <article><h3>Long content</h3><ul><li>Keep header and tab controls outside the scrolling body.</li><li>Use one internal scroll owner.</li><li>Contain overscroll to avoid moving the game beneath the dialog.</li><li>Do not shrink body text below a comfortable reading size merely to fit more.</li></ul></article>
-        <article><h3>Dialog transitions</h3><ul><li>Do not stack modal dialogs.</li><li>Close the source, open the destination, then restore the source when appropriate.</li><li>Tabs belong inside one dialog when they describe parallel views of the same object.</li><li>Use a separate dialog when the task changes substantially.</li></ul></article>
-      </div>
-    </section>
-
-    <section id="specimen">
-      <div class="section-head">
-        <div><span class="kicker">06 · Interactive specimen</span><h2>The standard shell.</h2></div>
-        <p>This specimen uses the production dialog stylesheet rather than a visual imitation.</p>
-      </div>
-      <div class="specimen">
-        <div class="demo-stage">
-          <button class="demo-open" type="button" aria-haspopup="dialog">OPEN DIALOG SPECIMEN</button>
-        </div>
-      </div>
-      <div class="code-block" style="margin-top:22px" tabindex="0" role="region" aria-label="Dialog markup example">
-<pre><code>&lt;dialog class="m8-dialog turn-dialog turn-dialog--standard" aria-labelledby="exampleTitle"&gt;
-  &lt;article class="m8-dialog-card turn-dialog__surface"&gt;
-    &lt;header class="m8-dialog-head turn-dialog__header"&gt;
-      &lt;div&gt;&lt;span&gt;EYEBROW&lt;/span&gt;&lt;h2 id="exampleTitle"&gt;TITLE&lt;/h2&gt;&lt;/div&gt;
-      &lt;button type="button" data-dialog-close aria-label="Close title"&gt;×&lt;/button&gt;
-    &lt;/header&gt;
-    &lt;div class="turn-dialog__body"&gt;…&lt;/div&gt;
-    &lt;div class="turn-dialog__actions"&gt;…&lt;/div&gt;
-  &lt;/article&gt;
-&lt;/dialog&gt;</code></pre>
+      <div class="grid">
+        <article class="card"><span class="principle-number">1</span><h3>Do not stack modal dialogs</h3><p>Close the source dialog before opening another modal. Restore the source when the reader or subtask closes if that is the user’s expected return point.</p></article>
+        <article class="card"><span class="principle-number">2</span><h3>Focus the heading first</h3><p>For information-heavy dialogs, focus the labelled heading programmatically with <code>tabindex="-1"</code>. Do not force initial focus to Close.</p></article>
+        <article class="card"><span class="principle-number">3</span><h3>Return focus</h3><p>Closing a dialog returns focus to the control that opened it. This applies to website About as well as in-game dialogs.</p></article>
+        <article class="card"><span class="principle-number">4</span><h3>Contain scrolling</h3><p>Use <code>overscroll-behavior</code>, stable scrollbars and an internal body so the modal shell does not slide around in short landscape viewports.</p></article>
+        <article class="card"><span class="principle-number">5</span><h3>Dismiss outside where appropriate</h3><p>Contextual reward detail can close on outside click. Task dialogs should not accidentally discard user input unless that behavior is explicitly safe.</p></article>
+        <article class="card"><span class="principle-number">6</span><h3>Respect reduced motion</h3><p>Dialog navigation should not depend on decorative animation. Scrolling and transition behavior simplify under reduced-motion preferences.</p></article>
       </div>
     </section>
   </main>
 
-  <dialog class="m8-dialog turn-dialog turn-dialog--standard" aria-labelledby="dialogSpecimenTitle">
-    <article class="m8-dialog-card turn-dialog__surface">
-      <header class="m8-dialog-head turn-dialog__header">
-        <div><span>NORMATIVE EXAMPLE</span><h2 id="dialogSpecimenTitle">DIALOG TITLE</h2></div>
-        <button type="button" data-dialog-close aria-label="Close dialog specimen">×</button>
-      </header>
-      <div class="turn-dialog__body demo-body">
-        <p>The shell owns the backdrop, boundaries, padding, title and close control. Feature content owns only what happens inside this body.</p>
-      </div>
-      <div class="turn-dialog__actions demo-actions">
-        <button type="button" data-dialog-close>DONE</button>
-      </div>
-    </article>
-  </dialog>
-
-  <footer>TURN design system · Dialog pattern · August 2026</footer>
-
-  <script>
-    const trigger = document.querySelector('.demo-open');
-    const dialog = document.querySelector('dialog');
-    const closeButtons = dialog.querySelectorAll('[data-dialog-close]');
-    const open = () => {
-      dialog.__returnFocus = trigger;
-      if (typeof dialog.showModal === 'function') dialog.showModal();
-      else dialog.setAttribute('open', '');
-      dialog.querySelector('.m8-dialog-head [data-dialog-close]')?.focus();
-    };
-    const close = () => {
-      if (typeof dialog.close === 'function' && dialog.open) dialog.close();
-      else {
-        dialog.removeAttribute('open');
-        dialog.__returnFocus?.focus();
-      }
-    };
-    trigger.addEventListener('click', open);
-    closeButtons.forEach((button) => button.addEventListener('click', close));
-    dialog.addEventListener('click', (event) => {
-      if (event.target === dialog) close();
-    });
-    dialog.addEventListener('close', () => dialog.__returnFocus?.focus());
-  </script>
+  <footer><div class="footer-inner"><strong>TURN Dialog System</strong><span>Current product language · September 2026</span></div></footer>
 </body>
 </html>

--- a/turn/design-reference.css
+++ b/turn/design-reference.css
@@ -1,0 +1,496 @@
+/* TURN design reference — current production product language. */
+
+:root {
+  --design-page-width: 1240px;
+  font-family: Inter, ui-rounded, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color-scheme: light;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; background: var(--turn-paper); }
+body {
+  margin: 0;
+  background: var(--turn-paper);
+  color: var(--turn-ink);
+  font-weight: 800;
+  line-height: 1.42;
+}
+button, input, summary { font: inherit; }
+a { color: inherit; }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+summary:focus-visible {
+  outline: 5px solid var(--turn-form-control-focus);
+  outline-offset: 4px;
+}
+
+.skip-link {
+  position: fixed;
+  z-index: 200;
+  top: 12px;
+  left: 12px;
+  padding: 10px 14px;
+  border: var(--turn-border-default) solid var(--turn-ink);
+  border-radius: var(--turn-radius-compact);
+  background: var(--turn-yellow-400);
+  box-shadow: var(--turn-shadow-default);
+  transform: translateY(-180%);
+}
+.skip-link:focus { transform: none; }
+
+.system-header {
+  border-bottom: 6px solid var(--turn-ink);
+  background: var(--turn-yellow-600);
+}
+.system-header__inner {
+  width: min(var(--design-page-width), 100%);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: clamp(86px, 11vw, 138px) minmax(0, 1fr) auto;
+  align-items: stretch;
+  min-height: clamp(118px, 18vw, 172px);
+}
+.turn-mark {
+  display: grid;
+  place-items: center;
+  border-right: 6px solid var(--turn-ink);
+  background: var(--turn-paper);
+  font-size: clamp(1.25rem, 2.7vw, 2.15rem);
+  font-weight: 1000;
+  letter-spacing: -.06em;
+  line-height: .82;
+  text-align: center;
+}
+.turn-mark span { display: block; transform: rotate(-4deg); }
+.system-title {
+  align-self: center;
+  min-width: 0;
+  padding: 18px clamp(20px, 4vw, 50px);
+}
+.system-title p { margin: 0 0 6px; font-size: .72rem; letter-spacing: .15em; text-transform: uppercase; }
+.system-title h1 {
+  margin: 0;
+  font-size: clamp(2.5rem, 6.5vw, 6.1rem);
+  font-weight: 1000;
+  letter-spacing: -.075em;
+  line-height: .78;
+}
+.system-meta {
+  align-self: center;
+  justify-self: end;
+  display: grid;
+  justify-items: end;
+  gap: 4px;
+  padding: 16px max(18px, env(safe-area-inset-right)) 16px 14px;
+  font-size: clamp(.64rem, 1vw, .8rem);
+  letter-spacing: .08em;
+  text-align: right;
+  text-transform: uppercase;
+}
+.system-meta strong { font-size: 1.08em; }
+
+.system-toolbar {
+  border-bottom: 4px solid var(--turn-ink);
+  background: var(--turn-blue-300);
+}
+.system-toolbar__inner {
+  width: min(var(--design-page-width), 100%);
+  margin: 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  padding: 12px clamp(18px, 3vw, 34px);
+}
+.system-toolbar a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 8px 14px;
+  border: 3px solid var(--turn-ink);
+  border-radius: var(--turn-radius-pill);
+  background: var(--turn-paper);
+  box-shadow: var(--turn-shadow-compact);
+  font-size: .78rem;
+  font-weight: 950;
+  letter-spacing: .04em;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+.system-toolbar a[aria-current="page"] { background: var(--turn-pink-500); }
+.system-toolbar a:last-child { margin-left: auto; background: var(--turn-orange-500); }
+.system-toolbar a:active { transform: translate(3px, 3px); box-shadow: 0 0 0 var(--turn-ink); }
+
+.section-nav {
+  position: sticky;
+  z-index: 80;
+  top: 0;
+  display: flex;
+  gap: 6px;
+  overflow-x: auto;
+  padding: 8px max(14px, calc((100vw - var(--design-page-width)) / 2 + 22px));
+  border-bottom: 4px solid var(--turn-ink);
+  background: rgb(255 248 232 / .97);
+  scrollbar-width: thin;
+}
+.section-nav a {
+  flex: 0 0 auto;
+  padding: 7px 10px;
+  border-radius: var(--turn-radius-pill);
+  font-size: .74rem;
+  font-weight: 950;
+  letter-spacing: .045em;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+.section-nav a:hover,
+.section-nav a:focus-visible { background: var(--turn-yellow-400); }
+
+main {
+  width: min(var(--design-page-width), 100%);
+  margin: 0 auto;
+  padding: clamp(38px, 6vw, 76px) clamp(18px, 3vw, 34px) 110px;
+}
+section { scroll-margin-top: 72px; margin-top: clamp(72px, 9vw, 118px); }
+section:first-child { margin-top: 0; }
+
+.section-head {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(270px, .55fr);
+  gap: 28px;
+  align-items: end;
+  margin-bottom: 28px;
+}
+.kicker,
+.token-label,
+.specimen-label {
+  font-size: .7rem;
+  font-weight: 1000;
+  letter-spacing: .15em;
+  text-transform: uppercase;
+}
+.section-head h2 {
+  margin: 7px 0 0;
+  font-size: clamp(2.35rem, 5.6vw, 4.9rem);
+  font-weight: 1000;
+  line-height: .84;
+  letter-spacing: -.065em;
+}
+.section-head p { margin: 0; max-width: 48ch; }
+
+.lead-board {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(300px, .65fr);
+  gap: 22px;
+  align-items: stretch;
+}
+.lead-copy,
+.status-board,
+.card,
+.board,
+.specimen,
+.table-wrap,
+.palette-board {
+  border: var(--turn-border-default) solid var(--turn-ink);
+  border-radius: var(--turn-radius-default);
+  background: var(--turn-white);
+  box-shadow: var(--turn-shadow-default);
+}
+.lead-copy { padding: clamp(24px, 4vw, 44px); background: var(--turn-paper); }
+.lead-copy h2 {
+  max-width: 12ch;
+  margin: 8px 0 16px;
+  font-size: clamp(2.7rem, 6vw, 5.7rem);
+  line-height: .82;
+  letter-spacing: -.07em;
+}
+.lead-copy p { max-width: 66ch; margin: 0; font-size: clamp(1rem, 1.6vw, 1.22rem); }
+.status-board { display: grid; align-content: center; gap: 16px; padding: 24px; background: var(--turn-blue-200); }
+.status-board strong { font-size: clamp(1.45rem, 2.7vw, 2.35rem); line-height: .95; }
+.status-row { display: grid; grid-template-columns: auto 1fr; gap: 10px; align-items: start; }
+.status-dot { width: 18px; height: 18px; margin-top: 2px; border: 3px solid var(--turn-ink); border-radius: 50%; background: var(--turn-green-500); }
+
+.grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 18px; }
+.card { padding: 22px; }
+.card:nth-child(4n + 1) { background: var(--turn-yellow-100); }
+.card:nth-child(4n + 2) { background: var(--turn-blue-100); }
+.card:nth-child(4n + 3) { background: var(--turn-green-100); }
+.card h3 { margin: 8px 0 8px; font-size: 1.3rem; line-height: 1; }
+.card p { margin: 0; }
+.card ul { margin: 12px 0 0; padding-left: 1.15rem; }
+.card li + li { margin-top: 6px; }
+
+.principle-number {
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border: 3px solid var(--turn-ink);
+  border-radius: 50%;
+  background: var(--turn-paper);
+  box-shadow: 2px 2px 0 var(--turn-ink);
+  font-size: 1rem;
+  font-weight: 1000;
+}
+
+.palette-board { padding: 22px; background: var(--turn-blue-100); }
+.palette-family + .palette-family { margin-top: 24px; }
+.palette-family h3 { margin: 0 0 10px; font-size: 1rem; letter-spacing: .08em; text-transform: uppercase; }
+.palette-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; }
+.swatch {
+  min-width: 0;
+  overflow: hidden;
+  border: 3px solid var(--turn-ink);
+  border-radius: var(--turn-radius-compact);
+  background: var(--turn-paper);
+  box-shadow: var(--turn-shadow-compact);
+}
+.swatch-colour { min-height: 82px; border-bottom: 3px solid var(--turn-ink); background: var(--swatch); }
+.swatch-copy { display: grid; gap: 3px; padding: 10px 11px 12px; }
+.swatch-copy code { overflow-wrap: anywhere; font-size: .72rem; font-weight: 900; }
+.swatch-copy span { font-size: .72rem; letter-spacing: .05em; text-transform: uppercase; }
+
+.table-wrap { overflow-x: auto; background: var(--turn-paper); }
+table { width: 100%; min-width: 780px; border-collapse: collapse; text-align: left; }
+th, td { padding: 13px 15px; border-bottom: 2px solid var(--turn-ink); vertical-align: top; }
+th { background: var(--turn-yellow-400); font-size: .7rem; letter-spacing: .1em; text-transform: uppercase; }
+tr:last-child td { border-bottom: 0; }
+td code { font-size: .78rem; font-weight: 850; }
+.mapping-preview { display: inline-block; width: 32px; height: 22px; margin-right: 8px; border: 2px solid var(--turn-ink); border-radius: 6px; background: var(--mapping); vertical-align: middle; }
+.mapping-group td { background: var(--turn-blue-100); font-size: .7rem; letter-spacing: .1em; text-transform: uppercase; }
+
+.geometry-row { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 14px; }
+.geometry-sample { min-height: 124px; padding: 16px; border: var(--turn-border-default) solid var(--turn-ink); background: var(--turn-paper); display: flex; align-items: end; }
+.geometry-sample.micro { border-radius: var(--turn-radius-micro); box-shadow: var(--turn-shadow-compact); }
+.geometry-sample.compact { border-radius: var(--turn-radius-compact); box-shadow: var(--turn-shadow-compact); }
+.geometry-sample.default { border-radius: var(--turn-radius-default); box-shadow: var(--turn-shadow-default); }
+.geometry-sample.hero { border-radius: var(--turn-radius-hero); box-shadow: var(--turn-shadow-hero); }
+.geometry-sample span { font-size: .72rem; letter-spacing: .08em; text-transform: uppercase; }
+
+.specimen { overflow: hidden; background: var(--turn-paper); }
+.specimen-head { display: flex; justify-content: space-between; gap: 14px; align-items: center; padding: 12px 16px; border-bottom: 3px solid var(--turn-ink); background: var(--turn-blue-200); }
+.specimen-body { padding: clamp(18px, 3vw, 30px); }
+.row { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; }
+.row + .row { margin-top: 18px; }
+
+.button-sample,
+.icon-button,
+.difficulty,
+.racer-chip,
+.menu-button {
+  display: inline-grid;
+  place-items: center;
+  border: 4px solid var(--turn-ink);
+  color: var(--turn-ink);
+  font-weight: 950;
+  text-transform: uppercase;
+}
+.button-sample { min-height: 52px; padding: 10px 18px; border-radius: var(--turn-radius-default); background: var(--turn-action-utility); box-shadow: var(--turn-shadow-default); }
+.button-sample.primary { border-radius: var(--turn-radius-pill); background: var(--turn-action-primary); }
+.button-sample.navigation { background: var(--turn-action-navigation); }
+.button-sample.success { background: var(--turn-action-success); }
+.button-sample.danger { background: var(--turn-action-danger); }
+.button-sample.info { background: var(--turn-action-information); }
+.button-sample:active,
+.icon-button:active,
+.menu-button:active { transform: translate(6px, 6px); box-shadow: 1px 1px 0 var(--turn-ink); }
+.icon-button { width: 52px; height: 52px; border-radius: 50%; background: var(--turn-action-navigation); box-shadow: var(--turn-shadow-default); font-size: 1.25rem; }
+.difficulty { min-width: 118px; min-height: 38px; padding: 7px 14px; border-width: 3px; border-radius: var(--turn-radius-pill); box-shadow: var(--turn-shadow-compact); font-size: .78rem; letter-spacing: .08em; }
+.difficulty.easy { background: var(--turn-difficulty-easy); }
+.difficulty.medium { background: var(--turn-difficulty-medium); }
+.difficulty.advanced { background: var(--turn-difficulty-advanced); }
+.difficulty.expert { background: var(--turn-difficulty-expert); }
+.difficulty.locked { background: var(--turn-difficulty-locked); }
+.racer-chip { min-height: 36px; padding: 5px 11px; border-width: 3px; border-radius: var(--turn-radius-pill); box-shadow: var(--turn-shadow-compact); font-size: .72rem; }
+.racer-chip:nth-child(1) { background: var(--turn-social-racer-1); }
+.racer-chip:nth-child(2) { background: var(--turn-social-racer-2); }
+.racer-chip:nth-child(3) { background: var(--turn-social-racer-3); }
+.racer-chip:nth-child(4) { background: var(--turn-social-racer-4); }
+.racer-chip:nth-child(5) { background: var(--turn-social-racer-5); }
+
+.form-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; }
+.form-card { position: relative; min-width: 0; margin: 0; padding: 18px; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-default); background: var(--turn-surface-raised); box-shadow: var(--turn-shadow-default); }
+.form-card legend,
+.form-card > h3 { display: table; width: fit-content; max-width: calc(100% - 24px); padding: 0 8px; background: var(--turn-surface-raised); font-size: 1.15rem; font-weight: 950; line-height: 1.1; }
+.form-card legend { margin-inline-start: 2px; }
+.form-card > h3 { position: relative; z-index: 1; margin: -30px 0 12px 2px; }
+.form-option { display: grid; grid-template-columns: auto minmax(0, 1fr); align-items: center; gap: 11px; margin-top: 12px; cursor: pointer; }
+.form-option strong,
+.form-option small { display: block; }
+.form-option small { margin-top: 2px; line-height: 1.25; }
+.form-card input[type="radio"],
+.form-card input[type="checkbox"] { appearance: none; width: 30px; height: 30px; margin: 0; border: 4px solid var(--turn-ink); background: var(--turn-form-control-idle); cursor: pointer; }
+.form-card input[type="radio"] { border-radius: 50%; }
+.form-card input[type="radio"]:checked { background: radial-gradient(circle, var(--turn-form-control-idle) 0 27%, transparent 30%), var(--turn-form-control-selected); }
+.form-card input[type="checkbox"] { border-radius: var(--turn-radius-micro); }
+.form-card input[type="checkbox"]:checked { background: var(--turn-form-control-selected); box-shadow: inset 0 0 0 7px var(--turn-form-control-selected); }
+.disclosure-sample { overflow: hidden; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-default); background: var(--turn-disclosure-panel); box-shadow: var(--turn-shadow-default); }
+.disclosure-sample summary { display: flex; align-items: center; gap: 10px; min-height: 56px; padding: 12px 15px; background: var(--turn-disclosure-trigger); cursor: pointer; font-weight: 950; }
+.disclosure-sample summary::marker { font-size: 1.25em; }
+.disclosure-panel { padding: 16px; border-top: 3px solid var(--turn-ink); }
+.disclosure-panel p { margin: 0; }
+
+.dialog-demo { max-width: 760px; margin: 0 auto; padding: 22px; border: 6px solid var(--turn-ink); border-radius: var(--turn-radius-hero); background: var(--turn-paper); box-shadow: var(--turn-shadow-hero); }
+.dialog-demo__head { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 18px; align-items: start; }
+.dialog-demo__eyebrow { font-size: .7rem; letter-spacing: .12em; text-transform: uppercase; }
+.dialog-demo h3 { margin: 3px 0 0; font-size: clamp(2rem, 4vw, 3.4rem); line-height: .9; letter-spacing: -.05em; }
+.dialog-demo__close { width: 50px; height: 50px; border: 4px solid var(--turn-ink); border-radius: 50%; background: var(--turn-orange-500); box-shadow: var(--turn-shadow-compact); font-size: 1.25rem; font-weight: 1000; }
+.dialog-demo__body { margin-top: 20px; display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+.dialog-demo__panel { min-height: 120px; padding: 16px; border: 3px solid var(--turn-ink); border-radius: var(--turn-radius-default); background: var(--turn-blue-100); }
+.dialog-demo__panel:last-child { background: var(--turn-yellow-100); }
+
+.gameplay-grid { display: grid; grid-template-columns: minmax(260px, .85fr) minmax(0, 1.15fr); gap: 20px; align-items: stretch; }
+.game-stage { position: relative; min-height: 420px; overflow: hidden; border: 6px solid var(--turn-ink); border-radius: var(--turn-radius-hero); background: var(--turn-road); box-shadow: var(--turn-shadow-hero); }
+.game-stage::before { content: ""; position: absolute; inset: 14% 18%; border: 22px solid var(--turn-paper); border-radius: 42%; opacity: .42; transform: rotate(-7deg); }
+.game-stage__label { position: absolute; top: 16px; left: 16px; padding: 5px 9px; border: 3px solid var(--turn-ink); border-radius: var(--turn-radius-pill); background: var(--turn-paper); font-size: .7rem; letter-spacing: .08em; text-transform: uppercase; }
+
+.drive-demo { position: absolute; right: 18px; bottom: 18px; width: 210px; height: 260px; display: grid; grid-template-rows: 32% 44% 24%; overflow: hidden; border: 4px solid var(--turn-ink); border-radius: 30px; background: var(--turn-control-gas); box-shadow: 7px 8px 0 var(--turn-ink); }
+.drive-demo__top { display: grid; grid-template-columns: 1fr 1fr; }
+.drive-demo button { border: 0; border-radius: 0; color: var(--turn-ink); font: inherit; font-size: .78rem; font-weight: 950; text-transform: uppercase; }
+.drive-demo__drift { border-right: 2px solid var(--turn-ink) !important; background: var(--turn-control-drift); }
+.drive-demo__boost { border-left: 2px solid var(--turn-ink) !important; background: var(--turn-control-boost); }
+.drive-demo__gas { border-top: 4px solid var(--turn-ink) !important; background: var(--turn-control-gas); }
+.drive-demo__brake { border-top: 4px solid var(--turn-ink) !important; background: var(--turn-control-brake); }
+.drive-demo__lock,
+.drive-demo__shift { position: absolute; right: calc(100% - 4px); width: 62px; display: grid; place-items: center; border: 4px solid var(--turn-ink); border-right: 0; border-radius: 999px 0 0 999px; font-size: .65rem; font-weight: 950; text-transform: uppercase; writing-mode: vertical-rl; transform: rotate(180deg); }
+.drive-demo__lock { top: 0; height: 32%; background: #748ffc; }
+.drive-demo__shift { top: 32%; height: 44%; background: var(--turn-green-500); }
+
+.score-demo { position: absolute; top: 66px; left: 18px; width: min(230px, calc(100% - 36px)); color: var(--turn-ink); }
+.score-row { position: relative; width: 185px; height: 96px; }
+.score-row + .score-row { margin-top: 4px; }
+.score-paper { position: relative; z-index: 1; display: grid; grid-template-rows: auto 1fr auto; height: 96px; padding: 9px 10px; border: 3px solid var(--turn-ink); border-radius: 15px; background: rgb(255 248 232 / .96); box-shadow: 4px 4px 0 var(--turn-ink); }
+.score-heading,
+.score-footer { display: flex; justify-content: space-between; align-items: baseline; gap: 6px; font-size: .52rem; letter-spacing: .07em; text-transform: uppercase; }
+.score-value { display: flex; align-items: center; justify-content: space-between; gap: 7px; }
+.score-value strong { font-size: 1.85rem; line-height: 1; letter-spacing: -.05em; }
+.score-value b { padding: 3px 6px; border: 2px solid var(--turn-ink); border-radius: 999px; background: var(--turn-blue-200); font-size: .76rem; }
+.score-row.flow .score-value b { background: var(--turn-pink-500); }
+.score-gauge { position: absolute; z-index: 0; top: 7px; left: calc(100% - 3px); width: 54px; height: 82px; overflow: hidden; border: 3px solid var(--turn-ink); border-radius: 0 10px 10px 0; background: var(--turn-ink); }
+.score-gauge i { position: absolute; inset: 5px; border-radius: 4px; background: linear-gradient(to right, var(--turn-blue-500), var(--turn-blue-200)); transform: scaleX(.72); transform-origin: left; }
+.score-row.flow .score-gauge i { background: linear-gradient(to right, var(--turn-pink-500), var(--turn-pink-200)); transform: scaleX(.84); }
+
+.gameplay-notes { display: grid; gap: 14px; }
+.gameplay-note { padding: 18px; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-default); background: var(--turn-white); box-shadow: var(--turn-shadow-default); }
+.gameplay-note:nth-child(2) { background: var(--turn-yellow-100); }
+.gameplay-note:nth-child(3) { background: var(--turn-blue-100); }
+.gameplay-note h3 { margin: 0 0 6px; }
+.gameplay-note p { margin: 0; }
+
+.progression-board { padding: 22px; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-hero); background: #e9fbf7; box-shadow: var(--turn-shadow-hero); }
+.progression-road { display: grid; grid-template-columns: repeat(5, minmax(72px, 1fr)); gap: 12px; }
+.reward-tile { min-height: 100px; display: grid; place-items: center; padding: 10px; border: 4px solid var(--turn-ink); border-radius: 20px; box-shadow: var(--turn-shadow-compact); font-size: .72rem; font-weight: 1000; letter-spacing: .05em; text-align: center; text-transform: uppercase; }
+.reward-tile.vehicle.locked { background: var(--turn-blue-100); }
+.reward-tile.vehicle.unlocked { background: var(--turn-blue-500); }
+.reward-tile.track.locked { background: var(--turn-green-200); }
+.reward-tile.track.unlocked { background: var(--turn-green-500); }
+.reward-tile.feature.locked { background: var(--turn-yellow-100); }
+.reward-tile.feature.unlocked { background: var(--turn-yellow-400); }
+.reward-tile.scoring.locked { background: var(--turn-pink-100); }
+.reward-tile.scoring.unlocked { background: var(--turn-pink-200); }
+.reward-tile.start-finish { background: repeating-linear-gradient(45deg, var(--turn-ink) 0 14px, var(--turn-paper) 14px 28px); color: var(--turn-paper); text-shadow: 2px 2px 0 var(--turn-ink); }
+.progression-legend { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; margin-top: 18px; }
+.progression-key { padding: 12px; border: 3px solid var(--turn-ink); border-radius: var(--turn-radius-compact); background: var(--turn-paper); }
+.progression-key strong { display: block; margin-bottom: 4px; }
+
+.layout-stack { display: grid; gap: 26px; }
+.layout-specimen { border: 6px solid var(--turn-ink); border-radius: var(--turn-radius-hero); overflow: hidden; background: var(--turn-paper); box-shadow: var(--turn-shadow-hero); }
+.layout-caption { display: flex; justify-content: space-between; gap: 12px; padding: 11px 15px; border-bottom: 4px solid var(--turn-ink); background: var(--turn-blue-200); font-size: .72rem; letter-spacing: .06em; text-transform: uppercase; }
+.home-mini { min-height: 390px; background: var(--turn-paper); }
+.home-mini__head { display: grid; grid-template-columns: 90px 1fr auto; min-height: 90px; border-bottom: 5px solid var(--turn-ink); background: var(--turn-yellow-600); }
+.home-mini__logo { display: grid; place-items: center; border-right: 5px solid var(--turn-ink); background: var(--turn-paper); font-size: 1.4rem; font-weight: 1000; }
+.home-mini__pitch { align-self: center; padding: 14px 18px; font-size: 1.2rem; line-height: .95; }
+.home-mini__build { align-self: center; padding: 12px 16px; font-size: .64rem; letter-spacing: .06em; text-transform: uppercase; }
+.home-mini__main { display: grid; grid-template-columns: minmax(0, 1fr) 230px; gap: 20px; padding: 20px; }
+.track-mini-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.track-mini { min-height: 120px; padding: 14px; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-default); background: var(--turn-white); box-shadow: var(--turn-shadow-default); }
+.track-mini h4 { margin: 0 0 8px; font-size: 1.1rem; }
+.track-mini p { margin: 0; font-size: .72rem; }
+.home-menu-mini { display: flex; flex-direction: column; gap: 12px; }
+.home-menu-mini h3 { margin: 0; }
+.menu-button { min-height: 44px; padding: 8px 10px; border-radius: var(--turn-radius-pill); background: var(--turn-paper); box-shadow: var(--turn-shadow-default); font-size: .72rem; }
+.menu-button.achievements { background: var(--turn-green-500); }
+.menu-button.race { margin-top: auto; background: var(--turn-pink-500); }
+
+.lot-mini { display: grid; grid-template-columns: minmax(0, 1.25fr) minmax(260px, .75fr); min-height: 340px; }
+.lot-mini__viewer { display: grid; place-items: center; background: var(--turn-blue-100); border-right: 5px solid var(--turn-ink); }
+.car-silhouette { width: 65%; height: 105px; border: 5px solid var(--turn-ink); border-radius: 48% 48% 24% 24%; background: var(--turn-blue-500); box-shadow: var(--turn-shadow-default); transform: skewX(-6deg); }
+.lot-mini__info { padding: 20px; background: var(--turn-paper); }
+.lot-mini__info h3 { margin: 0 0 5px; font-size: 2rem; line-height: .9; }
+.stat-row { display: grid; grid-template-columns: 105px 1fr; gap: 8px; align-items: center; margin-top: 10px; font-size: .72rem; }
+.stat-meter { height: 16px; border: 3px solid var(--turn-ink); border-radius: 999px; background: var(--turn-muted); overflow: hidden; }
+.stat-meter i { display: block; height: 100%; background: var(--turn-green-500); }
+.stat-row:nth-of-type(4) .stat-meter i,
+.stat-row:nth-of-type(5) .stat-meter i { background: var(--turn-blue-500); }
+.stat-row:nth-of-type(6) .stat-meter i,
+.stat-row:nth-of-type(7) .stat-meter i { background: var(--turn-yellow-400); }
+
+.a11y-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; }
+.a11y-card { padding: 20px; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-default); background: var(--turn-white); box-shadow: var(--turn-shadow-default); }
+.a11y-card:nth-child(2n) { background: var(--turn-blue-100); }
+.a11y-card h3 { margin: 0 0 7px; }
+.a11y-card p { margin: 0; }
+
+.legacy-note { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 20px; align-items: center; padding: 22px; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-default); background: var(--turn-yellow-100); box-shadow: var(--turn-shadow-default); }
+.legacy-note h3 { margin: 0 0 6px; }
+.legacy-note p { margin: 0; max-width: 70ch; }
+.legacy-badge { padding: 8px 12px; border: 3px solid var(--turn-ink); border-radius: var(--turn-radius-pill); background: var(--turn-paper); font-size: .7rem; letter-spacing: .09em; text-transform: uppercase; }
+
+footer { border-top: 5px solid var(--turn-ink); background: var(--turn-yellow-600); }
+.footer-inner { width: min(var(--design-page-width), 100%); margin: 0 auto; display: flex; justify-content: space-between; gap: 20px; padding: 22px clamp(18px, 3vw, 34px); font-size: .72rem; letter-spacing: .06em; text-transform: uppercase; }
+
+@media (max-width: 900px) {
+  .system-header__inner { grid-template-columns: 92px minmax(0, 1fr); }
+  .system-meta { grid-column: 1 / -1; justify-self: stretch; display: flex; justify-content: space-between; gap: 10px; padding: 10px 18px; border-top: 4px solid var(--turn-ink); text-align: left; }
+  .lead-board,
+  .gameplay-grid { grid-template-columns: 1fr; }
+  .grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .palette-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .progression-road { grid-template-columns: repeat(4, minmax(72px, 1fr)); }
+  .progression-legend { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@media (max-width: 700px) {
+  .section-head { grid-template-columns: 1fr; gap: 10px; }
+  .grid,
+  .form-grid,
+  .a11y-grid,
+  .geometry-row { grid-template-columns: 1fr; }
+  .palette-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .dialog-demo__body { grid-template-columns: 1fr; }
+  .home-mini__main { grid-template-columns: 1fr; }
+  .home-menu-mini { display: grid; grid-template-columns: 1fr 1fr; }
+  .home-menu-mini h3 { grid-column: 1 / -1; }
+  .menu-button.race { margin-top: 0; }
+  .lot-mini { grid-template-columns: 1fr; }
+  .lot-mini__viewer { min-height: 220px; border-right: 0; border-bottom: 5px solid var(--turn-ink); }
+  .progression-road { grid-template-columns: repeat(3, minmax(72px, 1fr)); }
+  .legacy-note { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 520px) {
+  .system-header__inner { grid-template-columns: 78px minmax(0, 1fr); min-height: 104px; }
+  .system-title { padding-inline: 16px; }
+  .system-title h1 { font-size: clamp(2.35rem, 13vw, 3.8rem); }
+  .system-toolbar a:last-child { margin-left: 0; }
+  main { padding-inline: 14px; }
+  .palette-grid { grid-template-columns: 1fr; }
+  .progression-road { grid-template-columns: repeat(2, minmax(72px, 1fr)); }
+  .progression-legend { grid-template-columns: 1fr; }
+  .home-mini__head { grid-template-columns: 72px 1fr; }
+  .home-mini__build { grid-column: 1 / -1; border-top: 4px solid var(--turn-ink); }
+  .track-mini-grid,
+  .home-menu-mini { grid-template-columns: 1fr; }
+  .home-menu-mini h3 { grid-column: auto; }
+  .game-stage { min-height: 560px; }
+  .score-demo { top: 60px; }
+  .drive-demo { right: 14px; bottom: 14px; width: 180px; height: 228px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  *, *::before, *::after { transition: none !important; animation: none !important; }
+}

--- a/turn/design-v2.tmp
+++ b/turn/design-v2.tmp
@@ -1,0 +1,1 @@
+placeholder

--- a/turn/design-v2.tmp
+++ b/turn/design-v2.tmp
@@ -1,1 +1,0 @@
-placeholder

--- a/turn/design.html
+++ b/turn/design.html
@@ -8,362 +8,488 @@
   <title>TURN Design System</title>
   <link rel="stylesheet" href="./design-tokens.css?revision=r162-social-sharing">
   <link rel="stylesheet" href="./design-semantic.css?revision=r162-social-sharing">
-  <link rel="stylesheet" href="./design-navigation.css?revision=r164-design-navigation">
-  <style>
-    :root { font-family: Inter, ui-rounded, system-ui, sans-serif; color-scheme: light; --design-page-width: 1180px; }
-    * { box-sizing: border-box; }
-    html { scroll-behavior: smooth; background: var(--turn-ink); }
-    body { margin: 0; background: var(--turn-ink); color: var(--turn-paper); font-weight: 800; line-height: 1.45; }
-    button, input, summary { font: inherit; }
-    a { color: inherit; }
-    code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
-    a:focus-visible, button:focus-visible, input:focus-visible, summary:focus-visible { outline: 5px solid var(--turn-form-control-focus); outline-offset: 4px; }
-
-    .skip-link { position: fixed; z-index: 100; top: 12px; left: 12px; padding: 10px 14px; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-compact); background: var(--turn-yellow-400); color: var(--turn-ink); box-shadow: var(--turn-shadow-default); transform: translateY(-180%); }
-    .skip-link:focus { transform: none; }
-    .hero { padding: clamp(48px, 9vw, 110px) max(24px, calc((100vw - 1180px) / 2)); background: linear-gradient(145deg, var(--turn-blue-500), var(--turn-green-500)); color: var(--turn-ink); }
-    .hero-inner { width: min(1180px, 100%); margin: auto; display: grid; grid-template-columns: 1fr auto; gap: 36px; align-items: center; }
-    .hero h1 { max-width: 8ch; margin: 18px 0 12px; font-size: clamp(4rem, 12vw, 8rem); line-height: .75; letter-spacing: -.08em; }
-    .hero p { max-width: 62rem; margin: 0; font-size: clamp(1rem, 2vw, 1.35rem); }
-    .hero img { width: min(220px, 30vw); border: 6px solid var(--turn-ink); border-radius: 24%; background: var(--turn-paper); box-shadow: var(--turn-shadow-hero); }
-    .eyebrow, .kicker, .token-label { font-size: .72rem; font-weight: 950; letter-spacing: .15em; text-transform: uppercase; }
-    .eyebrow { display: inline-block; padding: 7px 11px; border: 3px solid var(--turn-ink); border-radius: var(--turn-radius-pill); background: var(--turn-yellow-400); box-shadow: var(--turn-shadow-compact); }
-
-    .section-nav { position: sticky; z-index: 50; top: 0; display: flex; gap: 8px; overflow-x: auto; padding: 10px max(18px, calc((100vw - 1180px) / 2)); border-block: 4px solid var(--turn-ink); background: rgb(255 248 232 / .97); color: var(--turn-ink); }
-    .section-nav a { flex: 0 0 auto; padding: 8px 12px; border-radius: var(--turn-radius-pill); text-decoration: none; }
-    .section-nav a:hover { background: var(--turn-yellow-400); }
-    main { width: min(1180px, 100%); margin: auto; padding: 72px 24px 120px; }
-    section { scroll-margin-top: 74px; margin-top: 100px; }
-    section:first-child { margin-top: 0; }
-    .section-head { display: grid; grid-template-columns: minmax(0, 1fr) minmax(250px, .55fr); gap: 28px; align-items: end; margin-bottom: 28px; }
-    .section-head h2 { margin: 7px 0 0; font-size: clamp(2.2rem, 5vw, 4.2rem); line-height: .9; letter-spacing: -.055em; }
-    .section-head p { margin: 0; color: rgb(255 248 232 / .78); }
-    .grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 18px; }
-    .card, .board { padding: 22px; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-default); background: var(--turn-paper); color: var(--turn-ink); box-shadow: var(--turn-shadow-default); }
-    .card h3 { margin: 8px 0; }
-    .card p { margin: 0; }
-    .board { display: grid; gap: 28px; }
-    .table-wrap { overflow-x: auto; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-default); background: var(--turn-paper); box-shadow: var(--turn-shadow-default); }
-    table { width: 100%; min-width: 760px; border-collapse: collapse; color: var(--turn-ink); text-align: left; }
-    th, td { padding: 14px 16px; border-bottom: 2px solid var(--turn-ink); vertical-align: top; }
-    th { background: var(--turn-yellow-400); font-size: .72rem; letter-spacing: .12em; text-transform: uppercase; }
-    tr:last-child td { border-bottom: 0; }
-    td code { font-size: .82rem; font-weight: 800; }
-    .mapping-group td { padding-block: 9px; background: color-mix(in srgb, var(--turn-blue-200) 38%, var(--turn-paper)); font-size: .72rem; letter-spacing: .12em; text-transform: uppercase; }
-
-    .colour-layer + .colour-layer { margin-top: 44px; }
-    .colour-layer-head { display: grid; grid-template-columns: minmax(0, 1fr) minmax(240px, .45fr); gap: 22px; align-items: end; margin-bottom: 18px; }
-    .colour-layer-head h3 { margin: 6px 0 0; font-size: clamp(1.6rem, 3.5vw, 2.7rem); line-height: .95; }
-    .colour-layer-head p { margin: 0; color: rgb(255 248 232 / .76); }
-    .palette-family + .palette-family { margin-top: 22px; }
-    .palette-family h4 { margin: 0 0 10px; font-size: 1rem; letter-spacing: .08em; text-transform: uppercase; }
-    .palette-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 14px; }
-    .swatch { min-width: 0; overflow: hidden; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-compact); background: var(--turn-paper); color: var(--turn-ink); box-shadow: var(--turn-shadow-compact); }
-    .swatch-colour { min-height: 94px; border-bottom: 4px solid var(--turn-ink); background: var(--swatch); }
-    .swatch-copy { display: grid; gap: 3px; padding: 11px 12px 13px; }
-    .swatch-copy code { overflow-wrap: anywhere; font-size: .76rem; font-weight: 900; }
-    .swatch-copy span { font-size: .78rem; letter-spacing: .06em; text-transform: uppercase; }
-    .mapping-preview { display: inline-block; width: 34px; height: 24px; margin-right: 8px; border: 3px solid var(--turn-ink); border-radius: var(--turn-radius-micro); background: var(--mapping); vertical-align: middle; }
-    .alias-note { margin: 14px 0 0; color: rgb(255 248 232 / .76); font-size: .9rem; }
-
-    .row { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; margin-top: 12px; }
-    .button-sample, .difficulty, .icon-button, .social-racer { display: inline-grid; place-items: center; border: 4px solid var(--turn-ink); color: var(--turn-ink); font-weight: 950; text-transform: uppercase; }
-    .button-sample { min-height: 52px; padding: 10px 18px; border-radius: var(--turn-radius-default); background: var(--turn-action-utility); box-shadow: var(--turn-shadow-default); }
-    .button-sample.primary { border-radius: var(--turn-radius-pill); background: var(--turn-action-primary); }
-    .button-sample.share { background: var(--turn-action-share); }
-    .button-sample.game { background: var(--turn-action-game); }
-    .button-sample.navigation { background: var(--turn-action-navigation); }
-    .icon-button { width: 52px; height: 52px; border-radius: var(--turn-radius-circle); background: var(--turn-action-navigation); box-shadow: var(--turn-shadow-default); font-size: 1.5rem; }
-    .share-icon { background: var(--turn-paper); }
-    .difficulty { min-width: 120px; min-height: 42px; padding: 7px 15px; border-width: 3px; border-radius: var(--turn-radius-pill); box-shadow: var(--turn-shadow-compact); }
-    .difficulty.easy { background: var(--turn-difficulty-easy); }
-    .difficulty.medium { background: var(--turn-difficulty-medium); }
-    .difficulty.advanced { background: var(--turn-difficulty-advanced); }
-    .difficulty.expert { background: var(--turn-difficulty-expert); }
-    .difficulty.hard { background: var(--turn-difficulty-hard); }
-    .difficulty.locked { background: var(--turn-difficulty-locked); }
-    .social-racer { min-height: 38px; padding: 6px 12px; border-width: 3px; border-radius: var(--turn-radius-pill); box-shadow: var(--turn-shadow-compact); font-size: .82rem; }
-    .social-racer.order-1 { background: var(--turn-social-racer-1); }
-    .social-racer.order-2 { background: var(--turn-social-racer-2); }
-    .social-racer.order-3 { background: var(--turn-social-racer-3); }
-    .social-racer.order-4 { background: var(--turn-social-racer-4); }
-    .social-racer.order-5 { background: var(--turn-social-racer-5); }
-    .social-racer.you { border-width: 4px; font-weight: 1000; }
-
-    .metadata-pattern { display: inline-grid; justify-items: end; gap: 3px; padding: 18px; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-default); background: var(--turn-yellow-600); box-shadow: var(--turn-shadow-default); }
-    .metadata-pattern span { font-size: .78rem; letter-spacing: .1em; }
-    .about-link { appearance: none; padding: 3px 0 5px; border: 0; background: transparent; color: inherit; font-weight: 950; text-decoration: underline; text-decoration-thickness: 2px; text-underline-offset: .18em; cursor: pointer; }
-    .form-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 22px; align-items: start; }
-    .form-card { position: relative; min-width: 0; margin: 0; padding: 18px; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-default); background: var(--turn-surface-raised); box-shadow: var(--turn-shadow-default); }
-    .form-card legend, .form-card > h3 { display: table; width: fit-content; max-width: calc(100% - 24px); padding: 0 8px; background: var(--turn-surface-raised); font-size: 1.25rem; font-weight: 950; line-height: 1.1; }
-    .form-card legend { margin-inline-start: 2px; }
-    .form-card > h3 { position: relative; z-index: 1; margin: -31px 0 14px 2px; }
-    .form-option { display: grid; grid-template-columns: auto minmax(0, 1fr); align-items: center; gap: 12px; margin-top: 12px; cursor: pointer; }
-    .form-option strong, .form-option small { display: block; }
-    .form-option small { margin-top: 2px; line-height: 1.3; }
-    .form-card input[type='radio'], .form-card input[type='checkbox'] { appearance: none; width: 30px; height: 30px; margin: 0; border: 4px solid var(--turn-ink); background-color: var(--turn-form-control-idle); background-position: center; background-repeat: no-repeat; cursor: pointer; }
-    .form-card input[type='radio'] { border-radius: var(--turn-radius-circle); }
-    .form-card input[type='radio']:checked { background: radial-gradient(circle, var(--turn-form-control-idle) 0 27%, transparent 30%), var(--turn-form-control-selected); }
-    .form-card input[type='checkbox'] { border-radius: var(--turn-radius-micro); }
-    .form-card input[type='checkbox']:checked { background-color: var(--turn-form-control-selected); box-shadow: inset 0 0 0 7px var(--turn-form-control-selected); }
-    .text-field { width: 100%; min-height: 52px; margin-top: 8px; padding: 10px 12px; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-compact); background: var(--turn-white); color: var(--turn-ink); font-weight: 900; text-transform: uppercase; }
-    .disclosure-sample { overflow: hidden; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-default); background: var(--turn-disclosure-panel); box-shadow: var(--turn-shadow-default); }
-    .disclosure-sample summary { display: flex; align-items: center; gap: 12px; min-height: 58px; padding: 12px 16px; background: var(--turn-disclosure-trigger); cursor: pointer; list-style: none; font-weight: 950; }
-    .disclosure-sample summary::-webkit-details-marker { display: none; }
-    .disclosure-symbol { flex: 0 0 auto; display: grid; place-items: center; width: 32px; height: 32px; border: 3px solid var(--turn-ink); border-radius: var(--turn-radius-circle); background: var(--turn-disclosure-panel); font-size: 1.35rem; line-height: 1; }
-    .disclosure-symbol::before { content: '+'; }
-    .disclosure-sample[open] .disclosure-symbol::before { content: '−'; }
-    .disclosure-panel { padding: 16px; border-top: 3px solid var(--turn-ink); background: var(--turn-disclosure-panel); }
-    .disclosure-panel p { margin: 0; }
-
-    .screens { display: grid; gap: 52px; }
-    .screen-item h3 { margin: 0 0 8px; font-size: 1.8rem; }
-    .screen { min-height: 400px; padding: 24px; border: 8px solid var(--turn-ink); border-radius: var(--turn-radius-hero); background: var(--turn-blue-300); color: var(--turn-ink); box-shadow: var(--turn-shadow-hero); }
-    .screen.yourturn { background: var(--turn-paper); }
-    .screen-head { display: flex; justify-content: space-between; gap: 14px; align-items: center; margin-bottom: 18px; }
-    .screen-head strong { font-size: clamp(2rem, 5vw, 4rem); }
-    .placeholder { display: grid; place-items: center; min-height: 170px; border: 4px dashed var(--turn-ink); border-radius: var(--turn-radius-default); background: rgb(255 255 255 / .35); font-size: 1.4rem; letter-spacing: .08em; }
-    .two-col { display: grid; grid-template-columns: minmax(0, 1fr) minmax(230px, .34fr); gap: 18px; }
-    .track-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
-    .track-card { position: relative; padding: 14px; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-default); background: var(--turn-paper); box-shadow: var(--turn-shadow-default); }
-    .track-card .top { display: flex; justify-content: space-between; align-items: center; gap: 8px; margin-bottom: 10px; }
-    .menu { display: flex; flex-direction: column; gap: 12px; }
-    .menu .primary { margin-top: auto; }
-    .hud { display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 16px; }
-    .chip { padding: 8px 11px; border: 3px solid var(--turn-ink); border-radius: var(--turn-radius-compact); background: var(--turn-paper); box-shadow: var(--turn-shadow-compact); }
-    .drive-pad { width: min(320px, 100%); margin: 18px 0 0 auto; display: grid; grid-template-rows: auto 100px 64px; overflow: hidden; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-hero); box-shadow: var(--turn-shadow-default); text-align: center; text-transform: uppercase; }
-    .drive-top { display: grid; grid-template-columns: 1fr 1fr; }
-    .drive-top span, .gas-zone, .brake-zone { display: grid; place-items: center; padding: 14px; }
-    .drive-top span:first-child { background: var(--turn-control-drift); }
-    .drive-top span:last-child { background: var(--turn-control-boost); border-left: 4px solid var(--turn-ink); }
-    .gas-zone { border-top: 4px solid var(--turn-ink); background: var(--turn-control-gas); }
-    .brake-zone { border-top: 4px solid var(--turn-ink); background: var(--turn-control-brake); }
-    .migration { display: grid; gap: 12px; margin: 0; padding: 0; list-style: none; }
-    .migration li { padding: 16px; border: 4px solid var(--turn-ink); border-radius: var(--turn-radius-default); background: var(--turn-paper); color: var(--turn-ink); box-shadow: var(--turn-shadow-compact); }
-    footer { padding: 40px 24px; border-top: 4px solid var(--turn-ink); background: var(--turn-yellow-600); color: var(--turn-ink); text-align: center; }
-
-    @media (max-width: 980px) { .palette-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
-    @media (max-width: 820px) { .hero-inner, .section-head, .grid, .form-grid, .two-col, .colour-layer-head { grid-template-columns: 1fr; } .track-grid { grid-template-columns: 1fr; } .palette-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
-    @media (max-width: 480px) { .palette-grid { grid-template-columns: 1fr; } }
-    @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; } }
-  </style>
+  <link rel="stylesheet" href="./design-reference.css?revision=r204-current-product-language">
 </head>
 <body>
-  <a class="skip-link" href="#main">Skip to the design system</a>
+  <a class="skip-link" href="#main">Skip to design system</a>
 
-  <header class="hero design-page-hero">
-    <div class="design-page-shell">
-      <nav class="design-page-nav" aria-label="Design system pages">
-        <a href="./design.html" aria-current="page">Design system</a>
-        <a href="./design-dialogs.html">Dialogs</a>
-        <a href="/turn/" target="_blank" rel="noopener noreferrer">Open TURN</a>
-      </nav>
-      <div class="design-page-hero-content">
-        <div class="hero-inner">
-          <div>
-            <span class="eyebrow">Normative production system · TURN 1.7</span>
-            <h1>TURN DESIGN SYSTEM</h1>
-            <p>A living reference built from TURN and YOUR TURN’s actual interaction patterns. Standardize the grammar, not the personality.</p>
-          </div>
-          <img src="./TURNicon.PNG" alt="TURN app icon">
-        </div>
+  <header class="system-header">
+    <div class="system-header__inner">
+      <div class="turn-mark" aria-hidden="true"><span>TURN</span></div>
+      <div class="system-title">
+        <p>Current product language · September 2026</p>
+        <h1>DESIGN SYSTEM</h1>
       </div>
-      <a class="design-page-scroll" href="#design-sections"><span aria-hidden="true">↓</span> Explore the system</a>
+      <div class="system-meta" aria-label="Reference baseline">
+        <strong>Production reference</strong>
+        <span>TURN 1.17.3</span>
+        <span>Build 2026.09.05-r203</span>
+      </div>
     </div>
   </header>
 
-  <nav id="design-sections" class="section-nav design-section-nav" aria-label="Design system sections">
-    <a href="#audit">Audit</a>
-    <a href="#colour">Colour</a>
-    <a href="#patterns">Patterns</a>
-    <a href="#screens">Game pages</a>
-    <a href="#migration">Adoption</a>
+  <div class="system-toolbar" aria-label="Design reference pages">
+    <div class="system-toolbar__inner">
+      <a href="./design.html" aria-current="page">Design system</a>
+      <a href="./design-dialogs.html">Dialogs</a>
+      <a href="./" target="_blank" rel="noopener">Open TURN</a>
+    </div>
+  </div>
+
+  <nav class="section-nav" aria-label="Design system sections">
+    <a href="#principles">Principles</a>
+    <a href="#foundations">Foundations</a>
+    <a href="#components">Components</a>
+    <a href="#gameplay">Gameplay</a>
+    <a href="#progression">Progression</a>
+    <a href="#layouts">Layouts</a>
+    <a href="#accessibility">Accessibility</a>
+    <a href="#legacy">Legacy</a>
   </nav>
 
   <main id="main">
-    <section id="audit">
+    <section id="principles" aria-labelledby="principles-title">
+      <div class="lead-board">
+        <div class="lead-copy">
+          <span class="kicker">Living reference</span>
+          <h2 id="principles-title">Built from the game, not beside it.</h2>
+          <p>TURN’s interface now has a stable production language: warm paper, hard black structure, saturated categorical colour, big readable type, tactile offset shadows and short purposeful motion. This reference documents what the shipped game actually does today instead of presenting an aspirational concept board.</p>
+        </div>
+        <aside class="status-board" aria-label="Current design-system status">
+          <span class="kicker">Current baseline</span>
+          <strong>One system across Home, The Lot, race HUD, dialogs and Trophy Road.</strong>
+          <div class="status-row"><span class="status-dot" aria-hidden="true"></span><span>Production components are the source of truth.</span></div>
+          <div class="status-row"><span class="status-dot" aria-hidden="true"></span><span>Colour reinforces meaning; text and shape still carry it.</span></div>
+          <div class="status-row"><span class="status-dot" aria-hidden="true"></span><span>Touch, keyboard, screen reader and reduced-motion states are first-class.</span></div>
+        </aside>
+      </div>
+
+      <div class="grid" style="margin-top: 22px">
+        <article class="card">
+          <span class="principle-number">1</span>
+          <h3>Paper + ink</h3>
+          <p>Paper is the default information surface. Ink creates borders, hierarchy and shadows. The world can be visually rich; UI surfaces stay deliberately legible.</p>
+        </article>
+        <article class="card">
+          <span class="principle-number">2</span>
+          <h3>Colour has a job</h3>
+          <p>Pink moves the player forward, orange changes context, green confirms or rewards, blue informs, yellow warns or powers, red marks danger.</p>
+        </article>
+        <article class="card">
+          <span class="principle-number">3</span>
+          <h3>Interaction has weight</h3>
+          <p>4px borders, rounded shapes and offset shadows make controls feel physical. Pressed states collapse that shadow instead of relying on subtle opacity.</p>
+        </article>
+        <article class="card">
+          <span class="principle-number">4</span>
+          <h3>Information stays literal</h3>
+          <p>Difficulty, progression state, scoring state and control meaning are always named. Colour is supportive, never the only carrier of meaning.</p>
+        </article>
+        <article class="card">
+          <span class="principle-number">5</span>
+          <h3>Motion earns its place</h3>
+          <p>Short wiggles, score pulses and control movement acknowledge state changes. Continuous motion is reserved for gameplay feedback and has a reduced-motion path.</p>
+        </article>
+        <article class="card">
+          <span class="principle-number">6</span>
+          <h3>Dense, not tiny</h3>
+          <p>TURN can show a lot at once, especially in landscape, but touch targets stay large and high-priority information keeps strong type and spacing.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="foundations" aria-labelledby="foundations-title">
       <div class="section-head">
-        <div><span class="kicker">01 · Current state</span><h2>One system beneath the character.</h2></div>
-        <p>TURN keeps black ink, warm paper, hard shadows and saturated colour. YOUR TURN uses the same grammar while adding explicit social action and racer-identity roles.</p>
+        <div>
+          <span class="kicker">Foundations</span>
+          <h2 id="foundations-title">The parts everything else is made from.</h2>
+        </div>
+        <p>The palette is intentionally small. Primitive colours describe the visual material; semantic roles describe why a colour is being used.</p>
       </div>
-      <div class="grid">
-        <article class="card"><span class="token-label">Keep</span><h3>TURN personality</h3><p>Chunky outlines, offset shadows, large type, simple shapes and playful colour fields.</p></article>
-        <article class="card"><span class="token-label">Consolidate</span><h3>Meaning across products</h3><p>Race, Share, Get the Game, Back, forms, disclosures and driving controls keep the same semantics across TURN and YOUR TURN.</p></article>
-        <article class="card"><span class="token-label">Retire</span><h3>One-off meaning</h3><p>Component type or a one-off screen does not invent a new colour meaning. Social colours encode join order, not leaderboard position.</p></article>
+
+      <div class="grid" style="margin-bottom: 28px">
+        <article class="card">
+          <span class="token-label">Type</span>
+          <h3>System sans, very heavy</h3>
+          <p>Use the platform/system sans stack. Major headings and controls typically sit between 900 and 1000 weight, with tight heading tracking and uppercase control labels.</p>
+        </article>
+        <article class="card">
+          <span class="token-label">Structure</span>
+          <h3>Black first</h3>
+          <p>Most important component boundaries are 4px black. Large dialog and shell edges may rise to 6px. Interior dividers can step down to 2–3px.</p>
+        </article>
+        <article class="card">
+          <span class="token-label">Elevation</span>
+          <h3>Offset, never blurry</h3>
+          <p>Compact 3px, standard 7px and hero 12px shadows are hard black offsets. They create tactile hierarchy without soft visual noise.</p>
+        </article>
       </div>
-      <div class="table-wrap" style="margin-top:24px" tabindex="0" role="region" aria-label="Normative design inventory">
-        <table>
-          <thead><tr><th>Area</th><th>Normative rule</th><th>Use</th></tr></thead>
-          <tbody>
-            <tr><td>Primary action</td><td>Pink 500 and pill</td><td>Install TURN, Race this track, Race this car</td></tr>
-            <tr><td>Social share</td><td>Pink 500</td><td>Share, Share Your Turn</td></tr>
-            <tr><td>Game handoff</td><td>Blue 500</td><td>Get the Game</td></tr>
-            <tr><td>Utility</td><td>Paper</td><td>Settings, How to Play, Give Feedback, Race Again</td></tr>
-            <tr><td>Navigation</td><td>Orange 500</td><td>Close, Back, Leave, Brake · Reverse</td></tr>
-            <tr><td>Racer identity</td><td>Five pale join-order colours</td><td>Name plates and social challenge identity; never race rank</td></tr>
-            <tr><td>Difficulty</td><td>Easy green 200, Medium yellow 200, Advanced orange 200, Expert red 200</td><td>Text remains mandatory</td></tr>
-            <tr><td>Form controls</td><td>Paper idle, Pink selected, Blue focus</td><td>Native radio, checkbox, range and text-input semantics</td></tr>
-            <tr><td>Disclosure</td><td>Blue trigger, Paper panel</td><td>Native details and summary</td></tr>
-          </tbody>
-        </table>
+
+      <div class="geometry-row" aria-label="Geometry scale">
+        <div class="geometry-sample micro"><span>Micro · 8px · 2–3px border</span></div>
+        <div class="geometry-sample compact"><span>Compact · 12px · 3px shadow</span></div>
+        <div class="geometry-sample default"><span>Default · 18px · 7px shadow</span></div>
+        <div class="geometry-sample hero"><span>Hero · 28px · 12px shadow</span></div>
+      </div>
+
+      <div class="palette-board" id="primitive-palette" style="margin-top: 28px">
+        <div class="section-head" style="margin-bottom: 18px">
+          <div><span class="kicker">Colour layer 1</span><h2 style="font-size: clamp(1.9rem, 4vw, 3.2rem)">Primitive palette</h2></div>
+          <p>Use these exact colours. Do not introduce near-duplicates for new UI states when an existing primitive already expresses the role.</p>
+        </div>
+
+        <div class="palette-family">
+          <h3>Neutral</h3>
+          <div class="palette-grid">
+            <div class="swatch" data-token="--turn-ink" style="--swatch: var(--turn-ink)"><div class="swatch-colour"></div><div class="swatch-copy"><code>--turn-ink</code><span>#08090a</span></div></div>
+            <div class="swatch" data-token="--turn-paper" style="--swatch: var(--turn-paper)"><div class="swatch-colour"></div><div class="swatch-copy"><code>--turn-paper</code><span>#fff8e8</span></div></div>
+            <div class="swatch" data-token="--turn-white" style="--swatch: var(--turn-white)"><div class="swatch-colour"></div><div class="swatch-copy"><code>--turn-white</code><span>#fffdf6</span></div></div>
+            <div class="swatch" data-token="--turn-road" style="--swatch: var(--turn-road)"><div class="swatch-colour"></div><div class="swatch-copy"><code>--turn-road</code><span>#44494f</span></div></div>
+            <div class="swatch" data-token="--turn-muted" style="--swatch: var(--turn-muted)"><div class="swatch-colour"></div><div class="swatch-copy"><code>--turn-muted</code><span>#d6d0c2</span></div></div>
+          </div>
+        </div>
+
+        <div class="palette-family">
+          <h3>Yellow</h3>
+          <div class="palette-grid">
+            <div class="swatch" data-token="--turn-yellow-600" style="--swatch: var(--turn-yellow-600)"><div class="swatch-colour"></div><div class="swatch-copy"><code>--turn-yellow-600</code><span>#ffbd12</span></div></div>
+            <div class="swatch" data-token="--turn-yellow-400" style="--swatch: var(--turn-yellow-400)"><div class="swatch-colour"></div><div class="swatch-copy"><code>--turn-yellow-400</code><span>#ffd43b</span></div></div>
+            <div class="swatch" data-token="--turn-yellow-200" style="--swatch: var(--turn-yellow-200)"><div class="swatch-colour"></div><div class="swatch-copy"><code>--turn-yellow-200</code><span>#ffe087</span></div></div>
+            <div class="swatch" data-token="--turn-yellow-100" style="--swatch: var(--turn-yellow-100)"><div class="swatch-colour"></div><div class="swatch-copy"><code>--turn-yellow-100</code><span>#fff0a8</span></div></div>
+          </div>
+        </div>
+
+        <div class="palette-family">
+          <h3>Blue</h3>
+          <div class="palette-grid">
+            <div class="swatch" data-token="--turn-blue-600" style="--swatch: var(--turn-blue-600)"><div class="swatch-colour"></div><div class="swatch-copy"><code>--turn-blue-600</code><span>#35b8e7</span></div></div>
+            <div class="swatch" data-token="--turn-blue-500" style="--swatch: var(--turn-blue-500)"><div class="swatch-colour"></div><div class="swatch-copy"><code>--turn-blue-500</code><span>#38d9ff</span></div></div>
+            <div class="swatch" data-token="--turn-blue-300" style="--swatch: var(--turn-blue-300)"><div class="swatch-colour"></div><div class="swatch-copy"><code>--turn-blue-300</code><span>#68c8f2</span></div></div>
+            <div class="swatch" data-token="--turn-blue-200" style="--swatch: var(--turn-blue-200)"><div class="swatch-colour"></div><div class="swatch-copy"><code>--turn-blue-200</code><span>#8ed8ff</span></div></div>
+            <div class="swatch" data-token="--turn-blue-100" style="--swatch: var(--turn-blue-100)"><div class="swatch-colour"></div><div class="swatch-copy"><code>--turn-blue-100</code><span>#bdeeff</span></div></div>
+          </div>
+        </div>
+
+        <div class="palette-family">
+          <h3>Pink · red · green · orange</h3>
+          <div class="palette-grid">
+            <div class="swatch" data-token="--turn-pink-500" style="--swatch: var(--turn-pink-500)"><div class="swatch-colour"></div><div class="swatch-copy"><code>--turn-pink-500</code><span>#ff4fa3</span></div></div>
+            <div class="swatch" data-token="--turn-pink-200" style="--swatch: var(--turn-pink-200)"><div class="swatch-colour"></div><div class="swatch-copy"><code>--turn-pink-200</code><span>#ff8caf</span></div></div>
+            <div class="swatch" data-token="--turn-pink-100" style="--swatch: var(--turn-pink-100)"><div class="swatch-colour"></div><div class="swatch-copy"><code>--turn-pink-100</code><span>#ffd1e6</span></div></div>
+            <div class="swatch" data-token="--turn-red-500" style="--swatch: var(--turn-red-500)"><div class="swatch-colour"></div><div class="swatch-copy"><code>--turn-red-500</code><span>#ff6b6b</span></div></div>
+            <div class="swatch" data-token="--turn-red-200" style="--swatch: var(--turn-red-200)"><div class="swatch-colour"></div><div class="swatch-copy"><code>--turn-red-200</code><span>#ff9b91</span></div></div>
+            <div class="swatch" data-token="--turn-green-500" style="--swatch: var(--turn-green-500)"><div class="swatch-colour"></div><div class="swatch-copy"><code>--turn-green-500</code><span>#8ce99a</span></div></div>
+            <div class="swatch" data-token="--turn-green-200" style="--swatch: var(--turn-green-200)"><div class="swatch-colour"></div><div class="swatch-copy"><code>--turn-green-200</code><span>#d9f5c2</span></div></div>
+            <div class="swatch" data-token="--turn-green-100" style="--swatch: var(--turn-green-100)"><div class="swatch-colour"></div><div class="swatch-copy"><code>--turn-green-100</code><span>#c8f5d0</span></div></div>
+            <div class="swatch" data-token="--turn-orange-500" style="--swatch: var(--turn-orange-500)"><div class="swatch-colour"></div><div class="swatch-copy"><code>--turn-orange-500</code><span>#ff7b54</span></div></div>
+            <div class="swatch" data-token="--turn-orange-200" style="--swatch: var(--turn-orange-200)"><div class="swatch-colour"></div><div class="swatch-copy"><code>--turn-orange-200</code><span>#ffb89f</span></div></div>
+            <div class="swatch" data-token="--turn-orange-100" style="--swatch: var(--turn-orange-100)"><div class="swatch-colour"></div><div class="swatch-copy"><code>--turn-orange-100</code><span>#ffd0ae</span></div></div>
+          </div>
+        </div>
+      </div>
+
+      <div id="semantic-mappings" style="margin-top: 32px">
+        <div class="section-head" style="margin-bottom: 18px">
+          <div><span class="kicker">Colour layer 2</span><h2 style="font-size: clamp(1.9rem, 4vw, 3.2rem)">Semantic mappings</h2></div>
+          <p>Semantic roles are stable product decisions. Components consume these roles instead of inventing a local colour meaning.</p>
+        </div>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Role</th><th>Mapping</th><th>Use</th></tr></thead>
+            <tbody>
+              <tr class="mapping-group"><td colspan="3">Surfaces</td></tr>
+              <tr data-semantic="--turn-surface-page"><td><span class="mapping-preview" style="--mapping:var(--turn-surface-page)"></span><code>--turn-surface-page</code></td><td><code>var(--turn-paper)</code></td><td>Primary UI canvas.</td></tr>
+              <tr data-semantic="--turn-surface-raised"><td><span class="mapping-preview" style="--mapping:var(--turn-surface-raised)"></span><code>--turn-surface-raised</code></td><td><code>var(--turn-white)</code></td><td>Cards and raised information surfaces.</td></tr>
+              <tr class="mapping-group"><td colspan="3">Actions</td></tr>
+              <tr data-semantic="--turn-action-primary"><td><span class="mapping-preview" style="--mapping:var(--turn-action-primary)"></span><code>--turn-action-primary</code></td><td><code>var(--turn-pink-500)</code></td><td>Main forward action: race, install, continue.</td></tr>
+              <tr data-semantic="--turn-action-share"><td><span class="mapping-preview" style="--mapping:var(--turn-action-share)"></span><code>--turn-action-share</code></td><td><code>var(--turn-pink-500)</code></td><td>Share a TURN challenge.</td></tr>
+              <tr data-semantic="--turn-action-utility"><td><span class="mapping-preview" style="--mapping:var(--turn-action-utility)"></span><code>--turn-action-utility</code></td><td><code>var(--turn-paper)</code></td><td>Settings, How to Play and neutral utilities.</td></tr>
+              <tr data-semantic="--turn-action-information"><td><span class="mapping-preview" style="--mapping:var(--turn-action-information)"></span><code>--turn-action-information</code></td><td><code>var(--turn-blue-500)</code></td><td>Information and explanatory emphasis.</td></tr>
+              <tr data-semantic="--turn-action-game"><td><span class="mapping-preview" style="--mapping:var(--turn-action-game)"></span><code>--turn-action-game</code></td><td><code>var(--turn-blue-500)</code></td><td>Handoff from YOUR TURN into the full game.</td></tr>
+              <tr data-semantic="--turn-action-success"><td><span class="mapping-preview" style="--mapping:var(--turn-action-success)"></span><code>--turn-action-success</code></td><td><code>var(--turn-green-500)</code></td><td>Achievement, saved or completed state.</td></tr>
+              <tr data-semantic="--turn-action-warning"><td><span class="mapping-preview" style="--mapping:var(--turn-action-warning)"></span><code>--turn-action-warning</code></td><td><code>var(--turn-yellow-400)</code></td><td>Warning or attention state.</td></tr>
+              <tr data-semantic="--turn-action-danger"><td><span class="mapping-preview" style="--mapping:var(--turn-action-danger)"></span><code>--turn-action-danger</code></td><td><code>var(--turn-red-500)</code></td><td>Danger, failure and destructive context.</td></tr>
+              <tr data-semantic="--turn-action-navigation"><td><span class="mapping-preview" style="--mapping:var(--turn-action-navigation)"></span><code>--turn-action-navigation</code></td><td><code>var(--turn-orange-500)</code></td><td>Close, leave, back and context change.</td></tr>
+              <tr class="mapping-group"><td colspan="3">Forms and disclosure</td></tr>
+              <tr data-semantic="--turn-form-control-idle"><td><span class="mapping-preview" style="--mapping:var(--turn-form-control-idle)"></span><code>--turn-form-control-idle</code></td><td><code>var(--turn-paper)</code></td><td>Unchecked native-style controls.</td></tr>
+              <tr data-semantic="--turn-form-control-selected"><td><span class="mapping-preview" style="--mapping:var(--turn-form-control-selected)"></span><code>--turn-form-control-selected</code></td><td><code>var(--turn-pink-500)</code></td><td>Selected radio and checkbox state.</td></tr>
+              <tr data-semantic="--turn-form-control-focus"><td><span class="mapping-preview" style="--mapping:var(--turn-form-control-focus)"></span><code>--turn-form-control-focus</code></td><td><code>var(--turn-blue-500)</code></td><td>Keyboard focus ring.</td></tr>
+              <tr data-semantic="--turn-disclosure-trigger"><td><span class="mapping-preview" style="--mapping:var(--turn-disclosure-trigger)"></span><code>--turn-disclosure-trigger</code></td><td><code>var(--turn-blue-300)</code></td><td>Native summary trigger.</td></tr>
+              <tr data-semantic="--turn-disclosure-panel"><td><span class="mapping-preview" style="--mapping:var(--turn-disclosure-panel)"></span><code>--turn-disclosure-panel</code></td><td><code>var(--turn-paper)</code></td><td>Expanded details content.</td></tr>
+              <tr class="mapping-group"><td colspan="3">Track difficulty</td></tr>
+              <tr data-semantic="--turn-difficulty-easy"><td><span class="mapping-preview" style="--mapping:var(--turn-difficulty-easy)"></span><code>--turn-difficulty-easy</code></td><td><code>var(--turn-green-200)</code></td><td>EASY.</td></tr>
+              <tr data-semantic="--turn-difficulty-medium"><td><span class="mapping-preview" style="--mapping:var(--turn-difficulty-medium)"></span><code>--turn-difficulty-medium</code></td><td><code>var(--turn-yellow-200)</code></td><td>MEDIUM.</td></tr>
+              <tr data-semantic="--turn-difficulty-advanced"><td><span class="mapping-preview" style="--mapping:var(--turn-difficulty-advanced)"></span><code>--turn-difficulty-advanced</code></td><td><code>var(--turn-orange-200)</code></td><td>ADVANCED.</td></tr>
+              <tr data-semantic="--turn-difficulty-expert"><td><span class="mapping-preview" style="--mapping:var(--turn-difficulty-expert)"></span><code>--turn-difficulty-expert</code></td><td><code>var(--turn-red-200)</code></td><td>EXPERT.</td></tr>
+              <tr data-semantic="--turn-difficulty-locked"><td><span class="mapping-preview" style="--mapping:var(--turn-difficulty-locked)"></span><code>--turn-difficulty-locked</code></td><td><code>var(--turn-muted)</code></td><td>Unavailable track.</td></tr>
+              <tr class="mapping-group"><td colspan="3">Driving controls</td></tr>
+              <tr data-semantic="--turn-control-gas"><td><span class="mapping-preview" style="--mapping:var(--turn-control-gas)"></span><code>--turn-control-gas</code></td><td><code>var(--turn-green-500)</code></td><td>GAS and positive speed stat accents.</td></tr>
+              <tr data-semantic="--turn-control-drift"><td><span class="mapping-preview" style="--mapping:var(--turn-control-drift)"></span><code>--turn-control-drift</code></td><td><code>var(--turn-blue-500)</code></td><td>DRIFT and handling accents.</td></tr>
+              <tr data-semantic="--turn-control-boost"><td><span class="mapping-preview" style="--mapping:var(--turn-control-boost)"></span><code>--turn-control-boost</code></td><td><code>var(--turn-yellow-400)</code></td><td>BOOST available charge.</td></tr>
+              <tr data-semantic="--turn-control-boost-empty"><td><span class="mapping-preview" style="--mapping:var(--turn-control-boost-empty)"></span><code>--turn-control-boost-empty</code></td><td><code>var(--turn-yellow-200)</code></td><td>BOOST empty remainder.</td></tr>
+              <tr data-semantic="--turn-control-brake"><td><span class="mapping-preview" style="--mapping:var(--turn-control-brake)"></span><code>--turn-control-brake</code></td><td><code>var(--turn-orange-500)</code></td><td>BRAKE / REVERSE.</td></tr>
+              <tr class="mapping-group"><td colspan="3">Social racer identity</td></tr>
+              <tr data-semantic="--turn-social-racer-1"><td><span class="mapping-preview" style="--mapping:var(--turn-social-racer-1)"></span><code>--turn-social-racer-1</code></td><td><code>var(--turn-pink-100)</code></td><td>Join order 1.</td></tr>
+              <tr data-semantic="--turn-social-racer-2"><td><span class="mapping-preview" style="--mapping:var(--turn-social-racer-2)"></span><code>--turn-social-racer-2</code></td><td><code>var(--turn-blue-100)</code></td><td>Join order 2.</td></tr>
+              <tr data-semantic="--turn-social-racer-3"><td><span class="mapping-preview" style="--mapping:var(--turn-social-racer-3)"></span><code>--turn-social-racer-3</code></td><td><code>var(--turn-green-100)</code></td><td>Join order 3.</td></tr>
+              <tr data-semantic="--turn-social-racer-4"><td><span class="mapping-preview" style="--mapping:var(--turn-social-racer-4)"></span><code>--turn-social-racer-4</code></td><td><code>var(--turn-yellow-100)</code></td><td>Join order 4.</td></tr>
+              <tr data-semantic="--turn-social-racer-5"><td><span class="mapping-preview" style="--mapping:var(--turn-social-racer-5)"></span><code>--turn-social-racer-5</code></td><td><code>var(--turn-orange-100)</code></td><td>Join order 5.</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div id="compatibility-aliases" style="margin-top: 28px">
+        <details class="disclosure-sample">
+          <summary>Compatibility aliases — production support, not new vocabulary</summary>
+          <div class="disclosure-panel">
+            <div class="table-wrap" style="box-shadow:none">
+              <table style="min-width:620px">
+                <thead><tr><th>Alias</th><th>Canonical target</th></tr></thead>
+                <tbody>
+                  <tr><td><code>--ink</code></td><td><code>var(--turn-ink)</code></td></tr>
+                  <tr><td><code>--paper</code></td><td><code>var(--turn-paper)</code></td></tr>
+                  <tr><td><code>--cyan</code></td><td><code>var(--turn-blue-500)</code></td></tr>
+                  <tr><td><code>--pink</code></td><td><code>var(--turn-pink-500)</code></td></tr>
+                  <tr><td><code>--yellow</code></td><td><code>var(--turn-yellow-400)</code></td></tr>
+                  <tr><td><code>--lime</code></td><td><code>var(--turn-green-500)</code></td></tr>
+                  <tr><td><code>--m8-ink</code></td><td><code>var(--turn-ink)</code></td></tr>
+                  <tr><td><code>--m8-cream</code></td><td><code>var(--turn-paper)</code></td></tr>
+                  <tr><td><code>--m8-pink</code></td><td><code>var(--turn-pink-500)</code></td></tr>
+                  <tr><td><code>--m8-yellow</code></td><td><code>var(--turn-yellow-600)</code></td></tr>
+                  <tr><td><code>--m8-blue</code></td><td><code>var(--turn-blue-300)</code></td></tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </details>
       </div>
     </section>
 
-    <section id="colour">
+    <section id="components" aria-labelledby="components-title">
       <div class="section-head">
-        <div><span class="kicker">02 · Colour system</span><h2>Primitive values first. Meaning second.</h2></div>
-        <p>Components consume semantic variables. Raw primitives remain available for expressive track art; reusable interface elements do not choose colours ad hoc.</p>
+        <div><span class="kicker">Components</span><h2 id="components-title">Controls should look like they belong in the same car.</h2></div>
+        <p>The system is deliberately repetitive: black border, obvious fill, heavy label, readable focus, tangible pressed state. Variation comes from meaning, not decoration.</p>
       </div>
 
-      <div class="colour-layer" id="primitive-palette">
-        <div class="colour-layer-head"><div><span class="token-label">Layer 1</span><h3>Primitive palette</h3></div><p>Every normative colour in <code>design-tokens.css</code>, including the pale social-racer family introduced with YOUR TURN.</p></div>
-        <div class="palette-family"><h4>Neutral</h4><div class="palette-grid" aria-label="Neutral primitive colours">
-          <article class="swatch" data-token="--turn-ink"><div class="swatch-colour" style="--swatch:#08090a"></div><div class="swatch-copy"><code>--turn-ink</code><span>#08090a</span></div></article>
-          <article class="swatch" data-token="--turn-paper"><div class="swatch-colour" style="--swatch:#fff8e8"></div><div class="swatch-copy"><code>--turn-paper</code><span>#fff8e8</span></div></article>
-          <article class="swatch" data-token="--turn-white"><div class="swatch-colour" style="--swatch:#fffdf6"></div><div class="swatch-copy"><code>--turn-white</code><span>#fffdf6</span></div></article>
-          <article class="swatch" data-token="--turn-road"><div class="swatch-colour" style="--swatch:#44494f"></div><div class="swatch-copy"><code>--turn-road</code><span>#44494f</span></div></article>
-          <article class="swatch" data-token="--turn-muted"><div class="swatch-colour" style="--swatch:#d6d0c2"></div><div class="swatch-copy"><code>--turn-muted</code><span>#d6d0c2</span></div></article>
-        </div></div>
-        <div class="palette-family"><h4>Yellow</h4><div class="palette-grid" aria-label="Yellow primitive colours">
-          <article class="swatch" data-token="--turn-yellow-600"><div class="swatch-colour" style="--swatch:#ffbd12"></div><div class="swatch-copy"><code>--turn-yellow-600</code><span>#ffbd12</span></div></article>
-          <article class="swatch" data-token="--turn-yellow-400"><div class="swatch-colour" style="--swatch:#ffd43b"></div><div class="swatch-copy"><code>--turn-yellow-400</code><span>#ffd43b</span></div></article>
-          <article class="swatch" data-token="--turn-yellow-200"><div class="swatch-colour" style="--swatch:#ffe087"></div><div class="swatch-copy"><code>--turn-yellow-200</code><span>#ffe087</span></div></article>
-          <article class="swatch" data-token="--turn-yellow-100"><div class="swatch-colour" style="--swatch:#fff0a8"></div><div class="swatch-copy"><code>--turn-yellow-100</code><span>#fff0a8</span></div></article>
-        </div></div>
-        <div class="palette-family"><h4>Blue</h4><div class="palette-grid" aria-label="Blue primitive colours">
-          <article class="swatch" data-token="--turn-blue-600"><div class="swatch-colour" style="--swatch:#35b8e7"></div><div class="swatch-copy"><code>--turn-blue-600</code><span>#35b8e7</span></div></article>
-          <article class="swatch" data-token="--turn-blue-500"><div class="swatch-colour" style="--swatch:#38d9ff"></div><div class="swatch-copy"><code>--turn-blue-500</code><span>#38d9ff</span></div></article>
-          <article class="swatch" data-token="--turn-blue-300"><div class="swatch-colour" style="--swatch:#68c8f2"></div><div class="swatch-copy"><code>--turn-blue-300</code><span>#68c8f2</span></div></article>
-          <article class="swatch" data-token="--turn-blue-200"><div class="swatch-colour" style="--swatch:#8ed8ff"></div><div class="swatch-copy"><code>--turn-blue-200</code><span>#8ed8ff</span></div></article>
-          <article class="swatch" data-token="--turn-blue-100"><div class="swatch-colour" style="--swatch:#bdeeff"></div><div class="swatch-copy"><code>--turn-blue-100</code><span>#bdeeff</span></div></article>
-        </div></div>
-        <div class="palette-family"><h4>Pink</h4><div class="palette-grid" aria-label="Pink primitive colours">
-          <article class="swatch" data-token="--turn-pink-500"><div class="swatch-colour" style="--swatch:#ff4fa3"></div><div class="swatch-copy"><code>--turn-pink-500</code><span>#ff4fa3</span></div></article>
-          <article class="swatch" data-token="--turn-pink-200"><div class="swatch-colour" style="--swatch:#ff8caf"></div><div class="swatch-copy"><code>--turn-pink-200</code><span>#ff8caf</span></div></article>
-          <article class="swatch" data-token="--turn-pink-100"><div class="swatch-colour" style="--swatch:#ffd1e6"></div><div class="swatch-copy"><code>--turn-pink-100</code><span>#ffd1e6</span></div></article>
-        </div></div>
-        <div class="palette-family"><h4>Red</h4><div class="palette-grid" aria-label="Red primitive colours">
-          <article class="swatch" data-token="--turn-red-500"><div class="swatch-colour" style="--swatch:#ff6b6b"></div><div class="swatch-copy"><code>--turn-red-500</code><span>#ff6b6b</span></div></article>
-          <article class="swatch" data-token="--turn-red-200"><div class="swatch-colour" style="--swatch:#ff9b91"></div><div class="swatch-copy"><code>--turn-red-200</code><span>#ff9b91</span></div></article>
-        </div></div>
-        <div class="palette-family"><h4>Green</h4><div class="palette-grid" aria-label="Green primitive colours">
-          <article class="swatch" data-token="--turn-green-500"><div class="swatch-colour" style="--swatch:#8ce99a"></div><div class="swatch-copy"><code>--turn-green-500</code><span>#8ce99a</span></div></article>
-          <article class="swatch" data-token="--turn-green-200"><div class="swatch-colour" style="--swatch:#d9f5c2"></div><div class="swatch-copy"><code>--turn-green-200</code><span>#d9f5c2</span></div></article>
-          <article class="swatch" data-token="--turn-green-100"><div class="swatch-colour" style="--swatch:#c8f5d0"></div><div class="swatch-copy"><code>--turn-green-100</code><span>#c8f5d0</span></div></article>
-        </div></div>
-        <div class="palette-family"><h4>Orange</h4><div class="palette-grid" aria-label="Orange primitive colours">
-          <article class="swatch" data-token="--turn-orange-500"><div class="swatch-colour" style="--swatch:#ff7b54"></div><div class="swatch-copy"><code>--turn-orange-500</code><span>#ff7b54</span></div></article>
-          <article class="swatch" data-token="--turn-orange-200"><div class="swatch-colour" style="--swatch:#ffb89f"></div><div class="swatch-copy"><code>--turn-orange-200</code><span>#ffb89f</span></div></article>
-          <article class="swatch" data-token="--turn-orange-100"><div class="swatch-colour" style="--swatch:#ffd0ae"></div><div class="swatch-copy"><code>--turn-orange-100</code><span>#ffd0ae</span></div></article>
-        </div></div>
+      <div class="specimen">
+        <div class="specimen-head"><strong>Actions</strong><span class="specimen-label">Production hierarchy</span></div>
+        <div class="specimen-body">
+          <div class="row">
+            <button class="button-sample primary" type="button">Race this track</button>
+            <button class="button-sample" type="button">Settings</button>
+            <button class="button-sample info" type="button">How to play</button>
+            <button class="button-sample success" type="button">Achievements</button>
+            <button class="button-sample navigation" type="button">Leave race</button>
+            <button class="button-sample danger" type="button">Danger</button>
+            <button class="icon-button" type="button" aria-label="Close">×</button>
+          </div>
+          <p style="margin:18px 0 0">Primary action is pink and pill-shaped. Neutral utilities recede to Paper. Navigation/context change is orange. Close is the same navigation colour even when expressed as a round icon.</p>
+        </div>
       </div>
 
-      <div class="colour-layer" id="semantic-mappings">
-        <div class="colour-layer-head"><div><span class="token-label">Layer 2</span><h3>Semantic variables and mappings</h3></div><p>These are the variables components should consume. Meaning survives when the same colour appears in more than one role.</p></div>
-        <div class="table-wrap" tabindex="0" role="region" aria-label="Semantic colour variable mappings"><table><thead><tr><th>Preview</th><th>Semantic variable</th><th>Maps to</th><th>Normative use</th></tr></thead><tbody>
-          <tr class="mapping-group"><td colspan="4">Surfaces</td></tr>
-          <tr data-semantic="--turn-surface-page"><td><span class="mapping-preview" style="--mapping:var(--turn-surface-page)"></span></td><td><code>--turn-surface-page</code></td><td><code>var(--turn-paper)</code></td><td>Default light page and panel surface.</td></tr>
-          <tr data-semantic="--turn-surface-raised"><td><span class="mapping-preview" style="--mapping:var(--turn-surface-raised)"></span></td><td><code>--turn-surface-raised</code></td><td><code>var(--turn-white)</code></td><td>Cards and controls raised above Paper.</td></tr>
-          <tr class="mapping-group"><td colspan="4">Actions</td></tr>
-          <tr data-semantic="--turn-action-primary"><td><span class="mapping-preview" style="--mapping:var(--turn-action-primary)"></span></td><td><code>--turn-action-primary</code></td><td><code>var(--turn-pink-500)</code></td><td>Main forward game flow: Install and Race.</td></tr>
-          <tr data-semantic="--turn-action-share"><td><span class="mapping-preview" style="--mapping:var(--turn-action-share)"></span></td><td><code>--turn-action-share</code></td><td><code>var(--turn-pink-500)</code></td><td>Share and Share Your Turn.</td></tr>
-          <tr data-semantic="--turn-action-utility"><td><span class="mapping-preview" style="--mapping:var(--turn-action-utility)"></span></td><td><code>--turn-action-utility</code></td><td><code>var(--turn-paper)</code></td><td>Quiet tools and secondary actions.</td></tr>
-          <tr data-semantic="--turn-action-information"><td><span class="mapping-preview" style="--mapping:var(--turn-action-information)"></span></td><td><code>--turn-action-information</code></td><td><code>var(--turn-blue-500)</code></td><td>Information and active guidance.</td></tr>
-          <tr data-semantic="--turn-action-game"><td><span class="mapping-preview" style="--mapping:var(--turn-action-game)"></span></td><td><code>--turn-action-game</code></td><td><code>var(--turn-blue-500)</code></td><td>Get the Game handoff from YOUR TURN to TURN.</td></tr>
-          <tr data-semantic="--turn-action-success"><td><span class="mapping-preview" style="--mapping:var(--turn-action-success)"></span></td><td><code>--turn-action-success</code></td><td><code>var(--turn-green-500)</code></td><td>Confirmed successful state, not generic emphasis.</td></tr>
-          <tr data-semantic="--turn-action-warning"><td><span class="mapping-preview" style="--mapping:var(--turn-action-warning)"></span></td><td><code>--turn-action-warning</code></td><td><code>var(--turn-yellow-400)</code></td><td>Attention and reversible caution.</td></tr>
-          <tr data-semantic="--turn-action-danger"><td><span class="mapping-preview" style="--mapping:var(--turn-action-danger)"></span></td><td><code>--turn-action-danger</code></td><td><code>var(--turn-red-500)</code></td><td>Invalid, destructive and error states.</td></tr>
-          <tr data-semantic="--turn-action-navigation"><td><span class="mapping-preview" style="--mapping:var(--turn-action-navigation)"></span></td><td><code>--turn-action-navigation</code></td><td><code>var(--turn-orange-500)</code></td><td>Close, Back, Leave and Brake · Reverse.</td></tr>
-          <tr class="mapping-group"><td colspan="4">Native forms and disclosures</td></tr>
-          <tr data-semantic="--turn-form-control-idle"><td><span class="mapping-preview" style="--mapping:var(--turn-form-control-idle)"></span></td><td><code>--turn-form-control-idle</code></td><td><code>var(--turn-paper)</code></td><td>Unselected controls.</td></tr>
-          <tr data-semantic="--turn-form-control-selected"><td><span class="mapping-preview" style="--mapping:var(--turn-form-control-selected)"></span></td><td><code>--turn-form-control-selected</code></td><td><code>var(--turn-pink-500)</code></td><td>Selected radio and checkbox state.</td></tr>
-          <tr data-semantic="--turn-form-control-focus"><td><span class="mapping-preview" style="--mapping:var(--turn-form-control-focus)"></span></td><td><code>--turn-form-control-focus</code></td><td><code>var(--turn-blue-500)</code></td><td>Visible keyboard focus.</td></tr>
-          <tr data-semantic="--turn-disclosure-trigger"><td><span class="mapping-preview" style="--mapping:var(--turn-disclosure-trigger)"></span></td><td><code>--turn-disclosure-trigger</code></td><td><code>var(--turn-blue-300)</code></td><td>Informational disclosure summary.</td></tr>
-          <tr data-semantic="--turn-disclosure-panel"><td><span class="mapping-preview" style="--mapping:var(--turn-disclosure-panel)"></span></td><td><code>--turn-disclosure-panel</code></td><td><code>var(--turn-paper)</code></td><td>Expanded disclosure content.</td></tr>
-          <tr class="mapping-group"><td colspan="4">Difficulty</td></tr>
-          <tr data-semantic="--turn-difficulty-easy"><td><span class="mapping-preview" style="--mapping:var(--turn-difficulty-easy)"></span></td><td><code>--turn-difficulty-easy</code></td><td><code>var(--turn-green-200)</code></td><td>Easy label support colour.</td></tr>
-          <tr data-semantic="--turn-difficulty-medium"><td><span class="mapping-preview" style="--mapping:var(--turn-difficulty-medium)"></span></td><td><code>--turn-difficulty-medium</code></td><td><code>var(--turn-yellow-200)</code></td><td>Medium label support colour.</td></tr>
-          <tr data-semantic="--turn-difficulty-advanced"><td><span class="mapping-preview" style="--mapping:var(--turn-difficulty-advanced)"></span></td><td><code>--turn-difficulty-advanced</code></td><td><code>var(--turn-orange-200)</code></td><td>Hard label support colour, distinct from danger.</td></tr>
-<tr data-semantic="--turn-difficulty-expert"><td><span class="mapping-preview" style="--mapping:var(--turn-difficulty-expert)"></span></td><td><code>--turn-difficulty-expert</code></td><td><code>var(--turn-red-200)</code></td><td>Hard label support colour, distinct from danger.</td></tr>
-          <tr data-semantic="--turn-difficulty-locked"><td><span class="mapping-preview" style="--mapping:var(--turn-difficulty-locked)"></span></td><td><code>--turn-difficulty-locked</code></td><td><code>var(--turn-muted)</code></td><td>Unavailable or future track.</td></tr>
-          <tr class="mapping-group"><td colspan="4">Driving controls</td></tr>
-          <tr data-semantic="--turn-control-gas"><td><span class="mapping-preview" style="--mapping:var(--turn-control-gas)"></span></td><td><code>--turn-control-gas</code></td><td><code>var(--turn-green-500)</code></td><td>Gas.</td></tr>
-          <tr data-semantic="--turn-control-drift"><td><span class="mapping-preview" style="--mapping:var(--turn-control-drift)"></span></td><td><code>--turn-control-drift</code></td><td><code>var(--turn-blue-500)</code></td><td>Drift.</td></tr>
-          <tr data-semantic="--turn-control-boost"><td><span class="mapping-preview" style="--mapping:var(--turn-control-boost)"></span></td><td><code>--turn-control-boost</code></td><td><code>var(--turn-yellow-400)</code></td><td>Available Boost charge.</td></tr>
-          <tr data-semantic="--turn-control-boost-empty"><td><span class="mapping-preview" style="--mapping:var(--turn-control-boost-empty)"></span></td><td><code>--turn-control-boost-empty</code></td><td><code>var(--turn-yellow-200)</code></td><td>Unfilled Boost meter.</td></tr>
-          <tr data-semantic="--turn-control-brake"><td><span class="mapping-preview" style="--mapping:var(--turn-control-brake)"></span></td><td><code>--turn-control-brake</code></td><td><code>var(--turn-orange-500)</code></td><td>Brake and Reverse.</td></tr>
-          <tr class="mapping-group"><td colspan="4">Social challenge identity</td></tr>
-          <tr data-semantic="--turn-social-racer-1"><td><span class="mapping-preview" style="--mapping:var(--turn-social-racer-1)"></span></td><td><code>--turn-social-racer-1</code></td><td><code>var(--turn-pink-100)</code></td><td>First racer to join a challenge.</td></tr>
-          <tr data-semantic="--turn-social-racer-2"><td><span class="mapping-preview" style="--mapping:var(--turn-social-racer-2)"></span></td><td><code>--turn-social-racer-2</code></td><td><code>var(--turn-blue-100)</code></td><td>Second racer.</td></tr>
-          <tr data-semantic="--turn-social-racer-3"><td><span class="mapping-preview" style="--mapping:var(--turn-social-racer-3)"></span></td><td><code>--turn-social-racer-3</code></td><td><code>var(--turn-green-100)</code></td><td>Third racer.</td></tr>
-          <tr data-semantic="--turn-social-racer-4"><td><span class="mapping-preview" style="--mapping:var(--turn-social-racer-4)"></span></td><td><code>--turn-social-racer-4</code></td><td><code>var(--turn-yellow-100)</code></td><td>Fourth racer.</td></tr>
-          <tr data-semantic="--turn-social-racer-5"><td><span class="mapping-preview" style="--mapping:var(--turn-social-racer-5)"></span></td><td><code>--turn-social-racer-5</code></td><td><code>var(--turn-orange-100)</code></td><td>Fifth participant / player colour when four rivals already exist.</td></tr>
-        </tbody></table></div>
+      <div class="specimen" style="margin-top: 22px">
+        <div class="specimen-head"><strong>Difficulty and identity</strong><span class="specimen-label">Text + colour</span></div>
+        <div class="specimen-body">
+          <div class="row">
+            <span class="difficulty easy">Easy</span>
+            <span class="difficulty medium">Medium</span>
+            <span class="difficulty advanced">Advanced</span>
+            <span class="difficulty expert">Expert</span>
+            <span class="difficulty locked">Locked</span>
+          </div>
+          <div class="row" aria-label="Stable racer join-order colours">
+            <span class="racer-chip">Racer 1</span><span class="racer-chip">Racer 2</span><span class="racer-chip">Racer 3</span><span class="racer-chip">Racer 4</span><span class="racer-chip">Racer 5</span>
+          </div>
+          <p style="margin:18px 0 0">Colour reinforces progression but never replaces the label. Social racer colour follows stable join order. A faster lap may change race rank, but never the racer’s social colour.</p>
+        </div>
       </div>
 
-      <div class="colour-layer" id="compatibility-aliases">
-        <div class="colour-layer-head"><div><span class="token-label">Bridge layer</span><h3>Compatibility aliases</h3></div><p>Existing selectors remain stable while migration continues. New components use the <code>--turn-*</code> roles above.</p></div>
-        <div class="table-wrap" tabindex="0" role="region" aria-label="Compatibility colour aliases"><table><thead><tr><th>Existing variable</th><th>Normative target</th><th>Status</th></tr></thead><tbody>
-          <tr><td><code>--ink</code></td><td><code>var(--turn-ink)</code></td><td>Compatibility alias</td></tr>
-          <tr><td><code>--paper</code></td><td><code>var(--turn-paper)</code></td><td>Compatibility alias</td></tr>
-          <tr><td><code>--cyan</code></td><td><code>var(--turn-blue-500)</code></td><td>Compatibility alias</td></tr>
-          <tr><td><code>--pink</code></td><td><code>var(--turn-pink-500)</code></td><td>Compatibility alias</td></tr>
-          <tr><td><code>--yellow</code></td><td><code>var(--turn-yellow-400)</code></td><td>Compatibility alias</td></tr>
-          <tr><td><code>--lime</code></td><td><code>var(--turn-green-500)</code></td><td>Compatibility alias</td></tr>
-          <tr><td><code>--m8-ink</code></td><td><code>var(--turn-ink)</code></td><td>Home compatibility alias</td></tr>
-          <tr><td><code>--m8-cream</code></td><td><code>var(--turn-paper)</code></td><td>Home compatibility alias</td></tr>
-          <tr><td><code>--m8-pink</code></td><td><code>var(--turn-pink-500)</code></td><td>Home compatibility alias</td></tr>
-          <tr><td><code>--m8-yellow</code></td><td><code>var(--turn-yellow-600)</code></td><td>Home compatibility alias</td></tr>
-          <tr><td><code>--m8-blue</code></td><td><code>var(--turn-blue-300)</code></td><td>Home compatibility alias</td></tr>
-        </tbody></table></div>
-        <p class="alias-note">Rule: aliases preserve existing visuals. They are not a second design system.</p>
+      <div class="form-grid" style="margin-top: 22px">
+        <fieldset class="form-card">
+          <legend>Steering</legend>
+          <label class="form-option"><input type="radio" name="steering" checked><span><strong>Device steering</strong><small>Tilt the device to steer.</small></span></label>
+          <label class="form-option"><input type="radio" name="steering"><span><strong>On-screen steering</strong><small>Use the steering pad.</small></span></label>
+          <label class="form-option"><input type="checkbox"><span><strong>Left-handed layout</strong><small>Move driving controls to the left.</small></span></label>
+        </fieldset>
+        <div class="form-card">
+          <h3>Native disclosure</h3>
+          <details class="disclosure-sample">
+            <summary>Drive By Ear</summary>
+            <div class="disclosure-panel"><p>Use native <code>details</code> and <code>summary</code>. The visible trigger is blue; expanded information returns to Paper.</p></div>
+          </details>
+        </div>
       </div>
 
-      <div class="colour-layer"><div class="board">
-        <div><span class="token-label">Difficulty in use</span><div class="row"><span class="difficulty easy">Easy</span><span class="difficulty medium">Medium</span><span class="difficulty advanced">Advanced</span>
-              <span class="difficulty expert">Expert</span><span class="difficulty locked">Locked</span></div><p>Colour reinforces progression but never replaces the label.</p></div>
-        <div><span class="token-label">Driving in use</span><div class="row"><span class="button-sample" style="background:var(--turn-control-gas)">Gas</span><span class="button-sample" style="background:var(--turn-control-drift)">Drift</span><span class="button-sample" style="background:var(--turn-control-boost)">Boost</span><span class="button-sample" style="background:var(--turn-control-brake)">Brake · Reverse</span></div></div>
-        <div><span class="token-label">Social identity in use</span><div class="row"><span class="social-racer order-1">Erik</span><span class="social-racer order-2">Arvid</span><span class="social-racer order-3">Kerstin</span><span class="social-racer order-4">Sol</span><span class="social-racer order-5 you">You</span></div><p>Colour follows stable join order. A faster lap may change race rank, but never the racer’s social colour.</p></div>
-      </div></div>
-    </section>
-
-    <section id="patterns">
-      <div class="section-head"><div><span class="kicker">03 · Interaction patterns</span><h2>Semantics stay native. Visuals stay TURN.</h2></div><p>HTML structure communicates meaning. Shared tokens communicate visual hierarchy across the game and its social challenge surface.</p></div>
-      <div class="board">
-        <div><span class="token-label">Forward flow</span><div class="row"><span class="button-sample primary">Install TURN</span><span class="button-sample primary">Race this track</span><span class="button-sample primary">Race this car</span></div></div>
-        <div><span class="token-label">Social challenge flow</span><div class="row"><span class="button-sample share">Share Your Turn</span><span class="button-sample game">Get the Game</span><span class="button-sample navigation">Back</span></div><p><strong>Share is a social forward action.</strong> Pink keeps it salient. Get the Game is a blue handoff into the full product. Back remains navigation orange. In TURN, the quiet circular share icon sits beside a selected track record and inside a new-personal-best result; the pink CTA appears inside the composer.</p></div>
-        <div><span class="token-label">Utility and Navigation</span><div class="row"><span class="button-sample">Settings</span><span class="button-sample">How to Play</span><span class="button-sample">Give Feedback</span><span class="button-sample">Race Again</span><span class="button-sample navigation">Leave race</span><span class="icon-button" aria-label="Close-button specimen">×</span><span class="icon-button share-icon" aria-label="Share icon specimen">↥</span></div></div>
-        <div><span class="token-label">Header metadata</span><div style="margin-top:12px"><span class="metadata-pattern"><span>TURN V1.7.0 · BUILD 2026.08.09-R163</span><button class="about-link" type="button">ABOUT TURN</button></span></div><p><strong>ABOUT TURN is visually a link but semantically a button</strong> because it opens a dialog.</p></div>
-        <div><span class="token-label">Required social name</span><div class="form-grid" style="margin-top:18px"><div class="form-card"><h3>Your name in the challenge</h3><label><span class="token-label">Name is required before sharing</span><input class="text-field" type="text" placeholder="WRITE YOUR NAME HERE" required></label></div><div class="form-card"><h3>Identity rule</h3><p>The display name is human-facing. A stable racer ID carries identity through a challenge chain; returning racers replace their own car rather than creating duplicates.</p></div></div></div>
-        <div><span class="token-label">Native form controls</span><p><strong>Legend and heading elements share one floating card-title treatment.</strong> Radio buttons communicate one-of-many choices; Checkboxes communicate independent on/off choices. Native semantics stay intact beneath the TURN styling.</p><div class="form-grid" style="margin-top:18px"><fieldset class="form-card"><legend>Steering</legend><label class="form-option"><input type="radio" name="designSteering" checked><span><strong>Device rotation</strong><small>Turn the whole device like a steering wheel.</small></span></label><label class="form-option"><input type="radio" name="designSteering"><span><strong>On-screen steering</strong><small>Use the steering control or a keyboard.</small></span></label></fieldset><section class="form-card" aria-labelledby="designAudioTitle"><h3 id="designAudioTitle">Audio</h3><label class="form-option"><input type="checkbox" checked><span><strong>Sound</strong><small>Turn every TURN sound on or off.</small></span></label><label class="form-option"><input type="checkbox"><span><strong>Drive By Ear™</strong><small>Spatial steering guidance and race information.</small></span></label></section></div></div>
-        <div><span class="token-label">Disclosure</span><p>The decorative state symbol sits directly before the summary text.</p><details class="disclosure-sample" style="margin-top:12px"><summary><span class="disclosure-symbol" aria-hidden="true"></span><span>Explore the Drive By Ear sounds</span></summary><div class="disclosure-panel"><p><strong>Blue trigger, Paper panel.</strong> The native details element communicates expanded and collapsed state.</p></div></details></div>
+      <div class="specimen" style="margin-top: 22px">
+        <div class="specimen-head"><strong>Dialog anatomy</strong><span class="specimen-label">Compact · standard · wide · reader</span></div>
+        <div class="specimen-body">
+          <div class="dialog-demo">
+            <div class="dialog-demo__head">
+              <div><span class="dialog-demo__eyebrow">Settings</span><h3>DRIVING</h3></div>
+              <button class="dialog-demo__close" type="button" aria-label="Close">×</button>
+            </div>
+            <div class="dialog-demo__body">
+              <div class="dialog-demo__panel"><strong>STEERING</strong><p>Group closely related native controls inside one readable card.</p></div>
+              <div class="dialog-demo__panel"><strong>COLOR</strong><p>Use the available width instead of stacking everything into one narrow column.</p></div>
+            </div>
+          </div>
+          <p style="margin:24px 0 0">The dialog surface owns its border, radius, shadow and scrolling. The header stays compact, the close action is orange, and headings get enough vertical room to avoid clipping on mobile Safari.</p>
+        </div>
       </div>
     </section>
 
-    <section id="screens">
-      <div class="section-head"><div><span class="kicker">04 · Example implementation</span><h2>Actual components, not substitute illustrations.</h2></div><p>Game content is labelled rather than imitated. The system demonstrates surrounding controls, hierarchy and social states.</p></div>
-      <div class="screens">
-        <article class="screen-item"><h3>Install</h3><div class="screen" role="img" aria-label="TURN install page design specimen"><div class="screen-head"><strong>TURN</strong><span>TURN V1.7.0 · BUILD 2026.08.09-R163</span></div><div class="placeholder">INSTALL ART</div><div class="row"><span class="button-sample primary">Install TURN</span></div></div></article>
-        <article class="screen-item"><h3>Home and track selection</h3><div class="screen" role="img" aria-label="TURN Home and track-selection design specimen"><div class="screen-head"><strong>CHOOSE YOUR TRACK</strong><span class="about-link">ABOUT TURN</span></div><div class="two-col"><div class="track-grid"><div class="track-card"><div class="top"><strong>COUNTRYSIDE</strong><span class="difficulty easy">Easy</span></div><div class="placeholder">TRACK PREVIEW</div><div class="row"><span>BEST 0:16.316</span><span class="icon-button share-icon" aria-label="Share selected track best specimen">↥</span></div></div><div class="track-card"><div class="top"><strong>AIRPORT</strong><span class="difficulty medium">Medium</span></div><div class="placeholder">TRACK PREVIEW</div></div><div class="track-card"><div class="top"><strong>HARBOR</strong><span class="difficulty advanced">Advanced</span></div><div class="placeholder">TRACK PREVIEW</div></div></div><div class="menu"><span class="button-sample">Settings</span><span class="button-sample">How to Play</span><span class="button-sample">Give Feedback</span><span class="button-sample primary">Race this track</span></div></div></div></article>
-        <article class="screen-item"><h3>The Lot</h3><div class="screen" role="img" aria-label="TURN The Lot design specimen"><div class="two-col"><div class="placeholder">3D CAR VIEW</div><div class="card"><h3>SPORTS SEDAN</h3><p>Top speed · Acceleration · Control · Drift</p><div class="row"><span class="button-sample primary">Race this car</span></div></div></div></div></article>
-        <article class="screen-item"><h3>Race</h3><div class="screen" role="img" aria-label="TURN race HUD and control design specimen"><div class="hud"><span class="chip">Speed 86 km/h</span><span class="chip">Lap 2</span><span class="chip">Position 3/5</span><span class="chip">Time 0:34.822</span></div><div class="placeholder">GAME VIEW</div><div class="drive-pad"><div class="drive-top"><span>Drift</span><span>Boost</span></div><div class="gas-zone">Gas</div><div class="brake-zone">Brake · Reverse</div></div></div></article>
-        <article class="screen-item"><h3>YOUR TURN challenge</h3><div class="screen yourturn" role="img" aria-label="YOUR TURN social challenge design specimen"><div class="screen-head"><strong>YOU BEAT ERIK</strong><span class="social-racer order-5 you">YOU</span></div><div class="row"><span class="social-racer order-1">ERIK · 0:18.750</span><span class="social-racer order-2">ARVID · 0:18.910</span><span class="social-racer order-3">KERSTIN · 0:19.102</span></div><div class="card" style="margin-top:22px"><h3>YOUR NAME IN THE CHALLENGE</h3><input class="text-field" type="text" value="ERIK" aria-label="Your name in the challenge specimen"><div class="row"><span class="button-sample share">Share Your Turn</span><span class="button-sample">Race Again</span><span class="button-sample game">Get the Game</span></div></div></div></article>
-        <article class="screen-item"><h3>Dialog</h3><div class="screen" role="img" aria-label="TURN How to Play dialog design specimen"><div class="screen-head"><strong>HOW TO PLAY</strong><span class="icon-button">×</span></div><div class="card"><h3>Drive By Ear™</h3><p>Paper content card with a Blue informational disclosure.</p><details class="disclosure-sample" style="margin-top:14px"><summary><span class="disclosure-symbol" aria-hidden="true"></span><span>Explore the Drive By Ear sounds</span></summary><div class="disclosure-panel"><p>Guidance, pace notes, grip, surfaces and recovery.</p></div></details></div></div></article>
+    <section id="gameplay" aria-labelledby="gameplay-title">
+      <div class="section-head">
+        <div><span class="kicker">Gameplay</span><h2 id="gameplay-title">The race HUD is instrumentation, not a website.</h2></div>
+        <p>Gameplay UI is dense, peripheral and fast to parse. Controls preserve large target areas; feedback stays near the thing it describes and avoids blocking the road.</p>
+      </div>
+
+      <div class="gameplay-grid">
+        <div class="game-stage" aria-label="Static race HUD specimen">
+          <span class="game-stage__label">Game view</span>
+          <div class="score-demo" aria-label="DRIFT and FLOW scorekeeper">
+            <div class="score-row">
+              <div class="score-paper"><div class="score-heading"><span>DRIFT</span><span>COMBO</span></div><div class="score-value"><strong>4,820</strong><b>×3</b></div><div class="score-footer"><span>LAP 12,940</span><span>BANKED</span></div></div>
+              <span class="score-gauge" aria-hidden="true"><i></i></span>
+            </div>
+            <div class="score-row flow">
+              <div class="score-paper"><div class="score-heading"><span>FLOW</span><span>CHAIN</span></div><div class="score-value"><strong>18,420</strong><b>×5.1</b></div><div class="score-footer"><span>LAP 31,220</span><span>SHIFT › DRIFT</span></div></div>
+              <span class="score-gauge" aria-hidden="true"><i></i></span>
+            </div>
+          </div>
+
+          <div class="drive-demo" aria-label="Unified drive pad">
+            <span class="drive-demo__lock">Lock</span>
+            <button class="drive-demo__shift" type="button">Shift</button>
+            <div class="drive-demo__top"><button class="drive-demo__drift" type="button">Drift</button><button class="drive-demo__boost" type="button">Boost</button></div>
+            <button class="drive-demo__gas" type="button">Gas</button>
+            <button class="drive-demo__brake" type="button">Brake · Reverse</button>
+          </div>
+        </div>
+
+        <div class="gameplay-notes">
+          <article class="gameplay-note"><h3>Unified drive pad</h3><p>DRIFT, BOOST, GAS and BRAKE/REVERSE share one physical block. LOCK and SHIFT slide out contextually rather than becoming permanent extra buttons.</p></article>
+          <article class="gameplay-note"><h3>Scorekeeper paper</h3><p>DRIFT and FLOW use fixed-height Paper rows with attached horizontal gauges. Numbers update on a throttled presentation path; scoring logic does not depend on HUD visibility.</p></article>
+          <article class="gameplay-note"><h3>Feedback hierarchy</h3><p>Loss, bank, multiplier, SHIFT roll and achievement feedback are brief overlays. They should never outrank steering, pace notes or immediate race safety information.</p></article>
+          <article class="gameplay-note"><h3>One-handed and mirrored play</h3><p>The control cluster and utility group can mirror for left-handed play. Device steering keeps the mirrored driving actions without inventing an unnecessary steering pad.</p></article>
+        </div>
       </div>
     </section>
 
-    <section id="migration">
-      <div class="section-head"><div><span class="kicker">05 · Adoption</span><h2>Core game and social challenge patterns are represented.</h2></div><p>The normative system now covers production TURN, YOUR TURN sharing, native forms, disclosures and social racer identity. Migration can continue component by component without inventing a parallel visual language.</p></div>
-      <ol class="migration">
-        <li><strong>Shared token file: active.</strong> Primitive, action, control and social-racer roles live in <code>design-tokens.css</code>.</li>
-        <li><strong>Compatibility aliases: active.</strong> Existing variables still resolve to normative primitives.</li>
-        <li><strong>Native components: active.</strong> Settings headings, radios, checkboxes, range input, text input and disclosures use shared rules.</li>
-        <li><strong>Social challenge semantics: active.</strong> Share, Get the Game and stable join-order colours are documented as product-level roles.</li>
-        <li><strong>Continue incrementally.</strong> Normalize remaining geometry and one-off raw colour values when touching those component families; do not churn working game UI solely for token purity.</li>
-      </ol>
+    <section id="progression" aria-labelledby="progression-title">
+      <div class="section-head">
+        <div><span class="kicker">Progression</span><h2 id="progression-title">Trophy Road is a literal road now.</h2></div>
+        <p>START → every real reward in progression order → FINISH. Reward type and lock state are visible at a glance, while the label and trophy target remain the accessible source of truth.</p>
+      </div>
+
+      <div class="progression-board">
+        <div class="progression-road" aria-label="Trophy Road colour specimen">
+          <div class="reward-tile start-finish">Start</div>
+          <div class="reward-tile vehicle unlocked">Vehicle<br>unlocked</div>
+          <div class="reward-tile feature unlocked">Perk<br>unlocked</div>
+          <div class="reward-tile track unlocked">Track<br>unlocked</div>
+          <div class="reward-tile scoring unlocked">Scoring<br>unlocked</div>
+          <div class="reward-tile vehicle locked">Vehicle<br>locked</div>
+          <div class="reward-tile feature locked">Feature<br>locked</div>
+          <div class="reward-tile track locked">Track<br>locked</div>
+          <div class="reward-tile scoring locked">Scoring<br>locked</div>
+          <div class="reward-tile start-finish">Finish</div>
+        </div>
+        <div class="progression-legend">
+          <div class="progression-key"><strong>Vehicle</strong><code>blue-100 → blue-500</code></div>
+          <div class="progression-key"><strong>Track</strong><code>green-200 → green-500</code></div>
+          <div class="progression-key"><strong>Feature / perk</strong><code>yellow-100 → yellow-400</code></div>
+          <div class="progression-key"><strong>Scoring</strong><code>pink-100 → pink-200</code></div>
+        </div>
+      </div>
+
+      <div class="grid" style="margin-top: 22px">
+        <article class="card"><span class="token-label">Selection</span><h3>Reward details use a modal</h3><p>Do not push the selected reward’s detail panel below the fold. Place the modal above or below the selected road row according to available space; clicking outside also closes it.</p></article>
+        <article class="card"><span class="token-label">Navigation</span><h3>Orange closes context</h3><p>Trophy Road’s detail close button uses <code>--turn-orange-500</code>, matching the global navigation/context-change role.</p></article>
+        <article class="card"><span class="token-label">Perks</span><h3>Motion means availability</h3><p>Locked perks stay still. Unlocked perks may get the attention wiggle, and selecting a car with an active perk gives the short confirmation wiggle.</p></article>
+      </div>
+    </section>
+
+    <section id="layouts" aria-labelledby="layouts-title">
+      <div class="section-head">
+        <div><span class="kicker">Layouts</span><h2 id="layouts-title">Current screens, reduced to their real structure.</h2></div>
+        <p>These are component-level specimens rather than decorative substitute illustrations. The intention is to preserve the shipped hierarchy while making the underlying pattern obvious.</p>
+      </div>
+
+      <div class="layout-stack">
+        <article class="layout-specimen">
+          <div class="layout-caption"><strong>Home / track selection</strong><span>Yellow header · Paper canvas · tracks + menu</span></div>
+          <div class="home-mini">
+            <div class="home-mini__head"><div class="home-mini__logo">TURN</div><div class="home-mini__pitch">A tiny racing game with a lot going on.</div><div class="home-mini__build">TURN 1.17.3 · 2026.09.05-r203</div></div>
+            <div class="home-mini__main">
+              <div>
+                <h3 style="margin:0 0 12px">TRACKS</h3>
+                <div class="track-mini-grid">
+                  <div class="track-mini"><span class="difficulty easy">Easy</span><h4>COUNTRYSIDE</h4><p>Best 00:32.41 · selected track record stays with the card.</p></div>
+                  <div class="track-mini"><span class="difficulty medium">Medium</span><h4>AIRPORT</h4><p>Track card owns difficulty, identity and record context.</p></div>
+                  <div class="track-mini"><span class="difficulty advanced">Advanced</span><h4>MIDNIGHT CITY</h4><p>Long card content still fits the same component.</p></div>
+                  <div class="track-mini"><span class="difficulty expert">Expert</span><h4>MOUNTAIN</h4><p>Expert is explicit text, not merely a red tint.</p></div>
+                </div>
+              </div>
+              <aside class="home-menu-mini"><h3>MENU</h3><button class="menu-button" type="button">Settings</button><button class="menu-button" type="button">How to play</button><button class="menu-button achievements" type="button">Achievements</button><button class="menu-button" type="button">Trophy road</button><button class="menu-button race" type="button">Race this track</button></aside>
+            </div>
+          </div>
+        </article>
+
+        <article class="layout-specimen">
+          <div class="layout-caption"><strong>The Lot</strong><span>Large car view · compact stat panel · direct race action</span></div>
+          <div class="lot-mini">
+            <div class="lot-mini__viewer"><div class="car-silhouette" aria-label="3D car view placeholder"></div></div>
+            <div class="lot-mini__info"><span class="kicker">Car 08 / 15</span><h3>SPORTS CAR</h3><p style="margin:0 0 12px">Selected car information stays close to its attributes and actions.</p>
+              <div class="stat-row"><span>Top speed</span><span class="stat-meter"><i style="width:80%"></i></span></div>
+              <div class="stat-row"><span>Acceleration</span><span class="stat-meter"><i style="width:72%"></i></span></div>
+              <div class="stat-row"><span>Drift</span><span class="stat-meter"><i style="width:88%"></i></span></div>
+              <div class="stat-row"><span>Control</span><span class="stat-meter"><i style="width:66%"></i></span></div>
+              <div class="stat-row"><span>Boost power</span><span class="stat-meter"><i style="width:76%"></i></span></div>
+              <div class="stat-row"><span>Boost tank</span><span class="stat-meter"><i style="width:70%"></i></span></div>
+              <div class="row" style="margin-top:18px"><button class="button-sample" type="button">Perk</button><button class="button-sample primary" type="button">Race this car</button></div>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section id="accessibility" aria-labelledby="accessibility-title">
+      <div class="section-head">
+        <div><span class="kicker">Accessibility</span><h2 id="accessibility-title">Not a mode. Part of the control system.</h2></div>
+        <p>TURN’s accessibility work is integrated into the same product language. The visual system should never create a second-class route for non-visual, keyboard or reduced-motion use.</p>
+      </div>
+
+      <div class="a11y-grid">
+        <article class="a11y-card"><h3>Screen reader</h3><p>Controls expose real names, roles and states. Gesture instructions are spoken where needed. Decorative score and progress colour never replaces programmatic labels.</p></article>
+        <article class="a11y-card"><h3>Drive By Ear</h3><p>Audio guidance is an equal gameplay channel. Visual feedback must not steal timing or attention from pace notes, off-road direction or recovery guidance.</p></article>
+        <article class="a11y-card"><h3>Blank screen</h3><p>Non-visual play is a deliberate feature, not a hidden debug state. UI flows and achievement logic continue to work without the visual game layer.</p></article>
+        <article class="a11y-card"><h3>Reduced motion</h3><p>Wiggles, pulses and continuous score noise stop or simplify under <code>prefers-reduced-motion</code>. State change remains legible through colour, text and layout.</p></article>
+        <article class="a11y-card"><h3>Left-handed layout</h3><p>The drive pad, LOCK/SHIFT bubbles and utility group mirror spatially while preserving their labels and interaction semantics.</p></article>
+        <article class="a11y-card"><h3>Focus and native semantics</h3><p>Blue focus rings stay obvious. Prefer native buttons, fieldsets, radio buttons, checkboxes, <code>details</code> and <code>summary</code> before inventing a custom interaction role.</p></article>
+      </div>
+    </section>
+
+    <section id="legacy" aria-labelledby="legacy-title">
+      <div class="section-head">
+        <div><span class="kicker">Legacy and migration</span><h2 id="legacy-title">Support old selectors. Don’t design new work around them.</h2></div>
+        <p>TURN grew quickly. Compatibility aliases and some historical class names remain in production because stability is more important than cosmetic purity.</p>
+      </div>
+      <div class="legacy-note">
+        <div><h3>Production reference, not proposal language</h3><p>New work should start from <code>--turn-*</code> primitives, semantic roles, the current dialog system, unified drive pad, ScoreFeedback and the current Home/Lot/Trophy Road patterns. Old <code>--m8-*</code> and short aliases remain only to keep shipped components safe while they are touched naturally.</p></div>
+        <span class="legacy-badge">Stable system</span>
+      </div>
+      <div class="grid" style="margin-top:22px">
+        <article class="card"><span class="token-label">Do</span><h3>Refactor when work reaches the component</h3><p>Move a touched component toward canonical tokens and anatomy when the change is already justified.</p></article>
+        <article class="card"><span class="token-label">Do not</span><h3>Churn working UI for purity</h3><p>Do not rewrite stable gameplay or accessibility behavior merely to remove an alias or old selector name.</p></article>
+        <article class="card"><span class="token-label">Regression</span><h3>Pin meaning, not screenshots alone</h3><p>Tests should protect semantic role, hierarchy, accessible state and critical geometry so the design system can evolve without becoming brittle.</p></article>
+      </div>
     </section>
   </main>
 
-  <footer><strong>TURN Design System · 1.7</strong><br>Preserve the personality. Standardize the rules underneath it.</footer>
+  <footer>
+    <div class="footer-inner"><strong>TURN Design System</strong><span>Current product language · September 2026</span></div>
+  </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Refreshes TURN’s design-system reference so it reads like the mature product that is currently shipping rather than an early concept / alpha documentation page.

- replaces the old full-screen gradient/prototype-style reference shell with TURN’s current yellow-header, Paper + Ink, hard-border and offset-shadow language
- updates the reference baseline to the current canonical release (`1.17.3 · 2026.09.05-r203`)
- documents the current Home and The Lot structure instead of old placeholder-board examples
- adds current gameplay specimens for the unified drive pad, contextual LOCK / SHIFT, and the DRIFT / FLOW scorekeeper
- documents the current Trophy Road category system and locked/unlocked token colours, contextual reward-detail modal and perk-motion rules
- brings the dialog reference into the same production-grade shell while preserving compact / standard / wide / reader anatomy and focus / scroll behavior
- gives accessibility its own first-class section: screen reader, Drive By Ear, Blank screen, reduced motion, left-handed controls and native semantics
- moves compatibility aliases into an explicit legacy/migration section: supported for production stability, but no longer presented as the design vocabulary for new work
- updates design-system and About/history regressions around the new current-product reference shell

The production token values and semantic mappings are intentionally unchanged. This PR changes the reference/documentation and its regression contract, not gameplay UI, physics, progression or release identity.