### PR TITLE
Fix TURN NEXT WORLD cache delivery

### DIFF
--- a/turn-next/index.html
+++ b/turn-next/index.html
@@ -69,7 +69,7 @@
   <link rel="stylesheet" href="./garage/lot-layout-r60.css?build=20260912-r218">
   <link rel="stylesheet" href="./m8-menu-font-fix.css?build=20260912-r218-menu-font-v3">
   <link rel="stylesheet" href="/turn-next/identity.css?source=20260912-r218-m8.5-logo">
-  <script defer src="/turn-next/identity.js?source=20260912-r218-m8.5-logo"></script>
+  <script defer src="/turn-next/identity.js?source=20260912-r218-m8.5-logo-world"></script>
   <script src="./install-gate.js?build=20260912-r218-social-browser"></script>
   <script src="./pwa-usable-viewport-r181.js?revision=r181-usable-web-layer"></script>
   <script src="./motion-safe-zone.js?build=20260912-r218"></script>

--- a/turn-next/scripts/build-parity-entry.mjs
+++ b/turn-next/scripts/build-parity-entry.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 const repositoryRoot = path.resolve(fileURLToPath(new URL('../..', import.meta.url)));
 const releasePath = path.join(repositoryRoot, 'turn', 'release.json');
 const outputPath = path.join(repositoryRoot, 'turn-next', 'index.html');
+const NEXT_IDENTITY_SOURCE = 'm8.5-logo-world';
 
 export function renderParityEntry(source, release) {
   const currentBuild = source.match(
@@ -15,10 +16,15 @@ export function renderParityEntry(source, release) {
   assert.ok(currentBuild, 'TURN NEXT entry must expose its source TURN build identity');
 
   const [, currentVersion, currentId, currentCacheKey] = currentBuild;
-  return source
+  const releaseAligned = source
     .replaceAll(currentVersion, release.version)
     .replaceAll(currentId, release.id)
     .replaceAll(currentCacheKey, release.cacheKey);
+
+  return releaseAligned.replace(
+    /\/turn-next\/identity\.js\?source=[^"']+/,
+    `/turn-next/identity.js?source=${release.cacheKey}-${NEXT_IDENTITY_SOURCE}`
+  );
 }
 
 function validateParityEntry(current, release) {
@@ -29,7 +35,11 @@ function validateParityEntry(current, release) {
   assert.match(current, new RegExp(`/turn-next/storage-bootstrap\\.js\\?source=${release.cacheKey}`));
   assert.match(current, /\/turn-next\/site\.webmanifest/);
   assert.match(current, /\/turn-next\/identity\.css/);
-  assert.match(current, /\/turn-next\/identity\.js/);
+  assert.match(
+    current,
+    new RegExp(`/turn-next/identity\\.js\\?source=${release.cacheKey}-${NEXT_IDENTITY_SOURCE}`),
+    'TURN NEXT identity changes must receive a staging-specific cache key even when production TURN is unchanged'
+  );
   assert.match(current, new RegExp(`/turn-next/app\\.js\\?source=${release.cacheKey}-browser-consent`));
   assert.match(current, new RegExp(`install-gate\\.js\\?build=${release.cacheKey}-social-browser`));
   assert.match(current, new RegExp(`install-gate\\.css\\?build=${release.cacheKey}-social-browser`));

--- a/turn-tests/turn-next-world-production.mjs
+++ b/turn-tests/turn-next-world-production.mjs
@@ -1,15 +1,18 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 
-const [identity, worldMode, worldData, worldCss] = await Promise.all([
+const [entry, identity, worldMode, worldData, worldCss] = await Promise.all([
+  fs.readFile(new URL('../turn-next/index.html', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-next/identity.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-next/world-mode.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-next/world-data.js', import.meta.url), 'utf8'),
   fs.readFile(new URL('../turn-next/world-mode.css', import.meta.url), 'utf8')
 ]);
 
+assert.match(entry, /\/turn-next\/identity\.js\?source=\d{8}-r\d+-m8\.5-logo-world/,
+  'TURN NEXT entry should cache-bust the identity bootstrap when staging-only features change');
 assert.match(identity, /import\('\/turn-next\/world-mode\.js'\)/,
-  'TURN NEXT identity should install WORLD without editing generated app/index files');
+  'TURN NEXT identity should install WORLD without changing the canonical production app');
 assert.match(identity, /__turnHomeLayout\?\.menu/,
   'WORLD should attach only after the protected Home layout exists');
 


### PR DESCRIPTION
## Summary

Fixes the reason the new TURN NEXT `WORLD` action can be missing on an existing browser/PWA installation.

The WORLD bootstrap lives in `turn-next/identity.js`, but #886 changed that file while keeping its previous `source=20260912-r218-m8.5-logo` URL. Existing clients could therefore legally reuse the pre-WORLD cached script.

This change:
- gives the TURN NEXT identity bootstrap a WORLD-specific staging cache key without changing production TURN
- makes the TURN NEXT entry generator enforce that staging cache key
- adds regression coverage so future TURN NEXT-only identity changes cannot silently reuse the stale bootstrap URL

Production TURN remains 1.19.4 / 2026.09.12-r218 because no `turn/` production code changes.