### PR TITLE
Diagnostic: render CHASE YOUR BEST paint pixels in Chromium and WebKit

### DIFF
--- a/.github/workflows/turn-supercar-lot-visual-smoke.yml
+++ b/.github/workflows/turn-supercar-lot-visual-smoke.yml
@@ -29,7 +29,9 @@ on:
       - 'turn/garage/lot-thumbnail-composition-r211.css'
       - 'turn/progression/trophy-road.js'
       - 'turn-lab/supercar-lot-visual.html'
+      - 'turn-lab/rival-paint-visual.html'
       - 'turn-tests/supercar-lot-visual-smoke.mjs'
+      - 'turn-tests/rival-paint-webgl-diagnostic.mjs'
       - '.github/workflows/turn-supercar-lot-visual-smoke.yml'
 
 concurrency:
@@ -42,7 +44,7 @@ permissions:
 jobs:
   visual-smoke:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -55,10 +57,10 @@ jobs:
       - name: Validate the authored Supercar wheel contract
         run: node turn-lab/tests/semantic-car-finish-production.mjs
 
-      - name: Install Playwright Chromium
+      - name: Install Playwright Chromium and WebKit
         run: |
           npm install --no-save playwright@1.55.0 pngjs@7.0.0
-          npx playwright install chromium
+          npx playwright install --with-deps chromium webkit
 
       - name: Start static TURN server
         run: |
@@ -73,11 +75,23 @@ jobs:
       - name: Render and validate the actual Lot preview
         run: node turn-tests/supercar-lot-visual-smoke.mjs
 
+      - name: Diagnose CHASE YOUR BEST semantic paint pixels
+        run: node turn-tests/rival-paint-webgl-diagnostic.mjs
+
       - name: Upload Supercar Lot inspection frames
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: supercar-lot-visual-smoke
           path: supercar-lot-visual-artifact
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload CHASE YOUR BEST paint diagnostic
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rival-paint-diagnostic
+          path: rival-paint-diagnostic-artifact
           if-no-files-found: warn
           retention-days: 7

--- a/turn-lab/rival-paint-car-models-probe.js
+++ b/turn-lab/rival-paint-car-models-probe.js
@@ -1,0 +1,40 @@
+import * as base from '/turn/vehicle/emergency-livery-models.js?revision=r223-training-car-taxi';
+
+export * from '/turn/vehicle/emergency-livery-models.js?revision=r223-training-car-taxi';
+
+function colorHex(value) {
+  if (!value) return null;
+  if (typeof value.getHexString === 'function') return `#${value.getHexString()}`;
+  return String(value);
+}
+
+function semanticRecords(visual) {
+  return (visual?.userData?.turnSemanticPaintRecords || []).map((record) => ({
+    nodeName: record.nodeName || '',
+    profileId: record.profileId || '',
+    primary: colorHex(record.primaryUniform?.value),
+    secondary: colorHex(record.secondaryUniform?.value),
+    hasPrimary: Boolean(record.primaryUniform),
+    hasSecondary: Boolean(record.secondaryUniform)
+  }));
+}
+
+export async function createCarVisual(options = {}) {
+  const visual = await base.createCarVisual(options);
+  const call = Object.freeze({
+    carId: options.carId,
+    color: options.color,
+    secondaryColor: options.secondaryColor,
+    ghost: options.ghost === true,
+    targetLength: options.targetLength,
+    visualColor: visual?.userData?.turnCarColor,
+    visualSecondaryColor: visual?.userData?.turnCarSecondaryColor,
+    visualGhost: visual?.userData?.turnGhost === true,
+    semanticRecords: semanticRecords(visual)
+  });
+  const calls = Array.isArray(globalThis.__rivalPaintCreateCalls)
+    ? globalThis.__rivalPaintCreateCalls
+    : [];
+  globalThis.__rivalPaintCreateCalls = [...calls, call];
+  return visual;
+}

