### PR TITLE
TURN: give Supercar Kenney wheels and secondary rims

### DIFF
--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -41,6 +41,15 @@ assert.deepEqual(
 );
 assert.deepEqual(
   catalog.normalizeStoredVehiclePaint({
+    carId: 'supercar',
+    color: '#000000',
+    secondaryColor: '#f8f9fa'
+  }, { migrateReplacedFactoryPaint: true }),
+  { carId: 'supercar', color: '#000000', secondaryColor: '#ffcc00', factoryPaint: true },
+  'The shipped black Supercar must gain its new yellow factory rims without rewriting custom paint'
+);
+assert.deepEqual(
+  catalog.normalizeStoredVehiclePaint({
     carId: 'convertible',
     color: '#0555aa',
     secondaryColor: '#abcdef'
@@ -72,7 +81,7 @@ assert.deepEqual(JSON.parse(selectionStorage.getItem(catalog.VEHICLE_SELECTION_K
 const secondaryCars = catalog.CAR_CATALOG.filter((car) => car.secondaryPaint);
 assert.deepEqual(
   secondaryCars.map((car) => car.id),
-  ['convertible', 'classic', 'vintage-racer', 'toy-racer', 'monster-truck', 'race-future', 'race', 'sedan-sports', 'sedan', 'suv', 'truck', 'van'],
+  ['convertible', 'classic', 'vintage-racer', 'toy-racer', 'monster-truck', 'race-future', 'race', 'sedan-sports', 'sedan', 'suv', 'truck', 'van', 'supercar'],
   'Every player-repaintable car should expose a semantic second picker'
 );
 assert.equal(secondaryCars[0].secondaryPaint.label, 'Lower body trim');
@@ -86,7 +95,19 @@ assert.equal(secondaryCars[5].secondaryPaint.label, 'Aero accents');
 assert.equal(secondaryCars[6].secondaryPaint.label, 'Aero trim');
 assert.equal(secondaryCars[7].secondaryPaint.label, 'Sport trim');
 assert.deepEqual(secondaryCars[7].secondaryPaint.meshNames, []);
-assert.ok(secondaryCars.slice(8).every((car) => car.secondaryPaint.label === 'Lower body trim'));
+assert.ok(secondaryCars.slice(8, 12).every((car) => car.secondaryPaint.label === 'Lower body trim'));
+const supercar = catalog.getCarDefinition('supercar');
+assert.equal(supercar.defaultColor, '#000000');
+assert.equal(supercar.defaultSecondaryColor, '#ffcc00');
+assert.deepEqual(supercar.defaultSecondaryColorP3, [1, 0.76, 0],
+  'Supercar factory rims must use TURN’s Display-P3 yellow');
+assert.equal(supercar.secondaryPaint?.label, 'Rims');
+assert.deepEqual(supercar.secondaryPaint?.meshNames, [
+  'supercar-rim-front-left',
+  'supercar-rim-front-right',
+  'supercar-rim-back-left',
+  'supercar-rim-back-right'
+]);
 
 const rallyGlb = await fs.readFile(new URL('../../turn/assets/cars/sedan-sports.glb', import.meta.url));
 const rallyJson = readGlbJson(rallyGlb, 'Rally Racer');
@@ -191,6 +212,19 @@ assert.deepEqual(
   })),
   { carId: 'suv', carColor: '#0555aa', carSecondaryColor: '#163f7a', factoryPaint: true },
   'Saved pink Luxury SUV ghosts from the swapped release must follow the repaired blue factory paint'
+);
+assert.deepEqual(
+  (({ carId, carColor, carSecondaryColor, factoryPaint }) => ({
+    carId, carColor, carSecondaryColor, factoryPaint
+  }))(storedReplay({
+    time: 10,
+    carId: 'supercar',
+    carColor: '#000000',
+    carSecondaryColor: '#f8f9fa',
+    frames: replayFrames
+  })),
+  { carId: 'supercar', carColor: '#000000', carSecondaryColor: '#ffcc00', factoryPaint: true },
+  'Saved factory Supercar ghosts must gain the new yellow rim color'
 );
 assert.deepEqual(
   (({ carColor, carSecondaryColor, factoryPaint }) => ({ carColor, carSecondaryColor, factoryPaint }))(

--- a/turn-lab/tests/semantic-car-finish-production.mjs
+++ b/turn-lab/tests/semantic-car-finish-production.mjs
@@ -7,6 +7,7 @@ const [
   catalogSource,
   semanticSource,
   carModelsSource,
+  supercarWheelsSource,
   emergencyBridgeSource,
   releaseSource,
   kenneyLicense,
@@ -16,6 +17,7 @@ const [
   fs.readFile(new URL('../../turn/vehicle/catalog.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/vehicle/semantic-car-finish.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/vehicle/car-models.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/vehicle/supercar-kenney-wheels.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/vehicle/emergency-livery-models.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/release.json', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/assets/KENNEY-ASSETS.md', import.meta.url), 'utf8'),
@@ -36,13 +38,23 @@ assert.match(release.id, /^\d{4}\.\d{2}\.\d{2}-r\d+$/);
 assert.equal(catalog.CAR_CATALOG.length, 16);
 assert.deepEqual(
   catalog.CAR_CATALOG
-    .filter((car) => car.id !== 'supercar' && !car.fixedLivery && !car.secondaryPaint)
+    .filter((car) => !car.fixedLivery && !car.secondaryPaint)
     .map((car) => car.id),
   [],
-  'Every established non-emergency car must expose its native secondary surface'
+  'Every non-emergency car must expose its native or deliberately mounted secondary surface'
 );
-assert.equal(catalog.getCarDefinition('supercar').secondaryPaint, null,
-  'Supercar must preserve the Cosmo model as a primary-paint-only car');
+const supercarDefinition = catalog.getCarDefinition('supercar');
+assert.equal(supercarDefinition.secondaryPaint?.label, 'Rims',
+  'Supercar secondary paint must be its deliberately mounted Kenney rims');
+assert.deepEqual(supercarDefinition.secondaryPaint?.meshNames, [
+  'supercar-rim-front-left',
+  'supercar-rim-front-right',
+  'supercar-rim-back-left',
+  'supercar-rim-back-right'
+]);
+assert.equal(supercarDefinition.defaultSecondaryColor, '#ffcc00');
+assert.deepEqual(supercarDefinition.defaultSecondaryColorP3, [1, 0.76, 0],
+  'Supercar factory rims must use TURN’s Display-P3 yellow');
 
 const paletteContracts = new Map([
   ['car', {
@@ -107,6 +119,8 @@ assert.ok(supercarPrimitives.every((primitive) => primitive.attributes?.COLOR_0 
 assert.match(carModelsSource, /loadEmbeddedSupercarSource/);
 assert.match(carModelsSource, /DecompressionStream\('gzip'\)/);
 assert.match(carModelsSource, /loaderForPack\(car\.pack\)\.parseAsync\(arrayBuffer, ''\)/);
+assert.match(carModelsSource, /installSupercarKenneyWheels\(model, trainingCarSource\)/,
+  'Supercar visuals must replace the Cosmo wheels with the verified Kenney donor geometry before paint traversal');
 
 assert.match(carModelsSource, /new THREE\.LoadingManager\(\)/);
 assert.match(carModelsSource, /setURLModifier/);
@@ -160,8 +174,12 @@ assert.ok(cellHits(classicBody, classicPrimary) > 0,
   'Training Car primary paint cells must intersect authored body triangles');
 assert.ok(cellHits(classicBody, classicSecondary) > 0,
   'Training Car secondary trim cells must intersect authored body triangles');
-assert.ok(cellHits(classicWheels, classicRims) > 0,
+const classicRimTriangles = cellHits(classicWheels, classicRims);
+const classicWheelTriangles = [...classicWheels.values()].reduce((sum, count) => sum + count, 0);
+assert.ok(classicRimTriangles > 0,
   'Training Car rim paint cells must intersect authored wheel triangles');
+assert.ok(classicRimTriangles < classicWheelTriangles,
+  'The Kenney donor wheel must contain both rim and tire triangles for the Supercar transplant');
 assert.equal(cellHits(classicBodyDoubleFlipped, classicPrimary), 0,
   'The retired double-V-flip must not accidentally become the semantic coordinate contract again');
 assert.equal(cellHits(classicBodyDoubleFlipped, classicSecondary), 0,
@@ -170,6 +188,17 @@ assert.equal(cellHits(classicWheelsDoubleFlipped, classicRims), 0,
   'The retired double-V-flip must miss the Training Car rim cells');
 assert.match(semanticSource, /'training-car': profile\(\{ primary: \[\[4, 2\], \[4, 3\]\], secondary: \[\[3, 4\], \[3, 5\]\], rims: \[\[3, 4\], \[3, 5\]\] \}\)/,
   'Training Car must use the verified Taxi-derived Car Kit palette cells');
+assert.match(supercarWheelsSource, /KENNEY_RIM_CELLS = new Set\(\['3,4', '3,5'\]\)/,
+  'Supercar rims must be split from the exact verified Kenney rim UV cells');
+assert.match(supercarWheelsSource, /SUPERCAR_TIRE_COLOR = 0x070809/,
+  'Supercar tires must stay deliberately near-black');
+assert.match(supercarWheelsSource, /roughness: 0\.96/);
+assert.match(supercarWheelsSource, /turnWheelSource = 'Kenney Car Kit 3\.1'/,
+  'The mounted wheels must retain explicit source provenance');
+assert.match(supercarWheelsSource, /splitKenneyWheelGeometry\(donor\.geometry\)/,
+  'The transplant must reuse the exact donor mesh geometry rather than draw replacement wheels');
+assert.doesNotMatch(supercarWheelsSource, /CylinderGeometry|TorusGeometry|LatheGeometry|SphereGeometry/,
+  'Supercar wheel transplant must not synthesize substitute wheel geometry');
 
 const luxurySuvCar = catalog.getCarDefinition('suv');
 assert.equal(luxurySuvCar.surfaceProfileId, 'suv-luxury',

--- a/turn/vehicle/car-models.js
+++ b/turn/vehicle/car-models.js
@@ -19,6 +19,7 @@ import {
   recolorSemanticCarFinish
 } from './semantic-car-finish.js';
 import { installLearnerCarLivery } from './learner-car-livery.js?revision=r223-training-car-taxi';
+import { installSupercarKenneyWheels } from './supercar-kenney-wheels.js?revision=r251-supercar-kenney-rims';
 
 const loadersByPack = new Map();
 const sourceCache = new Map();
@@ -90,6 +91,10 @@ export async function createCarVisual({
   const source = await loadCarSource(car.id);
   const root = new THREE.Group();
   const model = source.clone(true);
+  if (car.id === 'supercar') {
+    const trainingCarSource = await loadCarSource('classic');
+    installSupercarKenneyWheels(model, trainingCarSource);
+  }
   model.rotation.y = Math.PI + car.modelYawQuarterTurns * Math.PI / 2;
   root.add(model);
 

--- a/turn/vehicle/catalog.js
+++ b/turn/vehicle/catalog.js
@@ -3,7 +3,7 @@ export const LEGACY_VEHICLE_ID = 'sedan';
 export const DEFAULT_VEHICLE_COLOR = '#ffcc00';
 export const DEFAULT_VEHICLE_SECONDARY_COLOR = '#f8f9fa';
 export const VEHICLE_SELECTION_KEY = 'turn-vehicle-selection-v1';
-export const VEHICLE_SELECTION_VERSION = 5;
+export const VEHICLE_SELECTION_VERSION = 6;
 export const VEHICLE_STAT_BUDGET = 18;
 export const SPORTS_SEDAN_EASTER_EGG_COLOR = '#666666';
 export const MAXED_VEHICLE_STATS = Object.freeze({
@@ -66,6 +66,7 @@ const DEFAULT_SECONDARY_COLOR_BY_ID = Object.freeze({
   'monster-truck': Object.freeze({ fallback: '#4f5504' }),
   'race-future': Object.freeze({ fallback: '#332244' }),
   race: Object.freeze({ fallback: '#222222' }),
+  supercar: Object.freeze({ fallback: '#ffcc00', p3: Object.freeze([1, 0.76, 0]) }),
   'sedan-sports': Object.freeze({ fallback: '#252a35', p3: Object.freeze([0.13, 0.15, 0.21]) }),
   firetruck: Object.freeze({ fallback: '#ffcc00', p3: Object.freeze([1, 0.76, 0]) }),
   police: Object.freeze({ fallback: '#f8f9fa', p3: Object.freeze([0.95, 0.97, 0.98]) }),
@@ -101,7 +102,8 @@ const REPLACED_FACTORY_PAINT_BY_ID = Object.freeze({
     Object.freeze({ color: '#7d123e', secondaryColor: '#2f0918' })
   ]),
   supercar: Object.freeze([
-    Object.freeze({ color: '#f8f9fa', secondaryColor: '#f8f9fa' })
+    Object.freeze({ color: '#f8f9fa', secondaryColor: '#f8f9fa' }),
+    Object.freeze({ color: '#000000', secondaryColor: '#f8f9fa' })
   ])
 });
 
@@ -260,6 +262,17 @@ const VISUAL_CUSTOMIZATION_BY_ID = Object.freeze({
   }),
   'toy-racer': Object.freeze({
     secondaryPaint: Object.freeze({ label: 'Rally trim', meshNames: Object.freeze(['spoiler']) })
+  }),
+  supercar: Object.freeze({
+    secondaryPaint: Object.freeze({
+      label: 'Rims',
+      meshNames: Object.freeze([
+        'supercar-rim-front-left',
+        'supercar-rim-front-right',
+        'supercar-rim-back-left',
+        'supercar-rim-back-right'
+      ])
+    })
   })
 });
 

--- a/turn/vehicle/supercar-kenney-wheels.js
+++ b/turn/vehicle/supercar-kenney-wheels.js
@@ -61,7 +61,7 @@ export function installSupercarKenneyWheels(model, trainingCarSource) {
       roughness: 0.96,
       metalness: 0
     });
-    tireMaterial.name = 'supercar-dark-tire';
+    tireMaterial.name = 'supercar-dark-foot';
     const tire = new THREE.Mesh(tireGeometry, tireMaterial);
     tire.name = spec.tire;
 

--- a/turn/vehicle/supercar-kenney-wheels.js
+++ b/turn/vehicle/supercar-kenney-wheels.js
@@ -1,0 +1,132 @@
+import * as THREE from 'three';
+
+const KENNEY_RIM_CELLS = new Set(['3,4', '3,5']);
+const SUPERCAR_TIRE_COLOR = 0x070809;
+const WHEEL_ROLES = Object.freeze([
+  Object.freeze({
+    role: 'wheel-front-left',
+    rim: 'supercar-rim-front-left',
+    tire: 'supercar-dark-foot-front-left'
+  }),
+  Object.freeze({
+    role: 'wheel-front-right',
+    rim: 'supercar-rim-front-right',
+    tire: 'supercar-dark-foot-front-right'
+  }),
+  Object.freeze({
+    role: 'wheel-back-left',
+    rim: 'supercar-rim-back-left',
+    tire: 'supercar-dark-foot-back-left'
+  }),
+  Object.freeze({
+    role: 'wheel-back-right',
+    rim: 'supercar-rim-back-right',
+    tire: 'supercar-dark-foot-back-right'
+  })
+]);
+
+export function installSupercarKenneyWheels(model, trainingCarSource) {
+  if (!model || !trainingCarSource) return false;
+  let replacements = 0;
+
+  for (const spec of WHEEL_ROLES) {
+    const target = model.getObjectByName(spec.role);
+    const donor = trainingCarSource.getObjectByName(spec.role);
+    if (!target || !donor?.isMesh || !donor.geometry) continue;
+
+    const targetBox = localBounds(target);
+    const donorBox = localBounds(donor);
+    if (targetBox.isEmpty() || donorBox.isEmpty()) continue;
+
+    const targetSize = targetBox.getSize(new THREE.Vector3());
+    const donorSize = donorBox.getSize(new THREE.Vector3());
+    const targetDiameter = Math.max(targetSize.y, targetSize.z);
+    const donorDiameter = Math.max(donorSize.y, donorSize.z);
+    if (!(targetDiameter > 0) || !(donorDiameter > 0)) continue;
+
+    const { tireGeometry, rimGeometry } = splitKenneyWheelGeometry(donor.geometry);
+    if (!tireGeometry || !rimGeometry) continue;
+
+    const scale = targetDiameter / donorDiameter;
+    const targetCenter = targetBox.getCenter(new THREE.Vector3());
+    const donorCenter = donorBox.getCenter(new THREE.Vector3());
+    const replacement = new THREE.Group();
+    replacement.name = `kenney-${spec.role}-assembly`;
+    replacement.position.copy(targetCenter).addScaledVector(donorCenter, -scale);
+    replacement.scale.setScalar(scale);
+    replacement.userData.turnWheelSource = 'Kenney Car Kit 3.1';
+
+    const tireMaterial = new THREE.MeshStandardMaterial({
+      color: SUPERCAR_TIRE_COLOR,
+      roughness: 0.96,
+      metalness: 0
+    });
+    tireMaterial.name = 'supercar-dark-tire';
+    const tire = new THREE.Mesh(tireGeometry, tireMaterial);
+    tire.name = spec.tire;
+
+    const rimMaterial = new THREE.MeshStandardMaterial({
+      color: 0xffffff,
+      roughness: 0.74,
+      metalness: 0.04
+    });
+    rimMaterial.name = 'secondary-paint supercar-rim';
+    const rim = new THREE.Mesh(rimGeometry, rimMaterial);
+    rim.name = spec.rim;
+
+    replacement.add(tire, rim);
+    target.clear();
+    if (target.isMesh) target.geometry = new THREE.BufferGeometry();
+    target.add(replacement);
+    replacements += 1;
+  }
+
+  return replacements === WHEEL_ROLES.length;
+}
+
+function splitKenneyWheelGeometry(sourceGeometry) {
+  const index = sourceGeometry?.index;
+  const uv = sourceGeometry?.getAttribute?.('uv');
+  if (!index || !uv || index.count < 3) return { tireGeometry: null, rimGeometry: null };
+
+  const tireIndices = [];
+  const rimIndices = [];
+  for (let offset = 0; offset + 2 < index.count; offset += 3) {
+    const a = index.getX(offset);
+    const b = index.getX(offset + 1);
+    const c = index.getX(offset + 2);
+    const u = (uv.getX(a) + uv.getX(b) + uv.getX(c)) / 3;
+    const v = (uv.getY(a) + uv.getY(b) + uv.getY(c)) / 3;
+    const cell = `${paletteCell(u)},${paletteCell(v)}`;
+    const destination = KENNEY_RIM_CELLS.has(cell) ? rimIndices : tireIndices;
+    destination.push(a, b, c);
+  }
+
+  if (!tireIndices.length || !rimIndices.length) return { tireGeometry: null, rimGeometry: null };
+  return {
+    tireGeometry: geometryRegion(sourceGeometry, tireIndices),
+    rimGeometry: geometryRegion(sourceGeometry, rimIndices)
+  };
+}
+
+function geometryRegion(sourceGeometry, indices) {
+  const geometry = sourceGeometry.clone();
+  geometry.clearGroups();
+  geometry.setIndex(indices);
+  geometry.computeBoundingBox();
+  geometry.computeBoundingSphere();
+  return geometry;
+}
+
+function paletteCell(value) {
+  return Math.max(0, Math.min(7, Math.floor(value * 8)));
+}
+
+function localBounds(object) {
+  const probe = object.clone(true);
+  probe.position.set(0, 0, 0);
+  probe.quaternion.identity();
+  probe.scale.set(1, 1, 1);
+  probe.updateMatrixWorld(true);
+  return new THREE.Box3().setFromObject(probe);
+}


### PR DESCRIPTION
Playtest polish for the 2300-trophy Supercar:

- transplant the exact Kenney Car Kit wheel geometry from the Learner Car onto the Supercar at runtime
- split the donor wheel geometry by the verified Kenney rim palette cells so the rims are a true secondary paint surface
- make the tires very dark and matte
- default the rims to TURN yellow with the existing Display-P3 wide-gamut spec (`#ffcc00` fallback, P3 `[1, 0.76, 0]`)
- migrate the previously shipped black-body/white-secondary factory pair to black + yellow

The Supercar body remains matte black by default; only the rims use the new secondary picker.