### PR TITLE
TURN: simplify speedometer display scale to 2.9

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -81,7 +81,6 @@
         "/turn/vehicle/car-models.js?revision=r253-supercar-release": "/turn/vehicle/car-models.js?revision=r257-authored-wheel-spin",
         "/turn/vehicle/emergency-livery-models.js": "/turn/vehicle/emergency-livery-models.js?revision=r223-training-car-taxi",
         "/turn/main.js?build=20260826-r184": "/turn/main.js?build=20260826-r184&revision=r221-trajectory-wheel-steering-30",
-        "/turn/ui/hud.js?build=20260720-r19": "/turn/ui/hud.js?revision=r270-speedometer-399",
         "/turn/input/motion.js": "/turn/input/motion.js?revision=r164-ipad-motion-profile",
         "/turn/race/session-orchestrator.js?source=20260729-r118-m8": "/turn/race/session-orchestrator.js?build=20260909-r212",
         "/turn/training/drive-by-ear-training.js?build=20260817-r172-r151-dbe-training-device-fixes": "/turn/training/drive-by-ear-training.js?build=20260905-r201&revision=r241-learning-achievements",

--- a/turn/index.html
+++ b/turn/index.html
@@ -92,7 +92,6 @@
         "/turn/vehicle/car-models.js?revision=r253-supercar-release": "/turn/vehicle/car-models.js?revision=r257-authored-wheel-spin",
         "/turn/vehicle/emergency-livery-models.js": "/turn/vehicle/emergency-livery-models.js?revision=r223-training-car-taxi",
         "/turn/main.js?build=20260826-r184": "/turn/main.js?build=20260826-r184&revision=r221-trajectory-wheel-steering-30",
-        "/turn/ui/hud.js?build=20260720-r19": "/turn/ui/hud.js?revision=r270-speedometer-399",
         "/turn/input/motion.js": "/turn/input/motion.js?revision=r164-ipad-motion-profile",
         "/turn/race/session-orchestrator.js?source=20260729-r118-m8": "/turn/race/session-orchestrator.js?build=20260909-r212",
         "/turn/training/drive-by-ear-training.js?build=20260817-r172-r151-dbe-training-device-fixes": "/turn/training/drive-by-ear-training.js?build=20260905-r201&revision=r241-learning-achievements",

--- a/turn/ui/hud.js
+++ b/turn/ui/hud.js
@@ -23,7 +23,7 @@ export function updateHudState({
   setRacePosition
 }) {
   const lapInvalid = state.lapActive && state.lapInvalid === true;
-  setText(speedEl, Math.round(state.speed * 3.6));
+  setText(speedEl, Math.round(state.speed * 2.9));
   setText(lapEl, state.lap);
   setText(lapTimeEl, lapInvalid ? 'LAP VOID' : formatTime(state.lapElapsed));
   setText(bestTimeEl, formatTime(state.bestTime));

--- a/turn/ui/hud.js
+++ b/turn/ui/hud.js
@@ -4,22 +4,7 @@ const PLAYER_MAP_INK = '#000000';
 const PLAYER_MAP_RADIUS = 9;
 const PLAYER_MAP_BORDER_WIDTH = 4;
 const PLAYER_MAP_INNER_RADIUS = 3;
-const MAX_SPEEDOMETER_KMH = 399;
-const BASE_GAME_MAX_SPEED = 88;
-const MAX_TOP_SPEED_MULTIPLIER = 1.12;
-const FUTURE_RACER_BOOST_SPEED_MULTIPLIER = 1.32;
-const FUTURE_RACER_OVERDRIVE_MULTIPLIER = 1.06;
-const ABSOLUTE_GAME_SPEED_LIMIT = BASE_GAME_MAX_SPEED
-  * MAX_TOP_SPEED_MULTIPLIER
-  * FUTURE_RACER_BOOST_SPEED_MULTIPLIER
-  * FUTURE_RACER_OVERDRIVE_MULTIPLIER;
-const SPEEDOMETER_KMH_PER_GAME_SPEED = MAX_SPEEDOMETER_KMH / ABSOLUTE_GAME_SPEED_LIMIT;
 const mapCache = new WeakMap();
-
-export function speedometerKmhFromGameSpeed(speed) {
-  const gameSpeed = Math.max(0, Number(speed) || 0);
-  return Math.min(MAX_SPEEDOMETER_KMH, Math.round(gameSpeed * SPEEDOMETER_KMH_PER_GAME_SPEED));
-}
 
 export function updateHudState({
   state,
@@ -38,7 +23,7 @@ export function updateHudState({
   setRacePosition
 }) {
   const lapInvalid = state.lapActive && state.lapInvalid === true;
-  setText(speedEl, speedometerKmhFromGameSpeed(state.speed));
+  setText(speedEl, Math.round(state.speed * 2.9));
   setText(lapEl, state.lap);
   setText(lapTimeEl, lapInvalid ? 'LAP VOID' : formatTime(state.lapElapsed));
   setText(bestTimeEl, formatTime(state.bestTime));


### PR DESCRIPTION
Follow-up to #849.

- Remove the derived 399 km/h calibration constants/helper and hard clamp.
- Restore the original one-operation HUD approach, changing only the display multiplier from 3.6 to 2.9:
  `setText(speedEl, Math.round(state.speed * 2.9));`
- Do not change vehicle physics, acceleration, top-speed limits, BOOST, OVERDRIVE, handling, or any other gameplay behavior.
- Remove the #849 HUD import-map override from TURN and TURN LAB; the resulting active HUD URL identity is still different from #849, so the corrected file is not left on the stale r270 identity.

399 km/h remains a useful design target rather than a hard cap.