### PR TITLE
TURN: keep FLOW inside expanded track cards

### DIFF
--- a/turn-tests/home-track-records-production.mjs
+++ b/turn-tests/home-track-records-production.mjs
@@ -116,8 +116,11 @@ assert.ok(rowGapCss.includes('.m8-track-continue')
   && rowGapCss.includes('margin-bottom: 5px;'),
   'RACE must reserve its resting/pressed shadow depth so its visual bottom matches the card-shadow baseline');
 assert.match(rowGapCss,
-  /is-showing-track-bests[\s\S]*\.m8-track-rail \.track-card \{[\s\S]*grid-template-rows: auto auto auto;[\s\S]*align-content: start;[\s\S]*padding-top: var\(--m8-track-compact-top-padding, 3px\);/,
-  'Expanded cards must anchor the compact summary at its measured closed-state top position');
+  /is-showing-track-bests[\s\S]*\.m8-track-rail \.track-card \{[\s\S]*grid-template-rows: auto auto auto;[\s\S]*align-content: start;[\s\S]*min-height: max-content;[\s\S]*padding-top: var\(--m8-track-compact-top-padding, 3px\);/,
+  'Expanded cards must anchor the compact summary at its measured closed-state top position while growing to fit all records');
+assert.match(rowGapCss,
+  /is-showing-track-bests[\s\S]*\.m8-track-rail \{[\s\S]*grid-auto-rows: minmax\(var\(--m8-track-card-min-block-size\), max-content\);/,
+  'Expanded grid rows must use intrinsic max-content sizing so FLOW cannot be clipped by the viewport-oriented row minimum');
 assert.match(rowGapCss,
   /is-showing-track-bests[\s\S]*\.m8-track-rail \.track-card-preview \{[\s\S]*height: clamp\(72px, 11vh, 104px\);/,
   'The expanded map preview must keep the exact compact height instead of resizing');

--- a/turn/home-track-row-gap-r200.css
+++ b/turn/home-track-row-gap-r200.css
@@ -12,11 +12,25 @@
  * The runtime snapshots the compact card's real top inset and the space needed to
  * begin records below the old card edge. Keeping the preview at its compact size
  * makes the marker, name, difficulty and map stay in exactly the same place.
+ *
+ * The base card clips its paint to the rounded border with overflow:hidden. That
+ * makes an `auto` implicit grid track allowed to stay at its viewport-oriented
+ * minimum even when the BEST content is taller, which clipped the FLOW row. In the
+ * expanded state only, make both the implicit row and the card's minimum height use
+ * intrinsic max-content sizing. The card therefore grows downward until BEST,
+ * TIME, DRIFT and FLOW are all inside the border; the compact summary geometry does
+ * not move.
  */
+.m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests
+  .m8-track-rail {
+  grid-auto-rows: minmax(var(--m8-track-card-min-block-size), max-content);
+}
+
 .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests
   .m8-track-rail .track-card {
   grid-template-rows: auto auto auto;
   align-content: start;
+  min-height: max-content;
   padding-top: var(--m8-track-compact-top-padding, 3px);
 }
 


### PR DESCRIPTION
Follow-up to #787.

The stable compact-summary geometry is correct now, but the expanded grid row is still allowed to stay at its viewport-oriented minimum because `.track-card` clips with `overflow: hidden`. That means the BEST content can be taller than the grid item and the last FLOW row gets clipped.

This change is deliberately narrow and expanded-state-only:

- keep the compact summary geometry from #787 unchanged
- keep the closed six-card layout untouched
- size expanded implicit grid rows with `max-content` rather than `auto`
- give expanded cards an intrinsic `min-height: max-content`
- preserve the rounded-card clipping; the card itself grows downward instead of letting record content escape
- keep the existing BEST / TIME / DRIFT / FLOW spacing and scroll behavior
- add regression assertions specifically guarding FLOW containment

No changes to SHOW/HIDE RECORDS persistence.