### PR TITLE
Fix CHASE YOUR BEST custom paint via race ghost path

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -126,7 +126,7 @@
         "/turn/ui/shift-feedback.js?revision=r232-double-shift": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/ui/shift-feedback.js?revision=r253-supercar-release": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/render/covered-rendering.js?build=20260909-r212": "/turn/render/covered-rendering.js?build=20260909-r212&revision=r164-long-session-robustness",
-        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r271-custom-paint-preview",
+        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r272-race-ghost-paint",
         "/turn/progression/lot-paint-reward.js?revision=r206-pwa-color": "/turn/progression/lot-paint-reward.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r206-race-before-locks": "/turn/garage/lot-showroom-experiment.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r252-supercar-outward-rims": "/turn/garage/lot-showroom-track-icon.js?revision=r2-swift-lot-ui",

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -259,8 +259,8 @@ assert.match(index, new RegExp(`lap-result-toast\\.css\\?build=${release.cacheKe
 assert.match(index, new RegExp(`rival-onboarding\\.css\\?build=${release.cacheKey}`));
 assert.equal(
   imports[`/turn/ui/rival-onboarding.js?build=${release.cacheKey}`],
-  `/turn/ui/rival-onboarding.js?build=${release.cacheKey}&revision=r271-custom-paint-preview`,
-  'Installed PWAs must refetch the custom-paint-safe CHASE YOUR BEST runtime'
+  `/turn/ui/rival-onboarding.js?build=${release.cacheKey}&revision=r272-race-ghost-paint`,
+  'Installed PWAs must refetch the race-ghost-aligned CHASE YOUR BEST runtime'
 );
 assert.ok(
   imports['./race/lap-system.js?build=20260720-r19']?.startsWith(`./race/lap-system-r86.js?build=${release.cacheKey}`),
@@ -328,7 +328,10 @@ assert.match(onboarding, /const customPaint = color !== getVehicleDefaultColor\(
   'CHASE YOUR BEST must detect PAINTJOB colours instead of treating them as factory paint');
 assert.match(onboarding, /if \(customPaint\) \{[\s\S]*runWarmupWhenIdle\(finishWarmup\);/,
   'Custom-paint previews must let the hidden render compile semantic paint in their actual WebGL context');
-assert.match(onboarding, /targetLength: 6\.4/, 'The onboarding model must use the Lot 3D viewer presentation scale');
+assert.match(onboarding, /sourceLength: 5\.5/, 'CHASE YOUR BEST must build from the same 5.5-unit competitor ghost template as the race');
+assert.match(onboarding, /targetLength: PREVIEW_PRESENTATION\.sourceLength/, 'The onboarding createCarVisual call must activate the canonical competitor-ghost paint path');
+assert.match(onboarding, /recolorCarVisual\(visual, color, secondaryColor\)/, 'Fresh onboarding ghosts must reassert the saved PAINTJOB through the shared recolour API');
+assert.match(onboarding, /targetLength: 6\.4/, 'The onboarding model must preserve its established 6.4-unit presentation scale');
 assert.match(onboarding, /PerspectiveCamera\(34, 1, 0\.1, 60\)/, 'The onboarding model must reuse the Lot viewer camera language');
 assert.match(onboarding, /camera\.position\.set\(7\.8, 4\.8, 8\.8\)/, 'The onboarding model must use the Lot viewer camera position');
 assert.match(onboarding, /HemisphereLight\(0xffffff, 0x5b6770, 3\.2\)/, 'The onboarding model must use the Lot viewer ambient lighting');

--- a/turn-tests/release-composition-production.mjs
+++ b/turn-tests/release-composition-production.mjs
@@ -386,8 +386,8 @@ const rivalRoute = Object.entries(headGraph.importMap.imports || {}).find(([spec
   /^\/turn\/ui\/rival-onboarding\.js\?build=\d{8}-r\d+$/.test(specifier)
 );
 assert.ok(rivalRoute, 'Production TURN must retain the release-bound rival onboarding route');
-assert.match(rivalRoute[1], /[?&]revision=r271-custom-paint-preview(?:&|$)/,
-  'Rival onboarding must use the custom-paint-safe preview identity');
+assert.match(rivalRoute[1], /[?&]revision=r272-race-ghost-paint(?:&|$)/,
+  'Rival onboarding must use the race-ghost-aligned paint identity');
 
 const workflows = Object.fromEntries(workflowEntries);
 for (const [workflowPath, source] of Object.entries(workflows)) {

--- a/turn/index.html
+++ b/turn/index.html
@@ -137,7 +137,7 @@
         "/turn/ui/shift-feedback.js?revision=r232-double-shift": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/ui/shift-feedback.js?revision=r253-supercar-release": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/render/covered-rendering.js?build=20260909-r212": "/turn/render/covered-rendering.js?build=20260909-r212&revision=r164-long-session-robustness",
-        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r271-custom-paint-preview",
+        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r272-race-ghost-paint",
         "/turn/progression/lot-paint-reward.js?revision=r206-pwa-color": "/turn/progression/lot-paint-reward.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r206-race-before-locks": "/turn/garage/lot-showroom-experiment.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r252-supercar-outward-rims": "/turn/garage/lot-showroom-track-icon.js?revision=r2-swift-lot-ui",

--- a/turn/ui/rival-onboarding.js
+++ b/turn/ui/rival-onboarding.js
@@ -7,7 +7,10 @@ import {
   normalizeVehicleId,
   normalizeVehicleSecondaryColor
 } from '../vehicle/catalog.js?build=20260720-r19';
-import { createCarVisual } from '../vehicle/car-models.js?build=20260720-r22';
+import {
+  createCarVisual,
+  recolorCarVisual
+} from '../vehicle/car-models.js?build=20260720-r22';
 
 const RESULT_TOAST_HANDOFF_MS = 4300;
 const ONBOARDING_VISIBLE_MS = 3200;
@@ -15,6 +18,13 @@ const ONBOARDING_EXIT_MS = 180;
 const PREVIEW_FALLBACK_PREP_DELAY_MS = 500;
 const PREVIEW_WARM_WIDTH = 126;
 const PREVIEW_WARM_HEIGHT = 92;
+const PREVIEW_PRESENTATION = Object.freeze({
+  // Build from the same 5.5-unit competitor template as the actual race ghost, then
+  // scale only the presentation. This keeps CHASE YOUR BEST on the exact same painted
+  // visual path instead of constructing an independent 6.4-unit ghost variant.
+  sourceLength: 5.5,
+  targetLength: 6.4
+});
 const VIEWER_INITIAL_YAW = THREE.MathUtils.degToRad(200);
 const VIEWER_ROTATION_RADIANS_PER_SECOND = 0.144;
 const VIEWER_FRAME_INTERVAL_MS = 1000 / 30;
@@ -400,11 +410,24 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
     color,
     secondaryColor,
     ghost: true,
-    targetLength: 6.4,
+    targetLength: PREVIEW_PRESENTATION.sourceLength,
     outline: true
   }).then((next) => {
     if (disposed) return;
     visual = next;
+
+    // Reassert the saved rival paint through the same recolour API used by The Lot.
+    // Fresh 5.5-unit visuals retain semantic uniform records; cache clones already
+    // share the exact painted material objects used by the race competitor template.
+    recolorCarVisual(visual, color, secondaryColor);
+
+    // 5.5 activates the canonical competitor-ghost cache. Counteract its featured
+    // surface multiplier while preserving the previous 6.4-unit onboarding framing.
+    const featuredMultiplier = Number(visual.userData?.turnFeaturedVisualSizeMultiplier) || 1;
+    visual.scale.multiplyScalar(
+      PREVIEW_PRESENTATION.targetLength
+        / (PREVIEW_PRESENTATION.sourceLength * featuredMultiplier)
+    );
     stage.add(visual);
     void warmRenderer();
   }).catch((error) => {


### PR DESCRIPTION
## Diagnosis

#851 proved that the saved PAINTJOB values and onboarding pill colour were correct, but the 3D CHASE YOUR BEST model still rendered gray. The previous shader-warmup diagnosis was therefore incomplete.

The onboarding was constructing its own 6.4-unit ghost visual, while the actual race rival uses TURN's canonical 5.5-unit competitor-ghost path. That path has its own paint-aware template cache keyed by car + primary + secondary colour.

## Fix

- build CHASE YOUR BEST from the same 5.5-unit competitor ghost path used by the racing rival
- keep the existing visual size by scaling only the onboarding presentation back to its established 6.4-unit framing
- explicitly reassert saved primary + secondary paint through `recolorCarVisual`, the same shared recolour API used by The Lot
- retain the hidden/prewarmed secondary WebGL context and #851's custom-paint warmup safeguard
- publish a fresh `r272-race-ghost-paint` onboarding identity in TURN and TURN LAB
- add regression guards for the shared competitor-ghost path and explicit PAINTJOB reapplication

No vehicle physics, rival storage, race ghost behavior, timing, or HUD layout is changed.