### PR TITLE
Make Open Horizon the Cliffside song

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -87,7 +87,7 @@
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
         "/turn/audio/audio-preferences.js?build=20260909-r212": "/turn/audio/audio-preferences.js?build=20260909-r212&revision=r197-audio-mix",
         "/turn/audio/racing-music-v2.js?build=20260909-r212-racing-music-warm-v2": "/turn/audio/racing-music-v5.js?revision=r197-audio-mix",
-        "/turn/audio/music/songbook.js?revision=r197-audio-mix": "/turn/audio/music/songbook.js?revision=r209-paper-skies",
+        "/turn/audio/music/songbook.js?revision=r197-audio-mix": "/turn/audio/music/songbook.js?revision=r210-open-horizon",
         "/turn/audio/music/instrument-bank.js?revision=r184-score-v2": "/turn/audio/music/instrument-bank.js?revision=r197-audio-mix",
         "/turn/audio/music/tone-runtime.js?revision=r184-score-v2": "/turn/audio/music/tone-runtime-ties.js?revision=r186-note-ties",
         "/turn/audio/music/song-tools.js?revision=r184-score-v2": "/turn/audio/music/song-tools.js?revision=r186-note-ties",

--- a/turn-tests/racing-music-production.mjs
+++ b/turn-tests/racing-music-production.mjs
@@ -67,7 +67,11 @@ assert.match(trackerIndex, /tracker\.js\?revision=r196-song-recovery/,
 // Creative score files are intentionally user-editable. Cache-bust their direct imports whenever
 // the checked-in scores change so installed Safari PWAs do not keep stale song modules.
 for (const songFile of ['menu-theme', 'countryside', 'airport', 'cliffside', 'harbor', 'midnight-city', 'mountain']) {
-  const revision = songFile === 'airport' ? 'r209-paper-skies' : 'r197-audio-mix';
+  const revision = songFile === 'airport'
+    ? 'r209-paper-skies'
+    : songFile === 'cliffside'
+      ? 'r210-open-horizon'
+      : 'r197-audio-mix';
   assert.match(songbookSource, new RegExp(`${songFile}\\.js\\?revision=${revision}`),
     `${songFile} must use the current user-score cache revision`);
 }
@@ -82,6 +86,12 @@ assert.equal(TRACK_SONGS.airport.bpm, 144, 'Paper Skies keeps its authored tempo
 assert.equal(TRACK_SONGS.airport.key, 'F# minor / E major', 'Paper Skies keeps its authored key metadata');
 assert.deepEqual(TRACK_SONGS.airport.form, ['bridge', 'bridge', 'tune', 'bridge', 'chorus', 'chorus'],
   'Paper Skies keeps the authored six-part arrangement');
+assert.equal(TRACK_SONGS.cliffside.id, 'cliffside', 'Cliffside keeps the canonical track song id');
+assert.equal(TRACK_SONGS.cliffside.name, 'Open Horizon', 'Cliffside exposes the new Open Horizon title');
+assert.equal(TRACK_SONGS.cliffside.bpm, 136, 'Open Horizon keeps its authored tempo');
+assert.equal(TRACK_SONGS.cliffside.key, 'B minor / D major', 'Open Horizon keeps its authored key metadata');
+assert.deepEqual(TRACK_SONGS.cliffside.form, ['tune', 'tune', 'bridge', 'tune', 'chorus', 'chorus'],
+  'Open Horizon keeps the authored six-part arrangement');
 
 const leadNames = new Set(Object.keys(LEAD_VOICES));
 const bassNames = new Set(Object.keys(BASS_VOICES));

--- a/turn-tests/racing-music-production.mjs
+++ b/turn-tests/racing-music-production.mjs
@@ -47,13 +47,13 @@ assert.equal(productionImports[audioPreferencesSpecifier], `/turn/audio/audio-pr
 assert.equal(labImports[audioPreferencesSpecifier], `/turn/audio/audio-preferences.js?build=${release.cacheKey}&revision=r197-audio-mix`);
 assert.equal(productionImports[instrumentBankSpecifier], '/turn/audio/music/instrument-bank.js?revision=r197-audio-mix');
 assert.equal(labImports[instrumentBankSpecifier], '/turn/audio/music/instrument-bank.js?revision=r197-audio-mix');
-assert.equal(productionImports[songbookSpecifier], '/turn/audio/music/songbook.js?revision=r209-paper-skies');
-assert.equal(labImports[songbookSpecifier], '/turn/audio/music/songbook.js?revision=r209-paper-skies');
+assert.equal(productionImports[songbookSpecifier], '/turn/audio/music/songbook.js?revision=r210-open-horizon');
+assert.equal(labImports[songbookSpecifier], '/turn/audio/music/songbook.js?revision=r210-open-horizon');
 assert.match(homeLayout, /audio\/racing-music-v2\.js\?build=\$\{buildKey\}-racing-music-warm-v2/);
 assert.match(engine, /music\/songbook\.js\?revision=r197-audio-mix/);
 assert.equal(
   trackerImports['./songbook.js?revision=r185-menu-orchestration'],
-  './songbook.js?revision=r209-paper-skies',
+  './songbook.js?revision=r210-open-horizon',
   'Music Tracker must bypass stale songbook modules after direct score edits'
 );
 assert.equal(

--- a/turn/audio/music/cliffside.js
+++ b/turn/audio/music/cliffside.js
@@ -1,94 +1,99 @@
 import { bars, makeSection, makeSong } from './song-tools.js?revision=r186-note-ties';
 
 const TUNE = makeSection({
-  name: 'tune',
-  leadVoice: 'reed', bassVoice: 'drive', arpVoice: 'organ', drumKit: 'brush',
+  name: 'tune', harmony: ['Bm7', 'G', 'D', 'A7'],
+  leadVoice: 'picked', bassVoice: 'warm', arpVoice: 'organ', drumKit: 'brush',
   lead: bars(
-    'E5 - G5 B5 D6 - B5 G5 E5 - G5 A5 B5 D6 E6 -',
-    'D6 - B5 A5 G5 - E5 G5 A5 B5 D6 B5 A5 G5 F#5 -',
-    'E5 - B5 D6 E6 G6 F#6 E6 D6 - B5 G5 A5 B5 D6 -',
-    'B5 D6 E6 G6 F#6 E6 D6 B5 A5 B5 G5 F#5 E5 B5 E6 -'
+    'B4 = D5 F#5 = A5 = F#5 E5 = D5 - F#5 = E5 -',
+    'G4 = B4 D5 = E5 = D5 B4 = A4 - B4 = G4 -',
+    'D5 = F#5 A5 = F#5 E5 D5 = C#5 B4 = A4 = F#4 -',
+    'E5 = F#5 A5 = G5 F#5 E5 = C#5 = B4 A4 = = -'
   ),
   bass: bars(
-    'E2 - E2 E3 - B2 D3 - E2 - G2 B2 D3 B2 E3 -',
-    'C2 - C3 G2 - C3 B2 - D2 - D3 A2 D3 F#3 A2 -',
-    'E2 - E3 B2 D3 B2 G2 - E2 B2 E3 - D3 B2 G2 -',
-    'C2 - G2 C3 B2 - D3 C3 D2 A2 D3 F#3 E2 B2 E3 -'
+    'B1 = F#2 - A2 = F#2 - D2 = F#2 - B2 = A2 -',
+    'G1 = D2 - B2 = G2 - D2 = G2 - B2 = D2 -',
+    'D2 = A2 - F#2 = A2 - D3 = A2 - F#2 = D2 -',
+    'A1 = E2 - G2 = E2 - C#2 = E2 - A2 = G2 -'
   ),
   arp: bars(
-    'E3 B3 G3 B3 E4 B3 G3 B3 E3 B3 G3 B3 E4 B3 G3 D4',
-    'C3 G3 E3 G3 C4 G3 E3 G3 D3 A3 F#3 A3 D4 A3 F#3 A3',
-    'E3 B3 G3 B3 E4 B3 G3 B3 E3 G3 B3 D4 E4 D4 B3 G3',
-    'C3 G3 E3 G3 C4 B3 G3 E3 D3 A3 F#3 A3 E3 B3 G3 E4'
+    'D4 - F#4 - A4 - F#4 - D5 - A4 - F#4 - E4 -',
+    'B3 - D4 - G4 - D4 - B4 - G4 - D4 - G3 -',
+    'F#3 - A3 - D4 - A3 - F#4 - D4 - A3 - F#3 -',
+    'G3 - A3 - C#4 - E4 - C#4 - A3 - G3 - E3 -'
   ),
   drums: bars(
-    'KH H H H SH H KH H KH H H H SH H K OH',
-    'KH H H H SH H K H KH H KH H SH H S OH',
-    'KH H H H SH H KH H KH H H H SH H K OH',
-    'KH H H H SH H KH H KH H SH H S S KS OH'
+    'K - H H S - H - K - H H S - O -',
+    'K - H H S - H - K H - H S - O -',
+    'K - H - S H H - K - H H S - O -',
+    'KH - H H S - H - K H H - S H O -'
   )
 });
 
 const BRIDGE = makeSection({
-  name: 'bridge',
-  leadVoice: 'reed', bassVoice: 'drive', arpVoice: 'organ', drumKit: 'brush',
+  name: 'bridge', harmony: ['Em7', 'C', 'Em7', 'A7'],
+  leadVoice: 'whistle', bassVoice: 'warm', arpVoice: 'organ', drumKit: 'brush',
   lead: bars(
-    'G5 - B5 D6 G6 F#6 D6 B5 A5 B5 D6 E6 D6 B5 G5 -',
-    'F#5 - A5 D6 F#6 E6 D6 A5 B5 D6 E6 F#6 E6 D6 A5 -',
-    'E5 G5 C6 E6 G6 E6 D6 C6 G5 C6 D6 E6 G6 E6 C6 -',
-    'F#5 A5 B5 D#6 F#6 D#6 B5 A5 F#5 A5 B5 D#6 F#6 D#6 B5 D#6'
+    'E5 = G5 B5 = A5 = G5 F#5 = E5 - D5 = E5 -',
+    'G5 = E5 D5 = C5 = E5 G5 = A5 - G5 = E5 -',
+    'E5 = G5 B5 = A5 = G5 F#5 = E5 - D5 = E5 -',
+    'C#5 = E5 A5 = G5 F#5 E5 = C#5 = B4 A4 = C#5 -'
   ),
   bass: bars(
-    'G2 - G2 D3 - G3 F#3 D3 G2 B2 D3 - G3 D3 B2 -',
-    'D2 - D3 A2 - D3 F#3 A2 D2 A2 D3 - F#3 D3 A2 -',
-    'C2 - C3 G2 - C3 E3 G2 C2 G2 C3 - E3 C3 G2 -',
-    'B1 - B2 F#2 A2 B2 D#3 F#3 B1 F#2 A2 B2 D#3 F#3 B2 D#3'
+    'E2 = B2 - D3 = B2 - G2 = B2 - E3 = D3 -',
+    'C2 = G2 - E3 = C3 - G2 = C3 - E3 = C3 -',
+    'E2 = B2 - D3 = B2 - G2 = B2 - E3 = D3 -',
+    'A1 = E2 - G2 = E2 - C#2 = E2 - A2 = G2 -'
   ),
   arp: bars(
-    'G4 D5 B4 D5 G5 D5 B4 D5 G4 B4 D5 G5 D5 B4 D5 G5',
-    'D4 A4 F#4 A4 D5 A4 F#4 A4 D4 F#4 A4 D5 F#5 D5 A4 F#4',
-    'C4 G4 E4 G4 C5 G4 E4 G4 C4 E4 G4 C5 E5 C5 G4 E4',
-    'B3 F#4 A4 D#5 B4 F#4 A4 D#5 B3 A4 D#5 F#5 A5 F#5 D#5 B4'
+    'G3 - B3 - D4 - B3 - G4 - D4 - B3 - G3 -',
+    'G3 - C4 - E4 - C4 - G4 - E4 - C4 - G3 -',
+    'G3 - B3 - D4 - B3 - G4 - D4 - B3 - G3 -',
+    'G3 - A3 - C#4 - E4 - C#4 - A3 - G3 - E3 -'
   ),
   drums: bars(
-    'KH H H H SH H KH H KH H KH H SH H K OH',
-    'KH H KH H SH H K H KH H KH H SH H KS OH',
-    'KH H H H SH H KH H KH H KH H SH H K OH',
-    'KH H KH H SH H KH H KS H KS H S KS KS KSO'
+    'K - H - S - H H K - H - S - O -',
+    'K - H - S - H - K - H H S - O -',
+    'K - H - S - H H K - H - S - O -',
+    'KH H - H S - H - K H H - S H O -'
   )
 });
 
 const CHORUS = makeSection({
-  name: 'chorus',
-  leadVoice: 'whistle', bassVoice: 'drive', arpVoice: 'glass', drumKit: 'brush',
+  name: 'chorus', harmony: ['G', 'D', 'Em7', 'A7'],
+  leadVoice: 'whistle', bassVoice: 'warm', arpVoice: 'organ', drumKit: 'brush',
   lead: bars(
-    'E5 E5 G5 G5 B5 B5 G5 G5 E6 E6 B5 B5 G5 G5 B5 B5',
-    'G5 G5 E5 E5 C6 C6 E6 E6 G6 G6 E6 E6 D6 D6 C6 C6',
-    'D6 D6 B5 B5 G5 G5 B5 B5 D6 D6 B5 B5 A5 A5 G5 G5',
-    'F#5 F#5 A5 A5 B5 B5 D#6 D#6 B5 B5 A5 A5 F#5 F#5 D#5 D#5'
+    'G5 = B5 D6 = B5 A5 G5 = F#5 = E5 D5 = G5 -',
+    'F#5 = A5 D6 = C#6 B5 A5 = F#5 = E5 D5 = A4 -',
+    'E5 = G5 B5 = A5 G5 F#5 = E5 = D5 B4 = E5 -',
+    'C#5 = E5 A5 = G5 F#5 E5 = C#5 = B4 A4 = C#5 -'
   ),
   bass: bars(
-    'E3 E3 E3 E3 B3 B3 B3 B3 E4 E4 E4 E4 B3 B3 B3 B3',
-    'C3 C3 C3 C3 G3 G3 G3 G3 C4 C4 C4 C4 G3 G3 G3 G3',
-    'G3 G3 G3 G3 D4 D4 D4 D4 G4 G4 G4 G4 D4 D4 D4 D4',
-    'B2 B2 B2 B2 F#3 F#3 F#3 F#3 A3 A3 A3 A3 D#4 D#4 F#4 F#4'
+    'G1 = D2 - B2 = G2 - D2 = G2 - B2 = D3 -',
+    'F#2 = A2 - D3 = A2 - F#2 = A2 - D3 = A2 -',
+    'E2 = B2 - D3 = B2 - G2 = B2 - E3 = D3 -',
+    'A1 = E2 - G2 = E2 - C#2 = E2 - A2 = G2 -'
   ),
   arp: bars(
-    'E5 - G5 - B5 - G5 - E6 - B5 - G5 - B5 -',
-    'C5 - E5 - G5 - E5 - C6 - G5 - E5 - G5 -',
-    'G5 - B5 - D6 - B5 - G6 - D6 - B5 - D6 -',
-    'B4 - D#5 - F#5 - A5 - B5 - F#5 - D#5 - F#5 -'
+    'B3 D4 G4 - D4 G4 B4 - G4 B4 D5 - B4 G4 D4 -',
+    'A3 D4 F#4 - D4 F#4 A4 - F#4 A4 D5 - A4 F#4 D4 -',
+    'G3 B3 D4 - B3 D4 G4 - D4 G4 B4 - G4 D4 B3 -',
+    'G3 A3 C#4 - A3 C#4 E4 - C#4 E4 G4 - E4 C#4 A3 -'
   ),
   drums: bars(
-    'KH H H H SH H - H KH H H H SH H K OH',
-    'KH H H H SH H - H KH H H OH SH H K OH',
-    'KH H H H SH H - H KH H H H SH H K OH',
-    'KH H H H SH H KH H KS H K OH SH H KS OH'
+    'KH H - H S H H - K H - H S H O -',
+    'KH H - H S - H H K H - H S H O -',
+    'KH H H - S H - H K H H - S H O -',
+    'KH H H - S H H - K H H H S H O -'
   )
 });
 
 export const CLIFFSIDE_SONG = makeSong({
-  id: 'cliffside', name: 'TURN Theme', bpm: 128, key: 'E minor',
-  style: 'warm arcade title anthem', swing: 0.12,
-  sections: [TUNE, BRIDGE, CHORUS], arrangement: ['tune', 'tune', 'bridge', 'tune', 'chorus', 'chorus']
+  id: 'cliffside',
+  name: 'Open Horizon',
+  bpm: 136,
+  key: 'B minor / D major',
+  style: 'flowing psychedelic pop with sweeping melodic lines, rolling bass and a strange cliff-edge harmonic turn',
+  swing: 0,
+  sections: [TUNE, BRIDGE, CHORUS],
+  arrangement: ['tune', 'tune', 'bridge', 'tune', 'chorus', 'chorus']
 });

--- a/turn/audio/music/index.html
+++ b/turn/audio/music/index.html
@@ -199,7 +199,7 @@
   <script type="importmap">
     {
       "imports": {
-        "./songbook.js?revision=r185-menu-orchestration": "./songbook.js?revision=r209-paper-skies",
+        "./songbook.js?revision=r185-menu-orchestration": "./songbook.js?revision=r210-open-horizon",
         "./instrument-bank.js?revision=r184-score-v2": "./instrument-bank.js?revision=r197-audio-mix",
         "./tracker-audio.js?revision=r187-music-tracker": "./tracker-audio.js?revision=r208-row-playhead"
       }

--- a/turn/audio/music/songbook.js
+++ b/turn/audio/music/songbook.js
@@ -1,7 +1,7 @@
 import { MENU_SONG } from './menu-theme.js?revision=r197-audio-mix';
 import { COUNTRYSIDE_SONG } from './countryside.js?revision=r197-audio-mix';
 import { AIRPORT_SONG } from './airport.js?revision=r209-paper-skies';
-import { CLIFFSIDE_SONG } from './cliffside.js?revision=r197-audio-mix';
+import { CLIFFSIDE_SONG } from './cliffside.js?revision=r210-open-horizon';
 import { HARBOR_SONG } from './harbor.js?revision=r197-audio-mix';
 import { MIDNIGHT_CITY_SONG } from './midnight-city.js?revision=r197-audio-mix';
 import { MOUNTAIN_SONG } from './mountain.js?revision=r197-audio-mix';

--- a/turn/index.html
+++ b/turn/index.html
@@ -98,7 +98,7 @@
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
         "/turn/audio/audio-preferences.js?build=20260909-r212": "/turn/audio/audio-preferences.js?build=20260909-r212&revision=r197-audio-mix",
         "/turn/audio/racing-music-v2.js?build=20260909-r212-racing-music-warm-v2": "/turn/audio/racing-music-v5.js?revision=r197-audio-mix",
-        "/turn/audio/music/songbook.js?revision=r197-audio-mix": "/turn/audio/music/songbook.js?revision=r209-paper-skies",
+        "/turn/audio/music/songbook.js?revision=r197-audio-mix": "/turn/audio/music/songbook.js?revision=r210-open-horizon",
         "/turn/audio/music/instrument-bank.js?revision=r184-score-v2": "/turn/audio/music/instrument-bank.js?revision=r197-audio-mix",
         "/turn/audio/music/tone-runtime.js?revision=r184-score-v2": "/turn/audio/music/tone-runtime-ties.js?revision=r186-note-ties",
         "/turn/audio/music/song-tools.js?revision=r184-score-v2": "/turn/audio/music/song-tools.js?revision=r186-note-ties",


### PR DESCRIPTION
Replaces the Cliffside score with the supplied Open Horizon composition while preserving TURN's canonical track identity (`CLIFFSIDE_SONG`, id `cliffside`). The Cliffside score import gets a fresh `r210-open-horizon` revision, and regression coverage now locks the title, tempo, key metadata and authored six-part arrangement alongside the existing engine/16-step validation.