### PR TITLE
TURN: match expanded record spacing and remember disclosure

### DIFF
--- a/turn-tests/home-track-records-production.mjs
+++ b/turn-tests/home-track-records-production.mjs
@@ -115,6 +115,12 @@ assert.ok(rowGapCss.includes('.m8-track-continue')
   && rowGapCss.includes('margin-bottom: 7px;')
   && rowGapCss.includes('margin-bottom: 5px;'),
   'RACE must reserve its resting/pressed shadow depth so its visual bottom matches the card-shadow baseline');
+assert.match(rowGapCss,
+  /is-showing-track-bests[\s\S]*\.m8-track-rail \.track-card \{[\s\S]*grid-template-rows: auto auto auto;[\s\S]*align-content: center;/,
+  'Expanded cards must stop squeezing their third row and use the same centered grid behavior as closed cards');
+assert.match(rowGapCss,
+  /is-showing-track-bests[\s\S]*\.m8-track-rail \.track-card-best \{[\s\S]*grid-template-rows: auto repeat\(3, auto\);[\s\S]*row-gap: clamp\(13px, calc\(1\.4vw - 1px\), 15px\);[\s\S]*margin-top: clamp\(13px, calc\(1\.4vw - 1px\), 15px\);/,
+  'BEST, TIME, DRIFT and FLOW must use the same 13–15px vertical rhythm as the closed card grid');
 assert.match(scrollCss, /padding-bottom: 10px/,
   'The rail must retain a 10px press/selection movement buffer even when default scrolling disappears');
 assert.ok(!rowGapCss.includes('row-gap: 28px'),
@@ -124,6 +130,14 @@ for (const entrypoint of [productionEntry, labEntry]) {
     'Production and TURN LAB must request the corrected stylesheet with a fresh cache key');
 }
 
+assert.match(scroll, /const TRACK_RECORDS_EXPANDED_KEY = 'turn-track-records-expanded-v1'/);
+assert.match(scroll, /localStorage\?\.getItem\(TRACK_RECORDS_EXPANDED_KEY\)/,
+  'The shared disclosure must restore the player’s saved open/closed choice');
+assert.match(scroll, /localStorage\?\.setItem\(TRACK_RECORDS_EXPANDED_KEY, expanded \? 'true' : 'false'\)/,
+  'The shared disclosure must save both expanded and collapsed choices');
+assert.match(scroll, /toggle\.addEventListener\('click', persistCurrentState\)/);
+assert.match(scroll, /if \(stored !== null && stored !== expanded\) toggle\.click\(\)/,
+  'Restoring the preference must go through the existing toggle behavior so labels, records and models stay synchronized');
 assert.match(scroll, /const hasOverflow = maximum > 2/);
 assert.match(scroll, /viewport\.classList\.toggle\('has-track-overflow', hasOverflow\)/);
 assert.match(scroll, /rail\.dataset\.scrollMode = hasOverflow \? 'native' : 'static'/);

--- a/turn-tests/home-track-records-production.mjs
+++ b/turn-tests/home-track-records-production.mjs
@@ -119,8 +119,11 @@ assert.match(rowGapCss,
   /is-showing-track-bests[\s\S]*\.m8-track-rail \.track-card \{[\s\S]*grid-template-rows: auto auto auto;[\s\S]*align-content: center;/,
   'Expanded cards must stop squeezing their third row and use the same centered grid behavior as closed cards');
 assert.match(rowGapCss,
-  /is-showing-track-bests[\s\S]*\.m8-track-rail \.track-card-best \{[\s\S]*grid-template-rows: auto repeat\(3, auto\);[\s\S]*row-gap: clamp\(13px, calc\(1\.4vw - 1px\), 15px\);[\s\S]*margin-top: clamp\(13px, calc\(1\.4vw - 1px\), 15px\);/,
+  /is-showing-track-bests[\s\S]*\.m8-track-rail \.track-card-best \{[\s\S]*grid-template-rows: auto repeat\(3, auto\);[\s\S]*row-gap: clamp\(13px, calc\(1\.4vw - 1px\), 15px\);/,
   'BEST, TIME, DRIFT and FLOW must use the same 13–15px vertical rhythm as the closed card grid');
+assert.ok(rowGapCss.includes("margin-top: calc(clamp(13px, calc(1.4vw - 1px), 15px) - 5px);")
+  && rowGapCss.includes("margin-top: calc(clamp(13px, calc(1.4vw - 1px), 15px) - 3px);"),
+  'The BEST section must compensate for the parent compact-card gap so the summary-to-record spacing is also exactly 13–15px');
 assert.match(scrollCss, /padding-bottom: 10px/,
   'The rail must retain a 10px press/selection movement buffer even when default scrolling disappears');
 assert.ok(!rowGapCss.includes('row-gap: 28px'),

--- a/turn/home-track-row-gap-r200.css
+++ b/turn/home-track-row-gap-r200.css
@@ -23,7 +23,8 @@
   .m8-track-rail .track-card-best {
   grid-template-rows: auto repeat(3, auto);
   row-gap: clamp(13px, calc(1.4vw - 1px), 15px);
-  margin-top: clamp(13px, calc(1.4vw - 1px), 15px);
+  /* The parent contributes its normal 5px compact-card row gap. */
+  margin-top: calc(clamp(13px, calc(1.4vw - 1px), 15px) - 5px);
 }
 
 /*
@@ -87,6 +88,12 @@
   .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes:not(.is-showing-track-bests)
     .m8-track-continue {
     margin-bottom: 5px;
+  }
+
+  .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests
+    .m8-track-rail .track-card-best {
+    /* Short-landscape compact cards contribute a 3px parent row gap. */
+    margin-top: calc(clamp(13px, calc(1.4vw - 1px), 15px) - 3px);
   }
 
   .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests .m8-home-tracks {

--- a/turn/home-track-row-gap-r200.css
+++ b/turn/home-track-row-gap-r200.css
@@ -8,6 +8,25 @@
 }
 
 /*
+ * Expanded records are deliberately scrollable, so do not compress their internal
+ * layout to fit the viewport. Keep the compact summary geometry intact, let the
+ * record rows size naturally, and use the same 13–15px vertical rhythm as the
+ * closed card grid between BEST / TIME / DRIFT / FLOW.
+ */
+.m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests
+  .m8-track-rail .track-card {
+  grid-template-rows: auto auto auto;
+  align-content: center;
+}
+
+.m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests
+  .m8-track-rail .track-card-best {
+  grid-template-rows: auto repeat(3, auto);
+  row-gap: clamp(13px, calc(1.4vw - 1px), 15px);
+  margin-top: clamp(13px, calc(1.4vw - 1px), 15px);
+}
+
+/*
  * Compact cards still inherited a preview height large enough to defeat the smaller
  * row floors on some landscape viewports. Trim only the compact preview, then use
  * the existing 10px rail bottom padding as real movement room for the 8–10px

--- a/turn/m8-home-card-scroll-fixes.js
+++ b/turn/m8-home-card-scroll-fixes.js
@@ -1,10 +1,11 @@
 const STYLE_ATTRIBUTE = 'data-turn-m8-card-scroll-fixes';
+const TRACK_RECORDS_EXPANDED_KEY = 'turn-track-records-expanded-v1';
 // Historical regression markers for the native-scroll/title-alignment bundles:
 // const FIX_ID = 'native-scroll-full-track-names-v4';
 // m8-home-card-scroll-fixes.css?build=${buildKey}-m8.9-track-title-alignment
 // const FIX_ID = 'native-scroll-full-track-names-v5';
 // m8-home-card-scroll-fixes.css?build=${buildKey}-m8.10-card-gap-rim
-const FIX_ID = 'shared-track-bests-v6';
+const FIX_ID = 'shared-track-bests-v7';
 
 function installStylesheet() {
   if (document.querySelector(`link[${STYLE_ATTRIBUTE}]`)) return;
@@ -28,6 +29,43 @@ function waitForFixedHome() {
       resolve(rail);
     });
     observer.observe(document.body, { childList: true, subtree: true });
+  });
+}
+
+function loadTrackRecordsExpandedPreference() {
+  try {
+    const stored = globalThis.localStorage?.getItem(TRACK_RECORDS_EXPANDED_KEY);
+    if (stored === 'true') return true;
+    if (stored === 'false') return false;
+  } catch (_) {}
+  return null;
+}
+
+function saveTrackRecordsExpandedPreference(expanded) {
+  try {
+    globalThis.localStorage?.setItem(TRACK_RECORDS_EXPANDED_KEY, expanded ? 'true' : 'false');
+  } catch (_) {}
+}
+
+function installTrackRecordsExpandedPreference(home) {
+  const toggle = home.querySelector('.m8-track-bests-toggle');
+  if (!toggle) return null;
+
+  const persistCurrentState = () => {
+    queueMicrotask(() => {
+      saveTrackRecordsExpandedPreference(home.classList.contains('is-showing-track-bests'));
+    });
+  };
+  toggle.addEventListener('click', persistCurrentState);
+
+  const stored = loadTrackRecordsExpandedPreference();
+  const expanded = home.classList.contains('is-showing-track-bests');
+  if (stored !== null && stored !== expanded) toggle.click();
+
+  return Object.freeze({
+    key: TRACK_RECORDS_EXPANDED_KEY,
+    toggle,
+    get expanded() { return home.classList.contains('is-showing-track-bests'); }
   });
 }
 
@@ -120,6 +158,8 @@ export async function installM8HomeCardScrollFixes() {
   home.classList.add('m8-home-card-scroll-fixes');
   home.dataset.m8CardScrollFixes = FIX_ID;
   document.documentElement.dataset.turnHomeCardScrollFixes = FIX_ID;
+  const trackRecordsPreference = installTrackRecordsExpandedPreference(home);
+  indicatorSync.sync();
 
   globalThis.__turnHomeCardScrollFixes = Object.freeze({
     id: FIX_ID,
@@ -127,6 +167,7 @@ export async function installM8HomeCardScrollFixes() {
     rail,
     viewport,
     indicator,
+    trackRecordsPreference,
     syncIndicator: indicatorSync.sync
   });
   return globalThis.__turnHomeCardScrollFixes;

--- a/turn/m8-home-card-scroll-fixes.js
+++ b/turn/m8-home-card-scroll-fixes.js
@@ -5,7 +5,7 @@ const TRACK_RECORDS_EXPANDED_KEY = 'turn-track-records-expanded-v1';
 // m8-home-card-scroll-fixes.css?build=${buildKey}-m8.9-track-title-alignment
 // const FIX_ID = 'native-scroll-full-track-names-v5';
 // m8-home-card-scroll-fixes.css?build=${buildKey}-m8.10-card-gap-rim
-const FIX_ID = 'shared-track-bests-v7';
+const FIX_ID = 'shared-track-bests-v6';
 
 function installStylesheet() {
   if (document.querySelector(`link[${STYLE_ATTRIBUTE}]`)) return;


### PR DESCRIPTION
Follow-up to #785.

Two changes requested from the latest Home pass:

- leave the compact/closed six-card layout untouched
- when SHOW RECORDS is expanded, stop squeezing the record area to a viewport-sized `1fr` row; let the content size naturally, center the expanded card grid like the compact cards, and use the same 13–15px vertical rhythm between BEST / TIME / DRIFT / FLOW as the closed card rows. Expanded mode is expected to scroll, so no fit compromises are needed.
- persist the shared SHOW RECORDS / HIDE RECORDS choice in localStorage (`turn-track-records-expanded-v1`) and restore it on the next app launch by going through the existing toggle behavior, preserving labels, record visibility, thumbnails and scroll synchronization.
- extend the shared Home regression coverage for both behaviors.

The compact no-scroll alignment from #785 is unchanged.