### PR TITLE
TURN: carry DRIFT and FLOW through lap finish

### DIFF
--- a/turn-tests/drift-attack-core-production.mjs
+++ b/turn-tests/drift-attack-core-production.mjs
@@ -93,6 +93,61 @@ assert.equal(lapResult.score, bankedBeforeLoss);
 assert.equal(lapResult.bankCount, 1);
 assert.equal(scorer.inspect().lapScore, 0, 'Completing a lap starts a fresh DRIFT tally');
 
+const continuityEvents = [];
+const continuityStates = [];
+const continuityScorer = createDriftAttackScorer({
+  onEvent: (type, detail) => continuityEvents.push({ type, detail }),
+  onState: (snapshot) => continuityStates.push({ ...snapshot })
+});
+continuityScorer.beginLap(0);
+let continuityNow = runFor(continuityScorer, 0.9, 1 / 60);
+continuityNow = runFor(continuityScorer, 0.4, 1 / 60, {
+  slip: radians(4),
+  startAt: continuityNow
+});
+continuityNow = runFor(continuityScorer, 0.9, 1 / 60, {
+  slip: radians(-62),
+  startAt: continuityNow
+});
+const beforeFinish = continuityScorer.inspect();
+assert.equal(beforeFinish.drifting, true);
+assert.equal(beforeFinish.multiplier, 2,
+  'The continuity fixture must cross the line in an active x2 drift');
+assert.ok(beforeFinish.unbanked > 0);
+assert.ok(beforeFinish.feedback.intensity > 0);
+const finishResult = continuityScorer.completeLap(continuityNow);
+const afterFinish = continuityScorer.inspect();
+assert.ok(finishResult.score >= beforeFinish.lapScore + beforeFinish.unbanked - 1,
+  'The completed lap must bank the active DRIFT earned up to the finish crossing');
+assert.equal(finishResult.bankCount, 2,
+  'The finish split counts as a bank for the completed lap without ending the live drift');
+assert.equal(afterFinish.lapScore, 0, 'The new lap DRIFT total starts from zero');
+assert.equal(afterFinish.unbanked, 0, 'The carried drift starts a fresh per-lap segment at the line');
+assert.equal(afterFinish.drifting, true, 'Crossing the line must not end an active drift');
+assert.equal(afterFinish.multiplier, beforeFinish.multiplier, 'DRIFT combo must survive the lap boundary');
+assert.equal(afterFinish.driftSeconds, beforeFinish.driftSeconds,
+  'Ongoing drift duration must survive so post-line scoring keeps the same build rate');
+assert.equal(afterFinish.feedback.active, true);
+assert.equal(afterFinish.feedback.score, 0);
+assert.equal(afterFinish.feedback.unbanked, 0);
+assert.equal(afterFinish.feedback.intensity, beforeFinish.feedback.intensity,
+  'The visible DRIFT gauge intensity must not collapse at the finish line');
+assert.ok(continuityEvents.some((event) =>
+  event.type === SCORE_FEEDBACK_EVENT.BANK
+    && event.detail.reason === 'lap'
+    && event.detail.announce === false
+), 'The finish split must expose a silent semantic DRIFT bank for FLOW and lap accounting');
+continuityNow = runFor(continuityScorer, 0.2, 1 / 60, {
+  slip: radians(-62),
+  startAt: continuityNow
+});
+assert.ok(continuityScorer.inspect().unbanked > 0,
+  'The continuing drift must immediately earn points for the new lap');
+assert.equal(continuityScorer.inspect().multiplier, 2);
+assert.ok(continuityScorer.inspect().driftSeconds > beforeFinish.driftSeconds,
+  'The ongoing drift must continue from its pre-line duration rather than restart its intensity curve');
+assert.equal(continuityStates.at(-1)?.active, true);
+
 const hysteresisScorer = createDriftAttackScorer();
 hysteresisScorer.beginLap(0);
 let hysteresisNow = runFor(hysteresisScorer, 1, 1 / 60);

