### PR TITLE
TURN: calibrate speedometer top speed to 399 km/h

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -81,6 +81,7 @@
         "/turn/vehicle/car-models.js?revision=r253-supercar-release": "/turn/vehicle/car-models.js?revision=r257-authored-wheel-spin",
         "/turn/vehicle/emergency-livery-models.js": "/turn/vehicle/emergency-livery-models.js?revision=r223-training-car-taxi",
         "/turn/main.js?build=20260826-r184": "/turn/main.js?build=20260826-r184&revision=r221-trajectory-wheel-steering-30",
+        "/turn/ui/hud.js?build=20260720-r19": "/turn/ui/hud.js?revision=r270-speedometer-399",
         "/turn/input/motion.js": "/turn/input/motion.js?revision=r164-ipad-motion-profile",
         "/turn/race/session-orchestrator.js?source=20260729-r118-m8": "/turn/race/session-orchestrator.js?build=20260909-r212",
         "/turn/training/drive-by-ear-training.js?build=20260817-r172-r151-dbe-training-device-fixes": "/turn/training/drive-by-ear-training.js?build=20260905-r201&revision=r241-learning-achievements",

--- a/turn/index.html
+++ b/turn/index.html
@@ -92,6 +92,7 @@
         "/turn/vehicle/car-models.js?revision=r253-supercar-release": "/turn/vehicle/car-models.js?revision=r257-authored-wheel-spin",
         "/turn/vehicle/emergency-livery-models.js": "/turn/vehicle/emergency-livery-models.js?revision=r223-training-car-taxi",
         "/turn/main.js?build=20260826-r184": "/turn/main.js?build=20260826-r184&revision=r221-trajectory-wheel-steering-30",
+        "/turn/ui/hud.js?build=20260720-r19": "/turn/ui/hud.js?revision=r270-speedometer-399",
         "/turn/input/motion.js": "/turn/input/motion.js?revision=r164-ipad-motion-profile",
         "/turn/race/session-orchestrator.js?source=20260729-r118-m8": "/turn/race/session-orchestrator.js?build=20260909-r212",
         "/turn/training/drive-by-ear-training.js?build=20260817-r172-r151-dbe-training-device-fixes": "/turn/training/drive-by-ear-training.js?build=20260905-r201&revision=r241-learning-achievements",

--- a/turn/ui/hud.js
+++ b/turn/ui/hud.js
@@ -4,7 +4,22 @@ const PLAYER_MAP_INK = '#000000';
 const PLAYER_MAP_RADIUS = 9;
 const PLAYER_MAP_BORDER_WIDTH = 4;
 const PLAYER_MAP_INNER_RADIUS = 3;
+const MAX_SPEEDOMETER_KMH = 399;
+const BASE_GAME_MAX_SPEED = 88;
+const MAX_TOP_SPEED_MULTIPLIER = 1.12;
+const FUTURE_RACER_BOOST_SPEED_MULTIPLIER = 1.32;
+const FUTURE_RACER_OVERDRIVE_MULTIPLIER = 1.06;
+const ABSOLUTE_GAME_SPEED_LIMIT = BASE_GAME_MAX_SPEED
+  * MAX_TOP_SPEED_MULTIPLIER
+  * FUTURE_RACER_BOOST_SPEED_MULTIPLIER
+  * FUTURE_RACER_OVERDRIVE_MULTIPLIER;
+const SPEEDOMETER_KMH_PER_GAME_SPEED = MAX_SPEEDOMETER_KMH / ABSOLUTE_GAME_SPEED_LIMIT;
 const mapCache = new WeakMap();
+
+export function speedometerKmhFromGameSpeed(speed) {
+  const gameSpeed = Math.max(0, Number(speed) || 0);
+  return Math.min(MAX_SPEEDOMETER_KMH, Math.round(gameSpeed * SPEEDOMETER_KMH_PER_GAME_SPEED));
+}
 
 export function updateHudState({
   state,
@@ -23,7 +38,7 @@ export function updateHudState({
   setRacePosition
 }) {
   const lapInvalid = state.lapActive && state.lapInvalid === true;
-  setText(speedEl, Math.round(state.speed * 3.6));
+  setText(speedEl, speedometerKmhFromGameSpeed(state.speed));
   setText(lapEl, state.lap);
   setText(lapTimeEl, lapInvalid ? 'LAP VOID' : formatTime(state.lapElapsed));
   setText(bestTimeEl, formatTime(state.bestTime));


### PR DESCRIPTION
First speedometer calibration pass only.

- Keep all vehicle physics, acceleration, speed limits and handling unchanged.
- Continue driving the HUD directly from `state.speed`.
- Replace the literal `× 3.6` display conversion with a single linear calibration anchored to the current absolute physical maximum: Future Racer at 5/5 TOP SPEED, BOOST active, and full OVERDRIVE.
- That physical cap is `88 × 1.12 × 1.32 × 1.06 = 137.905152` game-speed units, mapped to exactly `399 km/h`.
- Clamp the displayed value to 399 so numerical overshoot cannot show an impossible value.
- Refresh the active HUD module URL identity in the production import map.

This deliberately does **not** implement the proposed 0–100 / normalised speed arc yet. Erik will playtest this linear top-speed calibration first.