### PR TITLE
TURN: rebalance APEX GRIP and TORQUE around OVERCHARGE

### DIFF
--- a/turn-lab/tests/trophy-road-production.mjs
+++ b/turn-lab/tests/trophy-road-production.mjs
@@ -221,10 +221,21 @@ assert.match(futurePerk?.description || '', /<strong>OVERDRIVE:<\/strong>/);
 const racePerk = getProductionTrophyRoadReward('race-car');
 assert.equal(racePerk?.threshold, 1100);
 assert.equal(racePerk?.perkTitle, 'APEX GRIP');
-assert.equal(racePerk?.perkDescription, 'Increased CONTROL when OVERCHARGED.');
+assert.equal(racePerk?.perkDescription,
+  'OVERCHARGE increases CONTROL and ACCELERATION beyond their ordinary limits.');
 assert.match(racePerk?.description || '', /<strong>APEX GRIP:<\/strong>/);
 assert.equal(getCarDefinition('race').perk?.title, 'APEX GRIP');
-assert.equal(getCarDefinition('race').perk?.description, 'Increased CONTROL when OVERCHARGED.');
+assert.equal(getCarDefinition('race').perk?.description,
+  'OVERCHARGE increases CONTROL and ACCELERATION beyond their ordinary limits.');
+
+const torquePerk = getProductionTrophyRoadReward('truck-torque');
+assert.equal(torquePerk?.threshold, 800);
+assert.equal(torquePerk?.perkTitle, 'TORQUE');
+assert.equal(torquePerk?.perkDescription,
+  'OVERCHARGE increases ACCELERATION and builds BOOST TANK up to 5/5.');
+assert.match(torquePerk?.description || '', /<strong>TORQUE<\/strong>/);
+assert.equal(getCarDefinition('truck').perk?.description,
+  'OVERCHARGE increases ACCELERATION and builds BOOST TANK up to 5/5.');
 
 const emergencyPerk = getProductionTrophyRoadReward('emergency-pack');
 assert.equal(emergencyPerk?.perkTitle, 'SIRENS');
@@ -649,4 +660,4 @@ assert.match(enhancementRuntime, /installLotPerkDisclosure/);
 assert.match(enhancementRuntime, /lot-perk-disclosure\.js\?revision=r243-mountain-1300/);
 assert.match(enhancementRuntime, /lot-trophy-gate\.js\?revision=r243-mountain-1300/);
 
-console.log('TURN Trophy Road Race Car slot migration, APEX GRIP, reward order and perk presentation regression passed.');
+console.log('TURN Trophy Road Race Car slot migration, APEX GRIP, TORQUE, reward order and perk presentation regression passed.');