--- a/turn-lab/rival-paint-visual.html
+++ b/turn-lab/rival-paint-visual.html
@@ -1,0 +1,187 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>TURN rival paint WebGL diagnostic</title>
+  <link rel="stylesheet" href="/turn/design-tokens.css">
+  <link rel="stylesheet" href="/turn/rival-onboarding.css">
+  <style>
+    html, body { margin: 0; min-height: 100%; background: #252a31; }
+    #hud { position: relative; width: 640px; height: 360px; overflow: hidden; }
+    #direct-host { width: 126px; height: 92px; }
+    #direct-host canvas { display: block; width: 100%; height: 100%; }
+  </style>
+  <script>
+    globalThis.__TURN_BUILD__ = Object.freeze({
+      version: '1.17.12',
+      id: '2026.09.09-r212',
+      cacheKey: '20260909-r212'
+    });
+  </script>
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
+        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
+        "/turn/vehicle/catalog.js": "/turn/vehicle/catalog.js?revision=r253-supercar-release",
+        "/turn/vehicle/catalog.js?build=20260720-r19": "/turn/vehicle/catalog.js?revision=r253-supercar-release",
+        "/turn/vehicle/semantic-car-finish.js": "/turn/vehicle/semantic-car-finish.js?revision=r223-training-car-taxi",
+        "/turn/vehicle/car-models.js": "/turn/vehicle/car-models.js?revision=r257-authored-wheel-spin",
+        "/turn/vehicle/car-models.js?build=20260720-r22": "/turn/vehicle/emergency-livery-models.js?revision=r223-training-car-taxi",
+        "/turn/vehicle/emergency-livery-models.js": "/turn/vehicle/emergency-livery-models.js?revision=r223-training-car-taxi",
+        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r253-supercar-release"
+      }
+    }
+  </script>
+</head>
+<body>
+  <div id="hud"></div>
+  <div id="direct-host"></div>
+  <script type="module">
+    import * as THREE from 'three';
+    import {
+      getVehicleDefaultColor,
+      getVehicleDefaultSecondaryColor,
+      makeGhostColor
+    } from '/turn/vehicle/catalog.js?build=20260720-r19';
+    import {
+      createCarVisual
+    } from '/turn/vehicle/car-models.js?build=20260720-r22';
+    import {
+      installRivalOnboarding
+    } from '/turn/ui/rival-onboarding.js?build=20260909-r212';
+
+    const params = new URLSearchParams(location.search);
+    const mode = params.get('mode') || 'onboarding';
+    const custom = params.get('paint') !== 'factory';
+    const carId = 'sedan';
+    const color = custom ? '#ff0000' : getVehicleDefaultColor(carId);
+    const secondaryColor = custom ? '#0000ff' : getVehicleDefaultSecondaryColor(carId);
+    const expectedGhostColor = makeGhostColor(color);
+    const expectedGhostSecondaryColor = makeGhostColor(secondaryColor);
+
+    globalThis.__rivalPaintDiagnosticReady = false;
+    globalThis.__rivalPaintDiagnosticFailure = null;
+    globalThis.__rivalPaintDiagnosticMetrics = null;
+
+    function fail(error) {
+      globalThis.__rivalPaintDiagnosticFailure = String(error?.stack || error?.message || error);
+    }
+
+    async function renderDirect(ghost) {
+      const host = document.querySelector('#direct-host');
+      document.querySelector('#hud').remove();
+      const scene = new THREE.Scene();
+      const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
+      renderer.outputColorSpace = THREE.SRGBColorSpace;
+      renderer.setPixelRatio(1);
+      renderer.setClearColor(0x000000, 0);
+      renderer.setSize(126, 92, false);
+      host.appendChild(renderer.domElement);
+
+      const camera = new THREE.PerspectiveCamera(34, 126 / 92, 0.1, 60);
+      camera.position.set(7.8, 4.8, 8.8);
+      camera.lookAt(0, 1.1, 0);
+      scene.add(new THREE.HemisphereLight(0xffffff, 0x5b6770, 3.2));
+      const key = new THREE.DirectionalLight(0xfff2c9, 4.2);
+      key.position.set(-6, 10, 7);
+      scene.add(key);
+
+      const stage = new THREE.Group();
+      stage.rotation.y = THREE.MathUtils.degToRad(200);
+      stage.rotation.x = 0.08;
+      scene.add(stage);
+
+      const visual = await createCarVisual({
+        carId,
+        color,
+        secondaryColor,
+        ghost,
+        targetLength: 6.4,
+        outline: true
+      });
+      stage.add(visual);
+      renderer.render(scene, camera);
+      globalThis.__rivalPaintDiagnosticMetrics = Object.freeze({
+        mode,
+        custom,
+        color,
+        secondaryColor,
+        expectedGhostColor,
+        expectedGhostSecondaryColor,
+        visualColor: visual.userData.turnCarColor,
+        visualSecondaryColor: visual.userData.turnCarSecondaryColor,
+        semanticRecordCount: visual.userData.turnSemanticPaintRecords?.length || 0,
+        canvasWidth: renderer.domElement.width,
+        canvasHeight: renderer.domElement.height
+      });
+      globalThis.__rivalPaintDiagnosticReady = true;
+    }
+
+    function runOnboarding() {
+      document.querySelector('#direct-host').remove();
+      const state = {
+        running: true,
+        vehicleId: carId,
+        vehicleColor: color,
+        vehicleSecondaryColor: secondaryColor,
+        competitorLaps: []
+      };
+      globalThis.__turnRuntime = { state };
+      installRivalOnboarding();
+      window.dispatchEvent(new CustomEvent('turn:ui-state-change', {
+        detail: { reason: 'race-started', running: true }
+      }));
+
+      globalThis.setTimeout(() => {
+        state.competitorLaps = [{
+          time: 12.34,
+          carId,
+          carColor: color,
+          carSecondaryColor: secondaryColor,
+          factoryPaint: !custom,
+          frames: Array.from({ length: 25 }, (_, index) => ({ t: index / 24, x: index, z: 0, h: 0 }))
+        }];
+        window.dispatchEvent(new CustomEvent('turn:ui-state-change', {
+          detail: { reason: 'lap-completed', running: true }
+        }));
+      }, 650);
+
+      const startedAt = performance.now();
+      const timer = globalThis.setInterval(() => {
+        const plate = document.querySelector('.rival-onboarding');
+        const canvas = plate?.querySelector('canvas');
+        if (plate?.classList.contains('is-visible') && canvas?.width > 0 && canvas?.height > 0) {
+          globalThis.clearInterval(timer);
+          globalThis.setTimeout(() => {
+            globalThis.__rivalPaintDiagnosticMetrics = Object.freeze({
+              mode,
+              custom,
+              color,
+              secondaryColor,
+              expectedGhostColor,
+              expectedGhostSecondaryColor,
+              pillColor: plate.style.getPropertyValue('--rival-onboarding-color'),
+              canvasWidth: canvas.width,
+              canvasHeight: canvas.height
+            });
+            globalThis.__rivalPaintDiagnosticReady = true;
+          }, 300);
+        } else if (performance.now() - startedAt > 12_000) {
+          globalThis.clearInterval(timer);
+          fail(new Error('Timed out waiting for CHASE YOUR BEST diagnostic reveal.'));
+        }
+      }, 50);
+    }
+
+    try {
+      if (mode === 'direct-ghost') void renderDirect(true).catch(fail);
+      else if (mode === 'direct-normal') void renderDirect(false).catch(fail);
+      else runOnboarding();
+    } catch (error) {
+      fail(error);
+    }
+  </script>
+</body>
+</html>

