### PR TITLE
TURN: keep x2+ combo gauges extended

### DIFF
--- a/turn-tests/drift-attack-core-production.mjs
+++ b/turn-tests/drift-attack-core-production.mjs
@@ -113,6 +113,37 @@ assert.equal(hysteresisScorer.inspect().drifting, false,
   'A genuinely settled car banks after the release delay');
 assert.ok(hysteresisScorer.inspect().lapScore > 0);
 
+const expiryStates = [];
+const expiryScorer = createDriftAttackScorer({
+  onState: (snapshot) => expiryStates.push({ ...snapshot })
+});
+expiryScorer.beginLap(0);
+let expiryNow = runFor(expiryScorer, 0.8, 1 / 60);
+expiryNow = runFor(expiryScorer, 0.4, 1 / 60, {
+  slip: radians(4),
+  startAt: expiryNow
+});
+expiryNow = runFor(expiryScorer, 0.55, 1 / 60, {
+  slip: radians(-62),
+  startAt: expiryNow
+});
+assert.equal(expiryScorer.inspect().multiplier, 2,
+  'A linked opposite drift reaches x2 before the presentation-expiry check');
+expiryNow = runFor(expiryScorer, 0.4, 1 / 60, {
+  slip: radians(4),
+  startAt: expiryNow
+});
+const linkedExpiryAt = expiryScorer.inspect().chainExpiresAt;
+assert.ok(linkedExpiryAt > expiryNow,
+  'Banking an x2 drift keeps the chain alive for the normal link window');
+expiryScorer.advance(1 / 60, linkedExpiryAt + 1, 5, 0, false, false, true);
+assert.equal(expiryScorer.inspect().multiplier, 1,
+  'DRIFT combo state returns to x1 when the chain window expires');
+assert.equal(expiryStates.at(-1)?.multiplier, 1,
+  'Chain expiry publishes the x1 state so a held-open HUD gauge can retract promptly');
+assert.equal(expiryStates.at(-1)?.active, false);
+assert.equal(expiryStates.at(-1)?.intensity, 0);
+
 function simulatedScore(dt) {
   const candidate = createDriftAttackScorer();
   candidate.beginLap(0);

--- a/turn-tests/score-feedback-production.mjs
+++ b/turn-tests/score-feedback-production.mjs
@@ -106,6 +106,12 @@ assert.equal(element(fixture, '[data-score-feedback-current]').textContent, '0')
 assert.equal(fixture.root.dataset.driftGaugeVisible, 'true');
 assert.equal(fixture.root.dataset.driftGaugeExtended, 'false',
   'An available zero-state DRIFT row keeps its paper but retracts its gauge');
+assert.equal(fixture.root.dataset.driftComboTier, '1');
+assert.equal(
+  element(fixture, '[data-score-feedback-meter-fill]').style.getPropertyValue('--score-feedback-gauge-fill-a'),
+  'hsl(195 44% 50%)',
+  'DRIFT starts with a deliberately muted cyan at x1'
+);
 
 const driftState = {
   active: true,
@@ -133,6 +139,12 @@ assert.equal(
 assert.equal(fixture.root.dataset.driftGaugeVisible, 'true');
 assert.equal(fixture.root.dataset.driftGaugeExtended, 'true',
   'The DRIFT gauge extends as soon as it has a non-zero fill');
+assert.equal(fixture.root.dataset.driftComboTier, '3');
+assert.equal(
+  element(fixture, '[data-score-feedback-meter-fill]').style.getPropertyValue('--score-feedback-gauge-fill-a'),
+  'hsl(195 60% 50%)',
+  'DRIFT cyan gains saturation at each higher combo tier'
+);
 assert.equal(fixture.root.dataset.flowGaugeVisible, 'false');
 assert.equal(fixture.root.dataset.flowGaugeExtended, 'false');
 assert.equal(fixture.root.dataset.gaugeChannel, 'drift');
@@ -213,7 +225,28 @@ assert.equal(
 assert.equal(fixture.root.dataset.flowGaugeVisible, 'true');
 assert.equal(fixture.root.dataset.flowGaugeExtended, 'true',
   'FLOW owns an independently extending gauge');
+assert.equal(fixture.root.dataset.flowComboTier, '5',
+  'Fractional FLOW multipliers use their floored saturation tier');
+assert.equal(
+  element(fixture, '[data-score-feedback-flow-meter-fill]').style.getPropertyValue('--score-feedback-gauge-fill-a'),
+  'hsl(339 76% 65%)',
+  'FLOW pink gains saturation with the combo tier'
+);
 assert.equal(fixture.root.dataset.flowHeat, 'hot');
+
+feedback.updateState(SCORE_FEEDBACK_CHANNEL.FLOW, {
+  ...flowState,
+  active: false,
+  intensity: 0
+}, 700);
+assert.equal(
+  element(fixture, '[data-score-feedback-flow-meter-fill]').style.getPropertyValue('--score-feedback-progress'),
+  '0',
+  'An idle moment inside a FLOW combo can reach the true zero gauge state'
+);
+assert.equal(fixture.root.dataset.flowGaugeExtended, 'true',
+  'FLOW keeps an empty gauge extended while its x2+ combo remains alive');
+feedback.updateState(SCORE_FEEDBACK_CHANNEL.FLOW, flowState, 800);
 
 feedback.publishEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, SCORE_FEEDBACK_EVENT.BANK, {
   label: 'DRIFT +2,840 ×4',
@@ -267,22 +300,57 @@ assert.equal(fixture.root.hidden, false, 'The DRIFT instrument does not flicker 
 assert.equal(element(fixture, '[data-score-feedback-current]').textContent, '0');
 assert.equal(element(fixture, '[data-score-feedback-total]').textContent, '4,820');
 assert.equal(fixture.root.dataset.driftGaugeExtended, 'false',
-  'A quiet DRIFT row preserves its lap total while retracting only the black gauge');
+  'A quiet x1 DRIFT row preserves its lap total while retracting only the black gauge');
 assert.equal(
   element(fixture, '[data-score-feedback-meter-fill]').style.getPropertyValue('--score-feedback-progress'),
   '0'
 );
+
+feedback.updateState(SCORE_FEEDBACK_CHANNEL.DRIFT, {
+  active: false,
+  score: 4820,
+  unbanked: 0,
+  multiplier: 2,
+  intensity: 0,
+  phase: 'quiet',
+  label: 'DRIFT'
+}, 4300);
+assert.equal(fixture.root.dataset.driftGaugeExtended, 'true',
+  'An empty DRIFT gauge remains extended while an x2+ combo is alive');
+assert.equal(fixture.root.dataset.driftComboTier, '2');
+assert.equal(
+  element(fixture, '[data-score-feedback-meter-fill]').style.getPropertyValue('--score-feedback-progress'),
+  '0',
+  'The held-open gauge exposes the existing cyan zero residue rather than fake fill'
+);
+assert.equal(
+  element(fixture, '[data-score-feedback-meter-fill]').style.getPropertyValue('--score-feedback-gauge-fill-a'),
+  'hsl(195 52% 50%)'
+);
+
+feedback.updateState(SCORE_FEEDBACK_CHANNEL.DRIFT, {
+  active: false,
+  score: 4820,
+  unbanked: 0,
+  multiplier: 1,
+  intensity: 0,
+  phase: 'quiet',
+  label: 'DRIFT'
+}, 4400);
+assert.equal(fixture.root.dataset.driftGaugeExtended, 'false',
+  'Normal gauge retraction resumes as soon as the combo falls below x2');
+
 feedback.publishEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, SCORE_FEEDBACK_EVENT.LOSS, {
   score: 120
-}, 4300);
-feedback.dismissEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, 4350);
+}, 4500);
+feedback.dismissEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, 4550);
 assert.equal(element(fixture, '[data-score-feedback-callout]').hidden, true);
 assert.equal(element(fixture, '[data-score-feedback-total]').textContent, '4,820',
   'Dismissing stale feedback must not clear the persistent lap total');
