### PR TITLE
TURN: give compact track grid the last few pixels

### DIFF
--- a/turn-tests/home-track-records-production.mjs
+++ b/turn-tests/home-track-records-production.mjs
@@ -98,11 +98,11 @@ assert.ok(rowGapCss.includes('padding: 3px 9px;'),
   'Track cards must use the requested 3px block and 9px inline padding');
 assert.ok(fixedCss.includes('--m8-track-card-min-block-size: 108px;') && fixedCss.includes('padding: 3px 9px;'),
   'Short landscape rows must shrink with their reduced block padding instead of absorbing it');
-assert.ok(rowGapCss.includes('--m8-track-card-min-block-size: clamp(120px, calc(20vh - 12px), 164px);')
+assert.ok(rowGapCss.includes('--m8-track-card-min-block-size: clamp(114px, calc(20vh - 18px), 158px);')
   && rowGapCss.includes('--m8-track-card-min-block-size: clamp(292px, calc(47vh - 12px), 378px);')
-  && rowGapCss.includes('--m8-track-card-min-block-size: 108px;')
+  && rowGapCss.includes('--m8-track-card-min-block-size: 102px;')
   && rowGapCss.includes('--m8-track-card-min-block-size: 274px;'),
-  'The fresh late stylesheet must correct every landscape row floor even when fixed-layout CSS is cached');
+  'The late landscape override must shave another 6px from each compact row without changing expanded records');
 assert.ok(!rowGapCss.includes('row-gap: 28px'),
   'No late-loaded rule may restore the old oversized vertical gap');
 for (const entrypoint of [productionEntry, labEntry]) {

--- a/turn/home-track-row-gap-r200.css
+++ b/turn/home-track-row-gap-r200.css
@@ -10,7 +10,7 @@
 /* These late overrides also reach clients with the previous fixed-layout CSS cached. */
 @media (orientation: landscape) {
   .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes .m8-home-tracks {
-    --m8-track-card-min-block-size: clamp(120px, calc(20vh - 12px), 164px);
+    --m8-track-card-min-block-size: clamp(114px, calc(20vh - 18px), 158px);
   }
 
   .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests .m8-home-tracks {
@@ -20,7 +20,7 @@
 
 @media (max-height: 560px) and (orientation: landscape) {
   .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes .m8-home-tracks {
-    --m8-track-card-min-block-size: 108px;
+    --m8-track-card-min-block-size: 102px;
   }
 
   .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests .m8-home-tracks {


### PR DESCRIPTION
## Summary

Follow-up to #782.

- keep the requested `3px 9px` card padding unchanged
- keep the current 13–15px vertical row gap unchanged
- shave another 6px from each compact landscape card-height floor (18px across the three rows)
- leave the expanded SHOW RECORDS card heights untouched
- update the production regression test to lock the final compact override

This targets the very small remaining default-view overflow shown after #782 without making the card internals any tighter.

## Verification

- regression expectation updated in `turn-tests/home-track-records-production.mjs`
- branch is based directly on merged #782 / current `main`