### PR TITLE
TURN: tighten track card padding

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -56,7 +56,7 @@
   <link rel="stylesheet" href="./accessibility/color-cues-r163.css?build=20260906-r207-accessible-paint">
   <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260906-r207-menu-font-v3">
   <link rel="stylesheet" href="./home-header-r425.css?revision=r425-header-boundary">
-  <link rel="stylesheet" href="./home-track-row-gap-r200.css?revision=r209-balanced-card-spacing">
+  <link rel="stylesheet" href="./home-track-row-gap-r200.css?revision=r210-compact-card-padding">
   <script src="./ui/page-zoom-baseline-r193.js?revision=r193-canonical-75"></script>
   <script src="/turn-lab/lab-bootstrap.js"></script>
   <script src="./pwa-usable-viewport-r181.js?revision=r181-usable-web-layer"></script>

--- a/turn-tests/home-track-records-production.mjs
+++ b/turn-tests/home-track-records-production.mjs
@@ -71,11 +71,11 @@ assert.match(home, /clearTrackRecordModels\(home\)/,
 assert.doesNotMatch(home, /setInterval|setAnimationLoop/,
   'The shared record view must add no polling or continuous animation loop');
 
-assert.match(fixedCss, /--m8-track-card-min-block-size: clamp\(126px, calc\(20vh - 6px\), 170px\)/,
+assert.match(fixedCss, /--m8-track-card-min-block-size: clamp\(120px, calc\(20vh - 12px\), 164px\)/,
   'Compact cards must be short enough for a comfortable six-card viewport');
-assert.match(fixedCss, /\.m8-track-rail \{[\s\S]*column-gap: clamp\(10px, 1\.4vw, 16px\)[\s\S]*row-gap: clamp\(14px, 1\.4vw, 16px\)/,
+assert.match(fixedCss, /\.m8-track-rail \{[\s\S]*column-gap: clamp\(10px, 1\.4vw, 16px\)[\s\S]*row-gap: clamp\(13px, calc\(1\.4vw - 1px\), 15px\)/,
   'The fixed-layout baseline must keep independently tunable track column and row gaps');
-assert.match(fixedCss, /\.is-showing-track-bests \.m8-home-tracks[\s\S]*--m8-track-card-min-block-size: clamp\(298px, calc\(47vh - 6px\), 384px\)/,
+assert.match(fixedCss, /\.is-showing-track-bests \.m8-home-tracks[\s\S]*--m8-track-card-min-block-size: clamp\(292px, calc\(47vh - 12px\), 378px\)/,
   'The shared state must expand every card to one consistent record height');
 assert.match(scrollCss, /\.is-showing-track-bests \.m8-track-rail \.track-card[\s\S]*grid-template-rows: auto auto minmax\(0, 1fr\)/);
 assert.match(scrollCss, /\.track-card-best\[hidden\][\s\S]*display: none !important/);
@@ -88,20 +88,25 @@ assert.match(scrollCss, /padding-left: calc\(var\(--track-record-stripe-width\) 
 assert.match(scrollCss, /\.track-card-record-model\[hidden\][\s\S]*display: none/);
 assert.match(scaleCss, /\.track-card-record[\s\S]*\.track-card-record-model/);
 
-assert.match(scrollCss, /\.m8-track-rail \{[\s\S]*column-gap: clamp\(14px, 1\.4vw, 16px\)[\s\S]*row-gap: clamp\(14px, 1\.4vw, 16px\)/,
-  'The horizontal card spacing must remain while rows use the requested balanced gap');
+assert.match(scrollCss, /\.m8-track-rail \{[\s\S]*column-gap: clamp\(14px, 1\.4vw, 16px\)[\s\S]*row-gap: clamp\(13px, calc\(1\.4vw - 1px\), 15px\)/,
+  'The horizontal card spacing must remain while every row-gap bound is 1px smaller');
 assert.doesNotMatch(scrollCss, /\.m8-track-rail \{[\s\S]{0,180}\n\s+gap: clamp\(14px, 1\.4vw, 16px\)/,
   'Track rows must not inherit the wider horizontal gap again');
-assert.ok(rowGapCss.includes('row-gap: clamp(14px, 1.4vw, 16px)'),
-  'The late-loaded compatibility stylesheet must preserve the balanced row gap');
-assert.ok(rowGapCss.includes('padding-block: clamp(6px, 0.75vw, 9px)'),
-  'Track cards must use about 30% less top and bottom padding');
-assert.ok(fixedCss.includes('--m8-track-card-min-block-size: 114px;') && fixedCss.includes('padding: 6px 9px;'),
+assert.ok(rowGapCss.includes('row-gap: clamp(13px, calc(1.4vw - 1px), 15px)'),
+  'The late-loaded compatibility stylesheet must preserve the 1px-smaller row gap');
+assert.ok(rowGapCss.includes('padding: 3px 9px;'),
+  'Track cards must use the requested 3px block and 9px inline padding');
+assert.ok(fixedCss.includes('--m8-track-card-min-block-size: 108px;') && fixedCss.includes('padding: 3px 9px;'),
   'Short landscape rows must shrink with their reduced block padding instead of absorbing it');
+assert.ok(rowGapCss.includes('--m8-track-card-min-block-size: clamp(120px, calc(20vh - 12px), 164px);')
+  && rowGapCss.includes('--m8-track-card-min-block-size: clamp(292px, calc(47vh - 12px), 378px);')
+  && rowGapCss.includes('--m8-track-card-min-block-size: 108px;')
+  && rowGapCss.includes('--m8-track-card-min-block-size: 274px;'),
+  'The fresh late stylesheet must correct every landscape row floor even when fixed-layout CSS is cached');
 assert.ok(!rowGapCss.includes('row-gap: 28px'),
   'No late-loaded rule may restore the old oversized vertical gap');
 for (const entrypoint of [productionEntry, labEntry]) {
-  assert.ok(entrypoint.includes('home-track-row-gap-r200.css?revision=r209-balanced-card-spacing'),
+  assert.ok(entrypoint.includes('home-track-row-gap-r200.css?revision=r210-compact-card-padding'),
     'Production and TURN LAB must request the corrected stylesheet with a fresh cache key');
 }
 

--- a/turn/home-track-row-gap-r200.css
+++ b/turn/home-track-row-gap-r200.css
@@ -1,9 +1,29 @@
 .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes .m8-track-rail {
-  /* Keep this late-loaded compatibility rule aligned with the balanced grid gap. */
-  row-gap: clamp(14px, 1.4vw, 16px);
+  /* Keep this late-loaded compatibility rule exactly 1px below the previous gap. */
+  row-gap: clamp(13px, calc(1.4vw - 1px), 15px);
 }
 
 .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes .m8-track-rail .track-card {
-  /* About 30% less block padding without disturbing the established inline inset. */
-  padding-block: clamp(6px, 0.75vw, 9px);
+  padding: 3px 9px;
+}
+
+/* These late overrides also reach clients with the previous fixed-layout CSS cached. */
+@media (orientation: landscape) {
+  .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes .m8-home-tracks {
+    --m8-track-card-min-block-size: clamp(120px, calc(20vh - 12px), 164px);
+  }
+
+  .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests .m8-home-tracks {
+    --m8-track-card-min-block-size: clamp(292px, calc(47vh - 12px), 378px);
+  }
+}
+
+@media (max-height: 560px) and (orientation: landscape) {
+  .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes .m8-home-tracks {
+    --m8-track-card-min-block-size: 108px;
+  }
+
+  .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests .m8-home-tracks {
+    --m8-track-card-min-block-size: 274px;
+  }
 }

--- a/turn/index.html
+++ b/turn/index.html
@@ -67,7 +67,7 @@
   <link rel="stylesheet" href="./accessibility/color-cues-r163.css?build=20260906-r207-accessible-paint">
   <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260906-r207-menu-font-v3">
   <link rel="stylesheet" href="./home-header-r425.css?revision=r425-header-boundary">
-  <link rel="stylesheet" href="./home-track-row-gap-r200.css?revision=r209-balanced-card-spacing">
+  <link rel="stylesheet" href="./home-track-row-gap-r200.css?revision=r210-compact-card-padding">
   <script src="./ui/page-zoom-baseline-r193.js?revision=r193-canonical-75"></script>
   <script src="./install-gate.js?build=20260906-r207-social-browser"></script>
   <script src="./pwa-usable-viewport-r181.js?revision=r181-usable-web-layer"></script>

--- a/turn/m8-home-card-scroll-fixes.css
+++ b/turn/m8-home-card-scroll-fixes.css
@@ -38,7 +38,7 @@
   padding-bottom: 10px;
   padding-right: 25px;
   column-gap: clamp(14px, 1.4vw, 16px);
-  row-gap: clamp(14px, 1.4vw, 16px);
+  row-gap: clamp(13px, calc(1.4vw - 1px), 15px);
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior-y: contain;

--- a/turn/m8-home-fixed-layout.css
+++ b/turn/m8-home-fixed-layout.css
@@ -71,7 +71,7 @@
 }
 
 .m8-home-fixed-layout .m8-home-tracks {
-  --m8-track-card-min-block-size: clamp(126px, calc(20vh - 6px), 170px);
+  --m8-track-card-min-block-size: clamp(120px, calc(20vh - 12px), 164px);
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
   min-width: 0;
@@ -79,7 +79,7 @@
 }
 
 .m8-home-fixed-layout.is-showing-track-bests .m8-home-tracks {
-  --m8-track-card-min-block-size: clamp(298px, calc(47vh - 6px), 384px);
+  --m8-track-card-min-block-size: clamp(292px, calc(47vh - 12px), 378px);
 }
 
 .m8-home-fixed-layout .m8-track-heading-row {
@@ -139,7 +139,7 @@
   grid-auto-rows: minmax(var(--m8-track-card-min-block-size), auto);
   align-content: start;
   column-gap: clamp(10px, 1.4vw, 16px);
-  row-gap: clamp(14px, 1.4vw, 16px);
+  row-gap: clamp(13px, calc(1.4vw - 1px), 15px);
   min-width: 0;
   min-height: 0;
   overflow-x: hidden;
@@ -262,11 +262,11 @@
 
 @media (max-height: 560px) and (orientation: landscape) {
   .m8-home-fixed-layout .m8-home-tracks {
-    --m8-track-card-min-block-size: 114px;
+    --m8-track-card-min-block-size: 108px;
   }
 
   .m8-home-fixed-layout.is-showing-track-bests .m8-home-tracks {
-    --m8-track-card-min-block-size: 280px;
+    --m8-track-card-min-block-size: 274px;
   }
 
   .m8-home-fixed-layout .m8-home-shell {
@@ -318,12 +318,12 @@
 
   .m8-home-fixed-layout .m8-track-rail {
     column-gap: 9px;
-    row-gap: 14px;
+    row-gap: 13px;
   }
 
   .m8-home-fixed-layout .m8-track-rail .track-card {
     min-height: var(--m8-track-card-min-block-size);
-    padding: 6px 9px;
+    padding: 3px 9px;
     gap: 5px;
   }
 


### PR DESCRIPTION
## Summary

- set Choose Track card padding to `3px 9px`
- reduce the responsive vertical row gap by exactly 1px, from 14–16px to 13–15px
- lower compact and expanded card-height floors by the matching 6px total so the smaller vertical padding actually reduces the grid height
- refresh the late-loaded production and TURN LAB stylesheet cache key
- include the corrected height floors in that fresh stylesheet so clients with the previous fixed-layout CSS cached still receive the full adjustment

## Verification

- `node turn-tests/home-track-records-production.mjs`
- `node turn-tests/home-navigation-production.mjs`
- `node turn-tests/short-viewport-repair-production.mjs`
- `node turn-tests/release-production.mjs`

Follow-up to #781.