### PR TITLE
TURN: unify non-visual driving achievement icon

### DIFF
--- a/turn-tests/trophy-road-detail-production.mjs
+++ b/turn-tests/trophy-road-detail-production.mjs
@@ -64,6 +64,13 @@ assert.match(AUTHORED_SAFETY_ICON, /aria-hidden="true"/);
 assert.doesNotMatch(AUTHORED_DRIFT_ICON, /mask/i);
 assert.doesNotMatch(AUTHORED_SAFETY_ICON, /mask/i);
 
+const trustYourEarsIcon = getAchievement('trust-your-ears')?.icon;
+assert.equal(trustYourEarsIcon, 'blind');
+for (const achievementId of ['drive-by-ear', 'listen-closely', 'beyond-sight']) {
+  assert.equal(getAchievement(achievementId)?.icon, trustYourEarsIcon,
+    `${achievementId} must use the same non-visual-driving icon as TRUST YOUR EARS`);
+}
+
 assert.match(view, /data-trophy-road-detail-layer hidden/);
 assert.match(view, /role="dialog"[\s\S]*aria-modal="true"[\s\S]*aria-labelledby="turnTrophyRoadDetailTitle"/,
   'Reward details must be exposed as a labelled modal within the one Achievements top-layer dialog');

--- a/turn/achievements/catalog-production.js
+++ b/turn/achievements/catalog-production.js
@@ -20,6 +20,13 @@ export const ICONS = Object.freeze({
   safety: AUTHORED_SAFETY_ICON
 });
 
+const DRIVE_BY_EAR_FAMILY_ICON = 'blind';
+const DRIVE_BY_EAR_FAMILY_ACHIEVEMENT_IDS = Object.freeze([
+  'trust-your-ears',
+  'listen-closely',
+  'beyond-sight'
+]);
+
 const CHROMATIC_CAMOUFLAGE = Object.freeze({
   id: 'chromatic-camouflage',
   category: base.CATEGORY.EXPLORATION,
@@ -75,7 +82,7 @@ export const DRIVE_BY_EAR_ACHIEVEMENT = Object.freeze({
   trophies: 50,
   title: 'DRIVE BY EAR',
   description: 'Finish all five parts of Drive By Ear 101.',
-  icon: 'listen',
+  icon: DRIVE_BY_EAR_FAMILY_ICON,
   progressMax: DRIVE_BY_EAR_PART_IDS.length
 });
 
@@ -116,6 +123,12 @@ export const TRACK_SAFETY_ACHIEVEMENTS = Object.freeze(
 );
 
 const rebalancedBaseAchievements = base.ACHIEVEMENTS.map((achievement) => {
+  if (DRIVE_BY_EAR_FAMILY_ACHIEVEMENT_IDS.includes(achievement.id)) {
+    return Object.freeze({
+      ...achievement,
+      icon: DRIVE_BY_EAR_FAMILY_ICON
+    });
+  }
   if (achievement.id === 'around-the-turn') {
     return Object.freeze({
       ...achievement,


### PR DESCRIPTION
Follow-up to the achievement icon cleanup.

DRIVE BY EAR, LISTEN CLOSELY and BEYOND SIGHT now use the exact same icon key as TRUST YOUR EARS.

Implementation keeps the mapping centralized in the production achievement catalog rather than duplicating per-surface rendering logic. Added regression coverage that compares all three achievements directly against TRUST YOUR EARS, so the family cannot silently diverge again.

No achievement logic, trophy values, descriptions, categories or unrelated artwork changed.