### PR TITLE
TURN: turn Lot cars forward and matte-black the Supercar

### DIFF
--- a/turn/garage/lot-showroom-experiment.js
+++ b/turn/garage/lot-showroom-experiment.js
@@ -9,8 +9,8 @@ import {
   normalizeVehicleColor,
   normalizeVehicleSecondaryColor,
   normalizeVehicleSelection
-} from '../vehicle/catalog.js?revision=r248-supercar';
-import { createCarVisual, recolorCarVisual } from '../vehicle/car-models.js?revision=r248-supercar';
+} from '../vehicle/catalog.js?revision=r250-supercar-finish';
+import { createCarVisual, recolorCarVisual } from '../vehicle/car-models.js?revision=r250-supercar-finish';
 import { recordPerformanceFrame } from '../performance-monitor.js?build=20260720-r20';
 import { describeColorCue } from '../accessibility/color-cues.js?revision=r163';
 import { isPaintUnlocked, LOCK_ICON } from '../progression/trophy-road.js?revision=r248-supercar';
@@ -28,7 +28,8 @@ import {
 } from './training-car-guide.js?revision=r1';
 
 const LOT_FRAME_INTERVAL_MS = 1000 / 30;
-const VIEWER_INITIAL_YAW = Math.PI - 0.55;
+const VIEWER_INITIAL_YAW = Math.PI - 0.34;
+const THUMBNAIL_INITIAL_YAW = Math.PI - 0.55;
 const THUMBNAIL_WIDTH = 240;
 const THUMBNAIL_HEIGHT = 108;
 let paintControlSerial = 0;
