### PR TITLE
TURN: simplify How to Play scoring copy

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -91,6 +91,7 @@
         "/turn/audio/music/song-tools.js?revision=r184-score-v2": "/turn/audio/music/song-tools.js?revision=r186-note-ties",
         "/turn/audio/music/song-tools.js?revision=r185-menu-orchestration": "/turn/audio/music/song-tools.js?revision=r186-note-ties",
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
+        "/turn/ui/how-to-play-guide.js?revision=r241-learning-achievements&build=20260909-r212": "/turn/ui/how-to-play-guide.js?revision=r263-how-to-play-copy&build=20260909-r212",
         "/turn/race/world-collision.js?build=20260723-r53": "/turn/race/world-collision.js?revision=mountain-long-prod-r1",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r241-learning-achievements",
         "/turn/achievements/catalog.js?revision=r222-awd-label": "/turn/achievements/catalog-track-icons.js?revision=r1-track-reward-icons",

--- a/turn-tests/form-disclosure-system.mjs
+++ b/turn-tests/form-disclosure-system.mjs
@@ -56,7 +56,7 @@ assert.match(components, /\.m8-dbe-guide\[open\] \.m8-disclosure-symbol::before[
 assert.match(components, /\.m8-dbe-guide-panel,[\s\S]*background: var\(--turn-disclosure-panel\)/);
 assert.doesNotMatch(components, /#eaf9ef/);
 
-assert.match(guide, /GUIDE_VERSION = 'r241-learning-achievements'/);
+assert.match(guide, /GUIDE_VERSION = 'r263-how-to-play-copy'/);
 assert.match(guide, /details\.className = 'm8-guide-card-disclosure'/);
 assert.match(guide, /section\.classList\.contains\('m8-guide-wide'\)/,
   'Drive By Ear must remain the non-collapsible outer card');
@@ -118,32 +118,12 @@ assert.match(design, /<details class="disclosure-sample">[\s\S]*<summary>Drive B
 assert.match(design, /<code>details<\/code>[\s\S]*<code>summary<\/code>/,
   'The current reference must explicitly prefer native details/summary semantics');
 
-assert.match(
-  settingsHome,
-  /id="m8AudioTitle"[\s\S]*<div class="m8-visual-settings"><\/div>[\s\S]*m8-record-setting/,
-  'Settings must reserve the second-column space beside Audio for visual preferences'
-);
-assert.match(
-  settingsLayout,
-  /\.m8-visual-settings \{[\s\S]*display: grid;[\s\S]*grid-template-rows: minmax\(0, 1fr\) auto;[\s\S]*gap: 16px;/,
-  'Player marker and Color must share a stacked visual-settings column'
-);
-assert.match(
-  settingsLayout,
-  /@media \(max-width: 760px\) and \(orientation: portrait\)[\s\S]*\.m8-visual-settings \{[\s\S]*display: contents;/,
-  'The visual-settings wrapper must preserve the one-column portrait flow'
-);
-assert.match(playerMarker, /visualSettings\.prepend\(fieldset\)/,
-  'Player marker must be the first card in the visual-settings column');
-assert.match(
-  playerMarker,
-  /\.m8-visual-settings \.turn-player-marker-options \{[\s\S]*grid-template-columns: 1fr;/,
-  'Player marker choices must remain readable in the half-width visual-settings column'
-);
-assert.match(colorAccessibility, /<h3 id="m8ColorCuesTitle">Color<\/h3>/,
-  'Color cues must use the concise Color section heading');
-assert.doesNotMatch(colorAccessibility, /m8ColorCuesTitle">Accessibility/);
-assert.match(colorAccessibility, /visualSettings\.append\(section\)/,
-  'Color must be the final card in the visual-settings column');
+assert.match(settingsHome, /<legend>Steering<\/legend>/);
+assert.match(settingsHome, /Device steering/);
+assert.match(settingsHome, /On-screen steering/);
+assert.match(settingsHome, /Left-handed layout/);
+assert.match(settingsLayout, /\.m8-setting-card[\s\S]*border-radius: 16px/);
+assert.match(playerMarker, /dataset\.colorAccessible/);
+assert.match(colorAccessibility, /data-turn-color-accessibility/);
 
-console.log('TURN native form controls, selection policy, headings and disclosure system passed.');
+console.log('TURN native form, disclosure, selection and current design-system contracts passed.');

--- a/turn-tests/form-disclosure-system.mjs
+++ b/turn-tests/form-disclosure-system.mjs
@@ -118,12 +118,32 @@ assert.match(design, /<details class="disclosure-sample">[\s\S]*<summary>Drive B
 assert.match(design, /<code>details<\/code>[\s\S]*<code>summary<\/code>/,
   'The current reference must explicitly prefer native details/summary semantics');
 
-assert.match(settingsHome, /<legend>Steering<\/legend>/);
-assert.match(settingsHome, /Device steering/);
-assert.match(settingsHome, /On-screen steering/);
-assert.match(settingsHome, /Left-handed layout/);
-assert.match(settingsLayout, /\.m8-setting-card[\s\S]*border-radius: 16px/);
-assert.match(playerMarker, /dataset\.colorAccessible/);
-assert.match(colorAccessibility, /data-turn-color-accessibility/);
+assert.match(
+  settingsHome,
+  /id="m8AudioTitle"[\s\S]*<div class="m8-visual-settings"><\/div>[\s\S]*m8-record-setting/,
+  'Settings must reserve the second-column space beside Audio for visual preferences'
+);
+assert.match(
+  settingsLayout,
+  /\.m8-visual-settings \{[\s\S]*display: grid;[\s\S]*grid-template-rows: minmax\(0, 1fr\) auto;[\s\S]*gap: 16px;/,
+  'Player marker and Color must share a stacked visual-settings column'
+);
+assert.match(
+  settingsLayout,
+  /@media \(max-width: 760px\) and \(orientation: portrait\)[\s\S]*\.m8-visual-settings \{[\s\S]*display: contents;/,
+  'The visual-settings wrapper must preserve the one-column portrait flow'
+);
+assert.match(playerMarker, /visualSettings\.prepend\(fieldset\)/,
+  'Player marker must be the first card in the visual-settings column');
+assert.match(
+  playerMarker,
+  /\.m8-visual-settings \.turn-player-marker-options \{[\s\S]*grid-template-columns: 1fr;/,
+  'Player marker choices must remain readable in the half-width visual-settings column'
+);
+assert.match(colorAccessibility, /<h3 id="m8ColorCuesTitle">Color<\/h3>/,
+  'Color cues must use the concise Color section heading');
+assert.doesNotMatch(colorAccessibility, /m8ColorCuesTitle">Accessibility/);
+assert.match(colorAccessibility, /visualSettings\.append\(section\)/,
+  'Color must be the final card in the visual-settings column');
 
-console.log('TURN native form, disclosure, selection and current design-system contracts passed.');
+console.log('TURN native form controls, selection policy, headings and disclosure system passed.');

--- a/turn-tests/how-to-play-guide-production.mjs
+++ b/turn-tests/how-to-play-guide-production.mjs
@@ -32,7 +32,12 @@ assert.ok(
   'The contextual reset enhancer must run only after the shared Settings dialog exists'
 );
 
-assert.match(guide, /GUIDE_VERSION = 'r241-learning-achievements'/);
+assert.match(guide, /GUIDE_VERSION = 'r263-how-to-play-copy'/);
+assert.match(guide, /updateTrackAndCarCopy\(dialog\)/);
+assert.match(guide, /Choose a track, then pick your car in <strong>THE LOT<\/strong> before racing/);
+assert.match(guide, /Use <strong>SHOW BEST<\/strong> to compare your saved TIME, DRIFT and FLOW records/);
+assert.doesNotMatch(guide, /SHOW RECORDS/,
+  'How to Play must use the current SHOW BEST control name');
 assert.match(guide, /slide between <strong>GAS<\/strong>, <strong>DRIFT<\/strong>, <strong>BOOST<\/strong> and <strong>BRAKE<\/strong>/);
 assert.match(guide, /BRAKE stops at zero without reversing/);
 assert.match(guide, /slide outward into <strong>REVERSE<\/strong>/);
@@ -49,18 +54,23 @@ assert.match(guide, /Uncaught OVERCHARGE leaks\. At its peak, it starts leaking 
 
 assert.match(guide, /title: 'SHIFT'/);
 assert.match(guide, /normal attributes and the alternate setup you configured in <strong>THE LOT<\/strong>/);
-assert.match(guide, /redistributes attribute points — it does not add free power/);
+assert.match(guide, /redistributes attribute points between the two setups/);
+assert.doesNotMatch(guide, /does not add free power/,
+  'SHIFT help should explain the mechanic positively rather than defend against an unstated misconception');
 assert.match(guide, /slide from GAS into SHIFT to swap setup, then SHIFT again to return/);
-assert.match(guide, /title: 'DRIFT POINTS'/);
-assert.match(guide, /DRIFT POINTS<\/strong> reward strong, fast, controlled slides — not pressing DRIFT/);
+assert.match(guide, /title: 'DRIFT ATTACK'/);
+assert.match(guide, /DRIFT ATTACK<\/strong> rewards strong, fast, controlled slides/);
+assert.doesNotMatch(guide, /not pressing DRIFT/,
+  'DRIFT ATTACK help must not introduce the confusing input-versus-score aside');
 assert.match(guide, /large live number is the current drift value at risk/);
 assert.match(guide, /Link drifts to raise <strong>COMBO<\/strong>/);
 assert.match(guide, /clean exit <strong>BANKS<\/strong>/);
 assert.match(guide, /<strong>LAP<\/strong> is this lap, <strong>LAST<\/strong> is your previous completed lap and <strong>BEST<\/strong> is the saved record for this track/);
-assert.match(guide, /title: 'FLOW POINTS'/);
-assert.match(guide, /FLOW POINTS<\/strong> reward useful choreography between systems such as SHIFT, BOOST, DRIFT, LOCK, OVERCHARGE catches and clean exits/);
-assert.match(guide, /Button presses alone score nothing/);
-assert.match(guide, /Variety and useful timing build <strong>COMBO<\/strong>/);
+assert.match(guide, /title: 'FLOW'/);
+assert.match(guide, /FLOW<\/strong> rewards chaining different driving techniques at the right moment/);
+assert.match(guide, /Mix techniques with useful timing to build <strong>COMBO<\/strong>/);
+assert.doesNotMatch(guide, /Button presses alone score nothing/,
+  'FLOW help should describe rewarding play rather than expose anti-spam implementation language');
 assert.match(guide, /gauge shows your current FLOW momentum/);
 
 assert.match(guide, /installGuideCardDisclosures\(dialog\)/);
@@ -198,4 +208,4 @@ assert.match(rivalStorage, /syncPrimaryRivalState\(state\)/);
 assert.match(trackManager, /clearRivalsState\(currentRuntime\.state, \{ trackId: activeTrackId \}\)/, 'The race reset implementation must clear only the current track storage key');
 assert.match(trackManager, /globalThis\.__turnResetRivals = resetCurrentTrackRivals/);
 
-console.log('TURN collapsible How to Play cards, SHIFT/scoring guidance, clean scorekeeper and contextual rival reset passed.');
+console.log('TURN collapsible How to Play cards, current player-facing copy, clean scorekeeper and contextual rival reset passed.');

--- a/turn/index.html
+++ b/turn/index.html
@@ -102,6 +102,7 @@
         "/turn/audio/music/song-tools.js?revision=r184-score-v2": "/turn/audio/music/song-tools.js?revision=r186-note-ties",
         "/turn/audio/music/song-tools.js?revision=r185-menu-orchestration": "/turn/audio/music/song-tools.js?revision=r186-note-ties",
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
+        "/turn/ui/how-to-play-guide.js?revision=r241-learning-achievements&build=20260909-r212": "/turn/ui/how-to-play-guide.js?revision=r263-how-to-play-copy&build=20260909-r212",
         "/turn/race/world-collision.js?build=20260723-r53": "/turn/race/world-collision.js?revision=mountain-long-prod-r1",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r241-learning-achievements",
         "/turn/achievements/catalog.js?revision=r222-awd-label": "/turn/achievements/catalog-track-icons.js?revision=r1-track-reward-icons",

--- a/turn/ui/how-to-play-guide.js
+++ b/turn/ui/how-to-play-guide.js
@@ -4,7 +4,7 @@ import {
   LEARNING_FEEDBACK_READY_EVENT
 } from '../achievements/learning-progress.js?revision=r1-learning-achievements';
 
-const GUIDE_VERSION = 'r241-learning-achievements';
+const GUIDE_VERSION = 'r263-how-to-play-copy';
 const PACE_NOTE_EXPLANATION = 'Before major corners, one to three beeps play in the ear on the turn side. One beep means a gentler corner, two means medium and three means tight. A long corner keeps the same number of beeps but holds the final beep longer: bip-beeeep for a long medium corner and bip-bip-beeeep for a long tight corner. Separate groups describe linked corners in the order you will meet them.';
 const GUIDE_CARD_ID_BY_NUMBER = Object.freeze({
   1: 'choose-track-and-car',
@@ -21,6 +21,7 @@ export function installHowToPlayGuide(root = document) {
   if (!dialog) return false;
   if (dialog.dataset.guideVersion === GUIDE_VERSION) return true;
 
+  updateTrackAndCarCopy(dialog);
   updateDriveControlCopy(dialog);
   updateDriftAndBoostCopy(dialog);
   installShiftAndScoringSections(dialog);
@@ -33,6 +34,14 @@ export function installHowToPlayGuide(root = document) {
   dialog.dataset.guideVersion = GUIDE_VERSION;
   document.documentElement.dataset.turnHowToPlayGuide = GUIDE_VERSION;
   return true;
+}
+
+function updateTrackAndCarCopy(dialog) {
+  const section = findGuideSection(dialog, 'Choose a track and car');
+  const paragraph = section?.querySelector('p');
+  if (!paragraph) return;
+
+  paragraph.innerHTML = 'Choose a track, then pick your car in <strong>THE LOT</strong> before racing. Use <strong>SHOW BEST</strong> to compare your saved TIME, DRIFT and FLOW records. TURN races you against recordings of your own fastest laps, not computer drivers.';
 }
 
 function updateDriveControlCopy(dialog) {
@@ -90,19 +99,19 @@ function installShiftAndScoringSections(dialog) {
     id: 'shift',
     number: '5',
     title: 'SHIFT',
-    copy: '<strong>SHIFT</strong> swaps between your car’s normal attributes and the alternate setup you configured in <strong>THE LOT</strong>. It redistributes attribute points — it does not add free power. During a race, slide from GAS into SHIFT to swap setup, then SHIFT again to return. Trade for what you need next: for example more DRIFT or CONTROL into a slide, or more acceleration and BOOST performance on the exit.'
+    copy: '<strong>SHIFT</strong> swaps between your car’s normal attributes and the alternate setup you configured in <strong>THE LOT</strong>. It redistributes attribute points between the two setups. During a race, slide from GAS into SHIFT to swap setup, then SHIFT again to return. Trade for what you need next: for example more DRIFT or CONTROL into a slide, or more acceleration and BOOST performance on the exit.'
   });
   const drift = makeGuideSection(dialog, {
     id: 'drift-points',
     number: '6',
-    title: 'DRIFT POINTS',
-    copy: '<strong>DRIFT POINTS</strong> reward strong, fast, controlled slides — not pressing DRIFT. The large live number is the current drift value at risk and the gauge shows how strongly it is scoring right now. Link drifts to raise <strong>COMBO</strong>. A clean exit <strong>BANKS</strong> the current drift; a failed drift can lose the unbanked points without erasing points already banked this lap. <strong>LAP</strong> is this lap, <strong>LAST</strong> is your previous completed lap and <strong>BEST</strong> is the saved record for this track.'
+    title: 'DRIFT ATTACK',
+    copy: '<strong>DRIFT ATTACK</strong> rewards strong, fast, controlled slides. The large live number is the current drift value at risk and the gauge shows how strongly it is scoring right now. Link drifts to raise <strong>COMBO</strong>. A clean exit <strong>BANKS</strong> the current drift; a failed drift can lose the unbanked points without erasing points already banked this lap. <strong>LAP</strong> is this lap, <strong>LAST</strong> is your previous completed lap and <strong>BEST</strong> is the saved record for this track.'
   });
   const flow = makeGuideSection(dialog, {
     id: 'flow-points',
     number: '7',
-    title: 'FLOW POINTS',
-    copy: '<strong>FLOW POINTS</strong> reward useful choreography between systems such as SHIFT, BOOST, DRIFT, LOCK, OVERCHARGE catches and clean exits. Button presses alone score nothing. Variety and useful timing build <strong>COMBO</strong>; repeating the same idea adds less and mistakes can break the chain. The gauge shows your current FLOW momentum. <strong>LAP</strong> is this lap, <strong>LAST</strong> is your previous completed lap and <strong>BEST</strong> is the saved record for this track.'
+    title: 'FLOW',
+    copy: '<strong>FLOW</strong> rewards chaining different driving techniques at the right moment: SHIFT, BOOST, DRIFT, LOCK, catching OVERCHARGE and clean exits. Mix techniques with useful timing to build <strong>COMBO</strong>; repeating the same idea adds less and mistakes can break the chain. The gauge shows your current FLOW momentum. <strong>LAP</strong> is this lap, <strong>LAST</strong> is your previous completed lap and <strong>BEST</strong> is the saved record for this track.'
   });
 
   grid.insertBefore(shift, before);


### PR DESCRIPTION
## Summary
- rename How to Play `DRIFT POINTS` to `DRIFT ATTACK` so it matches the Trophy Road unlock
- remove the confusing “not pressing DRIFT” aside and keep the explanation focused on what earns score
- rename `FLOW POINTS` to `FLOW` to match its unlock and replace implementation-facing anti-spam wording with positive player guidance
- remove the similarly defensive “does not add free power” line from SHIFT and explain redistribution directly
- correct the stale `SHOW RECORDS` reference to the current `SHOW BEST` control and make the track → THE LOT flow explicit
- update both How to Play regression contracts around the current player-facing copy
- publish a fresh guide-module identity in production and TURN LAB so installed/PWA clients cannot keep the previous help text