--- a/turn-lab/tests/vehicle-drift-production.mjs
+++ b/turn-lab/tests/vehicle-drift-production.mjs
@@ -9,6 +9,7 @@ import {
   getVehicleSpeedLimit,
   resolveDriftSpeedMultiplier,
   resolveOverchargedControlMultiplier,
+  resolveVehicleOverchargedAccelerationMultiplier,
   updateVehicleOverdriveState,
   vehicleHasOverdrive,
   vehicleIgnoresOffRoadPenalty
@@ -286,11 +287,16 @@ const raceCar = CAR_CATALOG.find((car) => car.id === 'race');
 assert.ok(raceCar, 'Race Car must remain in the vehicle catalog');
 assert.equal(raceCar.defaultColor, '#5d503f', 'Race Car factory paint must be the current brown');
 assert.equal(raceCar.perk?.title, 'APEX GRIP');
-assert.equal(raceCar.perk?.description, 'Increased CONTROL when OVERCHARGED.');
+assert.equal(raceCar.perk?.description,
+  'OVERCHARGE increases CONTROL and ACCELERATION beyond their ordinary limits.');
 assert.equal(raceCar.tuning.controlMultiplier, 1.07,
   'Race Car must retain its ordinary 4/5 CONTROL tuning when it is not OVERCHARGED');
 assert.equal(raceCar.tuning.overchargeControlMultiplier, 1.21,
   'APEX GRIP must extend the established CONTROL curve one tier beyond its visible 5/5 ceiling');
+assert.equal(raceCar.tuning.accelerationMultiplier, 1.08,
+  'Race Car must retain its ordinary 4/5 ACCELERATION tuning outside OVERCHARGE');
+assert.equal(raceCar.tuning.overchargeAccelerationMultiplier, 1.24,
+  'APEX GRIP ACCELERATION must extend the established curve one tier beyond visible 5/5');
 assert.equal(resolveOverchargedControlMultiplier({
   controlMultiplier: raceCar.tuning.controlMultiplier,
   overchargeControlMultiplier: raceCar.tuning.overchargeControlMultiplier,
@@ -301,22 +307,75 @@ assert.equal(resolveOverchargedControlMultiplier({
   overchargeControlMultiplier: raceCar.tuning.overchargeControlMultiplier,
   overcharge: 0.001
 }), 1.21,
-  'Any live OVERCHARGE must activate APEX GRIP without requiring a separate catch flag');
+  'Any live OVERCHARGE must activate APEX GRIP CONTROL without requiring a separate catch flag');
+assert.equal(resolveVehicleOverchargedAccelerationMultiplier({
+  vehicleId: raceCar.id,
+  accelerationMultiplier: raceCar.tuning.accelerationMultiplier,
+  overchargeAccelerationMultiplier: raceCar.tuning.overchargeAccelerationMultiplier,
+  overcharge: 0
+}), 1.08);
+assert.equal(resolveVehicleOverchargedAccelerationMultiplier({
+  vehicleId: raceCar.id,
+  accelerationMultiplier: raceCar.tuning.accelerationMultiplier,
+  overchargeAccelerationMultiplier: raceCar.tuning.overchargeAccelerationMultiplier,
+  overcharge: 0.001
+}), 1.24,
+  'Any live OVERCHARGE must immediately activate APEX GRIP ACCELERATION');
+const visibleFiveAcceleration = deriveVehicleTuning({ ...raceCar.stats, acceleration: 5 }).accelerationMultiplier;
+assert.equal(visibleFiveAcceleration, 1.16);
+assert.equal(resolveVehicleOverchargedAccelerationMultiplier({
+  vehicleId: raceCar.id,
+  accelerationMultiplier: visibleFiveAcceleration,
+  overchargeAccelerationMultiplier: raceCar.tuning.overchargeAccelerationMultiplier,
+  overcharge: 1
+}), 1.24,
+  'APEX GRIP ACCELERATION must still exceed a visible 5/5 STANDARD or SHIFT baseline');
 for (const car of CAR_CATALOG.filter((candidate) => candidate.id !== 'race')) {
   assert.equal(resolveOverchargedControlMultiplier({
     controlMultiplier: car.tuning.controlMultiplier,
     overchargeControlMultiplier: car.tuning.overchargeControlMultiplier,
     overcharge: 1
-  }), car.tuning.controlMultiplier, `${car.name} must not inherit APEX GRIP`);
+  }), car.tuning.controlMultiplier, `${car.name} must not inherit APEX GRIP CONTROL`);
 }
 assert.match(mainSource, /boostOvercharge: globalThis\.__turnBoostOvercharge \|\| 0/,
   'The current OVERCHARGE amount must reach vehicle physics every frame');
-assert.match(physicsSource, /state\.apexGripActive = controlMultiplier > baseControlMultiplier/,
-  'Physics must expose whether the selected tuning is actively receiving APEX GRIP');
+assert.match(physicsSource, /state\.apexGripActive = String\(state\.vehicleId \|\| ''\) === 'race'/,
+  'Physics must expose whether Race Car is actively receiving APEX GRIP');
 
 const truck = CAR_CATALOG.find((car) => car.id === 'truck');
 assert.ok(truck, 'Truck must remain in the vehicle catalog');
 assert.equal(truck.defaultColor, '#b93632', 'Truck factory paint must be the former Race Car red');