--- a/turn-tests/flow-production.mjs
+++ b/turn-tests/flow-production.mjs
@@ -95,6 +95,51 @@ assert.ok(firstLap.score > 0);
 assert.ok(scorer.acceptTechnique({ technique: 'drift', token: 'DRIFT', basePoints: 50, now: 6100 }),
   'Completing one lap must immediately arm FLOW for the next continuous lap');
 
+const continuityStates = [];
+const continuityScorer = createFlowScorer({
+  onState: (snapshot) => continuityStates.push({ ...snapshot, tokens: [...snapshot.tokens] })
+});
+continuityScorer.beginLap(0);
+continuityScorer.acceptTechnique({ technique: 'drift', token: 'DRIFT', basePoints: 100, now: 100 });
+continuityScorer.acceptTechnique({ technique: 'boost', token: 'BOOST', basePoints: 100, now: 250 });
+continuityScorer.acceptTechnique({ technique: 'overcharge-catch', token: 'CATCH', basePoints: 100, now: 400 });
+const flowBeforeFinish = continuityScorer.inspect();
+const flowStateBeforeFinish = continuityStates.at(-1);
+assert.ok(flowBeforeFinish.multiplier > 1);
+assert.ok(flowStateBeforeFinish.intensity > 0);
+const continuityResult = continuityScorer.completeLap(500);
+const flowAfterFinish = continuityScorer.inspect();
+const flowStateAfterFinish = continuityStates.at(-1);
+assert.equal(continuityResult.score, flowBeforeFinish.lapScore,
+  'The completed lap must bank all FLOW earned up to the finish line');
+assert.equal(flowAfterFinish.lapScore, 0, 'The new lap FLOW total starts from zero');
+assert.equal(flowAfterFinish.multiplier, flowBeforeFinish.multiplier, 'FLOW combo must survive the lap boundary');
+assert.equal(flowAfterFinish.chainLength, flowBeforeFinish.chainLength,
+  'The live FLOW chain must remain continuous through the finish');
+assert.equal(flowAfterFinish.lastTechnique, flowBeforeFinish.lastTechnique);
+assert.equal(flowAfterFinish.lastTechniqueAt, flowBeforeFinish.lastTechniqueAt,
+  'The normal FLOW expiry deadline must remain anchored to the real last technique');
+assert.deepEqual(flowAfterFinish.tokens, flowBeforeFinish.tokens,
+  'FLOW technique history must not visually reset at the line');
+assert.equal(flowAfterFinish.techniqueCount, 0,
+  'Per-lap technique accounting must restart even while the chain itself carries');
+assert.equal(flowStateAfterFinish.active, true);
+assert.equal(flowStateAfterFinish.score, 0);
+assert.equal(flowStateAfterFinish.unbanked, 0);
+assert.equal(flowStateAfterFinish.multiplier, flowStateBeforeFinish.multiplier);
+assert.equal(flowStateAfterFinish.intensity, flowStateBeforeFinish.intensity,
+  'The FLOW gauge intensity must remain unchanged at lap completion');
+const firstNewLapTechnique = continuityScorer.acceptTechnique({
+  technique: 'shift',
+  token: 'SHIFT',
+  basePoints: 100,
+  now: 650
+});
+assert.ok(firstNewLapTechnique.awarded > 100,
+  'The first new-lap technique must benefit immediately from the carried FLOW combo');
+assert.equal(continuityScorer.inspect().lapScore, firstNewLapTechnique.awarded,
+  'Only post-line FLOW points belong to the new lap');
+
 const originalCustomEvent = globalThis.CustomEvent;
 globalThis.CustomEvent = TurnEvent;
 try {
@@ -123,6 +168,75 @@ try {
   assert.equal(dormantRuntime.isEnabled(), true,
     'The post-migration achievements-ready event must activate newly derived FLOW entitlement');
   assert.equal(dormantFeedback.visible, true);
+
+  const carryTarget = new EventTargetStub();
+  const carryFeedback = makeFeedback();
+  const carryTimers = new Map();
+  let nextCarryTimer = 1;
+  const carryRuntime = createFlowRuntime({
+    state: { lapActive: true, trackId: 'harbor', vehicleId: 'sedan' },
+    storage: new MemoryStorage(),
+    eventTarget: carryTarget,
+    scoreFeedback: carryFeedback,
+    isUnlocked: () => true,
+    setTimer(callback, delay) {
+      const id = nextCarryTimer;
+      nextCarryTimer += 1;
+      carryTimers.set(id, { callback, delay });
+      return id;
+    },
+    clearTimer(id) {
+      carryTimers.delete(id);
+    }
+  });
+  carryRuntime.beginLap(0);
+  carryTarget.emit('turn:drive-technique-state', {
+    zone: 'drift',
+    lockRequested: false,
+    at: 20
+  });
+  carryTarget.emit('turn:drift-score-event', { type: 'build', at: 40 });
+  carryTarget.emit('turn:boost-outcome', {
+    useful: true,
+    speedGain: 3,
+    duration: 1,
+    at: 400
+  });
+  carryTarget.emit('turn:drift-score-event', {
+    type: 'bank',
+    score: 650,
+    duration: 1.8,
+    reason: 'lap',
+    at: 900
+  });
+  const carriedFlowBefore = carryRuntime.scorer.inspect();
+  assert.ok(carriedFlowBefore.multiplier > 1,
+    'The lap-boundary DRIFT bank must be part of the completed FLOW chain');
+  assert.equal(carryTimers.size, 1, 'A live FLOW chain must own one expiry timer before the line');
+  const carriedResult = carryRuntime.completeLap({ now: 900, time: 48, valid: false, ranked: true });
+  const carriedFlowAfter = carryRuntime.scorer.inspect();
+  assert.equal(carriedResult.score, carriedFlowBefore.lapScore);
+  assert.equal(carriedFlowAfter.lapScore, 0);
+  assert.equal(carriedFlowAfter.multiplier, carriedFlowBefore.multiplier);
+  assert.equal(carriedFlowAfter.chainLength, carriedFlowBefore.chainLength);
+  assert.equal(carryTimers.size, 1,
+    'Completing a lap must not cancel the normal FLOW combo-expiry timer');
+  carryTarget.emit('turn:drive-technique-state', {
+    zone: 'drift',
+    lockRequested: true,
+    at: 1050
+  });
+  carryTarget.emit('turn:drift-score-event', {
+    type: 'bank',
+    score: 720,
+    duration: 2.1,
+    reason: 'exit',
+    at: 1500
+  });
+  assert.ok(carryRuntime.scorer.inspect().lapScore > 0,
+    'The continuing drift must score FLOW immediately on the new lap without another BUILD event');
+  assert.deepEqual(carryRuntime.scorer.inspect().tokens.slice(-3), ['LOCK', 'DRIFT', 'EXIT'],
+    'Post-line LOCK/DRIFT context must continue from the carried active drift');
 
   const state = { lapActive: true, trackId: 'mountain', vehicleId: 'sedan' };
   const storage = new MemoryStorage();
@@ -293,10 +407,17 @@ try {
   assert.equal(feedback.states.length, hiddenCommitCount,
     'Hidden FLOW presentation does not stop semantic scoring or perform HUD commits');
 
+  const beforeLapCompletion = runtime.scorer.inspect();
   const result = runtime.completeLap({ now: 11900, time: 52, valid: true, ranked: true });
   assert.ok(result.score > 0);
+  assert.equal(result.score, beforeLapCompletion.lapScore);
   assert.equal(result.newBest, true);
   assert.equal(result.maxMultiplier > 1, true);
+  assert.equal(runtime.scorer.inspect().lapScore, 0);
+  assert.equal(runtime.scorer.inspect().multiplier, beforeLapCompletion.multiplier,
+    'Runtime lap completion must preserve the active FLOW multiplier');
+  assert.equal(runtime.scorer.inspect().chainLength, beforeLapCompletion.chainLength,
+    'Runtime lap completion must preserve the active FLOW chain');
   assert.equal(getBestFlowRecord('mountain', storage).score, result.score);
   assert.equal(getBestFlowRecord('mountain', storage).hitAt, 123456);
   assert.ok(JSON.parse(storage.getItem(FLOW_RECORDS_STORAGE_KEY)).tracks.mountain);
@@ -310,11 +431,18 @@ const [flowSource, runtimeSource, controlsSource] = await Promise.all([
   fs.readFile(new URL('../turn/scoring/flow-runtime.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/ui/gameplay-controls.js', import.meta.url), 'utf8')
 ]);
+const runtimeCompleteLapSection = runtimeSource.slice(
+  runtimeSource.indexOf('function completeLap('),
+  runtimeSource.indexOf('function setHudVisible(')
+);
 assert.doesNotMatch(flowSource, /requestAnimationFrame|setInterval|querySelector|localStorage/);
 assert.doesNotMatch(runtimeSource, /requestAnimationFrame|setInterval|driftSlipAngle|velocity|heading/,
   'FLOW is event-driven and never re-analyzes vehicle drift');
 assert.match(runtimeSource, /turn:drift-score-event/);
 assert.match(runtimeSource, /turn:shift-outcome/);
+assert.doesNotMatch(runtimeCompleteLapSection, /clearChainTimer\(\)/,
+  'A lap finish must leave the active FLOW chain expiry timer running');
+assert.match(runtimeCompleteLapSection, /scorer\.completeLap\(now\)/);
 assert.match(controlsSource, /turn:boost-outcome/);
 assert.match(controlsSource, /turn:overcharge-catch/);
 assert.match(controlsSource, /reason === 'lap-started' \|\| reason === 'lap-completed'[\s\S]*resetScoringOutcomeTracking\(\{ continueBoost: true \}\)/,

--- a/turn/scoring/drift-attack.js
+++ b/turn/scoring/drift-attack.js
@@ -337,16 +337,55 @@ export function createDriftAttackScorer({ onState = null, onEvent = null } = {})
 
   function completeLap(now = 0) {
     const timestamp = finiteNumber(now);
-    if (drifting) bank(timestamp, 'lap');
+    const carriedPhase = feedbackState.phase;
+    const carriedIntensity = feedbackState.intensity;
+
+    if (drifting) {
+      const bankedExact = currentExact;
+      const bankedScore = Math.max(0, Math.round(bankedExact));
+      const bankedDirection = direction;
+      const duration = driftSeconds;
+
+      // The finish line is an accounting boundary, not a handling boundary.
+      // Credit everything earned before the crossing to the completed lap while
+      // leaving the live drift, combo, direction and duration intact for the next.
+      lapExact += bankedExact;
+      currentExact = 0;
+      if (bankedScore >= MIN_BANK_SCORE) {
+        bankCount += 1;
+        bestBank = Math.max(bestBank, bankedScore);
+        maxMultiplier = Math.max(maxMultiplier, multiplier);
+        emitEvent(SCORE_FEEDBACK_EVENT.BANK, {
+          score: bankedScore,
+          lapScore: Math.max(0, Math.round(lapExact)),
+          multiplier,
+          direction: bankedDirection,
+          duration,
+          reason: 'lap',
+          announce: false
+        }, timestamp);
+      }
+    }
+
     const result = Object.freeze({
       score: Math.max(0, Math.round(lapExact)),
       bankCount,
       bestBank,
       maxMultiplier
     });
+
     attemptActive = true;
-    resetLapValues();
-    syncFeedback(timestamp);
+    lapExact = 0;
+    currentExact = 0;
+    bankCount = 0;
+    bestBank = 0;
+    maxMultiplier = Math.max(1, multiplier);
+    syncFeedback(
+      timestamp,
+      drifting,
+      drifting ? carriedPhase : 'quiet',
+      drifting ? carriedIntensity : 0
+    );
     return result;
   }
 

--- a/turn/scoring/flow-runtime.js
+++ b/turn/scoring/flow-runtime.js
@@ -309,7 +309,13 @@ export function createFlowRuntime({
       accept('clean-exit', 'EXIT', clamp(18 + duration * 8, 20, 56), now, { outcome: 'controlled-transition' });
     }
     lastDriftBankAt = now;
-    driftContext = null;
+    driftContext = detail.reason === 'lap'
+      ? {
+          active: true,
+          usedLock: latestLockRequested,
+          contextualShift: null
+        }
+      : null;
   }
 
   function onBoostOutcome(event) {
@@ -401,7 +407,6 @@ export function createFlowRuntime({
     carId = state.vehicleId
   } = {}) {
     if (!enabled) return Object.freeze({ available: false });
-    clearChainTimer();
     const scoreResult = scorer.completeLap(now);
     const eligible = valid === true && ranked !== false;
     const previousBest = getBestFlowRecord(trackId, targetStorage);

--- a/turn/scoring/flow.js
+++ b/turn/scoring/flow.js
@@ -144,18 +144,24 @@ export function createFlowScorer({ onState = null, onTechnique = null } = {}) {
   }
 
   function completeLap(now = 0) {
+    const timestamp = finiteNumber(now);
+    const carriedPhase = feedbackState.phase;
     const result = Object.freeze({
       score: Math.max(0, Math.round(lapScore)),
       maxMultiplier,
       maxChain,
       techniqueCount
     });
-    // TURN laps continue immediately across the finish line. Match the DRIFT
-    // scorer by arming the next attempt here instead of waiting for another
-    // explicit race-start event that will not fire between ordinary laps.
+
+    // A lap boundary closes only the score ledger. Keep the live chain,
+    // multiplier, technique history and intensity so FLOW feels continuous
+    // through the line while the new lap starts counting from zero.
     attemptActive = true;
-    resetLapValues();
-    syncFeedback(now, 0, 'quiet');
+    lapScore = 0;
+    maxMultiplier = Math.max(1, multiplier);
+    maxChain = Math.max(0, chainLength);
+    techniqueCount = 0;
+    syncFeedback(timestamp, 0, carriedPhase);
     return result;
   }
 


### PR DESCRIPTION
Closes #775

## What changed
- completing a lap now banks the active DRIFT segment into the lap that just finished without ending the physical/scoring drift
- the new lap starts DRIFT at 0 while preserving multiplier, direction, accumulated drift duration and gauge intensity
- DRIFT duration is deliberately carried so ongoing post-line scoring keeps the same build rate rather than restarting its intensity curve
- FLOW now resets only per-lap score accounting at the line while preserving its live multiplier, chain, tokens, last-technique timing and gauge intensity
- FLOW's normal combo-expiry timer remains active across the lap boundary
- a lap-boundary DRIFT bank counts toward the completed FLOW lap, while the carried drift context remains alive so post-line LOCK/DRIFT can continue without a synthetic new BUILD event
- ordinary combo expiry/failure behavior is unchanged

## Regression coverage
- active x2 DRIFT banks into the completed lap, resets visible score to 0 and continues with identical multiplier/intensity/duration
- continued DRIFT after the line immediately scores only into the new lap
- active FLOW resets score to 0 but preserves multiplier, chain, tokens, timing and intensity
- first post-line FLOW technique uses the carried multiplier
- runtime preserves the FLOW expiry timer through completion
- DRIFT -> lap boundary -> post-line LOCK/DRIFT continuity works without a second BUILD event

## Concurrency
This branch starts at current `main` after #774. It only changes `turn/scoring/*` and scoring regressions. It does not touch `main.js`, `gameplay-controls.js`, vehicle physics, BRAKE/REVERSE UI, or release metadata, so it stays isolated from the ongoing BRAKE/REVERSE slider work.