### PR TITLE
TURN: complete #769 SAFETY and DRIFT icon mapping

### DIFF
--- a/turn-tests/trophy-road-detail-production.mjs
+++ b/turn-tests/trophy-road-detail-production.mjs
@@ -1,6 +1,16 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import { trophyRoadDetailPlacement } from '../turn/achievements/view.js';
+import {
+  ICONS,
+  TRACK_IDS,
+  getAchievement
+} from '../turn/achievements/catalog.js';
+import { TROPHY_ROAD_REWARD_ICONS } from '../turn/progression/trophy-road.js';
+import {
+  AUTHORED_DRIFT_ICON,
+  AUTHORED_SAFETY_ICON
+} from '../turn/ui/authored-icons.js';
 
 const [view, feedback, styles] = await Promise.all([
   fs.readFile(new URL('../turn/achievements/view.js', import.meta.url), 'utf8'),
@@ -33,6 +43,26 @@ assert.deepEqual(trophyRoadDetailPlacement({
   left: 10,
   width: 980
 }, 'A lower selected row must place the modal above and clamp it to viewport edges');
+
+assert.equal(ICONS.drift, AUTHORED_DRIFT_ICON,
+  'Achievement DRIFT artwork must come from the shared authored SVG source');
+assert.equal(ICONS.safety, AUTHORED_SAFETY_ICON,
+  'Achievement SAFETY artwork must come from the shared authored SVG source');
+assert.equal(getAchievement('around-the-turn')?.icon, 'safety');
+assert.equal(getAchievement('on-course-of-course')?.icon, 'safety',
+  'ON COURSE, OF COURSE belongs to the SAFETY artwork family');
+for (const trackId of TRACK_IDS) {
+  assert.equal(getAchievement(`${trackId}-safety`)?.icon, 'safety',
+    `${trackId} SAFETY must use the shared SAFETY artwork`);
+}
+assert.equal(TROPHY_ROAD_REWARD_ICONS.drift, AUTHORED_DRIFT_ICON,
+  'The DRIFT ATTACK Trophy Road reward must reuse the authored DRIFT SVG');
+assert.match(AUTHORED_DRIFT_ICON, /currentColor/);
+assert.match(AUTHORED_SAFETY_ICON, /currentColor/);
+assert.match(AUTHORED_DRIFT_ICON, /aria-hidden="true"/);
+assert.match(AUTHORED_SAFETY_ICON, /aria-hidden="true"/);
+assert.doesNotMatch(AUTHORED_DRIFT_ICON, /mask/i);
+assert.doesNotMatch(AUTHORED_SAFETY_ICON, /mask/i);
 
 assert.match(view, /data-trophy-road-detail-layer hidden/);
 assert.match(view, /role="dialog"[\s\S]*aria-modal="true"[\s\S]*aria-labelledby="turnTrophyRoadDetailTitle"/,
@@ -88,4 +118,4 @@ assert.match(feedback, /turn:trophy-road-detail-closed[\s\S]*handleDetailClosed/
 assert.doesNotMatch(feedback, /requestAnimationFrame|scrollLeft|scrollBy|scrollWidth|clientWidth/,
   'The complete road grid must not retain carousel geometry or an animation-frame layout path');
 
-console.log('TURN Trophy Road anchored reward modal, focus, placement and showcase lifecycle passed.');
+console.log('TURN Trophy Road anchored reward modal, focus, placement, shared icon mapping and showcase lifecycle passed.');

--- a/turn/achievements/catalog-production.js
+++ b/turn/achievements/catalog-production.js
@@ -9,143 +9,10 @@ import {
   HOW_TO_PLAY_DISCLOSURE_IDS,
   LEARN_TO_PLAY_ACHIEVEMENT_ID
 } from './learning-progress.js?revision=r1-learning-achievements';
-
-const AUTHORED_DRIFT_ICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800" aria-hidden="true">
-  <path
-    d="M 222 195 C 132 286, 63 409, 53 605"
-    fill="none"
-    stroke="currentColor"
-    stroke-width="49"
-    stroke-linecap="round"
-  />
-
-  <path
-    d="M 398 266 C 326 346, 268 454, 258 598"
-    fill="none"
-    stroke="currentColor"
-    stroke-width="49"
-    stroke-linecap="round"
-  />
-
-  <path
-    d="M 467 596
-       C 475 504, 509 401, 571 321
-       C 626 251, 700 198, 790 148"
-    fill="none"
-    stroke="currentColor"
-    stroke-width="49"
-    stroke-linecap="butt"
-    stroke-dasharray="54 51"
-  />
-
-  <g transform="rotate(-15 371 169)">
-    <rect
-      x="183"
-      y="62"
-      width="384"
-      height="215"
-      rx="31"
-      fill="currentColor"
-    />
-
-    <rect x="232" y="103" width="59" height="122" fill="transparent" />
-    <rect x="464" y="103" width="44" height="122" fill="transparent" />
-  </g>
-</svg>`;
-
-const AUTHORED_SAFETY_ICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800" aria-hidden="true">
-
-  <!-- Left broken road edge -->
-  <path
-    d="
-      M 142 150
-      C 205 220, 225 318, 198 410
-      C 166 518, 130 610, 122 714
-    "
-    fill="none"
-    stroke="currentColor"
-    stroke-width="58"
-    stroke-linecap="butt"
-    stroke-dasharray="78 62"
-  />
-
-  <!-- Right broken road edge -->
-  <path
-    d="
-      M 605 104
-      C 681 194, 708 301, 688 397
-      C 663 505, 632 608, 636 710
-    "
-    fill="none"
-    stroke="currentColor"
-    stroke-width="58"
-    stroke-linecap="butt"
-    stroke-dasharray="78 62"
-  />
-
-  <!-- Left tyre trail -->
-  <path
-    d="
-      M 365 368
-      C 405 443, 412 512, 365 570
-      C 310 637, 286 678, 282 724
-    "
-    fill="none"
-    stroke="currentColor"
-    stroke-width="58"
-    stroke-linecap="round"
-  />
-
-  <!-- Right tyre trail -->
-  <path
-    d="
-      M 455 348
-      C 520 421, 540 504, 505 574
-      C 469 645, 454 686, 453 722
-    "
-    fill="none"
-    stroke="currentColor"
-    stroke-width="58"
-    stroke-linecap="round"
-  />
-
-<!-- Car -->
-<g transform="rotate(-20 400 300)">
-
-  <!-- Main body, with windows cut out -->
-  <path
-    d="
-      M 335 155
-      H 465
-      Q 500 155 500 190
-      V 405
-      Q 500 440 465 440
-      H 335
-      Q 300 440 300 405
-      V 190
-      Q 300 155 335 155
-      Z
-
-      M 337 210
-      H 463
-      V 239
-      H 337
-      Z
-
-      M 337 294
-      H 463
-      V 323
-      H 337
-      Z
-    "
-    fill="currentColor"
-    fill-rule="evenodd"
-    clip-rule="evenodd"
-  />
-
-</g>
-
-</svg>`;
+import {
+  AUTHORED_DRIFT_ICON,
+  AUTHORED_SAFETY_ICON
+} from '../ui/authored-icons.js?revision=r245-shared-drift-safety-icons';
 
 export const ICONS = Object.freeze({
   ...base.ICONS,
@@ -258,6 +125,7 @@ const rebalancedBaseAchievements = base.ACHIEVEMENTS.map((achievement) => {
   if (achievement.id === 'on-course-of-course') {
     return Object.freeze({
       ...achievement,
+      icon: 'safety',
       recommendation: 'Targets: Countryside < 15 seconds · Airport < 20 seconds · Cliffside < 20 seconds · Harbor < 30 seconds · Midnight City < 70 seconds · Mountain < 70 seconds'
     });
   }

--- a/turn/progression/trophy-road.js
+++ b/turn/progression/trophy-road.js
@@ -1,3 +1,5 @@
+import { AUTHORED_DRIFT_ICON } from '../ui/authored-icons.js?revision=r245-shared-drift-safety-icons';
+
 export const TROPHY_ROAD_STORAGE_KEY = 'turn-achievements-v1';
 export const TROPHY_ROAD_STORAGE_VERSION = 9;
 export const TROPHY_ROAD_MAX_THRESHOLD = 2200;
@@ -20,7 +22,7 @@ export const TROPHY_ROAD_REWARD_ICONS = Object.freeze({
   rally: authoredRewardIcon('rally-racer'),
   mountain: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M4 42 23 13l8 12L40 8l20 34Z"></path><path d="m17 22 6-9 5 8 4-6 8-7 7 13"></path><path d="M39 42c5-8 9-11 15-13M43 35l4 2-2 4 5 2"></path></svg>',
   shift: authoredRewardIcon('shift'),
-  drift: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M7 10c24 2 35 13 32 33"></path><path d="M21 6c25 5 37 19 31 37"></path><path d="M5 21h8M17 29h8M31 38h8"></path></svg>',
+  drift: AUTHORED_DRIFT_ICON,
   flow: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M4 24c8-16 18-16 28 0s20 16 28 0"></path><path d="M4 34c8-16 18-16 28 0s20 16 28 0"></path></svg>',
   perk: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M35 3 14 28h15l-3 17 24-28H35Z"></path><path d="M8 11h12M5 18h10M46 35h11"></path></svg>'
 });

--- a/turn/ui/authored-icons.js
+++ b/turn/ui/authored-icons.js
@@ -1,0 +1,140 @@
+// Authored TURN icon artwork shared by Achievements and Trophy Road.
+// Keep these strings as the source-of-truth SVG markup rather than duplicating
+// or reconstructing the artwork at each rendering surface.
+
+export const AUTHORED_DRIFT_ICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800" aria-hidden="true">
+  <path
+    d="M 222 195 C 132 286, 63 409, 53 605"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="49"
+    stroke-linecap="round"
+  />
+
+  <path
+    d="M 398 266 C 326 346, 268 454, 258 598"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="49"
+    stroke-linecap="round"
+  />
+
+  <path
+    d="M 467 596
+       C 475 504, 509 401, 571 321
+       C 626 251, 700 198, 790 148"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="49"
+    stroke-linecap="butt"
+    stroke-dasharray="54 51"
+  />
+
+  <g transform="rotate(-15 371 169)">
+    <rect
+      x="183"
+      y="62"
+      width="384"
+      height="215"
+      rx="31"
+      fill="currentColor"
+    />
+
+    <rect x="232" y="103" width="59" height="122" fill="transparent" />
+    <rect x="464" y="103" width="44" height="122" fill="transparent" />
+  </g>
+</svg>`;
+
+export const AUTHORED_SAFETY_ICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800" aria-hidden="true">
+
+  <!-- Left broken road edge -->
+  <path
+    d="
+      M 142 150
+      C 205 220, 225 318, 198 410
+      C 166 518, 130 610, 122 714
+    "
+    fill="none"
+    stroke="currentColor"
+    stroke-width="58"
+    stroke-linecap="butt"
+    stroke-dasharray="78 62"
+  />
+
+  <!-- Right broken road edge -->
+  <path
+    d="
+      M 605 104
+      C 681 194, 708 301, 688 397
+      C 663 505, 632 608, 636 710
+    "
+    fill="none"
+    stroke="currentColor"
+    stroke-width="58"
+    stroke-linecap="butt"
+    stroke-dasharray="78 62"
+  />
+
+  <!-- Left tyre trail -->
+  <path
+    d="
+      M 365 368
+      C 405 443, 412 512, 365 570
+      C 310 637, 286 678, 282 724
+    "
+    fill="none"
+    stroke="currentColor"
+    stroke-width="58"
+    stroke-linecap="round"
+  />
+
+  <!-- Right tyre trail -->
+  <path
+    d="
+      M 455 348
+      C 520 421, 540 504, 505 574
+      C 469 645, 454 686, 453 722
+    "
+    fill="none"
+    stroke="currentColor"
+    stroke-width="58"
+    stroke-linecap="round"
+  />
+
+<!-- Car -->
+<g transform="rotate(-20 400 300)">
+
+  <!-- Main body, with windows cut out -->
+  <path
+    d="
+      M 335 155
+      H 465
+      Q 500 155 500 190
+      V 405
+      Q 500 440 465 440
+      H 335
+      Q 300 440 300 405
+      V 190
+      Q 300 155 335 155
+      Z
+
+      M 337 210
+      H 463
+      V 239
+      H 337
+      Z
+
+      M 337 294
+      H 463
+      V 323
+      H 337
+      Z
+    "
+    fill="currentColor"
+    fill-rule="evenodd"
+    clip-rule="evenodd"
+  />
+
+</g>
+
+</svg>`;


### PR DESCRIPTION
Follow-up to #769 for the two surfaces that were missed in the first integration.

- `ON COURSE, OF COURSE` now uses the authored SAFETY SVG, alongside AROUND THE TURN and the six track SAFETY achievements.
- The Trophy Road `DRIFT ATTACK` reward now uses the authored DRIFT SVG instead of the older generic drift line art.
- The authored DRIFT and SAFETY markup now lives in one shared `turn/ui/authored-icons.js` module, so Achievements and Trophy Road reuse the exact same source rather than duplicating SVG strings.
- `currentColor`, decorative `aria-hidden`, and the no-mask/no-runtime-generation constraints are preserved.
- Added regression coverage that asserts the complete SAFETY family mapping and exact DRIFT artwork reuse on Trophy Road.

No achievement logic, Trophy Road thresholds, reward order, or unrelated artwork changes.