### PR TITLE
TURN: implement authored DRIFT and SAFETY achievement SVGs

### DIFF
--- a/turn/achievements/catalog-production.js
+++ b/turn/achievements/catalog-production.js
@@ -11,7 +11,8 @@ import {
 } from './learning-progress.js?revision=r1-learning-achievements';
 
 function authoredAchievementIcon(name) {
-  return `<span class="turn-authored-achievement-icon is-${name}" aria-hidden="true"></span>`;
+  const source = `/turn/assets/achievements/${name}.svg`;
+  return `<span class="turn-authored-achievement-icon is-${name}" aria-hidden="true" style="display:block;width:100%;height:100%;background:currentColor;-webkit-mask:url('${source}') center/contain no-repeat;mask:url('${source}') center/contain no-repeat"></span>`;
 }
 
 export const ICONS = Object.freeze({

--- a/turn/achievements/catalog-production.js
+++ b/turn/achievements/catalog-production.js
@@ -10,6 +10,16 @@ import {
   LEARN_TO_PLAY_ACHIEVEMENT_ID
 } from './learning-progress.js?revision=r1-learning-achievements';
 
+function authoredAchievementIcon(name) {
+  return `<span class="turn-authored-achievement-icon is-${name}" aria-hidden="true"></span>`;
+}
+
+export const ICONS = Object.freeze({
+  ...base.ICONS,
+  drift: authoredAchievementIcon('drift'),
+  safety: authoredAchievementIcon('safety')
+});
+
 const CHROMATIC_CAMOUFLAGE = Object.freeze({
   id: 'chromatic-camouflage',
   category: base.CATEGORY.EXPLORATION,
@@ -101,11 +111,17 @@ export const TRACK_SAFETY_ACHIEVEMENTS = Object.freeze(
     trophies: 75,
     title: `${base.TRACK_NAMES[trackId].toUpperCase()} SAFETY`,
     description: `Finish ${base.TRACK_NAMES[trackId]} without going off-road in under ${SAFETY_TARGET_LABELS[trackId]}.`,
-    icon: 'route'
+    icon: 'safety'
   }))
 );
 
 const rebalancedBaseAchievements = base.ACHIEVEMENTS.map((achievement) => {
+  if (achievement.id === 'around-the-turn') {
+    return Object.freeze({
+      ...achievement,
+      icon: 'safety'
+    });
+  }
   if (achievement.id === 'on-course-of-course') {
     return Object.freeze({
       ...achievement,

--- a/turn/assets/achievements/drift.svg
+++ b/turn/assets/achievements/drift.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800" aria-hidden="true">
+  <path
+    d="M 222 195 C 132 286, 63 409, 53 605"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="49"
+    stroke-linecap="round"
+  />
+
+  <path
+    d="M 398 266 C 326 346, 268 454, 258 598"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="49"
+    stroke-linecap="round"
+  />
+
+  <path
+    d="M 467 596
+       C 475 504, 509 401, 571 321
+       C 626 251, 700 198, 790 148"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="49"
+    stroke-linecap="butt"
+    stroke-dasharray="54 51"
+  />
+
+  <g transform="rotate(-15 371 169)">
+    <rect
+      x="183"
+      y="62"
+      width="384"
+      height="215"
+      rx="31"
+      fill="currentColor"
+    />
+
+    <rect x="232" y="103" width="59" height="122" fill="transparent" />
+    <rect x="464" y="103" width="44" height="122" fill="transparent" />
+  </g>
+</svg>

--- a/turn/assets/achievements/safety.svg
+++ b/turn/assets/achievements/safety.svg
@@ -1,0 +1,93 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800" aria-hidden="true">
+
+  <!-- Left broken road edge -->
+  <path
+    d="
+      M 142 150
+      C 205 220, 225 318, 198 410
+      C 166 518, 130 610, 122 714
+    "
+    fill="none"
+    stroke="currentColor"
+    stroke-width="58"
+    stroke-linecap="butt"
+    stroke-dasharray="78 62"
+  />
+
+  <!-- Right broken road edge -->
+  <path
+    d="
+      M 605 104
+      C 681 194, 708 301, 688 397
+      C 663 505, 632 608, 636 710
+    "
+    fill="none"
+    stroke="currentColor"
+    stroke-width="58"
+    stroke-linecap="butt"
+    stroke-dasharray="78 62"
+  />
+
+  <!-- Left tyre trail -->
+  <path
+    d="
+      M 365 368
+      C 405 443, 412 512, 365 570
+      C 310 637, 286 678, 282 724
+    "
+    fill="none"
+    stroke="currentColor"
+    stroke-width="58"
+    stroke-linecap="round"
+  />
+
+  <!-- Right tyre trail -->
+  <path
+    d="
+      M 455 348
+      C 520 421, 540 504, 505 574
+      C 469 645, 454 686, 453 722
+    "
+    fill="none"
+    stroke="currentColor"
+    stroke-width="58"
+    stroke-linecap="round"
+  />
+
+<!-- Car -->
+<g transform="rotate(-20 400 300)">
+
+  <!-- Main body, with windows cut out -->
+  <path
+    d="
+      M 335 155
+      H 465
+      Q 500 155 500 190
+      V 405
+      Q 500 440 465 440
+      H 335
+      Q 300 440 300 405
+      V 190
+      Q 300 155 335 155
+      Z
+
+      M 337 210
+      H 463
+      V 239
+      H 337
+      Z
+
+      M 337 294
+      H 463
+      V 323
+      H 337
+      Z
+    "
+    fill="currentColor"
+    fill-rule="evenodd"
+    clip-rule="evenodd"
+  />
+
+</g>
+
+</svg>


### PR DESCRIPTION
Implements #769 using the supplied SVGs as source-of-truth assets.

Changes:
- adds `turn/assets/achievements/drift.svg` exactly from the issue
- adds `turn/assets/achievements/safety.svg` exactly from the issue
- reuses the DRIFT asset for every DRIFT scoring achievement through the existing `drift` icon key
- maps AROUND THE TURN and all six `… SAFETY` achievements to the shared SAFETY asset
- leaves ON COURSE, OF COURSE and every unrelated achievement artwork unchanged

Integration follows the same authored-asset pattern already used by Trophy Road: the achievement icon catalog returns one decorative span which masks the external SVG and paints it with `currentColor`. That keeps one source asset per family, preserves locked/unlocked/toast theming, avoids duplicated inline SVG markup, raster fallbacks, external dependencies, or runtime SVG construction.

The existing achievement card/toast pipeline is otherwise unchanged.