### PR TITLE
Finish Open Horizon for Cliffside

### DIFF
--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -197,7 +197,7 @@
       <div class="install-art" aria-hidden="true"><img class="install-icon" src="./TURNicon.PNG?icon=20260803-profile-512" alt=""></div>
       <div class="install-card">
         <span class="install-kicker">TURN LAB · MOUNTAIN LONG COURSE</span>
-        <h1>TURN LAB</h1>
+        <h1 id="installTitle">TURN LAB</h1>
         <p class="install-copy">Test a substantially longer MOUNTAIN lap on the current production TURN engine. Production TURN stays untouched.</p>
         <div class="install-actions">
           <button id="installTurnButton" class="install-primary" type="button">Install TURN LAB</button>

--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -87,7 +87,7 @@
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
         "/turn/audio/audio-preferences.js?build=20260909-r212": "/turn/audio/audio-preferences.js?build=20260909-r212&revision=r197-audio-mix",
         "/turn/audio/racing-music-v2.js?build=20260909-r212-racing-music-warm-v2": "/turn/audio/racing-music-v5.js?revision=r197-audio-mix",
-        "/turn/audio/music/songbook.js?revision=r197-audio-mix": "/turn/audio/music/songbook.js?revision=r211-breakwater",
+        "/turn/audio/music/songbook.js?revision=r197-audio-mix": "/turn/audio/music/songbook.js?revision=r212-open-horizon-final",
         "/turn/audio/music/instrument-bank.js?revision=r184-score-v2": "/turn/audio/music/instrument-bank.js?revision=r197-audio-mix",
         "/turn/audio/music/tone-runtime.js?revision=r184-score-v2": "/turn/audio/music/tone-runtime-ties.js?revision=r186-note-ties",
         "/turn/audio/music/song-tools.js?revision=r184-score-v2": "/turn/audio/music/song-tools.js?revision=r186-note-ties",
@@ -245,9 +245,9 @@
         </div>
         <section class="score-feedback-state score-feedback-flow-state" data-score-feedback-flow-state>
           <div class="score-feedback-heading"><span>FLOW</span><span>COMBO</span></div>
-          <div class="score-feedback-values"><strong data-score-feedback-flow-current>0</strong><b data-score-feedback-flow-multiplier>×1</b></div>
+          <div class="score-feedback-values"><strong data-score-feedback-flow-current>0</strong><b data-score-feedback-multiplier>×1</b></div>
           <div class="score-feedback-footer">
-            <div class="score-feedback-lap"><span>LAP</span><b data-score-feedback-flow-total>0</b></div>
+            <div class="score-feedback-lap"><span>LAP</span><b data-score-feedback-total>0</b></div>
             <div class="score-feedback-techniques" data-score-feedback-flow-techniques aria-hidden="true">
               <span></span><span></span><span></span><span></span><span></span>
             </div>

--- a/turn-lab/index.html
+++ b/turn-lab/index.html
@@ -197,7 +197,7 @@
       <div class="install-art" aria-hidden="true"><img class="install-icon" src="./TURNicon.PNG?icon=20260803-profile-512" alt=""></div>
       <div class="install-card">
         <span class="install-kicker">TURN LAB · MOUNTAIN LONG COURSE</span>
-        <h1 id="installTitle">TURN LAB</h1>
+        <h1>TURN LAB</h1>
         <p class="install-copy">Test a substantially longer MOUNTAIN lap on the current production TURN engine. Production TURN stays untouched.</p>
         <div class="install-actions">
           <button id="installTurnButton" class="install-primary" type="button">Install TURN LAB</button>
@@ -245,9 +245,9 @@
         </div>
         <section class="score-feedback-state score-feedback-flow-state" data-score-feedback-flow-state>
           <div class="score-feedback-heading"><span>FLOW</span><span>COMBO</span></div>