--- a/turn-lab/rival-paint-visual.html
+++ b/turn-lab/rival-paint-visual.html
@@ -28,7 +28,7 @@
         "/turn/vehicle/catalog.js?build=20260720-r19": "/turn/vehicle/catalog.js?revision=r253-supercar-release",
         "/turn/vehicle/semantic-car-finish.js": "/turn/vehicle/semantic-car-finish.js?revision=r223-training-car-taxi",
         "/turn/vehicle/car-models.js": "/turn/vehicle/car-models.js?revision=r257-authored-wheel-spin",
-        "/turn/vehicle/car-models.js?build=20260720-r22": "/turn/vehicle/emergency-livery-models.js?revision=r223-training-car-taxi",
+        "/turn/vehicle/car-models.js?build=20260720-r22": "/turn-lab/rival-paint-car-models-probe.js",
         "/turn/vehicle/emergency-livery-models.js": "/turn/vehicle/emergency-livery-models.js?revision=r223-training-car-taxi",
         "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r253-supercar-release"
       }
@@ -61,12 +61,17 @@
     const expectedGhostColor = makeGhostColor(color);
     const expectedGhostSecondaryColor = makeGhostColor(secondaryColor);
 
+    globalThis.__rivalPaintCreateCalls = [];
     globalThis.__rivalPaintDiagnosticReady = false;
     globalThis.__rivalPaintDiagnosticFailure = null;
     globalThis.__rivalPaintDiagnosticMetrics = null;
 
     function fail(error) {
       globalThis.__rivalPaintDiagnosticFailure = String(error?.stack || error?.message || error);
+    }
+
+    function createCalls() {
+      return [...(globalThis.__rivalPaintCreateCalls || [])];
     }
 
     async function renderDirect(ghost) {
@@ -113,6 +118,7 @@
         visualColor: visual.userData.turnCarColor,
         visualSecondaryColor: visual.userData.turnCarSecondaryColor,
         semanticRecordCount: visual.userData.turnSemanticPaintRecords?.length || 0,
+        createCalls: createCalls(),
         canvasWidth: renderer.domElement.width,
         canvasHeight: renderer.domElement.height
       });
