### PR TITLE
Diagnose CHASE YOUR BEST paint with visible-first WebGL render

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -126,7 +126,7 @@
         "/turn/ui/shift-feedback.js?revision=r232-double-shift": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/ui/shift-feedback.js?revision=r253-supercar-release": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/render/covered-rendering.js?build=20260909-r212": "/turn/render/covered-rendering.js?build=20260909-r212&revision=r164-long-session-robustness",
-        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r253-supercar-release",
+        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r275-visible-first-paint",
         "/turn/progression/lot-paint-reward.js?revision=r206-pwa-color": "/turn/progression/lot-paint-reward.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r206-race-before-locks": "/turn/garage/lot-showroom-experiment.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r252-supercar-outward-rims": "/turn/garage/lot-showroom-track-icon.js?revision=r2-swift-lot-ui",

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -259,8 +259,8 @@ assert.match(index, new RegExp(`lap-result-toast\\.css\\?build=${release.cacheKe
 assert.match(index, new RegExp(`rival-onboarding\\.css\\?build=${release.cacheKey}`));
 assert.equal(
   imports[`/turn/ui/rival-onboarding.js?build=${release.cacheKey}`],
-  `/turn/ui/rival-onboarding.js?build=${release.cacheKey}&revision=r253-supercar-release`,
-  'Installed PWAs must refetch the prewarmed CHASE YOUR BEST runtime'
+  `/turn/ui/rival-onboarding.js?build=${release.cacheKey}&revision=r275-visible-first-paint`,
+  'Installed PWAs must refetch the visible-first CHASE YOUR BEST diagnostic runtime'
 );
 assert.ok(
   imports['./race/lap-system.js?build=20260720-r19']?.startsWith(`./race/lap-system-r86.js?build=${release.cacheKey}`),

--- a/turn-lab/tests/runtime-hotpath-performance-production.mjs
+++ b/turn-lab/tests/runtime-hotpath-performance-production.mjs
@@ -69,29 +69,31 @@ assert.doesNotMatch(rewardPlacementFunction, /requestAnimationFrame|setInterval|
 assert.match(achievementView, /requestAnimationFrame/,
   'Achievement entrance animations should cross a frame boundary without a forced reflow');
 
-// CHASE YOUR BEST has its own WebGL context. The newer semantic car shaders make a first
-// render there materially more expensive than the original r40 implementation, so the context,
-// model and shader programs must be prepared before the first rival is saved/revealed.
+// CHASE YOUR BEST still prepares its optional renderer/model during the first lap, but this
+// diagnostic intentionally forbids GPU program compilation or rendering while its ancestor is
+// display:none. The first WebGL render is scheduled only after reveal() removes hidden.
 const revealFunction = rivalOnboarding.match(/  function reveal\(\) \{[\s\S]*?\n  \}/)?.[0] || '';
 assert.ok(revealFunction, 'Rival onboarding must keep a bounded reveal function');
 assert.doesNotMatch(revealFunction, /offsetWidth|offsetHeight|getBoundingClientRect|renderer\.render|renderFrame/,
-  'CHASE YOUR BEST reveal must not force layout or perform a first WebGL render');
-assert.match(revealFunction, /requestAnimationFrame/,
-  'CHASE YOUR BEST should cross a frame boundary without a forced reflow');
+  'CHASE YOUR BEST reveal must not force layout or render synchronously');
+assert.match(revealFunction, /plate\.hidden = false[\s\S]*requestAnimationFrame/,
+  'CHASE YOUR BEST must leave display:none before scheduling preview startup');
 assert.match(rivalOnboarding, /reason === 'race-started'[\s\S]*!hasRival && state[\s\S]*preparePreview\(state\)/,
-  'The first-rival 3D preview must begin preparing during the first race, not at lap completion');
+  'The first-rival 3D model/context may still prepare during the first race');
 assert.match(rivalOnboarding, /requestIdleCallback\(prepare\)/,
-  'Optional rival-preview context creation must wait for browser idle time when supported');
-assert.match(rivalOnboarding, /renderer\.compileAsync\(scene, camera\)/,
-  'The separate onboarding WebGL context must asynchronously precompile semantic car shaders');
-assert.match(rivalOnboarding, /renderer\.render\(scene, camera\);\s*warmed = true;/,
-  'The preview must warm one hidden frame before becoming eligible for visible rendering');
+  'Optional rival-preview preparation must wait for browser idle time when supported');
+assert.doesNotMatch(rivalOnboarding, /renderer\.compileAsync\(|renderer\.compile\(/,
+  'The diagnostic must not compile the CHASE YOUR BEST WebGL scene while hidden');
+assert.doesNotMatch(rivalOnboarding, /warmed|finishWarmup|warmRenderer|runWarmupWhenIdle/,
+  'The hidden GPU prewarm lifecycle must be fully absent from this diagnostic');
 const previewStart = rivalOnboarding.match(/    start\(\) \{[\s\S]*?\n    \},/)?.[0] || '';
 assert.ok(previewStart, 'Rival onboarding preview must expose a bounded start method');
+assert.match(previewStart, /resize\(\)/,
+  'Visible startup must measure the real preview host after display:none has been removed');
 assert.doesNotMatch(previewStart, /renderer\.render|renderFrame|compile/,
-  'Starting the visible rival preview must never discover GPU programs synchronously');
+  'Starting the visible rival preview must not synchronously compile or render');
 assert.match(previewStart, /requestAnimationFrame\(tick\)/,
-  'Visible rival rendering should begin on a later animation frame');
+  'The first GPU render must occur on a later animation frame after visible startup');
 
 // One logical unlock batch may award multiple achievements and Trophy Road rewards. Persist it once.
 assert.match(achievementStore, /function batch\(callback\)/);
@@ -152,4 +154,4 @@ const worldHomeGate = worldRender.indexOf('await waitForHomeBeforeCosmetics();')
 assert.ok(worldPrewarm >= 0 && worldHomeGate >= 0 && worldPrewarm < worldHomeGate,
   'World cosmetic module graph must prewarm before Home while installation still waits for Home');
 
-console.log('TURN runtime hot-path, observer, rival-preview and deferred-loading performance contracts passed.');
+console.log('TURN runtime hot-path, observer, visible-first rival-preview and deferred-loading performance contracts passed.');

--- a/turn-tests/release-composition-production.mjs
+++ b/turn-tests/release-composition-production.mjs
@@ -386,8 +386,8 @@ const rivalRoute = Object.entries(headGraph.importMap.imports || {}).find(([spec
   /^\/turn\/ui\/rival-onboarding\.js\?build=\d{8}-r\d+$/.test(specifier)
 );
 assert.ok(rivalRoute, 'Production TURN must retain the release-bound rival onboarding route');
-assert.match(rivalRoute[1], /[?&]revision=r253-supercar-release(?:&|$)/,
-  'Rival onboarding must use the current release graph instead of its pre-SUPERCAR identity');
+assert.match(rivalRoute[1], /[?&]revision=r275-visible-first-paint(?:&|$)/,
+  'Rival onboarding must use the visible-first PAINTJOB diagnostic identity');
 
 const workflows = Object.fromEntries(workflowEntries);
 for (const [workflowPath, source] of Object.entries(workflows)) {

--- a/turn/index.html
+++ b/turn/index.html
@@ -137,7 +137,7 @@
         "/turn/ui/shift-feedback.js?revision=r232-double-shift": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/ui/shift-feedback.js?revision=r253-supercar-release": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/render/covered-rendering.js?build=20260909-r212": "/turn/render/covered-rendering.js?build=20260909-r212&revision=r164-long-session-robustness",
-        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r253-supercar-release",
+        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r275-visible-first-paint",
         "/turn/progression/lot-paint-reward.js?revision=r206-pwa-color": "/turn/progression/lot-paint-reward.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r206-race-before-locks": "/turn/garage/lot-showroom-experiment.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r252-supercar-outward-rims": "/turn/garage/lot-showroom-track-icon.js?revision=r2-swift-lot-ui",

--- a/turn/ui/rival-onboarding.js
+++ b/turn/ui/rival-onboarding.js
@@ -120,8 +120,9 @@ export function installRivalOnboarding() {
     plate.hidden = false;
     plate.classList.remove('is-visible', 'is-leaving');
 
-    // Cross a frame boundary instead of forcing a synchronous layout read. The 3D
-    // preview is prepared independently; revealing CHASE YOUR BEST must never wait for WebGL.
+    // The diagnostic lifecycle deliberately keeps all GPU compilation/rendering out
+    // of the display:none phase. Cross one frame after unhiding; start() then resizes
+    // the real host and schedules the first WebGL render for the following frame.
     revealFrame = requestAnimationFrame(() => {
       revealFrame = 0;
       if (plate.hidden) return;
@@ -183,9 +184,9 @@ export function installRivalOnboarding() {
       if (!plate.hidden) preview.start();
     };
 
-    // With no rival yet, race-started gives us an entire first lap to prepare the
-    // optional second WebGL context. Do it only when the browser reports idle time.
-    // Older engines get a delayed fallback, still well before the first rival reveal.
+    // CPU-side/context/model preparation still happens during the first lap. The one
+    // thing intentionally deferred is GPU program initialization/rendering while the
+    // onboarding subtree has display:none.
     if (typeof globalThis.requestIdleCallback === 'function') {
       preparationIdleHandle = globalThis.requestIdleCallback(prepare);
     } else {
@@ -249,8 +250,8 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
   renderer.outputColorSpace = THREE.SRGBColorSpace;
   renderer.setPixelRatio(Math.min(devicePixelRatio, 1.35));
   renderer.setClearColor(0x000000, 0);
-  // Warm at the maximum CSS preview size so the visible reveal does not discover a
-  // larger drawing buffer. This surface is still tiny compared with the race canvas.
+  // Allocate the small drawing buffer up front, but do not compile or render while
+  // the onboarding subtree is hidden. This isolates the Mobile Safari lifecycle.
   renderer.setSize(PREVIEW_WARM_WIDTH, PREVIEW_WARM_HEIGHT, false);
   modelHost.appendChild(renderer.domElement);
 
@@ -271,10 +272,7 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
   let visual = null;
   let disposed = false;
   let active = false;
-  let warmed = false;
   let animationFrame = 0;
-  let warmIdleHandle = 0;
-  let warmTimer = 0;
   let lastTickAt = 0;
   let lastRenderAt = 0;
   let yaw = VIEWER_INITIAL_YAW;
@@ -285,7 +283,6 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
     camera.aspect = width / height;
     camera.updateProjectionMatrix();
     renderer.setSize(Math.round(width), Math.round(height), false);
-    if (active && warmed && reducedMotion) renderer.render(scene, camera);
   };
 
   const resize = () => {
@@ -295,19 +292,15 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
   };
 
   const renderFrame = (now) => {
-    if (disposed || !warmed) return;
+    if (disposed || !visual) return;
     stage.rotation.y = yaw;
     stage.rotation.x = 0.08;
-    if (visual) visual.position.y = reducedMotion ? 0 : Math.sin((now / 1000) * 2.1) * 0.04;
+    visual.position.y = reducedMotion ? 0 : Math.sin((now / 1000) * 2.1) * 0.04;
     renderer.render(scene, camera);
   };
 
   const tick = (now) => {
     if (!active || disposed) return;
-    if (!warmed) {
-      animationFrame = requestAnimationFrame(tick);
-      return;
-    }
     const dt = Math.min(0.1, Math.max(0, (now - lastTickAt) / 1000));
     lastTickAt = now;
     if (!reducedMotion) yaw += dt * VIEWER_ROTATION_RADIANS_PER_SECOND;
@@ -326,68 +319,6 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
     : null;
   observer?.observe(modelHost);
 
-  const runWarmupWhenIdle = (callback) => {
-    if (disposed) return;
-    if (typeof globalThis.requestIdleCallback === 'function') {
-      warmIdleHandle = globalThis.requestIdleCallback(() => {
-        warmIdleHandle = 0;
-        if (!disposed) callback();
-      });
-    } else {
-      warmTimer = window.setTimeout(() => {
-        warmTimer = 0;
-        if (!disposed) callback();
-      }, 120);
-    }
-  };
-
-  const finishWarmup = () => {
-    if (disposed || !visual) return;
-    // One hidden render uploads geometry and textures after shader compilation. The
-    // first visible frame then has no new GPU program or texture work to discover.
-    renderer.render(scene, camera);
-    warmed = true;
-    if (active && !animationFrame) {
-      lastTickAt = performance.now();
-      animationFrame = requestAnimationFrame(tick);
-    }
-  };
-
-  const warmRenderer = async () => {
-    if (disposed || !visual) return;
-    try {
-      if (typeof renderer.compileAsync === 'function') {
-        // The native semantic paint system made these shaders more substantial than
-        // the original r40 onboarding. Compile them asynchronously in this separate
-        // WebGL context rather than on the CHASE YOUR BEST reveal frame.
-        await renderer.compileAsync(scene, camera);
-        if (disposed) return;
-        runWarmupWhenIdle(finishWarmup);
-      } else {
-        runWarmupWhenIdle(() => {
-          if (disposed) return;
-          renderer.compile(scene, camera);
-          finishWarmup();
-        });
-      }
-    } catch (error) {
-      if (disposed) return;
-      console.warn('TURN: first rival preview shader warm-up failed.', error);
-      // Even the recovery compile stays off the reveal path. If it fails too, keep the
-      // onboarding copy and hide only the optional model.
-      runWarmupWhenIdle(() => {
-        if (disposed) return;
-        try {
-          renderer.compile(scene, camera);
-          finishWarmup();
-        } catch (fallbackError) {
-          console.warn('TURN: first rival preview fallback warm-up failed.', fallbackError);
-          onError?.(fallbackError);
-        }
-      });
-    }
-  };
-
   void createCarVisual({
     carId,
     color,
@@ -399,7 +330,6 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
     if (disposed) return;
     visual = next;
     stage.add(visual);
-    void warmRenderer();
   }).catch((error) => {
     if (disposed) return;
     console.warn('TURN: first rival could not load in the onboarding viewer.', error);
@@ -412,10 +342,11 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
     start() {
       if (disposed || active) return;
       active = true;
+      resize();
       lastTickAt = performance.now();
-      if (!observer) resize();
-      // Never synchronously render on reveal. If warm-up is still finishing, CHASE
-      // YOUR BEST appears on time and the 3D ghost joins on a later animation frame.
+      lastRenderAt = 0;
+      // First GPU work happens on the next frame, after the parent has left
+      // display:none and after reveal() has applied the visible presentation state.
       animationFrame = requestAnimationFrame(tick);
     },
     dispose() {
@@ -423,10 +354,6 @@ function createGhostPreview({ modelHost, carId, color, secondaryColor, onError }
       disposed = true;
       active = false;
       cancelAnimationFrame(animationFrame);
-      if (warmIdleHandle && typeof globalThis.cancelIdleCallback === 'function') {
-        globalThis.cancelIdleCallback(warmIdleHandle);
-      }
-      window.clearTimeout(warmTimer);
       observer?.disconnect();
       renderer.dispose();
       renderer.domElement.remove();


### PR DESCRIPTION
Controlled experiment for #856, starting from the exact post-#850 baseline restored by #855.

This changes one architectural variable only: CHASE YOUR BEST may still create its secondary WebGL context and load/build the exact saved `ghost: true` 6.4-unit rival model during the first lap, but it does **no shader compile and no renderer.render() while the onboarding subtree is `hidden` / `display:none`**.

At reveal:
- remove `hidden`
- cross one animation frame
- resize against the real host
- schedule the first actual WebGL render on the following frame, after the visible state is applied

Paint values, rival storage, ghost construction, cache machinery, `car-models.js`, semantic paint, camera, timing and layout are unchanged.

Also publishes a fresh `r275-visible-first-paint` module identity in TURN and TURN LAB, and updates regression/composition guards so the diagnostic lifecycle itself is explicit.

If PAINTJOB colour returns on Mobile Safari, that strongly confirms the hidden-GPU-prewarm boundary introduced in #637 as the trigger. If it remains factory-coloured, we can reject that hypothesis cleanly and continue from the restored baseline.