### PR TITLE
TURN: fix Supercar rim paint visibility

### DIFF
--- a/turn/vehicle/supercar-kenney-wheels.js
+++ b/turn/vehicle/supercar-kenney-wheels.js
@@ -68,11 +68,19 @@ export function installSupercarKenneyWheels(model, trainingCarSource) {
     const rimMaterial = new THREE.MeshStandardMaterial({
       color: 0xffffff,
       roughness: 0.74,
-      metalness: 0.04
+      metalness: 0.04,
+      polygonOffset: true,
+      polygonOffsetFactor: -2,
+      polygonOffsetUnits: -2
     });
     rimMaterial.name = 'secondary-paint supercar-rim';
     const rim = new THREE.Mesh(rimGeometry, rimMaterial);
     rim.name = spec.rim;
+    // Kenney's wheel contains overlapping/coplanar face layers. Keep the
+    // separately painted rim layer visibly above the dark tire face without
+    // changing the authored wheel geometry.
+    rim.renderOrder = 2;
+    rim.userData.turnSecondaryPaintSurface = true;
 
     replacement.add(tire, rim);
     target.clear();


### PR DESCRIPTION
Fixes the Supercar Kenney rims rendering black even when the secondary picker is yellow.

The donor wheel has coplanar/overlapping face layers. The rim triangles were receiving secondary paint, but the dark tire surface could still win depth testing. This change keeps the authored Kenney geometry and gives the separately painted rim layer a small polygon depth bias plus render priority so the selected rim color remains visible.

No geometry is regenerated; tires remain near-black and matte, rims remain the secondary paint surface with factory Display-P3 TURN yellow.