### PR TITLE
TURN: make LAP VOID track-aware and more forgiving

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -140,7 +140,7 @@
         "./garage/lot-enhancement-runtime.js?revision=r163-native-picker-parent-click&build=20260809-r163": "./garage/lot-enhancement-runtime.js?build=20260909-r212&revision=r243-mountain-1300",
         "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260909-r212&revision=r252-supercar-outward-rims",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260909-r212",
-        "./race/lap-system.js?build=20260720-r19": "./race/lap-system-r86.js?build=20260909-r212&revision=mountain-long-prod-r1",
+        "./race/lap-system.js?build=20260720-r19": "./race/lap-system-r86.js?build=20260909-r212&revision=r262-forgiving-lap-void",
         "./race/game-state.js": "./race/game-state.js?build=20260909-r212",
         "./race/replay-system.js": "./race/replay-system.js?build=20260909-r212",
         "./race/rival-storage.js": "./race/rival-storage.js?build=20260909-r212&revision=r223-training-car-taxi",

--- a/turn-lab/tests/balance-and-checkpoints.mjs
+++ b/turn-lab/tests/balance-and-checkpoints.mjs
@@ -6,6 +6,11 @@ import {
   crossedForwardGate,
   updateLapProgressState
 } from '../../turn/race/lap-system.js';
+import {
+  COUNTRYSIDE_CHECKPOINT_GATE_HALF_WIDTH_FACTOR,
+  LAP_VOID_DISABLED_TRACKS,
+  updateLapProgressState as updateProductionLapProgressState
+} from '../../turn/race/lap-system-r86.js';
 import { resetRaceToStage } from '../../turn/race/game-state.js';
 
 const catalogSource = await fs.readFile(new URL('../../turn/vehicle/catalog.js', import.meta.url), 'utf8');
@@ -27,6 +32,10 @@ assert.deepEqual(
 );
 
 assert.ok(LAP_CHECKPOINTS.length >= 10, 'anti-shortcut checkpoint chain must stay dense');