-          <div class="score-feedback-values"><strong data-score-feedback-flow-current>0</strong><b data-score-feedback-multiplier>×1</b></div>
+          <div class="score-feedback-values"><strong data-score-feedback-flow-current>0</strong><b data-score-feedback-flow-multiplier>×1</b></div>
           <div class="score-feedback-footer">
-            <div class="score-feedback-lap"><span>LAP</span><b data-score-feedback-total>0</b></div>
+            <div class="score-feedback-lap"><span>LAP</span><b data-score-feedback-flow-total>0</b></div>
             <div class="score-feedback-techniques" data-score-feedback-flow-techniques aria-hidden="true">
               <span></span><span></span><span></span><span></span><span></span>
             </div>

--- a/turn-tests/racing-music-production.mjs
+++ b/turn-tests/racing-music-production.mjs
@@ -47,13 +47,13 @@ assert.equal(productionImports[audioPreferencesSpecifier], `/turn/audio/audio-pr
 assert.equal(labImports[audioPreferencesSpecifier], `/turn/audio/audio-preferences.js?build=${release.cacheKey}&revision=r197-audio-mix`);
 assert.equal(productionImports[instrumentBankSpecifier], '/turn/audio/music/instrument-bank.js?revision=r197-audio-mix');
 assert.equal(labImports[instrumentBankSpecifier], '/turn/audio/music/instrument-bank.js?revision=r197-audio-mix');
-assert.equal(productionImports[songbookSpecifier], '/turn/audio/music/songbook.js?revision=r211-breakwater');
-assert.equal(labImports[songbookSpecifier], '/turn/audio/music/songbook.js?revision=r211-breakwater');
+assert.equal(productionImports[songbookSpecifier], '/turn/audio/music/songbook.js?revision=r212-open-horizon-final');
+assert.equal(labImports[songbookSpecifier], '/turn/audio/music/songbook.js?revision=r212-open-horizon-final');
 assert.match(homeLayout, /audio\/racing-music-v2\.js\?build=\$\{buildKey\}-racing-music-warm-v2/);
 assert.match(engine, /music\/songbook\.js\?revision=r197-audio-mix/);
 assert.equal(
   trackerImports['./songbook.js?revision=r185-menu-orchestration'],
-  './songbook.js?revision=r211-breakwater',
+  './songbook.js?revision=r212-open-horizon-final',
   'Music Tracker must bypass stale songbook modules after direct score edits'
 );
 assert.equal(
@@ -70,7 +70,7 @@ for (const songFile of ['menu-theme', 'countryside', 'airport', 'cliffside', 'ha
   const revision = songFile === 'airport'
     ? 'r209-paper-skies'
     : songFile === 'cliffside'
-      ? 'r210-open-horizon'
+      ? 'r212-open-horizon-final'
       : songFile === 'harbor'
         ? 'r211-breakwater'
         : 'r197-audio-mix';
@@ -89,11 +89,11 @@ assert.equal(TRACK_SONGS.airport.key, 'F# minor / E major', 'Paper Skies keeps i
 assert.deepEqual(TRACK_SONGS.airport.form, ['bridge', 'bridge', 'tune', 'bridge', 'chorus', 'chorus'],
   'Paper Skies keeps the authored six-part arrangement');
 assert.equal(TRACK_SONGS.cliffside.id, 'cliffside', 'Cliffside keeps the canonical track song id');
-assert.equal(TRACK_SONGS.cliffside.name, 'Open Horizon', 'Cliffside exposes the new Open Horizon title');
+assert.equal(TRACK_SONGS.cliffside.name, 'Open Horizon', 'Cliffside exposes the final Open Horizon title');
 assert.equal(TRACK_SONGS.cliffside.bpm, 136, 'Open Horizon keeps its authored tempo');
 assert.equal(TRACK_SONGS.cliffside.key, 'B minor / D major', 'Open Horizon keeps its authored key metadata');
-assert.deepEqual(TRACK_SONGS.cliffside.form, ['tune', 'tune', 'bridge', 'tune', 'chorus', 'chorus'],
-  'Open Horizon keeps the authored six-part arrangement');
+assert.deepEqual(TRACK_SONGS.cliffside.form, ['tune', 'tune', 'bridge', 'bridge', 'chorus', 'chorus'],
+  'Open Horizon keeps the final authored six-part arrangement');
 assert.equal(TRACK_SONGS.harbor.id, 'harbor', 'Harbor keeps the canonical track song id');
 assert.equal(TRACK_SONGS.harbor.name, 'Breakwater', 'Harbor exposes the new Breakwater title');
 assert.equal(TRACK_SONGS.harbor.bpm, 128, 'Breakwater keeps its authored tempo');

--- a/turn/audio/music/cliffside.js
+++ b/turn/audio/music/cliffside.js
@@ -2,18 +2,18 @@ import { bars, makeSection, makeSong } from './song-tools.js?revision=r186-note-
 
 const TUNE = makeSection({
   name: 'tune', harmony: ['Bm7', 'G', 'D', 'A7'],
-  leadVoice: 'picked', bassVoice: 'warm', arpVoice: 'organ', drumKit: 'brush',
+  leadVoice: 'bell', bassVoice: 'sub', arpVoice: 'glass', drumKit: 'brush',
   lead: bars(
-    'B4 = D5 F#5 = A5 = F#5 E5 = D5 - F#5 = E5 -',
-    'G4 = B4 D5 = E5 = D5 B4 = A4 - B4 = G4 -',
-    'D5 = F#5 A5 = F#5 E5 D5 = C#5 B4 = A4 = F#4 -',
-    'E5 = F#5 A5 = G5 F#5 E5 = C#5 = B4 A4 = = -'
+    'B4 - D5 F#5 - A5 - F#5 E5 - D5 - F#5 - E5 -',
+    'G4 - B4 D5 - E5 - D5 B4 - A4 - B4 - G4 -',
+    'D5 - F#5 A5 - F#5 E5 D5 - C#5 B4 - A4 - F#4 -',
+    'E5 - F#5 A5 - G5 F#5 E5 - C#5 - B4 A4 - - -'
   ),
   bass: bars(
-    'B1 = F#2 - A2 = F#2 - D2 = F#2 - B2 = A2 -',
-    'G1 = D2 - B2 = G2 - D2 = G2 - B2 = D2 -',
-    'D2 = A2 - F#2 = A2 - D3 = A2 - F#2 = D2 -',
-    'A1 = E2 - G2 = E2 - C#2 = E2 - A2 = G2 -'
+    'B1 = F#2 - A2 - F#2 - D2 - F#2 - B2 - A2 -',
+    'G1 = - - B2 - G2 - D2 - G2 - B1 = D2 -',
+    'D2 = A2 - F#2 - A2 - D3 - A2 - F#2 - D2 -',
+    'A1 = E2 - G2 - E2 - C#2 - E2 - A1 = G2 -'
   ),
   arp: bars(
     'D4 - F#4 - A4 - F#4 - D5 - A4 - F#4 - E4 -',
@@ -22,78 +22,73 @@ const TUNE = makeSection({
     'G3 - A3 - C#4 - E4 - C#4 - A3 - G3 - E3 -'
   ),
   drums: bars(
-    'K - H H S - H - K - H H S - O -',
-    'K - H H S - H - K H - H S - O -',
-    'K - H - S H H - K - H H S - O -',
-    'KH - H H S - H - K H H - S H O -'
+    'K - H H S - H - K - H H S - OT -',
+    'K - H H S - H - K H - H S - OT -',
+    'K - H - S H H - K - H H S - OT -',
+    'KH - H H S - H - K H H - ST H OT -'
   )
 });
 
 const BRIDGE = makeSection({
-  name: 'bridge', harmony: ['Em7', 'C', 'Em7', 'A7'],
-  leadVoice: 'whistle', bassVoice: 'warm', arpVoice: 'organ', drumKit: 'brush',
+  name: 'bridge', harmony: ['G', 'A', 'Bm7', 'F#7'],
+  leadVoice: 'bell', bassVoice: 'sub', arpVoice: 'organ', drumKit: 'brush',
   lead: bars(
-    'E5 = G5 B5 = A5 = G5 F#5 = E5 - D5 = E5 -',
-    'G5 = E5 D5 = C5 = E5 G5 = A5 - G5 = E5 -',
-    'E5 = G5 B5 = A5 = G5 F#5 = E5 - D5 = E5 -',
-    'C#5 = E5 A5 = G5 F#5 E5 = C#5 = B4 A4 = C#5 -'
+    'D5 - D5 G5 - A5 B5 - A5 - G5 A5 B5 - D6 -',
+    'E5 - E5 A5 - B5 C#6 - B5 - A5 B5 C#6 - E6 -',
+    'F#5 - F#5 B5 - D6 F#6 - D6 - B5 A5 F#5 - D5 -',
+    'F#5 F#5 A#5 C#6 - B5 A#5 - F#5 - E5 C#5 A#4 - F#4 -'
   ),
   bass: bars(
-    'E2 = B2 - D3 = B2 - G2 = B2 - E3 = D3 -',
-    'C2 = G2 - E3 = C3 - G2 = C3 - E3 = C3 -',
-    'E2 = B2 - D3 = B2 - G2 = B2 - E3 = D3 -',
-    'A1 = E2 - G2 = E2 - C#2 = E2 - A2 = G2 -'
+    'G1 = D2 - G2 - B2 - D2 = B2 - A2 - G2 -',
+    'A1 = E2 - A2 - C#3 - E2 = C#3 - B2 - A2 -',
+    'B1 = F#2 - B2 - D3 - F#2 = D3 - C#3 - B2 -',
+    'F#1 = C#2 - F#2 - A#2 - C#2 = A#2 - F#2 - C#2 -'
   ),
   arp: bars(
-    'G3 - B3 - D4 - B3 - G4 - D4 - B3 - G3 -',
-    'G3 - C4 - E4 - C4 - G4 - E4 - C4 - G3 -',
-    'G3 - B3 - D4 - B3 - G4 - D4 - B3 - G3 -',
-    'G3 - A3 - C#4 - E4 - C#4 - A3 - G3 - E3 -'
+    '- B3 D4 - G4 D4 - B4 - D4 G4 - A4 G4 D4 -',
+    '- C#4 E4 - A4 E4 - C#5 - E4 A4 - B4 A4 E4 -',
+    '- D4 F#4 - B4 F#4 - D5 - F#4 B4 - A4 F#4 D4 -',
+    '- A#3 C#4 - F#4 C#4 - A#4 - C#4 F#4 - E4 C#4 A#3 -'
   ),
   drums: bars(
-    'K - H - S - H H K - H - S - O -',
-    'K - H - S - H - K - H H S - O -',
-    'K - H - S - H H K - H - S - O -',
-    'KH H - H S - H - K H H - S H O -'
+    'K - H - S - H - K H H - ST - OT -',
+    'K - H H S - H - K H H - ST - OT -',
+    'KH H H - S H H - K H H - ST H OT -',
+    'KH H H - S H H - K H H H ST HT OT -'
   )
 });
 
 const CHORUS = makeSection({
-  name: 'chorus', harmony: ['G', 'D', 'Em7', 'A7'],
-  leadVoice: 'whistle', bassVoice: 'warm', arpVoice: 'organ', drumKit: 'brush',
+  name: 'chorus', harmony: ['D', 'A', 'Bm7', 'G'],
+  leadVoice: 'whistle', bassVoice: 'sub', arpVoice: 'organ', drumKit: 'brush',
   lead: bars(
-    'G5 = B5 D6 = B5 A5 G5 = F#5 = E5 D5 = G5 -',
-    'F#5 = A5 D6 = C#6 B5 A5 = F#5 = E5 D5 = A4 -',
-    'E5 = G5 B5 = A5 G5 F#5 = E5 = D5 B4 = E5 -',
-    'C#5 = E5 A5 = G5 F#5 E5 = C#5 = B4 A4 = C#5 -'
+    'A5 A5 B5 A5 - F#5 - D5 - F#5 A5 B5 - A5 - -',
+    'A5 A5 B5 A5 - E5 - C#5 - E5 A5 B5 - C#6 - -',
+    'B5 B5 D6 B5 - F#5 - D5 - F#5 A5 B5 - D6 - -',
+    'B5 A5 G5 F#5 - D5 - G5 - A5 B5 A5 G5 - F#5 -'
   ),
   bass: bars(
-    'G1 = D2 - B2 = G2 - D2 = G2 - B2 = D3 -',
-    'F#2 = A2 - D3 = A2 - F#2 = A2 - D3 = A2 -',
-    'E2 = B2 - D3 = B2 - G2 = B2 - E3 = D3 -',
-    'A1 = E2 - G2 = E2 - C#2 = E2 - A2 = G2 -'
+    'D2 = A2 - F#2 = F#3 - A1 = F#3 - E2 = D3 -',
+    'A1 = E2 - C#2 = C#3 - E2 = C#3 - B1 = A2 -',
+    'B1 = F#2 - E2 = D3 - F#2 = D3 - C#2 = B2 -',
+    'G1 = D2 - F2 = B2 - D2 = B2 - A1 = G2 -'
   ),
   arp: bars(
-    'B3 D4 G4 - D4 G4 B4 - G4 B4 D5 - B4 G4 D4 -',
-    'A3 D4 F#4 - D4 F#4 A4 - F#4 A4 D5 - A4 F#4 D4 -',
-    'G3 B3 D4 - B3 D4 G4 - D4 G4 B4 - G4 D4 B3 -',
-    'G3 A3 C#4 - A3 C#4 E4 - C#4 E4 G4 - E4 C#4 A3 -'
+    'F#4 A4 D5 - A4 D5 F#5 - D5 A4 F#4 - A4 D5 A4 -',
+    'E4 A4 C#5 - A4 C#5 E5 - C#5 A4 E4 - A4 C#5 A4 -',
+    'F#4 B4 D5 - B4 D5 F#5 - D5 B4 F#4 - B4 D5 B4 -',
+    'D4 G4 B4 - G4 B4 D5 - B4 G4 D4 - G4 B4 G4 -'
   ),
   drums: bars(
-    'KH H - H S H H - K H - H S H O -',
-    'KH H - H S - H H K H - H S H O -',
-    'KH H H - S H - H K H H - S H O -',
-    'KH H H - S H H - K H H H S H O -'
+    'KH H H - S H H - KH H H - S H HOT T',
+    'KH H H - S H H - KH H H - S H HOT T',
+    'KH H H - S H H - KH H H - S H HOT T',
+    'KH H H - S H H - KH H KOH H ST HT OT CT'
   )
 });
 
 export const CLIFFSIDE_SONG = makeSong({
-  id: 'cliffside',
-  name: 'Open Horizon',
-  bpm: 136,
-  key: 'B minor / D major',
-  style: 'flowing psychedelic pop with sweeping melodic lines, rolling bass and a strange cliff-edge harmonic turn',
-  swing: 0,
-  sections: [TUNE, BRIDGE, CHORUS],
-  arrangement: ['tune', 'tune', 'bridge', 'tune', 'chorus', 'chorus']
+  id: 'cliffside', name: 'Open Horizon', bpm: 136, key: 'B minor / D major',
+  style: 'flowing melodic pop with an expansive verse, rising pre-chorus tension and an immediate open-horizon hook', swing: 0,
+  sections: [TUNE, BRIDGE, CHORUS], arrangement: ['tune', 'tune', 'bridge', 'bridge', 'chorus', 'chorus']
 });

--- a/turn/audio/music/index.html
+++ b/turn/audio/music/index.html
@@ -199,7 +199,7 @@
   <script type="importmap">
     {
       "imports": {
-        "./songbook.js?revision=r185-menu-orchestration": "./songbook.js?revision=r211-breakwater",
+        "./songbook.js?revision=r185-menu-orchestration": "./songbook.js?revision=r212-open-horizon-final",
         "./instrument-bank.js?revision=r184-score-v2": "./instrument-bank.js?revision=r197-audio-mix",
         "./tracker-audio.js?revision=r187-music-tracker": "./tracker-audio.js?revision=r208-row-playhead"
       }

--- a/turn/audio/music/songbook.js
+++ b/turn/audio/music/songbook.js
@@ -1,7 +1,7 @@
 import { MENU_SONG } from './menu-theme.js?revision=r197-audio-mix';
 import { COUNTRYSIDE_SONG } from './countryside.js?revision=r197-audio-mix';
 import { AIRPORT_SONG } from './airport.js?revision=r209-paper-skies';
-import { CLIFFSIDE_SONG } from './cliffside.js?revision=r210-open-horizon';
+import { CLIFFSIDE_SONG } from './cliffside.js?revision=r212-open-horizon-final';
 import { HARBOR_SONG } from './harbor.js?revision=r211-breakwater';
 import { MIDNIGHT_CITY_SONG } from './midnight-city.js?revision=r197-audio-mix';
 import { MOUNTAIN_SONG } from './mountain.js?revision=r197-audio-mix';

--- a/turn/index.html
+++ b/turn/index.html
@@ -98,7 +98,7 @@
         "/turn/audio/audio-system.js?build=20260809-r163": "/turn/audio/audio-system.js?build=20260809-r163&revision=r163-voiceover-native-picker-events",
         "/turn/audio/audio-preferences.js?build=20260909-r212": "/turn/audio/audio-preferences.js?build=20260909-r212&revision=r197-audio-mix",
         "/turn/audio/racing-music-v2.js?build=20260909-r212-racing-music-warm-v2": "/turn/audio/racing-music-v5.js?revision=r197-audio-mix",
-        "/turn/audio/music/songbook.js?revision=r197-audio-mix": "/turn/audio/music/songbook.js?revision=r211-breakwater",
+        "/turn/audio/music/songbook.js?revision=r197-audio-mix": "/turn/audio/music/songbook.js?revision=r212-open-horizon-final",
         "/turn/audio/music/instrument-bank.js?revision=r184-score-v2": "/turn/audio/music/instrument-bank.js?revision=r197-audio-mix",
         "/turn/audio/music/tone-runtime.js?revision=r184-score-v2": "/turn/audio/music/tone-runtime-ties.js?revision=r186-note-ties",
         "/turn/audio/music/song-tools.js?revision=r184-score-v2": "/turn/audio/music/song-tools.js?revision=r186-note-ties",


### PR DESCRIPTION
Replaces the earlier Cliffside score with the user's finished Open Horizon arrangement while preserving TURN's canonical identity (`CLIFFSIDE_SONG`, id `cliffside`). The final version changes the instrumentation and authored notes throughout, updates the arrangement to `T T B B C C`, and keeps the title, 136 BPM tempo, and B minor / D major metadata.

Cache routing is bumped to `r212-open-horizon-final` in production TURN, TURN LAB, and Music Tracker so installed Safari/PWA sessions do not retain the earlier score. The racing-music regression is updated to lock the fresh score revision and final six-part form while continuing to validate instruments, bar lengths, harmony counts, and generated-audio constraints.