### PR TITLE
Group achievement filters and add SCORING

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -264,7 +264,7 @@
   <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260909-r212-r534-heading-first-about-r224-modal-headings"></script>
   <script src="./ui/startup-screen-reader-handoff-r529.js?build=20260909-r212&revision=r531-screen-reader-followup"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r243-mountain-1300"></script>
-  <script type="module" src="./app.js?build=20260909-r212-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r420-music-warm-r426-loading-copy-r164-long-session-robustness-post-soak-r199-card-gap-rim-r518-landmark-framing-ground-layering-showroom-r200-pwa-color-r206-r532-countryside-nature-r221-trajectory-wheel-steering-30-r220-race-apex-guide-r224-modal-headings"></script>
+  <script type="module" src="./app.js?build=20260909-r212-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r420-music-warm-r426-loading-copy-r164-long-session-robustness-post-soak-r199-card-gap-rim-r518-landmark-framing-ground-layering-showroom-r200-pwa-color-r206-r532-countryside-nature-r221-trajectory-wheel-steering-30-r220-race-apex-guide-r224-modal-headings-r254-achievement-filter-rows"></script>
   <script type="module" src="./render/skid-continuity-r198.js?revision=r198-skid-continuity"></script>
   <script type="module" src="./tracks/cliffside-inner-buildings-r202.js?revision=r202-kenney-suburban-village"></script>
   <script type="module" src="./tracks/cliffside-house-inset-r203.js?revision=r203-inset-edge-houses"></script>

