### PR TITLE
TURN: restore SHOW RECORDS in How to Play

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -91,7 +91,7 @@
         "/turn/audio/music/song-tools.js?revision=r184-score-v2": "/turn/audio/music/song-tools.js?revision=r186-note-ties",
         "/turn/audio/music/song-tools.js?revision=r185-menu-orchestration": "/turn/audio/music/song-tools.js?revision=r186-note-ties",
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
-        "/turn/ui/how-to-play-guide.js?revision=r241-learning-achievements&build=20260909-r212": "/turn/ui/how-to-play-guide.js?revision=r263-how-to-play-copy&build=20260909-r212",
+        "/turn/ui/how-to-play-guide.js?revision=r241-learning-achievements&build=20260909-r212": "/turn/ui/how-to-play-guide.js?revision=r264-show-records-copy&build=20260909-r212",
         "/turn/race/world-collision.js?build=20260723-r53": "/turn/race/world-collision.js?revision=mountain-long-prod-r1",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r241-learning-achievements",
         "/turn/achievements/catalog.js?revision=r222-awd-label": "/turn/achievements/catalog-track-icons.js?revision=r1-track-reward-icons",

--- a/turn-tests/how-to-play-guide-production.mjs
+++ b/turn-tests/how-to-play-guide-production.mjs
@@ -35,9 +35,7 @@ assert.ok(
 assert.match(guide, /GUIDE_VERSION = 'r263-how-to-play-copy'/);
 assert.match(guide, /updateTrackAndCarCopy\(dialog\)/);
 assert.match(guide, /Choose a track, then pick your car in <strong>THE LOT<\/strong> before racing/);
-assert.match(guide, /Use <strong>SHOW BEST<\/strong> to compare your saved TIME, DRIFT and FLOW records/);
-assert.doesNotMatch(guide, /SHOW RECORDS/,
-  'How to Play must use the current SHOW BEST control name');
+assert.match(guide, /Use <strong>SHOW RECORDS<\/strong> to compare your saved TIME, DRIFT and FLOW records/);
 assert.match(guide, /slide between <strong>GAS<\/strong>, <strong>DRIFT<\/strong>, <strong>BOOST<\/strong> and <strong>BRAKE<\/strong>/);
 assert.match(guide, /BRAKE stops at zero without reversing/);
 assert.match(guide, /slide outward into <strong>REVERSE<\/strong>/);
@@ -205,7 +203,7 @@ assert.match(rivalStorage, /localStorage\.removeItem\(rivalKey\(trackId\)\)/);
 assert.match(rivalStorage, /localStorage\.removeItem\(ghostKey\(trackId\)\)/);
 assert.match(rivalStorage, /state\.trackId = activeTrackId/, 'An all-track reset must preserve the runtime’s active track');
 assert.match(rivalStorage, /syncPrimaryRivalState\(state\)/);
-assert.match(trackManager, /clearRivalsState\(currentRuntime\.state, \{ trackId: activeTrackId \}\)/, 'The race reset implementation must clear only the current track storage key');
+assert.match(trackManager, /clearRivalsState\(currentRuntime\.state, \{ trackId: activeTrackId \}\)/, 'The race Settings path must clear only the current track storage key');
 assert.match(trackManager, /globalThis\.__turnResetRivals = resetCurrentTrackRivals/);
 
 console.log('TURN collapsible How to Play cards, current player-facing copy, clean scorekeeper and contextual rival reset passed.');

--- a/turn/index.html
+++ b/turn/index.html
@@ -102,7 +102,7 @@
         "/turn/audio/music/song-tools.js?revision=r184-score-v2": "/turn/audio/music/song-tools.js?revision=r186-note-ties",
         "/turn/audio/music/song-tools.js?revision=r185-menu-orchestration": "/turn/audio/music/song-tools.js?revision=r186-note-ties",
         "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
-        "/turn/ui/how-to-play-guide.js?revision=r241-learning-achievements&build=20260909-r212": "/turn/ui/how-to-play-guide.js?revision=r263-how-to-play-copy&build=20260909-r212",
+        "/turn/ui/how-to-play-guide.js?revision=r241-learning-achievements&build=20260909-r212": "/turn/ui/how-to-play-guide.js?revision=r264-show-records-copy&build=20260909-r212",
         "/turn/race/world-collision.js?build=20260723-r53": "/turn/race/world-collision.js?revision=mountain-long-prod-r1",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r241-learning-achievements",
         "/turn/achievements/catalog.js?revision=r222-awd-label": "/turn/achievements/catalog-track-icons.js?revision=r1-track-reward-icons",

--- a/turn/ui/how-to-play-guide.js
+++ b/turn/ui/how-to-play-guide.js
@@ -41,7 +41,7 @@ function updateTrackAndCarCopy(dialog) {
   const paragraph = section?.querySelector('p');
   if (!paragraph) return;
 
-  paragraph.innerHTML = 'Choose a track, then pick your car in <strong>THE LOT</strong> before racing. Use <strong>SHOW BEST</strong> to compare your saved TIME, DRIFT and FLOW records. TURN races you against recordings of your own fastest laps, not computer drivers.';
+  paragraph.innerHTML = 'Choose a track, then pick your car in <strong>THE LOT</strong> before racing. Use <strong>SHOW RECORDS</strong> to compare your saved TIME, DRIFT and FLOW records. TURN races you against recordings of your own fastest laps, not computer drivers.';
 }
 
 function updateDriveControlCopy(dialog) {


### PR DESCRIPTION
Corrects my mistaken cleanup in #840. The track chooser control is SHOW RECORDS, not SHOW BEST.

- restore SHOW RECORDS in the How to Play track/car copy
- update the regression contract to match the actual control name
- leave the DRIFT ATTACK/FLOW/SHIFT copy cleanup from #840 intact