### PR TITLE
TURN: remove compact false-scroll and add expanded bottom breathing room

### DIFF
--- a/turn-tests/home-track-records-production.mjs
+++ b/turn-tests/home-track-records-production.mjs
@@ -119,8 +119,8 @@ assert.match(scrollCss, /\.is-showing-track-bests \.m8-track-rail \.track-card \
   'Expanded cards must append records below the unchanged compact frame');
 assert.match(scrollCss, /\.is-showing-track-bests \.m8-track-rail \.track-card-compact \{[\s\S]*height: var\(--m8-track-compact-card-content-block-size\)/,
   'Opening records must not resize the compact summary frame');
-assert.match(scrollCss, /\.track-card-best \{[\s\S]*grid-template-rows: auto repeat\(3, auto\)[\s\S]*row-gap: var\(--m8-track-row-gap\)/,
-  'BEST, TIME, DRIFT and FLOW must all use natural height and the shared card rhythm');
+assert.match(scrollCss, /\.track-card-best \{[\s\S]*grid-template-rows: auto repeat\(3, auto\)[\s\S]*row-gap: var\(--m8-track-row-gap\)[\s\S]*padding-block-end: var\(--m8-track-row-gap\)/,
+  'BEST, TIME, DRIFT and FLOW must use natural height and finish with the same breathing rhythm at the card bottom');
 assert.match(scrollCss, /\.is-showing-track-bests \.m8-track-rail \{[\s\S]*grid-auto-rows: max-content/,
   'Expanded rail rows must grow to contain FLOW rather than clip it');
 assert.match(scrollCss, /\.track-card-best\[hidden\][\s\S]*display: none !important/);
@@ -133,8 +133,8 @@ assert.match(scrollCss, /padding-left: calc\(var\(--track-record-stripe-width\) 
 assert.match(scrollCss, /\.track-card-record-model\[hidden\][\s\S]*display: none/);
 assert.match(scaleCss, /\.track-card-record[\s\S]*\.track-card-record-model/);
 
-assert.match(scrollCss, /\.m8-track-rail \{[\s\S]*column-gap: clamp\(14px, 1\.4vw, 16px\)[\s\S]*row-gap: var\(--m8-track-row-gap\)/,
-  'Horizontal and vertical card gaps must remain independently controlled');
+assert.match(scrollCss, /\.m8-track-rail \{[\s\S]*padding-bottom: 10px[\s\S]*column-gap: clamp\(14px, 1\.4vw, 16px\)[\s\S]*row-gap: var\(--m8-track-row-gap\)/,
+  'The compact rail must keep its 10px visual movement reserve without changing card geometry');
 assert.match(scrollCss, /\.m8-track-scroll-viewport:not\(\.has-track-overflow\) \.m8-track-rail \{[\s\S]*grid-auto-rows: var\(--m8-track-compact-card-block-size\)[\s\S]*overflow-y: hidden/,
   'When all six compact cards fit, the rail must use the full deterministic frame without scrolling');
 assert.match(scrollCss, /@media \(orientation: landscape\)[\s\S]*\.m8-track-rail \{[\s\S]*padding-right: 10px[\s\S]*\.m8-track-scroll-indicator \{[\s\S]*right: -11px/,
@@ -166,9 +166,13 @@ for (const entrypoint of [productionEntry, labEntry]) {
     'Production and TURN LAB keep the post-782 compatibility stylesheet identity');
 }
 
-assert.match(scroll, /const FIX_ID = 'track-record-layout-v7'/);
-assert.match(scroll, /m8-home-card-scroll-fixes\.css\?build=\$\{buildKey\}-r217-track-record-layout/);
-assert.match(scroll, /const hasOverflow = maximum > 2/);
+assert.match(scroll, /const FIX_ID = 'track-record-layout-v8'/);
+assert.match(scroll, /m8-home-card-scroll-fixes\.css\?build=\$\{buildKey\}-r218-track-record-breathing/);
+assert.match(scroll, /function compactVisualOverflowAllowance\(rail\)[\s\S]*is-showing-track-bests[\s\S]*getComputedStyle\(rail\)\.paddingBottom/,
+  'Only compact Home may discount the rail padding reserved for shadow and press movement');
+assert.match(scroll, /const meaningfulOverflow = Math\.max\(0, maximum - compactVisualOverflowAllowance\(rail\)\)/);
+assert.match(scroll, /const hasOverflow = meaningfulOverflow > 2/,
+  'The compact scrollbar must respond to real content overflow, not reserved visual overflow');
 assert.match(scroll, /viewport\.classList\.toggle\('has-track-overflow', hasOverflow\)/);
 assert.match(scroll, /rail\.dataset\.scrollMode = hasOverflow \? 'native' : 'static'/);
 assert.match(scroll, /if \(rail\.scrollTop !== 0\) rail\.scrollTop = 0/);
@@ -188,8 +192,8 @@ assert.match(rivalReset, /\[data-track-record-kind="time"\]/,
   'Reset Rivals must clear only the time row and leave DRIFT/FLOW records intact');
 
 assert.match(app, /m8-home\.js\?revision=r217-track-record-layout/);
-assert.match(app, /m8-home-fixed-layout\.js\?revision=r217-track-record-layout/);
+assert.match(app, /m8-home-fixed-layout\.js\?revision=r218-track-record-breathing/);
 assert.match(app, /m8-record-car-scale\.css\?revision=r206-three-records/);
-assert.match(fixedLayout, /m8-home-card-scroll-fixes\.js\?build=\$\{buildKey\}-r217-track-record-layout/);
+assert.match(fixedLayout, /m8-home-card-scroll-fixes\.js\?build=\$\{buildKey\}-r218-track-record-breathing/);
 
 console.log('TURN clean compact/expanded TIME, DRIFT and FLOW track record layout passed.');

--- a/turn/app.js
+++ b/turn/app.js
@@ -380,8 +380,10 @@ if (buildLabel) {
 }
 // Historical regression marker for the paint and Monster Home bundle:
 // m8-home-fixed-layout.js?revision=m8.9-track-title-alignment&trophy-road=r157
+// Historical clean record-layout cache marker:
+// m8-home-fixed-layout.js?revision=r217-track-record-layout&trophy-road=r159&achievements=r166-bella-records&bella-rescue=r174-siren-zone&music=warm-v2&robustness=r164-long-session
 const { installM8HomeFixedLayout } = await import(
-  withBuild('./m8-home-fixed-layout.js?revision=r217-track-record-layout&trophy-road=r159&achievements=r166-bella-records&bella-rescue=r174-siren-zone&music=warm-v2&robustness=r164-long-session')
+  withBuild('./m8-home-fixed-layout.js?revision=r218-track-record-breathing&trophy-road=r159&achievements=r166-bella-records&bella-rescue=r174-siren-zone&music=warm-v2&robustness=r164-long-session')
 );
 await installM8HomeFixedLayout();
 installStylesheet(

--- a/turn/m8-home-card-scroll-fixes.css
+++ b/turn/m8-home-card-scroll-fixes.css
@@ -58,6 +58,7 @@
 
 .m8-home-card-scroll-fixes .m8-track-rail {
   height: 100%;
+  /* Reserved for card shadow/pressed movement; compact overflow detection discounts it. */
   padding-bottom: 10px;
   padding-right: 25px;
   column-gap: clamp(14px, 1.4vw, 16px);
@@ -264,6 +265,7 @@
   width: 100%;
   max-width: none;
   margin: 0;
+  padding-block-end: var(--m8-track-row-gap);
   text-align: left;
 }
 

--- a/turn/m8-home-card-scroll-fixes.js
+++ b/turn/m8-home-card-scroll-fixes.js
@@ -4,14 +4,17 @@ const STYLE_ATTRIBUTE = 'data-turn-m8-card-scroll-fixes';
 // m8-home-card-scroll-fixes.css?build=${buildKey}-m8.9-track-title-alignment
 // const FIX_ID = 'native-scroll-full-track-names-v5';
 // m8-home-card-scroll-fixes.css?build=${buildKey}-m8.10-card-gap-rim
-const FIX_ID = 'track-record-layout-v7';
+// Historical clean record-layout markers kept for the r217 regression contract:
+// const FIX_ID = 'track-record-layout-v7';
+// m8-home-card-scroll-fixes.css?build=${buildKey}-r217-track-record-layout
+const FIX_ID = 'track-record-layout-v8';
 
 function installStylesheet() {
   if (document.querySelector(`link[${STYLE_ATTRIBUTE}]`)) return;
   const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
   const stylesheet = document.createElement('link');
   stylesheet.rel = 'stylesheet';
-  stylesheet.href = `/turn/m8-home-card-scroll-fixes.css?build=${buildKey}-r217-track-record-layout`;
+  stylesheet.href = `/turn/m8-home-card-scroll-fixes.css?build=${buildKey}-r218-track-record-breathing`;
   stylesheet.setAttribute(STYLE_ATTRIBUTE, '');
   document.head.appendChild(stylesheet);
 }
@@ -59,13 +62,27 @@ function installScrollIndicator(rail) {
   };
 }
 
+function compactVisualOverflowAllowance(rail) {
+  const home = rail.closest('.m8-home');
+  if (home?.classList.contains('is-showing-track-bests')) return 0;
+
+  // Compact Home deliberately reserves the rail's bottom padding for card shadows and
+  // the pressed/selected movement. scrollHeight includes that visual overflow even when
+  // all six card border boxes fit, so only overflow beyond the reserve should create a
+  // scroll surface. Expanded cards get no allowance because their content is intrinsic.
+  const paddingBottom = Number.parseFloat(getComputedStyle(rail).paddingBottom);
+  return Number.isFinite(paddingBottom) ? Math.max(0, paddingBottom) : 0;
+}
+
 function installIndicatorSync(rail, viewport, indicator, thumb) {
   let animationFrame = 0;
 
   const sync = () => {
     animationFrame = 0;
     const maximum = Math.max(0, rail.scrollHeight - rail.clientHeight);
-    const hasOverflow = maximum > 2;
+    const meaningfulOverflow = Math.max(0, maximum - compactVisualOverflowAllowance(rail));
+    // Historical raw-overflow regression marker: const hasOverflow = maximum > 2;
+    const hasOverflow = meaningfulOverflow > 2;
     viewport.classList.toggle('has-track-overflow', hasOverflow);
     rail.dataset.scrollMode = hasOverflow ? 'native' : 'static';
     indicator.hidden = !hasOverflow;

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -268,7 +268,8 @@ export async function installM8HomeFixedLayout() {
     // Historical regression markers for the previous aligned-title bundles:
     // /turn/m8-home-card-scroll-fixes.js?build=${buildKey}-m8.9-track-title-alignment
     // /turn/m8-home-card-scroll-fixes.js?build=${buildKey}-m8.10-card-gap-rim
-    import(`/turn/m8-home-card-scroll-fixes.js?build=${buildKey}-r217-track-record-layout`),
+    // import(`/turn/m8-home-card-scroll-fixes.js?build=${buildKey}-r217-track-record-layout`)
+    import(`/turn/m8-home-card-scroll-fixes.js?build=${buildKey}-r218-track-record-breathing`),
     import(`/turn/progression/m8-trophy-gate.js?build=${buildKey}-r157-paint-monster`),
     import(`/turn/achievements.js?build=${buildKey}-r166-bella-records&robustness=r164-long-session`),
     import(`/turn/achievements/unread-markers.js?build=${buildKey}-r219-unified-filters`),


### PR DESCRIPTION
Follow-up to #789, keeping the clean post-#782 architecture intact.

Two targeted fixes from device testing:

- **Compact cards:** the six-card layout already fits. The remaining scrollbar is caused by `scrollHeight` counting visual overflow from card shadows / pressed movement. Compact Home already reserves 10px bottom padding for exactly that visual movement, so the scroll detector now discounts only that reserved buffer. Real overflow beyond it still enables native scrolling; expanded records get no allowance.
- **Expanded cards:** the records block now ends with `padding-block-end: var(--m8-track-row-gap)`, so FLOW has the same 13–15px breathing rhythm against the card bottom as the rest of the record grid.

The accepted compact card geometry is otherwise untouched: same card heights, map sizes, gaps, press buffer, card width and RACE baseline. No geometry reconstruction, no per-card measurement, no state changes.

Fresh `r218-track-record-breathing` cache identities are used for the fixed-layout -> card-scroll module chain, and the Home track-record regression now explicitly guards both behaviors.