### PR TITLE
TURN: rebalance track card vertical spacing

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -56,7 +56,7 @@
   <link rel="stylesheet" href="./accessibility/color-cues-r163.css?build=20260906-r207-accessible-paint">
   <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260906-r207-menu-font-v3">
   <link rel="stylesheet" href="./home-header-r425.css?revision=r425-header-boundary">
-  <link rel="stylesheet" href="./home-track-row-gap-r200.css?revision=r208-compact-vertical-gap">
+  <link rel="stylesheet" href="./home-track-row-gap-r200.css?revision=r209-balanced-card-spacing">
   <script src="./ui/page-zoom-baseline-r193.js?revision=r193-canonical-75"></script>
   <script src="/turn-lab/lab-bootstrap.js"></script>
   <script src="./pwa-usable-viewport-r181.js?revision=r181-usable-web-layer"></script>

--- a/turn-tests/home-track-records-production.mjs
+++ b/turn-tests/home-track-records-production.mjs
@@ -89,7 +89,7 @@ assert.match(scrollCss, /\.track-card-record-model\[hidden\][\s\S]*display: none
 assert.match(scaleCss, /\.track-card-record[\s\S]*\.track-card-record-model/);
 
 assert.match(scrollCss, /\.m8-track-rail \{[\s\S]*column-gap: clamp\(14px, 1\.4vw, 16px\)[\s\S]*row-gap: clamp\(14px, 1\.4vw, 16px\)/,
-  'The good horizontal card spacing must remain while rows sit closer together');
+  'The horizontal card spacing must remain while rows use the requested balanced gap');
 assert.doesNotMatch(scrollCss, /\.m8-track-rail \{[\s\S]{0,180}\n\s+gap: clamp\(14px, 1\.4vw, 16px\)/,
   'Track rows must not inherit the wider horizontal gap again');
 assert.ok(rowGapCss.includes('row-gap: clamp(14px, 1.4vw, 16px)'),

--- a/turn-tests/home-track-records-production.mjs
+++ b/turn-tests/home-track-records-production.mjs
@@ -71,11 +71,11 @@ assert.match(home, /clearTrackRecordModels\(home\)/,
 assert.doesNotMatch(home, /setInterval|setAnimationLoop/,
   'The shared record view must add no polling or continuous animation loop');
 
-assert.match(fixedCss, /--m8-track-card-min-block-size: clamp\(132px, 20vh, 176px\)/,
+assert.match(fixedCss, /--m8-track-card-min-block-size: clamp\(126px, calc\(20vh - 6px\), 170px\)/,
   'Compact cards must be short enough for a comfortable six-card viewport');
-assert.match(fixedCss, /\.m8-track-rail \{[\s\S]*column-gap: clamp\(10px, 1\.4vw, 16px\)[\s\S]*row-gap: clamp\(8px, 0\.85vw, 10px\)/,
+assert.match(fixedCss, /\.m8-track-rail \{[\s\S]*column-gap: clamp\(10px, 1\.4vw, 16px\)[\s\S]*row-gap: clamp\(14px, 1\.4vw, 16px\)/,
   'The fixed-layout baseline must keep independently tunable track column and row gaps');
-assert.match(fixedCss, /\.is-showing-track-bests \.m8-home-tracks[\s\S]*--m8-track-card-min-block-size: clamp\(304px, 47vh, 390px\)/,
+assert.match(fixedCss, /\.is-showing-track-bests \.m8-home-tracks[\s\S]*--m8-track-card-min-block-size: clamp\(298px, calc\(47vh - 6px\), 384px\)/,
   'The shared state must expand every card to one consistent record height');
 assert.match(scrollCss, /\.is-showing-track-bests \.m8-track-rail \.track-card[\s\S]*grid-template-rows: auto auto minmax\(0, 1fr\)/);
 assert.match(scrollCss, /\.track-card-best\[hidden\][\s\S]*display: none !important/);
@@ -88,16 +88,20 @@ assert.match(scrollCss, /padding-left: calc\(var\(--track-record-stripe-width\) 
 assert.match(scrollCss, /\.track-card-record-model\[hidden\][\s\S]*display: none/);
 assert.match(scaleCss, /\.track-card-record[\s\S]*\.track-card-record-model/);
 
-assert.match(scrollCss, /\.m8-track-rail \{[\s\S]*column-gap: clamp\(14px, 1\.4vw, 16px\)[\s\S]*row-gap: clamp\(8px, 0\.85vw, 10px\)/,
+assert.match(scrollCss, /\.m8-track-rail \{[\s\S]*column-gap: clamp\(14px, 1\.4vw, 16px\)[\s\S]*row-gap: clamp\(14px, 1\.4vw, 16px\)/,
   'The good horizontal card spacing must remain while rows sit closer together');
 assert.doesNotMatch(scrollCss, /\.m8-track-rail \{[\s\S]{0,180}\n\s+gap: clamp\(14px, 1\.4vw, 16px\)/,
   'Track rows must not inherit the wider horizontal gap again');
-assert.ok(rowGapCss.includes('row-gap: clamp(8px, 0.85vw, 10px)'),
-  'The late-loaded compatibility stylesheet must preserve the compact row gap');
+assert.ok(rowGapCss.includes('row-gap: clamp(14px, 1.4vw, 16px)'),
+  'The late-loaded compatibility stylesheet must preserve the balanced row gap');
+assert.ok(rowGapCss.includes('padding-block: clamp(6px, 0.75vw, 9px)'),
+  'Track cards must use about 30% less top and bottom padding');
+assert.ok(fixedCss.includes('--m8-track-card-min-block-size: 114px;') && fixedCss.includes('padding: 6px 9px;'),
+  'Short landscape rows must shrink with their reduced block padding instead of absorbing it');
 assert.ok(!rowGapCss.includes('row-gap: 28px'),
   'No late-loaded rule may restore the old oversized vertical gap');
 for (const entrypoint of [productionEntry, labEntry]) {
-  assert.ok(entrypoint.includes('home-track-row-gap-r200.css?revision=r208-compact-vertical-gap'),
+  assert.ok(entrypoint.includes('home-track-row-gap-r200.css?revision=r209-balanced-card-spacing'),
     'Production and TURN LAB must request the corrected stylesheet with a fresh cache key');
 }
 

--- a/turn/home-track-row-gap-r200.css
+++ b/turn/home-track-row-gap-r200.css
@@ -1,4 +1,9 @@
 .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes .m8-track-rail {
-  /* Keep this late-loaded compatibility rule aligned with the compact grid gap. */
-  row-gap: clamp(8px, 0.85vw, 10px);
+  /* Keep this late-loaded compatibility rule aligned with the balanced grid gap. */
+  row-gap: clamp(14px, 1.4vw, 16px);
+}
+
+.m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes .m8-track-rail .track-card {
+  /* About 30% less block padding without disturbing the established inline inset. */
+  padding-block: clamp(6px, 0.75vw, 9px);
 }

--- a/turn/index.html
+++ b/turn/index.html
@@ -67,7 +67,7 @@
   <link rel="stylesheet" href="./accessibility/color-cues-r163.css?build=20260906-r207-accessible-paint">
   <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260906-r207-menu-font-v3">
   <link rel="stylesheet" href="./home-header-r425.css?revision=r425-header-boundary">
-  <link rel="stylesheet" href="./home-track-row-gap-r200.css?revision=r208-compact-vertical-gap">
+  <link rel="stylesheet" href="./home-track-row-gap-r200.css?revision=r209-balanced-card-spacing">
   <script src="./ui/page-zoom-baseline-r193.js?revision=r193-canonical-75"></script>
   <script src="./install-gate.js?build=20260906-r207-social-browser"></script>
   <script src="./pwa-usable-viewport-r181.js?revision=r181-usable-web-layer"></script>

--- a/turn/m8-home-card-scroll-fixes.css
+++ b/turn/m8-home-card-scroll-fixes.css
@@ -38,7 +38,7 @@
   padding-bottom: 10px;
   padding-right: 25px;
   column-gap: clamp(14px, 1.4vw, 16px);
-  row-gap: clamp(8px, 0.85vw, 10px);
+  row-gap: clamp(14px, 1.4vw, 16px);
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior-y: contain;

--- a/turn/m8-home-fixed-layout.css
+++ b/turn/m8-home-fixed-layout.css
@@ -71,7 +71,7 @@
 }
 
 .m8-home-fixed-layout .m8-home-tracks {
-  --m8-track-card-min-block-size: clamp(132px, 20vh, 176px);
+  --m8-track-card-min-block-size: clamp(126px, calc(20vh - 6px), 170px);
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
   min-width: 0;
@@ -79,7 +79,7 @@
 }
 
 .m8-home-fixed-layout.is-showing-track-bests .m8-home-tracks {
-  --m8-track-card-min-block-size: clamp(304px, 47vh, 390px);
+  --m8-track-card-min-block-size: clamp(298px, calc(47vh - 6px), 384px);
 }
 
 .m8-home-fixed-layout .m8-track-heading-row {
@@ -139,7 +139,7 @@
   grid-auto-rows: minmax(var(--m8-track-card-min-block-size), auto);
   align-content: start;
   column-gap: clamp(10px, 1.4vw, 16px);
-  row-gap: clamp(8px, 0.85vw, 10px);
+  row-gap: clamp(14px, 1.4vw, 16px);
   min-width: 0;
   min-height: 0;
   overflow-x: hidden;
@@ -262,11 +262,11 @@
 
 @media (max-height: 560px) and (orientation: landscape) {
   .m8-home-fixed-layout .m8-home-tracks {
-    --m8-track-card-min-block-size: 120px;
+    --m8-track-card-min-block-size: 114px;
   }
 
   .m8-home-fixed-layout.is-showing-track-bests .m8-home-tracks {
-    --m8-track-card-min-block-size: 286px;
+    --m8-track-card-min-block-size: 280px;
   }
 
   .m8-home-fixed-layout .m8-home-shell {
@@ -318,12 +318,12 @@
 
   .m8-home-fixed-layout .m8-track-rail {
     column-gap: 9px;
-    row-gap: 8px;
+    row-gap: 14px;
   }
 
   .m8-home-fixed-layout .m8-track-rail .track-card {
     min-height: var(--m8-track-card-min-block-size);
-    padding: 9px;
+    padding: 6px 9px;
     gap: 5px;
   }
 


### PR DESCRIPTION
## Summary

- increase the Choose Track row gap from 8–10 px to 14–16 px (+6 px)
- reduce card top and bottom padding by about 30%, while preserving the existing left and right padding
- lower compact and expanded row-height floors by the corresponding 6 px so the padding reduction actually shortens the grid instead of being absorbed by `align-content: center`
- keep the horizontal card gap unchanged
- refresh the corrected spacing stylesheet in TURN and TURN LAB

## Layout effect

In the short-landscape layout, card padding changes from 9 px on every side to 6 px vertically / 9 px horizontally, and the compact row floor changes from 120 px to 114 px. Across the three compact rows this saves 18 px; the two larger row gaps add 12 px, so the complete grid is still about 6 px shorter while the cards no longer look crowded together.

## Regression coverage

The Home track-record regression now checks:

- the balanced 14–16 px gap in every cascade layer
- the 6–9 px block-padding override
- the reduced row-height floor that makes the padding change affect overflow
- the refreshed production and TURN LAB stylesheet cache key

Follow-up to #779 and #780.