### PR TITLE
Fix CHASE YOUR BEST cached custom paint

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -126,7 +126,7 @@
         "/turn/ui/shift-feedback.js?revision=r232-double-shift": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/ui/shift-feedback.js?revision=r253-supercar-release": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/render/covered-rendering.js?build=20260909-r212": "/turn/render/covered-rendering.js?build=20260909-r212&revision=r164-long-session-robustness",
-        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r272-race-ghost-paint",
+        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r273-cached-paint-handles",
         "/turn/progression/lot-paint-reward.js?revision=r206-pwa-color": "/turn/progression/lot-paint-reward.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r206-race-before-locks": "/turn/garage/lot-showroom-experiment.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r252-supercar-outward-rims": "/turn/garage/lot-showroom-track-icon.js?revision=r2-swift-lot-ui",

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -259,8 +259,8 @@ assert.match(index, new RegExp(`lap-result-toast\\.css\\?build=${release.cacheKe
 assert.match(index, new RegExp(`rival-onboarding\\.css\\?build=${release.cacheKey}`));
 assert.equal(
   imports[`/turn/ui/rival-onboarding.js?build=${release.cacheKey}`],
-  `/turn/ui/rival-onboarding.js?build=${release.cacheKey}&revision=r272-race-ghost-paint`,
-  'Installed PWAs must refetch the race-ghost-aligned CHASE YOUR BEST runtime'
+  `/turn/ui/rival-onboarding.js?build=${release.cacheKey}&revision=r273-cached-paint-handles`,
+  'Installed PWAs must refetch the cached-paint-handle-safe CHASE YOUR BEST runtime'
 );
 assert.ok(
   imports['./race/lap-system.js?build=20260720-r19']?.startsWith(`./race/lap-system-r86.js?build=${release.cacheKey}`),
@@ -330,7 +330,12 @@ assert.match(onboarding, /if \(customPaint\) \{[\s\S]*runWarmupWhenIdle\(finishW
   'Custom-paint previews must let the hidden render compile semantic paint in their actual WebGL context');
 assert.match(onboarding, /sourceLength: 5\.5/, 'CHASE YOUR BEST must build from the same 5.5-unit competitor ghost template as the race');
 assert.match(onboarding, /targetLength: PREVIEW_PRESENTATION\.sourceLength/, 'The onboarding createCarVisual call must activate the canonical competitor-ghost paint path');
-assert.match(onboarding, /recolorCarVisual\(visual, color, secondaryColor\)/, 'Fresh onboarding ghosts must reassert the saved PAINTJOB through the shared recolour API');
+assert.match(onboarding, /function restoreCachedGhostPaintHandles\(visual\)/,
+  'Cached competitor ghosts must restore semantic paint handles before the onboarding reuses them');
+assert.match(onboarding, /turnFastGhostClone[\s\S]*turnSemanticPaintRecords = semanticPaintRecords/,
+  'The fast-clone path must rebuild its root semantic uniform references from cached materials');
+assert.match(onboarding, /restoreCachedGhostPaintHandles\(visual\);\s*recolorCarVisual\(visual, color, secondaryColor\)/,
+  'CHASE YOUR BEST must restore cached paint handles before reasserting the saved PAINTJOB');
 assert.match(onboarding, /targetLength: 6\.4/, 'The onboarding model must preserve its established 6.4-unit presentation scale');
 assert.match(onboarding, /PerspectiveCamera\(34, 1, 0\.1, 60\)/, 'The onboarding model must reuse the Lot viewer camera language');
 assert.match(onboarding, /camera\.position\.set\(7\.8, 4\.8, 8\.8\)/, 'The onboarding model must use the Lot viewer camera position');

--- a/turn-tests/release-composition-production.mjs
+++ b/turn-tests/release-composition-production.mjs
@@ -386,8 +386,8 @@ const rivalRoute = Object.entries(headGraph.importMap.imports || {}).find(([spec
   /^\/turn\/ui\/rival-onboarding\.js\?build=\d{8}-r\d+$/.test(specifier)
 );
 assert.ok(rivalRoute, 'Production TURN must retain the release-bound rival onboarding route');
-assert.match(rivalRoute[1], /[?&]revision=r272-race-ghost-paint(?:&|$)/,
-  'Rival onboarding must use the race-ghost-aligned paint identity');
+assert.match(rivalRoute[1], /[?&]revision=r273-cached-paint-handles(?:&|$)/,
+  'Rival onboarding must use the cached-paint-handle-safe identity');
 
 const workflows = Object.fromEntries(workflowEntries);
 for (const [workflowPath, source] of Object.entries(workflows)) {

--- a/turn/index.html
+++ b/turn/index.html
@@ -137,7 +137,7 @@
         "/turn/ui/shift-feedback.js?revision=r232-double-shift": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/ui/shift-feedback.js?revision=r253-supercar-release": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/render/covered-rendering.js?build=20260909-r212": "/turn/render/covered-rendering.js?build=20260909-r212&revision=r164-long-session-robustness",
-        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r272-race-ghost-paint",
+        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r273-cached-paint-handles",
         "/turn/progression/lot-paint-reward.js?revision=r206-pwa-color": "/turn/progression/lot-paint-reward.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r206-race-before-locks": "/turn/garage/lot-showroom-experiment.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r252-supercar-outward-rims": "/turn/garage/lot-showroom-track-icon.js?revision=r2-swift-lot-ui",

--- a/turn/ui/rival-onboarding.js
+++ b/turn/ui/rival-onboarding.js
@@ -249,6 +249,40 @@ export function installRivalOnboarding() {
   });
 }
 
+function restoreCachedGhostPaintHandles(visual) {
+  if (!visual?.userData?.turnFastGhostClone) return;
+
+  const semanticPaintRecords = [];
+  const primaryPaintMaterials = [];
+  const secondaryPaintMaterials = [];
+  const seenMaterials = new Set();
+
+  visual.traverse((node) => {
+    if (!node?.isMesh || !node.material) return;
+    const materials = Array.isArray(node.material) ? node.material : [node.material];
+    for (const material of materials) {
+      if (!material || seenMaterials.has(material)) continue;
+      seenMaterials.add(material);
+      const semantic = material.userData?.turnSemanticPaint;
+      if (!semantic) continue;
+      semanticPaintRecords.push(semantic);
+      if (semantic.primary) primaryPaintMaterials.push(material);
+      if (semantic.secondary) secondaryPaintMaterials.push(material);
+    }
+  });
+
+  // The fast competitor clone deliberately drops these root-level arrays, but the
+  // shared materials still retain the semantic uniform records. Rebuild only the
+  // handles needed by recolorCarVisual so this secondary renderer can reassert the
+  // exact saved PAINTJOB instead of falling back to the template/factory uniforms.
+  visual.userData.turnSemanticPaintRecords = semanticPaintRecords;
+  visual.userData.turnPrimaryPaintMaterials = primaryPaintMaterials;
+  visual.userData.turnSecondaryPaintMaterials = secondaryPaintMaterials;
+  visual.userData.turnPaintMaterials = [
+    ...new Set([...primaryPaintMaterials, ...secondaryPaintMaterials])
+  ];
+}
+
 function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }) {
   const scene = new THREE.Scene();
   const renderer = new THREE.WebGLRenderer({
@@ -416,9 +450,9 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
     if (disposed) return;
     visual = next;
 
-    // Reassert the saved rival paint through the same recolour API used by The Lot.
-    // Fresh 5.5-unit visuals retain semantic uniform records; cache clones already
-    // share the exact painted material objects used by the race competitor template.
+    // The shared 5.5-unit fast clone intentionally omits root paint handles. Restore
+    // its semantic uniform references before reapplying the saved rival PAINTJOB.
+    restoreCachedGhostPaintHandles(visual);
     recolorCarVisual(visual, color, secondaryColor);
 
     // 5.5 activates the canonical competitor-ghost cache. Counteract its featured


### PR DESCRIPTION
## Diagnosis

#852 moved CHASE YOUR BEST onto the correct 5.5-unit competitor-ghost path, which fixed the gray/unpainted model. The remaining factory-colour bug is in that path's fast clone optimization: `cloneCompetitorGhostVisual()` intentionally clears the clone's root-level semantic paint handle arrays.

The cached materials still retain their `material.userData.turnSemanticPaint` uniform records, but `recolorCarVisual()` can only reach those uniforms through `root.userData.turnSemanticPaintRecords`. In the onboarding's separate WebGL context, the explicit PAINTJOB reapply from #852 therefore became a no-op for semantic Kenney paint and the cached template/factory uniforms won.

## Fix

- when CHASE YOUR BEST receives a fast competitor clone, rebuild its root semantic paint records and primary/secondary material handles from the cached materials
- only then reapply the saved rival's exact primary + secondary colours through the existing shared `recolorCarVisual()` API
- keep the same 5.5-unit competitor template/cache path and 6.4-unit onboarding presentation scale
- keep the existing hidden warmup, timing, layout and second WebGL context unchanged
- publish a fresh `r273-cached-paint-handles` onboarding identity in TURN and TURN LAB
- strengthen regression coverage so cached ghost paint handles must be restored before PAINTJOB reapplication

No vehicle physics, rival storage, race ghost placement/animation, or HUD layout is changed.