+assert.equal(truck.perk?.description,
+  'OVERCHARGE increases ACCELERATION and builds BOOST TANK up to 5/5.');
+assert.equal(truck.tuning.overchargeAccelerationMultiplier, 1.24,
+  'TORQUE must use the same beyond-5/5 ACCELERATION target as APEX GRIP');
+assert.equal(resolveVehicleOverchargedAccelerationMultiplier({
+  vehicleId: truck.id,
+  perkUnlocked: false,
+  accelerationMultiplier: truck.tuning.accelerationMultiplier,
+  overchargeAccelerationMultiplier: truck.tuning.overchargeAccelerationMultiplier,
+  overcharge: 1
+}), truck.tuning.accelerationMultiplier,
+  'Locked TORQUE must not change ACCELERATION');
+assert.equal(resolveVehicleOverchargedAccelerationMultiplier({
+  vehicleId: truck.id,
+  perkUnlocked: true,
+  accelerationMultiplier: truck.tuning.accelerationMultiplier,
+  overchargeAccelerationMultiplier: truck.tuning.overchargeAccelerationMultiplier,
+  overcharge: 0.001
+}), 1.24,
+  'Unlocked TORQUE must immediately apply the APEX-style ACCELERATION buff on any live OVERCHARGE');
+for (const car of CAR_CATALOG.filter((candidate) => candidate.id !== 'race' && candidate.id !== 'truck')) {
+  assert.equal(resolveVehicleOverchargedAccelerationMultiplier({
+    vehicleId: car.id,
+    perkUnlocked: true,
+    accelerationMultiplier: car.tuning.accelerationMultiplier,
+    overchargeAccelerationMultiplier: car.tuning.overchargeAccelerationMultiplier,
+    overcharge: 1
+  }), car.tuning.accelerationMultiplier, `${car.name} must not inherit the OVERCHARGE ACCELERATION perk`);
+}
+assert.match(physicsSource, /state\.torqueActive = String\(state\.vehicleId \|\| ''\) === 'truck'/,
+  'Physics must expose whether unlocked TORQUE is actively receiving its OVERCHARGE ACCELERATION buff');
 
 assert.match(
   showcaseSource,
@@ -468,4 +527,4 @@ for (const car of CAR_CATALOG) {
   }
 }
 
-console.log('TURN all-car attribute-to-physics integrity, APEX GRIP, DRIFTAGE, TWITCHY TURNY, OVERSIZED and OVERDRIVE contracts passed for all 15 cars.');
+console.log('TURN all-car attribute-to-physics integrity, APEX GRIP, TORQUE, DRIFTAGE, TWITCHY TURNY, OVERSIZED and OVERDRIVE contracts passed for all 15 cars.');

