### PR TITLE
TURN: align blank-screen guidance with the race-cue lane

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -190,15 +190,26 @@
   </script>
 </head><body>
   <section class="install-gate" id="installGate" aria-labelledby="installTitle">
-    <div class="install-art" aria-hidden="true"><img class="install-icon" src="./TURNicon.PNG?icon=20260803-profile-512" alt=""></div>
-    <div class="install-card">
-      <span class="install-kicker">TURN LAB · MOUNTAIN LONG COURSE</span>
-      <h1 id="installTitle">TURN LAB</h1>
-      <p class="install-copy">Test a substantially longer MOUNTAIN lap on the current production TURN engine. Production TURN stays untouched.</p>
-      <div class="install-actions">
-        <button id="installTurnButton" class="install-primary" type="button">Install TURN LAB</button>
-        <p class="install-note">TURN LAB has separate saves. Install it as a separate Home Screen app, or test the MOUNTAIN experiment in this browser.</p>
-        <button class="install-secondary" id="playBrowserButton" type="button">Play in browser anyway</button>
+    <div class="install-shell">
+      <div class="install-art" aria-hidden="true"><img class="install-icon" src="./TURNicon.PNG?icon=20260803-profile-512" alt=""></div>
+      <div class="install-card">
+        <span class="install-kicker">TURN LAB · MOUNTAIN LONG COURSE</span>
+        <h1 id="installTitle">TURN LAB</h1>
+        <p class="install-copy">Test a substantially longer MOUNTAIN lap on the current production TURN engine. Production TURN stays untouched.</p>
+        <div class="install-actions">
+          <button id="installTurnButton" class="install-primary" type="button">Install TURN LAB</button>
+          <p class="install-note" id="installNote">TURN LAB has separate saves. Install it as a separate Home Screen app, or test the MOUNTAIN experiment in this browser.</p>
+          <button class="install-secondary" id="playBrowserButton" type="button">Play in browser anyway</button>
+        </div>
+      </div>
+    </div>
+    <div class="install-guide" id="installGuide" role="dialog" aria-modal="true" aria-labelledby="installGuideTitle" hidden>
+      <div class="install-guide-card">
+        <div class="install-guide-head">
+          <h2 id="installGuideTitle">Add TURN LAB to your Home Screen</h2>
+          <button class="install-close" id="installGuideClose" type="button" aria-label="Close install instructions">×</button>
+        </div>
+        <div class="install-steps" id="installSteps"></div>
       </div>
     </div>
   </section>

--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -43,7 +43,7 @@
   <link rel="stylesheet" href="./lap-result-toast.css?build=20260909-r212">
   <link rel="stylesheet" href="./scoring/score-feedback.css?build=20260909-r212">
   <link rel="stylesheet" href="./peripheral-hud-r261.css?revision=r261-mirrored-periphery">
-  <link rel="stylesheet" href="./hud-feedback-r267.css?revision=r267-tested-salvage">
+  <link rel="stylesheet" href="./hud-feedback-r267.css?revision=r268-category2-cue-lane">
   <link rel="stylesheet" href="./rival-onboarding.css?build=20260909-r212">
   <link rel="stylesheet" href="./track-select.css?build=20260909-r212">
   <link rel="stylesheet" href="./track-select-r54.css?build=20260909-r212">
@@ -129,7 +129,7 @@
         "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r253-supercar-release",
         "/turn/progression/lot-paint-reward.js?revision=r206-pwa-color": "/turn/progression/lot-paint-reward.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r206-race-before-locks": "/turn/garage/lot-showroom-experiment.js?revision=r243-mountain-1300",
