### PR TITLE
TURN: standardize and place in-race HUD notifications

### DIFF
--- a/.github/workflows/turn-hud-notifications.yml
+++ b/.github/workflows/turn-hud-notifications.yml
@@ -4,16 +4,26 @@ on:
   pull_request:
     paths:
       - 'turn/ui/hud-notifications.js'
+      - 'turn/ui/hud-notification-runtime.js'
       - 'turn/hud-notifications.css'
+      - 'turn/scoring/score-feedback.js'
+      - 'turn/scoring/scorekeeper-records.js'
       - 'turn-tests/hud-notification-components.mjs'
+      - 'turn-tests/hud-notification-layout-production.mjs'
+      - 'turn-tests/score-feedback-production.mjs'
       - '.github/workflows/turn-hud-notifications.yml'
   push:
     branches:
       - main
     paths:
       - 'turn/ui/hud-notifications.js'
+      - 'turn/ui/hud-notification-runtime.js'
       - 'turn/hud-notifications.css'
+      - 'turn/scoring/score-feedback.js'
+      - 'turn/scoring/scorekeeper-records.js'
       - 'turn-tests/hud-notification-components.mjs'
+      - 'turn-tests/hud-notification-layout-production.mjs'
+      - 'turn-tests/score-feedback-production.mjs'
       - '.github/workflows/turn-hud-notifications.yml'
 
 permissions:
@@ -39,10 +49,29 @@ jobs:
       - name: Syntax-check notification modules
         run: |
           node --check turn/ui/hud-notifications.js
+          node --check turn/ui/hud-notification-runtime.js
+          node --check turn/scoring/score-feedback.js
+          node --check turn/scoring/scorekeeper-records.js
           node --check turn-tests/hud-notification-components.mjs
+          node --check turn-tests/hud-notification-layout-production.mjs
+          node --check turn-tests/score-feedback-production.mjs
 
       - name: Lint notification modules
-        run: npx --yes eslint@9.39.1 turn/ui/hud-notifications.js turn-tests/hud-notification-components.mjs
+        run: >-
+          npx --yes eslint@9.39.1
+          turn/ui/hud-notifications.js
+          turn/ui/hud-notification-runtime.js
+          turn/scoring/score-feedback.js
+          turn/scoring/scorekeeper-records.js
+          turn-tests/hud-notification-components.mjs
+          turn-tests/hud-notification-layout-production.mjs
+          turn-tests/score-feedback-production.mjs
 
       - name: Run notification component regression
         run: node turn-tests/hud-notification-components.mjs
+
+      - name: Run standardized HUD layout regression
+        run: node turn-tests/hud-notification-layout-production.mjs
+
+      - name: Run embedded score-event regression
+        run: node turn-tests/score-feedback-production.mjs