--- a/turn-tests/startup-and-unread-production.mjs
+++ b/turn-tests/startup-and-unread-production.mjs
@@ -80,7 +80,7 @@ assert.doesNotMatch(screenReaderCoordinator, /speak\(`\$\{readyMessage\} \$\{NON
   'The old portrait-ready plus onboarding utterance must not return');
 
 assert.match(fixedLayout, /achievements\/unread-markers\.js\?build=\$\{buildKey\}-r219-unified-filters/);
-assert.match(fixedLayout, /achievements\/trophy-road-feedback\.js\?build=\$\{buildKey\}-r244-reward-toast-guide/);
+assert.match(fixedLayout, /achievements\/trophy-road-feedback\.js\?build=\$\{buildKey\}-r254-achievement-filter-rows/);
 assert.match(fixedLayout, /installAchievementUnreadMarkers\(achievements\)/);
 assert.match(fixedLayout, /achievementUnreadMarkers,/);
 assert.match(fixedLayout, /function installDriveByEarSpokenLabels\(training\)/);
@@ -95,12 +95,24 @@ assert.match(unreadMarkers, /new MutationObserver\(queueDecoration\)/);
 assert.match(unreadMarkers, /listObserver\.observe\(list, \{ childList: true \}\)/);
 assert.doesNotMatch(unreadMarkers, /function installFilterButtons|function handleFilterClick/,
   'Unread decoration must not install a second competing achievement-filter controller');
-assert.match(trophyRoadFeedback, /Object\.freeze\(\{ id: 'hidden', label: 'HIDDEN' \}\)/,
+assert.match(trophyRoadFeedback, /Object\.freeze\(\{ id: 'hidden', label: 'HIDDEN', kind: 'tag' \}\)/,
   'Achievements must expose a dedicated Hidden filter');
-assert.match(trophyRoadFeedback, /Object\.freeze\(\{ id: 'new', label: 'NEW' \}\)/,
+assert.match(trophyRoadFeedback, /Object\.freeze\(\{ id: 'new', label: 'NEW', kind: 'tag' \}\)/,
   'Achievements must always expose a New filter');
-assert.match(trophyRoadFeedback, /Object\.freeze\(\{ id: 'locked', label: 'LOCKED' \}\)/,
+assert.match(trophyRoadFeedback, /Object\.freeze\(\{ id: 'locked', label: 'LOCKED', kind: 'status' \}\)/,
   'The existing Locked filter must remain available alongside the composable tags');
+assert.match(trophyRoadFeedback, /Object\.freeze\(\{ id: CATEGORY\.SCORING, label: 'SCORING', kind: 'tag' \}\)/,
+  'Achievements must expose a dedicated Scoring filter');
+assert.match(trophyRoadFeedback, /id: 'meta'[\s\S]*label: 'ALL'[\s\S]*label: 'NEW'[\s\S]*label: 'UNLOCKED'[\s\S]*label: 'LOCKED'/,
+  'Meta achievement filters must stay together on the first row');
+assert.match(trophyRoadFeedback, /id: 'general'[\s\S]*label: 'GETTING STARTED'[\s\S]*label: 'WAYS TO PLAY'[\s\S]*label: 'EXPLORATION'[\s\S]*label: 'HIDDEN'/,
+  'General achievement categories must stay together on the second row');
+assert.match(trophyRoadFeedback, /id: 'competition'[\s\S]*label: 'RACING'[\s\S]*label: 'TIME TRIALS'[\s\S]*label: 'SCORING'/,
+  'Racing, Time Trials and Scoring must stay together on the third row');
+assert.match(trophyRoadFeedback, /row\.className = 'turn-achievements-filter-row'/,
+  'Achievement filter rows must be explicit DOM groups');
+assert.match(trophyRoadFeedback, /\.turn-achievements-filters \{[\s\S]*display: grid;[\s\S]*\.turn-achievements-filter-row \{[\s\S]*display: flex;/,
+  'Achievement filter groups must render as separate rows while preserving pill wrapping within each row');
 assert.doesNotMatch(trophyRoadFeedback, /newButton\.hidden\s*=/,
   'NEW must stay visible in the filter row even when there is nothing new');
 assert.match(trophyRoadFeedback, /newButton\.disabled = !available/,

--- a/turn/achievements/trophy-road-feedback.js
+++ b/turn/achievements/trophy-road-feedback.js
@@ -8,19 +8,40 @@ import {
   getTrophyRoadReward
 } from '../progression/trophy-road.js?revision=r253-supercar-release';
 
-const TAG_FILTERS = Object.freeze([
-  Object.freeze({ id: 'new', label: 'NEW' }),
-  Object.freeze({ id: CATEGORY.ONBOARDING, label: 'GETTING STARTED' }),
-  Object.freeze({ id: CATEGORY.WAYS_TO_PLAY, label: 'WAYS TO PLAY' }),
-  Object.freeze({ id: CATEGORY.EXPLORATION, label: 'EXPLORATION' }),
-  Object.freeze({ id: CATEGORY.RACING, label: 'RACING' }),
-  Object.freeze({ id: CATEGORY.TIME_TRIALS, label: 'TIME TRIALS' }),
-  Object.freeze({ id: 'hidden', label: 'HIDDEN' })
+const FILTER_ROWS = Object.freeze([
+  Object.freeze({
+    id: 'meta',
+    label: 'Achievement state and newness',
+    filters: Object.freeze([
+      Object.freeze({ id: 'all', label: 'ALL', kind: 'all' }),
+      Object.freeze({ id: 'new', label: 'NEW', kind: 'tag' }),
+      Object.freeze({ id: 'unlocked', label: 'UNLOCKED', kind: 'status' }),
+      Object.freeze({ id: 'locked', label: 'LOCKED', kind: 'status' })
+    ])
+  }),
+  Object.freeze({
+    id: 'general',
+    label: 'General achievement categories',
+    filters: Object.freeze([
+      Object.freeze({ id: CATEGORY.ONBOARDING, label: 'GETTING STARTED', kind: 'tag' }),
+      Object.freeze({ id: CATEGORY.WAYS_TO_PLAY, label: 'WAYS TO PLAY', kind: 'tag' }),
+      Object.freeze({ id: CATEGORY.EXPLORATION, label: 'EXPLORATION', kind: 'tag' }),
+      Object.freeze({ id: 'hidden', label: 'HIDDEN', kind: 'tag' })
+    ])
+  }),
+  Object.freeze({
+    id: 'competition',
+    label: 'Racing and scoring achievement categories',
+    filters: Object.freeze([
+      Object.freeze({ id: CATEGORY.RACING, label: 'RACING', kind: 'tag' }),
+      Object.freeze({ id: CATEGORY.TIME_TRIALS, label: 'TIME TRIALS', kind: 'tag' }),
+      Object.freeze({ id: CATEGORY.SCORING, label: 'SCORING', kind: 'tag' })
+    ])
+  })
 ]);
-const STATUS_FILTERS = Object.freeze([
-  Object.freeze({ id: 'unlocked', label: 'UNLOCKED' }),
-  Object.freeze({ id: 'locked', label: 'LOCKED' })
-]);
+const FILTERS = Object.freeze(FILTER_ROWS.flatMap(({ filters }) => filters));
+const TAG_FILTERS = Object.freeze(FILTERS.filter(({ kind }) => kind === 'tag'));
+const STATUS_FILTERS = Object.freeze(FILTERS.filter(({ kind }) => kind === 'status'));
 let installed = null;
 
 function ensureFeedbackStylesheet() {
@@ -29,7 +50,7 @@ function ensureFeedbackStylesheet() {
   if (!stylesheet) {
     stylesheet = document.createElement('link');
     stylesheet.rel = 'stylesheet';
-    stylesheet.href = `/turn/progression/trophy-road-r157.css?build=${buildKey}-r244-reward-toast-guide`;
+    stylesheet.href = `/turn/progression/trophy-road-r157.css?build=${buildKey}-r254-achievement-filter-rows`;
     stylesheet.setAttribute('data-turn-trophy-road-feedback', '');
   }
   document.head.appendChild(stylesheet);
@@ -42,6 +63,18 @@ function makeFilterButton(id, label, pressed = false) {
   button.setAttribute('aria-pressed', String(pressed));
   button.textContent = label;
   return button;
+}
+
+function makeFilterRow({ id, label, filters }) {
+  const row = document.createElement('div');
+  row.className = 'turn-achievements-filter-row';
+  row.dataset.achievementFilterRow = id;
+  row.setAttribute('role', 'group');
+  row.setAttribute('aria-label', label);
+  row.append(...filters.map(({ id: filterId, label: filterLabel, kind }) => (
+    makeFilterButton(filterId, filterLabel, kind === 'all')
+  )));
+  return row;
 }
 
 function prepareSummary(dialog) {
@@ -73,11 +106,7 @@ function prepareFilters(dialog) {
   const container = dialog.querySelector('.turn-achievements-filters');
   if (!container) return null;
   container.setAttribute('aria-label', 'Achievement filters. Choose one or more.');
-  container.replaceChildren(
-    makeFilterButton('all', 'ALL', true),
-    ...TAG_FILTERS.map(({ id, label }) => makeFilterButton(id, label)),
-    ...STATUS_FILTERS.map(({ id, label }) => makeFilterButton(id, label))
-  );
+  container.replaceChildren(...FILTER_ROWS.map(makeFilterRow));
 
   const tagIds = new Set(TAG_FILTERS.map(({ id }) => id));
   const statusIds = new Set(STATUS_FILTERS.map(({ id }) => id));

--- a/turn/achievements/trophy-road-feedback.js
+++ b/turn/achievements/trophy-road-feedback.js
@@ -8,6 +8,7 @@ import {
   getTrophyRoadReward
 } from '../progression/trophy-road.js?revision=r253-supercar-release';
 
+const FILTER_STYLE_ID = 'turn-achievement-filter-row-styles';
 const FILTER_ROWS = Object.freeze([
   Object.freeze({
     id: 'meta',
@@ -50,10 +51,29 @@ function ensureFeedbackStylesheet() {
   if (!stylesheet) {
     stylesheet = document.createElement('link');
     stylesheet.rel = 'stylesheet';
-    stylesheet.href = `/turn/progression/trophy-road-r157.css?build=${buildKey}-r254-achievement-filter-rows`;
+    stylesheet.href = `/turn/progression/trophy-road-r157.css?build=${buildKey}-r244-reward-toast-guide`;
     stylesheet.setAttribute('data-turn-trophy-road-feedback', '');
   }
   document.head.appendChild(stylesheet);
+}
+
+function ensureFilterStyles() {
+  if (document.getElementById(FILTER_STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = FILTER_STYLE_ID;
+  style.textContent = `
+    .turn-achievements-filters {
+      display: grid;
+      gap: 9px;
+    }
+    .turn-achievements-filter-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 9px;
+      align-items: center;
+    }
+  `;
+  document.head.appendChild(style);
 }
 
 function makeFilterButton(id, label, pressed = false) {
@@ -319,6 +339,7 @@ function installRoadBehavior({ achievements, summary }) {
 export function installTrophyRoadFeedback(achievements = globalThis.__turnAchievements) {
   if (installed) return installed;
   ensureFeedbackStylesheet();
+  ensureFilterStyles();
   const dialog = achievements?.dialog;
   if (!dialog || !achievements.store) return null;
 

--- a/turn/app.js
+++ b/turn/app.js
@@ -383,7 +383,7 @@ if (buildLabel) {
 // Historical clean record-layout cache marker:
 // m8-home-fixed-layout.js?revision=r217-track-record-layout&trophy-road=r159&achievements=r166-bella-records&bella-rescue=r174-siren-zone&music=warm-v2&robustness=r164-long-session
 const { installM8HomeFixedLayout } = await import(
-  withBuild('./m8-home-fixed-layout.js?revision=r218-track-record-breathing&trophy-road=r159&achievements=r166-bella-records&bella-rescue=r174-siren-zone&music=warm-v2&robustness=r164-long-session')
+  withBuild('./m8-home-fixed-layout.js?revision=r218-track-record-breathing&trophy-road=r159&achievements=r166-bella-records&achievement-filters=r254&bella-rescue=r174-siren-zone&music=warm-v2&robustness=r164-long-session')
 );
 await installM8HomeFixedLayout();
 installStylesheet(

--- a/turn/index.html
+++ b/turn/index.html
@@ -261,7 +261,7 @@
   <script type="module" src="./ui/about-history-bootstrap-r165.js?build=20260909-r212-r534-heading-first-about-r224-modal-headings"></script>
   <script src="./ui/startup-screen-reader-handoff-r529.js?build=20260909-r212&revision=r531-screen-reader-followup"></script>
   <script type="module" src="./testing/admin-unlock-sequence.js?revision=r243-mountain-1300"></script>
-  <script type="module" src="./app.js?build=20260909-r212-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r420-music-warm-r426-loading-copy-r164-long-session-robustness-post-soak-r199-card-gap-rim-r518-landmark-framing-ground-layering-showroom-r200-pwa-color-r206-r532-countryside-nature-r221-trajectory-wheel-steering-30-r220-race-apex-guide-r224-modal-headings"></script>
+  <script type="module" src="./app.js?build=20260909-r212-browser-consent-r176-bella-road-derived-zone-voiceover-paint-parent-click-r420-music-warm-r426-loading-copy-r164-long-session-robustness-post-soak-r199-card-gap-rim-r518-landmark-framing-ground-layering-showroom-r200-pwa-color-r206-r532-countryside-nature-r221-trajectory-wheel-steering-30-r220-race-apex-guide-r224-modal-headings-r254-achievement-filter-rows"></script>
   <script type="module" src="./render/skid-continuity-r198.js?revision=r198-skid-continuity"></script>
   <script type="module" src="./tracks/cliffside-inner-buildings-r202.js?revision=r202-kenney-suburban-village"></script>
   <script type="module" src="./tracks/cliffside-house-inset-r203.js?revision=r203-inset-edge-houses"></script>

--- a/turn/m8-home-fixed-layout.js
+++ b/turn/m8-home-fixed-layout.js
@@ -275,7 +275,7 @@ export async function installM8HomeFixedLayout() {
     import(`/turn/achievements/unread-markers.js?build=${buildKey}-r219-unified-filters`),
     import(`/turn/achievements/secret-achievements.js?build=${buildKey}-r174-bella-siren-zone`),
     import(`/turn/achievements/challenge-expansion-r166.js?build=${buildKey}-r166-bella-records`),
-    import(`/turn/achievements/trophy-road-feedback.js?build=${buildKey}-r244-reward-toast-guide&robustness=r164-long-session`),
+    import(`/turn/achievements/trophy-road-feedback.js?build=${buildKey}-r254-achievement-filter-rows&robustness=r164-long-session`),
     import(`/turn/training/drive-by-ear-training.js?build=${buildKey}-r151-dbe-training-device-fixes`)
   ]);
 


### PR DESCRIPTION
Implements the new three-row Achievements filter layout from the mockup:

- row 1: ALL, NEW, UNLOCKED, LOCKED
- row 2: GETTING STARTED, WAYS TO PLAY, EXPLORATION, HIDDEN
- row 3: RACING, TIME TRIALS, SCORING
- adds the missing SCORING filter without changing the existing composable filter behaviour
- keeps each row as an explicit accessible group while allowing pills to wrap within a row on narrow viewports
- cache-busts the updated filter controller and extends the production regression coverage

Source of truth: current `main` at `2680620`.