### PR TITLE
TURN: save per-car paint and reflect it in Lot thumbnails

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -112,7 +112,7 @@
         "/turn/garage/lot-enhancement-runtime.js?revision=r164-post-soak&build=20260826-r184": "/turn/garage/lot-enhancement-runtime.js?revision=r243-mountain-1300&build=20260906-r207",
         "/turn/garage/lot-enhancement-runtime.js?revision=r164-post-soak&build=20260906-r207": "/turn/garage/lot-enhancement-runtime.js?revision=r243-mountain-1300&build=20260906-r207",
         "/turn/m8-home.js?revision=r131-motion-permission-retry&trophy-road=r159&showroom=r200&build=20260818-r175": "/turn/m8-home.js?revision=r131-motion-permission-retry&trophy-road=r159&showroom=r206-pwa-color&build=20260818-r175",
-        "/turn/garage/lot-track-select.js?revision=r200-production-candidate": "/turn/garage/lot-track-select.js?revision=r243-mountain-1300",
+        "/turn/garage/lot-track-select.js?revision=r200-production-candidate": "/turn/garage/lot-track-select.js?revision=r246-lot-saved-paint",
         "./garage/lot-accessibility-r118.js?build=20260729-r118": "./garage/lot-accessibility-r118.js?build=20260906-r207&revision=r163-voiceover-first-lot-focus",
         "./garage/lot-enhancement-runtime.js?revision=r163-native-picker-parent-click&build=20260809-r163": "./garage/lot-enhancement-runtime.js?build=20260906-r207&revision=r243-mountain-1300",
         "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260906-r207&revision=r223-training-car-taxi",

--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -206,7 +206,73 @@ assert.deepEqual(
   'A saved custom rival PAINTJOB must survive the factory migration'
 );
 
