### PR TITLE
TURN: finish compact track fit with press buffer

### DIFF
--- a/turn-tests/home-track-records-production.mjs
+++ b/turn-tests/home-track-records-production.mjs
@@ -98,11 +98,19 @@ assert.ok(rowGapCss.includes('padding: 3px 9px;'),
   'Track cards must use the requested 3px block and 9px inline padding');
 assert.ok(fixedCss.includes('--m8-track-card-min-block-size: 108px;') && fixedCss.includes('padding: 3px 9px;'),
   'Short landscape rows must shrink with their reduced block padding instead of absorbing it');
-assert.ok(rowGapCss.includes('--m8-track-card-min-block-size: clamp(114px, calc(20vh - 18px), 158px);')
+assert.ok(rowGapCss.includes('--m8-track-card-min-block-size: clamp(108px, calc(20vh - 24px), 152px);')
   && rowGapCss.includes('--m8-track-card-min-block-size: clamp(292px, calc(47vh - 12px), 378px);')
-  && rowGapCss.includes('--m8-track-card-min-block-size: 102px;')
+  && rowGapCss.includes('--m8-track-card-min-block-size: 96px;')
   && rowGapCss.includes('--m8-track-card-min-block-size: 274px;'),
-  'The late landscape override must shave another 6px from each compact row without changing expanded records');
+  'The final landscape override must create more compact-fit headroom without changing expanded records');
+assert.ok(rowGapCss.includes('height: clamp(72px, 11vh, 104px);')
+  && rowGapCss.includes('height: 66px;'),
+  'Compact preview heights must shrink with the row floors so intrinsic preview size cannot restore overflow');
+assert.ok(rowGapCss.includes('.m8-track-scroll-viewport:not(.has-track-overflow) .m8-track-rail')
+  && rowGapCss.includes('align-content: end;'),
+  'A fitting compact grid must use the spare vertical room above the cards and share the RACE baseline');
+assert.match(scrollCss, /padding-bottom: 10px/,
+  'The rail must retain a 10px press/selection movement buffer even when default scrolling disappears');
 assert.ok(!rowGapCss.includes('row-gap: 28px'),
   'No late-loaded rule may restore the old oversized vertical gap');
 for (const entrypoint of [productionEntry, labEntry]) {

--- a/turn/home-track-row-gap-r200.css
+++ b/turn/home-track-row-gap-r200.css
@@ -7,10 +7,31 @@
   padding: 3px 9px;
 }
 
+/*
+ * Compact cards still inherited a preview height large enough to defeat the smaller
+ * row floors on some landscape viewports. Trim only the compact preview, then use
+ * the existing 10px rail bottom padding as real movement room for the 8–10px
+ * pressed/selected card translation instead of counting it as disposable space.
+ */
+.m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes:not(.is-showing-track-bests)
+  .m8-track-rail .track-card-preview {
+  height: clamp(72px, 11vh, 104px);
+}
+
+/*
+ * Once all six cards genuinely fit including that press buffer, anchor the rows to
+ * the bottom of the rail. The final card shadow then shares the RACE button's visual
+ * bottom instead of leaving a taller cream strip under the track grid.
+ */
+.m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes:not(.is-showing-track-bests)
+  .m8-track-scroll-viewport:not(.has-track-overflow) .m8-track-rail {
+  align-content: end;
+}
+
 /* These late overrides also reach clients with the previous fixed-layout CSS cached. */
 @media (orientation: landscape) {
   .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes .m8-home-tracks {
-    --m8-track-card-min-block-size: clamp(114px, calc(20vh - 18px), 158px);
+    --m8-track-card-min-block-size: clamp(108px, calc(20vh - 24px), 152px);
   }
 
   .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests .m8-home-tracks {
@@ -20,7 +41,12 @@
 
 @media (max-height: 560px) and (orientation: landscape) {
   .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes .m8-home-tracks {
-    --m8-track-card-min-block-size: 102px;
+    --m8-track-card-min-block-size: 96px;
+  }
+
+  .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes:not(.is-showing-track-bests)
+    .m8-track-rail .track-card-preview {
+    height: 66px;
   }
 
   .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests .m8-home-tracks {


### PR DESCRIPTION
Follow-up to #782 and #783.

The last row-floor reductions were not sufficient because compact cards could still be held open by the preview's intrinsic height. This follow-up fixes the actual limiting dimension and uses the existing bottom room deliberately.

- keep card padding at `3px 9px`
- keep the 13–15px vertical row gap
- trim only compact preview height so the smaller row floors can actually take effect
- reduce the compact landscape row floors another 6px; expanded SHOW RECORDS heights are unchanged
- retain the existing 10px bottom rail padding as a real buffer for the cards' 8–10px pressed/selected translation
- when all six cards fit, bottom-align the compact grid inside that buffered rail so the final card shadow shares the RACE button's visual bottom instead of leaving the larger cream strip
- extend the shared Home regression test for intrinsic preview height, baseline alignment, and the retained press buffer

This is based directly on current `main` after merged #783.