### PR TITLE
TURN: match record-car thumbnails to 200° Lot angle

### DIFF
--- a/turn/ui/track-best-car.js
+++ b/turn/ui/track-best-car.js
@@ -13,6 +13,7 @@ const THUMBNAIL_HEIGHT = 140;
 const THUMBNAIL_ALPHA_THRESHOLD = 8;
 const THUMBNAIL_CROP_PADDING = 5;
 const HOME_THUMBNAIL_IDLE_TIMEOUT_MS = 700;
+const RECORD_CAR_INITIAL_YAW = THREE.MathUtils.degToRad(200);
 const thumbnailCache = new Map();
 let renderQueue = Promise.resolve();
 
@@ -113,7 +114,7 @@ async function renderThumbnail({ carId, color, secondaryColor }) {
       targetLength: 6.4,
       outline: true
     });
-    visual.rotation.y = Math.PI - 0.55;
+    visual.rotation.y = RECORD_CAR_INITIAL_YAW;
     scene.add(visual);
     renderer.render(scene, camera);
     return croppedThumbnailDataUrl(renderer.domElement);


### PR DESCRIPTION
Rotate the 3D car renders used for TIME / DRIFT / FLOW record thumbnails to the same 200° starting angle as the large 3D viewer in The Lot.

This only changes the one-shot record thumbnail camera presentation; stored record data, paint, cropping, size and rendering lifecycle are unchanged.