### PR TITLE
TURN: keep expanded track summaries fixed in place

### DIFF
--- a/turn-tests/home-track-records-production.mjs
+++ b/turn-tests/home-track-records-production.mjs
@@ -116,14 +116,20 @@ assert.ok(rowGapCss.includes('.m8-track-continue')
   && rowGapCss.includes('margin-bottom: 5px;'),
   'RACE must reserve its resting/pressed shadow depth so its visual bottom matches the card-shadow baseline');
 assert.match(rowGapCss,
-  /is-showing-track-bests[\s\S]*\.m8-track-rail \.track-card \{[\s\S]*grid-template-rows: auto auto auto;[\s\S]*align-content: center;/,
-  'Expanded cards must stop squeezing their third row and use the same centered grid behavior as closed cards');
+  /is-showing-track-bests[\s\S]*\.m8-track-rail \.track-card \{[\s\S]*grid-template-rows: auto auto auto;[\s\S]*align-content: start;[\s\S]*padding-top: var\(--m8-track-compact-top-padding, 3px\);/,
+  'Expanded cards must anchor the compact summary at its measured closed-state top position');
 assert.match(rowGapCss,
-  /is-showing-track-bests[\s\S]*\.m8-track-rail \.track-card-best \{[\s\S]*grid-template-rows: auto repeat\(3, auto\);[\s\S]*row-gap: clamp\(13px, calc\(1\.4vw - 1px\), 15px\);/,
-  'BEST, TIME, DRIFT and FLOW must use the same 13–15px vertical rhythm as the closed card grid');
-assert.ok(rowGapCss.includes("margin-top: calc(clamp(13px, calc(1.4vw - 1px), 15px) - 5px);")
-  && rowGapCss.includes("margin-top: calc(clamp(13px, calc(1.4vw - 1px), 15px) - 3px);"),
-  'The BEST section must compensate for the parent compact-card gap so the summary-to-record spacing is also exactly 13–15px');
+  /is-showing-track-bests[\s\S]*\.m8-track-rail \.track-card-preview \{[\s\S]*height: clamp\(72px, 11vh, 104px\);/,
+  'The expanded map preview must keep the exact compact height instead of resizing');
+assert.match(rowGapCss,
+  /is-showing-track-bests[\s\S]*\.m8-track-rail \.track-card-best \{[\s\S]*grid-template-rows: auto repeat\(3, auto\);[\s\S]*row-gap: clamp\(13px, calc\(1\.4vw - 1px\), 15px\);[\s\S]*--m8-track-expanded-records-margin/,
+  'Expanded BEST, TIME, DRIFT and FLOW rows must size naturally below the preserved compact frame');
+assert.match(rowGapCss,
+  /is-showing-track-bests[\s\S]*\.m8-track-rail \{[\s\S]*padding-right: 10px;/,
+  'Opening records must keep the closed-state card-column width instead of shrinking for the scroll indicator');
+assert.match(rowGapCss,
+  /is-showing-track-bests[\s\S]*\.m8-track-scroll-viewport \{[\s\S]*overflow: visible;[\s\S]*\.m8-track-scroll-indicator \{[\s\S]*right: -11px;/,
+  'The expanded scroll indicator must move into the existing track/menu gap rather than move the cards');
 assert.match(scrollCss, /padding-bottom: 10px/,
   'The rail must retain a 10px press/selection movement buffer even when default scrolling disappears');
 assert.ok(!rowGapCss.includes('row-gap: 28px'),
@@ -134,13 +140,17 @@ for (const entrypoint of [productionEntry, labEntry]) {
 }
 
 assert.match(scroll, /const TRACK_RECORDS_EXPANDED_KEY = 'turn-track-records-expanded-v1'/);
+assert.match(scroll, /function captureCompactTrackCardGeometry\(home\)[\s\S]*getBoundingClientRect\(\)[\s\S]*--m8-track-compact-top-padding[\s\S]*--m8-track-expanded-records-margin/,
+  'The runtime must snapshot the real compact geometry before expanding records');
+assert.match(scroll, /toggle\.addEventListener\('click', captureBeforeExpansion, \{ capture: true \}\)/,
+  'Compact geometry must be captured before the existing SHOW RECORDS click handler changes state');
 assert.match(scroll, /localStorage\?\.getItem\(TRACK_RECORDS_EXPANDED_KEY\)/,
   'The shared disclosure must restore the player’s saved open/closed choice');
 assert.match(scroll, /localStorage\?\.setItem\(TRACK_RECORDS_EXPANDED_KEY, expanded \? 'true' : 'false'\)/,
   'The shared disclosure must save both expanded and collapsed choices');
 assert.match(scroll, /toggle\.addEventListener\('click', persistCurrentState\)/);
-assert.match(scroll, /if \(stored !== null && stored !== expanded\) toggle\.click\(\)/,
-  'Restoring the preference must go through the existing toggle behavior so labels, records and models stay synchronized');
+assert.match(scroll, /await nextAnimationFrame\(\)[\s\S]*captureCompactTrackCardGeometry\(home\)[\s\S]*if \(stored !== null && stored !== expanded\) toggle\.click\(\)/,
+  'Persisted expansion must restore only after the compact geometry has been measured');
 assert.match(scroll, /const hasOverflow = maximum > 2/);
 assert.match(scroll, /viewport\.classList\.toggle\('has-track-overflow', hasOverflow\)/);
 assert.match(scroll, /rail\.dataset\.scrollMode = hasOverflow \? 'native' : 'static'/);

--- a/turn/home-track-row-gap-r200.css
+++ b/turn/home-track-row-gap-r200.css
@@ -8,27 +8,55 @@
 }
 
 /*
- * Expanded records are deliberately scrollable, so do not compress their internal
- * layout to fit the viewport. Keep the compact summary geometry intact, let the
- * record rows size naturally, and use the same 13–15px vertical rhythm as the
- * closed card grid between BEST / TIME / DRIFT / FLOW.
+ * Expanded cards must be the compact card plus records below it, not a new layout.
+ * The runtime snapshots the compact card's real top inset and the space needed to
+ * begin records below the old card edge. Keeping the preview at its compact size
+ * makes the marker, name, difficulty and map stay in exactly the same place.
  */
 .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests
   .m8-track-rail .track-card {
   grid-template-rows: auto auto auto;
-  align-content: center;
+  align-content: start;
+  padding-top: var(--m8-track-compact-top-padding, 3px);
+}
+
+.m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests
+  .m8-track-rail .track-card-preview {
+  height: clamp(72px, 11vh, 104px);
 }
 
 .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests
   .m8-track-rail .track-card-best {
   grid-template-rows: auto repeat(3, auto);
   row-gap: clamp(13px, calc(1.4vw - 1px), 15px);
-  /* The parent contributes its normal 5px compact-card row gap. */
-  margin-top: calc(clamp(13px, calc(1.4vw - 1px), 15px) - 5px);
+  margin-top: var(
+    --m8-track-expanded-records-margin,
+    calc(clamp(13px, calc(1.4vw - 1px), 15px) - 5px)
+  );
 }
 
 /*
- * Compact cards still inherited a preview height large enough to defeat the smaller
+ * Opening records must not narrow the card grid just because the scroll indicator
+ * appears. Keep the same 10px right-side card/shadow gutter as the closed state and
+ * let the indicator sit partly in the existing track/menu gap instead.
+ */
+.m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests
+  .m8-track-rail {
+  padding-right: 10px;
+}
+
+.m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests
+  .m8-track-scroll-viewport {
+  overflow: visible;
+}
+
+.m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests
+  .m8-track-scroll-indicator {
+  right: -11px;
+}
+
+/*
+ * Compact cards still inherit a preview height large enough to defeat the smaller
  * row floors on some landscape viewports. Trim only the compact preview, then use
  * the existing 10px rail bottom padding as real movement room for the 8–10px
  * pressed/selected card translation instead of counting it as disposable space.
@@ -81,6 +109,8 @@
   }
 
   .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes:not(.is-showing-track-bests)
+    .m8-track-rail .track-card-preview,
+  .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests
     .m8-track-rail .track-card-preview {
     height: 66px;
   }
@@ -92,8 +122,15 @@
 
   .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests
     .m8-track-rail .track-card-best {
-    /* Short-landscape compact cards contribute a 3px parent row gap. */
-    margin-top: calc(clamp(13px, calc(1.4vw - 1px), 15px) - 3px);
+    margin-top: var(
+      --m8-track-expanded-records-margin,
+      calc(clamp(13px, calc(1.4vw - 1px), 15px) - 3px)
+    );
+  }
+
+  .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests
+    .m8-track-scroll-indicator {
+    right: -8px;
   }
 
   .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests .m8-home-tracks {

--- a/turn/m8-home-card-scroll-fixes.js
+++ b/turn/m8-home-card-scroll-fixes.js
@@ -47,16 +47,92 @@ function saveTrackRecordsExpandedPreference(expanded) {
   } catch (_) {}
 }
 
-function installTrackRecordsExpandedPreference(home) {
+function px(value) {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function setPixelVariable(element, name, value) {
+  const rounded = Math.round(Math.max(0, value) * 100) / 100;
+  element.style.setProperty(name, `${rounded}px`);
+}
+
+function captureCompactTrackCardGeometry(home) {
+  if (home.classList.contains('is-showing-track-bests')) return;
+  const rail = home.querySelector('.m8-track-rail');
+  if (!rail) return;
+
+  const railRowGap = px(getComputedStyle(rail).rowGap);
+  for (const card of rail.querySelectorAll('.track-card')) {
+    const choice = card.querySelector('.track-card-choice');
+    const difficulty = card.querySelector('.track-card-difficulty');
+    const preview = card.querySelector('.track-card-preview');
+    if (!choice || !difficulty || !preview) continue;
+
+    const cardRect = card.getBoundingClientRect();
+    if (!(cardRect.width > 0 && cardRect.height > 0)) continue;
+    const choiceRect = choice.getBoundingClientRect();
+    const difficultyRect = difficulty.getBoundingClientRect();
+    const previewRect = preview.getBoundingClientRect();
+    const cardStyle = getComputedStyle(card);
+    const borderTop = px(cardStyle.borderTopWidth);
+    const cardRowGap = px(cardStyle.rowGap);
+
+    const compactContentTop = Math.min(choiceRect.top, previewRect.top);
+    const compactContentBottom = Math.max(
+      choiceRect.bottom,
+      difficultyRect.bottom,
+      previewRect.bottom
+    );
+    const compactTopPadding = compactContentTop - cardRect.top - borderTop;
+    const compactContentBottomFromTop = compactContentBottom - cardRect.top;
+    const expandedRecordsMargin = cardRect.height
+      + railRowGap
+      - compactContentBottomFromTop
+      - cardRowGap;
+
+    setPixelVariable(card, '--m8-track-compact-top-padding', compactTopPadding);
+    setPixelVariable(card, '--m8-track-expanded-records-margin', expandedRecordsMargin);
+  }
+}
+
+function nextAnimationFrame() {
+  return new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
+async function installTrackRecordsExpandedPreference(home) {
   const toggle = home.querySelector('.m8-track-bests-toggle');
   if (!toggle) return null;
 
+  const captureBeforeExpansion = () => {
+    if (!home.classList.contains('is-showing-track-bests')) {
+      captureCompactTrackCardGeometry(home);
+    }
+  };
+  toggle.addEventListener('click', captureBeforeExpansion, { capture: true });
+
   const persistCurrentState = () => {
     queueMicrotask(() => {
-      saveTrackRecordsExpandedPreference(home.classList.contains('is-showing-track-bests'));
+      const expanded = home.classList.contains('is-showing-track-bests');
+      saveTrackRecordsExpandedPreference(expanded);
+      if (!expanded) requestAnimationFrame(() => captureCompactTrackCardGeometry(home));
     });
   };
   toggle.addEventListener('click', persistCurrentState);
+
+  let resizeFrame = 0;
+  window.addEventListener('resize', () => {
+    if (home.classList.contains('is-showing-track-bests') || resizeFrame) return;
+    resizeFrame = requestAnimationFrame(() => {
+      resizeFrame = 0;
+      captureCompactTrackCardGeometry(home);
+    });
+  }, { passive: true });
+
+  // Let the fixed-layout and card-scroll styles settle before taking the geometry
+  // snapshot used by a persisted expanded state. The DOM always starts compact.
+  await nextAnimationFrame();
+  captureCompactTrackCardGeometry(home);
 
   const stored = loadTrackRecordsExpandedPreference();
   const expanded = home.classList.contains('is-showing-track-bests');
@@ -158,7 +234,7 @@ export async function installM8HomeCardScrollFixes() {
   home.classList.add('m8-home-card-scroll-fixes');
   home.dataset.m8CardScrollFixes = FIX_ID;
   document.documentElement.dataset.turnHomeCardScrollFixes = FIX_ID;
-  const trackRecordsPreference = installTrackRecordsExpandedPreference(home);
+  const trackRecordsPreference = await installTrackRecordsExpandedPreference(home);
   indicatorSync.sync();
 
   globalThis.__turnHomeCardScrollFixes = Object.freeze({


### PR DESCRIPTION
Follow-up to #786.

The previous pass treated the expanded card as one centered layout. That is the opposite of the intended behavior: opening records should not reposition the radio marker, track name, difficulty badge or map at all.

This fixes the expanded state as an extension of the compact card instead:

- snapshot each compact card's actual rendered summary geometry before expansion
- keep the compact top inset when SHOW RECORDS opens
- keep the map preview at the exact compact size
- begin BEST / TIME / DRIFT / FLOW below the old compact-card edge with the existing 13–15px rhythm
- let expanded rows size naturally so record content grows the card instead of clipping through its bottom
- keep the expanded card grid at the same width as the compact state; the scroll indicator moves into the existing track/menu gap instead of narrowing the cards
- preserve the saved SHOW RECORDS / HIDE RECORDS preference from #786
- recapture compact geometry after collapsing and on closed-state resize
- update the Home record regression to lock the stable-header behavior

The closed six-card layout from #785 remains unchanged.