### PR TITLE
TURN: rebuild track record cards from clean post-#782 structure

### DIFF
--- a/turn-tests/home-navigation-production.mjs
+++ b/turn-tests/home-navigation-production.mjs
@@ -34,7 +34,7 @@ const [
 ]);
 
 assert.match(productionApp, /installM8HomeNavigation/);
-assert.match(productionApp, /m8-home\.js\?revision=r206-shared-track-bests/);
+assert.match(productionApp, /m8-home\.js\?revision=r217-track-record-layout/);
 assert.match(productionApp, /installM8HomeFixedLayout/);
 assert.match(
   productionApp,
@@ -246,7 +246,7 @@ assert.match(fixedLayoutSource, /raceButton\.textContent = 'RACE'/);
 assert.match(fixedLayoutSource, /Race on \$\{spokenTrackName\(selectedTrackName\)\}/);
 assert.match(fixedLayoutSource, /new MutationObserver\(syncRaceLabel\)/);
 assert.match(fixedLayoutSource, /\/turn\/m8-home-card-scroll-fixes\.js\?build=\$\{buildKey\}-m8\.9-track-title-alignment/);
-assert.match(fixedLayoutSource, /import\(`\/turn\/m8-home-card-scroll-fixes\.js\?build=\$\{buildKey\}-r206-shared-track-bests`\)/);
+assert.match(fixedLayoutSource, /import\(`\/turn\/m8-home-card-scroll-fixes\.js\?build=\$\{buildKey\}-r217-track-record-layout`\)/);
 assert.match(fixedLayoutSource, /installM8HomeCardScrollFixes\(\)/);
 assert.match(fixedLayoutSource, /turnHomeLayout = LAYOUT_ID/);
 
@@ -272,8 +272,8 @@ assert.match(fixedLayoutCss, /@media \(max-height: 560px\) and \(orientation: la
 assert.match(fixedLayoutCss, /@media \(max-width: 760px\) and \(orientation: portrait\)[\s\S]*\.m8-home-fixed-layout \.m8-home-head[\s\S]*padding: 0 12px 0 0/);
 assert.match(fixedLayoutCss, /prefers-reduced-motion/);
 
-assert.match(cardScrollSource, /const FIX_ID = 'shared-track-bests-v6'/);
-assert.match(cardScrollSource, /m8-home-card-scroll-fixes\.css\?build=\$\{buildKey\}-r206-shared-track-bests/);
+assert.match(cardScrollSource, /const FIX_ID = 'track-record-layout-v7'/);
+assert.match(cardScrollSource, /m8-home-card-scroll-fixes\.css\?build=\$\{buildKey\}-r217-track-record-layout/);
 assert.match(cardScrollSource, /m8-track-scroll-indicator/);
 assert.match(cardScrollSource, /ResizeObserver/);
 assert.match(cardScrollSource, /rail\.style\.scrollSnapType = 'none'/);
@@ -281,6 +281,8 @@ assert.match(cardScrollSource, /rail\.dataset\.scrollMode = 'native'/);
 assert.match(cardScrollSource, /turnHomeCardScrollFixes = FIX_ID/);
 assert.doesNotMatch(cardScrollSource, /pointerdown|pointermove|setPointerCapture|releasePointerCapture/);
 assert.doesNotMatch(cardScrollSource, /preventDefault\(\)|stopImmediatePropagation\(\)|startInertia|velocity/);
+assert.doesNotMatch(cardScrollSource, /localStorage|getBoundingClientRect|TRACK_RECORDS_EXPANDED_KEY/,
+  'The scroll module must stay presentation-only');
 
 assert.match(cardScrollCss, /\.m8-track-scroll-viewport/);
 assert.match(cardScrollCss, /\.m8-track-scroll-indicator/);
@@ -290,14 +292,14 @@ assert.match(cardScrollCss, /-webkit-overflow-scrolling: touch/);
 assert.match(cardScrollCss, /scroll-snap-type: none !important/);
 assert.match(cardScrollCss, /overscroll-behavior-y: contain/);
 assert.doesNotMatch(cardScrollCss, /touch-action: none|cursor: grab|cursor: grabbing|is-drag-scrolling/);
+assert.match(cardScrollCss, /\.track-card-compact[\s\S]*grid-template-columns: minmax\(0, 1fr\) minmax\(108px, 39%\)/);
 assert.match(cardScrollCss, /\.track-card-summary[\s\S]*display: contents/);
 assert.match(cardScrollCss, /\.track-card-choice[\s\S]*grid-row: 1[\s\S]*align-items: center/);
 assert.match(cardScrollCss, /\.track-card-choice-marker[\s\S]*margin-top: 0/);
 assert.match(cardScrollCss, /\.track-card-difficulty[\s\S]*grid-row: 2/);
 assert.match(cardScrollCss, /\.track-card-preview[\s\S]*grid-row: 1 \/ 3/);
-assert.match(cardScrollCss, /\.track-card-best[\s\S]*grid-row: 3[\s\S]*repeat\(3, minmax\(0, 1fr\)\)/);
+assert.match(cardScrollCss, /\.track-card-best[\s\S]*grid-row: 2[\s\S]*repeat\(3, auto\)/);
 assert.match(cardScrollCss, /\.track-card-record-model[\s\S]*justify-self: end/);
-assert.match(cardScrollCss, /grid-template-columns: minmax\(0, 1fr\) minmax\(108px, 39%\)/);
 assert.match(cardScrollCss, /\.track-card-name[\s\S]*font-size: clamp\(1\.056rem, 1\.86vw, 1\.656rem\)[\s\S]*text-overflow: clip[\s\S]*white-space: normal/);
 assert.match(cardScrollCss, /@media \(max-height: 560px\) and \(orientation: landscape\)[\s\S]*\.track-card-name[\s\S]*font-size: clamp\(0\.96rem, 1\.704vw, 1\.296rem\)/);
 assert.doesNotMatch(cardScrollCss, /\.track-card-name[\s\S]{0,240}text-overflow: ellipsis/);
@@ -315,4 +317,4 @@ assert.match(orchestrator, /function leaveRace\(\)/);
 assert.match(orchestrator, /publish\('home-open'\)/);
 assert.match(orchestrator, /phase = 'home'/);
 
-console.log('TURN production M8 Home, prepared showroom entry, fresh-document motion permission recovery, larger aligned track names, native scrollbar divider and NEXT wrapper contracts passed.');
+console.log('TURN production M8 Home, prepared showroom entry, fresh-document motion permission recovery, stable record-card layout, native scrollbar divider and NEXT wrapper contracts passed.');

--- a/turn-tests/home-track-records-production.mjs
+++ b/turn-tests/home-track-records-production.mjs
@@ -38,14 +38,14 @@ assert.match(home, /renderTrackRecord\('time', 'TIME', 'track-card-best-time'\)/
 assert.match(home, /renderTrackRecord\('drift', 'DRIFT', 'track-card-best-drift'\)/);
 assert.match(home, /renderTrackRecord\('flow', 'FLOW', 'track-card-best-flow'\)/);
 assert.match(home, /track-card-records" data-track-best="\$\{track\.id\}" hidden/,
-  'Every card must start compact without exposing an oversized BEST panel');
+  'Every unlocked card must start with its records block hidden');
 
 const recordMarkup = home.slice(
   home.indexOf('function renderTrackRecord'),
   home.indexOf('function renderTrackCard')
 );
 assert.doesNotMatch(recordMarkup, /<(?:button|input|details|summary|select|textarea)\b/i,
-  'Record content inside each track button must remain static and non-interactive');
+  'Record rows inside each track button must remain static and non-interactive');
 assert.equal((home.match(/class="m8-track-bests-toggle"/g) || []).length, 1,
   'Home must expose one shared record toggle, not one disclosure per track');
 assert.ok(
@@ -54,114 +54,130 @@ assert.ok(
 );
 assert.match(home, /aria-controls="m8TrackRail"[\s\S]*aria-expanded="false"/);
 assert.match(home, /trackBestsToggle\.addEventListener\('click', toggleTrackBests\)/);
-assert.match(home, /home\.classList\.toggle\('is-showing-track-bests'\)/);
 assert.match(home, /bestBox\.hidden = !expanded/);
 assert.match(home, /expanded \? 'HIDE RECORDS' : 'SHOW RECORDS'/);
+
+const cardMarkup = home.slice(
+  home.indexOf('function renderTrackCard'),
+  home.indexOf('function recordCarName')
+);
+assert.match(cardMarkup, /class="track-card-compact"[\s\S]*class="track-card-preview"/,
+  'Every card must have one explicit compact frame containing the stable summary and map');
+assert.match(cardMarkup, /class="track-card-compact"[\s\S]*class="track-card-best track-card-records"/,
+  'Unlocked records must be a sibling block after the canonical compact frame');
+const unlockedMarkup = cardMarkup.slice(cardMarkup.lastIndexOf('return `'));
+assert.ok(
+  unlockedMarkup.indexOf('class="track-card-compact"') < unlockedMarkup.indexOf('class="track-card-best track-card-records"'),
+  'The unlocked records block must follow, never wrap, the compact frame'
+);
 
 assert.match(home, /if \(!record \|\| !model \|\| !renderModels\) return null/,
   'Compact Home must not request decorative WebGL record thumbnails');
 assert.match(home, /for \(const request of requests\)[\s\S]*await renderBestCarThumbnail\(request\.record\)/,
   'Expanded record cars must render serially in visible progression order');
 assert.match(home, /generation !== previewGeneration \|\| !trackRecordModelsShouldRender\(root\)/,
-  'Hiding Home or collapsing BEST must stop the remaining thumbnail queue');
+  'Hiding Home or collapsing records must stop the remaining thumbnail queue');
 assert.match(home, /if \(expanded\) refreshTrackRecords\(home, \{ renderModels: true \}\)/,
-  'The one explicit SHOW RECORDS action may start the queued record-car work');
+  'Showing records may start the queued record-car work');
 assert.match(home, /clearTrackRecordModels\(home\)/,
-  'Collapsing all records must invalidate pending model publication');
+  'Collapsing records must invalidate pending model publication');
 assert.doesNotMatch(home, /setInterval|setAnimationLoop/,
   'The shared record view must add no polling or continuous animation loop');
 
