### PR TITLE
TURN: align compact Home grid and menu frame

### DIFF
--- a/turn-tests/home-track-records-production.mjs
+++ b/turn-tests/home-track-records-production.mjs
@@ -107,8 +107,14 @@ assert.ok(rowGapCss.includes('height: clamp(72px, 11vh, 104px);')
   && rowGapCss.includes('height: 66px;'),
   'Compact preview heights must shrink with the row floors so intrinsic preview size cannot restore overflow');
 assert.ok(rowGapCss.includes('.m8-track-scroll-viewport:not(.has-track-overflow) .m8-track-rail')
-  && rowGapCss.includes('align-content: end;'),
-  'A fitting compact grid must use the spare vertical room above the cards and share the RACE baseline');
+  && rowGapCss.includes('grid-auto-rows: minmax(var(--m8-track-card-min-block-size), 1fr);')
+  && rowGapCss.includes('align-content: stretch;')
+  && rowGapCss.includes('padding-right: 10px;'),
+  'A fitting compact grid must fill the shared top/bottom frame and reclaim the hidden scrollbar gutter');
+assert.ok(rowGapCss.includes('.m8-track-continue')
+  && rowGapCss.includes('margin-bottom: 7px;')
+  && rowGapCss.includes('margin-bottom: 5px;'),
+  'RACE must reserve its resting/pressed shadow depth so its visual bottom matches the card-shadow baseline');
 assert.match(scrollCss, /padding-bottom: 10px/,
   'The rail must retain a 10px press/selection movement buffer even when default scrolling disappears');
 assert.ok(!rowGapCss.includes('row-gap: 28px'),

--- a/turn/home-track-row-gap-r200.css
+++ b/turn/home-track-row-gap-r200.css
@@ -19,13 +19,29 @@
 }
 
 /*
- * Once all six cards genuinely fit including that press buffer, anchor the rows to
- * the bottom of the rail. The final card shadow then shares the RACE button's visual
- * bottom instead of leaving a taller cream strip under the track grid.
+ * When the compact six-card grid fits, use the whole available track body instead
+ * of parking the rows at the bottom. Equal flexible rows preserve the established
+ * 13–15px row gap while aligning the first card row with SETTINGS and keeping the
+ * last row at the shared lower baseline. The scrollbar gutter is no longer needed
+ * in this state, so leave only the 10px needed for the cards' right-hand shadow.
  */
 .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes:not(.is-showing-track-bests)
   .m8-track-scroll-viewport:not(.has-track-overflow) .m8-track-rail {
-  align-content: end;
+  grid-auto-rows: minmax(var(--m8-track-card-min-block-size), 1fr);
+  align-content: stretch;
+  padding-right: 10px;
+}
+
+/*
+ * RACE uses a 7px resting shadow and translates 6px with a 1px shadow when pressed.
+ * Reserve that same 7px below the button so its visual bottom, resting or pressed,
+ * lands on the track-card shadow baseline rather than below it.
+ */
+@media (orientation: landscape) {
+  .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes:not(.is-showing-track-bests)
+    .m8-track-continue {
+    margin-bottom: 7px;
+  }
 }
 
 /* These late overrides also reach clients with the previous fixed-layout CSS cached. */
@@ -47,6 +63,11 @@
   .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes:not(.is-showing-track-bests)
     .m8-track-rail .track-card-preview {
     height: 66px;
+  }
+
+  .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes:not(.is-showing-track-bests)
+    .m8-track-continue {
+    margin-bottom: 5px;
   }
 
   .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests .m8-home-tracks {


### PR DESCRIPTION
Follow-up to #784.

The compact grid now fits, which exposes three geometry mismatches from the old scroll layout. This aligns the default Home to the supplied red-line mockup without reopening scrolling:

- keep the existing `3px 9px` card padding and 13–15px row gap
- when all six cards fit, use equal flexible row tracks instead of bottom-packing the grid, so row 1 aligns with SETTINGS and row 3 still reaches the shared lower frame
- reclaim the hidden scrollbar gutter, leaving 10px on the right solely for the card shadow; the right-hand card/shadow edge now lines up with SHOW RECORDS and the track/menu column boundary
- reserve the RACE button's own resting/pressed shadow depth at the bottom (7px normally, 5px in the short-landscape treatment), so its visual bottom matches the card-shadow baseline in either interaction state
- retain the existing 10px track-card press/selection buffer
- extend the Home record regression to lock these alignment rules

Expanded SHOW RECORDS geometry and portrait layout are untouched.