### PR TITLE
TURN: keep SHARE beside the open TIME record

### DIFF
--- a/turn-tests/yourturn-turn-sharing-production.mjs
+++ b/turn-tests/yourturn-turn-sharing-production.mjs
@@ -94,6 +94,16 @@ assert.match(shareCss, /\.turn-yourturn-share-back[\s\S]*#ff9b66/,
   'Back remains the navigation orange');
 assert.match(shareCss, /\.turn-yourturn-track-slot[\s\S]*position: relative/,
   'The separate share button must use a valid sibling wrapper rather than nesting a button inside the track button');
+assert.match(shareCss, /\.m8-home:not\(\.is-showing-track-bests\) \.turn-yourturn-track-share \{[\s\S]*display: none !important/,
+  'Closed track cards must never show the Home SHARE control over the map');
+assert.match(shareCss, /anchor-scope: --turn-yourturn-time-copy/,
+  'Each card wrapper must scope its own TIME-row anchor');
+assert.match(shareCss, /\.track-card-record\.is-time \.track-card-record-copy \{[\s\S]*anchor-name: --turn-yourturn-time-copy/,
+  'The share control must be visually anchored to the TIME record copy, not the card corner');
+assert.match(shareCss, /\.m8-home\.is-showing-track-bests \.turn-yourturn-track-share \{[\s\S]*right: auto;[\s\S]*bottom: auto/,
+  'Expanded Home must explicitly retire the old bottom-right placement that covered FLOW');
+assert.match(shareCss, /position-anchor: --turn-yourturn-time-copy;[\s\S]*left: calc\(anchor\(right\) \+ clamp\(10px, 1vw, 14px\)\);[\s\S]*top: anchor\(center\)/,
+  'Supporting browsers must place SHARE directly beside the TIME record');
 
 assert.match(profileSource, /turn-social-racer-id-v1/);
 assert.match(profileSource, /turn-social-racer-name-v1/);
@@ -123,4 +133,4 @@ assert.match(yourTurnUi, /adoptSocialRacerIdentity\(\{ id: existing\.id, name: t
 assert.match(yourTurnUi, /challenge\.racers\.some\(\(racer\) => racer\.id === sessionState\.racerId\)/,
   'A recognized racer ID must bypass unnecessary identity confirmation');
 
-console.log('TURN → YOUR TURN seed sharing, short transport, remembered names and returning-racer claim regression passed.');
+console.log('TURN → YOUR TURN seed sharing, time-record Home placement, short transport, remembered names and returning-racer claim regression passed.');

--- a/turn-tests/yourturn-turn-sharing-production.mjs
+++ b/turn-tests/yourturn-turn-sharing-production.mjs
@@ -100,8 +100,11 @@ assert.match(shareCss, /anchor-scope: --turn-yourturn-time-copy/,
   'Each card wrapper must scope its own TIME-row anchor');
 assert.match(shareCss, /\.track-card-record\.is-time \.track-card-record-copy \{[\s\S]*anchor-name: --turn-yourturn-time-copy/,
   'The share control must be visually anchored to the TIME record copy, not the card corner');
-assert.match(shareCss, /\.m8-home\.is-showing-track-bests \.turn-yourturn-track-share \{[\s\S]*right: auto;[\s\S]*bottom: auto/,
-  'Expanded Home must explicitly retire the old bottom-right placement that covered FLOW');
+const trackShareRule = shareCss.match(/\.turn-yourturn-track-share \{[\s\S]*?\n\}/)?.[0] || '';
+assert.match(trackShareRule, /left: 42%;[\s\S]*top: 50%/,
+  'Browsers without CSS anchor positioning must still keep SHARE in the TIME-record area');
+assert.doesNotMatch(trackShareRule, /right:|bottom:/,
+  'The Home SHARE control must not retain the old bottom-right corner placement');
 assert.match(shareCss, /position-anchor: --turn-yourturn-time-copy;[\s\S]*left: calc\(anchor\(right\) \+ clamp\(10px, 1vw, 14px\)\);[\s\S]*top: anchor\(center\)/,
   'Supporting browsers must place SHARE directly beside the TIME record');
 

--- a/turn/social/your-turn-share.css
+++ b/turn/social/your-turn-share.css
@@ -44,10 +44,11 @@
 .turn-yourturn-track-share {
   position: absolute;
   z-index: 4;
-  right: 16px;
-  bottom: 16px;
+  left: 42%;
+  top: 50%;
   width: clamp(46px, 4.6vw, 58px);
   height: clamp(46px, 4.6vw, 58px);
+  translate: -50% -50%;
 }
 
 .turn-yourturn-track-share[hidden],
@@ -282,11 +283,6 @@
   .turn-yourturn-share-actions button {
     min-height: 40px;
   }
-
-  .turn-yourturn-track-share {
-    right: 11px;
-    bottom: 11px;
-  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -314,14 +310,6 @@
 
 .m8-home:not(.is-showing-track-bests) .turn-yourturn-track-share {
   display: none !important;
-}
-
-.m8-home.is-showing-track-bests .turn-yourturn-track-share {
-  right: auto;
-  bottom: auto;
-  left: 42%;
-  top: 50%;
-  translate: -50% -50%;
 }
 
 @supports (anchor-name: --turn-yourturn-time-copy) {

--- a/turn/social/your-turn-share.css
+++ b/turn/social/your-turn-share.css
@@ -294,3 +294,41 @@
     backdrop-filter: none;
   }
 }
+
+/*
+ * The track card itself is a button, so the SHARE button must stay its sibling rather
+ * than becoming an invalid interactive descendant. Scope a CSS anchor to each wrapper
+ * and visually attach that sibling to the TIME record only while records are open.
+ */
+.turn-yourturn-track-slot {
+  anchor-scope: --turn-yourturn-time-copy;
+}
+
+.m8-home.is-showing-track-bests
+  .turn-yourturn-track-slot:has(> .turn-yourturn-track-share:not([hidden]))
+  .track-card-record.is-time .track-card-record-copy {
+  width: fit-content;
+  max-width: calc(100% - clamp(62px, 6vw, 78px));
+  anchor-name: --turn-yourturn-time-copy;
+}
+
+.m8-home:not(.is-showing-track-bests) .turn-yourturn-track-share {
+  display: none !important;
+}
+
+.m8-home.is-showing-track-bests .turn-yourturn-track-share {
+  right: auto;
+  bottom: auto;
+  left: 42%;
+  top: 50%;
+  translate: -50% -50%;
+}
+
+@supports (anchor-name: --turn-yourturn-time-copy) {
+  .m8-home.is-showing-track-bests .turn-yourturn-track-share {
+    position-anchor: --turn-yourturn-time-copy;
+    left: calc(anchor(right) + clamp(10px, 1vw, 14px));
+    top: anchor(center);
+    translate: 0 -50%;
+  }
+}


### PR DESCRIPTION
Moves the Home SHARE affordance away from the card corner without changing the track-card interaction model.

The track card itself remains one button, so SHARE deliberately remains a sibling button in the existing wrapper (no nested interactive element). CSS now scopes an anchor per card and visually attaches that sibling to the selected card’s TIME record when SHOW RECORDS is open.

Behavior:
- closed cards never show SHARE, so it cannot cover the track map
- expanded cards show SHARE only for the selected track when a shareable TIME replay exists, as before
- SHARE is positioned beside the TIME record instead of bottom-right, so it cannot cover the FLOW thumbnail
- the existing lap-result SHARE action is unchanged
- a non-anchor-positioning fallback keeps the control in the TIME area rather than the card corner

Added regression assertions for the closed-state suppression, sibling architecture, TIME-row anchor and retirement of bottom-right expanded placement.