### PR TITLE
Restore TURN to exact post-#850 state

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -126,7 +126,7 @@
         "/turn/ui/shift-feedback.js?revision=r232-double-shift": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/ui/shift-feedback.js?revision=r253-supercar-release": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/render/covered-rendering.js?build=20260909-r212": "/turn/render/covered-rendering.js?build=20260909-r212&revision=r164-long-session-robustness",
-        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r274-lot-paint-path",
+        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r253-supercar-release",
         "/turn/progression/lot-paint-reward.js?revision=r206-pwa-color": "/turn/progression/lot-paint-reward.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r206-race-before-locks": "/turn/garage/lot-showroom-experiment.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r252-supercar-outward-rims": "/turn/garage/lot-showroom-track-icon.js?revision=r2-swift-lot-ui",

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -259,8 +259,8 @@ assert.match(index, new RegExp(`lap-result-toast\\.css\\?build=${release.cacheKe
 assert.match(index, new RegExp(`rival-onboarding\\.css\\?build=${release.cacheKey}`));
 assert.equal(
   imports[`/turn/ui/rival-onboarding.js?build=${release.cacheKey}`],
-  `/turn/ui/rival-onboarding.js?build=${release.cacheKey}&revision=r274-lot-paint-path`,
-  'Installed PWAs must refetch the Lot-paint-path CHASE YOUR BEST runtime'
+  `/turn/ui/rival-onboarding.js?build=${release.cacheKey}&revision=r253-supercar-release`,
+  'Installed PWAs must refetch the prewarmed CHASE YOUR BEST runtime'
 );
 assert.ok(
   imports['./race/lap-system.js?build=20260720-r19']?.startsWith(`./race/lap-system-r86.js?build=${release.cacheKey}`),
@@ -323,23 +323,8 @@ assert.match(onboarding, /!hadRival && hasRival\) schedule\(rivals\[0\]\)/, 'The
 assert.match(onboarding, /source\.carId \|\| source\.vehicleId/, 'The prepared preview must use the selected model and confirm it against the saved ghost model');
 assert.match(onboarding, /source\.carColor \|\| source\.vehicleColor/, 'The prepared preview must use the selected body paint and confirm it against saved ghost paint');
 assert.match(onboarding, /source\.carSecondaryColor \|\| source\.vehicleSecondaryColor/, 'The prepared preview must preserve selected and saved secondary paint');
-assert.match(onboarding, /const customPaint = color !== getVehicleDefaultColor\(carId\)[\s\S]*secondaryColor !== getVehicleDefaultSecondaryColor\(carId\)/,
-  'CHASE YOUR BEST must detect PAINTJOB colours instead of treating them as factory paint');
-assert.match(onboarding, /const previewColor = customPaint \? makeGhostColor\(color\) : color;/,
-  'A custom body PAINTJOB must be ghost-lightened before entering the proven Lot paint path');
-assert.match(onboarding, /const previewSecondaryColor = customPaint \? makeGhostColor\(secondaryColor\) : secondaryColor;/,
-  'A custom secondary PAINTJOB must be ghost-lightened before entering the proven Lot paint path');
-assert.match(onboarding, /if \(customPaint\) \{[\s\S]*runWarmupWhenIdle\(finishWarmup\);/,
-  'Custom-paint previews must let the hidden render compile paint in their actual WebGL context');
-assert.match(onboarding, /sourceLength: 5\.5/, 'Factory CHASE YOUR BEST previews may still reuse the 5.5-unit competitor ghost cache');
-assert.match(onboarding, /ghost: !customPaint/, 'PAINTJOB previews must bypass the cached ghost-construction branch');
-assert.match(onboarding, /targetLength: customPaint[\s\S]*PREVIEW_PRESENTATION\.targetLength[\s\S]*PREVIEW_PRESENTATION\.sourceLength/,
-  'PAINTJOB previews must construct at the Lot 6.4-unit presentation size while factory ghosts keep the cached source size');
-assert.match(onboarding, /if \(customPaint\) \{\s*recolorCarVisual\(visual, previewColor, previewSecondaryColor\);/,
-  'CHASE YOUR BEST must use the same post-construction recolour step as the Lot viewer for a saved PAINTJOB');
-assert.doesNotMatch(onboarding, /restoreCachedGhostPaintHandles/,
-  'PAINTJOB correctness must not depend on reconstructing cached race-ghost paint handles');
-assert.match(onboarding, /targetLength: 6\.4/, 'The onboarding model must preserve its established 6.4-unit presentation scale');
+assert.match(onboarding, /ghost: true/, 'The onboarding model must use the same lighter solid ghost treatment as race rivals');
+assert.match(onboarding, /targetLength: 6\.4/, 'The onboarding model must use the Lot 3D viewer presentation scale');
 assert.match(onboarding, /PerspectiveCamera\(34, 1, 0\.1, 60\)/, 'The onboarding model must reuse the Lot viewer camera language');
 assert.match(onboarding, /camera\.position\.set\(7\.8, 4\.8, 8\.8\)/, 'The onboarding model must use the Lot viewer camera position');
 assert.match(onboarding, /HemisphereLight\(0xffffff, 0x5b6770, 3\.2\)/, 'The onboarding model must use the Lot viewer ambient lighting');

--- a/turn-tests/release-composition-production.mjs
+++ b/turn-tests/release-composition-production.mjs
@@ -386,8 +386,8 @@ const rivalRoute = Object.entries(headGraph.importMap.imports || {}).find(([spec
   /^\/turn\/ui\/rival-onboarding\.js\?build=\d{8}-r\d+$/.test(specifier)
 );
 assert.ok(rivalRoute, 'Production TURN must retain the release-bound rival onboarding route');
-assert.match(rivalRoute[1], /[?&]revision=r274-lot-paint-path(?:&|$)/,
-  'Rival onboarding must route saved PAINTJOB previews through the proven Lot paint path');
+assert.match(rivalRoute[1], /[?&]revision=r253-supercar-release(?:&|$)/,
+  'Rival onboarding must use the current release graph instead of its pre-SUPERCAR identity');
 
 const workflows = Object.fromEntries(workflowEntries);
 for (const [workflowPath, source] of Object.entries(workflows)) {

--- a/turn/index.html
+++ b/turn/index.html
@@ -137,7 +137,7 @@
         "/turn/ui/shift-feedback.js?revision=r232-double-shift": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/ui/shift-feedback.js?revision=r253-supercar-release": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/render/covered-rendering.js?build=20260909-r212": "/turn/render/covered-rendering.js?build=20260909-r212&revision=r164-long-session-robustness",
-        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r274-lot-paint-path",
+        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r253-supercar-release",
         "/turn/progression/lot-paint-reward.js?revision=r206-pwa-color": "/turn/progression/lot-paint-reward.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r206-race-before-locks": "/turn/garage/lot-showroom-experiment.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r252-supercar-outward-rims": "/turn/garage/lot-showroom-track-icon.js?revision=r2-swift-lot-ui",

--- a/turn/ui/rival-onboarding.js
+++ b/turn/ui/rival-onboarding.js
@@ -7,10 +7,7 @@ import {
   normalizeVehicleId,
   normalizeVehicleSecondaryColor
 } from '../vehicle/catalog.js?build=20260720-r19';
-import {
-  createCarVisual,
-  recolorCarVisual
-} from '../vehicle/car-models.js?build=20260720-r22';
+import { createCarVisual } from '../vehicle/car-models.js?build=20260720-r22';
 
 const RESULT_TOAST_HANDOFF_MS = 4300;
 const ONBOARDING_VISIBLE_MS = 3200;
@@ -18,13 +15,6 @@ const ONBOARDING_EXIT_MS = 180;
 const PREVIEW_FALLBACK_PREP_DELAY_MS = 500;
 const PREVIEW_WARM_WIDTH = 126;
 const PREVIEW_WARM_HEIGHT = 92;
-const PREVIEW_PRESENTATION = Object.freeze({
-  // Factory paint can reuse the canonical 5.5-unit competitor ghost cache. A saved
-  // PAINTJOB deliberately uses the Lot's proven uncached 6.4-unit paint path instead,
-  // with its colours lightened before construction to preserve the ghost appearance.
-  sourceLength: 5.5,
-  targetLength: 6.4
-});
 const VIEWER_INITIAL_YAW = THREE.MathUtils.degToRad(200);
 const VIEWER_ROTATION_RADIANS_PER_SECOND = 0.144;
 const VIEWER_FRAME_INTERVAL_MS = 1000 / 30;
@@ -289,10 +279,6 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
   let lastRenderAt = 0;
   let yaw = VIEWER_INITIAL_YAW;
   const reducedMotion = globalThis.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches === true;
-  const customPaint = color !== getVehicleDefaultColor(carId)
-    || secondaryColor !== getVehicleDefaultSecondaryColor(carId);
-  const previewColor = customPaint ? makeGhostColor(color) : color;
-  const previewSecondaryColor = customPaint ? makeGhostColor(secondaryColor) : secondaryColor;
 
   const resizeTo = (width, height) => {
     if (disposed || !width || !height) return;
@@ -370,11 +356,10 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
   const warmRenderer = async () => {
     if (disposed || !visual) return;
     try {
-      if (customPaint) {
-        // Match The Lot: PAINTJOB shader compilation belongs to an actual render in
-        // this WebGL context, never to the race-ghost cache or a precompile shortcut.
-        runWarmupWhenIdle(finishWarmup);
-      } else if (typeof renderer.compileAsync === 'function') {
+      if (typeof renderer.compileAsync === 'function') {
+        // The native semantic paint system made these shaders more substantial than
+        // the original r40 onboarding. Compile them asynchronously in this separate
+        // WebGL context rather than on the CHASE YOUR BEST reveal frame.
         await renderer.compileAsync(scene, camera);
         if (disposed) return;
         runWarmupWhenIdle(finishWarmup);
@@ -403,34 +388,16 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
     }
   };
 
-  // Custom PAINTJOBs intentionally use the exact construction pattern that already
-  // works in The Lot: a fresh non-ghost 6.4-unit visual, then recolour it in this
-  // renderer's own context. We pre-lighten the two paint channels so it still reads
-  // as the same solid ghost. Factory paint keeps the cheaper cached race-ghost path.
   void createCarVisual({
     carId,
-    color: previewColor,
-    secondaryColor: previewSecondaryColor,
-    ghost: !customPaint,
-    targetLength: customPaint
-      ? PREVIEW_PRESENTATION.targetLength
-      : PREVIEW_PRESENTATION.sourceLength,
+    color,
+    secondaryColor,
+    ghost: true,
+    targetLength: 6.4,
     outline: true
   }).then((next) => {
     if (disposed) return;
     visual = next;
-
-    if (customPaint) {
-      recolorCarVisual(visual, previewColor, previewSecondaryColor);
-    } else {
-      // 5.5 activates the canonical competitor-ghost cache. Counteract its featured
-      // surface multiplier while preserving the established 6.4-unit framing.
-      const featuredMultiplier = Number(visual.userData?.turnFeaturedVisualSizeMultiplier) || 1;
-      visual.scale.multiplyScalar(
-        PREVIEW_PRESENTATION.targetLength
-          / (PREVIEW_PRESENTATION.sourceLength * featuredMultiplier)
-      );
-    }
     stage.add(visual);
     void warmRenderer();
   }).catch((error) => {


### PR DESCRIPTION
Rollback of the unsuccessful CHASE YOUR BEST paint experiments in #851–#854.

This does **not** rewrite history. It creates one normal revert-style commit whose tree restores the five changed files to their exact contents at merge commit `201b49dfe3e006f6aa80decbe624441594b7335d` (the successful merge of #850).

Verified with `compare_commits`: comparing #850's merge commit to this branch reports **zero changed files**. So the resulting repository contents are exactly the post-#850 state, while preserving #851–#854 in history for investigation.

After this rollback, the custom PAINTJOB/CHASE YOUR BEST bug is intentionally present again. We will investigate from that clean baseline instead of stacking further fixes.