-        "/turn/garage/lot-showroom-experiment.js?revision=r252-supercar-outward-rims": "/turn/garage/lot-showroom-track-icon.js?revision=r2-swift-lot-ui",
+        "/turn/garage/lot-showroom-experiment.js?revision=r252-supercar": "/turn/garage/lot-showroom-track-icon.js?revision=r2-swift-lot-ui",
         "/turn/vehicle/catalog.js?build=20260804-r157-factory-colors": "/turn/vehicle/catalog.js?revision=r253-supercar-release",
         "/turn/vehicle/catalog.js?build=20260720-r20&revision=r588-canonical-attributes": "/turn/vehicle/catalog.js?revision=r253-supercar-release",
         "/turn/vehicle/catalog.js?revision=r164-vintage-rally-polish": "/turn/vehicle/catalog.js?revision=r253-supercar-release",

--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -129,7 +129,7 @@
         "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r253-supercar-release",
         "/turn/progression/lot-paint-reward.js?revision=r206-pwa-color": "/turn/progression/lot-paint-reward.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r206-race-before-locks": "/turn/garage/lot-showroom-experiment.js?revision=r243-mountain-1300",
-        "/turn/garage/lot-showroom-experiment.js?revision=r252-supercar": "/turn/garage/lot-showroom-track-icon.js?revision=r2-swift-lot-ui",
+        "/turn/garage/lot-showroom-experiment.js?revision=r252-supercar-outward-rims": "/turn/garage/lot-showroom-track-icon.js?revision=r2-swift-lot-ui",
         "/turn/vehicle/catalog.js?build=20260804-r157-factory-colors": "/turn/vehicle/catalog.js?revision=r253-supercar-release",
         "/turn/vehicle/catalog.js?build=20260720-r20&revision=r588-canonical-attributes": "/turn/vehicle/catalog.js?revision=r253-supercar-release",
         "/turn/vehicle/catalog.js?revision=r164-vintage-rally-polish": "/turn/vehicle/catalog.js?revision=r253-supercar-release",
@@ -190,26 +190,15 @@
   </script>
 </head><body>
   <section class="install-gate" id="installGate" aria-labelledby="installTitle">
-    <div class="install-shell">
-      <div class="install-art" aria-hidden="true"><img class="install-icon" src="./TURNicon.PNG?icon=20260803-profile-512" alt=""></div>
-      <div class="install-card">
-        <span class="install-kicker">TURN LAB · MOUNTAIN LONG COURSE</span>
-        <h1 id="installTitle">TURN LAB</h1>
-        <p class="install-copy">Test a substantially longer MOUNTAIN lap on the current production TURN engine. Production TURN stays untouched.</p>
-        <div class="install-actions">
-          <button id="installTurnButton" class="install-primary" type="button">Install TURN LAB</button>
-          <p class="install-note" id="installNote">TURN LAB has separate saves. Install it as a separate Home Screen app, or test the MOUNTAIN experiment in this browser.</p>
-          <button class="install-secondary" id="playBrowserButton" type="button">Play in browser anyway</button>
-        </div>
-      </div>
-    </div>
-    <div class="install-guide" id="installGuide" role="dialog" aria-modal="true" aria-labelledby="installGuideTitle" hidden>
-      <div class="install-guide-card">
-        <div class="install-guide-head">
-          <h2 id="installGuideTitle">Add TURN LAB to your Home Screen</h2>
-          <button class="install-close" id="installGuideClose" type="button" aria-label="Close install instructions">×</button>
-        </div>
-        <div class="install-steps" id="installSteps"></div>
+    <div class="install-art" aria-hidden="true"><img class="install-icon" src="./TURNicon.PNG?icon=20260803-profile-512" alt=""></div>
+    <div class="install-card">
+      <span class="install-kicker">TURN LAB · MOUNTAIN LONG COURSE</span>
+      <h1 id="installTitle">TURN LAB</h1>
+      <p class="install-copy">Test a substantially longer MOUNTAIN lap on the current production TURN engine. Production TURN stays untouched.</p>
+      <div class="install-actions">
+        <button id="installTurnButton" class="install-primary" type="button">Install TURN LAB</button>
+        <p class="install-note">TURN LAB has separate saves. Install it as a separate Home Screen app, or test the MOUNTAIN experiment in this browser.</p>
+        <button class="install-secondary" id="playBrowserButton" type="button">Play in browser anyway</button>
       </div>
     </div>
   </section>

