### PR TITLE
Use authored PERK icon across Trophy Road and The Lot

### DIFF
--- a/turn/garage/lot-enhancement-runtime.js
+++ b/turn/garage/lot-enhancement-runtime.js
@@ -28,6 +28,7 @@ export function prepareLotEnhancements() {
     import('./lot-shift.js?revision=r243-mountain-1300'),
     import('./lot-accessibility-r118.js?build=20260729-r118&revision=r588-canonical-attributes'),
     import('./lot-perk-disclosure.js?revision=r243-mountain-1300'),
+    import('./lot-perk-icon.js'),
     import('./lot-card-scroll-boundary.js?revision=r216-meter-density'),
     import('./lot-vehicle-copy.js?revision=r223-training-car-taxi'),
     import('./lot-trophy-order.js'),
@@ -39,6 +40,7 @@ export function prepareLotEnhancements() {
     shift,
     accessibility,
     perkDisclosure,
+    perkIcon,
     scrollBoundary,
     vehicleCopy,
     trophyOrder,
@@ -51,6 +53,7 @@ export function prepareLotEnhancements() {
       installLotShift: shift.installLotShift,
       installLotAccessibility: accessibility.installLotAccessibility,
       installLotPerkDisclosure: perkDisclosure.installLotPerkDisclosure,
+      installLotPerkIcon: perkIcon.installLotPerkIcon,
       installLotCardScrollBoundary: scrollBoundary.installLotCardScrollBoundary,
       installLotVehicleCopy: vehicleCopy.installLotVehicleCopy,
       installLotTrophyOrder: trophyOrder.installLotTrophyOrder,
@@ -130,6 +133,7 @@ export function enhanceLotNow(root = document.body) {
     gateLotNow,
     gateLotPaintNow,
     installLotPerkDisclosure,
+    installLotPerkIcon,
     installLotStatLegend,
     installLotLayout,
     installLotShift,
@@ -144,6 +148,7 @@ export function enhanceLotNow(root = document.body) {
   const removeTrophyGate = gateLotNow(scope);
   const removePaintGate = gateLotPaintNow(scope);
   const removePerkDisclosure = installLotPerkDisclosure(scope);
+  const removePerkIcon = installLotPerkIcon(scope);
   const removeStatLegend = installLotStatLegend(scope);
   const removeLayout = installLotLayout(scope);
   const removeShift = installLotShift(scope);
@@ -161,6 +166,7 @@ export function enhanceLotNow(root = document.body) {
     removeShift();
     removeLayout();
     removeStatLegend();
+    removePerkIcon();
     removePerkDisclosure();
     removePaintGate();
     removeTrophyGate();

--- a/turn/garage/lot-perk-icon.js
+++ b/turn/garage/lot-perk-icon.js
@@ -1,0 +1,66 @@
+import { AUTHORED_PERK_ICON } from '../ui/perk-icon.js';
+
+const STYLE_ID = 'turn-lot-perk-authored-icon-styles';
+
+function installStyles() {
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = `
+    .lot-perk-disclosure .lot-perk-head {
+      justify-content: flex-start;
+    }
+
+    .lot-perk-disclosure .lot-perk-icon {
+      display: grid;
+      flex: 0 0 46px;
+      width: 46px;
+      height: 47px;
+      margin-top: 1px;
+      color: var(--ink, #08090a);
+      place-items: center;
+    }
+
+    .lot-perk-disclosure .lot-perk-icon svg {
+      display: block;
+      width: 100%;
+      height: 100%;
+      overflow: visible;
+    }
+
+    .lot-perk-disclosure .lot-perk-heading {
+      flex: 1 1 auto;
+    }
+
+    .lot-perk-disclosure .lot-perk-close {
+      margin-left: auto;
+    }
+
+    @media (max-height: 520px) {
+      .lot-perk-disclosure .lot-perk-icon {
+        flex-basis: 40px;
+        width: 40px;
+        height: 41px;
+      }
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+export function installLotPerkIcon(root = document.body) {
+  const head = root?.querySelector?.('.lot-perk-disclosure .lot-perk-head');
+  if (!head) return () => {};
+
+  const existing = head.querySelector(':scope > .lot-perk-icon');
+  if (existing) return () => {};
+
+  installStyles();
+
+  const icon = document.createElement('span');
+  icon.className = 'lot-perk-icon';
+  icon.setAttribute('aria-hidden', 'true');
+  icon.innerHTML = AUTHORED_PERK_ICON;
+  head.insertBefore(icon, head.firstChild);
+
+  return () => icon.remove();
+}

--- a/turn/progression/trophy-road-track-icons.js
+++ b/turn/progression/trophy-road-track-icons.js
@@ -1,13 +1,15 @@
-// Trophy Road presentation overlay for the authored track icons.
+// Trophy Road presentation overlay for authored reward icons.
 // Progression thresholds and reward behavior remain in the canonical module.
 
 import * as base from './trophy-road.js?revision=r253-supercar-release-base';
 import { TRACK_ICON_MARKUP } from '../ui/track-icons.js?revision=r1-track-reward-icons';
+import { AUTHORED_PERK_ICON } from '../ui/perk-icon.js';
 
 export * from './trophy-road.js?revision=r253-supercar-release-base';
 
 export const TROPHY_ROAD_REWARD_ICONS = Object.freeze({
   ...base.TROPHY_ROAD_REWARD_ICONS,
   skyline: TRACK_ICON_MARKUP['midnight-city'],
-  mountain: TRACK_ICON_MARKUP.mountain
+  mountain: TRACK_ICON_MARKUP.mountain,
+  perk: AUTHORED_PERK_ICON
 });

--- a/turn/ui/perk-icon.js
+++ b/turn/ui/perk-icon.js
@@ -1,0 +1,28 @@
+// Authored PERK artwork shared by Trophy Road and The Lot.
+// The original gray canvas is intentionally omitted so every surface remains transparent.
+
+export const AUTHORED_PERK_ICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1048 1075" aria-hidden="true" focusable="false">
+  <g fill="none" stroke="currentColor" stroke-linecap="butt" stroke-linejoin="round">
+    <rect x="188.5" y="209.5" width="676" height="683" rx="56" stroke-width="40"/>
+    <path d="M736.5 79 V523 H624" stroke-width="36"/>
+    <path d="M49 359 H562" stroke-width="36"/>
+    <path d="M49 475 H464 V675 H680" stroke-width="36"/>
+    <path d="M341 630 V767 H565 V1009" stroke-width="36"/>
+  </g>
+
+  <path fill="currentColor" fill-rule="evenodd"
+        d="M555 301 H617 A27 27 0 0 1 644 328 V390 A27 27 0 0 1 617 417 H555 A27 27 0 0 1 528 390 V328 A27 27 0 0 1 555 301 Z
+           M562 335 H610 V383 H562 Z"/>
+
+  <path fill="currentColor" fill-rule="evenodd"
+        d="M658 523 A60 60 0 1 1 538 523 A60 60 0 1 1 658 523 Z
+           M624.5 523 A26.5 26.5 0 1 1 571.5 523 A26.5 26.5 0 1 1 624.5 523 Z"/>
+
+  <path fill="currentColor" fill-rule="evenodd"
+        d="M399 603 A60 60 0 1 1 279 603 A60 60 0 1 1 399 603 Z
+           M365.5 603 A26.5 26.5 0 1 1 312.5 603 A26.5 26.5 0 1 1 365.5 603 Z"/>
+
+  <path fill="currentColor" fill-rule="evenodd"
+        d="M674 610 H742 A28 28 0 0 1 770 638 V707 A28 28 0 0 1 742 735 H674 A28 28 0 0 1 646 707 V638 A28 28 0 0 1 674 610 Z
+           M680 645 H736 V701 H680 Z"/>
+</svg>`;


### PR DESCRIPTION
Uses the new transparent circuit-board PERK artwork as one shared authored SVG source.

- Trophy Road perk rewards now use the authored PERK icon, including reward info/detail surfaces that consume `TROPHY_ROAD_REWARD_ICONS`.
- The Lot perk information popover now shows the same decorative icon beside the PERK heading.
- The icon inherits `currentColor`, keeps its background/cutouts transparent, and is hidden from accessibility APIs because the adjacent text already names the content.
- The Lot integration is a small canonical enhancement module; no new manual `revision=` identity or revision-suffixed file is introduced.

This PR intentionally does not change TURN release/build identity yet. If merged to production, the merge step should increment the TURN build from r216 and assess the patch release bump/cache routing at that point.