### PR TITLE
Fix CHASE YOUR BEST custom paint via Lot path

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -244,7 +244,7 @@
           <div class="score-feedback-heading"><span>FLOW</span><span>COMBO</span></div>
           <div class="score-feedback-values"><strong data-score-feedback-flow-current>0</strong><b data-score-feedback-flow-multiplier>×1</b></div>
           <div class="score-feedback-footer">
-            <div class="score-feedback-lap"><span>LAP</span><b data-score-feedback-total>0</b></div>
+            <div class="score-feedback-lap"><span>LAP</span><b data-score-feedback-flow-total>0</b></div>
             <div class="score-feedback-techniques" data-score-feedback-flow-techniques aria-hidden="true">
               <span></span><span></span><span></span><span></span><span></span>
             </div>

--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -126,7 +126,7 @@
         "/turn/ui/shift-feedback.js?revision=r232-double-shift": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/ui/shift-feedback.js?revision=r253-supercar-release": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/render/covered-rendering.js?build=20260909-r212": "/turn/render/covered-rendering.js?build=20260909-r212&revision=r164-long-session-robustness",
-        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r273-cached-paint-handles",
+        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r274-lot-paint-path",
         "/turn/progression/lot-paint-reward.js?revision=r206-pwa-color": "/turn/progression/lot-paint-reward.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r206-race-before-locks": "/turn/garage/lot-showroom-experiment.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r252-supercar-outward-rims": "/turn/garage/lot-showroom-track-icon.js?revision=r2-swift-lot-ui",
@@ -244,7 +244,7 @@
           <div class="score-feedback-heading"><span>FLOW</span><span>COMBO</span></div>
           <div class="score-feedback-values"><strong data-score-feedback-flow-current>0</strong><b data-score-feedback-flow-multiplier>×1</b></div>
           <div class="score-feedback-footer">
