### PR TITLE
TURN: preserve DRIFT and FLOW record car paint

### DIFF
--- a/turn-lab/tests/track-best-model-production.mjs
+++ b/turn-lab/tests/track-best-model-production.mjs
@@ -1,7 +1,43 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [index, releaseSource, app, selector, renderer, css, scaleCss, hud] = await Promise.all([
+import {
+  DRIFT_RECORDS_STORAGE_KEY,
+  getBestDriftRecord,
+  saveBestDriftRecord
+} from '../../turn/scoring/drift-records.js';
+import {
+  FLOW_RECORDS_STORAGE_KEY,
+  getBestFlowRecord,
+  saveBestFlowRecord
+} from '../../turn/scoring/flow-records.js';
+
+class MemoryStorage {
+  constructor() {
+    this.values = new Map();
+  }
+
+  getItem(key) {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key, value) {
+    this.values.set(key, String(value));
+  }
+}
+
+const [
+  index,
+  releaseSource,
+  app,
+  selector,
+  renderer,
+  css,
+  scaleCss,
+  hud,
+  driftRuntime,
+  flowRuntime
+] = await Promise.all([
   fs.readFile(new URL('../../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/release.json', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/app.js', import.meta.url), 'utf8'),
@@ -9,7 +45,9 @@ const [index, releaseSource, app, selector, renderer, css, scaleCss, hud] = awai
   fs.readFile(new URL('../../turn/ui/track-best-car.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/track-select-r61.css', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/m8-record-car-scale.css', import.meta.url), 'utf8'),
-  fs.readFile(new URL('../../turn/ui/hud.js', import.meta.url), 'utf8')
+  fs.readFile(new URL('../../turn/ui/hud.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/scoring/drift-attack-runtime.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/scoring/flow-runtime.js', import.meta.url), 'utf8')
 ]);
 
 const release = JSON.parse(releaseSource);
@@ -35,6 +73,10 @@ assert.match(selector, /aria-hidden="true"/, 'The decorative model must not dupl
 assert.match(selector, /model\.hidden = false/, 'The model must appear only after its render succeeds');
 assert.match(selector, /for \(const track of TRACK_CATALOG\)/, 'Locked placeholder slots must never request a record thumbnail');
 
+assert.match(renderer, /getVehicleDefaultColor\(car\.id\)/,
+  'Legacy score records without paint must fall back to that car’s body default, not TURN’s global yellow');
+assert.match(renderer, /getVehicleDefaultSecondaryColor\(car\.id\)/,
+  'Legacy score records without paint must fall back to that car’s secondary default, not global white');
 assert.match(renderer, /createCarVisual\(\{[\s\S]*carId,[\s\S]*color,[\s\S]*secondaryColor/, 'The thumbnail must use the real local GLB and its recorded paint');
 assert.match(renderer, /preserveDrawingBuffer: true/, 'The one-shot WebGL render must remain capturable after drawing');
 assert.match(renderer, /croppedThumbnailDataUrl\(renderer\.domElement\)/, 'The rendered car must be cropped before becoming the reusable image');
@@ -46,6 +88,64 @@ assert.match(renderer, /renderQueue/, 'Multiple record cars must render serially
 assert.match(renderer, /renderer\.dispose\(\)/, 'Each one-shot renderer must release GPU resources');
 assert.match(renderer, /renderer\.forceContextLoss\?\.\(\)/, 'The temporary WebGL context must be explicitly released');
 assert.doesNotMatch(renderer, /requestAnimationFrame|setAnimationLoop|setInterval/, 'Record thumbnails must add no continuous render loop');
+
+for (const [runtimeSource, label] of [[driftRuntime, 'DRIFT'], [flowRuntime, 'FLOW']]) {
+  assert.match(runtimeSource, /carColor = state\.vehicleColor/,
+    `${label} bests must capture the body paint active when the score was set`);
+  assert.match(runtimeSource, /carSecondaryColor = state\.vehicleSecondaryColor/,
+    `${label} bests must capture the secondary paint active when the score was set`);
+  assert.match(runtimeSource, /carId,[\s\S]*carColor,[\s\S]*carSecondaryColor,[\s\S]*lapTime: time/,
+    `${label} runtime must persist the complete record-car paint pair`);
+}
+
+const driftPaintStorage = new MemoryStorage();
+saveBestDriftRecord({
+  trackId: 'countryside',
+  score: 5753,
+  carId: 'classic',
+  carColor: '#FFCC00',
+  carSecondaryColor: '#222222',
+  hitAt: 100
+}, driftPaintStorage);
+assert.deepEqual(getBestDriftRecord('countryside', driftPaintStorage), {
+  score: 5753,
+  carId: 'classic',
+  hitAt: 100,
+  carColor: '#ffcc00',
+  carSecondaryColor: '#222222'
+}, 'DRIFT records must preserve the car paint that produced the best');
+assert.equal(JSON.parse(driftPaintStorage.getItem(DRIFT_RECORDS_STORAGE_KEY)).version, 2);
+
+const flowPaintStorage = new MemoryStorage();
+saveBestFlowRecord({
+  trackId: 'countryside',
+  score: 6037,
+  carId: 'race',
+  carColor: '#5D503F',
+  carSecondaryColor: '#222222',
+  hitAt: 200
+}, flowPaintStorage);
+assert.deepEqual(getBestFlowRecord('countryside', flowPaintStorage), {
+  score: 6037,
+  carId: 'race',
+  hitAt: 200,
+  carColor: '#5d503f',
+  carSecondaryColor: '#222222'
+}, 'FLOW records must preserve the car paint that produced the best');
+assert.equal(JSON.parse(flowPaintStorage.getItem(FLOW_RECORDS_STORAGE_KEY)).version, 2);
+
+const legacyPaintStorage = new MemoryStorage();
+legacyPaintStorage.setItem(DRIFT_RECORDS_STORAGE_KEY, JSON.stringify({
+  version: 1,
+  tracks: {
+    countryside: { score: 1000, carId: 'classic', hitAt: 1 }
+  }
+}));
+assert.deepEqual(getBestDriftRecord('countryside', legacyPaintStorage), {
+  score: 1000,
+  carId: 'classic',
+  hitAt: 1
+}, 'Paint-aware record normalization must keep pre-paint DRIFT saves readable');
 
 assert.match(bestLayoutBlock, /grid-template-columns: max-content max-content;/, 'BEST copy and car must use content-sized columns');
 assert.match(bestLayoutBlock, /justify-content: start;/, 'The BEST cluster must remain left anchored');
@@ -83,4 +183,4 @@ assert.ok(
 );
 assert.doesNotMatch(hud, /queueMicrotask|requestAnimationFrame|setInterval/, 'The player marker must remain part of the existing synchronous HUD paint');
 
-console.log(`TURN ${release.id} three-record Home cars and one top-layer canonical player marker passed.`);
+console.log(`TURN ${release.id} three-record Home cars, exact score paint and one top-layer canonical player marker passed.`);

--- a/turn/scoring/drift-attack-runtime.js
+++ b/turn/scoring/drift-attack-runtime.js
@@ -6,7 +6,7 @@ import { createDriftAttackScorer } from './drift-attack.js';
 import {
   getBestDriftRecord,
   saveBestDriftRecord
-} from './drift-records.js';
+} from './drift-records.js?revision=r219-record-paint';
 
 export const DRIFT_ATTACK_FEATURE_ID = 'drift-attack';
 export const DRIFT_HUD_STORAGE_KEY = 'turn-drift-hud-v1';
@@ -176,7 +176,9 @@ export function createDriftAttackRuntime({
     valid = false,
     ranked = true,
     trackId = state.trackId,
-    carId = state.vehicleId
+    carId = state.vehicleId,
+    carColor = state.vehicleColor,
+    carSecondaryColor = state.vehicleSecondaryColor
   } = {}) {
     if (!enabled) return Object.freeze({ available: false });
 
@@ -188,6 +190,8 @@ export function createDriftAttackRuntime({
         trackId,
         score: scoreResult.score,
         carId,
+        carColor,
+        carSecondaryColor,
         lapTime: time,
         hitAt: wallClock()
       }, targetStorage)

--- a/turn/scoring/drift-records.js
+++ b/turn/scoring/drift-records.js
@@ -1,7 +1,8 @@
 export const DRIFT_RECORDS_STORAGE_KEY = 'turn-drift-records-v1';
-export const DRIFT_RECORDS_STORAGE_VERSION = 1;
+export const DRIFT_RECORDS_STORAGE_VERSION = 2;
 
 const DEFAULT_TRACK_ID = 'countryside';
+const HEX_COLOR_PATTERN = /^#[0-9a-f]{6}$/i;
 
 function storageOrDefault(storage) {
   if (storage !== undefined) return storage;
@@ -22,6 +23,11 @@ function finitePositive(value, fallback = null) {
   return Number.isFinite(number) && number > 0 ? number : fallback;
 }
 
+function normalizePaint(value) {
+  const normalized = typeof value === 'string' ? value.toLowerCase() : '';
+  return HEX_COLOR_PATTERN.test(normalized) ? normalized : null;
+}
+
 function normalizeRecord(record) {
   const score = Math.round(finitePositive(record?.score, 0));
   if (score <= 0) return null;
@@ -30,6 +36,10 @@ function normalizeRecord(record) {
     carId: String(record?.carId || 'classic'),
     hitAt: finitePositive(record?.hitAt)
   };
+  const carColor = normalizePaint(record?.carColor);
+  const carSecondaryColor = normalizePaint(record?.carSecondaryColor);
+  if (carColor) normalized.carColor = carColor;
+  if (carSecondaryColor) normalized.carSecondaryColor = carSecondaryColor;
   const lapTime = finitePositive(record?.lapTime);
   if (lapTime != null) normalized.lapTime = lapTime;
   return Object.freeze(normalized);
@@ -55,12 +65,21 @@ export function saveBestDriftRecord({
   trackId,
   score,
   carId,
+  carColor,
+  carSecondaryColor,
   lapTime,
   hitAt = Date.now()
 } = {}, storage) {
   const targetStorage = storageOrDefault(storage);
   const normalizedTrackId = normalizeTrackId(trackId);
-  const candidate = normalizeRecord({ score, carId, lapTime, hitAt });
+  const candidate = normalizeRecord({
+    score,
+    carId,
+    carColor,
+    carSecondaryColor,
+    lapTime,
+    hitAt
+  });
   const current = getBestDriftRecord(normalizedTrackId, targetStorage);
   if (!candidate || (current && candidate.score <= current.score)) {
     return Object.freeze({ record: current, isNewBest: false, saved: false });

--- a/turn/scoring/flow-records.js
+++ b/turn/scoring/flow-records.js
@@ -1,7 +1,8 @@
 export const FLOW_RECORDS_STORAGE_KEY = 'turn-flow-records-v1';
-export const FLOW_RECORDS_STORAGE_VERSION = 1;
+export const FLOW_RECORDS_STORAGE_VERSION = 2;
 
 const DEFAULT_TRACK_ID = 'countryside';
+const HEX_COLOR_PATTERN = /^#[0-9a-f]{6}$/i;
 
 function storageOrDefault(storage) {
   if (storage !== undefined) return storage;
@@ -22,6 +23,11 @@ function finitePositive(value, fallback = null) {
   return Number.isFinite(number) && number > 0 ? number : fallback;
 }
 
+function normalizePaint(value) {
+  const normalized = typeof value === 'string' ? value.toLowerCase() : '';
+  return HEX_COLOR_PATTERN.test(normalized) ? normalized : null;
+}
+
 function normalizeRecord(record) {
   const score = Math.round(finitePositive(record?.score, 0));
   if (score <= 0) return null;
@@ -30,6 +36,10 @@ function normalizeRecord(record) {
     carId: String(record?.carId || 'classic'),
     hitAt: finitePositive(record?.hitAt)
   };
+  const carColor = normalizePaint(record?.carColor);
+  const carSecondaryColor = normalizePaint(record?.carSecondaryColor);
+  if (carColor) normalized.carColor = carColor;
+  if (carSecondaryColor) normalized.carSecondaryColor = carSecondaryColor;
   const lapTime = finitePositive(record?.lapTime);
   if (lapTime != null) normalized.lapTime = lapTime;
   return Object.freeze(normalized);
@@ -55,12 +65,21 @@ export function saveBestFlowRecord({
   trackId,
   score,
   carId,
+  carColor,
+  carSecondaryColor,
   lapTime,
   hitAt = Date.now()
 } = {}, storage) {
   const targetStorage = storageOrDefault(storage);
   const normalizedTrackId = normalizeTrackId(trackId);
-  const candidate = normalizeRecord({ score, carId, lapTime, hitAt });
+  const candidate = normalizeRecord({
+    score,
+    carId,
+    carColor,
+    carSecondaryColor,
+    lapTime,
+    hitAt
+  });
   const current = getBestFlowRecord(normalizedTrackId, targetStorage);
   if (!candidate || (current && candidate.score <= current.score)) {
     return Object.freeze({ record: current, isNewBest: false, saved: false });

--- a/turn/scoring/flow-runtime.js
+++ b/turn/scoring/flow-runtime.js
@@ -9,7 +9,7 @@ import {
 import {
   getBestFlowRecord,
   saveBestFlowRecord
-} from './flow-records.js';
+} from './flow-records.js?revision=r219-record-paint';
 
 export const FLOW_FEATURE_ID = 'flow';
 export const FLOW_HUD_STORAGE_KEY = 'turn-flow-hud-v1';
@@ -404,7 +404,9 @@ export function createFlowRuntime({
     valid = false,
     ranked = true,
     trackId = state.trackId,
-    carId = state.vehicleId
+    carId = state.vehicleId,
+    carColor = state.vehicleColor,
+    carSecondaryColor = state.vehicleSecondaryColor
   } = {}) {
     if (!enabled) return Object.freeze({ available: false });
     const scoreResult = scorer.completeLap(now);
@@ -415,6 +417,8 @@ export function createFlowRuntime({
         trackId,
         score: scoreResult.score,
         carId,
+        carColor,
+        carSecondaryColor,
         lapTime: time,
         hitAt: wallClock()
       }, targetStorage)

--- a/turn/ui/track-best-car.js
+++ b/turn/ui/track-best-car.js
@@ -2,6 +2,8 @@ import * as THREE from 'three';
 import { createCarVisual } from '../vehicle/car-models.js?build=20260720-r22';
 import {
   getCarDefinition,
+  getVehicleDefaultColor,
+  getVehicleDefaultSecondaryColor,
   normalizeVehicleColor,
   normalizeVehicleSecondaryColor
 } from '../vehicle/catalog.js?build=20260724-r59';
@@ -41,8 +43,14 @@ async function waitForHomeThumbnailSlot() {
 
 export function renderBestCarThumbnail(bestLap) {
   const car = getCarDefinition(bestLap?.carId);
-  const color = normalizeVehicleColor(bestLap?.carColor);
-  const secondaryColor = normalizeVehicleSecondaryColor(bestLap?.carSecondaryColor);
+  const color = normalizeVehicleColor(
+    bestLap?.carColor,
+    getVehicleDefaultColor(car.id)
+  );
+  const secondaryColor = normalizeVehicleSecondaryColor(
+    bestLap?.carSecondaryColor,
+    getVehicleDefaultSecondaryColor(car.id)
+  );
   const cacheKey = `${car.id}:${color}:${secondaryColor}`;
 
   if (!thumbnailCache.has(cacheKey)) {


### PR DESCRIPTION
Fixes the record thumbnail paint bug without touching the #789/#790 card layout.

Root cause: TIME records already store `carColor` and `carSecondaryColor`, but DRIFT/FLOW score records only stored `carId`. `track-best-car.js` then normalized the missing paint fields against TURN's global yellow/white fallback, so every DRIFT/FLOW thumbnail rendered as yellow/white.

This PR fixes both old and new records cleanly:
- DRIFT and FLOW record payloads now persist body + secondary paint alongside the winning car (payload schema version 2; existing v1 records remain readable)
- both scoring runtimes capture `state.vehicleColor` and `state.vehicleSecondaryColor` at the same moment the PB is saved
- record paint values are validated/normalized before persistence
- legacy DRIFT/FLOW records that predate paint storage now render with that vehicle's actual factory defaults instead of the global yellow/white fallback
- custom-painted future PBs render with the exact paint pair used when the record was set
- focused regression coverage checks stored paint, runtime capture, legacy compatibility and car-specific renderer fallback

No Home card geometry, scrolling, disclosure state or record-row layout is changed.