-feedback.clearChannel(SCORE_FEEDBACK_CHANNEL.DRIFT, 4400);
+feedback.clearChannel(SCORE_FEEDBACK_CHANNEL.DRIFT, 4600);
 assert.equal(fixture.root.hidden, false, 'Clearing a visible channel leaves its zero-state instrument mounted');
 assert.equal(element(fixture, '[data-score-feedback-total]').textContent, '0');
-feedback.setChannelVisible(SCORE_FEEDBACK_CHANNEL.DRIFT, false, 4500);
+feedback.setChannelVisible(SCORE_FEEDBACK_CHANNEL.DRIFT, false, 4700);
 assert.equal(fixture.root.hidden, true, 'The HUD setting still removes the scoring instrument');
 assert.equal(
   element(fixture, '[data-score-feedback-flow-meter-fill]').style.getPropertyValue('--score-feedback-progress'),
@@ -303,6 +371,12 @@ assert.doesNotMatch(source, /createElement|appendChild|replaceChildren/,
   'ScoreFeedback must reuse the fixed document nodes');
 assert.match(source, /data-score-feedback-flow-meter-fill/,
   'The shared engine must already understand the optional future FLOW gauge mount');
+assert.match(source, /GAUGE_SATURATION_AT_X1 = 44/,
+  'The combo palette starts muted instead of at full saturation');
+assert.match(source, /driftGaugeProgress > 0 \|\| driftComboHeld/,
+  'DRIFT gauge persistence is keyed to fill or a live x2+ combo');
+assert.match(source, /flowGaugeProgress > 0 \|\| flowComboHeld/,
+  'FLOW uses the same combo-held gauge rule');
 assert.match(css, /--score-feedback-paper-height: 104px/,
   'Each scoring paper row has a stable gameplay height');
 assert.match(css, /--score-feedback-gauge-height: calc\(var\(--score-feedback-paper-height\) - 14px\)/,

--- a/turn/scoring/drift-attack.js
+++ b/turn/scoring/drift-attack.js
@@ -234,10 +234,13 @@ export function createDriftAttackScorer({ onState = null, onEvent = null } = {})
   }
 
   function expireChain(now) {
-    if (drifting || !chainExpiresAt || now <= chainExpiresAt) return;
+    if (drifting || !chainExpiresAt || now <= chainExpiresAt) return false;
+    const expiredMultiplier = multiplier;
     chainExpiresAt = 0;
     lastBankDirection = 0;
     multiplier = 1;
+    if (expiredMultiplier >= 2) syncFeedback(now);
+    return true;
   }
 
   function sample(sampleDt, now, speed, slipAngle, offRoad, collided) {

--- a/turn/scoring/score-feedback.js
+++ b/turn/scoring/score-feedback.js
@@ -45,6 +45,10 @@ const CHANNEL_LABEL = Object.freeze({
   [SCORE_FEEDBACK_CHANNEL.FLOW]: 'FLOW'
 });
 
+const GAUGE_SATURATION_AT_X1 = 44;
+const GAUGE_SATURATION_STEP = 8;
+const GAUGE_MAX_COMBO_TIER = 8;
+
 const numberFormatter = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 0
 });
