### PR TITLE
TURN: extend Midnight City sign neon accents

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -169,7 +169,7 @@
         "./tracks/definitions.js": "./tracks/definitions.js?build=20260909-r212&revision=mountain-long-prod-r1",
         "./tracks/elevation.js": "./tracks/elevation.js?build=20260909-r212",
         "./tracks/pace-notes.js": "./tracks/pace-notes.js?build=20260909-r212&revision=mountain-long-prod-r1",
-        "./tracks/registry.js": "./tracks/registry.js?build=20260909-r212&revision=mountain-long-prod-r1",
+        "./tracks/registry.js": "./tracks/registry.js?build=20260909-r212&revision=mountain-long-prod-r1-r519-midnight-full-width-accents",
         "./tracks/track-manager.js?build=20260722-r52": "./tracks/track-manager.js?build=20260909-r212"
       }
     }

--- a/turn/index.html
+++ b/turn/index.html
@@ -180,7 +180,7 @@
         "./tracks/definitions.js": "./tracks/definitions.js?build=20260909-r212&revision=mountain-long-prod-r1",
         "./tracks/elevation.js": "./tracks/elevation.js?build=20260909-r212",
         "./tracks/pace-notes.js": "./tracks/pace-notes.js?build=20260909-r212&revision=mountain-long-prod-r1",
-        "./tracks/registry.js": "./tracks/registry.js?build=20260909-r212&revision=mountain-long-prod-r1",
+        "./tracks/registry.js": "./tracks/registry.js?build=20260909-r212&revision=mountain-long-prod-r1-r519-midnight-full-width-accents",
         "./tracks/track-manager.js?build=20260722-r52": "./tracks/track-manager.js?build=20260909-r212"
       }
     }

--- a/turn/tracks/registry.js
+++ b/turn/tracks/registry.js
@@ -14,7 +14,7 @@ import {
 import { isForgivingTrackSurface } from './airport-runoff.js?build=20260722-r52';
 import './contextual-road-edges.js?revision=r518-signature-yellow';
 import './road-contour-color-r512.js?revision=r513-countryside';
-import './start-area-polish-r519.js?revision=r519-start-area-consistency-v2';
+import './start-area-polish-r519.js?revision=r519-midnight-full-width-accents';
 import './airport-start-banner-r520.js?revision=r520-signature-yellow';
 import './procedural-surface-polish-r522.js?revision=r524-procedural-surfaces-contrast-r171';
 import './airport-surface-contrast-r525.js?revision=r525-airport-ground-contrast';

--- a/turn/tracks/start-area-polish-r519.js
+++ b/turn/tracks/start-area-polish-r519.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 
-const REVISION = 'r519-start-area-consistency';
+const REVISION = 'r519-midnight-full-width-accents';
 const INK = 0x08090a;
 const TURN_YELLOW = 0xffbd12;
 const FLAG_RECHECK_DELAYS_MS = Object.freeze([0, 220, 700, 1600, 3200]);
@@ -152,13 +152,13 @@ function makeMidnightStartTexture() {
   context.lineWidth = 7;
   context.strokeStyle = cyan;
   context.beginPath();
-  context.moveTo(40, 25);
-  context.lineTo(165, 25);
+  context.moveTo(20, 25);
+  context.lineTo(canvas.width - 20, 25);
   context.stroke();
   context.strokeStyle = pink;
   context.beginPath();
-  context.moveTo(canvas.width - 165, canvas.height - 25);
-  context.lineTo(canvas.width - 40, canvas.height - 25);
+  context.moveTo(20, canvas.height - 25);
+  context.lineTo(canvas.width - 20, canvas.height - 25);
   context.stroke();
   context.shadowBlur = 0;
 


### PR DESCRIPTION
Small visual polish from the latest MIDNIGHT CITY race screenshot.

- Extend the cyan top accent across the full usable width of the start sign.
- Extend the pink bottom accent across the full usable width as well.
- Refresh the active start-area polish revision in the track registry so the updated canvas texture is not served from a stale module identity.

No geometry, collision, lighting, HUD, or gameplay changes.