### PR TITLE
TURN: fix track card vertical gap override

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -56,7 +56,7 @@
   <link rel="stylesheet" href="./accessibility/color-cues-r163.css?build=20260906-r207-accessible-paint">
   <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260906-r207-menu-font-v3">
   <link rel="stylesheet" href="./home-header-r425.css?revision=r425-header-boundary">
-  <link rel="stylesheet" href="./home-track-row-gap-r200.css?revision=r200-match-horizontal-gap">
+  <link rel="stylesheet" href="./home-track-row-gap-r200.css?revision=r208-compact-vertical-gap">
   <script src="./ui/page-zoom-baseline-r193.js?revision=r193-canonical-75"></script>
   <script src="/turn-lab/lab-bootstrap.js"></script>
   <script src="./pwa-usable-viewport-r181.js?revision=r181-usable-web-layer"></script>

--- a/turn-tests/home-track-records-production.mjs
+++ b/turn-tests/home-track-records-production.mjs
@@ -8,10 +8,13 @@ const [
   fixedCss,
   scroll,
   scrollCss,
+  rowGapCss,
   scaleCss,
   trophyGate,
   screenReader,
-  rivalReset
+  rivalReset,
+  productionEntry,
+  labEntry
 ] = await Promise.all([
   fs.readFile(new URL('../turn/m8-home.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/app.js', import.meta.url), 'utf8'),
@@ -19,10 +22,13 @@ const [
   fs.readFile(new URL('../turn/m8-home-fixed-layout.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/m8-home-card-scroll-fixes.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/m8-home-card-scroll-fixes.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/home-track-row-gap-r200.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/m8-record-car-scale.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/progression/m8-trophy-gate.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/ui/startup-screen-reader-handoff-r529.js', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../turn/ui/home-rival-reset.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../turn/ui/home-rival-reset.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn-lab/index.html', import.meta.url), 'utf8')
 ]);
 
 assert.match(home, /getBestDriftRecord/);
@@ -86,6 +92,14 @@ assert.match(scrollCss, /\.m8-track-rail \{[\s\S]*column-gap: clamp\(14px, 1\.4v
   'The good horizontal card spacing must remain while rows sit closer together');
 assert.doesNotMatch(scrollCss, /\.m8-track-rail \{[\s\S]{0,180}\n\s+gap: clamp\(14px, 1\.4vw, 16px\)/,
   'Track rows must not inherit the wider horizontal gap again');
+assert.ok(rowGapCss.includes('row-gap: clamp(8px, 0.85vw, 10px)'),
+  'The late-loaded compatibility stylesheet must preserve the compact row gap');
+assert.ok(!rowGapCss.includes('row-gap: 28px'),
+  'No late-loaded rule may restore the old oversized vertical gap');
+for (const entrypoint of [productionEntry, labEntry]) {
+  assert.ok(entrypoint.includes('home-track-row-gap-r200.css?revision=r208-compact-vertical-gap'),
+    'Production and TURN LAB must request the corrected stylesheet with a fresh cache key');
+}
 
 assert.match(scroll, /const hasOverflow = maximum > 2/);
 assert.match(scroll, /viewport\.classList\.toggle\('has-track-overflow', hasOverflow\)/);

--- a/turn/home-track-row-gap-r200.css
+++ b/turn/home-track-row-gap-r200.css
@@ -1,4 +1,4 @@
 .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes .m8-track-rail {
-  /* Match the visible horizontal breathing room after the cards' 10px down-shadow. */
-  row-gap: 28px;
+  /* Keep this late-loaded compatibility rule aligned with the compact grid gap. */
+  row-gap: clamp(8px, 0.85vw, 10px);
 }

--- a/turn/index.html
+++ b/turn/index.html
@@ -67,7 +67,7 @@
   <link rel="stylesheet" href="./accessibility/color-cues-r163.css?build=20260906-r207-accessible-paint">
   <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260906-r207-menu-font-v3">
   <link rel="stylesheet" href="./home-header-r425.css?revision=r425-header-boundary">
-  <link rel="stylesheet" href="./home-track-row-gap-r200.css?revision=r200-match-horizontal-gap">
+  <link rel="stylesheet" href="./home-track-row-gap-r200.css?revision=r208-compact-vertical-gap">
   <script src="./ui/page-zoom-baseline-r193.js?revision=r193-canonical-75"></script>
   <script src="./install-gate.js?build=20260906-r207-social-browser"></script>
   <script src="./pwa-usable-viewport-r181.js?revision=r181-usable-web-layer"></script>


### PR DESCRIPTION
## Root cause

#779 correctly split the track grid into independent column and row gaps, but `home-track-row-gap-r200.css` is loaded afterward and uses a more specific selector. Its legacy `row-gap: 28px` therefore continued to win in the cascade.

## Fix

- align the late-loaded compatibility rule with the intended responsive 8–10 px vertical gap
- keep the existing horizontal gap unchanged
- refresh the stylesheet cache key in both TURN and TURN LAB
- extend the Home track-record regression to cover the late cascade layer and both entrypoint cache keys

## Verification

- branch content checks confirm the effective late rule is `clamp(8px, 0.85vw, 10px)`
- the stale `row-gap: 28px` declaration is absent
- production and TURN LAB both request the corrected stylesheet revision

Follow-up to #779.