--- a/turn-tests/hud-notification-layout-production.mjs
+++ b/turn-tests/hud-notification-layout-production.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const [runtime, components, css, scoreFeedback, scorekeeper] = await Promise.all([
+  fs.readFile(new URL('../turn/ui/hud-notification-runtime.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/ui/hud-notifications.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/hud-notifications.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/scoring/score-feedback.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/scoring/scorekeeper-records.js', import.meta.url), 'utf8')
+]);
+
+// Component 1: one race-status slot takes over the complete normal stats footprint.
+assert.match(runtime, /controller\.elementFor\(HUD_NOTIFICATION_SLOT\.RACE_STATUS\)/);
+assert.match(runtime, /stats\.classList\?\.add\?\('turn-hud-race-status-host'\)/);
+assert.match(runtime, /stats\.append\(statusSlot\)/,
+  'Race status is physically hosted by .stats instead of guessing its viewport geometry');
+assert.match(css, /\.stats\.turn-hud-race-status-host > \.turn-hud-notification-slot\[data-slot="race-status"\] \{[\s\S]*?inset: 0;[\s\S]*?width: 100%;[\s\S]*?height: 100%;/,
+  'Component 1 covers speed/lap/time/best exactly');
+assert.match(runtime, /makeLapResultBody/);
+assert.match(runtime, /'LAP', `\$\{place\}\/\$\{total\} · \$\{formatLapTime\(result\.time\)\}`/);
+assert.match(runtime, /\[\['DRIFT', result\.drift\], \['FLOW', result\.flow\]\]/,
+  'Lap status reuses both scoring result channels');
+assert.match(runtime, /kicker: 'LAP VOID'/);
+assert.match(runtime, /STAY ON THE TRACK!/);
+
+// Component 2: one GO!-derived pill owns all race cues, including legacy producers
+// and the prepared CHASE YOUR BEST viewer.
+assert.match(components, /RACE_CUE: 'race-cue'/);
+assert.match(css, /data-slot="race-cue"[\s\S]*?--turn-hud-notification-radius: var\(--turn-radius-pill, 999px\)/,
+  'Race cues retain the maximally rounded GO! silhouette');
+assert.match(runtime, /legacy-message:\$\{copy\}/,
+  'Existing #message producers migrate into the shared race-cue component');
+assert.match(runtime, /PATIENT ON BOARD\|MAYDAY\|SECONDS/,
+  'MAYDAY guidance has explicit danger semantics rather than a one-off visual');
+assert.match(runtime, /rival\.classList\.add\('turn-hud-notification', 'turn-hud-rival-cue'\)/,
+  'CHASE YOUR BEST reuses Component 2 without throwing away its warmed 3D viewer');
+assert.match(css, /\.turn-hud-rival-cue \{[\s\S]*?position: relative !important;/);
+
+// Component 3: one smaller progression surface, queued by the shared controller.
+assert.match(components, /\[HUD_NOTIFICATION_SLOT\.PROGRESSION\]: 'queue'/);
+assert.match(runtime, /reward \? HUD_NOTIFICATION_KIND\.REWARD : HUD_NOTIFICATION_KIND\.ACHIEVEMENT/);
+assert.match(css, /data-slot="progression"[\s\S]*?width: min\(500px, 44vw\);[\s\S]*?min-height: 56px;/,
+  'Progression is deliberately smaller than the old toast footprint');
+assert.match(runtime, /toast\.setAttribute\?\.\('aria-hidden', 'true'\)/,
+  'The hidden legacy progression node cannot duplicate the shared accessible announcement');
+assert.match(runtime, /onActivate: \(\) => toast\.click\?\.\(\)/,
+  'Reward notification actions retain the existing feature-owned interaction');
+
+// Component 4: fixed channel-local event plates live inside each scorekeeper paper
+// and cover BEST, never the large live score.
+assert.match(scorekeeper, /ensureEventCallout\(documentRef, root, 'drift'\)/);
+assert.match(scorekeeper, /ensureEventCallout\(documentRef, root, 'flow'\)/);
+assert.match(scorekeeper, /data-score-feedback-\$\{channel\}-callout/);
+assert.match(scoreFeedback, /const activeEvents = \{/);
+assert.match(scoreFeedback, /renderEventCallout\(SCORE_FEEDBACK_CHANNEL\.DRIFT\)/);
+assert.match(scoreFeedback, /renderEventCallout\(SCORE_FEEDBACK_CHANNEL\.FLOW\)/);
+assert.match(css, /\.turn-score-event-callout \{[\s\S]*?right: 7px;[\s\S]*?bottom: 6px;/,
+  'Right-handed scoring callouts occupy the BEST corner');
+assert.match(scoreFeedback, /setText\(currentScore, formatScore\(liveScore\)\)/);
+assert.match(scoreFeedback, /setText\(flowCurrentScore, formatScore\(liveScore\)\)/,
+  'Local callout rendering does not replace either channel live value');
+
+// The complete asymmetric notification composition mirrors from the existing root
+// handedness state. Component 1 follows .topbar/.stats automatically.
+assert.match(css, /:root\.turn-left-handed-controls \.turn-hud-notification-slot\[data-slot="race-cue"\] \{[\s\S]*?right:/);
+assert.match(css, /:root\.turn-left-handed-controls \.turn-hud-notification-slot\[data-slot="progression"\] \{[\s\S]*?right:/);
+assert.match(css, /:root\.turn-left-handed-controls \.turn-score-event-callout \{[\s\S]*?right: auto;[\s\S]*?left: 7px;/);
+assert.doesNotMatch(runtime, /insertBefore|after\(|before\(/,
+  'Mirroring does not mutate semantic/focus order');
+
+// Legacy visuals remain state/action sources during migration but no longer compete
+// visually. Existing race/lap message announcers stay canonical where explicitly kept.
+assert.match(css, /turn-hud-notifications-active \.lap-result-toast \{ display: none !important; \}/);
+assert.match(css, /turn-hud-notifications-active \.turn-achievement-toast[\s\S]*?visibility: hidden !important;/);
+assert.match(css, /turn-hud-notifications-active #message[\s\S]*?clip-path: inset\(50%\)/);
+assert.match(runtime, /announce: false[\s\S]*Existing lap-result announcer remains the single speech owner/);
+assert.match(runtime, /announce: false[\s\S]*#message remains the canonical polite speech source/);
+
+assert.match(css, /@media \(prefers-reduced-motion: reduce\)[\s\S]*?animation: none;/,
+  'Shared notifications have a no-motion presentation path');
+assert.doesNotMatch(css, /filter\s*:/,
+  'The standardized HUD avoids compositor-expensive filters');
+assert.match(scoreFeedback, /installHudNotificationRuntime/,
+  'Production, TURN NEXT and TURN LAB activate the same notification composition through shared ScoreFeedback');
+assert.match(runtime, /hud-notifications\.css\?revision=r266-standard-hud/,
+  'The dynamically loaded notification CSS has an explicit release identity');
+
+console.log('TURN standardized HUD notification layout regression passed.');

--- a/turn-tests/score-feedback-production.mjs
+++ b/turn-tests/score-feedback-production.mjs
@@ -9,36 +9,16 @@ import {
 } from '../turn/scoring/score-feedback.js';
 
 class FakeClassList {
-  constructor() {
-    this.values = new Set();
-  }
-
-  toggle(name, force) {
-    if (force) this.values.add(name);
-    else this.values.delete(name);
-  }
-
-  remove(...names) {
-    for (const name of names) this.values.delete(name);
-  }
-
-  contains(name) {
-    return this.values.has(name);
-  }
+  constructor() { this.values = new Set(); }
+  toggle(name, force) { if (force) this.values.add(name); else this.values.delete(name); }
+  remove(...names) { for (const name of names) this.values.delete(name); }
+  contains(name) { return this.values.has(name); }
 }
 
 class FakeStyle {
-  constructor() {
-    this.values = new Map();
-  }
-
-  setProperty(name, value) {
-    this.values.set(name, String(value));
-  }
-
-  getPropertyValue(name) {
-    return this.values.get(name) || '';
-  }
+  constructor() { this.values = new Map(); }
+  setProperty(name, value) { this.values.set(name, String(value)); }
+  getPropertyValue(name) { return this.values.get(name) || ''; }
 }
 
 class FakeElement {
@@ -50,10 +30,7 @@ class FakeElement {
     this.classList = new FakeClassList();
     this.children = [];
   }
-
-  querySelectorAll(selector) {
-    return selector === 'span' ? this.children : [];
-  }
+  querySelectorAll(selector) { return selector === 'span' ? this.children : []; }
 }
 
 function makeFixture() {
@@ -72,24 +49,22 @@ function makeFixture() {
     '[data-score-feedback-flow-multiplier]',
     '[data-score-feedback-flow-total]',
     '[data-score-feedback-flow-techniques]',
-    '[data-score-feedback-callout]',
-    '[data-score-feedback-callout-label]',
-    '[data-score-feedback-callout-score]',
+    '[data-score-feedback-drift-callout]',
+    '[data-score-feedback-drift-callout-label]',
+    '[data-score-feedback-drift-callout-score]',
+    '[data-score-feedback-flow-callout]',
+    '[data-score-feedback-flow-callout-label]',
+    '[data-score-feedback-flow-callout-score]',
     '[data-score-feedback-announcer]'
   ];
   const elements = new Map(selectors.map((selector) => [selector, new FakeElement()]));
-  elements.get('[data-score-feedback-flow-techniques]').children = Array.from(
-    { length: 5 },
-    () => new FakeElement()
-  );
+  elements.get('[data-score-feedback-flow-techniques]').children = Array.from({ length: 5 }, () => new FakeElement());
   const root = new FakeElement();
   root.querySelector = (selector) => elements.get(selector) || null;
   return { root, elements };
 }
 
-function element(fixture, selector) {
-  return fixture.elements.get(selector);
-}
+function element(fixture, selector) { return fixture.elements.get(selector); }
 
 const fixture = makeFixture();
 const sounds = [];
@@ -104,14 +79,9 @@ assert.equal(fixture.root.hidden, false, 'An available scoring row remains visib
 assert.equal(element(fixture, '[data-score-feedback-state]').hidden, false);
 assert.equal(element(fixture, '[data-score-feedback-current]').textContent, '0');
 assert.equal(fixture.root.dataset.driftGaugeVisible, 'true');
-assert.equal(fixture.root.dataset.driftGaugeExtended, 'false',
-  'An available zero-state DRIFT row keeps its paper but retracts its gauge');
+assert.equal(fixture.root.dataset.driftGaugeExtended, 'false', 'An available zero-state DRIFT row keeps its paper but retracts its gauge');
 assert.equal(fixture.root.dataset.driftComboTier, '1');
-assert.equal(
-  element(fixture, '[data-score-feedback-meter-fill]').style.getPropertyValue('--score-feedback-gauge-fill-a'),
-  'hsl(195 44% 50%)',
-  'DRIFT starts with a deliberately muted cyan at x1'
-);
+assert.equal(element(fixture, '[data-score-feedback-meter-fill]').style.getPropertyValue('--score-feedback-gauge-fill-a'), 'hsl(195 44% 50%)', 'DRIFT starts with a deliberately muted cyan at x1');
 
 const driftState = {
   active: true,
@@ -127,24 +97,12 @@ assert.equal(fixture.root.hidden, false);
 assert.equal(element(fixture, '[data-score-feedback-current]').textContent, '1,740');
 assert.equal(element(fixture, '[data-score-feedback-total]').textContent, '4,820');
 assert.equal(element(fixture, '[data-score-feedback-multiplier]').textContent, '×3');
-assert.equal(
-  element(fixture, '[data-score-feedback-meter-fill]').style.getPropertyValue('--score-feedback-progress'),
-  '0.72'
-);
-assert.equal(
-  element(fixture, '[data-score-feedback-flow-meter-fill]').style.getPropertyValue('--score-feedback-progress'),
-  '0',
-  'The future FLOW gauge stays dormant while only DRIFT is active'
-);
+assert.equal(element(fixture, '[data-score-feedback-meter-fill]').style.getPropertyValue('--score-feedback-progress'), '0.72');
+assert.equal(element(fixture, '[data-score-feedback-flow-meter-fill]').style.getPropertyValue('--score-feedback-progress'), '0', 'The FLOW gauge stays dormant while only DRIFT is active');
 assert.equal(fixture.root.dataset.driftGaugeVisible, 'true');
-assert.equal(fixture.root.dataset.driftGaugeExtended, 'true',
-  'The DRIFT gauge extends as soon as it has a non-zero fill');
+assert.equal(fixture.root.dataset.driftGaugeExtended, 'true', 'The DRIFT gauge extends as soon as it has a non-zero fill');
 assert.equal(fixture.root.dataset.driftComboTier, '3');
-assert.equal(
-  element(fixture, '[data-score-feedback-meter-fill]').style.getPropertyValue('--score-feedback-gauge-fill-a'),
-  'hsl(195 60% 50%)',
-  'DRIFT cyan gains saturation at each higher combo tier'
-);
+assert.equal(element(fixture, '[data-score-feedback-meter-fill]').style.getPropertyValue('--score-feedback-gauge-fill-a'), 'hsl(195 60% 50%)', 'DRIFT cyan gains saturation at each higher combo tier');
 assert.equal(fixture.root.dataset.flowGaugeVisible, 'false');
 assert.equal(fixture.root.dataset.flowGaugeExtended, 'false');
 assert.equal(fixture.root.dataset.gaugeChannel, 'drift');
@@ -152,42 +110,23 @@ assert.equal(fixture.root.dataset.gaugeHeat, 'warm');
 
 driftState.unbanked = 1820;
 feedback.updateState(SCORE_FEEDBACK_CHANNEL.DRIFT, driftState, 100 + SCORE_FEEDBACK_COMMIT_INTERVAL_MS / 2);
-assert.equal(
-  element(fixture, '[data-score-feedback-current]').textContent,
-  '1,740',
-  'Rapid score ticks are not committed at physics frequency'
-);
+assert.equal(element(fixture, '[data-score-feedback-current]').textContent, '1,740', 'Rapid score ticks are not committed at physics frequency');
 feedback.commit(100 + SCORE_FEEDBACK_COMMIT_INTERVAL_MS);
 assert.equal(element(fixture, '[data-score-feedback-current]').textContent, '1,820');
 
-feedback.publishEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, SCORE_FEEDBACK_EVENT.BANK, {
-  score: 1820,
-  multiplier: 3
-}, 300);
-assert.equal(element(fixture, '[data-score-feedback-callout-label]').textContent, '✓ BANKED ×3');
-assert.equal(element(fixture, '[data-score-feedback-callout-score]').textContent, '+1,820');
-assert.equal(element(fixture, '[data-score-feedback-callout]').dataset.event, 'bank');
+feedback.publishEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, SCORE_FEEDBACK_EVENT.BANK, { score: 1820, multiplier: 3 }, 300);
+assert.equal(element(fixture, '[data-score-feedback-drift-callout-label]').textContent, '✓ BANKED ×3');
+assert.equal(element(fixture, '[data-score-feedback-drift-callout-score]').textContent, '+1,820');
+assert.equal(element(fixture, '[data-score-feedback-drift-callout]').dataset.event, 'bank');
+assert.equal(element(fixture, '[data-score-feedback-flow-callout]').hidden, true);
 assert.deepEqual(sounds, ['drift:bank']);
 
-const lowerPriorityAccepted = feedback.publishEvent(
-  SCORE_FEEDBACK_CHANNEL.FLOW,
-  SCORE_FEEDBACK_EVENT.TECHNIQUE,
-  { label: 'BOOST › DRIFT' },
-  350
-);
-assert.equal(lowerPriorityAccepted, false, 'A technique event cannot replace an active release');
-assert.equal(element(fixture, '[data-score-feedback-callout]').dataset.event, 'bank');
-
-feedback.publishEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, SCORE_FEEDBACK_EVENT.PERSONAL_BEST, {
-  score: 8420
-}, 400);
-assert.equal(element(fixture, '[data-score-feedback-callout-label]').textContent, 'NEW BEST');
+assert.equal(feedback.publishEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, SCORE_FEEDBACK_EVENT.TECHNIQUE, { label: 'LOW PRIORITY' }, 350), false, 'A lower-priority DRIFT event cannot replace an active DRIFT release');
+assert.equal(element(fixture, '[data-score-feedback-drift-callout]').dataset.event, 'bank');
+feedback.publishEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, SCORE_FEEDBACK_EVENT.PERSONAL_BEST, { score: 8420 }, 400);
+assert.equal(element(fixture, '[data-score-feedback-drift-callout-label]').textContent, 'NEW BEST');
 await Promise.resolve();
-assert.equal(
-  element(fixture, '[data-score-feedback-announcer]').textContent,
-  'New drift best.',
-  'Higher-priority semantic events may replace an announcement inside the rate limit'
-);
+assert.equal(element(fixture, '[data-score-feedback-announcer]').textContent, 'New drift best.', 'Higher-priority semantic events may replace an announcement inside the rate limit');
 
 const flowState = {
   active: true,
@@ -202,73 +141,46 @@ const flowState = {
 feedback.setChannelVisible(SCORE_FEEDBACK_CHANNEL.FLOW, true, 500);
 feedback.updateState(SCORE_FEEDBACK_CHANNEL.FLOW, flowState, 600);
 assert.equal(fixture.root.dataset.channel, 'flow', 'FLOW becomes persistent context when both channels are active');
-assert.equal(element(fixture, '[data-score-feedback-current]').textContent, '1,820',
-  'DRIFT keeps its own paper readout when FLOW is active');
+assert.equal(element(fixture, '[data-score-feedback-current]').textContent, '1,820', 'DRIFT keeps its live paper readout when FLOW is active');
 assert.equal(element(fixture, '[data-score-feedback-flow-current]').textContent, '18,420');
 assert.equal(element(fixture, '[data-score-feedback-flow-total]').textContent, '18,420');
 assert.equal(element(fixture, '[data-score-feedback-flow-multiplier]').textContent, '×5.1');
-assert.deepEqual(
-  element(fixture, '[data-score-feedback-flow-techniques]').children.map((token) => token.textContent),
-  ['SHIFT', 'DRIFT', 'LOCK', 'BOOST', 'EXIT'],
-  'FLOW reuses its fixed technique-token pool instead of creating DOM nodes in the scoring path'
-);
-assert.equal(
-  element(fixture, '[data-score-feedback-meter-fill]').style.getPropertyValue('--score-feedback-progress'),
-  '0.72',
-  'DRIFT keeps its own independent gauge value when FLOW becomes active'
-);
-assert.equal(
-  element(fixture, '[data-score-feedback-flow-meter-fill]').style.getPropertyValue('--score-feedback-progress'),
-  '0.84',
-  'FLOW can drive the same gauge contract independently'
-);
+assert.deepEqual(element(fixture, '[data-score-feedback-flow-techniques]').children.map((token) => token.textContent), ['SHIFT', 'DRIFT', 'LOCK', 'BOOST', 'EXIT'], 'FLOW reuses its fixed technique-token pool instead of creating DOM nodes in the scoring path');
+assert.equal(element(fixture, '[data-score-feedback-meter-fill]').style.getPropertyValue('--score-feedback-progress'), '0.72', 'DRIFT keeps its own independent gauge value when FLOW becomes active');
+assert.equal(element(fixture, '[data-score-feedback-flow-meter-fill]').style.getPropertyValue('--score-feedback-progress'), '0.84', 'FLOW drives its gauge independently');
 assert.equal(fixture.root.dataset.flowGaugeVisible, 'true');
-assert.equal(fixture.root.dataset.flowGaugeExtended, 'true',
-  'FLOW owns an independently extending gauge');
-assert.equal(fixture.root.dataset.flowComboTier, '5',
-  'Fractional FLOW multipliers use their floored saturation tier');
-assert.equal(
-  element(fixture, '[data-score-feedback-flow-meter-fill]').style.getPropertyValue('--score-feedback-gauge-fill-a'),
-  'hsl(339 76% 65%)',
-  'FLOW pink gains saturation with the combo tier'
-);
+assert.equal(fixture.root.dataset.flowGaugeExtended, 'true', 'FLOW owns an independently extending gauge');
+assert.equal(fixture.root.dataset.flowComboTier, '5', 'Fractional FLOW multipliers use their floored saturation tier');
+assert.equal(element(fixture, '[data-score-feedback-flow-meter-fill]').style.getPropertyValue('--score-feedback-gauge-fill-a'), 'hsl(339 76% 65%)', 'FLOW pink gains saturation with the combo tier');
 assert.equal(fixture.root.dataset.flowHeat, 'hot');
 
-feedback.updateState(SCORE_FEEDBACK_CHANNEL.FLOW, {
-  ...flowState,
-  active: false,
-  intensity: 0
-}, 700);
-assert.equal(
-  element(fixture, '[data-score-feedback-flow-meter-fill]').style.getPropertyValue('--score-feedback-progress'),
-  '0',
-  'An idle moment inside a FLOW combo can reach the true zero gauge state'
-);
-assert.equal(fixture.root.dataset.flowGaugeExtended, 'true',
-  'FLOW keeps an empty gauge extended while its x2+ combo remains alive');
+assert.equal(feedback.publishEvent(SCORE_FEEDBACK_CHANNEL.FLOW, SCORE_FEEDBACK_EVENT.MILESTONE, { score: 2480, multiplier: 7 }, 650), true);
+assert.equal(element(fixture, '[data-score-feedback-flow-callout-label]').textContent, 'FLOW ×7');
+assert.equal(element(fixture, '[data-score-feedback-flow-callout-score]').textContent, '2,480');
+assert.equal(element(fixture, '[data-score-feedback-flow-callout]').dataset.event, 'milestone');
+assert.equal(element(fixture, '[data-score-feedback-drift-callout-label]').textContent, 'NEW BEST', 'FLOW does not displace the DRIFT paper event');
+assert.equal(element(fixture, '[data-score-feedback-current]').textContent, '1,820', 'Embedded DRIFT callout never replaces the current live DRIFT value');
+assert.equal(element(fixture, '[data-score-feedback-flow-current]').textContent, '18,420', 'Embedded FLOW callout never replaces the current live FLOW value');
+assert.equal(feedback.inspect().activeEvents.flow.active, true);
+assert.equal(feedback.inspect().activeEvents.drift.active, true);
+
+feedback.updateState(SCORE_FEEDBACK_CHANNEL.FLOW, { ...flowState, active: false, intensity: 0 }, 700);
+assert.equal(element(fixture, '[data-score-feedback-flow-meter-fill]').style.getPropertyValue('--score-feedback-progress'), '0', 'An idle moment inside a FLOW combo can reach the true zero gauge state');
+assert.equal(fixture.root.dataset.flowGaugeExtended, 'true', 'FLOW keeps an empty gauge extended while its x2+ combo remains alive');
 feedback.updateState(SCORE_FEEDBACK_CHANNEL.FLOW, flowState, 800);
 
-feedback.publishEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, SCORE_FEEDBACK_EVENT.BANK, {
-  label: 'DRIFT +2,840 ×4',
-  score: 2840,
-  multiplier: 4
-}, 3000);
+feedback.publishEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, SCORE_FEEDBACK_EVENT.BANK, { label: 'DRIFT +2,840 ×4', score: 2840, multiplier: 4 }, 3000);
 assert.equal(fixture.root.dataset.channel, 'flow');
-assert.equal(element(fixture, '[data-score-feedback-callout-label]').textContent, 'DRIFT +2,840 ×4');
-
+assert.equal(element(fixture, '[data-score-feedback-drift-callout-label]').textContent, 'DRIFT +2,840 ×4');
 feedback.setChannelVisible(SCORE_FEEDBACK_CHANNEL.DRIFT, false, 3100);
-assert.equal(element(fixture, '[data-score-feedback-callout]').hidden, true);
+assert.equal(element(fixture, '[data-score-feedback-drift-callout]').hidden, true);
 assert.equal(fixture.root.hidden, false, 'Hiding DRIFT presentation leaves active FLOW context visible');
 assert.equal(fixture.root.dataset.driftGaugeVisible, 'false');
 assert.equal(fixture.root.dataset.driftGaugeExtended, 'false');
 assert.equal(fixture.root.dataset.flowGaugeVisible, 'true');
-assert.equal(feedback.publishEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, SCORE_FEEDBACK_EVENT.BANK, {
-  score: 9999
-}, 3150), false, 'A hidden channel cannot take presentation priority from a visible channel');
-assert.equal(feedback.publishEvent(SCORE_FEEDBACK_CHANNEL.FLOW, SCORE_FEEDBACK_EVENT.TECHNIQUE, {
-  label: 'CLEAN LINE'
-}, 3160), true);
-assert.equal(element(fixture, '[data-score-feedback-callout-label]').textContent, 'CLEAN LINE');
+assert.equal(feedback.publishEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, SCORE_FEEDBACK_EVENT.BANK, { score: 9999 }, 3150), false, 'A hidden channel cannot publish a visual event');
+assert.equal(feedback.publishEvent(SCORE_FEEDBACK_CHANNEL.FLOW, SCORE_FEEDBACK_EVENT.TECHNIQUE, { label: 'CLEAN LINE' }, 3160), true);
+assert.equal(element(fixture, '[data-score-feedback-flow-callout-label]').textContent, 'CLEAN LINE');
 feedback.setChannelVisible(SCORE_FEEDBACK_CHANNEL.FLOW, false, 3200);
 assert.equal(fixture.root.hidden, true, 'Presentation visibility is independent per scoring channel');
 
@@ -277,89 +189,43 @@ feedback.updateState(SCORE_FEEDBACK_CHANNEL.FLOW, flowState, 3400);
 feedback.clearChannel(SCORE_FEEDBACK_CHANNEL.DRIFT, 3500);
 assert.equal(fixture.root.dataset.channel, 'flow', 'Clearing DRIFT must not reset FLOW');
 assert.equal(feedback.inspect().flow.score, 18420);
-
 feedback.reset(4000);
 assert.equal(fixture.root.hidden, true);
 assert.equal(feedback.inspect().drift.score, 0);
-assert.equal(
-  element(fixture, '[data-score-feedback-meter-fill]').style.getPropertyValue('--score-feedback-progress'),
-  '0'
-);
+assert.equal(feedback.inspect().activeEvents.drift.active, false);
+assert.equal(feedback.inspect().activeEvents.flow.active, false);
+assert.equal(element(fixture, '[data-score-feedback-meter-fill]').style.getPropertyValue('--score-feedback-progress'), '0');
 
 feedback.setChannelVisible(SCORE_FEEDBACK_CHANNEL.DRIFT, true, 4100);
-feedback.updateState(SCORE_FEEDBACK_CHANNEL.DRIFT, {
-  active: false,
-  score: 4820,
-  unbanked: 0,
-  multiplier: 1,
-  intensity: 0,
-  phase: 'quiet',
-  label: 'DRIFT'
-}, 4200);
+feedback.updateState(SCORE_FEEDBACK_CHANNEL.DRIFT, { active: false, score: 4820, unbanked: 0, multiplier: 1, intensity: 0, phase: 'quiet', label: 'DRIFT' }, 4200);
 assert.equal(fixture.root.hidden, false, 'The DRIFT instrument does not flicker out between drifts');
 assert.equal(element(fixture, '[data-score-feedback-current]').textContent, '0');
 assert.equal(element(fixture, '[data-score-feedback-total]').textContent, '4,820');
-assert.equal(fixture.root.dataset.driftGaugeExtended, 'false',
-  'A quiet x1 DRIFT row preserves its lap total while retracting only the black gauge');
-assert.equal(
-  element(fixture, '[data-score-feedback-meter-fill]').style.getPropertyValue('--score-feedback-progress'),
-  '0'
-);
-
-feedback.updateState(SCORE_FEEDBACK_CHANNEL.DRIFT, {
-  active: false,
-  score: 4820,
-  unbanked: 0,
-  multiplier: 2,
-  intensity: 0,
-  phase: 'quiet',
-  label: 'DRIFT'
-}, 4300);
-assert.equal(fixture.root.dataset.driftGaugeExtended, 'true',
-  'An empty DRIFT gauge remains extended while an x2+ combo is alive');
+assert.equal(fixture.root.dataset.driftGaugeExtended, 'false', 'A quiet x1 DRIFT row preserves its lap total while retracting only the black gauge');
+assert.equal(element(fixture, '[data-score-feedback-meter-fill]').style.getPropertyValue('--score-feedback-progress'), '0');
+feedback.updateState(SCORE_FEEDBACK_CHANNEL.DRIFT, { active: false, score: 4820, unbanked: 0, multiplier: 2, intensity: 0, phase: 'quiet', label: 'DRIFT' }, 4300);
+assert.equal(fixture.root.dataset.driftGaugeExtended, 'true', 'An empty DRIFT gauge remains extended while an x2+ combo is alive');
 assert.equal(fixture.root.dataset.driftComboTier, '2');
-assert.equal(
-  element(fixture, '[data-score-feedback-meter-fill]').style.getPropertyValue('--score-feedback-progress'),
-  '0',
-  'The held-open gauge exposes the existing cyan zero residue rather than fake fill'
-);
-assert.equal(
-  element(fixture, '[data-score-feedback-meter-fill]').style.getPropertyValue('--score-feedback-gauge-fill-a'),
-  'hsl(195 52% 50%)'
-);
-
-feedback.updateState(SCORE_FEEDBACK_CHANNEL.DRIFT, {
-  active: false,
-  score: 4820,
-  unbanked: 0,
-  multiplier: 1,
-  intensity: 0,
-  phase: 'quiet',
-  label: 'DRIFT'
-}, 4400);
-assert.equal(fixture.root.dataset.driftGaugeExtended, 'false',
-  'Normal gauge retraction resumes as soon as the combo falls below x2');
-
-feedback.publishEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, SCORE_FEEDBACK_EVENT.LOSS, {
-  score: 120
-}, 4500);
+assert.equal(element(fixture, '[data-score-feedback-meter-fill]').style.getPropertyValue('--score-feedback-progress'), '0', 'The held-open gauge exposes the existing cyan zero residue rather than fake fill');
+assert.equal(element(fixture, '[data-score-feedback-meter-fill]').style.getPropertyValue('--score-feedback-gauge-fill-a'), 'hsl(195 52% 50%)');
+feedback.updateState(SCORE_FEEDBACK_CHANNEL.DRIFT, { active: false, score: 4820, unbanked: 0, multiplier: 1, intensity: 0, phase: 'quiet', label: 'DRIFT' }, 4400);
+assert.equal(fixture.root.dataset.driftGaugeExtended, 'false', 'Normal gauge retraction resumes as soon as the combo falls below x2');
+feedback.publishEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, SCORE_FEEDBACK_EVENT.LOSS, { score: 120 }, 4500);
 feedback.dismissEvent(SCORE_FEEDBACK_CHANNEL.DRIFT, 4550);
-assert.equal(element(fixture, '[data-score-feedback-callout]').hidden, true);
-assert.equal(element(fixture, '[data-score-feedback-total]').textContent, '4,820',
-  'Dismissing stale feedback must not clear the persistent lap total');
+assert.equal(element(fixture, '[data-score-feedback-drift-callout]').hidden, true);
+assert.equal(element(fixture, '[data-score-feedback-total]').textContent, '4,820', 'Dismissing stale feedback must not clear the persistent lap total');
 feedback.clearChannel(SCORE_FEEDBACK_CHANNEL.DRIFT, 4600);
 assert.equal(fixture.root.hidden, false, 'Clearing a visible channel leaves its zero-state instrument mounted');
 assert.equal(element(fixture, '[data-score-feedback-total]').textContent, '0');
 feedback.setChannelVisible(SCORE_FEEDBACK_CHANNEL.DRIFT, false, 4700);
 assert.equal(fixture.root.hidden, true, 'The HUD setting still removes the scoring instrument');
-assert.equal(
-  element(fixture, '[data-score-feedback-flow-meter-fill]').style.getPropertyValue('--score-feedback-progress'),
-  '0'
-);
+assert.equal(element(fixture, '[data-score-feedback-flow-meter-fill]').style.getPropertyValue('--score-feedback-progress'), '0');
 
-const [source, css, index, nextIndex, labIndex, main] = await Promise.all([
+const [source, css, hudCss, recordsSource, index, nextIndex, labIndex, main] = await Promise.all([
   fs.readFile(new URL('../turn/scoring/score-feedback.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/scoring/score-feedback.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/hud-notifications.css', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn/scoring/scorekeeper-records.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-next/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-lab/index.html', import.meta.url), 'utf8'),
@@ -367,99 +233,59 @@ const [source, css, index, nextIndex, labIndex, main] = await Promise.all([
 ]);
 
 assert.doesNotMatch(source, /requestAnimationFrame/);
-assert.doesNotMatch(source, /createElement|appendChild|replaceChildren/,
-  'ScoreFeedback must reuse the fixed document nodes');
-assert.match(source, /data-score-feedback-flow-meter-fill/,
-  'The shared engine must already understand the optional future FLOW gauge mount');
-assert.match(source, /GAUGE_SATURATION_AT_X1 = 44/,
-  'The combo palette starts muted instead of at full saturation');
-assert.match(source, /driftGaugeProgress > 0 \|\| driftComboHeld/,
-  'DRIFT gauge persistence is keyed to fill or a live x2+ combo');
-assert.match(source, /flowGaugeProgress > 0 \|\| flowComboHeld/,
-  'FLOW uses the same combo-held gauge rule');
-assert.match(css, /--score-feedback-paper-height: 104px/,
-  'Each scoring paper row has a stable gameplay height');
-assert.match(css, /--score-feedback-gauge-height: calc\(var\(--score-feedback-paper-height\) - 14px\)/,
-  'The attached gauge fills nearly the full stable scoring-row height');
-assert.match(css, /top: var\(--score-feedback-gauge-inset-y\)/,
-  'The attached gauge keeps equal optical insets inside its scoring row');
-assert.match(css, /transform: scaleX\(var\(--score-feedback-progress, 0\)\)/,
-  'Score gauges fill horizontally without layout work');
-assert.doesNotMatch(css, /transform: scaleY\(var\(--score-feedback-progress, 0\)\)/,
-  'The old vertical fill contract is gone');
-assert.match(css, /background: linear-gradient\(\s*to right,/,
-  'The channel colour also travels along the x-axis');
-for (const [mountName, markup] of [
-  ['TURN', index],
-  ['TURN NEXT', nextIndex],
-  ['TURN LAB', labIndex]
-]) {
-  assert.match(
-    markup,
-    /data-score-feedback-label>DRIFT<\/span><span>COMBO<\/span>/,
-    `${mountName} exposes COMBO vocabulary in accessible markup`
-  );
-  assert.match(markup, /data-score-feedback-flow-current>0<\/strong>/,
-    `${mountName} includes the fixed FLOW paper row`);
-  assert.equal((markup.match(/data-score-feedback-flow-techniques/g) || []).length, 1,
-    `${mountName} includes one fixed FLOW technique pool`);
-  assert.equal((markup.match(/class="score-feedback-gauge-shell"/g) || []).length, 2,
-    `${mountName} mounts one compositor shell for each scoring gauge`);
-  assert.match(
-    markup,
-    /class="score-feedback-gauge-shell" data-score-channel="drift" aria-hidden="true">\s*<div class="score-feedback-meter">/,
-    `${mountName} keeps the DRIFT gauge decorative and nested inside its retracting shell`
-  );
-  assert.ok(
-    markup.indexOf('class="score-feedback-gauge-shell" data-score-channel="drift"') < markup.indexOf('class="score-feedback-state"'),
-    `${mountName} keeps the gauge behind the paper as a sibling stacking layer`
-  );
+assert.doesNotMatch(source, /createElement|appendChild|replaceChildren/, 'ScoreFeedback must reuse fixed document nodes');
+assert.match(source, /activeEvents/, 'ScoreFeedback owns independent channel-local event state');
+assert.match(source, /data-score-feedback-drift-callout/);
+assert.match(source, /data-score-feedback-flow-callout/);
+assert.match(source, /installHudNotificationRuntime/, 'The shared scoring composition activates the standardized in-race HUD');
+assert.match(recordsSource, /ensureEventCallout\(documentRef, root, 'drift'\)/);
+assert.match(recordsSource, /ensureEventCallout\(documentRef, root, 'flow'\)/);
+assert.match(recordsSource, /className = 'turn-score-event-callout'/, 'Scorekeeper composition creates one fixed event plate in each paper');
+assert.match(source, /data-score-feedback-flow-meter-fill/);
+assert.match(source, /GAUGE_SATURATION_AT_X1 = 44/);
+assert.match(source, /driftGaugeProgress > 0 \|\| driftComboHeld/);
+assert.match(source, /flowGaugeProgress > 0 \|\| flowComboHeld/);
+assert.match(css, /--score-feedback-paper-height: 104px/);
+assert.match(css, /--score-feedback-gauge-height: calc\(var\(--score-feedback-paper-height\) - 14px\)/);
+assert.match(css, /top: var\(--score-feedback-gauge-inset-y\)/);
+assert.match(css, /transform: scaleX\(var\(--score-feedback-progress, 0\)\)/);
+assert.doesNotMatch(css, /transform: scaleY\(var\(--score-feedback-progress, 0\)\)/);
+assert.match(css, /background: linear-gradient\(\s*to right,/);
+for (const [mountName, markup] of [['TURN', index], ['TURN NEXT', nextIndex], ['TURN LAB', labIndex]]) {
+  assert.match(markup, /data-score-feedback-label>DRIFT<\/span><span>COMBO<\/span>/, `${mountName} exposes COMBO vocabulary`);
+  assert.match(markup, /data-score-feedback-flow-current>0<\/strong>/, `${mountName} includes the FLOW paper row`);
+  assert.equal((markup.match(/data-score-feedback-flow-techniques/g) || []).length, 1, `${mountName} includes one fixed FLOW technique pool`);
+  assert.equal((markup.match(/class="score-feedback-gauge-shell"/g) || []).length, 2, `${mountName} mounts one shell for each scoring gauge`);
+  assert.match(markup, /class="score-feedback-gauge-shell" data-score-channel="drift" aria-hidden="true">\s*<div class="score-feedback-meter">/);
+  assert.ok(markup.indexOf('class="score-feedback-gauge-shell" data-score-channel="drift"') < markup.indexOf('class="score-feedback-state"'), `${mountName} keeps gauge behind paper`);
 }
-assert.match(css, /\.score-feedback-state \{[\s\S]*?z-index: 1;/,
-  'The paper owns the foreground stacking layer');
-assert.match(css, /\.score-feedback-gauge-shell \{[\s\S]*?z-index: 0;/,
-  'The attached gauge sits behind the paper instead of intruding into it');
-assert.match(css, /\.score-feedback-gauge-shell \{[\s\S]*?opacity: \.75;/,
-  'Extended DRIFT and FLOW instruments retain the requested translucent weight');
-assert.match(css, /\.score-feedback-gauge-shell \{[\s\S]*?transform: translateZ\(0\) scaleX\(1\)/,
-  'A live gauge expands to its complete horizontal footprint');
-assert.match(
-  css,
-  /data-drift-gauge-extended="false"[\s\S]*?data-flow-gauge-extended="false"[\s\S]*?transform: translateZ\(0\) scaleX\(0\);[\s\S]*?transition-delay: 180ms;/,
-  'Zero-state gauges retract after a slight compositor-only delay'
-);
-assert.match(css, /\.score-feedback-row \{[\s\S]*?height: var\(--score-feedback-paper-height\)/,
-  'DRIFT and FLOW each retain one fixed-height scoring row');
-assert.match(css, /--score-feedback-gauge-track: var\(--turn-ink\);/,
-  'The gauge body uses the canonical TURN ink token');
-assert.doesNotMatch(css, /#(?:000(?:000)?|08090a)\b/i,
-  'ScoreFeedback never substitutes a local black for --turn-ink');
-assert.match(css, /data-score-channel="flow"/,
-  'The reusable horizontal gauge primitive has a FLOW channel treatment ready for #739');
-assert.match(
-  css,
-  /\.score-feedback-row \{[\s\S]*?position: relative;[\s\S]*?height: var\(--score-feedback-paper-height\)/,
-  'Each FLOW gauge is aligned inside its own fixed paper row');
-assert.match(css, /@keyframes turn-score-gauge-rush/,
-  'High-intensity scoring keeps a transform-driven peripheral-noise layer');
-assert.match(css, /translateX/,
-  'Gauge rush/noise follows the horizontal scoring axis');
-assert.match(css, /score-feedback-meter::before/,
-  'A type-coloured zero remnant survives inside the black track');
-assert.doesNotMatch(css, /filter\s*:/,
-  'ScoreFeedback buildup avoids filter effects on the low-end hot path');
+assert.match(hudCss, /\.turn-score-event-callout \{[\s\S]*?right: 7px;[\s\S]*?bottom: 6px;/, 'Component 4 occupies the BEST corner instead of the live-value area');
+assert.match(hudCss, /:root\.turn-left-handed-controls \.turn-score-event-callout \{[\s\S]*?right: auto;[\s\S]*?left: 7px;/, 'Component 4 mirrors to the opposite BEST corner for left-handed play');
+assert.match(hudCss, /\.turn-score-event-callout\[data-event="bank"\][\s\S]*?var\(--turn-green-500/);
+assert.match(hudCss, /\.turn-score-event-callout\[data-event="loss"\][\s\S]*?var\(--turn-red-500/);
+assert.match(hudCss, /\.turn-score-event-callout\[data-event="milestone"\][\s\S]*?var\(--turn-yellow-400/);
+assert.match(css, /\.score-feedback-state \{[\s\S]*?z-index: 1;/);
+assert.match(css, /\.score-feedback-gauge-shell \{[\s\S]*?z-index: 0;/);
+assert.match(css, /\.score-feedback-gauge-shell \{[\s\S]*?opacity: \.75;/);
+assert.match(css, /\.score-feedback-gauge-shell \{[\s\S]*?transform: translateZ\(0\) scaleX\(1\)/);
+assert.match(css, /data-drift-gauge-extended="false"[\s\S]*?data-flow-gauge-extended="false"[\s\S]*?transform: translateZ\(0\) scaleX\(0\);[\s\S]*?transition-delay: 180ms;/);
+assert.match(css, /\.score-feedback-row \{[\s\S]*?height: var\(--score-feedback-paper-height\)/);
+assert.match(css, /--score-feedback-gauge-track: var\(--turn-ink\);/);
+assert.doesNotMatch(css, /#(?:000(?:000)?|08090a)\b/i);
+assert.match(css, /data-score-channel="flow"/);
+assert.match(css, /\.score-feedback-row \{[\s\S]*?position: relative;[\s\S]*?height: var\(--score-feedback-paper-height\)/);
+assert.match(css, /@keyframes turn-score-gauge-rush/);
+assert.match(css, /translateX/);
+assert.match(css, /score-feedback-meter::before/);
+assert.doesNotMatch(css, /filter\s*:/);
 assert.doesNotMatch(css, /transition:[^;]*(?:width|height|top|left)/);
 assert.match(css, /@media \(prefers-reduced-motion: reduce\)/);
-assert.match(css, /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.score-feedback-gauge-shell,[\s\S]*?transition: none;/,
-  'Reduced-motion mode removes gauge extension and retraction transitions');
+assert.match(css, /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.score-feedback-gauge-shell,[\s\S]*?transition: none;/);
 assert.match(index, /id="scoreFeedback"/);
-assert.match(nextIndex, /id="scoreFeedback"/,
-  'TURN NEXT must provide the fixed ScoreFeedback DOM expected by the canonical runtime');
-assert.match(labIndex, /id="scoreFeedback"/,
-  'TURN LAB must provide the fixed ScoreFeedback DOM expected by the canonical runtime');
+assert.match(nextIndex, /id="scoreFeedback"/);
+assert.match(labIndex, /id="scoreFeedback"/);
 assert.match(index, /data-score-feedback-announcer role="status" aria-live="polite"/);
 assert.doesNotMatch(index, /data-score-feedback-current[^>]*aria-live/);
-assert.match(main, /scoreFeedback\.commit\(now\)/,
-  'ScoreFeedback commits through TURN\'s existing throttled HUD path');
+assert.match(main, /scoreFeedback\.commit\(now\)/);
 
 console.log('TURN shared ScoreFeedback engine regression passed.');

--- a/turn/hud-notifications.css
+++ b/turn/hud-notifications.css
@@ -1,10 +1,4 @@
-/*
- * Shared in-race notification primitives.
- *
- * This file deliberately defines component geometry and semantics only. Final
- * race-HUD placement is owned by the peripheral HUD composition so right- and
- * left-handed layouts can mirror from one source of truth.
- */
+/* Shared in-race notification components and final #842 HUD composition. */
 .turn-hud-notifications {
   position: absolute;
   z-index: 35;
@@ -59,21 +53,14 @@
   place-items: center;
   min-width: 0;
 }
-
-.turn-hud-notification__media[hidden] {
-  display: none;
-}
+.turn-hud-notification__media[hidden] { display: none; }
 
 .turn-hud-notification__copy,
 .turn-hud-notification__body {
   min-width: 0;
   flex: 1 1 auto;
 }
-
-.turn-hud-notification__copy {
-  display: grid;
-  gap: 2px;
-}
+.turn-hud-notification__copy { display: grid; gap: 2px; }
 
 .turn-hud-notification__kicker,
 .turn-hud-notification__title,
@@ -83,7 +70,6 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
-
 .turn-hud-notification__kicker,
 .turn-hud-notification__badge {
   font-size: clamp(.46rem, 1vw, .62rem);
@@ -92,20 +78,17 @@
   line-height: 1;
   text-transform: uppercase;
 }
-
 .turn-hud-notification__title {
   font-size: clamp(.78rem, 1.65vw, 1.05rem);
   font-weight: 950;
   letter-spacing: .025em;
   line-height: 1.02;
 }
-
 .turn-hud-notification__detail {
   font-size: clamp(.56rem, 1.15vw, .72rem);
   font-weight: 850;
   line-height: 1.08;
 }
-
 .turn-hud-notification__badge {
   flex: 0 0 auto;
   padding: 5px 8px 6px;
@@ -115,84 +98,190 @@
   white-space: nowrap;
 }
 
-/* Component 1: wide race/lap status surface. */
+/* Component 1 lives *inside* .stats, so its opaque plate exactly covers the
+   speed/lap/time/best instruments without changing their DOM or reading order. */
+.stats.turn-hud-race-status-host { position: relative; }
+.stats.turn-hud-race-status-host > .turn-hud-notification-slot[data-slot="race-status"] {
+  z-index: 8;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
 .turn-hud-notification[data-slot="race-status"] {
-  width: min(760px, 100%);
-  min-height: 58px;
+  width: 100%;
+  height: 100%;
+  min-height: var(--turn-peripheral-stats-height, 58px);
   padding: 7px 12px 8px;
   --turn-hud-notification-radius: var(--turn-radius-default, 16px);
 }
-
 .turn-hud-notification[data-slot="race-status"] .turn-hud-notification__title {
   font-size: clamp(.92rem, 2vw, 1.24rem);
 }
+.turn-race-status-grid {
+  display: grid;
+  width: 100%;
+  height: 100%;
+  grid-template-columns: minmax(11rem, 1.45fr) repeat(2, minmax(7rem, 1fr));
+  align-items: stretch;
+}
+.turn-race-status-cell {
+  display: grid;
+  min-width: 0;
+  align-content: center;
+  grid-template-columns: max-content 1fr;
+  column-gap: 5px;
+  padding: 0 clamp(9px, 1.4vw, 16px);
+  border-inline-start: 2px solid color-mix(in srgb, var(--turn-ink, #08090a) 35%, transparent);
+}
+.turn-race-status-cell:first-child {
+  padding-inline-start: 0;
+  border-inline-start: 0;
+}
+.turn-race-status-cell small {
+  grid-column: 1 / -1;
+  font-size: clamp(.42rem, .85vw, .56rem);
+  font-weight: 950;
+  letter-spacing: .08em;
+  line-height: 1;
+}
+.turn-race-status-cell strong {
+  overflow: hidden;
+  font-size: clamp(.78rem, 1.8vw, 1.15rem);
+  font-weight: 950;
+  line-height: 1.02;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.turn-race-status-cell b {
+  align-self: end;
+  overflow: hidden;
+  padding-bottom: 1px;
+  font-size: clamp(.42rem, .82vw, .54rem);
+  font-weight: 950;
+  line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
-/* Component 2: compact TURN command/cue pill, based on the existing GO plate. */
-.turn-hud-notification[data-slot="race-cue"] {
+/* Component 2: one maximally rounded GO!-style cue lane. The anchor mirrors
+   around the centre with the peripheral HUD, rather than changing DOM order. */
+.turn-hud-notification-slot[data-slot="race-cue"] {
+  top: calc(var(--turn-peripheral-score-top, 84px) + 132px);
+  left: calc(var(--turn-peripheral-left-edge, 12px) + var(--score-feedback-paper-width, 190px) + var(--score-feedback-gauge-width, 52px) + 18px);
+  right: auto;
+  display: flex;
+  max-width: min(60vw, 720px);
+  justify-content: flex-start;
+}
+:root.turn-left-handed-controls .turn-hud-notification-slot[data-slot="race-cue"] {
+  right: calc(var(--turn-peripheral-right-edge, 12px) + var(--score-feedback-paper-width, 190px) + var(--score-feedback-gauge-width, 52px) + 18px);
+  left: auto;
+  justify-content: flex-end;
+}
+.turn-hud-notification[data-slot="race-cue"],
+.turn-hud-rival-cue {
   width: max-content;
-  max-width: min(72vw, 720px);
+  max-width: min(60vw, 720px);
   min-height: 38px;
   padding: 6px 13px 7px;
   --turn-hud-notification-radius: var(--turn-radius-pill, 999px);
 }
-
 .turn-hud-notification[data-slot="race-cue"] .turn-hud-notification__copy {
   display: flex;
   align-items: baseline;
   gap: 7px;
 }
-
 .turn-hud-notification[data-slot="race-cue"] .turn-hud-notification__kicker,
 .turn-hud-notification[data-slot="race-cue"] .turn-hud-notification__title,
-.turn-hud-notification[data-slot="race-cue"] .turn-hud-notification__detail {
-  white-space: nowrap;
+.turn-hud-notification[data-slot="race-cue"] .turn-hud-notification__detail { white-space: nowrap; }
+
+/* Adopted CHASE YOUR BEST keeps its prepared WebGL preview but uses Component 2
+   geometry and the same slot instead of a separate viewport coordinate system. */
+.turn-hud-rival-cue {
+  position: relative !important;
+  inset: auto !important;
+  display: flex !important;
+  align-items: center;
+  overflow: hidden;
+}
+.turn-hud-rival-cue .rival-onboarding-copy {
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
 }
 
-/* Component 3: progression plate, intentionally smaller than the old toast. */
+/* Component 3: compact progression queue, mirrored just inboard of the scoring
+   column. Achievement and Trophy Road rewards share this exact anchor. */
+.turn-hud-notification-slot[data-slot="progression"] {
+  top: var(--turn-peripheral-score-top, 84px);
+  left: calc(var(--turn-peripheral-left-edge, 12px) + var(--score-feedback-paper-width, 190px) + var(--score-feedback-gauge-width, 52px) + 18px);
+  right: auto;
+}
+:root.turn-left-handed-controls .turn-hud-notification-slot[data-slot="progression"] {
+  right: calc(var(--turn-peripheral-right-edge, 12px) + var(--score-feedback-paper-width, 190px) + var(--score-feedback-gauge-width, 52px) + 18px);
+  left: auto;
+}
 .turn-hud-notification[data-slot="progression"] {
-  width: min(520px, 46vw);
-  min-height: 60px;
-  padding: 7px 9px 8px;
+  width: min(500px, 44vw);
+  min-height: 56px;
+  padding: 6px 8px 7px;
   --turn-hud-notification-radius: var(--turn-radius-compact, 13px);
 }
-
 .turn-hud-notification[data-slot="progression"] .turn-hud-notification__media {
-  width: clamp(38px, 4.5vw, 50px);
+  width: clamp(36px, 4vw, 46px);
   align-self: stretch;
   border: 2px solid var(--turn-ink, #08090a);
   border-radius: var(--turn-radius-compact, 11px);
   background: var(--turn-paper, #fff8e8);
 }
+.turn-progression-icon,
+.turn-progression-icon > svg { width: 100%; height: 100%; }
 
-/* Semantic variants. Colour reinforces the explicit text; it never carries meaning alone. */
+/* The legacy visual surfaces stay as semantic/event sources during this migration.
+   Their visuals no longer compete with the shared components. */
+.turn-hud-notifications-active .lap-result-toast { display: none !important; }
+.turn-hud-notifications-active .turn-achievement-toast {
+  visibility: hidden !important;
+  pointer-events: none !important;
+}
+.turn-hud-notifications-active #message {
+  position: fixed !important;
+  width: 1px !important;
+  height: 1px !important;
+  margin: -1px !important;
+  padding: 0 !important;
+  overflow: hidden !important;
+  clip: rect(0 0 0 0) !important;
+  clip-path: inset(50%) !important;
+  border: 0 !important;
+  white-space: nowrap !important;
+}
+
+/* Semantic variants. Meaning is also always stated in copy. */
 .turn-hud-notification[data-kind="info"],
-.turn-hud-notification[data-kind="command"] {
-  --turn-hud-notification-surface: var(--turn-yellow-400, #ffd43b);
-}
-
-.turn-hud-notification[data-kind="guidance"] {
-  --turn-hud-notification-surface: var(--turn-paper, #fff8e8);
-}
-
+.turn-hud-notification[data-kind="command"] { --turn-hud-notification-surface: var(--turn-yellow-400, #ffd43b); }
+.turn-hud-notification[data-kind="guidance"] { --turn-hud-notification-surface: var(--turn-paper, #fff8e8); }
 .turn-hud-notification[data-kind="success"],
-.turn-hud-notification[data-kind="achievement"] {
-  --turn-hud-notification-surface: var(--turn-green-500, #8ce99a);
-}
+.turn-hud-notification[data-kind="achievement"] { --turn-hud-notification-surface: var(--turn-green-500, #8ce99a); }
+.turn-hud-notification[data-kind="danger"] { --turn-hud-notification-surface: var(--turn-red-500, #ff6b6b); }
+.turn-hud-notification[data-kind="reward"] { --turn-hud-notification-surface: var(--turn-yellow-400, #ffd43b); }
 
-.turn-hud-notification[data-kind="danger"] {
-  --turn-hud-notification-surface: var(--turn-red-500, #ff6b6b);
-}
-
-.turn-hud-notification[data-kind="reward"] {
-  --turn-hud-notification-surface: var(--turn-yellow-400, #ffd43b);
-}
-
-/* Component 4 primitive. Placement inside DRIFT/FLOW paper is composed elsewhere. */
+/* Component 4 is channel-local and occupies the BEST corner of each paper.
+   The large live DRIFT/FLOW value remains untouched. The physical inboard corner
+   mirrors with handedness while logical DOM order remains unchanged. */
+.score-feedback-state { position: relative; }
 .turn-score-event-callout {
+  position: absolute;
+  z-index: 4;
+  right: 7px;
+  bottom: 6px;
+  left: auto;
   box-sizing: border-box;
   display: grid;
   width: max-content;
-  max-width: 72%;
+  max-width: 58%;
+  min-width: 62px;
   gap: 2px;
   padding: 5px 7px 6px;
   border: 2px solid var(--turn-ink, #08090a);
@@ -203,15 +292,12 @@
   pointer-events: none;
   animation: turn-hud-notification-enter 180ms cubic-bezier(.2, .82, .3, 1) both;
 }
-
-.turn-score-event-callout[hidden] {
-  display: none;
+:root.turn-left-handed-controls .turn-score-event-callout {
+  right: auto;
+  left: 7px;
 }
-
-.turn-score-event-callout[data-state="leaving"] {
-  animation: turn-hud-notification-exit 160ms ease-in both;
-}
-
+.turn-score-event-callout[hidden] { display: none; }
+.turn-score-event-callout[data-state="leaving"] { animation: turn-hud-notification-exit 160ms ease-in both; }
 .turn-score-event-callout strong,
 .turn-score-event-callout b {
   overflow: hidden;
@@ -219,72 +305,73 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-
-.turn-score-event-callout strong {
-  font-size: clamp(.52rem, 1.15vw, .68rem);
-  letter-spacing: .045em;
-}
-
-.turn-score-event-callout b {
-  font-size: clamp(.72rem, 1.7vw, 1rem);
-}
-
-.turn-score-event-callout[data-event="bank"] {
-  background: var(--turn-green-500, #8ce99a);
-}
-
-.turn-score-event-callout[data-event="loss"] {
-  background: var(--turn-red-500, #ff6b6b);
-}
-
-.turn-score-event-callout[data-event="milestone"] {
-  background: var(--turn-yellow-400, #ffd43b);
-}
-
+.turn-score-event-callout strong { font-size: clamp(.52rem, 1.15vw, .68rem); letter-spacing: .045em; }
+.turn-score-event-callout b { font-size: clamp(.72rem, 1.7vw, 1rem); }
+.turn-score-event-callout[data-event="bank"] { background: var(--turn-green-500, #8ce99a); }
+.turn-score-event-callout[data-event="loss"] { background: var(--turn-red-500, #ff6b6b); }
+.turn-score-event-callout[data-event="milestone"] { background: var(--turn-yellow-400, #ffd43b); }
 .turn-score-event-callout[data-event="personal-best"],
-.turn-score-event-callout[data-event="lap-result"] {
-  background: var(--turn-pink-500, #ff4fa3);
-}
+.turn-score-event-callout[data-event="lap-result"] { background: var(--turn-pink-500, #ff4fa3); }
 
 @keyframes turn-hud-notification-enter {
   from { opacity: 0; transform: translateY(5px) scale(.97); }
   to { opacity: 1; transform: translateY(0) scale(1); }
 }
-
 @keyframes turn-hud-notification-exit {
   from { opacity: 1; transform: translateY(0) scale(1); }
   to { opacity: 0; transform: translateY(3px) scale(.985); }
 }
 
-@media (max-height: 430px) and (orientation: landscape) {
-  .turn-hud-notification[data-slot="race-status"] {
+@media (max-height: 560px) and (orientation: landscape) {
+  .turn-hud-notification-slot[data-slot="progression"] {
+    top: var(--turn-peripheral-score-top, 76px);
+  }
+  .turn-hud-notification-slot[data-slot="race-cue"] {
+    top: calc(var(--turn-peripheral-score-top, 76px) + 112px);
+  }
+  .turn-hud-notification[data-slot="progression"] {
+    width: min(440px, 42vw);
     min-height: 48px;
+    padding: 5px 7px 6px;
+    border-width: 2px;
+    box-shadow: 3px 3px 0 var(--turn-ink, #08090a);
+  }
+  .turn-hud-notification[data-slot="race-status"] {
     padding: 5px 9px 6px;
     border-width: 2px;
     box-shadow: 3px 3px 0 var(--turn-ink, #08090a);
   }
-
-  .turn-hud-notification[data-slot="race-cue"] {
+  .turn-hud-notification[data-slot="race-cue"],
+  .turn-hud-rival-cue {
     min-height: 32px;
     padding: 4px 10px 5px;
     border-width: 2px;
     box-shadow: 3px 3px 0 var(--turn-ink, #08090a);
   }
+  .turn-score-event-callout { right: 5px; bottom: 5px; padding: 4px 6px 5px; }
+  :root.turn-left-handed-controls .turn-score-event-callout { right: auto; left: 5px; }
+}
 
-  .turn-hud-notification[data-slot="progression"] {
-    width: min(480px, 45vw);
-    min-height: 50px;
-    padding: 5px 7px 6px;
-    border-width: 2px;
-    box-shadow: 3px 3px 0 var(--turn-ink, #08090a);
+@media (max-height: 360px) and (orientation: landscape) {
+  .turn-race-status-grid { grid-template-columns: minmax(8rem, 1.35fr) repeat(2, minmax(5.5rem, 1fr)); }
+  .turn-race-status-cell { padding-inline: 6px; }
+  .turn-hud-notification-slot[data-slot="progression"],
+  .turn-hud-notification-slot[data-slot="race-cue"] {
+    left: calc(var(--turn-peripheral-left-edge, 12px) + 126px + 38px + 10px);
   }
+  :root.turn-left-handed-controls .turn-hud-notification-slot[data-slot="progression"],
+  :root.turn-left-handed-controls .turn-hud-notification-slot[data-slot="race-cue"] {
+    right: calc(var(--turn-peripheral-right-edge, 12px) + 126px + 38px + 10px);
+    left: auto;
+  }
+  .turn-hud-notification-slot[data-slot="race-cue"] { top: calc(var(--turn-peripheral-score-top, 60px) + 88px); }
+  .turn-hud-notification[data-slot="progression"] { width: min(390px, 40vw); }
+  .turn-score-event-callout { max-width: 62%; padding: 3px 5px 4px; border-radius: 8px; }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .turn-hud-notification,
   .turn-hud-notification[data-state="leaving"],
   .turn-score-event-callout,
-  .turn-score-event-callout[data-state="leaving"] {
-    animation: none;
-  }
+  .turn-score-event-callout[data-state="leaving"] { animation: none; }
 }

--- a/turn/scoring/score-feedback.js
+++ b/turn/scoring/score-feedback.js
@@ -1,4 +1,5 @@
 import { installScorekeeperRecords } from './scorekeeper-records.js';
+import { installHudNotificationRuntime } from '../ui/hud-notification-runtime.js?revision=r266-standard-hud';
 
 export const SCORE_FEEDBACK_CHANNEL = Object.freeze({
   DRIFT: 'drift',
@@ -81,6 +82,21 @@ function makeChannel(label) {
     phase: 'quiet',
     label,
     tokens: ['', '', '', '', '']
+  };
+}
+
+function makeEvent(channel) {
+  return {
+    active: false,
+    channel,
+    type: SCORE_FEEDBACK_EVENT.BUILD,
+    priority: 0,
+    score: 0,
+    multiplier: 1,
+    label: '',
+    announcement: '',
+    expiresAt: 0,
+    revision: 0
   };
 }
 
@@ -255,10 +271,13 @@ export function createScoreFeedback({
 } = {}) {
   if (!root) throw new Error('TURN ScoreFeedback requires a fixed root element.');
 
-  // Scorekeeper history is presentation composition, not a DRIFT runtime side effect.
-  // Install it before retaining any optional DOM references so it can remove the
-  // intentionally hidden FLOW token strip in the production document.
-  installScorekeeperRecords({ documentRef: root.ownerDocument || globalThis.document });
+  const documentRef = root.ownerDocument || globalThis.document;
+  // Scorekeeper history and event callouts are fixed presentation composition,
+  // installed before retaining DOM references so scoring never creates nodes.
+  installScorekeeperRecords({ documentRef });
+  // ScoreFeedback is shared by production TURN, TURN NEXT and TURN LAB, so this
+  // is the single composition point for the standardized in-race HUD runtime.
+  installHudNotificationRuntime({ documentRef });
 
   const statePanel = requiredElement(root, '[data-score-feedback-state]');
   const driftReadout = optionalElement(root, '[data-score-feedback-drift-readout]') || statePanel;
@@ -275,27 +294,35 @@ export function createScoreFeedback({
   const flowLapScore = optionalElement(root, '[data-score-feedback-flow-total]');
   const flowTechniquePool = optionalElement(root, '[data-score-feedback-flow-techniques]');
   const flowTechniqueTokens = flowTechniquePool?.querySelectorAll?.('span') || [];
-  const callout = requiredElement(root, '[data-score-feedback-callout]');
-  const calloutLabel = requiredElement(root, '[data-score-feedback-callout-label]');
-  const calloutScore = requiredElement(root, '[data-score-feedback-callout-score]');
+  const driftCallout = requiredElement(root, '[data-score-feedback-drift-callout]');
+  const driftCalloutLabel = requiredElement(root, '[data-score-feedback-drift-callout-label]');
+  const driftCalloutScore = requiredElement(root, '[data-score-feedback-drift-callout-score]');
+  const flowCallout = requiredElement(root, '[data-score-feedback-flow-callout]');
+  const flowCalloutLabel = requiredElement(root, '[data-score-feedback-flow-callout-label]');
+  const flowCalloutScore = requiredElement(root, '[data-score-feedback-flow-callout-score]');
   const announcer = requiredElement(root, '[data-score-feedback-announcer]');
 
   const channels = {
     [SCORE_FEEDBACK_CHANNEL.DRIFT]: makeChannel(CHANNEL_LABEL.drift),
     [SCORE_FEEDBACK_CHANNEL.FLOW]: makeChannel(CHANNEL_LABEL.flow)
   };
-  const activeEvent = {
-    active: false,
-    channel: SCORE_FEEDBACK_CHANNEL.DRIFT,
-    type: SCORE_FEEDBACK_EVENT.BUILD,
-    priority: 0,
-    score: 0,
-    multiplier: 1,
-    label: '',
-    announcement: '',
-    expiresAt: 0,
-    revision: 0
+  const activeEvents = {
+    [SCORE_FEEDBACK_CHANNEL.DRIFT]: makeEvent(SCORE_FEEDBACK_CHANNEL.DRIFT),
+    [SCORE_FEEDBACK_CHANNEL.FLOW]: makeEvent(SCORE_FEEDBACK_CHANNEL.FLOW)
   };
+  const callouts = {
+    [SCORE_FEEDBACK_CHANNEL.DRIFT]: {
+      root: driftCallout,
+      label: driftCalloutLabel,
+      score: driftCalloutScore
+    },
+    [SCORE_FEEDBACK_CHANNEL.FLOW]: {
+      root: flowCallout,
+      label: flowCalloutLabel,
+      score: flowCalloutScore
+    }
+  };
+
   const minCommitInterval = Math.max(80, finiteNumber(commitIntervalMs, SCORE_FEEDBACK_COMMIT_INTERVAL_MS));
   const minAnnouncementInterval = Math.max(
     500,
@@ -329,11 +356,7 @@ export function createScoreFeedback({
   function setChannelVisible(channel, visible, now = 0) {
     const normalizedChannel = normalizeChannel(channel);
     channels[normalizedChannel].visible = visible !== false;
-    if (!channels[normalizedChannel].visible
-      && activeEvent.active
-      && activeEvent.channel === normalizedChannel) {
-      clearEvent();
-    }
+    if (!channels[normalizedChannel].visible) clearEvent(normalizedChannel);
     dirty = true;
     return commit(now, true);
   }
@@ -347,10 +370,13 @@ export function createScoreFeedback({
     }
     if (!channels[normalizedChannel].visible) return false;
 
+    const activeEvent = activeEvents[normalizedChannel];
     const priority = Math.max(
       SCORE_FEEDBACK_PRIORITY[normalizedType] || 0,
       finiteNumber(detail.priority)
     );
+    // Event competition is local to a scorekeeper paper. A FLOW milestone must
+    // never suppress a DRIFT bank/loss (or vice versa).
     if (activeEvent.active && timestamp < activeEvent.expiresAt && priority < activeEvent.priority) {
       return false;
     }
@@ -358,7 +384,6 @@ export function createScoreFeedback({
     const score = Math.max(0, finiteNumber(detail.score));
     const eventMultiplier = Math.max(1, finiteNumber(detail.multiplier, 1));
     activeEvent.active = true;
-    activeEvent.channel = normalizedChannel;
     activeEvent.type = normalizedType;
     activeEvent.priority = priority;
     activeEvent.score = score;
@@ -383,14 +408,12 @@ export function createScoreFeedback({
     activeEvent.revision += 1;
     dirty = true;
 
-    if (channels[normalizedChannel].visible) {
-      announceActiveEvent(timestamp);
-      if (typeof onSound === 'function') onSound(normalizedType, normalizedChannel, detail);
-    }
+    announceActiveEvent(activeEvent, timestamp);
+    if (typeof onSound === 'function') onSound(normalizedType, normalizedChannel, detail);
     return commit(timestamp, true);
   }
 
-  function announceActiveEvent(now) {
+  function announceActiveEvent(activeEvent, now) {
     const message = activeEvent.announcement.trim();
     if (!message) return false;
     const higherPriority = activeEvent.priority > lastAnnouncementPriority;
@@ -406,7 +429,9 @@ export function createScoreFeedback({
     return true;
   }
 
-  function clearEvent() {
+  function clearEvent(channel) {
+    const normalizedChannel = normalizeChannel(channel);
+    const activeEvent = activeEvents[normalizedChannel];
     activeEvent.active = false;
     activeEvent.priority = 0;
     activeEvent.expiresAt = 0;
@@ -427,25 +452,25 @@ export function createScoreFeedback({
   function clearChannel(channel, now = 0) {
     const normalizedChannel = normalizeChannel(channel);
     resetChannelState(channels[normalizedChannel]);
-    if (activeEvent.active && activeEvent.channel === normalizedChannel) clearEvent();
+    clearEvent(normalizedChannel);
     dirty = true;
     return commit(now, true);
   }
 
   function dismissEvent(channel, now = 0) {
     const normalizedChannel = normalizeChannel(channel);
-    if (!activeEvent.active || activeEvent.channel !== normalizedChannel) return false;
-    clearEvent();
+    if (!activeEvents[normalizedChannel].active) return false;
+    clearEvent(normalizedChannel);
     dirty = true;
     return commit(now, true);
   }
 
   function reset(now = 0) {
-    for (const channel of Object.values(channels)) {
+    for (const [channelName, channel] of Object.entries(channels)) {
       resetChannelState(channel);
       channel.visible = false;
+      clearEvent(channelName);
     }
-    clearEvent();
     announcementRevision += 1;
     announcer.textContent = '';
     lastAnnouncementPriority = 0;
@@ -453,12 +478,54 @@ export function createScoreFeedback({
     return commit(now, true);
   }
 
+  function eventScoreText(activeEvent) {
+    if (!(activeEvent.score > 0)) return '';
+    return activeEvent.type === SCORE_FEEDBACK_EVENT.BANK
+      ? `+${formatScore(activeEvent.score)}`
+      : formatScore(activeEvent.score);
+  }
+
+  function renderEventCallout(channel) {
+    const activeEvent = activeEvents[channel];
+    const callout = callouts[channel];
+    const visible = channels[channel].visible && activeEvent.active;
+    setHidden(callout.root, !visible);
+    if (!visible) {
+      callout.root.classList.remove('is-release', 'is-event-a', 'is-event-b');
+      return false;
+    }
+
+    setData(callout.root, 'event', activeEvent.type);
+    setData(callout.root, 'channel', channel);
+    setText(callout.label, activeEvent.label);
+    const scoreText = eventScoreText(activeEvent);
+    setText(callout.score, scoreText);
+    callout.score.hidden = !scoreText;
+    callout.root.classList.toggle(
+      'is-release',
+      activeEvent.priority >= SCORE_FEEDBACK_PRIORITY[SCORE_FEEDBACK_EVENT.BANK]
+    );
+    const evenRevision = activeEvent.revision % 2 === 0;
+    callout.root.classList.toggle('is-event-a', !evenRevision);
+    callout.root.classList.toggle('is-event-b', evenRevision);
+    return true;
+  }
+
   function commit(now = 0, force = false) {
     const timestamp = finiteNumber(now);
-    if (activeEvent.active && timestamp >= activeEvent.expiresAt) {
-      clearEvent();
+    let eventExpired = false;
+    for (const channel of Object.values(SCORE_FEEDBACK_CHANNEL)) {
+      const activeEvent = activeEvents[channel];
+      if (activeEvent.active && timestamp >= activeEvent.expiresAt) {
+        clearEvent(channel);
+        eventExpired = true;
+      }
+    }
+    if (eventExpired) {
       dirty = true;
-      lastAnnouncementPriority = 0;
+      if (!Object.values(activeEvents).some((activeEvent) => activeEvent.active)) {
+        lastAnnouncementPriority = 0;
+      }
     }
     if (!dirty || (!force && timestamp - lastCommitAt < minCommitInterval)) return false;
 
@@ -477,7 +544,6 @@ export function createScoreFeedback({
           : flow.visible
             ? flow
             : null;
-    const eventVisible = activeEvent.active && channels[activeEvent.channel].visible;
     const flowHasOwnGauge = Boolean(flowGaugeFill);
     const fallbackGaugeToFlow = !flowHasOwnGauge && flowActive && primary === flow;
     const driftGaugeActive = driftActive || fallbackGaugeToFlow;
@@ -563,25 +629,10 @@ export function createScoreFeedback({
       setData(root, 'phase', primary.phase);
     }
 
-    setHidden(callout, !eventVisible);
-    if (eventVisible) {
-      setData(callout, 'event', activeEvent.type);
-      setData(callout, 'channel', activeEvent.channel);
-      setText(calloutLabel, activeEvent.label);
-      const eventScore = activeEvent.type === SCORE_FEEDBACK_EVENT.BANK
-        ? `+${formatScore(activeEvent.score)}`
-        : formatScore(activeEvent.score);
-      setText(calloutScore, activeEvent.score > 0 ? eventScore : '');
-      calloutScore.hidden = !(activeEvent.score > 0);
-      callout.classList.toggle('is-release', activeEvent.priority >= SCORE_FEEDBACK_PRIORITY.bank);
-      const evenRevision = activeEvent.revision % 2 === 0;
-      callout.classList.toggle('is-event-a', !evenRevision);
-      callout.classList.toggle('is-event-b', evenRevision);
-    } else {
-      callout.classList.remove('is-release', 'is-event-a', 'is-event-b');
-    }
+    renderEventCallout(SCORE_FEEDBACK_CHANNEL.DRIFT);
+    renderEventCallout(SCORE_FEEDBACK_CHANNEL.FLOW);
 
-    setHidden(root, !drift.visible && !flow.visible && !eventVisible);
+    setHidden(root, !drift.visible && !flow.visible);
     dirty = false;
     lastCommitAt = timestamp;
     if (phaseStartedAt != null) recordPhase('hud', Math.max(0, performanceNow() - phaseStartedAt));
@@ -589,8 +640,19 @@ export function createScoreFeedback({
   }
 
   function inspect() {
+    const eventSnapshots = {
+      [SCORE_FEEDBACK_CHANNEL.DRIFT]: { ...activeEvents[SCORE_FEEDBACK_CHANNEL.DRIFT] },
+      [SCORE_FEEDBACK_CHANNEL.FLOW]: { ...activeEvents[SCORE_FEEDBACK_CHANNEL.FLOW] }
+    };
+    // Keep the old single-event inspection shape for diagnostics while exposing
+    // the authoritative channel-local event state introduced by #842.
+    const legacyEvent = Object.values(eventSnapshots)
+      .filter((activeEvent) => activeEvent.active)
+      .sort((left, right) => right.priority - left.priority || right.expiresAt - left.expiresAt)[0]
+      || eventSnapshots[SCORE_FEEDBACK_CHANNEL.DRIFT];
     return {
-      activeEvent: { ...activeEvent },
+      activeEvent: { ...legacyEvent },
+      activeEvents: eventSnapshots,
       drift: { ...channels[SCORE_FEEDBACK_CHANNEL.DRIFT] },
       flow: { ...channels[SCORE_FEEDBACK_CHANNEL.FLOW] },
       lastCommitAt

--- a/turn/scoring/scorekeeper-records.js
+++ b/turn/scoring/scorekeeper-records.js
@@ -170,6 +170,30 @@ function ensureHistoryReadouts(documentRef, root, channel) {
   return { last, best };
 }
 
+function ensureEventCallout(documentRef, root, channel) {
+  const row = scoreState(root, channel);
+  if (!row) return null;
+
+  const selector = `[data-score-feedback-${channel}-callout]`;
+  let callout = row.querySelector?.(selector);
+  if (callout) return callout;
+
+  callout = documentRef.createElement('section');
+  callout.className = 'turn-score-event-callout';
+  callout.setAttribute(`data-score-feedback-${channel}-callout`, '');
+  callout.setAttribute('aria-hidden', 'true');
+  callout.hidden = true;
+
+  const label = documentRef.createElement('strong');
+  label.setAttribute(`data-score-feedback-${channel}-callout-label`, '');
+  const score = documentRef.createElement('b');
+  score.setAttribute(`data-score-feedback-${channel}-callout-score`, '');
+  score.hidden = true;
+  callout.append(label, score);
+  row.append?.(callout);
+  return callout;
+}
+
 function setBest(valueNode, score) {
   if (!valueNode) return;
   const next = formatScore(score, { emptyWhenMissing: true, emptyWhenZero: true });
@@ -205,6 +229,13 @@ export function installScorekeeperRecords({
   ensureScorekeeperStyle(documentRef);
   const drift = ensureHistoryReadouts(documentRef, root, 'drift');
   const flow = ensureHistoryReadouts(documentRef, root, 'flow');
+
+  // #842: DRIFT and FLOW own independent event plates inside their paper boxes.
+  // They deliberately cover the BEST corner rather than the large live score.
+  // ScoreFeedback retains and updates these fixed nodes; no scoring-path DOM is created.
+  ensureEventCallout(documentRef, root, 'drift');
+  ensureEventCallout(documentRef, root, 'flow');
+
   const targetStorage = storageOrDefault(storage);
 
   function refreshBest(trackId = getTrackId()) {

--- a/turn/ui/hud-notification-runtime.js
+++ b/turn/ui/hud-notification-runtime.js
@@ -1,0 +1,298 @@
+import {
+  HUD_NOTIFICATION_KIND,
+  HUD_NOTIFICATION_SLOT,
+  createHudNotificationController
+} from './hud-notifications.js';
+
+const STYLE_ID = 'turnHudNotificationsStyles';
+const STYLE_HREF = '/turn/hud-notifications.css?revision=r266-standard-hud';
+const RACE_STATUS_RESULT_PRIORITY = 20;
+const RACE_STATUS_VOID_PRIORITY = 40;
+const scoreFormatter = new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 });
+
+function text(value) {
+  return value == null ? '' : String(value);
+}
+
+function number(value, fallback = 0) {
+  const result = Number(value);
+  return Number.isFinite(result) ? result : fallback;
+}
+
+function ensureStylesheet(documentRef) {
+  if (!documentRef?.head || documentRef.getElementById?.(STYLE_ID)) return;
+  const link = documentRef.createElement('link');
+  link.id = STYLE_ID;
+  link.rel = 'stylesheet';
+  link.href = STYLE_HREF;
+  documentRef.head.append(link);
+}
+
+function makeStatusCell(documentRef, label, value, status = '') {
+  const cell = documentRef.createElement('span');
+  cell.className = 'turn-race-status-cell';
+
+  const kicker = documentRef.createElement('small');
+  kicker.textContent = label;
+  const main = documentRef.createElement('strong');
+  main.textContent = value;
+  cell.append(kicker, main);
+
+  if (status) {
+    const aside = documentRef.createElement('b');
+    aside.textContent = status;
+    cell.append(aside);
+  }
+  return cell;
+}
+
+function formatLapTime(seconds) {
+  const value = Math.max(0, number(seconds));
+  const minutes = Math.floor(value / 60);
+  const secs = Math.floor(value % 60).toString().padStart(2, '0');
+  const millis = Math.floor((value % 1) * 1000).toString().padStart(3, '0');
+  return `${minutes}:${secs}.${millis}`;
+}
+
+function makeLapResultBody(documentRef, result = {}) {
+  const body = documentRef.createElement('span');
+  body.className = 'turn-race-status-grid';
+  const place = Math.max(1, Math.round(number(result.position, 1)));
+  const total = Math.max(1, Math.round(number(result.total, 1)));
+  body.append(makeStatusCell(documentRef, 'LAP', `${place}/${total} · ${formatLapTime(result.time)}`));
+
+  for (const [label, scoreResult] of [['DRIFT', result.drift], ['FLOW', result.flow]]) {
+    if (scoreResult?.available !== true || !Number.isFinite(Number(scoreResult.score))) continue;
+    const score = scoreFormatter.format(Math.max(0, Math.round(Number(scoreResult.score))));
+    const best = Math.max(0, Math.round(Number(scoreResult.bestScore) || 0));
+    const status = scoreResult.newBest === true
+      ? 'NEW BEST'
+      : best > 0
+        ? `BEST ${scoreFormatter.format(best)}`
+        : '';
+    body.append(makeStatusCell(documentRef, label, score, status));
+  }
+  return body;
+}
+
+function defaultLapResultAnnouncement(result = {}) {
+  const place = Math.max(1, Math.round(number(result.position, 1)));
+  const total = Math.max(1, Math.round(number(result.total, 1)));
+  return `Lap result. Position ${place} of ${total}. Time ${formatLapTime(result.time)}.`;
+}
+
+function cueKind(message) {
+  const upper = text(message).toUpperCase();
+  if (/PATIENT ON BOARD|MAYDAY|SECONDS/.test(upper)) return HUD_NOTIFICATION_KIND.DANGER;
+  if (/CENTERED|CALIBRAT|READY|GOOD/.test(upper)) return HUD_NOTIFICATION_KIND.SUCCESS;
+  if (/GO!|CHASE YOUR BEST/.test(upper)) return HUD_NOTIFICATION_KIND.COMMAND;
+  return HUD_NOTIFICATION_KIND.GUIDANCE;
+}
+
+function cuePriority(message) {
+  const upper = text(message).toUpperCase();
+  if (/PATIENT ON BOARD|MAYDAY/.test(upper)) return 40;
+  if (/GO!/.test(upper)) return 30;
+  return 10;
+}
+
+function isVisibleToast(element) {
+  return Boolean(element && element.hidden !== true && element.classList?.contains?.('is-visible'));
+}
+
+function cloneMedia(documentRef, source) {
+  if (!source) return null;
+  const media = documentRef.createElement('span');
+  media.className = 'turn-progression-icon';
+  media.innerHTML = source.innerHTML || '';
+  return media;
+}
+
+function installLegacyMessageBridge({ controller, documentRef, windowRef }) {
+  const message = documentRef.querySelector?.('#message');
+  if (!message || typeof MutationObserver !== 'function') return () => {};
+  let lastSignature = '';
+
+  const sync = () => {
+    if (!message.classList?.contains?.('show')) return;
+    const copy = text(message.textContent).trim();
+    if (!copy) return;
+    const signature = `${copy}|${message.className}`;
+    if (signature === lastSignature) return;
+    lastSignature = signature;
+    controller.publish(HUD_NOTIFICATION_SLOT.RACE_CUE, {
+      id: `legacy-message:${copy}`,
+      kind: cueKind(copy),
+      title: copy,
+      priority: cuePriority(copy),
+      durationMs: 2800,
+      // #message remains the existing polite status source until its producers
+      // migrate semantically. The shared visual must not speak it twice.
+      announce: false
+    });
+  };
+
+  const observer = new MutationObserver(sync);
+  observer.observe(message, { attributes: true, attributeFilter: ['class'], childList: true, characterData: true, subtree: true });
+  windowRef?.addEventListener?.('turn:ui-state-change', (event) => {
+    if (!event.detail?.running) {
+      lastSignature = '';
+      controller.clear(HUD_NOTIFICATION_SLOT.RACE_CUE);
+    }
+  });
+  sync();
+  return () => observer.disconnect();
+}
+
+function installProgressionBridge({ controller, documentRef }) {
+  if (typeof MutationObserver !== 'function') return () => {};
+  const seenVisible = new WeakSet();
+
+  const publishToast = (toast) => {
+    if (!toast?.matches?.('.turn-achievement-toast') || !isVisibleToast(toast)) {
+      if (toast && !isVisibleToast(toast)) seenVisible.delete(toast);
+      return;
+    }
+    if (seenVisible.has(toast)) return;
+    seenVisible.add(toast);
+
+    const reward = toast.classList.contains('turn-trophy-reward-toast');
+    const label = text(toast.querySelector?.('[data-achievement-toast-label]')?.textContent).trim();
+    const title = text(toast.querySelector?.('[data-achievement-toast-title]')?.textContent).trim();
+    const badge = text(toast.querySelector?.('[data-achievement-toast-badge]')?.textContent).trim();
+    const guide = toast.querySelector?.('[data-trophy-reward-guide]');
+    const guideCopy = guide && !guide.hidden ? text(guide.textContent).trim() : '';
+    const icon = cloneMedia(documentRef, toast.querySelector?.('.turn-achievement-toast-icon'));
+    const stableTitle = title || (reward ? 'TROPHY ROAD REWARD' : 'ACHIEVEMENT');
+
+    controller.publish(HUD_NOTIFICATION_SLOT.PROGRESSION, {
+      id: `${reward ? 'reward' : 'achievement'}:${stableTitle}:${badge}`,
+      kind: reward ? HUD_NOTIFICATION_KIND.REWARD : HUD_NOTIFICATION_KIND.ACHIEVEMENT,
+      kicker: label,
+      title: stableTitle,
+      detail: guideCopy,
+      badge,
+      mediaNode: icon,
+      durationMs: 3200,
+      announce: false,
+      ...(reward ? {
+        actionLabel: toast.getAttribute?.('aria-label') || `Open Achievements. ${stableTitle}`,
+        onActivate: () => toast.click?.()
+      } : {})
+    });
+  };
+
+  const scan = (root = documentRef) => {
+    for (const toast of root.querySelectorAll?.('.turn-achievement-toast') || []) publishToast(toast);
+  };
+  const observer = new MutationObserver((records) => {
+    for (const record of records) {
+      if (record.target?.matches?.('.turn-achievement-toast')) publishToast(record.target);
+      for (const node of record.addedNodes || []) {
+        if (node?.matches?.('.turn-achievement-toast')) publishToast(node);
+        scan(node);
+      }
+    }
+  });
+  observer.observe(documentRef.body, { attributes: true, attributeFilter: ['class', 'hidden'], childList: true, subtree: true });
+  scan();
+  return () => observer.disconnect();
+}
+
+function installRivalBridge({ controller, documentRef }) {
+  if (typeof MutationObserver !== 'function') return () => {};
+  let rival = documentRef.querySelector?.('.rival-onboarding');
+  let slot = controller.elementFor(HUD_NOTIFICATION_SLOT.RACE_CUE);
+
+  const adopt = () => {
+    rival ||= documentRef.querySelector?.('.rival-onboarding');
+    if (!rival || rival.dataset.turnHudAdopted === 'true') return;
+    rival.dataset.turnHudAdopted = 'true';
+    rival.dataset.slot = HUD_NOTIFICATION_SLOT.RACE_CUE;
+    rival.dataset.kind = HUD_NOTIFICATION_KIND.COMMAND;
+    rival.classList.add('turn-hud-notification', 'turn-hud-rival-cue');
+    slot.append(rival);
+  };
+
+  const observer = new MutationObserver(() => adopt());
+  observer.observe(documentRef.body, { childList: true, subtree: true });
+  adopt();
+  return () => observer.disconnect();
+}
+
+export function installHudNotificationRuntime({
+  documentRef = globalThis.document,
+  windowRef = globalThis,
+  hud = documentRef?.querySelector?.('#hud')
+} = {}) {
+  if (globalThis.__turnHudNotifications?.controller) return globalThis.__turnHudNotifications;
+  if (!hud) return null;
+  ensureStylesheet(documentRef);
+  documentRef.documentElement?.classList?.add?.('turn-hud-notifications-active');
+
+  const controller = createHudNotificationController({ hud, documentRef });
+  const cleanups = [];
+
+  const onLapResult = (event) => {
+    const result = event.detail || {};
+    controller.publish(HUD_NOTIFICATION_SLOT.RACE_STATUS, {
+      id: `lap-result:${number(result.position)}:${number(result.time)}`,
+      kind: HUD_NOTIFICATION_KIND.INFO,
+      contentNode: makeLapResultBody(documentRef, result),
+      priority: RACE_STATUS_RESULT_PRIORITY,
+      durationMs: 4000,
+      // The canonical lap-result announcer remains the single speech owner.
+      announce: false
+    });
+  };
+  const onLapInvalid = (event) => {
+    const guidance = event.detail?.reason === 'missed-checkpoint' ? 'STAY ON THE TRACK!' : 'TRY AGAIN';
+    controller.publish(HUD_NOTIFICATION_SLOT.RACE_STATUS, {
+      id: `lap-void:${event.detail?.reason || 'invalid'}`,
+      kind: HUD_NOTIFICATION_KIND.DANGER,
+      kicker: 'LAP VOID',
+      title: guidance,
+      priority: RACE_STATUS_VOID_PRIORITY,
+      durationMs: 4000,
+      announce: false
+    });
+  };
+  const onUiState = (event) => {
+    if (!event.detail?.running || event.detail?.reason === 'race-reset') {
+      controller.clear(HUD_NOTIFICATION_SLOT.RACE_STATUS);
+    }
+  };
+  windowRef.addEventListener?.('turn:lap-result', onLapResult);
+  windowRef.addEventListener?.('turn:lap-invalid', onLapInvalid);
+  windowRef.addEventListener?.('turn:ui-state-change', onUiState);
+  cleanups.push(() => windowRef.removeEventListener?.('turn:lap-result', onLapResult));
+  cleanups.push(() => windowRef.removeEventListener?.('turn:lap-invalid', onLapInvalid));
+  cleanups.push(() => windowRef.removeEventListener?.('turn:ui-state-change', onUiState));
+  cleanups.push(installLegacyMessageBridge({ controller, documentRef, windowRef }));
+  cleanups.push(installProgressionBridge({ controller, documentRef }));
+  cleanups.push(installRivalBridge({ controller, documentRef }));
+
+  const api = Object.freeze({
+    controller,
+    publishRaceCue(detail) {
+      return controller.publish(HUD_NOTIFICATION_SLOT.RACE_CUE, detail);
+    },
+    publishProgression(detail) {
+      return controller.publish(HUD_NOTIFICATION_SLOT.PROGRESSION, detail);
+    },
+    clearRaceCue() {
+      return controller.clear(HUD_NOTIFICATION_SLOT.RACE_CUE);
+    },
+    destroy() {
+      for (const cleanup of cleanups.splice(0)) cleanup?.();
+      controller.destroy();
+      documentRef.documentElement?.classList?.remove?.('turn-hud-notifications-active');
+      if (globalThis.__turnHudNotifications?.controller === controller) delete globalThis.__turnHudNotifications;
+    }
+  });
+  globalThis.__turnHudNotifications = api;
+  return api;
+}
+
+export const HUD_NOTIFICATION_STYLE_HREF = STYLE_HREF;
+export { defaultLapResultAnnouncement };

--- a/turn/ui/hud-notification-runtime.js
+++ b/turn/ui/hud-notification-runtime.js
@@ -31,13 +31,11 @@ function ensureStylesheet(documentRef) {
 function makeStatusCell(documentRef, label, value, status = '') {
   const cell = documentRef.createElement('span');
   cell.className = 'turn-race-status-cell';
-
   const kicker = documentRef.createElement('small');
   kicker.textContent = label;
   const main = documentRef.createElement('strong');
   main.textContent = value;
   cell.append(kicker, main);
-
   if (status) {
     const aside = documentRef.createElement('b');
     aside.textContent = status;
@@ -75,12 +73,6 @@ function makeLapResultBody(documentRef, result = {}) {
   return body;
 }
 
-function defaultLapResultAnnouncement(result = {}) {
-  const place = Math.max(1, Math.round(number(result.position, 1)));
-  const total = Math.max(1, Math.round(number(result.total, 1)));
-  return `Lap result. Position ${place} of ${total}. Time ${formatLapTime(result.time)}.`;
-}
-
 function cueKind(message) {
   const upper = text(message).toUpperCase();
   if (/PATIENT ON BOARD|MAYDAY|SECONDS/.test(upper)) return HUD_NOTIFICATION_KIND.DANGER;
@@ -108,9 +100,14 @@ function cloneMedia(documentRef, source) {
   return media;
 }
 
+function mutationObserverFrom(windowRef) {
+  return windowRef?.MutationObserver || globalThis.MutationObserver;
+}
+
 function installLegacyMessageBridge({ controller, documentRef, windowRef }) {
   const message = documentRef.querySelector?.('#message');
-  if (!message || typeof MutationObserver !== 'function') return () => {};
+  const MutationObserverRef = mutationObserverFrom(windowRef);
+  if (!message || typeof MutationObserverRef !== 'function') return () => {};
   let lastSignature = '';
 
   const sync = () => {
@@ -126,26 +123,36 @@ function installLegacyMessageBridge({ controller, documentRef, windowRef }) {
       title: copy,
       priority: cuePriority(copy),
       durationMs: 2800,
-      // #message remains the existing polite status source until its producers
-      // migrate semantically. The shared visual must not speak it twice.
+      // #message remains the canonical polite speech source during the migration.
       announce: false
     });
   };
 
-  const observer = new MutationObserver(sync);
-  observer.observe(message, { attributes: true, attributeFilter: ['class'], childList: true, characterData: true, subtree: true });
-  windowRef?.addEventListener?.('turn:ui-state-change', (event) => {
+  const observer = new MutationObserverRef(sync);
+  observer.observe(message, {
+    attributes: true,
+    attributeFilter: ['class'],
+    childList: true,
+    characterData: true,
+    subtree: true
+  });
+  const onUiState = (event) => {
     if (!event.detail?.running) {
       lastSignature = '';
       controller.clear(HUD_NOTIFICATION_SLOT.RACE_CUE);
     }
-  });
+  };
+  windowRef?.addEventListener?.('turn:ui-state-change', onUiState);
   sync();
-  return () => observer.disconnect();
+  return () => {
+    observer.disconnect();
+    windowRef?.removeEventListener?.('turn:ui-state-change', onUiState);
+  };
 }
 
-function installProgressionBridge({ controller, documentRef }) {
-  if (typeof MutationObserver !== 'function') return () => {};
+function installProgressionBridge({ controller, documentRef, windowRef }) {
+  const MutationObserverRef = mutationObserverFrom(windowRef);
+  if (typeof MutationObserverRef !== 'function' || !documentRef?.body) return () => {};
   const seenVisible = new WeakSet();
 
   const publishToast = (toast) => {
@@ -164,6 +171,13 @@ function installProgressionBridge({ controller, documentRef }) {
     const guideCopy = guide && !guide.hidden ? text(guide.textContent).trim() : '';
     const icon = cloneMedia(documentRef, toast.querySelector?.('.turn-achievement-toast-icon'));
     const stableTitle = title || (reward ? 'TROPHY ROAD REWARD' : 'ACHIEVEMENT');
+    const announcement = toast.getAttribute?.('aria-label')
+      || [label, stableTitle, badge].filter(Boolean).join('. ');
+
+    // The old node stays alive as the feature-owned action target, but the shared
+    // component becomes both the visible and accessible notification surface.
+    toast.setAttribute?.('aria-hidden', 'true');
+    if ('tabIndex' in toast) toast.tabIndex = -1;
 
     controller.publish(HUD_NOTIFICATION_SLOT.PROGRESSION, {
       id: `${reward ? 'reward' : 'achievement'}:${stableTitle}:${badge}`,
@@ -174,9 +188,9 @@ function installProgressionBridge({ controller, documentRef }) {
       badge,
       mediaNode: icon,
       durationMs: 3200,
-      announce: false,
+      announcement,
       ...(reward ? {
-        actionLabel: toast.getAttribute?.('aria-label') || `Open Achievements. ${stableTitle}`,
+        actionLabel: announcement || `Open Achievements. ${stableTitle}`,
         onActivate: () => toast.click?.()
       } : {})
     });
@@ -185,7 +199,7 @@ function installProgressionBridge({ controller, documentRef }) {
   const scan = (root = documentRef) => {
     for (const toast of root.querySelectorAll?.('.turn-achievement-toast') || []) publishToast(toast);
   };
-  const observer = new MutationObserver((records) => {
+  const observer = new MutationObserverRef((records) => {
     for (const record of records) {
       if (record.target?.matches?.('.turn-achievement-toast')) publishToast(record.target);
       for (const node of record.addedNodes || []) {
@@ -194,15 +208,21 @@ function installProgressionBridge({ controller, documentRef }) {
       }
     }
   });
-  observer.observe(documentRef.body, { attributes: true, attributeFilter: ['class', 'hidden'], childList: true, subtree: true });
+  observer.observe(documentRef.body, {
+    attributes: true,
+    attributeFilter: ['class', 'hidden'],
+    childList: true,
+    subtree: true
+  });
   scan();
   return () => observer.disconnect();
 }
 
-function installRivalBridge({ controller, documentRef }) {
-  if (typeof MutationObserver !== 'function') return () => {};
+function installRivalBridge({ controller, documentRef, windowRef }) {
+  const MutationObserverRef = mutationObserverFrom(windowRef);
+  if (typeof MutationObserverRef !== 'function' || !documentRef?.body) return () => {};
   let rival = documentRef.querySelector?.('.rival-onboarding');
-  let slot = controller.elementFor(HUD_NOTIFICATION_SLOT.RACE_CUE);
+  const slot = controller.elementFor(HUD_NOTIFICATION_SLOT.RACE_CUE);
 
   const adopt = () => {
     rival ||= documentRef.querySelector?.('.rival-onboarding');
@@ -214,7 +234,7 @@ function installRivalBridge({ controller, documentRef }) {
     slot.append(rival);
   };
 
-  const observer = new MutationObserver(() => adopt());
+  const observer = new MutationObserverRef(adopt);
   observer.observe(documentRef.body, { childList: true, subtree: true });
   adopt();
   return () => observer.disconnect();
@@ -233,6 +253,19 @@ export function installHudNotificationRuntime({
   const controller = createHudNotificationController({ hud, documentRef });
   const cleanups = [];
 
+  // Component 1 is physically hosted by .stats. This guarantees exact coverage
+  // even when compact/iPad layouts change the number or width of stat chips.
+  const stats = documentRef.querySelector?.('.stats');
+  const statusSlot = controller.elementFor(HUD_NOTIFICATION_SLOT.RACE_STATUS);
+  if (stats && statusSlot) {
+    stats.classList?.add?.('turn-hud-race-status-host');
+    stats.append(statusSlot);
+    cleanups.push(() => {
+      stats.classList?.remove?.('turn-hud-race-status-host');
+      if (statusSlot.parentElement !== controller.host) controller.host.prepend?.(statusSlot);
+    });
+  }
+
   const onLapResult = (event) => {
     const result = event.detail || {};
     controller.publish(HUD_NOTIFICATION_SLOT.RACE_STATUS, {
@@ -241,7 +274,7 @@ export function installHudNotificationRuntime({
       contentNode: makeLapResultBody(documentRef, result),
       priority: RACE_STATUS_RESULT_PRIORITY,
       durationMs: 4000,
-      // The canonical lap-result announcer remains the single speech owner.
+      // Existing lap-result announcer remains the single speech owner.
       announce: false
     });
   };
@@ -269,8 +302,8 @@ export function installHudNotificationRuntime({
   cleanups.push(() => windowRef.removeEventListener?.('turn:lap-invalid', onLapInvalid));
   cleanups.push(() => windowRef.removeEventListener?.('turn:ui-state-change', onUiState));
   cleanups.push(installLegacyMessageBridge({ controller, documentRef, windowRef }));
-  cleanups.push(installProgressionBridge({ controller, documentRef }));
-  cleanups.push(installRivalBridge({ controller, documentRef }));
+  cleanups.push(installProgressionBridge({ controller, documentRef, windowRef }));
+  cleanups.push(installRivalBridge({ controller, documentRef, windowRef }));
 
   const api = Object.freeze({
     controller,
@@ -295,4 +328,3 @@ export function installHudNotificationRuntime({
 }
 
 export const HUD_NOTIFICATION_STYLE_HREF = STYLE_HREF;
-export { defaultLapResultAnnouncement };


### PR DESCRIPTION
Completes the placement/migration half of #842 on top of merged foundation PR #843.

### Four standardized notification families

1. **Race status** — LAP result / LAP VOID now use one shared status component physically hosted inside `.stats`, so it exactly covers SPEED/LAP/TIME/BEST while active and restores the existing instruments when it expires.
2. **Race cue** — one maximally rounded GO!-style pill/slot receives existing short race messages (including MAYDAY/blank-screen/steering feedback) and adopts the prepared CHASE YOUR BEST viewer without creating another WebGL implementation.
3. **Progression** — achievement and Trophy Road reward surfaces feed one smaller shared component and queue sequentially. Reward interaction is preserved; the legacy node is demoted from the accessibility tree to avoid duplicate focus/speech.
4. **Scoring** — DRIFT and FLOW now have independent channel-local event plates inside their paper boxes. The callout occupies the BEST corner and never replaces the large live value. Cross-channel events may coexist; priority remains local to each channel.

### Mirroring / accessibility
- race cue and progression anchors mirror from TURN's existing handedness root state
- the score-event BEST corner mirrors right ↔ left
- race status follows the already-mirrored `.stats` / minimap composition automatically
- visual mirroring does not reorder the DOM/focus sequence
- existing canonical lap/message announcements are retained without duplicate speech
- progression uses the shared polite announcer
- reduced-motion removes notification entrance/exit motion

### Migration architecture
Existing feature modules remain state owners. `hud-notification-runtime.js` is presentation/orchestration only and is installed through shared ScoreFeedback so production TURN, TURN NEXT and TURN LAB use the same composition. Existing `#message`, lap-result and progression nodes remain compatibility/action sources while their old visuals are suppressed.

### Regression coverage
- focused component/controller regression from #843
- new full placement/mirroring contract
- updated ScoreFeedback regression for independent DRIFT/FLOW callouts and preservation of live values
- release-composition and full TURN suite remain authoritative; this PR does not weaken them

Closes #842