@@ -163,6 +169,7 @@
               expectedGhostColor,
               expectedGhostSecondaryColor,
               pillColor: plate.style.getPropertyValue('--rival-onboarding-color'),
+              createCalls: createCalls(),
               canvasWidth: canvas.width,
               canvasHeight: canvas.height
             });

--- a/turn-tests/rival-paint-webgl-diagnostic.mjs
+++ b/turn-tests/rival-paint-webgl-diagnostic.mjs
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { chromium, webkit } from 'playwright';
+import { PNG } from 'pngjs';
+
+const baseUrl = process.env.TURN_VISUAL_BASE_URL || 'http://127.0.0.1:8000';
+const outputDir = process.env.TURN_RIVAL_PAINT_OUTPUT || 'rival-paint-diagnostic-artifact';
+await fs.mkdir(outputDir, { recursive: true });
+
+const cases = [
+  { mode: 'direct-normal', paint: 'custom' },
+  { mode: 'direct-ghost', paint: 'custom' },
+  { mode: 'direct-ghost', paint: 'factory' },
+  { mode: 'onboarding', paint: 'custom' },
+  { mode: 'onboarding', paint: 'factory' }
+];
+
+const browserTypes = [
+  ['chromium', chromium],
+  ['webkit', webkit]
+];
+const report = {};
+
+for (const [browserName, browserType] of browserTypes) {
+  const launchOptions = browserName === 'chromium'
+    ? { headless: true, args: ['--use-gl=angle', '--use-angle=swiftshader', '--enable-webgl', '--ignore-gpu-blocklist'] }
+    : { headless: true };
+  const browser = await browserType.launch(launchOptions);
+  const context = await browser.newContext({
+    viewport: { width: 640, height: 360 },
+    deviceScaleFactor: 1,
+    reducedMotion: 'reduce'
+  });
+  const results = {};
+
+  try {
+    for (const diagnosticCase of cases) {
+      const page = await context.newPage();
+      const browserErrors = [];
+      page.on('pageerror', (error) => browserErrors.push(`pageerror: ${error.message}`));
+      page.on('console', (message) => {
+        if (message.type() === 'error') browserErrors.push(`console error: ${message.text()}`);
+      });
+
+      const key = `${diagnosticCase.mode}-${diagnosticCase.paint}`;
+      let failure = null;
+      let metrics = null;
+      let pixels = null;
+      try {
+        const response = await page.goto(
+          `${baseUrl}/turn-lab/rival-paint-visual.html?mode=${diagnosticCase.mode}&paint=${diagnosticCase.paint}`,
+          { waitUntil: 'domcontentloaded', timeout: 90_000 }
+        );
+        assert.equal(response?.ok(), true, `${browserName} ${key} fixture must load`);
+        await page.waitForFunction(
+          () => globalThis.__rivalPaintDiagnosticReady === true || Boolean(globalThis.__rivalPaintDiagnosticFailure),
+          null,
+          { timeout: 20_000 }
+        );
+        failure = await page.evaluate(() => globalThis.__rivalPaintDiagnosticFailure || null);
+        metrics = await page.evaluate(() => globalThis.__rivalPaintDiagnosticMetrics || null);
+        if (!failure) {
+          const selector = diagnosticCase.mode === 'onboarding'
+            ? '.rival-onboarding-model canvas'
+            : '#direct-host canvas';
+          const canvas = page.locator(selector);
+          const image = await canvas.screenshot({
+            path: path.join(outputDir, `${browserName}-${key}.png`)
+          });
+          pixels = pixelMetrics(image);
+        } else {
+          await page.screenshot({
+            path: path.join(outputDir, `${browserName}-${key}-failure.png`),
+            fullPage: true
+          }).catch(() => {});
+        }
+      } catch (error) {
+        failure = String(error?.stack || error?.message || error);
+        await page.screenshot({
+          path: path.join(outputDir, `${browserName}-${key}-exception.png`),
+          fullPage: true
+        }).catch(() => {});
+      } finally {
+        await page.close();
+      }
+
+      results[key] = { metrics, pixels, browserErrors, failure };
+    }
+  } finally {
+    await browser.close();
+  }
+
+  const directCustom = results['direct-normal-custom'];
+  const ghostCustom = results['direct-ghost-custom'];
+  const ghostFactory = results['direct-ghost-factory'];
+  const onboardingCustom = results['onboarding-custom'];
+  const onboardingFactory = results['onboarding-factory'];
+
+  for (const [key, result] of Object.entries(results)) {
+    assert.equal(result.failure, null, `${browserName} ${key} failed: ${result.failure}`);
+    assert.equal(result.browserErrors.length, 0, `${browserName} ${key} browser errors: ${result.browserErrors.join('\n')}`);
+    assert.ok(result.pixels?.opaque > 0, `${browserName} ${key} must produce pixels`);
+  }
+
+  assert.equal(directCustom.metrics?.visualColor, '#ff0000', `${browserName} direct visual must retain custom body data`);
+  assert.equal(ghostCustom.metrics?.visualColor, '#ff0000', `${browserName} ghost visual must retain custom body data`);
+  assert.ok(directCustom.metrics?.semanticRecordCount > 0, `${browserName} direct custom visual must install semantic paint records`);
+  assert.ok(ghostCustom.metrics?.semanticRecordCount > 0, `${browserName} custom ghost must install semantic paint records`);
+
+  const classification = {
+    directNormalCustomRed: directCustom.pixels.redDominant,
+    directGhostCustomRed: ghostCustom.pixels.redDominant,
+    directGhostFactoryRed: ghostFactory.pixels.redDominant,
+    onboardingCustomRed: onboardingCustom.pixels.redDominant,
+    onboardingFactoryRed: onboardingFactory.pixels.redDominant,
+    directGhostPaintVisible: ghostCustom.pixels.redDominant > ghostFactory.pixels.redDominant + 12,
+    onboardingPaintVisible: onboardingCustom.pixels.redDominant > onboardingFactory.pixels.redDominant + 12,
+    onboardingPillCarriesCustomPaint:
+      onboardingCustom.metrics?.pillColor === onboardingCustom.metrics?.expectedGhostColor
+  };
+
+  report[browserName] = { results, classification };
+  console.log(`${browserName}: ${JSON.stringify(classification)}`);
+}
+
+await fs.writeFile(path.join(outputDir, 'report.json'), `${JSON.stringify(report, null, 2)}\n`);
+console.log('TURN CHASE YOUR BEST paint diagnostic completed; see report.json and rendered canvases.');
+
+function pixelMetrics(buffer) {
+  const image = PNG.sync.read(buffer);
+  let opaque = 0;
+  let redDominant = 0;
+  let blueDominant = 0;
+  let tealDominant = 0;
+  for (let offset = 0; offset < image.data.length; offset += 4) {
+    const r = image.data[offset];
+    const g = image.data[offset + 1];
+    const b = image.data[offset + 2];
+    const a = image.data[offset + 3];
+    if (a < 16) continue;
+    opaque += 1;
+    if (r > 115 && r > g * 1.16 && r > b * 1.16) redDominant += 1;
+    if (b > 115 && b > r * 1.16 && b > g * 1.16) blueDominant += 1;
+    if (g > r * 1.08 && b > r * 1.08 && Math.abs(g - b) < 45) tealDominant += 1;
+  }
+  return { width: image.width, height: image.height, opaque, redDominant, blueDominant, tealDominant };
+}


### PR DESCRIPTION
Non-production diagnostic for #856. Do not merge as a feature/fix.

Current `main` has already been restored to the exact post-#850 tree via #858. This branch adds an isolated render fixture and browser-pixel diagnostic only.

The diagnostic renders the same Sedan PAINTJOB (`#ff0000` body / `#0000ff` secondary) through three paths:
- fresh non-ghost `createCarVisual`
- fresh `ghost: true` `createCarVisual`
- the real `installRivalOnboarding()` zero-to-one CHASE YOUR BEST lifecycle

It also renders factory ghost controls, records semantic-paint metadata and the CHASE pill colour, screenshots each canvas, and counts red-dominant pixels. The same matrix runs in Playwright Chromium and WebKit. This should tell us whether the failure is in the ghost semantic material generally, in the onboarding component specifically, or only in physical iOS Safari.

No `turn/*` production source or release identity is changed.