+assert.equal(COUNTRYSIDE_CHECKPOINT_GATE_HALF_WIDTH_FACTOR, 3,
+  'Countryside must give new players a much broader valid racing corridor');
+assert.deepEqual(LAP_VOID_DISABLED_TRACKS, ['cliffside'],
+  'Cliffside physical containment should make checkpoint-based LAP VOID unnecessary');
 
 class Vec3 {
   constructor(x = 0, y = 0, z = 0) {
@@ -139,6 +148,91 @@ updateLapProgressState({
 });
 assert.equal(skippedGateState.lapCheckpointIndex, 0, 'skipping the required checkpoint must not advance the ordered chain');
 assert.equal(skippedGateState.lapInvalid, true, 'crossing a later gate before the required one must permanently invalidate the current attempt');
+
+for (const lateralOffset of [-70, 70]) {
+  const countrysideState = {
+    trackId: 'countryside',
+    lapActive: true,
+    lapInvalid: false,
+    lapCheckpointIndex: 0,
+    lapStartedAt: 0,
+    lapElapsed: 0,
+    position: new Vec3(firstCheckpointIndex + 2, 0, lateralOffset),
+    velocity: new Vec3(10, 0, 0),
+    progress: LAP_CHECKPOINTS[0],
+    trackDistance: Math.abs(lateralOffset),
+    lapPreviousPosition: { x: firstCheckpointIndex - 2, z: lateralOffset }
+  };
+  updateProductionLapProgressState({
+    state: countrysideState,
+    nearestAfter: { sample: samples[firstCheckpointIndex] },
+    samples,
+    trackWidth: 27,
+    now: 1360,
+    beginTimedLap: () => assert.fail('a wide Countryside checkpoint crossing must not restart the lap'),
+    completeLap: () => assert.fail('the first Countryside checkpoint must not complete the lap'),
+    recordGhostFrame: () => {}
+  });
+  assert.equal(countrysideState.lapCheckpointIndex, 1,
+    'Countryside must accept broad excursions on either side of the road');
+  assert.equal(countrysideState.lapInvalid, false,
+    'a harmless wide Countryside line must remain a valid lap');
+}
+
+const cliffsideState = {
+  trackId: 'cliffside',
+  lapActive: true,
+  lapInvalid: false,
+  lapCheckpointIndex: 0,
+  lapStartedAt: 0,
+  lapElapsed: 0,
+  position: new Vec3(2, 0, 0),
+  velocity: new Vec3(10, 0, 0),
+  progress: 0,
+  trackDistance: 0,
+  lapPreviousPosition: { x: -2, z: 0 }
+};
+let cliffsideCompleted = 0;
+updateProductionLapProgressState({
+  state: cliffsideState,
+  nearestAfter: { sample: samples[0] },
+  samples,
+  trackWidth: 27,
+  now: 1370,
+  beginTimedLap: () => assert.fail('an active Cliffside lap must not restart at the finish'),
+  completeLap: () => { cliffsideCompleted += 1; },
+  recordGhostFrame: () => {}
+});
+assert.equal(cliffsideCompleted, 1,
+  'Cliffside must complete from the physical start/finish gate without checkpoint LAP VOID');
+assert.equal(cliffsideState.lapInvalid, false,
+  'Cliffside containment must not produce checkpoint-based LAP VOID');
+
+const airportState = {
+  trackId: 'airport',
+  lapActive: true,
+  lapInvalid: false,
+  lapCheckpointIndex: 0,
+  lapStartedAt: 0,
+  lapElapsed: 0,
+  position: new Vec3(secondCheckpointIndex + 2, 0, 0),
+  velocity: new Vec3(10, 0, 0),
+  progress: LAP_CHECKPOINTS[1],
+  trackDistance: 0,
+  lapPreviousPosition: { x: secondCheckpointIndex - 2, z: 0 }
+};
+updateProductionLapProgressState({
+  state: airportState,
+  nearestAfter: { sample: samples[secondCheckpointIndex] },
+  samples,
+  trackWidth: 27,
+  now: 1380,
+  beginTimedLap: () => {},
+  completeLap: () => {},
+  recordGhostFrame: () => {}
+});
+assert.equal(airportState.lapInvalid, true,
+  'open shortcut-prone tracks such as Airport must retain ordered checkpoint protection');
 
 assert.equal(
   crossedForwardGate(
@@ -256,10 +350,11 @@ assert.equal(resetState.lapCheckpointIndex, 0, 'reset must clear checkpoint prog
 assert.equal(resetState.lapInvalid, false, 'Restart Lap must clear the persistent invalid-lap state');
 assert.equal(resetState.lapActive, false, 'reset must return to staged pre-lap state');
 
-const [carModelsSource, mainSource, lapSystemSource, gameStateSource] = await Promise.all([
+const [carModelsSource, mainSource, lapSystemSource, productionLapSystemSource, gameStateSource] = await Promise.all([
   fs.readFile(new URL('../../turn/vehicle/car-models.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/main.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/race/lap-system.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../../turn/race/lap-system-r86.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../../turn/race/game-state.js', import.meta.url), 'utf8')
 ]);
 assert.match(carModelsSource, /const TIRE_COLOR = 0x17191c/, 'asset vehicle wheels must be forced to a dark tire colour');
@@ -271,10 +366,16 @@ assert.match(mainSource, /const car = makeCar\(0x38d9ff, 1\)/, 'additional proce
 assert.match(lapSystemSource, /crossedForwardGate/, 'production lap registration must use swept physical gates');
 assert.match(lapSystemSource, /crossedLaterCheckpointGate/, 'passing a later gate must expose the moment a lap becomes irrecoverably invalid');
 assert.match(lapSystemSource, /state\.lapInvalid = true/, 'skipped route detection must persist invalidity for the current attempt');
-assert.match(lapSystemSource, /CHECKPOINT_GATE_HALF_WIDTH_FACTOR = 1\.05/, 'checkpoint gates must allow broad grass and verge racing lines');
+assert.match(lapSystemSource, /CHECKPOINT_GATE_HALF_WIDTH_FACTOR = 1\.05/, 'default checkpoint gates must retain their established anti-shortcut width');
+assert.match(lapSystemSource, /checkpointGateHalfWidthFactor = CHECKPOINT_GATE_HALF_WIDTH_FACTOR/,
+  'track policy must be able to widen checkpoints without widening start/finish');
 assert.match(lapSystemSource, /START_GATE_HALF_WIDTH_FACTOR = 0\.82/, 'start and finish must keep the established narrower crossing gate');
 assert.match(lapSystemSource, /turn:lap-invalid/, 'an incomplete checkpoint chain must report an invalid lap instead of failing silently');
 assert.doesNotMatch(lapSystemSource, /crossedStartByProgress/, 'start and finish must not retain the retired progress-wrap fallback');
+assert.match(productionLapSystemSource, /COUNTRYSIDE_CHECKPOINT_GATE_HALF_WIDTH_FACTOR = 3/,
+  'Countryside must expose its user-tested broad excursion allowance');
+assert.match(productionLapSystemSource, /LAP_VOID_DISABLED_TRACKS = Object\.freeze\(\['cliffside'\]\)/,
+  'physically contained Cliffside must opt out of checkpoint LAP VOID');
 assert.match(gameStateSource, /state\.lapInvalid = false/, 'race staging must clear invalid-lap status');
 
-console.log('TURN forgiving swept lap gates, early invalid-lap state, single-source start line and anti-shortcut regression passed.');
+console.log('TURN forgiving per-track swept lap gates, contained-track opt-out and anti-shortcut regression passed.');

--- a/turn-tests/super-sedan-unranked-production.mjs
+++ b/turn-tests/super-sedan-unranked-production.mjs
@@ -167,8 +167,8 @@ assert.match(runtimeSource, /detail\?\.ranked === false[\s\S]*?qualifyingTimeTri
 assert.match(chromaticSource, /getStoredBestLap/,
   'Chromatic Camouflage must continue to use the centrally filtered ranked best lap');
 for (const index of [productionIndex, labIndex]) {
-  assert.match(index, new RegExp(`lap-system-r86\\.js\\?build=${release.cacheKey}&revision=mountain-long-prod-r1`),
-    'Prod and TURN LAB must route the lap runtime through the fresh MOUNTAIN-safe module URL');
+  assert.match(index, new RegExp(`lap-system-r86\\.js\\?build=${release.cacheKey}&revision=r262-forgiving-lap-void`),
+    'Prod and TURN LAB must route the lap runtime through the fresh track-aware module URL');
   assert.match(index, new RegExp(`rival-storage\\.js\\?build=${release.cacheKey}&revision=r223-training-car-taxi`),
     'Prod and TURN LAB must cache-bust ranked rival storage with the current release identity');
   assert.match(index, /achievements\/runtime\.js\?revision=r244-reward-toast-guide/,

--- a/turn/index.html
+++ b/turn/index.html
@@ -151,7 +151,7 @@
         "./garage/lot-enhancement-runtime.js?revision=r163-native-picker-parent-click&build=20260809-r163": "./garage/lot-enhancement-runtime.js?build=20260909-r212&revision=r243-mountain-1300",
         "./garage/lot-r10.js?build=20260720-r19": "./garage/lot-track-select.js?build=20260909-r212&revision=r252-supercar-outward-rims",
         "./render/camera.js?build=20260720-r19": "./render/camera.js?build=20260909-r212",
-        "./race/lap-system.js?build=20260720-r19": "./race/lap-system-r86.js?build=20260909-r212&revision=mountain-long-prod-r1",
+        "./race/lap-system.js?build=20260720-r19": "./race/lap-system-r86.js?build=20260909-r212&revision=r262-forgiving-lap-void",
         "./race/game-state.js": "./race/game-state.js?build=20260909-r212",
         "./race/replay-system.js": "./race/replay-system.js?build=20260909-r212",
         "./race/rival-storage.js": "./race/rival-storage.js?build=20260909-r212&revision=r223-training-car-taxi",

--- a/turn/race/lap-system-r86.js
+++ b/turn/race/lap-system-r86.js
@@ -5,16 +5,31 @@ export const LAP_CHECKPOINTS = baseLapSystem.LAP_CHECKPOINTS;
 export const MOUNTAIN_LONG_CHECKPOINTS = Object.freeze(
   Array.from({ length: 24 }, (_, index) => (index + 1) / 25)
 );
+export const COUNTRYSIDE_CHECKPOINT_GATE_HALF_WIDTH_FACTOR = 3;
+export const LAP_VOID_DISABLED_TRACKS = Object.freeze(['cliffside']);
+const NO_CHECKPOINTS = Object.freeze([]);
 
 export const beginTimedLapState = baseLapSystem.beginTimedLapState;
 export const crossedForwardGate = baseLapSystem.crossedForwardGate;
 
 export function updateLapProgressState(options = {}) {
   const trackId = options.state?.trackId || globalThis.__turnGetTrackId?.();
-  const checkpoints = options.checkpoints || (
-    trackId === 'mountain' ? MOUNTAIN_LONG_CHECKPOINTS : LAP_CHECKPOINTS
+  const checkpoints = options.checkpoints ?? (
+    LAP_VOID_DISABLED_TRACKS.includes(trackId)
+      ? NO_CHECKPOINTS
+      : trackId === 'mountain'
+        ? MOUNTAIN_LONG_CHECKPOINTS
+        : LAP_CHECKPOINTS
   );
-  return baseLapSystem.updateLapProgressState({ ...options, checkpoints });
+  const checkpointGateHalfWidthFactor = options.checkpointGateHalfWidthFactor ?? (
+    trackId === 'countryside' ? COUNTRYSIDE_CHECKPOINT_GATE_HALF_WIDTH_FACTOR : undefined
+  );
+
+  return baseLapSystem.updateLapProgressState({
+    ...options,
+    checkpoints,
+    ...(checkpointGateHalfWidthFactor == null ? {} : { checkpointGateHalfWidthFactor })
+  });
 }
 
 export function completeLapState(options) {

--- a/turn/race/lap-system-r86.js
+++ b/turn/race/lap-system-r86.js
@@ -7,6 +7,7 @@ export const MOUNTAIN_LONG_CHECKPOINTS = Object.freeze(
 );
 export const COUNTRYSIDE_CHECKPOINT_GATE_HALF_WIDTH_FACTOR = 3;
 export const LAP_VOID_DISABLED_TRACKS = Object.freeze(['cliffside']);
+const COUNTRYSIDE_TRACK_CENTER = Object.freeze({ x: 0, z: 0 });
 const NO_CHECKPOINTS = Object.freeze([]);
 
 export const beginTimedLapState = baseLapSystem.beginTimedLapState;
@@ -24,11 +25,19 @@ export function updateLapProgressState(options = {}) {
   const checkpointGateHalfWidthFactor = options.checkpointGateHalfWidthFactor ?? (
     trackId === 'countryside' ? COUNTRYSIDE_CHECKPOINT_GATE_HALF_WIDTH_FACTOR : undefined
   );
+  const checkpointGateCenterPoint = options.checkpointGateCenterPoint ?? (
+    trackId === 'countryside' ? COUNTRYSIDE_TRACK_CENTER : undefined
+  );
+  const checkpointGateOuterHalfWidthFactor = options.checkpointGateOuterHalfWidthFactor ?? (
+    trackId === 'countryside' ? Infinity : undefined
+  );
 
   return baseLapSystem.updateLapProgressState({
     ...options,
     checkpoints,
-    ...(checkpointGateHalfWidthFactor == null ? {} : { checkpointGateHalfWidthFactor })
+    ...(checkpointGateHalfWidthFactor == null ? {} : { checkpointGateHalfWidthFactor }),
+    ...(checkpointGateCenterPoint == null ? {} : { checkpointGateCenterPoint }),
+    ...(checkpointGateOuterHalfWidthFactor == null ? {} : { checkpointGateOuterHalfWidthFactor })
   });
 }
 

--- a/turn/race/lap-system-r86.js
+++ b/turn/race/lap-system-r86.js
@@ -1,4 +1,4 @@
-import * as baseLapSystem from './lap-system.js?revision=r223-training-car-taxi';
+import * as baseLapSystem from './lap-system.js?revision=r262-forgiving-lap-void';
 import { isSportsSedanEasterEgg } from '../vehicle/catalog.js?build=20260720-r20';
 
 export const LAP_CHECKPOINTS = baseLapSystem.LAP_CHECKPOINTS;

--- a/turn/race/lap-system.js
+++ b/turn/race/lap-system.js
@@ -55,6 +55,7 @@ export function updateLapProgressState({
   samples,
   trackWidth,
   checkpoints = LAP_CHECKPOINTS,
+  checkpointGateHalfWidthFactor = CHECKPOINT_GATE_HALF_WIDTH_FACTOR,
   now,
   beginTimedLap,
   completeLap,
@@ -62,7 +63,7 @@ export function updateLapProgressState({
 }) {
   const currentPosition = snapshotPosition(state.position);
   const previousPosition = state.lapPreviousPosition || currentPosition;
-  const checkpointGateHalfWidth = trackWidth * CHECKPOINT_GATE_HALF_WIDTH_FACTOR;
+  const checkpointGateHalfWidth = trackWidth * checkpointGateHalfWidthFactor;
   const startGateHalfWidth = trackWidth * START_GATE_HALF_WIDTH_FACTOR;
   const nextCheckpoint = checkpoints[state.lapCheckpointIndex];
 

--- a/turn/race/lap-system.js
+++ b/turn/race/lap-system.js
@@ -56,6 +56,8 @@ export function updateLapProgressState({
   trackWidth,
   checkpoints = LAP_CHECKPOINTS,
   checkpointGateHalfWidthFactor = CHECKPOINT_GATE_HALF_WIDTH_FACTOR,
+  checkpointGateCenterPoint = null,
+  checkpointGateOuterHalfWidthFactor = checkpointGateHalfWidthFactor,
   now,
   beginTimedLap,
   completeLap,
@@ -64,6 +66,10 @@ export function updateLapProgressState({
   const currentPosition = snapshotPosition(state.position);
   const previousPosition = state.lapPreviousPosition || currentPosition;
   const checkpointGateHalfWidth = trackWidth * checkpointGateHalfWidthFactor;
+  const checkpointGateOuterHalfWidth = trackWidth * checkpointGateOuterHalfWidthFactor;
+  const checkpointGatePolicy = checkpointGateCenterPoint
+    ? { centerPoint: checkpointGateCenterPoint, outwardHalfWidth: checkpointGateOuterHalfWidth }
+    : null;
   const startGateHalfWidth = trackWidth * START_GATE_HALF_WIDTH_FACTOR;
   const nextCheckpoint = checkpoints[state.lapCheckpointIndex];
 
@@ -74,7 +80,8 @@ export function updateLapProgressState({
       previousPosition,
       currentPosition,
       checkpointSample,
-      checkpointGateHalfWidth
+      checkpointGateHalfWidth,
+      checkpointGatePolicy
     );
 
     const insideCheckpointGate = !state.lapPreviousPosition
@@ -89,7 +96,8 @@ export function updateLapProgressState({
       currentPosition,
       samples,
       checkpoints,
-      checkpointGateHalfWidth
+      checkpointGateHalfWidth,
+      checkpointGatePolicy
     })) {
       // Crossing a later ordered gate proves that the required route was skipped.
       // Keep timing internally for rival playback, but the HUD can stop presenting
@@ -260,7 +268,7 @@ export function completeLapState({
   };
 }
 
-export function crossedForwardGate(previousPosition, currentPosition, gateSample, halfWidth) {
+export function crossedForwardGate(previousPosition, currentPosition, gateSample, halfWidth, gatePolicy = null) {
   if (!previousPosition || !currentPosition || !gateSample?.point || !gateSample?.tangent) return false;
 
   const tangentX = Number(gateSample.tangent.x) || 0;
@@ -288,9 +296,19 @@ export function crossedForwardGate(previousPosition, currentPosition, gateSample
   const crossingT = Math.min(1, Math.max(0, -previousLongitudinal / longitudinalStep));
   const crossingX = previousPosition.x + (currentPosition.x - previousPosition.x) * crossingT;
   const crossingZ = previousPosition.z + (currentPosition.z - previousPosition.z) * crossingT;
-  const lateralDistance = Math.abs((crossingX - centerX) * nx + (crossingZ - centerZ) * nz);
+  const lateralOffset = (crossingX - centerX) * nx + (crossingZ - centerZ) * nz;
 
-  return lateralDistance <= halfWidth;
+  if (!gatePolicy?.centerPoint) return Math.abs(lateralOffset) <= halfWidth;
+
+  const centerLateralOffset = ((Number(gatePolicy.centerPoint.x) || 0) - centerX) * nx
+    + ((Number(gatePolicy.centerPoint.z) || 0) - centerZ) * nz;
+  const inwardSign = centerLateralOffset < 0 ? -1 : 1;
+  const inwardOffset = lateralOffset * inwardSign;
+  const outwardHalfWidth = Number.isFinite(gatePolicy.outwardHalfWidth)
+    ? Math.max(0, gatePolicy.outwardHalfWidth)
+    : Infinity;
+
+  return inwardOffset <= halfWidth && inwardOffset >= -outwardHalfWidth;
 }
 
 function crossedLaterCheckpointGate({
@@ -299,12 +317,19 @@ function crossedLaterCheckpointGate({
   currentPosition,
   samples,
   checkpoints,
-  checkpointGateHalfWidth
+  checkpointGateHalfWidth,
+  checkpointGatePolicy
 }) {
   for (let index = state.lapCheckpointIndex + 1; index < checkpoints.length; index += 1) {
     const sample = checkpointSampleAt(samples, checkpoints[index]);
     if (state.velocity.dot(sample.tangent) <= 2) continue;
-    if (crossedForwardGate(previousPosition, currentPosition, sample, checkpointGateHalfWidth)) return true;
+    if (crossedForwardGate(
+      previousPosition,
+      currentPosition,
+      sample,
+      checkpointGateHalfWidth,
+      checkpointGatePolicy
+    )) return true;
   }
   return false;
 }


### PR DESCRIPTION
## Summary
- make COUNTRYSIDE checkpoint gates effectively unbounded on the outside of the circuit, where leaving the road only makes the route longer/slower
- allow 3× track-width inward checkpoint reach on COUNTRYSIDE, leaving ample beginner recovery space while retaining a central no-cut region
- keep the physical start/finish gate narrow and unchanged
- disable checkpoint-based LAP VOID on physically contained CLIFFSIDE
- retain ordered anti-shortcut protection on Airport, Harbor, Midnight City and Mountain
- extend the balance/anti-shortcut regression with behavioral coverage for Countryside, Cliffside and Airport
- publish fresh lap-module URL identities so installed/PWA clients cannot retain the old LAP VOID behavior

COUNTRYSIDE is 27 m wide: the inward checkpoint reach is 81 m from the centreline (about 67.5 m beyond the inner road edge), while the outward side has no checkpoint-distance limit. The player still has to cross every checkpoint in order, so going wide cannot create a shortcut.