### PR TITLE
TURN: put Future Racer before Monster in The Lot

### DIFF
--- a/turn/garage/lot-trophy-order.js
+++ b/turn/garage/lot-trophy-order.js
@@ -11,8 +11,8 @@ export const LOT_TROPHY_ORDER = Object.freeze([
   'firetruck',
   'ambulance',
   'police',
-  'monster-truck',
   'race-future',
+  'monster-truck',
   'toy-racer'
 ]);
 


### PR DESCRIPTION
Keep The Lot carousel aligned with Trophy Road vehicle unlock order.

- Moves `race-future` ahead of `monster-truck` in the canonical Lot carousel order.
- Leaves every other vehicle position unchanged.
- This matches Trophy Road: Future Racer unlocks at 1600 trophies, Monster at 1800, Rally Racer at 2000.

No vehicle stats, unlock thresholds, gating, labels, or showroom behavior changed.