### PR TITLE
Fix CHASE YOUR BEST PAINTJOB double normalization

### DIFF
--- a/.github/workflows/turn-supercar-lot-visual-smoke.yml
+++ b/.github/workflows/turn-supercar-lot-visual-smoke.yml
@@ -17,6 +17,8 @@ on:
       - 'turn/assets/cars/training-car.glb'
       - 'turn/design-tokens.css'
       - 'turn/styles.css'
+      - 'turn/rival-onboarding.css'
+      - 'turn/ui/rival-onboarding.js'
       - 'turn/garage/lot-info-panel-r212.css'
       - 'turn/garage/lot-info-typography-r213.css'
       - 'turn/garage/lot-layout-r60.css'
@@ -75,7 +77,7 @@ jobs:
       - name: Render and validate the actual Lot preview
         run: node turn-tests/supercar-lot-visual-smoke.mjs
 
-      - name: Diagnose CHASE YOUR BEST semantic paint pixels
+      - name: Validate CHASE YOUR BEST custom paint pixels
         run: node turn-tests/rival-paint-webgl-diagnostic.mjs
 
       - name: Upload Supercar Lot inspection frames

--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -126,7 +126,7 @@
         "/turn/ui/shift-feedback.js?revision=r232-double-shift": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/ui/shift-feedback.js?revision=r253-supercar-release": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/render/covered-rendering.js?build=20260909-r212": "/turn/render/covered-rendering.js?build=20260909-r212&revision=r164-long-session-robustness",
-        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r253-supercar-release",
+        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r276-rival-paint-normalization",
         "/turn/progression/lot-paint-reward.js?revision=r206-pwa-color": "/turn/progression/lot-paint-reward.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r206-race-before-locks": "/turn/garage/lot-showroom-experiment.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r252-supercar-outward-rims": "/turn/garage/lot-showroom-track-icon.js?revision=r2-swift-lot-ui",

--- a/turn-lab/rival-paint-visual.html
+++ b/turn-lab/rival-paint-visual.html
@@ -30,7 +30,7 @@
         "/turn/vehicle/car-models.js": "/turn/vehicle/car-models.js?revision=r257-authored-wheel-spin",
         "/turn/vehicle/car-models.js?build=20260720-r22": "/turn-lab/rival-paint-car-models-probe.js",
         "/turn/vehicle/emergency-livery-models.js": "/turn/vehicle/emergency-livery-models.js?revision=r223-training-car-taxi",
-        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r253-supercar-release"
+        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r276-rival-paint-normalization"
       }
     }
   </script>

