### PR TITLE
TURN: remove in-race recalibration and fix steering contour bleed

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -270,7 +270,7 @@
   <script type="module" src="./tracks/cliffside-house-inset-r203.js?revision=r203-inset-edge-houses"></script>
   <script type="module" src="./tracks/kenney-track-landmarks-r517.js?revision=r532-countryside-nature-polish"></script>
   <script type="module" src="./input/qe-drive-controls-bootstrap.js?revision=r418-qe"></script>
-  <script type="module" src="./ui/r411-race-controls.js?revision=r229-minor-ux-polish"></script>
+  <script type="module" src="./ui/r411-race-controls.js?revision=r269-race-controls"></script>
   <script type="module" src="./ui/trophy-road-highlight-perk-polish-r258.js?revision=r258-highlight-perk-polish"></script>
   <script type="module" src="./accessibility/color-accessibility-r163.js?build=20260909-r212-paint-basics"></script>
   <script type="module" src="./achievements/chromatic-camouflage-r183.js?revision=r183-production"></script>

--- a/turn-tests/yourturn-r411-production.mjs
+++ b/turn-tests/yourturn-r411-production.mjs
@@ -23,8 +23,8 @@ const [
 assert.match(yourTurnIndex, /race-controls-r417\.js\?revision=r417/);
 assert.match(yourTurnIndex, /track-map-r417\.js\?revision=r417/);
 assert.match(yourTurnIndex, /r411\.css\?revision=r411/);
-assert.match(turnIndex, /ui\/r411-race-controls\.js\?revision=r229-minor-ux-polish/,
-  'TURN must cache-bust the race-control entry when the UX polish bundle changes');
+assert.match(turnIndex, /ui\/r411-race-controls\.js\?revision=r269-race-controls/,
+  'TURN must cache-bust the race-control entry when the active-race controls change');
 
 assert.match(yourTurnMap, /getTrackPreviewPoints/,
   'YOUR TURN maps must derive from TURN canonical track geometry');
@@ -55,12 +55,16 @@ assert.match(yourTurnCss, /\.yourturn-challenge-button\.is-lap-invalid[\s\S]*#ff
 assert.doesNotMatch(yourTurnCss, /\.utility-group\s*\{/,
   'The mockup must not cause global utility-row spacing or alignment changes');
 
-assert.match(turnControls, /menuState === 'racing'[\s\S]*restartButton\.hidden = false[\s\S]*recalibrateButton\.hidden = false/,
-  'TURN must expose Restart Lap and Recalibrate during an active race');
-assert.match(turnControls, /utilityGroup\.prepend\(recalibrateButton\);[\s\S]*utilityGroup\.prepend\(restartButton\)/,
-  'TURN active-race DOM order must be Restart Lap then Recalibrate');
+assert.match(turnControls, /menuState === 'racing'[\s\S]*restartButton\.hidden = false[\s\S]*recalibrateButton\.hidden = true/,
+  'TURN must expose Restart Lap but hide Recalibrate during an active race');
+assert.match(turnControls, /utilityGroup\.prepend\(restartButton\)/,
+  'TURN active-race DOM order must keep Restart Lap in the utility strip');
+assert.match(turnControls, /menuState !== 'staged'[\s\S]*recalibrateButton\.hidden = false/,
+  'TURN must restore Recalibrate when the player is back at the staged start line');
 assert.match(turnControls, /blankScreenButton\.after\(recalibrateButton\)/,
   'TURN must restore Recalibrate to its established staged position after Blank Screen');
+assert.match(turnControls, /\.manual-steer \{[\s\S]*background-clip: padding-box/,
+  'TURN must keep the yellow steering fill inside the thick rounded contour');
 assert.match(turnControls, /back-to-start-button[\s\S]*#ff7b54/,
   'TURN Restart Lap must be orange during a valid active lap');
 assert.match(turnControls, /back-to-start-button\.is-lap-invalid[\s\S]*#ff6b6b/,

--- a/turn/index.html
+++ b/turn/index.html
@@ -267,7 +267,7 @@
   <script type="module" src="./tracks/cliffside-house-inset-r203.js?revision=r203-inset-edge-houses"></script>
   <script type="module" src="./tracks/kenney-track-landmarks-r517.js?revision=r532-countryside-nature-polish"></script>
   <script type="module" src="./input/qe-drive-controls-bootstrap.js?revision=r418-qe"></script>
-  <script type="module" src="./ui/r411-race-controls.js?revision=r229-minor-ux-polish"></script>
+  <script type="module" src="./ui/r411-race-controls.js?revision=r269-race-controls"></script>
   <script type="module" src="./ui/trophy-road-highlight-perk-polish-r258.js?revision=r258-highlight-perk-polish"></script>
   <script type="module" src="./accessibility/color-accessibility-r163.js?build=20260909-r212-paint-basics"></script>
   <script type="module" src="./achievements/chromatic-camouflage-r183.js?revision=r183-production"></script>

--- a/turn/ui/r411-race-controls.js
+++ b/turn/ui/r411-race-controls.js
@@ -14,6 +14,12 @@ function installStyles() {
       background: #ff6b6b;
     }
 
+    /* Keep the yellow steering fill inside its rounded contour. In WebKit the
+       background can otherwise show through the thick rounded border corners. */
+    .manual-steer {
+      background-clip: padding-box;
+    }
+
     /* NEW is an availability cue: draw attention while unseen achievements exist,
        then get out of the way once the player has actively chosen the filter. */
     .turn-achievements-filters button[data-achievement-filter="new"]:not(:disabled):not([aria-pressed="true"])::after {
@@ -53,16 +59,16 @@ function install() {
     const menuState = utilityGroup.dataset.menuState;
     if (menuState === 'racing') {
       restartButton.hidden = false;
-      recalibrateButton.hidden = false;
-      // The active-race order is intentionally RESTART LAP → RECALIBRATE.
-      // Moving the existing nodes keeps visual and keyboard focus order aligned.
-      utilityGroup.prepend(recalibrateButton);
+      recalibrateButton.hidden = true;
+      // Recalibration belongs to the staged start-line setup. During a race,
+      // keep the utility strip to the action that is actually needed: Restart Lap.
       utilityGroup.prepend(restartButton);
       return;
     }
 
     if (menuState !== 'staged') return;
 
+    recalibrateButton.hidden = false;
     // Restore TURN's established start-line order without touching gaps, alignment,
     // or the position of Settings/Achievements/Spectate added by their own modules.
     const blankScreenButton = utilityGroup.querySelector('.turn-screen-blank-control');


### PR DESCRIPTION
Small follow-up to #846 based on the latest in-race screenshots.

This keeps the start-line setup intact but simplifies the active race UI:

- Recalibrate remains available while staged at the start line, but is hidden once the race is active. Restart Lap remains the sole direct utility action during racing.
- The on-screen steering surface clips its yellow fill to the padding box so WebKit cannot paint the fill through the thick rounded black contour at the corners. The steering geometry, hit area, handedness placement and values are unchanged.
- The TURN race-control entry receives a fresh URL identity and regression coverage is updated for both behaviors.

No changes to lap feedback, score feedback, achievement/reward banners, or Category 2 cue placement.