### PR TITLE
Make Breakwater the Harbor song

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -87,7 +87,7 @@
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
         "/turn/audio/audio-preferences.js?build=20260909-r212": "/turn/audio/audio-preferences.js?build=20260909-r212&revision=r197-audio-mix",
         "/turn/audio/racing-music-v2.js?build=20260909-r212-racing-music-warm-v2": "/turn/audio/racing-music-v5.js?revision=r197-audio-mix",
-        "/turn/audio/music/songbook.js?revision=r197-audio-mix": "/turn/audio/music/songbook.js?revision=r210-open-horizon",
+        "/turn/audio/music/songbook.js?revision=r197-audio-mix": "/turn/audio/music/songbook.js?revision=r211-breakwater",
         "/turn/audio/music/instrument-bank.js?revision=r184-score-v2": "/turn/audio/music/instrument-bank.js?revision=r197-audio-mix",
         "/turn/audio/music/tone-runtime.js?revision=r184-score-v2": "/turn/audio/music/tone-runtime-ties.js?revision=r186-note-ties",
         "/turn/audio/music/song-tools.js?revision=r184-score-v2": "/turn/audio/music/song-tools.js?revision=r186-note-ties",

--- a/turn-tests/racing-music-production.mjs
+++ b/turn-tests/racing-music-production.mjs
@@ -47,13 +47,13 @@ assert.equal(productionImports[audioPreferencesSpecifier], `/turn/audio/audio-pr
 assert.equal(labImports[audioPreferencesSpecifier], `/turn/audio/audio-preferences.js?build=${release.cacheKey}&revision=r197-audio-mix`);
 assert.equal(productionImports[instrumentBankSpecifier], '/turn/audio/music/instrument-bank.js?revision=r197-audio-mix');
 assert.equal(labImports[instrumentBankSpecifier], '/turn/audio/music/instrument-bank.js?revision=r197-audio-mix');
-assert.equal(productionImports[songbookSpecifier], '/turn/audio/music/songbook.js?revision=r210-open-horizon');
-assert.equal(labImports[songbookSpecifier], '/turn/audio/music/songbook.js?revision=r210-open-horizon');
+assert.equal(productionImports[songbookSpecifier], '/turn/audio/music/songbook.js?revision=r211-breakwater');
+assert.equal(labImports[songbookSpecifier], '/turn/audio/music/songbook.js?revision=r211-breakwater');
 assert.match(homeLayout, /audio\/racing-music-v2\.js\?build=\$\{buildKey\}-racing-music-warm-v2/);
 assert.match(engine, /music\/songbook\.js\?revision=r197-audio-mix/);
 assert.equal(
   trackerImports['./songbook.js?revision=r185-menu-orchestration'],
-  './songbook.js?revision=r210-open-horizon',
+  './songbook.js?revision=r211-breakwater',
   'Music Tracker must bypass stale songbook modules after direct score edits'
 );
 assert.equal(
@@ -71,7 +71,9 @@ for (const songFile of ['menu-theme', 'countryside', 'airport', 'cliffside', 'ha
     ? 'r209-paper-skies'
     : songFile === 'cliffside'
       ? 'r210-open-horizon'
-      : 'r197-audio-mix';
+      : songFile === 'harbor'
+        ? 'r211-breakwater'
+        : 'r197-audio-mix';
   assert.match(songbookSource, new RegExp(`${songFile}\\.js\\?revision=${revision}`),
     `${songFile} must use the current user-score cache revision`);
 }
@@ -92,6 +94,12 @@ assert.equal(TRACK_SONGS.cliffside.bpm, 136, 'Open Horizon keeps its authored te
 assert.equal(TRACK_SONGS.cliffside.key, 'B minor / D major', 'Open Horizon keeps its authored key metadata');
 assert.deepEqual(TRACK_SONGS.cliffside.form, ['tune', 'tune', 'bridge', 'tune', 'chorus', 'chorus'],
   'Open Horizon keeps the authored six-part arrangement');
+assert.equal(TRACK_SONGS.harbor.id, 'harbor', 'Harbor keeps the canonical track song id');
+assert.equal(TRACK_SONGS.harbor.name, 'Breakwater', 'Harbor exposes the new Breakwater title');
+assert.equal(TRACK_SONGS.harbor.bpm, 128, 'Breakwater keeps its authored tempo');
+assert.equal(TRACK_SONGS.harbor.key, 'E minor', 'Breakwater keeps its authored key metadata');
+assert.deepEqual(TRACK_SONGS.harbor.form, ['tune', 'tune', 'bridge', 'tune', 'chorus', 'chorus'],
+  'Breakwater keeps the authored six-part arrangement');
 
 const leadNames = new Set(Object.keys(LEAD_VOICES));
 const bassNames = new Set(Object.keys(BASS_VOICES));

--- a/turn/audio/music/harbor.js
+++ b/turn/audio/music/harbor.js
@@ -1,94 +1,99 @@
 import { bars, makeSection, makeSong } from './song-tools.js?revision=r186-note-ties';
 
 const TUNE = makeSection({
-  name: 'tune',
-  leadVoice: 'brass', bassVoice: 'drone', arpVoice: 'metal', drumKit: 'industrial',
+  name: 'tune', harmony: ['Em7', 'G', 'Am7', 'B7'],
+  leadVoice: 'brass', bassVoice: 'drone', arpVoice: 'organ', drumKit: 'industrial',
   lead: bars(
-    'E5 - G5 B5 D6 - B5 G5 E5 - G5 A5 B5 D6 E6 -',
-    'D6 - B5 A5 G5 - E5 G5 A5 B5 D6 B5 A5 G5 F#5 -',
-    'E5 - B5 D6 E6 G6 F#6 E6 D6 - B5 G5 A5 B5 D6 -',
-    'B5 D6 E6 G6 F#6 E6 D6 B5 A5 B5 G5 F#5 E5 B5 E6 -'
+    'E5 G5 A5 - - E5 G5 A5 - - B4 D5 E5 - - -',
+    'G5 A5 B5 - - G5 A5 B5 - - D5 E5 G5 - - -',
+    'A5 C6 D6 - - A5 C6 D6 - - E5 G5 A5 - - -',
+    'B5 D#6 E6 - - B5 D#6 E6 - - A5 F#5 D#5 - B4 -'
   ),
   bass: bars(
-    'E2 = = = - - D2 = E2 = = = - - D2 =',
-    'C2 = = = - - D2 = C2 = = = - - F2 =',
-    'E2 = = = - - G2 = E2 = = = - - G2 =',
-    'C2 = = = - - E2 = D2 = = = - - E2 ='
+    'E2 - B2 - E3 - D3 - B2 - G2 - B2 - D3 -',
+    'G2 - D3 - G3 - B2 - D3 - B2 - D3 - G2 -',
+    'A2 - E3 - A3 - G3 - E3 - C3 - E3 - G3 -',
+    'B2 - F#3 - B3 - A3 - F#3 - D#3 - F#3 - A3 -'
   ),
   arp: bars(
-    'E4 B4 G4 B4 E5 B4 G4 B4 E4 B4 G4 B4 E5 B4 G4 D5',
-    'C4 G4 E4 G4 C5 G4 E4 G4 D4 A4 F#4 A4 D5 A4 F#4 A4',
-    'E4 B4 G4 B4 E5 B4 G4 B4 E4 G4 B4 D5 E5 D5 B4 G4',
-    'C4 G4 E4 G4 C5 B4 G4 E4 D4 A4 F#4 A4 E4 B4 G4 E5'
+    '- - - E4 - - - G4 - - - B4 - - D4 -',
+    '- - - G4 - - - B4 - - - D5 - - B4 -',
+    '- - - A4 - - - C5 - - - E5 - - G4 -',
+    '- - - B4 - - - D#5 - - - F#5 - - A4 -'
   ),
   drums: bars(
-    'KH H H H SH H KH H KH H H H SH H K OH',
-    'KH H H H SH H K H KH H KH H SH H S OH',
-    'KH H H H SH H KH H KH H H H SH H K OH',
-    'KH H H H SH H KH H KH H SH H S S KS OH'
+    'KH - H - S - H - KH - H - S - H -',
+    'KH - H - S - H - KH - H - S - H -',
+    'KH - H - S - H - KH - H - S - H -',
+    'KH - H - S - H - KH - H - S H T T'
   )
 });
 
 const BRIDGE = makeSection({
-  name: 'bridge',
-  leadVoice: 'bell', bassVoice: 'drone', arpVoice: 'metal', drumKit: 'industrial',
+  name: 'bridge', harmony: ['C', 'Am7', 'Em7', 'B7'],
+  leadVoice: 'brass', bassVoice: 'drone', arpVoice: 'organ', drumKit: 'industrial',
   lead: bars(
-    'G5 - B5 D6 G6 F#6 D6 B5 A5 B5 D6 E6 D6 B5 G5 -',
-    'F#5 - A5 D6 F#6 E6 D6 A5 B5 D6 E6 F#6 E6 D6 A5 -',
-    'E5 G5 C6 E6 G6 E6 D6 C6 G5 C6 D6 E6 G6 E6 C6 -',
-    'F#5 A5 B5 D#6 F#6 D#6 B5 A5 F#5 A5 B5 D#6 F#6 D#6 B5 D#6'
+    'E6 E6 G6 A6 - G6 E6 - G6 A6 C7 A6 - G6 E6 -',
+    'E6 E6 G6 A6 - G6 E6 - C6 E6 G6 E6 - D6 C6 -',
+    'E6 E6 G6 A6 - G6 E6 - A6 Bb6 B6 D7 - B6 A6 -',
+    'B6 B6 A6 F#6 - D#6 B5 - D#6 F#6 A6 F#6 - D#6 B5 -'
   ),
   bass: bars(
-    'G2 = = = = = G2 = G2 = G2 = = G2 G2 =',
-    'D2 = = = = = D2 = D2 = D2 = = D2 D2 =',
-    'C2 = = = = = C2 = C2 = C2 = = C2 C2 =',
-    'B1 = = = = = B1 = B1 = B1 = B1 B1 B1 B1'
+    'C3 - G3 - C4 - E3 - G3 - E3 - G3 - E3 -',
+    'A2 - E3 - A3 - G3 - E3 - C3 - E3 - C3 -',
+    'E2 - B2 - E3 - D3 - G2 - B2 - D3 - B2 -',
+    'B2 - F#3 - B3 - A3 - F#3 - D#3 - F#3 - A3 -'
   ),
   arp: bars(
-    'G5 D6 B5 D6 G6 D6 B5 D6 G5 B5 D6 G6 D6 B5 D6 G6',
-    'D5 A5 F#5 A5 D6 A5 F#5 A5 D5 F#5 A5 D6 F#6 D6 A5 F#5',
-    'C5 G5 E5 G5 C6 G5 E5 G5 C5 E5 G5 C6 E6 C6 G5 E5',
-    'B4 F#5 A5 D#6 B5 F#5 A5 D#6 B4 A5 D#6 F#6 A6 F#6 D#6 B5'
+    'G4 - C5 - E5 - C5 - G4 - E4 - C4 - E4 -',
+    'A4 - C5 - E5 - C5 - A4 - G4 - E4 - C4 -',
+    'E4 - G4 - B4 - D5 - B4 - G4 - E4 - D4 -',
+    'F#4 - A4 - B4 - D#5 - B4 - A4 - F#4 - D#4 -'
   ),
   drums: bars(
-    'KH H H H SH H KH H KH H KH H SH H K OH',
-    'KH H KH H SH H K H KH H KH H SH H KS OH',
-    'KH H H H SH H KH H KH H KH H SH H K OH',
-    'KH H KH H SH H KH H KS H KS H S KS KS KSO'
+    'KH - H - S - H - KH - H - S - H -',
+    'KH - H - S - H - KH - H - S - H -',
+    'KH - H - S - H - KH - H - S - H -',
+    'KH - H - S - H - KH - H - S H T T'
   )
 });
 
 const CHORUS = makeSection({
-  name: 'chorus',
-  leadVoice: 'brass', bassVoice: 'drone', arpVoice: 'metal', drumKit: 'industrial',
+  name: 'chorus', harmony: ['Em', 'D', 'C', 'B7'],
+  leadVoice: 'whistle', bassVoice: 'drone', arpVoice: 'organ', drumKit: 'industrial',
   lead: bars(
-    'E5 E5 G5 G5 B5 B5 G5 G5 E6 E6 B5 B5 G5 G5 B5 B5',
-    'G5 G5 E5 E5 C6 C6 E6 E6 G6 G6 E6 E6 D6 D6 C6 C6',
-    'D6 D6 B5 B5 G5 G5 B5 B5 D6 D6 B5 B5 A5 A5 G5 G5',
-    'F#5 F#5 A5 A5 B5 B5 D#6 D#6 B5 B5 A5 A5 F#5 F#5 D#5 D#5'
+    'E5 E5 G5 A5 B5 - B5 A5 G5 - E5 G5 A5 - B5 -',
+    'D6 - B5 A5 G5 - F#5 E5 D5 - F#5 A5 B5 - A5 -',
+    'C6 - C6 B5 G5 - E5 G5 A5 - G5 E5 D5 - C5 -',
+    'B5 B5 A5 F#5 D#5 - F#5 A5 B5 - A5 F#5 D#5 - B4 -'
   ),
   bass: bars(
-    'E2 = = = - - B2 - E2 = = = - - B2 -',
-    'C2 = = = - - G2 - C2 = = = - - G2 -',
-    'G2 = = = - - D3 - G2 = = = - - D3 -',
-    'B1 = = = F#2 = = = B1 = = = - - F#3 -'
+    'E2 - B2 - E3 - G3 - B2 - G3 - E3 - B2 -',
+    'D2 - A2 - D3 - F#3 - A3 - F#3 - D3 - A2 -',
+    'C2 - G2 - C3 - E3 - G3 - E3 - C3 - G2 -',
+    'B1 - F#2 - B2 - D#3 - F#3 - D#3 - B2 - A2 -'
   ),
   arp: bars(
-    'E5 - G5 - B5 - G5 - E6 - B5 - G5 - B5 -',
-    'C5 - E5 - G5 - E5 - C6 - G5 - E5 - G5 -',
-    'G5 - B5 - D6 - B5 - G6 - D6 - B5 - D6 -',
-    'B4 - D#5 - F#5 - A5 - B5 - F#5 - D#5 - F#5 -'
+    'E4 G4 B4 - G4 B4 E5 - B4 E5 G5 - E5 B4 G4 -',
+    'D4 F#4 A4 - F#4 A4 D5 - A4 D5 F#5 - D5 A4 F#4 -',
+    'C4 E4 G4 - E4 G4 C5 - G4 C5 E5 - C5 G4 E4 -',
+    'B3 D#4 F#4 - D#4 F#4 B4 - F#4 B4 D#5 - B4 F#4 D#4 -'
   ),
   drums: bars(
-    'KH H H H SH H - H KH H H H SH H K OH',
-    'KH H H H SH H - H KH H H OH SH H K OH',
-    'KH H H H SH H - H KH H H H SH H K OH',
-    'KH H H H SH H KH H KS H K OH SH H KS OH'
+    'KH - H - S - H - KH - H - S - H -',
+    'KH - H - S - H - KH - H - S - H -',
+    'KH - H - S - H - KH - H - S - H -',
+    'KH - H - S - H - KH - H - S H T T'
   )
 });
 
 export const HARBOR_SONG = makeSong({
-  id: 'harbor', name: 'TURN Theme', bpm: 136, key: 'E minor',
-  style: 'warm arcade title anthem', swing: 0,
-  sections: [TUNE, BRIDGE, CHORUS], arrangement: ['tune', 'tune', 'bridge', 'tune', 'chorus', 'chorus']
+  id: 'harbor',
+  name: 'Breakwater',
+  bpm: 128,
+  key: 'E minor',
+  style: 'hard straight-ahead rock and roll with bluesy riffs, driving organ and a heavy descending chorus',
+  swing: 0,
+  sections: [TUNE, BRIDGE, CHORUS],
+  arrangement: ['tune', 'tune', 'bridge', 'tune', 'chorus', 'chorus']
 });

--- a/turn/audio/music/index.html
+++ b/turn/audio/music/index.html
@@ -199,7 +199,7 @@
   <script type="importmap">
     {
       "imports": {
-        "./songbook.js?revision=r185-menu-orchestration": "./songbook.js?revision=r210-open-horizon",
+        "./songbook.js?revision=r185-menu-orchestration": "./songbook.js?revision=r211-breakwater",
         "./instrument-bank.js?revision=r184-score-v2": "./instrument-bank.js?revision=r197-audio-mix",
         "./tracker-audio.js?revision=r187-music-tracker": "./tracker-audio.js?revision=r208-row-playhead"
       }

--- a/turn/audio/music/songbook.js
+++ b/turn/audio/music/songbook.js
@@ -2,7 +2,7 @@ import { MENU_SONG } from './menu-theme.js?revision=r197-audio-mix';
 import { COUNTRYSIDE_SONG } from './countryside.js?revision=r197-audio-mix';
 import { AIRPORT_SONG } from './airport.js?revision=r209-paper-skies';
 import { CLIFFSIDE_SONG } from './cliffside.js?revision=r210-open-horizon';
-import { HARBOR_SONG } from './harbor.js?revision=r197-audio-mix';
+import { HARBOR_SONG } from './harbor.js?revision=r211-breakwater';
 import { MIDNIGHT_CITY_SONG } from './midnight-city.js?revision=r197-audio-mix';
 import { MOUNTAIN_SONG } from './mountain.js?revision=r197-audio-mix';
 

--- a/turn/index.html
+++ b/turn/index.html
@@ -98,7 +98,7 @@
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
         "/turn/audio/audio-preferences.js?build=20260909-r212": "/turn/audio/audio-preferences.js?build=20260909-r212&revision=r197-audio-mix",
         "/turn/audio/racing-music-v2.js?build=20260909-r212-racing-music-warm-v2": "/turn/audio/racing-music-v5.js?revision=r197-audio-mix",
-        "/turn/audio/music/songbook.js?revision=r197-audio-mix": "/turn/audio/music/songbook.js?revision=r210-open-horizon",
+        "/turn/audio/music/songbook.js?revision=r197-audio-mix": "/turn/audio/music/songbook.js?revision=r211-breakwater",
         "/turn/audio/music/instrument-bank.js?revision=r184-score-v2": "/turn/audio/music/instrument-bank.js?revision=r197-audio-mix",
         "/turn/audio/music/tone-runtime.js?revision=r184-score-v2": "/turn/audio/music/tone-runtime-ties.js?revision=r186-note-ties",
         "/turn/audio/music/song-tools.js?revision=r184-score-v2": "/turn/audio/music/song-tools.js?revision=r186-note-ties",


### PR DESCRIPTION
Replaces the Harbor score with the supplied Breakwater composition while preserving TURN's canonical track identity (`HARBOR_SONG`, id `harbor`). Adds a fresh `r211-breakwater` score revision through the songbook/cache routing so production, TURN LAB and Music Tracker all load the new score. Regression coverage locks the title, tempo, key metadata and six-part arrangement while retaining the existing 16-step/instrument validation.