-            <div class="score-feedback-lap"><span>LAP</span><b data-score-feedback-flow-total>0</b></div>
+            <div class="score-feedback-lap"><span>LAP</span><b data-score-feedback-total>0</b></div>
             <div class="score-feedback-techniques" data-score-feedback-flow-techniques aria-hidden="true">
               <span></span><span></span><span></span><span></span><span></span>
             </div>

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -259,8 +259,8 @@ assert.match(index, new RegExp(`lap-result-toast\\.css\\?build=${release.cacheKe
 assert.match(index, new RegExp(`rival-onboarding\\.css\\?build=${release.cacheKey}`));
 assert.equal(
   imports[`/turn/ui/rival-onboarding.js?build=${release.cacheKey}`],
-  `/turn/ui/rival-onboarding.js?build=${release.cacheKey}&revision=r273-cached-paint-handles`,
-  'Installed PWAs must refetch the cached-paint-handle-safe CHASE YOUR BEST runtime'
+  `/turn/ui/rival-onboarding.js?build=${release.cacheKey}&revision=r274-lot-paint-path`,
+  'Installed PWAs must refetch the Lot-paint-path CHASE YOUR BEST runtime'
 );
 assert.ok(
   imports['./race/lap-system.js?build=20260720-r19']?.startsWith(`./race/lap-system-r86.js?build=${release.cacheKey}`),
@@ -323,19 +323,22 @@ assert.match(onboarding, /!hadRival && hasRival\) schedule\(rivals\[0\]\)/, 'The
 assert.match(onboarding, /source\.carId \|\| source\.vehicleId/, 'The prepared preview must use the selected model and confirm it against the saved ghost model');
 assert.match(onboarding, /source\.carColor \|\| source\.vehicleColor/, 'The prepared preview must use the selected body paint and confirm it against saved ghost paint');
 assert.match(onboarding, /source\.carSecondaryColor \|\| source\.vehicleSecondaryColor/, 'The prepared preview must preserve selected and saved secondary paint');
-assert.match(onboarding, /ghost: true/, 'The onboarding model must use the same lighter solid ghost treatment as race rivals');
 assert.match(onboarding, /const customPaint = color !== getVehicleDefaultColor\(carId\)[\s\S]*secondaryColor !== getVehicleDefaultSecondaryColor\(carId\)/,
   'CHASE YOUR BEST must detect PAINTJOB colours instead of treating them as factory paint');
+assert.match(onboarding, /const previewColor = customPaint \? makeGhostColor\(color\) : color;/,
+  'A custom body PAINTJOB must be ghost-lightened before entering the proven Lot paint path');
+assert.match(onboarding, /const previewSecondaryColor = customPaint \? makeGhostColor\(secondaryColor\) : secondaryColor;/,
+  'A custom secondary PAINTJOB must be ghost-lightened before entering the proven Lot paint path');
 assert.match(onboarding, /if \(customPaint\) \{[\s\S]*runWarmupWhenIdle\(finishWarmup\);/,
-  'Custom-paint previews must let the hidden render compile semantic paint in their actual WebGL context');
-assert.match(onboarding, /sourceLength: 5\.5/, 'CHASE YOUR BEST must build from the same 5.5-unit competitor ghost template as the race');
-assert.match(onboarding, /targetLength: PREVIEW_PRESENTATION\.sourceLength/, 'The onboarding createCarVisual call must activate the canonical competitor-ghost paint path');
-assert.match(onboarding, /function restoreCachedGhostPaintHandles\(visual\)/,
-  'Cached competitor ghosts must restore semantic paint handles before the onboarding reuses them');
-assert.match(onboarding, /turnFastGhostClone[\s\S]*turnSemanticPaintRecords = semanticPaintRecords/,
-  'The fast-clone path must rebuild its root semantic uniform references from cached materials');
-assert.match(onboarding, /restoreCachedGhostPaintHandles\(visual\);\s*recolorCarVisual\(visual, color, secondaryColor\)/,
-  'CHASE YOUR BEST must restore cached paint handles before reasserting the saved PAINTJOB');
+  'Custom-paint previews must let the hidden render compile paint in their actual WebGL context');
+assert.match(onboarding, /sourceLength: 5\.5/, 'Factory CHASE YOUR BEST previews may still reuse the 5.5-unit competitor ghost cache');
+assert.match(onboarding, /ghost: !customPaint/, 'PAINTJOB previews must bypass the cached ghost-construction branch');
+assert.match(onboarding, /targetLength: customPaint[\s\S]*PREVIEW_PRESENTATION\.targetLength[\s\S]*PREVIEW_PRESENTATION\.sourceLength/,
+  'PAINTJOB previews must construct at the Lot 6.4-unit presentation size while factory ghosts keep the cached source size');
+assert.match(onboarding, /if \(customPaint\) \{\s*recolorCarVisual\(visual, previewColor, previewSecondaryColor\);/,
+  'CHASE YOUR BEST must use the same post-construction recolour step as the Lot viewer for a saved PAINTJOB');
+assert.doesNotMatch(onboarding, /restoreCachedGhostPaintHandles/,
+  'PAINTJOB correctness must not depend on reconstructing cached race-ghost paint handles');
 assert.match(onboarding, /targetLength: 6\.4/, 'The onboarding model must preserve its established 6.4-unit presentation scale');
 assert.match(onboarding, /PerspectiveCamera\(34, 1, 0\.1, 60\)/, 'The onboarding model must reuse the Lot viewer camera language');
 assert.match(onboarding, /camera\.position\.set\(7\.8, 4\.8, 8\.8\)/, 'The onboarding model must use the Lot viewer camera position');

--- a/turn-tests/release-composition-production.mjs
+++ b/turn-tests/release-composition-production.mjs
@@ -386,8 +386,8 @@ const rivalRoute = Object.entries(headGraph.importMap.imports || {}).find(([spec
   /^\/turn\/ui\/rival-onboarding\.js\?build=\d{8}-r\d+$/.test(specifier)
 );
 assert.ok(rivalRoute, 'Production TURN must retain the release-bound rival onboarding route');
-assert.match(rivalRoute[1], /[?&]revision=r273-cached-paint-handles(?:&|$)/,
-  'Rival onboarding must use the cached-paint-handle-safe identity');
+assert.match(rivalRoute[1], /[?&]revision=r274-lot-paint-path(?:&|$)/,
+  'Rival onboarding must route saved PAINTJOB previews through the proven Lot paint path');
 
 const workflows = Object.fromEntries(workflowEntries);
 for (const [workflowPath, source] of Object.entries(workflows)) {

--- a/turn/index.html
+++ b/turn/index.html
@@ -137,7 +137,7 @@
         "/turn/ui/shift-feedback.js?revision=r232-double-shift": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/ui/shift-feedback.js?revision=r253-supercar-release": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/render/covered-rendering.js?build=20260909-r212": "/turn/render/covered-rendering.js?build=20260909-r212&revision=r164-long-session-robustness",
-        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r273-cached-paint-handles",
+        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r274-lot-paint-path",
         "/turn/progression/lot-paint-reward.js?revision=r206-pwa-color": "/turn/progression/lot-paint-reward.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r206-race-before-locks": "/turn/garage/lot-showroom-experiment.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r252-supercar-outward-rims": "/turn/garage/lot-showroom-track-icon.js?revision=r2-swift-lot-ui",

--- a/turn/ui/rival-onboarding.js
+++ b/turn/ui/rival-onboarding.js
@@ -19,9 +19,9 @@ const PREVIEW_FALLBACK_PREP_DELAY_MS = 500;
 const PREVIEW_WARM_WIDTH = 126;
 const PREVIEW_WARM_HEIGHT = 92;
 const PREVIEW_PRESENTATION = Object.freeze({
-  // Build from the same 5.5-unit competitor template as the actual race ghost, then
-  // scale only the presentation. This keeps CHASE YOUR BEST on the exact same painted
-  // visual path instead of constructing an independent 6.4-unit ghost variant.
+  // Factory paint can reuse the canonical 5.5-unit competitor ghost cache. A saved
+  // PAINTJOB deliberately uses the Lot's proven uncached 6.4-unit paint path instead,
+  // with its colours lightened before construction to preserve the ghost appearance.
   sourceLength: 5.5,
   targetLength: 6.4
 });
@@ -249,40 +249,6 @@ export function installRivalOnboarding() {
   });
 }
 
-function restoreCachedGhostPaintHandles(visual) {
-  if (!visual?.userData?.turnFastGhostClone) return;
-
-  const semanticPaintRecords = [];
-  const primaryPaintMaterials = [];
-  const secondaryPaintMaterials = [];
-  const seenMaterials = new Set();
-
-  visual.traverse((node) => {
-    if (!node?.isMesh || !node.material) return;
-    const materials = Array.isArray(node.material) ? node.material : [node.material];
-    for (const material of materials) {
-      if (!material || seenMaterials.has(material)) continue;
-      seenMaterials.add(material);
-      const semantic = material.userData?.turnSemanticPaint;
-      if (!semantic) continue;
-      semanticPaintRecords.push(semantic);
-      if (semantic.primary) primaryPaintMaterials.push(material);
-      if (semantic.secondary) secondaryPaintMaterials.push(material);
-    }
-  });
-
-  // The fast competitor clone deliberately drops these root-level arrays, but the
-  // shared materials still retain the semantic uniform records. Rebuild only the
-  // handles needed by recolorCarVisual so this secondary renderer can reassert the
-  // exact saved PAINTJOB instead of falling back to the template/factory uniforms.
-  visual.userData.turnSemanticPaintRecords = semanticPaintRecords;
-  visual.userData.turnPrimaryPaintMaterials = primaryPaintMaterials;
-  visual.userData.turnSecondaryPaintMaterials = secondaryPaintMaterials;
-  visual.userData.turnPaintMaterials = [
-    ...new Set([...primaryPaintMaterials, ...secondaryPaintMaterials])
-  ];
-}
-
 function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }) {
   const scene = new THREE.Scene();
   const renderer = new THREE.WebGLRenderer({
@@ -325,6 +291,8 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
   const reducedMotion = globalThis.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches === true;
   const customPaint = color !== getVehicleDefaultColor(carId)
     || secondaryColor !== getVehicleDefaultSecondaryColor(carId);
+  const previewColor = customPaint ? makeGhostColor(color) : color;
+  const previewSecondaryColor = customPaint ? makeGhostColor(secondaryColor) : secondaryColor;
 
   const resizeTo = (width, height) => {
     if (disposed || !width || !height) return;
@@ -403,14 +371,10 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
     if (disposed || !visual) return;
     try {
       if (customPaint) {
-        // PAINTJOB colours are applied by semantic onBeforeCompile shaders. Let the
-        // hidden idle render own their first compilation in this secondary WebGL
-        // context; precompiling them here can leave the preview on its source palette.
+        // Match The Lot: PAINTJOB shader compilation belongs to an actual render in
+        // this WebGL context, never to the race-ghost cache or a precompile shortcut.
         runWarmupWhenIdle(finishWarmup);
       } else if (typeof renderer.compileAsync === 'function') {
-        // The native semantic paint system made these shaders more substantial than
-        // the original r40 onboarding. Compile them asynchronously in this separate
-        // WebGL context rather than on the CHASE YOUR BEST reveal frame.
         await renderer.compileAsync(scene, camera);
         if (disposed) return;
         runWarmupWhenIdle(finishWarmup);
@@ -439,29 +403,34 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
     }
   };
 
+  // Custom PAINTJOBs intentionally use the exact construction pattern that already
+  // works in The Lot: a fresh non-ghost 6.4-unit visual, then recolour it in this
+  // renderer's own context. We pre-lighten the two paint channels so it still reads
+  // as the same solid ghost. Factory paint keeps the cheaper cached race-ghost path.
   void createCarVisual({
     carId,
-    color,
-    secondaryColor,
-    ghost: true,
-    targetLength: PREVIEW_PRESENTATION.sourceLength,
+    color: previewColor,
+    secondaryColor: previewSecondaryColor,
+    ghost: !customPaint,
+    targetLength: customPaint
+      ? PREVIEW_PRESENTATION.targetLength
+      : PREVIEW_PRESENTATION.sourceLength,
     outline: true
   }).then((next) => {
     if (disposed) return;
     visual = next;
 
-    // The shared 5.5-unit fast clone intentionally omits root paint handles. Restore
-    // its semantic uniform references before reapplying the saved rival PAINTJOB.
-    restoreCachedGhostPaintHandles(visual);
-    recolorCarVisual(visual, color, secondaryColor);
-
-    // 5.5 activates the canonical competitor-ghost cache. Counteract its featured
-    // surface multiplier while preserving the previous 6.4-unit onboarding framing.
-    const featuredMultiplier = Number(visual.userData?.turnFeaturedVisualSizeMultiplier) || 1;
-    visual.scale.multiplyScalar(
-      PREVIEW_PRESENTATION.targetLength
-        / (PREVIEW_PRESENTATION.sourceLength * featuredMultiplier)
-    );
+    if (customPaint) {
+      recolorCarVisual(visual, previewColor, previewSecondaryColor);
+    } else {
+      // 5.5 activates the canonical competitor-ghost cache. Counteract its featured
+      // surface multiplier while preserving the established 6.4-unit framing.
+      const featuredMultiplier = Number(visual.userData?.turnFeaturedVisualSizeMultiplier) || 1;
+      visual.scale.multiplyScalar(
+        PREVIEW_PRESENTATION.targetLength
+          / (PREVIEW_PRESENTATION.sourceLength * featuredMultiplier)
+      );
+    }
     stage.add(visual);
     void warmRenderer();
   }).catch((error) => {


### PR DESCRIPTION
## Diagnosis

The cleared-data repro rules out stale rival migration/data as the explanation. #851–#853 were still trying to make the cached `ghost: true` construction path behave correctly in CHASE YOUR BEST's separate WebGL context. The saved rival colour reaches onboarding, but that path still resolves visually to the factory ghost paint.

The Lot already has a proven custom-paint rendering path: a fresh, uncached, non-ghost 6.4-unit visual followed by `recolorCarVisual()` in the viewer's own context.

## Fix

- for a saved PAINTJOB, CHASE YOUR BEST now uses that same fresh 6.4-unit Lot construction/recolour path instead of the competitor-ghost cache
- primary and secondary PAINTJOB colours are passed through `makeGhostColor()` first, preserving the lighter solid-ghost appearance without using the problematic `ghost: true` paint branch
- factory-painted cars keep the existing cached 5.5-unit competitor-ghost path and established 6.4-unit framing
- remove #853's cached-paint-handle reconstruction from onboarding
- keep timing, 30 fps preview cap, WebGL warm-up, camera, layout, rival storage and race ghosts unchanged
- publish fresh `r274-lot-paint-path` identities in TURN and TURN LAB and update regression/composition guards

No vehicle physics, handling, rival persistence, race-ghost behavior or HUD layout is changed.