### PR TITLE
TURN: add semantic HUD notification components

### DIFF
--- a/.github/workflows/turn-hud-notifications.yml
+++ b/.github/workflows/turn-hud-notifications.yml
@@ -1,0 +1,44 @@
+name: TURN HUD notifications
+
+on:
+  pull_request:
+    paths:
+      - 'turn/ui/hud-notifications.js'
+      - 'turn/hud-notifications.css'
+      - 'turn-tests/hud-notification-components.mjs'
+      - '.github/workflows/turn-hud-notifications.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'turn/ui/hud-notifications.js'
+      - 'turn/hud-notifications.css'
+      - 'turn-tests/hud-notification-components.mjs'
+      - '.github/workflows/turn-hud-notifications.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  components:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Syntax-check notification modules
+        run: |
+          node --check turn/ui/hud-notifications.js
+          node --check turn-tests/hud-notification-components.mjs
+
+      - name: Lint notification modules
+        run: npx --yes eslint@9.39.1 turn/ui/hud-notifications.js turn-tests/hud-notification-components.mjs
+
+      - name: Run notification component regression
+        run: node turn-tests/hud-notification-components.mjs

--- a/.github/workflows/turn-hud-notifications.yml
+++ b/.github/workflows/turn-hud-notifications.yml
@@ -19,6 +19,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   components:
     runs-on: ubuntu-latest

--- a/.github/workflows/turn-hud-notifications.yml
+++ b/.github/workflows/turn-hud-notifications.yml
@@ -21,7 +21,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   components:

--- a/turn-tests/hud-notification-components.mjs
+++ b/turn-tests/hud-notification-components.mjs
@@ -1,0 +1,247 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+import {
+  HUD_NOTIFICATION_KIND,
+  HUD_NOTIFICATION_POLICY,
+  HUD_NOTIFICATION_SLOT,
+  createHudNotificationController
+} from '../turn/ui/hud-notifications.js';
+
+class FakeClassList {
+  constructor(owner) {
+    this.owner = owner;
+    this.values = new Set();
+  }
+
+  add(...names) {
+    for (const name of names) this.values.add(name);
+    this.owner.className = [...this.values].join(' ');
+  }
+}
+
+class FakeElement {
+  constructor(tagName = 'div') {
+    this.tagName = tagName.toUpperCase();
+    this.children = [];
+    this.parentElement = null;
+    this.dataset = {};
+    this.attributes = new Map();
+    this.className = '';
+    this.classList = new FakeClassList(this);
+    this.textContent = '';
+    this.hidden = false;
+    this.listeners = new Map();
+    this.type = '';
+  }
+
+  append(...nodes) {
+    for (const node of nodes) {
+      if (!node) continue;
+      if (node.parentElement) node.remove();
+      node.parentElement = this;
+      this.children.push(node);
+    }
+  }
+
+  remove() {
+    if (!this.parentElement) return;
+    const siblings = this.parentElement.children;
+    const index = siblings.indexOf(this);
+    if (index >= 0) siblings.splice(index, 1);
+    this.parentElement = null;
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, String(value));
+  }
+
+  getAttribute(name) {
+    return this.attributes.get(name) || null;
+  }
+
+  addEventListener(type, callback) {
+    this.listeners.set(type, callback);
+  }
+
+  click() {
+    this.listeners.get('click')?.({ currentTarget: this });
+  }
+}
+
+class FakeDocument {
+  createElement(tagName) {
+    return new FakeElement(tagName);
+  }
+}
+
+function createTimers() {
+  let nextId = 1;
+  const pending = new Map();
+  return {
+    set(callback, delay) {
+      const id = nextId++;
+      pending.set(id, { callback, delay });
+      return id;
+    },
+    clear(id) {
+      pending.delete(id);
+    },
+    runNext() {
+      const entry = [...pending.entries()].sort((a, b) => a[1].delay - b[1].delay || a[0] - b[0])[0];
+      if (!entry) return false;
+      pending.delete(entry[0]);
+      entry[1].callback();
+      return true;
+    },
+    count() {
+      return pending.size;
+    }
+  };
+}
+
+const documentRef = new FakeDocument();
+const hud = new FakeElement('div');
+const timers = createTimers();
+const controller = createHudNotificationController({
+  hud,
+  documentRef,
+  setTimer: (callback, delay) => timers.set(callback, delay),
+  clearTimer: (id) => timers.clear(id),
+  queueMicrotaskRef: (callback) => callback(),
+  exitMs: 20
+});
+
+assert.deepEqual(HUD_NOTIFICATION_POLICY, {
+  [HUD_NOTIFICATION_SLOT.RACE_STATUS]: 'replace',
+  [HUD_NOTIFICATION_SLOT.RACE_CUE]: 'replace',
+  [HUD_NOTIFICATION_SLOT.PROGRESSION]: 'queue'
+});
+assert.equal(hud.children.length, 1, 'The controller mounts one shared HUD notification host');
+assert.equal(controller.host.children.length, 4,
+  'The host contains three semantic slots and one shared polite announcer');
+assert.equal(controller.host.children.at(-1).getAttribute('role'), 'status');
+assert.equal(controller.host.children.at(-1).getAttribute('aria-live'), 'polite');
+for (const slot of Object.values(HUD_NOTIFICATION_SLOT)) {
+  assert.equal(controller.elementFor(slot).getAttribute('aria-live'), 'off',
+    `${slot} visuals must not create a second live-region announcement`);
+}
+
+assert.equal(controller.publish(HUD_NOTIFICATION_SLOT.RACE_STATUS, {
+  id: 'lap-result-1',
+  kind: HUD_NOTIFICATION_KIND.INFO,
+  kicker: 'LAP',
+  title: '2/3 · 0:23.305',
+  priority: 20,
+  announcement: 'Lap two of three. 23.305 seconds.'
+}), true);
+assert.equal(controller.inspect()[HUD_NOTIFICATION_SLOT.RACE_STATUS].active.id, 'lap-result-1');
+assert.equal(controller.host.children.at(-1).textContent, 'Lap two of three. 23.305 seconds.');
+assert.equal(controller.publish(HUD_NOTIFICATION_SLOT.RACE_STATUS, {
+  id: 'low-priority',
+  title: 'Ignore me',
+  priority: 10
+}), false, 'Lower-priority race state cannot displace a current higher-priority state');
+assert.equal(controller.publish(HUD_NOTIFICATION_SLOT.RACE_STATUS, {
+  id: 'lap-void-1',
+  kind: HUD_NOTIFICATION_KIND.DANGER,
+  kicker: 'LAP VOID',
+  title: 'STAY ON THE TRACK!',
+  priority: 40
+}), true);
+assert.equal(controller.inspect()[HUD_NOTIFICATION_SLOT.RACE_STATUS].active.kind, HUD_NOTIFICATION_KIND.DANGER);
+
+let activated = 0;
+assert.equal(controller.publish(HUD_NOTIFICATION_SLOT.RACE_CUE, {
+  id: 'go',
+  kind: HUD_NOTIFICATION_KIND.COMMAND,
+  title: 'GO!',
+  actionLabel: 'Start racing',
+  onActivate: () => { activated += 1; },
+  announce: false
+}), true);
+const cuePlate = controller.elementFor(HUD_NOTIFICATION_SLOT.RACE_CUE).children[0];
+assert.equal(cuePlate.tagName, 'BUTTON', 'Actionable notification variants use real button semantics');
+assert.equal(cuePlate.getAttribute('aria-label'), 'Start racing');
+cuePlate.click();
+assert.equal(activated, 1);
+
+const customBody = new FakeElement('span');
+customBody.textContent = 'DRIFT 722 · FLOW 2,089';
+controller.publish(HUD_NOTIFICATION_SLOT.RACE_STATUS, {
+  id: 'lap-result-custom',
+  kind: HUD_NOTIFICATION_KIND.INFO,
+  contentNode: customBody,
+  announcement: 'Lap result with scoring summary.',
+  priority: 50
+});
+const statusPlate = controller.elementFor(HUD_NOTIFICATION_SLOT.RACE_STATUS).children[0];
+assert.equal(statusPlate.children[1].className, 'turn-hud-notification__body',
+  'Complex status content can use the shared shell without flattening the lap/score structure');
+assert.equal(statusPlate.children[1].children[0], customBody);
+
+assert.equal(controller.publish(HUD_NOTIFICATION_SLOT.PROGRESSION, {
+  id: 'achievement:mayday',
+  kind: HUD_NOTIFICATION_KIND.ACHIEVEMENT,
+  kicker: 'ACHIEVEMENT UNLOCKED',
+  title: 'MAYDAY!',
+  badge: '+100 TROPHIES',
+  announce: false
+}), true);
+assert.equal(controller.publish(HUD_NOTIFICATION_SLOT.PROGRESSION, {
+  id: 'reward:awd',
+  kind: HUD_NOTIFICATION_KIND.REWARD,
+  kicker: 'TROPHY ROAD REWARD',
+  title: 'AWD · TRACTION',
+  badge: 'UNLOCKED',
+  announce: false
+}), true);
+assert.equal(controller.publish(HUD_NOTIFICATION_SLOT.PROGRESSION, {
+  id: 'reward:awd',
+  kind: HUD_NOTIFICATION_KIND.REWARD,
+  title: 'DUPLICATE'
+}), false, 'Queued progression notifications de-duplicate stable ids');
+assert.equal(controller.inspect()[HUD_NOTIFICATION_SLOT.PROGRESSION].active.id, 'achievement:mayday');
+assert.deepEqual(
+  controller.inspect()[HUD_NOTIFICATION_SLOT.PROGRESSION].queued.map((item) => item.id),
+  ['reward:awd']
+);
+controller.dismiss(HUD_NOTIFICATION_SLOT.PROGRESSION);
+assert.equal(controller.elementFor(HUD_NOTIFICATION_SLOT.PROGRESSION).children[0].dataset.state, 'leaving');
+assert.equal(timers.runNext(), true, 'The short exit timer can complete the current progression notification');
+assert.equal(controller.inspect()[HUD_NOTIFICATION_SLOT.PROGRESSION].active.id, 'reward:awd',
+  'Progression notifications advance sequentially rather than stacking');
+assert.equal(controller.elementFor(HUD_NOTIFICATION_SLOT.PROGRESSION).children.length, 1);
+
+controller.destroy();
+assert.equal(hud.children.length, 0);
+assert.equal(timers.count(), 0, 'Destroy clears all notification timers');
+
+const [source, css] = await Promise.all([
+  fs.readFile(new URL('../turn/ui/hud-notifications.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/hud-notifications.css', import.meta.url), 'utf8')
+]);
+
+assert.match(source, /RACE_STATUS: 'race-status'/);
+assert.match(source, /RACE_CUE: 'race-cue'/);
+assert.match(source, /PROGRESSION: 'progression'/);
+assert.match(source, /\[HUD_NOTIFICATION_SLOT\.PROGRESSION\]: 'queue'/);
+assert.match(source, /announcer\.setAttribute\('role', 'status'\)/);
+assert.match(source, /announcer\.setAttribute\('aria-live', 'polite'\)/);
+assert.doesNotMatch(source, /role['"],?\s*['"]alert|aria-live['"],?\s*['"]assertive/,
+  'Shared HUD notifications stay non-interruptive by default');
+assert.doesNotMatch(source, /offsetWidth|offsetHeight|getBoundingClientRect/,
+  'Component entrance/exit must not depend on forced layout reads');
+assert.match(css, /data-slot="race-cue"[\s\S]*--turn-hud-notification-radius: var\(--turn-radius-pill, 999px\)/,
+  'Component 2 uses the maximally rounded GO-style pill');
+assert.match(css, /data-slot="progression"[\s\S]*width: min\(520px, 46vw\)/,
+  'Component 3 has a deliberately more compact maximum footprint');
+assert.match(css, /\.turn-score-event-callout\[data-event="bank"\][\s\S]*var\(--turn-green-500/);
+assert.match(css, /\.turn-score-event-callout\[data-event="loss"\][\s\S]*var\(--turn-red-500/);
+assert.match(css, /\.turn-score-event-callout\[data-event="milestone"\][\s\S]*var\(--turn-yellow-400/);
+assert.match(css, /@media \(prefers-reduced-motion: reduce\)[\s\S]*animation: none;/,
+  'All shared notification motion has a reduced-motion path');
+assert.doesNotMatch(css, /filter\s*:/,
+  'HUD notifications avoid filter effects in the race compositor');
+
+console.log('TURN HUD notification component and semantic-slot regression passed.');

--- a/turn/hud-notifications.css
+++ b/turn/hud-notifications.css
@@ -1,0 +1,290 @@
+/*
+ * Shared in-race notification primitives.
+ *
+ * This file deliberately defines component geometry and semantics only. Final
+ * race-HUD placement is owned by the peripheral HUD composition so right- and
+ * left-handed layouts can mirror from one source of truth.
+ */
+.turn-hud-notifications {
+  position: absolute;
+  z-index: 35;
+  inset: 0;
+  overflow: visible;
+  pointer-events: none;
+}
+
+.turn-hud-notification-slot {
+  position: absolute;
+  min-width: 0;
+  pointer-events: none;
+}
+
+.turn-hud-notification {
+  --turn-hud-notification-surface: var(--turn-action-warning, var(--turn-yellow-400, #ffd43b));
+  --turn-hud-notification-radius: var(--turn-radius-default, 16px);
+  box-sizing: border-box;
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: clamp(7px, 1.1vw, 11px);
+  margin: 0;
+  border: var(--turn-border-default, 3px) solid var(--turn-ink, #08090a);
+  border-radius: var(--turn-hud-notification-radius);
+  background: var(--turn-hud-notification-surface);
+  box-shadow: var(--turn-shadow-default, 5px 5px 0 var(--turn-ink, #08090a));
+  color: var(--turn-ink, #08090a);
+  font: inherit;
+  text-align: start;
+  pointer-events: none;
+  animation: turn-hud-notification-enter 180ms cubic-bezier(.2, .82, .3, 1) both;
+}
+
+.turn-hud-notification[data-state="leaving"] {
+  animation: turn-hud-notification-exit 160ms ease-in both;
+}
+
+.turn-hud-notification.is-actionable {
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.turn-hud-notification.is-actionable:focus-visible {
+  outline: 3px solid var(--turn-action-information, var(--turn-blue-500, #38d9ff));
+  outline-offset: 3px;
+}
+
+.turn-hud-notification__media {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  min-width: 0;
+}
+
+.turn-hud-notification__media[hidden] {
+  display: none;
+}
+
+.turn-hud-notification__copy,
+.turn-hud-notification__body {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.turn-hud-notification__copy {
+  display: grid;
+  gap: 2px;
+}
+
+.turn-hud-notification__kicker,
+.turn-hud-notification__title,
+.turn-hud-notification__detail,
+.turn-hud-notification__badge {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.turn-hud-notification__kicker,
+.turn-hud-notification__badge {
+  font-size: clamp(.46rem, 1vw, .62rem);
+  font-weight: 950;
+  letter-spacing: .07em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.turn-hud-notification__title {
+  font-size: clamp(.78rem, 1.65vw, 1.05rem);
+  font-weight: 950;
+  letter-spacing: .025em;
+  line-height: 1.02;
+}
+
+.turn-hud-notification__detail {
+  font-size: clamp(.56rem, 1.15vw, .72rem);
+  font-weight: 850;
+  line-height: 1.08;
+}
+
+.turn-hud-notification__badge {
+  flex: 0 0 auto;
+  padding: 5px 8px 6px;
+  border: 2px solid var(--turn-ink, #08090a);
+  border-radius: var(--turn-radius-pill, 999px);
+  background: var(--turn-yellow-400, #ffd43b);
+  white-space: nowrap;
+}
+
+/* Component 1: wide race/lap status surface. */
+.turn-hud-notification[data-slot="race-status"] {
+  width: min(760px, 100%);
+  min-height: 58px;
+  padding: 7px 12px 8px;
+  --turn-hud-notification-radius: var(--turn-radius-default, 16px);
+}
+
+.turn-hud-notification[data-slot="race-status"] .turn-hud-notification__title {
+  font-size: clamp(.92rem, 2vw, 1.24rem);
+}
+
+/* Component 2: compact TURN command/cue pill, based on the existing GO plate. */
+.turn-hud-notification[data-slot="race-cue"] {
+  width: max-content;
+  max-width: min(72vw, 720px);
+  min-height: 38px;
+  padding: 6px 13px 7px;
+  --turn-hud-notification-radius: var(--turn-radius-pill, 999px);
+}
+
+.turn-hud-notification[data-slot="race-cue"] .turn-hud-notification__copy {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+}
+
+.turn-hud-notification[data-slot="race-cue"] .turn-hud-notification__kicker,
+.turn-hud-notification[data-slot="race-cue"] .turn-hud-notification__title,
+.turn-hud-notification[data-slot="race-cue"] .turn-hud-notification__detail {
+  white-space: nowrap;
+}
+
+/* Component 3: progression plate, intentionally smaller than the old toast. */
+.turn-hud-notification[data-slot="progression"] {
+  width: min(520px, 46vw);
+  min-height: 60px;
+  padding: 7px 9px 8px;
+  --turn-hud-notification-radius: var(--turn-radius-compact, 13px);
+}
+
+.turn-hud-notification[data-slot="progression"] .turn-hud-notification__media {
+  width: clamp(38px, 4.5vw, 50px);
+  align-self: stretch;
+  border: 2px solid var(--turn-ink, #08090a);
+  border-radius: var(--turn-radius-compact, 11px);
+  background: var(--turn-paper, #fff8e8);
+}
+
+/* Semantic variants. Colour reinforces the explicit text; it never carries meaning alone. */
+.turn-hud-notification[data-kind="info"],
+.turn-hud-notification[data-kind="command"] {
+  --turn-hud-notification-surface: var(--turn-yellow-400, #ffd43b);
+}
+
+.turn-hud-notification[data-kind="guidance"] {
+  --turn-hud-notification-surface: var(--turn-paper, #fff8e8);
+}
+
+.turn-hud-notification[data-kind="success"],
+.turn-hud-notification[data-kind="achievement"] {
+  --turn-hud-notification-surface: var(--turn-green-500, #8ce99a);
+}
+
+.turn-hud-notification[data-kind="danger"] {
+  --turn-hud-notification-surface: var(--turn-red-500, #ff6b6b);
+}
+
+.turn-hud-notification[data-kind="reward"] {
+  --turn-hud-notification-surface: var(--turn-yellow-400, #ffd43b);
+}
+
+/* Component 4 primitive. Placement inside DRIFT/FLOW paper is composed elsewhere. */
+.turn-score-event-callout {
+  box-sizing: border-box;
+  display: grid;
+  width: max-content;
+  max-width: 72%;
+  gap: 2px;
+  padding: 5px 7px 6px;
+  border: 2px solid var(--turn-ink, #08090a);
+  border-radius: var(--turn-radius-compact, 10px);
+  background: var(--turn-yellow-400, #ffd43b);
+  box-shadow: var(--turn-shadow-compact, 3px 3px 0 var(--turn-ink, #08090a));
+  color: var(--turn-ink, #08090a);
+  pointer-events: none;
+  animation: turn-hud-notification-enter 180ms cubic-bezier(.2, .82, .3, 1) both;
+}
+
+.turn-score-event-callout[hidden] {
+  display: none;
+}
+
+.turn-score-event-callout[data-state="leaving"] {
+  animation: turn-hud-notification-exit 160ms ease-in both;
+}
+
+.turn-score-event-callout strong,
+.turn-score-event-callout b {
+  overflow: hidden;
+  line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.turn-score-event-callout strong {
+  font-size: clamp(.52rem, 1.15vw, .68rem);
+  letter-spacing: .045em;
+}
+
+.turn-score-event-callout b {
+  font-size: clamp(.72rem, 1.7vw, 1rem);
+}
+
+.turn-score-event-callout[data-event="bank"] {
+  background: var(--turn-green-500, #8ce99a);
+}
+
+.turn-score-event-callout[data-event="loss"] {
+  background: var(--turn-red-500, #ff6b6b);
+}
+
+.turn-score-event-callout[data-event="milestone"] {
+  background: var(--turn-yellow-400, #ffd43b);
+}
+
+.turn-score-event-callout[data-event="personal-best"],
+.turn-score-event-callout[data-event="lap-result"] {
+  background: var(--turn-pink-500, #ff4fa3);
+}
+
+@keyframes turn-hud-notification-enter {
+  from { opacity: 0; transform: translateY(5px) scale(.97); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+@keyframes turn-hud-notification-exit {
+  from { opacity: 1; transform: translateY(0) scale(1); }
+  to { opacity: 0; transform: translateY(3px) scale(.985); }
+}
+
+@media (max-height: 430px) and (orientation: landscape) {
+  .turn-hud-notification[data-slot="race-status"] {
+    min-height: 48px;
+    padding: 5px 9px 6px;
+    border-width: 2px;
+    box-shadow: 3px 3px 0 var(--turn-ink, #08090a);
+  }
+
+  .turn-hud-notification[data-slot="race-cue"] {
+    min-height: 32px;
+    padding: 4px 10px 5px;
+    border-width: 2px;
+    box-shadow: 3px 3px 0 var(--turn-ink, #08090a);
+  }
+
+  .turn-hud-notification[data-slot="progression"] {
+    width: min(480px, 45vw);
+    min-height: 50px;
+    padding: 5px 7px 6px;
+    border-width: 2px;
+    box-shadow: 3px 3px 0 var(--turn-ink, #08090a);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .turn-hud-notification,
+  .turn-hud-notification[data-state="leaving"],
+  .turn-score-event-callout,
+  .turn-score-event-callout[data-state="leaving"] {
+    animation: none;
+  }
+}

--- a/turn/ui/hud-notifications.js
+++ b/turn/ui/hud-notifications.js
@@ -97,15 +97,21 @@ function createPlate(documentRef, slot, notification) {
   if (notification.mediaNode) media.append(notification.mediaNode);
   else media.hidden = true;
 
-  const copy = documentRef.createElement('span');
-  copy.className = 'turn-hud-notification__copy';
-  appendIf(copy, makeTextNode(documentRef, 'turn-hud-notification__kicker', notification.kicker));
-  appendIf(copy, makeTextNode(documentRef, 'turn-hud-notification__title', notification.title));
-  appendIf(copy, makeTextNode(documentRef, 'turn-hud-notification__detail', notification.detail));
+  const body = documentRef.createElement('span');
+  body.className = notification.contentNode
+    ? 'turn-hud-notification__body'
+    : 'turn-hud-notification__copy';
+  if (notification.contentNode) {
+    body.append(notification.contentNode);
+  } else {
+    appendIf(body, makeTextNode(documentRef, 'turn-hud-notification__kicker', notification.kicker));
+    appendIf(body, makeTextNode(documentRef, 'turn-hud-notification__title', notification.title));
+    appendIf(body, makeTextNode(documentRef, 'turn-hud-notification__detail', notification.detail));
+  }
 
   const badge = makeTextNode(documentRef, 'turn-hud-notification__badge', notification.badge);
   appendIf(plate, media);
-  appendIf(plate, copy);
+  appendIf(plate, body);
   appendIf(plate, badge);
   return plate;
 }

--- a/turn/ui/hud-notifications.js
+++ b/turn/ui/hud-notifications.js
@@ -124,12 +124,20 @@ function makeSlotRecord(element) {
   };
 }
 
+function defaultQueueMicrotask(callback) {
+  if (typeof globalThis.queueMicrotask === 'function') {
+    globalThis.queueMicrotask(callback);
+    return;
+  }
+  Promise.resolve().then(callback);
+}
+
 export function createHudNotificationController({
   hud,
   documentRef = globalThis.document,
   setTimer = (callback, delay) => globalThis.setTimeout?.(callback, delay) || 0,
   clearTimer = (timer) => globalThis.clearTimeout?.(timer),
-  queueMicrotaskRef = (callback) => globalThis.queueMicrotask?.(callback) ?? Promise.resolve().then(callback),
+  queueMicrotaskRef = defaultQueueMicrotask,
   exitMs = HUD_NOTIFICATION_EXIT_MS
 } = {}) {
   if (!hud || !documentRef?.createElement) {

--- a/turn/ui/hud-notifications.js
+++ b/turn/ui/hud-notifications.js
@@ -1,0 +1,316 @@
+export const HUD_NOTIFICATION_SLOT = Object.freeze({
+  RACE_STATUS: 'race-status',
+  RACE_CUE: 'race-cue',
+  PROGRESSION: 'progression'
+});
+
+export const HUD_NOTIFICATION_KIND = Object.freeze({
+  INFO: 'info',
+  COMMAND: 'command',
+  GUIDANCE: 'guidance',
+  SUCCESS: 'success',
+  DANGER: 'danger',
+  ACHIEVEMENT: 'achievement',
+  REWARD: 'reward'
+});
+
+export const HUD_NOTIFICATION_POLICY = Object.freeze({
+  [HUD_NOTIFICATION_SLOT.RACE_STATUS]: 'replace',
+  [HUD_NOTIFICATION_SLOT.RACE_CUE]: 'replace',
+  [HUD_NOTIFICATION_SLOT.PROGRESSION]: 'queue'
+});
+
+export const HUD_NOTIFICATION_DEFAULT_DURATION_MS = Object.freeze({
+  [HUD_NOTIFICATION_SLOT.RACE_STATUS]: 4000,
+  [HUD_NOTIFICATION_SLOT.RACE_CUE]: 2800,
+  [HUD_NOTIFICATION_SLOT.PROGRESSION]: 3200
+});
+
+export const HUD_NOTIFICATION_EXIT_MS = 160;
+
+const SLOT_VALUES = new Set(Object.values(HUD_NOTIFICATION_SLOT));
+const KIND_VALUES = new Set(Object.values(HUD_NOTIFICATION_KIND));
+
+function finiteNumber(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function normalizeSlot(slot) {
+  const value = String(slot || '');
+  if (!SLOT_VALUES.has(value)) throw new TypeError(`Unknown TURN HUD notification slot: ${value || '(empty)'}`);
+  return value;
+}
+
+function normalizeKind(kind) {
+  const value = String(kind || HUD_NOTIFICATION_KIND.INFO);
+  return KIND_VALUES.has(value) ? value : HUD_NOTIFICATION_KIND.INFO;
+}
+
+function text(value) {
+  return value == null ? '' : String(value);
+}
+
+function defaultAnnouncement(notification) {
+  return [notification.kicker, notification.title, notification.detail, notification.badge]
+    .map((part) => text(part).trim())
+    .filter(Boolean)
+    .join('. ');
+}
+
+function accessibleActionLabel(notification) {
+  return text(notification.actionLabel).trim() || defaultAnnouncement(notification);
+}
+
+function makeTextNode(documentRef, className, value) {
+  if (!text(value).trim()) return null;
+  const node = documentRef.createElement('span');
+  node.className = className;
+  node.textContent = text(value);
+  return node;
+}
+
+function appendIf(parent, node) {
+  if (node) parent.append(node);
+}
+
+function createPlate(documentRef, slot, notification) {
+  const interactive = typeof notification.onActivate === 'function';
+  const plate = documentRef.createElement(interactive ? 'button' : 'div');
+  plate.className = 'turn-hud-notification';
+  plate.dataset.slot = slot;
+  plate.dataset.kind = normalizeKind(notification.kind);
+  plate.dataset.state = 'visible';
+
+  if (interactive) {
+    plate.type = 'button';
+    plate.classList.add('is-actionable');
+    plate.setAttribute('aria-label', accessibleActionLabel(notification));
+    plate.addEventListener('click', notification.onActivate);
+  } else {
+    plate.setAttribute('aria-hidden', 'true');
+  }
+
+  const media = documentRef.createElement('span');
+  media.className = 'turn-hud-notification__media';
+  media.setAttribute('aria-hidden', 'true');
+  if (notification.mediaNode) media.append(notification.mediaNode);
+  else media.hidden = true;
+
+  const copy = documentRef.createElement('span');
+  copy.className = 'turn-hud-notification__copy';
+  appendIf(copy, makeTextNode(documentRef, 'turn-hud-notification__kicker', notification.kicker));
+  appendIf(copy, makeTextNode(documentRef, 'turn-hud-notification__title', notification.title));
+  appendIf(copy, makeTextNode(documentRef, 'turn-hud-notification__detail', notification.detail));
+
+  const badge = makeTextNode(documentRef, 'turn-hud-notification__badge', notification.badge);
+  appendIf(plate, media);
+  appendIf(plate, copy);
+  appendIf(plate, badge);
+  return plate;
+}
+
+function makeSlotRecord(element) {
+  return {
+    element,
+    active: null,
+    queue: []
+  };
+}
+
+export function createHudNotificationController({
+  hud,
+  documentRef = globalThis.document,
+  setTimer = (callback, delay) => globalThis.setTimeout?.(callback, delay) || 0,
+  clearTimer = (timer) => globalThis.clearTimeout?.(timer),
+  queueMicrotaskRef = (callback) => globalThis.queueMicrotask?.(callback) ?? Promise.resolve().then(callback),
+  exitMs = HUD_NOTIFICATION_EXIT_MS
+} = {}) {
+  if (!hud || !documentRef?.createElement) {
+    throw new TypeError('TURN HUD notifications require a HUD element and document.');
+  }
+
+  const host = documentRef.createElement('div');
+  host.className = 'turn-hud-notifications';
+  host.setAttribute('data-turn-hud-notifications', '');
+
+  const slots = {};
+  for (const slot of Object.values(HUD_NOTIFICATION_SLOT)) {
+    const element = documentRef.createElement('div');
+    element.className = 'turn-hud-notification-slot';
+    element.dataset.slot = slot;
+    element.setAttribute('data-turn-hud-slot', slot);
+    element.setAttribute('aria-live', 'off');
+    host.append(element);
+    slots[slot] = makeSlotRecord(element);
+  }
+
+  const announcer = documentRef.createElement('p');
+  announcer.className = 'turn-sr-only turn-hud-notification-announcer';
+  announcer.setAttribute('role', 'status');
+  announcer.setAttribute('aria-live', 'polite');
+  announcer.setAttribute('aria-atomic', 'true');
+  host.append(announcer);
+  hud.append(host);
+
+  let destroyed = false;
+  let announcementRevision = 0;
+  const normalizedExitMs = Math.max(0, finiteNumber(exitMs, HUD_NOTIFICATION_EXIT_MS));
+
+  function announce(message) {
+    const value = text(message).trim();
+    if (!value) return;
+    const revision = ++announcementRevision;
+    announcer.textContent = '';
+    queueMicrotaskRef(() => {
+      if (!destroyed && revision === announcementRevision) announcer.textContent = value;
+    });
+  }
+
+  function release(record, slot, { advance = true } = {}) {
+    if (!record?.active) {
+      if (advance) showNext(slot);
+      return;
+    }
+    const current = record.active;
+    clearTimer(current.hideTimer);
+    clearTimer(current.exitTimer);
+    current.node.remove?.();
+    record.active = null;
+    if (typeof current.notification.onDismiss === 'function') {
+      current.notification.onDismiss();
+    }
+    if (advance) showNext(slot);
+  }
+
+  function beginExit(slot) {
+    const record = slots[slot];
+    if (!record?.active) return false;
+    const current = record.active;
+    clearTimer(current.hideTimer);
+    current.hideTimer = 0;
+    current.node.dataset.state = 'leaving';
+    current.exitTimer = setTimer(() => release(record, slot), normalizedExitMs);
+    return true;
+  }
+
+  function mount(slot, notification) {
+    const record = slots[slot];
+    const node = createPlate(documentRef, slot, notification);
+    record.element.append(node);
+
+    const durationMs = Math.max(
+      250,
+      finiteNumber(notification.durationMs, HUD_NOTIFICATION_DEFAULT_DURATION_MS[slot])
+    );
+    const active = {
+      notification,
+      node,
+      priority: finiteNumber(notification.priority),
+      hideTimer: 0,
+      exitTimer: 0
+    };
+    record.active = active;
+    active.hideTimer = setTimer(() => beginExit(slot), durationMs);
+
+    const shouldAnnounce = notification.announce !== false;
+    if (shouldAnnounce) announce(notification.announcement || defaultAnnouncement(notification));
+    return node;
+  }
+
+  function showNext(slot) {
+    const record = slots[slot];
+    if (!record || record.active || !record.queue.length || destroyed) return false;
+    mount(slot, record.queue.shift());
+    return true;
+  }
+
+  function publish(slotValue, detail = {}) {
+    if (destroyed) return false;
+    const slot = normalizeSlot(slotValue);
+    const record = slots[slot];
+    const notification = {
+      ...detail,
+      kind: normalizeKind(detail.kind),
+      id: text(detail.id)
+    };
+
+    if (HUD_NOTIFICATION_POLICY[slot] === 'queue') {
+      const duplicateId = notification.id && (
+        record.active?.notification?.id === notification.id
+        || record.queue.some((queued) => queued.id === notification.id)
+      );
+      if (duplicateId) return false;
+      if (record.active) {
+        record.queue.push(notification);
+        return true;
+      }
+      mount(slot, notification);
+      return true;
+    }
+
+    if (record.active) {
+      const nextPriority = finiteNumber(notification.priority);
+      if (nextPriority < record.active.priority) return false;
+      release(record, slot, { advance: false });
+    }
+    mount(slot, notification);
+    return true;
+  }
+
+  function dismiss(slotValue, { clearQueue = false } = {}) {
+    const slot = normalizeSlot(slotValue);
+    const record = slots[slot];
+    if (clearQueue) record.queue.length = 0;
+    return beginExit(slot);
+  }
+
+  function clear(slotValue) {
+    const slot = normalizeSlot(slotValue);
+    const record = slots[slot];
+    record.queue.length = 0;
+    release(record, slot, { advance: false });
+    return true;
+  }
+
+  function inspect() {
+    return Object.fromEntries(Object.entries(slots).map(([slot, record]) => [slot, {
+      active: record.active ? {
+        id: record.active.notification.id,
+        kind: record.active.notification.kind,
+        title: text(record.active.notification.title),
+        priority: record.active.priority
+      } : null,
+      queued: record.queue.map((notification) => ({
+        id: notification.id,
+        kind: notification.kind,
+        title: text(notification.title)
+      }))
+    }]));
+  }
+
+  function destroy() {
+    if (destroyed) return;
+    destroyed = true;
+    announcementRevision += 1;
+    for (const slot of Object.values(HUD_NOTIFICATION_SLOT)) {
+      const record = slots[slot];
+      record.queue.length = 0;
+      release(record, slot, { advance: false });
+    }
+    announcer.textContent = '';
+    host.remove?.();
+  }
+
+  return Object.freeze({
+    host,
+    publish,
+    dismiss,
+    clear,
+    inspect,
+    destroy,
+    elementFor(slotValue) {
+      return slots[normalizeSlot(slotValue)].element;
+    }
+  });
+}


### PR DESCRIPTION
Foundation PR for #842.

This deliberately does **not** wire or reposition any production HUD surface yet. It adds the reusable notification controller/component primitives and a focused CI regression so the placement/migration work can be isolated in a second PR.

### Included
- semantic slots: `race-status`, `race-cue`, `progression`
- explicit replace vs queue policies
- priority handling for status/cue slots
- sequential progression queue with stable-id de-duplication
- one shared polite live announcer; visual slots themselves are not live regions
- real button semantics for actionable variants
- support for structured/custom component bodies and optional media
- component styling for:
  - Component 1 wide race-status surface
  - Component 2 maximally rounded GO-style cue pill
  - Component 3 slightly smaller progression plate
  - Component 4 compact score-event primitive
- reduced-motion treatment and TURN token usage
- dedicated HUD-notification CI/regression

### Not in this PR
No existing producer imports this controller yet, and `turn/index.html` / TURN LAB / TURN NEXT are untouched. Therefore current production HUD behaviour and cache identities are unchanged by this foundation PR.

The follow-up PR will migrate #842’s existing notification producers and implement final right-/left-handed placement, including scorekeeper callouts covering BEST without obscuring the live DRIFT/FLOW values.

Closes no issue; #842 remains open until the migration PR lands.