@@ -86,6 +90,13 @@ function setData(element, key, value) {
   if (element.dataset[key] !== text) element.dataset[key] = text;
 }
 
+function setStyleProperty(element, property, value) {
+  if (!element?.style?.setProperty) return;
+  const text = String(value);
+  if (element.style.getPropertyValue?.(property) === text) return;
+  element.style.setProperty(property, text);
+}
+
 function requiredElement(root, selector) {
   const element = root?.querySelector?.(selector);
   if (!element) throw new Error(`TURN ScoreFeedback could not find ${selector}.`);
@@ -115,6 +126,46 @@ function heatTier(intensity, active = true) {
   if (value >= 0.74) return 'hot';
   if (value >= 0.5) return 'warm';
   return 'build';
+}
+
+function comboTier(multiplier) {
+  return clamp(
+    Math.floor(Math.max(1, finiteNumber(multiplier, 1))),
+    1,
+    GAUGE_MAX_COMBO_TIER
+  );
+}
+
+function gaugePalette(channel, multiplier) {
+  const tier = comboTier(multiplier);
+  const saturation = Math.min(
+    100,
+    GAUGE_SATURATION_AT_X1 + (tier - 1) * GAUGE_SATURATION_STEP
+  );
+  const highlightSaturation = Math.min(100, saturation + 8);
+  if (channel === SCORE_FEEDBACK_CHANNEL.FLOW) {
+    return {
+      tier,
+      fillA: `hsl(339 ${saturation}% 65%)`,
+      fillB: `hsl(336 ${highlightSaturation}% 78%)`
+    };
+  }
+  return {
+    tier,
+    fillA: `hsl(195 ${saturation}% 50%)`,
+    fillB: `hsl(191 ${highlightSaturation}% 70%)`
+  };
+}
+
+function applyGaugePalette(fill, channel, multiplier) {
+  if (!fill) return comboTier(multiplier);
+  const palette = gaugePalette(channel, multiplier);
+  const gauge = fill.parentElement;
+  for (const target of [gauge, fill]) {
+    setStyleProperty(target, '--score-feedback-gauge-fill-a', palette.fillA);
+    setStyleProperty(target, '--score-feedback-gauge-fill-b', palette.fillB);
+  }
+  return palette.tier;
 }
 
 function defaultEventLabel(type, channel, score, multiplier) {
@@ -396,6 +447,18 @@ export function createScoreFeedback({
     const driftGaugeIntensity = fallbackGaugeToFlow ? flow.intensity : drift.intensity;
     const driftGaugeProgress = driftGaugeActive ? driftGaugeIntensity : 0;
     const flowGaugeProgress = flowActive ? flow.intensity : 0;
+    const driftComboHeld = fallbackGaugeToFlow
+      ? flow.multiplier >= 2
+      : drift.multiplier >= 2;
+    const flowComboHeld = flow.multiplier >= 2;
+    const driftComboTier = applyGaugePalette(
+      driftGaugeFill,
+      fallbackGaugeToFlow ? SCORE_FEEDBACK_CHANNEL.FLOW : SCORE_FEEDBACK_CHANNEL.DRIFT,
+      fallbackGaugeToFlow ? flow.multiplier : drift.multiplier
+    );
+    const flowComboTier = flowGaugeFill
+      ? applyGaugePalette(flowGaugeFill, SCORE_FEEDBACK_CHANNEL.FLOW, flow.multiplier)
+      : comboTier(flow.multiplier);
 
     driftGaugeFill.style.setProperty(
       '--score-feedback-progress',
@@ -413,8 +476,14 @@ export function createScoreFeedback({
     setData(root, 'flowVisible', flow.visible);
     setData(root, 'driftGaugeVisible', driftGaugeVisible);
     setData(root, 'flowGaugeVisible', Boolean(flowHasOwnGauge && flow.visible));
-    setData(root, 'driftGaugeExtended', driftGaugeVisible && driftGaugeProgress > 0);
-    setData(root, 'flowGaugeExtended', Boolean(flowHasOwnGauge && flow.visible && flowGaugeProgress > 0));
+    setData(root, 'driftGaugeExtended', driftGaugeVisible && (driftGaugeProgress > 0 || driftComboHeld));
+    setData(
+      root,
+      'flowGaugeExtended',
+      Boolean(flowHasOwnGauge && flow.visible && (flowGaugeProgress > 0 || flowComboHeld))
+    );
+    setData(root, 'driftComboTier', driftComboTier);
+    setData(root, 'flowComboTier', flowComboTier);
     setData(root, 'driftHeat', heatTier(drift.intensity, driftActive));
     setData(root, 'flowHeat', heatTier(flow.intensity, flowActive));
     setData(root, 'gaugeHeat', heatTier(driftGaugeIntensity, driftGaugeActive));


### PR DESCRIPTION
Closes #771

## Summary
- keeps DRIFT and FLOW gauge shells extended whenever their current combo multiplier is x2 or higher, even when the fill itself is at zero
- preserves the existing cyan/pink zero-residue instead of making an active combo look like it disappeared
- returns to the existing 180 ms retract behavior as soon as the combo drops below x2
- publishes DRIFT chain expiry back to ScoreFeedback so an x2+ held gauge does not remain stale after the 1.4 s link window ends
- progressively increases DRIFT cyan / FLOW pink saturation from muted x1 through fully saturated x8; fractional FLOW multipliers use the floored whole tier
- applies the same tier colour to the fill and zero residue without CSS filters or any new timer/render loop

## Performance / accessibility
- reuses the existing throttled ScoreFeedback commit path
- colour updates are CSS custom-property writes guarded against redundant values
- no new animation loop, observer, timer or scoring sampler
- multiplier text remains the authoritative non-colour combo indication
- reduced-motion behavior is unchanged

## Scope / concurrency
This intentionally touches only scoring presentation/core regression files (`score-feedback.js`, `drift-attack.js`, and their focused tests). It does not touch the drive pad, BRAKE/REVERSE controls, app shell, release metadata, index markup, or the work currently separating BRAKE and REVERSE.

## Verification
The existing CI workflow will run the shared ScoreFeedback and DRIFT core regressions, including new coverage for:
- zero-fill x2+ persistence
- x1 retraction
- DRIFT/FLOW saturation tiers
- fractional FLOW tier flooring
- DRIFT chain-expiry presentation reset

Release/cache identity is deliberately left untouched here to avoid colliding with the concurrent BRAKE/REVERSE work; this can be folded into that work's next release bump if desired.