### PR TITLE
TURN: make SHIFT dot confirm the first post-FLOW toggle

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -119,6 +119,7 @@
         "/turn/vehicle/flow-shift.js?revision=r248-supercar": "/turn/vehicle/flow-shift.js?revision=r255-flow-shift-accessibility",
         "/turn/vehicle/flow-shift.js?revision=r253-supercar-release": "/turn/vehicle/flow-shift.js?revision=r255-flow-shift-accessibility",
         "/turn/vehicle/flow-shift.js?revision=r254-flow-shift-authority": "/turn/vehicle/flow-shift.js?revision=r255-flow-shift-accessibility",
+        "/turn/vehicle/flow-shift.js?revision=r255-flow-shift-accessibility": "/turn/vehicle/flow-shift.js?revision=r260-post-flow-dot-feedback",
         "/turn/ui/shift-feedback.js?revision=r232-double-shift": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/ui/shift-feedback.js?revision=r253-supercar-release": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/render/covered-rendering.js?build=20260909-r212": "/turn/render/covered-rendering.js?build=20260909-r212&revision=r164-long-session-robustness",

--- a/turn/index.html
+++ b/turn/index.html
@@ -130,6 +130,7 @@
         "/turn/vehicle/flow-shift.js?revision=r248-supercar": "/turn/vehicle/flow-shift.js?revision=r255-flow-shift-accessibility",
         "/turn/vehicle/flow-shift.js?revision=r253-supercar-release": "/turn/vehicle/flow-shift.js?revision=r255-flow-shift-accessibility",
         "/turn/vehicle/flow-shift.js?revision=r254-flow-shift-authority": "/turn/vehicle/flow-shift.js?revision=r255-flow-shift-accessibility",
+        "/turn/vehicle/flow-shift.js?revision=r255-flow-shift-accessibility": "/turn/vehicle/flow-shift.js?revision=r260-post-flow-dot-feedback",
         "/turn/ui/shift-feedback.js?revision=r232-double-shift": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/ui/shift-feedback.js?revision=r253-supercar-release": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/render/covered-rendering.js?build=20260909-r212": "/turn/render/covered-rendering.js?build=20260909-r212&revision=r164-long-session-robustness",

--- a/turn/vehicle/flow-shift.js
+++ b/turn/vehicle/flow-shift.js
@@ -186,7 +186,10 @@ function ensurePresentationStyles() {
       line-height: 0;
     }
 
-    .drive-stack.is-shift-active .drive-shift-bubble i {
+    /* Passive FLOW loss carries the current regular SHIFT tuning without a new
+       player action. Suppress the dot for that carried state; the next deliberate
+       SHIFT toggle clears `carried`, making the dot appear as immediate feedback. */
+    .drive-stack.is-shift-active .drive-shift-bubble:not([data-flow-shift="carried"]) i {
       width: .56rem;
       opacity: 1;
     }

--- a/turn/vehicle/flow-shift.js
+++ b/turn/vehicle/flow-shift.js
@@ -188,7 +188,7 @@ function ensurePresentationStyles() {
 
     /* Passive FLOW loss carries the current regular SHIFT tuning without a new
        player action. Suppress the dot for that carried state; the next deliberate
-       SHIFT toggle clears `carried`, making the dot appear as immediate feedback. */
+       SHIFT toggle clears carried, making the dot appear as immediate feedback. */
     .drive-stack.is-shift-active .drive-shift-bubble:not([data-flow-shift="carried"]) i {
       width: .56rem;
       opacity: 1;


### PR DESCRIPTION
## Summary
- keep the SHIFT dot hidden when FLOW SHIFT is lost passively and the current regular SHIFT tuning is merely carried over
- show the dot on the next deliberate SHIFT toggle, so the first post-FLOW attribute change has immediate visible feedback
- preserve the existing carried SHIFT tuning, pressed semantics, focus/recovery behavior, and forced-colors handling

## Behavior
Before: `FLOW SHIFT` (no dot) → passive FLOW loss → `SHIFT •` → first deliberate SHIFT had no new dot feedback.

After: `FLOW SHIFT` (no dot) → passive FLOW loss → `SHIFT` → first deliberate SHIFT → `SHIFT •`.

Implementation is deliberately presentation-only: the existing `data-flow-shift="carried"` state now suppresses the dot until an intentional SHIFT event clears that carried state.