--- a/turn-lab/tests/vehicle-perks-production.mjs
+++ b/turn-lab/tests/vehicle-perks-production.mjs
@@ -18,7 +18,6 @@ import {
   GRADUATED_TOTAL_SECONDS,
   STANDARD_LOCK_DRAG_ADD,
   TORQUE_BUILD_SECONDS,
-  TORQUE_DECAY_SECONDS,
   TRACTION_MIN_OFFROAD_PENALTY,
   advanceVehiclePerkRuntimeState,
   resetVehiclePerkRuntimeState,
@@ -65,6 +64,8 @@ assert.ok(awd && truck && van && suv && sportsCar && learner,
   'Every dynamic-perk car must remain in the canonical catalog');
 assert.equal(awd.perk?.title, 'TRACTION');
 assert.equal(truck.perk?.title, 'TORQUE');
+assert.equal(truck.perk?.description,
+  'OVERCHARGE increases ACCELERATION and builds BOOST TANK up to 5/5.');
 assert.equal(van.perk?.title, 'CARRY ON');
 
 // TRACTION is a partial shoulder-depth curve, never an OVERSIZED-style exemption.
@@ -124,37 +125,71 @@ const partialLimit = getVehicleSpeedLimit({
 assert.ok(Math.abs(partialLimit - (100 + (73 - 100) * shallowPenalty)) < 1e-12,
   'The AWD shoulder factor must blend the real speed ceiling rather than toggle a cosmetic state');
 
-// TORQUE is runtime-only, builds under ordinary GAS, decays on release and always
-// recomposes from the currently active STANDARD/SHIFT tuning.
+// TORQUE is activated by OVERCHARGE, not sustained GAS. OVERCHARGE immediately
+// unlocks the acceleration perk in physics while runtime progress grows only the
+// normalized BOOST TANK capacity toward 5/5 from the active STANDARD/SHIFT base.
 const lockedTruck = perkState(truck.id, false, truck.tuning);
 lockedTruck.vehiclePerkProgress = 1;
-advanceVehiclePerkRuntimeState({ state: lockedTruck, dt: 0.1, gasHeld: true });
+advanceVehiclePerkRuntimeState({ state: lockedTruck, dt: 0.1, overcharge: 0.4 });
 assert.equal(lockedTruck.vehiclePerkProgress, 0);
 assert.equal(resolveVehiclePerkTuning({ state: lockedTruck, tuning: truck.tuning }), truck.tuning,
   'Locked TORQUE must return the exact ordinary tuning object');
 
 const torqueTruck = perkState(truck.id, true, truck.tuning);
 advanceForSeconds(torqueTruck, TORQUE_BUILD_SECONDS, { gasHeld: true });
+assert.equal(torqueTruck.vehiclePerkProgress, 0,
+  'Holding GAS by itself must no longer build TORQUE');
+advanceForSeconds(torqueTruck, TORQUE_BUILD_SECONDS, { overcharge: 0.4 });
 assert.equal(torqueTruck.vehiclePerkProgress, 1);
-assert.equal(
-  resolveVehiclePerkTuning({ state: torqueTruck, tuning: truck.tuning }).accelerationMultiplier,
-  deriveVehicleTuning({ ...truck.stats, acceleration: 5 }).accelerationMultiplier,
-  'Sustained GAS must build Truck acceleration to the canonical 5/5 effect'
-);
-advanceForSeconds(torqueTruck, TORQUE_DECAY_SECONDS, { gasHeld: false });
-assert.ok(torqueTruck.vehiclePerkProgress <= 1e-12, 'Releasing GAS must smoothly remove TORQUE');
+const maxTorqueTank = resolveVehiclePerkTuning({ state: torqueTruck, tuning: truck.tuning });
+assert.equal(maxTorqueTank.accelerationMultiplier, truck.tuning.accelerationMultiplier,
+  'TORQUE tank progress must not recreate the old gradual ACCELERATION ramp');
+assert.equal(maxTorqueTank.boostDurationSeconds, 3.74,
+  'TORQUE must progressively grow BOOST TANK capacity to the canonical 5/5 ceiling');
 
-const shiftOneTuning = deriveVehicleTuning({ ...truck.stats, acceleration: 1 });
-const shiftFourTuning = deriveVehicleTuning({ ...truck.stats, acceleration: 4 });
-const shiftingTruck = perkState(truck.id, true, shiftOneTuning);
-advanceForSeconds(shiftingTruck, TORQUE_BUILD_SECONDS / 2, { gasHeld: true });
+advanceVehiclePerkRuntimeState({
+  state: torqueTruck,
+  dt: 0.1,
+  overcharge: 0,
+  boostActive: true
+});
+assert.equal(torqueTruck.vehiclePerkProgress, 1,
+  'Spending OVERCHARGE through one continuous BOOST must retain the built tank reserve');
+advanceVehiclePerkRuntimeState({
+  state: torqueTruck,
+  dt: 0.1,
+  overcharge: 0,
+  boostActive: false
+});
+assert.equal(torqueTruck.vehiclePerkProgress, 0,
+  'Once OVERCHARGE and its continuous BOOST spend are over, TORQUE must return to baseline');
+assert.equal(resolveVehiclePerkTuning({ state: torqueTruck, tuning: truck.tuning }), truck.tuning);
+
+const shiftOneTankTuning = deriveVehicleTuning({ ...truck.stats, boostDuration: 1 });
+const shiftFourTankTuning = deriveVehicleTuning({ ...truck.stats, boostDuration: 4 });
+const shiftingTruck = perkState(truck.id, true, shiftOneTankTuning);
+advanceForSeconds(shiftingTruck, TORQUE_BUILD_SECONDS / 2, { overcharge: 0.3 });
 const retainedProgress = shiftingTruck.vehiclePerkProgress;
-const fromOne = resolveVehiclePerkTuning({ state: shiftingTruck, tuning: shiftOneTuning }).accelerationMultiplier;
-const fromFour = resolveVehiclePerkTuning({ state: shiftingTruck, tuning: shiftFourTuning }).accelerationMultiplier;
+const fromOneTank = resolveVehiclePerkTuning({
+  state: shiftingTruck,
+  tuning: shiftOneTankTuning
+}).boostDurationSeconds;
+const fromFourTank = resolveVehiclePerkTuning({
+  state: shiftingTruck,
+  tuning: shiftFourTankTuning
+}).boostDurationSeconds;
 assert.equal(shiftingTruck.vehiclePerkProgress, retainedProgress,
-  'Changing SHIFT baseline must preserve the live TORQUE progress fraction');
-assert.ok(fromFour > fromOne && fromFour < 1.16,
-  'TORQUE must immediately recompose from the new active base without a stale multiplier');
+  'Changing SHIFT baseline must preserve the live TORQUE tank-build fraction');
+assert.ok(fromFourTank > fromOneTank && fromFourTank < 3.74,
+  'TORQUE must immediately recompose tank growth from the new active STANDARD/SHIFT base');
+assert.match(physicsSource,
+  /advanceVehiclePerkRuntimeState\(\{[\s\S]*overcharge: boostOvercharge,[\s\S]*boostActive: effectiveBoostActive/,
+  'Vehicle physics must feed live OVERCHARGE and BOOST-spend state into TORQUE');
+assert.match(controlsSource,
+  /vehicleEffectiveTuning\?\.boostDurationSeconds[\s\S]*__turnVehicleTuning\?\.boostDurationSeconds/,
+  'Boost consumption must read TORQUE’s effective tank capacity before the ordinary base capacity');
+assert.match(controlsSource, /globalThis\.__turnBoostCharge = boostCharge/,
+  'Growing TORQUE capacity must preserve normalized charge instead of manufacturing Boost');
 
 // CARRY ON changes only the explicit LOCK drag term. Rotation, grip, slide and
 // ordinary DRIFT stay in the shared physics path.

--- a/turn/progression/trophy-road.js
+++ b/turn/progression/trophy-road.js
@@ -54,8 +54,8 @@ const TROPHY_ROAD_REWARD_DEFINITIONS = Object.freeze([
     vehicleIds: Object.freeze(['race']),
     icon: 'race',
     perkTitle: 'APEX GRIP',
-    perkDescription: 'Increased CONTROL when OVERCHARGED.',
-    description: 'Unlock the Race Car: high-speed handling built for precise lines.<br><strong>APEX GRIP:</strong> Increased CONTROL when OVERCHARGED.'
+    perkDescription: 'OVERCHARGE increases CONTROL and ACCELERATION beyond their ordinary limits.',
+    description: 'Unlock the Race Car: high-speed handling built for precise lines.<br><strong>APEX GRIP:</strong> OVERCHARGE increases CONTROL and ACCELERATION beyond their ordinary limits.'
   }),
   Object.freeze({
     id: 'emergency-pack',
@@ -138,8 +138,8 @@ const TROPHY_ROAD_REWARD_DEFINITIONS = Object.freeze([
     vehicleId: 'truck',
     icon: 'perk',
     perkTitle: 'TORQUE',
-    perkDescription: 'ACCELERATION builds while GAS is held, up to 5/5.',
-    description: 'Unlock <strong>TORQUE</strong> for Truck. ACCELERATION builds while GAS is held, up to 5/5.'
+    perkDescription: 'OVERCHARGE increases ACCELERATION and builds BOOST TANK up to 5/5.',
+    description: 'Unlock <strong>TORQUE</strong> for Truck. OVERCHARGE increases ACCELERATION and builds BOOST TANK up to 5/5.'
   }),
   Object.freeze({
     id: 'van-carry-on',

--- a/turn/vehicle/catalog.js
+++ b/turn/vehicle/catalog.js
@@ -132,7 +132,7 @@ const VEHICLE_PERK_BY_ID = Object.freeze({
   }),
   race: Object.freeze({
     title: 'APEX GRIP',
-    description: 'Increased CONTROL when OVERCHARGED.'
+    description: 'OVERCHARGE increases CONTROL and ACCELERATION beyond their ordinary limits.'
   }),
   'sedan-sports': Object.freeze({
     title: 'DRIFT DEMON',
@@ -154,7 +154,7 @@ const VEHICLE_PERK_BY_ID = Object.freeze({
   }),
   truck: Object.freeze({
     title: 'TORQUE',
-    description: 'ACCELERATION builds while GAS is held, up to 5/5.',
+    description: 'OVERCHARGE increases ACCELERATION and builds BOOST TANK up to 5/5.',
     rewardId: 'truck-torque',
     threshold: 800
   }),
@@ -185,7 +185,11 @@ const TUNING_OVERRIDE_BY_ID = Object.freeze({
     driftBoostRechargeMultiplier: 3.6
   }),
   race: Object.freeze({
-    overchargeControlMultiplier: 1.21
+    overchargeControlMultiplier: 1.21,
+    overchargeAccelerationMultiplier: 1.24
+  }),
+  truck: Object.freeze({
+    overchargeAccelerationMultiplier: 1.24
   }),
   van: Object.freeze({
     lockDragAdd: 0.07

--- a/turn/vehicle/perk-runtime.js
+++ b/turn/vehicle/perk-runtime.js
@@ -4,7 +4,6 @@ export const TRACTION_MIN_OFFROAD_PENALTY = 0.22;
 export const TRACTION_SHALLOW_DEPTH_RATIO = 0.08;
 export const TRACTION_DEEP_DEPTH_RATIO = 0.42;
 export const TORQUE_BUILD_SECONDS = 3.2;
-export const TORQUE_DECAY_SECONDS = 1.4;
 export const CARRY_ON_LOCK_DRAG_ADD = 0.07;
 export const STANDARD_LOCK_DRAG_ADD = 0.18;
 export const FULL_TANK_BUILD_SECONDS = 8;
@@ -133,21 +132,28 @@ export function resolveVehicleLockDragAdd({
 export function advanceVehiclePerkRuntimeState({
   state,
   dt = 0,
-  gasHeld = false,
   driftHeld = false,
   offRoad = false,
   collided = false,
-  speed = state?.speed || 0
+  speed = state?.speed || 0,
+  overcharge = 0,
+  boostActive = false
 } = {}) {
   if (!state) return 0;
   syncVehiclePerkRuntimeState(state);
 
   const elapsed = clamp(dt, 0, 0.1);
   if (activePerk(state, 'truck')) {
-    const delta = gasHeld
-      ? elapsed / TORQUE_BUILD_SECONDS
-      : -elapsed / TORQUE_DECAY_SECONDS;
-    state.vehiclePerkProgress = clampProgress(state.vehiclePerkProgress + delta);
+    if ((Number(overcharge) || 0) > 0) {
+      state.vehiclePerkProgress = clampProgress(
+        state.vehiclePerkProgress + elapsed / TORQUE_BUILD_SECONDS
+      );
+    } else if (boostActive !== true) {
+      // If OVERCHARGE is spent through BOOST, keep the built tank for that
+      // continuous BOOST use. Leaking/ending OVERCHARGE or releasing BOOST
+      // restores the active STANDARD/SHIFT baseline immediately.
+      state.vehiclePerkProgress = 0;
+    }
   } else if (activePerk(state, 'suv')) {
     if (offRoad || collided) {
       state.vehiclePerkProgress = 0;
@@ -199,9 +205,9 @@ export function resolveVehiclePerkTuning({ state, tuning } = {}) {
     ? { ...baseTuning }
     : Object.assign(state.vehicleEffectiveTuning, baseTuning);
   if (torqueActive) {
-    effective.accelerationMultiplier = lerp(
-      Number(baseTuning.accelerationMultiplier) || 1,
-      MAX_ATTRIBUTE_TUNING.accelerationMultiplier,
+    effective.boostDurationSeconds = lerp(
+      Number(baseTuning.boostDurationSeconds) || MAX_ATTRIBUTE_TUNING.boostDurationSeconds,
+      MAX_ATTRIBUTE_TUNING.boostDurationSeconds,
       progress
     );
   }

--- a/turn/vehicle/physics.js
+++ b/turn/vehicle/physics.js
@@ -44,6 +44,26 @@ export function resolveOverchargedControlMultiplier({
   );
 }
 
+export function resolveVehicleOverchargedAccelerationMultiplier({
+  vehicleId = '',
+  perkUnlocked = false,
+  accelerationMultiplier = 1,
+  overchargeAccelerationMultiplier = accelerationMultiplier,
+  overcharge = 0
+} = {}) {
+  const baseAccelerationMultiplier = positiveNumber(accelerationMultiplier, 1);
+  const normalizedVehicleId = String(vehicleId || '');
+  const ownsOverchargeAcceleration = normalizedVehicleId === 'race'
+    || (normalizedVehicleId === 'truck' && perkUnlocked === true);
+  if (!ownsOverchargeAcceleration || nonNegativeNumber(overcharge, 0) <= 0) {
+    return baseAccelerationMultiplier;
+  }
+  return Math.max(
+    baseAccelerationMultiplier,
+    positiveNumber(overchargeAccelerationMultiplier, baseAccelerationMultiplier)
+  );
+}
+
 export function updateVehicleOverdriveState({
   state,
   dt = 0,
@@ -156,14 +176,26 @@ function updateVehiclePhysicsStateCore({
 
   const baseTuning = vehicleTuning || globalThis.__turnVehicleTuning;
   const tuning = resolveVehiclePerkTuning({ state, tuning: baseTuning });
-  const accelerationMultiplier = positiveNumber(tuning?.accelerationMultiplier, 1);
+  const baseAccelerationMultiplier = positiveNumber(tuning?.accelerationMultiplier, 1);
+  const accelerationMultiplier = resolveVehicleOverchargedAccelerationMultiplier({
+    vehicleId: state.vehicleId,
+    perkUnlocked: state.vehiclePerkUnlocked,
+    accelerationMultiplier: baseAccelerationMultiplier,
+    overchargeAccelerationMultiplier: tuning?.overchargeAccelerationMultiplier,
+    overcharge: boostOvercharge
+  });
   const baseControlMultiplier = positiveNumber(tuning?.controlMultiplier, 1);
   const controlMultiplier = resolveOverchargedControlMultiplier({
     controlMultiplier: baseControlMultiplier,
     overchargeControlMultiplier: tuning?.overchargeControlMultiplier,
     overcharge: boostOvercharge
   });
-  state.apexGripActive = controlMultiplier > baseControlMultiplier;
+  state.apexGripActive = String(state.vehicleId || '') === 'race'
+    && (controlMultiplier > baseControlMultiplier
+      || accelerationMultiplier > baseAccelerationMultiplier);
+  state.torqueActive = String(state.vehicleId || '') === 'truck'
+    && state.vehiclePerkUnlocked === true
+    && accelerationMultiplier > baseAccelerationMultiplier;
   const driftEngineMultiplier = positiveNumber(tuning?.driftEngineMultiplier, 0.86);
   const driftDragAdd = nonNegativeNumber(tuning?.driftDragAdd, 0.1);
   const driftSpeedMultiplier = clamp(positiveNumber(tuning?.driftSpeedMultiplier, 0.84), 0.5, 0.99);
@@ -396,7 +428,8 @@ function updateVehiclePhysicsStateCore({
   advanceVehiclePerkRuntimeState({
     state,
     dt,
-    gasHeld: driveThrottle > 0 && !driftHeld && !effectiveBoostActive,
+    overcharge: boostOvercharge,
+    boostActive: effectiveBoostActive,
     driftHeld,
     offRoad: state.offRoad,
     collided: collision.collided,


### PR DESCRIPTION
Closes #770

## What changed
- APEX GRIP keeps its existing beyond-5/5 CONTROL buff and now gives ACCELERATION the same kind of immediate OVERCHARGE-only boost
- APEX GRIP ACCELERATION reaches 1.24, one tuning tier beyond the visible 5/5 ACCELERATION ceiling of 1.16
- TORQUE removes the old sustained-GAS acceleration ramp entirely
- unlocked TORQUE now receives the same immediate 1.24 ACCELERATION target whenever OVERCHARGE is live
- TORQUE progressively grows BOOST TANK capacity from the active STANDARD/SHIFT baseline toward canonical 5/5 while OVERCHARGED
- because BOOST charge is already normalized 0..1, a full tank remains 100% full as capacity grows; no charge is manufactured
- if OVERCHARGE is spent directly through BOOST, the built capacity is retained for that one continuous BOOST spend, then returns to the active baseline when the spend ends
- canonical Lot/Trophy Road perk copy now describes the new behavior

## Design intent
GAS is not a second activation gate. OVERCHARGE owns the temporary ACCELERATION buff; catching it with GAS simply makes that higher ACCELERATION immediately useful. This makes catching OVERCHARGE a real alternative to instantly cashing it into BOOST.

## Regression coverage
- Race Car keeps ordinary 4/5 CONTROL + ACCELERATION outside OVERCHARGE
- APEX GRIP CONTROL remains 1.21 and ACCELERATION becomes 1.24 during any live OVERCHARGE
- APEX GRIP ACCELERATION still exceeds a visible 5/5 STANDARD/SHIFT baseline
- locked TORQUE has no effect
- GAS alone no longer builds TORQUE
- TORQUE ACCELERATION is immediate rather than progressive
- TORQUE tank growth caps at canonical 5/5 and recomposes from SHIFT baselines
- continuous BOOST can consume the built reserve after OVERCHARGE is spent
- ending OVERCHARGE/BOOST returns cleanly to the active baseline

## Concurrency
This was branched from current `main` after #773. It deliberately does **not** touch `turn/ui/gameplay-controls.js`, the drive-pad UI, BRAKE/REVERSE controls, `main.js`, or release metadata. The small physics changes are confined to OVERCHARGE acceleration resolution near tuning setup and the perk-runtime state sync at the end of the physics step, leaving Work’s BRAKE/REVERSE implementation area alone.