### PR TITLE
Add semantic real-world WORLD mode to TURN NEXT

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,8 @@ export default [
   {
     files: [
       'turn-next/m8-home.js',
+      'turn-next/world-data.js',
+      'turn-next/world-mode.js',
       'turn/input/motion.js',
       'turn/motion-safe-zone.js',
       'turn/platform/*.js',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,7 @@ const readonlyGlobals = {
   localStorage: 'readonly',
   process: 'readonly',
   URL: 'readonly',
+  URLSearchParams: 'readonly',
   window: 'readonly',
   document: 'readonly',
   CustomEvent: 'readonly',

--- a/turn-next/README.md
+++ b/turn-next/README.md
@@ -17,6 +17,24 @@ Completed foundations:
 - audible limit cue on every rearmed hard crossing
 - first-per-side VoiceOver announcement during each race
 
+## WORLD experiment
+
+TURN NEXT also contains an isolated real-world free-roam experiment. It is intentionally additive and does not change the generated TURN NEXT parity entry files or production TURN.
+
+From the TURN NEXT Home menu, **WORLD** opens a small-area loader that can use entered coordinates, browser geolocation, or the Alpine demo preset. The experiment:
+
+- queries OpenStreetMap through Overpass for drivable roads, buildings, water, land use, woodland, parks and aeroways
+- generates road widths and markings from map semantics rather than using raster or satellite imagery
+- extrudes building footprints and uses simplified building bounds for collision
+- scatters low-poly trees inside mapped woodland
+- loads open Terrarium elevation tiles and builds low-poly terrain
+- feeds the mapped road network into TURN’s existing nearest-track physics while a scene override applies terrain height and pitch
+- suppresses competitive lap/record state while WORLD is active
+- restores the previously selected canonical TURN track when the player leaves WORLD
+- keeps visible OpenStreetMap and terrain-data attribution in the setup and WORLD HUD
+
+The loaded area is deliberately bounded to a maximum 1.25 km radius so public data services and mobile/tablet rendering stay within experiment-scale limits.
+
 ## Canonical motion safe zone
 
 The accepted Safe Zone M3 and Limit M4.2 behavior is no longer a TURN NEXT override.

--- a/turn-next/identity.js
+++ b/turn-next/identity.js
@@ -1,4 +1,6 @@
 (() => {
+  let worldModeLoading = false;
+
   function rewriteInstallCopy(root) {
     const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
     const nodes = [];
@@ -36,6 +38,34 @@
     document.documentElement.dataset.turnLegacyStart = 'retired';
   }
 
+  function installWorldModeWhenReady() {
+    if (worldModeLoading || globalThis.__turnNextWorldMode) return true;
+    const home = globalThis.__turnNextHome || globalThis.__turnHome;
+    const menu = globalThis.__turnHomeLayout?.menu;
+    if (!globalThis.__turnRuntime || !globalThis.__turnNextRaceSession || !home || !menu) return false;
+
+    worldModeLoading = true;
+    import('/turn-next/world-mode.js')
+      .then(({ installWorldMode }) => installWorldMode())
+      .catch((error) => {
+        worldModeLoading = false;
+        console.warn('TURN NEXT: WORLD experiment could not install.', error);
+      });
+    return true;
+  }
+
+  function scheduleWorldMode() {
+    let attempts = 0;
+    const tryInstall = () => {
+      if (installWorldModeWhenReady()) return;
+      attempts += 1;
+      if (attempts < 240) requestAnimationFrame(tryInstall);
+    };
+    tryInstall();
+    document.addEventListener('turn:home-ready', tryInstall);
+    window.addEventListener('turn:runtime-ready', tryInstall);
+  }
+
   function installIdentity() {
     document.documentElement.dataset.turnDeployment = 'next';
     retireLegacyStartPanel();
@@ -47,6 +77,7 @@
       observer.observe(gate, { childList: true, subtree: true, characterData: true });
     }
 
+    scheduleWorldMode();
     const source = globalThis.__TURN_BUILD__;
     console.info(`TURN NEXT: test runtime loaded from TURN ${source?.id || 'unknown source'}.`);
   }

--- a/turn-next/world-data.js
+++ b/turn-next/world-data.js
@@ -1,0 +1,780 @@
+import * as THREE from 'three';
+
+const OVERPASS_ENDPOINTS = Object.freeze([
+  'https://overpass-api.de/api/interpreter',
+  'https://overpass.kumi.systems/api/interpreter'
+]);
+const TERRAIN_TILE_ROOT = 'https://s3.amazonaws.com/elevation-tiles-prod/terrarium';
+const TERRAIN_ZOOM = 12;
+const TERRAIN_EXAGGERATION = 1.12;
+const METERS_PER_DEGREE_LATITUDE = 111_320;
+const ROAD_SAMPLE_SPACING = 12;
+const TERRAIN_SEGMENTS = 48;
+const MAX_BUILDINGS = 260;
+const MAX_LAND_POLYGONS = 140;
+const MAX_TREES = 180;
+const MAX_COLLIDERS = 180;
+const MAX_ROAD_SAMPLES = 4_500;
+const MAP_CACHE = new Map();
+const TERRAIN_TILE_CACHE = new Map();
+
+const ROAD_CLASSES = new Set([
+  'motorway', 'motorway_link', 'trunk', 'trunk_link', 'primary', 'primary_link',
+  'secondary', 'secondary_link', 'tertiary', 'tertiary_link', 'unclassified',
+  'residential', 'living_street', 'service', 'track'
+]);
+const LAND_TAGS = new Set([
+  'forest', 'farmland', 'meadow', 'grass', 'residential', 'commercial',
+  'industrial', 'recreation_ground', 'cemetery'
+]);
+const BUILDING_PALETTE = Object.freeze([
+  0xd6c1a0, 0xcaa37f, 0xb58c72, 0xe1d0b7, 0xa9937e, 0xc6b9a8
+]);
+
+export async function loadSemanticWorld({
+  latitude,
+  longitude,
+  radiusMeters = 900,
+  signal,
+  onStatus = () => {}
+} = {}) {
+  const center = normalizeCenter(latitude, longitude);
+  const radius = clamp(Number(radiusMeters) || 900, 450, 1_250);
+  const bounds = boundsAround(center, radius * 1.08);
+
+  onStatus('Loading roads and map semantics…');
+  const mapPromise = loadOpenStreetMap(bounds, signal);
+  onStatus('Loading terrain elevation…');
+  const terrainPromise = loadTerrain(center, bounds, signal).catch((error) => {
+    console.warn('TURN NEXT WORLD: terrain tiles unavailable; using flat relief.', error);
+    return createFlatTerrain(center);
+  });
+
+  const [map, terrain] = await Promise.all([mapPromise, terrainPromise]);
+  onStatus('Building low-poly world…');
+  const built = buildWorld({ map, terrain, center, radius });
+  if (built.samples.length < 2) {
+    disposeSemanticWorld(built.world);
+    throw new Error('No drivable OpenStreetMap roads were found in this area. Try a nearby place or a larger radius.');
+  }
+
+  return Object.freeze({
+    ...built,
+    center,
+    radius,
+    bounds,
+    terrain,
+    mapElementCount: map.elements.length,
+    toGeo(x, z) {
+      return Object.freeze({
+        lat: center.lat - Number(z || 0) / METERS_PER_DEGREE_LATITUDE,
+        lon: center.lon + Number(x || 0) / longitudeMetersPerDegree(center.lat)
+      });
+    }
+  });
+}
+
+export function disposeSemanticWorld(world) {
+  if (!world) return;
+  world.traverse((node) => {
+    node.geometry?.dispose?.();
+    if (Array.isArray(node.material)) node.material.forEach((material) => material?.dispose?.());
+    else node.material?.dispose?.();
+  });
+  world.removeFromParent?.();
+}
+
+async function loadOpenStreetMap(bounds, signal) {
+  const key = [bounds.south, bounds.west, bounds.north, bounds.east]
+    .map((value) => value.toFixed(4)).join(':');
+  if (MAP_CACHE.has(key)) return MAP_CACHE.get(key);
+
+  const bbox = `${bounds.south},${bounds.west},${bounds.north},${bounds.east}`;
+  const query = `[out:json][timeout:22];\n(\n`
+    + `way[\"highway\"~\"motorway|motorway_link|trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|living_street|service|track\"](${bbox});\n`
+    + `way[\"aeroway\"~\"runway|taxiway\"](${bbox});\n`
+    + `way[\"building\"](${bbox});\n`
+    + `way[\"natural\"~\"water|wood\"](${bbox});\n`
+    + `way[\"water\"](${bbox});\n`
+    + `way[\"landuse\"](${bbox});\n`
+    + `way[\"leisure\"~\"park|pitch|recreation_ground\"](${bbox});\n`
+    + `way[\"waterway\"=\"riverbank\"](${bbox});\n`
+    + `);\nout tags geom;`;
+
+  let lastError = null;
+  for (const endpoint of OVERPASS_ENDPOINTS) {
+    try {
+      const response = await globalThis.fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8' },
+        body: new URLSearchParams({ data: query }),
+        signal
+      });
+      if (!response.ok) throw new Error(`OpenStreetMap query failed with HTTP ${response.status}.`);
+      const data = await response.json();
+      if (!Array.isArray(data?.elements)) throw new Error('OpenStreetMap returned an unexpected response.');
+      MAP_CACHE.set(key, data);
+      return data;
+    } catch (error) {
+      if (error?.name === 'AbortError') throw error;
+      lastError = error;
+    }
+  }
+  throw lastError || new Error('OpenStreetMap data could not be loaded.');
+}
+
+async function loadTerrain(center, bounds, signal) {
+  const corners = [
+    [bounds.west, bounds.north], [bounds.east, bounds.north],
+    [bounds.west, bounds.south], [bounds.east, bounds.south]
+  ].map(([lon, lat]) => lonLatToTile(lon, lat, TERRAIN_ZOOM));
+  const minX = Math.floor(Math.min(...corners.map((tile) => tile.x)));
+  const maxX = Math.floor(Math.max(...corners.map((tile) => tile.x)));
+  const minY = Math.floor(Math.min(...corners.map((tile) => tile.y)));
+  const maxY = Math.floor(Math.max(...corners.map((tile) => tile.y)));
+  const tiles = new Map();
+  const tasks = [];
+
+  for (let x = minX; x <= maxX; x += 1) {
+    for (let y = minY; y <= maxY; y += 1) {
+      tasks.push(loadTerrainTile(TERRAIN_ZOOM, x, y, signal).then((tile) => {
+        tiles.set(`${x}:${y}`, tile);
+      }));
+    }
+  }
+  await Promise.all(tasks);
+
+  const rawAt = (lat, lon) => sampleTerrainTileSet(tiles, lat, lon, TERRAIN_ZOOM);
+  const centerRaw = rawAt(center.lat, center.lon);
+  const longitudeMeters = longitudeMetersPerDegree(center.lat);
+  const heightAtLatLon = (lat, lon) => (rawAt(lat, lon) - centerRaw) * TERRAIN_EXAGGERATION;
+  const heightAtWorld = (x, z) => {
+    const lat = center.lat - z / METERS_PER_DEGREE_LATITUDE;
+    const lon = center.lon + x / longitudeMeters;
+    return heightAtLatLon(lat, lon);
+  };
+
+  return Object.freeze({
+    available: true,
+    zoom: TERRAIN_ZOOM,
+    source: 'Mapzen Terrain Tiles',
+    centerElevation: centerRaw,
+    heightAtLatLon,
+    heightAtWorld
+  });
+}
+
+function createFlatTerrain(center) {
+  return Object.freeze({
+    available: false,
+    zoom: null,
+    source: 'flat fallback',
+    centerElevation: 0,
+    heightAtLatLon: () => 0,
+    heightAtWorld: () => 0,
+    center
+  });
+}
+
+async function loadTerrainTile(zoom, x, y, signal) {
+  const key = `${zoom}:${x}:${y}`;
+  if (TERRAIN_TILE_CACHE.has(key)) return TERRAIN_TILE_CACHE.get(key);
+  const promise = (async () => {
+    const response = await globalThis.fetch(`${TERRAIN_TILE_ROOT}/${zoom}/${x}/${y}.png`, { signal });
+    if (!response.ok) throw new Error(`Terrain tile failed with HTTP ${response.status}.`);
+    const blob = await response.blob();
+    const source = typeof globalThis.createImageBitmap === 'function'
+      ? await globalThis.createImageBitmap(blob)
+      : await imageFromBlob(blob);
+    const canvas = document.createElement('canvas');
+    canvas.width = source.width;
+    canvas.height = source.height;
+    const context = canvas.getContext('2d', { willReadFrequently: true });
+    if (!context) throw new Error('Terrain canvas could not be created.');
+    context.drawImage(source, 0, 0);
+    const data = context.getImageData(0, 0, canvas.width, canvas.height).data;
+    source.close?.();
+    return Object.freeze({ width: canvas.width, height: canvas.height, data });
+  })();
+  TERRAIN_TILE_CACHE.set(key, promise);
+  try {
+    return await promise;
+  } catch (error) {
+    TERRAIN_TILE_CACHE.delete(key);
+    throw error;
+  }
+}
+
+function imageFromBlob(blob) {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(blob);
+    const image = new globalThis.Image();
+    image.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(image);
+    };
+    image.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error('Terrain image could not be decoded.'));
+    };
+    image.src = url;
+  });
+}
+
+function sampleTerrainTileSet(tiles, lat, lon, zoom) {
+  const tilePosition = lonLatToTile(lon, lat, zoom);
+  const x = Math.floor(tilePosition.x);
+  const y = Math.floor(tilePosition.y);
+  const tile = tiles.get(`${x}:${y}`);
+  if (!tile) return 0;
+  const pixelX = clamp(Math.floor((tilePosition.x - x) * tile.width), 0, tile.width - 1);
+  const pixelY = clamp(Math.floor((tilePosition.y - y) * tile.height), 0, tile.height - 1);
+  const offset = (pixelY * tile.width + pixelX) * 4;
+  const red = tile.data[offset];
+  const green = tile.data[offset + 1];
+  const blue = tile.data[offset + 2];
+  return (red * 256 + green + blue / 256) - 32768;
+}
+
+function buildWorld({ map, terrain, center, radius }) {
+  const world = new THREE.Group();
+  world.name = 'TURN NEXT semantic real world';
+  world.userData.turnNextWorld = true;
+
+  const terrainMesh = makeTerrainMesh(terrain, radius);
+  world.add(terrainMesh);
+
+  const semanticWays = map.elements.filter((element) => element.type === 'way' && element.geometry?.length >= 2);
+  const landWays = semanticWays.filter((way) => isLandPolygon(way));
+  const buildingWays = semanticWays.filter((way) => Boolean(way.tags?.building));
+  const roadWays = semanticWays.filter((way) => isDrivableWay(way));
+
+  const landStats = installLandPolygons(world, landWays, terrain, center);
+  const roadResult = installRoadNetwork(world, roadWays, terrain, center);
+  const buildingResult = installBuildings(world, buildingWays, terrain, center);
+  const trees = installForestTrees(world, landWays, terrain, center);
+
+  const samples = capSamples(roadResult.samples, MAX_ROAD_SAMPLES);
+  const startIndex = closestSampleIndex(samples, 0, 0);
+  const collisionProfile = Object.freeze({
+    freeRoamDistance: radius * 3,
+    colliders: Object.freeze(buildingResult.colliders.slice(0, MAX_COLLIDERS))
+  });
+
+  return {
+    world,
+    samples,
+    startIndex,
+    collisionProfile,
+    stats: Object.freeze({
+      roads: roadResult.roadCount,
+      buildings: buildingResult.count,
+      semanticAreas: landStats.count,
+      trees,
+      terrain: terrain.available
+    })
+  };
+}
+
+function makeTerrainMesh(terrain, radius) {
+  const size = radius * 2.35;
+  const geometry = new THREE.PlaneGeometry(size, size, TERRAIN_SEGMENTS, TERRAIN_SEGMENTS);
+  const position = geometry.attributes.position;
+  const colors = [];
+  const low = new THREE.Color(0x6f9f67);
+  const high = new THREE.Color(0x827d73);
+
+  for (let index = 0; index < position.count; index += 1) {
+    const x = position.getX(index);
+    const z = -position.getY(index);
+    const height = terrain.heightAtWorld(x, z);
+    position.setZ(index, height);
+    const slopeTint = clamp((height + 20) / 180, 0, 1);
+    const color = low.clone().lerp(high, slopeTint);
+    colors.push(color.r, color.g, color.b);
+  }
+  geometry.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
+  geometry.rotateX(-Math.PI / 2);
+  geometry.computeVertexNormals();
+  const mesh = new THREE.Mesh(
+    geometry,
+    new THREE.MeshStandardMaterial({
+      vertexColors: true,
+      roughness: 1,
+      metalness: 0,
+      flatShading: true
+    })
+  );
+  mesh.name = 'DEM terrain';
+  mesh.receiveShadow = true;
+  return mesh;
+}
+
+function installRoadNetwork(world, ways, terrain, center) {
+  const positions = [];
+  const colors = [];
+  const indices = [];
+  const samples = [];
+  const dashTransforms = [];
+  let vertexOffset = 0;
+  let cumulativeDistance = 0;
+  let roadCount = 0;
+
+  for (const way of ways) {
+    const points = densifyGeometry(way.geometry, center, terrain, ROAD_SAMPLE_SPACING, roadVerticalOffset(way));
+    if (points.length < 2) continue;
+    roadCount += 1;
+    const width = roadWidth(way.tags || {});
+    const color = roadColor(way.tags || {});
+    const roadSamples = pointsToSamples(points, cumulativeDistance);
+    if (roadSamples.length) cumulativeDistance = roadSamples.at(-1).distance + ROAD_SAMPLE_SPACING;
+    samples.push(...roadSamples);
+
+    for (let index = 0; index < roadSamples.length; index += 1) {
+      const sample = roadSamples[index];
+      const left = sample.point.clone().addScaledVector(sample.normal, width / 2);
+      const right = sample.point.clone().addScaledVector(sample.normal, -width / 2);
+      positions.push(left.x, left.y, left.z, right.x, right.y, right.z);
+      colors.push(color.r, color.g, color.b, color.r, color.g, color.b);
+      if (index < roadSamples.length - 1) {
+        const offset = vertexOffset + index * 2;
+        indices.push(offset, offset + 2, offset + 1, offset + 1, offset + 2, offset + 3);
+      }
+    }
+
+    if (shouldMarkCenter(way.tags || {})) {
+      let distance = 10;
+      for (let index = 1; index < roadSamples.length && dashTransforms.length < 700; index += 1) {
+        const previous = roadSamples[index - 1];
+        const current = roadSamples[index];
+        const segment = current.point.distanceTo(previous.point);
+        distance += segment;
+        if (distance < 18) continue;
+        distance = 0;
+        dashTransforms.push(current);
+      }
+    }
+    vertexOffset += roadSamples.length * 2;
+  }
+
+  if (positions.length) {
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+    geometry.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
+    geometry.setIndex(indices);
+    geometry.computeVertexNormals();
+    const roads = new THREE.Mesh(
+      geometry,
+      new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.96, metalness: 0, side: THREE.DoubleSide })
+    );
+    roads.name = 'OpenStreetMap roads';
+    roads.receiveShadow = true;
+    world.add(roads);
+  }
+
+  if (dashTransforms.length) {
+    const dash = new THREE.InstancedMesh(
+      new THREE.BoxGeometry(0.22, 0.045, 4.2),
+      new THREE.MeshStandardMaterial({ color: 0xf8f3df, roughness: 0.9 }),
+      dashTransforms.length
+    );
+    const marker = new THREE.Object3D();
+    dashTransforms.forEach((sample, index) => {
+      marker.position.copy(sample.point);
+      marker.position.y += 0.07;
+      marker.rotation.set(0, Math.atan2(sample.tangent.x, sample.tangent.z), 0);
+      marker.updateMatrix();
+      dash.setMatrixAt(index, marker.matrix);
+    });
+    dash.instanceMatrix.needsUpdate = true;
+    dash.name = 'Semantic road markings';
+    world.add(dash);
+  }
+
+  return { samples, roadCount };
+}
+
+function installBuildings(world, ways, terrain, center) {
+  const group = new THREE.Group();
+  group.name = 'OpenStreetMap buildings';
+  const colliders = [];
+  let count = 0;
+
+  for (const way of ways) {
+    if (count >= MAX_BUILDINGS) break;
+    const polygon = geometryToWorldPolygon(way.geometry, center);
+    if (polygon.length < 3 || polygonArea(polygon) < 10) continue;
+    const centroid = polygonCentroid(polygon);
+    const height = buildingHeight(way.tags || {}, way.id);
+    const baseY = terrain.heightAtWorld(centroid.x, centroid.z) + 0.08;
+    const geometry = extrudePolygon(polygon, centroid, height);
+    if (!geometry) continue;
+    const color = BUILDING_PALETTE[Math.abs(Number(way.id) || count) % BUILDING_PALETTE.length];
+    const mesh = new THREE.Mesh(
+      geometry,
+      new THREE.MeshStandardMaterial({ color, roughness: 0.91, metalness: 0, flatShading: true })
+    );
+    mesh.position.set(centroid.x, baseY, centroid.z);
+    mesh.castShadow = true;
+    mesh.receiveShadow = true;
+    group.add(mesh);
+    const bounds = polygonBounds(polygon);
+    if (colliders.length < MAX_COLLIDERS && bounds.width > 2.5 && bounds.depth > 2.5) {
+      colliders.push(Object.freeze({
+        type: 'box',
+        minX: bounds.minX,
+        maxX: bounds.maxX,
+        minZ: bounds.minZ,
+        maxZ: bounds.maxZ
+      }));
+    }
+    count += 1;
+  }
+  world.add(group);
+  return { count, colliders };
+}
+
+function installLandPolygons(world, ways, terrain, center) {
+  const group = new THREE.Group();
+  group.name = 'OpenStreetMap land semantics';
+  let count = 0;
+  for (const way of ways) {
+    if (count >= MAX_LAND_POLYGONS) break;
+    const polygon = geometryToWorldPolygon(way.geometry, center);
+    if (polygon.length < 3 || polygonArea(polygon) < 30) continue;
+    const centroid = polygonCentroid(polygon);
+    const shape = polygonShape(polygon, centroid);
+    const geometry = new THREE.ShapeGeometry(shape);
+    geometry.rotateX(-Math.PI / 2);
+    const mesh = new THREE.Mesh(
+      geometry,
+      new THREE.MeshStandardMaterial({ color: semanticAreaColor(way.tags || {}), roughness: 1, metalness: 0, side: THREE.DoubleSide })
+    );
+    mesh.position.set(centroid.x, terrain.heightAtWorld(centroid.x, centroid.z) + 0.045, centroid.z);
+    mesh.receiveShadow = true;
+    mesh.name = semanticAreaName(way.tags || {});
+    group.add(mesh);
+    count += 1;
+  }
+  world.add(group);
+  return { count };
+}
+
+function installForestTrees(world, ways, terrain, center) {
+  const forests = ways.filter((way) => way.tags?.natural === 'wood' || way.tags?.landuse === 'forest');
+  const placements = [];
+  for (const way of forests) {
+    if (placements.length >= MAX_TREES) break;
+    const polygon = geometryToWorldPolygon(way.geometry, center);
+    if (polygon.length < 3) continue;
+    const bounds = polygonBounds(polygon);
+    const area = Math.max(0, polygonArea(polygon));
+    const target = clamp(Math.round(area / 5_000), 3, 18);
+    const random = seededRandom(Number(way.id) || 1);
+    let attempts = 0;
+    while (placements.length < MAX_TREES && attempts < target * 14) {
+      attempts += 1;
+      const x = bounds.minX + random() * bounds.width;
+      const z = bounds.minZ + random() * bounds.depth;
+      if (!pointInsidePolygon(x, z, polygon)) continue;
+      placements.push({ x, z, scale: 0.75 + random() * 0.7, rotation: random() * Math.PI * 2 });
+      if (placements.length % target === 0 && attempts >= target) break;
+    }
+  }
+  if (!placements.length) return 0;
+
+  const trees = new THREE.InstancedMesh(
+    new THREE.ConeGeometry(2.7, 8.5, 5),
+    new THREE.MeshStandardMaterial({ color: 0x35683f, roughness: 1, flatShading: true }),
+    placements.length
+  );
+  const marker = new THREE.Object3D();
+  placements.forEach((placement, index) => {
+    marker.position.set(
+      placement.x,
+      terrain.heightAtWorld(placement.x, placement.z) + 4.1 * placement.scale,
+      placement.z
+    );
+    marker.rotation.set(0, placement.rotation, 0);
+    marker.scale.setScalar(placement.scale);
+    marker.updateMatrix();
+    trees.setMatrixAt(index, marker.matrix);
+  });
+  trees.instanceMatrix.needsUpdate = true;
+  trees.castShadow = true;
+  trees.name = 'Semantic forest';
+  world.add(trees);
+  return placements.length;
+}
+
+function densifyGeometry(geometry, center, terrain, spacing, verticalOffset) {
+  const result = [];
+  for (let index = 1; index < geometry.length; index += 1) {
+    const a = geometry[index - 1];
+    const b = geometry[index];
+    const start = geoToWorld(a.lat, a.lon, center);
+    const end = geoToWorld(b.lat, b.lon, center);
+    const distance = Math.hypot(end.x - start.x, end.z - start.z);
+    const steps = Math.max(1, Math.ceil(distance / spacing));
+    for (let step = index === 1 ? 0 : 1; step <= steps; step += 1) {
+      const amount = step / steps;
+      const lat = lerp(a.lat, b.lat, amount);
+      const lon = lerp(a.lon, b.lon, amount);
+      const point = geoToWorld(lat, lon, center);
+      point.y = terrain.heightAtLatLon(lat, lon) + 0.14 + verticalOffset;
+      result.push(point);
+    }
+  }
+  return result;
+}
+
+function pointsToSamples(points, distanceStart) {
+  const samples = [];
+  let distance = distanceStart;
+  for (let index = 0; index < points.length; index += 1) {
+    const point = points[index];
+    const previous = points[Math.max(0, index - 1)];
+    const next = points[Math.min(points.length - 1, index + 1)];
+    const tangent = next.clone().sub(previous).normalize();
+    const normal = new THREE.Vector3(-tangent.z, 0, tangent.x).normalize();
+    if (index) distance += point.distanceTo(points[index - 1]);
+    samples.push({ point, tangent, normal, distance });
+  }
+  return samples;
+}
+
+function capSamples(samples, limit) {
+  if (samples.length <= limit) return samples;
+  const stride = samples.length / limit;
+  return Array.from({ length: limit }, (_, index) => samples[Math.floor(index * stride)]);
+}
+
+function isDrivableWay(way) {
+  const highway = way.tags?.highway;
+  const aeroway = way.tags?.aeroway;
+  return ROAD_CLASSES.has(highway) || aeroway === 'runway' || aeroway === 'taxiway';
+}
+
+function roadWidth(tags) {
+  if (tags.aeroway === 'runway') return 46;
+  if (tags.aeroway === 'taxiway') return 18;
+  const defaults = {
+    motorway: 13, motorway_link: 8, trunk: 12, trunk_link: 8,
+    primary: 10.5, primary_link: 7.5, secondary: 9.5, secondary_link: 7,
+    tertiary: 8.5, tertiary_link: 6.5, residential: 7, unclassified: 6.5,
+    living_street: 6, service: 5, track: 4
+  };
+  const lanes = parseInt(tags.lanes, 10);
+  const laneWidth = Number.isFinite(lanes) && lanes > 0 ? lanes * 3.15 + 1.2 : 0;
+  return Math.max(defaults[tags.highway] || 6, laneWidth);
+}
+
+function roadColor(tags) {
+  if (tags.aeroway) return new THREE.Color(0x4a4d52);
+  const surface = String(tags.surface || '').toLowerCase();
+  if (/gravel|dirt|ground|unpaved|fine_gravel|compacted/.test(surface) || tags.highway === 'track') {
+    return new THREE.Color(0x8b7d69);
+  }
+  if (/motorway|trunk|primary/.test(tags.highway || '')) return new THREE.Color(0x353a40);
+  return new THREE.Color(0x464b50);
+}
+
+function shouldMarkCenter(tags) {
+  if (tags.aeroway) return false;
+  if (['track', 'service', 'living_street'].includes(tags.highway)) return false;
+  const surface = String(tags.surface || '').toLowerCase();
+  return !/gravel|dirt|ground|unpaved/.test(surface);
+}
+
+function roadVerticalOffset(way) {
+  if (way.tags?.bridge === 'yes' || way.tags?.bridge === 'viaduct') return 1.35;
+  if (way.tags?.tunnel === 'yes') return -0.2;
+  const layer = Number.parseInt(way.tags?.layer, 10);
+  return Number.isFinite(layer) ? clamp(layer, -2, 3) * 0.45 : 0;
+}
+
+function buildingHeight(tags, seed) {
+  const explicit = Number.parseFloat(tags.height);
+  if (Number.isFinite(explicit) && explicit > 2) return clamp(explicit, 3, 80);
+  const levels = Number.parseFloat(tags['building:levels']);
+  if (Number.isFinite(levels) && levels > 0) return clamp(levels * 3.1, 3, 80);
+  return 6.5 + (Math.abs(Number(seed) || 0) % 5) * 1.5;
+}
+
+function isLandPolygon(way) {
+  if (!isClosedWay(way)) return false;
+  const tags = way.tags || {};
+  if (tags.natural === 'water' || tags.natural === 'wood') return true;
+  if (tags.water || tags.waterway === 'riverbank') return true;
+  if (LAND_TAGS.has(tags.landuse)) return true;
+  return ['park', 'pitch', 'recreation_ground'].includes(tags.leisure);
+}
+
+function semanticAreaColor(tags) {
+  if (tags.natural === 'water' || tags.water || tags.waterway === 'riverbank') return 0x3b98b5;
+  if (tags.natural === 'wood' || tags.landuse === 'forest') return 0x4c7a4e;
+  if (tags.landuse === 'farmland') return 0xc5b36d;
+  if (tags.landuse === 'industrial') return 0x98958e;
+  if (tags.landuse === 'commercial') return 0xb6a69a;
+  if (tags.landuse === 'residential') return 0xb9b49d;
+  if (tags.leisure === 'pitch') return 0x70a766;
+  return 0x7fb36f;
+}
+
+function semanticAreaName(tags) {
+  if (tags.natural === 'water' || tags.water || tags.waterway === 'riverbank') return 'Semantic water';
+  if (tags.natural === 'wood' || tags.landuse === 'forest') return 'Semantic woodland';
+  return `Semantic ${tags.landuse || tags.leisure || 'land'}`;
+}
+
+function extrudePolygon(polygon, centroid, height) {
+  try {
+    const shape = polygonShape(polygon, centroid);
+    const geometry = new THREE.ExtrudeGeometry(shape, {
+      depth: height,
+      bevelEnabled: false,
+      curveSegments: 1,
+      steps: 1
+    });
+    geometry.rotateX(-Math.PI / 2);
+    geometry.computeVertexNormals();
+    return geometry;
+  } catch (_) {
+    return null;
+  }
+}
+
+function polygonShape(polygon, centroid) {
+  const shape = new THREE.Shape();
+  polygon.forEach((point, index) => {
+    const x = point.x - centroid.x;
+    const y = -(point.z - centroid.z);
+    if (index === 0) shape.moveTo(x, y);
+    else shape.lineTo(x, y);
+  });
+  shape.closePath();
+  return shape;
+}
+
+function geometryToWorldPolygon(geometry, center) {
+  const points = geometry.map((point) => geoToWorld(point.lat, point.lon, center));
+  if (points.length > 2 && points[0].distanceToSquared(points.at(-1)) < 0.01) points.pop();
+  return points;
+}
+
+function isClosedWay(way) {
+  const geometry = way.geometry;
+  if (!Array.isArray(geometry) || geometry.length < 4) return false;
+  const first = geometry[0];
+  const last = geometry.at(-1);
+  return Math.abs(first.lat - last.lat) < 1e-7 && Math.abs(first.lon - last.lon) < 1e-7;
+}
+
+function polygonArea(points) {
+  let area = 0;
+  for (let index = 0; index < points.length; index += 1) {
+    const current = points[index];
+    const next = points[(index + 1) % points.length];
+    area += current.x * next.z - next.x * current.z;
+  }
+  return Math.abs(area) / 2;
+}
+
+function polygonCentroid(points) {
+  const total = points.reduce((sum, point) => ({ x: sum.x + point.x, z: sum.z + point.z }), { x: 0, z: 0 });
+  return { x: total.x / points.length, z: total.z / points.length };
+}
+
+function polygonBounds(points) {
+  const xs = points.map((point) => point.x);
+  const zs = points.map((point) => point.z);
+  const minX = Math.min(...xs);
+  const maxX = Math.max(...xs);
+  const minZ = Math.min(...zs);
+  const maxZ = Math.max(...zs);
+  return { minX, maxX, minZ, maxZ, width: maxX - minX, depth: maxZ - minZ };
+}
+
+function pointInsidePolygon(x, z, polygon) {
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i, i += 1) {
+    const a = polygon[i];
+    const b = polygon[j];
+    const crosses = ((a.z > z) !== (b.z > z))
+      && (x < (b.x - a.x) * (z - a.z) / ((b.z - a.z) || 1e-9) + a.x);
+    if (crosses) inside = !inside;
+  }
+  return inside;
+}
+
+function seededRandom(seed) {
+  let value = (seed >>> 0) || 1;
+  return () => {
+    value ^= value << 13;
+    value ^= value >>> 17;
+    value ^= value << 5;
+    return (value >>> 0) / 4_294_967_296;
+  };
+}
+
+function closestSampleIndex(samples, x, z) {
+  let bestIndex = 0;
+  let bestDistance = Infinity;
+  samples.forEach((sample, index) => {
+    const dx = sample.point.x - x;
+    const dz = sample.point.z - z;
+    const distance = dx * dx + dz * dz;
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestIndex = index;
+    }
+  });
+  return bestIndex;
+}
+
+function normalizeCenter(latitude, longitude) {
+  const lat = Number(latitude);
+  const lon = Number(longitude);
+  if (!Number.isFinite(lat) || lat < -85 || lat > 85) throw new Error('Latitude must be between -85 and 85.');
+  if (!Number.isFinite(lon) || lon < -180 || lon > 180) throw new Error('Longitude must be between -180 and 180.');
+  return Object.freeze({ lat, lon });
+}
+
+function boundsAround(center, radius) {
+  const latDelta = radius / METERS_PER_DEGREE_LATITUDE;
+  const lonDelta = radius / longitudeMetersPerDegree(center.lat);
+  return Object.freeze({
+    south: center.lat - latDelta,
+    west: center.lon - lonDelta,
+    north: center.lat + latDelta,
+    east: center.lon + lonDelta
+  });
+}
+
+function geoToWorld(lat, lon, center) {
+  return new THREE.Vector3(
+    (lon - center.lon) * longitudeMetersPerDegree(center.lat),
+    0,
+    -(lat - center.lat) * METERS_PER_DEGREE_LATITUDE
+  );
+}
+
+function longitudeMetersPerDegree(latitude) {
+  return Math.max(1, METERS_PER_DEGREE_LATITUDE * Math.cos(THREE.MathUtils.degToRad(latitude)));
+}
+
+function lonLatToTile(lon, lat, zoom) {
+  const scale = 2 ** zoom;
+  const x = (lon + 180) / 360 * scale;
+  const latitudeRadians = THREE.MathUtils.degToRad(clamp(lat, -85.05112878, 85.05112878));
+  const y = (1 - Math.asinh(Math.tan(latitudeRadians)) / Math.PI) / 2 * scale;
+  return { x, y };
+}
+
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}

