### PR TITLE
TURN: use the authored Supercar icon everywhere

### DIFF
--- a/turn/progression/trophy-road.css
+++ b/turn/progression/trophy-road.css
@@ -387,6 +387,10 @@
   --turn-trophy-road-authored-source: url('../assets/trophy-road/monster-truck.svg');
 }
 
+.turn-trophy-road-authored-icon.is-supercar {
+  --turn-trophy-road-authored-source: url('../assets/trophy-road/supercar.svg');
+}
+
 .turn-trophy-road-marker svg,
 .turn-trophy-road-highlight-icon svg,
 .turn-trophy-road-detail-icon svg,

--- a/turn/progression/trophy-road.js
+++ b/turn/progression/trophy-road.js
@@ -23,7 +23,7 @@ export const TROPHY_ROAD_REWARD_ICONS = Object.freeze({
   monster: authoredRewardIcon('monster-truck'),
   vintage: authoredRewardIcon('vintage-racer'),
   rally: authoredRewardIcon('rally-racer'),
-  supercar: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M5 32 13 22l14-6h16l9 7 7 3v10H5Z"></path><path d="m20 22 9-4h12l6 5H20Z"></path><circle cx="17" cy="36" r="6"></circle><circle cx="49" cy="36" r="6"></circle><path d="M43 15h13v4H45M50 15v8"></path></svg>',
+  supercar: authoredRewardIcon('supercar'),
   mountain: '<svg viewBox="0 0 64 48" aria-hidden="true" focusable="false"><path d="M4 42 23 13l8 12L40 8l20 34Z"></path><path d="m17 22 6-9 5 8 4-6 8-7 7 13"></path><path d="M39 42c5-8 9-11 15-13M43 35l4 2-2 4 5 2"></path></svg>',
   shift: authoredRewardIcon('shift'),
   drift: AUTHORED_DRIFT_ICON,


### PR DESCRIPTION
Use the supplied `supercar.svg` as the canonical Trophy Road icon rather than only overriding the road marker.

This changes `TROPHY_ROAD_REWARD_ICONS.supercar` to the authored-icon path and maps `.is-supercar` to the existing asset, so the same silhouette is now used everywhere that shared reward icon appears: the road marker, Latest Reward/status cards, reward details, reward toast/replay, and static fallback surfaces.

The existing marker-specific CSS remains harmlessly compatible, but the icon source is no longer marker-specific.