-console.log(`TURN ${release.id} Hatchback, Rally Racer and native secondary paint passed.`);
+const savedLotPaint = await import(new URL(
+  `../../turn/garage/lot-saved-paint.js?saved-paint-test=${Date.now()}`,
+  import.meta.url
+));
+const futureFactoryPaint = {
+  color: catalog.getVehicleDefaultColor('race-future'),
+  secondaryColor: catalog.getVehicleDefaultSecondaryColor('race-future')
+};
+assert.equal(savedLotPaint.getSavedLotPaint('race-future'), null,
+  'A car without an explicit SAVE must keep its factory thumbnail paint');
+assert.deepEqual(savedLotPaint.resolveLotPaint('race-future'), futureFactoryPaint);
+assert.deepEqual(
+  savedLotPaint.saveLotPaint('race-future', { color: '#f8f9fa', secondaryColor: '#8ce99a' }),
+  { color: '#f8f9fa', secondaryColor: '#8ce99a' },
+  'SAVE must persist both paint channels for one specific car'
+);
+assert.deepEqual(
+  savedLotPaint.resolveLotPaint('race-future'),
+  { color: '#f8f9fa', secondaryColor: '#8ce99a' },
+  'The saved paint pair must become the Future Racer thumbnail and selection paint'
+);
+assert.equal(savedLotPaint.getSavedLotPaint('monster-truck'), null,
+  'Saving Future Racer paint must not bleed into another car');
+assert.deepEqual(savedLotPaint.resetLotPaint('race-future'), futureFactoryPaint,
+  'RESET must return the selected car to its current factory paint');
+assert.equal(savedLotPaint.getSavedLotPaint('race-future'), null,
+  'RESET must remove the per-car saved override');
+assert.equal(
+  savedLotPaint.saveLotPaint('police', { color: '#123456', secondaryColor: '#654321' }),
+  null,
+  'Fixed emergency liveries must never gain player-saved paint'
+);
+
+const [showroomSource, paintGateSource, wrapperSource, enhancementSource, savedPaintCss] = await Promise.all([
+  fs.readFile(new URL('../../turn/garage/lot-showroom-experiment.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/progression/lot-paint-reward.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-track-select.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-enhancement-runtime.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/garage/lot-saved-paint.css', import.meta.url), 'utf8')
+]);
+assert.match(showroomSource, /const thumbnailPaint = resolveLotPaint\(car\.id\)/,
+  'Thumbnail loading fallbacks must start from saved paint instead of factory paint');
+assert.match(showroomSource, /thumbnailRenderer\.renderAll\(LOT_CARS, carButtons, resolveLotPaint\)/,
+  'The initial 3D thumbnail pass must render every remembered per-car paint pair');
+assert.match(showroomSource, /thumbnailRenderer\.renderOne\(car, button, paint\)/,
+  'SAVE and RESET must refresh only the affected thumbnail');
+assert.match(showroomSource, /className = 'lot-paint-save-action'/);
+assert.match(showroomSource, /button\.textContent = resetMode \? 'RESET' : 'SAVE'/,
+  'The paint action must visibly switch between SAVE and RESET');
+assert.match(showroomSource, /saveLotPaint\(selectedCarId, selectedPaint\(\)\)/);
+assert.match(showroomSource, /resetLotPaint\(selectedCarId\)/);
+assert.match(showroomSource, /let pending = Promise\.resolve\(\)/,
+  'Single-thumbnail refreshes must serialize behind the initial low-power render rather than open concurrent WebGL contexts');
+assert.match(paintGateSource, /if \(freeColor && !paintUnlocked\) forceFactoryPaint\(carId\)/,
+  'The paint gate may force factory paint only while PAINTJOB is locked');
+assert.doesNotMatch(paintGateSource, /!paintUnlocked \|\| changedCar/,
+  'Changing cars after PAINTJOB unlock must not erase a remembered paint pair');
+assert.match(wrapperSource, /lot-enhancement-runtime\.js\?revision=r246-lot-saved-paint/);
+assert.match(wrapperSource, /lot-showroom-experiment\.js\?revision=r246-lot-saved-paint/);
+assert.match(wrapperSource, /lot-saved-paint\.css\?revision=r246-lot-saved-paint/);
+assert.match(enhancementSource, /lot-paint-reward\.js\?revision=r246-lot-saved-paint/);
+assert.match(savedPaintCss, /\.lot-paint-save-action\[data-mode='reset'\]/,
+  'RESET must have a distinct paper treatment while SAVE remains the cyan action');
+assert.match(index, /"\/turn\/garage\/lot-track-select\.js\?revision=r200-production-candidate": "\/turn\/garage\/lot-track-select\.js\?revision=r246-lot-saved-paint"/,
+  'Production must route existing Home callers through the fresh saved-paint wrapper URL');
+
+console.log(`TURN ${release.id} Hatchback, Rally Racer, native secondary paint and saved Lot paint passed.`);
 
 function readGlbJson(buffer, label) {
   assert.equal(buffer.toString('utf8', 0, 4), 'glTF');

--- a/turn-lab/tests/paint-lock-observer-production.mjs
+++ b/turn-lab/tests/paint-lock-observer-production.mjs
@@ -109,7 +109,10 @@ assert.match(showroomCleanupCss, /\.lot-showroom \.lot-color-control\[hidden\][\
 // The existing paint state model still owns the value and state, not the PWA face.
 assert.match(paintGate, /function applyNativeSwatchFace\(control\)/);
 assert.match(paintGate, /control\.style\.setProperty\('--lot-color-swatch', input\.value\)/);
-assert.match(syncBody, /if \(freeColor && \(!paintUnlocked \|\| changedCar\)\) forceFactoryPaint\(carId\)/);
+assert.match(syncBody, /if \(freeColor && !paintUnlocked\) forceFactoryPaint\(carId\)/,
+  'Factory paint may be forced only while PAINTJOB is locked');
+assert.doesNotMatch(syncBody, /changedCar/,
+  'Changing cars after PAINTJOB unlock must preserve the per-car saved paint selected by the showroom');
 assert.match(syncBody, /control\.hidden = paintLocked/);
 assert.match(syncBody, /input\.disabled = paintLocked/);
 assert.match(syncBody, /if \(paintLocked\) ensureLockButton\(carId\);[\s\S]*else removeLockPresentation\(\)/);
@@ -160,18 +163,22 @@ assert.deepEqual(order.slice(order.indexOf('race')), lockedTail,
   'The horizontal Lot and its keyboard/VoiceOver order must put every reward car after the standard starting cars');
 
 // --- Fresh module identities for already-installed PWAs -----------------------
-assert.match(lotRuntime, /lot-paint-reward\.js\?revision=r243-mountain-1300/,
-  'The app-level enhancement runtime must load the current Trophy Road paint threshold');
-assert.match(lotWrapper, /lot-enhancement-runtime\.js\?revision=r243-mountain-1300/,
-  'The showroom wrapper must use the current Trophy Road enhancement-runtime identity');
+assert.match(lotRuntime, /lot-paint-reward\.js\?revision=r246-lot-saved-paint/,
+  'The app-level enhancement runtime must load the saved-paint-aware PAINTJOB gate');
+assert.match(lotWrapper, /lot-enhancement-runtime\.js\?revision=r246-lot-saved-paint/,
+  'The showroom wrapper must bypass the cached enhancement runtime for per-car paint');
 assert.match(lotWrapper, /lot-pwa-color-swatch\.js\?revision=r206-pwa-color/);
-assert.match(lotWrapper, /lot-showroom-experiment\.js\?revision=r243-mountain-1300/);
+assert.match(lotWrapper, /lot-showroom-experiment\.js\?revision=r246-lot-saved-paint/,
+  'The wrapper must load the saved-paint-aware showroom under a fresh URL');
+assert.match(lotWrapper, /lot-saved-paint\.css\?revision=r246-lot-saved-paint/,
+  'The SAVE/RESET action must load with the same fresh showroom revision');
 assert.match(lotWrapper, /SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r206-polish'/);
 assert.match(lotWrapper, /lot-showroom-cleanup-r201\.css\?revision=r206-pwa-color/);
 assert.match(index, /\/turn\/garage\/lot-enhancement-runtime\.js\?revision=r164-post-soak&build=20260826-r184"\s*:\s*"\/turn\/garage\/lot-enhancement-runtime\.js\?revision=r243-mountain-1300/,
-  'Old installed app runtime URLs must bridge to the current Lot runtime');
+  'Old installed app runtime URLs must retain their existing bridge');
 assert.match(index, /\/turn\/m8-home\.js\?revision=r131-motion-permission-retry&trophy-road=r159&showroom=r200&build=20260818-r175"\s*:\s*"\/turn\/m8-home\.js\?revision=r131-motion-permission-retry&trophy-road=r159&showroom=r206-pwa-color&build=20260818-r175/);
-assert.match(index, /\/turn\/garage\/lot-track-select\.js\?revision=r200-production-candidate"\s*:\s*"\/turn\/garage\/lot-track-select\.js\?revision=r243-mountain-1300/);
+assert.match(index, /\/turn\/garage\/lot-track-select\.js\?revision=r200-production-candidate"\s*:\s*"\/turn\/garage\/lot-track-select\.js\?revision=r246-lot-saved-paint/,
+  'Existing Home callers must cross a fresh cache boundary into the saved-paint wrapper');
 assert.match(
   index,
   new RegExp(`app\\.js\\?build=${release.cacheKey}-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click[^\"]*-pwa-color-r206`),
@@ -191,7 +198,7 @@ assert.equal(
 assert.equal(
   imports['/turn/garage/lot-showroom-experiment.js?revision=r206-race-before-locks'],
   '/turn/garage/lot-showroom-experiment.js?revision=r243-mountain-1300',
-  'Installed PWAs must refetch the showroom module when the visible Trophy Road order changes'
+  'Installed PWAs must retain the previous showroom cache bridge while new callers use r246'
 );
 for (const staleCatalogSpecifier of [
   '/turn/vehicle/catalog.js?build=20260804-r157-factory-colors',
@@ -214,4 +221,4 @@ assert.match(perkPresentation, /getCarDefinition\(vehicleId\)\?\.perk/);
 assert.doesNotMatch(perkPresentation, /observer\.observe\(screen,/);
 assert.match(app, /trophy-road-r157\.css\?revision=r244-reward-toast-guide/);
 
-console.log('TURN Lot PWA swatch compositing, factory-color imports, reward-car catalog coherence, state matrix, cue geometry, cache bridge, car order and observer safety regressions passed.');
+console.log('TURN Lot PWA swatch compositing, saved per-car paint, reward-car catalog coherence, state matrix, cue geometry, cache bridge, car order and observer safety regressions passed.');

--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -5,6 +5,7 @@
 // Historical regression marker: lot-paint-reward.js?revision=r203-color-label
 // Historical regression marker: lot-paint-reward.js?revision=r204-color-control-rebuild
 // Historical regression marker: lot-paint-reward.js?revision=r205-color-baseline
+// Historical regression marker: lot-paint-reward.js?revision=r243-mountain-1300
 // Historical regression marker: lot-accessibility-r118.js?build=20260729-r118
 
 // Historical regression markers for the established enhancement layers:
@@ -31,7 +32,7 @@ export function prepareLotEnhancements() {
     import('./lot-vehicle-copy.js?revision=r223-training-car-taxi'),
     import('./lot-trophy-order.js'),
     import('../progression/lot-trophy-gate.js?revision=r243-mountain-1300'),
-    import('../progression/lot-paint-reward.js?revision=r243-mountain-1300')
+    import('../progression/lot-paint-reward.js?revision=r246-lot-saved-paint')
   ]).then(([
     statLegend,
     layout,

--- a/turn/garage/lot-saved-paint.css
+++ b/turn/garage/lot-saved-paint.css
@@ -1,0 +1,57 @@
+.lot-showroom .lot-paint-save-action {
+  box-sizing: border-box;
+  flex: 0 0 auto;
+  min-width: 76px;
+  height: 34px;
+  margin: 0 1px;
+  padding: 0 13px;
+  border: 2px solid var(--ink, #08090a);
+  border-radius: 999px;
+  background: var(--cyan, #38d9ff);
+  box-shadow: 3px 3px 0 var(--ink, #08090a);
+  color: var(--ink, #08090a);
+  font: inherit;
+  font-size: .58rem;
+  font-weight: 950;
+  letter-spacing: .08em;
+  line-height: 1;
+  text-align: center;
+  text-transform: uppercase;
+  white-space: nowrap;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.lot-showroom .lot-paint-save-action[data-mode='reset'] {
+  background: var(--paper, #fff8e8);
+}
+
+.lot-showroom .lot-paint-save-action:active:not(:disabled) {
+  transform: translate(2px, 2px);
+  box-shadow: 1px 1px 0 var(--ink, #08090a);
+}
+
+.lot-showroom .lot-paint-save-action:focus-visible {
+  outline: 4px solid var(--cyan, #38d9ff);
+  outline-offset: 3px;
+}
+
+.lot-showroom .lot-paint-save-action:disabled {
+  opacity: .42;
+  box-shadow: none;
+  cursor: default;
+}
+
+.lot-showroom .lot-colors[data-paint-state='locked'] .lot-paint-save-action,
+.lot-showroom .lot-colors[data-vehicle-color-mode='fixed'] .lot-paint-save-action {
+  display: none;
+}
+
+@media (max-height: 520px) {
+  .lot-showroom .lot-paint-save-action {
+    min-width: 68px;
+    height: 30px;
+    padding-inline: 10px;
+    font-size: .51rem;
+  }
+}

--- a/turn/garage/lot-saved-paint.js
+++ b/turn/garage/lot-saved-paint.js
@@ -1,0 +1,92 @@
+import {
+  getCarDefinition,
+  getVehicleDefaultColor,
+  getVehicleDefaultSecondaryColor,
+  normalizeVehicleColor,
+  normalizeVehicleId,
+  normalizeVehicleSecondaryColor
+} from '../vehicle/catalog.js?build=20260720-r20&revision=r246-lot-saved-paint';
+
+export const LOT_SAVED_PAINT_KEY = 'turn-lot-saved-paint-v1';
+export const LOT_SAVED_PAINT_VERSION = 1;
+
+function factoryPaint(carId) {
+  const id = normalizeVehicleId(carId);
+  return {
+    color: getVehicleDefaultColor(id),
+    secondaryColor: getVehicleDefaultSecondaryColor(id)
+  };
+}
+
+export function lotPaintMatches(left, right) {
+  return Boolean(left && right)
+    && String(left.color || '').toLowerCase() === String(right.color || '').toLowerCase()
+    && String(left.secondaryColor || '').toLowerCase() === String(right.secondaryColor || '').toLowerCase();
+}
+
+function normalizeLotPaint(carId, paint) {
+  const id = normalizeVehicleId(carId);
+  return {
+    color: normalizeVehicleColor(paint?.color, getVehicleDefaultColor(id)),
+    secondaryColor: normalizeVehicleSecondaryColor(
+      paint?.secondaryColor,
+      getVehicleDefaultSecondaryColor(id)
+    )
+  };
+}
+
+function readStore() {
+  try {
+    const stored = JSON.parse(localStorage.getItem(LOT_SAVED_PAINT_KEY));
+    if (!stored || typeof stored !== 'object') return { paints: {} };
+    const paints = stored.paints && typeof stored.paints === 'object' ? stored.paints : {};
+    return { paints: { ...paints } };
+  } catch (_) {
+    return { paints: {} };
+  }
+}
+
+function writeStore(paints) {
+  try {
+    localStorage.setItem(LOT_SAVED_PAINT_KEY, JSON.stringify({
+      version: LOT_SAVED_PAINT_VERSION,
+      paints
+    }));
+  } catch (_) {}
+}
+
+export function getSavedLotPaint(carId) {
+  const id = normalizeVehicleId(carId);
+  const car = getCarDefinition(id);
+  if (car.fixedLivery) return null;
+
+  const raw = readStore().paints[id];
+  if (!raw) return null;
+  const paint = normalizeLotPaint(id, raw);
+  return lotPaintMatches(paint, factoryPaint(id)) ? null : paint;
+}
+
+export function resolveLotPaint(carId) {
+  return getSavedLotPaint(carId) || factoryPaint(carId);
+}
+
+export function saveLotPaint(carId, paint) {
+  const id = normalizeVehicleId(carId);
+  const car = getCarDefinition(id);
+  if (car.fixedLivery) return null;
+
+  const normalized = normalizeLotPaint(id, paint);
+  const store = readStore();
+  if (lotPaintMatches(normalized, factoryPaint(id))) delete store.paints[id];
+  else store.paints[id] = normalized;
+  writeStore(store.paints);
+  return getSavedLotPaint(id);
+}
+
+export function resetLotPaint(carId) {
+  const id = normalizeVehicleId(carId);
+  const store = readStore();
+  delete store.paints[id];
+  writeStore(store.paints);
+  return factoryPaint(id);
+}

--- a/turn/garage/lot-showroom-experiment.js
+++ b/turn/garage/lot-showroom-experiment.js
@@ -9,11 +9,18 @@ import {
   normalizeVehicleColor,
   normalizeVehicleSecondaryColor,
   normalizeVehicleSelection
-} from '../vehicle/catalog.js?build=20260720-r20&revision=r588-canonical-attributes';
+} from '../vehicle/catalog.js?build=20260720-r20&revision=r246-lot-saved-paint';
 import { createCarVisual, recolorCarVisual } from '../vehicle/car-models.js?build=20260720-r22';
 import { recordPerformanceFrame } from '../performance-monitor.js?build=20260720-r20';
 import { describeColorCue } from '../accessibility/color-cues.js?revision=r163';
-import { LOCK_ICON } from '../progression/trophy-road.js?revision=r243-mountain-1300';
+import { isPaintUnlocked, LOCK_ICON } from '../progression/trophy-road.js?revision=r243-mountain-1300';
+import {
+  getSavedLotPaint,
+  lotPaintMatches,
+  resetLotPaint,
+  resolveLotPaint,
+  saveLotPaint
+} from './lot-saved-paint.js?revision=r246-lot-saved-paint';
 import {
   hasTriedTrainingCar,
   installTrainingCarGuide,
@@ -153,8 +160,9 @@ export function showTheLot({ initialSelection } = {}) {
       button.className = 'lot-car-option';
       button.setAttribute('role', 'radio');
       button.dataset.carId = car.id;
-      button.style.setProperty('--lot-car-color', getVehicleDefaultColor(car.id));
-      button.style.setProperty('--lot-car-secondary', getVehicleDefaultSecondaryColor(car.id));
+      const thumbnailPaint = resolveLotPaint(car.id);
+      button.style.setProperty('--lot-car-color', thumbnailPaint.color);
+      button.style.setProperty('--lot-car-secondary', thumbnailPaint.secondaryColor);
 
       const preview = document.createElement('span');
       preview.className = 'lot-car-option-preview';
@@ -256,6 +264,7 @@ export function showTheLot({ initialSelection } = {}) {
             }
           }));
         }
+        if (isPaintUnlocked()) paintControls.push(makePaintAction());
         colors.replaceChildren(...paintControls);
         colors.hidden = false;
         colors.removeAttribute('aria-hidden');
@@ -288,8 +297,9 @@ export function showTheLot({ initialSelection } = {}) {
       const changedCar = carId !== selectedCarId;
       selectedCarId = carId;
       if (changedCar) {
-        selectedColor = getVehicleDefaultColor(carId);
-        selectedSecondaryColor = getVehicleDefaultSecondaryColor(carId);
+        const paint = resolveLotPaint(carId);
+        selectedColor = paint.color;
+        selectedSecondaryColor = paint.secondaryColor;
       }
       updateSelectionUi({ reveal });
       if (focus) carButtons.get(carId)?.focus();
@@ -363,9 +373,92 @@ export function showTheLot({ initialSelection } = {}) {
       return control;
     }
 
+    function selectedPaint() {
+      return { color: selectedColor, secondaryColor: selectedSecondaryColor };
+    }
+
+    function syncPaintAction(button = colors.querySelector('.lot-paint-save-action')) {
+      if (!button) return;
+      const car = getCarDefinition(selectedCarId);
+      const current = selectedPaint();
+      const saved = getSavedLotPaint(selectedCarId);
+      const factory = {
+        color: getVehicleDefaultColor(selectedCarId),
+        secondaryColor: getVehicleDefaultSecondaryColor(selectedCarId)
+      };
+      const matchesSaved = Boolean(saved && lotPaintMatches(current, saved));
+      const matchesFactory = lotPaintMatches(current, factory);
+      const resetMode = Boolean(saved && (matchesSaved || matchesFactory));
+
+      button.dataset.mode = resetMode ? 'reset' : 'save';
+      button.textContent = resetMode ? 'RESET' : 'SAVE';
+      button.disabled = !resetMode && !saved && matchesFactory;
+      button.setAttribute(
+        'aria-label',
+        resetMode
+          ? `Reset ${car.name} colors to factory colors`
+          : `Save ${car.name} colors for The Lot`
+      );
+    }
+
+    function updatePaintInputs(paint) {
+      const controls = [...colors.querySelectorAll('.lot-color-control')];
+      const body = controls.find((control) => control.dataset.paintLabel?.toLowerCase() === 'body')
+        ?.querySelector('input[type="color"]');
+      const secondary = controls.find((control) => control.dataset.paintLabel?.toLowerCase() !== 'body')
+        ?.querySelector('input[type="color"]');
+      for (const [input, value] of [[body, paint.color], [secondary, paint.secondaryColor]]) {
+        if (!input || input.value.toLowerCase() === value.toLowerCase()) continue;
+        input.value = value;
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+    }
+
+    function refreshThumbnail(carId) {
+      const car = getCarDefinition(carId);
+      const button = carButtons.get(carId);
+      if (!car || !button) return;
+      const paint = resolveLotPaint(carId);
+      button.style.setProperty('--lot-car-color', paint.color);
+      button.style.setProperty('--lot-car-secondary', paint.secondaryColor);
+      void thumbnailRenderer.renderOne(car, button, paint);
+    }
+
+    function makePaintAction() {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'lot-paint-save-action';
+      button.addEventListener('click', () => {
+        if (button.dataset.mode === 'reset') {
+          const factory = resetLotPaint(selectedCarId);
+          selectedColor = factory.color;
+          selectedSecondaryColor = factory.secondaryColor;
+          updatePaintInputs(factory);
+          viewer.recolor(selectedColor, selectedSecondaryColor);
+          syncPaintAction(button);
+          refreshThumbnail(selectedCarId);
+          return;
+        }
+
+        saveLotPaint(selectedCarId, selectedPaint());
+        syncPaintAction(button);
+        refreshThumbnail(selectedCarId);
+      });
+      syncPaintAction(button);
+      return button;
+    }
+
     function applySelectedPaint() {
       viewer.recolor(selectedColor, selectedSecondaryColor);
+      syncPaintAction();
     }
+
+    const handlePaintUnlocked = () => {
+      if (getCarDefinition(selectedCarId).fixedLivery) return;
+      updateSelectionUi({ refreshViewer: false, reveal: false });
+    };
+    window.addEventListener('turn:paint-controls-unlocked', handlePaintUnlocked);
 
     raceButton.addEventListener('click', () => finish({
       carId: selectedCarId,
@@ -382,6 +475,7 @@ export function showTheLot({ initialSelection } = {}) {
       disposed = true;
       lockObserver.disconnect();
       window.removeEventListener('turn:trophy-road-updated', syncAvailabilitySummary);
+      window.removeEventListener('turn:paint-controls-unlocked', handlePaintUnlocked);
       resizeObserver.disconnect();
       thumbnailRenderer.cancel();
       viewer.dispose();
@@ -395,7 +489,7 @@ export function showTheLot({ initialSelection } = {}) {
     requestAnimationFrame(() => {
       viewer.resize();
       revealSelectedCar();
-      void thumbnailRenderer.renderAll(LOT_CARS, carButtons);
+      void thumbnailRenderer.renderAll(LOT_CARS, carButtons, resolveLotPaint);
     });
   });
 }
@@ -568,8 +662,9 @@ function createThumbnailRenderer() {
   let cancelled = false;
   let renderer = null;
   let activeVisual = null;
+  let pending = Promise.resolve();
 
-  async function renderAll(cars, carButtons) {
+  async function renderBatch(cars, carButtons, paintForCar) {
     if (cancelled) return;
 
     const scene = new THREE.Scene();
@@ -603,12 +698,16 @@ function createThumbnailRenderer() {
         const button = carButtons.get(car.id);
         const canvas = button?.querySelector('.lot-car-option-thumbnail');
         if (!canvas) continue;
+        const paint = paintForCar?.(car.id) || {
+          color: getVehicleDefaultColor(car.id),
+          secondaryColor: getVehicleDefaultSecondaryColor(car.id)
+        };
 
         try {
           const visual = await createCarVisual({
             carId: car.id,
-            color: getVehicleDefaultColor(car.id),
-            secondaryColor: getVehicleDefaultSecondaryColor(car.id),
+            color: paint.color,
+            secondaryColor: paint.secondaryColor,
             targetLength: 5.8,
             outline: true
           });
@@ -651,8 +750,19 @@ function createThumbnailRenderer() {
     }
   }
 
+  function enqueue(cars, carButtons, paintForCar) {
+    const job = pending.then(() => renderBatch(cars, carButtons, paintForCar));
+    pending = job.catch(() => {});
+    return job;
+  }
+
   return {
-    renderAll,
+    renderAll(cars, carButtons, paintForCar) {
+      return enqueue(cars, carButtons, paintForCar);
+    },
+    renderOne(car, button, paint) {
+      return enqueue([car], new Map([[car.id, button]]), () => paint);
+    },
     cancel() {
       cancelled = true;
       if (activeVisual) disposeVisualMaterials(activeVisual);

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -1,7 +1,7 @@
 import {
   enhanceLotNow,
   prepareLotEnhancements
-} from './lot-enhancement-runtime.js?revision=r243-mountain-1300';
+} from './lot-enhancement-runtime.js?revision=r246-lot-saved-paint';
 import { installLotPwaColorSwatches } from './lot-pwa-color-swatch.js?revision=r206-pwa-color';
 import { chooseTrackBeforeLot } from '../tracks/track-manager.js?build=20260722-r52';
 import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -34,6 +34,7 @@ const SHOWROOM_THUMBNAIL_STYLE_ID = 'turn-lot-thumbnail-r211-composition';
 const SHOWROOM_INFO_STYLE_ID = 'turn-lot-info-r212-fit';
 const SHOWROOM_TYPOGRAPHY_STYLE_ID = 'turn-lot-info-r214-worst-case-fit';
 const SHOWROOM_SHIFT_STYLE_ID = 'turn-lot-shift-r228';
+const SHOWROOM_SAVED_PAINT_STYLE_ID = 'turn-lot-saved-paint-r246';
 let showroomStylePromise = null;
 let originalLotPromise = null;
 let originalLotModule = null;
@@ -87,6 +88,10 @@ function prepareShowroomStyles() {
     prepareStylesheet(
       SHOWROOM_SHIFT_STYLE_ID,
       './lot-shift.css?revision=r229-shift-feedback'
+    ),
+    prepareStylesheet(
+      SHOWROOM_SAVED_PAINT_STYLE_ID,
+      './lot-saved-paint.css?revision=r246-lot-saved-paint'
     )
   ]);
   return showroomStylePromise;
@@ -94,7 +99,7 @@ function prepareShowroomStyles() {
 
 function loadOriginalLot() {
   if (!originalLotPromise) {
-    originalLotPromise = import('./lot-showroom-experiment.js?revision=r243-mountain-1300')
+    originalLotPromise = import('./lot-showroom-experiment.js?revision=r246-lot-saved-paint')
       .then((module) => {
         originalLotModule = module;
         return module;

--- a/turn/index.html
+++ b/turn/index.html
@@ -123,7 +123,7 @@
         "/turn/garage/lot-enhancement-runtime.js?revision=r164-post-soak&build=20260826-r184": "/turn/garage/lot-enhancement-runtime.js?revision=r243-mountain-1300&build=20260906-r207",
         "/turn/garage/lot-enhancement-runtime.js?revision=r164-post-soak&build=20260906-r207": "/turn/garage/lot-enhancement-runtime.js?revision=r243-mountain-1300&build=20260906-r207",
         "/turn/m8-home.js?revision=r131-motion-permission-retry&trophy-road=r159&showroom=r200&build=20260818-r175": "/turn/m8-home.js?revision=r131-motion-permission-retry&trophy-road=r159&showroom=r206-pwa-color&build=20260818-r175",
-        "/turn/garage/lot-track-select.js?revision=r200-production-candidate": "/turn/garage/lot-track-select.js?revision=r243-mountain-1300",
+        "/turn/garage/lot-track-select.js?revision=r200-production-candidate": "/turn/garage/lot-track-select.js?revision=r246-lot-saved-paint",
         "./garage/lot-accessibility-r118.js?build=20260729-r118": "./garage/lot-accessibility-r118.js?build=20260906-r207&revision=r163-voiceover-first-lot-focus",
         "./garage/lot-enhancement-runtime.js?revision=r163-native-picker-parent-click&build=20260809-r163": "./garage/lot-enhancement-runtime.js?build=20260906-r207&revision=r243-mountain-1300",
         "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260906-r207&revision=r223-training-car-taxi",

--- a/turn/progression/lot-paint-reward.js
+++ b/turn/progression/lot-paint-reward.js
@@ -249,7 +249,6 @@ export function gateLotPaintNow(root = document.body) {
       const carId = selectedCarId(screen);
       const car = CAR_BY_ID.get(carId);
       const paintUnlocked = isPaintUnlocked();
-      const changedCar = Boolean(carId) && carId !== lastCarId;
       const carLocked = selectedCarIsLocked(screen);
       const freeColor = Boolean(car && !car.fixedLivery);
       const controls = [...colors.querySelectorAll('.lot-color-control:not(.lot-fixed-livery)')];
@@ -264,7 +263,7 @@ export function gateLotPaintNow(root = document.body) {
       ensureVisibleLabel(car);
       syncNativeSwatchFaces();
 
-      if (freeColor && (!paintUnlocked || changedCar)) forceFactoryPaint(carId);
+      if (freeColor && !paintUnlocked) forceFactoryPaint(carId);
 
       const paintLocked = Boolean(freeColor && !paintUnlocked);
       colors.classList.toggle('is-paint-locked', paintLocked);

--- a/turn/progression/lot-paint-reward.js
+++ b/turn/progression/lot-paint-reward.js
@@ -71,7 +71,6 @@ export function gateLotPaintNow(root = document.body) {
   if (!colors || !raceButton || !picker) return () => {};
 
   let syncing = false;
-  let lastCarId = selectedCarId(screen);
   let paintWasUnlocked = isPaintUnlocked();
 
   function paintControl(label = 'body') {
@@ -290,7 +289,6 @@ export function gateLotPaintNow(root = document.body) {
         window.dispatchEvent(new CustomEvent('turn:paint-controls-unlocked'));
       }
       paintWasUnlocked = paintUnlocked;
-      lastCarId = carId;
       screen.dataset.turnPaintUnlocked = String(paintUnlocked);
     } finally {
       syncing = false;


### PR DESCRIPTION
Implements the explicit SAVE / RESET paint flow from the Lot mockup.

- The two native paint controls still preview changes immediately on the selected 3D car.
- A cyan SAVE action appears beside them once PAINTJOB is unlocked.
- SAVE stores body + secondary paint for that specific vehicle and refreshes only that vehicle’s 3D carousel thumbnail.
- Saved paint is remembered independently per car and is restored when that car is selected again.
- Once saved, the action becomes RESET; RESET removes the per-car override, restores factory paint in the preview and thumbnail, and returns the action to SAVE.
- Emergency/fixed-livery vehicles remain non-paintable and never receive saved overrides.
- Unsaved experimentation does not rewrite the carousel thumbnail or another vehicle’s paint.
- Thumbnail refreshes serialize behind the existing low-power initial thumbnail pass, so SAVE does not create competing WebGL contexts.
- The existing PAINTJOB gate now forces factory paint only while PAINTJOB is actually locked; changing cars after unlock no longer destroys remembered paint.
- Production and TURN LAB route the existing Home caller through a fresh saved-paint Lot revision.

Adds persistence and integration regression coverage without changing vehicle stats, Trophy Road thresholds, current race-selection storage, or the native color-picker interaction.