@@ -679,7 +680,7 @@ function createThumbnailRenderer() {
     scene.add(rim);
 
     const stage = new THREE.Group();
-    stage.rotation.y = VIEWER_INITIAL_YAW;
+    stage.rotation.y = THUMBNAIL_INITIAL_YAW;
     scene.add(stage);
     const camera = new THREE.PerspectiveCamera(36, THUMBNAIL_WIDTH / THUMBNAIL_HEIGHT, 0.1, 80);
 

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -99,7 +99,7 @@ function prepareShowroomStyles() {
 
 function loadOriginalLot() {
   if (!originalLotPromise) {
-    originalLotPromise = import('./lot-showroom-experiment.js?revision=r246-lot-saved-paint')
+    originalLotPromise = import('./lot-showroom-experiment.js?revision=r250-supercar-finish')
       .then((module) => {
         originalLotModule = module;
         return module;

--- a/turn/garage/lot-track-select.js
+++ b/turn/garage/lot-track-select.js
@@ -14,6 +14,7 @@ import { showTrackIntro } from '../ui/track-intro.js?build=20260725-r75';
 // lot-enhancement-runtime.js?revision=r214-future-racer-fit
 // lot-enhancement-runtime.js?revision=r217-stable-perk-slot&build=20260804-r157
 // lot-showroom-experiment.js?revision=r200-production-candidate
+// lot-showroom-experiment.js?revision=r246-lot-saved-paint
 // export async function showEnhancedLot
 // SHOWROOM_CLEANUP_STYLE_ID = 'turn-lot-showroom-r203-polish'
 // lot-showroom-cleanup-r201.css?revision=r203-thumbnail-color-polish

--- a/turn/vehicle/car-models.js
+++ b/turn/vehicle/car-models.js
@@ -8,7 +8,7 @@ import {
   makeGhostColor,
   normalizeVehicleColor,
   normalizeVehicleSecondaryColor
-} from './catalog.js?revision=r250-supercar-finish';
+} from './catalog.js';
 import {
   makeWideGamutSpec,
   setThreeColor

--- a/turn/vehicle/car-models.js
+++ b/turn/vehicle/car-models.js
@@ -8,7 +8,7 @@ import {
   makeGhostColor,
   normalizeVehicleColor,
   normalizeVehicleSecondaryColor
-} from './catalog.js';
+} from './catalog.js?revision=r250-supercar-finish';
 import {
   makeWideGamutSpec,
   setThreeColor
@@ -26,6 +26,8 @@ const normalizationMetricsCache = new Map();
 const competitorGhostTemplateCache = new Map();
 const buildKey = globalThis.__TURN_BUILD__?.cacheKey || '';
 const TIRE_COLOR = 0x17191c;
+const SUPERCAR_MATTE_ROUGHNESS = 0.78;
+const SUPERCAR_MATTE_METALNESS = 0.04;
 const FEATURED_SURFACE_TARGET_LENGTHS = new Set([5.15, 5.5]);
 const REVERSED_FRONT_WHEEL_LABEL_IDS = new Set(['vintage-racer']);
 const COMPETITOR_GHOST_TARGET_LENGTH = 5.5;
@@ -156,6 +158,15 @@ export async function createCarVisual({
     } else if (paintable && material.color) {
       setThreeColor(material.color, ghost ? ghostColor : requestedColorSpec);
       primaryPaintMaterials.push(material);
+    }
+
+    if (car.id === 'supercar' && paintable) {
+      if ('roughness' in material) material.roughness = Math.max(
+        Number(material.roughness) || 0,
+        SUPERCAR_MATTE_ROUGHNESS
+      );
+      if ('metalness' in material) material.metalness = SUPERCAR_MATTE_METALNESS;
+      material.needsUpdate = true;
     }
 
     if (ghost) {

--- a/turn/vehicle/catalog.js
+++ b/turn/vehicle/catalog.js
@@ -3,7 +3,7 @@ export const LEGACY_VEHICLE_ID = 'sedan';
 export const DEFAULT_VEHICLE_COLOR = '#ffcc00';
 export const DEFAULT_VEHICLE_SECONDARY_COLOR = '#f8f9fa';
 export const VEHICLE_SELECTION_KEY = 'turn-vehicle-selection-v1';
-export const VEHICLE_SELECTION_VERSION = 4;
+export const VEHICLE_SELECTION_VERSION = 5;
 export const VEHICLE_STAT_BUDGET = 18;
 export const SPORTS_SEDAN_EASTER_EGG_COLOR = '#666666';
 export const MAXED_VEHICLE_STATS = Object.freeze({
@@ -43,7 +43,7 @@ const DEFAULT_COLOR_BY_ID = Object.freeze({
   'monster-truck': Object.freeze({ fallback: '#3f5a3c', p3: Object.freeze([0.21, 0.35, 0.19]) }),
   'race-future': Object.freeze({ fallback: '#222222' }),
   race: Object.freeze({ fallback: '#5d503f' }),
-  supercar: Object.freeze({ fallback: '#f8f9fa', p3: Object.freeze([0.95, 0.97, 0.98]) }),
+  supercar: Object.freeze({ fallback: '#000000' }),
   'sedan-sports': Object.freeze({ fallback: '#5e3c87', p3: Object.freeze([0.36, 0.19, 0.56]) }),
   sedan: Object.freeze({ fallback: '#2b6a70', p3: Object.freeze([0.12, 0.41, 0.43]) }),
   suv: Object.freeze({ fallback: '#0555aa', p3: Object.freeze([0.02, 0.333, 0.667]) }),
@@ -99,6 +99,9 @@ const REPLACED_FACTORY_PAINT_BY_ID = Object.freeze({
   ]),
   suv: Object.freeze([
     Object.freeze({ color: '#7d123e', secondaryColor: '#2f0918' })
+  ]),
+  supercar: Object.freeze([
+    Object.freeze({ color: '#f8f9fa', secondaryColor: '#f8f9fa' })
   ])
 });
 


### PR DESCRIPTION
Playtest polish for The Lot and Supercar:

- turn the large 3D Lot preview about 12° more toward the viewer while preserving the existing thumbnail angle
- make #000000 the Supercar factory body color and migrate the previously shipped white factory pair to black
- reduce the Supercar body material's metalness and raise roughness for a matte TURN-style finish, while leaving glass, lamps, tyres and chrome rims protected
- refresh the nested showroom/model/catalog module identities so installed PWAs receive the changes

The Supercar remains primary-paint-only in this PR; its source model does not expose a clean second body surface without deliberate model/UV work.