--- a/turn-lab/tests/lap-result-toast-production.mjs
+++ b/turn-lab/tests/lap-result-toast-production.mjs
@@ -259,8 +259,8 @@ assert.match(index, new RegExp(`lap-result-toast\\.css\\?build=${release.cacheKe
 assert.match(index, new RegExp(`rival-onboarding\\.css\\?build=${release.cacheKey}`));
 assert.equal(
   imports[`/turn/ui/rival-onboarding.js?build=${release.cacheKey}`],
-  `/turn/ui/rival-onboarding.js?build=${release.cacheKey}&revision=r253-supercar-release`,
-  'Installed PWAs must refetch the prewarmed CHASE YOUR BEST runtime'
+  `/turn/ui/rival-onboarding.js?build=${release.cacheKey}&revision=r276-rival-paint-normalization`,
+  'Installed PWAs must refetch the single-normalization CHASE YOUR BEST runtime'
 );
 assert.ok(
   imports['./race/lap-system.js?build=20260720-r19']?.startsWith(`./race/lap-system-r86.js?build=${release.cacheKey}`),
@@ -323,6 +323,10 @@ assert.match(onboarding, /!hadRival && hasRival\) schedule\(rivals\[0\]\)/, 'The
 assert.match(onboarding, /source\.carId \|\| source\.vehicleId/, 'The prepared preview must use the selected model and confirm it against the saved ghost model');
 assert.match(onboarding, /source\.carColor \|\| source\.vehicleColor/, 'The prepared preview must use the selected body paint and confirm it against saved ghost paint');
 assert.match(onboarding, /source\.carSecondaryColor \|\| source\.vehicleSecondaryColor/, 'The prepared preview must preserve selected and saved secondary paint');
+assert.match(onboarding, /preparePreview\(rival\)/,
+  'The saved rival contract must enter preview preparation before normalization');
+assert.doesNotMatch(onboarding, /preparePreview\(normalized\)/,
+  'An already-normalized preview object must never be normalized again and fall back to factory paint');
 assert.match(onboarding, /ghost: true/, 'The onboarding model must use the same lighter solid ghost treatment as race rivals');
 assert.match(onboarding, /targetLength: 6\.4/, 'The onboarding model must use the Lot 3D viewer presentation scale');
 assert.match(onboarding, /PerspectiveCamera\(34, 1, 0\.1, 60\)/, 'The onboarding model must reuse the Lot viewer camera language');

--- a/turn-tests/release-composition-production.mjs
+++ b/turn-tests/release-composition-production.mjs
@@ -386,8 +386,8 @@ const rivalRoute = Object.entries(headGraph.importMap.imports || {}).find(([spec
   /^\/turn\/ui\/rival-onboarding\.js\?build=\d{8}-r\d+$/.test(specifier)
 );
 assert.ok(rivalRoute, 'Production TURN must retain the release-bound rival onboarding route');
-assert.match(rivalRoute[1], /[?&]revision=r253-supercar-release(?:&|$)/,
-  'Rival onboarding must use the current release graph instead of its pre-SUPERCAR identity');
+assert.match(rivalRoute[1], /[?&]revision=r276-rival-paint-normalization(?:&|$)/,
+  'Rival onboarding must use the single-normalization PAINTJOB identity');
 
 const workflows = Object.fromEntries(workflowEntries);
 for (const [workflowPath, source] of Object.entries(workflows)) {
@@ -449,6 +449,8 @@ for (const dependency of [
   'turn/vehicle/catalog.js',
   'turn/vehicle/learner-car-livery.js',
   'turn/vehicle/wide-gamut.js',
+  'turn/ui/rival-onboarding.js',
+  'turn/rival-onboarding.css',
   'turn/garage/lot-saved-paint.js',
   'turn/garage/lot-showroom-experiment.css',
   'turn/progression/trophy-road.js'

--- a/turn-tests/rival-paint-webgl-diagnostic.mjs
+++ b/turn-tests/rival-paint-webgl-diagnostic.mjs
@@ -108,6 +108,14 @@ for (const [browserName, browserType] of browserTypes) {
   assert.ok(directCustom.metrics?.semanticRecordCount > 0, `${browserName} direct custom visual must install semantic paint records`);
   assert.ok(ghostCustom.metrics?.semanticRecordCount > 0, `${browserName} custom ghost must install semantic paint records`);
 
+  const customCreateCalls = onboardingCustom.metrics?.createCalls || [];
+  assert.equal(customCreateCalls.length, 1,
+    `${browserName} CHASE YOUR BEST must not replace the prepared custom rival with a second factory-colour preview`);
+  assert.equal(customCreateCalls[0]?.color, '#ff0000',
+    `${browserName} CHASE YOUR BEST must construct the saved custom body colour`);
+  assert.equal(customCreateCalls[0]?.secondaryColor, '#0000ff',
+    `${browserName} CHASE YOUR BEST must construct the saved custom secondary colour`);
+
   const classification = {
     directNormalCustomRed: directCustom.pixels.redDominant,
     directGhostCustomRed: ghostCustom.pixels.redDominant,
@@ -115,17 +123,24 @@ for (const [browserName, browserType] of browserTypes) {
     onboardingCustomRed: onboardingCustom.pixels.redDominant,
     onboardingFactoryRed: onboardingFactory.pixels.redDominant,
     directGhostPaintVisible: ghostCustom.pixels.redDominant > ghostFactory.pixels.redDominant + 12,
-    onboardingPaintVisible: onboardingCustom.pixels.redDominant > onboardingFactory.pixels.redDominant + 12,
+    onboardingPaintVisible: onboardingCustom.pixels.redDominant > onboardingFactory.pixels.redDominant + 100,
     onboardingPillCarriesCustomPaint:
       onboardingCustom.metrics?.pillColor === onboardingCustom.metrics?.expectedGhostColor
   };
+
+  assert.equal(classification.directGhostPaintVisible, true,
+    `${browserName} direct ghost control must visibly render its custom paint`);
+  assert.equal(classification.onboardingPaintVisible, true,
+    `${browserName} CHASE YOUR BEST must visibly render the saved custom paint instead of factory paint`);
+  assert.equal(classification.onboardingPillCarriesCustomPaint, true,
+    `${browserName} CHASE YOUR BEST pill must stay coupled to the saved custom paint`);
 
   report[browserName] = { results, classification };
   console.log(`${browserName}: ${JSON.stringify(classification)}`);
 }
 
 await fs.writeFile(path.join(outputDir, 'report.json'), `${JSON.stringify(report, null, 2)}\n`);
-console.log('TURN CHASE YOUR BEST paint diagnostic completed; see report.json and rendered canvases.');
+console.log('TURN CHASE YOUR BEST custom-paint browser regression passed in Chromium and WebKit.');
 
 function pixelMetrics(buffer) {
   const image = PNG.sync.read(buffer);

--- a/turn/index.html
+++ b/turn/index.html
@@ -137,7 +137,7 @@
         "/turn/ui/shift-feedback.js?revision=r232-double-shift": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/ui/shift-feedback.js?revision=r253-supercar-release": "/turn/ui/shift-feedback.js?revision=r255-flow-shift-accessibility",
         "/turn/render/covered-rendering.js?build=20260909-r212": "/turn/render/covered-rendering.js?build=20260909-r212&revision=r164-long-session-robustness",
-        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r253-supercar-release",
+        "/turn/ui/rival-onboarding.js?build=20260909-r212": "/turn/ui/rival-onboarding.js?build=20260909-r212&revision=r276-rival-paint-normalization",
         "/turn/progression/lot-paint-reward.js?revision=r206-pwa-color": "/turn/progression/lot-paint-reward.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r206-race-before-locks": "/turn/garage/lot-showroom-experiment.js?revision=r243-mountain-1300",
         "/turn/garage/lot-showroom-experiment.js?revision=r252-supercar-outward-rims": "/turn/garage/lot-showroom-track-icon.js?revision=r2-swift-lot-ui",

--- a/turn/ui/rival-onboarding.js
+++ b/turn/ui/rival-onboarding.js
@@ -202,8 +202,10 @@ export function installRivalOnboarding() {
     plate.style.setProperty('--rival-onboarding-color', makeGhostColor(normalized.color));
     // Normally this is already the exact preview prepared at race-started. If the
     // saved rival differs for any reason, prepare the corrected model without making
-    // the reveal wait for it.
-    preparePreview(normalized);
+    // the reveal wait for it. Pass the saved rival contract itself; preparePreview()
+    // owns normalization, so an already-normalized { color, secondaryColor } object
+    // must not be normalized a second time and fall back to factory paint.
+    preparePreview(rival);
 
     showTimer = window.setTimeout(() => {
       showTimer = 0;


### PR DESCRIPTION
## Root cause

#859's browser probe showed that CHASE YOUR BEST created the correct custom-painted ghost first, then replaced it with a second factory-painted preview. `schedule(rival)` normalized the saved rival and passed that already-normalized `{ carId, color, secondaryColor }` object into `preparePreview()`, which normalized it again using the saved/state field names (`carColor` / `vehicleColor`). That second pass therefore fell back to factory paint.

## Fix

- pass the saved rival contract directly from `schedule()` to `preparePreview()` so normalization has a single owner
- keep the existing canonical `ghost: true`, 6.4-unit renderer/shader/warmup path unchanged
- refresh TURN and TURN LAB's active rival-onboarding identity
- convert #859's Chromium/WebKit pixel diagnostic into a failing regression: custom onboarding must create one custom-painted visual and its rendered pixels must differ materially from factory paint
- make that pixel regression run automatically whenever rival-onboarding JS/CSS changes
- add static guards against reintroducing `preparePreview(normalized)`

No storage, PAINTJOB, car-model, ghost-cache, shader, physics, timing or handling logic is changed.

Closes #856 once verified and merged.