### PR TITLE
TURN: make Supercar body paint match garage colors

### DIFF
--- a/turn-lab/tests/native-paint-production.mjs
+++ b/turn-lab/tests/native-paint-production.mjs
@@ -149,6 +149,16 @@ assert.doesNotMatch(css, /\.lot-color\[aria-pressed=/, 'The retired custom swatc
 assert.match(carModels, /turnSecondaryPaintMaterials/);
 assert.match(carModels, /turnSemanticPaintRecords/);
 assert.match(carModels, /recolorSemanticCarFinish/);
+assert.match(
+  carModels,
+  /if \(car\.id === 'supercar' && paintable\) \{[\s\S]*material\.map = null;[\s\S]*turnSupercarDirectPaint = true;/,
+  'Supercar lacquer must use the picker colour directly instead of multiplying it by Cosmo’s dark body texture'
+);
+assert.match(
+  carModels,
+  /SUPERCAR_MATTE_ROUGHNESS = 0\.78[\s\S]*SUPERCAR_MATTE_METALNESS = 0\.04/,
+  'Supercar direct paint must keep the matte TURN-like finish'
+);
 assert.match(semanticFinish, /surfaceProfileId \|\| car\.id/,
   'Semantic paint must follow the mounted source model rather than assuming gameplay ID equals mesh identity');
 assert.match(semanticFinish, /material\.onBeforeCompile/,

--- a/turn-tests/supercar-lot-visual-smoke.mjs
+++ b/turn-tests/supercar-lot-visual-smoke.mjs
@@ -32,6 +32,8 @@ let visualFailure = null;
 let metrics = null;
 let factoryPixels = 0;
 let customPixels = 0;
+let factoryBrightNeutralPixels = 0;
+let whiteBodyPixels = 0;
 try {
   const response = await page.goto(`${baseUrl}/turn-lab/supercar-lot-visual.html`, {
     waitUntil: 'domcontentloaded',
@@ -50,12 +52,21 @@ try {
   const canvas = page.locator('.lot-view-host canvas');
   const factory = await canvas.screenshot({ path: path.join(outputDir, 'factory-yellow-rims.png') });
   factoryPixels = countPixels(factory, ({ r, g, b }) => r > 135 && g > 85 && b < 95);
+  factoryBrightNeutralPixels = countPixels(factory, brightNeutralPixel);
 
   const rimInput = page.getByLabel('Rims colour');
   await rimInput.fill('#ff00ff');
   await page.waitForTimeout(250);
   const custom = await canvas.screenshot({ path: path.join(outputDir, 'custom-magenta-rims.png') });
   customPixels = countPixels(custom, ({ r, g, b }) => r > 125 && g < 105 && b > 115);
+
+  await rimInput.fill('#ffcc00');
+  const bodyInput = page.getByLabel('Body colour');
+  await bodyInput.fill('#ffffff');
+  await page.waitForTimeout(250);
+  const whiteBody = await canvas.screenshot({ path: path.join(outputDir, 'custom-white-body.png') });
+  whiteBodyPixels = countPixels(whiteBody, brightNeutralPixel);
+
   await page.screenshot({ path: path.join(outputDir, 'lot-preview.png'), fullPage: true });
 } catch (error) {
   visualFailure = String(error?.stack || error?.message || error);
@@ -66,7 +77,15 @@ try {
 
 await fs.writeFile(
   path.join(outputDir, 'metrics.json'),
-  `${JSON.stringify({ metrics, factoryPixels, customPixels, browserErrors, visualFailure }, null, 2)}\n`
+  `${JSON.stringify({
+    metrics,
+    factoryPixels,
+    customPixels,
+    factoryBrightNeutralPixels,
+    whiteBodyPixels,
+    browserErrors,
+    visualFailure
+  }, null, 2)}\n`
 );
 
 if (visualFailure) throw new Error(visualFailure);
@@ -81,8 +100,17 @@ assert.ok(factoryPixels >= 20,
   `Factory Lot preview must expose visible TURN-yellow pixels, found ${factoryPixels}`);
 assert.ok(customPixels >= 20,
   `Changing the actual Rims picker must expose visible magenta rim pixels, found ${customPixels}`);
+assert.ok(
+  whiteBodyPixels >= factoryBrightNeutralPixels + 500,
+  `Changing the actual Body picker to white must visibly brighten the Supercar lacquer; `
+    + `factory had ${factoryBrightNeutralPixels} bright neutral pixels and white had ${whiteBodyPixels}`
+);
 
-console.log('TURN Supercar outward-facing Kenney rims passed in the actual Lot 3D preview.');
+console.log('TURN Supercar Kenney rims and direct TURN-like body paint passed in the actual Lot 3D preview.');
+
+function brightNeutralPixel({ r, g, b }) {
+  return r > 175 && g > 175 && b > 175 && Math.max(r, g, b) - Math.min(r, g, b) < 24;
+}
 
 function countPixels(buffer, predicate) {
   const image = PNG.sync.read(buffer);

--- a/turn/vehicle/car-models.js
+++ b/turn/vehicle/car-models.js
@@ -166,6 +166,13 @@ export async function createCarVisual({
     }
 
     if (car.id === 'supercar' && paintable) {
+      // Cosmo's Ghini bakes a dark grey body colour into its base-color map.
+      // Multiplying TURN's picker colour by that map makes every paint choice
+      // much darker than the rest of the garage. The model geometry already
+      // supplies the panel shading we need, so treat paintable body surfaces
+      // like TURN lacquer: direct colour + lighting, with no baked dark tint.
+      material.map = null;
+      material.userData.turnSupercarDirectPaint = true;
       if ('roughness' in material) material.roughness = Math.max(
         Number(material.roughness) || 0,
         SUPERCAR_MATTE_ROUGHNESS


### PR DESCRIPTION
Makes the Supercar primary paint behave like TURN lacquer instead of tinting Cosmo's dark baked body texture.

- keep the Ghini/Cosmo geometry, lights, glass and other protected surfaces intact
- on paintable Supercar body surfaces, remove the dark base-color map from the paint channel so the native picker color is used directly under scene lighting
- keep the existing matte finish (roughness 0.78, metalness 0.04)
- preserve Kenney tire/rim handling and the secondary rim color
- add regression coverage that the Supercar paint path no longer multiplies the picker color by the Cosmo body map

This is intentionally scoped to Supercar primary paint only.