### PR TITLE
TURN: make WINNER achievements work on consecutive laps

### DIFF
--- a/turn/achievements/challenge-expansion-r166.js
+++ b/turn/achievements/challenge-expansion-r166.js
@@ -221,7 +221,10 @@ export function installAchievementChallengeExpansion({
 
   const handleUiState = (event) => {
     const reason = event.detail?.reason;
-    if (reason === 'lap-started') beginLap();
+    // TURN immediately starts the next timed lap after a finish. `lap-completed`
+    // is published after that reset and after the just-finished lap has joined the
+    // rival list, so it is the correct boundary for the next achievement attempt.
+    if (reason === 'lap-started' || reason === 'lap-completed') beginLap();
     if (reason === 'race-reset') resetLap();
     if (Object.prototype.hasOwnProperty.call(event.detail || {}, 'running')
         && event.detail.running === false) {


### PR DESCRIPTION
Fixes the old `… WINNER` session-boundary bug.

Root cause: the achievement challenge tracker opened an attempt only on `lap-started`. TURN emits that event for the first timed lap of a race session, but after a completed lap the race loop immediately rolls into the next timed lap and emits `lap-completed` instead. `turn:lap-result` then cleared the achievement attempt, so lap 2+ in the same session had no attempt to evaluate. Restarting the race happened to make it work because the next lap got a fresh `lap-started` event.

The fix treats `lap-completed` as the automatic next-lap boundary too. Importantly, TURN publishes it after the completed lap has been saved into `state.competitorLaps`, so the next attempt snapshots the newly increased rival count. That means a fifth lap can correctly earn WINNER after the first four laps created four saved rivals in the same session.

No rival-storage, race-position, scoring, UI, or achievement qualification thresholds are changed.