+assert.match(home, /const TRACK_RECORDS_EXPANDED_KEY = 'turn-track-records-expanded-v1'/);
+assert.match(home, /function loadTrackRecordsExpandedPreference\(\)[\s\S]*localStorage\.getItem\(TRACK_RECORDS_EXPANDED_KEY\) === 'true'/,
+  'Home itself must own restoration of the shared record disclosure');
+assert.match(home, /function saveTrackRecordsExpandedPreference\(expanded\)[\s\S]*localStorage\.setItem\(TRACK_RECORDS_EXPANDED_KEY, expanded \? 'true' : 'false'\)/,
+  'Home itself must persist both record disclosure states');
+assert.match(home, /home\.classList\.toggle\('is-showing-track-bests', loadTrackRecordsExpandedPreference\(\)\)/,
+  'The saved disclosure state must be applied before Home is attached');
+assert.match(home, /function setTrackRecordsExpanded\(expanded, \{ persist = false \} = \{\}\)[\s\S]*syncTrackBestVisibility\(\)/,
+  'One Home-owned setter must synchronize class, visible records and accessible state');
+assert.match(home, /setTrackRecordsExpanded\(!trackRecordsAreExpanded\(home\), \{ persist: true \}\)/,
+  'The shared button must persist through the canonical Home setter');
+assert.doesNotMatch(home, /toggle\.click\(|trackBestsToggle\.click\(/,
+  'Restoration must never synthesize a user click');
+
 assert.match(fixedCss, /--m8-track-card-min-block-size: clamp\(120px, calc\(20vh - 12px\), 164px\)/,
-  'Compact cards must be short enough for a comfortable six-card viewport');
+  'The fixed-layout stylesheet remains the stable post-782 baseline');
 assert.match(fixedCss, /\.m8-track-rail \{[\s\S]*column-gap: clamp\(10px, 1\.4vw, 16px\)[\s\S]*row-gap: clamp\(13px, calc\(1\.4vw - 1px\), 15px\)/,
   'The fixed-layout baseline must keep independently tunable track column and row gaps');
-assert.match(fixedCss, /\.is-showing-track-bests \.m8-home-tracks[\s\S]*--m8-track-card-min-block-size: clamp\(292px, calc\(47vh - 12px\), 378px\)/,
-  'The shared state must expand every card to one consistent record height');
-assert.match(scrollCss, /\.is-showing-track-bests \.m8-track-rail \.track-card[\s\S]*grid-template-rows: auto auto minmax\(0, 1fr\)/);
+
+assert.match(scrollCss, /--m8-track-compact-card-min-block-size: clamp\(108px, calc\(20vh - 24px\), 152px\)/,
+  'The consolidated card component owns the final compact landscape floor');
+assert.match(scrollCss, /--m8-track-compact-card-min-block-size: 96px/,
+  'Short landscape retains the final compact floor that removed the last default overflow');
+assert.match(scrollCss, /container-type: size/,
+  'The track viewport must provide a CSS size container for deterministic compact-row sizing');
+assert.match(scrollCss, /--m8-track-compact-card-block-size: max\([\s\S]*100cqh[\s\S]*2 \* var\(--m8-track-row-gap\)[\s\S]*\/ 3\)/,
+  'Landscape compact row height must be derived in CSS from the actual viewport, not measured in JavaScript');
+assert.match(scrollCss, /--m8-track-compact-card-content-block-size: calc\([\s\S]*--m8-track-compact-card-block-size[\s\S]*--m8-track-card-border-width[\s\S]*--m8-track-card-block-padding/,
+  'Expanded cards must reuse the exact closed-card content frame');
+assert.match(scrollCss, /\.track-card-compact \{[\s\S]*grid-template-columns: minmax\(0, 1fr\) minmax\(108px, 39%\)[\s\S]*align-content: center/,
+  'Marker, name, difficulty and map must share one canonical compact grid');
+assert.match(scrollCss, /\.is-showing-track-bests \.m8-track-rail \.track-card \{[\s\S]*grid-template-rows: var\(--m8-track-compact-card-content-block-size\) max-content[\s\S]*align-content: start/,
+  'Expanded cards must append records below the unchanged compact frame');
+assert.match(scrollCss, /\.is-showing-track-bests \.m8-track-rail \.track-card-compact \{[\s\S]*height: var\(--m8-track-compact-card-content-block-size\)/,
+  'Opening records must not resize the compact summary frame');
+assert.match(scrollCss, /\.track-card-best \{[\s\S]*grid-template-rows: auto repeat\(3, auto\)[\s\S]*row-gap: var\(--m8-track-row-gap\)/,
+  'BEST, TIME, DRIFT and FLOW must all use natural height and the shared card rhythm');
+assert.match(scrollCss, /\.is-showing-track-bests \.m8-track-rail \{[\s\S]*grid-auto-rows: max-content/,
+  'Expanded rail rows must grow to contain FLOW rather than clip it');
 assert.match(scrollCss, /\.track-card-best\[hidden\][\s\S]*display: none !important/);
 assert.match(scrollCss, /\.track-card-record\.is-drift[\s\S]*--turn-blue-300/);
 assert.match(scrollCss, /\.track-card-record\.is-flow[\s\S]*--turn-pink-500/);
 assert.match(scrollCss, /\.track-card-record::before[\s\S]*border: 2px solid var\(--m8-ink\)/,
   'Record accents need a TURN-ink outline so they remain distinct on every track paper colour');
 assert.match(scrollCss, /padding-left: calc\(var\(--track-record-stripe-width\) \+ var\(--track-record-stripe-gap\)\)/,
-  'Record copy must retain deliberate breathing room after the outlined accent stripe');
+  'Record copy must retain breathing room after the outlined accent stripe');
 assert.match(scrollCss, /\.track-card-record-model\[hidden\][\s\S]*display: none/);
 assert.match(scaleCss, /\.track-card-record[\s\S]*\.track-card-record-model/);
 
-assert.match(scrollCss, /\.m8-track-rail \{[\s\S]*column-gap: clamp\(14px, 1\.4vw, 16px\)[\s\S]*row-gap: clamp\(13px, calc\(1\.4vw - 1px\), 15px\)/,
-  'The horizontal card spacing must remain while every row-gap bound is 1px smaller');
-assert.doesNotMatch(scrollCss, /\.m8-track-rail \{[\s\S]{0,180}\n\s+gap: clamp\(14px, 1\.4vw, 16px\)/,
-  'Track rows must not inherit the wider horizontal gap again');
+assert.match(scrollCss, /\.m8-track-rail \{[\s\S]*column-gap: clamp\(14px, 1\.4vw, 16px\)[\s\S]*row-gap: var\(--m8-track-row-gap\)/,
+  'Horizontal and vertical card gaps must remain independently controlled');
+assert.match(scrollCss, /\.m8-track-scroll-viewport:not\(\.has-track-overflow\) \.m8-track-rail \{[\s\S]*grid-auto-rows: var\(--m8-track-compact-card-block-size\)[\s\S]*overflow-y: hidden/,
+  'When all six compact cards fit, the rail must use the full deterministic frame without scrolling');
+assert.match(scrollCss, /@media \(orientation: landscape\)[\s\S]*\.m8-track-rail \{[\s\S]*padding-right: 10px[\s\S]*\.m8-track-scroll-indicator \{[\s\S]*right: -11px/,
+  'Landscape must keep identical card width whether the scroll indicator is visible or not');
+assert.match(scrollCss, /height: clamp\(72px, 11vh, 104px\)/,
+  'The compact preview must stay at the final no-scroll size');
+assert.match(scrollCss, /height: 66px/,
+  'Short landscape must keep its compact preview size');
+assert.match(scrollCss, /not\(\.is-showing-track-bests\) \.m8-track-continue \{[\s\S]*margin-bottom: 7px/,
+  'RACE must reserve its resting shadow depth at the shared compact baseline');
+assert.match(scrollCss, /margin-bottom: 5px/,
+  'Short landscape must preserve the reduced RACE baseline reserve');
+
 assert.ok(rowGapCss.includes('row-gap: clamp(13px, calc(1.4vw - 1px), 15px)'),
-  'The late-loaded compatibility stylesheet must preserve the 1px-smaller row gap');
+  'The post-782 compatibility stylesheet must preserve the requested row gap');
 assert.ok(rowGapCss.includes('padding: 3px 9px;'),
-  'Track cards must use the requested 3px block and 9px inline padding');
-assert.ok(fixedCss.includes('--m8-track-card-min-block-size: 108px;') && fixedCss.includes('padding: 3px 9px;'),
-  'Short landscape rows must shrink with their reduced block padding instead of absorbing it');
-assert.ok(rowGapCss.includes('--m8-track-card-min-block-size: clamp(108px, calc(20vh - 24px), 152px);')
+  'The post-782 compatibility stylesheet must preserve 3px 9px card padding');
+assert.ok(rowGapCss.includes('--m8-track-card-min-block-size: clamp(120px, calc(20vh - 12px), 164px);')
   && rowGapCss.includes('--m8-track-card-min-block-size: clamp(292px, calc(47vh - 12px), 378px);')
-  && rowGapCss.includes('--m8-track-card-min-block-size: 96px;')
+  && rowGapCss.includes('--m8-track-card-min-block-size: 108px;')
   && rowGapCss.includes('--m8-track-card-min-block-size: 274px;'),
-  'The final landscape override must create more compact-fit headroom without changing expanded records');
-assert.ok(rowGapCss.includes('height: clamp(72px, 11vh, 104px);')
-  && rowGapCss.includes('height: 66px;'),
-  'Compact preview heights must shrink with the row floors so intrinsic preview size cannot restore overflow');
-assert.ok(rowGapCss.includes('.m8-track-scroll-viewport:not(.has-track-overflow) .m8-track-rail')
-  && rowGapCss.includes('grid-auto-rows: minmax(var(--m8-track-card-min-block-size), 1fr);')
-  && rowGapCss.includes('align-content: stretch;')
-  && rowGapCss.includes('padding-right: 10px;'),
-  'A fitting compact grid must fill the shared top/bottom frame and reclaim the hidden scrollbar gutter');
-assert.ok(rowGapCss.includes('.m8-track-continue')
-  && rowGapCss.includes('margin-bottom: 7px;')
-  && rowGapCss.includes('margin-bottom: 5px;'),
-  'RACE must reserve its resting/pressed shadow depth so its visual bottom matches the card-shadow baseline');
-assert.match(rowGapCss,
-  /is-showing-track-bests[\s\S]*\.m8-track-rail \.track-card \{[\s\S]*grid-template-rows: auto auto auto;[\s\S]*align-content: start;[\s\S]*min-height: max-content;[\s\S]*padding-top: var\(--m8-track-compact-top-padding, 3px\);/,
-  'Expanded cards must anchor the compact summary at its measured closed-state top position while growing to fit all records');
-assert.match(rowGapCss,
-  /is-showing-track-bests[\s\S]*\.m8-track-rail \{[\s\S]*grid-auto-rows: minmax\(var\(--m8-track-card-min-block-size\), max-content\);/,
-  'Expanded grid rows must use intrinsic max-content sizing so FLOW cannot be clipped by the viewport-oriented row minimum');
-assert.match(rowGapCss,
-  /is-showing-track-bests[\s\S]*\.m8-track-rail \.track-card-preview \{[\s\S]*height: clamp\(72px, 11vh, 104px\);/,
-  'The expanded map preview must keep the exact compact height instead of resizing');
-assert.match(rowGapCss,
-  /is-showing-track-bests[\s\S]*\.m8-track-rail \.track-card-best \{[\s\S]*grid-template-rows: auto repeat\(3, auto\);[\s\S]*row-gap: clamp\(13px, calc\(1\.4vw - 1px\), 15px\);[\s\S]*--m8-track-expanded-records-margin/,
-  'Expanded BEST, TIME, DRIFT and FLOW rows must size naturally below the preserved compact frame');
-assert.match(rowGapCss,
-  /is-showing-track-bests[\s\S]*\.m8-track-rail \{[\s\S]*padding-right: 10px;/,
-  'Opening records must keep the closed-state card-column width instead of shrinking for the scroll indicator');
-assert.match(rowGapCss,
-  /is-showing-track-bests[\s\S]*\.m8-track-scroll-viewport \{[\s\S]*overflow: visible;[\s\S]*\.m8-track-scroll-indicator \{[\s\S]*right: -11px;/,
-  'The expanded scroll indicator must move into the existing track/menu gap rather than move the cards');
-assert.match(scrollCss, /padding-bottom: 10px/,
-  'The rail must retain a 10px press/selection movement buffer even when default scrolling disappears');
+  'The compatibility stylesheet must be restored exactly to its post-782 sizing role');
+assert.doesNotMatch(rowGapCss, /track-card-preview|track-card-best|m8-track-continue|track-scroll-indicator|grid-auto-rows|compact-card/,
+  'The late compatibility stylesheet must not become a second Home layout engine again');
 assert.ok(!rowGapCss.includes('row-gap: 28px'),
   'No late-loaded rule may restore the old oversized vertical gap');
 for (const entrypoint of [productionEntry, labEntry]) {
   assert.ok(entrypoint.includes('home-track-row-gap-r200.css?revision=r210-compact-card-padding'),
-    'Production and TURN LAB must request the corrected stylesheet with a fresh cache key');
+    'Production and TURN LAB keep the post-782 compatibility stylesheet identity');
 }
 
-assert.match(scroll, /const TRACK_RECORDS_EXPANDED_KEY = 'turn-track-records-expanded-v1'/);
-assert.match(scroll, /function captureCompactTrackCardGeometry\(home\)[\s\S]*getBoundingClientRect\(\)[\s\S]*--m8-track-compact-top-padding[\s\S]*--m8-track-expanded-records-margin/,
-  'The runtime must snapshot the real compact geometry before expanding records');
-assert.match(scroll, /toggle\.addEventListener\('click', captureBeforeExpansion, \{ capture: true \}\)/,
-  'Compact geometry must be captured before the existing SHOW RECORDS click handler changes state');
-assert.match(scroll, /localStorage\?\.getItem\(TRACK_RECORDS_EXPANDED_KEY\)/,
-  'The shared disclosure must restore the player’s saved open/closed choice');
-assert.match(scroll, /localStorage\?\.setItem\(TRACK_RECORDS_EXPANDED_KEY, expanded \? 'true' : 'false'\)/,
-  'The shared disclosure must save both expanded and collapsed choices');
-assert.match(scroll, /toggle\.addEventListener\('click', persistCurrentState\)/);
-assert.match(scroll, /await nextAnimationFrame\(\)[\s\S]*captureCompactTrackCardGeometry\(home\)[\s\S]*if \(stored !== null && stored !== expanded\) toggle\.click\(\)/,
-  'Persisted expansion must restore only after the compact geometry has been measured');
+assert.match(scroll, /const FIX_ID = 'track-record-layout-v7'/);
+assert.match(scroll, /m8-home-card-scroll-fixes\.css\?build=\$\{buildKey\}-r217-track-record-layout/);
 assert.match(scroll, /const hasOverflow = maximum > 2/);
 assert.match(scroll, /viewport\.classList\.toggle\('has-track-overflow', hasOverflow\)/);
 assert.match(scroll, /rail\.dataset\.scrollMode = hasOverflow \? 'native' : 'static'/);
 assert.match(scroll, /if \(rail\.scrollTop !== 0\) rail\.scrollTop = 0/);
-assert.match(scrollCss, /\.m8-track-scroll-viewport:not\(\.has-track-overflow\) \.m8-track-rail[\s\S]*overflow-y: hidden/,
-  'A fully fitting six-card grid must disable its now-unnecessary scroll surface');
 assert.match(scroll, /indicator\.hidden = !hasOverflow/,
   'The custom scroll indicator must disappear with the scroll surface');
+assert.doesNotMatch(scroll, /TRACK_RECORDS_EXPANDED_KEY|localStorage|getBoundingClientRect|--m8-track-compact-top-padding|--m8-track-expanded-records-margin/,
+  'The scroll module must remain presentation-only: no disclosure state or runtime geometry reconstruction');
+assert.doesNotMatch(home, /getBoundingClientRect|--m8-track-compact-top-padding|--m8-track-expanded-records-margin/,
+  'Home record disclosure must not depend on measured geometry');
 
 assert.match(home, /dataset\.trackAccessibleLabel = label/);
 assert.match(trophyGate, /entry\.card\.dataset\.trackAccessibleLabel \|\| entry\.originalLabel/,
@@ -171,9 +187,9 @@ assert.match(screenReader, /card\.dataset\.trackAccessibleLabel/,
 assert.match(rivalReset, /\[data-track-record-kind="time"\]/,
   'Reset Rivals must clear only the time row and leave DRIFT/FLOW records intact');
 
-assert.match(app, /m8-home\.js\?revision=r206-shared-track-bests/);
-assert.match(app, /m8-home-fixed-layout\.js\?revision=r206-shared-track-bests/);
+assert.match(app, /m8-home\.js\?revision=r217-track-record-layout/);
+assert.match(app, /m8-home-fixed-layout\.js\?revision=r217-track-record-layout/);
 assert.match(app, /m8-record-car-scale\.css\?revision=r206-three-records/);
-assert.match(fixedLayout, /m8-home-card-scroll-fixes\.js\?build=\$\{buildKey\}-r206-shared-track-bests/);
+assert.match(fixedLayout, /m8-home-card-scroll-fixes\.js\?build=\$\{buildKey\}-r217-track-record-layout/);
 
-console.log('TURN shared compact/expanded TIME, DRIFT and FLOW track records passed.');
+console.log('TURN clean compact/expanded TIME, DRIFT and FLOW track record layout passed.');

--- a/turn/app.js
+++ b/turn/app.js
@@ -358,7 +358,7 @@ installStylesheet(
 );
 installStylesheet('./rival-reset-context-r127.css', 'data-turn-rival-reset-context');
 const { installM8HomeNavigation } = await import(
-  withBuild('./m8-home.js?revision=r206-shared-track-bests&trophy-road=r159&showroom=r200')
+  withBuild('./m8-home.js?revision=r217-track-record-layout&trophy-road=r159&showroom=r200')
 );
 const home = await installM8HomeNavigation();
 globalThis.__turnHome = home;
@@ -381,7 +381,7 @@ if (buildLabel) {
 // Historical regression marker for the paint and Monster Home bundle:
 // m8-home-fixed-layout.js?revision=m8.9-track-title-alignment&trophy-road=r157
 const { installM8HomeFixedLayout } = await import(
-  withBuild('./m8-home-fixed-layout.js?revision=r206-shared-track-bests&trophy-road=r159&achievements=r166-bella-records&bella-rescue=r174-siren-zone&music=warm-v2&robustness=r164-long-session')
+  withBuild('./m8-home-fixed-layout.js?revision=r217-track-record-layout&trophy-road=r159&achievements=r166-bella-records&bella-rescue=r174-siren-zone&music=warm-v2&robustness=r164-long-session')
 );
 await installM8HomeFixedLayout();
 installStylesheet(

--- a/turn/home-track-row-gap-r200.css
+++ b/turn/home-track-row-gap-r200.css
@@ -7,109 +7,10 @@
   padding: 3px 9px;
 }
 
-/*
- * Expanded cards must be the compact card plus records below it, not a new layout.
- * The runtime snapshots the compact card's real top inset and the space needed to
- * begin records below the old card edge. Keeping the preview at its compact size
- * makes the marker, name, difficulty and map stay in exactly the same place.
- *
- * The base card clips its paint to the rounded border with overflow:hidden. That
- * makes an `auto` implicit grid track allowed to stay at its viewport-oriented
- * minimum even when the BEST content is taller, which clipped the FLOW row. In the
- * expanded state only, make both the implicit row and the card's minimum height use
- * intrinsic max-content sizing. The card therefore grows downward until BEST,
- * TIME, DRIFT and FLOW are all inside the border; the compact summary geometry does
- * not move.
- */
-.m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests
-  .m8-track-rail {
-  grid-auto-rows: minmax(var(--m8-track-card-min-block-size), max-content);
-}
-
-.m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests
-  .m8-track-rail .track-card {
-  grid-template-rows: auto auto auto;
-  align-content: start;
-  min-height: max-content;
-  padding-top: var(--m8-track-compact-top-padding, 3px);
-}
-
-.m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests
-  .m8-track-rail .track-card-preview {
-  height: clamp(72px, 11vh, 104px);
-}
-
-.m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests
-  .m8-track-rail .track-card-best {
-  grid-template-rows: auto repeat(3, auto);
-  row-gap: clamp(13px, calc(1.4vw - 1px), 15px);
-  margin-top: var(
-    --m8-track-expanded-records-margin,
-    calc(clamp(13px, calc(1.4vw - 1px), 15px) - 5px)
-  );
-}
-
-/*
- * Opening records must not narrow the card grid just because the scroll indicator
- * appears. Keep the same 10px right-side card/shadow gutter as the closed state and
- * let the indicator sit partly in the existing track/menu gap instead.
- */
-.m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests
-  .m8-track-rail {
-  padding-right: 10px;
-}
-
-.m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests
-  .m8-track-scroll-viewport {
-  overflow: visible;
-}
-
-.m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests
-  .m8-track-scroll-indicator {
-  right: -11px;
-}
-
-/*
- * Compact cards still inherit a preview height large enough to defeat the smaller
- * row floors on some landscape viewports. Trim only the compact preview, then use
- * the existing 10px rail bottom padding as real movement room for the 8–10px
- * pressed/selected card translation instead of counting it as disposable space.
- */
-.m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes:not(.is-showing-track-bests)
-  .m8-track-rail .track-card-preview {
-  height: clamp(72px, 11vh, 104px);
-}
-
-/*
- * When the compact six-card grid fits, use the whole available track body instead
- * of parking the rows at the bottom. Equal flexible rows preserve the established
- * 13–15px row gap while aligning the first card row with SETTINGS and keeping the
- * last row at the shared lower baseline. The scrollbar gutter is no longer needed
- * in this state, so leave only the 10px needed for the cards' right-hand shadow.
- */
-.m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes:not(.is-showing-track-bests)
-  .m8-track-scroll-viewport:not(.has-track-overflow) .m8-track-rail {
-  grid-auto-rows: minmax(var(--m8-track-card-min-block-size), 1fr);
-  align-content: stretch;
-  padding-right: 10px;
-}
-
-/*
- * RACE uses a 7px resting shadow and translates 6px with a 1px shadow when pressed.
- * Reserve that same 7px below the button so its visual bottom, resting or pressed,
- * lands on the track-card shadow baseline rather than below it.
- */
-@media (orientation: landscape) {
-  .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes:not(.is-showing-track-bests)
-    .m8-track-continue {
-    margin-bottom: 7px;
-  }
-}
-
 /* These late overrides also reach clients with the previous fixed-layout CSS cached. */
 @media (orientation: landscape) {
   .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes .m8-home-tracks {
-    --m8-track-card-min-block-size: clamp(108px, calc(20vh - 24px), 152px);
+    --m8-track-card-min-block-size: clamp(120px, calc(20vh - 12px), 164px);
   }
 
   .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests .m8-home-tracks {
@@ -119,32 +20,7 @@
 
 @media (max-height: 560px) and (orientation: landscape) {
   .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes .m8-home-tracks {
-    --m8-track-card-min-block-size: 96px;
-  }
-
-  .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes:not(.is-showing-track-bests)
-    .m8-track-rail .track-card-preview,
-  .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests
-    .m8-track-rail .track-card-preview {
-    height: 66px;
-  }
-
-  .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes:not(.is-showing-track-bests)
-    .m8-track-continue {
-    margin-bottom: 5px;
-  }
-
-  .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests
-    .m8-track-rail .track-card-best {
-    margin-top: var(
-      --m8-track-expanded-records-margin,
-      calc(clamp(13px, calc(1.4vw - 1px), 15px) - 3px)
-    );
-  }
-
-  .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests
-    .m8-track-scroll-indicator {
-    right: -8px;
+    --m8-track-card-min-block-size: 108px;
   }
 
   .m8-home.m8-home-fixed-layout.m8-home-card-scroll-fixes.is-showing-track-bests .m8-home-tracks {

--- a/turn/m8-home-card-scroll-fixes.css
+++ b/turn/m8-home-card-scroll-fixes.css
@@ -1,8 +1,31 @@
+.m8-home-card-scroll-fixes .m8-home-tracks {
+  --m8-track-compact-card-min-block-size: clamp(108px, calc(20vh - 24px), 152px);
+  --m8-track-card-min-block-size: var(--m8-track-compact-card-min-block-size);
+}
+
+.m8-home-card-scroll-fixes.is-showing-track-bests .m8-home-tracks {
+  /* Expanded rows are content-sized. The compact frame has its own stable size below. */
+  --m8-track-card-min-block-size: 0px;
+}
+
 .m8-home-card-scroll-fixes .m8-track-scroll-viewport {
+  --m8-track-row-gap: clamp(13px, calc(1.4vw - 1px), 15px);
+  --m8-track-card-border-width: 5px;
+  --m8-track-card-block-padding: 3px;
+  --m8-track-compact-card-block-size: max(
+    var(--m8-track-compact-card-min-block-size),
+    calc((100cqh - 13px - (2 * var(--m8-track-row-gap))) / 3)
+  );
+  --m8-track-compact-card-content-block-size: calc(
+    var(--m8-track-compact-card-block-size)
+    - (2 * var(--m8-track-card-border-width))
+    - (2 * var(--m8-track-card-block-padding))
+  );
   position: relative;
   min-width: 0;
   min-height: 0;
   overflow: hidden;
+  container-type: size;
 }
 
 .m8-home-card-scroll-fixes .m8-track-scroll-viewport::before,
@@ -38,7 +61,9 @@
   padding-bottom: 10px;
   padding-right: 25px;
   column-gap: clamp(14px, 1.4vw, 16px);
-  row-gap: clamp(13px, calc(1.4vw - 1px), 15px);
+  row-gap: var(--m8-track-row-gap);
+  grid-auto-rows: minmax(var(--m8-track-card-min-block-size), auto);
+  align-content: start;
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior-y: contain;
@@ -50,9 +75,15 @@
   -webkit-user-select: none;
 }
 
-.m8-home-card-scroll-fixes .m8-track-scroll-viewport:not(.has-track-overflow) .m8-track-rail {
+.m8-home-card-scroll-fixes:not(.is-showing-track-bests)
+  .m8-track-scroll-viewport:not(.has-track-overflow) .m8-track-rail {
+  grid-auto-rows: var(--m8-track-compact-card-block-size);
   overflow-y: hidden;
   overscroll-behavior-y: none;
+}
+
+.m8-home-card-scroll-fixes.is-showing-track-bests .m8-track-rail {
+  grid-auto-rows: max-content;
 }
 
 .m8-home-card-scroll-fixes .m8-track-rail .track-card,
@@ -120,19 +151,46 @@
   opacity: 0.25;
 }
 
+/*
+ * A track card has one canonical compact frame plus an optional records block.
+ * The compact frame is the same size in both disclosure states, so the marker,
+ * name, difficulty and map never need to be measured or reconstructed in JS.
+ */
 .m8-home-card-scroll-fixes .m8-track-rail .track-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr);
+  align-items: stretch;
+  align-content: stretch;
+  gap: 0;
+  overflow: hidden;
+}
+
+.m8-home-card-scroll-fixes .m8-track-rail .track-card-compact {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(108px, 39%);
   grid-template-rows: auto auto;
   align-items: start;
   align-content: center;
   gap: 5px clamp(8px, 1vw, 13px);
-  overflow: hidden;
+  min-width: 0;
+  min-height: 0;
+  width: 100%;
+  height: 100%;
 }
 
 .m8-home-card-scroll-fixes.is-showing-track-bests .m8-track-rail .track-card {
-  grid-template-rows: auto auto minmax(0, 1fr);
+  grid-template-rows: var(--m8-track-compact-card-content-block-size) max-content;
   align-content: start;
+  row-gap: calc(
+    var(--m8-track-row-gap)
+    + var(--m8-track-card-border-width)
+    + var(--m8-track-card-block-padding)
+  );
+}
+
+.m8-home-card-scroll-fixes.is-showing-track-bests .m8-track-rail .track-card-compact {
+  height: var(--m8-track-compact-card-content-block-size);
 }
 
 .m8-home-card-scroll-fixes .m8-track-rail .track-card-summary {
@@ -187,30 +245,42 @@
   width: 100%;
   min-width: 0;
   min-height: 0;
-  height: clamp(76px, 12vh, 112px);
+  height: clamp(72px, 11vh, 104px);
   margin: 0;
 }
 
 .m8-home-card-scroll-fixes .m8-track-rail .track-card-best {
-  grid-column: 1 / -1;
-  grid-row: 3;
+  grid-column: 1;
+  grid-row: 2;
   align-self: stretch;
   display: grid;
   grid-template-columns: minmax(0, 1fr);
-  grid-template-rows: auto repeat(3, minmax(0, 1fr));
+  grid-template-rows: auto repeat(3, auto);
   align-items: stretch;
-  gap: clamp(5px, 0.7vh, 8px);
+  row-gap: var(--m8-track-row-gap);
+  column-gap: 0;
   min-width: 0;
   min-height: 0;
   width: 100%;
   max-width: none;
-  margin-top: clamp(5px, 0.8vh, 9px);
-  column-gap: 0;
+  margin: 0;
   text-align: left;
 }
 
 .m8-home-card-scroll-fixes .m8-track-rail .track-card-best[hidden] {
   display: none !important;
+}
+
+.m8-home-card-scroll-fixes:not(.is-showing-track-bests)
+  .m8-track-rail .track-card-coming-soon {
+  display: none;
+}
+
+.m8-home-card-scroll-fixes.is-showing-track-bests
+  .m8-track-rail .track-card-coming-soon {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: auto;
 }
 
 .m8-home-card-scroll-fixes .m8-track-rail .track-card-records-title {
@@ -307,40 +377,62 @@
   display: none;
 }
 
-.m8-home-card-scroll-fixes .m8-track-rail .track-card-coming-soon {
-  align-self: end;
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-template-rows: 1fr;
-}
-
 .m8-home-card-scroll-fixes .m8-track-rail .track-card-coming-soon .track-card-best-copy > * {
   display: block;
 }
 
-@media (max-height: 560px) and (orientation: landscape) {
+/*
+ * Landscape has a dedicated gap between the track browser and MENU. Put the custom
+ * scroll indicator there in every state so showing records never changes card width.
+ */
+@media (orientation: landscape) {
+  .m8-home-card-scroll-fixes .m8-track-scroll-viewport {
+    overflow: visible;
+  }
+
   .m8-home-card-scroll-fixes .m8-track-rail {
-    padding-right: 22px;
+    padding-right: 10px;
   }
 
   .m8-home-card-scroll-fixes .m8-track-scroll-viewport::before,
   .m8-home-card-scroll-fixes .m8-track-scroll-viewport::after {
-    right: 22px;
+    right: 10px;
   }
 
   .m8-home-card-scroll-fixes .m8-track-scroll-indicator {
+    right: -11px;
+  }
+
+  .m8-home-card-scroll-fixes:not(.is-showing-track-bests) .m8-track-continue {
+    margin-bottom: 7px;
+  }
+}
+
+@media (max-height: 820px) and (orientation: landscape) {
+  .m8-home-card-scroll-fixes .m8-track-scroll-viewport {
+    --m8-track-card-border-width: 4px;
+  }
+}
+
+@media (max-height: 560px) and (orientation: landscape) {
+  .m8-home-card-scroll-fixes .m8-home-tracks {
+    --m8-track-compact-card-min-block-size: 96px;
+  }
+
+  .m8-home-card-scroll-fixes .m8-track-scroll-viewport {
+    --m8-track-row-gap: 13px;
+  }
+
+  .m8-home-card-scroll-fixes .m8-track-scroll-indicator {
+    right: -8px;
     bottom: 10px;
     width: 13px;
     border-width: 2px;
   }
 
-  .m8-home-card-scroll-fixes .m8-track-rail .track-card {
+  .m8-home-card-scroll-fixes .m8-track-rail .track-card-compact {
     grid-template-columns: minmax(0, 1fr) minmax(94px, 38%);
     gap: 3px 8px;
-  }
-
-  .m8-home-card-scroll-fixes.is-showing-track-bests .m8-track-rail .track-card {
-    grid-template-rows: auto auto minmax(0, 1fr);
   }
 
   .m8-home-card-scroll-fixes .m8-track-rail .track-card-name {
@@ -349,11 +441,7 @@
   }
 
   .m8-home-card-scroll-fixes .m8-track-rail .track-card-preview {
-    height: 70px;
-  }
-
-  .m8-home-card-scroll-fixes .m8-track-rail .track-card-best {
-    gap: 4px;
+    height: 66px;
   }
 
   .m8-home-card-scroll-fixes .m8-track-rail .track-card-record {
@@ -366,9 +454,24 @@
   .m8-home-card-scroll-fixes .m8-track-rail .track-card-record-model {
     height: 46px;
   }
+
+  .m8-home-card-scroll-fixes:not(.is-showing-track-bests) .m8-track-continue {
+    margin-bottom: 5px;
+  }
 }
 
 @media (max-width: 760px) and (orientation: portrait) {
+  .m8-home-card-scroll-fixes .m8-home-tracks {
+    --m8-track-compact-card-min-block-size: 142px;
+  }
+
+  .m8-home-card-scroll-fixes .m8-track-scroll-viewport {
+    --m8-track-compact-card-block-size: max(
+      var(--m8-track-compact-card-min-block-size),
+      calc((100cqh - 13px - (5 * var(--m8-track-row-gap))) / 6)
+    );
+  }
+
   .m8-home-card-scroll-fixes .m8-track-rail {
     padding-right: 22px;
   }
@@ -378,7 +481,7 @@
     right: 22px;
   }
 
-  .m8-home-card-scroll-fixes .m8-track-rail .track-card {
+  .m8-home-card-scroll-fixes .m8-track-rail .track-card-compact {
     grid-template-columns: minmax(0, 1fr) minmax(104px, 38%);
   }
 }

--- a/turn/m8-home-card-scroll-fixes.js
+++ b/turn/m8-home-card-scroll-fixes.js
@@ -1,18 +1,17 @@
 const STYLE_ATTRIBUTE = 'data-turn-m8-card-scroll-fixes';
-const TRACK_RECORDS_EXPANDED_KEY = 'turn-track-records-expanded-v1';
 // Historical regression markers for the native-scroll/title-alignment bundles:
 // const FIX_ID = 'native-scroll-full-track-names-v4';
 // m8-home-card-scroll-fixes.css?build=${buildKey}-m8.9-track-title-alignment
 // const FIX_ID = 'native-scroll-full-track-names-v5';
 // m8-home-card-scroll-fixes.css?build=${buildKey}-m8.10-card-gap-rim
-const FIX_ID = 'shared-track-bests-v6';
+const FIX_ID = 'track-record-layout-v7';
 
 function installStylesheet() {
   if (document.querySelector(`link[${STYLE_ATTRIBUTE}]`)) return;
   const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
   const stylesheet = document.createElement('link');
   stylesheet.rel = 'stylesheet';
-  stylesheet.href = `/turn/m8-home-card-scroll-fixes.css?build=${buildKey}-r206-shared-track-bests`;
+  stylesheet.href = `/turn/m8-home-card-scroll-fixes.css?build=${buildKey}-r217-track-record-layout`;
   stylesheet.setAttribute(STYLE_ATTRIBUTE, '');
   document.head.appendChild(stylesheet);
 }
@@ -29,119 +28,6 @@ function waitForFixedHome() {
       resolve(rail);
     });
     observer.observe(document.body, { childList: true, subtree: true });
-  });
-}
-
-function loadTrackRecordsExpandedPreference() {
-  try {
-    const stored = globalThis.localStorage?.getItem(TRACK_RECORDS_EXPANDED_KEY);
-    if (stored === 'true') return true;
-    if (stored === 'false') return false;
-  } catch (_) {}
-  return null;
-}
-
-function saveTrackRecordsExpandedPreference(expanded) {
-  try {
-    globalThis.localStorage?.setItem(TRACK_RECORDS_EXPANDED_KEY, expanded ? 'true' : 'false');
-  } catch (_) {}
-}
-
-function px(value) {
-  const parsed = Number.parseFloat(value);
-  return Number.isFinite(parsed) ? parsed : 0;
-}
-
-function setPixelVariable(element, name, value) {
-  const rounded = Math.round(Math.max(0, value) * 100) / 100;
-  element.style.setProperty(name, `${rounded}px`);
-}
-
-function captureCompactTrackCardGeometry(home) {
-  if (home.classList.contains('is-showing-track-bests')) return;
-  const rail = home.querySelector('.m8-track-rail');
-  if (!rail) return;
-
-  const railRowGap = px(getComputedStyle(rail).rowGap);
-  for (const card of rail.querySelectorAll('.track-card')) {
-    const choice = card.querySelector('.track-card-choice');
-    const difficulty = card.querySelector('.track-card-difficulty');
-    const preview = card.querySelector('.track-card-preview');
-    if (!choice || !difficulty || !preview) continue;
-
-    const cardRect = card.getBoundingClientRect();
-    if (!(cardRect.width > 0 && cardRect.height > 0)) continue;
-    const choiceRect = choice.getBoundingClientRect();
-    const difficultyRect = difficulty.getBoundingClientRect();
-    const previewRect = preview.getBoundingClientRect();
-    const cardStyle = getComputedStyle(card);
-    const borderTop = px(cardStyle.borderTopWidth);
-    const cardRowGap = px(cardStyle.rowGap);
-
-    const compactContentTop = Math.min(choiceRect.top, previewRect.top);
-    const compactContentBottom = Math.max(
-      choiceRect.bottom,
-      difficultyRect.bottom,
-      previewRect.bottom
-    );
-    const compactTopPadding = compactContentTop - cardRect.top - borderTop;
-    const compactContentBottomFromTop = compactContentBottom - cardRect.top;
-    const expandedRecordsMargin = cardRect.height
-      + railRowGap
-      - compactContentBottomFromTop
-      - cardRowGap;
-
-    setPixelVariable(card, '--m8-track-compact-top-padding', compactTopPadding);
-    setPixelVariable(card, '--m8-track-expanded-records-margin', expandedRecordsMargin);
-  }
-}
-
-function nextAnimationFrame() {
-  return new Promise((resolve) => requestAnimationFrame(resolve));
-}
-
-async function installTrackRecordsExpandedPreference(home) {
-  const toggle = home.querySelector('.m8-track-bests-toggle');
-  if (!toggle) return null;
-
-  const captureBeforeExpansion = () => {
-    if (!home.classList.contains('is-showing-track-bests')) {
-      captureCompactTrackCardGeometry(home);
-    }
-  };
-  toggle.addEventListener('click', captureBeforeExpansion, { capture: true });
-
-  const persistCurrentState = () => {
-    queueMicrotask(() => {
-      const expanded = home.classList.contains('is-showing-track-bests');
-      saveTrackRecordsExpandedPreference(expanded);
-      if (!expanded) requestAnimationFrame(() => captureCompactTrackCardGeometry(home));
-    });
-  };
-  toggle.addEventListener('click', persistCurrentState);
-
-  let resizeFrame = 0;
-  window.addEventListener('resize', () => {
-    if (home.classList.contains('is-showing-track-bests') || resizeFrame) return;
-    resizeFrame = requestAnimationFrame(() => {
-      resizeFrame = 0;
-      captureCompactTrackCardGeometry(home);
-    });
-  }, { passive: true });
-
-  // Let the fixed-layout and card-scroll styles settle before taking the geometry
-  // snapshot used by a persisted expanded state. The DOM always starts compact.
-  await nextAnimationFrame();
-  captureCompactTrackCardGeometry(home);
-
-  const stored = loadTrackRecordsExpandedPreference();
-  const expanded = home.classList.contains('is-showing-track-bests');
-  if (stored !== null && stored !== expanded) toggle.click();
-
-  return Object.freeze({
-    key: TRACK_RECORDS_EXPANDED_KEY,
-    toggle,
-    get expanded() { return home.classList.contains('is-showing-track-bests'); }
   });
 }
 
@@ -234,8 +120,6 @@ export async function installM8HomeCardScrollFixes() {
   home.classList.add('m8-home-card-scroll-fixes');
   home.dataset.m8CardScrollFixes = FIX_ID;
   document.documentElement.dataset.turnHomeCardScrollFixes = FIX_ID;
-  const trackRecordsPreference = await installTrackRecordsExpandedPreference(home);
-  indicatorSync.sync();
 
   globalThis.__turnHomeCardScrollFixes = Object.freeze({
     id: FIX_ID,
@@ -243,7 +127,6 @@ export async function installM8HomeCardScrollFixes() {
     rail,
     viewport,
     indicator,
-    trackRecordsPreference,
     syncIndicator: indicatorSync.sync
   });
   return globalThis.__turnHomeCardScrollFixes;

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -268,7 +268,7 @@ export async function installM8HomeFixedLayout() {
     // Historical regression markers for the previous aligned-title bundles:
     // /turn/m8-home-card-scroll-fixes.js?build=${buildKey}-m8.9-track-title-alignment
     // /turn/m8-home-card-scroll-fixes.js?build=${buildKey}-m8.10-card-gap-rim
-    import(`/turn/m8-home-card-scroll-fixes.js?build=${buildKey}-r206-shared-track-bests`),
+    import(`/turn/m8-home-card-scroll-fixes.js?build=${buildKey}-r217-track-record-layout`),
     import(`/turn/progression/m8-trophy-gate.js?build=${buildKey}-r157-paint-monster`),
     import(`/turn/achievements.js?build=${buildKey}-r166-bella-records&robustness=r164-long-session`),
     import(`/turn/achievements/unread-markers.js?build=${buildKey}-r219-unified-filters`),

--- a/turn/m8-home.js
+++ b/turn/m8-home.js
@@ -26,6 +26,7 @@ const STEERING_MODE = Object.freeze({ MOTION: 'motion', MANUAL: 'manual' });
 const ICON_REVISION = '20260803-profile-512';
 const SCORE_FORMATTER = new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 });
 const TRACK_RECORD_KINDS = Object.freeze(['time', 'drift', 'flow']);
+const TRACK_RECORDS_EXPANDED_KEY = 'turn-track-records-expanded-v1';
 
 let installed = false;
 let previewGeneration = 0;
@@ -81,6 +82,23 @@ function saveSteeringMode(mode) {
     localStorage.setItem(STEERING_MODE_KEY, normalized);
   } catch (_) {}
   return normalized;
+}
+
+function loadTrackRecordsExpandedPreference() {
+  try {
+    return localStorage.getItem(TRACK_RECORDS_EXPANDED_KEY) === 'true';
+  } catch (_) {
+    return false;
+  }
+}
+
+function saveTrackRecordsExpandedPreference(expanded) {
+  try {
+    localStorage.setItem(TRACK_RECORDS_EXPANDED_KEY, expanded ? 'true' : 'false');
+    return true;
+  } catch (_) {
+    return false;
+  }
 }
 
 function selectedVehicle(runtime) {
@@ -167,17 +185,19 @@ function renderTrackCard(track) {
         disabled
         style="--track-accent:${track.accent};--track-accent-soft:${track.accentSoft}"
       >
-        <span class="track-card-summary">
-          <span class="track-card-choice">
-            <span class="track-card-choice-marker" aria-hidden="true"></span>
-            <strong class="track-card-name">${track.name}</strong>
+        <span class="track-card-compact">
+          <span class="track-card-summary">
+            <span class="track-card-choice">
+              <span class="track-card-choice-marker" aria-hidden="true"></span>
+              <strong class="track-card-name">${track.name}</strong>
+            </span>
+            <strong class="track-card-difficulty">LOCKED</strong>
           </span>
-          <span class="track-card-best track-card-coming-soon">
-            <span class="track-card-best-copy"><span>BEST:</span><strong>COMING SOON</strong></span>
-          </span>
-          <strong class="track-card-difficulty">LOCKED</strong>
+          <span class="track-card-preview" aria-hidden="true">${makeLockedPreviewSvg()}</span>
         </span>
-        <span class="track-card-preview" aria-hidden="true">${makeLockedPreviewSvg()}</span>
+        <span class="track-card-best track-card-coming-soon">
+          <span class="track-card-best-copy"><span>BEST:</span><strong>COMING SOON</strong></span>
+        </span>
       </button>`;
   }
 
@@ -191,20 +211,22 @@ function renderTrackCard(track) {
       aria-pressed="false"
       style="--track-accent:${track.accent};--track-accent-soft:${track.accentSoft}"
     >
-      <span class="track-card-summary">
-        <span class="track-card-choice">
-          <span class="track-card-choice-marker" aria-hidden="true"></span>
-          <strong class="track-card-name">${track.name.toUpperCase()}</strong>
+      <span class="track-card-compact">
+        <span class="track-card-summary">
+          <span class="track-card-choice">
+            <span class="track-card-choice-marker" aria-hidden="true"></span>
+            <strong class="track-card-name">${track.name.toUpperCase()}</strong>
+          </span>
+          <strong class="track-card-difficulty">${track.difficulty}</strong>
         </span>
-        <span class="track-card-best track-card-records" data-track-best="${track.id}" hidden>
-          <strong class="track-card-records-title">BEST:</strong>
-          ${renderTrackRecord('time', 'TIME', 'track-card-best-time')}
-          ${renderTrackRecord('drift', 'DRIFT', 'track-card-best-drift')}
-          ${renderTrackRecord('flow', 'FLOW', 'track-card-best-flow')}
-        </span>
-        <strong class="track-card-difficulty">${track.difficulty}</strong>
+        <span class="track-card-preview" aria-hidden="true">${makePreviewSvg(track.id, track.accent)}</span>
       </span>
-      <span class="track-card-preview" aria-hidden="true">${makePreviewSvg(track.id, track.accent)}</span>
+      <span class="track-card-best track-card-records" data-track-best="${track.id}" hidden>
+        <strong class="track-card-records-title">BEST:</strong>
+        ${renderTrackRecord('time', 'TIME', 'track-card-best-time')}
+        ${renderTrackRecord('drift', 'DRIFT', 'track-card-best-drift')}
+        ${renderTrackRecord('flow', 'FLOW', 'track-card-best-flow')}
+      </span>
     </button>`;
 }
 
@@ -597,7 +619,6 @@ function installLotRaceGate({ raceSession, getSteeringMode, onAccessReady }) {
       raceButton.focus();
     }
   };
-
   raceButton.addEventListener('click', gate, true);
   return () => raceButton.removeEventListener('click', gate, true);
 }
@@ -617,6 +638,7 @@ export async function installM8HomeNavigation() {
 
   const home = document.createElement('section');
   home.className = 'm8-home';
+  home.classList.toggle('is-showing-track-bests', loadTrackRecordsExpandedPreference());
   home.setAttribute('aria-labelledby', 'm8HomeTitle');
   home.innerHTML = `
     <div class="m8-home-shell">
@@ -740,9 +762,16 @@ export async function installM8HomeNavigation() {
     }));
   }
 
-  function toggleTrackBests() {
-    home.classList.toggle('is-showing-track-bests');
+  function setTrackRecordsExpanded(expanded, { persist = false } = {}) {
+    const next = Boolean(expanded);
+    home.classList.toggle('is-showing-track-bests', next);
+    if (persist) saveTrackRecordsExpandedPreference(next);
     syncTrackBestVisibility();
+    return next;
+  }
+
+  function toggleTrackBests() {
+    setTrackRecordsExpanded(!trackRecordsAreExpanded(home), { persist: true });
   }
 
   function showHome({ focus = false } = {}) {
@@ -851,7 +880,8 @@ export async function installM8HomeNavigation() {
     continueToTrack,
     leaveRaceForHome,
     getSelectedTrackId: () => selectedTrackId,
-    getSteeringMode: loadSteeringMode
+    getSteeringMode: loadSteeringMode,
+    getTrackRecordsExpanded: () => trackRecordsAreExpanded(home)
   });
 
   syncRaceSettingsVisibility();


### PR DESCRIPTION
Clean replacement for the #783–#788 patch stack, based on the reviewed post-#782 architecture.

This deliberately removes the accumulated compatibility/measurement work and rebuilds the final behavior around one structural rule: every track card is a canonical compact frame plus an optional records block below it.

### What changes
- restore `home-track-row-gap-r200.css` to its small post-#782 compatibility role
- remove runtime `getBoundingClientRect()` geometry capture and per-card positioning variables
- move SHOW/HIDE RECORDS persistence into `m8-home.js`, which owns the disclosure state
- restore saved state directly, without synthesizing `.click()`
- wrap marker/name/difficulty/map in one stable `.track-card-compact` frame used unchanged in both states
- append BEST / TIME / DRIFT / FLOW below that frame with natural intrinsic height
- use CSS container sizing for the compact six-card frame, preserving the final no-scroll geometry and press buffer without JS measurement
- keep landscape card width constant whether the scroll indicator is present or not
- preserve final 3px 9px padding, 13–15px row rhythm, compact preview sizing and RACE baseline
- give the rebuilt Home/card modules fresh `r217-track-record-layout` cache identities
- replace patch-specific regression assertions with structural contracts that forbid geometry measurement/state ownership in the scroll module

### Intended result
Closed cards should match the accepted compact layout exactly. Opening records must not move or resize the radio/check, track name, difficulty or map; it only grows each card downward to reveal BEST, TIME, DRIFT and FLOW. Expanded mode is expected to scroll.

No unrelated TURN behavior is intentionally changed.