### PR TITLE
TURN: salvage score callouts and full-width lap feedback

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -43,6 +43,7 @@
   <link rel="stylesheet" href="./lap-result-toast.css?build=20260909-r212">
   <link rel="stylesheet" href="./scoring/score-feedback.css?build=20260909-r212">
   <link rel="stylesheet" href="./peripheral-hud-r261.css?revision=r261-mirrored-periphery">
+  <link rel="stylesheet" href="./hud-feedback-r267.css?revision=r267-tested-salvage">
   <link rel="stylesheet" href="./rival-onboarding.css?build=20260909-r212">
   <link rel="stylesheet" href="./track-select.css?build=20260909-r212">
   <link rel="stylesheet" href="./track-select-r54.css?build=20260909-r212">

--- a/turn/hud-feedback-r267.css
+++ b/turn/hud-feedback-r267.css
@@ -1,0 +1,164 @@
+/*
+ * HUD feedback salvage after the #842 rollback.
+ *
+ * Keep the existing lap-result and ScoreFeedback runtimes as state owners.
+ * This file only gives the already-existing surfaces the placements that tested
+ * well: lap feedback owns the full top instrumentation lane, and scoring
+ * callouts sit inside the relevant paper box without covering the live value.
+ */
+
+/* --------------------------------------------------------------------------
+ * Lap result / LAP VOID
+ * -------------------------------------------------------------------------- */
+
+.lap-result-toast {
+  --turn-lap-feedback-map-width: min(24vw, 184px);
+  --turn-lap-feedback-map-shell: calc(var(--turn-lap-feedback-map-width) + 18px);
+  --turn-lap-feedback-gap: clamp(8px, 1vw, 12px);
+  top: max(10px, env(safe-area-inset-top));
+  right: calc(
+    var(--turn-peripheral-right-edge, max(12px, env(safe-area-inset-right)))
+    + var(--turn-lap-feedback-map-shell)
+    + var(--turn-lap-feedback-gap)
+  );
+  left: var(--turn-peripheral-left-edge, max(12px, env(safe-area-inset-left)));
+  width: auto;
+  height: var(--turn-peripheral-stats-height, clamp(58px, 8vh, 66px));
+  min-height: 0;
+  padding: 6px 12px 7px;
+  transform-origin: left top;
+}
+
+/* LAP VOID is the same component and therefore uses the same complete lane. */
+.lap-result-toast.is-invalid {
+  width: auto;
+}
+
+/* The existing handedness state already mirrors the stats/minimap top bar.
+ * Mirror this independent overlay to the same physical side without changing
+ * DOM or screen-reader order.
+ */
+:root.turn-left-handed-controls .lap-result-toast {
+  right: var(--turn-peripheral-right-edge, max(12px, env(safe-area-inset-right)));
+  left: calc(
+    var(--turn-peripheral-left-edge, max(12px, env(safe-area-inset-left)))
+    + var(--turn-lap-feedback-map-shell)
+    + var(--turn-lap-feedback-gap)
+  );
+  transform-origin: right top;
+}
+
+/* --------------------------------------------------------------------------
+ * DRIFT / FLOW event callout
+ * -------------------------------------------------------------------------- */
+
+/*
+ * The existing ScoreFeedback engine still owns timing, priority, speech and
+ * data. We only move its existing transient callout into the paper footprint.
+ * data-channel tells us which paper the current event belongs to.
+ *
+ * The large live score stays untouched; the callout borrows the BEST corner.
+ */
+:root .score-feedback .score-feedback-callout,
+:root .score-feedback[data-score-layout="dual"] .score-feedback-callout {
+  z-index: 4;
+  top: auto;
+  right: 7px;
+  bottom: 6px;
+  left: auto;
+  box-sizing: border-box;
+  width: max-content;
+  max-width: 58%;
+  min-width: 62px;
+  padding: 5px 7px 6px;
+  overflow: hidden;
+  border: 2px solid var(--turn-ink);
+  border-radius: 10px;
+  box-shadow: 3px 3px 0 var(--turn-ink);
+  transform-origin: right bottom;
+}
+
+/* In dual-score mode the DRIFT paper is the upper half; FLOW remains anchored
+ * to the lower paper. Using the live container height keeps this correct when
+ * short landscape viewports shrink both paper rows together.
+ */
+:root .score-feedback[data-score-layout="dual"] .score-feedback-callout[data-channel="drift"] {
+  top: auto;
+  bottom: calc(50% + 7px);
+}
+
+:root .score-feedback .score-feedback-callout[data-channel="flow"] {
+  top: auto;
+  bottom: 6px;
+}
+
+:root .score-feedback .score-feedback-callout strong {
+  font-size: clamp(.52rem, 1.15vw, .68rem);
+  letter-spacing: .045em;
+  line-height: 1;
+}
+
+:root .score-feedback .score-feedback-callout b {
+  margin-top: 2px;
+  font-size: clamp(.72rem, 1.7vw, 1rem);
+  line-height: 1;
+}
+
+:root.turn-left-handed-controls .score-feedback .score-feedback-callout,
+:root.turn-left-handed-controls .score-feedback[data-score-layout="dual"] .score-feedback-callout {
+  right: auto;
+  left: 7px;
+  transform-origin: left bottom;
+}
+
+@media (max-width: 760px) and (orientation: landscape) {
+  .lap-result-toast {
+    --turn-lap-feedback-map-width: min(21vw, 142px);
+    --turn-lap-feedback-map-shell: calc(var(--turn-lap-feedback-map-width) + 16px);
+  }
+}
+
+@media (max-height: 430px) {
+  .lap-result-toast {
+    padding: 5px 10px 6px;
+  }
+
+  :root .score-feedback .score-feedback-callout,
+  :root .score-feedback[data-score-layout="dual"] .score-feedback-callout {
+    right: 5px;
+    bottom: 5px;
+    padding: 4px 6px 5px;
+    border-radius: 9px;
+  }
+
+  :root .score-feedback[data-score-layout="dual"] .score-feedback-callout[data-channel="drift"] {
+    bottom: calc(50% + 6px);
+  }
+
+  :root .score-feedback .score-feedback-callout[data-channel="flow"] {
+    bottom: 5px;
+  }
+
+  :root.turn-left-handed-controls .score-feedback .score-feedback-callout,
+  :root.turn-left-handed-controls .score-feedback[data-score-layout="dual"] .score-feedback-callout {
+    right: auto;
+    left: 5px;
+  }
+}
+
+@media (max-height: 360px) and (orientation: landscape) {
+  .lap-result-toast {
+    --turn-lap-feedback-map-width: min(16vw, 96px);
+    --turn-lap-feedback-map-shell: calc(var(--turn-lap-feedback-map-width) + 12px);
+    padding: 4px 8px 5px;
+    border-width: 2px;
+    border-radius: 10px;
+    box-shadow: 2px 2px 0 var(--ink);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lap-result-toast {
+    transform: none;
+  }
+}

--- a/turn/index.html
+++ b/turn/index.html
@@ -54,6 +54,7 @@
   <link rel="stylesheet" href="./lap-result-toast.css?build=20260909-r212">
   <link rel="stylesheet" href="./scoring/score-feedback.css?build=20260909-r212">
   <link rel="stylesheet" href="./peripheral-hud-r261.css?revision=r261-mirrored-periphery">
+  <link rel="stylesheet" href="./hud-feedback-r267.css?revision=r267-tested-salvage">
   <link rel="stylesheet" href="./rival-onboarding.css?build=20260909-r212">
   <link rel="stylesheet" href="./track-select.css?build=20260909-r212">
   <link rel="stylesheet" href="./track-select-r54.css?build=20260909-r212">
@@ -101,7 +102,7 @@
         "/turn/audio/music/tone-runtime.js?revision=r184-score-v2": "/turn/audio/music/tone-runtime-ties.js?revision=r186-note-ties",
         "/turn/audio/music/song-tools.js?revision=r184-score-v2": "/turn/audio/music/song-tools.js?revision=r186-note-ties",
         "/turn/audio/music/song-tools.js?revision=r185-menu-orchestration": "/turn/audio/music/song-tools.js?revision=r186-note-ties",
-        "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
+        "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r212&revision=r163-restart-source-label",
         "/turn/ui/how-to-play-guide.js?revision=r241-learning-achievements&build=20260909-r212": "/turn/ui/how-to-play-guide.js?revision=r264-show-records-copy&build=20260909-r212",
         "/turn/race/world-collision.js?build=20260723-r53": "/turn/race/world-collision.js?revision=mountain-long-prod-r1",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r241-learning-achievements",

--- a/turn/index.html
+++ b/turn/index.html
@@ -102,7 +102,7 @@
         "/turn/audio/music/tone-runtime.js?revision=r184-score-v2": "/turn/audio/music/tone-runtime-ties.js?revision=r186-note-ties",
         "/turn/audio/music/song-tools.js?revision=r184-score-v2": "/turn/audio/music/song-tools.js?revision=r186-note-ties",
         "/turn/audio/music/song-tools.js?revision=r185-menu-orchestration": "/turn/audio/music/song-tools.js?revision=r186-note-ties",
-        "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r212&revision=r163-restart-source-label",
+        "/turn/ui/in-game-menu.js?build=20260809-r163": "/turn/ui/in-game-menu.js?build=20260809-r163&revision=r163-restart-source-label",
         "/turn/ui/how-to-play-guide.js?revision=r241-learning-achievements&build=20260909-r212": "/turn/ui/how-to-play-guide.js?revision=r264-show-records-copy&build=20260909-r212",
         "/turn/race/world-collision.js?build=20260723-r53": "/turn/race/world-collision.js?revision=mountain-long-prod-r1",
         "/turn/achievements/catalog.js?revision=r166-bella-records": "/turn/achievements/catalog-chromatic-r183.js?revision=r241-learning-achievements",


### PR DESCRIPTION
Incremental salvage from #842 after the #843/#844 rollback.

This deliberately does **not** restore the generic HUD notification architecture. It keeps the current post-#841 runtimes as source of truth and only reuses the two presentation changes that tested well.

### Lap result / LAP VOID
- keep the existing `lap-result-toast.js` runtime, timing, result data and accessibility announcement
- move its existing yellow lap-result surface to the top instrumentation lane
- use the full available width from the stats-side safe edge to the minimap
- `LAP VOID / STAY ON THE TRACK!` uses that same full-width lane instead of its old narrow width
- match the existing stats-row height so the surface feels like temporary top-row content rather than another floating toast
- mirror the lane in left-handed mode so it remains opposite the minimap

### DRIFT / FLOW feedback
- keep the current ScoreFeedback engine and event lifecycle unchanged
- move the existing transient event callout into the relevant scorekeeper paper using its existing `data-channel`
- place it over the BEST corner, never over the large live DRIFT/FLOW value
- mirror the in-paper corner for left-handed mode
- preserve existing colors, timing, animation, speech and scoring behavior

### Scope / safety
- production-only presentation salvage
- one new isolated CSS file (`hud-feedback-r267.css`) loaded after the current peripheral HUD CSS
- no changes to race, lap, scoring, achievement, rival, or notification state machines
- #842 remains open for the progression banner and the Component 2 / GO!-style cue redesign

Refs #842