--- a/turn/hud-feedback-r267.css
+++ b/turn/hud-feedback-r267.css
@@ -49,6 +49,26 @@
 }
 
 /* --------------------------------------------------------------------------
+ * Category 2 race cues
+ * -------------------------------------------------------------------------- */
+
+/* GO!, PATIENT ON BOARD and STEERING + TILT CENTERED already share #message,
+ * which is a compact yellow TURN pill at 22% from the top. CHASE YOUR BEST is
+ * already in the same visual lane at 20%. The blank-screen confirmation was
+ * the remaining outlier: move only that existing surface into the same lane
+ * and give it the same fully rounded pill silhouette. Keep its neutral paper
+ * colour and its existing status semantics/timing.
+ *
+ * screen-blanking.js appends its stylesheet at runtime, so the body-qualified
+ * selector deliberately has enough specificity to keep this placement without
+ * changing the feature runtime or its cache identity.
+ */
+body .turn-screen-blank-toast {
+  top: 20%;
+  border-radius: 999px;
+}
+
+/* --------------------------------------------------------------------------
  * DRIFT / FLOW event callout
  * -------------------------------------------------------------------------- */
 
@@ -121,6 +141,10 @@
 @media (max-height: 430px) {
   .lap-result-toast {
     padding: 5px 10px 6px;
+  }
+
+  body .turn-screen-blank-toast {
+    top: 16%;
   }
 
   :root .score-feedback .score-feedback-callout,

--- a/turn/index.html
+++ b/turn/index.html
@@ -54,7 +54,7 @@
   <link rel="stylesheet" href="./lap-result-toast.css?build=20260909-r212">
   <link rel="stylesheet" href="./scoring/score-feedback.css?build=20260909-r212">
   <link rel="stylesheet" href="./peripheral-hud-r261.css?revision=r261-mirrored-periphery">
-  <link rel="stylesheet" href="./hud-feedback-r267.css?revision=r267-tested-salvage">
+  <link rel="stylesheet" href="./hud-feedback-r267.css?revision=r268-category2-cue-lane">
   <link rel="stylesheet" href="./rival-onboarding.css?build=20260909-r212">
   <link rel="stylesheet" href="./track-select.css?build=20260909-r212">
   <link rel="stylesheet" href="./track-select-r54.css?build=20260909-r212">


### PR DESCRIPTION
Small follow-up to #845 / #842.

After checking current `main`, most Category 2 cues are already much closer to the intended design than the mockup inventory suggests:

- `GO!`, `PATIENT ON BOARD ...` and `STEERING + TILT CENTERED` already share the same existing `#message` pill at ~22% from the top.
- `CHASE YOUR BEST` already uses its own compact pill in the same visual lane at ~20%.
- The remaining placement outlier is the blank-screen confirmation, which still appears at the very top of the viewport with a 14px corner radius.

This PR therefore avoids rebuilding or standardising the component architecture. It only:

- moves the existing blank-screen confirmation into the same Category 2 visual lane (`top: 20%`, `16%` on short landscape viewports, matching CHASE YOUR BEST's current responsive placement)
- changes that surface to a fully rounded `999px` pill
- keeps its existing neutral paper colour, copy, duration, live-region semantics, and screen-blanking state machine untouched
- makes no changes to the already-good GO!, CHASE YOUR BEST, progression, lap-result, or DRIFT/FLOW behavior
- refreshes the existing HUD feedback stylesheet identity consistently in TURN and TURN LAB so installed/cached clients receive the change

The override lives in the existing post-rollback `hud-feedback-r267.css`; no new notification runtime or component system is introduced.

Refs #842