--- a/turn-next/world-data.js
+++ b/turn-next/world-data.js
@@ -91,14 +91,14 @@ async function loadOpenStreetMap(bounds, signal) {
 
   const bbox = `${bounds.south},${bounds.west},${bounds.north},${bounds.east}`;
   const query = `[out:json][timeout:22];\n(\n`
-    + `way[\"highway\"~\"motorway|motorway_link|trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|living_street|service|track\"](${bbox});\n`
-    + `way[\"aeroway\"~\"runway|taxiway\"](${bbox});\n`
-    + `way[\"building\"](${bbox});\n`
-    + `way[\"natural\"~\"water|wood\"](${bbox});\n`
-    + `way[\"water\"](${bbox});\n`
-    + `way[\"landuse\"](${bbox});\n`
-    + `way[\"leisure\"~\"park|pitch|recreation_ground\"](${bbox});\n`
-    + `way[\"waterway\"=\"riverbank\"](${bbox});\n`
+    + `way["highway"~"motorway|motorway_link|trunk|trunk_link|primary|primary_link|secondary|secondary_link|tertiary|tertiary_link|unclassified|residential|living_street|service|track"](${bbox});\n`
+    + `way["aeroway"~"runway|taxiway"](${bbox});\n`
+    + `way["building"](${bbox});\n`
+    + `way["natural"~"water|wood"](${bbox});\n`
+    + `way["water"](${bbox});\n`
+    + `way["landuse"](${bbox});\n`
+    + `way["leisure"~"park|pitch|recreation_ground"](${bbox});\n`
+    + `way["waterway"="riverbank"](${bbox});\n`
     + `);\nout tags geom;`;
 
   let lastError = null;
@@ -222,13 +222,37 @@ function imageFromBlob(blob) {
 }
 
 function sampleTerrainTileSet(tiles, lat, lon, zoom) {
+  const firstTile = tiles.values().next().value;
+  if (!firstTile) return 0;
   const tilePosition = lonLatToTile(lon, lat, zoom);
-  const x = Math.floor(tilePosition.x);
-  const y = Math.floor(tilePosition.y);
-  const tile = tiles.get(`${x}:${y}`);
+  const globalX = tilePosition.x * firstTile.width;
+  const globalY = tilePosition.y * firstTile.height;
+  const x0 = Math.floor(globalX);
+  const y0 = Math.floor(globalY);
+  const x1 = x0 + 1;
+  const y1 = y0 + 1;
+  const tx = globalX - x0;
+  const ty = globalY - y0;
+  const top = lerp(
+    terrainPixel(tiles, x0, y0, firstTile.width, firstTile.height),
+    terrainPixel(tiles, x1, y0, firstTile.width, firstTile.height),
+    tx
+  );
+  const bottom = lerp(
+    terrainPixel(tiles, x0, y1, firstTile.width, firstTile.height),
+    terrainPixel(tiles, x1, y1, firstTile.width, firstTile.height),
+    tx
+  );
+  return lerp(top, bottom, ty);
+}
+
+function terrainPixel(tiles, globalX, globalY, width, height) {
+  const tileX = Math.floor(globalX / width);
+  const tileY = Math.floor(globalY / height);
+  const tile = tiles.get(`${tileX}:${tileY}`);
   if (!tile) return 0;
-  const pixelX = clamp(Math.floor((tilePosition.x - x) * tile.width), 0, tile.width - 1);
-  const pixelY = clamp(Math.floor((tilePosition.y - y) * tile.height), 0, tile.height - 1);
+  const pixelX = ((globalX % width) + width) % width;
+  const pixelY = ((globalY % height) + height) % height;
   const offset = (pixelY * tile.width + pixelX) * 4;
   const red = tile.data[offset];
   const green = tile.data[offset + 1];
@@ -472,13 +496,14 @@ function installForestTrees(world, ways, terrain, center) {
     const target = clamp(Math.round(area / 5_000), 3, 18);
     const random = seededRandom(Number(way.id) || 1);
     let attempts = 0;
-    while (placements.length < MAX_TREES && attempts < target * 14) {
+    let added = 0;
+    while (placements.length < MAX_TREES && added < target && attempts < target * 14) {
       attempts += 1;
       const x = bounds.minX + random() * bounds.width;
       const z = bounds.minZ + random() * bounds.depth;
       if (!pointInsidePolygon(x, z, polygon)) continue;
       placements.push({ x, z, scale: 0.75 + random() * 0.7, rotation: random() * Math.PI * 2 });
-      if (placements.length % target === 0 && attempts >= target) break;
+      added += 1;
     }
   }
   if (!placements.length) return 0;

--- a/turn-next/world-mode.css
+++ b/turn-next/world-mode.css
@@ -1,0 +1,270 @@
+.turn-next-world-launcher {
+  min-height: 36px;
+  border: 2px solid #08090a;
+  border-radius: 8px;
+  background: var(--turn-cyan-500, #38d9ff);
+  color: #08090a;
+  box-shadow: 0 3px 0 #08090a;
+  font: 900 0.78rem/1 system-ui, sans-serif;
+  letter-spacing: 0.07em;
+  cursor: pointer;
+}
+
+.turn-next-world-launcher:active {
+  transform: translateY(2px);
+  box-shadow: 0 1px 0 #08090a;
+}
+
+.turn-next-world-dialog {
+  width: min(680px, calc(100vw - 32px));
+  max-height: calc(100dvh - 28px);
+  margin: auto;
+  padding: 0;
+  border: 3px solid #08090a;
+  border-radius: 14px;
+  background: #fff8e8;
+  color: #08090a;
+  box-shadow: 8px 8px 0 #08090a;
+  overflow: auto;
+}
+
+.turn-next-world-dialog::backdrop {
+  background: rgb(8 9 10 / 72%);
+}
+
+.turn-next-world-card {
+  display: grid;
+  gap: 16px;
+  padding: 18px;
+}
+
+.turn-next-world-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.turn-next-world-header span {
+  display: block;
+  margin-bottom: 4px;
+  font: 800 0.7rem/1 system-ui, sans-serif;
+  letter-spacing: 0.08em;
+}
+
+.turn-next-world-header h2 {
+  margin: 0;
+  font: 1000 clamp(2rem, 8vw, 4rem)/0.85 system-ui, sans-serif;
+  letter-spacing: -0.07em;
+}
+
+.turn-next-world-close {
+  width: 42px;
+  height: 42px;
+  flex: none;
+  border: 2px solid #08090a;
+  border-radius: 50%;
+  background: #ff7b54;
+  color: #08090a;
+  font: 900 1.65rem/1 system-ui, sans-serif;
+  cursor: pointer;
+}
+
+.turn-next-world-copy,
+.turn-next-world-note,
+.turn-next-world-credits,
+.turn-next-world-status {
+  margin: 0;
+  font: 700 0.84rem/1.35 system-ui, sans-serif;
+}
+
+.turn-next-world-copy {
+  max-width: 58ch;
+  font-size: 0.95rem;
+}
+
+.turn-next-world-fields {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.turn-next-world-fields label {
+  display: grid;
+  gap: 5px;
+  font: 900 0.68rem/1 system-ui, sans-serif;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.turn-next-world-fields input,
+.turn-next-world-fields select {
+  width: 100%;
+  min-height: 42px;
+  box-sizing: border-box;
+  border: 2px solid #08090a;
+  border-radius: 7px;
+  background: #fff;
+  color: #08090a;
+  padding: 7px 9px;
+  font: 800 0.9rem/1 system-ui, sans-serif;
+}
+
+.turn-next-world-presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.turn-next-world-presets button,
+.turn-next-world-drive,
+.turn-next-world-hud button {
+  min-height: 40px;
+  border: 2px solid #08090a;
+  border-radius: 8px;
+  padding: 8px 13px;
+  background: #fff;
+  color: #08090a;
+  box-shadow: 0 3px 0 #08090a;
+  font: 900 0.75rem/1 system-ui, sans-serif;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+}
+
+.turn-next-world-drive {
+  justify-self: stretch;
+  min-height: 48px;
+  background: #ffd43b;
+  font-size: 0.9rem;
+}
+
+.turn-next-world-presets button:disabled,
+.turn-next-world-drive:disabled {
+  opacity: 0.55;
+  cursor: progress;
+}
+
+.turn-next-world-status {
+  min-height: 1.35em;
+  color: #4f4640;
+}
+
+.turn-next-world-note,
+.turn-next-world-credits {
+  font-size: 0.7rem;
+  color: #5d514a;
+}
+
+.turn-next-world-credits a,
+.turn-next-world-hud-credit a {
+  color: inherit;
+  text-decoration-thickness: 1px;
+}
+
+.turn-next-world-hud {
+  position: fixed;
+  z-index: 6000;
+  top: max(8px, env(safe-area-inset-top));
+  left: 50%;
+  transform: translateX(-50%);
+  display: grid;
+  grid-template-columns: auto auto;
+  gap: 6px 10px;
+  align-items: center;
+  min-width: min(540px, calc(100vw - 190px));
+  max-width: calc(100vw - 32px);
+  padding: 8px 10px;
+  border: 2px solid #08090a;
+  border-radius: 10px;
+  background: rgb(255 248 232 / 92%);
+  color: #08090a;
+  box-shadow: 0 3px 0 #08090a;
+  pointer-events: auto;
+}
+
+.turn-next-world-hud[hidden] {
+  display: none;
+}
+
+.turn-next-world-hud-copy {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 9px;
+  align-items: baseline;
+  min-width: 0;
+  font: 800 0.66rem/1.2 system-ui, sans-serif;
+}
+
+.turn-next-world-hud-copy strong {
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+}
+
+.turn-next-world-hud-copy span {
+  white-space: nowrap;
+}
+
+.turn-next-world-hud button {
+  min-height: 34px;
+  padding: 6px 10px;
+  background: #ff7b54;
+  box-shadow: none;
+  font-size: 0.65rem;
+}
+
+.turn-next-world-hud-credit {
+  grid-column: 1 / -1;
+  display: flex;
+  gap: 5px;
+  justify-content: center;
+  font: 700 0.56rem/1 system-ui, sans-serif;
+  opacity: 0.78;
+}
+
+body.turn-next-world-active #hud .map-wrap,
+body.turn-next-world-active #hud .chip:has(#lap),
+body.turn-next-world-active #hud .chip:has(#lapTime),
+body.turn-next-world-active #hud .chip:has(#bestTime),
+body.turn-next-world-active #scoreFeedback {
+  display: none !important;
+}
+
+@media (max-width: 720px) {
+  .turn-next-world-fields {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .turn-next-world-fields label:last-child {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+  .turn-next-world-dialog {
+    width: min(780px, calc(100vw - 28px));
+  }
+
+  .turn-next-world-card {
+    gap: 10px;
+    padding: 12px 14px;
+  }
+
+  .turn-next-world-header h2 {
+    font-size: 2.4rem;
+  }
+
+  .turn-next-world-copy {
+    font-size: 0.78rem;
+  }
+
+  .turn-next-world-fields input,
+  .turn-next-world-fields select {
+    min-height: 36px;
+  }
+
+  .turn-next-world-hud {
+    top: max(5px, env(safe-area-inset-top));
+    min-width: min(500px, calc(100vw - 190px));
+    padding: 5px 8px;
+  }
+}

--- a/turn-next/world-mode.js
+++ b/turn-next/world-mode.js
@@ -155,6 +155,9 @@ function bindView(view, session, context) {
   view.driveButton.addEventListener('click', () => void startWorld(session, context, view));
   view.leaveButton.addEventListener('click', () => void leaveWorld(session, context, view));
   view.dialog.addEventListener('cancel', () => session.controller?.abort());
+  view.dialog.addEventListener('close', () => {
+    if (session.loading && !session.active) session.controller?.abort();
+  });
 }
 
 function useBrowserLocation(view) {
@@ -208,16 +211,23 @@ async function startWorld(session, context, view) {
     session.snapshot = captureSnapshot(context.runtime, context.home);
     session.worldData = worldData;
     await enterWorld(session, context, view, access);
-    closeDialog(view.dialog);
+    closeDialog(view.dialog, { restoreFocus: false });
     return true;
   } catch (error) {
+    if (session.snapshot) {
+      try {
+        await leaveWorld(session, context, view);
+      } catch (restoreError) {
+        console.warn('TURN NEXT WORLD could not fully restore the previous track.', restoreError);
+      }
+    } else if (session.worldData) {
+      disposeSemanticWorld(session.worldData.world);
+      session.worldData = null;
+    }
     if (error?.name !== 'AbortError') {
       console.warn('TURN NEXT WORLD could not start.', error);
       setStatus(view, error instanceof Error ? error.message : 'The real-world experiment could not start.');
-    }
-    if (session.worldData && !session.active) {
-      disposeSemanticWorld(session.worldData.world);
-      session.worldData = null;
+      if (!view.dialog.open) openDialog(view.dialog, session.returnFocus);
     }
     return false;
   } finally {
@@ -459,11 +469,11 @@ function openDialog(dialog, returnFocus) {
   else dialog.setAttribute('open', '');
 }
 
-function closeDialog(dialog) {
+function closeDialog(dialog, { restoreFocus = true } = {}) {
   try {
     dialog.close();
   } catch (_) {
     dialog.removeAttribute('open');
   }
-  dialog.__turnReturnFocus?.focus?.();
+  if (restoreFocus) dialog.__turnReturnFocus?.focus?.();
 }

--- a/turn-next/world-mode.js
+++ b/turn-next/world-mode.js
@@ -1,0 +1,469 @@
+import { updateRaceCameraState } from '/turn/render/camera.js?build=20260720-r19&revision=r270-camera-hotpath';
+import { activateTrack } from '/turn/tracks/track-manager.js?source=20260729-r118-m8';
+import { disposeSemanticWorld, loadSemanticWorld } from '/turn-next/world-data.js';
+
+const WORLD_TRACK_ID = 'turn-next-world';
+const DEFAULT_RADIUS = 900;
+const DEMO_LOCATION = Object.freeze({ lat: 45.9237, lon: 6.8694 });
+let installed = false;
+
+export async function installWorldMode() {
+  if (installed) return globalThis.__turnNextWorldMode;
+  const runtime = globalThis.__turnRuntime;
+  const raceSession = globalThis.__turnNextRaceSession;
+  const home = globalThis.__turnNextHome || globalThis.__turnHome;
+  const menu = globalThis.__turnHomeLayout?.menu || document.querySelector('.m8-home-menu');
+  if (!runtime || !raceSession || !home || !menu) return null;
+
+  installed = true;
+  installStylesheet();
+  const view = createView();
+  const launcher = createLauncher(menu, view.dialog);
+  const session = {
+    active: false,
+    loading: false,
+    worldData: null,
+    snapshot: null,
+    frame: 0,
+    returnFocus: launcher,
+    controller: null,
+    lastHudUpdate: 0
+  };
+
+  bindView(view, session, { runtime, raceSession, home });
+
+  const api = Object.freeze({
+    open: () => openDialog(view.dialog, launcher),
+    leave: () => leaveWorld(session, { runtime, raceSession, home }, view),
+    getState: () => Object.freeze({ active: session.active, loading: session.loading })
+  });
+  globalThis.__turnNextWorldMode = api;
+  return api;
+}
+
+function installStylesheet() {
+  if (document.querySelector('link[data-turn-next-world-style]')) return;
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = '/turn-next/world-mode.css';
+  link.dataset.turnNextWorldStyle = '';
+  document.head.appendChild(link);
+}
+
+function createLauncher(menu, dialog) {
+  const existing = menu.querySelector('[data-turn-next-world-launcher]');
+  if (existing) return existing;
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'turn-next-world-launcher';
+  button.dataset.turnNextWorldLauncher = '';
+  button.textContent = 'WORLD';
+  button.setAttribute('aria-label', 'Open the TURN NEXT real-world driving experiment');
+  const status = menu.querySelector('.m8-home-status');
+  menu.insertBefore(button, status || menu.querySelector('.m8-race-button'));
+  button.addEventListener('click', () => openDialog(dialog, button));
+  return button;
+}
+
+function createView() {
+  const dialog = document.createElement('dialog');
+  dialog.className = 'turn-next-world-dialog';
+  dialog.setAttribute('aria-labelledby', 'turnNextWorldTitle');
+  dialog.innerHTML = `
+    <form method="dialog" class="turn-next-world-card">
+      <header class="turn-next-world-header">
+        <div>
+          <span>TURN NEXT EXPERIMENT</span>
+          <h2 id="turnNextWorldTitle">WORLD</h2>
+        </div>
+        <button type="submit" class="turn-next-world-close" aria-label="Close real-world driving experiment">×</button>
+      </header>
+      <p class="turn-next-world-copy">Drive a low-poly 3D version of a real place using TURN. Roads, buildings, water, land use and terrain are generated from open map semantics. No satellite imagery.</p>
+      <div class="turn-next-world-fields">
+        <label>Latitude
+          <input name="latitude" inputmode="decimal" type="number" min="-85" max="85" step="0.0001" required>
+        </label>
+        <label>Longitude
+          <input name="longitude" inputmode="decimal" type="number" min="-180" max="180" step="0.0001" required>
+        </label>
+        <label>World radius
+          <select name="radius">
+            <option value="650">650 m · lighter</option>
+            <option value="900" selected>900 m · default</option>
+            <option value="1250">1.25 km · heavier</option>
+          </select>
+        </label>
+      </div>
+      <div class="turn-next-world-presets" aria-label="Location helpers">
+        <button type="button" data-world-location>USE MY LOCATION</button>
+        <button type="button" data-world-demo>ALPINE DEMO</button>
+      </div>
+      <p class="turn-next-world-status" role="status" aria-live="polite"></p>
+      <button type="button" class="turn-next-world-drive" data-world-drive>DRIVE HERE</button>
+      <p class="turn-next-world-note">This is a live experiment using public open-data services. Small areas are intentional.</p>
+      <p class="turn-next-world-credits">
+        Map data <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noreferrer">© OpenStreetMap contributors</a> ·
+        Terrain <a href="https://registry.opendata.aws/terrain-tiles/" target="_blank" rel="noreferrer">Mapzen/Tilezen open elevation tiles</a>
+      </p>
+    </form>`;
+  document.body.appendChild(dialog);
+
+  const hud = document.createElement('section');
+  hud.className = 'turn-next-world-hud';
+  hud.hidden = true;
+  hud.setAttribute('aria-label', 'TURN NEXT World status');
+  hud.innerHTML = `
+    <div class="turn-next-world-hud-copy">
+      <strong>WORLD</strong>
+      <span data-world-coordinates></span>
+      <span data-world-stats></span>
+    </div>
+    <button type="button" data-world-leave>LEAVE WORLD</button>
+    <div class="turn-next-world-hud-credit">
+      <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noreferrer">© OpenStreetMap</a>
+      <span aria-hidden="true">·</span>
+      <a href="https://registry.opendata.aws/terrain-tiles/" target="_blank" rel="noreferrer">terrain data</a>
+    </div>`;
+  document.body.appendChild(hud);
+
+  return {
+    dialog,
+    hud,
+    latitude: dialog.elements.latitude,
+    longitude: dialog.elements.longitude,
+    radius: dialog.elements.radius,
+    locationButton: dialog.querySelector('[data-world-location]'),
+    demoButton: dialog.querySelector('[data-world-demo]'),
+    driveButton: dialog.querySelector('[data-world-drive]'),
+    status: dialog.querySelector('.turn-next-world-status'),
+    leaveButton: hud.querySelector('[data-world-leave]'),
+    coordinates: hud.querySelector('[data-world-coordinates]'),
+    stats: hud.querySelector('[data-world-stats]')
+  };
+}
+
+function bindView(view, session, context) {
+  view.demoButton.addEventListener('click', () => {
+    view.latitude.value = DEMO_LOCATION.lat.toFixed(4);
+    view.longitude.value = DEMO_LOCATION.lon.toFixed(4);
+    view.radius.value = String(DEFAULT_RADIUS);
+    setStatus(view, 'Alpine demo coordinates loaded. Press Drive Here to start.');
+    view.driveButton.focus();
+  });
+
+  view.locationButton.addEventListener('click', () => useBrowserLocation(view));
+  view.driveButton.addEventListener('click', () => void startWorld(session, context, view));
+  view.leaveButton.addEventListener('click', () => void leaveWorld(session, context, view));
+  view.dialog.addEventListener('cancel', () => session.controller?.abort());
+}
+
+function useBrowserLocation(view) {
+  if (!globalThis.navigator?.geolocation) {
+    setStatus(view, 'Location is not available in this browser. Enter coordinates instead.');
+    return;
+  }
+  view.locationButton.disabled = true;
+  setStatus(view, 'Requesting your location…');
+  globalThis.navigator.geolocation.getCurrentPosition(
+    (position) => {
+      view.latitude.value = position.coords.latitude.toFixed(5);
+      view.longitude.value = position.coords.longitude.toFixed(5);
+      setStatus(view, 'Location loaded. Press Drive Here to start.');
+      view.locationButton.disabled = false;
+      view.driveButton.focus();
+    },
+    (error) => {
+      setStatus(view, error?.message || 'Location could not be read. Enter coordinates instead.');
+      view.locationButton.disabled = false;
+    },
+    { enableHighAccuracy: false, timeout: 10_000, maximumAge: 120_000 }
+  );
+}
+
+async function startWorld(session, context, view) {
+  if (session.active || session.loading) return false;
+  const latitude = Number(view.latitude.value);
+  const longitude = Number(view.longitude.value);
+  const radiusMeters = Number(view.radius.value) || DEFAULT_RADIUS;
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+    setStatus(view, 'Enter a latitude and longitude, or use one of the location helpers.');
+    return false;
+  }
+
+  session.loading = true;
+  session.controller = new globalThis.AbortController();
+  view.driveButton.disabled = true;
+  view.driveButton.setAttribute('aria-busy', 'true');
+  setStatus(view, 'Preparing controls…');
+
+  try {
+    const access = await prepareAccess(context.home, context.raceSession);
+    const worldData = await loadSemanticWorld({
+      latitude,
+      longitude,
+      radiusMeters,
+      signal: session.controller.signal,
+      onStatus: (message) => setStatus(view, message)
+    });
+    session.snapshot = captureSnapshot(context.runtime, context.home);
+    session.worldData = worldData;
+    await enterWorld(session, context, view, access);
+    closeDialog(view.dialog);
+    return true;
+  } catch (error) {
+    if (error?.name !== 'AbortError') {
+      console.warn('TURN NEXT WORLD could not start.', error);
+      setStatus(view, error instanceof Error ? error.message : 'The real-world experiment could not start.');
+    }
+    if (session.worldData && !session.active) {
+      disposeSemanticWorld(session.worldData.world);
+      session.worldData = null;
+    }
+    return false;
+  } finally {
+    session.loading = false;
+    session.controller = null;
+    view.driveButton.disabled = false;
+    view.driveButton.removeAttribute('aria-busy');
+  }
+}
+
+async function prepareAccess(home, raceSession) {
+  const steeringMode = home.getSteeringMode?.() || 'manual';
+  return steeringMode === 'motion'
+    ? raceSession.prepareMotionAccess()
+    : raceSession.prepareManualAccess();
+}
+
+async function enterWorld(session, { runtime, raceSession, home }, view, access) {
+  const worldData = session.worldData;
+  if (!worldData) throw new Error('The real-world scene was not built.');
+
+  if (runtime.activeWorld) runtime.activeWorld.visible = false;
+  runtime.samples.splice(0, runtime.samples.length, ...worldData.samples);
+  runtime.trackSpatialIndex.replaceSamples(runtime.samples);
+  runtime.trackId = WORLD_TRACK_ID;
+  runtime.activeTrack = Object.freeze({
+    id: WORLD_TRACK_ID,
+    name: 'WORLD',
+    freeRoamDistance: worldData.radius * 3,
+    collisionProfile: worldData.collisionProfile
+  });
+  runtime.state.trackId = WORLD_TRACK_ID;
+  runtime.state.trackSampleCount = runtime.samples.length;
+  runtime.scene.add(worldData.world);
+  runtime.activeWorld = worldData.world;
+  runtime.scene.background?.setHex?.(0x82c8df);
+  if (runtime.scene.fog?.color) {
+    runtime.scene.fog.color.setHex(0xaacbd2);
+    runtime.scene.fog.near = worldData.radius * 0.45;
+    runtime.scene.fog.far = worldData.radius * 1.85;
+  }
+
+  globalThis.__turnGetTrackId = () => WORLD_TRACK_ID;
+  globalThis.__turnGetCollisionProfile = () => worldData.collisionProfile;
+  globalThis.__turnIsForgivingSurface = () => false;
+  runtime.openLot = () => leaveWorld(session, { runtime, raceSession, home }, view);
+
+  home.hideHome();
+  document.body.classList.add('turn-next-world-active');
+  view.hud.hidden = false;
+  view.stats.textContent = formatStats(worldData.stats);
+  session.active = true;
+
+  await raceSession.startGame(access?.fullscreenPromise || Promise.resolve(false), { announceStart: false });
+  runtime.state.freeRoam = true;
+  positionAtStart(runtime, worldData);
+  runtime.setSceneOverride((dt) => renderWorldFrame(runtime, worldData, dt));
+  if (!session.frame) session.frame = requestAnimationFrame(() => worldFrame(session, { runtime }, view));
+  showMessage('EXPLORE THE REAL WORLD', 1700);
+  window.dispatchEvent(new CustomEvent('turn:next-world-started', {
+    detail: Object.freeze({
+      latitude: worldData.center.lat,
+      longitude: worldData.center.lon,
+      radius: worldData.radius
+    })
+  }));
+}
+
+function captureSnapshot(runtime, home) {
+  return Object.freeze({
+    trackId: home.getSelectedTrackId?.() || runtime.state.trackId || 'countryside',
+    openLot: runtime.openLot,
+    getTrackId: globalThis.__turnGetTrackId,
+    getCollisionProfile: globalThis.__turnGetCollisionProfile,
+    isForgivingSurface: globalThis.__turnIsForgivingSurface
+  });
+}
+
+function positionAtStart(runtime, worldData) {
+  const sample = worldData.samples[worldData.startIndex] || worldData.samples[0];
+  runtime.setGameMode(runtime.GAME_MODE.STAGED);
+  runtime.state.freeRoam = true;
+  runtime.state.position.copy(sample.point);
+  runtime.state.position.y = worldData.terrain.heightAtWorld(sample.point.x, sample.point.z) + 0.18;
+  runtime.state.velocity.set(0, 0, 0);
+  runtime.state.heading = Math.atan2(sample.tangent.x, sample.tangent.z);
+  runtime.state.speed = 0;
+  runtime.state.driftAmount = 0;
+  runtime.state.driftSlipAngle = 0;
+  runtime.state.offRoad = false;
+  runtime.state.trackDistance = 0;
+  runtime.state.progress = worldData.startIndex / worldData.samples.length;
+  runtime.state.lastProgress = runtime.state.progress;
+  runtime.state.nearestTrackIndex = worldData.startIndex;
+  runtime.state.lapActive = false;
+  runtime.state.lapStartedAt = 0;
+  runtime.state.lapElapsed = 0;
+  runtime.state.lapCheckpointIndex = 0;
+  runtime.state.recording = [];
+  runtime.playerCar.position.copy(runtime.state.position);
+  runtime.playerCar.rotation.y = runtime.state.heading + Math.PI;
+  for (const car of runtime.competitorCars || []) car.visible = false;
+  runtime.setRacePosition?.(null, 1);
+}
+
+function renderWorldFrame(runtime, worldData, dt) {
+  const state = runtime.state;
+  const terrainY = worldData.terrain.heightAtWorld(state.position.x, state.position.z);
+  state.position.y = terrainY + 0.18;
+  const forward = runtime.getForward();
+  const probe = 3.8;
+  const front = worldData.terrain.heightAtWorld(
+    state.position.x + forward.x * probe,
+    state.position.z + forward.z * probe
+  );
+  const back = worldData.terrain.heightAtWorld(
+    state.position.x - forward.x * probe,
+    state.position.z - forward.z * probe
+  );
+  const pitch = Math.atan2(front - back, probe * 2);
+  state.surfacePitch = pitch;
+
+  runtime.playerCar.position.copy(state.position);
+  runtime.playerCar.rotation.x = pitch;
+  runtime.playerCar.rotation.y = state.heading + Math.PI;
+  runtime.playerCar.rotation.z = -state.steering * 0.035 - state.velocity.dot(runtime.getRight()) * 0.0025;
+  runtime.animateWheels?.(runtime.playerCar, state.steering, state.speed, dt);
+
+  updateRaceCameraState({
+    state,
+    camera: runtime.camera,
+    cameraPosition: runtime.cameraPosition,
+    cameraTarget: runtime.cameraTarget,
+    getForward: runtime.getForward,
+    getRight: runtime.getRight,
+    samples: [],
+    maxSpeed: runtime.maxSpeed,
+    dt
+  });
+  return true;
+}
+
+function worldFrame(session, { runtime }, view) {
+  if (!session.active) {
+    session.frame = 0;
+    return;
+  }
+  const worldData = session.worldData;
+  if (runtime.state.running && worldData) {
+    clampToWorld(runtime.state, worldData.radius * 1.04);
+    suppressCompetitiveRaceState(runtime.state);
+    const now = globalThis.performance.now();
+    if (now - session.lastHudUpdate > 180) {
+      const geo = worldData.toGeo(runtime.state.position.x, runtime.state.position.z);
+      view.coordinates.textContent = `${geo.lat.toFixed(5)}, ${geo.lon.toFixed(5)}`;
+      session.lastHudUpdate = now;
+    }
+  }
+  session.frame = requestAnimationFrame(() => worldFrame(session, { runtime }, view));
+}
+
+function suppressCompetitiveRaceState(state) {
+  state.freeRoam = true;
+  state.lapActive = false;
+  state.lapInvalid = false;
+  state.lapElapsed = 0;
+  state.lapCheckpointIndex = 0;
+  state.recording = [];
+  state.suppressNextLapStartMessage = true;
+}
+
+function clampToWorld(state, limit) {
+  const distance = Math.hypot(state.position.x, state.position.z);
+  if (distance <= limit) return;
+  const nx = state.position.x / distance;
+  const nz = state.position.z / distance;
+  state.position.x = nx * limit;
+  state.position.z = nz * limit;
+  const outwardSpeed = state.velocity.x * nx + state.velocity.z * nz;
+  if (outwardSpeed > 0) {
+    state.velocity.x -= nx * outwardSpeed * 1.15;
+    state.velocity.z -= nz * outwardSpeed * 1.15;
+  }
+  state.speed = state.velocity.length();
+}
+
+async function leaveWorld(session, { runtime, raceSession, home }, view) {
+  if (!session.active && !session.snapshot) return false;
+  session.controller?.abort();
+  if (session.frame) cancelAnimationFrame(session.frame);
+  session.frame = 0;
+  runtime.setSceneOverride(null);
+  raceSession.leaveRace();
+  runtime.state.freeRoam = false;
+  document.body.classList.remove('turn-next-world-active');
+  view.hud.hidden = true;
+
+  const snapshot = session.snapshot;
+  const worldData = session.worldData;
+  if (worldData) disposeSemanticWorld(worldData.world);
+  if (snapshot) {
+    globalThis.__turnGetTrackId = snapshot.getTrackId;
+    globalThis.__turnGetCollisionProfile = snapshot.getCollisionProfile;
+    globalThis.__turnIsForgivingSurface = snapshot.isForgivingSurface;
+    runtime.openLot = snapshot.openLot;
+    await activateTrack(snapshot.trackId, runtime);
+  }
+
+  session.active = false;
+  session.worldData = null;
+  session.snapshot = null;
+  session.lastHudUpdate = 0;
+  home.showHome({ focus: true });
+  session.returnFocus?.focus?.();
+  window.dispatchEvent(new CustomEvent('turn:next-world-left'));
+  return true;
+}
+
+function formatStats(stats) {
+  const terrain = stats.terrain ? 'terrain' : 'flat terrain';
+  return `${stats.roads} roads · ${stats.buildings} buildings · ${stats.semanticAreas} areas · ${terrain}`;
+}
+
+function setStatus(view, message) {
+  view.status.textContent = message;
+}
+
+function showMessage(text, duration = 1600) {
+  const message = document.querySelector('#message');
+  if (!message) return;
+  message.textContent = text;
+  message.classList.add('show');
+  globalThis.setTimeout(() => message.classList.remove('show'), duration);
+}
+
+function openDialog(dialog, returnFocus) {
+  dialog.__turnReturnFocus = returnFocus;
+  if (typeof dialog.showModal === 'function') dialog.showModal();
+  else dialog.setAttribute('open', '');
+}
+
+function closeDialog(dialog) {
+  try {
+    dialog.close();
+  } catch (_) {
+    dialog.removeAttribute('open');
+  }
+  dialog.__turnReturnFocus?.focus?.();
+}

--- a/turn-next/world-mode.js
+++ b/turn-next/world-mode.js
@@ -9,6 +9,7 @@ let installed = false;
 
 export async function installWorldMode() {
   if (installed) return globalThis.__turnNextWorldMode;
+
   const runtime = globalThis.__turnRuntime;
   const raceSession = globalThis.__turnNextRaceSession;
   const home = globalThis.__turnNextHome || globalThis.__turnHome;
@@ -53,6 +54,7 @@ function installStylesheet() {
 function createLauncher(menu, dialog) {
   const existing = menu.querySelector('[data-turn-next-world-launcher]');
   if (existing) return existing;
+
   const button = document.createElement('button');
   button.type = 'button';
   button.className = 'turn-next-world-launcher';
@@ -129,9 +131,9 @@ function createView() {
   return {
     dialog,
     hud,
-    latitude: dialog.elements.latitude,
-    longitude: dialog.elements.longitude,
-    radius: dialog.elements.radius,
+    latitude: dialog.querySelector('[name="latitude"]'),
+    longitude: dialog.querySelector('[name="longitude"]'),
+    radius: dialog.querySelector('[name="radius"]'),
     locationButton: dialog.querySelector('[data-world-location]'),
     demoButton: dialog.querySelector('[data-world-demo]'),
     driveButton: dialog.querySelector('[data-world-drive]'),
@@ -165,6 +167,7 @@ function useBrowserLocation(view) {
     setStatus(view, 'Location is not available in this browser. Enter coordinates instead.');
     return;
   }
+
   view.locationButton.disabled = true;
   setStatus(view, 'Requesting your location…');
   globalThis.navigator.geolocation.getCurrentPosition(
@@ -185,6 +188,7 @@ function useBrowserLocation(view) {
 
 async function startWorld(session, context, view) {
   if (session.active || session.loading) return false;
+
   const latitude = Number(view.latitude.value);
   const longitude = Number(view.longitude.value);
   const radiusMeters = Number(view.radius.value) || DEFAULT_RADIUS;
@@ -224,6 +228,7 @@ async function startWorld(session, context, view) {
       disposeSemanticWorld(session.worldData.world);
       session.worldData = null;
     }
+
     if (error?.name !== 'AbortError') {
       console.warn('TURN NEXT WORLD could not start.', error);
       setStatus(view, error instanceof Error ? error.message : 'The real-world experiment could not start.');
@@ -319,7 +324,7 @@ function positionAtStart(runtime, worldData) {
   runtime.state.driftSlipAngle = 0;
   runtime.state.offRoad = false;
   runtime.state.trackDistance = 0;
-  runtime.state.progress = worldData.startIndex / worldData.samples.length;
+  runtime.state.progress = worldData.startIndex / runtime.samples.length;
   runtime.state.lastProgress = runtime.state.progress;
   runtime.state.nearestTrackIndex = worldData.startIndex;
   runtime.state.lapActive = false;
@@ -335,8 +340,8 @@ function positionAtStart(runtime, worldData) {
 
 function renderWorldFrame(runtime, worldData, dt) {
   const state = runtime.state;
-  const terrainY = worldData.terrain.heightAtWorld(state.position.x, state.position.z);
-  state.position.y = terrainY + 0.18;
+  state.position.y = worldData.terrain.heightAtWorld(state.position.x, state.position.z) + 0.18;
+
   const forward = runtime.getForward();
   const probe = 3.8;
   const front = worldData.terrain.heightAtWorld(
@@ -375,6 +380,7 @@ function worldFrame(session, { runtime }, view) {
     session.frame = 0;
     return;
   }
+
   const worldData = session.worldData;
   if (runtime.state.running && worldData) {
     clampToWorld(runtime.state, worldData.radius * 1.04);
@@ -386,6 +392,7 @@ function worldFrame(session, { runtime }, view) {
       session.lastHudUpdate = now;
     }
   }
+
   session.frame = requestAnimationFrame(() => worldFrame(session, { runtime }, view));
 }
 
@@ -402,6 +409,7 @@ function suppressCompetitiveRaceState(state) {
 function clampToWorld(state, limit) {
   const distance = Math.hypot(state.position.x, state.position.z);
   if (distance <= limit) return;
+
   const nx = state.position.x / distance;
   const nz = state.position.z / distance;
   state.position.x = nx * limit;
@@ -416,6 +424,7 @@ function clampToWorld(state, limit) {
 
 async function leaveWorld(session, { runtime, raceSession, home }, view) {
   if (!session.active && !session.snapshot) return false;
+
   session.controller?.abort();
   if (session.frame) cancelAnimationFrame(session.frame);
   session.frame = 0;

--- a/turn-tests/turn-next-world-production.mjs
+++ b/turn-tests/turn-next-world-production.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+const [identity, worldMode, worldData, worldCss] = await Promise.all([
+  fs.readFile(new URL('../turn-next/identity.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn-next/world-mode.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn-next/world-data.js', import.meta.url), 'utf8'),
+  fs.readFile(new URL('../turn-next/world-mode.css', import.meta.url), 'utf8')
+]);
+
+assert.match(identity, /import\('\/turn-next\/world-mode\.js'\)/,
+  'TURN NEXT identity should install WORLD without editing generated app/index files');
+assert.match(identity, /__turnHomeLayout\?\.menu/,
+  'WORLD should attach only after the protected Home layout exists');
+
+assert.match(worldData, /overpass-api\.de\/api\/interpreter/,
+  'WORLD should load semantic map data from an OpenStreetMap Overpass endpoint');
+assert.match(worldData, /way\[\\"highway\\"/,
+  'WORLD should derive drivable road geometry from OpenStreetMap highway semantics');
+assert.match(worldData, /way\[\\"building\\"\]/,
+  'WORLD should derive low-poly buildings from OpenStreetMap building footprints');
+assert.match(worldData, /natural\\"~\\"water\|wood/,
+  'WORLD should use semantic water and woodland data rather than raster map imagery');
+assert.match(worldData, /elevation-tiles-prod\/terrarium/,
+  'WORLD should load open Terrarium elevation tiles');
+assert.match(worldData, /\(red \* 256 \+ green \+ blue \/ 256\) - 32768/,
+  'WORLD should decode Terrarium elevation values');
+assert.doesNotMatch(worldData, /mapbox|google\s*maps|satellite/i,
+  'WORLD data loading must not introduce a satellite/raster basemap provider');
+
+assert.match(worldMode, /runtime\.samples\.splice\(0, runtime\.samples\.length, \.\.\.worldData\.samples\)/,
+  'WORLD should feed its real road network into the existing TURN physics runtime');
+assert.match(worldMode, /runtime\.trackSpatialIndex\.replaceSamples\(runtime\.samples\)/,
+  'WORLD should rebuild TURN nearest-road lookup for the imported road network');
+assert.match(worldMode, /runtime\.setSceneOverride\(\(dt\) => renderWorldFrame/,
+  'WORLD should use the TURN scene override to apply terrain altitude without forking core physics');
+assert.match(worldMode, /terrain\.heightAtWorld/,
+  'WORLD should pose the car against DEM terrain height');
+assert.match(worldMode, /await activateTrack\(snapshot\.trackId, runtime\)/,
+  'Leaving WORLD should restore the selected canonical TURN track');
+assert.match(worldMode, /© OpenStreetMap contributors/,
+  'WORLD setup must expose OpenStreetMap attribution');
+assert.match(worldMode, /registry\.opendata\.aws\/terrain-tiles/,
+  'WORLD should expose terrain-data attribution');
+assert.match(worldCss, /turn-next-world-active/,
+  'WORLD should own an isolated TURN NEXT presentation state');
+
+console.log('TURN NEXT WORLD static contract passed.');


### PR DESCRIPTION
## Summary

Adds an isolated **WORLD** experiment to `/turn-next/` that lets TURN drive around a small real-world area rendered as low-poly 3D from open map semantics.

### Data and rendering
- Queries OpenStreetMap through Overpass for roads, buildings, water, land use, woodland, parks and runway/taxiway semantics.
- Builds actual 3D road ribbons with class-/lane-aware widths, surface-aware coloring and lightweight center markings.
- Extrudes mapped building footprints and supplies simplified building collision bounds.
- Renders semantic land/water areas and instanced low-poly woodland.
- Loads open Mapzen/Tilezen Terrarium elevation tiles, decodes and bilinearly samples elevation, and generates low-poly terrain.
- No satellite imagery or raster basemap is rendered.

### TURN integration
- Reuses the current TURN runtime, vehicle physics, controls, drift/boost and chase camera.
- Temporarily replaces the active road samples/spatial index while WORLD is active.
- Uses the existing scene-override hook to pose the car to DEM terrain height/pitch.
- Suppresses competitive lap/record state in free roam.
- Restores the previously selected canonical TURN track and runtime hooks on exit or failed launch.
- Adds visible OpenStreetMap + terrain-data attribution.

### UX / performance
- Home gets an additive `WORLD` action only in TURN NEXT.
- Player can enter coordinates, explicitly request browser geolocation, or use an Alpine demo preset.
- Area sizes are intentionally bounded to 650 m / 900 m / 1.25 km radii.
- Caps building, semantic-area, tree, collider and road-sample counts for mobile/tablet experiment-scale rendering.

### Safety boundaries
- Production TURN is untouched.
- Generated `turn-next/app.js` and `turn-next/index.html` are untouched.
- No TURN release/build bump: this changes only TURN NEXT staging/test surfaces.

### Validation
- Added `turn-tests/turn-next-world-production.mjs` static contract coverage.
- WORLD modules are included in the existing ESLint scope.
- Branch starts from current `main` (`b5f7c2e4`, TURN 1.19.4 / 2026.09.12-r218) and is not behind it.